### PR TITLE
feat(orchard_controller): schedule same-model requests by runtime capacity

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -942,6 +942,11 @@ When no node is immediately eligible:
 * max wait defaults to `3000 ms`
 * max queued requests per tenant defaults to `32`
 
+With controller queue admission enabled, a scheduler `cluster_busy` result observed after a static queue grant SHALL be treated as queue-waitable live placement capacity exhaustion.
+The controller SHALL return the request to the same controller queue lane for the requested model/version under the original max queue wait budget instead of extending the deadline.
+If no eligible live placement appears before that deadline, the terminal public outcome SHALL be `queue_timeout`.
+With controller queue admission disabled, `cluster_busy` remains an immediate admission failure.
+
 Queue discipline:
 
 * one FIFO queue per tenant

--- a/SPEC.md
+++ b/SPEC.md
@@ -774,7 +774,7 @@ Compatibility and defaulting rules:
 * absent or empty `runtime_memory_budgets` on `StatusResponse` SHALL mean no memory-budget observation is available
 * absent or empty `runtime_memory_budgets` SHALL NOT be treated as a status-probe error
 * `runtime_memory_budgets` SHALL remain observe-only telemetry except for the Phase 4E scheduler-ranking guard defined in §5.7 and §7.5.3; it SHALL NOT affect node readiness, model admission, request admission, scheduling eligibility, hosted-tool eligibility, public error contracts, queue ordering, or memory-budget enforcement
-* when `memory_admission.enabled = true`, `Orchard.Scheduler.MultiNode` MAY use only `RuntimeMemoryBudget.status_code == "ok"` plus `headroom_available == true` as a positive, non-excluding ranking preference below loadedness, active request count, health, live prefix-cache fingerprint match, historical cache affinity, and any enabled safe-tokenization capable-worker preference, and above deterministic `node_id`
+* when `memory_admission.enabled = true`, `Orchard.Scheduler.MultiNode` MAY use only `RuntimeMemoryBudget.status_code == "ok"` plus `headroom_available == true` as a positive, non-excluding ranking preference below loadedness, requested-placement active request count when known, health, live prefix-cache fingerprint match, historical cache affinity, and any enabled safe-tokenization capable-worker preference, and above deterministic `node_id`
 * absent, empty, stale, malformed, disabled, unavailable, invalid, device-info-failed, compute-failed, non-`ok`, or `headroom_available != true` memory telemetry SHALL be rank-neutral and fail open
 * current `RuntimeMemoryBudget.status_code` vocabulary is: `ok`, `disabled`, `device_info_unavailable`, `device_info_invalid`, `resident_memory_unavailable`, `compute_failed`, `invalid_status`
 * absent or empty `runtime_prefix_cache_statuses` on `StatusResponse` SHALL mean no prefix-cache observation is available
@@ -944,6 +944,8 @@ When no node is immediately eligible:
 
 With controller queue admission enabled, a scheduler `cluster_busy` result observed after a static queue grant SHALL be treated as queue-waitable live placement capacity exhaustion.
 The controller SHALL return the request to the same controller queue lane for the requested model/version under the original max queue wait budget instead of extending the deadline.
+Requeued grants SHALL preserve the original `queued_at`, admission order, and queue deadline.
+The queue manager MAY defer the requeued lane until the next poll interval before re-granting to avoid a tight scheduler retry loop.
 If no eligible live placement appears before that deadline, the terminal public outcome SHALL be `queue_timeout`.
 With controller queue admission disabled, `cluster_busy` remains an immediate admission failure.
 
@@ -1078,7 +1080,7 @@ The score/bonus model above is the broader M4 scheduling contract. The current b
 Controller-side cache-affinity, safe-tokenization capable-worker preference, Phase 4D tie-only scoring, and memory-admission ranking for the bounded current implementation SHALL use the following late tie-break order among otherwise schedulable candidates in the same residency/load/health position:
 
 1. loaded model already present
-2. lower active request count
+2. lower active request count for the requested placement when a valid matching `RuntimeModelPlacement` is available, otherwise lower node `active_request_count`
 3. healthier node (`healthy` before `degraded`)
 4. live prefix-cache fingerprint match, only when both `cache_affinity.enabled=true` and `cache_affinity.live_fingerprint_match_enabled=true`
 5. historical cache-affinity match from recent completed placements, when cache affinity is enabled
@@ -2326,7 +2328,7 @@ Runtime memory-budget wire semantics:
 * omitted or empty `runtime_memory_budgets` SHALL NOT be treated as a node status error, readiness failure, or admission failure
 * `RuntimeMemoryBudget.status_code` values in this slice are: `ok`, `disabled`, `device_info_unavailable`, `device_info_invalid`, `resident_memory_unavailable`, `compute_failed`, `invalid_status`
 * `RuntimeMemoryBudget.resident_memory_bytes` is copied from static manifest-derived model metadata; it is a lower-bound/payload-size estimate, not a runtime memory probe
-* positive resident-memory metadata MAY make `status_code = ok` and `headroom_available = true` when the observe-only arithmetic has enough inputs; when `memory_admission.enabled = true`, that exact positive observation MAY be used by `Orchard.Scheduler.MultiNode` only as a non-gating, non-excluding ranking preference below loadedness, active request count, health, live prefix-cache fingerprint match, historical cache affinity, and any enabled safe-tokenization capable-worker preference
+* positive resident-memory metadata MAY make `status_code = ok` and `headroom_available = true` when the observe-only arithmetic has enough inputs; when `memory_admission.enabled = true`, that exact positive observation MAY be used by `Orchard.Scheduler.MultiNode` only as a non-gating, non-excluding ranking preference below loadedness, requested-placement active request count when known, health, live prefix-cache fingerprint match, historical cache affinity, and any enabled safe-tokenization capable-worker preference
 * neither `RuntimeMemoryBudget.status_code` nor `RuntimeMemoryBudget.resident_memory_bytes` is an enforcement input in this slice; they SHALL NOT alter readiness, request admission rejection, model admission, scheduler eligibility, hosted-tool eligibility, public error contracts, queue ordering, or `memory_budget_mode` enforcement
 * absent, empty, stale, malformed, disabled, unavailable, invalid, device-info-failed, compute-failed, non-`ok`, or `headroom_available != true` memory telemetry SHALL be rank-neutral and fail open
 * `estimated_headroom_bytes` SHALL NOT be used as a threshold, continuous score, request-rejection input, or operator-tunable memory admission knob in this slice
@@ -2354,6 +2356,17 @@ Runtime prefix-cache wire semantics:
 * in `:observe_only` mode, score telemetry remains ranking-neutral and SHALL NOT alter runtime readiness, request admission, model admission, scheduler eligibility, queue ordering, hosted-tool eligibility, `worker_generation_mode`, or `memory_budget_mode` enforcement
 * in `:tie_only` mode, score MAY affect ranking only as a bounded conditional step before final deterministic `node_id`, only for the leading rank-equivalence group (all current ranking elements equal except `node_id`, including any enabled safe-tokenization capable-worker preference), and only when an authoritative resident challenger (`status_code = "ok"`, `resident_fingerprint_match = true`, `score_tier = "resident_fingerprint"`) is compared against a comparable `ok` non-resident incumbent (`status_code = "ok"`, `resident_fingerprint_match = false`, `score_tier` is `"no_match"` or `"recent_fingerprint_only"`)
 * in `:tie_only` mode, deterministic `node_id` ordering remains the fallback whenever promotion conditions are not met; any non-`ok`, timeout, `UNIMPLEMENTED`/`unsupported_version`, missing, malformed, or transport-failure score outcome for either incumbent or challenger SHALL preserve base order fail-open and SHALL never be surfaced as tenant-facing request errors
+
+Runtime model-placement wire semantics:
+
+* `StatusResponse.runtime_model_placements` SHALL report active request count and max concurrency for each loaded runtime/model path through the existing `GetStatus` probe
+* omitted or empty `runtime_model_placements` SHALL mean no explicit per-placement capacity observation is available
+* omitted or empty `runtime_model_placements` SHALL NOT be treated as a node status error, readiness failure, admission failure, model-admission failure, or scheduler-eligibility failure for otherwise idle candidates
+* a matching placement capacity observation is valid only when exactly one entry matches the requested `model_ref`, `active_request_count >= 0`, and `max_concurrency > 0`
+* duplicate matching entries, malformed matching entries, non-matching entries, or `max_concurrency <= 0` SHALL make placement capacity unknown for that request
+* unknown placement capacity SHALL NOT prove eligibility for an already-active loaded-model candidate; an already-active loaded-model candidate MAY remain eligible only when exactly one valid matching entry reports `active_request_count < max_concurrency`
+* when multiple eligible candidates remain, the scheduler SHALL rank by the requested placement's active request count before health when a valid matching placement observation is available; otherwise it SHALL use node `active_request_count`
+
 * controller persistence of selected prefix-cache diagnostics in `requests.scheduler_decision` SHALL be guarded by `orchard_controller.inference.cache_introspection.enabled`, which defaults to `false`; when disabled, prefix-cache fields SHALL be stripped before scheduler-decision persistence
 * score-RPC collection SHALL be default-off behind `orchard_controller.inference.prefix_cache_scoring.enabled` (default `false`).
 * when both `prefix_cache_scoring.enabled=true` and `cache_introspection.enabled=true`, the controller MAY persist only sanitized flat `selected_prefix_cache_score_*` scalars for the selected candidate; for non-`ok` score status only bounded status/tier/source diagnostics MAY persist.

--- a/SPEC.md
+++ b/SPEC.md
@@ -782,6 +782,10 @@ Compatibility and defaulting rules:
 * aggregate `runtime_prefix_cache_statuses` counters SHALL remain observe-only telemetry and SHALL NOT affect node readiness, model admission, request admission, scheduling eligibility, queue ordering, hosted-tool eligibility, or `worker_generation_mode`; the Phase 4C bounded HMAC fingerprint field MAY affect scheduler ranking only as the explicitly configured non-gating tie-breaker defined in §5.7 and §7.5.3
 * current `RuntimePrefixCacheStatus.status_code` vocabulary is: `ok`, `disabled`, `unavailable`, `error`, `invalid_status`
 * these status codes are observational only in this slice and SHALL NOT gate readiness, admission, or scheduling
+* absent or empty `runtime_model_placements` on `StatusResponse` SHALL mean no explicit per-placement capacity observation is available
+* absent or empty `runtime_model_placements` SHALL NOT be treated as a status-probe error
+* `runtime_model_placements` entries SHALL report controller-observed capacity for loaded model placements using `model_ref`, `active_request_count`, and `max_concurrency`; `max_concurrency <= 0`, malformed entries, duplicate matching entries, or non-matching entries SHALL be treated as unknown capacity
+* unknown placement capacity SHALL NOT prove scheduler eligibility for an already-active node; `Orchard.Scheduler.MultiNode` MAY keep a matching loaded-model active candidate eligible only when exactly one valid matching `runtime_model_placements` entry reports `active_request_count < max_concurrency`
 
 Effective readiness rules for future hosted routing:
 
@@ -2155,6 +2159,12 @@ message RuntimePrefixCacheStatus {
   repeated string prefix_cache_fingerprints = 16;
 }
 
