### PR TITLE
chore: pin openspec tooling command surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ erl_crash.dump
 .elixir_ls/
 
 # Node (if Phoenix assets)
+/node_modules/
 /assets/node_modules/
 
 # macOS
@@ -52,6 +53,7 @@ native/*/.venv-pkg/
 /prompt-exports/
 **/prompt-exports/
 /.codex/
+/.claude/
 /.repoprompt/
 /.plannotator/
 /.lavish/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,9 @@ Rules:
   deltas; add `design.md` when the change has technical ambiguity, migration
   risk, security/performance concerns, or cross-module impact.
 - Before implementation or PR handoff, run
-  `mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive`.
+  `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive`.
 - After archiving or syncing accepted behavior, run
-  `mise exec -- npm run openspec -- validate --all --strict --no-interactive`.
+  `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`.
 - Review generated main specs for placeholder prose such as `Purpose TBD`;
   strict validation accepts some incomplete prose that still needs human review.
 - Do not mirror large sections of `SPEC.md` into OpenSpec specs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Orchard is a sovereign on-prem LLM orchestration platform for Apple Silicon macO
 implementation decision must trace to `SPEC.md`, tests, product docs, a
 decision record, or an explicitly approved issue/PR decision.
 
-If `SPEC.md`, docs, future OpenSpec materials, tests, or implementation disagree
+If `SPEC.md`, docs, OpenSpec materials, tests, or implementation disagree
 about product behavior, treat the PR as blocked until the branch reconciles the
 conflict. `SPEC.md` wins until explicitly updated.
 
@@ -28,7 +28,7 @@ interview JSON, annotation state, tool session identifiers, credentials, DSNs,
 or machine-specific paths.
 
 Durable conclusions belong in this repo: `SPEC.md`, `docs/**`,
-`docs/decisions/**`, tests, code, or future verified OpenSpec materials.
+`docs/decisions/**`, tests, code, or approved OpenSpec materials.
 
 ## Planning And Local Goals
 
@@ -58,6 +58,30 @@ Do not commit active `goals/<slug>/` packages, raw interview JSON, review JSON,
 metadata JSON, local evidence logs, local paths, or tool session identifiers.
 If goal material becomes durable, promote the conclusion into `SPEC.md`,
 product docs, decisions, tests, or code.
+
+## OpenSpec Workflow
+
+OpenSpec is initialized as Orchard's collaborator-reviewable change-intent
+workflow under `SPEC.md`. Use it for substantial behavior, architecture, API,
+security/governance, node lifecycle, scheduling, packaging, or
+collaborator-owned changes.
+
+Rules:
+
+- `SPEC.md` remains the apex product contract.
+- OpenSpec change packages live in `openspec/changes/<change-id>/`.
+- Each OpenSpec change should include `proposal.md`, `tasks.md`, and spec
+  deltas; add `design.md` when the change has technical ambiguity, migration
+  risk, security/performance concerns, or cross-module impact.
+- Before implementation or PR handoff, run
+  `mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive`.
+- After archiving or syncing accepted behavior, run
+  `mise exec -- npm run openspec -- validate --all --strict --no-interactive`.
+- Review generated main specs for placeholder prose such as `Purpose TBD`;
+  strict validation accepts some incomplete prose that still needs human review.
+- Do not mirror large sections of `SPEC.md` into OpenSpec specs.
+- Do not commit generated `.codex/`, `.claude/`, prompt exports, local context
+  stores, tool session identifiers, or machine-local execution evidence.
 
 ## Architecture (from SPEC.md)
 
@@ -102,6 +126,41 @@ Agent accelerators such as RepoPrompt, codemap, ast-grep, Refero, Superpowers,
 and Exa may help with discovery, review, design, and research. Discover their
 available roles/workflows live before assuming a stale tool surface. They do not
 own product truth and must not become required human collaborator dependencies.
+
+## Agent Command Surface
+
+Prefer the repo command surface when it exists. `Makefile` targets are thin
+aliases over documented `mise exec --` commands; they do not define product
+truth or validation policy.
+
+Authority order:
+
+1. `SPEC.md`, this `AGENTS.md`, and product docs define behavior and workflow.
+2. `docs/tooling.md` defines pinned runtime/tool versions.
+3. `Makefile` provides convenience entrypoints only.
+
+If a `Makefile` target and the docs disagree, treat the docs as authoritative
+and fix the `Makefile`.
+
+Recommended targets:
+
+- `make setup` — install pinned repo dependencies.
+- `make dev` — run source dev in the foreground.
+- `make dev-controller` — run the source-dev controller host in the foreground.
+- `make dev-node-agent` — run the source-dev node-agent host in the foreground.
+- `make openspec` — run pinned OpenSpec validation.
+- `make format` — run Elixir formatter.
+- `make test` — run the default test suite.
+- `make check-elixir` — run the full Elixir quality workflow.
+
+`make dev` must remain a foreground/blocking command equivalent to
+`mise exec -- bin/dev`. Do not background the dev server from `make dev`. If
+background operation is needed, use explicit targets such as `dev-bg`,
+`dev-stop`, and `dev-status` with PID/log handling.
+
+Do not assume packaged Orchard BEAM processes under
+`/Library/Application Support/Orchard/` mean source dev is running. Source dev
+uses the repo checkout and defaults to HTTP `:4000` plus gRPC `:50071`.
 
 ## LiveView Console Conventions
 
