### PR TITLE
docs: rename local development guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,7 @@ See `packaging/pkg/README.md` for full PKG operator documentation and `packaging
 | CONTRIBUTING.md | Human collaborator workflow |
 | mise.toml | Pinned local toolchain contract |
 | docs/tooling.md | mise, validation command, and local tool guidance |
+| docs/local-dev.md | Source development setup and smoke-test guidance |
 | docs/process.md | Artifact lifecycle and process guidance |
 | docs/decisions/ | ADR-style durable decisions |
 | goals/README.md | Local goal package policy |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ When to bypass `bin/dev`:
 - `mise exec -- iex -S mix phx.server` — manual server start with custom env vars
 - `mise exec -- mix test` — test suite (uses its own DB and port 50071 via `test.exs`)
 
-See `docs/m1-local-dev.md` for full environment setup and configuration.
+See `docs/local-dev.md` for full environment setup and configuration.
 
 ## Packaging (PKG)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ branch reconciles the conflict. `SPEC.md` wins until explicitly updated.
 
 - Read `README.md`.
 - Read `SPEC.md` for normative behavior.
-- Use `docs/m1-local-dev.md` for source development setup.
+- Use `docs/local-dev.md` for source development setup.
 - Use `packaging/pkg/README.md` for packaged installer behavior.
 
 ## Change Workflow

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Clients (SDKs / curl / apps)
   disabled)
 
 See [docs/tooling.md](docs/tooling.md) for required local toolchain setup,
-[docs/m1-local-dev.md](docs/m1-local-dev.md) for dev setup, and
+[docs/local-dev.md](docs/local-dev.md) for dev setup, and
 [packaging/pkg/README.md](packaging/pkg/README.md) for operator transport
 configuration, including nginx/Caddy/Traefik snippets.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ must be rewritten into this repo before it counts as Orchard truth.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) explains human collaboration workflow.
 - [`AGENTS.md`](AGENTS.md) explains automation and agent workflow.
 - [`docs/tooling.md`](docs/tooling.md) explains the required mise toolchain and local accelerator tools.
+- [`docs/local-dev.md`](docs/local-dev.md) explains source development setup and smoke checks.
 - [`docs/process.md`](docs/process.md) explains artifact lifecycle and review gates.
 - [`openspec/README.md`](openspec/README.md) reserves a future structured-change workflow subordinate to `SPEC.md`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ top-level normative product/system contract.
 - `../CONTRIBUTING.md` — human collaborator workflow
 - `../AGENTS.md` — contributor and agent workflow
 - `tooling.md` — required local toolchain and agent accelerator guidance
+- `local-dev.md` — source development setup and smoke-test guidance
 - `process.md` — artifact lifecycle and review gates
 
 ## What belongs here
@@ -49,5 +50,6 @@ top-level normative product/system contract.
 
 - `milestones/` — milestone execution plans and active milestone status
 - `tooling.md` — mise, validation command, and local tool guidance
+- `local-dev.md` — source development setup and smoke-test guidance
 - `process.md` — artifact lifecycle and review gates
 - `decisions/` — ADR-style records for durable implementation decisions

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,4 +1,4 @@
-# M1 Local Development
+# Local Development
 
 Local development setup for the Orchard inference stack. Default mode is
 single-node; multi-node source-dev testing is supported via env vars
@@ -115,7 +115,7 @@ Source-dev defaults remain disabled unless explicitly enabled via env vars:
 `ORCHARD_CACHE_INTROSPECTION_ENABLED=false`, and
 `ORCHARD_MEMORY_ADMISSION_ENABLED=false` when unset. The three advanced
 cache-affinity numeric knobs above are optional overrides for
-`:orchard_controller, :inference` and otherwise use shared M1 defaults.
+`:orchard_controller, :inference` and otherwise use shared runtime defaults.
 
 ##### Cache-affinity and memory-admission config regression smoke (source-dev)
 
@@ -201,7 +201,7 @@ on transport modes, truthy/falsy values, and validation behavior.
 | `config/test.exs` | Test environment: sandbox DB, `fake_runtime?: true` |
 | `config/prod.exs` | Prod placeholder |
 | `config/runtime.exs` | Release-time config from env vars |
-| `config/m1_runtime_defaults.exs` | Shared defaults for M1 runtime settings |
+| `config/m1_runtime_defaults.exs` | Shared defaults for source-dev runtime settings |
 
 ### Dev Directory Structure
 
@@ -731,13 +731,13 @@ mise exec -- mix ecto.migrate
 mise exec -- iex -S mix phx.server
 ```
 