+message RuntimeModelPlacement {
+  ModelRef model_ref = 1;
+  uint32 active_request_count = 2;
+  uint32 max_concurrency = 3;
+}
+
 message StatusResponse {
   WorkerState worker_state = 1;
   repeated ModelRef loaded_models = 2;
@@ -2166,6 +2176,7 @@ message StatusResponse {
   repeated RuntimeMemoryBudget runtime_memory_budgets = 8;
   repeated RuntimePrefixCacheStatus runtime_prefix_cache_statuses = 9;
   bool supports_prompt_token_ids = 10;
+  repeated RuntimeModelPlacement runtime_model_placements = 11;
 }
 
 message EnsureModelLoadedRequest {

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -230,6 +230,8 @@ defmodule Orchard.Inference do
       max_queued_per_tenant: 32,
       poll_interval_ms: 100,
       capacity: 1,
+      tenant_default_weight: 1,
+      tenant_weights: %{},
       owner_runtime: false,
       single_controller_ack: false
     ]

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -20,6 +20,7 @@ defmodule Orchard.Inference.ChatError do
           | :tokenization_internal
           | :model_load_failed
           | :model_busy
+          | :cluster_busy
           | :queue_full
           | :queue_timeout
           | :request_timed_out
@@ -101,15 +102,17 @@ defmodule Orchard.Inference.ChatError do
   def from_execute_error({:model_load_failed, %ModelLoadFailure{} = failure}),
     do: build(:model_load_failed, model_load_failure: failure)
 
-  def from_execute_error(reason) when reason in [:model_busy, :queue_full, :queue_timeout],
-    do: build_admission_error(reason, nil)
+  def from_execute_error(reason)
+      when reason in [:model_busy, :cluster_busy, :queue_full, :queue_timeout],
+      do: build_admission_error(reason, nil)
 
   def from_execute_error({kind, message})
-      when kind in [:model_busy, :queue_full, :queue_timeout] and is_binary(message),
+      when kind in [:model_busy, :cluster_busy, :queue_full, :queue_timeout] and
+             is_binary(message),
       do: build_admission_error(kind, message)
 
   def from_execute_error({kind, detail})
-      when kind in [:model_busy, :queue_full, :queue_timeout],
+      when kind in [:model_busy, :cluster_busy, :queue_full, :queue_timeout],
       do: build_admission_error(kind, nil, detail)
 
   def from_execute_error(reason), do: build(:internal, detail: reason)
@@ -234,6 +237,16 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def api_mapping(%__MODULE__{kind: :cluster_busy}) do
+    %{
+      status: :service_unavailable,
+      type: "server_error",
+      code: "cluster_busy",
+      message: "Cluster is busy",
+      param: nil
+    }
+  end
+
   def api_mapping(%__MODULE__{kind: :queue_full}) do
     %{
       status: :too_many_requests,
@@ -347,6 +360,15 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def terminal_attrs(%__MODULE__{kind: :cluster_busy} = error) do
+    %{
+      state: :failed,
+      http_status: 503,
+      error_code: error.source_code || "cluster_busy",
+      error_message: error.source_message || "Cluster is busy"
+    }
+  end
+
   def terminal_attrs(%__MODULE__{kind: :queue_full} = error) do
     %{
       state: :failed,
@@ -426,6 +448,7 @@ defmodule Orchard.Inference.ChatError do
     do: :request_timed_out
 
   defp failed_event_kind("model_busy"), do: :model_busy
+  defp failed_event_kind("cluster_busy"), do: :cluster_busy
   defp failed_event_kind("queue_full"), do: :queue_full
   defp failed_event_kind("queue_timeout"), do: :queue_timeout
 

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -3,8 +3,8 @@ defmodule Orchard.Inference.QueueManager do
   BEAM-local controller admission owner for the bounded queue-first slice.
 
   The owner grants at most `capacity` active requests per `{model_id, version}`
-  lane, queues same-lane callers up to a tenant-global cap, and monitors queued
-  callers so disconnected clients cannot be scheduled later.
+  lane, queues callers by tenant FIFO, and monitors queued callers so
+  disconnected clients cannot be scheduled later.
   """
 
   use GenServer
@@ -81,6 +81,10 @@ defmodule Orchard.Inference.QueueManager do
 
   defstruct server: __MODULE__,
             lanes: %{},
+            tenant_queues: %{},
+            tenant_order: [],
+            tenant_rr_index: 0,
+            scheduler_tick_ref: nil,
             entries: %{},
             monitors: %{},
             grants: %{},
@@ -95,6 +99,7 @@ defmodule Orchard.Inference.QueueManager do
   @ticket_result_max_count 1_024
   @manager_restart_wait_ms 1_000
   @manager_restart_poll_ms 10
+  @max_tenant_weight 100
 
   @type admission_request :: %{
           request_id: Ecto.UUID.t() | String.t(),
@@ -226,11 +231,25 @@ defmodule Orchard.Inference.QueueManager do
   def handle_call(:reset, _from, state), do: {:reply, :ok, reset_state(state)}
 
   def handle_call({:acquire, request, config}, {_waiter_pid, _tag}, state) do
-    state = prune_recovered_grants(request.queue_key, state)
+    state =
+      request.queue_key
+      |> prune_recovered_grants(state)
+      |> maybe_grant_next_global()
+
     lane = Map.get(state.lanes, request.queue_key, empty_lane())
 
     cond do
-      active_capacity?(lane, config.capacity) ->
+      tenant_has_queued_entries?(state, request.tenant_id) and
+          tenant_queue_full?(state, request.tenant_id, config.max_queued_per_tenant) ->
+        metadata = error_metadata(:queue_full, request.queue_key)
+        {:reply, {:error, :queue_full, metadata}, state}
+
+      tenant_has_queued_entries?(state, request.tenant_id) ->
+        {ticket, state} = enqueue_request(request, config, state)
+        {:reply, {:queued, ticket}, state}
+
+      active_capacity?(lane, config.capacity) and
+          not queue_key_has_queued_entries?(state, request.queue_key) ->
         {grant, state} = grant_immediate(request, config, state)
         {:reply, {:ok, grant}, state}
 
@@ -261,7 +280,7 @@ defmodule Orchard.Inference.QueueManager do
         state =
           state
           |> put_entry_update(entry)
-          |> then(&maybe_grant_next(ticket.queue_key, &1))
+          |> maybe_grant_next_global()
 
         {:noreply, state}
 
@@ -301,7 +320,7 @@ defmodule Orchard.Inference.QueueManager do
 
         state
         |> put_lane(queue_key, lane)
-        |> then(&maybe_grant_next(queue_key, &1))
+        |> maybe_grant_next_global()
       else
         state
       end
@@ -336,6 +355,14 @@ defmodule Orchard.Inference.QueueManager do
       :error ->
         {:noreply, state}
     end
+  end
+
+  def handle_info(:queue_tick, state) do
+    state =
+      %{state | scheduler_tick_ref: nil}
+      |> maybe_grant_next_global()
+
+    {:noreply, state}
   end
 
   def handle_info({:DOWN, monitor_ref, :process, _pid, _reason}, state) do
@@ -660,7 +687,7 @@ defmodule Orchard.Inference.QueueManager do
     else
       entry
       |> remove_entry(state)
-      |> then(&maybe_grant_next(entry.queue_key, &1))
+      |> maybe_grant_next_global()
     end
   end
 
@@ -719,7 +746,7 @@ defmodule Orchard.Inference.QueueManager do
     entry
     |> remove_entry(state)
     |> maybe_put_ticket_result(entry, result)
-    |> then(&maybe_grant_next(entry.queue_key, &1))
+    |> maybe_grant_next_global()
   end
 
   defp park_queued_terminalization(entry, state, operation, metadata, result, label, reason) do
@@ -848,7 +875,7 @@ defmodule Orchard.Inference.QueueManager do
       |> drop_active_grant(grant_id, grant.queue_key)
       |> remove_monitor(monitor_ref)
 
-    maybe_grant_next(grant.queue_key, state)
+    maybe_grant_next_global(state)
   end
 
   defp handle_grant_owner_down_outcome(
@@ -1079,7 +1106,7 @@ defmodule Orchard.Inference.QueueManager do
     |> Enum.reduce(state, fn {grant_id, grant}, state ->
       if terminal_request?(grant.request_id) do
         state = drop_active_grant(state, grant_id, grant.queue_key)
-        maybe_grant_next(grant.queue_key, state)
+        maybe_grant_next_global(state)
       else
         state
       end
@@ -1176,20 +1203,51 @@ defmodule Orchard.Inference.QueueManager do
       capacity: max(config[:capacity] || 1, 1),
       max_wait_ms: max(config[:max_wait_ms] || 0, 0),
       max_queued_per_tenant: max(config[:max_queued_per_tenant] || 0, 0),
-      poll_interval_ms: max(config[:poll_interval_ms] || 100, 1)
+      poll_interval_ms: max(config[:poll_interval_ms] || 100, 1),
+      tenant_default_weight: normalize_tenant_weight(config[:tenant_default_weight]),
+      tenant_weights: normalize_tenant_weights(config[:tenant_weights] || %{})
     }
   end
 
+  defp normalize_tenant_weights(weights) when is_map(weights) do
+    weights
+    |> Enum.reduce(%{}, fn {tenant_id, weight}, acc ->
+      normalized_weight =
+        weight
+        |> normalize_tenant_weight()
+
+      Map.put(acc, to_string(tenant_id), normalized_weight)
+    end)
+  end
+
+  defp normalize_tenant_weights(_weights), do: %{}
+
+  defp normalize_tenant_weight(weight) when is_integer(weight),
+    do: weight |> max(1) |> min(@max_tenant_weight)
+
+  defp normalize_tenant_weight(_weight), do: 1
+
   defp queue_key(model_id, version), do: "#{model_id}@#{version}"
 
-  defp empty_lane, do: %{active: %{}, queue: [], blocked_until_monotonic_ms: nil, block_ref: nil}
+  defp empty_lane, do: %{active: %{}, blocked_until_monotonic_ms: nil, block_ref: nil}
 
   defp active_capacity?(lane, capacity) do
-    map_size(lane.active) < capacity and lane.queue == [] and not lane_blocked?(lane)
+    map_size(lane.active) < capacity and not lane_blocked?(lane)
   end
 
   defp tenant_queue_full?(state, tenant_id, max_queued_per_tenant) do
     Map.get(state.tenant_counts, tenant_id, 0) >= max_queued_per_tenant
+  end
+
+  defp tenant_has_queued_entries?(state, tenant_id) do
+    case Map.get(state.tenant_queues, tenant_id) do
+      %{queue: [_head | _tail]} -> true
+      _other -> false
+    end
+  end
+
+  defp queue_key_has_queued_entries?(state, queue_key) do
+    Enum.any?(state.entries, fn {_ticket_ref, entry} -> entry.queue_key == queue_key end)
   end
 
   defp grant_immediate(request, config, state) do
@@ -1240,24 +1298,41 @@ defmodule Orchard.Inference.QueueManager do
     {ticket, put_entry(entry, state)}
   end
 
-  defp put_entry(entry, state) do
-    lane = Map.get(state.lanes, entry.queue_key, empty_lane())
-    lane = %{lane | queue: lane.queue ++ [entry.ticket_ref]}
+  defp put_entry(entry, state, opts \\ []) do
+    position = Keyword.get(opts, :position, :back)
+    tenant_id = entry.tenant_id
+    tenant_queue = Map.get(state.tenant_queues, tenant_id, %{queue: []})
+    queue = put_ticket_in_tenant_queue(tenant_queue.queue, entry.ticket_ref, position)
+    tenant_queues = Map.put(state.tenant_queues, tenant_id, %{tenant_queue | queue: queue})
 
-    %{
+    state = %{
       state
-      | lanes: Map.put(state.lanes, entry.queue_key, lane),
+      | tenant_queues: tenant_queues,
+        tenant_order: maybe_append_tenant_order(state, tenant_id),
         entries: Map.put(state.entries, entry.ticket_ref, entry),
         monitors: Map.put(state.monitors, entry.monitor_ref, {:caller, entry.ticket_ref}),
-        tenant_counts: Map.update(state.tenant_counts, entry.tenant_id, 1, &(&1 + 1))
+        tenant_counts: Map.update(state.tenant_counts, tenant_id, 1, &(&1 + 1))
     }
+
+    schedule_queue_tick(state)
+  end
+
+  defp put_ticket_in_tenant_queue(queue, ticket_ref, :front), do: [ticket_ref | queue]
+  defp put_ticket_in_tenant_queue(queue, ticket_ref, :back), do: queue ++ [ticket_ref]
+
+  defp maybe_append_tenant_order(state, tenant_id) do
+    if tenant_has_queued_entries?(state, tenant_id) do
+      state.tenant_order
+    else
+      state.tenant_order ++ [tenant_id]
+    end
   end
 
   defp release_grant(grant_id, state) do
     case Map.fetch(state.grants, grant_id) do
       {:ok, %{queue_key: queue_key}} ->
         state = drop_active_grant(state, grant_id, queue_key)
-        maybe_grant_next(queue_key, state)
+        maybe_grant_next_global(state)
 
       :error ->
         state
@@ -1290,8 +1365,7 @@ defmodule Orchard.Inference.QueueManager do
         state = drop_active_grant(state, grant.grant_id, grant_state.queue_key)
         metadata = disconnect_metadata(grant_state)
 
-        {{:error, :request_caller_disconnect, metadata},
-         maybe_grant_next(grant_state.queue_key, state)}
+        {{:error, :request_caller_disconnect, metadata}, maybe_grant_next_global(state)}
 
       true ->
         requeue_live_grant(grant, grant_state, request, config, state)
@@ -1307,14 +1381,18 @@ defmodule Orchard.Inference.QueueManager do
     if remaining_ms <= 0 do
       metadata = timeout_metadata(grant_state, queued_at)
       terminalize_requeued_timeout(request, grant_state, queued_at, config, metadata)
-      {{:error, :queue_timeout, metadata}, maybe_grant_next(grant_state.queue_key, state)}
+      {{:error, :queue_timeout, metadata}, maybe_grant_next_global(state)}
     else
       {ticket, state} =
         request
         |> requeue_entry(config, grant_state, queued_at, remaining_ms)
         |> put_requeued_entry(state)
 
-      state = block_lane_retry(request.queue_key, config.poll_interval_ms, state)
+      state =
+        request.queue_key
+        |> block_lane_retry(config.poll_interval_ms, state)
+        |> maybe_grant_next_global()
+
       {{:queued, ticket}, state}
     end
   end
@@ -1357,62 +1435,90 @@ defmodule Orchard.Inference.QueueManager do
     {ticket, entry}
   end
 
-  defp put_requeued_entry({ticket, entry}, state), do: {ticket, put_entry(entry, state)}
+  defp put_requeued_entry({ticket, entry}, state),
+    do: {ticket, put_entry(entry, state, position: :front)}
 
-  defp maybe_grant_next(queue_key, state) do
-    lane = Map.get(state.lanes, queue_key, empty_lane())
+  defp maybe_grant_next_global(state) do
+    case grant_one_queued_entry(state) do
+      {:granted, state} -> maybe_grant_next_global(state)
+      {:removed, state} -> maybe_grant_next_global(state)
+      :blocked -> schedule_queue_tick(state)
+    end
+  end
+
+  defp grant_one_queued_entry(state) do
+    ring = tenant_ring(state)
+
+    if ring == [] do
+      :blocked
+    else
+      scan_tenant_ring(ring, state, 0, rem(state.tenant_rr_index, length(ring)))
+    end
+  end
+
+  defp scan_tenant_ring(ring, _state, scanned, _index) when scanned >= length(ring), do: :blocked
+
+  defp scan_tenant_ring(ring, state, scanned, index) do
+    tenant_id = Enum.at(ring, index)
+
+    case tenant_head_entry(state, tenant_id) do
+      {:ok, entry} -> maybe_grant_tenant_head(entry, ring, state, scanned, index)
+      :empty -> scan_tenant_ring(ring, state, scanned + 1, next_ring_index(ring, index))
+      {:stale, ticket_ref} -> {:removed, remove_stale_tenant_ticket(state, tenant_id, ticket_ref)}
+    end
+  end
+
+  defp maybe_grant_tenant_head(%{terminal_operation: operation}, _ring, _state, _scanned, _index)
+       when not is_nil(operation),
+       do: :blocked
+
+  defp maybe_grant_tenant_head(%{await_from: nil}, ring, state, scanned, index) do
+    scan_tenant_ring(ring, state, scanned + 1, next_ring_index(ring, index))
+  end
+
+  defp maybe_grant_tenant_head(entry, ring, state, scanned, index) do
+    lane = Map.get(state.lanes, entry.queue_key, empty_lane())
 
     cond do
-      not lane_has_capacity?(lane) ->
-        state
+      not queued_process_alive?(entry) ->
+        {:removed, disconnect_queued_entry(entry, state)}
 
-      lane_blocked?(lane) ->
-        state
-
-      lane.queue == [] ->
-        state
+      not lane_has_capacity?(lane) or lane_blocked?(lane) ->
+        scan_tenant_ring(ring, state, scanned + 1, next_ring_index(ring, index))
 
       true ->
-        grant_next_awaiting_entry(queue_key, lane, state)
+        state = %{grant_queued_entry(entry, state) | tenant_rr_index: index + 1}
+        {:granted, state}
     end
   end
 
-  defp grant_next_awaiting_entry(queue_key, lane, state) do
-    case lane.queue do
-      [] ->
-        state
+  defp next_ring_index(ring, index), do: rem(index + 1, length(ring))
 
-      [ticket_ref | rest] ->
+  defp tenant_head_entry(state, tenant_id) do
+    case Map.get(state.tenant_queues, tenant_id) do
+      %{queue: [ticket_ref | _rest]} ->
         case Map.fetch(state.entries, ticket_ref) do
-          {:ok, %{terminal_operation: operation}} when not is_nil(operation) ->
-            state
-
-          {:ok, %{await_from: nil}} ->
-            state
-
-          {:ok, entry} ->
-            maybe_grant_awaiting_entry(queue_key, lane, rest, entry, state)
-
-          :error ->
-            lane = %{lane | queue: rest}
-            state = %{state | lanes: Map.put(state.lanes, queue_key, lane)}
-            maybe_grant_next(queue_key, state)
+          {:ok, entry} -> {:ok, entry}
+          :error -> {:stale, ticket_ref}
         end
+
+      _other ->
+        :empty
     end
   end
 
-  defp maybe_grant_awaiting_entry(queue_key, lane, rest, entry, state) do
-    if queued_process_alive?(entry) do
-      grant_live_queued_entry(queue_key, lane, rest, entry, state)
-    else
-      disconnect_queued_entry(entry, state)
-    end
+  defp tenant_ring(state) do
+    config = Orchard.Inference.queue_admission_config() |> normalize_config()
+
+    state.tenant_order
+    |> Enum.filter(&tenant_has_queued_entries?(state, &1))
+    |> Enum.flat_map(fn tenant_id ->
+      List.duplicate(tenant_id, tenant_weight(tenant_id, config))
+    end)
   end
 
-  defp grant_live_queued_entry(queue_key, lane, rest, entry, state) do
-    lane = %{lane | queue: rest}
-    state = put_lane(state, queue_key, lane)
-    grant_queued_entry(entry, state)
+  defp tenant_weight(tenant_id, config) do
+    Map.get(config.tenant_weights, to_string(tenant_id), config.tenant_default_weight)
   end
 
   defp queued_process_alive?(entry) do
@@ -1441,11 +1547,7 @@ defmodule Orchard.Inference.QueueManager do
 
     lane = Map.get(state.lanes, entry.queue_key, empty_lane())
 
-    lane = %{
-      lane
-      | active: Map.put(lane.active, grant.grant_id, true),
-        queue: Enum.reject(lane.queue, &(&1 == entry.ticket_ref))
-    }
+    lane = %{lane | active: Map.put(lane.active, grant.grant_id, true)}
 
     monitors =
       state.monitors
@@ -1468,11 +1570,14 @@ defmodule Orchard.Inference.QueueManager do
     %{
       state
       | lanes: Map.put(state.lanes, grant.queue_key, lane),
+        tenant_queues: remove_from_tenant_queues(state.tenant_queues, entry),
+        tenant_order: remove_empty_tenants(state.tenant_order, state.tenant_queues, entry),
         entries: Map.delete(state.entries, entry.ticket_ref),
         monitors: monitors,
         grants: grants,
         tenant_counts: decrement_tenant_count(state.tenant_counts, entry.tenant_id)
     }
+    |> maybe_cancel_queue_tick()
   end
 
   defp put_immediate_grant(%Grant{} = grant, request, config, started_monotonic_ms, state) do
@@ -1510,17 +1615,54 @@ defmodule Orchard.Inference.QueueManager do
       clear_awaiter_monitor(entry)
     end
 
-    lane = Map.get(state.lanes, entry.queue_key, empty_lane())
-    lane = %{lane | queue: Enum.reject(lane.queue, &(&1 == entry.ticket_ref))}
     monitors = remove_entry_monitors(state.monitors, entry)
 
     %{
       state
-      | lanes: Map.put(state.lanes, entry.queue_key, lane),
+      | tenant_queues: remove_from_tenant_queues(state.tenant_queues, entry),
+        tenant_order: remove_empty_tenants(state.tenant_order, state.tenant_queues, entry),
         entries: Map.delete(state.entries, entry.ticket_ref),
         monitors: monitors,
         tenant_counts: decrement_tenant_count(state.tenant_counts, entry.tenant_id)
     }
+    |> maybe_cancel_queue_tick()
+  end
+
+  defp remove_stale_tenant_ticket(state, tenant_id, ticket_ref) do
+    entry = %{tenant_id: tenant_id, ticket_ref: ticket_ref}
+
+    %{
+      state
+      | tenant_queues: remove_from_tenant_queues(state.tenant_queues, entry),
+        tenant_order: remove_empty_tenants(state.tenant_order, state.tenant_queues, entry)
+    }
+    |> maybe_cancel_queue_tick()
+  end
+
+  defp remove_from_tenant_queues(tenant_queues, entry) do
+    case Map.fetch(tenant_queues, entry.tenant_id) do
+      {:ok, tenant_queue} ->
+        queue = Enum.reject(tenant_queue.queue, &(&1 == entry.ticket_ref))
+
+        if queue == [] do
+          Map.delete(tenant_queues, entry.tenant_id)
+        else
+          Map.put(tenant_queues, entry.tenant_id, %{tenant_queue | queue: queue})
+        end
+
+      :error ->
+        tenant_queues
+    end
+  end
+
+  defp remove_empty_tenants(tenant_order, tenant_queues, entry) do
+    tenant_queues = remove_from_tenant_queues(tenant_queues, entry)
+
+    if Map.has_key?(tenant_queues, entry.tenant_id) do
+      tenant_order
+    else
+      Enum.reject(tenant_order, &(&1 == entry.tenant_id))
+    end
   end
 
   defp remove_entry_monitors(monitors, entry) do
@@ -1564,6 +1706,33 @@ defmodule Orchard.Inference.QueueManager do
   defp put_lane(state, queue_key, lane) do
     %{state | lanes: Map.put(state.lanes, queue_key, lane)}
   end
+
+  defp schedule_queue_tick(%{scheduler_tick_ref: tick_ref} = state) when is_reference(tick_ref),
+    do: state
+
+  defp schedule_queue_tick(state) do
+    if queues_empty?(state) do
+      state
+    else
+      poll_interval_ms =
+        Orchard.Inference.queue_admission_config()
+        |> Keyword.get(:poll_interval_ms, 100)
+        |> max(1)
+
+      %{state | scheduler_tick_ref: Process.send_after(self(), :queue_tick, poll_interval_ms)}
+    end
+  end
+
+  defp maybe_cancel_queue_tick(state) do
+    if queues_empty?(state) do
+      cancel_timer(state.scheduler_tick_ref)
+      %{state | scheduler_tick_ref: nil, tenant_rr_index: 0}
+    else
+      state
+    end
+  end
+
+  defp queues_empty?(state), do: map_size(state.tenant_queues) == 0
 
   defp decrement_tenant_count(tenant_counts, tenant_id) do
     case Map.get(tenant_counts, tenant_id, 0) do
@@ -1628,7 +1797,10 @@ defmodule Orchard.Inference.QueueManager do
 
   defp elapsed_ms(started_monotonic_ms), do: max(monotonic_ms() - started_monotonic_ms, 0)
 
-  defp cancel_timer(timeout_ref), do: Process.cancel_timer(timeout_ref, async: true, info: false)
+  defp cancel_timer(timer_ref) when is_reference(timer_ref),
+    do: Process.cancel_timer(timer_ref, async: true, info: false)
+
+  defp cancel_timer(_timer_ref), do: false
 
   defp now_iso8601,
     do: DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_iso8601()

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -114,6 +114,10 @@ defmodule Orchard.Inference.QueueManager do
           {:ok, Grant.t()}
           | {:error, :queue_timeout | :request_caller_disconnect, map()}
 
+  @type requeue_result ::
+          {:queued, Ticket.t()}
+          | {:error, :queue_timeout | :request_caller_disconnect | :invalid_requeue, map()}
+
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
@@ -148,6 +152,16 @@ defmodule Orchard.Inference.QueueManager do
   @spec await(Ticket.t()) :: await_result()
   def await(%Ticket{} = ticket) do
     call_manager(ticket.server, {:await, ticket}, :infinity)
+  end
+
+  @spec requeue(Grant.t(), admission_request(), keyword()) :: requeue_result()
+  def requeue(%Grant{} = grant, attrs, opts \\ []) do
+    config = Keyword.get(opts, :config, Orchard.Inference.queue_admission_config())
+
+    call_manager(
+      grant.server,
+      {:requeue, grant, normalize_request(attrs), normalize_config(config)}
+    )
   end
 
   @spec abandon(Ticket.t()) :: :ok
@@ -217,7 +231,7 @@ defmodule Orchard.Inference.QueueManager do
 
     cond do
       active_capacity?(lane, config.capacity) ->
-        {grant, state} = grant_immediate(request, state)
+        {grant, state} = grant_immediate(request, config, state)
         {:reply, {:ok, grant}, state}
 
       tenant_queue_full?(state, request.tenant_id, config.max_queued_per_tenant) ->
@@ -232,6 +246,11 @@ defmodule Orchard.Inference.QueueManager do
 
   def handle_call({:release, grant_id}, _from, state) do
     {:reply, :ok, release_grant(grant_id, state)}
+  end
+
+  def handle_call({:requeue, %Grant{} = grant, request, config}, _from, state) do
+    {result, state} = requeue_grant(grant, request, config, state)
+    {:reply, result, state}
   end
 
   def handle_call({:await, %Ticket{} = ticket}, from, state) do
@@ -269,6 +288,23 @@ defmodule Orchard.Inference.QueueManager do
   def handle_info(:prune_recovered_grants, state) do
     state = prune_all_recovered_grants(state)
     schedule_recovered_prune(state)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:lane_retry, queue_key, block_ref}, state) do
+    lane = Map.get(state.lanes, queue_key, empty_lane())
+
+    state =
+      if lane.block_ref == block_ref do
+        lane = %{lane | blocked_until_monotonic_ms: nil, block_ref: nil}
+
+        state
+        |> put_lane(queue_key, lane)
+        |> then(&maybe_grant_next(queue_key, &1))
+      else
+        state
+      end
 
     {:noreply, state}
   end
@@ -1146,19 +1182,20 @@ defmodule Orchard.Inference.QueueManager do
 
   defp queue_key(model_id, version), do: "#{model_id}@#{version}"
 
-  defp empty_lane, do: %{active: %{}, queue: []}
+  defp empty_lane, do: %{active: %{}, queue: [], blocked_until_monotonic_ms: nil, block_ref: nil}
 
   defp active_capacity?(lane, capacity) do
-    map_size(lane.active) < capacity and lane.queue == []
+    map_size(lane.active) < capacity and lane.queue == [] and not lane_blocked?(lane)
   end
 
   defp tenant_queue_full?(state, tenant_id, max_queued_per_tenant) do
     Map.get(state.tenant_counts, tenant_id, 0) >= max_queued_per_tenant
   end
 
-  defp grant_immediate(request, state) do
-    grant = build_grant(state, request.queue_key, :immediate, nil, monotonic_ms())
-    {grant, put_immediate_grant(grant, request, state)}
+  defp grant_immediate(request, config, state) do
+    started_monotonic_ms = monotonic_ms()
+    grant = build_grant(state, request.queue_key, :immediate, nil, started_monotonic_ms)
+    {grant, put_immediate_grant(grant, request, config, started_monotonic_ms, state)}
   end
 
   defp enqueue_request(request, config, state) do
@@ -1166,6 +1203,8 @@ defmodule Orchard.Inference.QueueManager do
     enqueued_monotonic_ms = monotonic_ms()
     queued_at = now_iso8601()
     monitor_ref = Process.monitor(request.caller_pid)
+    queue_deadline_monotonic_ms = enqueued_monotonic_ms + config.max_wait_ms
+
     timeout_ref = Process.send_after(self(), {:queue_timeout, ticket_ref}, config.max_wait_ms)
 
     ticket = %Ticket{
@@ -1190,6 +1229,7 @@ defmodule Orchard.Inference.QueueManager do
       timeout_ref: timeout_ref,
       queued_at: queued_at,
       enqueued_monotonic_ms: enqueued_monotonic_ms,
+      queue_deadline_monotonic_ms: queue_deadline_monotonic_ms,
       terminal_operation: nil,
       terminal_metadata: nil,
       terminal_result: nil,
@@ -1224,11 +1264,109 @@ defmodule Orchard.Inference.QueueManager do
     end
   end
 
+  defp requeue_grant(%Grant{} = grant, request, config, state) do
+    case Map.fetch(state.grants, grant.grant_id) do
+      {:ok, grant_state} ->
+        requeue_active_grant(grant, grant_state, request, config, state)
+
+      :error ->
+        metadata = error_metadata(:invalid_requeue, request.queue_key)
+        {{:error, :invalid_requeue, metadata}, state}
+    end
+  end
+
+  defp requeue_active_grant(grant, grant_state, request, config, state) do
+    cond do
+      grant_state.queue_key != request.queue_key ->
+        metadata = error_metadata(:invalid_requeue, request.queue_key)
+        {{:error, :invalid_requeue, metadata}, state}
+
+      grant_state.request_id != request.request_id or grant_state.public_id != request.public_id or
+          grant_state.tenant_id != request.tenant_id ->
+        metadata = error_metadata(:invalid_requeue, request.queue_key)
+        {{:error, :invalid_requeue, metadata}, state}
+
+      not Process.alive?(request.caller_pid) ->
+        state = drop_active_grant(state, grant.grant_id, grant_state.queue_key)
+        metadata = disconnect_metadata(grant_state)
+
+        {{:error, :request_caller_disconnect, metadata},
+         maybe_grant_next(grant_state.queue_key, state)}
+
+      true ->
+        requeue_live_grant(grant, grant_state, request, config, state)
+    end
+  end
+
+  defp requeue_live_grant(grant, grant_state, request, config, state) do
+    now_ms = monotonic_ms()
+    remaining_ms = grant_state.queue_deadline_monotonic_ms - now_ms
+    queued_at = grant_state.queued_at || now_iso8601()
+    state = drop_active_grant(state, grant.grant_id, grant_state.queue_key)
+
+    if remaining_ms <= 0 do
+      metadata = timeout_metadata(grant_state, queued_at)
+      terminalize_requeued_timeout(request, grant_state, queued_at, config, metadata)
+      {{:error, :queue_timeout, metadata}, maybe_grant_next(grant_state.queue_key, state)}
+    else
+      {ticket, state} =
+        request
+        |> requeue_entry(config, grant_state, queued_at, remaining_ms)
+        |> put_requeued_entry(state)
+
+      state = block_lane_retry(request.queue_key, config.poll_interval_ms, state)
+      {{:queued, ticket}, state}
+    end
+  end
+
+  defp requeue_entry(request, config, grant_state, queued_at, remaining_ms) do
+    ticket_ref = make_ref()
+    monitor_ref = Process.monitor(request.caller_pid)
+    timeout_ref = Process.send_after(self(), {:queue_timeout, ticket_ref}, remaining_ms)
+
+    ticket = %Ticket{
+      server: grant_state.server,
+      ticket_ref: ticket_ref,
+      queue_key: request.queue_key,
+      queued_at: queued_at,
+      enqueued_monotonic_ms: grant_state.enqueued_monotonic_ms,
+      max_wait_ms: config.max_wait_ms
+    }
+
+    entry = %{
+      ticket_ref: ticket_ref,
+      request_id: request.request_id,
+      public_id: request.public_id,
+      tenant_id: request.tenant_id,
+      queue_key: request.queue_key,
+      caller_pid: request.caller_pid,
+      await_from: nil,
+      awaiter_monitor_ref: nil,
+      monitor_ref: monitor_ref,
+      timeout_ref: timeout_ref,
+      queued_at: queued_at,
+      enqueued_monotonic_ms: grant_state.enqueued_monotonic_ms,
+      queue_deadline_monotonic_ms: grant_state.queue_deadline_monotonic_ms,
+      terminal_operation: nil,
+      terminal_metadata: nil,
+      terminal_result: nil,
+      terminal_retry_ref: nil,
+      terminal_retry_after_ms: config.poll_interval_ms
+    }
+
+    {ticket, entry}
+  end
+
+  defp put_requeued_entry({ticket, entry}, state), do: {ticket, put_entry(entry, state)}
+
   defp maybe_grant_next(queue_key, state) do
     lane = Map.get(state.lanes, queue_key, empty_lane())
 
     cond do
       not lane_has_capacity?(lane) ->
+        state
+
+      lane_blocked?(lane) ->
         state
 
       lane.queue == [] ->
@@ -1273,7 +1411,7 @@ defmodule Orchard.Inference.QueueManager do
 
   defp grant_live_queued_entry(queue_key, lane, rest, entry, state) do
     lane = %{lane | queue: rest}
-    state = %{state | lanes: Map.put(state.lanes, queue_key, lane)}
+    state = put_lane(state, queue_key, lane)
     grant_queued_entry(entry, state)
   end
 
@@ -1318,8 +1456,13 @@ defmodule Orchard.Inference.QueueManager do
       Map.put(state.grants, grant.grant_id, %{
         queue_key: grant.queue_key,
         request_id: entry.request_id,
+        public_id: entry.public_id,
+        tenant_id: entry.tenant_id,
         owner_monitor_ref: entry.awaiter_monitor_ref,
-        queued_at: entry.queued_at
+        queued_at: entry.queued_at,
+        enqueued_monotonic_ms: entry.enqueued_monotonic_ms,
+        queue_deadline_monotonic_ms: entry.queue_deadline_monotonic_ms,
+        server: state.server
       })
 
     %{
@@ -1332,7 +1475,7 @@ defmodule Orchard.Inference.QueueManager do
     }
   end
 
-  defp put_immediate_grant(%Grant{} = grant, request, state) do
+  defp put_immediate_grant(%Grant{} = grant, request, config, started_monotonic_ms, state) do
     owner_monitor_ref = Process.monitor(request.caller_pid)
     lane = Map.get(state.lanes, grant.queue_key, empty_lane())
     lane = %{lane | active: Map.put(lane.active, grant.grant_id, true)}
@@ -1340,8 +1483,13 @@ defmodule Orchard.Inference.QueueManager do
     grant_state = %{
       queue_key: grant.queue_key,
       request_id: request.request_id,
+      public_id: request.public_id,
+      tenant_id: request.tenant_id,
       owner_monitor_ref: owner_monitor_ref,
-      queued_at: nil
+      queued_at: nil,
+      enqueued_monotonic_ms: started_monotonic_ms,
+      queue_deadline_monotonic_ms: started_monotonic_ms + config.max_wait_ms,
+      server: state.server
     }
 
     %{
@@ -1396,6 +1544,27 @@ defmodule Orchard.Inference.QueueManager do
     map_size(lane.active) < capacity
   end
 
+  defp lane_blocked?(%{block_ref: block_ref}) when is_reference(block_ref), do: true
+  defp lane_blocked?(_lane), do: false
+
+  defp block_lane_retry(queue_key, poll_interval_ms, state) do
+    lane = Map.get(state.lanes, queue_key, empty_lane())
+    block_ref = make_ref()
+    Process.send_after(self(), {:lane_retry, queue_key, block_ref}, poll_interval_ms)
+
+    lane = %{
+      lane
+      | blocked_until_monotonic_ms: monotonic_ms() + poll_interval_ms,
+        block_ref: block_ref
+    }
+
+    put_lane(state, queue_key, lane)
+  end
+
+  defp put_lane(state, queue_key, lane) do
+    %{state | lanes: Map.put(state.lanes, queue_key, lane)}
+  end
+
   defp decrement_tenant_count(tenant_counts, tenant_id) do
     case Map.get(tenant_counts, tenant_id, 0) do
       count when count <= 1 -> Map.delete(tenant_counts, tenant_id)
@@ -1425,6 +1594,33 @@ defmodule Orchard.Inference.QueueManager do
     :queue_timeout
     |> error_metadata(entry.queue_key, elapsed_ms(entry))
     |> Map.put(:queued_at, entry.queued_at)
+  end
+
+  defp timeout_metadata(grant_state, queued_at) do
+    :queue_timeout
+    |> error_metadata(grant_state.queue_key, elapsed_ms(grant_state.enqueued_monotonic_ms))
+    |> Map.put(:queued_at, queued_at)
+  end
+
+  defp terminalize_requeued_timeout(request, grant_state, queued_at, config, metadata) do
+    entry = %{
+      request_id: request.request_id,
+      queue_key: request.queue_key,
+      queued_at: queued_at,
+      enqueued_monotonic_ms: grant_state.enqueued_monotonic_ms,
+      terminal_retry_after_ms: config.poll_interval_ms
+    }
+
+    case terminalize_queue_timeout(entry, metadata) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[QueueManager] requeued grant timeout terminalization failed for " <>
+            "#{request.public_id}: #{inspect(reason)}"
+        )
+    end
   end
 
   defp elapsed_ms(%{enqueued_monotonic_ms: enqueued_monotonic_ms}),

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -90,6 +90,7 @@ defmodule Orchard.Inference.QueueManager do
             grants: %{},
             tenant_counts: %{},
             ticket_results: %{},
+            next_admission_sequence: 0,
             owner_runtime: false
 
   @pre_dispatch_states [:admitted, :queued]
@@ -1251,12 +1252,16 @@ defmodule Orchard.Inference.QueueManager do
   end
 
   defp grant_immediate(request, config, state) do
+    {admission_sequence, state} = take_admission_sequence(state)
     started_monotonic_ms = monotonic_ms()
     grant = build_grant(state, request.queue_key, :immediate, nil, started_monotonic_ms)
-    {grant, put_immediate_grant(grant, request, config, started_monotonic_ms, state)}
+
+    {grant,
+     put_immediate_grant(grant, request, config, started_monotonic_ms, admission_sequence, state)}
   end
 
   defp enqueue_request(request, config, state) do
+    {admission_sequence, state} = take_admission_sequence(state)
     ticket_ref = make_ref()
     enqueued_monotonic_ms = monotonic_ms()
     queued_at = now_iso8601()
@@ -1287,6 +1292,7 @@ defmodule Orchard.Inference.QueueManager do
       timeout_ref: timeout_ref,
       queued_at: queued_at,
       enqueued_monotonic_ms: enqueued_monotonic_ms,
+      admission_sequence: admission_sequence,
       queue_deadline_monotonic_ms: queue_deadline_monotonic_ms,
       terminal_operation: nil,
       terminal_metadata: nil,
@@ -1302,7 +1308,7 @@ defmodule Orchard.Inference.QueueManager do
     position = Keyword.get(opts, :position, :back)
     tenant_id = entry.tenant_id
     tenant_queue = Map.get(state.tenant_queues, tenant_id, %{queue: []})
-    queue = put_ticket_in_tenant_queue(tenant_queue.queue, entry.ticket_ref, position)
+    queue = put_ticket_in_tenant_queue(tenant_queue.queue, entry, position, state.entries)
     tenant_queues = Map.put(state.tenant_queues, tenant_id, %{tenant_queue | queue: queue})
 
     state = %{
@@ -1317,8 +1323,31 @@ defmodule Orchard.Inference.QueueManager do
     schedule_queue_tick(state)
   end
 
-  defp put_ticket_in_tenant_queue(queue, ticket_ref, :front), do: [ticket_ref | queue]
-  defp put_ticket_in_tenant_queue(queue, ticket_ref, :back), do: queue ++ [ticket_ref]
+  defp put_ticket_in_tenant_queue(queue, entry, :front, _entries),
+    do: [entry.ticket_ref | queue]
+
+  defp put_ticket_in_tenant_queue(queue, entry, :back, _entries),
+    do: queue ++ [entry.ticket_ref]
+
+  defp put_ticket_in_tenant_queue(queue, entry, :admission_order, entries) do
+    {before, after_} =
+      Enum.split_while(queue, fn ticket_ref ->
+        case Map.fetch(entries, ticket_ref) do
+          {:ok, existing_entry} -> entry_order_key(existing_entry) <= entry_order_key(entry)
+          :error -> true
+        end
+      end)
+
+    before ++ [entry.ticket_ref | after_]
+  end
+
+  defp entry_order_key(entry),
+    do: {entry.enqueued_monotonic_ms, Map.get(entry, :admission_sequence, 0)}
+
+  defp take_admission_sequence(state) do
+    sequence = state.next_admission_sequence
+    {sequence, %{state | next_admission_sequence: sequence + 1}}
+  end
 
   defp maybe_append_tenant_order(state, tenant_id) do
     if tenant_has_queued_entries?(state, tenant_id) do
@@ -1424,6 +1453,7 @@ defmodule Orchard.Inference.QueueManager do
       timeout_ref: timeout_ref,
       queued_at: queued_at,
       enqueued_monotonic_ms: grant_state.enqueued_monotonic_ms,
+      admission_sequence: Map.get(grant_state, :admission_sequence, 0),
       queue_deadline_monotonic_ms: grant_state.queue_deadline_monotonic_ms,
       terminal_operation: nil,
       terminal_metadata: nil,
@@ -1436,7 +1466,7 @@ defmodule Orchard.Inference.QueueManager do
   end
 
   defp put_requeued_entry({ticket, entry}, state),
-    do: {ticket, put_entry(entry, state, position: :front)}
+    do: {ticket, put_entry(entry, state, position: :admission_order)}
 
   defp maybe_grant_next_global(state) do
     case grant_one_queued_entry(state) do
@@ -1468,9 +1498,9 @@ defmodule Orchard.Inference.QueueManager do
     end
   end
 
-  defp maybe_grant_tenant_head(%{terminal_operation: operation}, _ring, _state, _scanned, _index)
+  defp maybe_grant_tenant_head(%{terminal_operation: operation}, ring, state, scanned, index)
        when not is_nil(operation),
-       do: :blocked
+       do: scan_tenant_ring(ring, state, scanned + 1, next_ring_index(ring, index))
 
   defp maybe_grant_tenant_head(%{await_from: nil}, ring, state, scanned, index) do
     scan_tenant_ring(ring, state, scanned + 1, next_ring_index(ring, index))
@@ -1563,6 +1593,7 @@ defmodule Orchard.Inference.QueueManager do
         owner_monitor_ref: entry.awaiter_monitor_ref,
         queued_at: entry.queued_at,
         enqueued_monotonic_ms: entry.enqueued_monotonic_ms,
+        admission_sequence: Map.get(entry, :admission_sequence, 0),
         queue_deadline_monotonic_ms: entry.queue_deadline_monotonic_ms,
         server: state.server
       })
@@ -1580,7 +1611,14 @@ defmodule Orchard.Inference.QueueManager do
     |> maybe_cancel_queue_tick()
   end
 
-  defp put_immediate_grant(%Grant{} = grant, request, config, started_monotonic_ms, state) do
+  defp put_immediate_grant(
+         %Grant{} = grant,
+         request,
+         config,
+         started_monotonic_ms,
+         admission_sequence,
+         state
+       ) do
     owner_monitor_ref = Process.monitor(request.caller_pid)
     lane = Map.get(state.lanes, grant.queue_key, empty_lane())
     lane = %{lane | active: Map.put(lane.active, grant.grant_id, true)}
@@ -1593,6 +1631,7 @@ defmodule Orchard.Inference.QueueManager do
       owner_monitor_ref: owner_monitor_ref,
       queued_at: nil,
       enqueued_monotonic_ms: started_monotonic_ms,
+      admission_sequence: admission_sequence,
       queue_deadline_monotonic_ms: started_monotonic_ms + config.max_wait_ms,
       server: state.server
     }

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -5,6 +5,8 @@ defmodule Orchard.Inference.QueueManager do
   The owner grants at most `capacity` active requests per `{model_id, version}`
   lane, queues callers by tenant FIFO, and monitors queued callers so
   disconnected clients cannot be scheduled later.
+  Cross-tenant grants use weighted round-robin, and live scheduler saturation can
+  requeue an active grant under its original queue deadline.
   """
 
   use GenServer

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -297,14 +297,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp acquire_queue_grant(db_request, canonical, caller) do
-    request = %{
-      request_id: db_request.id,
-      public_id: db_request.public_id,
-      tenant_id: db_request.tenant_id,
-      model_id: canonical.model_ref.model_id,
-      version: canonical.model_ref.version,
-      caller_pid: caller
-    }
+    request = queue_admission_request(db_request, canonical, caller)
 
     case Inference.queue_manager().acquire(request) do
       {:ok, %QueueManager.Grant{} = grant} ->
@@ -316,6 +309,17 @@ defmodule Orchard.Inference.RequestOrchestrator do
       {:error, reason, metadata} ->
         persist_queue_terminal_metadata(db_request, metadata, reason)
     end
+  end
+
+  defp queue_admission_request(db_request, canonical, caller) do
+    %{
+      request_id: db_request.id,
+      public_id: db_request.public_id,
+      tenant_id: db_request.tenant_id,
+      model_id: canonical.model_ref.model_id,
+      version: canonical.model_ref.version,
+      caller_pid: caller
+    }
   end
 
   defp await_queued_grant(db_request, ticket) do
@@ -337,10 +341,17 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp record_queued_admission(db_request, ticket) do
-    with :ok <- advance_fsm(db_request.id, :queued),
+    with :ok <- maybe_advance_queued(db_request.id),
          {:ok, _request} <-
            Requests.record_schedule(db_request, QueueManager.queued_metadata(ticket)) do
       :ok
+    end
+  end
+
+  defp maybe_advance_queued(request_id) do
+    case Requests.get_request!(request_id).state do
+      :queued -> :ok
+      _other -> advance_fsm(request_id, :queued)
     end
   end
 
@@ -400,9 +411,39 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp dispatch_with_queue_grant(db_request, canonical, model, grant, execution_opts) do
-    do_dispatch_with_queue_grant(db_request, canonical, model, grant, execution_opts)
+    case do_dispatch_with_queue_grant(db_request, canonical, model, grant, execution_opts) do
+      {:error, :cluster_busy} ->
+        requeue_after_cluster_busy(db_request, canonical, model, grant, execution_opts)
+
+      result ->
+        result
+    end
   after
     Inference.queue_manager().release(grant)
+  end
+
+  defp requeue_after_cluster_busy(db_request, canonical, model, grant, execution_opts) do
+    request = queue_admission_request(db_request, canonical, execution_opts.caller)
+
+    case Inference.queue_manager().requeue(grant, request) do
+      {:queued, %QueueManager.Ticket{} = ticket} ->
+        with {:ok, next_grant} <- await_queued_grant(db_request, ticket) do
+          dispatch_if_queue_request_live(db_request, canonical, model, next_grant, execution_opts)
+        end
+
+      {:error, :request_caller_disconnect, metadata} ->
+        with {:ok, _request} <- Requests.record_schedule(db_request, metadata),
+             :ok <-
+               terminalize_pre_dispatch_disconnect(
+                 db_request,
+                 execution_opts.terminal_persister
+               ) do
+          {:error, {:admission_already_terminalized, :request_caller_disconnect}}
+        end
+
+      {:error, reason, metadata} ->
+        handle_queue_await_error(db_request, metadata, reason, false)
+    end
   end
 
   defp do_dispatch_with_queue_grant(db_request, canonical, model, grant, execution_opts) do

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -4,7 +4,7 @@ defmodule Orchard.Scheduler.MultiNode do
   selects the best candidate for dispatch.
 
   Ranking order (descending priority):
-  1. Exclude live candidates with `active_request_count > 0`
+  1. Exclude full candidates, or active candidates with unknown placement capacity
   2. Node has the requested model already loaded
   3. Healthier node (`:healthy` over `:degraded`)
   4. Live prefix-cache fingerprint match when explicitly enabled
@@ -20,7 +20,7 @@ defmodule Orchard.Scheduler.MultiNode do
   - No schedulable nodes remain after filtering
 
   Returns `{:error, :cluster_busy}` when live probes joined to persisted schedulable
-  nodes, but every joined candidate is already active.
+  nodes, but every joined candidate is full or active with unknown capacity.
   """
 
   alias Orchard.CanonicalRequest
@@ -102,20 +102,20 @@ defmodule Orchard.Scheduler.MultiNode do
       |> Enum.filter(&Map.has_key?(schedulable_map, &1.node_id))
       |> Enum.map(&Map.put(&1, :node, schedulable_map[&1.node_id]))
 
-    idle_candidates = Enum.reject(candidates, &active_candidate?/1)
+    available_candidates = Enum.reject(candidates, &candidate_full?/1)
 
     cond do
       candidates == [] ->
         fallback_schedule(request, targets)
 
-      idle_candidates == [] ->
+      available_candidates == [] ->
         {:error, :cluster_busy}
 
       true ->
         cache_affinity_config = Inference.cache_affinity_config()
 
         {affinity_candidates, affinity_context} =
-          CacheAffinity.prepare(request, idle_candidates, cache_affinity_config)
+          CacheAffinity.prepare(request, available_candidates, cache_affinity_config)
 
         live_fingerprint_match_enabled? =
           CacheAffinity.live_fingerprint_match_enabled?(cache_affinity_config)
@@ -193,13 +193,18 @@ defmodule Orchard.Scheduler.MultiNode do
                   nil
 
                 node_id ->
+                  loaded_model? = model_loaded?(response, request)
+
                   %{
                     node_id: node_id,
                     target: target,
-                    loaded_model?: model_loaded?(response, request),
+                    loaded_model?: loaded_model?,
                     active_request_count: response.active_request_count || 0,
                     supports_prompt_token_ids: prompt_token_ids_supported?(response)
                   }
+                  |> maybe_put_model_placement_capacity(
+                    model_placement_capacity_for(response, request.model_ref, loaded_model?)
+                  )
                   |> maybe_put_prefix_cache_status(
                     prefix_cache_status_for(response, request.model_ref)
                   )
@@ -222,10 +227,16 @@ defmodule Orchard.Scheduler.MultiNode do
     end
   end
 
-  defp active_candidate?(%{active_request_count: count}) when is_integer(count) and count > 0,
+  defp candidate_full?(%{
+         model_placement_capacity: %{active_request_count: active, max_concurrency: max}
+       })
+       when is_integer(active) and is_integer(max) and max > 0,
+       do: active >= max
+
+  defp candidate_full?(%{active_request_count: count}) when is_integer(count) and count > 0,
     do: true
 
-  defp active_candidate?(_candidate), do: false
+  defp candidate_full?(_candidate), do: false
 
   defp extract_valid_node_id(%{node_metadata: %{node_id: node_id}}) when is_binary(node_id) do
     case Ecto.UUID.cast(node_id) do
@@ -308,6 +319,60 @@ defmodule Orchard.Scheduler.MultiNode do
   end
 
   defp memory_budget_model_ref_matches?(_budget, _model_ref), do: false
+
+  defp model_placement_capacity_for(_response, _model_ref, false), do: nil
+
+  defp model_placement_capacity_for(response, %CanonicalRequest.ModelRef{} = model_ref, true) do
+    response
+    |> Map.get(:runtime_model_placements, [])
+    |> matching_model_placements(model_ref)
+    |> case do
+      [placement] -> valid_model_placement_capacity(placement)
+      _none_or_ambiguous -> nil
+    end
+  end
+
+  defp matching_model_placements(placements, model_ref) when is_list(placements),
+    do: Enum.filter(placements, &model_placement_matches?(&1, model_ref))
+
+  defp matching_model_placements(_placements, _model_ref), do: []
+
+  defp model_placement_matches?(placement, model_ref) when is_map(placement) do
+    case Map.get(placement, :model_ref) || Map.get(placement, "model_ref") do
+      %{model_id: model_id, version: version}
+      when is_binary(model_id) and is_binary(version) ->
+        model_id == model_ref.model_id and version == model_ref.version
+
+      %{"model_id" => model_id, "version" => version}
+      when is_binary(model_id) and is_binary(version) ->
+        model_id == model_ref.model_id and version == model_ref.version
+
+      _other ->
+        false
+    end
+  end
+
+  defp model_placement_matches?(_placement, _model_ref), do: false
+
+  defp valid_model_placement_capacity(placement) when is_map(placement) do
+    active =
+      Map.get(placement, :active_request_count) || Map.get(placement, "active_request_count")
+
+    max = Map.get(placement, :max_concurrency) || Map.get(placement, "max_concurrency")
+
+    if is_integer(active) and active >= 0 and is_integer(max) and max > 0 do
+      %{active_request_count: active, max_concurrency: max}
+    else
+      nil
+    end
+  end
+
+  defp valid_model_placement_capacity(_placement), do: nil
+
+  defp maybe_put_model_placement_capacity(map, nil), do: map
+
+  defp maybe_put_model_placement_capacity(map, capacity),
+    do: Map.put(map, :model_placement_capacity, capacity)
 
   defp maybe_put_prefix_cache_status(map, nil), do: map
   defp maybe_put_prefix_cache_status(map, status), do: Map.put(map, :prefix_cache_status, status)

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -6,13 +6,14 @@ defmodule Orchard.Scheduler.MultiNode do
   Ranking order (descending priority):
   1. Exclude full candidates, or active candidates with unknown placement capacity
   2. Node has the requested model already loaded
-  3. Healthier node (`:healthy` over `:degraded`)
-  4. Live prefix-cache fingerprint match when explicitly enabled
-  5. Cache-affinity match when explicitly enabled
-  6. Prompt-token-ID capable worker preference when explicitly enabled and safe mode is not `:off`
-  7. Memory headroom positive signal when explicitly enabled
-  8. Gated Phase 4D tie-only `ScorePrefixCache` reselection, when explicitly enabled
-  9. Lexicographically smaller `node_id` (deterministic tie-break)
+  3. Lower active request count for the requested placement
+  4. Healthier node (`:healthy` over `:degraded`)
+  5. Live prefix-cache fingerprint match when explicitly enabled
+  6. Cache-affinity match when explicitly enabled
+  7. Prompt-token-ID capable worker preference when explicitly enabled and safe mode is not `:off`
+  8. Memory headroom positive signal when explicitly enabled
+  9. Gated Phase 4D tie-only `ScorePrefixCache` reselection, when explicitly enabled
+  10. Lexicographically smaller `node_id` (deterministic tie-break)
 
   Falls back to `SingleNode.default_schedule/1` when:
   - No targets are configured
@@ -734,9 +735,22 @@ defmodule Orchard.Scheduler.MultiNode do
   defp base_rank(candidate) do
     [
       not candidate.loaded_model?,
+      active_request_rank(candidate),
       health_rank(candidate.node.health)
     ]
   end
+
+  defp active_request_rank(%{
+         model_placement_capacity: %{active_request_count: active_request_count}
+       })
+       when is_integer(active_request_count) and active_request_count >= 0,
+       do: active_request_count
+
+  defp active_request_rank(%{active_request_count: active_request_count})
+       when is_integer(active_request_count) and active_request_count >= 0,
+       do: active_request_count
+
+  defp active_request_rank(_candidate), do: 0
 
   defp health_rank(:healthy), do: 0
   defp health_rank(:degraded), do: 1

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -4,8 +4,8 @@ defmodule Orchard.Scheduler.MultiNode do
   selects the best candidate for dispatch.
 
   Ranking order (descending priority):
-  1. Node has the requested model already loaded
-  2. Lower `active_request_count`
+  1. Exclude live candidates with `active_request_count > 0`
+  2. Node has the requested model already loaded
   3. Healthier node (`:healthy` over `:degraded`)
   4. Live prefix-cache fingerprint match when explicitly enabled
   5. Cache-affinity match when explicitly enabled
@@ -15,9 +15,12 @@ defmodule Orchard.Scheduler.MultiNode do
   9. Lexicographically smaller `node_id` (deterministic tie-break)
 
   Falls back to `SingleNode.default_schedule/1` when:
-  - Only 0 or 1 targets are configured
+  - No targets are configured
   - All probes fail
   - No schedulable nodes remain after filtering
+
+  Returns `{:error, :cluster_busy}` when live probes joined to persisted schedulable
+  nodes, but every joined candidate is already active.
   """
 
   alias Orchard.CanonicalRequest
@@ -63,7 +66,7 @@ defmodule Orchard.Scheduler.MultiNode do
   def schedule(%CanonicalRequest{} = request, opts) when is_list(opts) do
     targets = Inference.runtime_client_targets()
 
-    if length(targets) <= 1 do
+    if targets == [] do
       fallback_schedule(request, targets)
     else
       schedule_multi(request, targets, opts)
@@ -99,72 +102,79 @@ defmodule Orchard.Scheduler.MultiNode do
       |> Enum.filter(&Map.has_key?(schedulable_map, &1.node_id))
       |> Enum.map(&Map.put(&1, :node, schedulable_map[&1.node_id]))
 
-    if candidates == [] do
-      fallback_schedule(request, targets)
-    else
-      cache_affinity_config = Inference.cache_affinity_config()
+    idle_candidates = Enum.reject(candidates, &active_candidate?/1)
 
-      {affinity_candidates, affinity_context} =
-        CacheAffinity.prepare(request, candidates, cache_affinity_config)
+    cond do
+      candidates == [] ->
+        fallback_schedule(request, targets)
 
-      live_fingerprint_match_enabled? =
-        CacheAffinity.live_fingerprint_match_enabled?(cache_affinity_config)
+      idle_candidates == [] ->
+        {:error, :cluster_busy}
 
-      prefix_cache_scoring_enabled? = Inference.prefix_cache_scoring_enabled?()
-      memory_admission_enabled? = Inference.memory_admission_enabled?()
+      true ->
+        cache_affinity_config = Inference.cache_affinity_config()
 
-      prefer_capable_workers? =
-        Inference.tokenizer_safe_mode_prefer_capable_workers?() and
-          Inference.tokenizer_safe_mode() != :off
+        {affinity_candidates, affinity_context} =
+          CacheAffinity.prepare(request, idle_candidates, cache_affinity_config)
 
-      annotated_candidates =
-        affinity_candidates
-        |> annotate_prefix_cache_fingerprint_matches(
-          affinity_context,
-          live_fingerprint_match_enabled?
-        )
-        |> annotate_capable_workers(prefer_capable_workers?)
-        |> annotate_memory_admission(memory_admission_enabled?)
+        live_fingerprint_match_enabled? =
+          CacheAffinity.live_fingerprint_match_enabled?(cache_affinity_config)
 
-      ranking_opts = [
-        live_fingerprint_match?: live_fingerprint_match_enabled?,
-        prefer_capable_workers?: prefer_capable_workers?,
-        memory_admission?: memory_admission_enabled?
-      ]
+        prefix_cache_scoring_enabled? = Inference.prefix_cache_scoring_enabled?()
+        memory_admission_enabled? = Inference.memory_admission_enabled?()
 
-      ranked = rank_candidates(annotated_candidates, ranking_opts)
+        prefer_capable_workers? =
+          Inference.tokenizer_safe_mode_prefer_capable_workers?() and
+            Inference.tokenizer_safe_mode() != :off
 
-      {selected, selected_score} =
-        select_candidate_with_prefix_cache_score(
-          request,
-          ranked,
-          client,
-          cache_affinity_config,
-          prefix_cache_scoring_enabled?,
-          ranking_opts
-        )
+        annotated_candidates =
+          affinity_candidates
+          |> annotate_prefix_cache_fingerprint_matches(
+            affinity_context,
+            live_fingerprint_match_enabled?
+          )
+          |> annotate_capable_workers(prefer_capable_workers?)
+          |> annotate_memory_admission(memory_admission_enabled?)
 
-      schedule =
-        %{
-          strategy: :multi_node,
-          request_id: request.public_id,
-          runtime_client_target: selected.target,
-          request_timeout_ms: Inference.request_timeout_ms(),
-          model_load_timeout_ms: Inference.model_load_timeout_ms(),
-          node_id: selected.node_id,
-          candidate_count: length(ranked),
-          selected_tier: if(selected.loaded_model?, do: "loaded", else: "cold")
-        }
-        |> maybe_put_prefix_cache_status(Map.get(selected, :prefix_cache_status))
-        |> maybe_put_prefix_cache_fingerprint_match(
-          selected,
-          live_fingerprint_match_enabled?
-        )
-        |> maybe_put_prefix_cache_score(selected_score)
-        |> maybe_put_memory_admission(selected, memory_admission_enabled?)
+        ranking_opts = [
+          live_fingerprint_match?: live_fingerprint_match_enabled?,
+          prefer_capable_workers?: prefer_capable_workers?,
+          memory_admission?: memory_admission_enabled?
+        ]
 
-      {:ok,
-       Map.merge(schedule, CacheAffinity.scheduler_metadata(affinity_context, ranked, selected))}
+        ranked = rank_candidates(annotated_candidates, ranking_opts)
+
+        {selected, selected_score} =
+          select_candidate_with_prefix_cache_score(
+            request,
+            ranked,
+            client,
+            cache_affinity_config,
+            prefix_cache_scoring_enabled?,
+            ranking_opts
+          )
+
+        schedule =
+          %{
+            strategy: :multi_node,
+            request_id: request.public_id,
+            runtime_client_target: selected.target,
+            request_timeout_ms: Inference.request_timeout_ms(),
+            model_load_timeout_ms: Inference.model_load_timeout_ms(),
+            node_id: selected.node_id,
+            candidate_count: length(ranked),
+            selected_tier: if(selected.loaded_model?, do: "loaded", else: "cold")
+          }
+          |> maybe_put_prefix_cache_status(Map.get(selected, :prefix_cache_status))
+          |> maybe_put_prefix_cache_fingerprint_match(
+            selected,
+            live_fingerprint_match_enabled?
+          )
+          |> maybe_put_prefix_cache_score(selected_score)
+          |> maybe_put_memory_admission(selected, memory_admission_enabled?)
+
+        {:ok,
+         Map.merge(schedule, CacheAffinity.scheduler_metadata(affinity_context, ranked, selected))}
     end
   end
 
@@ -211,6 +221,11 @@ defmodule Orchard.Scheduler.MultiNode do
         nil
     end
   end
+
+  defp active_candidate?(%{active_request_count: count}) when is_integer(count) and count > 0,
+    do: true
+
+  defp active_candidate?(_candidate), do: false
 
   defp extract_valid_node_id(%{node_metadata: %{node_id: node_id}}) when is_binary(node_id) do
     case Ecto.UUID.cast(node_id) do
@@ -654,7 +669,6 @@ defmodule Orchard.Scheduler.MultiNode do
   defp base_rank(candidate) do
     [
       not candidate.loaded_model?,
-      candidate.active_request_count,
       health_rank(candidate.node.health)
     ]
   end

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -818,11 +818,12 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     end
 
     @tag :db
-    test "SPEC.md §5.2/§5.4 queue admission capacity two admits overlapping chat completions", %{
-      bundle: bundle
-    } do
+    test "SPEC.md §5.2/§5.4/§7.5 queue admission capacity two exposes WorkerProcess telemetry over gRPC",
+         %{
+           bundle: bundle
+         } do
       put_queue_admission_config!(capacity: 2, max_wait_ms: 2_000)
-      put_blocking_runtime_adapter!(self())
+      put_blocking_runtime_adapter!(self(), max_concurrent_requests: 2)
       create_queue_model!(bundle, "chat-queue-capacity2-model")
 
       %{token: token} = create_api_key_with_token!("chat-queue-capacity2")
@@ -843,6 +844,12 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
 
         refute second_request_id == first_request_id
 
+        status = grpc_status_snapshot()
+        placement = runtime_model_placement!(status, "chat-queue-capacity2-model", "v1")
+        assert status.active_request_count == 2
+        assert placement.active_request_count == 2
+        assert placement.max_concurrency == 2
+
         assert wait_for_queued_request("chat-queue-capacity2-model@v1")
 
         refute_receive {:queue_admission_runtime_started, _pid, _request_id,
@@ -861,6 +868,15 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
 
         conns = Enum.map(tasks, &Task.await(&1, 5_000))
         assert Enum.map(conns, & &1.status) == [200, 200, 200]
+        assert wait_until(fn -> grpc_status_snapshot().active_request_count == 0 end)
+
+        final_status = grpc_status_snapshot()
+
+        final_placement =
+          runtime_model_placement!(final_status, "chat-queue-capacity2-model", "v1")
+
+        assert final_placement.active_request_count == 0
+        assert final_placement.max_concurrency == 2
 
         assert_queue_result_count!("chat-queue-capacity2-model@v1", "immediate", 2)
         assert_queue_result_count!("chat-queue-capacity2-model@v1", "queued", 1)

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -817,6 +817,71 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
     end
 
+    @tag :db
+    test "SPEC.md §5.2/§5.4 queue admission capacity two admits overlapping chat completions", %{
+      bundle: bundle
+    } do
+      put_queue_admission_config!(capacity: 2, max_wait_ms: 2_000)
+      put_blocking_runtime_adapter!(self())
+      create_queue_model!(bundle, "chat-queue-capacity2-model")
+
+      %{token: token} = create_api_key_with_token!("chat-queue-capacity2")
+
+      params = %{
+        "model" => "chat-queue-capacity2-model@v1",
+        "messages" => [%{"role" => "user", "content" => "hello"}]
+      }
+
+      Process.put(:queue_admission_runtime_pids, [])
+      tasks = Enum.map(1..3, fn _index -> Task.async(fn -> post_chat(params, token) end) end)
+
+      try do
+        {first_pid, first_request_id} = runtime_start_message("chat-queue-capacity2-model")
+        remember_runtime_pid(first_pid)
+        {second_pid, second_request_id} = runtime_start_message("chat-queue-capacity2-model")
+        remember_runtime_pid(second_pid)
+
+        refute second_request_id == first_request_id
+
+        assert wait_for_queued_request("chat-queue-capacity2-model@v1")
+
+        refute_receive {:queue_admission_runtime_started, _pid, _request_id,
+                        "chat-queue-capacity2-model"},
+                       100
+
+        send(first_pid, :queue_admission_runtime_release)
+
+        {third_pid, third_request_id} = runtime_start_message("chat-queue-capacity2-model")
+        remember_runtime_pid(third_pid)
+
+        refute third_request_id in [first_request_id, second_request_id]
+
+        send(second_pid, :queue_admission_runtime_release)
+        send(third_pid, :queue_admission_runtime_release)
+
+        conns = Enum.map(tasks, &Task.await(&1, 5_000))
+        assert Enum.map(conns, & &1.status) == [200, 200, 200]
+
+        assert_queue_result_count!("chat-queue-capacity2-model@v1", "immediate", 2)
+        assert_queue_result_count!("chat-queue-capacity2-model@v1", "queued", 1)
+
+        Enum.each(
+          requests_with_queue_result!("chat-queue-capacity2-model@v1", "immediate"),
+          &assert_queue_metadata(&1, "immediate", granted?: true)
+        )
+
+        [queued] = requests_with_queue_result!("chat-queue-capacity2-model@v1", "queued")
+        assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
+      after
+        Enum.each(Process.get(:queue_admission_runtime_pids, []), fn pid ->
+          send(pid, :queue_admission_runtime_release)
+        end)
+
+        Enum.each(tasks, &Task.shutdown(&1, :brutal_kill))
+        Process.delete(:queue_admission_runtime_pids)
+      end
+    end
+
     test "SPEC.md §7.2.7 returns top-level chat envelopes for busy and queue execute errors" do
       cases = [
         {:model_busy, 503, "server_error", "model_busy"},
@@ -1447,7 +1512,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       {"persist-model", "v1"},
       {"persist-non-stream-model", "v1"},
       {"tenant-scope-model", "v1"},
-      {"chat-queue-overlap-model", "v1"}
+      {"chat-queue-overlap-model", "v1"},
+      {"chat-queue-capacity2-model", "v1"}
     ]
 
     cache_paths =
@@ -1460,6 +1526,11 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       end)
 
     %{hash: hash, source_path: source_path, cache_paths: cache_paths}
+  end
+
+  defp remember_runtime_pid(pid) do
+    pids = Process.get(:queue_admission_runtime_pids, [])
+    Process.put(:queue_admission_runtime_pids, [pid | pids])
   end
 
   defmodule StubChatOrchestrator do

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -9,10 +9,7 @@ defmodule Orchard.API.ResponsesControllerTest do
 
   alias Orchard.API.Router
   alias Orchard.ArtifactBundle
-  alias Orchard.Cluster.V1.StatusResponse
-  alias Orchard.Dispatch.GrpcNodeRuntimeClient
   alias Orchard.Governance
-  alias Orchard.Inference
   alias Orchard.Inference.QueueManager
   alias Orchard.InferenceEvent
   alias Orchard.Node
@@ -1363,23 +1360,5 @@ defmodule Orchard.API.ResponsesControllerTest do
   defp remember_runtime_pid(pid) do
     pids = Process.get(:queue_admission_runtime_pids, [])
     Process.put(:queue_admission_runtime_pids, [pid | pids])
-  end
-
-  defp grpc_status_snapshot do
-    target = Inference.runtime_client_target()
-    assert {:ok, channel} = GrpcNodeRuntimeClient.connect(target)
-
-    try do
-      assert {:ok, %StatusResponse{} = status} = GrpcNodeRuntimeClient.status(channel)
-      status
-    after
-      GrpcNodeRuntimeClient.disconnect(channel)
-    end
-  end
-
-  defp runtime_model_placement!(%StatusResponse{} = status, model_id, version) do
-    Enum.find(status.runtime_model_placements, fn placement ->
-      placement.model_ref.model_id == model_id and placement.model_ref.version == version
-    end) || flunk("runtime model placement not found for #{model_id}@#{version}")
   end
 end

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -9,7 +9,10 @@ defmodule Orchard.API.ResponsesControllerTest do
 
   alias Orchard.API.Router
   alias Orchard.ArtifactBundle
+  alias Orchard.Cluster.V1.StatusResponse
+  alias Orchard.Dispatch.GrpcNodeRuntimeClient
   alias Orchard.Governance
+  alias Orchard.Inference
   alias Orchard.Inference.QueueManager
   alias Orchard.InferenceEvent
   alias Orchard.Node
@@ -421,11 +424,12 @@ defmodule Orchard.API.ResponsesControllerTest do
     assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
   end
 
-  test "SPEC.md §5.2/§5.4 queue admission capacity two admits overlapping responses requests", %{
-    bundle: bundle
-  } do
+  test "SPEC.md §5.2/§5.4/§7.5 queue admission capacity two exposes WorkerProcess telemetry over gRPC",
+       %{
+         bundle: bundle
+       } do
     put_queue_admission_config!(capacity: 2, max_wait_ms: 2_000)
-    put_blocking_runtime_adapter!(self())
+    put_blocking_runtime_adapter!(self(), max_concurrent_requests: 2)
     create_queue_model!(bundle, "responses-queue-capacity2-model")
 
     %{token: token} = create_api_key_with_token!("responses-queue-capacity2")
@@ -446,6 +450,12 @@ defmodule Orchard.API.ResponsesControllerTest do
 
       refute second_request_id == first_request_id
 
+      status = grpc_status_snapshot()
+      placement = runtime_model_placement!(status, "responses-queue-capacity2-model", "v1")
+      assert status.active_request_count == 2
+      assert placement.active_request_count == 2
+      assert placement.max_concurrency == 2
+
       assert wait_for_queued_request("responses-queue-capacity2-model@v1")
 
       refute_receive {:queue_admission_runtime_started, _pid, _request_id,
@@ -464,6 +474,7 @@ defmodule Orchard.API.ResponsesControllerTest do
 
       conns = Enum.map(tasks, &Task.await(&1, 5_000))
       assert Enum.map(conns, & &1.status) == [200, 200, 200]
+      assert wait_until(fn -> grpc_status_snapshot().active_request_count == 0 end)
 
       assert_queue_result_count!("responses-queue-capacity2-model@v1", "immediate", 2)
       assert_queue_result_count!("responses-queue-capacity2-model@v1", "queued", 1)
@@ -1352,5 +1363,23 @@ defmodule Orchard.API.ResponsesControllerTest do
   defp remember_runtime_pid(pid) do
     pids = Process.get(:queue_admission_runtime_pids, [])
     Process.put(:queue_admission_runtime_pids, [pid | pids])
+  end
+
+  defp grpc_status_snapshot do
+    target = Inference.runtime_client_target()
+    assert {:ok, channel} = GrpcNodeRuntimeClient.connect(target)
+
+    try do
+      assert {:ok, %StatusResponse{} = status} = GrpcNodeRuntimeClient.status(channel)
+      status
+    after
+      GrpcNodeRuntimeClient.disconnect(channel)
+    end
+  end
+
+  defp runtime_model_placement!(%StatusResponse{} = status, model_id, version) do
+    Enum.find(status.runtime_model_placements, fn placement ->
+      placement.model_ref.model_id == model_id and placement.model_ref.version == version
+    end) || flunk("runtime model placement not found for #{model_id}@#{version}")
   end
 end

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -421,6 +421,70 @@ defmodule Orchard.API.ResponsesControllerTest do
     assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
   end
 
+  test "SPEC.md §5.2/§5.4 queue admission capacity two admits overlapping responses requests", %{
+    bundle: bundle
+  } do
+    put_queue_admission_config!(capacity: 2, max_wait_ms: 2_000)
+    put_blocking_runtime_adapter!(self())
+    create_queue_model!(bundle, "responses-queue-capacity2-model")
+
+    %{token: token} = create_api_key_with_token!("responses-queue-capacity2")
+
+    params = %{
+      "model" => "responses-queue-capacity2-model@v1",
+      "input" => "hello"
+    }
+
+    Process.put(:queue_admission_runtime_pids, [])
+    tasks = Enum.map(1..3, fn _index -> Task.async(fn -> post_responses(params, token) end) end)
+
+    try do
+      {first_pid, first_request_id} = runtime_start_message("responses-queue-capacity2-model")
+      remember_runtime_pid(first_pid)
+      {second_pid, second_request_id} = runtime_start_message("responses-queue-capacity2-model")
+      remember_runtime_pid(second_pid)
+
+      refute second_request_id == first_request_id
+
+      assert wait_for_queued_request("responses-queue-capacity2-model@v1")
+
+      refute_receive {:queue_admission_runtime_started, _pid, _request_id,
+                      "responses-queue-capacity2-model"},
+                     100
+
+      send(first_pid, :queue_admission_runtime_release)
+
+      {third_pid, third_request_id} = runtime_start_message("responses-queue-capacity2-model")
+      remember_runtime_pid(third_pid)
+
+      refute third_request_id in [first_request_id, second_request_id]
+
+      send(second_pid, :queue_admission_runtime_release)
+      send(third_pid, :queue_admission_runtime_release)
+
+      conns = Enum.map(tasks, &Task.await(&1, 5_000))
+      assert Enum.map(conns, & &1.status) == [200, 200, 200]
+
+      assert_queue_result_count!("responses-queue-capacity2-model@v1", "immediate", 2)
+      assert_queue_result_count!("responses-queue-capacity2-model@v1", "queued", 1)
+
+      Enum.each(
+        requests_with_queue_result!("responses-queue-capacity2-model@v1", "immediate"),
+        &assert_queue_metadata(&1, "immediate", granted?: true)
+      )
+
+      [queued] = requests_with_queue_result!("responses-queue-capacity2-model@v1", "queued")
+      assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
+    after
+      Enum.each(Process.get(:queue_admission_runtime_pids, []), fn pid ->
+        send(pid, :queue_admission_runtime_release)
+      end)
+
+      Enum.each(tasks, &Task.shutdown(&1, :brutal_kill))
+      Process.delete(:queue_admission_runtime_pids)
+    end
+  end
+
   test "SPEC.md §7.2.7 returns top-level sync responses envelopes for busy and queue execute errors" do
     cases = [
       {:model_busy, 503, "server_error", "model_busy"},
@@ -1235,7 +1299,8 @@ defmodule Orchard.API.ResponsesControllerTest do
           {"responses-success-model", "v1"},
           {"responses-replay-model", "v1"},
           {"responses-stream-model", "v1"},
-          {"responses-queue-overlap-model", "v1"}
+          {"responses-queue-overlap-model", "v1"},
+          {"responses-queue-capacity2-model", "v1"}
         ],
         fn {model_id, version} ->
           cache_path = Path.join([models_root, model_id, version])
@@ -1282,5 +1347,10 @@ defmodule Orchard.API.ResponsesControllerTest do
         result -> result
       end
     end
+  end
+
+  defp remember_runtime_pid(pid) do
+    pids = Process.get(:queue_admission_runtime_pids, [])
+    Process.put(:queue_admission_runtime_pids, [pid | pids])
   end
 end

--- a/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
@@ -157,6 +157,32 @@ defmodule Orchard.Inference.ChatErrorTest do
            }
   end
 
+  test "cluster_busy execute errors preserve scheduler saturation mapping" do
+    error = ChatError.from_execute_error(:cluster_busy)
+
+    assert ChatError.api_mapping(error) == %{
+             status: :service_unavailable,
+             type: "server_error",
+             code: "cluster_busy",
+             message: "Cluster is busy",
+             param: nil
+           }
+
+    assert ChatError.sse_mapping(error) == %{
+             type: "server_error",
+             code: "cluster_busy",
+             message: "Cluster is busy",
+             param: nil
+           }
+
+    assert ChatError.terminal_attrs(error) == %{
+             state: :failed,
+             http_status: 503,
+             error_code: "cluster_busy",
+             error_message: "Cluster is busy"
+           }
+  end
+
   test "tooling_not_supported failed events preserve a 400 invalid_request_error mapping" do
     event =
       InferenceEvent.failed(

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -53,6 +53,196 @@ defmodule Orchard.Inference.QueueManagerTest do
     end)
   end
 
+  test "SPEC.md §5.4 cross-tenant weighted round-robin grants one tenant turn at a time" do
+    tenant_a = Ecto.UUID.generate()
+    tenant_b = Ecto.UUID.generate()
+
+    with_queue_admission_config(queue_config(max_wait_ms: 1_000), fn ->
+      assert {:ok, held_grant} =
+               QueueManager.acquire(admission_request("req-held", tenant_id: tenant_a))
+
+      assert {:queued, ticket_a1} =
+               QueueManager.acquire(admission_request("req-a1", tenant_id: tenant_a))
+
+      assert {:queued, ticket_a2} =
+               QueueManager.acquire(admission_request("req-a2", tenant_id: tenant_a))
+
+      assert {:queued, ticket_b1} =
+               QueueManager.acquire(admission_request("req-b1", tenant_id: tenant_b))
+
+      awaiter_a1 = await_and_hold(ticket_a1, :a1)
+      awaiter_a2 = await_and_hold(ticket_a2, :a2)
+      awaiter_b1 = await_and_hold(ticket_b1, :b1)
+
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_a1) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_a2) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_b1) end)
+
+      assert :ok = QueueManager.release(held_grant)
+      assert_receive {:await_result, :a1, {:ok, grant_a1}}, 1_000
+      refute_receive {:await_result, :a2, _}, 20
+      refute_receive {:await_result, :b1, _}, 20
+
+      assert :ok = QueueManager.release(grant_a1)
+      assert_receive {:await_result, :b1, {:ok, grant_b1}}, 1_000
+      refute_receive {:await_result, :a2, _}, 20
+
+      assert :ok = QueueManager.release(grant_b1)
+      assert_receive {:await_result, :a2, {:ok, grant_a2}}, 1_000
+
+      assert :ok = QueueManager.release(grant_a2)
+      stop_awaiter(awaiter_a1)
+      stop_awaiter(awaiter_a2)
+      stop_awaiter(awaiter_b1)
+    end)
+  end
+
+  test "SPEC.md §5.4 tenant FIFO blocks later same-tenant lane while older request waits" do
+    tenant_id = Ecto.UUID.generate()
+
+    with_queue_admission_config(queue_config(max_wait_ms: 1_000), fn ->
+      assert {:ok, model_a_grant} =
+               QueueManager.acquire(
+                 admission_request("req-model-a-held",
+                   tenant_id: tenant_id,
+                   model_id: "queue-model-a"
+                 )
+               )
+
+      assert {:ok, model_b_grant} =
+               QueueManager.acquire(
+                 admission_request("req-model-b-held",
+                   tenant_id: tenant_id,
+                   model_id: "queue-model-b"
+                 )
+               )
+
+      assert {:queued, ticket_a} =
+               QueueManager.acquire(
+                 admission_request("req-model-a-queued",
+                   tenant_id: tenant_id,
+                   model_id: "queue-model-a"
+                 )
+               )
+
+      assert {:queued, ticket_b} =
+               QueueManager.acquire(
+                 admission_request("req-model-b-queued",
+                   tenant_id: tenant_id,
+                   model_id: "queue-model-b"
+                 )
+               )
+
+      awaiter_a = await_and_hold(ticket_a, :same_tenant_a)
+      awaiter_b = await_and_hold(ticket_b, :same_tenant_b)
+
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_a) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_b) end)
+
+      assert :ok = QueueManager.release(model_b_grant)
+      refute_receive {:await_result, :same_tenant_b, _}, 50
+
+      assert :ok = QueueManager.release(model_a_grant)
+      assert_receive {:await_result, :same_tenant_a, {:ok, grant_a}}, 1_000
+      assert_receive {:await_result, :same_tenant_b, {:ok, grant_b}}, 1_000
+
+      assert :ok = QueueManager.release(grant_a)
+      assert :ok = QueueManager.release(grant_b)
+      stop_awaiter(awaiter_a)
+      stop_awaiter(awaiter_b)
+    end)
+  end
+
+  test "SPEC.md §5.4 weighted round-robin honors configured tenant weights" do
+    tenant_a = Ecto.UUID.generate()
+    tenant_b = Ecto.UUID.generate()
+
+    config =
+      queue_config(
+        max_wait_ms: 1_000,
+        tenant_weights: %{tenant_a => 1, tenant_b => 2}
+      )
+
+    with_queue_admission_config(config, fn ->
+      assert {:ok, held_grant} =
+               QueueManager.acquire(admission_request("req-weight-held", tenant_id: tenant_a))
+
+      assert {:queued, ticket_a1} =
+               QueueManager.acquire(admission_request("req-weight-a1", tenant_id: tenant_a))
+
+      assert {:queued, ticket_a2} =
+               QueueManager.acquire(admission_request("req-weight-a2", tenant_id: tenant_a))
+
+      assert {:queued, ticket_b1} =
+               QueueManager.acquire(admission_request("req-weight-b1", tenant_id: tenant_b))
+
+      assert {:queued, ticket_b2} =
+               QueueManager.acquire(admission_request("req-weight-b2", tenant_id: tenant_b))
+
+      awaiter_a1 = await_and_hold(ticket_a1, :weight_a1)
+      awaiter_a2 = await_and_hold(ticket_a2, :weight_a2)
+      awaiter_b1 = await_and_hold(ticket_b1, :weight_b1)
+      awaiter_b2 = await_and_hold(ticket_b2, :weight_b2)
+
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_a1) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_a2) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_b1) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_b2) end)
+
+      assert :ok = QueueManager.release(held_grant)
+      assert_receive {:await_result, :weight_a1, {:ok, grant_a1}}, 1_000
+
+      assert :ok = QueueManager.release(grant_a1)
+      assert_receive {:await_result, :weight_b1, {:ok, grant_b1}}, 1_000
+
+      assert :ok = QueueManager.release(grant_b1)
+      assert_receive {:await_result, :weight_b2, {:ok, grant_b2}}, 1_000
+      refute_receive {:await_result, :weight_a2, _}, 20
+
+      assert :ok = QueueManager.release(grant_b2)
+      assert_receive {:await_result, :weight_a2, {:ok, grant_a2}}, 1_000
+
+      assert :ok = QueueManager.release(grant_a2)
+      stop_awaiter(awaiter_a1)
+      stop_awaiter(awaiter_a2)
+      stop_awaiter(awaiter_b1)
+      stop_awaiter(awaiter_b2)
+    end)
+  end
+
+  test "SPEC.md §5.4 pre-await queued work prevents same-lane immediate bypass" do
+    tenant_a = Ecto.UUID.generate()
+    tenant_b = Ecto.UUID.generate()
+
+    with_queue_admission_config(queue_config(max_wait_ms: 1_000), fn ->
+      assert {:ok, held_grant} =
+               QueueManager.acquire(admission_request("req-pre-await-held", tenant_id: tenant_a))
+
+      assert {:queued, ticket_a} =
+               QueueManager.acquire(admission_request("req-pre-await-a", tenant_id: tenant_a))
+
+      assert :ok = QueueManager.release(held_grant)
+
+      assert {:queued, ticket_b} =
+               QueueManager.acquire(admission_request("req-pre-await-b", tenant_id: tenant_b))
+
+      awaiter_a = await_and_hold(ticket_a, :pre_await_a)
+      awaiter_b = await_and_hold(ticket_b, :pre_await_b)
+
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_b) end)
+
+      assert_receive {:await_result, :pre_await_a, {:ok, grant_a}}, 1_000
+      refute_receive {:await_result, :pre_await_b, _}, 20
+
+      assert :ok = QueueManager.release(grant_a)
+      assert_receive {:await_result, :pre_await_b, {:ok, grant_b}}, 1_000
+
+      assert :ok = QueueManager.release(grant_b)
+      stop_awaiter(awaiter_a)
+      stop_awaiter(awaiter_b)
+    end)
+  end
+
   test "requeue defers an active grant behind the lane retry interval" do
     config = queue_config(max_wait_ms: 500, poll_interval_ms: 50)
 
