### PR TITLE
fix: harden collaborator stub dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ setup-elixir:
 	mise install
 	ERL_AFLAGS="$(MIX_BOOTSTRAP_ERL_AFLAGS)" mise exec -- mix local.hex --if-missing --force
 	ERL_AFLAGS="$(MIX_BOOTSTRAP_ERL_AFLAGS)" mise exec -- mix local.rebar --if-missing --force
-	mise exec -- mix deps.get
+	ERL_AFLAGS="$(MIX_BOOTSTRAP_ERL_AFLAGS)" mise exec -- mix deps.get
 
 setup-native:
 	mise exec -- uv sync --directory native/orchard_tokenizer

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: help setup setup-elixir setup-native setup-openspec dev dev-controller dev-node-agent openspec format compile credo dialyzer test cover check-elixir
 
+MIX_BOOTSTRAP_ERL_AFLAGS = -ssl protocol_version \"['tlsv1.2']\"
+
 help:
 	@printf '%s\n' \
 	  'Orchard command targets:' \
@@ -17,6 +19,8 @@ setup: setup-elixir setup-native setup-openspec
 setup-elixir:
 	mise trust
 	mise install
+	ERL_AFLAGS="$(MIX_BOOTSTRAP_ERL_AFLAGS)" mise exec -- mix local.hex --if-missing --force
+	ERL_AFLAGS="$(MIX_BOOTSTRAP_ERL_AFLAGS)" mise exec -- mix local.rebar --if-missing --force
 	mise exec -- mix deps.get
 
 setup-native:

--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ This creates a native macOS PKG installer following the naming convention
 `Orchard-<version>-<date>-<git-sha>.pkg`. Use `--clean` for reproducible
 builds from scratch, or `--allow-dirty` for development builds.
 