@@ -212,7 +271,8 @@ Rules:
 
 ## Dev Environment
 
-**Start with:** `mise exec -- bin/dev`
+**Start with:** `make dev` when a `Makefile` is available; otherwise
+`mise exec -- bin/dev`.
 
 This single command creates the dev database if needed, runs migrations, sets
 the dev gRPC port to 50071 (avoiding conflict with the packaged BEAM on 50061),
@@ -280,6 +340,7 @@ See `packaging/pkg/README.md` for full PKG operator documentation and `packaging
 | README.md | High-level product and roadmap overview |
 | CONTRIBUTING.md | Human collaborator workflow |
 | CONTEXT-MAP.md | Domain-modeling discovery map for glossary context |
+| Makefile | Thin convenience command index over `mise exec --` |
 | mise.toml | Pinned local toolchain contract |
 | docs/glossary/CONTEXT.md | Shared Orchard product glossary |
 | docs/tooling.md | mise, validation command, and local tool guidance |
@@ -288,6 +349,6 @@ See `packaging/pkg/README.md` for full PKG operator documentation and `packaging
 | docs/architecture.md | Contributor architecture and repo-boundary orientation |
 | docs/decisions/ | ADR-style durable decisions |
 | goals/README.md | Local goal package policy |
-| openspec/README.md | Reserved structured-change workflow |
+| openspec/README.md | Initialized OpenSpec change workflow |
 | mix.exs | Umbrella project root |
 | docs/code-quality.md | ex_slop + ex_dna plugin reference and tuning guide |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@ macOS. This repository is the collaborator-facing source of truth.
 5. `docs/glossary/CONTEXT.md` defines shared Orchard product language.
 6. `docs/process.md` explains artifact lifecycle and review gates.
 7. `docs/decisions/**` records durable decisions not already fixed by `SPEC.md`.
-8. `openspec/README.md` reserves a structured-change path subordinate to `SPEC.md`.
+8. `openspec/README.md` explains the initialized OpenSpec change workflow
+   subordinate to `SPEC.md`.
 
 If these disagree about product behavior, treat the PR as blocked until the
 branch reconciles the conflict. `SPEC.md` wins until explicitly updated.
@@ -39,10 +40,30 @@ Behavior-changing or architecture-significant work must state its `SPEC.md`
 impact in the issue or PR. If the behavior is not covered by `SPEC.md`, update
 the relevant durable artifact before or with the implementation.
 
+Use OpenSpec for substantial behavior, architecture, API, security/governance,
+node lifecycle, scheduling, packaging, or collaborator-owned changes. OpenSpec
+change packages live under `openspec/changes/<change-id>/` and must remain
+subordinate to `SPEC.md`.
+
 ## Validation
 
 Run the relevant validation workflow from `AGENTS.md` and report exact commands
 and outcomes in the PR. For bug fixes, include a regression test when practical.
+
+For OpenSpec-backed work, also run:
+
+```sh
+mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive
+```
+
+After archiving or syncing accepted OpenSpec behavior, run:
+
+```sh
+mise exec -- npm run openspec -- validate --all --strict --no-interactive
+```
+
+Review archived specs for placeholders such as `Purpose TBD`; strict validation
+does not catch unfinished prose.
 
 ## Artifact Hygiene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,9 @@ does not catch unfinished prose.
 ## Artifact Hygiene
 
 Do not commit prompt exports, local execution evidence, private notes, active
-goal packages, raw interview JSON, tool session identifiers, credentials, DSNs,
-or machine-specific paths.
+goal packages, raw interview JSON, local context stores such as `.codex/` or
+`.claude/`, tool session identifiers, credentials, DSNs, or machine-specific
+paths.
 
 Active `goals/<slug>/` packages are local transient execution scaffolding.
 Only `goals/README.md` and `goals/_template/**` are tracked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,13 @@ and outcomes in the PR. For bug fixes, include a regression test when practical.
 For OpenSpec-backed work, also run:
 
 ```sh
-mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive
+OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive
 ```
 
 After archiving or syncing accepted OpenSpec behavior, run:
 
 ```sh
-mise exec -- npm run openspec -- validate --all --strict --no-interactive
+OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive
 ```
 
 Review archived specs for placeholders such as `Purpose TBD`; strict validation

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ dev-node-agent:
 	mise exec -- bin/dev-node-agent
 
 openspec:
-	mise exec -- npm run openspec -- validate --all --strict --no-interactive
+	OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive
 
 format:
 	mise exec -- mix format

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+.PHONY: help setup setup-elixir setup-native setup-openspec dev dev-controller dev-node-agent openspec format compile credo dialyzer test cover check-elixir
+
+help:
+	@printf '%s\n' \
+	  'Orchard command targets:' \
+	  '  make setup          Install pinned repo dependencies' \
+	  '  make dev            Run source dev in the foreground' \
+	  '  make dev-controller Run source-dev controller host' \
+	  '  make dev-node-agent Run source-dev node-agent host' \
+	  '  make openspec       Run pinned OpenSpec validation' \
+	  '  make format         Run Elixir formatter' \
+	  '  make test           Run default test suite' \
+	  '  make check-elixir   Run full Elixir quality workflow'
+
+setup: setup-elixir setup-native setup-openspec
+
+setup-elixir:
+	mise trust
+	mise install
+	mise exec -- mix deps.get
+
+setup-native:
+	mise exec -- uv sync --directory native/orchard_tokenizer
+	mise exec -- uv sync --directory native/orchard_worker_mlx
+
+setup-openspec:
+	mise exec -- npm ci --ignore-scripts
+
+dev:
+	mise exec -- bin/dev
+
+dev-controller:
+	mise exec -- bin/dev-controller
+
+dev-node-agent:
+	mise exec -- bin/dev-node-agent
+
+openspec:
+	mise exec -- npm run openspec -- validate --all --strict --no-interactive
+
+format:
+	mise exec -- mix format
+
+compile:
+	mise exec -- mix compile --warnings-as-errors
+
+credo:
+	mise exec -- mix credo --strict
+
+dialyzer:
+	mise exec -- mix dialyzer
+
+test:
+	mise exec -- mix test
+
+cover:
+	mise exec -- mix test --cover
+
+check-elixir: format compile credo dialyzer test cover

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Clients (SDKs / curl / apps)
 | APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
 | Packaging | DMG, PKG, launchd |
 | CLI | `orchardctl` |
-| Toolchain | mise-pinned Erlang/OTP, Elixir, Python, and uv |
+| Toolchain | mise-pinned Erlang/OTP, Elixir, Python, uv, Node.js, npm, and OpenSpec |
 
 ### Current transport behavior
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ must be rewritten into this repo before it counts as Orchard truth.
 - [`docs/tooling.md`](docs/tooling.md) explains the required mise toolchain and local accelerator tools.
 - [`docs/local-dev.md`](docs/local-dev.md) explains source development setup and smoke checks.
 - [`docs/process.md`](docs/process.md) explains artifact lifecycle and review gates.
-- [`openspec/README.md`](openspec/README.md) reserves a future structured-change workflow subordinate to `SPEC.md`.
+- [`openspec/README.md`](openspec/README.md) explains the initialized OpenSpec
+  change workflow subordinate to `SPEC.md`.
 
 Active local `goals/<slug>/` packages are transient execution scaffolding and
 are ignored by default.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,10 @@ large spec sections.
 
 ### I want to run it locally
 
-- [`tooling.md`](tooling.md) — mise/uv toolchain and validation commands.
-- [`local-dev.md`](local-dev.md) — source-dev setup, `bin/dev`, split-role dev,
+- [`tooling.md`](tooling.md) — mise/uv/npm toolchain, Makefile aliases, and
+  validation commands.
+- [`local-dev.md`](local-dev.md) — source-dev setup, `make dev` / `bin/dev`,
+  split-role dev,
   smoke checks, and environment notes.
 
 ### I want to contribute code
@@ -75,6 +77,7 @@ updated.
 - Prefer practical execution guidance over prose.
 - Keep current implementation status separate from target architecture.
 - Update or delete stale docs quickly.
-- Do not commit raw prompt exports, active goal packages, tool session IDs,
-  credentials, DSNs, or machine-specific evidence.
+- Do not commit raw prompt exports, active goal packages, local context stores
+  such as `.codex/` or `.claude/`, tool session IDs, credentials, DSNs, or
+  machine-specific evidence.
 - Promote durable conclusions into standalone docs, decisions, tests, or code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ large spec sections.
 - [`../AGENTS.md`](../AGENTS.md) — automation/agent workflow and quality gates.
 - [`process.md`](process.md) — artifact lifecycle and review gates.
 - [`code-quality.md`](code-quality.md) — Credo, ex_slop, and ex_dna policy.
+- [`../openspec/README.md`](../openspec/README.md) — OpenSpec change workflow
+  for substantial collaborator-reviewed changes.
 
 ### I want to change Console UI
 
@@ -58,6 +60,8 @@ large spec sections.
 - Normative product/system behavior: `../SPEC.md`.
 - Human workflow: `../CONTRIBUTING.md`.
 - Agent workflow and validation: `../AGENTS.md`.
+- OpenSpec change intent: `../openspec/README.md` and
+  `../openspec/changes/<change-id>/`.
 - Artifact lifecycle: `process.md` and `../goals/README.md`.
 
 If docs, tests, implementation, and `SPEC.md` disagree about product behavior,

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -11,7 +11,7 @@ orientation, and [`tooling.md`](tooling.md) for pinned tool versions.
 
 | Dependency | Version | Notes |
 |------------|---------|-------|
-| mise | see `../mise.toml` | Required for Erlang/OTP, Elixir, Python, and uv |
+| mise | see `../mise.toml` | Required for Erlang/OTP, Elixir, Python, uv, Node.js, and npm |
 | PostgreSQL | ≥ 15 | Local instance |
 
 See [Tooling](tooling.md) for the pinned runtime versions and standard