@@ -1202,6 +1392,25 @@ defmodule Orchard.Inference.QueueManagerTest do
       Process.sleep(20)
       wait_until(fun, attempts - 1)
     end
+  end
+
+  defp await_and_hold(ticket, label) do
+    parent = self()
+
+    spawn(fn ->
+      result = QueueManager.await(ticket)
+      send(parent, {:await_result, label, result})
+
+      receive do
+        :stop -> :ok
+      after
+        2_000 -> :ok
+      end
+    end)
+  end
+
+  defp stop_awaiter(pid) do
+    send(pid, :stop)
   end
 
   defp queue_entry_awaiting?(ticket, manager \\ QueueManager) do

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -33,6 +33,26 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert :ok = QueueManager.release(queued_grant)
   end
 
+  test "capacity two admits two active requests and queues the third" do
+    with_queue_admission_config(queue_config(capacity: 2, max_wait_ms: 1_000), fn ->
+      assert {:ok, first_grant} = QueueManager.acquire(admission_request("req-capacity2-a"))
+      assert first_grant.queue_result == :immediate
+
+      assert {:ok, second_grant} = QueueManager.acquire(admission_request("req-capacity2-b"))
+      assert second_grant.queue_result == :immediate
+
+      assert {:queued, third_ticket} = QueueManager.acquire(admission_request("req-capacity2-c"))
+
+      assert :ok = QueueManager.release(first_grant)
+      assert {:ok, third_grant} = QueueManager.await(third_ticket)
+      assert third_grant.queue_result == :queued
+      assert third_grant.queued_at != nil
+
+      assert :ok = QueueManager.release(second_grant)
+      assert :ok = QueueManager.release(third_grant)
+    end)
+  end
+
   test "SPEC.md §3.6 immediate grant holder death releases lane before explicit release" do
     db_request = create_request!("req_queue_immediate_holder_death", state: :admitted)
 
