### PR TITLE
feat(orchard_cli): add support bundle creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ target behavior are governed by `SPEC.md` §14.
 
 Some SPEC-required CLI paths are present before their milestone implementation:
 `orchardctl cluster init`, `orchardctl node join`, `orchardctl nodes admit`,
-`orchardctl requests inspect`, and `orchardctl support bundle create` return
-command-specific deferred-status errors with the current supported path.
+and `orchardctl requests inspect` return command-specific deferred-status
+errors with the current supported path. `orchardctl support bundle create`
+creates a local diagnostic `.tar.gz` with bounded redacted logs, redacted
+config, service status, node snapshots, and request summaries.
 
 ## Spec
 

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -13,7 +13,8 @@ This README is orientation only. Normative CLI requirements live in
   upgrades, tenants, API keys, nodes, and models.
 - SPEC-required future command paths that return explicit deferred status until
   their milestones land: `cluster init`, `node join`, `nodes admit`,
-  `requests inspect`, and `support bundle create`.
+  and `requests inspect`.
+- Local diagnostic support bundle creation via `support bundle create`.
 - CLI helpers that wrap release scripts and packaged service management.
 - Human-readable operator output and command validation.
 
@@ -23,6 +24,11 @@ The deferred paths above are advertised by `orchardctl`, exit non-zero when
 run, and print command-specific usage, `SPEC.md` traceability, and the current
 supported source-dev or packaged workflow. `--help` for the same paths is
 side-effect free.
+
+`orchardctl support bundle create` writes a local `.tar.gz` with bounded
+redacted logs, redacted config, service status, node snapshots, and request
+summaries. It records `support_bundle.generated` when the controller Repo is
+available and reports skipped audit status otherwise.
 
 ## Does not own
 

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -28,7 +28,11 @@ side-effect free.
 `orchardctl support bundle create` writes a local `.tar.gz` with bounded
 redacted logs, redacted config, service status, node snapshots, and request
 summaries. It records `support_bundle.generated` when the controller Repo is
-available and reports skipped audit status otherwise.
+available and reports skipped audit status otherwise. By default the archive is
+written under `<support-root>/support/`; operators can override the destination
+with `--output`, read an alternate local state tree with `--support-root`, cap
+per-file log tail bytes with `--max-log-bytes`, and use `--json` for
+machine-readable output.
 
 ## Does not own
 

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -13,11 +13,13 @@ defmodule OrchardCLI.Commands.Support do
   @config_files ~w(controller.env node-agent.env console.env)
   @preferred_log_files ~w(controller.log node-agent.log console.log)
   @sensitive_key_parts ~w(
-    activation authorization bearer cookie dsn keyfile password passwd passphrase pem secret
+    activation authorization bearer cookie credential dsn keyfile password passwd passphrase pem
+    secret signature
   )
   @sensitive_key_compounds ~w(
     access_key api_key apikey cacertfile certfile database_url license_certificate
-    machine_certificate private_key sentry_dsn x_api_key
+    machine_certificate private_key security_token sentry_dsn x_amz_credential
+    x_amz_security_token x_amz_signature x_api_key
   )
   @sensitive_key_compact_fragments ~w(
     accesskey accesstoken apitoken authtoken bearertoken clientsecret idtoken licensekey
@@ -46,7 +48,7 @@ defmodule OrchardCLI.Commands.Support do
     ~s("prompt"),
     "prompt="
   ]