@@ -22,29 +22,37 @@ See [Tooling](tooling.md) for the pinned runtime versions and standard
 ```bash
 # 1. Clone and install dependencies
 cd orchard
+make setup
+
+# 2. Start the dev server (creates DB, migrates, starts Phoenix + node-agent)
+make dev
+```
+
+If you need the underlying commands instead of Makefile aliases:
+
+```bash
 mise trust
 mise install
 mise exec -- mix deps.get
-
-# 2. Install native Python packages (dev mode)
 mise exec -- uv sync --directory native/orchard_tokenizer
 mise exec -- uv sync --directory native/orchard_worker_mlx
-
-# 3. Start the dev server (creates DB, migrates, starts Phoenix + node-agent)
+mise exec -- npm ci --ignore-scripts
 mise exec -- bin/dev
+```
 
-# 4. Import a model bundle (in the running IEx session)
+```elixir
+# 3. Import a model bundle (in the running IEx session)
 OrchardCLI.main(["models", "import", "/path/to/model-bundle", "--activate"])
 
-# 5. Create a tenant and API key for /v1 API calls (in the running IEx session)
+# 4. Create a tenant and API key for /v1 API calls (in the running IEx session)
 OrchardCLI.main(["tenants", "create", "--slug", "dev", "--name", "Dev"])
 OrchardCLI.main(["api-keys", "create", "--tenant-id", "<tenant-id>", "--name", "dev"])
 ```
 
-`bin/dev` is the single entrypoint for source development. It creates the dev
-database if missing, runs migrations, and starts `iex -S mix phx.server` with
-the dev gRPC port set to **50071** (avoiding conflict with the packaged BEAM
-on 50061).
+`make dev` wraps `mise exec -- bin/dev`. `bin/dev` is the single low-level
+entrypoint for source development. It creates the dev database if missing, runs
+migrations, and starts `iex -S mix phx.server` with the dev gRPC port set to
+**50071** (avoiding conflict with the packaged BEAM on 50061).
 
 The controller listens on `http://localhost:4000` and the node-agent
 gRPC server on `127.0.0.1:50071`.
@@ -57,7 +65,7 @@ Orchard has two transport profiles:
 
 ### Source dev (this page)
 