@@ -1132,6 +1152,21 @@ defmodule Orchard.Inference.QueueManagerTest do
       ],
       overrides
     )
+  end
+
+  defp with_queue_admission_config(queue_admission_config, fun) do
+    previous = Application.fetch_env!(:orchard_controller, :inference)
+
+    previous
+    |> Keyword.put(:queue_admission, queue_admission_config)
+    |> then(&Application.put_env(:orchard_controller, :inference, &1))
+
+    try do
+      fun.()
+    after
+      QueueManager.reset()
+      Application.put_env(:orchard_controller, :inference, previous)
+    end
   end
 
   defp wait_until(fun, attempts \\ 50)

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -53,6 +53,29 @@ defmodule Orchard.Inference.QueueManagerTest do
     end)
   end
 
+  test "requeue defers an active grant behind the lane retry interval" do
+    config = queue_config(max_wait_ms: 500, poll_interval_ms: 50)
+
+    with_queue_admission_config(config, fn ->
+      request = admission_request("req-requeue")
+
+      assert {:ok, grant} = QueueManager.acquire(request)
+      assert {:queued, ticket} = QueueManager.requeue(grant, request)
+
+      awaiter = Task.async(fn -> QueueManager.await(ticket) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket) end)
+      refute_receive {:unexpected_immediate_regrant, _}, 20
+      refute Task.yield(awaiter, 0)
+
+      assert {:ok, requeued_grant} = Task.await(awaiter, 500)
+      assert requeued_grant.queue_result == :queued
+      assert requeued_grant.queue_wait_ms >= config[:poll_interval_ms]
+
+      assert :ok = QueueManager.release(grant)
+      assert :ok = QueueManager.release(requeued_grant)
+    end)
+  end
+
   test "SPEC.md §3.6 immediate grant holder death releases lane before explicit release" do
     db_request = create_request!("req_queue_immediate_holder_death", state: :admitted)
 

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -244,7 +244,7 @@ defmodule Orchard.Inference.QueueManagerTest do
   end
 
   test "requeue defers an active grant behind the lane retry interval" do