-  @assignment_key_regex ~r/(?:^|[\s,{;?&])["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?\s*(?:=>|:|=)/
+  @assignment_key_regex ~r/(?:^|[\s,{;?&#])["']?([A-Za-z_][A-Za-z0-9_.\[\]-]*)["']?\s*(?:=>|:|=)/
   @bearer_value_regex ~r/\bbearer\s+[^\s,;]+/i
   @credential_url_userinfo_regex ~r/\b[a-z][a-z0-9+.-]*:\/\/[^\s\/?#@]*:[^\s\/?#@]*@[^\s\/?#]+/i
   @credential_token_assignment_regex ~r/\b(?:api|access|auth|bearer|id|refresh|session|license)[-_\s]+tokens?\s*(?:=>|:|=)/i
@@ -560,16 +562,40 @@ defmodule OrchardCLI.Commands.Support do
 
   defp sensitive_log_payload_key?(parts, compact) do
     compact in @sensitive_log_payload_keys or
-      sensitive_log_token_id_key?(compact) or
+      sensitive_log_token_id_key?(parts, compact) or
       Enum.any?(["messages", "prompt"], &(&1 in parts)) or
+      bracketed_payload_key?(parts) or
       List.last(parts) in ["content", "input"]
   end
 
-  defp sensitive_log_token_id_key?(compact) do
+  defp bracketed_payload_key?([root | rest]) when root in ["content", "input"] do
+    Enum.any?(rest, &numeric_part?/1) or
+      Enum.any?(rest, &(&1 in ["content", "input", "message", "text"]))
+  end
+
+  defp bracketed_payload_key?(_parts), do: false
+
+  defp sensitive_log_token_id_key?(parts, compact) do
+    parts
+    |> compact_without_numeric_parts()
+    |> then(&[compact, &1])
+    |> Enum.uniq()
+    |> Enum.any?(&sensitive_log_token_id_compact?/1)
+  end
+
+  defp compact_without_numeric_parts(parts) do
+    parts
+    |> Enum.reject(&numeric_part?/1)
+    |> Enum.join("_")
+  end
+
+  defp sensitive_log_token_id_compact?(compact) do
     compact in ["input_ids", "token_ids"] or
       String.ends_with?(compact, "_input_ids") or
       String.ends_with?(compact, "_token_ids")
   end
+
+  defp numeric_part?(part), do: String.match?(part, ~r/^\d+$/)
 
   defp safe_diagnostic_key?(compact), do: compact in @safe_diagnostic_keys
 
@@ -592,7 +618,10 @@ defmodule OrchardCLI.Commands.Support do
   defp collect_logs!(stage_dir, support_root, max_log_bytes, runtime) do
     logs_root = Path.join(support_root, "logs")
     limits = log_collection_limits(runtime)
-    {candidates, discovery_capped?} = log_file_candidates(logs_root, limits.max_discovery_entries)
+
+    {candidates, discovery_capped?} =
+      log_file_candidates(logs_root, limits.max_discovery_entries, runtime)
+
     {selected, skipped_for_count} = select_log_candidates(candidates, limits.max_files)
 
     skipped_for_discovery =
@@ -681,14 +710,12 @@ defmodule OrchardCLI.Commands.Support do
     end
   end
 
-  defp log_file_candidates(root, max_discovery_entries) do
+  defp log_file_candidates(root, max_discovery_entries, runtime) do
     if real_directory?(root) do
       {preferred, seen, remaining} = preferred_log_candidates(root, max_discovery_entries)
+      {candidates, capped?} = find_log_file_candidates(root, seen, remaining, runtime)
 
-      {candidates, _seen, _remaining, capped?} =
-        log_file_candidates_in_dir(root, root, remaining, seen, [])
-
-      {preferred ++ Enum.reverse(candidates), capped?}
+      {preferred ++ candidates, capped?}
     else
       {[], false}
     end
@@ -721,56 +748,101 @@ defmodule OrchardCLI.Commands.Support do
     end
   end
 
-  defp log_file_candidates_in_dir(root, dir, remaining, seen, candidates) do
-    case File.ls(dir) do
-      {:ok, entries} ->
-        entries
-        |> Enum.sort()
-        |> Enum.reduce_while(
-          {candidates, seen, remaining, false},
-          &log_file_candidate_entry_reducer(root, dir, &1, &2)
-        )
+  defp find_log_file_candidates(root, seen, remaining, runtime) do
+    case find_executable(runtime) do
+      nil ->
+        {[], false}
 
-      {:error, _reason} ->
-        {candidates, seen, remaining, false}
+      executable ->
+        port =
+          Port.open(
+            {:spawn_executable, executable},
+            [:binary, :exit_status, args: [root, "-type", "f", "-print0"]]
+          )
+
+        collect_find_log_candidates(port, root, seen, max(remaining, 0), [], "")
     end
   end
 
-  defp log_file_candidate_entry_reducer(root, dir, entry, {candidates, seen, remaining, capped?}) do
-    path = Path.join(dir, entry)
+  defp find_executable(runtime) do
+    runtime
+    |> Map.get(:find_executable, fn -> System.find_executable("find") end)
+    |> then(& &1.())
+  end
 
+  defp collect_find_log_candidates(port, root, seen, remaining, candidates, buffer) do
+    receive do
+      {^port, {:data, data}} ->
+        {paths, buffer} = find_output_paths(buffer <> data)
+
+        case reduce_find_log_paths(paths, root, seen, remaining, candidates) do
+          {:cont, seen, remaining, candidates} ->
+            collect_find_log_candidates(port, root, seen, remaining, candidates, buffer)
+
+          {:halt, candidates} ->
+            close_find_port(port)
+            {Enum.reverse(candidates), true}
+        end
+
+      {^port, {:exit_status, _status}} ->
+        {candidates, _seen, _remaining, capped?} =
+          reduce_final_find_buffer(buffer, root, seen, remaining, candidates)
+
+        {Enum.reverse(candidates), capped?}
+    end
+  end
+
+  defp find_output_paths(buffer) do
+    parts = :binary.split(buffer, <<0>>, [:global])
+    {Enum.drop(parts, -1), List.last(parts) || ""}
+  end
+
+  defp reduce_final_find_buffer("", _root, seen, remaining, candidates) do
+    {candidates, seen, remaining, false}
+  end
+
+  defp reduce_final_find_buffer(buffer, root, seen, remaining, candidates) do
+    case reduce_find_log_paths([buffer], root, seen, remaining, candidates) do
+      {:cont, seen, remaining, candidates} -> {candidates, seen, remaining, false}
+      {:halt, candidates} -> {candidates, seen, remaining, true}
+    end
+  end
+
+  defp reduce_find_log_paths([], _root, seen, remaining, candidates) do
+    {:cont, seen, remaining, candidates}
+  end
+
+  defp reduce_find_log_paths([path | rest], root, seen, remaining, candidates) do
     cond do
+      path == "" ->
+        reduce_find_log_paths(rest, root, seen, remaining, candidates)
+
       MapSet.member?(seen, path) ->
-        {:cont, {candidates, seen, remaining, capped?}}
+        reduce_find_log_paths(rest, root, seen, remaining, candidates)
 
       remaining <= 0 ->
-        {:halt, {candidates, seen, remaining, true}}
+        {:halt, candidates}
 
       true ->
-        log_file_candidate_for_entry(root, path, remaining, seen, candidates, capped?)
+        seen = MapSet.put(seen, path)
+
+        case regular_file_stat(path) do
+          {:ok, stat} ->
+            candidate = log_file_candidate(root, path, stat)
+            reduce_find_log_paths(rest, root, seen, remaining - 1, [candidate | candidates])
+
+          :error ->
+            reduce_find_log_paths(rest, root, seen, remaining, candidates)
+        end
     end
   end
 
-  defp log_file_candidate_for_entry(root, path, remaining, seen, candidates, capped?) do
-    seen = MapSet.put(seen, path)
-    remaining = remaining - 1
-
-    case File.lstat(path) do
-      {:ok, %{type: :regular} = stat} ->
-        {:cont, {[log_file_candidate(root, path, stat) | candidates], seen, remaining, capped?}}
-
-      {:ok, %{type: :directory}} when remaining > 0 ->
-        {candidates, seen, remaining, child_capped?} =
-          log_file_candidates_in_dir(root, path, remaining, seen, candidates)
-
-        {:cont, {candidates, seen, remaining, capped? or child_capped?}}
-
-      {:ok, %{type: :directory}} ->
-        {:cont, {candidates, seen, remaining, true}}
-
-      _other ->
-        {:cont, {candidates, seen, remaining, capped?}}
+  defp close_find_port(port) do
+    if Port.info(port) != nil do
+      Port.close(port)
     end
+
+    :ok
   end
 
   defp log_file_candidate(root, path, stat) do
@@ -1255,6 +1327,7 @@ defmodule OrchardCLI.Commands.Support do
       audit_support_bundle: &Orchard.Governance.audit_support_bundle_generated/1,
       cmd: &System.cmd/3,
       file_regular?: &File.regular?/1,
+      find_executable: fn -> System.find_executable("find") end,
       list_nodes: &Orchard.Nodes.list_nodes/0,
       list_recent_requests: &Orchard.Requests.list_recent_requests/1,
       log_collection_limits: fn ->

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -12,26 +12,18 @@ defmodule OrchardCLI.Commands.Support do
     access_key activation apikey api_key authorization bearer cacertfile certfile cookie
     database_url dsn keyfile license password pem private_key secret sentry_dsn token
   )
-  @sensitive_log_markers [
-    "authorization",
-    "bearer ",
-    "cookie:",
-    "database_url",
-    "postgres://",
-    "ecto://",
-    "secret",
-    "private_key",
-    "license",
-    "api_key",
-    "x-api-key",
-    "sentry_dsn",
-    "canonical_request",
-    "request_payload",
-    "response_payload",
-    "\"messages\"",
-    "\"prompt\"",
-    "prompt="
-  ]
+  @sensitive_log_markers @sensitive_env_fragments ++
+                           [
+                             "postgres://",
+                             "ecto://",
+                             "x-api-key",
+                             "canonical_request",
+                             "request_payload",
+                             "response_payload",
+                             "\"messages\"",
+                             "\"prompt\"",
+                             "prompt="
+                           ]
 
   @type runtime :: map()
   @type command_opts :: %{
@@ -385,7 +377,16 @@ defmodule OrchardCLI.Commands.Support do
     |> Enum.map_join("\n", &redact_env_line/1)
   end
 
-  defp redact_env_line("#" <> _rest = line), do: line
+  defp redact_env_line("#" <> rest = line) do
+    case String.split(rest, "=", parts: 2) do
+      [key, _value] ->
+        if sensitive_env_key?(key), do: "##{key}=[redacted]", else: line
+
+      _other ->
+        line
+    end
+  end
+
   defp redact_env_line(""), do: ""
 
   defp redact_env_line(line) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -404,32 +404,85 @@ defmodule OrchardCLI.Commands.Support do
   end
 
   defp redact_env_file(contents) do
-    contents
-    |> String.split("\n", trim: false)
-    |> Enum.map_join("\n", &redact_env_line/1)
+    {lines, _state} =
+      contents
+      |> String.split("\n", trim: false)
+      |> Enum.map_reduce(:clear, &redact_env_line/2)
+
+    Enum.join(lines, "\n")
   end
 
-  defp redact_env_line("#" <> rest = line) do
+  defp redact_env_line(line, :private_key) do
+    state = if Regex.match?(@private_key_end_regex, line), do: :clear, else: :private_key
+    {"[redacted]", state}
+  end
+
+  defp redact_env_line(line, {:quote, quote}) do
+    state = if contains_unescaped_quote?(line, quote), do: :clear, else: {:quote, quote}
+    {"[redacted]", state}
+  end
+
+  defp redact_env_line(line, :clear) do
+    case env_assignment(line) do
+      {:assignment, prefix, key, value} ->
+        if sensitive_env_key?(key) or sensitive_value?(value) do
+          {"#{prefix}#{key}=[redacted]", env_secret_block_state(value)}
+        else
+          {line, :clear}
+        end
+
+      _other ->
+        {line, :clear}
+    end
+  end
+
+  defp env_assignment("#" <> rest) do
     case String.split(rest, "=", parts: 2) do
-      [key, _value] ->
-        if sensitive_env_key?(key), do: "##{key}=[redacted]", else: line
-
-      _other ->
-        line
+      [key, value] -> {:assignment, "#", key, value}
+      _other -> :none
     end
   end
 
-  defp redact_env_line(""), do: ""
-
-  defp redact_env_line(line) do
+  defp env_assignment(line) do
     case String.split(line, "=", parts: 2) do
-      [key, _value] ->
-        if sensitive_env_key?(key), do: "#{key}=[redacted]", else: line
-
-      _other ->
-        line
+      [key, value] -> {:assignment, "", key, value}
+      _other -> :none
     end
   end
+
+  defp env_secret_block_state(value) do
+    if Regex.match?(@private_key_begin_regex, value) and
+         not Regex.match?(@private_key_end_regex, value) do
+      :private_key
+    else
+      env_quoted_block_state(value)
+    end
+  end
+
+  defp env_quoted_block_state(value) do
+    value = String.trim_leading(value)
+
+    cond do
+      String.starts_with?(value, "\"") ->
+        quoted_block_state(value, "\"")
+
+      String.starts_with?(value, "'") ->
+        quoted_block_state(value, "'")
+
+      true ->
+        :clear
+    end
+  end
+
+  defp quoted_block_state(value, quote) do
+    value
+    |> String.slice(1..-1//1)
+    |> contains_unescaped_quote?(quote)
+    |> then(fn closed? -> if closed?, do: :clear, else: {:quote, quote} end)
+  end
+
+  defp contains_unescaped_quote?(value, "\""), do: Regex.match?(~r/(^|[^\\])"/, value)
+  defp contains_unescaped_quote?(value, "'"), do: Regex.match?(~r/(^|[^\\])'/, value)
 
   defp sensitive_env_key?(key) do
     {parts, compact} = key_identity(key)
@@ -742,23 +795,49 @@ defmodule OrchardCLI.Commands.Support do
 
   defp redact_log_line?(line) do
     sensitive_log_literal?(line) or
-      Regex.match?(@bearer_value_regex, line) or
-      Regex.match?(@credential_url_userinfo_regex, line) or
       Regex.match?(@credential_token_assignment_regex, line) or
       Regex.match?(@license_secret_assignment_regex, line) or
-      Regex.match?(@private_key_regex, line) or
-      sensitive_log_assignment?(line)
+      sensitive_value?(line)
   end
 
   defp sensitive_log_literal?(line) do
-    normalized = String.downcase(line)
-    Enum.any?(@sensitive_log_literals, &String.contains?(normalized, &1))
+    line
+    |> log_line_forms()
+    |> Enum.map(&String.downcase/1)
+    |> Enum.any?(fn normalized ->
+      Enum.any?(@sensitive_log_literals, &String.contains?(normalized, &1))
+    end)
+  end
+
+  defp sensitive_value?(value) do
+    value_secret? =
+      value
+      |> log_line_forms()
+      |> Enum.any?(fn form ->
+        Regex.match?(@bearer_value_regex, form) or
+          Regex.match?(@credential_url_userinfo_regex, form) or
+          Regex.match?(@private_key_regex, form)
+      end)
+
+    value_secret? or sensitive_log_assignment?(value)
   end
 
   defp sensitive_log_assignment?(line) do
     line
+    |> log_line_forms()
+    |> Enum.any?(&sensitive_log_assignment_in_form?/1)
+  end
+
+  defp sensitive_log_assignment_in_form?(line) do
+    line
     |> then(&Regex.scan(@assignment_key_regex, &1, capture: :all_but_first))
     |> Enum.any?(fn [key] -> sensitive_log_key?(key) end)
+  end
+
+  defp log_line_forms(line) do
+    unescaped = Regex.replace(~r/\\+(["'])/, line, fn _match, quote -> quote end)
+
+    if unescaped == line, do: [line], else: [line, unescaped]
   end
 
   defp write_json!(stage_dir, relative_path, data) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -462,8 +462,15 @@ defmodule OrchardCLI.Commands.Support do
 
   defp sensitive_log_payload_key?(parts, compact) do
     compact in @sensitive_log_payload_keys or
+      sensitive_log_token_id_key?(compact) or
       Enum.any?(["messages", "prompt"], &(&1 in parts)) or
       List.last(parts) in ["content", "input"]
+  end
+
+  defp sensitive_log_token_id_key?(compact) do
+    compact in ["input_ids", "token_ids"] or
+      String.ends_with?(compact, "_input_ids") or
+      String.ends_with?(compact, "_token_ids")
   end
 
   defp safe_diagnostic_key?(compact), do: compact in @safe_diagnostic_keys

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -8,22 +8,37 @@ defmodule OrchardCLI.Commands.Support do
   @usage_exit_code 2
 
   @config_files ~w(controller.env node-agent.env console.env)
-  @sensitive_env_fragments ~w(
-    access_key activation apikey api_key authorization bearer cacertfile certfile cookie
-    database_url dsn keyfile license password pem private_key secret sentry_dsn token
+  @sensitive_key_parts ~w(
+    activation authorization bearer cookie dsn keyfile password passwd passphrase pem secret
   )
-  @sensitive_log_markers @sensitive_env_fragments ++
-                           [
-                             "postgres://",
-                             "ecto://",
-                             "x-api-key",
-                             "canonical_request",
-                             "request_payload",
-                             "response_payload",
-                             "\"messages\"",
-                             "\"prompt\"",
-                             "prompt="
-                           ]
+  @sensitive_key_compounds ~w(
+    access_key api_key apikey cacertfile certfile database_url private_key sentry_dsn x_api_key
+  )
+  @sensitive_token_partners ~w(access api auth bearer id license refresh secret session)
+  @sensitive_license_partners ~w(activation key secret token)
+  @sensitive_env_license_keys ~w(license orchard_license)
+  @safe_diagnostic_keys ~w(
+    completion_tokens input_tokens license_enforcement license_mode orchard_license_enforcement
+    orchard_license_mode orchard_tokenizer_executable output_tokens prompt_token_ids prompt_tokens
+    token_count tokenizer_executable tokens_per_second total_tokens worker_supports_prompt_token_ids
+  )
+  @sensitive_log_literals [
+    "postgres://",
+    "ecto://",
+    "canonical_request",
+    "request_payload",
+    "response_payload",
+    ~s("messages"),
+    ~s("prompt"),
+    "prompt="
+  ]
+  @assignment_key_regex ~r/(?:^|[\s,{;])["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?\s*(?:=>|:|=)/
+  @bearer_value_regex ~r/\bbearer\s+[^\s,;]+/i
+  @credential_token_assignment_regex ~r/\b(?:api|access|auth|bearer|id|refresh|session|license)[-_\s]+tokens?\s*(?:=>|:|=)/i
+  @license_secret_assignment_regex ~r/\blicense[-_\s]+(?:activation|key|secret|token)\s*(?:=>|:|=)/i
+  @private_key_regex ~r/-----BEGIN [A-Z ]*PRIVATE KEY-----|\bprivate[-_\s]+key\s*(?:=>|:|=)/i
+  @temp_dir_attempts 20
+  @archive_finalize_attempts 100
 
   @type runtime :: map()
   @type command_opts :: %{
@@ -122,51 +137,46 @@ defmodule OrchardCLI.Commands.Support do
     now = runtime.now.()
     output_dir = opts.output_dir || Path.join(opts.support_root, "support")
     basename = "orchard-support-bundle-#{timestamp_for_path(now)}"
-    bundle_name = available_bundle_name(output_dir, basename)
-    archive_path = Path.join(output_dir, bundle_name <> ".tar.gz")
-    path_nonce = runtime.path_nonce.()
-    archive_dir = Path.join(output_dir, ".#{bundle_name}-#{path_nonce}.archive")
-    temp_archive_path = Path.join(archive_dir, bundle_name <> ".tar.gz.tmp")
-    stage_dir = Path.join(output_dir, ".#{bundle_name}-#{path_nonce}.stage")
 
     result =
       try do
         ensure_output_dir!(output_dir)
 
-        File.rm_rf!(stage_dir)
-        File.rm_rf!(archive_dir)
-        ensure_private_dir!(stage_dir)
-        ensure_private_dir!(archive_dir)
-        build_stage!(stage_dir, opts, runtime, now)
+        with_bundle_temp_root(output_dir, basename, runtime, fn temp_root ->
+          stage_dir = Path.join(temp_root, "stage")
+          archive_dir = Path.join(temp_root, "archive")
+          temp_archive_path = Path.join(archive_dir, basename <> ".tar.gz.tmp")
 
-        with :ok <- runtime.archive.(stage_dir, temp_archive_path),
-             :ok <- secure_archive(temp_archive_path),
-             :ok <- move_archive(temp_archive_path, archive_path) do
-          audit =
-            record_audit(runtime, %{
-              archive_name: Path.basename(archive_path),
-              bundle_format: "orchard.support_bundle.v1",
-              generated_at: DateTime.to_iso8601(now),
-              max_log_bytes: opts.max_log_bytes
-            })
+          ensure_private_dir!(stage_dir)
+          ensure_private_dir!(archive_dir)
+          build_stage!(stage_dir, opts, runtime, now)
 
-          bundle = %{
-            archive_path: archive_path,
-            audit: audit,
-            generated_at: DateTime.to_iso8601(now)
-          }
+          with :ok <- runtime.archive.(stage_dir, temp_archive_path),
+               :ok <- secure_archive(temp_archive_path),
+               {:ok, archive_path} <- finalize_archive(temp_archive_path, output_dir, basename) do
+            audit =
+              record_audit(runtime, %{
+                archive_name: Path.basename(archive_path),
+                bundle_format: "orchard.support_bundle.v1",
+                generated_at: DateTime.to_iso8601(now),
+                max_log_bytes: opts.max_log_bytes
+              })
 
-          {:ok, bundle}
-        end
+            bundle = %{
+              archive_path: archive_path,
+              audit: audit,
+              generated_at: DateTime.to_iso8601(now)
+            }
+
+            {:ok, bundle}
+          end
+        end)
       rescue
         exception ->
           {:error, "Error: failed to create support bundle: #{Exception.message(exception)}", 1}
       catch
         kind, reason ->
           {:error, "Error: failed to create support bundle: #{inspect({kind, reason})}", 1}
-      after
-        File.rm_rf(stage_dir)
-        File.rm_rf(archive_dir)
       end
 
     case result do
@@ -400,8 +410,57 @@ defmodule OrchardCLI.Commands.Support do
   end
 
   defp sensitive_env_key?(key) do
-    normalized = key |> String.trim() |> String.downcase()
-    Enum.any?(@sensitive_env_fragments, &String.contains?(normalized, &1))
+    {parts, compact} = key_identity(key)
+
+    cond do
+      safe_diagnostic_key?(compact) -> false
+      sensitive_key?(parts, compact) -> true
+      compact in @sensitive_env_license_keys -> true
+      sensitive_license_key?(parts) -> true
+      true -> false
+    end
+  end
+
+  defp sensitive_log_key?(key) do
+    {parts, compact} = key_identity(key)
+
+    cond do
+      safe_diagnostic_key?(compact) -> false
+      sensitive_key?(parts, compact) -> true
+      sensitive_license_key?(parts) -> true
+      true -> false
+    end
+  end
+
+  defp sensitive_key?(parts, compact) do
+    compact in @sensitive_key_compounds or
+      Enum.any?(@sensitive_key_compounds, &String.contains?(compact, &1)) or
+      Enum.any?(@sensitive_key_parts, &(&1 in parts)) or
+      token_secret_key?(parts, compact)
+  end
+
+  defp token_secret_key?(parts, compact) do
+    compact == "token" or String.ends_with?(compact, "_token") or
+      (Enum.any?(parts, &(&1 in ["token", "tokens"])) and
+         Enum.any?(@sensitive_token_partners, &(&1 in parts)))
+  end
+
+  defp sensitive_license_key?(parts) do
+    "license" in parts and Enum.any?(@sensitive_license_partners, &(&1 in parts))
+  end
+
+  defp safe_diagnostic_key?(compact), do: compact in @safe_diagnostic_keys
+
+  defp key_identity(key) do
+    parts =
+      key
+      |> String.trim()
+      |> String.trim_leading("#")
+      |> String.trim()
+      |> String.downcase()
+      |> String.split(~r/[^a-z0-9]+/, trim: true)
+
+    {parts, Enum.join(parts, "_")}
   end
 
   defp collect_logs!(stage_dir, support_root, max_log_bytes) do
@@ -440,26 +499,42 @@ defmodule OrchardCLI.Commands.Support do
     File.chmod!(path, 0o700)
   end
 
-  defp available_bundle_name(output_dir, basename),
-    do: available_bundle_name(output_dir, basename, 0)
+  defp with_bundle_temp_root(output_dir, basename, runtime, fun) do
+    temp_root = create_bundle_temp_root!(output_dir, basename, runtime)
 
-  defp available_bundle_name(output_dir, basename, 0) do
-    if File.exists?(Path.join(output_dir, basename <> ".tar.gz")) do
-      available_bundle_name(output_dir, basename, 1)
-    else
-      basename
+    try do
+      fun.(temp_root)
+    after
+      File.rm_rf(temp_root)
     end
   end
 
-  defp available_bundle_name(output_dir, basename, suffix) do
-    candidate = "#{basename}-#{suffix}"
+  defp create_bundle_temp_root!(output_dir, basename, runtime) do
+    create_bundle_temp_root!(output_dir, basename, runtime, 0)
+  end
 
-    if File.exists?(Path.join(output_dir, candidate <> ".tar.gz")) do
-      available_bundle_name(output_dir, basename, suffix + 1)
-    else
-      candidate
+  defp create_bundle_temp_root!(_output_dir, _basename, _runtime, @temp_dir_attempts) do
+    raise "failed to create unique support bundle temporary directory"
+  end
+
+  defp create_bundle_temp_root!(output_dir, basename, runtime, attempt) do
+    path = private_temp_root_path(output_dir, basename, runtime.path_nonce.())
+
+    case File.mkdir(path) do
+      :ok ->
+        File.chmod!(path, 0o700)
+        path
+
+      {:error, :eexist} ->
+        create_bundle_temp_root!(output_dir, basename, runtime, attempt + 1)
+
+      {:error, reason} ->
+        raise File.Error, reason: reason, action: "make directory", path: path
     end
   end
+
+  defp private_temp_root_path(output_dir, basename, path_nonce),
+    do: Path.join(output_dir, ".#{basename}-#{path_nonce}.tmp")
 
   defp regular_files(root) do
     case File.lstat(root) do
@@ -565,13 +640,26 @@ defmodule OrchardCLI.Commands.Support do
   defp redact_log_line(""), do: ""
 
   defp redact_log_line(line) do
-    normalized = String.downcase(line)
-
-    if Enum.any?(@sensitive_log_markers, &String.contains?(normalized, &1)) do
-      "[redacted log line]"
-    else
-      line
+    cond do
+      sensitive_log_literal?(line) -> "[redacted log line]"
+      Regex.match?(@bearer_value_regex, line) -> "[redacted log line]"
+      Regex.match?(@credential_token_assignment_regex, line) -> "[redacted log line]"
+      Regex.match?(@license_secret_assignment_regex, line) -> "[redacted log line]"
+      Regex.match?(@private_key_regex, line) -> "[redacted log line]"
+      sensitive_log_assignment?(line) -> "[redacted log line]"
+      true -> line
     end
+  end
+
+  defp sensitive_log_literal?(line) do
+    normalized = String.downcase(line)
+    Enum.any?(@sensitive_log_literals, &String.contains?(normalized, &1))
+  end
+
+  defp sensitive_log_assignment?(line) do
+    line
+    |> then(&Regex.scan(@assignment_key_regex, &1, capture: :all_but_first))
+    |> Enum.any?(fn [key] -> sensitive_log_key?(key) end)
   end
 
   defp write_json!(stage_dir, relative_path, data) do
@@ -606,17 +694,27 @@ defmodule OrchardCLI.Commands.Support do
     end
   end
 
-  defp move_archive(temp_archive_path, archive_path) do
-    if File.exists?(archive_path) do
-      {:error, "Error: support bundle already exists: #{archive_path}"}
-    else
-      case File.rename(temp_archive_path, archive_path) do
-        :ok ->
-          :ok
+  defp finalize_archive(temp_archive_path, output_dir, basename) do
+    finalize_archive(temp_archive_path, output_dir, basename, 0)
+  end
 
-        {:error, reason} ->
-          {:error, "Error: failed to move support bundle: #{:file.format_error(reason)}"}
-      end
+  defp finalize_archive(_temp_archive_path, _output_dir, _basename, @archive_finalize_attempts) do
+    {:error, "Error: failed to move support bundle: no available archive name"}
+  end
+
+  defp finalize_archive(temp_archive_path, output_dir, basename, attempt) do
+    bundle_name = if attempt == 0, do: basename, else: "#{basename}-#{attempt}"
+    archive_path = Path.join(output_dir, bundle_name <> ".tar.gz")
+
+    case File.ln(temp_archive_path, archive_path) do
+      :ok ->
+        {:ok, archive_path}
+
+      {:error, :eexist} ->
+        finalize_archive(temp_archive_path, output_dir, basename, attempt + 1)
+
+      {:error, reason} ->
+        {:error, "Error: failed to move support bundle: #{:file.format_error(reason)}"}
     end
   end
 
@@ -728,7 +826,7 @@ defmodule OrchardCLI.Commands.Support do
       list_recent_requests: &Orchard.Requests.list_recent_requests/1,
       nodes_summary: &Orchard.Nodes.summary/0,
       now: fn -> DateTime.utc_now() |> DateTime.truncate(:second) end,
-      path_nonce: fn -> System.unique_integer([:positive]) |> Integer.to_string(36) end,
+      path_nonce: fn -> :crypto.strong_rand_bytes(18) |> Base.url_encode64(padding: false) end,
       requests_performance_summary: &Orchard.Requests.performance_summary/0,
       requests_summary: &Orchard.Requests.summary/0,
       status_snapshot: &Status.snapshot/1,

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -14,14 +14,18 @@ defmodule OrchardCLI.Commands.Support do
   @sensitive_key_compounds ~w(
     access_key api_key apikey cacertfile certfile database_url private_key sentry_dsn x_api_key
   )
+  @sensitive_key_compact_fragments ~w(password passwd passphrase)
+  @sensitive_key_compact_aliases ~w(dbpass pgpass pgpassfile)
   @sensitive_token_partners ~w(access api auth bearer id license refresh secret session)
   @sensitive_license_partners ~w(activation key secret token)
   @sensitive_env_license_keys ~w(license orchard_license)
   @safe_diagnostic_keys ~w(
     completion_tokens input_tokens license_enforcement license_mode orchard_license_enforcement
     orchard_license_mode orchard_tokenizer_executable output_tokens prompt_token_ids prompt_tokens
-    token_count tokenizer_executable tokens_per_second total_tokens worker_supports_prompt_token_ids
+    supports_prompt_token_ids token_count tokenizer_executable tokens_per_second total_tokens
+    worker_supports_prompt_token_ids
   )
+  @sensitive_log_payload_keys ~w(content input input_text message_content messages prompt prompt_text)
   @sensitive_log_literals [
     "postgres://",
     "ecto://",
@@ -36,6 +40,8 @@ defmodule OrchardCLI.Commands.Support do
   @bearer_value_regex ~r/\bbearer\s+[^\s,;]+/i
   @credential_token_assignment_regex ~r/\b(?:api|access|auth|bearer|id|refresh|session|license)[-_\s]+tokens?\s*(?:=>|:|=)/i
   @license_secret_assignment_regex ~r/\blicense[-_\s]+(?:activation|key|secret|token)\s*(?:=>|:|=)/i
+  @private_key_begin_regex ~r/-----BEGIN [A-Z ]*PRIVATE KEY-----/i
+  @private_key_end_regex ~r/-----END [A-Z ]*PRIVATE KEY-----/i
   @private_key_regex ~r/-----BEGIN [A-Z ]*PRIVATE KEY-----|\bprivate[-_\s]+key\s*(?:=>|:|=)/i
   @temp_dir_attempts 20
   @archive_finalize_attempts 100
@@ -428,6 +434,7 @@ defmodule OrchardCLI.Commands.Support do
       safe_diagnostic_key?(compact) -> false
       sensitive_key?(parts, compact) -> true
       sensitive_license_key?(parts) -> true
+      sensitive_log_payload_key?(parts, compact) -> true
       true -> false
     end
   end
@@ -435,6 +442,8 @@ defmodule OrchardCLI.Commands.Support do
   defp sensitive_key?(parts, compact) do
     compact in @sensitive_key_compounds or
       Enum.any?(@sensitive_key_compounds, &String.contains?(compact, &1)) or
+      compact in @sensitive_key_compact_aliases or
+      Enum.any?(@sensitive_key_compact_fragments, &String.contains?(compact, &1)) or
       Enum.any?(@sensitive_key_parts, &(&1 in parts)) or
       token_secret_key?(parts, compact)
   end
@@ -447,6 +456,12 @@ defmodule OrchardCLI.Commands.Support do
 
   defp sensitive_license_key?(parts) do
     "license" in parts and Enum.any?(@sensitive_license_partners, &(&1 in parts))
+  end
+
+  defp sensitive_log_payload_key?(parts, compact) do
+    compact in @sensitive_log_payload_keys or
+      Enum.any?(["messages", "prompt"], &(&1 in parts)) or
+      List.last(parts) in ["content", "input"]
   end
 
   defp safe_diagnostic_key?(compact), do: compact in @safe_diagnostic_keys
@@ -629,26 +644,44 @@ defmodule OrchardCLI.Commands.Support do
 
   defp redact_log_file(content) do
     if String.valid?(content) do
-      content
-      |> String.split("\n", trim: false)
-      |> Enum.map_join("\n", &redact_log_line/1)
+      {lines, _in_private_key?} =
+        content
+        |> String.split("\n", trim: false)
+        |> Enum.map_reduce(false, &redact_log_line/2)
+
+      Enum.join(lines, "\n")
     else
       "[redacted binary log content]\n"
     end
   end
 
+  defp redact_log_line("", false), do: {"", false}
+
+  defp redact_log_line(line, true) do
+    {"[redacted log line]", not Regex.match?(@private_key_end_regex, line)}
+  end
+
+  defp redact_log_line(line, false) do
+    in_private_key? =
+      Regex.match?(@private_key_begin_regex, line) and
+        not Regex.match?(@private_key_end_regex, line)
+
+    {redact_log_line(line), in_private_key?}
+  end
+
   defp redact_log_line(""), do: ""
 
   defp redact_log_line(line) do
-    cond do
-      sensitive_log_literal?(line) -> "[redacted log line]"
-      Regex.match?(@bearer_value_regex, line) -> "[redacted log line]"
-      Regex.match?(@credential_token_assignment_regex, line) -> "[redacted log line]"
-      Regex.match?(@license_secret_assignment_regex, line) -> "[redacted log line]"
-      Regex.match?(@private_key_regex, line) -> "[redacted log line]"
-      sensitive_log_assignment?(line) -> "[redacted log line]"
-      true -> line
-    end
+    if redact_log_line?(line), do: "[redacted log line]", else: line
+  end
+
+  defp redact_log_line?(line) do
+    sensitive_log_literal?(line) or
+      Regex.match?(@bearer_value_regex, line) or
+      Regex.match?(@credential_token_assignment_regex, line) or
+      Regex.match?(@license_secret_assignment_regex, line) or
+      Regex.match?(@private_key_regex, line) or
+      sensitive_log_assignment?(line)
   end
 
   defp sensitive_log_literal?(line) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -12,7 +12,8 @@ defmodule OrchardCLI.Commands.Support do
     activation authorization bearer cookie dsn keyfile password passwd passphrase pem secret
   )
   @sensitive_key_compounds ~w(
-    access_key api_key apikey cacertfile certfile database_url private_key sentry_dsn x_api_key
+    access_key api_key apikey cacertfile certfile database_url license_certificate
+    machine_certificate private_key sentry_dsn x_api_key
   )
   @sensitive_key_compact_fragments ~w(password passwd passphrase)
   @sensitive_key_compact_aliases ~w(dbpass pgpass pgpassfile)
@@ -21,7 +22,7 @@ defmodule OrchardCLI.Commands.Support do
   @sensitive_env_license_keys ~w(license orchard_license)
   @safe_diagnostic_keys ~w(
     completion_tokens input_tokens license_enforcement license_mode orchard_license_enforcement
-    orchard_license_mode orchard_tokenizer_executable output_tokens prompt_token_ids prompt_tokens
+    orchard_license_mode orchard_tokenizer_executable output_tokens prompt_tokens
     supports_prompt_token_ids token_count tokenizer_executable tokens_per_second total_tokens
     worker_supports_prompt_token_ids
   )
@@ -32,6 +33,7 @@ defmodule OrchardCLI.Commands.Support do
     "canonical_request",
     "request_payload",
     "response_payload",
+    "prompt_token_ids_length_mismatch",
     ~s("messages"),
     ~s("prompt"),
     "prompt="
@@ -467,15 +469,19 @@ defmodule OrchardCLI.Commands.Support do
   defp safe_diagnostic_key?(compact), do: compact in @safe_diagnostic_keys
 
   defp key_identity(key) do
-    parts =
+    normalized =
       key
       |> String.trim()
       |> String.trim_leading("#")
       |> String.trim()
+      |> Macro.underscore()
       |> String.downcase()
-      |> String.split(~r/[^a-z0-9]+/, trim: true)
+      |> String.replace(~r/[^a-z0-9]+/, "_")
+      |> String.trim("_")
 
-    {parts, Enum.join(parts, "_")}
+    parts = String.split(normalized, "_", trim: true)
+
+    {parts, normalized}
   end
 
   defp collect_logs!(stage_dir, support_root, max_log_bytes) do
@@ -647,12 +653,46 @@ defmodule OrchardCLI.Commands.Support do
       {lines, _in_private_key?} =
         content
         |> String.split("\n", trim: false)
-        |> Enum.map_reduce(false, &redact_log_line/2)
+        |> redact_log_lines(initial_private_key_state?(content))
 
       Enum.join(lines, "\n")
     else
       "[redacted binary log content]\n"
     end
+  end
+
+  defp redact_log_lines([line | rest], true) do
+    if truncated_log_marker?(line) do
+      {redacted, in_private_key?} = Enum.map_reduce(rest, true, &redact_log_line/2)
+      {[line | redacted], in_private_key?}
+    else
+      Enum.map_reduce([line | rest], true, &redact_log_line/2)
+    end
+  end
+
+  defp redact_log_lines(lines, in_private_key?) do
+    Enum.map_reduce(lines, in_private_key?, &redact_log_line/2)
+  end
+
+  defp initial_private_key_state?(content) do
+    case {first_regex_index(@private_key_begin_regex, content),
+          first_regex_index(@private_key_end_regex, content)} do
+      {nil, nil} -> false
+      {nil, _end_index} -> true
+      {begin_index, end_index} when is_integer(end_index) -> end_index < begin_index
+      {_begin_index, nil} -> false
+    end
+  end
+
+  defp first_regex_index(regex, content) do
+    case Regex.run(regex, content, return: :index) do
+      [{index, _length} | _rest] -> index
+      nil -> nil
+    end
+  end
+
+  defp truncated_log_marker?(line) do
+    String.starts_with?(line, "[truncated to last ") and String.ends_with?(line, " bytes]")
   end
 
   defp redact_log_line("", false), do: {"", false}

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -38,8 +38,9 @@ defmodule OrchardCLI.Commands.Support do
     ~s("prompt"),
     "prompt="
   ]
-  @assignment_key_regex ~r/(?:^|[\s,{;])["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?\s*(?:=>|:|=)/
+  @assignment_key_regex ~r/(?:^|[\s,{;?&])["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?\s*(?:=>|:|=)/
   @bearer_value_regex ~r/\bbearer\s+[^\s,;]+/i
+  @credential_url_userinfo_regex ~r/\b[a-z][a-z0-9+.-]*:\/\/[^\s\/?#@]*:[^\s\/?#@]*@[^\s\/?#]+/i
   @credential_token_assignment_regex ~r/\b(?:api|access|auth|bearer|id|refresh|session|license)[-_\s]+tokens?\s*(?:=>|:|=)/i
   @license_secret_assignment_regex ~r/\blicense[-_\s]+(?:activation|key|secret|token)\s*(?:=>|:|=)/i
   @private_key_begin_regex ~r/-----BEGIN [A-Z ]*PRIVATE KEY-----/i
@@ -365,20 +366,14 @@ defmodule OrchardCLI.Commands.Support do
   end
 
   defp collect_config!(stage_dir, support_root) do
-    copied =
-      support_root
-      |> Path.join("config")
-      |> config_paths()
-      |> Enum.reduce(0, fn {source_path, dest_name}, count ->
-        case read_regular_file(source_path) do
-          {:ok, contents} ->
-            write_text!(stage_dir, Path.join("config", dest_name), contents)
-            count + 1
+    config_dir = Path.join(support_root, "config")
 
-          :error ->
-            count
-        end
-      end)
+    copied =
+      if real_directory?(config_dir) do
+        collect_config_files!(stage_dir, config_dir)
+      else
+        0
+      end
 
     if copied == 0 do
       write_text!(stage_dir, "config/README.txt", "No Orchard env config files were found.\n")
@@ -387,6 +382,25 @@ defmodule OrchardCLI.Commands.Support do
 
   defp config_paths(config_dir) do
     Enum.map(@config_files, fn file -> {Path.join(config_dir, file), file} end)
+  end
+
+  defp collect_config_files!(stage_dir, config_dir) do
+    config_dir
+    |> config_paths()
+    |> Enum.reduce(0, fn config_path, count ->
+      copy_config_file!(stage_dir, config_path, count)
+    end)
+  end
+
+  defp copy_config_file!(stage_dir, {source_path, dest_name}, count) do
+    case read_regular_file(source_path) do
+      {:ok, contents} ->
+        write_text!(stage_dir, Path.join("config", dest_name), contents)
+        count + 1
+
+      :error ->
+        count
+    end
   end
 
   defp redact_env_file(contents) do
@@ -565,9 +579,13 @@ defmodule OrchardCLI.Commands.Support do
     do: Path.join(output_dir, ".#{basename}-#{path_nonce}.tmp")
 
   defp regular_files(root) do
-    case File.lstat(root) do
-      {:ok, %{type: :directory}} -> regular_files_in_dir(root)
-      _other -> []
+    if real_directory?(root), do: regular_files_in_dir(root), else: []
+  end
+
+  defp real_directory?(path) do
+    case File.lstat(path) do
+      {:ok, %{type: :directory}} -> true
+      _other -> false
     end
   end
 
@@ -725,6 +743,7 @@ defmodule OrchardCLI.Commands.Support do
   defp redact_log_line?(line) do
     sensitive_log_literal?(line) or
       Regex.match?(@bearer_value_regex, line) or
+      Regex.match?(@credential_url_userinfo_regex, line) or
       Regex.match?(@credential_token_assignment_regex, line) or
       Regex.match?(@license_secret_assignment_regex, line) or
       Regex.match?(@private_key_regex, line) or

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -133,7 +133,8 @@ defmodule OrchardCLI.Commands.Support do
     bundle_name = available_bundle_name(output_dir, basename)
     archive_path = Path.join(output_dir, bundle_name <> ".tar.gz")
     path_nonce = runtime.path_nonce.()
-    temp_archive_path = Path.join(output_dir, ".#{bundle_name}-#{path_nonce}.tar.gz.tmp")
+    archive_dir = Path.join(output_dir, ".#{bundle_name}-#{path_nonce}.archive")
+    temp_archive_path = Path.join(archive_dir, bundle_name <> ".tar.gz.tmp")
     stage_dir = Path.join(output_dir, ".#{bundle_name}-#{path_nonce}.stage")
 
     result =
@@ -141,8 +142,9 @@ defmodule OrchardCLI.Commands.Support do
         ensure_output_dir!(output_dir)
 
         File.rm_rf!(stage_dir)
-        File.rm(temp_archive_path)
+        File.rm_rf!(archive_dir)
         ensure_private_dir!(stage_dir)
+        ensure_private_dir!(archive_dir)
         build_stage!(stage_dir, opts, runtime, now)
 
         with :ok <- runtime.archive.(stage_dir, temp_archive_path),
@@ -172,7 +174,7 @@ defmodule OrchardCLI.Commands.Support do
           {:error, "Error: failed to create support bundle: #{inspect({kind, reason})}", 1}
       after
         File.rm_rf(stage_dir)
-        File.rm(temp_archive_path)
+        File.rm_rf(archive_dir)
       end
 
     case result do
@@ -358,12 +360,13 @@ defmodule OrchardCLI.Commands.Support do
       |> Path.join("config")
       |> config_paths()
       |> Enum.reduce(0, fn {source_path, dest_name}, count ->
-        if File.regular?(source_path) do
-          contents = source_path |> File.read!() |> redact_env_file()
-          write_text!(stage_dir, Path.join("config", dest_name), contents)
-          count + 1
-        else
-          count
+        case read_regular_file(source_path) do
+          {:ok, contents} ->
+            write_text!(stage_dir, Path.join("config", dest_name), contents)
+            count + 1
+
+          :error ->
+            count
         end
       end)
 
@@ -403,21 +406,25 @@ defmodule OrchardCLI.Commands.Support do
   defp collect_logs!(stage_dir, support_root, max_log_bytes) do
     logs_root = Path.join(support_root, "logs")
 
-    case regular_files(logs_root) do
-      [] ->
-        write_text!(stage_dir, "logs/README.txt", "No Orchard log files were found.\n")
+    copied =
+      logs_root
+      |> regular_files()
+      |> Enum.reduce(0, fn source_path, count ->
+        rel = Path.relative_to(source_path, logs_root)
+        dest = Path.join("logs", rel)
 
-      paths ->
-        Enum.each(paths, fn source_path ->
-          rel = Path.relative_to(source_path, logs_root)
-          dest = Path.join("logs", rel)
+        case tail_file(source_path, max_log_bytes) do
+          {:ok, content} ->
+            write_text!(stage_dir, dest, redact_log_file(content))
+            count + 1
 
-          write_text!(
-            stage_dir,
-            dest,
-            source_path |> tail_file!(max_log_bytes) |> redact_log_file()
-          )
-        end)
+          :error ->
+            count
+        end
+      end)
+
+    if copied == 0 do
+      write_text!(stage_dir, "logs/README.txt", "No Orchard log files were found.\n")
     end
   end
 
@@ -477,21 +484,58 @@ defmodule OrchardCLI.Commands.Support do
     _exception -> []
   end
 
-  defp tail_file!(path, max_bytes) do
-    {:ok, stat} = File.stat(path)
+  defp read_regular_file(path) do
+    with {:ok, first_stat} <- regular_file_stat(path),
+         {:ok, contents} <- File.read(path),
+         {:ok, second_stat} <- regular_file_stat(path),
+         true <- same_file?(first_stat, second_stat) do
+      {:ok, redact_env_file(contents)}
+    else
+      _other -> :error
+    end
+  end
 
-    {:ok, content} =
-      File.open(path, [:read, :binary], fn file ->
-        offset = max(stat.size - max_bytes, 0)
-        {:ok, _position} = :file.position(file, offset)
+  defp regular_file_stat(path) do
+    case File.lstat(path) do
+      {:ok, %{type: :regular} = stat} -> {:ok, stat}
+      _other -> :error
+    end
+  end
 
-        case IO.binread(file, max_bytes) do
-          :eof -> ""
-          data -> data
-        end
-      end)
+  defp same_file?(first_stat, second_stat) do
+    first_stat.major_device == second_stat.major_device and
+      first_stat.minor_device == second_stat.minor_device and
+      first_stat.inode == second_stat.inode
+  end
 
-    if stat.size > max_bytes do
+  defp tail_file(path, max_bytes) do
+    with {:ok, first_stat} <- regular_file_stat(path),
+         {:ok, {:ok, content}} <-
+           File.open(path, [:read, :binary], fn file ->
+             read_tail_content(file, first_stat.size, max_bytes)
+           end),
+         {:ok, second_stat} <- regular_file_stat(path),
+         true <- same_file?(first_stat, second_stat) do
+      {:ok, format_tail_content(content, first_stat.size, max_bytes)}
+    else
+      _other -> :error
+    end
+  end
+
+  defp read_tail_content(file, file_size, max_bytes) do
+    offset = max(file_size - max_bytes, 0)
+
+    with {:ok, _position} <- :file.position(file, offset) do
+      case IO.binread(file, max_bytes) do
+        :eof -> {:ok, ""}
+        data when is_binary(data) -> {:ok, data}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp format_tail_content(content, file_size, max_bytes) do
+    if file_size > max_bytes do
       "[truncated to last #{max_bytes} bytes]\n" <> discard_partial_first_line(content)
     else
       content

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -7,6 +7,7 @@ defmodule OrchardCLI.Commands.Support do
   @default_max_log_bytes 1_048_576
   @default_max_log_files 32
   @default_max_total_log_bytes 8_388_608
+  @default_max_log_discovery_entries 512
   @usage_exit_code 2
 
   @config_files ~w(controller.env node-agent.env console.env)
@@ -19,7 +20,9 @@ defmodule OrchardCLI.Commands.Support do
     machine_certificate private_key sentry_dsn x_api_key
   )
   @sensitive_key_compact_fragments ~w(
-    accesskey licensekey password passwd passphrase privatekey secretkey
+    accesskey accesstoken apitoken authtoken bearertoken clientsecret idtoken licensekey
+    licensesecret licensetoken password passwd passphrase privatekey refreshtoken
+    secretkey sessiontoken
   )
   @sensitive_key_compact_aliases ~w(dbpass pgpass pgpassfile)
   @sensitive_token_partners ~w(access api auth bearer id license refresh secret session)
@@ -48,9 +51,9 @@ defmodule OrchardCLI.Commands.Support do
   @credential_url_userinfo_regex ~r/\b[a-z][a-z0-9+.-]*:\/\/[^\s\/?#@]*:[^\s\/?#@]*@[^\s\/?#]+/i
   @credential_token_assignment_regex ~r/\b(?:api|access|auth|bearer|id|refresh|session|license)[-_\s]+tokens?\s*(?:=>|:|=)/i
   @license_secret_assignment_regex ~r/\blicense[-_\s]+(?:activation|key|secret|token)\s*(?:=>|:|=)/i
-  @private_key_begin_regex ~r/-----BEGIN [A-Z ]*PRIVATE KEY-----/i
-  @private_key_end_regex ~r/-----END [A-Z ]*PRIVATE KEY-----/i
-  @private_key_regex ~r/-----BEGIN [A-Z ]*PRIVATE KEY-----|\bprivate[-_\s]+key\s*(?:=>|:|=)/i
+  @secret_block_begin_regex ~r/-----BEGIN (?:[A-Z ]*PRIVATE KEY|LICENSE FILE|MACHINE FILE)-----/i
+  @secret_block_end_regex ~r/-----END (?:[A-Z ]*PRIVATE KEY|LICENSE FILE|MACHINE FILE)-----/i
+  @secret_block_regex ~r/-----BEGIN (?:[A-Z ]*PRIVATE KEY|LICENSE FILE|MACHINE FILE)-----|\bprivate[-_\s]+key\s*(?:=>|:|=)/i
   @temp_dir_attempts 20
   @archive_finalize_attempts 100
 
@@ -437,8 +440,8 @@ defmodule OrchardCLI.Commands.Support do
     Enum.join(lines, "\n")
   end
 
-  defp redact_env_line(line, :private_key) do
-    state = if Regex.match?(@private_key_end_regex, line), do: :clear, else: :private_key
+  defp redact_env_line(line, :secret_block) do
+    state = if Regex.match?(@secret_block_end_regex, line), do: :clear, else: :secret_block
     {"[redacted]", state}
   end
 
@@ -476,9 +479,9 @@ defmodule OrchardCLI.Commands.Support do
   end
 
   defp env_secret_block_state(value) do
-    if Regex.match?(@private_key_begin_regex, value) and
-         not Regex.match?(@private_key_end_regex, value) do
-      :private_key
+    if Regex.match?(@secret_block_begin_regex, value) and
+         not Regex.match?(@secret_block_end_regex, value) do
+      :secret_block
     else
       env_quoted_block_state(value)
     end
@@ -588,9 +591,12 @@ defmodule OrchardCLI.Commands.Support do
 
   defp collect_logs!(stage_dir, support_root, max_log_bytes, runtime) do
     logs_root = Path.join(support_root, "logs")
-    candidates = log_file_candidates(logs_root)
     limits = log_collection_limits(runtime)
+    {candidates, discovery_capped?} = log_file_candidates(logs_root, limits.max_discovery_entries)
     {selected, skipped_for_count} = select_log_candidates(candidates, limits.max_files)
+
+    skipped_for_discovery =
+      if discovery_capped?, do: [%{path: ".", reason: "discovery_limit"}], else: []
 
     {copied, bytes_retained, skipped, truncated} =
       collect_selected_logs!(
@@ -598,7 +604,7 @@ defmodule OrchardCLI.Commands.Support do
         selected,
         max_log_bytes,
         limits.max_total_bytes,
-        Enum.reverse(skipped_for_count)
+        Enum.reverse(skipped_for_discovery ++ skipped_for_count)
       )
 
     if copied == 0 do
@@ -607,9 +613,11 @@ defmodule OrchardCLI.Commands.Support do
 
     %{
       bytes_retained: bytes_retained,
+      discovery_capped: discovery_capped?,
       files_available: length(candidates),
       files_collected: copied,
       files_skipped: length(skipped),
+      max_discovery_entries: limits.max_discovery_entries,
       max_log_bytes_per_file: max_log_bytes,
       max_log_files: limits.max_files,
       max_total_log_bytes: limits.max_total_bytes,
@@ -673,24 +681,96 @@ defmodule OrchardCLI.Commands.Support do
     end
   end
 
-  defp log_file_candidates(root) do
-    if real_directory?(root), do: log_file_candidates_in_dir(root, root), else: []
+  defp log_file_candidates(root, max_discovery_entries) do
+    if real_directory?(root) do
+      {preferred, seen, remaining} = preferred_log_candidates(root, max_discovery_entries)
+
+      {candidates, _seen, _remaining, capped?} =
+        log_file_candidates_in_dir(root, root, remaining, seen, [])
+
+      {preferred ++ Enum.reverse(candidates), capped?}
+    else
+      {[], false}
+    end
   end
 
-  defp log_file_candidates_in_dir(root, dir) do
-    dir
-    |> File.ls!()
-    |> Enum.flat_map(fn entry ->
-      path = Path.join(dir, entry)
+  defp preferred_log_candidates(root, max_discovery_entries) do
+    @preferred_log_files
+    |> Enum.reduce_while(
+      {[], MapSet.new(), max_discovery_entries},
+      &preferred_log_candidate_reducer(root, &1, &2)
+    )
+    |> then(fn {candidates, seen, remaining} -> {Enum.reverse(candidates), seen, remaining} end)
+  end
 
-      case File.lstat(path) do
-        {:ok, %{type: :regular} = stat} -> [log_file_candidate(root, path, stat)]
-        {:ok, %{type: :directory}} -> log_file_candidates_in_dir(root, path)
-        _other -> []
-      end
-    end)
-  rescue
-    _exception -> []
+  defp preferred_log_candidate_reducer(_root, _rel, {candidates, seen, remaining})
+       when remaining <= 0 do
+    {:halt, {candidates, seen, remaining}}
+  end
+
+  defp preferred_log_candidate_reducer(root, rel, {candidates, seen, remaining}) do
+    path = Path.join(root, rel)
+    seen = MapSet.put(seen, path)
+
+    case File.lstat(path) do
+      {:ok, %{type: :regular} = stat} ->
+        {:cont, {[log_file_candidate(root, path, stat) | candidates], seen, remaining - 1}}
+
+      _other ->
+        {:cont, {candidates, seen, remaining}}
+    end
+  end
+
+  defp log_file_candidates_in_dir(root, dir, remaining, seen, candidates) do
+    case File.ls(dir) do
+      {:ok, entries} ->
+        entries
+        |> Enum.sort()
+        |> Enum.reduce_while(
+          {candidates, seen, remaining, false},
+          &log_file_candidate_entry_reducer(root, dir, &1, &2)
+        )
+
+      {:error, _reason} ->
+        {candidates, seen, remaining, false}
+    end
+  end
+
+  defp log_file_candidate_entry_reducer(root, dir, entry, {candidates, seen, remaining, capped?}) do
+    path = Path.join(dir, entry)
+
+    cond do
+      MapSet.member?(seen, path) ->
+        {:cont, {candidates, seen, remaining, capped?}}
+
+      remaining <= 0 ->
+        {:halt, {candidates, seen, remaining, true}}
+
+      true ->
+        log_file_candidate_for_entry(root, path, remaining, seen, candidates, capped?)
+    end
+  end
+
+  defp log_file_candidate_for_entry(root, path, remaining, seen, candidates, capped?) do
+    seen = MapSet.put(seen, path)
+    remaining = remaining - 1
+
+    case File.lstat(path) do
+      {:ok, %{type: :regular} = stat} ->
+        {:cont, {[log_file_candidate(root, path, stat) | candidates], seen, remaining, capped?}}
+
+      {:ok, %{type: :directory}} when remaining > 0 ->
+        {candidates, seen, remaining, child_capped?} =
+          log_file_candidates_in_dir(root, path, remaining, seen, candidates)
+
+        {:cont, {candidates, seen, remaining, capped? or child_capped?}}
+
+      {:ok, %{type: :directory}} ->
+        {:cont, {candidates, seen, remaining, true}}
+
+      _other ->
+        {:cont, {candidates, seen, remaining, capped?}}
+    end
   end
 
   defp log_file_candidate(root, path, stat) do
@@ -813,6 +893,11 @@ defmodule OrchardCLI.Commands.Support do
       |> then(& &1.())
 
     %{
+      max_discovery_entries:
+        non_negative_limit(
+          Map.get(limits, :max_discovery_entries),
+          @default_max_log_discovery_entries
+        ),
       max_files: non_negative_limit(Map.get(limits, :max_files), @default_max_log_files),
       max_total_bytes:
         non_negative_limit(Map.get(limits, :max_total_bytes), @default_max_total_log_bytes)
@@ -898,10 +983,10 @@ defmodule OrchardCLI.Commands.Support do
 
   defp redact_log_file(content) do
     if String.valid?(content) do
-      {lines, _in_private_key?} =
+      {lines, _in_secret_block?} =
         content
         |> String.split("\n", trim: false)
-        |> redact_log_lines(initial_private_key_state?(content))
+        |> redact_log_lines(initial_secret_block_state?(content))
 
       Enum.join(lines, "\n")
     else
@@ -911,20 +996,20 @@ defmodule OrchardCLI.Commands.Support do
 
   defp redact_log_lines([line | rest], true) do
     if truncated_log_marker?(line) do
-      {redacted, in_private_key?} = Enum.map_reduce(rest, true, &redact_log_line/2)
-      {[line | redacted], in_private_key?}
+      {redacted, in_secret_block?} = Enum.map_reduce(rest, true, &redact_log_line/2)
+      {[line | redacted], in_secret_block?}
     else
       Enum.map_reduce([line | rest], true, &redact_log_line/2)
     end
   end
 
-  defp redact_log_lines(lines, in_private_key?) do
-    Enum.map_reduce(lines, in_private_key?, &redact_log_line/2)
+  defp redact_log_lines(lines, in_secret_block?) do
+    Enum.map_reduce(lines, in_secret_block?, &redact_log_line/2)
   end
 
-  defp initial_private_key_state?(content) do
-    case {first_regex_index(@private_key_begin_regex, content),
-          first_regex_index(@private_key_end_regex, content)} do
+  defp initial_secret_block_state?(content) do
+    case {first_regex_index(@secret_block_begin_regex, content),
+          first_regex_index(@secret_block_end_regex, content)} do
       {nil, nil} -> false
       {nil, _end_index} -> true
       {begin_index, end_index} when is_integer(end_index) -> end_index < begin_index
@@ -946,15 +1031,15 @@ defmodule OrchardCLI.Commands.Support do
   defp redact_log_line("", false), do: {"", false}
 
   defp redact_log_line(line, true) do
-    {"[redacted log line]", not Regex.match?(@private_key_end_regex, line)}
+    {"[redacted log line]", not Regex.match?(@secret_block_end_regex, line)}
   end
 
   defp redact_log_line(line, false) do
-    in_private_key? =
-      Regex.match?(@private_key_begin_regex, line) and
-        not Regex.match?(@private_key_end_regex, line)
+    in_secret_block? =
+      Regex.match?(@secret_block_begin_regex, line) and
+        not Regex.match?(@secret_block_end_regex, line)
 
-    {redact_log_line(line), in_private_key?}
+    {redact_log_line(line), in_secret_block?}
   end
 
   defp redact_log_line(""), do: ""
@@ -986,7 +1071,7 @@ defmodule OrchardCLI.Commands.Support do
       |> Enum.any?(fn form ->
         Regex.match?(@bearer_value_regex, form) or
           Regex.match?(@credential_url_userinfo_regex, form) or
-          Regex.match?(@private_key_regex, form)
+          Regex.match?(@secret_block_regex, form)
       end)
 
     value_secret? or sensitive_log_assignment?(value)

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -1,22 +1,757 @@
 defmodule OrchardCLI.Commands.Support do
   @moduledoc false
 
-  alias OrchardCLI.Commands.Deferred
+  alias OrchardCLI.Commands.{LifecycleSupport, Status}
 
-  @commands [
-    %{
-      path: ["bundle", "create"],
-      usage: "orchardctl support bundle create",
-      summary: "Create a local diagnostic support bundle (SPEC.md 11.9).",
-      status:
-        "Defined by SPEC.md 11.9 for the M5 diagnostics milestone; not implemented in the current build.",
-      guidance: [
-        "Use orchardctl status, controller logs, node-agent logs, and packaging/pkg/README.md troubleshooting steps for current diagnostics.",
-        "Do not collect secrets from controller.env, node-agent.env, TLS keys, or license bundles into ad hoc support archives."
-      ]
-    }
+  @default_support_root "/Library/Application Support/Orchard"
+  @default_max_log_bytes 1_048_576
+  @usage_exit_code 2
+
+  @config_files ~w(controller.env node-agent.env console.env)
+  @sensitive_env_fragments ~w(
+    access_key activation apikey api_key authorization bearer cacertfile certfile cookie
+    database_url dsn keyfile license password pem private_key secret sentry_dsn token
+  )
+  @sensitive_log_markers [
+    "authorization",
+    "bearer ",
+    "cookie:",
+    "database_url",
+    "postgres://",
+    "ecto://",
+    "secret",
+    "private_key",
+    "license",
+    "api_key",
+    "x-api-key",
+    "sentry_dsn",
+    "canonical_request",
+    "request_payload",
+    "response_payload",
+    "\"messages\"",
+    "\"prompt\"",
+    "prompt="
   ]
 
+  @type runtime :: map()
+  @type command_opts :: %{
+          required(:json?) => boolean(),
+          required(:max_log_bytes) => non_neg_integer(),
+          required(:output_dir) => String.t() | nil,
+          required(:support_root) => String.t()
+        }
+
   @spec run([String.t()]) :: OrchardCLI.command_result()
-  def run(args), do: Deferred.run(args, %{name: "support", commands: @commands})
+  def run(args), do: run(args, default_runtime())
+
+  @doc false
+  @spec run([String.t()], runtime()) :: OrchardCLI.command_result()
+  def run([], _runtime), do: {:error, group_usage(), 1}
+  def run(["help"], _runtime), do: {:ok, group_usage()}
+  def run(["--help"], _runtime), do: {:ok, group_usage()}
+
+  def run(["bundle"], _runtime),
+    do: usage_error("Missing support bundle subcommand.", group_usage())
+
+  def run(["bundle", "help"], _runtime), do: {:ok, bundle_usage()}
+  def run(["bundle", "--help"], _runtime), do: {:ok, bundle_usage()}
+  def run(["bundle", "create" | rest], runtime), do: run_create(rest, runtime)
+
+  def run([arg | _rest], _runtime) do
+    if option?(arg) do
+      usage_error("Unknown option: #{arg}", group_usage())
+    else
+      usage_error("Unknown support subcommand: #{arg}", group_usage())
+    end
+  end
+
+  defp run_create(args, runtime) do
+    case parse_create_args(args, default_create_opts(runtime)) do
+      {:run, opts} -> create_bundle(opts, runtime)
+      :help -> {:ok, create_usage()}
+      {:error, message} -> usage_error(message, create_usage())
+    end
+  end
+
+  defp parse_create_args(["help"], _opts), do: :help
+
+  defp parse_create_args(args, opts) do
+    case rejected_boolean_negation(args) do
+      nil ->
+        parse_create_options(args, opts)
+
+      option ->
+        {:error, "Unknown option: #{option}"}
+    end
+  end
+
+  defp parse_create_options(args, opts) do
+    {parsed, rest, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          output: :string,
+          support_root: :string,
+          max_log_bytes: :integer,
+          json: :boolean,
+          help: :boolean
+        ],
+        aliases: [o: :output]
+      )
+
+    cond do
+      invalid != [] ->
+        {option, _value} = List.first(invalid)
+        {:error, "Unknown option: #{option}"}
+
+      rest != [] ->
+        {:error, "Unexpected argument for support bundle create: #{List.first(rest)}"}
+
+      Keyword.get(parsed, :help, false) ->
+        :help
+
+      Keyword.get(parsed, :max_log_bytes, opts.max_log_bytes) < 0 ->
+        {:error, "--max-log-bytes must be greater than or equal to 0"}
+
+      true ->
+        {:run,
+         %{
+           opts
+           | json?: Keyword.get(parsed, :json, false),
+             max_log_bytes: Keyword.get(parsed, :max_log_bytes, opts.max_log_bytes),
+             output_dir: Keyword.get(parsed, :output, opts.output_dir),
+             support_root: Keyword.get(parsed, :support_root, opts.support_root)
+         }}
+    end
+  end
+
+  defp rejected_boolean_negation(args), do: Enum.find(args, &(&1 in ["--no-json", "--no-help"]))
+
+  defp create_bundle(opts, runtime) do
+    now = runtime.now.()
+    output_dir = opts.output_dir || Path.join(opts.support_root, "support")
+    basename = "orchard-support-bundle-#{timestamp_for_path(now)}"
+    bundle_name = available_bundle_name(output_dir, basename)
+    archive_path = Path.join(output_dir, bundle_name <> ".tar.gz")
+    path_nonce = runtime.path_nonce.()
+    temp_archive_path = Path.join(output_dir, ".#{bundle_name}-#{path_nonce}.tar.gz.tmp")
+    stage_dir = Path.join(output_dir, ".#{bundle_name}-#{path_nonce}.stage")
+
+    result =
+      try do
+        ensure_output_dir!(output_dir)
+
+        File.rm_rf!(stage_dir)
+        File.rm(temp_archive_path)
+        ensure_private_dir!(stage_dir)
+        build_stage!(stage_dir, opts, runtime, now)
+
+        with :ok <- runtime.archive.(stage_dir, temp_archive_path),
+             :ok <- secure_archive(temp_archive_path),
+             :ok <- move_archive(temp_archive_path, archive_path) do
+          audit =
+            record_audit(runtime, %{
+              archive_name: Path.basename(archive_path),
+              bundle_format: "orchard.support_bundle.v1",
+              generated_at: DateTime.to_iso8601(now),
+              max_log_bytes: opts.max_log_bytes
+            })
+
+          bundle = %{
+            archive_path: archive_path,
+            audit: audit,
+            generated_at: DateTime.to_iso8601(now)
+          }
+
+          {:ok, bundle}
+        end
+      rescue
+        exception ->
+          {:error, "Error: failed to create support bundle: #{Exception.message(exception)}", 1}
+      catch
+        kind, reason ->
+          {:error, "Error: failed to create support bundle: #{inspect({kind, reason})}", 1}
+      after
+        File.rm_rf(stage_dir)
+        File.rm(temp_archive_path)
+      end
+
+    case result do
+      {:ok, bundle} -> {:ok, render_success(bundle, opts)}
+      {:error, message, code} -> {:error, message, code}
+      {:error, message} -> {:error, message, 1}
+    end
+  end
+
+  defp build_stage!(stage_dir, opts, runtime, now) do
+    write_text!(stage_dir, "README.txt", readme_text())
+    write_json!(stage_dir, "manifest.json", manifest(opts, runtime, now))
+    write_json!(stage_dir, "diagnostics/system.json", system_snapshot(opts, runtime, now))
+    write_json!(stage_dir, "diagnostics/status.json", status_snapshot(opts.support_root, runtime))
+
+    write_json!(
+      stage_dir,
+      "diagnostics/services.json",
+      service_snapshot(opts.support_root, runtime)
+    )
+
+    write_json!(stage_dir, "diagnostics/nodes.json", nodes_snapshot(runtime))
+    write_json!(stage_dir, "diagnostics/requests.json", requests_snapshot(runtime))
+
+    collect_config!(stage_dir, opts.support_root)
+    collect_logs!(stage_dir, opts.support_root, opts.max_log_bytes)
+  end
+
+  defp manifest(opts, runtime, now) do
+    %{
+      bundle_format: "orchard.support_bundle.v1",
+      command: "orchardctl support bundle create",
+      generated_at: DateTime.to_iso8601(now),
+      orchard_version: runtime.version.(),
+      max_log_bytes: opts.max_log_bytes,
+      spec_references: [
+        "SPEC.md 7.3.1 Operator API support-bundles endpoint",
+        "SPEC.md 11.9 CLI orchardctl support bundle create",
+        "SPEC.md Milestone 5 support bundle contains logs, config, node snapshots, request summary"
+      ],
+      contents: [
+        "diagnostics/system.json",
+        "diagnostics/status.json",
+        "diagnostics/services.json",
+        "diagnostics/nodes.json",
+        "diagnostics/requests.json",
+        "config/*.env redacted when present",
+        "logs/** bounded and redacted tail copies when present"
+      ]
+    }
+  end
+
+  defp system_snapshot(_opts, runtime, now) do
+    %{
+      status: "ok",
+      data: %{
+        generated_at: DateTime.to_iso8601(now),
+        orchard_version: runtime.version.(),
+        elixir_version: System.version(),
+        otp_release: System.otp_release(),
+        os_type: inspect(:os.type())
+      }
+    }
+  end
+
+  defp status_snapshot(support_root, runtime) do
+    status_runtime =
+      runtime
+      |> Map.put(:read_install_role, fn -> File.read(install_role_marker(support_root)) end)
+      |> Map.put(:endpoint_metadata_path, Path.join([support_root, "public", "endpoint.json"]))
+
+    safe_snapshot(fn ->
+      runtime.status_snapshot.(status_runtime)
+      |> Orchard.SentryFilter.filter()
+    end)
+  end
+
+  defp service_snapshot(support_root, runtime) do
+    service_runtime =
+      Map.put(runtime, :read_install_role, fn -> File.read(install_role_marker(support_root)) end)
+
+    safe_snapshot(fn ->
+      role = detected_role(service_runtime)
+
+      %{
+        role: role,
+        services:
+          :start
+          |> LifecycleSupport.services(service_runtime)
+          |> Enum.map(&service_status(&1, service_runtime))
+      }
+    end)
+  end
+
+  defp nodes_snapshot(runtime) do
+    safe_snapshot(fn ->
+      %{
+        summary: runtime.nodes_summary.(),
+        nodes: Enum.map(runtime.list_nodes.(), &node_summary/1)
+      }
+    end)
+  end
+
+  defp requests_snapshot(runtime) do
+    safe_snapshot(fn ->
+      %{
+        summary: runtime.requests_summary.(),
+        performance: runtime.requests_performance_summary.(),
+        recent: Enum.map(runtime.list_recent_requests.(25), &request_summary/1)
+      }
+    end)
+  end
+
+  defp safe_snapshot(fun) do
+    %{status: "ok", data: fun.()}
+  rescue
+    exception ->
+      %{status: "unavailable", error: "snapshot unavailable", reason: exception_type(exception)}
+  catch
+    kind, _reason ->
+      %{status: "unavailable", error: "snapshot unavailable", reason: inspect(kind)}
+  end
+
+  defp exception_type(%{__struct__: module}), do: inspect(module)
+
+  defp detected_role(runtime) do
+    case LifecycleSupport.detect_install_role(runtime) do
+      {:ok, role} -> LifecycleSupport.display_role(role)
+      {:error, reason, _message, _code} -> Atom.to_string(reason)
+    end
+  end
+
+  defp service_status(service, runtime) do
+    file_regular? = Map.get(runtime, :file_regular?, &File.regular?/1)
+
+    %{
+      id: service.id,
+      label: service.label,
+      display_name: service.display_name,
+      plist: Path.basename(service.plist_path),
+      plist_present: file_regular?.(service.plist_path),
+      launchd_loaded: LifecycleSupport.service_loaded?(service, runtime)
+    }
+  end
+
+  defp node_summary(node) do
+    %{
+      id: field(node, :id),
+      display_name: field(node, :display_name),
+      hostname: field(node, :hostname),
+      state: field(node, :state),
+      health: field(node, :health),
+      agent_version: field(node, :agent_version),
+      last_heartbeat_at: field(node, :last_heartbeat_at),
+      connect_host: field(node, :connect_host),
+      connect_port: field(node, :connect_port),
+      capabilities: field(node, :capabilities),
+      tool_readiness: field(node, :tool_readiness)
+    }
+  end
+
+  defp request_summary(request) do
+    %{
+      id: field(request, :id),
+      public_id: field(request, :public_id),
+      endpoint: field(request, :endpoint),
+      requested_model: field(request, :requested_model),
+      state: field(request, :state),
+      stream: field(request, :stream),
+      node_id: field(request, :node_id),
+      http_status: field(request, :http_status),
+      error_code: field(request, :error_code),
+      input_tokens: field(request, :input_tokens),
+      output_tokens: field(request, :output_tokens),
+      inserted_at: field(request, :inserted_at),
+      completed_at: field(request, :completed_at)
+    }
+  end
+
+  defp collect_config!(stage_dir, support_root) do
+    copied =
+      support_root
+      |> Path.join("config")
+      |> config_paths()
+      |> Enum.reduce(0, fn {source_path, dest_name}, count ->
+        if File.regular?(source_path) do
+          contents = source_path |> File.read!() |> redact_env_file()
+          write_text!(stage_dir, Path.join("config", dest_name), contents)
+          count + 1
+        else
+          count
+        end
+      end)
+
+    if copied == 0 do
+      write_text!(stage_dir, "config/README.txt", "No Orchard env config files were found.\n")
+    end
+  end
+
+  defp config_paths(config_dir) do
+    Enum.map(@config_files, fn file -> {Path.join(config_dir, file), file} end)
+  end
+
+  defp redact_env_file(contents) do
+    contents
+    |> String.split("\n", trim: false)
+    |> Enum.map_join("\n", &redact_env_line/1)
+  end
+
+  defp redact_env_line("#" <> _rest = line), do: line
+  defp redact_env_line(""), do: ""
+
+  defp redact_env_line(line) do
+    case String.split(line, "=", parts: 2) do
+      [key, _value] ->
+        if sensitive_env_key?(key), do: "#{key}=[redacted]", else: line
+
+      _other ->
+        line
+    end
+  end
+
+  defp sensitive_env_key?(key) do
+    normalized = key |> String.trim() |> String.downcase()
+    Enum.any?(@sensitive_env_fragments, &String.contains?(normalized, &1))
+  end
+
+  defp collect_logs!(stage_dir, support_root, max_log_bytes) do
+    logs_root = Path.join(support_root, "logs")
+
+    case regular_files(logs_root) do
+      [] ->
+        write_text!(stage_dir, "logs/README.txt", "No Orchard log files were found.\n")
+
+      paths ->
+        Enum.each(paths, fn source_path ->
+          rel = Path.relative_to(source_path, logs_root)
+          dest = Path.join("logs", rel)
+
+          write_text!(
+            stage_dir,
+            dest,
+            source_path |> tail_file!(max_log_bytes) |> redact_log_file()
+          )
+        end)
+    end
+  end
+
+  defp ensure_output_dir!(path) do
+    existed? = File.dir?(path)
+    File.mkdir_p!(path)
+    unless existed?, do: File.chmod!(path, 0o700)
+  end
+
+  defp ensure_private_dir!(path) do
+    File.mkdir_p!(path)
+    File.chmod!(path, 0o700)
+  end
+
+  defp available_bundle_name(output_dir, basename),
+    do: available_bundle_name(output_dir, basename, 0)
+
+  defp available_bundle_name(output_dir, basename, 0) do
+    if File.exists?(Path.join(output_dir, basename <> ".tar.gz")) do
+      available_bundle_name(output_dir, basename, 1)
+    else
+      basename
+    end
+  end
+
+  defp available_bundle_name(output_dir, basename, suffix) do
+    candidate = "#{basename}-#{suffix}"
+
+    if File.exists?(Path.join(output_dir, candidate <> ".tar.gz")) do
+      available_bundle_name(output_dir, basename, suffix + 1)
+    else
+      candidate
+    end
+  end
+
+  defp regular_files(root) do
+    case File.lstat(root) do
+      {:ok, %{type: :directory}} -> regular_files_in_dir(root)
+      _other -> []
+    end
+  end
+
+  defp regular_files_in_dir(dir) do
+    dir
+    |> File.ls!()
+    |> Enum.flat_map(fn entry ->
+      path = Path.join(dir, entry)
+
+      case File.lstat(path) do
+        {:ok, %{type: :regular}} -> [path]
+        {:ok, %{type: :directory}} -> regular_files_in_dir(path)
+        _other -> []
+      end
+    end)
+    |> Enum.sort()
+  rescue
+    _exception -> []
+  end
+
+  defp tail_file!(path, max_bytes) do
+    {:ok, stat} = File.stat(path)
+
+    {:ok, content} =
+      File.open(path, [:read, :binary], fn file ->
+        offset = max(stat.size - max_bytes, 0)
+        {:ok, _position} = :file.position(file, offset)
+
+        case IO.binread(file, max_bytes) do
+          :eof -> ""
+          data -> data
+        end
+      end)
+
+    if stat.size > max_bytes do
+      "[truncated to last #{max_bytes} bytes]\n" <> discard_partial_first_line(content)
+    else
+      content
+    end
+  end
+
+  defp discard_partial_first_line(""), do: ""
+
+  defp discard_partial_first_line(content) do
+    case :binary.match(content, "\n") do
+      {index, 1} -> binary_part(content, index + 1, byte_size(content) - index - 1)
+      :nomatch -> ""
+    end
+  end
+
+  defp redact_log_file(content) do
+    if String.valid?(content) do
+      content
+      |> String.split("\n", trim: false)
+      |> Enum.map_join("\n", &redact_log_line/1)
+    else
+      "[redacted binary log content]\n"
+    end
+  end
+
+  defp redact_log_line(""), do: ""
+
+  defp redact_log_line(line) do
+    normalized = String.downcase(line)
+
+    if Enum.any?(@sensitive_log_markers, &String.contains?(normalized, &1)) do
+      "[redacted log line]"
+    else
+      line
+    end
+  end
+
+  defp write_json!(stage_dir, relative_path, data) do
+    write_text!(stage_dir, relative_path, Jason.encode!(json_safe(data), pretty: true) <> "\n")
+  end
+
+  defp write_text!(stage_dir, relative_path, content) do
+    write_binary!(stage_dir, relative_path, content)
+  end
+
+  defp write_binary!(stage_dir, relative_path, content) do
+    path = Path.join(stage_dir, relative_path)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, content)
+    File.chmod!(path, 0o600)
+  end
+
+  defp archive_stage(stage_dir, archive_path) do
+    case System.cmd("tar", ["-czf", archive_path, "-C", stage_dir, "."], stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, code} -> {:error, "Error: tar failed with exit #{code}: #{String.trim(output)}"}
+    end
+  end
+
+  defp secure_archive(path) do
+    case File.chmod(path, 0o600) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, "Error: failed to secure support bundle: #{:file.format_error(reason)}"}
+    end
+  end
+
+  defp move_archive(temp_archive_path, archive_path) do
+    if File.exists?(archive_path) do
+      {:error, "Error: support bundle already exists: #{archive_path}"}
+    else
+      case File.rename(temp_archive_path, archive_path) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          {:error, "Error: failed to move support bundle: #{:file.format_error(reason)}"}
+      end
+    end
+  end
+
+  defp record_audit(runtime, event) do
+    case runtime.audit_support_bundle.(event) do
+      :ok -> %{status: "recorded"}
+      :skipped -> %{status: "skipped", reason: "controller_repo_unavailable"}
+      {:error, reason} -> %{status: "failed", reason: inspect(reason)}
+      other -> %{status: "unknown", reason: inspect(other)}
+    end
+  rescue
+    _exception in [DBConnection.ConnectionError, DBConnection.OwnershipError, Postgrex.Error] ->
+      %{status: "skipped", reason: "audit unavailable"}
+
+    exception ->
+      %{status: "failed", reason: exception_type(exception)}
+  catch
+    kind, reason ->
+      %{status: "failed", reason: inspect({kind, reason})}
+  end
+
+  defp render_success(
+         %{archive_path: archive_path, audit: audit, generated_at: generated_at},
+         %{json?: true}
+       ) do
+    Jason.encode!(%{
+      archive_path: archive_path,
+      audit: audit,
+      generated_at: generated_at,
+      bundle_format: "orchard.support_bundle.v1"
+    })
+  end
+
+  defp render_success(%{archive_path: archive_path, audit: audit}, %{json?: false}) do
+    """
+    Created support bundle: #{archive_path}
+    Audit: #{audit_line(audit)}
+    Contents: manifest.json, diagnostics/, redacted config/, bounded redacted logs/
+    """
+    |> String.trim()
+  end
+
+  defp audit_line(%{status: "recorded"}), do: "recorded"
+  defp audit_line(%{status: "skipped", reason: reason}), do: "skipped (#{reason})"
+  defp audit_line(%{status: status, reason: reason}), do: "#{status} (#{reason})"
+  defp audit_line(%{status: status}), do: status
+
+  defp json_safe(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp json_safe(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
+  defp json_safe(%Date{} = value), do: Date.to_iso8601(value)
+  defp json_safe(%Time{} = value), do: Time.to_iso8601(value)
+
+  defp json_safe(value) when is_map(value) do
+    value
+    |> maybe_from_struct()
+    |> Enum.reject(fn {key, _value} -> key == :__meta__ or key == "__meta__" end)
+    |> Map.new(fn {key, nested} -> {json_key(key), json_safe(nested)} end)
+  end
+
+  defp json_safe(value) when is_list(value), do: Enum.map(value, &json_safe/1)
+  defp json_safe(value) when is_tuple(value), do: value |> Tuple.to_list() |> json_safe()
+  defp json_safe(nil), do: nil
+  defp json_safe(true), do: true
+  defp json_safe(false), do: false
+  defp json_safe(value) when is_atom(value), do: Atom.to_string(value)
+  defp json_safe(value), do: value
+
+  defp maybe_from_struct(%{__struct__: _module} = value), do: Map.from_struct(value)
+  defp maybe_from_struct(value), do: value
+
+  defp json_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp json_key(key), do: to_string(key)
+
+  defp field(value, key) when is_map(value) do
+    case Map.fetch(value, key) do
+      {:ok, field_value} -> field_value
+      :error -> Map.get(value, Atom.to_string(key))
+    end
+  end
+
+  defp field(_value, _key), do: nil
+
+  defp timestamp_for_path(%DateTime{} = now) do
+    now
+    |> DateTime.truncate(:second)
+    |> DateTime.to_iso8601()
+    |> String.replace(~r/[^0-9A-Za-z]/, "")
+  end
+
+  defp install_role_marker(support_root),
+    do: Path.join([support_root, "support", ".install-role"])
+
+  defp default_create_opts(runtime) do
+    %{
+      json?: false,
+      max_log_bytes: @default_max_log_bytes,
+      output_dir: nil,
+      support_root: runtime.support_root.()
+    }
+  end
+
+  defp default_runtime do
+    %{
+      archive: &archive_stage/2,
+      audit_support_bundle: &Orchard.Governance.audit_support_bundle_generated/1,
+      cmd: &System.cmd/3,
+      file_regular?: &File.regular?/1,
+      list_nodes: &Orchard.Nodes.list_nodes/0,
+      list_recent_requests: &Orchard.Requests.list_recent_requests/1,
+      nodes_summary: &Orchard.Nodes.summary/0,
+      now: fn -> DateTime.utc_now() |> DateTime.truncate(:second) end,
+      path_nonce: fn -> System.unique_integer([:positive]) |> Integer.to_string(36) end,
+      requests_performance_summary: &Orchard.Requests.performance_summary/0,
+      requests_summary: &Orchard.Requests.summary/0,
+      status_snapshot: &Status.snapshot/1,
+      support_root: fn -> System.get_env("ORCHARD_SUPPORT_ROOT") || @default_support_root end,
+      version: fn -> Orchard.version() end
+    }
+  end
+
+  defp group_usage do
+    """
+    orchardctl support
+
+    Usage:
+      orchardctl support help
+      orchardctl support bundle create [options]
+
+    Commands:
+      bundle create    Create a local diagnostic support bundle (SPEC.md 11.9, M5).
+    """
+    |> String.trim()
+  end
+
+  defp bundle_usage do
+    """
+    orchardctl support bundle
+
+    Usage:
+      orchardctl support bundle create [options]
+
+    Commands:
+      create    Create a local diagnostic support bundle.
+    """
+    |> String.trim()
+  end
+
+  defp create_usage do
+    """
+    orchardctl support bundle create [options]
+
+    Creates a local support bundle with bounded redacted logs, redacted config,
+    service status, node snapshots, and request summaries.
+
+    Options:
+      --output DIR           Write the .tar.gz bundle to DIR.
+      --support-root PATH    Read Orchard local state from PATH.
+      --max-log-bytes BYTES  Include at most BYTES from each log file.
+      --json                 Emit machine-readable creation output.
+      --help                 Show this help.
+    """
+    |> String.trim()
+  end
+
+  defp readme_text do
+    """
+    Orchard support bundle
+
+    This bundle was created by orchardctl support bundle create.
+    It is intended for diagnostics under the SPEC.md M5 support-bundle contract.
+
+    Redaction policy:
+    - config/*.env files are line-redacted for keys that commonly contain secrets.
+    - TLS keys, license bundles, model artifacts, and request payload bodies are not collected.
+    - logs are bounded tail copies and lines containing common sensitive markers are redacted.
+    """
+    |> String.trim()
+    |> Kernel.<>("\n")
+  end
+
+  defp usage_error(message, usage), do: {:error, "#{message}\n\n#{usage}", @usage_exit_code}
+  defp option?(arg), do: String.starts_with?(arg, "-")
 end

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -5,9 +5,12 @@ defmodule OrchardCLI.Commands.Support do
 
   @default_support_root "/Library/Application Support/Orchard"
   @default_max_log_bytes 1_048_576
+  @default_max_log_files 32
+  @default_max_total_log_bytes 8_388_608
   @usage_exit_code 2
 
   @config_files ~w(controller.env node-agent.env console.env)
+  @preferred_log_files ~w(controller.log node-agent.log console.log)
   @sensitive_key_parts ~w(
     activation authorization bearer cookie dsn keyfile password passwd passphrase pem secret
   )
@@ -15,11 +18,13 @@ defmodule OrchardCLI.Commands.Support do
     access_key api_key apikey cacertfile certfile database_url license_certificate
     machine_certificate private_key sentry_dsn x_api_key
   )
-  @sensitive_key_compact_fragments ~w(password passwd passphrase)
+  @sensitive_key_compact_fragments ~w(
+    accesskey licensekey password passwd passphrase privatekey secretkey
+  )
   @sensitive_key_compact_aliases ~w(dbpass pgpass pgpassfile)
   @sensitive_token_partners ~w(access api auth bearer id license refresh secret session)
   @sensitive_license_partners ~w(activation key secret token)
-  @sensitive_env_license_keys ~w(license orchard_license)
+  @sensitive_bare_license_keys ~w(license orchard_license)
   @safe_diagnostic_keys ~w(
     completion_tokens input_tokens license_enforcement license_mode orchard_license_enforcement
     orchard_license_mode orchard_tokenizer_executable output_tokens prompt_tokens
@@ -197,7 +202,6 @@ defmodule OrchardCLI.Commands.Support do
 
   defp build_stage!(stage_dir, opts, runtime, now) do
     write_text!(stage_dir, "README.txt", readme_text())
-    write_json!(stage_dir, "manifest.json", manifest(opts, runtime, now))
     write_json!(stage_dir, "diagnostics/system.json", system_snapshot(opts, runtime, now))
     write_json!(stage_dir, "diagnostics/status.json", status_snapshot(opts.support_root, runtime))
 
@@ -211,16 +215,24 @@ defmodule OrchardCLI.Commands.Support do
     write_json!(stage_dir, "diagnostics/requests.json", requests_snapshot(runtime))
 
     collect_config!(stage_dir, opts.support_root)
-    collect_logs!(stage_dir, opts.support_root, opts.max_log_bytes)
+    log_collection = collect_logs!(stage_dir, opts.support_root, opts.max_log_bytes, runtime)
+
+    write_json!(stage_dir, "diagnostics/logs.json", %{
+      status: "ok",
+      data: log_collection
+    })
+
+    write_json!(stage_dir, "manifest.json", manifest(opts, runtime, now, log_collection))
   end
 
-  defp manifest(opts, runtime, now) do
+  defp manifest(opts, runtime, now, log_collection) do
     %{
       bundle_format: "orchard.support_bundle.v1",
       command: "orchardctl support bundle create",
       generated_at: DateTime.to_iso8601(now),
       orchard_version: runtime.version.(),
       max_log_bytes: opts.max_log_bytes,
+      log_collection: manifest_log_collection(log_collection),
       spec_references: [
         "SPEC.md 7.3.1 Operator API support-bundles endpoint",
         "SPEC.md 11.9 CLI orchardctl support bundle create",
@@ -232,10 +244,23 @@ defmodule OrchardCLI.Commands.Support do
         "diagnostics/services.json",
         "diagnostics/nodes.json",
         "diagnostics/requests.json",
+        "diagnostics/logs.json",
         "config/*.env redacted when present",
         "logs/** bounded and redacted tail copies when present"
       ]
     }
+  end
+
+  defp manifest_log_collection(log_collection) do
+    Map.take(log_collection, [
+      :bytes_retained,
+      :files_available,
+      :files_collected,
+      :files_skipped,
+      :max_log_bytes_per_file,
+      :max_log_files,
+      :max_total_log_bytes
+    ])
   end
 
   defp system_snapshot(_opts, runtime, now) do
@@ -490,7 +515,7 @@ defmodule OrchardCLI.Commands.Support do
     cond do
       safe_diagnostic_key?(compact) -> false
       sensitive_key?(parts, compact) -> true
-      compact in @sensitive_env_license_keys -> true
+      bare_license_key?(compact) -> true
       sensitive_license_key?(parts) -> true
       true -> false
     end
@@ -502,6 +527,7 @@ defmodule OrchardCLI.Commands.Support do
     cond do
       safe_diagnostic_key?(compact) -> false
       sensitive_key?(parts, compact) -> true
+      bare_license_key?(compact) -> true
       sensitive_license_key?(parts) -> true
       sensitive_log_payload_key?(parts, compact) -> true
       true -> false
@@ -526,6 +552,8 @@ defmodule OrchardCLI.Commands.Support do
   defp sensitive_license_key?(parts) do
     "license" in parts and Enum.any?(@sensitive_license_partners, &(&1 in parts))
   end
+
+  defp bare_license_key?(compact), do: compact in @sensitive_bare_license_keys
 
   defp sensitive_log_payload_key?(parts, compact) do
     compact in @sensitive_log_payload_keys or
@@ -558,29 +586,36 @@ defmodule OrchardCLI.Commands.Support do
     {parts, normalized}
   end
 
-  defp collect_logs!(stage_dir, support_root, max_log_bytes) do
+  defp collect_logs!(stage_dir, support_root, max_log_bytes, runtime) do
     logs_root = Path.join(support_root, "logs")
+    candidates = log_file_candidates(logs_root)
+    limits = log_collection_limits(runtime)
+    {selected, skipped_for_count} = select_log_candidates(candidates, limits.max_files)
 
-    copied =
-      logs_root
-      |> regular_files()
-      |> Enum.reduce(0, fn source_path, count ->
-        rel = Path.relative_to(source_path, logs_root)
-        dest = Path.join("logs", rel)
-
-        case tail_file(source_path, max_log_bytes) do
-          {:ok, content} ->
-            write_text!(stage_dir, dest, redact_log_file(content))
-            count + 1
-
-          :error ->
-            count
-        end
-      end)
+    {copied, bytes_retained, skipped, truncated} =
+      collect_selected_logs!(
+        stage_dir,
+        selected,
+        max_log_bytes,
+        limits.max_total_bytes,
+        Enum.reverse(skipped_for_count)
+      )
 
     if copied == 0 do
       write_text!(stage_dir, "logs/README.txt", "No Orchard log files were found.\n")
     end
+
+    %{
+      bytes_retained: bytes_retained,
+      files_available: length(candidates),
+      files_collected: copied,
+      files_skipped: length(skipped),
+      max_log_bytes_per_file: max_log_bytes,
+      max_log_files: limits.max_files,
+      max_total_log_bytes: limits.max_total_bytes,
+      skipped: Enum.reverse(skipped),
+      truncated: Enum.reverse(truncated)
+    }
   end
 
   defp ensure_output_dir!(path) do
@@ -631,10 +666,6 @@ defmodule OrchardCLI.Commands.Support do
   defp private_temp_root_path(output_dir, basename, path_nonce),
     do: Path.join(output_dir, ".#{basename}-#{path_nonce}.tmp")
 
-  defp regular_files(root) do
-    if real_directory?(root), do: regular_files_in_dir(root), else: []
-  end
-
   defp real_directory?(path) do
     case File.lstat(path) do
       {:ok, %{type: :directory}} -> true
@@ -642,22 +673,154 @@ defmodule OrchardCLI.Commands.Support do
     end
   end
 
-  defp regular_files_in_dir(dir) do
+  defp log_file_candidates(root) do
+    if real_directory?(root), do: log_file_candidates_in_dir(root, root), else: []
+  end
+
+  defp log_file_candidates_in_dir(root, dir) do
     dir
     |> File.ls!()
     |> Enum.flat_map(fn entry ->
       path = Path.join(dir, entry)
 
       case File.lstat(path) do
-        {:ok, %{type: :regular}} -> [path]
-        {:ok, %{type: :directory}} -> regular_files_in_dir(path)
+        {:ok, %{type: :regular} = stat} -> [log_file_candidate(root, path, stat)]
+        {:ok, %{type: :directory}} -> log_file_candidates_in_dir(root, path)
         _other -> []
       end
     end)
-    |> Enum.sort()
   rescue
     _exception -> []
   end
+
+  defp log_file_candidate(root, path, stat) do
+    rel = Path.relative_to(path, root)
+
+    %{
+      path: path,
+      rel: rel,
+      mtime_seconds: datetime_to_seconds(stat.mtime),
+      preferred_index: preferred_log_index(rel)
+    }
+  end
+
+  defp datetime_to_seconds(datetime), do: :calendar.datetime_to_gregorian_seconds(datetime)
+
+  defp preferred_log_index(rel) do
+    case Enum.find_index(@preferred_log_files, &(&1 == rel or &1 == Path.basename(rel))) do
+      nil -> length(@preferred_log_files)
+      index -> index
+    end
+  end
+
+  defp select_log_candidates(candidates, max_files) do
+    candidates
+    |> Enum.sort_by(&log_candidate_sort_key/1)
+    |> Enum.split(max_files)
+    |> then(fn {selected, skipped} ->
+      {selected, Enum.map(skipped, &log_skip(&1, "file_count_limit"))}
+    end)
+  end
+
+  defp log_candidate_sort_key(candidate) do
+    {candidate.preferred_index, -candidate.mtime_seconds, candidate.rel}
+  end
+
+  defp collect_selected_logs!(
+         stage_dir,
+         selected,
+         max_log_bytes,
+         max_total_log_bytes,
+         skipped_for_count
+       ) do
+    Enum.reduce(selected, {0, 0, skipped_for_count, []}, fn candidate,
+                                                            {copied, bytes_retained, skipped,
+                                                             truncated} ->
+      case allowed_log_read_bytes(max_log_bytes, bytes_retained, max_total_log_bytes) do
+        :skip ->
+          {copied, bytes_retained, [log_skip(candidate, "total_log_bytes_limit") | skipped],
+           truncated}
+
+        read_bytes ->
+          copy_log_candidate!(
+            stage_dir,
+            candidate,
+            read_bytes,
+            copied,
+            bytes_retained,
+            skipped,
+            truncated
+          )
+      end
+    end)
+  end
+
+  defp allowed_log_read_bytes(0, _bytes_retained, _max_total_log_bytes), do: 0
+
+  defp allowed_log_read_bytes(max_log_bytes, bytes_retained, max_total_log_bytes) do
+    remaining = max_total_log_bytes - bytes_retained
+
+    if remaining > 0 do
+      min(max_log_bytes, remaining)
+    else
+      :skip
+    end
+  end
+
+  defp copy_log_candidate!(
+         stage_dir,
+         candidate,
+         read_bytes,
+         copied,
+         bytes_retained,
+         skipped,
+         truncated
+       ) do
+    dest = Path.join("logs", candidate.rel)
+
+    case tail_file(candidate.path, read_bytes) do
+      {:ok, content, info} ->
+        write_text!(stage_dir, dest, redact_log_file(content))
+
+        truncated =
+          if info.truncated? do
+            [log_truncated(candidate, info) | truncated]
+          else
+            truncated
+          end
+
+        {copied + 1, bytes_retained + info.retained_bytes, skipped, truncated}
+
+      :error ->
+        {copied, bytes_retained, [log_skip(candidate, "unavailable") | skipped], truncated}
+    end
+  end
+
+  defp log_skip(candidate, reason), do: %{path: candidate.rel, reason: reason}
+
+  defp log_truncated(candidate, info) do
+    %{
+      path: candidate.rel,
+      original_bytes: info.original_bytes,
+      retained_bytes: info.retained_bytes
+    }
+  end
+
+  defp log_collection_limits(runtime) do
+    limits =
+      runtime
+      |> Map.get(:log_collection_limits, fn -> %{} end)
+      |> then(& &1.())
+
+    %{
+      max_files: non_negative_limit(Map.get(limits, :max_files), @default_max_log_files),
+      max_total_bytes:
+        non_negative_limit(Map.get(limits, :max_total_bytes), @default_max_total_log_bytes)
+    }
+  end
+
+  defp non_negative_limit(value, _fallback) when is_integer(value) and value >= 0, do: value
+  defp non_negative_limit(_value, fallback), do: fallback
 
   defp read_regular_file(path) do
     with {:ok, first_stat} <- regular_file_stat(path),
@@ -691,11 +854,18 @@ defmodule OrchardCLI.Commands.Support do
            end),
          {:ok, second_stat} <- regular_file_stat(path),
          true <- same_file?(first_stat, second_stat) do
-      {:ok, format_tail_content(content, first_stat.size, max_bytes)}
+      {:ok, format_tail_content(content, first_stat.size, max_bytes),
+       %{
+         original_bytes: first_stat.size,
+         retained_bytes: min(first_stat.size, max_bytes),
+         truncated?: first_stat.size > max_bytes
+       }}
     else
       _other -> :error
     end
   end
+
+  defp read_tail_content(_file, _file_size, 0), do: {:ok, ""}
 
   defp read_tail_content(file, file_size, max_bytes) do
     offset = max(file_size - max_bytes, 0)
@@ -1002,6 +1172,9 @@ defmodule OrchardCLI.Commands.Support do
       file_regular?: &File.regular?/1,
       list_nodes: &Orchard.Nodes.list_nodes/0,
       list_recent_requests: &Orchard.Requests.list_recent_requests/1,
+      log_collection_limits: fn ->
+        %{max_files: @default_max_log_files, max_total_bytes: @default_max_total_log_bytes}
+      end,
       nodes_summary: &Orchard.Nodes.summary/0,
       now: fn -> DateTime.utc_now() |> DateTime.truncate(:second) end,
       path_nonce: fn -> :crypto.strong_rand_bytes(18) |> Base.url_encode64(padding: false) end,
@@ -1050,7 +1223,7 @@ defmodule OrchardCLI.Commands.Support do
     Options:
       --output DIR           Write the .tar.gz bundle to DIR.
       --support-root PATH    Read Orchard local state from PATH.
-      --max-log-bytes BYTES  Include at most BYTES from each log file.
+      --max-log-bytes BYTES  Include at most BYTES from each collected log file.
       --json                 Emit machine-readable creation output.
       --help                 Show this help.
     """
@@ -1067,7 +1240,8 @@ defmodule OrchardCLI.Commands.Support do
     Redaction policy:
     - config/*.env files are line-redacted for keys that commonly contain secrets.
     - TLS keys, license bundles, model artifacts, and request payload bodies are not collected.
-    - logs are bounded tail copies and lines containing common sensitive markers are redacted.
+    - logs are bounded by per-file, file-count, and aggregate tail-copy caps.
+    - collected log lines containing common sensitive markers are redacted.
     """
     |> String.trim()
     |> Kernel.<>("\n")

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -250,6 +250,67 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute log =~ "plain-token-secret"
   end
 
+  test "redaction covers compact password keys, PEM blocks, and payload assignments", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    File.write!(
+      Path.join([support_root, "config", "controller.env"]),
+      """
+      PGPASSWORD=pg-secret
+      #PGPASSWORD=old-pg-secret
+      ORCHARD_PUBLIC_HOST=orchard.local
+      """
+    )
+
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      """
+      PGPASSWORD=pg-log-secret
+      prompt: private prompt text
+      %{messages: [%{role: "user", content: "private message text"}]}
+      input: private input text
+      content: private content text
+      -----BEGIN PRIVATE KEY-----
+      MIIPrivateKeyBody
+      -----END PRIVATE KEY-----
+      input_tokens=12 prompt_tokens=8 token_count=20
+      safe diagnostic line
+      """
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "payload-redaction")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    config = File.read!(Path.join([extract_dir, "config", "controller.env"]))
+    assert config =~ "PGPASSWORD=[redacted]"
+    assert config =~ "#PGPASSWORD=[redacted]"
+    assert config =~ "ORCHARD_PUBLIC_HOST=orchard.local"
+    refute config =~ "pg-secret"
+    refute config =~ "old-pg-secret"
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log =~ "input_tokens=12 prompt_tokens=8 token_count=20"
+    assert log =~ "safe diagnostic line"
+    assert log =~ "[redacted log line]"
+    refute log =~ "pg-log-secret"
+    refute log =~ "private prompt text"
+    refute log =~ "private message text"
+    refute log =~ "private input text"
+    refute log =~ "private content text"
+    refute log =~ "MIIPrivateKeyBody"
+    refute log =~ "PRIVATE KEY"
+  end
+
   test "config collection skips symlinked env files", %{
     support_root: support_root,
     output_dir: output_dir,

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -51,6 +51,8 @@ defmodule OrchardCLI.Commands.SupportTest do
       OPENAI_API_KEY=sk-test
       ORCHARD_API_KEY=orch_test.secret
       AWS_ACCESS_KEY_ID=AKIASECRET
+      #SECRET_KEY_BASE=old-super-secret
+      # DATABASE_URL=postgres://user:old-password@localhost/old_orchard
       ORCHARD_PUBLIC_HOST=orchard.local
       """
     )
@@ -99,7 +101,10 @@ defmodule OrchardCLI.Commands.SupportTest do
     assert config =~ "OPENAI_API_KEY=[redacted]"
     assert config =~ "ORCHARD_API_KEY=[redacted]"
     assert config =~ "AWS_ACCESS_KEY_ID=[redacted]"
+    assert config =~ "#SECRET_KEY_BASE=[redacted]"
+    assert config =~ "# DATABASE_URL=[redacted]"
     refute config =~ "super-secret"
+    refute config =~ "old-super-secret"
     refute config =~ "postgres://user"
     refute config =~ "sk-test"
     refute config =~ "orch_test.secret"
@@ -135,6 +140,8 @@ defmodule OrchardCLI.Commands.SupportTest do
       booted
       Authorization: Bearer orch_secret.token
       request_payload={"prompt":"private prompt"}
+      password=orch_password
+      token=orch_token
       ready
       """
     )
@@ -170,6 +177,8 @@ defmodule OrchardCLI.Commands.SupportTest do
     assert log =~ "[redacted log line]"
     refute log =~ "orch_secret"
     refute log =~ "private prompt"
+    refute log =~ "orch_password"
+    refute log =~ "orch_token"
 
     truncated_log = File.read!(Path.join([extract_dir, "logs", "truncated.log"]))
     refute truncated_log =~ "orch_partial_secret"

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -286,6 +286,75 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute log =~ "[1,2,3]"
   end
 
+  test "redaction covers bare license assignments and compact secret keys", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    File.write!(
+      Path.join([support_root, "config", "controller.env"]),
+      """
+      LICENSE=env-license-secret
+      SECRETKEY=env-secret-key
+      PRIVATEKEY=env-private-key
+      ACCESSKEY=env-access-key
+      LICENSEKEY=env-license-key
+      ORCHARD_LICENSE_ENFORCEMENT=strict
+      ORCHARD_LICENSE_MODE=offline
+      """
+    )
+
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      """
+      license=log-license-secret
+      orchard_license=log-orchard-license-secret
+      callback=/cb?license=query-license-secret&license_mode=offline
+      SECRETKEY=log-secret-key
+      PRIVATEKEY=log-private-key
+      ACCESSKEY=log-access-key
+      LICENSEKEY=log-license-key
+      ORCHARD_LICENSE_ENFORCEMENT=strict license_mode=offline
+      """
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "compact-key-redaction")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    config = File.read!(Path.join([extract_dir, "config", "controller.env"]))
+    assert config =~ "LICENSE=[redacted]"
+    assert config =~ "SECRETKEY=[redacted]"
+    assert config =~ "PRIVATEKEY=[redacted]"
+    assert config =~ "ACCESSKEY=[redacted]"
+    assert config =~ "LICENSEKEY=[redacted]"
+    assert config =~ "ORCHARD_LICENSE_ENFORCEMENT=strict"
+    assert config =~ "ORCHARD_LICENSE_MODE=offline"
+    refute config =~ "env-license-secret"
+    refute config =~ "env-secret-key"
+    refute config =~ "env-private-key"
+    refute config =~ "env-access-key"
+    refute config =~ "env-license-key"
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log =~ "[redacted log line]"
+    assert log =~ "ORCHARD_LICENSE_ENFORCEMENT=strict license_mode=offline"
+    refute log =~ "log-license-secret"
+    refute log =~ "log-orchard-license-secret"
+    refute log =~ "query-license-secret"
+    refute log =~ "log-secret-key"
+    refute log =~ "log-private-key"
+    refute log =~ "log-access-key"
+    refute log =~ "log-license-key"
+  end
+
   test "redaction preserves tokenizer and license diagnostics while redacting credentials", %{
     support_root: support_root,
     output_dir: output_dir,
@@ -633,6 +702,113 @@ defmodule OrchardCLI.Commands.SupportTest do
              "No Orchard log files were found."
   end
 
+  test "log collection caps file count and prefers Orchard service logs", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    controller_log = Path.join([support_root, "logs", "controller.log"])
+    File.write!(controller_log, "controller\n")
+    touch_log!(controller_log, 1)
+
+    for index <- 1..5 do
+      path = Path.join([support_root, "logs", "rotated-#{index}.log"])
+      File.write!(path, "rotated #{index}\n")
+      touch_log!(path, index + 10)
+    end
+
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:log_collection_limits, fn -> %{max_files: 3, max_total_bytes: 1_024} end)
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "log-file-count-cap")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    assert File.exists?(Path.join([extract_dir, "logs", "controller.log"]))
+    assert File.exists?(Path.join([extract_dir, "logs", "rotated-5.log"]))
+    assert File.exists?(Path.join([extract_dir, "logs", "rotated-4.log"]))
+    refute File.exists?(Path.join([extract_dir, "logs", "rotated-3.log"]))
+
+    log_collection = read_json!(extract_dir, "diagnostics/logs.json")
+    assert get_in(log_collection, ["data", "files_available"]) == 6
+    assert get_in(log_collection, ["data", "files_collected"]) == 3
+    assert get_in(log_collection, ["data", "files_skipped"]) == 3
+
+    assert %{"path" => "rotated-3.log", "reason" => "file_count_limit"} in get_in(
+             log_collection,
+             ["data", "skipped"]
+           )
+
+    manifest = read_json!(extract_dir, "manifest.json")
+    assert get_in(manifest, ["log_collection", "files_collected"]) == 3
+  end
+
+  test "log collection caps aggregate retained bytes and records metadata", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    for index <- 1..3 do
+      path = Path.join([support_root, "logs", "aggregate-#{index}.log"])
+      File.write!(path, "prefix\n" <> String.duplicate(Integer.to_string(index), 24))
+      touch_log!(path, index)
+    end
+
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:log_collection_limits, fn -> %{max_files: 10, max_total_bytes: 25} end)
+
+    assert {:ok, _output} =
+             Support.run(
+               [
+                 "bundle",
+                 "create",
+                 "--support-root",
+                 support_root,
+                 "--output",
+                 output_dir,
+                 "--max-log-bytes",
+                 "20"
+               ],
+               runtime
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "log-aggregate-cap")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    assert File.exists?(Path.join([extract_dir, "logs", "aggregate-3.log"]))
+    assert File.exists?(Path.join([extract_dir, "logs", "aggregate-2.log"]))
+    refute File.exists?(Path.join([extract_dir, "logs", "aggregate-1.log"]))
+
+    log_collection = read_json!(extract_dir, "diagnostics/logs.json")
+    assert get_in(log_collection, ["data", "bytes_retained"]) == 25
+
+    assert %{"path" => "aggregate-1.log", "reason" => "total_log_bytes_limit"} in get_in(
+             log_collection,
+             ["data", "skipped"]
+           )
+
+    truncated_paths =
+      log_collection
+      |> get_in(["data", "truncated"])
+      |> Enum.map(& &1["path"])
+
+    assert "aggregate-3.log" in truncated_paths
+    assert "aggregate-2.log" in truncated_paths
+  end
+
   test "truncated logs omit the first partial line before redaction",
        %{support_root: support_root, output_dir: output_dir, tmp_dir: tmp_dir} do
     File.write!(
@@ -972,5 +1148,9 @@ defmodule OrchardCLI.Commands.SupportTest do
     |> Path.join(relative_path)
     |> File.read!()
     |> Jason.decode!()
+  end
+
+  defp touch_log!(path, second) do
+    assert :ok = :file.change_time(String.to_charlist(path), {{2026, 1, 1}, {0, 0, second}})
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -184,6 +184,47 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute truncated_log =~ "orch_partial_secret"
   end
 
+  test "log collection redacts credential URLs and query secrets", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      """
+      booted
+      postgresql://orchard:db-secret@db.local/orchard
+      callback=/health?api_key=query-api-secret&token=query-token-secret
+      redirect=https://user:http-secret@example.test/path
+      license=/status?license_key=query-license-secret
+      stats=/status?token_count=7&license_mode=offline
+      ready
+      """
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "credential-url-redaction")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log =~ "booted"
+    assert log =~ "ready"
+    assert log =~ "stats=/status?token_count=7&license_mode=offline"
+    assert log =~ "[redacted log line]"
+    refute log =~ "db-secret"
+    refute log =~ "query-api-secret"
+    refute log =~ "query-token-secret"
+    refute log =~ "http-secret"
+    refute log =~ "query-license-secret"
+  end
+
   test "redaction preserves tokenizer and license diagnostics while redacting credentials", %{
     support_root: support_root,
     output_dir: output_dir,
@@ -463,6 +504,39 @@ defmodule OrchardCLI.Commands.SupportTest do
 
     archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
     extract_dir = Path.join(tmp_dir, "symlink-config")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    refute File.exists?(Path.join([extract_dir, "config", "controller.env"]))
+
+    assert File.read!(Path.join([extract_dir, "config", "README.txt"])) =~
+             "No Orchard env config files were found."
+  end
+
+  test "config collection skips symlinked config directories", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    outside_config_dir = Path.join(tmp_dir, "outside-config")
+    File.mkdir_p!(outside_config_dir)
+
+    File.write!(
+      Path.join(outside_config_dir, "controller.env"),
+      "ORCHARD_PUBLIC_HOST=leaked.example\n"
+    )
+
+    File.rm_rf!(Path.join(support_root, "config"))
+    File.ln_s!(outside_config_dir, Path.join(support_root, "config"))
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "symlink-config-dir")
     File.mkdir_p!(extract_dir)
     assert_tar_extract!(archive_path, extract_dir)
 

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -299,6 +299,10 @@ defmodule OrchardCLI.Commands.SupportTest do
       PRIVATEKEY=env-private-key
       ACCESSKEY=env-access-key
       LICENSEKEY=env-license-key
+      ACCESSTOKEN=env-access-token
+      REFRESHTOKEN=env-refresh-token
+      CLIENTSECRET=env-client-secret
+      LICENSESECRET=env-license-secret
       ORCHARD_LICENSE_ENFORCEMENT=strict
       ORCHARD_LICENSE_MODE=offline
       """
@@ -314,6 +318,10 @@ defmodule OrchardCLI.Commands.SupportTest do
       PRIVATEKEY=log-private-key
       ACCESSKEY=log-access-key
       LICENSEKEY=log-license-key
+      ACCESSTOKEN=log-access-token
+      REFRESHTOKEN=log-refresh-token
+      CLIENTSECRET=log-client-secret
+      LICENSESECRET=log-license-secret
       ORCHARD_LICENSE_ENFORCEMENT=strict license_mode=offline
       """
     )
@@ -335,6 +343,10 @@ defmodule OrchardCLI.Commands.SupportTest do
     assert config =~ "PRIVATEKEY=[redacted]"
     assert config =~ "ACCESSKEY=[redacted]"
     assert config =~ "LICENSEKEY=[redacted]"
+    assert config =~ "ACCESSTOKEN=[redacted]"
+    assert config =~ "REFRESHTOKEN=[redacted]"
+    assert config =~ "CLIENTSECRET=[redacted]"
+    assert config =~ "LICENSESECRET=[redacted]"
     assert config =~ "ORCHARD_LICENSE_ENFORCEMENT=strict"
     assert config =~ "ORCHARD_LICENSE_MODE=offline"
     refute config =~ "env-license-secret"
@@ -342,6 +354,10 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute config =~ "env-private-key"
     refute config =~ "env-access-key"
     refute config =~ "env-license-key"
+    refute config =~ "env-access-token"
+    refute config =~ "env-refresh-token"
+    refute config =~ "env-client-secret"
+    refute config =~ "env-license-secret"
 
     log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
     assert log =~ "[redacted log line]"
@@ -353,6 +369,10 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute log =~ "log-private-key"
     refute log =~ "log-access-key"
     refute log =~ "log-license-key"
+    refute log =~ "log-access-token"
+    refute log =~ "log-refresh-token"
+    refute log =~ "log-client-secret"
+    refute log =~ "log-license-secret"
   end
 
   test "redaction preserves tokenizer and license diagnostics while redacting credentials", %{
@@ -446,6 +466,12 @@ defmodule OrchardCLI.Commands.SupportTest do
       -----BEGIN PRIVATE KEY-----
       MIIPrivateKeyBody
       -----END PRIVATE KEY-----
+      -----BEGIN LICENSE FILE-----
+      MIILicenseFileBody
+      -----END LICENSE FILE-----
+      -----BEGIN MACHINE FILE-----
+      MIIMachineFileBody
+      -----END MACHINE FILE-----
       input_tokens=12 prompt_tokens=8 token_count=20
       safe diagnostic line
       """
@@ -480,6 +506,10 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute log =~ "private content text"
     refute log =~ "MIIPrivateKeyBody"
     refute log =~ "PRIVATE KEY"
+    refute log =~ "MIILicenseFileBody"
+    refute log =~ "LICENSE FILE"
+    refute log =~ "MIIMachineFileBody"
+    refute log =~ "MACHINE FILE"
   end
 
   test "redaction covers prompt token IDs and camel-case sensitive keys", %{
@@ -807,6 +837,55 @@ defmodule OrchardCLI.Commands.SupportTest do
 
     assert "aggregate-3.log" in truncated_paths
     assert "aggregate-2.log" in truncated_paths
+  end
+
+  test "log discovery caps traversal and records metadata", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    controller_log = Path.join([support_root, "logs", "controller.log"])
+    File.write!(controller_log, "controller\n")
+    touch_log!(controller_log, 1)
+
+    for index <- 1..5 do
+      path = Path.join([support_root, "logs", "rotated-#{index}.log"])
+      File.write!(path, "rotated #{index}\n")
+      touch_log!(path, index + 10)
+    end
+
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:log_collection_limits, fn ->
+        %{max_files: 10, max_total_bytes: 1_024, max_discovery_entries: 3}
+      end)
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "log-discovery-cap")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    assert File.exists?(Path.join([extract_dir, "logs", "controller.log"]))
+    assert File.exists?(Path.join([extract_dir, "logs", "rotated-1.log"]))
+    assert File.exists?(Path.join([extract_dir, "logs", "rotated-2.log"]))
+    refute File.exists?(Path.join([extract_dir, "logs", "rotated-3.log"]))
+
+    log_collection = read_json!(extract_dir, "diagnostics/logs.json")
+    assert get_in(log_collection, ["data", "files_available"]) == 3
+    assert get_in(log_collection, ["data", "discovery_capped"]) == true
+    assert get_in(log_collection, ["data", "max_discovery_entries"]) == 3
+
+    assert %{"path" => ".", "reason" => "discovery_limit"} in get_in(
+             log_collection,
+             ["data", "skipped"]
+           )
   end
 
   test "truncated logs omit the first partial line before redaction",

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -184,6 +184,72 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute truncated_log =~ "orch_partial_secret"
   end
 
+  test "redaction preserves tokenizer and license diagnostics while redacting credentials", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    File.write!(
+      Path.join([support_root, "config", "controller.env"]),
+      """
+      ORCHARD_TOKENIZER_EXECUTABLE=/Library/Application Support/Orchard/native/tokenizer
+      ORCHARD_LICENSE_ENFORCEMENT=strict
+      ORCHARD_LICENSE_MODE=offline
+      ORCHARD_LICENSE_KEY=lic-secret
+      ORCHARD_ACCESS_TOKEN=access-secret
+      ORCHARD_TOKEN=plain-token-secret
+      """
+    )
+
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      """
+      tokenizer loaded executable=/Library/Application Support/Orchard/native/tokenizer
+      input_tokens=12 output_tokens=4 token_count=16
+      ORCHARD_LICENSE_ENFORCEMENT=strict license_mode=offline
+      license_key=lic-secret
+      api_token=api-secret
+      token=plain-token-secret
+      """
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "precise-redaction")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    config = File.read!(Path.join([extract_dir, "config", "controller.env"]))
+
+    assert config =~
+             "ORCHARD_TOKENIZER_EXECUTABLE=/Library/Application Support/Orchard/native/tokenizer"
+
+    assert config =~ "ORCHARD_LICENSE_ENFORCEMENT=strict"
+    assert config =~ "ORCHARD_LICENSE_MODE=offline"
+    assert config =~ "ORCHARD_LICENSE_KEY=[redacted]"
+    assert config =~ "ORCHARD_ACCESS_TOKEN=[redacted]"
+    assert config =~ "ORCHARD_TOKEN=[redacted]"
+    refute config =~ "lic-secret"
+    refute config =~ "access-secret"
+    refute config =~ "plain-token-secret"
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+
+    assert log =~
+             "tokenizer loaded executable=/Library/Application Support/Orchard/native/tokenizer"
+
+    assert log =~ "input_tokens=12 output_tokens=4 token_count=16"
+    assert log =~ "ORCHARD_LICENSE_ENFORCEMENT=strict license_mode=offline"
+    refute log =~ "lic-secret"
+    refute log =~ "api-secret"
+    refute log =~ "plain-token-secret"
+  end
+
   test "config collection skips symlinked env files", %{
     support_root: support_root,
     output_dir: output_dir,
@@ -308,9 +374,70 @@ defmodule OrchardCLI.Commands.SupportTest do
              )
 
     assert_received {:archive_dir, archive_dir, 0o700}
-    assert Path.dirname(archive_dir) == output_dir
+    temp_root = Path.dirname(archive_dir)
+    assert Path.dirname(temp_root) == output_dir
+    assert Path.basename(archive_dir) == "archive"
     refute archive_dir == output_dir
-    refute File.exists?(archive_dir)
+    refute File.exists?(temp_root)
+  end
+
+  test "temporary path collision does not remove another in-flight bundle directory",
+       %{support_root: support_root, output_dir: output_dir} do
+    File.mkdir_p!(output_dir)
+
+    colliding_stage_dir =
+      Path.join(output_dir, ".orchard-support-bundle-20260622T123456Z-collide.stage")
+
+    File.mkdir_p!(colliding_stage_dir)
+    File.write!(Path.join(colliding_stage_dir, "sentinel"), "owned")
+
+    {:ok, nonce_agent} = Agent.start(fn -> ["collide", "fresh"] end)
+    on_exit(fn -> Agent.stop(nonce_agent) end)
+
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:path_nonce, fn ->
+        Agent.get_and_update(nonce_agent, fn
+          [nonce | rest] -> {nonce, rest}
+          [] -> {"fresh", []}
+        end)
+      end)
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime
+             )
+
+    assert File.read!(Path.join(colliding_stage_dir, "sentinel")) == "owned"
+  end
+
+  test "final archive creation retries without overwriting an existing bundle",
+       %{support_root: support_root, output_dir: output_dir} do
+    File.mkdir_p!(output_dir)
+
+    existing_archive = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:archive, fn stage_dir, temp_archive_path ->
+        :ok = archive_stage(stage_dir, temp_archive_path)
+        File.write!(existing_archive, "existing archive")
+        :ok
+      end)
+
+    assert {:ok, output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime
+             )
+
+    retry_archive = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z-1.tar.gz")
+    assert output =~ "Created support bundle: #{retry_archive}"
+    assert File.read!(existing_archive) == "existing archive"
+    assert File.regular?(retry_archive)
   end
 
   test "snapshot failures do not serialize raw exception messages",
@@ -359,17 +486,7 @@ defmodule OrchardCLI.Commands.SupportTest do
 
     assert message =~ "tar failed"
     refute File.exists?(Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz"))
-
-    refute File.exists?(
-             Path.join(
-               output_dir,
-               ".orchard-support-bundle-20260622T123456Z-testnonce.tar.gz.tmp"
-             )
-           )
-
-    refute File.exists?(
-             Path.join(output_dir, ".orchard-support-bundle-20260622T123456Z-testnonce.stage")
-           )
+    assert File.ls!(output_dir) == []
   end
 
   test "json output reports archive path", %{support_root: support_root, output_dir: output_dir} do

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -195,9 +195,13 @@ defmodule OrchardCLI.Commands.SupportTest do
       booted
       postgresql://orchard:db-secret@db.local/orchard
       callback=/health?api_key=query-api-secret&token=query-token-secret
+      fragment=https://idp.test/cb#access_token=fragment-access-secret
+      presigned=https://storage.test/object?X-Amz-Credential=amz-credential-secret&X-Amz-Signature=amz-signature-secret&X-Amz-Security-Token=amz-security-token-secret
+      signed_only=https://storage.test/object?X-Amz-Signature=amz-signature-only-secret&X-Amz-Expires=60
       redirect=https://user:http-secret@example.test/path
       license=/status?license_key=query-license-secret
       stats=/status?token_count=7&license_mode=offline
+      fragment_stats=/status#token_count=7&license_mode=offline
       ready
       """
     )
@@ -217,10 +221,16 @@ defmodule OrchardCLI.Commands.SupportTest do
     assert log =~ "booted"
     assert log =~ "ready"
     assert log =~ "stats=/status?token_count=7&license_mode=offline"
+    assert log =~ "fragment_stats=/status#token_count=7&license_mode=offline"
     assert log =~ "[redacted log line]"
     refute log =~ "db-secret"
     refute log =~ "query-api-secret"
     refute log =~ "query-token-secret"
+    refute log =~ "fragment-access-secret"
+    refute log =~ "amz-credential-secret"
+    refute log =~ "amz-signature-secret"
+    refute log =~ "amz-security-token-secret"
+    refute log =~ "amz-signature-only-secret"
     refute log =~ "http-secret"
     refute log =~ "query-license-secret"
   end
@@ -236,6 +246,8 @@ defmodule OrchardCLI.Commands.SupportTest do
       ORCHARD_PUBLIC_HOST=orchard.local
       REDIS_URL=redis://:redis-secret@localhost:6379/0
       WEBHOOK=/callback?api_key=env-query-secret&token_count=7
+      FRAGMENT_URL=https://idp.test/cb#access_token=env-fragment-secret
+      SIGNED_URL=https://storage.test/object?X-Amz-Signature=env-amz-signature-secret
       PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
       EnvPrivateKeyBody
       -----END PRIVATE KEY-----"
@@ -269,9 +281,13 @@ defmodule OrchardCLI.Commands.SupportTest do
     assert config =~ "ORCHARD_PUBLIC_HOST=orchard.local"
     assert config =~ "REDIS_URL=[redacted]"
     assert config =~ "WEBHOOK=[redacted]"
+    assert config =~ "FRAGMENT_URL=[redacted]"
+    assert config =~ "SIGNED_URL=[redacted]"
     assert config =~ "PRIVATE_KEY=[redacted]"
     refute config =~ "redis-secret"
     refute config =~ "env-query-secret"
+    refute config =~ "env-fragment-secret"
+    refute config =~ "env-amz-signature-secret"
     refute config =~ "EnvPrivateKeyBody"
     refute config =~ "PRIVATE KEY"
 
@@ -538,6 +554,9 @@ defmodule OrchardCLI.Commands.SupportTest do
       tokenIds: [444, 555, 666]
       input_ids=[777, 888, 999]
       inputIds: [123, 234, 345]
+      messages[0].content=bracketed message secret
+      input[0].text=bracketed input secret
+      token_ids[0]=909
       tokenizer failed with prompt_token_ids_length_mismatch ids=[707, 808]
       supports_prompt_token_ids=true worker_supports_prompt_token_ids=true token_count=3
       input_tokens=9 prompt_tokens=8 total_tokens=17 token_count=17
@@ -591,6 +610,9 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute log =~ "444"
     refute log =~ "777"
     refute log =~ "123"
+    refute log =~ "bracketed message secret"
+    refute log =~ "bracketed input secret"
+    refute log =~ "909"
     refute log =~ "707"
     refute log =~ "log-access-secret"
     refute log =~ "log-client-secret"
@@ -872,10 +894,15 @@ defmodule OrchardCLI.Commands.SupportTest do
     File.mkdir_p!(extract_dir)
     assert_tar_extract!(archive_path, extract_dir)
 
-    assert File.exists?(Path.join([extract_dir, "logs", "controller.log"]))
-    assert File.exists?(Path.join([extract_dir, "logs", "rotated-1.log"]))
-    assert File.exists?(Path.join([extract_dir, "logs", "rotated-2.log"]))
-    refute File.exists?(Path.join([extract_dir, "logs", "rotated-3.log"]))
+    collected_logs =
+      extract_dir
+      |> Path.join("logs/*.log")
+      |> Path.wildcard()
+      |> Enum.map(&Path.basename/1)
+
+    assert "controller.log" in collected_logs
+    assert length(collected_logs) == 3
+    assert Enum.count(collected_logs, &String.starts_with?(&1, "rotated-")) == 2
 
     log_collection = read_json!(extract_dir, "diagnostics/logs.json")
     assert get_in(log_collection, ["data", "files_available"]) == 3

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -1,0 +1,436 @@
+defmodule OrchardCLI.Commands.SupportTest do
+  use ExUnit.Case, async: false
+
+  alias OrchardCLI.Commands.Support
+
+  @fixed_now ~U[2026-06-22 12:34:56Z]
+
+  setup do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "orchard support test #{System.unique_integer([:positive])}")
+
+    support_root = Path.join(tmp_dir, "Application Support/Orchard")
+    output_dir = Path.join(tmp_dir, "output")
+
+    File.mkdir_p!(Path.join([support_root, "config"]))
+    File.mkdir_p!(Path.join([support_root, "logs", "workers"]))
+    File.mkdir_p!(Path.join([support_root, "support"]))
+    File.write!(Path.join([support_root, "support", ".install-role"]), "all\n")
+
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    %{support_root: support_root, output_dir: output_dir, tmp_dir: tmp_dir}
+  end
+
+  test "help displays support bundle create usage", %{support_root: support_root} do
+    assert {:ok, group} = Support.run(["--help"], runtime(support_root))
+    assert group =~ "orchardctl support bundle create"
+
+    assert {:ok, command} = Support.run(["bundle", "create", "--help"], runtime(support_root))
+    assert command =~ "--output DIR"
+    assert command =~ "--support-root PATH"
+    assert command =~ "--max-log-bytes BYTES"
+  end
+
+  test "unknown create option exits with usage error", %{support_root: support_root} do
+    assert {:error, message, 2} =
+             Support.run(["bundle", "create", "--bogus"], runtime(support_root))
+
+    assert message =~ "Unknown option: --bogus"
+    assert message =~ "orchardctl support bundle create"
+  end
+
+  test "SPEC M5 bundle contains redacted config, bounded logs, node snapshots, and request summary",
+       %{support_root: support_root, output_dir: output_dir, tmp_dir: tmp_dir} do
+    File.write!(
+      Path.join([support_root, "config", "controller.env"]),
+      """
+      PORT=4000
+      SECRET_KEY_BASE=super-secret
+      DATABASE_URL=postgres://user:password@localhost/orchard
+      OPENAI_API_KEY=sk-test
+      ORCHARD_API_KEY=orch_test.secret
+      AWS_ACCESS_KEY_ID=AKIASECRET
+      ORCHARD_PUBLIC_HOST=orchard.local
+      """
+    )
+
+    File.write!(Path.join([support_root, "logs", "controller.log"]), "abcdefghij")
+    File.write!(Path.join([support_root, "logs", "workers", "worker.log"]), "worker-ready\n")
+
+    assert {:ok, output} =
+             Support.run(
+               [
+                 "bundle",
+                 "create",
+                 "--support-root",
+                 support_root,
+                 "--output",
+                 output_dir,
+                 "--max-log-bytes",
+                 "4"
+               ],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    assert output =~ "Created support bundle: #{archive_path}"
+    assert output =~ "Audit: recorded"
+    assert File.regular?(archive_path)
+    assert Bitwise.band(File.stat!(archive_path).mode, 0o777) == 0o600
+    assert_received {:support_bundle_audit, audit_event}
+    assert audit_event.archive_name == Path.basename(archive_path)
+    refute Map.has_key?(audit_event, :support_root)
+
+    extract_dir = Path.join(tmp_dir, "extracted")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    manifest = read_json!(extract_dir, "manifest.json")
+
+    assert manifest["bundle_format"] == "orchard.support_bundle.v1"
+    assert Enum.any?(manifest["spec_references"], &String.contains?(&1, "SPEC.md 11.9"))
+
+    config = File.read!(Path.join([extract_dir, "config", "controller.env"]))
+    assert config =~ "PORT=4000"
+    assert config =~ "ORCHARD_PUBLIC_HOST=orchard.local"
+    assert config =~ "SECRET_KEY_BASE=[redacted]"
+    assert config =~ "DATABASE_URL=[redacted]"
+    assert config =~ "OPENAI_API_KEY=[redacted]"
+    assert config =~ "ORCHARD_API_KEY=[redacted]"
+    assert config =~ "AWS_ACCESS_KEY_ID=[redacted]"
+    refute config =~ "super-secret"
+    refute config =~ "postgres://user"
+    refute config =~ "sk-test"
+    refute config =~ "orch_test.secret"
+    refute config =~ "AKIASECRET"
+
+    controller_log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert controller_log == "[truncated to last 4 bytes]\n"
+
+    worker_log = File.read!(Path.join([extract_dir, "logs", "workers", "worker.log"]))
+    assert worker_log == "[truncated to last 4 bytes]\n"
+
+    nodes = read_json!(extract_dir, "diagnostics/nodes.json")
+    assert nodes["status"] == "ok"
+    assert get_in(nodes, ["data", "summary", "total"]) == 1
+    assert get_in(nodes, ["data", "nodes", Access.at(0), "display_name"]) == "node-a"
+
+    requests = read_json!(extract_dir, "diagnostics/requests.json")
+    assert requests["status"] == "ok"
+    assert get_in(requests, ["data", "summary", "total"]) == 2
+    assert get_in(requests, ["data", "recent", Access.at(0), "public_id"]) == "req_1"
+    assert get_in(requests, ["data", "recent", Access.at(0), "stream"]) == false
+    refute Jason.encode!(requests) =~ "request_payload"
+  end
+
+  test "log collection redacts sensitive lines", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      """
+      booted
+      Authorization: Bearer orch_secret.token
+      request_payload={"prompt":"private prompt"}
+      ready
+      """
+    )
+
+    File.write!(
+      Path.join([support_root, "logs", "truncated.log"]),
+      "Authorization: Bearer orch_partial_secret\nready\n"
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               [
+                 "bundle",
+                 "create",
+                 "--support-root",
+                 support_root,
+                 "--output",
+                 output_dir,
+                 "--max-log-bytes",
+                 "512"
+               ],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "redacted")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log =~ "booted"
+    assert log =~ "ready"
+    assert log =~ "[redacted log line]"
+    refute log =~ "orch_secret"
+    refute log =~ "private prompt"
+
+    truncated_log = File.read!(Path.join([extract_dir, "logs", "truncated.log"]))
+    refute truncated_log =~ "orch_partial_secret"
+  end
+
+  test "truncated logs omit the first partial line before redaction",
+       %{support_root: support_root, output_dir: output_dir, tmp_dir: tmp_dir} do
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      "Authorization: Bearer orch_partial_secret\nsafe\n"
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               [
+                 "bundle",
+                 "create",
+                 "--support-root",
+                 support_root,
+                 "--output",
+                 output_dir,
+                 "--max-log-bytes",
+                 "12"
+               ],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "truncated")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log == "[truncated to last 12 bytes]\nsafe\n"
+    refute log =~ "orch_partial_secret"
+  end
+
+  test "existing output directory permissions are not changed",
+       %{support_root: support_root, output_dir: output_dir} do
+    File.mkdir_p!(output_dir)
+    File.chmod!(output_dir, 0o755)
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    assert Bitwise.band(File.stat!(output_dir).mode, 0o777) == 0o755
+  end
+
+  test "snapshot failures do not serialize raw exception messages",
+       %{support_root: support_root, output_dir: output_dir, tmp_dir: tmp_dir} do
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:nodes_summary, fn ->
+        raise "DATABASE_URL=postgres://user:password@localhost/orchard"
+      end)
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "snapshot-error")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    nodes = read_json!(extract_dir, "diagnostics/nodes.json")
+    assert nodes["status"] == "unavailable"
+    assert nodes["error"] == "snapshot unavailable"
+    assert nodes["reason"] == "RuntimeError"
+    refute Jason.encode!(nodes) =~ "postgres://"
+    refute Jason.encode!(nodes) =~ "password"
+  end
+
+  test "archive failure removes temporary archive and stage directory",
+       %{support_root: support_root, output_dir: output_dir} do
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:archive, fn _stage_dir, temp_archive_path ->
+        File.write!(temp_archive_path, "partial")
+        {:error, "Error: tar failed with exit 2: no space left"}
+      end)
+
+    assert {:error, message, 1} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime
+             )
+
+    assert message =~ "tar failed"
+    refute File.exists?(Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz"))
+
+    refute File.exists?(
+             Path.join(
+               output_dir,
+               ".orchard-support-bundle-20260622T123456Z-testnonce.tar.gz.tmp"
+             )
+           )
+
+    refute File.exists?(
+             Path.join(output_dir, ".orchard-support-bundle-20260622T123456Z-testnonce.stage")
+           )
+  end
+
+  test "json output reports archive path", %{support_root: support_root, output_dir: output_dir} do
+    assert {:ok, output} =
+             Support.run(
+               [
+                 "bundle",
+                 "create",
+                 "--support-root",
+                 support_root,
+                 "--output",
+                 output_dir,
+                 "--json"
+               ],
+               runtime(support_root)
+             )
+
+    decoded = Jason.decode!(output)
+    assert decoded["bundle_format"] == "orchard.support_bundle.v1"
+    assert decoded["archive_path"] =~ "orchard-support-bundle-20260622T123456Z.tar.gz"
+    assert decoded["audit"] == %{"status" => "recorded"}
+  end
+
+  test "create help is side-effect free", %{support_root: support_root} do
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:archive, fn _stage_dir, _archive_path -> flunk("help must not archive") end)
+
+    assert {:ok, message} = Support.run(["bundle", "create", "--help"], runtime)
+    assert message =~ "orchardctl support bundle create"
+  end
+
+  defp runtime(support_root) do
+    %{
+      archive: &archive_stage/2,
+      audit_support_bundle: fn event ->
+        send(self(), {:support_bundle_audit, event})
+        :ok
+      end,
+      cmd: &launchctl_stub/3,
+      file_regular?: fn path -> String.ends_with?(path, "com.orchard.controller.plist") end,
+      list_nodes: fn ->
+        [
+          %{
+            id: "node-id-a",
+            display_name: "node-a",
+            hostname: "node-a.local",
+            state: :active,
+            health: :healthy,
+            agent_version: "0.5.0-dev",
+            last_heartbeat_at: @fixed_now,
+            connect_host: "127.0.0.1",
+            connect_port: 50_071,
+            capabilities: %{"supports_prompt_token_ids" => true},
+            tool_readiness: %{}
+          }
+        ]
+      end,
+      list_recent_requests: fn _limit ->
+        [
+          %{
+            id: "request-id-a",
+            public_id: "req_1",
+            endpoint: :responses,
+            requested_model: "test-model",
+            state: :completed,
+            stream: false,
+            node_id: "node-id-a",
+            http_status: 200,
+            error_code: nil,
+            input_tokens: 12,
+            output_tokens: 4,
+            inserted_at: @fixed_now,
+            completed_at: @fixed_now,
+            request_payload: %{"must" => "not be serialized"}
+          }
+        ]
+      end,
+      nodes_summary: fn ->
+        %{
+          total: 1,
+          by_state: %{active: 1},
+          by_health: %{healthy: 1, degraded: 0, unhealthy: 0, unreachable: 0}
+        }
+      end,
+      now: fn -> @fixed_now end,
+      path_nonce: fn -> "testnonce" end,
+      requests_performance_summary: fn ->
+        %{
+          sample_size: 1,
+          avg_ttft_ms: 10.0,
+          avg_generation_ms: 20.0,
+          avg_total_latency_ms: 30.0,
+          avg_tokens_per_second: 2.0
+        }
+      end,
+      requests_summary: fn ->
+        %{
+          total: 2,
+          active: 1,
+          terminal: 1,
+          by_state: %{running: 1, completed: 1}
+        }
+      end,
+      status_snapshot: fn _runtime ->
+        %{
+          state: :ready,
+          role: :all,
+          body: %{
+            "status" => "ok",
+            "runtime" => %{
+              "node_id" => "node-id-a",
+              "worker_state" => "idle",
+              "counts" => %{"loaded_models" => 1}
+            }
+          }
+        }
+      end,
+      support_root: fn -> support_root end,
+      version: fn -> "0.5.0-dev" end
+    }
+  end
+
+  defp launchctl_stub("launchctl", ["print", "system/com.orchard.controller"], opts) do
+    assert opts[:stderr_to_stdout] == true
+    {"{ pid = 123 }", 0}
+  end
+
+  defp launchctl_stub("launchctl", ["print", "system/com.orchard.node-agent"], opts) do
+    assert opts[:stderr_to_stdout] == true
+    {"Could not find service", 113}
+  end
+
+  defp launchctl_stub(program, args, _opts) do
+    flunk("unexpected command: #{inspect({program, args})}")
+  end
+
+  defp archive_stage(stage_dir, archive_path) do
+    case System.cmd("tar", ["-czf", archive_path, "-C", stage_dir, "."], stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, code} -> {:error, "tar failed #{code}: #{output}"}
+    end
+  end
+
+  defp assert_tar_extract!(archive_path, extract_dir) do
+    assert {"", 0} = System.cmd("tar", ["-xzf", archive_path, "-C", extract_dir])
+  end
+
+  defp read_json!(root, relative_path) do
+    root
+    |> Path.join(relative_path)
+    |> File.read!()
+    |> Jason.decode!()
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -175,6 +175,58 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute truncated_log =~ "orch_partial_secret"
   end
 
+  test "config collection skips symlinked env files", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    outside_path = Path.join(tmp_dir, "outside.env")
+    File.write!(outside_path, "ORCHARD_PUBLIC_HOST=leaked.example\n")
+    File.ln_s!(outside_path, Path.join([support_root, "config", "controller.env"]))
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "symlink-config")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    refute File.exists?(Path.join([extract_dir, "config", "controller.env"]))
+
+    assert File.read!(Path.join([extract_dir, "config", "README.txt"])) =~
+             "No Orchard env config files were found."
+  end
+
+  test "log collection skips files that become unavailable", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    log_path = Path.join([support_root, "logs", "controller.log"])
+    File.write!(log_path, "ready\n")
+    File.chmod!(log_path, 0o000)
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "unavailable-log")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    refute File.exists?(Path.join([extract_dir, "logs", "controller.log"]))
+
+    assert File.read!(Path.join([extract_dir, "logs", "README.txt"])) =~
+             "No Orchard log files were found."
+  end
+
   test "truncated logs omit the first partial line before redaction",
        %{support_root: support_root, output_dir: output_dir, tmp_dir: tmp_dir} do
     File.write!(
@@ -219,6 +271,37 @@ defmodule OrchardCLI.Commands.SupportTest do
              )
 
     assert Bitwise.band(File.stat!(output_dir).mode, 0o777) == 0o755
+  end
+
+  test "temporary archive is written under a private directory",
+       %{support_root: support_root, output_dir: output_dir} do
+    File.mkdir_p!(output_dir)
+    File.chmod!(output_dir, 0o755)
+
+    runtime =
+      support_root
+      |> runtime()
+      |> Map.put(:archive, fn stage_dir, temp_archive_path ->
+        archive_dir = Path.dirname(temp_archive_path)
+
+        send(
+          self(),
+          {:archive_dir, archive_dir, Bitwise.band(File.stat!(archive_dir).mode, 0o777)}
+        )
+
+        archive_stage(stage_dir, temp_archive_path)
+      end)
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime
+             )
+
+    assert_received {:archive_dir, archive_dir, 0o700}
+    assert Path.dirname(archive_dir) == output_dir
+    refute archive_dir == output_dir
+    refute File.exists?(archive_dir)
   end
 
   test "snapshot failures do not serialize raw exception messages",

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -333,8 +333,13 @@ defmodule OrchardCLI.Commands.SupportTest do
       """
       prompt_token_ids=[101, 202, 303]
       promptTokenIds: [404, 505, 606]
+      token_ids=[111, 222, 333]
+      tokenIds: [444, 555, 666]
+      input_ids=[777, 888, 999]
+      inputIds: [123, 234, 345]
       tokenizer failed with prompt_token_ids_length_mismatch ids=[707, 808]
       supports_prompt_token_ids=true worker_supports_prompt_token_ids=true token_count=3
+      input_tokens=9 prompt_tokens=8 total_tokens=17 token_count=17
       accessToken=log-access-secret
       clientSecret: log-client-secret
       secretAccessKey=log-secret-access-key
@@ -377,9 +382,14 @@ defmodule OrchardCLI.Commands.SupportTest do
     assert log =~
              "supports_prompt_token_ids=true worker_supports_prompt_token_ids=true token_count=3"
 
+    assert log =~ "input_tokens=9 prompt_tokens=8 total_tokens=17 token_count=17"
     assert log =~ "safe diagnostic line"
     refute log =~ "101"
     refute log =~ "404"
+    refute log =~ "111"
+    refute log =~ "444"
+    refute log =~ "777"
+    refute log =~ "123"
     refute log =~ "707"
     refute log =~ "log-access-secret"
     refute log =~ "log-client-secret"

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -225,6 +225,67 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute log =~ "query-license-secret"
   end
 
+  test "redaction covers env secret values, multiline env blocks, and escaped JSON logs", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    File.write!(
+      Path.join([support_root, "config", "controller.env"]),
+      """
+      ORCHARD_PUBLIC_HOST=orchard.local
+      REDIS_URL=redis://:redis-secret@localhost:6379/0
+      WEBHOOK=/callback?api_key=env-query-secret&token_count=7
+      PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+      EnvPrivateKeyBody
+      -----END PRIVATE KEY-----"
+      """
+    )
+
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      ~S"""
+      booted
+      body={\"prompt\":\"escaped prompt secret\"}
+      payload=\"{\\\"messages\\\":[{\\\"content\\\":\\\"escaped message secret\\\"}]}\"
+      tokenizer diagnostic prompt_tokens=2 token_count=2
+      ids={\"input_ids\":[1,2,3]}
+      ready
+      """
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "env-value-redaction")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    config = File.read!(Path.join([extract_dir, "config", "controller.env"]))
+    assert config =~ "ORCHARD_PUBLIC_HOST=orchard.local"
+    assert config =~ "REDIS_URL=[redacted]"
+    assert config =~ "WEBHOOK=[redacted]"
+    assert config =~ "PRIVATE_KEY=[redacted]"
+    refute config =~ "redis-secret"
+    refute config =~ "env-query-secret"
+    refute config =~ "EnvPrivateKeyBody"
+    refute config =~ "PRIVATE KEY"
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log =~ "booted"
+    assert log =~ "tokenizer diagnostic prompt_tokens=2 token_count=2"
+    assert log =~ "ready"
+    assert log =~ "[redacted log line]"
+    refute log =~ "escaped prompt secret"
+    refute log =~ "escaped message secret"
+    refute log =~ "input_ids"
+    refute log =~ "[1,2,3]"
+  end
+
   test "redaction preserves tokenizer and license diagnostics while redacting credentials", %{
     support_root: support_root,
     output_dir: output_dir,

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -311,6 +311,131 @@ defmodule OrchardCLI.Commands.SupportTest do
     refute log =~ "PRIVATE KEY"
   end
 
+  test "redaction covers prompt token IDs and camel-case sensitive keys", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    File.write!(
+      Path.join([support_root, "config", "controller.env"]),
+      """
+      accessToken=env-access-secret
+      clientSecret=env-client-secret
+      secretAccessKey=env-secret-access-key
+      license_certificate=env-license-certificate
+      machine_certificate=env-machine-certificate
+      ORCHARD_TOKENIZER_EXECUTABLE=/Library/Application Support/Orchard/native/tokenizer
+      """
+    )
+
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      """
+      prompt_token_ids=[101, 202, 303]
+      promptTokenIds: [404, 505, 606]
+      tokenizer failed with prompt_token_ids_length_mismatch ids=[707, 808]
+      supports_prompt_token_ids=true worker_supports_prompt_token_ids=true token_count=3
+      accessToken=log-access-secret
+      clientSecret: log-client-secret
+      secretAccessKey=log-secret-access-key
+      license_certificate=log-license-certificate
+      machine_certificate=log-machine-certificate
+      safe diagnostic line
+      """
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               ["bundle", "create", "--support-root", support_root, "--output", output_dir],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "token-id-redaction")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    config = File.read!(Path.join([extract_dir, "config", "controller.env"]))
+    assert config =~ "accessToken=[redacted]"
+    assert config =~ "clientSecret=[redacted]"
+    assert config =~ "secretAccessKey=[redacted]"
+    assert config =~ "license_certificate=[redacted]"
+    assert config =~ "machine_certificate=[redacted]"
+
+    assert config =~
+             "ORCHARD_TOKENIZER_EXECUTABLE=/Library/Application Support/Orchard/native/tokenizer"
+
+    refute config =~ "env-access-secret"
+    refute config =~ "env-client-secret"
+    refute config =~ "env-secret-access-key"
+    refute config =~ "env-license-certificate"
+    refute config =~ "env-machine-certificate"
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log =~ "[redacted log line]"
+
+    assert log =~
+             "supports_prompt_token_ids=true worker_supports_prompt_token_ids=true token_count=3"
+
+    assert log =~ "safe diagnostic line"
+    refute log =~ "101"
+    refute log =~ "404"
+    refute log =~ "707"
+    refute log =~ "log-access-secret"
+    refute log =~ "log-client-secret"
+    refute log =~ "log-secret-access-key"
+    refute log =~ "log-license-certificate"
+    refute log =~ "log-machine-certificate"
+  end
+
+  test "truncated PEM tails redact through unmatched private key terminators", %{
+    support_root: support_root,
+    output_dir: output_dir,
+    tmp_dir: tmp_dir
+  } do
+    retained_tail = """
+    MIIPrivateKeyBody1
+    MIIPrivateKeyBody2
+    -----END PRIVATE KEY-----
+    safe diagnostic line
+    """
+
+    File.write!(
+      Path.join([support_root, "logs", "controller.log"]),
+      """
+      before
+      -----BEGIN PRIVATE KEY-----
+      """ <> retained_tail
+    )
+
+    assert {:ok, _output} =
+             Support.run(
+               [
+                 "bundle",
+                 "create",
+                 "--support-root",
+                 support_root,
+                 "--output",
+                 output_dir,
+                 "--max-log-bytes",
+                 Integer.to_string(byte_size(retained_tail))
+               ],
+               runtime(support_root)
+             )
+
+    archive_path = Path.join(output_dir, "orchard-support-bundle-20260622T123456Z.tar.gz")
+    extract_dir = Path.join(tmp_dir, "truncated-pem")
+    File.mkdir_p!(extract_dir)
+    assert_tar_extract!(archive_path, extract_dir)
+
+    log = File.read!(Path.join([extract_dir, "logs", "controller.log"]))
+    assert log =~ "[truncated to last #{byte_size(retained_tail)} bytes]"
+    assert log =~ "[redacted log line]"
+    assert log =~ "safe diagnostic line"
+    refute log =~ "MIIPrivateKeyBody"
+    refute log =~ "PRIVATE KEY"
+  end
+
   test "config collection skips symlinked env files", %{
     support_root: support_root,
     output_dir: output_dir,

--- a/apps/orchard_cli/test/orchard_cli_test.exs
+++ b/apps/orchard_cli/test/orchard_cli_test.exs
@@ -13,7 +13,6 @@ defmodule OrchardCLITest do
     Node,
     Nodes,
     Requests,
-    Support,
     Tenants
   }
 
@@ -98,8 +97,7 @@ defmodule OrchardCLITest do
       {Cluster, ["init"], "orchardctl cluster init"},
       {Node, ["join"], "orchardctl node join"},
       {Nodes, ["admit"], "orchardctl nodes admit"},
-      {Requests, ["inspect"], "orchardctl requests inspect"},
-      {Support, ["bundle", "create"], "orchardctl support bundle create"}
+      {Requests, ["inspect"], "orchardctl requests inspect"}
     ]
 
     for {module, args, usage} <- commands do
@@ -120,8 +118,7 @@ defmodule OrchardCLITest do
       ["cluster", "init"],
       ["node", "join"],
       ["nodes", "admit"],
-      ["requests", "inspect"],
-      ["support", "bundle", "create"]
+      ["requests", "inspect"]
     ]
 
     for command <- commands do
@@ -142,8 +139,7 @@ defmodule OrchardCLITest do
       {Cluster, ["init", "--help"], "orchardctl cluster init"},
       {Node, ["join", "--help"], "orchardctl node join"},
       {Nodes, ["admit", "--help"], "orchardctl nodes admit"},
-      {Requests, ["inspect", "--help"], "orchardctl requests inspect"},
-      {Support, ["bundle", "create", "--help"], "orchardctl support bundle create"}
+      {Requests, ["inspect", "--help"], "orchardctl requests inspect"}
     ]
 
     for {module, args, usage} <- commands do
@@ -159,8 +155,7 @@ defmodule OrchardCLITest do
     commands = [
       {Cluster, "cluster", "init"},
       {Node, "node", "join"},
-      {Requests, "requests", "inspect"},
-      {Support, "support", "bundle create"}
+      {Requests, "requests", "inspect"}
     ]
 
     for {module, group, relative_command} <- commands do
@@ -169,6 +164,39 @@ defmodule OrchardCLITest do
       assert message =~ "  #{relative_command}  "
       refute message =~ "  #{group} #{relative_command}  "
     end
+  end
+
+  test "support bundle create dispatches through main and writes an archive" do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "orchard cli support #{System.unique_integer([:positive])}")
+
+    support_root = Path.join(tmp_dir, "Application Support/Orchard")
+    output_dir = Path.join(tmp_dir, "bundles")
+
+    File.mkdir_p!(Path.join(support_root, "support"))
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    output =
+      capture_io(fn ->
+        OrchardCLI.main(
+          [
+            "support",
+            "bundle",
+            "create",
+            "--support-root",
+            support_root,
+            "--output",
+            output_dir
+          ],
+          &no_halt/1
+        )
+      end)
+
+    assert [_, archive_path] = Regex.run(~r/Created support bundle: (.+\.tar\.gz)/, output)
+    assert File.regular?(archive_path)
+
+    assert output =~
+             "Contents: manifest.json, diagnostics/, redacted config/, bounded redacted logs/"
   end
 
   test "env command without subcommand exits non-zero" do

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -131,6 +131,12 @@ defmodule Orchard.Governance do
     end
   end
 
+  @doc """
+  Records a best-effort `support_bundle.generated` audit event when the Repo is running.
+
+  The payload is intentionally limited to bundle metadata and excludes local
+  support-root paths.
+  """
   @spec audit_support_bundle_generated(map()) :: :ok | :skipped | {:error, Changeset.t()}
   def audit_support_bundle_generated(attrs) when is_map(attrs) do
     if repo_started?() do

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -131,6 +131,35 @@ defmodule Orchard.Governance do
     end
   end
 
+  @spec audit_support_bundle_generated(map()) :: :ok | :skipped | {:error, Changeset.t()}
+  def audit_support_bundle_generated(attrs) when is_map(attrs) do
+    if repo_started?() do
+      attrs = normalize_attrs(attrs)
+
+      %AuditLog{}
+      |> audit_log_impl().changeset(%{
+        tenant_id: legacy_tenant_id(),
+        api_key_id: nil,
+        actor_type: "operator",
+        actor_id: nil,
+        action: "support_bundle.generated",
+        target_type: "support_bundle",
+        target_id: Map.get(attrs, "archive_name"),
+        occurred_at: utc_now(),
+        payload: support_bundle_audit_payload(attrs)
+      })
+      |> Repo.insert()
+      |> case do
+        {:ok, _audit_log} -> :ok
+        {:error, changeset} -> {:error, sanitize_changeset(changeset)}
+      end
+    else
+      :skipped
+    end
+  end
+
+  def audit_support_bundle_generated(_attrs), do: audit_support_bundle_generated(%{})
+
   @spec revoke_api_key(ApiKey.t() | Ecto.UUID.t()) ::
           {:ok, ApiKey.t()} | {:error, Changeset.t() | :api_key_not_found}
   def revoke_api_key(%ApiKey{id: api_key_id}), do: revoke_api_key(api_key_id)
@@ -257,6 +286,15 @@ defmodule Orchard.Governance do
   end
 
   defp fetch_api_key_for_audit(_token), do: :skip
+
+  defp support_bundle_audit_payload(attrs) do
+    attrs
+    |> Map.take(["archive_name", "bundle_format", "generated_at", "max_log_bytes"])
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp repo_started?, do: Process.whereis(Repo) != nil
 
   defp normalize_generated_secret(%{token: token}) when is_binary(token),
     do: normalize_generated_secret(token)

--- a/apps/orchard_controller/test/orchard/governance/governance_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/governance_test.exs
@@ -364,6 +364,40 @@ defmodule Orchard.GovernanceTest do
     end
   end
 
+  describe "audit_support_bundle_generated/1" do
+    test "writes a legacy-tenant audit row without local support paths" do
+      assert :ok =
+               Governance.audit_support_bundle_generated(%{
+                 archive_name: "orchard-support-bundle-20260622T123456Z.tar.gz",
+                 bundle_format: "orchard.support_bundle.v1",
+                 generated_at: "2026-06-22T12:34:56Z",
+                 max_log_bytes: 1024,
+                 support_root: "/Library/Application Support/Orchard"
+               })
+
+      audit_log =
+        Repo.one!(
+          from(audit_log in AuditLog,
+            where:
+              audit_log.tenant_id == ^Governance.legacy_tenant_id() and
+                audit_log.action == "support_bundle.generated"
+          )
+        )
+
+      assert audit_log.api_key_id == nil
+      assert audit_log.actor_type == "operator"
+      assert audit_log.target_type == "support_bundle"
+      assert audit_log.target_id == "orchard-support-bundle-20260622T123456Z.tar.gz"
+
+      assert audit_log.payload == %{
+               "archive_name" => "orchard-support-bundle-20260622T123456Z.tar.gz",
+               "bundle_format" => "orchard.support_bundle.v1",
+               "generated_at" => "2026-06-22T12:34:56Z",
+               "max_log_bytes" => 1024
+             }
+    end
+  end
+
   describe "revoke_api_key/1" do
     test "revokes once, writes one audit row, and treats later revokes as a noop" do
       tenant = create_tenant!("tenant-revoke")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,9 +16,11 @@ product/system/build contract.
   a target mode but is not implemented.
 - **Current CLI limitation:** SPEC-required future paths such as
   `orchardctl cluster init`, `orchardctl node join`,
-  `orchardctl nodes admit`, `orchardctl requests inspect`, and
-  `orchardctl support bundle create` are routed by `orchardctl` but return
-  deferred-status errors with the current supported path.
+  `orchardctl nodes admit`, and `orchardctl requests inspect` are routed by
+  `orchardctl` but return deferred-status errors with the current supported
+  path. `orchardctl support bundle create` creates a local diagnostic archive
+  with bounded redacted logs, redacted config, service status, node snapshots,
+  and request summaries.
 
 When this guide and `SPEC.md` disagree, treat the branch as blocked until the
 conflict is reconciled. `SPEC.md` wins until explicitly updated.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -737,10 +737,12 @@ sudo launchctl kickstart -k system/com.orchard.node-agent
 deferred status in this build. `orchardctl support bundle create` creates a
 local diagnostic `.tar.gz` containing bounded redacted logs, redacted config,
 service status, node snapshots, and request summaries; use `--support-root` and
-`--output` to point it at an isolated source-dev fixture. It records
-`support_bundle.generated` only when the controller Repo is already available.
-Console request views, health/readiness endpoints, and controller or node-agent
-logs remain useful for interactive source-dev diagnostics.
+`--output` to point it at an isolated source-dev fixture. Use
+`--max-log-bytes` to cap each retained log tail and `--json` when scripting
+bundle creation. It records `support_bundle.generated` only when the controller
+Repo is already available. Console request views, health/readiness endpoints,
+and controller or node-agent logs remain useful for interactive source-dev
+diagnostics.
 
 | Failure | Likely Cause | Where to Look |
 |---------|-------------|---------------|

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -733,10 +733,14 @@ sudo launchctl kickstart -k system/com.orchard.node-agent
 
 ## Smoke Test Troubleshooting
 
-`orchardctl requests inspect` and `orchardctl support bundle create` are
-SPEC-required diagnostics paths that return deferred status in this build. Use
+`orchardctl requests inspect` is a SPEC-required diagnostics path that returns
+deferred status in this build. `orchardctl support bundle create` creates a
+local diagnostic `.tar.gz` containing bounded redacted logs, redacted config,
+service status, node snapshots, and request summaries; use `--support-root` and
+`--output` to point it at an isolated source-dev fixture. It records
+`support_bundle.generated` only when the controller Repo is already available.
 Console request views, health/readiness endpoints, and controller or node-agent
-logs for current source-dev diagnostics.
+logs remain useful for interactive source-dev diagnostics.
 
 | Failure | Likely Cause | Where to Look |
 |---------|-------------|---------------|

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1041,9 +1041,13 @@ configuration rather than crash-looping with missing setup.
 returns deferred status. `orchardctl support bundle create` creates a local
 diagnostic `.tar.gz` with bounded redacted logs, redacted config, service
 status, node snapshots, and request summaries. It records
-`support_bundle.generated` when the controller Repo is available. Use
-`orchardctl status`, readiness output, service logs, support bundles, and the
-troubleshooting tables in this runbook for current packaged diagnostics.
+`support_bundle.generated` when the controller Repo is available. Archives are
+written to `/Library/Application Support/Orchard/support/` by default; use
+`--output`, `--support-root`, `--max-log-bytes`, and `--json` when support
+needs a different destination, alternate state tree, tighter log bound, or
+machine-readable output. Use `orchardctl status`, readiness output, service
+logs, support bundles, and the troubleshooting tables in this runbook for
+current packaged diagnostics.
 
 ### Advanced migration fallback
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1037,10 +1037,13 @@ env generation, service start, and `orchardctl status` are the supported path.
 This deferred bootstrap ensures services start with valid environment and TLS
 configuration rather than crash-looping with missing setup.
 
-`orchardctl requests inspect` and `orchardctl support bundle create` are also
-SPEC-required diagnostics paths that return deferred status. Use
-`orchardctl status`, readiness output, service logs, and the troubleshooting
-tables in this runbook for current packaged diagnostics.
+`orchardctl requests inspect` is also a SPEC-required diagnostics path that
+returns deferred status. `orchardctl support bundle create` creates a local
+diagnostic `.tar.gz` with bounded redacted logs, redacted config, service
+status, node snapshots, and request summaries. It records
+`support_bundle.generated` when the controller Repo is available. Use
+`orchardctl status`, readiness output, service logs, support bundles, and the
+troubleshooting tables in this runbook for current packaged diagnostics.
 
 ### Advanced migration fallback
 


### PR DESCRIPTION
## Intent

Implement the SPEC.md-traceable orchardctl support bundle create command from latest main as the smallest real local support bundle implementation: reconcile SPEC.md, current CLI surfaces, and existing support/diagnostics plumbing; produce a useful local .tar.gz bundle with manifest, status/service diagnostics, node snapshots, request summaries, redacted config, bounded redacted logs, restrictive permissions, cleanup on failure, clean help/usage and JSON output; add a best-effort support_bundle.generated audit hook when the controller Repo is available; add regression tests and update docs only where behavior changed. Broader /ops/v1/support-bundles, node diagnostics RPC, and controller-owned support-bundle manager remain future M5 surfaces and must not be represented as complete.

## What Changed
- Added `orchardctl support bundle create` to produce a local `.tar.gz` bundle with manifest, service/status diagnostics, node snapshots, request summaries, redacted config, bounded redacted logs, JSON output, restrictive archive permissions, and cleanup on failure.
- Hardened support bundle collection around symlink/path handling, concurrent archive creation, log discovery caps, rotated-log read failures, and redaction for secrets, URLs, request payloads, token IDs, PEM/license blocks, and compact credential keys.
- Added support bundle regression coverage plus documentation updates in the CLI, local-dev, architecture, packaging, and top-level README docs, and added a best-effort `support_bundle.generated` governance audit hook when the controller Repo is available.

## Risk Assessment

⚠️ Medium: The change is security-sensitive and fairly large, but the reviewed implementation is bounded, best-effort on unavailable diagnostics, and includes focused regression coverage for the main leak and path-handling risks found in prior rounds.

## Testing

After an initial mise trust setup block, the focused support-bundle CLI and governance regression tests passed; a manual CLI run generated a real support bundle archive with JSON output, `0600` archive permissions, expected manifest/diagnostics/config/log entries, redacted secrets in config and logs, and best-effort audit skipped because no controller Repo was available in the manual run.

<details>
<summary>Evidence: Support bundle manual evidence summary</summary>

<code>CLI JSON showed bundle_format `orchard.support_bundle.v1`, audit skipped because the controller Repo was unavailable, and an archive path under the evidence directory. Extracted archive had `-rw-------` permissions and contained `manifest.json`, `README.txt`, `diagnostics/*.json`, redacted `config/controller.env`, and redacted logs. The config preserved `PORT` and `ORCHARD_PUBLIC_HOST` while redacting `DATABASE_URL` and `SECRET_KEY_BASE`; controller log secret-bearing lines became `[redacted log line]`.</code>

```text
CLI JSON:
{"bundle_format":"orchard.support_bundle.v1","generated_at":"2026-06-22T16:42:08Z","audit":{"reason":"controller_repo_unavailable","status":"skipped"},"archive_path":"/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQQVDN0MZZ2D476QTKYV6MD/bundles/orchard-support-bundle-20260622T164208Z.tar.gz"}

Archive permissions:
-rw------- /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQQVDN0MZZ2D476QTKYV6MD/bundles/orchard-support-bundle-20260622T164208Z.tar.gz

Archive entries:
./
./README.txt
./config/
./config/controller.env
./diagnostics/
./diagnostics/logs.json
./diagnostics/nodes.json
./diagnostics/requests.json
./diagnostics/services.json
./diagnostics/status.json
./diagnostics/system.json
./logs/
./logs/controller.log
./logs/workers/
./logs/workers/worker.log
./manifest.json

Manifest excerpt:
%{
  "bundle_format" => "orchard.support_bundle.v1",
  "command" => "orchardctl support bundle create",
  "contents" => ["diagnostics/system.json", "diagnostics/status.json",
   "diagnostics/services.json", "diagnostics/nodes.json",
   "diagnostics/requests.json", "diagnostics/logs.json",
   "config/*.env redacted when present",
   "logs/** bounded and redacted tail copies when present"],
  "max_log_bytes" => 4096,
  "spec_references" => ["SPEC.md 7.3.1 Operator API support-bundles endpoint",
   "SPEC.md 11.9 CLI orchardctl support bundle create",
   "SPEC.md Milestone 5 support bundle contains logs, config, node snapshots, request summary"]
}

Redacted config:
PORT=4000
DATABASE_URL=[redacted]
SECRET_KEY_BASE=[redacted]
ORCHARD_PUBLIC_HOST=orchard.local

Redacted controller log:
booted
[redacted log line]
[redacted log line]
ready

Diagnostics status files:
diagnostics/system.json: ok
diagnostics/status.json: ok
diagnostics/services.json: ok
diagnostics/nodes.json: ok
diagnostics/requests.json: unavailable
diagnostics/logs.json: ok
```
</details>
- Evidence: Generated support bundle archive (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVQQVDN0MZZ2D476QTKYV6MD/bundles/orchard-support-bundle-20260622T164208Z.tar.gz</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (11) ✅</summary>

- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:361` - Config files are accepted with `File.regular?/1`, which follows symlinks, so a `controller.env`/`node-agent.env` symlink can cause the support bundle to copy and only env-line-redact an arbitrary file outside the support root. Use `File.lstat/1` and only collect real regular files, matching the log collector&#39;s no-symlink behavior.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/support.ex:548` - The temp archive is created by `tar -czf` before `secure_archive/1` chmods it, so in an existing readable output directory the bundle can briefly exist with the process umask, commonly `0644`. Create/open the temp archive with mode `0600` before writing, or stream tar output into a securely-created file.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/support.ex:481` - A log file that is deleted or rotated after `regular_files/1` lists it makes `tail_file!/2` raise on `File.stat/1` or `File.open/3`, failing the whole bundle. Treat per-log read failures as skipped/unavailable entries so support bundle creation remains best-effort while services are running.

🔧 Fix: Harden support bundle file handling
2 errors still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:388` - Commented env assignments are copied verbatim, so a common rotation pattern like `#DATABASE_URL=postgres://...` or `#SECRET_KEY_BASE=...` will leak into the bundle even though the active form is redacted. Apply the same key-based redaction to commented env-assignment lines instead of returning all `#` lines unchanged.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:15` - The log redaction marker set omits basic secret indicators such as `password` and `token`, so log lines like `password=...` or `token=...` are included unredacted. Add those key-style markers or use the same sensitive-fragment policy as env redaction for logs.

🔧 Fix: Harden support bundle redaction
2 warnings still open:
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/support.ex:127` - `path_nonce` is only unique within the current BEAM, so two separate `orchardctl support bundle create` invocations in the same second can choose the same hidden stage/archive paths and final basename. The `File.rm_rf!` setup can then remove another in-flight bundle, and the later `File.rename/2` can overwrite the first archive; use a cross-process-unique temp dir plus no-clobber finalization/retry.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/support.ex:11` - The substring redaction policy treats `token` and `license` as sensitive anywhere in the key or log line, so useful non-secret diagnostics like `ORCHARD_TOKENIZER_EXECUTABLE`, tokenizer/token-count log lines, and `ORCHARD_LICENSE_ENFORCEMENT` are removed wholesale. Confirm whether that loss of support-bundle signal is intended, or switch to key/value-aware matching with safe tokenizer/license-mode exceptions.

🔧 Fix: Harden support bundle concurrency and redaction
3 errors still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:435` - `sensitive_key?/2` only matches exact split parts or underscored compounds, so compact secret names like `PGPASSWORD=...` are not redacted in env files or key/value log lines. Add explicit compact aliases or compact substring checks for password/passwd/passphrase-style keys.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:39` - Raw multi-line private keys are only redacted on the `BEGIN PRIVATE KEY` line; the base64 body and `END` line are copied into the bundle. Make log redaction stateful across PEM blocks, or redact the whole file/tail when a private-key block is detected.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:25` - Log payload redaction misses common unquoted/atom-key prompt shapes such as `prompt: ...` or `%{messages: [...]}` because only quoted `&#34;prompt&#34;`/`&#34;messages&#34;` and `prompt=` are treated as sensitive, and `prompt` is not a sensitive assignment key. Treat prompt/messages/input/content keys as sensitive for log assignment matching without affecting token-count diagnostics.

🔧 Fix: Harden support bundle redaction
3 errors still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:24` - `prompt_token_ids` is whitelisted as a safe diagnostic key, so support logs containing `prompt_token_ids=[...]` or tokenizer/canonical-request errors with prompt token ID values can be copied into the bundle even though those IDs can reconstruct request content. Keep count/capability fields safe, but redact actual `prompt_token_ids` / `promptTokenIds` values and related error lines.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:665` - PEM redaction only enters private-key state when the retained log tail includes the `BEGIN PRIVATE KEY` line. If `--max-log-bytes` cuts into the middle of a PEM block, the remaining base64 body and `END PRIVATE KEY` line are copied into the bundle; fail closed for truncated tails that contain an unmatched private-key terminator, or redact the truncated tail through the terminator.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:469` - Support-bundle key normalization does not handle camelCase sensitive keys or the license bundle certificate keys already treated as sensitive elsewhere, so lines like `accessToken=...`, `clientSecret: ...`, `secretAccessKey=...`, or `license_certificate=...` are preserved. Use the existing Macro.underscore-style normalization/sensitive vocabulary or add equivalent coverage here.

🔧 Fix: Harden support bundle redaction
1 error still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:463` - Log redaction still misses generic token-id fields such as `token_ids: [1,2,3]` and `input_ids=[...]`; those arrays can reconstruct prompt/request content just like `prompt_token_ids`, but `sensitive_log_payload_key?/2` only recognizes prompt/messages/input/content keys. Treat token-id/input-id assignment keys as sensitive while keeping count-only diagnostics like `input_tokens`, `prompt_tokens`, and `token_count` preserved.

🔧 Fix: Redact generic token ID log fields
2 errors still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:370` - `support_root/config` is never verified as a real directory, so a symlinked config directory is followed before `read_regular_file/1` lstat-checks the final env filename. A root-run bundle can still copy a `controller.env`/`node-agent.env` from outside the support root; lstat the config dir and skip unless it is a real directory, matching the log tree traversal policy.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:30` - Log redaction still misses credential-bearing URLs because the literal set only covers `postgres://`/`ecto://` and the assignment regex ignores query-string separators. Lines like `postgresql://user:password@host/db` or `/path?api_key=...&amp;token=...` can be copied into the bundle; add URL/query-aware secret detection for common DSN schemes and sensitive query keys.

🔧 Fix: Harden support bundle path and URL redaction
3 errors still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:426` - Env config redaction only checks the key name, so credential-bearing values under otherwise-benign keys, such as `REDIS_URL=redis://:secret@host` or `WEBHOOK=/cb?api_key=secret`, are copied into the bundle. Reuse the URL/query/private-key value detection for env lines before preserving any value.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:406` - Config redaction is stateless per line, so a quoted multiline secret such as `PRIVATE_KEY=&#34;-----BEGIN PRIVATE KEY-----` has only the assignment line redacted while the PEM body and terminator remain in `config/*.env`. Track multiline secret blocks in env redaction and redact through the closing line.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:37` - Log redaction does not recognize escaped JSON payload keys, so common lines like `body={\&#34;prompt\&#34;:\&#34;secret\&#34;}` or `payload=\&#34;{\\\&#34;messages\\\&#34;:[...]}\&#34;` avoid both the literal checks and the assignment regex. Add escaped-key coverage for prompt/messages/input/content and token-id fields.

🔧 Fix: Harden support bundle secret redaction
3 issues (2 errors, 1 warning) still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:499` - Bare license assignment keys are not treated as sensitive in log/value redaction, so lines like `license=lic-secret`, `orchard_license=...`, or `/callback?license=...` can be preserved even though bare `LICENSE` env keys are redacted. Apply the same bare-license policy to log/query assignment keys while keeping explicit safe diagnostics like `license_mode` and `license_enforcement`.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:511` - Compact all-caps secret names without separators are still missed: `SECRETKEY=...`, `PRIVATEKEY=...` without a PEM marker, `ACCESSKEY=...`, or `LICENSEKEY=...` normalize to a single non-sensitive part and are copied from env files or key/value logs. Add explicit compact aliases/fragments for these common key forms, similar to the `PGPASSWORD` fix.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/support.ex:566` - Log collection is only bounded per file; it recursively includes every regular file under `logs/`, so many rotated logs can create an arbitrarily large bundle and long-running tar step despite the “bounded logs” contract. Decide on a total byte/file cap or restrict collection to known recent log files.

🔧 Fix: Harden support bundle redaction and log caps
3 issues (2 errors, 1 warning) still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:546` - Compact credential names such as `ACCESSTOKEN=...`, `REFRESHTOKEN=...`, `CLIENTSECRET=...`, or `LICENSESECRET=...` normalize to one part and are not in the compact fragment list, so they are copied from env files or key/value logs. Add compact token/secret aliases or suffix checks while preserving the existing safe token-count diagnostics.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:925` - Stateful block redaction only detects private-key PEM blocks, so a logged `-----BEGIN LICENSE FILE-----` or `-----BEGIN MACHINE FILE-----` block will keep its base64 body in the bundle even though license bundles are supposed to be excluded. Redact license/machine certificate blocks the same way private-key blocks are redacted.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/support.ex:591` - The log caps are applied only after `log_file_candidates/1` recursively enumerates every regular file under `logs/`, so a large rotated-log tree can still make bundle creation spend unbounded time and memory before selecting 32 files. Bound traversal itself, or stream a top-N candidate selection while recording that discovery was capped.

🔧 Fix: Harden support bundle redaction and discovery
3 issues (2 errors, 1 warning) still open:
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:49` - The query/fragment redaction path does not treat `#` as an assignment delimiter and the sensitive query-key vocabulary misses signing keys, so credential-bearing URLs such as `https://idp/cb#access_token=...` or presigned URLs with `X-Amz-Signature=...` can be preserved in env values or logs. Add fragment-aware scanning and sensitive URL query aliases for signature/credential/security-token forms while keeping safe token-count diagnostics.
- 🚨 `apps/orchard_cli/lib/orchard_cli/commands/support.ex:49` - Flattened payload keys with bracketed paths are not parsed by the assignment regex, so lines such as `messages[0].content=...`, `input[0].text=...`, or token-id arrays under bracketed keys can bypass request-payload redaction and be copied into the bundle. Extend log key parsing to recognize bracketed payload paths for prompt/messages/input/content and token-id fields.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/support.ex:725` - The discovery cap is applied after `File.ls/1` and `Enum.sort/1` materialize every entry in a log directory, so a single huge `logs/` directory can still consume unbounded time and memory before selection stops. Bound directory traversal itself or switch to a known-log plus streaming top-N selection while retaining capped-discovery metadata.

🔧 Fix: Harden support bundle redaction and log traversal
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_cli/test/orchard_cli/commands/support_test.exs apps/orchard_cli/test/orchard_cli_test.exs:169 apps/orchard_controller/test/orchard/governance/governance_test.exs` (blocked before execution by untrusted mise config)</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- mix test apps/orchard_cli/test/orchard_cli/commands/support_test.exs apps/orchard_cli/test/orchard_cli_test.exs:169 apps/orchard_controller/test/orchard/governance/governance_test.exs`
- <code>Manual evidence run: created a local support root with secret-bearing config and logs, then ran `MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; ORCHARD_SUPPORT_ROOT=&#34;$SUPPORT_ROOT&#34; MIX_ENV=test mise exec -- mix run -e &#39;OrchardCLI.main([&#34;support&#34;, &#34;bundle&#34;, &#34;create&#34;, &#34;--output&#34;, System.fetch_env!(&#34;OUTPUT_DIR&#34;), &#34;--max-log-bytes&#34;, &#34;4096&#34;, &#34;--json&#34;])&#39;`</code>
- <code>Evidence inspection: extracted the generated `.tar.gz` with `tar -xzf`, listed archive entries with `tar -tzf`, checked archive permissions with `stat -f &#39;%Sp %N&#39;`, and inspected `manifest.json`, redacted `config/controller.env`, redacted `logs/controller.log`, and diagnostics status JSON files</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