-## M1 Limitations
+## Current Source-Dev Limitations
 
 - Source dev controller uses loopback HTTP (`127.0.0.1:4000`); packaged
   installs default to degraded loopback HTTP until an operator selects
   `reverse_proxy` or `direct_https` (see [Transport Modes](#transport-modes))
 - Source dev gRPC on port 50071; packaged installs on 50061
-- Node-agent gRPC remains loopback and non-TLS in M1
+- Source-dev node-agent gRPC remains loopback and non-TLS
 - Single implicit tenant (no auth/RBAC — deferred to M2)
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
 - No distributed Erlang across machines


### PR DESCRIPTION
## Intent

Validate the Orchard docs-only local development guide rename: keep the work on current main, rename docs/m1-local-dev.md to docs/local-dev.md, update README/CONTRIBUTING/AGENTS references, remove milestone-specific guide wording, and preserve legitimate M1 references like milestone tables, Apple Silicon chip names, and the config/m1_runtime_defaults.exs filename.

## What Changed

- Renamed `docs/m1-local-dev.md` to `docs/local-dev.md` and updated the guide title/link text to remove milestone-specific local-development wording.
- Updated `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `docs/README.md` to point contributors at the renamed local development guide.
- Preserved legitimate M1 references while removing stale references to the old guide filename.

## Risk Assessment

✅ Low: The branch is a tightly scoped docs-only rename with internal references updated and no stale `m1-local-dev` links found in the repository.

## Testing

Baseline diff/ancestry checks confirmed a single docs-only rename commit, focused docs validation proved the renamed guide and references work end-to-end with 18 local markdown links resolved, rendered README and local-dev HTML evidence was captured, and the worktree stayed clean; the only gap is that the pinned `mise` project test slice could not run because the toolchain is untrusted/missing and rate-limited in this isolated environment.

<details>
<summary>Evidence: Rendered README with updated local-dev link</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc 3.10" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>Orchard README local-dev link evidence</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    html {
      color: #1a1a1a;
      background-color: #fdfdfd;
    }
    body {
      margin: 0 auto;
      max-width: 36em;
      padding-left: 50px;
      padding-right: 50px;
      padding-top: 50px;
      padding-bottom: 50px;
      hyphens: auto;
      overflow-wrap: break-word;
      text-rendering: optimizeLegibility;
      font-kerning: normal;
    }
    @media (max-width: 600px) {
      body {
        font-size: 0.9em;
        padding: 12px;
      }
      h1 {
        font-size: 1.8em;
      }
    }
    @media print {
      html {
        background-color: white;
      }
      body {
        background-color: transparent;
        color: black;
        font-size: 12pt;
      }
      p, h2, h3 {
        orphans: 3;
        widows: 3;
      }
      h2, h3, h4 {
        page-break-after: avoid;
      }
    }
    p {
      margin: 1em 0;
    }
    a {
      color: #1a1a1a;
    }
    a:visited {
      color: #1a1a1a;
    }
    img {
      max-width: 100%;
    }
    svg {
      height: auto;
      max-width: 100%;
    }
    h1, h2, h3, h4, h5, h6 {
      margin-top: 1.4em;
    }
    h5, h6 {
      font-size: 1em;
      font-style: italic;
    }
    h6 {
      font-weight: normal;
    }
    ol, ul {
      padding-left: 1.7em;
      margin-top: 1em;
    }
    li > ol, li > ul {
      margin-top: 0;
    }
    blockquote {
      margin: 1em 0 1em 1.7em;
      padding-left: 1em;
      border-left: 2px solid #e6e6e6;
      color: #606060;
    }
    code {
      white-space: pre-wrap;
      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
      font-size: 85%;
      margin: 0;
      hyphens: manual;
    }
    pre {
      margin: 1em 0;
      overflow: auto;
    }
    pre code {
      padding: 0;
      overflow: visible;
      overflow-wrap: normal;
    }
    .sourceCode {
     background-color: transparent;
     overflow: visible;
    }
    hr {
      border: none;
      border-top: 1px solid #1a1a1a;
      height: 1px;
      margin: 1em 0;
    }
    table {
      margin: 1em 0;
      border-collapse: collapse;
      width: 100%;
      overflow-x: auto;
      display: block;
      font-variant-numeric: lining-nums tabular-nums;
    }
    table caption {
      margin-bottom: 0.75em;
    }
    tbody {
      margin-top: 0.5em;
      border-top: 1px solid #1a1a1a;
      border-bottom: 1px solid #1a1a1a;
    }
    th {
      border-top: 1px solid #1a1a1a;
      padding: 0.25em 0.5em 0.25em 0.5em;
    }
    td {
      padding: 0.125em 0.5em 0.25em 0.5em;
    }
    header {
      margin-bottom: 4em;
      text-align: center;
    }
    #TOC li {
      list-style: none;
    }
    #TOC ul {
      padding-left: 1.3em;
    }
    #TOC > ul {
      padding-left: 0;
    }
    #TOC a:not(:hover) {
      text-decoration: none;
    }
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: 1.5em;}
    div.column{flex: auto;}
    @media screen {
    div.columns{gap: min(4vw, 1.5em);}
    div.column{overflow-x: auto;}
    }
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
    /* CSS for syntax highlighting */
    html { -webkit-text-size-adjust: 100%; }
    pre > code.sourceCode { white-space: pre; position: relative; }
    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
    pre > code.sourceCode > span:empty { height: 1.2em; }
    .sourceCode { overflow: visible; }
    code.sourceCode > span { color: inherit; text-decoration: inherit; }
    div.sourceCode { margin: 1em 0; }
    pre.sourceCode { margin: 0; }
    @media screen {
    div.sourceCode { overflow: auto; }
    }
    @media print {
    pre > code.sourceCode { white-space: pre-wrap; }
    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
    }
    pre.numberSource code
      { counter-reset: source-line 0; }
    pre.numberSource code > span
      { position: relative; left: -4em; counter-increment: source-line; }
    pre.numberSource code > span > a:first-child::before
      { content: counter(source-line);
        position: relative; left: -1em; text-align: right; vertical-align: baseline;
        border: none; display: inline-block;
        -webkit-touch-callout: none; -webkit-user-select: none;
        -khtml-user-select: none; -moz-user-select: none;
        -ms-user-select: none; user-select: none;
        padding: 0 4px; width: 4em;
        color: #aaaaaa;
      }
    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
    div.sourceCode
      {   }
    @media screen {
    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
    }
    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
    code span.at { color: #7d9029; } /* Attribute */
    code span.bn { color: #40a070; } /* BaseN */
    code span.bu { color: #008000; } /* BuiltIn */
    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
    code span.ch { color: #4070a0; } /* Char */
    code span.cn { color: #880000; } /* Constant */
    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
    code span.dt { color: #902000; } /* DataType */
    code span.dv { color: #40a070; } /* DecVal */
    code span.er { color: #ff0000; font-weight: bold; } /* Error */
    code span.ex { } /* Extension */
    code span.fl { color: #40a070; } /* Float */
    code span.fu { color: #06287e; } /* Function */
    code span.im { color: #008000; font-weight: bold; } /* Import */
    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
    code span.op { color: #666666; } /* Operator */
    code span.ot { color: #007020; } /* Other */
    code span.pp { color: #bc7a00; } /* Preprocessor */
    code span.sc { color: #4070a0; } /* SpecialChar */
    code span.ss { color: #bb6688; } /* SpecialString */
    code span.st { color: #4070a0; } /* String */
    code span.va { color: #19177c; } /* Variable */
    code span.vs { color: #4070a0; } /* VerbatimString */
    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
  </style>
</head>
<body>
<header id="title-block-header">
<h1 class="title">Orchard README local-dev link evidence</h1>
</header>
<h1 id="orchard">Orchard</h1>
<p><strong>Your LLMs. Your hardware. Your rules.</strong></p>
<p>Orchard is a sovereign on-prem LLM orchestration platform for 1–4
Apple Silicon macOS machines. It runs inference on your own hardware,
behind your own firewall, with no cloud dependency.</p>
<h2 id="what-it-does">What it does</h2>
<ul>
<li>Orchestrates LLM inference across 1–4 Mac nodes using <a
href="https://github.com/ml-explore/mlx">MLX</a></li>
<li>Exposes OpenAI-compatible APIs with <code>/v1/responses</code> as
the canonical abstraction and <code>/v1/chat/completions</code> as a
compatibility facade</li>
<li>Multi-tenant with full RBAC, API key scoping, quotas, and audit
logs</li>
<li>Ships as a native macOS DMG/PKG — no Docker or Kubernetes required
for operators; managed Postgres uses lo

... [982 bytes truncated] ...

n Postgres. No distributed Erlang across
machines.</li>
<li>All cross-node traffic over gRPC/mTLS. Workers never exposed on the
network.</li>
<li>Token streams always pass through the controller for governance and
accounting.</li>
<li>HA-lite only: exactly one active leader, active/standby via Postgres
advisory locks, no active/active consensus.</li>
</ul>
<h2 id="tech-stack">Tech stack</h2>
<table>
<colgroup>
<col style="width: 46%" />
<col style="width: 53%" />
</colgroup>
<thead>
<tr>
<th>Layer</th>
<th>Choice</th>
</tr>
</thead>
<tbody>
<tr>
<td>Language</td>
<td>Elixir/OTP (umbrella app)</td>
</tr>
<tr>
<td>Database</td>
<td>Postgres</td>
</tr>
<tr>
<td>Inference</td>
<td>MLX-LM runtime adapter managed by the node agent</td>
</tr>
<tr>
<td>Internal RPC</td>
<td>gRPC over mTLS</td>
</tr>
<tr>
<td>APIs</td>
<td>Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged
installs)</td>
</tr>
<tr>
<td>Packaging</td>
<td>DMG, PKG, launchd</td>
</tr>
<tr>
<td>CLI</td>
<td><code>orchardctl</code></td>
</tr>
<tr>
<td>Toolchain</td>
<td>mise-pinned Erlang/OTP, Elixir, Python, and uv</td>
</tr>
</tbody>
</table>
<h3 id="current-transport-behavior">Current transport behavior</h3>
<ul>
<li><strong>Source dev:</strong> controller runs on loopback HTTP
(<code>127.0.0.1:4000</code>); CORS disabled unless explicitly
configured</li>
<li><strong>Packaged installs:</strong> controller defaults to degraded
loopback HTTP (<code>ORCHARD_TRANSPORT_MODE=plain_http_localhost</code>)
until an operator selects <code>direct_https</code> or
<code>reverse_proxy</code>; legacy <code>ORCHARD_TLS_*</code> variables
are one-release compatibility shims</li>
<li><strong>Provider-neutral TLS:</strong> the PKG installer does not
generate or procure production certificates by default. Operators can
use reverse-proxy TLS termination, direct HTTPS with operator cert/key
paths, proprietary/paid CAs, internal PKI or air-gapped HTTPS, or
explicit local-CA helper output from <code>orchardctl tls init</code>
for dev-lab bootstrap.</li>
<li><strong>Forwarded headers:</strong> reverse-proxy mode trusts
<code>x-forwarded-*</code> only from loopback by default; non-loopback
proxy binds require <code>ORCHARD_TRUSTED_PROXIES</code>.</li>
<li><strong>CORS:</strong> explicit origin allowlist via
<code>ORCHARD_CORS_ORIGINS</code> (empty = disabled)</li>
</ul>
<p>See <a href="docs/tooling.md">docs/tooling.md</a> for required local
toolchain setup, <a href="docs/local-dev.md">docs/local-dev.md</a> for
dev setup, and <a
href="packaging/pkg/README.md">packaging/pkg/README.md</a> for operator
transport configuration, including nginx/Caddy/Traefik snippets.</p>
<h3 id="building-releases">Building releases</h3>
<p>For distribution or testing the packaged installer:</p>
<div class="sourceCode" id="cb2"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mise</span> exec <span class="at">--</span> ./scripts/build-pkg.sh</span></code></pre></div>
<p>This creates a native macOS PKG installer following the naming
convention
<code>Orchard-&lt;version&gt;-&lt;date&gt;-&lt;git-sha&gt;.pkg</code>.
Use <code>--clean</code> for reproducible builds from scratch, or
<code>--allow-dirty</code> for development builds.</p>
<p><strong>Prerequisites:</strong> <code>mise install</code> from the
repo root, plus macOS packaging tools. The script validates dependencies
and provides helpful errors if anything is missing.</p>
<p>See <a
href="packaging/pkg/README.md#building-the-pkg">packaging/pkg/README.md</a>
for full build documentation.</p>
<h2 id="deployment-modes">Deployment modes</h2>
<p>These are the target product topologies defined by
<code>SPEC.md</code>:</p>
<ol type="1">
<li><strong>All-in-one</strong> — single Mac runs everything (controller
+ node agent + worker + managed Postgres)</li>
<li><strong>Controller + workers</strong> — 1 Mac as control plane, 1–3
Macs as worker nodes; Postgres is either managed on the controller host
or operator-managed externally</li>
<li><strong>HA-lite</strong> — up to 2 controllers with exactly 1 active
leader, still within the overall 1–4 Mac deployment limit, with
operator-managed endpoint failover</li>
</ol>
<p>Current packaged controller-bearing installs may require External
Database Mode until Managed Database Mode is implemented and
enabled.</p>
<p>The macOS PKG uses a universal payload with role selection at install
time. Seed
<code>/Library/Application Support/Orchard/support/.install-role.request</code>
with <code>all</code>, <code>controller</code>, or
<code>node-agent</code> before running <code>installer</code>; the
installed marker is
<code>/Library/Application Support/Orchard/support/.install-role</code>.
Source development has matching split-role scripts:
<code>bin/dev-controller</code> for the controller host and
<code>bin/dev-node-agent</code> for worker hosts.</p>
<h2 id="roadmap">Roadmap</h2>
<table>
<colgroup>
<col style="width: 61%" />
<col style="width: 38%" />
</colgroup>
<thead>
<tr>
<th>Milestone</th>
<th>Scope</th>
</tr>
</thead>
<tbody>
<tr>
<td>M0</td>
<td>Skeleton and packaging foundation (umbrella, Postgres, launchd,
<code>/health/live</code>, <code>/health/ready</code>)</td>
</tr>
<tr>
<td>M1</td>
<td>Single-node inference MVP (<code>GET /v1/models</code>,
<code>POST /v1/chat/completions</code>, SSE streaming, MLX worker;
compatibility-first while the internal canonical abstraction remains
Responses-based)</td>
</tr>
<tr>
<td>M2</td>
<td>Responses API and governance core (public
<code>POST /v1/responses</code>, tenants, API keys, quotas, audit,
idempotency)</td>
</tr>
<tr>
<td>M3</td>
<td>Node lifecycle and cluster join (bootstrap/cert join, heartbeats,
pools, cordon/drain/maintenance)</td>
</tr>
<tr>
<td>M4</td>
<td>Multi-node scheduler and placements (tiered scoring, queueing,
<code>EnsureModelLoaded</code>, pre-first-token retry)</td>
</tr>
<tr>
<td>M5</td>
<td>Observability and diagnostics (Prometheus, OTel tracing, structured
logs, support bundles)</td>
</tr>
<tr>
<td>M6</td>
<td>Security hardening and air-gap (mTLS, cert renewal, retention modes,
offline import/install)</td>
</tr>
<tr>
<td>M7</td>
<td>Upgrade safety and HA-lite controller (leadership locks, migration
ownership, rolling upgrades, <code>orchardctl upgrade plan</code>)</td>
</tr>
</tbody>
</table>
<h2 id="status">Status</h2>
<p>Pre-release. Building from spec.</p>
<h2 id="spec">Spec</h2>
<p><a href="SPEC.md"><code>SPEC.md</code></a> is the normative build
contract — every implementation decision traces back to it.</p>
<h2 id="contributing-and-workflow">Contributing And Workflow</h2>
<p>This repository is the collaborator-facing source of truth for
Orchard. Historical coordination/workbench notes may inform work, but
active guidance must be rewritten into this repo before it counts as
Orchard truth.</p>
<ul>
<li><a href="SPEC.md"><code>SPEC.md</code></a> is the top-level
normative build contract.</li>
<li><a href="CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> explains
human collaboration workflow.</li>
<li><a href="AGENTS.md"><code>AGENTS.md</code></a> explains automation
and agent workflow.</li>
<li><a href="docs/tooling.md"><code>docs/tooling.md</code></a> explains
the required mise toolchain and local accelerator tools.</li>
<li><a href="docs/process.md"><code>docs/process.md</code></a> explains
artifact lifecycle and review gates.</li>
<li><a href="openspec/README.md"><code>openspec/README.md</code></a>
reserves a future structured-change workflow subordinate to
<code>SPEC.md</code>.</li>
</ul>
<p>Active local <code>goals/&lt;slug&gt;/</code> packages are transient
execution scaffolding and are ignored by default.</p>
<h2 id="background">Background</h2>
<p>Orchard is a ground-up rewrite of <a
href="https://github.com/najibninaba/kapitan-orchard">Kapitan
Orchard</a> (v1: Rust + Kafka + Redis + Tauri). The rewrite replaces the
distributed streaming architecture with Elixir/OTP + Postgres for
simpler operations, better fault tolerance, and native macOS
integration.</p>
<h2 id="license">License</h2>
<p>Proprietary. All rights reserved.</p>
</body>
</html>
```
</details>
- Evidence: Rendered renamed Local Development guide (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVPEHYCMPC9Y99HG3XMRP981/local-dev-rendered.html</code>)
<details>
<summary>Evidence: Docs rename validation transcript</summary>

`Focused validation passed: docs/local-dev.md exists, docs/m1-local-dev.md is absent, README/CONTRIBUTING/AGENTS point to docs/local-dev.md, the guide title/intro are no longer M1-specific, no tracked text file references m1-local-dev, remaining M1 mentions are limited to milestone table rows, config/m1_runtime_defaults.exs, and Apple Silicon M1/M2/M3/M4, and 18 README/local-dev markdown links resolve.`

```text
Orchard local development docs rename validation
Worktree: /Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVPEHYCMPC9Y99HG3XMRP981
Commit under test: 707df28

PASS renamed guide exists at docs/local-dev.md
PASS old milestone-specific filename is absent
PASS README points readers at docs/local-dev.md
PASS CONTRIBUTING points contributors at docs/local-dev.md
PASS AGENTS points agents at docs/local-dev.md
PASS renamed guide title is generic local development
PASS renamed guide intro no longer labels itself as an M1 guide
PASS no tracked text file references docs/m1-local-dev.md or m1-local-dev
PASS remaining M1 mentions in changed user-facing docs are the intended milestone/chip/config references
PASS local markdown links in README.md and docs/local-dev.md resolve (18 links checked)

Allowed M1 references observed:
- README.md:118: | M1 | Single-node inference MVP (`GET /v1/models`, `POST /v1/chat/completions`, SSE streaming, MLX worker; compatibility-first while the internal canonical abstraction remains Responses-based) |
- AGENTS.md:77: | M1 | Single-node inference MVP (`GET /v1/models`, `POST /v1/chat/completions`, SSE, MLX worker) |
- docs/local-dev.md:204: | `config/m1_runtime_defaults.exs` | Shared defaults for source-dev runtime settings |
- docs/local-dev.md:379: - Apple Silicon Mac (M1/M2/M3/M4)

README/local-dev markdown links checked:
- README.md -> docs/tooling.md
- README.md -> docs/local-dev.md
- README.md -> packaging/pkg/README.md
- README.md -> packaging/pkg/README.md#building-the-pkg
- README.md -> SPEC.md
- README.md -> SPEC.md
- README.md -> CONTRIBUTING.md
- README.md -> AGENTS.md
- README.md -> docs/tooling.md
- README.md -> docs/process.md
- README.md -> openspec/README.md
- docs/local-dev.md -> #two-node-source-dev-cluster-testing
- docs/local-dev.md -> tooling.md
- docs/local-dev.md -> ../packaging/pkg/README.md
- docs/local-dev.md -> ../packaging/pkg/README.md#console-troubleshooting
- docs/local-dev.md -> ../packaging/pkg/README.md
- docs/local-dev.md -> ../packaging/pkg/README.md
- docs/local-dev.md -> #transport-modes
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m54s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Could not run the intended project ExUnit slice through the pinned toolchain. `mise exec` rejected this isolated worktree&#39;s untrusted `mise.toml`; using an environment-scoped trust override avoided `mise trust`, but then `mise` attempted to install missing pinned tools and hit GitHub API rate limits, so I stopped it rather than modifying user-level toolchain state. The docs-specific validation and rendered evidence passed.
- `git diff --name-status 22639809075053f0d57e627734fc83413b063689..707df282aecfb24c76a09ec2b7fa545d6b686786`
- `rg -n "m1-local-dev|local-dev\\.md|M1|m1_runtime_defaults|Apple M1|M1 " README.md CONTRIBUTING.md AGENTS.md SPEC.md docs config`
- `test ! -e docs/m1-local-dev.md && test -e docs/local-dev.md`
- `pandoc --standalone README.md --metadata title='Orchard README local-dev link evidence' --output /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVPEHYCMPC9Y99HG3XMRP981/readme-rendered.html`
- `pandoc --standalone docs/local-dev.md --metadata title='Orchard Local Development guide evidence' --output /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVPEHYCMPC9Y99HG3XMRP981/local-dev-rendered.html`
- <code>Inline Ruby docs validation script checking rename presence/absence, updated references, stale filename removal, allowed M1 references, and 18 local markdown links; wrote `docs-rename-validation.txt`</code>
- <code>Attempted `mise exec -- mix --version` and `mise exec -- mix deps`; both were blocked by untrusted `mise.toml` before project tests could run</code>
- <code>Attempted `MISE_TRUSTED_CONFIG_PATHS=&lt;worktree&gt;/mise.toml mise exec -- mix --version`; stopped after it began installing missing pinned tools and hit GitHub API rate limits</code>
- `git merge-base --is-ancestor 22639809075053f0d57e627734fc83413b063689 707df282aecfb24c76a09ec2b7fa545d6b686786`
- `git rev-list --count 22639809075053f0d57e627734fc83413b063689..707df282aecfb24c76a09ec2b7fa545d6b686786`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