-When running from a source checkout (`mise exec -- bin/dev` or
+When running from a source checkout (`make dev`, `mise exec -- bin/dev`, or
 `mise exec -- iex -S mix phx.server`):
 
 - Controller listens on **HTTP** at `http://127.0.0.1:4000`
@@ -116,8 +124,8 @@ posture.
 | `PORT` | `4000` | HTTP listen port |
 
 Cache-affinity, cache-introspection, and memory-admission env vars are read
-when `config/dev.exs` is evaluated at BEAM startup. Restart
-`mise exec -- bin/dev` or `mise exec -- iex -S mix phx.server` after changing
+when `config/dev.exs` is evaluated at BEAM startup. Restart `make dev`,
+`mise exec -- bin/dev`, or `mise exec -- iex -S mix phx.server` after changing
 them.
 
 Source-dev defaults remain disabled unless explicitly enabled via env vars:
@@ -735,7 +743,7 @@ Required production env vars:
 All-in-one local boot (dev):
 
 1. PostgreSQL must be running
-2. Run `mise exec -- bin/dev` — this handles DB bootstrap and server start:
+2. Run `make dev` or `mise exec -- bin/dev` — this handles DB bootstrap and server start:
    - Creates `orchard_dev` database if missing
    - Runs pending migrations
    - Exports dev gRPC port (50071)

--- a/docs/process.md
+++ b/docs/process.md
@@ -51,7 +51,7 @@ rewrite the durable conclusion instead of copying the stale plan.
 - Private local artifacts are not committed.
 - Active `goals/<slug>/` directories are not staged.
 - OpenSpec-backed changes pass
-  `mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive`.
+  `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive`.
 - Archived OpenSpec specs do not contain placeholders such as `Purpose TBD`.
 - Validation commands and outcomes are recorded.
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -20,9 +20,10 @@ For durable decisions, see [`decisions/README.md`](decisions/README.md).
 | Typo or docs clarification | Direct PR |
 | Small bug | Direct PR plus regression test when practical |
 | Internal refactor | Direct PR plus validation |
-| Behavior change | PR must state `SPEC.md` impact |
+| Behavior change | OpenSpec change or PR must state `SPEC.md` impact |
 | Architecture decision | Add or update `docs/decisions/**` when not already covered |
 | Normative invariant change | Update `SPEC.md` in the same branch |
+| Collaborator-owned substantial change | OpenSpec change package plus normal PR |
 
 ## Artifact Lifecycle
 
@@ -31,8 +32,10 @@ For durable decisions, see [`decisions/README.md`](decisions/README.md).
 | Idea or issue | GitHub issue, PR note, local scratch | Commit only if standalone and useful |
 | Local goal package | `goals/<slug>/` | Ignored; not committed by default |
 | Execution evidence | local evidence dirs and logs | Ignored unless sanitized and promoted |
+| OpenSpec proposed change | `openspec/changes/<change-id>/` | Commit when ready for collaborator review |
 | Shared product language | `docs/glossary/CONTEXT.md` | Commit when standalone and aligned with `SPEC.md` |
 | Durable decision | `docs/decisions/**` | Commit when standalone and product-relevant |
+| Accepted OpenSpec behavior | `openspec/specs/**`, `SPEC.md`, docs, tests, code | Commit only after reconciliation |
 | Normative behavior | `SPEC.md`, code, tests | Commit through normal review |
 
 ## Re-Grounding Rule
@@ -47,6 +50,9 @@ rewrite the durable conclusion instead of copying the stale plan.
 - Product docs do not duplicate large normative sections from `SPEC.md`.
 - Private local artifacts are not committed.
 - Active `goals/<slug>/` directories are not staged.
+- OpenSpec-backed changes pass
+  `mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive`.
+- Archived OpenSpec specs do not contain placeholders such as `Purpose TBD`.
 - Validation commands and outcomes are recorded.
 
 ## Optional Local Tools

--- a/docs/process.md
+++ b/docs/process.md
@@ -31,7 +31,7 @@ For durable decisions, see [`decisions/README.md`](decisions/README.md).
 |---|---|---|
 | Idea or issue | GitHub issue, PR note, local scratch | Commit only if standalone and useful |
 | Local goal package | `goals/<slug>/` | Ignored; not committed by default |
-| Execution evidence | local evidence dirs and logs | Ignored unless sanitized and promoted |
+| Local context/evidence | `.codex/`, `.claude/`, local evidence dirs, and logs | Ignored unless sanitized and promoted |
 | OpenSpec proposed change | `openspec/changes/<change-id>/` | Commit when ready for collaborator review |
 | Shared product language | `docs/glossary/CONTEXT.md` | Commit when standalone and aligned with `SPEC.md` |
 | Durable decision | `docs/decisions/**` | Commit when standalone and product-relevant |
@@ -52,6 +52,8 @@ rewrite the durable conclusion instead of copying the stale plan.
 - Active `goals/<slug>/` directories are not staged.
 - OpenSpec-backed changes pass
   `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive`.
+- Archived or synced OpenSpec behavior passes
+  `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`.
 - Archived OpenSpec specs do not contain placeholders such as `Purpose TBD`.
 - Validation commands and outcomes are recorded.
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -26,6 +26,9 @@ The pinned toolchain currently covers:
 | Elixir | `1.20.0-otp-29` | Mix, umbrella compilation, tests, releases |
 | Python | `3.11.15` | Native tokenizer and MLX worker packages |
 | uv | `0.11.23` | Python package sync, virtualenvs, native tests |
+| Node.js | `24.17.0` | Repository-local OpenSpec CLI runtime |
+| npm | `11.13.0` | Package manager bundled with pinned Node.js |
+| OpenSpec | `@fission-ai/openspec@1.4.1` | OpenSpec change/spec validation |
 
 The mise environment also sets:
 
@@ -116,13 +119,26 @@ mise exec -- mix proto.gen.worker
 
 ## Node Policy
 
-Orchard currently has JavaScript assets, but no first-party `package.json`,
-`npm`, `pnpm`, or `yarn` workflow. Phoenix asset builds use the Mix-managed
-`esbuild` and `tailwind` packages.
+Orchard has a minimal first-party npm workflow for repository-local OpenSpec
+validation. The only root npm dependency is the pinned OpenSpec CLI in
+`package.json` / `package-lock.json`.
 
-Do not add an npm-based or Node-based workflow without first adding the Node
-version to `mise.toml` and updating this document. If a first-party
-`package.json` appears, Node becomes part of the required mise toolchain.
+Phoenix asset builds still use the Mix-managed `esbuild` and `tailwind`
+packages. Do not add general app JavaScript dependencies, asset builds, or an
+alternate Node workflow without updating `mise.toml`, `package.json`,
+`package-lock.json`, and this document.
+
+Install the pinned Node package tools from the repo root:
+
+```bash
+mise exec -- npm ci --ignore-scripts
+```
+
+Run OpenSpec through the pinned npm script:
+
+```bash
+mise exec -- npm run openspec -- validate --all --strict --no-interactive
+```
 
 ## Tools Outside mise
 
@@ -139,6 +155,10 @@ by mise:
 
 Document these in the relevant runbook or packaging guide rather than adding
 them to `mise.toml`.
+
+OpenSpec is initialized for collaborator-reviewable change packages and pinned
+through the root npm workflow. For OpenSpec-backed branches, run the validation
+commands in [`../openspec/README.md`](../openspec/README.md).
 
 ## Agent Accelerator Tools
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -50,8 +50,24 @@ tool resolution matters.
 mise exec -- mix deps.get
 mise exec -- uv sync --directory native/orchard_tokenizer
 mise exec -- uv sync --directory native/orchard_worker_mlx
+mise exec -- npm ci --ignore-scripts
 mise exec -- bin/dev
 ```
+
+The root `Makefile` provides thin aliases over these pinned commands for common
+workflows:
+
+```bash
+make setup
+make dev
+make dev-controller
+make dev-node-agent
+make openspec
+make check-elixir
+```
+
+Use the documented `mise exec --` commands as the authority when a Makefile
+target and this guide disagree.
 
 Elixir validation:
 
@@ -122,6 +138,9 @@ mise exec -- mix proto.gen.worker
 Orchard has a minimal first-party npm workflow for repository-local OpenSpec
 validation. The only root npm dependency is the pinned OpenSpec CLI in
 `package.json` / `package-lock.json`.
+
+The root `.npmrc` sets `save-exact=true`; keep Node tool dependencies exact and
+commit the resulting `package-lock.json` changes.
 
 Phoenix asset builds still use the Mix-managed `esbuild` and `tailwind`
 packages. Do not add general app JavaScript dependencies, asset builds, or an
@@ -199,8 +218,8 @@ Toolchain bumps must be intentional. For any change to `mise.toml`:
 3. Run the affected validation gates under `mise exec --`.
 4. For Erlang/OTP or Elixir bumps, run the full Elixir workflow.
 5. For Python or uv bumps, run both native package workflows.
-6. For future Node bumps, run the first-party Node workflow that required the
-   pin.
+6. For Node, npm, or OpenSpec bumps, run the first-party Node workflow that
+   required the pin.
 
 If a toolchain bump changes product behavior or packaging behavior, state the
 `SPEC.md` impact and update the relevant docs, tests, or decision record.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -137,7 +137,7 @@ mise exec -- npm ci --ignore-scripts
 Run OpenSpec through the pinned npm script:
 
 ```bash
-mise exec -- npm run openspec -- validate --all --strict --no-interactive
+OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive
 ```
 
 ## Tools Outside mise

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ erlang = "29.0.2"
 elixir = "1.20.0-otp-29"
 python = "3.11.15"
 uv = "0.11.23"
+node = "24.17.0"
 
 [env]
 UV_PYTHON = "3.11"

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -1,15 +1,63 @@
 # OpenSpec
 
-This directory is reserved for a future structured-change workflow.
+This directory contains Orchard's initialized OpenSpec workflow.
 
 `SPEC.md` remains Orchard's top-level normative product/system contract.
 OpenSpec materials must be subordinate to `SPEC.md` and must not become a
 competing source of truth.
 
-Current policy:
+## Status
 
-- Do not create OpenSpec config or templates until the Orchard team verifies
-  the intended OpenSpec tooling and file format.
-- Do not mirror large sections of `SPEC.md` here.
-- If future OpenSpec changes are adopted, accepted behavior must reconcile with
-  `SPEC.md`, tests, and implementation in the same branch.
+- `config.yaml` selects the `spec-driven` schema.
+- Proposed changes live under `changes/<change-id>/`.
+- Accepted or archived specs live under `specs/<capability>/spec.md`.
+- Archived changes live under `changes/archive/`.
+
+## When To Use OpenSpec
+
+Use OpenSpec for substantial behavior, architecture, API, security/governance,
+node lifecycle, scheduling, packaging, or collaborator-owned changes.
+
+Small typo fixes, internal refactors, straightforward bug fixes, and tactical UI
+changes may still use direct PRs when `SPEC.md` impact is clear.
+
+## Change Package Shape
+
+A reviewable change package should include:
+
+- `proposal.md` for what changes and why
+- `specs/<capability>/spec.md` for requirement deltas
+- `tasks.md` for implementation checklist
+- `design.md` when the change has technical ambiguity, migration risk,
+  security/performance concerns, or cross-module impact
+
+Do not mirror large sections of `SPEC.md` here. Cite or summarize the affected
+contract and reconcile accepted behavior back into `SPEC.md`, docs, tests, and
+code as needed.
+
+## Validation
+
+Before implementing or handing off an OpenSpec-backed PR:
+
+```sh
+mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive
+```
+
+After archiving or syncing accepted behavior:
+
+```sh
+mise exec -- npm run openspec -- validate --all --strict --no-interactive
+```
+
+Strict validation checks structure, not product correctness. Review generated
+main specs for placeholders such as `Purpose TBD`, and treat stale or ambiguous
+requirements as blockers until reconciled with `SPEC.md`.
+
+## Artifact Hygiene
+
+Commit OpenSpec config and reviewed change/spec artifacts when they are durable
+and collaborator-facing.
+
+Do not commit generated `.codex/`, `.claude/`, prompt exports, local context
+stores, tool session identifiers, local evidence logs, credentials, DSNs, or
+machine-specific paths.

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -40,13 +40,13 @@ code as needed.
 Before implementing or handing off an OpenSpec-backed PR:
 
 ```sh
-mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive
+OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate <change-id> --type change --strict --no-interactive
 ```
 
 After archiving or syncing accepted behavior:
 
 ```sh
-mise exec -- npm run openspec -- validate --all --strict --no-interactive
+OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive
 ```
 
 Strict validation checks structure, not product correctness. Review generated

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -31,6 +31,12 @@ A reviewable change package should include:
 - `design.md` when the change has technical ambiguity, migration risk,
   security/performance concerns, or cross-module impact
 
+Requirement deltas use `SHALL` or `MUST` for normative behavior, include at
+least one scenario per requirement, and cite the affected `SPEC.md` section when
+changing product behavior. Tasks use checkbox items such as
+`- [ ] 1.1 Update validation docs`. Design files record alternatives and
+trade-offs when a durable technical choice is being made.
+
 Do not mirror large sections of `SPEC.md` here. Cite or summarize the affected
 contract and reconcile accepted behavior back into `SPEC.md`, docs, tests, and
 code as needed.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,25 @@
+schema: spec-driven
+
+context: |
+  Orchard is a sovereign on-prem LLM orchestration platform for Apple Silicon macOS.
+  Tech stack: Elixir/OTP umbrella app, Phoenix/LiveView console, Postgres, gRPC over mTLS, native macOS packaging, MLX-LM runtime adapter.
+  SPEC.md is the top-level normative product/system contract. OpenSpec materials are subordinate change-intent artifacts.
+  Behavior-changing work must state SPEC.md impact and reconcile accepted behavior with SPEC.md, docs, tests, and implementation.
+  Do not copy private workbench context, prompt exports, active goal packages, local evidence paths, credentials, DSNs, or tool session identifiers into OpenSpec artifacts.
+
+rules:
+  proposal:
+    - State SPEC.md impact explicitly, or say "No SPEC.md behavior impact."
+    - Keep proposals focused on why and what; put implementation details in design.md.
+    - Do not mirror large sections of SPEC.md.
+  specs:
+    - Use SHALL or MUST for normative requirements.
+    - Every requirement must include at least one scenario.
+    - Cite the affected SPEC.md section when changing product behavior.
+  design:
+    - Include design.md for cross-module, security, performance, migration, packaging, persistence, scheduling, or API changes.
+    - Record alternatives and trade-offs when a durable technical choice is being made.
+  tasks:
+    - Use checkbox tasks in the form "- [ ] X.Y Task description".
+    - Include validation tasks for OpenSpec and the relevant AGENTS.md workflow.
+    - Include a placeholder review task after archive or sync to remove generated prose such as "Purpose TBD".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1214 @@
+{
+  "name": "orchard-tooling",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "orchard-tooling",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@fission-ai/openspec": "1.4.1"
+      },
+      "engines": {
+        "node": "24.17.0",
+        "npm": "11.13.0"
+      }
+    },
+    "node_modules/@fission-ai/openspec": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.4.1.tgz",
+      "integrity": "sha512-C/NQsybgjqtSr29QAv4NbO1bZTgozu8GAUSiONthenZ5W4TQ2bvyj8LVmr76qb90iGeTLEFkcdnI+iYYaFLKyA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/prompts": "^7.8.0",
+        "chalk": "^5.5.0",
+        "commander": "^14.0.0",
+        "cross-spawn": "7.0.6",
+        "fast-glob": "^3.3.3",
+        "ora": "^8.2.0",
+        "posthog-node": "^5.20.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.0.17"
+      },
+      "bin": {
+        "openspec": "bin/openspec.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.35.3",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.35.3.tgz",
+      "integrity": "sha512-EsGPbSLl39Jgo2KZ+kI9UAxFnh5nddaN5bNm2rXvUwF+vGmam9eN1EXeNbxhRU7ulEeIiGdm7XjoU7pzavkgIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.390.2"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.390.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.390.2.tgz",
+      "integrity": "sha512-WcfKz2GNn2vfDX8vXmJYbKxegPxVWHuDQ/pHdAn0HoZDXDFnEp/+x3qBQA+fEvtbPjjtjgAt2wIgJMlM7asx7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.38.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.38.2.tgz",
+      "integrity": "sha512-eiKpU+vX4hVuHbO/EosvPHsmh2AVIdoVmWss/uUOs1t4b0ViCblw2o8OIFqHxKj3mYRnSOBlX0Dw3wBvcCaYpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.35.3"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "11.13.0"
   },
   "scripts": {
-    "openspec": "openspec"
+    "openspec": "OPENSPEC_TELEMETRY=0 openspec"
   },
   "devDependencies": {
     "@fission-ai/openspec": "1.4.1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "orchard-tooling",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Repository-local tooling pins for Orchard collaborator workflows.",
+  "packageManager": "npm@11.13.0",
+  "engines": {
+    "node": "24.17.0",
+    "npm": "11.13.0"
+  },
+  "scripts": {
+    "openspec": "openspec"
+  },
+  "devDependencies": {
+    "@fission-ai/openspec": "1.4.1"
+  }
+}


### PR DESCRIPTION
## Intent

Validate the committed Orchard docs/tooling change that pins OpenSpec through mise/npm, adds a thin Makefile command surface, and updates AGENTS/docs so collaborators and agents use reproducible commands without product runtime changes.

## What Changed

- Pin OpenSpec through the repo-managed Node/npm toolchain with committed package metadata, `.npmrc`, and mise wiring so collaborators can install and run the same CLI version.
- Add Makefile helpers for setup, help, and OpenSpec validation, with OpenSpec telemetry disabled by default for routine repo validation.
- Update contributor, agent, tooling, local-dev, process, and OpenSpec docs to make the pinned command surface and validation workflow explicit.

## Risk Assessment

✅ Low: The change is limited to repository-local tooling pins, Makefile aliases, OpenSpec config, and matching docs, with the prior telemetry concern addressed in both commands and validation snippets.

## Testing

I exercised the complete end-user OpenSpec tooling path for this docs/tooling branch: first confirmed the diff scope, captured the Makefile help surface, observed that plain `mise exec` requires the documented trust step in this isolated worktree, used `MISE_TRUSTED_CONFIG_PATHS` to simulate that trust without modifying user-level config, verified Node `v24.17.0`, npm `11.13.0`, and OpenSpec `1.4.1`, ran `make setup-openspec`, ran `make openspec`, saved CLI transcripts as evidence, removed generated `node_modules`, and finished with a clean worktree.

<details>
<summary>Evidence: Makefile command surface</summary>

<code>Orchard command targets include `make setup-openspec` through setup and `make openspec` for pinned OpenSpec validation.</code>

```text
Orchard command targets:
  make setup          Install pinned repo dependencies
  make dev            Run source dev in the foreground
  make dev-controller Run source-dev controller host
  make dev-node-agent Run source-dev node-agent host
  make openspec       Run pinned OpenSpec validation
  make format         Run Elixir formatter
  make test           Run default test suite
  make check-elixir   Run full Elixir quality workflow
```
</details>
<details>
<summary>Evidence: mise-pinned Node version</summary>

`v24.17.0`

```text
v24.17.0
```
</details>
<details>
<summary>Evidence: mise-pinned npm version</summary>

`11.13.0`

```text
11.13.0
```
</details>
<details>
<summary>Evidence: OpenSpec setup transcript</summary>

<code>`make setup-openspec` ran `mise exec -- npm ci --ignore-scripts` and installed 80 packages from the lockfile with 0 vulnerabilities reported.</code>

```text
mise exec -- npm ci --ignore-scripts

added 80 packages, and audited 81 packages in 572ms

25 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```
</details>
<details>
<summary>Evidence: Pinned OpenSpec dependency</summary>

<code>`npm ls` reports `@fission-ai/openspec@1.4.1`; the npm script reports OpenSpec CLI version `1.4.1`.</code>

```text
orchard-tooling@0.0.0 /Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVQ2B9VY8YET5J5M7K527QGK
└── @fission-ai/openspec@1.4.1
```
</details>
<details>
<summary>Evidence: Strict OpenSpec validation transcript</summary>

<code>`make openspec` invoked `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` and completed successfully with `No items found to validate.`</code>

```text
OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive

> orchard-tooling@0.0.0 openspec
> OPENSPEC_TELEMETRY=0 openspec validate --all --strict --no-interactive

No items found to validate.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `Makefile:39` - `make openspec` now runs the pinned OpenSpec CLI without an opt-out env var; `@fission-ai/openspec@1.4.1` enables telemetry by default for every command, persists an anonymous ID/notice in the user config dir, and attempts outbound PostHog traffic unless `OPENSPEC_TELEMETRY=0`, `DO_NOT_TRACK=1`, or `CI=true` is set. For Orchard&#39;s sovereign/air-gap-oriented workflow, wrap the Makefile target and documented validation snippets with `OPENSPEC_TELEMETRY=0` so routine validation stays repo-local and non-networked by default.

🔧 Fix: Disable OpenSpec telemetry by default
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pwd`
- `git status --short --branch`
- `git diff --stat 7ecc5c38bd4cad83eb110ab5d9fe26811622181d..5e41118132ff9ec2eb196a7759594d3424d240b0`
- `git diff --name-only 7ecc5c38bd4cad83eb110ab5d9fe26811622181d..5e41118132ff9ec2eb196a7759594d3424d240b0`
- `make help > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/make-help.txt 2>&1`
- `mise exec -- node --version > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/node-version.txt 2>&1`
- `mise exec -- npm --version > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/npm-version.txt 2>&1`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVQ2B9VY8YET5J5M7K527QGK/mise.toml mise exec -- node --version > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/node-version-trusted-env.txt 2>&1`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVQ2B9VY8YET5J5M7K527QGK/mise.toml mise exec -- npm --version > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/npm-version-trusted-env.txt 2>&1`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVQ2B9VY8YET5J5M7K527QGK/mise.toml make setup-openspec > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/make-setup-openspec.txt 2>&1`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVQ2B9VY8YET5J5M7K527QGK/mise.toml mise exec -- npm ls @fission-ai/openspec --depth=0 > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/npm-ls-openspec.txt 2>&1`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVQ2B9VY8YET5J5M7K527QGK/mise.toml mise exec -- npm run openspec -- --version > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/openspec-version.txt 2>&1`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KVQ2B9VY8YET5J5M7K527QGK/mise.toml make openspec > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQ2B9VY8YET5J5M7K527QGK/make-openspec.txt 2>&1`
- `rm -rf node_modules`
- `test ! -d node_modules`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