-    config = queue_config(max_wait_ms: 500, poll_interval_ms: 50)
+    config = queue_config(max_wait_ms: 500, poll_interval_ms: 200)
 
     with_queue_admission_config(config, fn ->
       request = admission_request("req-requeue")
@@ -254,15 +254,44 @@ defmodule Orchard.Inference.QueueManagerTest do
 
       awaiter = Task.async(fn -> QueueManager.await(ticket) end)
       assert wait_until(fn -> queue_entry_awaiting?(ticket) end)
-      refute_receive {:unexpected_immediate_regrant, _}, 20
-      refute Task.yield(awaiter, 0)
+      refute Task.yield(awaiter, 50)
 
-      assert {:ok, requeued_grant} = Task.await(awaiter, 500)
+      assert {:ok, requeued_grant} = Task.await(awaiter, 1_000)
       assert requeued_grant.queue_result == :queued
       assert requeued_grant.queue_wait_ms >= config[:poll_interval_ms]
 
       assert :ok = QueueManager.release(grant)
       assert :ok = QueueManager.release(requeued_grant)
+    end)
+  end
+
+  test "SPEC.md §5.4 requeued active grants preserve original same-tenant FIFO order" do
+    tenant_id = Ecto.UUID.generate()
+    config = queue_config(capacity: 2, max_wait_ms: 1_000, poll_interval_ms: 50)
+
+    with_queue_admission_config(config, fn ->
+      request_a = admission_request("req-requeue-fifo-a", tenant_id: tenant_id)
+      request_b = admission_request("req-requeue-fifo-b", tenant_id: tenant_id)
+
+      assert {:ok, grant_a} = QueueManager.acquire(request_a)
+      assert {:ok, grant_b} = QueueManager.acquire(request_b)
+
+      assert {:queued, ticket_a} = QueueManager.requeue(grant_a, request_a)
+      assert {:queued, ticket_b} = QueueManager.requeue(grant_b, request_b)
+
+      awaiter_a = Task.async(fn -> QueueManager.await(ticket_a) end)
+
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_a) end)
+      assert {:ok, requeued_grant_a} = Task.await(awaiter_a, 1_000)
+
+      awaiter_b = Task.async(fn -> QueueManager.await(ticket_b) end)
+
+      assert {:ok, requeued_grant_b} = Task.await(awaiter_b, 1_000)
+
+      assert requeued_grant_a.queued_at == ticket_a.queued_at
+      assert requeued_grant_b.queued_at == ticket_b.queued_at
+      assert :ok = QueueManager.release(requeued_grant_a)
+      assert :ok = QueueManager.release(requeued_grant_b)
     end)
   end
 
@@ -456,7 +485,7 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert :ok = QueueManager.release(grant)
   end
 
-  test "SPEC.md §3.6 queue timeout persistence failure retains queue until retry succeeds" do
+  test "SPEC.md §3.6 queue timeout persistence retry does not stall other tenants" do
     request_id = Ecto.UUID.generate()
     public_id = "req_queue_timeout_persistence_retry"
 
@@ -486,7 +515,9 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert queue_entry_terminal_pending?(timeout_ticket)
 
     assert :ok = QueueManager.release(held_grant)
-    refute Task.yield(next_awaiter, 100)
+    assert {:ok, next_grant} = Task.await(next_awaiter, 2_000)
+    assert next_grant.queue_result == :queued
+    assert queue_entry_terminal_pending?(timeout_ticket)
 
     db_request = insert_request_with_id!(request_id, public_id, state: :queued)
 
@@ -498,8 +529,6 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert request.error_code == "queue_timeout"
     assert_queue_metadata(request, "queue_timeout", queued?: true)
 
-    assert {:ok, next_grant} = Task.await(next_awaiter, 2_000)
-    assert next_grant.queue_result == :queued
     assert :ok = QueueManager.release(next_grant)
   end
 
@@ -613,7 +642,7 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert :ok = QueueManager.release(grant)
   end
 
-  test "SPEC.md §3.6 queued disconnect persistence failure retains queue until retry succeeds" do
+  test "SPEC.md §3.6 queued disconnect persistence retry does not stall other tenants" do
     request_id = Ecto.UUID.generate()
     public_id = "req_queue_disconnect_persistence_retry"
 
@@ -646,7 +675,9 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert wait_until(fn -> queue_entry_terminal_pending?(disconnect_ticket) end)
 
     assert :ok = QueueManager.release(held_grant)
-    refute Task.yield(next_awaiter, 100)
+    assert {:ok, next_grant} = Task.await(next_awaiter, 2_000)
+    assert next_grant.queue_result == :queued
+    assert queue_entry_terminal_pending?(disconnect_ticket)
 
     db_request = insert_request_with_id!(request_id, public_id, state: :queued)
 
@@ -661,8 +692,6 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert request.error_code == "request_caller_disconnect"
     assert_queue_metadata(request, "interrupted_before_dispatch", queued?: true)
 
-    assert {:ok, next_grant} = Task.await(next_awaiter, 2_000)
-    assert next_grant.queue_result == :queued
     assert :ok = QueueManager.release(next_grant)
   end
 

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -327,6 +327,29 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler do
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.StubLiveCapacityScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
+
+  def schedule(%CanonicalRequest{} = request) do
+    owner = Application.fetch_env!(:orchard_controller, :request_orchestrator_live_capacity_owner)
+    send(owner, {:live_capacity_schedule_attempt, self(), request.public_id})
+
+    receive do
+      {:live_capacity_schedule_reply, reply} ->
+        reply
+    after
+      1_000 ->
+        {:error, :cluster_busy}
+    end
+  end
+
+  def schedule_success(%CanonicalRequest{} = request),
+    do: StubMultiNodeScheduler.schedule(request)
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.CapturingRuntimeAdapter do
   @behaviour Orchard.Node.RuntimeAdapter
 
@@ -497,6 +520,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     only: [assert_queue_metadata: 2, assert_queue_metadata: 3]
 
   alias Orchard.Inference.RequestOrchestratorTest.StubCacheAffinityScheduler