-**Prerequisites:** `mise install` from the repo root, plus macOS packaging
-tools. The script validates dependencies and provides helpful errors if
-anything is missing.
+**Prerequisites:** run `make setup` from the repo root, or run
+`mise trust && mise install` plus the setup commands in
+[`docs/local-dev.md`](docs/local-dev.md), before building. You also need the
+macOS packaging tools. The script validates dependencies and provides helpful
+errors if anything is missing.
 
 See [packaging/pkg/README.md](packaging/pkg/README.md#building-the-pkg) for
 full build documentation.

--- a/apps/orchard_cli/test/orchard_cli/build_pkg_script_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/build_pkg_script_test.exs
@@ -39,6 +39,21 @@ defmodule OrchardCLI.BuildPkgScriptTest do
     assert script =~ "default channel: trial"
   end
 
+  test "package build bootstraps pinned asset dependencies before deploy" do
+    script = File.read!(@script_path)
+
+    mix_deps_index = index_of(script, "mix deps.get")
+    assets_setup_index = index_of(script, "MIX_ENV=prod mix assets.setup")
+    assets_deploy_index = index_of(script, "MIX_ENV=prod mix assets.deploy")
+
+    assert is_integer(mix_deps_index)
+    assert is_integer(assets_setup_index)
+    assert is_integer(assets_deploy_index)
+
+    assert mix_deps_index < assets_setup_index
+    assert assets_setup_index < assets_deploy_index
+  end
+
   defp index_of(haystack, needle) do
     case :binary.match(haystack, needle) do
       {index, _length} -> index

--- a/apps/orchard_controller/mix.exs
+++ b/apps/orchard_controller/mix.exs
@@ -65,7 +65,7 @@ defmodule OrchardController.MixProject do
       setup: ["deps.get", "assets.setup", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
+      "assets.setup": [&npm_ci/1],
       "assets.build": ["tailwind orchard", "esbuild orchard"],
       "assets.deploy": [
         "tailwind orchard --minify",
@@ -73,5 +73,22 @@ defmodule OrchardController.MixProject do
         "phx.digest"
       ]
     ]
+  end
+
+  defp npm_ci(_args) do
+    npm =
+      System.find_executable("npm") ||
+        Mix.raise("npm not found. Run `mise install` before running `mix assets.setup`.")
+
+    case System.cmd(
+           npm,
+           ["ci", "--ignore-scripts"],
+           cd: Path.expand("../..", __DIR__),
+           into: IO.stream(:stdio, :line),
+           stderr_to_stdout: true
+         ) do
+      {_output, 0} -> :ok
+      {_output, status} -> Mix.raise("npm ci --ignore-scripts failed with exit status #{status}")
+    end
   end
 end

--- a/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
@@ -1,28 +1,29 @@
 defmodule Orchard.Node.RuntimeEnvValidationTest do
   use ExUnit.Case, async: false
 
-  @tracked_env_vars [
-    "RELEASE_NAME",
+  @config_env_vars [
+    "DATABASE_URL",
+    "ECTO_IPV6",
+    "HF_TOKEN",
     "MIX_RELEASE_NAME",
-    "ORCHARD_SUPPORT_ROOT",
-    "ORCHARD_WORKER_BACKEND",
-    "ORCHARD_WORKER_GENERATION_MODE",
-    "ORCHARD_WORKER_MAX_CONCURRENT_REQUESTS_PER_MODEL",
-    "ORCHARD_WORKER_AUTO_MAX_CONCURRENT_REQUESTS_PER_MODEL",
-    "ORCHARD_WORKER_MEMORY_BUDGET_MODE",
-    "ORCHARD_WORKER_MEMORY_BUDGET_UTILIZATION",
-    "ORCHARD_WORKER_MEMORY_BUDGET_OVERHEAD_BYTES"
+    "PGDATABASE",
+    "PGHOST",
+    "PGPASSWORD",
+    "PGUSER",
+    "PHX_HOST",
+    "POOL_SIZE",
+    "PORT",
+    "RELEASE_NAME",
+    "SECRET_KEY_BASE"
   ]
 
   setup do
-    snapshot = Map.new(@tracked_env_vars, fn key -> {key, System.get_env(key)} end)
+    snapshot =
+      System.get_env()
+      |> Enum.filter(fn {key, _value} -> config_env_key?(key) end)
+      |> Map.new()
 
-    on_exit(fn ->
-      Enum.each(snapshot, fn
-        {key, nil} -> System.delete_env(key)
-        {key, value} -> System.put_env(key, value)
-      end)
-    end)
+    on_exit(fn -> restore_config_env!(snapshot) end)
 
     :ok
   end
@@ -137,6 +138,19 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert runtime[:worker_generation_mode] == "batch"
   end
 
+  test "dev.exs evaluation ignores ambient config env outside overrides" do
+    System.put_env("PORT", "not-a-port")
+    System.put_env("ORCHARD_PREFIX_CACHE_SCORING_MAX_RANKING_CANDIDATES", "0")
+
+    runtime =
+      read_dev_config!(%{"ORCHARD_WORKER_BACKEND" => "stub"})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:worker_backend] == "stub"
+    assert runtime[:worker_generation_mode] == "stream"
+  end
+
   test "runtime.exs accepts valid worker generation and memory settings in prod" do
     config =
       read_runtime_config!(%{
@@ -184,7 +198,7 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
   end
 
   defp put_config_env!(env) do
-    Enum.each(@tracked_env_vars, &System.delete_env/1)
+    clear_config_env!()
 
     Enum.each(env, fn
       {key, nil} -> System.delete_env(key)
@@ -198,5 +212,21 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
 
   defp dev_config_path do
     Path.expand("../../../../../config/dev.exs", __DIR__)
+  end
+
+  defp restore_config_env!(snapshot) do
+    clear_config_env!()
+    Enum.each(snapshot, fn {key, value} -> System.put_env(key, value) end)
+  end
+
+  defp clear_config_env! do
+    System.get_env()
+    |> Map.keys()
+    |> Enum.filter(&config_env_key?/1)
+    |> Enum.each(&System.delete_env/1)
+  end
+
+  defp config_env_key?(key) do
+    key in @config_env_vars or String.starts_with?(key, "ORCHARD_")
   end
 end

--- a/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
@@ -5,6 +5,7 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     "RELEASE_NAME",
     "MIX_RELEASE_NAME",
     "ORCHARD_SUPPORT_ROOT",
+    "ORCHARD_WORKER_BACKEND",
     "ORCHARD_WORKER_GENERATION_MODE",
     "ORCHARD_WORKER_MAX_CONCURRENT_REQUESTS_PER_MODEL",
     "ORCHARD_WORKER_AUTO_MAX_CONCURRENT_REQUESTS_PER_MODEL",
@@ -90,6 +91,52 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert runtime[:worker_memory_budget_overhead_bytes] == 1_073_741_824
   end
 
+  test "runtime.exs defaults stub backend generation to stream in prod" do
+    runtime =
+      read_runtime_config!(%{"ORCHARD_WORKER_BACKEND" => "stub"})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:worker_backend] == "stub"
+    assert runtime[:worker_generation_mode] == "stream"
+  end
+
+  test "runtime.exs explicit generation mode overrides stub backend default in prod" do
+    runtime =
+      read_runtime_config!(%{
+        "ORCHARD_WORKER_BACKEND" => "stub",
+        "ORCHARD_WORKER_GENERATION_MODE" => "batch"
+      })
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:worker_backend] == "stub"
+    assert runtime[:worker_generation_mode] == "batch"
+  end
+
+  test "dev.exs defaults stub backend generation to stream" do
+    runtime =
+      read_dev_config!(%{"ORCHARD_WORKER_BACKEND" => "stub"})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:worker_backend] == "stub"
+    assert runtime[:worker_generation_mode] == "stream"
+  end
+
+  test "dev.exs explicit generation mode overrides stub backend default" do
+    runtime =
+      read_dev_config!(%{
+        "ORCHARD_WORKER_BACKEND" => "stub",
+        "ORCHARD_WORKER_GENERATION_MODE" => "batch"
+      })
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:worker_backend] == "stub"
+    assert runtime[:worker_generation_mode] == "batch"
+  end
+
   test "runtime.exs accepts valid worker generation and memory settings in prod" do
     config =
       read_runtime_config!(%{
@@ -125,15 +172,31 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
 
     base
     |> Map.merge(overrides)
-    |> Enum.each(fn
-      {key, nil} -> System.delete_env(key)
-      {key, value} -> System.put_env(key, value)
-    end)
+    |> put_config_env!()
 
     Config.Reader.read!(runtime_config_path(), env: :prod)
   end
 
+  defp read_dev_config!(overrides) do
+    put_config_env!(overrides)
+
+    Config.Reader.read!(dev_config_path(), env: :dev)
+  end
+
+  defp put_config_env!(env) do
+    Enum.each(@tracked_env_vars, &System.delete_env/1)
+
+    Enum.each(env, fn
+      {key, nil} -> System.delete_env(key)
+      {key, value} -> System.put_env(key, value)
+    end)
+  end
+
   defp runtime_config_path do
     Path.expand("../../../../../config/runtime.exs", __DIR__)
+  end
+
+  defp dev_config_path do
+    Path.expand("../../../../../config/dev.exs", __DIR__)
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -61,6 +61,8 @@ config :orchard_shared,
 # esbuild (JS bundling for LiveView client hooks)
 config :esbuild,
   version: "0.25.0",
+  version_check: false,
+  path: Path.expand("../node_modules/.bin/esbuild", __DIR__),
   orchard: [
     args: ~w(js/app.js --bundle --target=es2020 --outdir=../priv/static/assets),
     cd: Path.expand("../apps/orchard_controller/assets", __DIR__),
@@ -70,6 +72,8 @@ config :esbuild,
 # tailwind (CSS compilation with brand palette)
 config :tailwind,
   version: "4.1.3",
+  version_check: false,
+  path: Path.expand("../node_modules/.bin/tailwindcss", __DIR__),
   orchard: [
     args: ~w(
       --input=css/app.css

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -240,6 +240,10 @@ memory_admission_config =
 
 node_runtime_defaults = Orchard.Config.M1RuntimeDefaults.node_runtime(dev_root)
 
+worker_backend =
+  env_optional_string.("ORCHARD_WORKER_BACKEND") ||
+    Keyword.fetch!(node_runtime_defaults, :worker_backend)
+
 worker_prefix_cache_mode =
   (fn ->
      mode =
@@ -257,7 +261,11 @@ worker_generation_mode =
   (fn ->
      mode =
        System.get_env("ORCHARD_WORKER_GENERATION_MODE") ||
-         Keyword.fetch!(node_runtime_defaults, :worker_generation_mode)
+         if worker_backend == "stub" do
+           "stream"
+         else
+           Keyword.fetch!(node_runtime_defaults, :worker_generation_mode)
+         end
 
      unless mode in ["stream", "batch"] do
        raise "ORCHARD_WORKER_GENERATION_MODE must be stream|batch, got: #{inspect(mode)}"
@@ -338,8 +346,7 @@ config :orchard_node_agent,
       worker_executable:
         System.get_env("ORCHARD_WORKER_EXECUTABLE") ||
           Path.join([repo_root, "native", "orchard_worker_mlx", "bin", "orchard-worker-mlx"]),
-      worker_backend:
-        env_optional_string.("ORCHARD_WORKER_BACKEND") || node_runtime_defaults[:worker_backend],
+      worker_backend: worker_backend,
       worker_prefix_cache_mode: worker_prefix_cache_mode,
       worker_generation_mode: worker_generation_mode,
       worker_max_concurrent_requests_per_model: worker_max_concurrent_requests_per_model,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -338,6 +338,8 @@ config :orchard_node_agent,
       worker_executable:
         System.get_env("ORCHARD_WORKER_EXECUTABLE") ||
           Path.join([repo_root, "native", "orchard_worker_mlx", "bin", "orchard-worker-mlx"]),
+      worker_backend:
+        env_optional_string.("ORCHARD_WORKER_BACKEND") || node_runtime_defaults[:worker_backend],
       worker_prefix_cache_mode: worker_prefix_cache_mode,
       worker_generation_mode: worker_generation_mode,
       worker_max_concurrent_requests_per_model: worker_max_concurrent_requests_per_model,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -93,6 +93,11 @@ env_optional_string = fn env_name ->
   end
 end
 
+default_worker_generation_mode = fn
+  "stub" -> "stream"
+  _backend -> "batch"
+end
+
 env_tokenizer_safe_mode = fn env_name, default ->
   case System.get_env(env_name) || default do
     value when value in [:off, "off"] ->
@@ -589,6 +594,8 @@ if config_env() == :prod do
   orchard_support_root =
     System.get_env("ORCHARD_SUPPORT_ROOT") || "/Library/Application Support/Orchard"
 
+  runtime_worker_backend = System.get_env("ORCHARD_WORKER_BACKEND") || "mlx"
+
   license_enforcement_mode =
     Orchard.Licensing.resolve_enforcement_mode(
       env_optional_string.("ORCHARD_LICENSE_ENFORCEMENT"),
@@ -1038,7 +1045,7 @@ if config_env() == :prod do
                 Path.join([orchard_support_root, "data", "worker-sockets"]),
             worker_executable:
               System.get_env("ORCHARD_WORKER_EXECUTABLE") || "orchard-worker-mlx",
-            worker_backend: System.get_env("ORCHARD_WORKER_BACKEND") || "mlx",
+            worker_backend: runtime_worker_backend,
             worker_ready_timeout_ms: env_int.("ORCHARD_WORKER_READY_TIMEOUT_MS", "5000"),
             worker_load_timeout_ms: env_int.("ORCHARD_WORKER_LOAD_TIMEOUT_MS", "120000"),
             worker_shutdown_timeout_ms: env_int.("ORCHARD_WORKER_SHUTDOWN_TIMEOUT_MS", "1000"),
@@ -1077,7 +1084,9 @@ if config_env() == :prod do
                end).(),
             worker_generation_mode:
               (fn ->
-                 mode = System.get_env("ORCHARD_WORKER_GENERATION_MODE") || "batch"
+                 mode =
+                   System.get_env("ORCHARD_WORKER_GENERATION_MODE") ||
+                     default_worker_generation_mode.(runtime_worker_backend)
 
                  unless mode in ["stream", "batch"] do
                    raise "ORCHARD_WORKER_GENERATION_MODE must be stream|batch, got: #{inspect(mode)}"

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -195,8 +195,7 @@ ELIXIR
 | `ORCHARD_MODELS_ROOT` | `tmp/dev/models` | Model artifact storage |
 | `ORCHARD_WORKER_SOCKET_DIR` | `tmp/dev/data/worker-sockets` | Worker UDS directory |
 | `ORCHARD_WORKER_EXECUTABLE` | `native/orchard_worker_mlx/bin/orchard-worker-mlx` (repo-root) | Worker binary path. Override via env var; default resolves from repo root in source-dev mode. |
-| `ORCHARD_WORKER_BACKEND` | `mlx` | Inference backend |
-| `ORCHARD_FAKE_RUNTIME` | `false` | Use fake runtime (for testing without GPU) |
+| `ORCHARD_WORKER_BACKEND` | `mlx` | Worker backend (`mlx` or `stub`) |
 | `ORCHARD_NODE_DISPLAY_NAME` | hostname | Human-readable node name shown in console |
 | `ORCHARD_LICENSE_ENFORCEMENT` | `off` (source dev) / `hard` (distributed packaged channels) | Licensing mode for startup and packaged useful-work admission: `off`, `warn`, or `hard` |
 
@@ -204,6 +203,8 @@ Node-agent runtime env vars are read when `config/dev.exs` is evaluated at BEAM
 startup. Restart `make dev`, `mise exec -- bin/dev`, or `mise exec --
 bin/dev-node-agent` after changing them. Use `ORCHARD_WORKER_BACKEND=stub` for
 cluster mechanics or rollback testing when real MLX inference is not required.
+`ORCHARD_FAKE_RUNTIME` is a release/runtime config knob; source-dev tests use
+the fake runtime through `config/test.exs`, not a dev env override.
 
 #### Controller Multi-Node (Source Dev)
 
@@ -435,8 +436,8 @@ separate from `mix test`, which uses the fake/stub runtime and requires no GPU.
 
 - Apple Silicon Mac (M1/M2/M3/M4)
 - A local Orchard model bundle directory (not downloaded by the script)
-- `mise install` already run in the repo
-- `mise exec -- mix deps.get` already run in the repo
+- `make setup` already run in the repo, or the equivalent manual setup commands
+  from [Quick Start](#quick-start)
 
 ### Required Environment Variable
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -47,11 +47,9 @@ If you need the underlying commands instead of Makefile aliases:
 ```bash
 mise trust
 mise install
-export ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\""
-mise exec -- mix local.hex --if-missing --force
-mise exec -- mix local.rebar --if-missing --force
-mise exec -- mix deps.get
-unset ERL_AFLAGS
+ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.hex --if-missing --force
+ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.rebar --if-missing --force
+ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix deps.get
 mise exec -- uv sync --directory native/orchard_tokenizer
 mise exec -- uv sync --directory native/orchard_worker_mlx
 mise exec -- npm ci --ignore-scripts
@@ -196,13 +194,16 @@ ELIXIR
 | `ORCHARD_WORKER_SOCKET_DIR` | `tmp/dev/data/worker-sockets` | Worker UDS directory |
 | `ORCHARD_WORKER_EXECUTABLE` | `native/orchard_worker_mlx/bin/orchard-worker-mlx` (repo-root) | Worker binary path. Override via env var; default resolves from repo root in source-dev mode. |
 | `ORCHARD_WORKER_BACKEND` | `mlx` | Worker backend (`mlx` or `stub`) |
+| `ORCHARD_WORKER_GENERATION_MODE` | `batch` for `mlx`, `stream` for unset `stub` | Worker generation runtime (`stream` or `batch`). Leave unset when using the stub backend. |
 | `ORCHARD_NODE_DISPLAY_NAME` | hostname | Human-readable node name shown in console |
 | `ORCHARD_LICENSE_ENFORCEMENT` | `off` (source dev) / `hard` (distributed packaged channels) | Licensing mode for startup and packaged useful-work admission: `off`, `warn`, or `hard` |
 
 Node-agent runtime env vars are read when `config/dev.exs` is evaluated at BEAM
 startup. Restart `make dev`, `mise exec -- bin/dev`, or `mise exec --
 bin/dev-node-agent` after changing them. Use `ORCHARD_WORKER_BACKEND=stub` for
-cluster mechanics or rollback testing when real MLX inference is not required.
+cluster mechanics or rollback testing when real MLX inference is not required;
+when `ORCHARD_WORKER_GENERATION_MODE` is unset, the stub backend resolves to
+stream mode automatically.
 `ORCHARD_FAKE_RUNTIME` is a release/runtime config knob; source-dev tests use
 the fake runtime through `config/test.exs`, not a dev env override.
 
@@ -390,7 +391,8 @@ ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0 \
 
 The node-agent boots standalone — no Postgres, controller, or asset watchers
 needed. Use `stub` backend for cluster mechanics testing; switch to `mlx` when
-real inference is required.
+real inference is required. No `ORCHARD_WORKER_GENERATION_MODE` override is
+needed for the stub backend; source dev resolves it to stream mode when unset.
 
 ### Verification
 
@@ -684,7 +686,9 @@ export ORCHARD_WORKER_BACKEND=stub
 mise exec -- iex -S mix phx.server
 ```
 
-Verify: the node-agent log will show `worker starting backend=stub`.
+Verify: the node-agent log will show `worker starting backend=stub`. No
+generation-mode override is required; `stub` resolves to stream mode when the
+mode env var is unset.
 
 ### Packaged Install (launchd)
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -17,6 +17,20 @@ orientation, and [`tooling.md`](tooling.md) for pinned tool versions.
 See [Tooling](tooling.md) for the pinned runtime versions and standard
 `mise exec --` command forms.
 
+PostgreSQL must be accepting TCP connections before `make dev` runs. On a
+Homebrew-managed Mac, install and start it with:
+
+```bash
+brew install postgresql@16
+brew services start postgresql@16
+pg_isready -h localhost
+```
+
+The dev config defaults to `PGUSER=postgres`, `PGPASSWORD=postgres`,
+`PGHOST=localhost`, and `PGDATABASE=orchard_dev`. Either create that local role
+with database-create privileges, or export `PGUSER`/`PGPASSWORD` for an
+existing local superuser before running `make dev`.
+
 ## Quick Start
 
 ```bash
@@ -33,6 +47,10 @@ If you need the underlying commands instead of Makefile aliases:
 ```bash
 mise trust
 mise install
+export ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\""
+mise exec -- mix local.hex --if-missing --force
+mise exec -- mix local.rebar --if-missing --force
+unset ERL_AFLAGS
 mise exec -- mix deps.get
 mise exec -- uv sync --directory native/orchard_tokenizer
 mise exec -- uv sync --directory native/orchard_worker_mlx
@@ -182,6 +200,11 @@ ELIXIR
 | `ORCHARD_NODE_DISPLAY_NAME` | hostname | Human-readable node name shown in console |
 | `ORCHARD_LICENSE_ENFORCEMENT` | `off` (source dev) / `hard` (distributed packaged channels) | Licensing mode for startup and packaged useful-work admission: `off`, `warn`, or `hard` |
 
+Node-agent runtime env vars are read when `config/dev.exs` is evaluated at BEAM
+startup. Restart `make dev`, `mise exec -- bin/dev`, or `mise exec --
+bin/dev-node-agent` after changing them. Use `ORCHARD_WORKER_BACKEND=stub` for
+cluster mechanics or rollback testing when real MLX inference is not required.
+
 #### Controller Multi-Node (Source Dev)
 
 | Variable | Default | Description |
@@ -239,7 +262,7 @@ tmp/dev/
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health/live` | Liveness probe |
-| GET | `/health/ready` | Readiness probe (DB check) |
+| GET | `/health/ready` | Readiness probe (DB, transport, runtime summary) |
 | GET | `/v1/models` | List active models; Bearer token required |
 | POST | `/v1/chat/completions` | Chat completion; stream + non-stream; Bearer token required |
 | POST | `/v1/responses` | Bounded Responses API subset; stream + non-stream; Bearer token required |
@@ -695,7 +718,7 @@ sudo launchctl kickstart -k system/com.orchard.node-agent
 
 1. Check service is running: `sudo launchctl list | grep orchard`
 2. Check backend in logs: look for `worker starting backend=stub` or `backend=mlx`
-3. Test inference: `curl http://localhost:4000/health/ready`
+3. Test source-dev liveness: `curl http://localhost:4000/health/live`
 4. Run a chat completion — stub returns canned responses, mlx returns real inference
 
 ## Smoke Test Troubleshooting
@@ -753,7 +776,10 @@ All-in-one local boot (dev):
 3. Import at least one model bundle with `OrchardCLI.main(["models", "import", "<path>", "--activate"])`
 4. Create a tenant and API key with `OrchardCLI.main(["tenants", ...])` and
    `OrchardCLI.main(["api-keys", ...])`
-5. API is ready for authenticated requests
+5. Source-dev HTTP is live at `/health/live`; `/health/ready` can remain
+   degraded under the default `plain_http_localhost` transport until HTTPS or a
+   reverse proxy is configured.
+6. API routes are reachable over loopback HTTP for authenticated local testing.
 
 Alternatively, for advanced debugging or when you need a BEAM without the
 HTTP server, you can run the steps manually:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -50,8 +50,8 @@ mise install
 export ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\""
 mise exec -- mix local.hex --if-missing --force
 mise exec -- mix local.rebar --if-missing --force
-unset ERL_AFLAGS
 mise exec -- mix deps.get
+unset ERL_AFLAGS
 mise exec -- uv sync --directory native/orchard_tokenizer
 mise exec -- uv sync --directory native/orchard_worker_mlx
 mise exec -- npm ci --ignore-scripts

--- a/docs/milestones/m0-foundation.md
+++ b/docs/milestones/m0-foundation.md
@@ -76,10 +76,13 @@ Establish the Orchard repository skeleton, release boundaries, health endpoints,
 ### Health surface
 
 - `/health/live` implemented as a basic controller liveness endpoint
-- `/health/ready` implemented for the M0 subset only:
+- `/health/ready` initially implemented for the M0 subset:
   - controller boot completed
   - Postgres reachable
   - migrations current, once the repo/migration pipeline is wired
+- Current readiness also reports public API transport posture; loopback
+  `plain_http_localhost` is degraded per `SPEC.md` §10.7, so source-dev smoke
+  checks should use `/health/live` for liveness.
 - tenant/model/key cache loading and HA-lite leadership gating remain deferred to later milestone work per `SPEC.md` §3.1
 
 ### Packaging scaffold
@@ -152,7 +155,8 @@ These checks support implementation confidence during M0 but are not independent
 - `mix compile` succeeds
 - CLI binary/module entrypoint resolves
 - `/health/live` responds
-- `/health/ready` responds for the planned M0 subset described above
+- `/health/ready` responds and reports the current readiness summary described
+  above
 - packaging skeleton matches expected Orchard naming and layout
 
 ## Validation

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -47,7 +47,9 @@ Documentation and automation should prefer the explicit form when reproducible
 tool resolution matters.
 
 ```bash
+export ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\""
 mise exec -- mix deps.get
+unset ERL_AFLAGS
 mise exec -- uv sync --directory native/orchard_tokenizer
 mise exec -- uv sync --directory native/orchard_worker_mlx
 mise exec -- npm ci --ignore-scripts

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -136,16 +136,19 @@ mise exec -- mix proto.gen.worker
 ## Node Policy
 
 Orchard has a minimal first-party npm workflow for repository-local OpenSpec
-validation. The only root npm dependency is the pinned OpenSpec CLI in
-`package.json` / `package-lock.json`.
+validation and the Phoenix asset CLI binaries used by source dev. The root npm
+dependencies are the pinned OpenSpec CLI plus pinned `esbuild`, `tailwindcss`,
+and `@tailwindcss/cli` versions in `package.json` / `package-lock.json`.
 
 The root `.npmrc` sets `save-exact=true`; keep Node tool dependencies exact and
 commit the resulting `package-lock.json` changes.
 
-Phoenix asset builds still use the Mix-managed `esbuild` and `tailwind`
-packages. Do not add general app JavaScript dependencies, asset builds, or an
-alternate Node workflow without updating `mise.toml`, `package.json`,
-`package-lock.json`, and this document.
+Phoenix asset builds still run through the Mix `esbuild` and `tailwind`
+wrappers, but those wrappers point at the npm-managed binaries under
+`node_modules/.bin` to avoid first-run binary downloads from inside
+`mix phx.server`. Do not add general app JavaScript dependencies, broader asset
+builds, or an alternate Node workflow without updating `mise.toml`,
+`package.json`, `package-lock.json`, and this document.
 
 Install the pinned Node package tools from the repo root:
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -49,11 +49,9 @@ Documentation and automation should prefer the explicit form when reproducible
 tool resolution matters.
 
 ```bash
-export ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\""
-mise exec -- mix local.hex --if-missing --force
-mise exec -- mix local.rebar --if-missing --force
-mise exec -- mix deps.get
-unset ERL_AFLAGS
+ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.hex --if-missing --force
+ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.rebar --if-missing --force
+ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix deps.get
 mise exec -- uv sync --directory native/orchard_tokenizer
 mise exec -- uv sync --directory native/orchard_worker_mlx
 mise exec -- npm ci --ignore-scripts

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -26,9 +26,11 @@ The pinned toolchain currently covers:
 | Elixir | `1.20.0-otp-29` | Mix, umbrella compilation, tests, releases |
 | Python | `3.11.15` | Native tokenizer and MLX worker packages |
 | uv | `0.11.23` | Python package sync, virtualenvs, native tests |
-| Node.js | `24.17.0` | Repository-local OpenSpec CLI runtime |
-| npm | `11.13.0` | Package manager bundled with pinned Node.js |
+| Node.js | `24.17.0` | Repository-local OpenSpec and Phoenix asset CLI runtime |
+| npm | `11.13.0` | Package manager for root tool and asset pins |
 | OpenSpec | `@fission-ai/openspec@1.4.1` | OpenSpec change/spec validation |
+| esbuild | `0.25.0` | Phoenix JavaScript asset bundling CLI |
+| Tailwind CSS | `4.1.3` | Phoenix CSS asset build CLI |
 
 The mise environment also sets:
 
@@ -48,6 +50,8 @@ tool resolution matters.
 
 ```bash
 export ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\""
+mise exec -- mix local.hex --if-missing --force
+mise exec -- mix local.rebar --if-missing --force
 mise exec -- mix deps.get
 unset ERL_AFLAGS
 mise exec -- uv sync --directory native/orchard_tokenizer

--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -30,6 +30,12 @@ using the real backend:
 mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx
 ```
 
+The CLI also supports `--generation-mode stream|batch`. The stub backend uses
+`stream` when no generation mode is provided and rejects `batch`; the node-agent
+source and packaged runtime configs mirror that by resolving
+`ORCHARD_WORKER_BACKEND=stub` to stream mode when
+`ORCHARD_WORKER_GENERATION_MODE` is unset.
+
 ## Proto contract
 
 The worker runtime proto lives at:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,439 @@
       "name": "orchard-tooling",
       "version": "0.0.0",
       "devDependencies": {
-        "@fission-ai/openspec": "1.4.1"
+        "@fission-ai/openspec": "1.4.1",
+        "@tailwindcss/cli": "4.1.3",
+        "esbuild": "0.25.0",
+        "tailwindcss": "4.1.3"
       },
       "engines": {
         "node": "24.17.0",
         "npm": "11.13.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@fission-ai/openspec": {
@@ -429,6 +857,346 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@posthog/core": {
       "version": "1.35.3",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.35.3.tgz",
@@ -445,6 +1213,260 @@
       "integrity": "sha512-WcfKz2GNn2vfDX8vXmJYbKxegPxVWHuDQ/pHdAn0HoZDXDFnEp/+x3qBQA+fEvtbPjjtjgAt2wIgJMlM7asx7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/cli": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.3.tgz",
+      "integrity": "sha512-irQW1LhBCi8O7OPrDVTyo6IZFqUDukGkcqOIxoU9d7zSOxU5LZQ1EB1KA981xmZpPIIfaowgdia8FSxaQrBonQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "^2.5.1",
+        "@tailwindcss/node": "4.1.3",
+        "@tailwindcss/oxide": "4.1.3",
+        "enhanced-resolve": "^5.18.1",
+        "mri": "^1.2.0",
+        "picocolors": "^1.1.1",
+        "tailwindcss": "4.1.3"
+      },
+      "bin": {
+        "tailwindcss": "dist/index.mjs"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.3.tgz",
+      "integrity": "sha512-H/6r6IPFJkCfBJZ2dKZiPJ7Ueb2wbL592+9bQEl2r73qbX6yGnmQVIfiUvDRB2YI0a3PWDrzUwkvQx1XW1bNkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "lightningcss": "1.29.2",
+        "tailwindcss": "4.1.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.3.tgz",
+      "integrity": "sha512-t16lpHCU7LBxDe/8dCj9ntyNpXaSTAgxWm1u2XQP5NiIu4KGSyrDJJRlK9hJ4U9yJxx0UKCVI67MJWFNll5mOQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.3",
+        "@tailwindcss/oxide-darwin-x64": "4.1.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.3.tgz",
+      "integrity": "sha512-cxklKjtNLwFl3mDYw4XpEfBY+G8ssSg9ADL4Wm6//5woi3XGqlxFsnV5Zb6v07dxw1NvEX2uoqsxO/zWQsgR+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.3.tgz",
+      "integrity": "sha512-mqkf2tLR5VCrjBvuRDwzKNShRu99gCAVMkVsaEOFvv6cCjlEKXRecPu9DEnxp6STk5z+Vlbh1M5zY3nQCXMXhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.3.tgz",
+      "integrity": "sha512-7sGraGaWzXvCLyxrc7d+CCpUN3fYnkkcso3rCzwUmo/LteAl2ZGCDlGvDD8Y/1D3ngxT8KgDj1DSwOnNewKhmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.3.tgz",
+      "integrity": "sha512-E2+PbcbzIReaAYZe997wb9rId246yDkCwAakllAWSGqe6VTg9hHle67hfH6ExjpV2LSK/siRzBUs5wVff3RW9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.3.tgz",
+      "integrity": "sha512-GvfbJ8wjSSjbLFFE3UYz4Eh8i4L6GiEYqCtA8j2Zd2oXriPuom/Ah/64pg/szWycQpzRnbDiJozoxFU2oJZyfg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.3.tgz",
+      "integrity": "sha512-35UkuCWQTeG9BHcBQXndDOrpsnt3Pj9NVIB4CgNiKmpG8GnCNXeMczkUpOoqcOhO6Cc/mM2W7kaQ/MTEENDDXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.3.tgz",
+      "integrity": "sha512-dm18aQiML5QCj9DQo7wMbt1Z2tl3Giht54uVR87a84X8qRtuXxUqnKQkRDK5B4bCOmcZ580lF9YcoMkbDYTXHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.3.tgz",
+      "integrity": "sha512-LMdTmGe/NPtGOaOfV2HuO7w07jI3cflPrVq5CXl+2O93DCewADK0uW1ORNAcfu2YxDUS035eY2W38TxrsqngxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.3.tgz",
+      "integrity": "sha512-aalNWwIi54bbFEizwl1/XpmdDrOaCjRFQRgtbv9slWjmNPuJJTIKPHf5/XXDARc9CneW9FkSTqTbyvNecYAEGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.3.tgz",
+      "integrity": "sha512-PEj7XR4OGTGoboTIAdXicKuWl4EQIjKHKuR+bFy9oYN7CFZo0eu74+70O4XuERX4yjqVZGAkCdglBODlgqcCXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.3.tgz",
+      "integrity": "sha512-T8gfxECWDBENotpw3HR9SmNiHC9AOJdxs+woasRZ8Q/J4VHN0OMs7F+4yVNZ9EVN26Wv6mZbK0jv7eHYuLJLwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -592,12 +1614,77 @@
         "node": ">= 8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -664,6 +1751,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -758,6 +1852,267 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
+      "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.29.2",
+        "lightningcss-darwin-x64": "1.29.2",
+        "lightningcss-freebsd-x64": "1.29.2",
+        "lightningcss-linux-arm-gnueabihf": "1.29.2",
+        "lightningcss-linux-arm64-gnu": "1.29.2",
+        "lightningcss-linux-arm64-musl": "1.29.2",
+        "lightningcss-linux-x64-gnu": "1.29.2",
+        "lightningcss-linux-x64-musl": "1.29.2",
+        "lightningcss-win32-arm64-msvc": "1.29.2",
+        "lightningcss-win32-x64-msvc": "1.29.2"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
+      "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
+      "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
+      "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
+      "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
+      "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
+      "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
+      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
+      "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
+      "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
+      "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
@@ -825,6 +2180,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -834,6 +2199,13 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/onetime": {
       "version": "7.0.0",
@@ -884,6 +2256,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -1080,6 +2459,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.3.tgz",
+      "integrity": "sha512-2Q+rw9vy1WFXu5cIxlvsabCwhU2qUwodGq03ODhLJ0jW4ek5BUtoCsnLB0qG+m8AHgEsSJcJGDSDe06FXlP74g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "openspec": "OPENSPEC_TELEMETRY=0 openspec"
   },
   "devDependencies": {
-    "@fission-ai/openspec": "1.4.1"
+    "@fission-ai/openspec": "1.4.1",
+    "@tailwindcss/cli": "4.1.3",
+    "esbuild": "0.25.0",
+    "tailwindcss": "4.1.3"
   }
 }

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1092,8 +1092,10 @@ rather than environment-variable installer overrides.
 ### Build Requirements
 
 Before building:
-1. **mise toolchain**: Run `mise install` from the repo root. This provides
-   pinned Erlang/OTP, Elixir, Python, and uv versions from `mise.toml`.
+1. **Repo setup**: Run `make setup` from the repo root, or run the equivalent
+   manual setup commands from `docs/local-dev.md`. This installs the pinned
+   mise toolchain, bootstraps the mise-owned Hex/Rebar installs, fetches Elixir
+   deps, syncs native Python packages, and installs root npm tool/asset pins.
 2. **Build shell**: Run builds through `mise exec -- ./scripts/build-pkg.sh`.
 3. **Git**: Clean working tree recommended (use `--allow-dirty` if needed)
 4. **macOS**: PKG build only works on macOS (uses `pkgbuild`)

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -143,6 +143,11 @@ echo 'ORCHARD_WORKER_BACKEND=stub' | sudo tee \
 sudo launchctl kickstart -k system/com.orchard.node-agent
 ```
 
+No `ORCHARD_WORKER_GENERATION_MODE` override is required for this rollback path;
+when the backend is `stub` and the mode env var is unset, packaged runtime
+configuration resolves generation mode to `stream`. If set explicitly, valid
+values are `stream` and `batch`; leave it unset for stub rollback.
+
 **Security note:** These files are sourced by shell scripts running as root
 (via launchd). The wrapper scripts validate ownership and permissions before
 sourcing — files that are not root-owned (`uid 0`) or have group/world

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -1544,16 +1544,18 @@ log_info "Cleaning previous release builds..."
 cd "$REPO_ROOT"
 rm -rf _build/prod/rel/orchard_{controller,node_agent,cli} _build/prod/lib/orchard_shared
 
-  # Fetch deps and build assets
-  log_info "Fetching Elixir dependencies..."
-  mix deps.get
-  
-  log_info "Building assets (controller app)..."
-  cd "$REPO_ROOT/apps/orchard_controller"
-  MIX_ENV=prod mix assets.deploy
-  cd "$REPO_ROOT"
-  
-  # Build releases
+log_info "Fetching Elixir dependencies..."
+mix deps.get
+
+log_info "Installing pinned asset dependencies..."
+cd "$REPO_ROOT/apps/orchard_controller"
+MIX_ENV=prod mix assets.setup
+
+log_info "Building assets (controller app)..."
+MIX_ENV=prod mix assets.deploy
+cd "$REPO_ROOT"
+
+# Build releases
 log_info "Building Elixir releases..."
 
 log_info "  → orchard_controller"


### PR DESCRIPTION
## Intent

Rerun the no-mistakes validation for the updated Orchard collaborator-path smoke branch after fixing the RP Investigate blocker. The new commit aligns ORCHARD_WORKER_BACKEND=stub with worker_generation_mode=stream by default in both dev and prod runtime config unless ORCHARD_WORKER_GENERATION_MODE is explicitly set, with regression tests for config/dev.exs and config/runtime.exs. Validate that the README/docs/local-dev collaborator flow remains accurate, the one-variable stub backend path now works, and the branch remains clean for PR #6.

## What Changed

- Hardened the collaborator source-dev path so `ORCHARD_WORKER_BACKEND=stub` defaults to stream generation unless explicitly overridden, with dev/prod runtime config coverage for the stub backend path.
- Updated setup, local-dev, milestone, native worker, and packaging docs to describe the one-variable stub workflow and collaborator bootstrap expectations.
- Bootstrapped Node asset dependencies in packaging/setup flows and isolated environment-sensitive dev config tests to avoid local env leakage.

## Risk Assessment

✅ Low: The branch is scoped to collaborator setup docs, pinned asset bootstrap, and runtime config defaulting; I did not find any new material risks beyond the previously ignored stub+batch behavior.

## Testing

Targeted regression tests and dev-script packaging tests passed after using a per-command mise trusted-path override; reviewer-visible transcripts show the one-variable stub collaborator path resolves to `worker_generation_mode=stream` in both dev and prod config and that the documented source-dev node-agent command boots in a PTY with its gRPC port open. Transient `tmp/` data from the boot check was removed, no listener remained on the test port, and the worktree had no uncommitted changes.

<details>
<summary>Evidence: Stub backend runtime config transcript</summary>

`dev/prod with ORCHARD_WORKER_BACKEND=stub and no ORCHARD_WORKER_GENERATION_MODE both resolved worker_generation_mode=stream.`

```text
source-dev collaborator command: ORCHARD_WORKER_BACKEND=stub mise exec -- bin/dev-node-agent
explicit ORCHARD_WORKER_GENERATION_MODE: absent
dev config worker_backend=stub
dev config worker_generation_mode=stream
prod release config worker_backend=stub
prod release config worker_generation_mode=stream
```
</details>
<details>
<summary>Evidence: Dev node-agent stub boot transcript</summary>

`PTY boot of the documented dev-node-agent command reached IEx, opened gRPC port 51717, and reported worker_backend=stub worker_generation_mode=stream.`

```text
command: ORCHARD_WORKER_BACKEND=stub ORCHARD_NODE_AGENT_LISTEN_PORT=51717 ORCHARD_RUNTIME_CLIENT_PORT=51717 mise exec -- bin/dev-node-agent
explicit ORCHARD_WORKER_GENERATION_MODE: absent
==> Starting Orchard dev node-agent (role: node-agent)
==> gRPC endpoint: 127.0.0.1:51717
Interactive Elixir (1.20.0) reached iex prompt in PTY
readiness: nc confirmed gRPC port 51717 is listening on 127.0.0.1
iex check: runtime worker_backend=stub worker_generation_mode=stream
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs:104` - The new tests bless `ORCHARD_WORKER_BACKEND=stub` plus explicit `ORCHARD_WORKER_GENERATION_MODE=batch`, but the launch path cannot honor that consistently: `WorkerRuntimeAdapter.worker_cli_args/1` omits `--generation-mode` when the value is `batch`, so the native CLI silently falls back to stub `stream` mode, while the BEAM side still treats the worker as batch-capable. Decide whether stub+batch should be rejected in config or supported end-to-end.
- ⚠️ `config/config.exs:65` - Asset config now hardcodes `node_modules/.bin/esbuild`, but the packaging build path still goes straight from `mix deps.get` to `mix assets.deploy`. A clean package build without prior `npm ci` will fail or use stale Node pins; have the packaging path run `npm ci --ignore-scripts`/`mix assets.setup` or preflight both binaries before asset deploy.
- ⚠️ `apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs:180` - `read_dev_config!/1` only clears `@tracked_env_vars`, but `config/dev.exs` also reads port, cache, prefix-cache, tokenizer, and other env vars. Local or CI env leakage can make these new dev config tests fail for unrelated reasons; clear/snapshot all env vars read by `dev.exs` for this helper.

🔧 Fix: Bootstrap assets and isolate config env
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs` initially hit mise trust for this isolated worktree; retried without global trust changes.</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix test apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix test apps/orchard_cli/test/orchard_cli/build_pkg_script_test.exs`
- `env -i ... MISE_TRUSTED_CONFIG_PATHS="$PWD" ORCHARD_WORKER_BACKEND=stub mise exec -- mix run --no-start -e '<dev/prod runtime config inspection>' | tee /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQGKJG29RHAFH6W1WGW2XNX/stub-backend-runtime-config.txt`
- <code>PTY manual check: `ORCHARD_WORKER_BACKEND=stub ORCHARD_NODE_AGENT_LISTEN_PORT=51717 ORCHARD_RUNTIME_CLIENT_PORT=51717 mise exec -- bin/dev-node-agent`, then `nc -z 127.0.0.1 51717`, then IEx runtime check for `worker_backend` and `worker_generation_mode`.</code>
- <code>Cleanup/closeout: `rm -rf tmp`, `lsof -nP -iTCP:51717 -sTCP:LISTEN`, `git status --porcelain=v1`, `git rev-parse HEAD`, `git branch --points-at HEAD`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
