### PR TITLE
docs: refresh collaborator documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,7 @@ See `packaging/pkg/README.md` for full PKG operator documentation and `packaging
 | docs/tooling.md | mise, validation command, and local tool guidance |
 | docs/local-dev.md | Source development setup and smoke-test guidance |
 | docs/process.md | Artifact lifecycle and process guidance |
+| docs/architecture.md | Contributor architecture and repo-boundary orientation |
 | docs/decisions/ | ADR-style durable decisions |
 | goals/README.md | Local goal package policy |
 | openspec/README.md | Reserved structured-change workflow |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,11 @@ branch reconciles the conflict. `SPEC.md` wins until explicitly updated.
 
 ## Getting Started
 
-- Read `README.md`.
+- Read `README.md` for product overview and status.
 - Read `SPEC.md` for normative behavior.
+- Use `docs/architecture.md` for repo and runtime orientation.
 - Use `docs/local-dev.md` for source development setup.
+- Use `docs/tooling.md` for pinned toolchain and validation commands.
 - Use `packaging/pkg/README.md` for packaged installer behavior.
 
 ## Change Workflow

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ The macOS PKG uses a universal payload with role selection at install time. Seed
 
 ## Status
 
-Pre-release. Building from spec. The roadmap and target behavior are governed by
-`SPEC.md` §14.
+Pre-release. Building from spec. The current source tree includes authenticated
+`/v1/models`, `/v1/chat/completions`, and a bounded `/v1/responses` slice; full
+M2 governance, RBAC, and quota behavior remain in progress. The roadmap and
+target behavior are governed by `SPEC.md` §14.
 
 ## Spec
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,27 @@
 
 Orchard is a sovereign on-prem LLM orchestration platform for 1–4 Apple Silicon macOS machines. It runs inference on your own hardware, behind your own firewall, with no cloud dependency.
 
-## What it does
+## Where to start
 
-- Orchestrates LLM inference across 1–4 Mac nodes using [MLX](https://github.com/ml-explore/mlx)
-- Exposes OpenAI-compatible APIs with `/v1/responses` as the canonical abstraction and `/v1/chat/completions` as a compatibility facade
-- Multi-tenant with full RBAC, API key scoping, quotas, and audit logs
-- Ships as a native macOS DMG/PKG — no Docker or Kubernetes required for operators; managed Postgres uses local macOS containerization when enabled, and no cloud account is required
-- Runs as launchd services with a menu bar app for local status
+- [`SPEC.md`](SPEC.md) is the normative build contract.
+- [`docs/README.md`](docs/README.md) is the collaborator docs hub.
+- [`docs/architecture.md`](docs/architecture.md) maps the repo and runtime boundaries.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) covers human collaboration workflow.
+- [`docs/local-dev.md`](docs/local-dev.md) covers source-dev setup.
+- [`packaging/pkg/README.md`](packaging/pkg/README.md) covers the current PKG runbook.
+
+## Target product capabilities
+
+Defined by `SPEC.md`, Orchard is being built to:
+
+- orchestrate LLM inference across 1–4 Mac nodes using [MLX](https://github.com/ml-explore/mlx);
+- expose OpenAI-compatible APIs with `/v1/responses` as the canonical abstraction and `/v1/chat/completions` as a compatibility facade;
+- support multi-tenant RBAC, API key scoping, quotas, and audit logs;
+- ship as native macOS PKG/DMG media with launchd services and no Kubernetes requirement;
+- support managed Postgres in a future local-container mode while also supporting external Postgres.
+
+Current packaged controller-bearing installs require external Postgres; managed
+Postgres and DMG media remain reserved/not implemented.
 
 ## Architecture
 
@@ -125,7 +139,8 @@ The macOS PKG uses a universal payload with role selection at install time. Seed
 
 ## Status
 
-Pre-release. Building from spec.
+Pre-release. Building from spec. The roadmap and target behavior are governed by
+`SPEC.md` §14.
 
 ## Spec
 
@@ -141,6 +156,8 @@ must be rewritten into this repo before it counts as Orchard truth.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) explains human collaboration workflow.
 - [`AGENTS.md`](AGENTS.md) explains automation and agent workflow.
 - [`docs/glossary/CONTEXT.md`](docs/glossary/CONTEXT.md) defines Orchard's shared product language.
+- [`docs/README.md`](docs/README.md) is the collaborator docs hub.
+- [`docs/architecture.md`](docs/architecture.md) explains repo and runtime boundaries.
 - [`docs/tooling.md`](docs/tooling.md) explains the required mise toolchain and local accelerator tools.
 - [`docs/local-dev.md`](docs/local-dev.md) explains source development setup and smoke checks.
 - [`docs/process.md`](docs/process.md) explains artifact lifecycle and review gates.

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -1,21 +1,28 @@
-# OrchardCLI
+# orchard_cli
 
-**TODO: Add description**
+`orchard_cli` builds the `orchardctl` operator/admin command surface used by
+source-dev workflows and packaged installs.
 
-## Installation
+This README is orientation only. Normative CLI requirements live in
+[`../../SPEC.md`](../../SPEC.md); repo/runtime boundaries are mapped in
+[`../../docs/architecture.md`](../../docs/architecture.md).
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `orchard_cli` to your list of dependencies in `mix.exs`:
+## Owns
 
-```elixir
-def deps do
-  [
-    {:orchard_cli, "~> 0.1.0"}
-  ]
-end
-```
+- Operator commands for cluster/bootstrap, environment, transport, migrations,
+  status, start/stop, support, upgrades, tenants, API keys, nodes, and models.
+- CLI helpers that wrap release scripts and packaged service management.
+- Human-readable operator output and command validation.
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/orchard_cli>.
+## Does not own
 
+- Controller business logic or persistence rules; see `../orchard_controller/`.
+- Node-agent runtime behavior; see `../orchard_node_agent/`.
+- Installer scripts and launchd plist installation; see
+  `../../packaging/pkg/README.md`.
+
+## Local work
+
+Run CLI tests and source-dev commands from the umbrella root through `mise exec --`.
+For setup and validation commands, see [`../../docs/tooling.md`](../../docs/tooling.md)
+and [`../../docs/local-dev.md`](../../docs/local-dev.md).

--- a/apps/orchard_cli/lib/orchard_cli.ex
+++ b/apps/orchard_cli/lib/orchard_cli.ex
@@ -1,6 +1,6 @@
 defmodule OrchardCLI do
   @moduledoc """
-  Placeholder `orchardctl` entrypoint for Milestone 0.
+  Dispatches `orchardctl` commands for source and packaged Orchard operators.
   """
 
   alias OrchardCLI.Commands.{

--- a/apps/orchard_controller/README.md
+++ b/apps/orchard_controller/README.md
@@ -1,21 +1,30 @@
-# Orchard
+# orchard_controller
 
-**TODO: Add description**
+Controller release for Orchard's public API, Console, persistence-backed control
+plane, admission/scheduling/dispatch paths, governance surfaces, and operator
+readiness behavior.
 
-## Installation
+This README is orientation only. Normative behavior lives in
+[`../../SPEC.md`](../../SPEC.md); repo/runtime boundaries are mapped in
+[`../../docs/architecture.md`](../../docs/architecture.md).
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `orchard_controller` to your list of dependencies in `mix.exs`:
+## Owns
 
-```elixir
-def deps do
-  [
-    {:orchard_controller, "~> 0.1.0"}
-  ]
-end
-```
+- Phoenix/Plug API endpoints and LiveView Console surfaces.
+- `Orchard.Repo` migrations and Postgres-backed controller state.
+- Request canonicalization, tokenization orchestration, admission, scheduling,
+  dispatch, lifecycle persistence, and public response serialization.
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/orchard_controller>.
+## Does not own
 
+- Node-local model execution or worker subprocess lifecycle; see
+  `../orchard_node_agent/` and `../../native/orchard_worker_mlx/`.
+- Shared generated transport modules and cross-app domain helpers; see
+  `../orchard_shared/`.
+- Packaged install policy; see `../../packaging/pkg/README.md`.
+
+## Local work
+
+Run source dev from the umbrella root with `mise exec -- bin/dev`. For setup and
+validation commands, see [`../../docs/local-dev.md`](../../docs/local-dev.md)
+and [`../../docs/tooling.md`](../../docs/tooling.md).

--- a/apps/orchard_controller/README.md
+++ b/apps/orchard_controller/README.md
@@ -11,6 +11,8 @@ This README is orientation only. Normative behavior lives in
 ## Owns
 
 - Phoenix/Plug API endpoints and LiveView Console surfaces.
+- Authenticated public `/v1` routes for models, chat completions, and the
+  bounded Responses API subset.
 - `Orchard.Repo` migrations and Postgres-backed controller state.
 - Request canonicalization, tokenization orchestration, admission, scheduling,
   dispatch, lifecycle persistence, and public response serialization.

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -2,7 +2,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   @moduledoc """
   Orchestrates the dispatch of an inference request to a node-agent.
 
-  Implements the M1 single-node dispatch flow:
+  Implements the current node-agent dispatch flow:
 
     schedule → connect → ensure_model_loaded → execute_inference → stream events
 

--- a/apps/orchard_controller/lib/orchard/inference/chat_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_orchestrator.ex
@@ -46,10 +46,11 @@ defmodule Orchard.Inference.ChatOrchestrator do
   Returns `{:ok, canonical_request, model}` if all pre-dispatch checks pass.
   This step does not persist anything or start dispatch — use `execute/3` for that.
 
-  `caller_context` is a keyword list from the request context plug:
-    * `:tenant_id` — resolved tenant (default: `"default"` in M1)
-    * `:principal_id` — resolved principal (nil in M1)
-    * `:api_key_id` — resolved API key (nil in M1)
+  `caller_context` is a keyword list from the request context plug or internal
+  caller:
+    * `:tenant_id` — resolved tenant
+    * `:principal_id` — resolved principal when available
+    * `:api_key_id` — resolved API key when available
 
   Returns `{:error, {:validation, errors}}` for request validation failures,
   `{:error, {:model_not_found, model_ref}}` when the requested model doesn't

--- a/apps/orchard_controller/lib/orchard/inference/chat_request_normalizer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_request_normalizer.ex
@@ -9,7 +9,7 @@ defmodule Orchard.Inference.ChatRequestNormalizer do
   - `model` string → `ModelRef` parsing (`model_id@version` or bare `model_id`)
   - Default value population
   - ID generation (internal_id, public_id)
-  - M1 single-tenant defaults (tenant_id: seeded legacy tenant UUID)
+  - Caller context propagation from authenticated public routes or internal callers
   """
 
   alias Orchard.CanonicalRequest
@@ -21,9 +21,9 @@ defmodule Orchard.Inference.ChatRequestNormalizer do
 
   ## Options (caller context)
 
-    * `:tenant_id` — resolved tenant (default: legacy tenant UUID for M1)
-    * `:principal_id` — resolved principal (default: `nil` for M1)
-    * `:api_key_id` — resolved API key (default: `nil` for M1)
+    * `:tenant_id` — resolved tenant (default: seeded legacy tenant UUID)
+    * `:principal_id` — resolved principal when available
+    * `:api_key_id` — resolved API key when available
 
   ## Options (test overrides)
 

--- a/apps/orchard_controller/lib/orchard/requests/request.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request.ex
@@ -2,13 +2,10 @@ defmodule Orchard.Requests.Request do
   @moduledoc """
   Ecto schema for durable inference request records.
 
-  ## M1 nullability note
-
-  In M1, rows are inserted at the `:received` state before the model is fully
-  resolved — so `model_id` and `canonical_request` may be `nil` on early rows.
-  `create_changeset/2` intentionally does not require these fields.
-  M2 should tighten this once the orchestration pipeline resolves the model
-  before persistence.
+  Request rows are inserted at the `:received` state after validation, model
+  resolution, tokenization, and canonical request serialization. Some fields
+  stay nullable for legacy rows and failure paths, while normal chat and
+  responses requests persist `model_id` and `canonical_request` at creation.
   """
 
   use Ecto.Schema

--- a/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
@@ -1,6 +1,6 @@
 defmodule Orchard.Scheduler.SingleNode do
   @moduledoc """
-  Injectable single-node scheduling seam for M1.
+  Injectable single-node scheduler and fallback for source-dev runtime targets.
   """
 
   alias Orchard.CanonicalRequest

--- a/apps/orchard_controller/test/fixtures/README.md
+++ b/apps/orchard_controller/test/fixtures/README.md
@@ -1,4 +1,9 @@
 # Test fixtures
 
-This directory is reserved for Orchard controller test fixtures used by later M1 work,
-including model bundle, tokenizer, and request payload samples.
+This directory holds Orchard controller fixtures used by model import,
+tokenizer, bundle-builder, API, and request-lifecycle tests.
+
+- `bundles/test-model-bundle/` is the canonical small model-bundle fixture for
+  parser/import/API tests.
+- `tokenizer/` contains focused tokenizer/template fixtures used by safe
+  tokenization and bundle-builder coverage.

--- a/apps/orchard_node_agent/README.md
+++ b/apps/orchard_node_agent/README.md
@@ -1,21 +1,29 @@
-# OrchardNodeAgent
+# orchard_node_agent
 
-**TODO: Add description**
+Node-agent release for Orchard's worker-node boundary. It exposes the internal
+node runtime endpoint, reports node/runtime status, manages model acquisition and
+cache state, and supervises local worker subprocesses.
 
-## Installation
+This README is orientation only. Normative behavior lives in
+[`../../SPEC.md`](../../SPEC.md); repo/runtime boundaries are mapped in
+[`../../docs/architecture.md`](../../docs/architecture.md).
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `orchard_node_agent` to your list of dependencies in `mix.exs`:
+## Owns
 
-```elixir
-def deps do
-  [
-    {:orchard_node_agent, "~> 0.1.0"}
-  ]
-end
-```
+- Node-local runtime service behavior used by the controller.
+- Model acquisition/cache/load coordination on a node.
+- Worker process supervision and node-local diagnostics/status reporting.
+- Manual Elixir binding for the node-agent ↔ worker proto.
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/orchard_node_agent>.
+## Does not own
 
+- Public API traffic or tenant/governance decisions; those terminate at the
+  controller.
+- Worker model-generation internals; see `../../native/orchard_worker_mlx/`.
+- Shared cluster proto source; see `../../proto/cluster/v1/`.
+
+## Local work
+
+Use `mise exec -- bin/dev-node-agent` for source-dev worker hosts. For split-role
+setup and validation commands, see [`../../docs/local-dev.md`](../../docs/local-dev.md)
+and [`../../docs/tooling.md`](../../docs/tooling.md).

--- a/apps/orchard_node_agent/lib/orchard/node/fake_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/fake_runtime_adapter.ex
@@ -1,6 +1,6 @@
 defmodule Orchard.Node.FakeRuntimeAdapter do
   @moduledoc """
-  Deterministic fake runtime adapter used by tests and early M1 runtime wiring.
+  Deterministic fake runtime adapter used by tests and local runtime wiring.
   """
 
   @behaviour Orchard.Node.RuntimeAdapter

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_server.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_server.ex
@@ -1,6 +1,7 @@
 defmodule Orchard.Node.RuntimeServer do
   @moduledoc """
-  Minimal node-runtime gRPC boundary for the M1 single-node runtime.
+  Node-agent gRPC service boundary for status, model lifecycle, inference,
+  cancellation, and scheduler cache probes.
   """
 
   use GRPC.Server, service: Orchard.Cluster.V1.NodeRuntimeService.Service

--- a/apps/orchard_shared/README.md
+++ b/apps/orchard_shared/README.md
@@ -1,21 +1,28 @@
-# OrchardShared
+# orchard_shared
 
-**TODO: Add description**
+Shared umbrella app for Orchard transport modules, cross-app domain structs, and
+small helpers used by controller, node-agent, and CLI releases.
 
-## Installation
+This README is orientation only. Normative shared contracts live in
+[`../../SPEC.md`](../../SPEC.md); repo/runtime boundaries are mapped in
+[`../../docs/architecture.md`](../../docs/architecture.md).
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `orchard_shared` to your list of dependencies in `mix.exs`:
+## Owns
 
-```elixir
-def deps do
-  [
-    {:orchard_shared, "~> 0.1.0"}
-  ]
-end
-```
+- Generated Elixir modules for `proto/cluster/v1/` under `lib/cluster/v1/`.
+- Shared domain structs and mappers used across releases.
+- Shared filesystem/path, build metadata, licensing, manifest, and Sentry helper
+  modules when they are release-neutral.
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/orchard_shared>.
+## Does not own
 
+- Controller workflows, persistence orchestration, or public API behavior.
+- Node-agent worker lifecycle and runtime supervision.
+- Product decisions that belong in `SPEC.md` or `../../docs/decisions/`.
+
+## Local work
+
+Regenerate cluster proto modules from the umbrella root with
+`mise exec -- mix proto.gen` when `../../proto/cluster/v1/*.proto` changes. See
+[`../../proto/cluster/v1/README.md`](../../proto/cluster/v1/README.md) and
+[`../../docs/tooling.md`](../../docs/tooling.md).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -8,7 +8,7 @@ This document is the tactical, component-level design contract for the Orchard
 Console v2 LiveView UI. It covers visual rules an agent must follow before
 emitting Tailwind classes, HEEx markup, or component changes.
 
-**It is downstream of `docs/brand-identity.md`.** The brand document is the
+**It is downstream of [`docs/brand-identity.md`](brand-identity.md).** The brand document is the
 authority for palette, typography, dark/light mapping, wordmark, and brand-bar.
 Anything in this document that appears to conflict with `docs/brand-identity.md`
 is wrong and must be revised — brand identity wins.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,57 +1,76 @@
 # Orchard Docs
 
-## Purpose
+This directory contains collaborator-facing orientation, tooling guidance,
+process docs, design guidance, and durable decisions for Orchard.
 
-This directory contains subordinate implementation guidance, process docs, and
-durable decision records for Orchard.
+`../SPEC.md` remains the top-level normative product/system/build contract.
+Docs here should help contributors navigate and execute work without duplicating
+large spec sections.
 
-Use these docs to support execution, planning, and decision-making during implementation.
-Do not treat anything here as a replacement for `SPEC.md`, which remains the
-top-level normative product/system contract.
+## Start by intent
 
-## Source of truth
+### I want to understand Orchard
 
-- `../SPEC.md` — normative product/system contract
-- `../README.md` — high-level project overview
-- `../CONTRIBUTING.md` — human collaborator workflow
-- `../AGENTS.md` — contributor and agent workflow
-- `glossary/CONTEXT.md` — shared Orchard product language
-- `tooling.md` — required local toolchain and agent accelerator guidance
-- `local-dev.md` — source development setup and smoke-test guidance
-- `process.md` — artifact lifecycle and review gates
+- [`../SPEC.md`](../SPEC.md) — normative product/system contract.
+- [`../README.md`](../README.md) — product overview and current status.
+- [`architecture.md`](architecture.md) — repo/runtime map for contributors.
+- [`glossary/CONTEXT.md`](glossary/CONTEXT.md) — shared vocabulary and
+  glossary.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — human collaborator workflow.
+- [`../AGENTS.md`](../AGENTS.md) — automation/agent workflow.
 
-## What belongs here
+### I want to run it locally
 
-- active milestone plans
-- implementation notes that reference the spec
-- local tooling and validation guidance
-- design decisions not already fixed by the spec
-- real runbooks once code and packaging exist
+- [`tooling.md`](tooling.md) — mise/uv toolchain and validation commands.
+- [`local-dev.md`](local-dev.md) — source-dev setup, `bin/dev`, split-role dev,
+  smoke checks, and environment notes.
 
-## What does not belong here
+### I want to contribute code
 
-- duplicated API contracts from `SPEC.md`
-- duplicated schema/state-machine definitions from `SPEC.md`
-- contributor workflow rules already covered in `AGENTS.md`
-- private or historical coordination workspace notes
-- raw prompt exports
-- active local goal packages
-- unsanitized local evidence
-- tool session identifiers
-- placeholder docs with no active use
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — human collaborator workflow.
+- [`../AGENTS.md`](../AGENTS.md) — automation/agent workflow and quality gates.
+- [`process.md`](process.md) — artifact lifecycle and review gates.
+- [`code-quality.md`](code-quality.md) — Credo, ex_slop, and ex_dna policy.
+
+### I want to change Console UI
+
+- [`brand-identity.md`](brand-identity.md) — brand palette, typography, logo,
+  and visual semantics.
+- [`DESIGN.md`](DESIGN.md) — tactical LiveView UI contract downstream of brand
+  identity.
+
+### I want to package or install Orchard
+
+- [`../packaging/pkg/README.md`](../packaging/pkg/README.md) — current PKG
+  build/operator runbook.
+- [`../packaging/container/postgres/README.md`](../packaging/container/postgres/README.md)
+  — managed Postgres status; not implemented today.
+- [`../packaging/dmg/README.md`](../packaging/dmg/README.md) — reserved future
+  DMG media notes.
+
+### I need to make a durable decision
+
+- [`decisions/README.md`](decisions/README.md) — ADR policy.
+- [`decisions/_template.md`](decisions/_template.md) — lightweight ADR template.
+
+## Normative vs orientation docs
+
+- Normative product/system behavior: `../SPEC.md`.
+- Human workflow: `../CONTRIBUTING.md`.
+- Agent workflow and validation: `../AGENTS.md`.
+- Artifact lifecycle: `process.md` and `../goals/README.md`.
+
+If docs, tests, implementation, and `SPEC.md` disagree about product behavior,
+treat the branch as blocked until reconciled. `SPEC.md` wins until explicitly
+updated.
 
 ## Writing rules
 
-- reference relevant `SPEC.md` sections
-- summarize; do not restate large normative sections
-- prefer practical execution guidance over prose
-- update or delete stale docs quickly
-
-## Current structure
-
-- `milestones/` — milestone execution plans and active milestone status
-- `glossary/` — shared Orchard product language
-- `tooling.md` — mise, validation command, and local tool guidance
-- `local-dev.md` — source development setup and smoke-test guidance
-- `process.md` — artifact lifecycle and review gates
-- `decisions/` — ADR-style records for durable implementation decisions
+- Reference relevant `SPEC.md` sections when behavior matters.
+- Summarize and link; do not restate large normative sections.
+- Prefer practical execution guidance over prose.
+- Keep current implementation status separate from target architecture.
+- Update or delete stale docs quickly.
+- Do not commit raw prompt exports, active goal packages, tool session IDs,
+  credentials, DSNs, or machine-specific evidence.
+- Promote durable conclusions into standalone docs, decisions, tests, or code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,9 +26,9 @@ The target topology is:
 ```text
 Public clients
   -> Controller (Phoenix/Elixir public APIs, Console, admission, scheduling)
-  -> Node Agent(s) over internal gRPC/mTLS
-  -> Worker Runtime subprocesses for local MLX inference
-  -> Postgres for durable state and coordination
+     -> Postgres for durable state and coordination
+     -> Node Agent(s) over internal gRPC/mTLS
+        -> Worker Runtime subprocesses for local MLX inference
 ```
 
 Core design rules from `SPEC.md`:
@@ -54,7 +54,7 @@ Core design rules from `SPEC.md`:
 | `packaging/` | PKG, launchd, reserved DMG/container assets, signing/build runbooks. |
 | `docs/` | Contributor-facing orientation, tooling, process, design, and durable decisions subordinate to `SPEC.md`. |
 
-Use [`../CONTEXT.md`](../CONTEXT.md) as the shared vocabulary glossary.
+Use [`glossary/CONTEXT.md`](glossary/CONTEXT.md) as the shared vocabulary glossary.
 
 ## Runtime flow orientation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,106 @@
+# Architecture Guide
+
+This guide orients collaborators to Orchard's repo and runtime boundaries. It is
+not a replacement for [`../SPEC.md`](../SPEC.md), which remains the normative
+product/system/build contract.
+
+## Authority and status
+
+- **Normative target:** `SPEC.md` defines the architecture, API contracts,
+  state machines, persistence rules, packaging requirements, and roadmap.
+- **Current source-dev reality:** this repo contains the Elixir umbrella apps,
+  native helper packages, proto contracts, launchd/pkg assets, and validation
+  workflows used to build toward that target.
+- **Current packaged/operator limitation:** controller-bearing packaged installs
+  require an external PostgreSQL server today. Managed Postgres is specified as
+  a target mode but is not implemented.
+
+When this guide and `SPEC.md` disagree, treat the branch as blocked until the
+conflict is reconciled. `SPEC.md` wins until explicitly updated.
+
+## System at a glance
+
+Orchard is an on-prem LLM orchestration platform for 1–4 Apple Silicon Macs.
+The target topology is:
+
+```text
+Public clients
+  -> Controller (Phoenix/Elixir public APIs, Console, admission, scheduling)
+  -> Node Agent(s) over internal gRPC/mTLS
+  -> Worker Runtime subprocesses for local MLX inference
+  -> Postgres for durable state and coordination
+```
+
+Core design rules from `SPEC.md`:
+
+- all durable state lives in Postgres;
+- public API traffic terminates at the controller;
+- token streams pass through the controller;
+- node agents are the network-reachable worker-node boundary;
+- worker runtimes are local subprocesses, not public services;
+- cross-node control traffic uses gRPC over mTLS in the target product.
+
+## Repository map
+
+| Path | Boundary |
+|---|---|
+| `apps/orchard_controller/` | Controller release: public APIs, Console, Repo, admission, scheduling, dispatch, governance, observability surfaces. |
+| `apps/orchard_node_agent/` | Node-agent release: node-local runtime endpoint, model acquisition/cache, worker supervision, status/diagnostics. |
+| `apps/orchard_cli/` | `orchardctl` CLI: operator/admin automation for source dev and packaged installs. |
+| `apps/orchard_shared/` | Shared generated proto modules, domain structs, helpers, licensing/build metadata. |
+| `native/orchard_tokenizer/` | Python helper for prompt rendering, exact token counts, and safe-tokenization support. |
+| `native/orchard_worker_mlx/` | Python MLX worker runtime package and node-agent ↔ worker proto. |
+| `proto/cluster/v1/` | Controller ↔ node-agent cluster RPC proto source. |
+| `packaging/` | PKG, launchd, reserved DMG/container assets, signing/build runbooks. |
+| `docs/` | Contributor-facing orientation, tooling, process, design, and durable decisions subordinate to `SPEC.md`. |
+
+Use [`../CONTEXT.md`](../CONTEXT.md) as the shared vocabulary glossary.
+
+## Runtime flow orientation
+
+### Target public inference
+
+This is the full-product target flow. Current source-dev paths may use implicit
+tenant/no-auth behavior until governance milestones are complete.
+
+1. Client calls a public `/v1` endpoint on the controller.
+2. Controller authenticates, canonicalizes, renders/tokenizes, admits, and
+   persists request state.
+3. Scheduler chooses a node/runtime target.
+4. Controller dispatches to a node agent.
+5. Node agent ensures a worker/model is ready and streams worker events back.
+6. Controller relays SSE/JSON to the client and finalizes usage/state.
+
+`/v1/responses` is the target canonical abstraction. `/v1/chat/completions` is
+the compatibility facade. See `SPEC.md` §3 and §7 for normative behavior.
+
+### Node and worker runtime
+
+The node agent owns worker subprocess lifecycle. The worker runtime owns local
+model loading/generation details. Public clients never talk to workers directly.
+
+Cluster RPC and worker RPC are separate contracts:
+
+- `proto/cluster/v1/` describes controller ↔ node-agent messages/services.
+- `native/orchard_worker_mlx/proto/` describes node-agent ↔ worker messages/services.
+
+### Persistence and coordination
+
+Postgres is the sole persistence and coordination layer. In the target product,
+managed Postgres is one supported topology; in the current packaged flow,
+controller-bearing installs require operator-provided external Postgres.
+
+## Where to make changes
+
+- Public API or Console behavior: start in `apps/orchard_controller/` and check
+  `SPEC.md`, [`DESIGN.md`](DESIGN.md), and tests.
+- Node-local runtime, worker supervision, or model acquisition: start in
+  `apps/orchard_node_agent/` and `native/orchard_worker_mlx/`.
+- Shared wire/domain types: start with proto or `apps/orchard_shared/`, then
+  regenerate/check downstream bindings.
+- CLI/operator automation: start in `apps/orchard_cli/` and
+  [`../packaging/pkg/README.md`](../packaging/pkg/README.md).
+- Toolchain/validation: use [`tooling.md`](tooling.md) and
+  [`local-dev.md`](local-dev.md).
+- Durable design decisions not already fixed by `SPEC.md`: add an ADR under
+  [`decisions/`](decisions/).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,8 +60,9 @@ Use [`glossary/CONTEXT.md`](glossary/CONTEXT.md) as the shared vocabulary glossa
 
 ### Target public inference
 
-This is the full-product target flow. Current source-dev paths may use implicit
-tenant/no-auth behavior until governance milestones are complete.
+This is the full-product target flow. Current public `/v1/*` routes resolve a
+tenant-scoped Bearer API key. Some direct internal tests/helpers still keep
+legacy tenant defaults until full RBAC and quota policy are complete.
 
 1. Client calls a public `/v1` endpoint on the controller.
 2. Controller authenticates, canonicalizes, renders/tokenizes, admits, and

--- a/docs/brand-identity.md
+++ b/docs/brand-identity.md
@@ -8,6 +8,9 @@
 This document defines the Orchard brand identity for the v2 Phoenix LiveView console,
 including logo, color palette, dark mode guidance, and visual guidelines.
 
+See [`DESIGN.md`](DESIGN.md) for tactical Console implementation rules downstream
+of this brand identity.
+
 ---
 
 ## Overview

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -3,13 +3,20 @@
 This directory holds ADR-style records for durable Orchard implementation
 decisions not already fixed by `SPEC.md`.
 
+Use a decision record when a choice is architecture-significant, affects future
+contributors, changes a boundary between components, or resolves ambiguity that
+is not already answered by `SPEC.md`.
+
 Decision records must be standalone:
 
-- reference relevant `SPEC.md` sections when applicable
-- explain the decision and consequences
-- avoid private planning context
-- avoid local paths and tool session identifiers
-- avoid duplicating full normative contracts from `SPEC.md`
+- reference relevant `SPEC.md` sections when applicable;
+- explain the decision and consequences;
+- state whether `SPEC.md` needs an update;
+- avoid private planning context, local paths, and tool session identifiers;
+- avoid duplicating full normative contracts from `SPEC.md`.
 
 Do not migrate historical coordination notes wholesale. Rewrite durable
 conclusions as concise product-facing decision records.
+
+Start from [`_template.md`](_template.md) when useful. Decisions already fixed by
+`SPEC.md` do not need duplicate ADRs.

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,22 @@
+# ADR: <title>
+
+## Status
+
+Proposed | Accepted | Superseded
+
+## Context
+
+What problem or ambiguity does this resolve? Reference relevant `SPEC.md`
+sections, tests, docs, or implementation evidence.
+
+## Decision
+
+What are we choosing?
+
+## Consequences
+
+What becomes easier, harder, constrained, or deferred?
+
+## SPEC.md impact
+
+No change required | Update required in <section> | Supersedes prior decision

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -4,6 +4,9 @@ Local development setup for the Orchard inference stack. Default mode is
 single-node; multi-node source-dev testing is supported via env vars
 (see [Two-Node Source-Dev Cluster Testing](#two-node-source-dev-cluster-testing)).
 
+Read [`architecture.md`](architecture.md) first if you need repo/runtime boundary
+orientation, and [`tooling.md`](tooling.md) for pinned tool versions.
+
 ## Prerequisites
 
 | Dependency | Version | Notes |

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -35,6 +35,10 @@ mise exec -- bin/dev
 
 # 4. Import a model bundle (in the running IEx session)
 OrchardCLI.main(["models", "import", "/path/to/model-bundle", "--activate"])
+
+# 5. Create a tenant and API key for /v1 API calls (in the running IEx session)
+OrchardCLI.main(["tenants", "create", "--slug", "dev", "--name", "Dev"])
+OrchardCLI.main(["api-keys", "create", "--tenant-id", "<tenant-id>", "--name", "dev"])
 ```
 
 `bin/dev` is the single entrypoint for source development. It creates the dev
@@ -44,6 +48,8 @@ on 50061).
 
 The controller listens on `http://localhost:4000` and the node-agent
 gRPC server on `127.0.0.1:50071`.
+Copy the API key token printed by `api-keys create` into
+`ORCHARD_API_KEY` for the `curl` examples below.
 
 ## Transport Modes
 
@@ -56,11 +62,13 @@ When running from a source checkout (`mise exec -- bin/dev` or
 
 - Controller listens on **HTTP** at `http://127.0.0.1:4000`
 - Node-agent gRPC listens on `127.0.0.1:50071` (avoids packaged BEAM on 50061)
+- Public `/v1/*` API routes require `Authorization: Bearer <api_key>`
 - CORS is disabled (empty allowlist in `config/dev.exs`)
 - No TLS setup is required
 
 All `curl` examples in this document use plain HTTP because they target the
-source dev controller.
+source dev controller. API examples assume `ORCHARD_API_KEY` contains a
+tenant-scoped API key token.
 
 ### Packaged install
 
@@ -224,14 +232,16 @@ tmp/dev/
 |--------|------|-------------|
 | GET | `/health/live` | Liveness probe |
 | GET | `/health/ready` | Readiness probe (DB check) |
-| GET | `/v1/models` | List active models |
-| POST | `/v1/chat/completions` | Chat completion (stream + non-stream) |
+| GET | `/v1/models` | List active models; Bearer token required |
+| POST | `/v1/chat/completions` | Chat completion; stream + non-stream; Bearer token required |
+| POST | `/v1/responses` | Bounded Responses API subset; stream + non-stream; Bearer token required |
 
 ### Example: Non-streaming
 
 ```bash
 curl -X POST http://localhost:4000/v1/chat/completions \
   -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $ORCHARD_API_KEY" \
   -d '{
     "model": "your-model@v1",
     "messages": [{"role": "user", "content": "Hello!"}]
@@ -243,10 +253,23 @@ curl -X POST http://localhost:4000/v1/chat/completions \
 ```bash
 curl -N -X POST http://localhost:4000/v1/chat/completions \
   -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $ORCHARD_API_KEY" \
   -d '{
     "model": "your-model@v1",
     "messages": [{"role": "user", "content": "Hello!"}],
     "stream": true
+  }'
+```
+
+### Example: Responses
+
+```bash
+curl -X POST http://localhost:4000/v1/responses \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $ORCHARD_API_KEY" \
+  -d '{
+    "model": "your-model@v1",
+    "input": "Hello!"
   }'
 ```
 
@@ -719,8 +742,10 @@ All-in-one local boot (dev):
    - Starts `iex -S mix phx.server`
    - Controller boots: Endpoint, Repo, Inference supervisor, gRPC client
    - Node-agent boots: ModelManager, WorkerSupervisor, gRPC server
-3. Import at least one model bundle (`orchardctl models import <path> --activate`)
-4. API is ready for requests
+3. Import at least one model bundle with `OrchardCLI.main(["models", "import", "<path>", "--activate"])`
+4. Create a tenant and API key with `OrchardCLI.main(["tenants", ...])` and
+   `OrchardCLI.main(["api-keys", ...])`
+5. API is ready for authenticated requests
 
 Alternatively, for advanced debugging or when you need a BEAM without the
 HTTP server, you can run the steps manually:
@@ -741,7 +766,8 @@ mise exec -- iex -S mix phx.server
   `reverse_proxy` or `direct_https` (see [Transport Modes](#transport-modes))
 - Source dev gRPC on port 50071; packaged installs on 50061
 - Source-dev node-agent gRPC remains loopback and non-TLS
-- Single implicit tenant (no auth/RBAC — deferred to M2)
+- Public `/v1/*` API routes require tenant-scoped Bearer API keys; full RBAC and
+  quota policy remain incomplete
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
 - No distributed Erlang across machines
 - Model import from local filesystem only (no remote download)

--- a/docs/process.md
+++ b/docs/process.md
@@ -9,6 +9,10 @@ not own product truth. Historical coordination workspaces can inform work, but
 active guidance must be promoted into this repo before it becomes Orchard
 truth.
 
+For repo/runtime orientation, start with [`architecture.md`](architecture.md).
+For transient goal-package policy, see [`../goals/README.md`](../goals/README.md).
+For durable decisions, see [`decisions/README.md`](decisions/README.md).
+
 ## Workflow Selection
 
 | Work | Process |

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -102,6 +102,9 @@ mise exec -- mix proto.gen
 mise exec -- mix proto.gen.worker
 ```
 
+- `mix proto.gen` additionally requires a host `protoc` binary and Orchard's
+  pinned `protoc-gen-elixir` escript. Install the escript through the pinned
+  Mix toolchain with `mise exec -- mix escript.install hex protobuf 0.16.0`.
 - `mix proto.gen` generates Elixir controller ↔ node-agent cluster modules from
   `proto/cluster/v1/{common,events,runtime}.proto` into
   `apps/orchard_shared/lib/cluster/v1/`.
@@ -127,6 +130,8 @@ Some dependencies are host services or Apple platform tools and are not managed
 by mise:
 
 - PostgreSQL local or external service
+- Protobuf compiler (`protoc`) and the pinned `protoc-gen-elixir` escript for
+  Elixir proto generation
 - Xcode Command Line Tools and macOS packaging tools such as `pkgbuild`,
   `pkgutil`, `codesign`, `xcrun`, and `notarytool`
 - model bundles and local MLX smoke-test data

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -92,6 +92,25 @@ Package builds should run through the same toolchain:
 mise exec -- ./scripts/build-pkg.sh
 ```
 
+## Generated Contracts
+
+Cluster and worker proto bindings are generated through Mix aliases from the
+repo root:
+
+```bash
+mise exec -- mix proto.gen
+mise exec -- mix proto.gen.worker
+```
+
+- `mix proto.gen` generates Elixir controller ↔ node-agent cluster modules from
+  `proto/cluster/v1/{common,events,runtime}.proto` into
+  `apps/orchard_shared/lib/cluster/v1/`.
+- `mix proto.gen.worker` generates Python bindings for the shared cluster protos
+  and `native/orchard_worker_mlx/proto/orchard/worker/v1/worker_runtime.proto`
+  into `native/orchard_worker_mlx/src/orchard_worker_mlx/generated/`.
+- The node-agent Elixir worker binding is maintained manually; see
+  `native/orchard_worker_mlx/README.md`.
+
 ## Node Policy
 
 Orchard currently has JavaScript assets, but no first-party `package.json`,

--- a/native/orchard_tokenizer/README.md
+++ b/native/orchard_tokenizer/README.md
@@ -1,15 +1,33 @@
 # orchard_tokenizer
 
-S6 bootstrap scaffold for Orchard's exact prompt rendering and token counting helper.
+Python helper package for Orchard prompt rendering, exact token counting, and
+safe-tokenization support. The controller calls the bundled `orchard-tokenizer`
+helper before scheduling, as required by `../../SPEC.md` §3.5.
 
 ## Entrypoints
 
-- project script (run from `native/orchard_tokenizer/`): `mise exec -- uv run orchard-tokenizer`
-- dev-only repo wrapper from the repo root: `mise exec -- native/orchard_tokenizer/bin/orchard-tokenizer`
-
-See `../../docs/tooling.md` for the required mise and uv workflow.
+- project script, from `native/orchard_tokenizer/`:
+  `mise exec -- uv run orchard-tokenizer`
+- dev-only repo wrapper, from the repo root:
+  `mise exec -- native/orchard_tokenizer/bin/orchard-tokenizer`
 
 ## Current behavior
 
-The CLI currently emits a structured JSON placeholder so the package, tests, and
-entrypoint wiring exist before the real tokenizer implementation lands in R4.
+The package implements the tokenizer helper contract used by the controller,
+including Hugging Face tokenizer JSON, SentencePiece tokenizer models,
+chat-template rendering, tool-aware payload fields, token counting, and
+safe-tokenization catalog/segmentation support. See package tests for the
+validated surface.
+
+## Validation
+
+From the repo root:
+
+```bash
+mise exec -- uv run --directory native/orchard_tokenizer ruff format
+mise exec -- uv run --directory native/orchard_tokenizer ruff check
+mise exec -- uv run --directory native/orchard_tokenizer pytest
+mise exec -- uv run --directory native/orchard_tokenizer pytest --cov
+```
+
+See `../../docs/tooling.md` for the required mise and uv workflow.

--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -10,6 +10,15 @@ inference generation, and health probing for Apple Silicon (MLX) backends.
 
 See `../../docs/tooling.md` for the required mise and uv workflow.
 
+## Responsibility boundary
+
+The worker owns local model loading, generation, prefix-cache/runtime telemetry,
+and MLX backend integration. The node agent supervises the worker process and is
+the network-reachable boundary for controller dispatch. Public clients never call
+this service directly.
+
+See `../../docs/architecture.md` for the broader runtime map.
+
 ## Proto contract
 
 The worker runtime proto lives at:

--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -19,6 +19,17 @@ this service directly.
 
 See `../../docs/architecture.md` for the broader runtime map.
 
+## Backend modes
+
+The standalone CLI supports `--backend stub` and `--backend mlx`. The CLI
+defaults to `stub` for hermetic local checks; the node-agent source and packaged
+runtime defaults `ORCHARD_WORKER_BACKEND` to `mlx`. Install MLX extras before
+using the real backend:
+
+```bash
+mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx
+```
+
 ## Proto contract
 
 The worker runtime proto lives at:

--- a/packaging/container/README.md
+++ b/packaging/container/README.md
@@ -1,6 +1,11 @@
-# Managed Postgres container skeleton
+# Managed Postgres container assets
 
-Milestone 0 placeholder for the managed Postgres mode described in `SPEC.md`.
-This path is reserved for Apple-Silicon-compatible local containerization assets, not Docker-first runtime assumptions.
+This path is reserved for future Managed Database Mode assets described in
+`../../SPEC.md`. It is not part of the current packaged install path.
 
-The launchd-facing command name for managed mode is expected to be `orchard-managed-postgres`, provided by packaging assets rather than an Elixir release.
+Managed Postgres is not implemented today. Controller-bearing packaged installs
+currently require an external PostgreSQL server; see `../pkg/README.md` and
+`postgres/README.md`.
+
+Future assets here should target Apple-Silicon-compatible local
+containerization, not Docker-first operator assumptions.

--- a/packaging/container/postgres/README.md
+++ b/packaging/container/postgres/README.md
@@ -1,7 +1,7 @@
 # Managed Postgres (not yet implemented)
 
-> **Status:** Scaffold only. The `orchard-managed-postgres` wrapper exits with
-> a "not implemented" error. The packaged controller currently requires an
+> **Status:** Not implemented. The `orchard-managed-postgres` wrapper exits
+> with a "not implemented" error. The packaged controller currently requires an
 > **external PostgreSQL** server.
 
 ## Intended future responsibilities

--- a/packaging/dmg/README.md
+++ b/packaging/dmg/README.md
@@ -1,4 +1,7 @@
-# DMG skeleton
+# DMG packaging
 
-Milestone 0 placeholder for Orchard interactive installer media.
-Expected contents later include `Orchard.pkg`, release notes, and checksums/signature metadata.
+Reserved for future interactive installer media. The current actionable
+packaging path is the PKG runbook in `../pkg/README.md`.
+
+Expected future DMG contents include `Orchard.pkg`, release notes, and
+checksums/signature metadata.

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1005,14 +1005,20 @@ controller-bearing installs (`all` or `controller`):
    command arguments.
 2. Run `sudo orchardctl env init` and fill in required database/runtime values.
 3. Run `sudo orchardctl migrate`.
-4. Run `sudo orchardctl transport enable-local-https --host HOST` for the local
+4. Create a tenant and API key before making public `/v1` API calls. The API key
+   token is printed once:
+   ```bash
+   sudo orchardctl tenants create --slug default --name "Default"
+   sudo orchardctl api-keys create --tenant-id <tenant-id> --name "Primary"
+   ```
+5. Run `sudo orchardctl transport enable-local-https --host HOST` for the local
    generated-CA direct HTTPS path, or configure an operator-managed direct HTTPS
    certificate/reverse-proxy transport before starting services.
-5. Optional, when browser Console access is desired: run
+6. Optional, when browser Console access is desired: run
    `sudo orchardctl console enable` and enter credentials only through the
    interactive prompt.
-6. Run `sudo orchardctl start`.
-7. Verify with `orchardctl status`.
+7. Run `sudo orchardctl start`.
+8. Verify with `orchardctl status`.
 
 For `node-agent` role installs, run `sudo orchardctl env init`, fill in the
 node-agent environment, then run `sudo orchardctl start` and verify with

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1,6 +1,10 @@
-# PKG skeleton
+# PKG Packaging and Operator Runbook
 
-Milestone 0 packaging placeholder for Orchard enterprise/unattended installs.
+Current packaged installs use a universal PKG payload with role selection for
+`all`, `controller`, and `node-agent` hosts. Controller-bearing installs require
+an **external PostgreSQL** server today; managed Postgres is not implemented and
+`orchard-managed-postgres` remains a placeholder that exits with an error.
+Services are installed by role and must be configured before start.
 
 ## Naming strategy
 

--- a/proto/cluster/v1/README.md
+++ b/proto/cluster/v1/README.md
@@ -29,10 +29,11 @@ Install the local compiler and Elixir plugin:
 
 ```bash
 brew install protobuf
-mix escript.install hex protobuf 0.16.0
+mise exec -- mix escript.install hex protobuf 0.16.0
 ```
 
-`mix proto.gen` validates that the installed Elixir generator version matches Orchard’s pinned `protoc-gen-elixir` version.
+`mise exec -- mix proto.gen` validates that the installed Elixir generator
+version matches Orchard’s pinned `protoc-gen-elixir` version.
 
 `orchard_shared` relies on `grpc`'s compatible protobuf runtime dependency at build/runtime; the pinned escript above is specifically for deterministic Elixir code generation.
 

--- a/proto/cluster/v1/README.md
+++ b/proto/cluster/v1/README.md
@@ -1,14 +1,19 @@
 # cluster/v1 proto workflow
 
-This directory is the source of truth for the internal Orchard controller ↔ node-agent RPC contract described in `SPEC.md`.
+This directory contains the checked-in proto sources used to generate Orchard's
+controller ↔ node-agent RPC bindings. `SPEC.md` remains the normative contract;
+if proto files, docs, tests, or implementation disagree with it, treat the
+branch as blocked until reconciled.
 
-## Milestone scope
+## Scope and current status
 
-- **S1** wires the gRPC/protobuf toolchain and documents generation.
-- **S2** fills the real M1 runtime contract.
-- `membership.proto` remains deferred until the cluster-join lifecycle work in later milestones.
+This directory owns the controller ↔ node-agent cluster RPC contract. It does
+not own the node-agent ↔ worker runtime contract; that lives under
+`../../../native/orchard_worker_mlx/proto/`.
 
-The seed definitions in `common.proto`, `events.proto`, and `runtime.proto` are intentionally minimal. They exist so Orchard can standardize the code generation workflow and compile against shared generated modules before the full M1 runtime surface lands.
+`common.proto`, `events.proto`, and `runtime.proto` are active generated inputs.
+`membership.proto` is present for the future cluster-join lifecycle slice but is
+excluded from the current generation aliases until that contract is implemented.
 
 ## Elixir toolchain
 
@@ -46,7 +51,7 @@ apps/orchard_shared/lib/cluster/v1/
 Use the repo-approved alias from the repository root:
 
 ```bash
-mix proto.gen
+mise exec -- mix proto.gen
 ```
 
 The alias wraps this underlying `protoc` invocation:
@@ -65,51 +70,36 @@ Notes:
 
 - `package_prefix=Orchard` keeps generated modules under the Orchard namespace (`Orchard.Cluster.V1.*`).
 - `membership.proto` is intentionally excluded until its contract is defined.
-- Re-run `mix proto.gen` whenever the checked-in proto files change.
+- Re-run `mise exec -- mix proto.gen` whenever the checked-in proto files change.
 
-## Python toolchain
+## Python worker codegen
 
-Python code generation is documented now so the later native packages can adopt the same checked-in proto source of truth. This section is **forward-looking in S1**: the repository does not yet contain the package skeletons needed to run these commands successfully.
+The worker package consumes generated Python bindings for both this cluster RPC
+surface and its own worker runtime RPC surface.
 
-### When this becomes actionable
-
-Start using this workflow once the native package scaffolds exist in S6 (or earlier if a package is added specifically for shared RPC generation).
-
-### Intended Python output locations
-
-The future native package layout should generate checked-in Python modules under package-owned source trees, for example:
+Generated Python modules live under:
 
 ```text
-native/orchard_worker_mlx/src/orchard_worker_mlx/generated/cluster/v1/
+native/orchard_worker_mlx/src/orchard_worker_mlx/generated/
 ```
 
-### Future package prerequisites
-
-Inside the owning Python package, use `uv`-managed tooling only and add the codegen dependency there:
+Run the repo-approved alias from the repository root:
 
 ```bash
-uv add --dev grpcio-tools
+mise exec -- mix proto.gen.worker
 ```
 
-### Future Python generation command
+The alias runs `grpc_tools.protoc` through the worker package's uv environment,
+with include paths for both `proto/` and `native/orchard_worker_mlx/proto/`.
+It generates:
 
-Once the package skeleton exists, run the generation step from the repository root or from the package environment that owns the output path:
+- `cluster/v1/*_pb2.py` and `cluster/v1/*_pb2_grpc.py` from this directory's
+  active cluster protos;
+- `orchard/worker/v1/*_pb2.py` and `orchard/worker/v1/*_pb2_grpc.py` from the
+  worker runtime proto.
 
-```bash
-uv run python -m grpc_tools.protoc \
-  -I proto \
-  --python_out=native/orchard_worker_mlx/src/orchard_worker_mlx/generated \
-  --grpc_python_out=native/orchard_worker_mlx/src/orchard_worker_mlx/generated \
-  proto/cluster/v1/common.proto \
-  proto/cluster/v1/events.proto \
-  proto/cluster/v1/runtime.proto
-```
-
-Notes:
-
-- The exact package destination becomes active once the native packages are created.
-- `membership.proto` remains deferred and is not part of the Python generation set yet.
-- Until the package skeleton exists, treat this as a documented target workflow rather than a runnable S1 command.
+`membership.proto` remains deferred and is not part of the current Python
+cluster generation set.
 
 ## Workflow rules
 

--- a/rel/README.md
+++ b/rel/README.md
@@ -1,7 +1,10 @@
 # Orchard releases
 
-Milestone 0 placeholder for release-specific overlays and helper scripts.
-Release definitions currently live in the umbrella `mix.exs`.
+Release definitions live in the umbrella `mix.exs`. This directory currently has
+no Mix release overlays; add release-specific overlays or helper scripts here
+only when the release build needs files that cannot live in `packaging/`.
 
 Internal release identities remain underscore-based (`orchard_controller`, `orchard_node_agent`, `orchard_cli`).
 Hyphenated daemon commands and `orchardctl` are treated as packaging-level wrapper names rather than renamed Mix release outputs.
+
+See `../packaging/pkg/README.md` for the current installer and operator runbook.


### PR DESCRIPTION
## Intent

Refresh Orchard's single-repo collaborator documentation now that external collaborators are beginning to work in the codebase. The branch should make the docs easier to navigate and more consistent without creating a competing source of truth: SPEC.md remains normative, README/docs/CONTRIBUTING/AGENTS should point to the right places, a concise architecture guide should orient contributors to repo and runtime boundaries, design docs should cross-link brand and tactical UI guidance, app/native/proto/package READMEs should replace stale generated or scaffold wording, and packaging docs should clearly separate target architecture from current operator limits like external Postgres and unimplemented managed Postgres/DMG. The user explicitly did not want milestone docs elevated, so no new milestone index or milestone navigation should be part of the collaborator path.

## What Changed

- Reworked the root README, docs hub, CONTRIBUTING/AGENTS pointers, local-dev/tooling/process docs, and Console design cross-links around `SPEC.md`, architecture, local development, packaging, and ADR guidance.
- Added `docs/architecture.md` and an ADR template, and refreshed app/native/proto/release READMEs to define ownership boundaries, generated contract workflows, and current runtime/package responsibilities.
- Clarified current operator limits and setup steps across PKG/container/DMG/local-dev docs, including external Postgres requirements, unimplemented managed Postgres/DMG paths, authenticated `/v1` examples, and tenant/API-key bootstrap.

## Risk Assessment

✅ Low: The reviewed changes are documentation-only, the prior architecture/link findings are fixed, and the remaining docs/navigation surface is internally consistent with SPEC.md at low merge risk.

## Testing

I inspected the docs-only branch diff, rendered the contributor-facing Markdown into an HTML evidence bundle, verified all changed-file relative Markdown links and checked anchors, checked collaborator-path content constraints around stale scaffold wording and milestone navigation, confirmed packaging limit wording, and verified the source worktree stayed clean. No linters, formatters, static analysis, or unrelated unit tests were run because the changed surface is documentation navigation and copy.

<details>
<summary>Evidence: Rendered collaborator docs bundle</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc 3.10" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>Orchard Collaborator Docs Refresh Evidence</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    html {
      color: #1a1a1a;
      background-color: #fdfdfd;
    }
    body {
      margin: 0 auto;
      max-width: 36em;
      padding-left: 50px;
      padding-right: 50px;
      padding-top: 50px;
      padding-bottom: 50px;
      hyphens: auto;
      overflow-wrap: break-word;
      text-rendering: optimizeLegibility;
      font-kerning: normal;
    }
    @media (max-width: 600px) {
      body {
        font-size: 0.9em;
        padding: 12px;
      }
      h1 {
        font-size: 1.8em;
      }
    }
    @media print {
      html {
        background-color: white;
      }
      body {
        background-color: transparent;
        color: black;
        font-size: 12pt;
      }
      p, h2, h3 {
        orphans: 3;
        widows: 3;
      }
      h2, h3, h4 {
        page-break-after: avoid;
      }
    }
    p {
      margin: 1em 0;
    }
    a {
      color: #1a1a1a;
    }
    a:visited {
      color: #1a1a1a;
    }
    img {
      max-width: 100%;
    }
    svg {
      height: auto;
      max-width: 100%;
    }
    h1, h2, h3, h4, h5, h6 {
      margin-top: 1.4em;
    }
    h5, h6 {
      font-size: 1em;
      font-style: italic;
    }
    h6 {
      font-weight: normal;
    }
    ol, ul {
      padding-left: 1.7em;
      margin-top: 1em;
    }
    li > ol, li > ul {
      margin-top: 0;
    }
    blockquote {
      margin: 1em 0 1em 1.7em;
      padding-left: 1em;
      border-left: 2px solid #e6e6e6;
      color: #606060;
    }
    code {
      white-space: pre-wrap;
      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
      font-size: 85%;
      margin: 0;
      hyphens: manual;
    }
    pre {
      margin: 1em 0;
      overflow: auto;
    }
    pre code {
      padding: 0;
      overflow: visible;
      overflow-wrap: normal;
    }
    .sourceCode {
     background-color: transparent;
     overflow: visible;
    }
    hr {
      border: none;
      border-top: 1px solid #1a1a1a;
      height: 1px;
      margin: 1em 0;
    }
    table {
      margin: 1em 0;
      border-collapse: collapse;
      width: 100%;
      overflow-x: auto;
      display: block;
      font-variant-numeric: lining-nums tabular-nums;
    }
    table caption {
      margin-bottom: 0.75em;
    }
    tbody {
      margin-top: 0.5em;
      border-top: 1px solid #1a1a1a;
      border-bottom: 1px solid #1a1a1a;
    }
    th {
      border-top: 1px solid #1a1a1a;
      padding: 0.25em 0.5em 0.25em 0.5em;
    }
    td {
      padding: 0.125em 0.5em 0.25em 0.5em;
    }
    header {
      margin-bottom: 4em;
      text-align: center;
    }
    #TOC li {
      list-style: none;
    }
    #TOC ul {
      padding-left: 1.3em;
    }
    #TOC > ul {
      padding-left: 0;
    }
    #TOC a:not(:hover) {
      text-decoration: none;
    }
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: 1.5em;}
    div.column{flex: auto;}
    @media screen {
    div.columns{gap: min(4vw, 1.5em);}
    div.column{overflow-x: auto;}
    }
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
    /* CSS for syntax highlighting */
    html { -webkit-text-size-adjust: 100%; }
    pre > code.sourceCode { white-space: pre; position: relative; }
    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
    pre > code.sourceCode > span:empty { height: 1.2em; }
    .sourceCode { overflow: visible; }
    code.sourceCode > span { color: inherit; text-decoration: inherit; }
    div.sourceCode { margin: 1em 0; }
    pre.sourceCode { margin: 0; }
    @media screen {
    div.sourceCode { overflow: auto; }
    }
    @media print {
    pre > code.sourceCode { white-space: pre-wrap; }
    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
    }
    pre.numberSource code
      { counter-reset: source-line 0; }
    pre.numberSource code > span
      { position: relative; left: -4em; counter-increment: source-line; }
    pre.numberSource code > span > a:first-child::before
      { content: counter(source-line);
        position: relative; left: -1em; text-align: right; vertical-align: baseline;
        border: none; display: inline-block;
        -webkit-touch-callout: none; -webkit-user-select: none;
        -khtml-user-select: none; -moz-user-select: none;
        -ms-user-select: none; user-select: none;
        padding: 0 4px; width: 4em;
        color: #aaaaaa;
      }
    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
    div.sourceCode
      {   }
    @media screen {
    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
    }
    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
    code span.at { color: #7d9029; } /* Attribute */
    code span.bn { color: #40a070; } /* BaseN */
    code span.bu { color: #008000; } /* BuiltIn */
    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
    code span.ch { color: #4070a0; } /* Char */
    code span.cn { color: #880000; } /* Constant */
    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
    code span.dt { color: #902000; } /* DataType */
    code span.dv { color: #40a070; } /* DecVal */
    code span.er { color: #ff0000; font-weight: bold; } /* Error */
    code span.ex { } /* Extension */
    code span.fl { color: #40a070; } /* Float */
    code span.fu { color: #06287e; } /* Function */
    code span.im { color: #008000; font-weight: bold; } /* Import */
    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
    code span.op { color: #666666; } /* Operator */
    code span.ot { color: #007020; } /* Other */
    code span.pp { color: #bc7a00; } /* Preprocessor */
    code span.sc { color: #4070a0; } /* SpecialChar */
    code span.ss { color: #bb6688; } /* SpecialString */
    code span.st { color: #4070a0; } /* String */
    code span.va { color: #19177c; } /* Variable */
    code span.vs { color: #4070a0; } /* VerbatimString */
    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
  </style>
</head>
<body>
<header id="title-block-header">
<h1 class="title">Orchard Collaborator Docs Refresh Evidence</h1>
</header>
<h1 id="orchard">Orchard</h1>
<p><strong>Your LLMs. Your hardware. Your rules.</strong></p>
<p>Orchard is a sovereign on-prem LLM orchestration platform for 1–4
Apple Silicon macOS machines. It runs inference on your own hardware,
behind your own firewall, with no cloud dependency.</p>
<h2 id="where-to-start">Where to start</h2>
<ul>
<li><a href="SPEC.md"><code>SPEC.md</code></a> is the normative build
contract.</li>
<li><a href="docs/README.md"><code>docs/README.md</code></a> is the
collaborator docs hub.</li>
<li><a href="docs/architecture.md"><code>docs/architecture.md</code></a>
maps the repo and runtime boundaries.</li>
<li><a href="CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> covers
human collaboration workflow.</li>
<li><a href="docs/local-dev.md"><code>docs/local-dev.md</c

... [211293 bytes truncated] ...

managed-postgres-container-assets">Managed Postgres container
assets</h1>
<p>This path is reserved for future Managed Database Mode assets
described in <code>../../SPEC.md</code>. It is not part of the current
packaged install path.</p>
<p>Managed Postgres is not implemented today. Controller-bearing
packaged installs currently require an external PostgreSQL server; see
<code>../pkg/README.md</code> and <code>postgres/README.md</code>.</p>
<p>Future assets here should target Apple-Silicon-compatible local
containerization, not Docker-first operator assumptions.</p>
<h1 id="managed-postgres-not-yet-implemented">Managed Postgres (not yet
implemented)</h1>
<blockquote>
<p><strong>Status:</strong> Not implemented. The
<code>orchard-managed-postgres</code> wrapper exits with a “not
implemented” error. The packaged controller currently requires an
<strong>external PostgreSQL</strong> server.</p>
</blockquote>
<h2 id="intended-future-responsibilities">Intended future
responsibilities</h2>
<ul>
<li>Local loopback-only Postgres runtime</li>
<li>Persistent data under
<code>/Library/Application Support/Orchard/data/</code></li>
<li>Health checks via <code>pg_isready</code></li>
<li>Automatic bootstrap during <code>postinstall</code></li>
</ul>
<h2 id="current-state">Current state</h2>
<p>The <code>com.orchard.postgres.plist</code> launchd service
definition exists but should <strong>not</strong> be bootstrapped until
a functional <code>orchard-managed-postgres</code> binary is available.
The installer does not bootstrap it by default.</p>
<h1 id="dmg-packaging">DMG packaging</h1>
<p>Reserved for future interactive installer media. The current
actionable packaging path is the PKG runbook in
<code>../pkg/README.md</code>.</p>
<p>Expected future DMG contents include <code>Orchard.pkg</code>,
release notes, and checksums/signature metadata.</p>
<h1 id="clusterv1-proto-workflow">cluster/v1 proto workflow</h1>
<p>This directory contains the checked-in proto sources used to generate
Orchard’s controller ↔︎ node-agent RPC bindings. <code>SPEC.md</code>
remains the normative contract; if proto files, docs, tests, or
implementation disagree with it, treat the branch as blocked until
reconciled.</p>
<h2 id="scope-and-current-status">Scope and current status</h2>
<p>This directory owns the controller ↔︎ node-agent cluster RPC contract.
It does not own the node-agent ↔︎ worker runtime contract; that lives
under <code>../../../native/orchard_worker_mlx/proto/</code>.</p>
<p><code>common.proto</code>, <code>events.proto</code>, and
<code>runtime.proto</code> are active generated inputs.
<code>membership.proto</code> is present for the future cluster-join
lifecycle slice but is excluded from the current generation aliases
until that contract is implemented.</p>
<h2 id="elixir-toolchain">Elixir toolchain</h2>
<p>Orchard standardizes on:</p>
<ul>
<li><a href="https://hex.pm/packages/protobuf"><code>protobuf</code></a>
for generated message modules</li>
<li><a href="https://hex.pm/packages/grpc"><code>grpc</code></a> for
generated service and stub modules</li>
<li><code>protoc</code> as the checked-in <code>.proto</code> compiler
input</li>
</ul>
<h3 id="prerequisites-1">Prerequisites</h3>
<p>Install the local compiler and Elixir plugin:</p>
<div class="sourceCode" id="cb85"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb85-1"><a href="#cb85-1" aria-hidden="true" tabindex="-1"></a><span class="ex">brew</span> install protobuf</span>
<span id="cb85-2"><a href="#cb85-2" aria-hidden="true" tabindex="-1"></a><span class="ex">mix</span> escript.install hex protobuf 0.16.0</span></code></pre></div>
<p><code>mix proto.gen</code> validates that the installed Elixir
generator version matches Orchard’s pinned
<code>protoc-gen-elixir</code> version.</p>
<p><code>orchard_shared</code> relies on <code>grpc</code>’s compatible
protobuf runtime dependency at build/runtime; the pinned escript above
is specifically for deterministic Elixir code generation.</p>
<h3 id="elixir-output-location">Elixir output location</h3>
<p>Generated Elixir modules live in:</p>
<pre class="text"><code>apps/orchard_shared/lib/cluster/v1/</code></pre>
<p><code>orchard_shared</code> is the single owner of generated Elixir
transport modules so the controller and node agent compile against one
shared contract implementation.</p>
<h3 id="generate-elixir-modules">Generate Elixir modules</h3>
<p>Use the repo-approved alias from the repository root:</p>
<div class="sourceCode" id="cb87"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb87-1"><a href="#cb87-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mise</span> exec <span class="at">--</span> mix proto.gen</span></code></pre></div>
<p>The alias wraps this underlying <code>protoc</code> invocation:</p>
<div class="sourceCode" id="cb88"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb88-1"><a href="#cb88-1" aria-hidden="true" tabindex="-1"></a><span class="ex">protoc</span> <span class="dt">\</span></span>
<span id="cb88-2"><a href="#cb88-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">-I</span> proto <span class="dt">\</span></span>
<span id="cb88-3"><a href="#cb88-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--plugin</span><span class="op">=</span>protoc-gen-elixir=<span class="st">&quot;</span><span class="va">$HOME</span><span class="st">/.mix/escripts/protoc-gen-elixir&quot;</span> <span class="dt">\</span></span>
<span id="cb88-4"><a href="#cb88-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--elixir_out</span><span class="op">=</span>plugins=grpc,package_prefix=Orchard:apps/orchard_shared/lib <span class="dt">\</span></span>
<span id="cb88-5"><a href="#cb88-5" aria-hidden="true" tabindex="-1"></a>  proto/cluster/v1/common.proto <span class="dt">\</span></span>
<span id="cb88-6"><a href="#cb88-6" aria-hidden="true" tabindex="-1"></a>  proto/cluster/v1/events.proto <span class="dt">\</span></span>
<span id="cb88-7"><a href="#cb88-7" aria-hidden="true" tabindex="-1"></a>  proto/cluster/v1/runtime.proto</span></code></pre></div>
<p>Notes:</p>
<ul>
<li><code>package_prefix=Orchard</code> keeps generated modules under
the Orchard namespace (<code>Orchard.Cluster.V1.*</code>).</li>
<li><code>membership.proto</code> is intentionally excluded until its
contract is defined.</li>
<li>Re-run <code>mise exec -- mix proto.gen</code> whenever the
checked-in proto files change.</li>
</ul>
<h2 id="python-worker-codegen">Python worker codegen</h2>
<p>The worker package consumes generated Python bindings for both this
cluster RPC surface and its own worker runtime RPC surface.</p>
<p>Generated Python modules live under:</p>
<pre class="text"><code>native/orchard_worker_mlx/src/orchard_worker_mlx/generated/</code></pre>
<p>Run the repo-approved alias from the repository root:</p>
<div class="sourceCode" id="cb90"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb90-1"><a href="#cb90-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mise</span> exec <span class="at">--</span> mix proto.gen.worker</span></code></pre></div>
<p>The alias runs <code>grpc_tools.protoc</code> through the worker
package’s uv environment, with include paths for both
<code>proto/</code> and <code>native/orchard_worker_mlx/proto/</code>.
It generates:</p>
<ul>
<li><code>cluster/v1/*_pb2.py</code> and
<code>cluster/v1/*_pb2_grpc.py</code> from this directory’s active
cluster protos;</li>
<li><code>orchard/worker/v1/*_pb2.py</code> and
<code>orchard/worker/v1/*_pb2_grpc.py</code> from the worker runtime
proto.</li>
</ul>
<p><code>membership.proto</code> remains deferred and is not part of the
current Python cluster generation set.</p>
<h2 id="workflow-rules">Workflow rules</h2>
<ul>
<li>Edit <code>.proto</code> files in this directory first.</li>
<li>Regenerate Elixir/Python outputs from the updated proto source.</li>
<li>Commit generated Elixir modules alongside the proto changes that
require them.</li>
<li>Keep Orchard-specific naming in generated Elixir modules via the
<code>Orchard</code> package prefix.</li>
</ul>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Changed Markdown link check</summary>

<code>changed_markdown_files=23&#10;relative_markdown_links_checked=76&#10;result=ok: every changed-file relative Markdown link target and checked anchor resolves</code>

```text
changed_markdown_files=23
relative_markdown_links_checked=76
result=ok: every changed-file relative Markdown link target and checked anchor resolves
```
</details>
<details>
<summary>Evidence: Collaborator docs content checks</summary>

<code>result=ok: no stale Hex package scaffold, generated TODO, or old milestone-placeholder wording in changed files&#10;result=ok: changed collaborator docs do not add milestone index/navigation links&#10;operator-limit evidence includes external Postgres, managed Postgres not implemented, and future DMG wording.</code>

```text
changed_markdown_files=23

[stale scaffold/generated wording check]
result=ok: no stale Hex package scaffold, generated TODO, or old milestone-placeholder wording in changed files

[milestone collaborator navigation check]
result=ok: changed collaborator docs do not add milestone index/navigation links

[operator-limit wording evidence]
packaging/dmg/README.md:3:Reserved for future interactive installer media. The current actionable
packaging/container/README.md:6:Managed Postgres is not implemented today. Controller-bearing packaged installs
README.md:26:Current packaged controller-bearing installs require external Postgres; managed
docs/architecture.md:15:  require an external PostgreSQL server today. Managed Postgres is specified as
packaging/pkg/README.md:5:an **external PostgreSQL** server today; managed Postgres is not implemented and
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `README.md` - merge conflict rebasing onto origin/main
- ⚠️ `docs/README.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/architecture.md:31` - The new topology diagram serializes Postgres after the worker runtime, which reads as Controller -&gt; Node Agent -&gt; Worker -&gt; Postgres. SPEC.md shows Postgres as a separate controller-side SQL/TLS dependency, while workers remain node-agent-supervised subprocesses; redraw this so contributors do not infer DB access belongs behind the worker boundary.
- ⚠️ `docs/architecture.md:57` - This glossary link points to ../CONTEXT.md, but that file does not exist; the repo glossary is docs/glossary/CONTEXT.md, so from this file the link should target glossary/CONTEXT.md.

🔧 Fix: Fix architecture topology docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat b6c23d634a6c03473c795eb166c0617d55220190..f0d73cdbfc87e2c87288a4e7c1cb71967e49c2a2` and `git diff --name-only b6c23d634a6c03473c795eb166c0617d55220190..f0d73cdbfc87e2c87288a4e7c1cb71967e49c2a2`</code>
- `pandoc --standalone --metadata title='Orchard Collaborator Docs Refresh Evidence' README.md docs/README.md docs/architecture.md docs/brand-identity.md docs/DESIGN.md packaging/pkg/README.md packaging/container/README.md packaging/container/postgres/README.md packaging/dmg/README.md proto/cluster/v1/README.md -o /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVPKCPK64KAY3VYC6F1NKA8N/collaborator-docs-render.html`
- `ruby - <<'RUBY' ... changed Markdown relative-link and heading-anchor checker ... RUBY | tee /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVPKCPK64KAY3VYC6F1NKA8N/changed-doc-links-check.txt`
- <code>`rg`-based checks over changed Markdown for stale generated/scaffold wording, new milestone navigation links, and explicit packaging current-limit wording, written to `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVPKCPK64KAY3VYC6F1NKA8N/collaborator-doc-content-checks.txt`</code>
- `rg -n 'Where to start|Start by intent|Architecture Guide|Managed Postgres|PKG Packaging|Reserved for future interactive installer media' /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVPKCPK64KAY3VYC6F1NKA8N/collaborator-docs-render.html`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