+  alias Orchard.Inference.RequestOrchestratorTest.StubLiveCapacityScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryTierOnlyScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryUnavailableScheduler
@@ -531,6 +555,9 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     previous_pre_await_queue_result =
       Application.get_env(:orchard_controller, :request_orchestrator_pre_await_queue_result)
 
+    previous_live_capacity_owner =
+      Application.get_env(:orchard_controller, :request_orchestrator_live_capacity_owner)
+
     if Process.whereis(:request_orchestrator_test_pid) do
       Process.unregister(:request_orchestrator_test_pid)
     end
@@ -546,6 +573,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       Application.put_env(:orchard_node_agent, :runtime, previous_runtime)
       restore_runtime_events(previous_runtime_events)
       restore_pre_await_queue_result(previous_pre_await_queue_result)
+      restore_live_capacity_owner(previous_live_capacity_owner)
       QueueManager.reset()
       ModelManager.reset()
       Enum.each(bundle.cache_paths, &File.rm_rf/1)
@@ -1278,6 +1306,74 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert request.state == :cancelled
     assert request.error_code == "request_caller_disconnect"
     assert_queue_metadata(request, "interrupted_before_dispatch", granted?: true)
+    refute :scheduled in request_event_states(request)
+
+    assert {:ok, next_grant} = hold_queue_lane(canonical)
+    assert :ok = QueueManager.release(next_grant)
+  end
+
+  test "queue admission requeues post-grant cluster_busy then schedules when live capacity returns",
+       %{bundle: bundle} do
+    put_queue_admission_config(enabled: true, max_wait_ms: 1_000, poll_interval_ms: 150)
+    put_live_capacity_scheduler_config()
+    put_capturing_runtime_adapter_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-live-capacity-requeue")
+    canonical = canonical_request("request-orchestrator-live-capacity-requeue", stream?: false)
+    public_id = canonical.public_id
+
+    task = Task.async(fn -> RequestOrchestrator.execute(canonical, model) end)
+
+    assert {:live_capacity_schedule_attempt, scheduler_pid, ^public_id} = live_capacity_attempt()
+
+    send(scheduler_pid, {:live_capacity_schedule_reply, {:error, :cluster_busy}})
+    assert wait_until(fn -> request_state(canonical.public_id) == :queued end)
+    refute_receive {:captured_execute_request, _request}, 50
+
+    queued_request = Requests.get_request_by_public_id(canonical.public_id)
+    assert_queue_metadata(queued_request, "queued", queued?: true)
+    refute Map.has_key?(queued_request.scheduler_decision || %{}, "queue_grant_id")
+
+    assert {:live_capacity_schedule_attempt, retry_scheduler_pid, ^public_id} =
+             live_capacity_attempt()
+
+    assert {:ok, schedule} = StubLiveCapacityScheduler.schedule_success(canonical)
+
+    send(retry_scheduler_pid, {:live_capacity_schedule_reply, {:ok, schedule}})
+
+    assert_receive {:captured_execute_request, _request}, 500
+    assert {:ok, ^canonical, events} = Task.await(task, 2_000)
+    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    states = request_event_states(request)
+
+    assert state_before?(states, :admitted, :queued)
+    assert state_before?(states, :queued, :scheduled)
+    assert_queue_metadata(request, "queued", queued?: true, granted?: true)
+
+    assert {:ok, next_grant} = hold_queue_lane(canonical)
+    assert :ok = QueueManager.release(next_grant)
+  end
+
+  test "queue admission times out post-grant cluster_busy without dispatching", %{bundle: bundle} do
+    put_queue_admission_config(enabled: true, max_wait_ms: 60, poll_interval_ms: 10)
+    put_live_capacity_scheduler_config()
+    put_capturing_runtime_adapter_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-live-capacity-timeout")
+    canonical = canonical_request("request-orchestrator-live-capacity-timeout", stream?: false)
+
+    task = Task.async(fn -> RequestOrchestrator.execute(canonical, model) end)
+    assert {:error, :queue_timeout} = reply_cluster_busy_until_done(task, canonical.public_id)
+    refute_receive {:captured_execute_request, _request}
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+
+    assert request.state == :timed_out
+    assert request.http_status == 504
+    assert request.error_code == "queue_timeout"
+    assert_queue_metadata(request, "queue_timeout", queued?: true)
     refute :scheduled in request_event_states(request)
 
     assert {:ok, next_grant} = hold_queue_lane(canonical)
@@ -2463,6 +2559,15 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     Application.put_env(:orchard_controller, :inference, inference)
   end
 
+  defp put_live_capacity_scheduler_config do
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.merge(scheduler_impl: StubLiveCapacityScheduler)
+
+    Application.put_env(:orchard_controller, :inference, inference)
+    Application.put_env(:orchard_controller, :request_orchestrator_live_capacity_owner, self())
+  end
+
   defp put_cache_affinity_scheduler_config do
     inference =
       Application.fetch_env!(:orchard_controller, :inference)
@@ -2646,6 +2751,41 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end
   end
 
+  defp live_capacity_attempt do
+    receive do
+      {:live_capacity_schedule_attempt, _scheduler_pid, _public_id} = attempt -> attempt
+    after
+      500 -> flunk("expected live capacity scheduler attempt")
+    end
+  end
+
+  defp reply_cluster_busy_until_done(task, public_id) do
+    deadline_ms = System.monotonic_time(:millisecond) + 1_000
+    reply_cluster_busy_until_done(task, public_id, deadline_ms)
+  end
+
+  defp reply_cluster_busy_until_done(task, public_id, deadline_ms) do
+    if System.monotonic_time(:millisecond) > deadline_ms do
+      flunk("request did not complete while scheduler kept returning cluster_busy")
+    end
+
+    case Task.yield(task, 0) do
+      {:ok, result} ->
+        result
+
+      nil ->
+        receive do
+          {:live_capacity_schedule_attempt, scheduler_pid, ^public_id} ->
+            send(scheduler_pid, {:live_capacity_schedule_reply, {:error, :cluster_busy}})
+        after
+          20 ->
+            :ok
+        end
+
+        reply_cluster_busy_until_done(task, public_id, deadline_ms)
+    end
+  end
+
   defp manager_restarted?(manager, previous_pid) do
     case GenServer.whereis(manager) do
       pid when is_pid(pid) and pid != previous_pid -> true
@@ -2800,6 +2940,17 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
         :orchard_controller,
         :request_orchestrator_pre_await_queue_result,
         result
+      )
+
+  defp restore_live_capacity_owner(nil),
+    do: Application.delete_env(:orchard_controller, :request_orchestrator_live_capacity_owner)
+
+  defp restore_live_capacity_owner(owner),
+    do:
+      Application.put_env(
+        :orchard_controller,
+        :request_orchestrator_live_capacity_owner,
+        owner
       )
 
   defp stage_test_bundle! do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -1143,6 +1143,42 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert_queue_metadata(request, "queued", queued?: true, granted?: true)
   end
 
+  test "queue admission capacity two schedules two active requests and queues overflow", %{
+    bundle: bundle
+  } do
+    put_queue_admission_config(enabled: true, capacity: 2, max_wait_ms: 1_000)
+
+    model = create_active_model!(bundle, "request-orchestrator-queue-capacity-two")
+    canonical = canonical_request("request-orchestrator-queue-capacity-two", stream?: false)
+
+    assert {:ok, first_grant} = hold_queue_lane(canonical)
+    assert {:ok, second_grant} = hold_queue_lane(canonical)
+
+    task = Task.async(fn -> RequestOrchestrator.execute(canonical, model) end)
+
+    try do
+      assert wait_until(fn -> request_state(canonical.public_id) == :queued end)
+
+      queued_request = Requests.get_request_by_public_id(canonical.public_id)
+      assert_queue_metadata(queued_request, "queued", queued?: true)
+
+      assert :ok = QueueManager.release(first_grant)
+      assert {:ok, ^canonical, events} = Task.await(task, 2_000)
+      assert Enum.any?(events, &InferenceEvent.terminal?/1)
+
+      request = Requests.get_request_by_public_id(canonical.public_id)
+      states = request_event_states(request)
+
+      assert state_before?(states, :admitted, :queued)
+      assert state_before?(states, :queued, :scheduled)
+      assert_queue_metadata(request, "queued", queued?: true, granted?: true)
+    after
+      QueueManager.release(first_grant)
+      QueueManager.release(second_grant)
+      Task.shutdown(task, :brutal_kill)
+    end
+  end
+
   test "queue admission returns queue_full before scheduling when tenant cap is exhausted", %{
     bundle: bundle
   } do

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -434,6 +434,20 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
       assert schedule.strategy == :single_node
     end
+
+    test "returns cluster_busy for one live active target instead of bypassing capacity checks" do
+      put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
+      node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node.id, host: "10.0.0.1", port: 50_061, active_request_count: 1)
+      )
+
+      assert {:error, :cluster_busy} =
+               MultiNode.schedule(canonical_request(), status_client: StubClient)
+    end
   end
 
   # -- Multi-node ranking --
@@ -529,7 +543,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.selected_tier == "loaded"
     end
 
-    test "prefers lower active_request_count when both cold" do
+    test "excludes active loaded node in favor of idle cold node" do
       node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
       node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
 
@@ -539,24 +553,43 @@ defmodule Orchard.Scheduler.MultiNodeTest do
         make_status(node_a.id,
           host: "10.0.0.1",
           port: 50_061,
-          active_request_count: 5
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 1
         )
       )
 
       stub_probe(
         "10.0.0.2",
         50_062,
-        make_status(node_b.id,
-          host: "10.0.0.2",
-          port: 50_062,
-          active_request_count: 2
-        )
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
       )
 
-      request = canonical_request()
+      request = canonical_request("test-model", "v1")
 
       assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
       assert schedule.node_id == node_b.id
+      assert schedule.selected_tier == "cold"
+      assert schedule.candidate_count == 1
+    end
+
+    test "returns cluster_busy when all joined candidates are active without fallback" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id, host: "10.0.0.1", port: 50_061, active_request_count: 1)
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062, active_request_count: 2)
+      )
+
+      assert {:error, :cluster_busy} =
+               MultiNode.schedule(canonical_request(), status_client: StubClient)
     end
 
     test "prefers healthy over degraded when tied" do
@@ -1662,7 +1695,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       refute exit_log =~ ":score_call_exit"
     end
 
-    test "does not let cache-affinity outrank active request count" do
+    test "does not let cache-affinity make an active candidate eligible" do
       put_inference(cache_affinity: [enabled: true, max_age_ms: 300_000, max_recent_requests: 8])
 
       id_a = "00000000-0000-0000-0000-000000000001"
@@ -1696,7 +1729,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.node_id == id_a
       assert schedule.cache_affinity_hint_available == true
       assert schedule.cache_affinity_selected_match == false
-      assert schedule.cache_affinity_candidate_count == 1
+      assert schedule.cache_affinity_candidate_count == 0
       assert schedule.selected_cache_tier == "hint_not_selected"
     end
 
@@ -1918,7 +1951,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.memory_admission_tier == "headroom_unknown"
     end
 
-    test "does not let memory admission outrank active load" do
+    test "memory headroom does not make an active candidate eligible" do
       put_inference(memory_admission: [enabled: true])
 
       id_a = "00000000-0000-0000-0000-000000000001"
@@ -1945,6 +1978,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
 
       assert schedule.node_id == id_a
+      assert schedule.candidate_count == 1
       assert schedule.memory_admission_tier == "headroom_unknown"
     end
 
@@ -2495,14 +2529,14 @@ defmodule Orchard.Scheduler.MultiNodeTest do
           health: :degraded
         })
 
-      # Node B has lower request count — should win among degraded peers
+      # Node A is the only idle degraded peer, so it remains eligible.
       stub_probe(
         "10.0.0.1",
         50_061,
         make_status(node_a.id,
           host: "10.0.0.1",
           port: 50_061,
-          active_request_count: 3,
+          active_request_count: 0,
           health: %{ready: true, health_code: "warn", health_message: "degraded"}
         )
       )
@@ -2522,8 +2556,8 @@ defmodule Orchard.Scheduler.MultiNodeTest do
 
       assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
       assert schedule.strategy == :multi_node
-      assert schedule.node_id == node_b.id
-      assert schedule.candidate_count == 2
+      assert schedule.node_id == node_a.id
+      assert schedule.candidate_count == 1
     end
 
     test "prefers loaded model even when all degraded" do

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -583,6 +583,57 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.candidate_count == 2
     end
 
+    test "prefers lower matching placement active count before health and node_id" do
+      node_a =
+        insert_node!(%{
+          id: "00000000-0000-0000-0000-000000000001",
+          advertise_addr: "10.0.0.1",
+          rpc_port: 50_061,
+          health: :healthy
+        })
+
+      node_b =
+        insert_node!(%{
+          id: "00000000-0000-0000-0000-000000000002",
+          advertise_addr: "10.0.0.2",
+          rpc_port: 50_062,
+          health: :degraded
+        })
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 2,
+          runtime_model_placements: [model_placement("test-model", "v1", 2, 3)]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id,
+          host: "10.0.0.2",
+          port: 50_062,
+          health: %{ready: true, health_code: "warn", health_message: "degraded"},
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 1,
+          runtime_model_placements: [model_placement("test-model", "v1", 1, 3)]
+        )
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert schedule.strategy == :multi_node
+      assert schedule.node_id == node_b.id
+      assert schedule.selected_tier == "loaded"
+      assert schedule.candidate_count == 2
+    end
+
     test "excludes active loaded node at matching placement capacity" do
       node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
       node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -132,6 +132,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     health = Keyword.get(opts, :health, nil)
     prefix_cache_statuses = Keyword.get(opts, :runtime_prefix_cache_statuses, [])
     memory_budgets = Keyword.get(opts, :runtime_memory_budgets, [])
+    model_placements = Keyword.get(opts, :runtime_model_placements, [])
     supports_prompt_token_ids = Keyword.get(opts, :supports_prompt_token_ids, false)
     display_name = Keyword.get(opts, :display_name, "node-#{node_id}")
     host = Keyword.get(opts, :host, "10.0.0.1")
@@ -152,7 +153,16 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       active_request_count: active_request_count,
       runtime_memory_budgets: memory_budgets,
       runtime_prefix_cache_statuses: prefix_cache_statuses,
+      runtime_model_placements: model_placements,
       supports_prompt_token_ids: supports_prompt_token_ids
+    }
+  end
+
+  defp model_placement(model_id, version, active_request_count, max_concurrency) do
+    %{
+      model_ref: %{model_id: model_id, version: version},
+      active_request_count: active_request_count,
+      max_concurrency: max_concurrency
     }
   end
 
@@ -543,7 +553,190 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.selected_tier == "loaded"
     end
 
-    test "excludes active loaded node in favor of idle cold node" do
+    test "keeps active loaded node eligible when matching placement capacity has room" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 1,
+          runtime_model_placements: [model_placement("test-model", "v1", 1, 2)]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert schedule.node_id == node_a.id
+      assert schedule.selected_tier == "loaded"
+      assert schedule.candidate_count == 2
+    end
+
+    test "excludes active loaded node at matching placement capacity" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 2,
+          runtime_model_placements: [model_placement("test-model", "v1", 2, 2)]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert schedule.node_id == node_b.id
+      assert schedule.selected_tier == "cold"
+      assert schedule.candidate_count == 1
+    end
+
+    test "excludes active loaded node with malformed placement capacity" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 1,
+          runtime_model_placements: [model_placement("other-model", "v1", 0, 2), %{}]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert schedule.node_id == node_b.id
+      assert schedule.selected_tier == "cold"
+      assert schedule.candidate_count == 1
+    end
+
+    test "excludes active loaded node with duplicate matching placement capacity" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+      duplicate = model_placement("test-model", "v1", 0, 2)
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 1,
+          runtime_model_placements: [duplicate, duplicate]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert schedule.node_id == node_b.id
+      assert schedule.selected_tier == "cold"
+      assert schedule.candidate_count == 1
+    end
+
+    test "excludes active loaded node with ambiguous matching placement capacity" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          active_request_count: 1,
+          runtime_model_placements: [
+            model_placement("test-model", "v1", 1, 2),
+            %{model_ref: %{model_id: "test-model", version: "v1"}}
+          ]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert schedule.node_id == node_b.id
+      assert schedule.selected_tier == "cold"
+      assert schedule.candidate_count == 1
+    end
+
+    test "excludes active cold node even when status includes spare placement capacity" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          active_request_count: 1,
+          runtime_model_placements: [model_placement("test-model", "v1", 0, 2)]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert schedule.node_id == node_b.id
+      assert schedule.selected_tier == "cold"
+      assert schedule.candidate_count == 1
+    end
+
+    test "excludes active loaded node in favor of idle cold node when capacity is unknown" do
       node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
       node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
 

--- a/apps/orchard_controller/test/support/queue_admission_api_support.ex
+++ b/apps/orchard_controller/test/support/queue_admission_api_support.ex
@@ -63,6 +63,9 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
   import Ecto.Query
   import ExUnit.Assertions
 
+  alias Orchard.Cluster.V1.StatusResponse
+  alias Orchard.Dispatch.GrpcNodeRuntimeClient
+  alias Orchard.Inference
   alias Orchard.Inference.QueueManager
   alias Orchard.Repo
   alias Orchard.Requests.Request
@@ -176,6 +179,24 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
     after
       timeout -> flunk("expected runtime start for #{model_id}")
     end
+  end
+
+  def grpc_status_snapshot do
+    target = Inference.runtime_client_target()
+    assert {:ok, channel} = GrpcNodeRuntimeClient.connect(target)
+
+    try do
+      assert {:ok, %StatusResponse{} = status} = GrpcNodeRuntimeClient.status(channel)
+      status
+    after
+      GrpcNodeRuntimeClient.disconnect(channel)
+    end
+  end
+
+  def runtime_model_placement!(%StatusResponse{} = status, model_id, version) do
+    Enum.find(status.runtime_model_placements, fn placement ->
+      placement.model_ref.model_id == model_id and placement.model_ref.version == version
+    end) || flunk("runtime model placement not found for #{model_id}@#{version}")
   end
 
   def assert_queue_metadata(request, queue_result, opts \\ []) do

--- a/apps/orchard_controller/test/support/queue_admission_api_support.ex
+++ b/apps/orchard_controller/test/support/queue_admission_api_support.ex
@@ -16,22 +16,24 @@ defmodule Orchard.TestSupport.QueueAdmissionRuntimeAdapter do
     runtime_owner = Keyword.fetch!(opts, :owner)
     generation_ref = make_ref()
 
-    send(
-      test_owner,
-      {:queue_admission_runtime_started, self(), request.request_id, request.model_id}
-    )
+    spawn(fn ->
+      send(
+        test_owner,
+        {:queue_admission_runtime_started, self(), request.request_id, request.model_id}
+      )
 
-    receive do
-      :queue_admission_runtime_release -> :ok
-    after
-      5_000 -> send(test_owner, {:queue_admission_runtime_release_timeout, request.request_id})
-    end
+      receive do
+        :queue_admission_runtime_release -> :ok
+      after
+        5_000 -> send(test_owner, {:queue_admission_runtime_release_timeout, request.request_id})
+      end
 
-    Enum.each(runtime_events(request), fn event ->
-      send(runtime_owner, {:runtime_adapter_event, generation_ref, event})
+      Enum.each(runtime_events(request), fn event ->
+        send(runtime_owner, {:runtime_adapter_event, generation_ref, event})
+      end)
+
+      send(runtime_owner, {:runtime_adapter_done, generation_ref})
     end)
-
-    send(runtime_owner, {:runtime_adapter_done, generation_ref})
 
     {:ok, generation_ref, adapter_state}
   end
@@ -96,6 +98,11 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
     runtime =
       Application.fetch_env!(:orchard_node_agent, :runtime)
       |> Keyword.put(:runtime_adapter_impl, QueueAdmissionRuntimeAdapter)
+      # The fake adapter must not serialize WorkerProcess while controller queue
+      # capacity is under test; production worker-adapter limits are covered elsewhere.
+      |> Keyword.put(:worker_generation_mode, "batch")
+      |> Keyword.put(:worker_max_concurrent_requests_per_model, 3)
+      |> Keyword.put(:test_only_allow_batch_admission_for_non_worker_adapters?, true)
 
     Application.put_env(:orchard_node_agent, :runtime, runtime)
     Application.put_env(:orchard_controller, :queue_admission_api_runtime_owner, test_owner)
@@ -133,15 +140,39 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
   end
 
   def request_with_queue_result!(requested_model, queue_result) do
-    Request
-    |> where([request], request.requested_model == ^requested_model)
-    |> Repo.all()
-    |> Enum.find(fn request ->
-      request.scheduler_decision && request.scheduler_decision["queue_result"] == queue_result
-    end)
+    requested_model
+    |> requests_with_queue_result!(queue_result)
+    |> List.first()
     |> case do
       nil -> flunk("expected #{requested_model} request with queue_result=#{queue_result}")
       request -> request
+    end
+  end
+
+  def requests_with_queue_result!(requested_model, queue_result) do
+    Request
+    |> where([request], request.requested_model == ^requested_model)
+    |> Repo.all()
+    |> Enum.filter(fn request ->
+      request.scheduler_decision && request.scheduler_decision["queue_result"] == queue_result
+    end)
+  end
+
+  def assert_queue_result_count!(requested_model, queue_result, expected_count) do
+    actual_count =
+      requested_model
+      |> requests_with_queue_result!(queue_result)
+      |> length()
+
+    assert actual_count == expected_count
+    :ok
+  end
+
+  def runtime_start_message(model_id, timeout \\ 2_000) do
+    receive do
+      {:queue_admission_runtime_started, pid, request_id, ^model_id} -> {pid, request_id}
+    after
+      timeout -> flunk("expected runtime start for #{model_id}")
     end
   end
 

--- a/apps/orchard_controller/test/support/queue_admission_api_support.ex
+++ b/apps/orchard_controller/test/support/queue_admission_api_support.ex
@@ -94,14 +94,16 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
     QueueManager.reset()
   end
 
-  def put_blocking_runtime_adapter!(test_owner) do
+  def put_blocking_runtime_adapter!(test_owner, opts \\ []) do
+    max_concurrent_requests = Keyword.get(opts, :max_concurrent_requests, 3)
+
     runtime =
       Application.fetch_env!(:orchard_node_agent, :runtime)
       |> Keyword.put(:runtime_adapter_impl, QueueAdmissionRuntimeAdapter)
       # The fake adapter must not serialize WorkerProcess while controller queue
       # capacity is under test; production worker-adapter limits are covered elsewhere.
       |> Keyword.put(:worker_generation_mode, "batch")
-      |> Keyword.put(:worker_max_concurrent_requests_per_model, 3)
+      |> Keyword.put(:worker_max_concurrent_requests_per_model, max_concurrent_requests)
       |> Keyword.put(:test_only_allow_batch_admission_for_non_worker_adapters?, true)
 
     Application.put_env(:orchard_node_agent, :runtime, runtime)

--- a/apps/orchard_node_agent/README.md
+++ b/apps/orchard_node_agent/README.md
@@ -13,6 +13,7 @@ This README is orientation only. Normative behavior lives in
 - Node-local runtime service behavior used by the controller.
 - Model acquisition/cache/load coordination on a node.
 - Worker process supervision and node-local diagnostics/status reporting.
+- Runtime placement capacity telemetry for loaded models.
 - Manual Elixir binding for the node-agent ↔ worker proto.
 
 ## Does not own

--- a/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
@@ -5,6 +5,8 @@ defmodule Orchard.Node.ModelManager do
   Ensure-load requests run as async supervised tasks with single-flight
   dedup: concurrent callers for the same `{model_id, version}` share one
   acquisition + worker-load pipeline and all receive the same reply.
+  Status responses include loaded-model placement capacity so the controller can
+  avoid dispatching to full same-model placements.
   """
 
   use GenServer

--- a/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
@@ -18,6 +18,7 @@ defmodule Orchard.Node.ModelManager do
   alias Orchard.Cluster.V1.ModelRef
   alias Orchard.Cluster.V1.RuntimeHealth
   alias Orchard.Cluster.V1.RuntimeMemoryBudget
+  alias Orchard.Cluster.V1.RuntimeModelPlacement
   alias Orchard.Cluster.V1.RuntimeNodeMetadata
   alias Orchard.Cluster.V1.RuntimePrefixCacheStatus
   alias Orchard.Cluster.V1.ScorePrefixCacheRequest
@@ -1256,7 +1257,8 @@ defmodule Orchard.Node.ModelManager do
       hosted_tool_readiness: tool_snapshot.readiness,
       runtime_memory_budgets: runtime_memory_budgets,
       runtime_prefix_cache_statuses: runtime_prefix_cache_statuses,
-      supports_prompt_token_ids: supports_prompt_token_ids
+      supports_prompt_token_ids: supports_prompt_token_ids,
+      runtime_model_placements: runtime_model_placements(state)
     }
   end
 
@@ -1311,6 +1313,18 @@ defmodule Orchard.Node.ModelManager do
     state.workers
     |> Enum.filter(fn {_key, entry} -> entry.placement_state == :PLACEMENT_STATE_LOADED end)
     |> Enum.sort_by(fn {{model_id, version}, _} -> {model_id, version} end)
+  end
+
+  defp runtime_model_placements(state) do
+    max_concurrency = Node.effective_worker_request_limit()
+
+    Enum.map(loaded_workers(state), fn {key, entry} ->
+      %RuntimeModelPlacement{
+        model_ref: entry.model_ref,
+        active_request_count: active_request_count_for_model(state.active_requests, key),
+        max_concurrency: max_concurrency
+      }
+    end)
   end
 
   defp runtime_memory_budget(%ModelRef{} = model_ref, budget) do

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -2539,6 +2539,80 @@ defmodule OrchardNodeAgentTest do
     )
   end
 
+  test "current status reports loaded model placement capacity", %{bundle: bundle} do
+    with_runtime_adapter(BlockingRuntimeAdapter, fn ->
+      assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+               NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+      assert %StatusResponse{
+               runtime_model_placements: [
+                 %{
+                   model_ref: %{model_id: @test_model_id, version: @test_version},
+                   active_request_count: 0,
+                   max_concurrency: 1
+                 }
+               ]
+             } = NodeStatus.current()
+    end)
+  end
+
+  test "current status reports stream mode placement max concurrency as one", %{bundle: bundle} do
+    with_runtime_config(
+      [
+        runtime_adapter_impl: BlockingRuntimeAdapter,
+        worker_generation_mode: "stream",
+        worker_max_concurrent_requests_per_model: 4,
+        test_only_allow_batch_admission_for_non_worker_adapters?: true
+      ],
+      fn ->
+        assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+                 NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+        assert %StatusResponse{
+                 runtime_model_placements: [
+                   %{
+                     model_ref: %{model_id: @test_model_id, version: @test_version},
+                     active_request_count: 0,
+                     max_concurrency: 1
+                   }
+                 ]
+               } = NodeStatus.current()
+      end
+    )
+  end
+
+  test "current status reports batch placement active count and max concurrency", %{
+    bundle: bundle
+  } do
+    with_runtime_config(
+      [
+        runtime_adapter_impl: BlockingRuntimeAdapter,
+        worker_generation_mode: "batch",
+        worker_max_concurrent_requests_per_model: 2,
+        test_only_allow_batch_admission_for_non_worker_adapters?: true
+      ],
+      fn ->
+        assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+                 NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+        request = execute_inference_request("req-batch-status-first")
+        assert :ok = NodeStatus.prepare_request(request, self())
+
+        assert %StatusResponse{
+                 runtime_model_placements: [
+                   %{
+                     model_ref: %{model_id: @test_model_id, version: @test_version},
+                     active_request_count: 1,
+                     max_concurrency: 2
+                   }
+                 ]
+               } = NodeStatus.current()
+
+        assert %{ok: true} = NodeStatus.cancel_request(request.request_id)
+      end
+    )
+  end
+
   test "batch mode still maps third request to gRPC model_busy without Accepted", %{
     bundle: bundle
   } do

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -2539,6 +2539,74 @@ defmodule OrchardNodeAgentTest do
     )
   end
 
+  test "batch mode accepts two same-model gRPC streams and reports active placement capacity", %{
+    bundle: bundle
+  } do
+    with_runtime_config(
+      [
+        runtime_adapter_impl: BlockingRuntimeAdapter,
+        worker_generation_mode: "batch",
+        worker_max_concurrent_requests_per_model: 2,
+        test_only_allow_batch_admission_for_non_worker_adapters?: true
+      ],
+      fn ->
+        request1 = execute_inference_request("req-batch-grpc-active-first")
+        request2 = execute_inference_request("req-batch-grpc-active-second")
+        request_id1 = request1.request_id
+        request_id2 = request2.request_id
+
+        with_channel(fn channel ->
+          assert {:ok, %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED}} =
+                   NodeRuntimeStub.ensure_model_loaded(
+                     channel,
+                     ensure_model_loaded_request(bundle)
+                   )
+
+          task1 = start_execute_inference_task(request1, self())
+          task2 = start_execute_inference_task(request2, self())
+
+          try do
+            assert_execute_inference_accepted([request_id1, request_id2])
+
+            refs = wait_for_generation_refs([request_id1, request_id2])
+
+            status = grpc_status_snapshot()
+            assert status.active_request_count == 2
+
+            placement = runtime_model_placement!(status, @test_model_id, @test_version)
+            assert placement.active_request_count == 2
+            assert placement.max_concurrency == 2
+
+            send_release(Map.fetch!(refs, request_id1))
+            send_release(Map.fetch!(refs, request_id2))
+
+            assert_blocking_stream_completed(Task.await(task1, 5_000))
+            assert_blocking_stream_completed(Task.await(task2, 5_000))
+
+            wait_until(fn ->
+              grpc_status_snapshot().active_request_count == 0
+            end)
+
+            final_status = grpc_status_snapshot()
+
+            final_placement =
+              runtime_model_placement!(final_status, @test_model_id, @test_version)
+
+            assert final_placement.active_request_count == 0
+            assert final_placement.max_concurrency == 2
+          after
+            try do
+              best_effort_release_generation_refs([request_id1, request_id2])
+            after
+              Task.shutdown(task1, :brutal_kill)
+              Task.shutdown(task2, :brutal_kill)
+            end
+          end
+        end)
+      end
+    )
+  end
+
   test "current status reports loaded model placement capacity", %{bundle: bundle} do
     with_runtime_adapter(BlockingRuntimeAdapter, fn ->
       assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
@@ -3789,6 +3857,203 @@ defmodule OrchardNodeAgentTest do
   end
 
   # -- Private helpers -------------------------------------------------------
+
+  defp start_execute_inference_task(request, test_pid) do
+    Task.async(fn ->
+      with_channel(&collect_execute_inference_events(&1, request, test_pid))
+    end)
+  end
+
+  defp collect_execute_inference_events(channel, request, test_pid) do
+    {:ok, event_stream} = NodeRuntimeStub.execute_inference(channel, request)
+
+    event_stream
+    |> Enum.reduce([], &collect_execute_inference_event(&1, &2, request, test_pid))
+    |> Enum.reverse()
+  end
+
+  defp collect_execute_inference_event(event, events, request, test_pid) do
+    notify_execute_inference_accepted(event, request.request_id, test_pid)
+    [event | events]
+  end
+
+  defp notify_execute_inference_accepted(
+         {:ok, %RPCInferenceEvent{event: {:accepted, %Accepted{}}}},
+         request_id,
+         test_pid
+       ) do
+    send(test_pid, {:execute_inference_accepted, request_id})
+  end
+
+  defp notify_execute_inference_accepted(_event, _request_id, _test_pid), do: :ok
+
+  defp assert_execute_inference_accepted(request_ids) do
+    expected = MapSet.new(request_ids)
+
+    accepted =
+      Enum.reduce_while(1..length(request_ids), MapSet.new(), fn _index, accepted ->
+        receive do
+          {:execute_inference_accepted, request_id} ->
+            next = MapSet.put(accepted, request_id)
+
+            if MapSet.equal?(next, expected) do
+              {:halt, next}
+            else
+              {:cont, next}
+            end
+        after
+          1_000 ->
+            flunk(
+              "missing accepted events for request ids: #{inspect(MapSet.difference(expected, accepted))}"
+            )
+        end
+      end)
+
+    assert MapSet.equal?(accepted, expected)
+  end
+
+  defp wait_for_generation_refs(request_ids, attempts \\ 80)
+
+  defp wait_for_generation_refs(request_ids, attempts) when attempts > 0 do
+    refs = generation_refs_for_request_ids(request_ids)
+
+    if map_size(refs) == length(request_ids) do
+      refs
+    else
+      Process.sleep(25)
+      wait_for_generation_refs(request_ids, attempts - 1)
+    end
+  end
+
+  defp wait_for_generation_refs(request_ids, 0) do
+    flunk("generation refs not active for request ids: #{inspect(request_ids)}")
+  end
+
+  defp generation_refs_for_request_ids(request_ids) do
+    case safe_worker_state() do
+      {:ok, worker_state} ->
+        generation_refs_for_worker_state(worker_state, MapSet.new(request_ids))
+
+      :error ->
+        %{}
+    end
+  end
+
+  defp generation_refs_for_worker_state(worker_state, request_ids) do
+    worker_state
+    |> Map.fetch!(:requests)
+    |> Enum.reduce(%{}, &put_generation_ref_if_requested(&1, &2, request_ids))
+  end
+
+  defp put_generation_ref_if_requested({request_id, request_state}, refs, request_ids) do
+    if MapSet.member?(request_ids, request_id) do
+      Map.put(refs, request_id, Map.fetch!(request_state, :generation_ref))
+    else
+      refs
+    end
+  end
+
+  defp runtime_model_placement!(%StatusResponse{} = status, model_id, version) do
+    Enum.find(status.runtime_model_placements, fn placement ->
+      placement.model_ref.model_id == model_id and placement.model_ref.version == version
+    end) || flunk("runtime model placement not found for #{model_id}@#{version}")
+  end
+
+  defp assert_blocking_stream_completed([
+         {:ok,
+          %RPCInferenceEvent{event: {:accepted, %Accepted{accepted_at_unix_ms: accepted_at}}}},
+         {:ok,
+          %RPCInferenceEvent{event: {:output_text_delta, %OutputTextDelta{delta: "released"}}}},
+         {:ok, %RPCInferenceEvent{event: {:completed, %Completed{} = completed}}}
+       ]) do
+    assert is_integer(accepted_at)
+    assert accepted_at > 0
+    assert completed.finish_reason == :FINISH_REASON_STOP
+
+    assert completed.usage == %TokenUsage{
+             input_tokens: 2,
+             output_tokens: 1,
+             total_tokens: 3
+           }
+  end
+
+  defp assert_blocking_stream_completed(events) do
+    flunk("unexpected ExecuteInference stream events: #{inspect(events)}")
+  end
+
+  defp best_effort_release_generation_refs(request_ids) do
+    request_ids
+    |> release_messages_for_request_ids()
+    |> Enum.each(fn {pid, generation_ref} -> send(pid, {:release, generation_ref}) end)
+  end
+
+  defp grpc_status_snapshot do
+    with_channel(fn channel ->
+      assert {:ok, %StatusResponse{} = status} =
+               NodeRuntimeStub.get_status(channel, %StatusRequest{})
+
+      status
+    end)
+  end
+
+  defp release_messages_for_request_ids(request_ids) do
+    case safe_worker_state() do
+      {:ok, worker_state} ->
+        release_messages_for_worker_state(worker_state, MapSet.new(request_ids))
+
+      :error ->
+        []
+    end
+  end
+
+  defp release_messages_for_worker_state(worker_state, request_ids) do
+    generations = get_in(worker_state, [:adapter_state, :generations]) || %{}
+    requests = Map.get(worker_state, :requests, %{})
+
+    requests
+    |> Enum.flat_map(&release_message_for_request(&1, generations, request_ids))
+  end
+
+  defp release_message_for_request({request_id, request_state}, generations, request_ids) do
+    if MapSet.member?(request_ids, request_id) do
+      release_message_for_generation(request_state, generations)
+    else
+      []
+    end
+  end
+
+  defp release_message_for_generation(request_state, generations) do
+    case Map.get(request_state, :generation_ref) do
+      nil -> []
+      generation_ref -> release_message_for_ref(generation_ref, generations)
+    end
+  end
+
+  defp release_message_for_ref(generation_ref, generations) do
+    case Map.get(generations, generation_ref) do
+      %{pid: pid} when is_pid(pid) -> [{pid, generation_ref}]
+      _missing_or_malformed -> []
+    end
+  end
+
+  defp safe_worker_state do
+    worker_pid()
+    |> fetch_worker_state_if_alive()
+  catch
+    :exit, _reason -> :error
+  end
+
+  defp fetch_worker_state_if_alive(pid) when is_pid(pid) do
+    if Process.alive?(pid), do: fetch_worker_state(pid), else: :error
+  end
+
+  defp fetch_worker_state_if_alive(_pid), do: :error
+
+  defp fetch_worker_state(pid) do
+    {:ok, :sys.get_state(pid)}
+  catch
+    :exit, _reason -> :error
+  end
 
   defp get_blocking_generation_ref do
     pid = worker_pid()

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -2607,6 +2607,111 @@ defmodule OrchardNodeAgentTest do
     )
   end
 
+  test "batch mode cancel drains one gRPC stream and frees same-model capacity", %{
+    bundle: bundle
+  } do
+    with_runtime_config(
+      [
+        runtime_adapter_impl: BlockingRuntimeAdapter,
+        worker_generation_mode: "batch",
+        worker_max_concurrent_requests_per_model: 2,
+        test_only_allow_batch_admission_for_non_worker_adapters?: true
+      ],
+      fn ->
+        request1 = execute_inference_request("req-batch-grpc-cancel-first")
+        request2 = execute_inference_request("req-batch-grpc-cancel-second")
+        request3 = execute_inference_request("req-batch-grpc-cancel-third")
+        request_id1 = request1.request_id
+        request_id2 = request2.request_id
+        request_id3 = request3.request_id
+
+        with_channel(fn channel ->
+          assert {:ok, %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED}} =
+                   NodeRuntimeStub.ensure_model_loaded(
+                     channel,
+                     ensure_model_loaded_request(bundle)
+                   )
+
+          task1 = start_execute_inference_task(request1, self())
+          task2 = start_execute_inference_task(request2, self())
+
+          try do
+            assert_execute_inference_accepted([request_id1, request_id2])
+
+            refs = wait_for_generation_refs([request_id1, request_id2])
+
+            status = grpc_status_snapshot()
+            assert status.active_request_count == 2
+
+            placement = runtime_model_placement!(status, @test_model_id, @test_version)
+            assert placement.active_request_count == 2
+            assert placement.max_concurrency == 2
+
+            assert {:ok, %{ok: true, message: "cancel accepted"}} =
+                     NodeRuntimeStub.cancel_inference(channel, %CancelInferenceRequest{
+                       request_id: request_id1,
+                       controller_session_id: request1.controller_session_id
+                     })
+
+            assert_cancelled_stream_failed(Task.await(task1, 5_000))
+
+            wait_until(fn ->
+              status = grpc_status_snapshot()
+              placement = runtime_model_placement!(status, @test_model_id, @test_version)
+
+              status.active_request_count == 1 and placement.active_request_count == 1 and
+                placement.max_concurrency == 2
+            end)
+
+            assert %{^request_id2 => _generation_ref} =
+                     generation_refs_for_request_ids([request_id2])
+
+            task3 = start_execute_inference_task(request3, self())
+
+            try do
+              assert_execute_inference_accepted([request_id3])
+
+              refs = Map.merge(refs, wait_for_generation_refs([request_id2, request_id3]))
+
+              refreshed_status = grpc_status_snapshot()
+
+              refreshed_placement =
+                runtime_model_placement!(refreshed_status, @test_model_id, @test_version)
+
+              assert refreshed_status.active_request_count == 2
+              assert refreshed_placement.active_request_count == 2
+              assert refreshed_placement.max_concurrency == 2
+
+              send_release(Map.fetch!(refs, request_id2))
+              send_release(Map.fetch!(refs, request_id3))
+
+              assert_blocking_stream_completed(Task.await(task2, 5_000))
+              assert_blocking_stream_completed(Task.await(task3, 5_000))
+
+              wait_until(fn ->
+                status = grpc_status_snapshot()
+                placement = runtime_model_placement!(status, @test_model_id, @test_version)
+
+                status.active_request_count == 0 and placement.active_request_count == 0 and
+                  placement.max_concurrency == 2
+              end)
+            after
+              best_effort_release_generation_refs([request_id2, request_id3])
+              Task.shutdown(task3, :brutal_kill)
+            end
+          after
+            try do
+              best_effort_release_generation_refs([request_id1, request_id2, request_id3])
+            after
+              Task.shutdown(task1, :brutal_kill)
+              Task.shutdown(task2, :brutal_kill)
+            end
+          end
+        end)
+      end
+    )
+  end
+
   test "current status reports loaded model placement capacity", %{bundle: bundle} do
     with_runtime_adapter(BlockingRuntimeAdapter, fn ->
       assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
@@ -3979,6 +4084,20 @@ defmodule OrchardNodeAgentTest do
 
   defp assert_blocking_stream_completed(events) do
     flunk("unexpected ExecuteInference stream events: #{inspect(events)}")
+  end
+
+  defp assert_cancelled_stream_failed([
+         {:ok,
+          %RPCInferenceEvent{event: {:accepted, %Accepted{accepted_at_unix_ms: accepted_at}}}},
+         {:ok, %RPCInferenceEvent{event: {:failed, failed}}}
+       ]) do
+    assert is_integer(accepted_at)
+    assert accepted_at > 0
+    assert failed.code == "cancelled"
+  end
+
+  defp assert_cancelled_stream_failed(events) do
+    flunk("unexpected cancelled ExecuteInference stream events: #{inspect(events)}")
   end
 
   defp best_effort_release_generation_refs(request_ids) do

--- a/apps/orchard_shared/lib/cluster/v1/runtime.pb.ex
+++ b/apps/orchard_shared/lib/cluster/v1/runtime.pb.ex
@@ -131,6 +131,19 @@ defmodule Orchard.Cluster.V1.HostedToolReadiness do
   field(:readiness_message, 5, type: :string, json_name: "readinessMessage")
 end
 
+defmodule Orchard.Cluster.V1.RuntimeModelPlacement do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "cluster.v1.RuntimeModelPlacement",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field(:model_ref, 1, type: Orchard.Cluster.V1.ModelRef, json_name: "modelRef")
+  field(:active_request_count, 2, type: :uint32, json_name: "activeRequestCount")
+  field(:max_concurrency, 3, type: :uint32, json_name: "maxConcurrency")
+end
+
 defmodule Orchard.Cluster.V1.StatusResponse do
   @moduledoc false
 
@@ -185,6 +198,12 @@ defmodule Orchard.Cluster.V1.StatusResponse do
   )
 
   field(:supports_prompt_token_ids, 10, type: :bool, json_name: "supportsPromptTokenIds")
+
+  field(:runtime_model_placements, 11,
+    repeated: true,
+    type: Orchard.Cluster.V1.RuntimeModelPlacement,
+    json_name: "runtimeModelPlacements"
+  )
 end
 
 defmodule Orchard.Cluster.V1.EnsureModelLoadedRequest do

--- a/apps/orchard_shared/test/orchard_shared_test.exs
+++ b/apps/orchard_shared/test/orchard_shared_test.exs
@@ -17,6 +17,7 @@ defmodule OrchardSharedTest do
     OutputTextDelta,
     PlacementState,
     RuntimeHealth,
+    RuntimeModelPlacement,
     RuntimeNodeMetadata,
     StatusResponse,
     TokenUsage,
@@ -166,6 +167,25 @@ defmodule OrchardSharedTest do
         health_message: "",
         affected_model: nil
       }
+    }
+
+    assert response == response |> StatusResponse.encode() |> StatusResponse.decode()
+  end
+
+  test "round-trips StatusResponse with runtime model placements" do
+    model_ref = %ModelRef{model_id: "test-model", version: "v1"}
+
+    response = %StatusResponse{
+      worker_state: :WORKER_STATE_BUSY,
+      loaded_models: [model_ref],
+      active_request_count: 2,
+      runtime_model_placements: [
+        %RuntimeModelPlacement{
+          model_ref: model_ref,
+          active_request_count: 2,
+          max_concurrency: 3
+        }
+      ]
     }
 
     assert response == response |> StatusResponse.encode() |> StatusResponse.decode()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,8 @@ the compatibility facade. See `SPEC.md` §3 and §7 for normative behavior.
 
 The node agent owns worker subprocess lifecycle. The worker runtime owns local
 model loading/generation details. Public clients never talk to workers directly.
+Node-agent status is also the live source for loaded-model placement capacity, including per-placement active requests and max concurrency.
+The controller scheduler uses that capacity telemetry to avoid dispatching to full same-model placements.
 
 Cluster RPC and worker RPC are separate contracts:
 

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -361,8 +361,14 @@ A scheduler suppression rule for repeatedly failing nodes or placements.
 _Avoid_: Node health
 
 **Queue**:
-A tenant-scoped FIFO wait path used after Admission when no Node is immediately eligible.
+A controller-owned wait path used after Admission when no Node or live placement capacity is immediately eligible.
+Each Tenant keeps FIFO order, and cross-tenant selection uses weighted round-robin.
 _Avoid_: Global backlog, Request lifecycle state
+
+**Cluster Busy**:
+A scheduler outcome meaning joined live candidates exist, but none can currently accept the request because placement capacity is exhausted or unknown for already-active candidates.
+With queue admission enabled, this can return the request to the same Queue deadline; otherwise it is a tenant-facing `503` capacity failure.
+_Avoid_: Transport failure, model not found, queue full
 
 **Cache Affinity**:
 A scheduler warmth hint based on recent request locality and optional prefix-cache fingerprints.
@@ -375,6 +381,11 @@ _Avoid_: Raw prompt fingerprint
 **Runtime Prefix-cache Status**:
 Runtime telemetry about prefix-cache configuration, counters, and bounded HMAC fingerprint presence; counters are observe-only, while fingerprint presence may be used only as a configured non-gating scheduler tie-break hint.
 _Avoid_: Readiness gate, admission gate, scheduler eligibility gate, tenant-facing signal, raw prompt or token data
+
+**Runtime Model Placement**:
+Live node-agent status for one loaded Model Placement, including `active_request_count` and `max_concurrency`.
+The scheduler uses it only to prove same-model placement capacity and to rank by requested-placement load.
+_Avoid_: Catalog State, durable placement record, model manifest metadata
 
 **Prefix-cache Score**:
 A bounded, fail-open score RPC result used only as explicitly configured scheduler tie-break telemetry.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -195,6 +195,8 @@ ELIXIR
 | `ORCHARD_WORKER_EXECUTABLE` | `native/orchard_worker_mlx/bin/orchard-worker-mlx` (repo-root) | Worker binary path. Override via env var; default resolves from repo root in source-dev mode. |
 | `ORCHARD_WORKER_BACKEND` | `mlx` | Worker backend (`mlx` or `stub`) |
 | `ORCHARD_WORKER_GENERATION_MODE` | `batch` for `mlx`, `stream` for unset `stub` | Worker generation runtime (`stream` or `batch`). Leave unset when using the stub backend. |
+| `ORCHARD_WORKER_MAX_CONCURRENT_REQUESTS_PER_MODEL` | `auto` | Per-loaded-model request admission limit in batch generation mode. Use an integer `>= 1` or `auto`. |
+| `ORCHARD_WORKER_AUTO_MAX_CONCURRENT_REQUESTS_PER_MODEL` | `3` | Effective per-model request limit when the max-concurrency setting is `auto`. |
 | `ORCHARD_NODE_DISPLAY_NAME` | hostname | Human-readable node name shown in console |
 | `ORCHARD_LICENSE_ENFORCEMENT` | `off` (source dev) / `hard` (distributed packaged channels) | Licensing mode for startup and packaged useful-work admission: `off`, `warn`, or `hard` |
 
@@ -206,6 +208,8 @@ when `ORCHARD_WORKER_GENERATION_MODE` is unset, the stub backend resolves to
 stream mode automatically.
 `ORCHARD_FAKE_RUNTIME` is a release/runtime config knob; source-dev tests use
 the fake runtime through `config/test.exs`, not a dev env override.
+Batch generation mode can admit multiple same-model requests up to the effective per-model limit.
+The node-agent reports that live placement capacity through `StatusResponse.runtime_model_placements` as `active_request_count` and `max_concurrency`; stream mode reports max concurrency as `1`.
 
 #### Controller Multi-Node (Source Dev)
 

--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -35,6 +35,9 @@ The CLI also supports `--generation-mode stream|batch`. The stub backend uses
 source and packaged runtime configs mirror that by resolving
 `ORCHARD_WORKER_BACKEND=stub` to stream mode when
 `ORCHARD_WORKER_GENERATION_MODE` is unset.
+In node-agent runtime, batch mode can admit concurrent same-model requests up to the effective per-model request limit.
+That limit is configured with `ORCHARD_WORKER_MAX_CONCURRENT_REQUESTS_PER_MODEL` or, when set to `auto`, `ORCHARD_WORKER_AUTO_MAX_CONCURRENT_REQUESTS_PER_MODEL`.
+The node-agent publishes the resulting loaded-placement capacity through cluster `StatusResponse.runtime_model_placements`.
 
 ## Proto contract
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -154,6 +154,9 @@ No `ORCHARD_WORKER_GENERATION_MODE` override is required for this rollback path;
 when the backend is `stub` and the mode env var is unset, packaged runtime
 configuration resolves generation mode to `stream`. If set explicitly, valid
 values are `stream` and `batch`; leave it unset for stub rollback.
+For MLX batch mode, `ORCHARD_WORKER_MAX_CONCURRENT_REQUESTS_PER_MODEL` controls same-model request admission per loaded placement.
+The default `auto` value resolves through `ORCHARD_WORKER_AUTO_MAX_CONCURRENT_REQUESTS_PER_MODEL`, currently `3`.
+The node-agent reports the effective placement limit in `StatusResponse.runtime_model_placements`.
 
 **Security note:** These files are sourced by shell scripts running as root
 (via launchd). The wrapper scripts validate ownership and permissions before

--- a/proto/cluster/v1/runtime.proto
+++ b/proto/cluster/v1/runtime.proto
@@ -121,6 +121,15 @@ message HostedToolReadiness {
   string readiness_message = 5;
 }
 
+// Per-loaded-model runtime concurrency status. An absent or empty list means
+// model-placement capacity is unknown to the controller and must not be treated
+// as a status-probe error.
+message RuntimeModelPlacement {
+  ModelRef model_ref = 1;
+  uint32 active_request_count = 2;
+  uint32 max_concurrency = 3;
+}
+
 // M1 assumes one effective worker/runtime path per node for the single-node MVP.
 // Fields 4-5 added for persistent node inventory (M3a Session 1).
 message StatusResponse {
@@ -134,6 +143,7 @@ message StatusResponse {
   repeated RuntimeMemoryBudget runtime_memory_budgets = 8;
   repeated RuntimePrefixCacheStatus runtime_prefix_cache_statuses = 9;
   bool supports_prompt_token_ids = 10;
+  repeated RuntimeModelPlacement runtime_model_placements = 11;
 }
 
 message EnsureModelLoadedRequest {

--- a/proto/cluster/v1/runtime.proto
+++ b/proto/cluster/v1/runtime.proto
@@ -123,7 +123,8 @@ message HostedToolReadiness {
 
 // Per-loaded-model runtime concurrency status. An absent or empty list means
 // model-placement capacity is unknown to the controller and must not be treated
-// as a status-probe error.
+// as a status-probe error. Controller scheduler use requires exactly one
+// matching entry with active_request_count >= 0 and max_concurrency > 0.
 message RuntimeModelPlacement {
   ModelRef model_ref = 1;
   uint32 active_request_count = 2;


### PR DESCRIPTION
## Intent

Bring in the GNHF concurrent inference capacity work as the first candidate branch: runtime model placement capacity telemetry in StatusResponse, scheduler admission based on per-placement same-model concurrency, queue-manager behavior for capacity-aware concurrent same-model admission and queuing, Chat Completions and Responses parity, node-agent status and cancellation regressions, and shared protobuf contract coverage. This branch should be treated as the compact PR-shaped candidate rather than the broader exploratory GNHF branches.

## What Changed
- Added runtime model placement capacity telemetry to the shared gRPC contract and node-agent status path so loaded model placements can report current and maximum same-model concurrency.
- Updated controller scheduling and queue management to admit overlapping same-model requests only when reported capacity is available, preserve tenant FIFO and weighted round-robin fairness, retry queue-enabled `cluster_busy` grants, and rank eligible placements by active request count.
- Expanded SPEC-traceable controller, API compatibility, node-agent, and protobuf regressions covering Responses and Chat Completions capacity parity, queue overflow, cancellation capacity drain, and shared contract coverage.

## Risk Assessment

⚠️ Medium: The change is broad across scheduler admission, queue requeue behavior, API parity, node-agent telemetry, and protobuf contracts, but the reviewed logic is spec-traceable and the prior blockers appear fixed.

## Testing

After avoiding a user-level `mise trust` write with a per-command trusted-path override, the shared protobuf and controller regression suites passed, focused node-agent capacity/status/cancellation tests passed, and the evidence test demonstrated Chat Completions and Responses capacity parity through real API calls, gRPC status telemetry, and persisted queue decisions. The only unresolved issue is the full node-agent file’s pre-existing real-worker Unix-socket path failure in this long worktree.

<details>
<summary>Evidence: API and gRPC capacity evidence</summary>

`Shows /v1/chat/completions and /v1/responses each accepting three same-model requests with capacity=2: two immediate active requests, one queued overflow request, gRPC placement telemetry at 2/2 while active, and 0/2 after completion.`

```text
{
  "generated_at": "2026-06-23T11:31:35Z",
  "scenarios": [
    {
      "endpoint": "/v1/chat/completions",
      "model": "nm-chat-capacity2-model@v1",
      "started_runtime_request_ids": [
        "chatcmpl-a492b254-2150-4833-8766-72d8b5164963",
        "chatcmpl-7aeaab21-b3f3-4d07-b0ce-d0c90304b5d3",
        "chatcmpl-4d0f83e9-5ef2-4fb8-869e-5b2a28be9c79"
      ],
      "http_statuses": [
        200,
        200,
        200
      ],
      "response_bodies": [
        {
          "choices": [
            {
              "finish_reason": "stop",
              "index": 0,
              "message": {
                "content": "queued ok",
                "role": "assistant"
              }
            }
          ],
          "created": 1782214295,
          "id": "chatcmpl-7aeaab21-b3f3-4d07-b0ce-d0c90304b5d3",
          "model": "nm-chat-capacity2-model@v1",
          "object": "chat.completion",
          "usage": {
            "completion_tokens": 2,
            "prompt_tokens": 3,
            "total_tokens": 5
          }
        },
        {
          "choices": [
            {
              "finish_reason": "stop",
              "index": 0,
              "message": {
                "content": "queued ok",
                "role": "assistant"
              }
            }
          ],
          "created": 1782214295,
          "id": "chatcmpl-4d0f83e9-5ef2-4fb8-869e-5b2a28be9c79",
          "model": "nm-chat-capacity2-model@v1",
          "object": "chat.completion",
          "usage": {
            "completion_tokens": 2,
            "prompt_tokens": 3,
            "total_tokens": 5
          }
        },
        {
          "choices": [
            {
              "finish_reason": "stop",
              "index": 0,
              "message": {
                "content": "queued ok",
                "role": "assistant"
              }
            }
          ],
          "created": 1782214295,
          "id": "chatcmpl-a492b254-2150-4833-8766-72d8b5164963",
          "model": "nm-chat-capacity2-model@v1",
          "object": "chat.completion",
          "usage": {
            "completion_tokens": 2,
            "prompt_tokens": 3,
            "total_tokens": 5
          }
        }
      ],
      "overflow_observation": {
        "queued_before_capacity_release": true,
        "third_started_before_capacity_release": false,
        "third_started_after_capacity_release": true
      },
      "grpc_status_while_two_active": {
        "active_request_count": 2,
        "placement": {
          "version": "v1",
          "max_concurrency": 2,
          "model_id": "nm-chat-capacity2-model",
          "active_request_count": 2
        }
      },
      "grpc_status_after_completion": {
        "active_request_count": 0,
        "placement": {
          "version": "v1",
          "max_concurrency": 2,
          "model_id": "nm-chat-capacity2-model",
          "active_request_count": 0
        }
      },
      "persisted_queue_decisions": [
        {
          "state": "completed",
          "endpoint": "chat_completions",
          "public_id": "chatcmpl-a492b254-2150-4833-8766-72d8b5164963",
          "queue_key": "nm-chat-capacity2-model@v1",
          "queue_result": "immediate",
          "queue_wait_ms": 0,
          "has_queue_grant_id": true
        },
        {
          "state": "completed",
          "endpoint": "chat_completions",
          "public_id": "chatcmpl-7aeaab21-b3f3-4d07-b0ce-d0c90304b5d3",
          "queue_key": "nm-chat-capacity2-model@v1",
          "queue_result": "immediate",
          "queue_wait_ms": 0,
          "has_queue_grant_id": true
        },
        {
          "state": "completed",
          "endpoint": "chat_completions",
          "public_id": "chatcmpl-4d0f83e9-5ef2-4fb8-869e-5b2a28be9c79",
          "queue_key": "nm-chat-capacity2-model@v1",
          "queue_result": "queued",
          "queue_wait_ms": 260,
          "has_queue_grant_id": true
        }
      ]
    },
    {
      "endpoint": "/v1/responses",
      "model": "nm-responses-capacity2-model@v1",
      "started_runtime_request_ids": [
        "resp_3791ebe5-4428-4604-bde8-ffa0adb6b846",
        "resp_08a83c4f-17ff-4cff-b3cb-f8ea26f803f2",
        "resp_bfa8f0d7-f690-48f7-a69b-af2389c7393c"
      ],
      "http_statuses": [
        200,
        200,
        200
      ],
      "response_bodies": [
        {
          "created_at": 1782214295,
          "error": null,
          "id": "resp_bfa8f0d7-f690-48f7-a69b-af2389c7393c",
          "metadata": {},
          "model": "nm-responses-capacity2-model@v1",
          "object": "response",
          "output": [
            {
              "content": [
                {
                  "annotations": [],
                  "text": "queued ok",
                  "type": "output_text"
                }
              ],
              "role": "assistant",
              "type": "message"
            }
          ],
          "output_text": "queued ok",
          "status": "completed",
          "usage": {
            "input_tokens": 3,
            "output_tokens": 2,
            "total_tokens": 5
          }
        },
        {
          "created_at": 1782214295,
          "error": null,
          "id": "resp_3791ebe5-4428-4604-bde8-ffa0adb6b846",
          "metadata": {},
          "model": "nm-responses-capacity2-model@v1",
          "object": "response",
          "output": [
            {
              "content": [
                {
                  "annotations": [],
                  "text": "queued ok",
                  "type": "output_text"
                }
              ],
              "role": "assistant",
              "type": "message"
            }
          ],
          "output_text": "queued ok",
          "status": "completed",
          "usage": {
            "input_tokens": 3,
            "output_tokens": 2,
            "total_tokens": 5
          }
        },
        {
          "created_at": 1782214295,
          "error": null,
          "id": "resp_08a83c4f-17ff-4cff-b3cb-f8ea26f803f2",
          "metadata": {},
          "model": "nm-responses-capacity2-model@v1",
          "object": "response",
          "output": [
            {
              "content": [
                {
                  "annotations": [],
                  "text": "queued ok",
                  "type": "output_text"
                }
              ],
              "role": "assistant",
              "type": "message"
            }
          ],
          "output_text": "queued ok",
          "status": "completed",
          "usage": {
            "input_tokens": 3,
            "output_tokens": 2,
            "total_tokens": 5
          }
        }
      ],
      "overflow_observation": {
        "queued_before_capacity_release": true,
        "third_started_before_capacity_release": false,
        "third_started_after_capacity_release": true
      },
      "grpc_status_while_two_active": {
        "active_request_count": 2,
        "placement": {
          "version": "v1",
          "max_concurrency": 2,
          "model_id": "nm-responses-capacity2-model",
          "active_request_count": 2
        }
      },
      "grpc_status_after_completion": {
        "active_request_count": 0,
        "placement": {
          "version": "v1",
          "max_concurrency": 2,
          "model_id": "nm-responses-capacity2-model",
          "active_request_count": 0
        }
      },
      "persisted_queue_decisions": [
        {
          "state": "completed",
          "endpoint": "responses",
          "public_id": "resp_08a83c4f-17ff-4cff-b3cb-f8ea26f803f2",
          "queue_key": "nm-responses-capacity2-model@v1",
          "queue_result": "immediate",
          "queue_wait_ms": 0,
          "has_queue_grant_id": true
        },
        {
          "state": "completed",
          "endpoint": "responses",
          "public_id": "resp_3791ebe5-4428-4604-bde8-ffa0adb6b846",
          "queue_key": "nm-responses-capacity2-model@v1",
          "queue_result": "immediate",
          "queue_wait_ms": 0,
          "has_queue_grant_id": true
        },
        {
          "state": "completed",
          "endpoint": "responses",
          "public_id": "resp_bfa8f0d7-f690-48f7-a69b-af2389c7393c",
          "queue_key": "nm-responses-capacity2-model@v1",
          "queue_result": "queued",
          "queue_wait_ms": 178,
          "has_queue_grant_id": true
        }
      ]
    }
  ]
}
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `apps/orchard_controller/lib/orchard/inference/queue_manager.ex:1439` - Requeued grants are always inserted at the front of the tenant queue. With queue capacity &gt; 1, two same-tenant active grants that both hit post-grant `cluster_busy` are requeued LIFO, so the later grant can run before the earlier one, violating the SPEC §5.4 strict tenant FIFO contract. Preserve the original admission order, for example by inserting requeued entries by `enqueued_monotonic_ms` instead of blindly prepending.
- ⚠️ `apps/orchard_controller/lib/orchard/inference/queue_manager.ex:1471` - A queued entry parked for terminalization retry stops the entire global scheduler scan by returning `:blocked`. That means one tenant whose timed-out/disconnected head entry cannot currently be terminalized can stall unrelated tenants and lanes until the retry succeeds. Treat this like the `await_from == nil` case and continue scanning the rest of the tenant ring while keeping that tenant blocked.

🔧 Fix: Preserve queue FIFO and scan fairness
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `apps/orchard_node_agent/test/orchard_node_agent_test.exs:2073` - The broad changed-file test command could not complete the entire node-agent file in this isolated long worktree. Six older real-worker tests failed because Python gRPC rejected the generated Unix socket path under `tmp/test/data/worker-sockets` as longer than the platform limit. The focused new node-agent capacity, status, and cancellation tests passed with the fake/blocking runtime.
- <code>`mise exec -- mix test apps/orchard_shared/test/orchard_shared_test.exs apps/orchard_node_agent/test/orchard_node_agent_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs apps/orchard_controller/test/orchard/inference/queue_manager_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs apps/orchard_controller/test/orchard/api/responses_controller_test.exs` - blocked by mise trust before tests ran</code>
- <code>`MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; mise exec -- mix test apps/orchard_shared/test/orchard_shared_test.exs apps/orchard_node_agent/test/orchard_node_agent_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs apps/orchard_controller/test/orchard/inference/queue_manager_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs apps/orchard_controller/test/orchard/api/responses_controller_test.exs` - shared/controller passed; full node-agent file hit the long Unix-socket path setup issue</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs:2542 apps/orchard_node_agent/test/orchard_node_agent_test.exs:2610 apps/orchard_node_agent/test/orchard_node_agent_test.exs:2715 apps/orchard_node_agent/test/orchard_node_agent_test.exs:2732 apps/orchard_node_agent/test/orchard_node_agent_test.exs:2757 apps/orchard_node_agent/test/orchard_node_agent_test.exs:2789`
- <code>`NO_MISTAKES_EVIDENCE_DIR=/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVT22SFHX0WVY85BAKKXVBMD MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; mise exec -- mix test apps/orchard_controller/test/no_mistakes_capacity_evidence_test.exs` - temporary evidence test rerun clean and then removed</code>
- `rm -rf tmp/test _build/test && git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
