### PR TITLE
fix(orchard_controller): enforce tenant active queue caps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -917,6 +917,7 @@ Quotas are tenant-scoped. Supported limits:
 * max output tokens per request
 * max queue wait ms
 
+Resolved concurrent active request limits SHALL appear on canonical requests as `resolved_policy.max_active_requests`.
 Quota admission SHALL serialize per tenant via advisory transaction lock on hashed tenant id.
 
 Admission accounting:
@@ -937,23 +938,28 @@ Admission accounting:
 
 ### 5.4 Queue model
 
-When no node is immediately eligible:
+When a request cannot be granted immediately because no node or live placement capacity is eligible, or because the tenant active request cap is exhausted:
 
 * request enters tenant FIFO queue
 * max wait defaults to `3000 ms`
 * max queued requests per tenant defaults to `32`
+* max active requests per tenant defaults to unlimited unless a resolved policy supplies `max_active_requests`
+
+When `resolved_policy.max_active_requests` is present, controller queue admission SHALL queue same-tenant requests once active grants for that tenant reach the limit, even if the requested model/version lane or a placement still has spare capacity.
+Recovered in-flight grants SHALL count against that tenant active cap until their Request reaches a terminal state.
 
 With controller queue admission enabled, a scheduler `cluster_busy` result observed after a static queue grant SHALL be treated as queue-waitable live placement capacity exhaustion.
 The controller SHALL return the request to the same controller queue lane for the requested model/version under the original max queue wait budget instead of extending the deadline.
 Requeued grants SHALL preserve the original `queued_at`, admission order, and queue deadline.
 The queue manager MAY defer the requeued lane until the next poll interval before re-granting to avoid a tight scheduler retry loop.
-If no eligible live placement appears before that deadline, the terminal public outcome SHALL be `queue_timeout`.
+If live placement capacity or tenant active capacity does not become available before that deadline, the terminal public outcome SHALL be `queue_timeout`.
 With controller queue admission disabled, `cluster_busy` remains an immediate admission failure.
 
 Queue discipline:
 
 * one FIFO queue per tenant
 * cross-tenant selection uses weighted round-robin
+* cross-tenant promotion skips tenants whose head entry lacks lane capacity or tenant active capacity without reordering that tenant's FIFO queue
 * tenant weight default = 1
 * within tenant, strict FIFO
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -943,9 +943,9 @@ When a request cannot be granted immediately because no node or live placement c
 * request enters tenant FIFO queue
 * max wait defaults to `3000 ms`
 * max queued requests per tenant defaults to `32`
-* max active requests per tenant defaults to unlimited unless a resolved policy supplies `max_active_requests`
+* max active requests per tenant defaults to unlimited unless controller queue configuration or a resolved policy supplies a cap
 
-When `resolved_policy.max_active_requests` is present, controller queue admission SHALL queue same-tenant requests once active grants for that tenant reach the limit, even if the requested model/version lane or a placement still has spare capacity.
+When `resolved_policy.max_active_requests` or controller queue configuration supplies a tenant active cap, controller queue admission SHALL queue same-tenant requests once active grants for that tenant reach the limit, even if the requested model/version lane or a placement still has spare capacity.
 Recovered in-flight grants SHALL count against that tenant active cap until their Request reaches a terminal state.
 
 With controller queue admission enabled, a scheduler `cluster_busy` result observed after a static queue grant SHALL be treated as queue-waitable live placement capacity exhaustion.

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,6 +308,7 @@ All public inference requests SHALL normalize into one internal struct:
     quota_id: UUID | nil,
     routing_policy_id: UUID | nil,
     allowed_pool_ids: [UUID],
+    max_active_requests: pos_integer() | nil,
     residency_preference: :required_loaded | :prefer_loaded | :allow_cold_load
   }
 }

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -227,6 +227,7 @@ defmodule Orchard.Inference do
     [
       enabled: false,
       max_wait_ms: 3_000,
+      max_active_per_tenant: nil,
       max_queued_per_tenant: 32,
       poll_interval_ms: 100,
       capacity: 1,

--- a/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
@@ -74,6 +74,7 @@ defmodule Orchard.Inference.CanonicalRequestSerializer do
       "quota_id" => resolved_policy.quota_id,
       "routing_policy_id" => resolved_policy.routing_policy_id,
       "allowed_pool_ids" => normalize_plain_data(resolved_policy.allowed_pool_ids),
+      "max_active_requests" => resolved_policy.max_active_requests,
       "residency_preference" => Atom.to_string(resolved_policy.residency_preference)
     }
   end

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -251,7 +251,7 @@ defmodule Orchard.Inference.QueueManager do
         {ticket, state} = enqueue_request(request, config, state)
         {:reply, {:queued, ticket}, state}
 
-      active_capacity?(lane, config.capacity) and
+      active_capacity?(lane, config.capacity) and tenant_active_capacity?(state, request, config) and
           not queue_key_has_queued_entries?(state, request.queue_key) ->
         {grant, state} = grant_immediate(request, config, state)
         {:reply, {:ok, grant}, state}
@@ -1051,7 +1051,7 @@ defmodule Orchard.Inference.QueueManager do
     queue_key = queue_key_from_request(request)
     grant_id = recovered_grant_id(request)
 
-    put_recovered_grant(grant_id, queue_key, request.id, state)
+    put_recovered_grant(grant_id, queue_key, request, state)
   end
 
   defp recovered_grant_id(request) do
@@ -1061,7 +1061,7 @@ defmodule Orchard.Inference.QueueManager do
     end
   end
 
-  defp put_recovered_grant(grant_id, queue_key, request_id, state) do
+  defp put_recovered_grant(grant_id, queue_key, request, state) do
     lane = Map.get(state.lanes, queue_key, empty_lane())
     lane = %{lane | active: Map.put(lane.active, grant_id, true)}
 
@@ -1071,7 +1071,8 @@ defmodule Orchard.Inference.QueueManager do
         grants:
           Map.put(state.grants, grant_id, %{
             queue_key: queue_key,
-            request_id: request_id,
+            request_id: request.id,
+            tenant_id: request.tenant_id,
             recovered?: true
           })
     }
@@ -1205,6 +1206,7 @@ defmodule Orchard.Inference.QueueManager do
     %{
       capacity: max(config[:capacity] || 1, 1),
       max_wait_ms: max(config[:max_wait_ms] || 0, 0),
+      max_active_per_tenant: normalize_max_active_per_tenant(config[:max_active_per_tenant]),
       max_queued_per_tenant: max(config[:max_queued_per_tenant] || 0, 0),
       poll_interval_ms: max(config[:poll_interval_ms] || 100, 1),
       tenant_default_weight: normalize_tenant_weight(config[:tenant_default_weight]),
@@ -1230,12 +1232,25 @@ defmodule Orchard.Inference.QueueManager do
 
   defp normalize_tenant_weight(_weight), do: 1
 
+  defp normalize_max_active_per_tenant(limit) when is_integer(limit) and limit >= 0, do: limit
+  defp normalize_max_active_per_tenant(_limit), do: nil
+
   defp queue_key(model_id, version), do: "#{model_id}@#{version}"
 
   defp empty_lane, do: %{active: %{}, blocked_until_monotonic_ms: nil, block_ref: nil}
 
   defp active_capacity?(lane, capacity) do
     map_size(lane.active) < capacity and not lane_blocked?(lane)
+  end
+
+  defp tenant_active_capacity?(state, %{tenant_id: tenant_id}, %{
+         max_active_per_tenant: limit
+       }) do
+    is_nil(limit) or active_grants_for_tenant(state, tenant_id) < limit
+  end
+
+  defp active_grants_for_tenant(state, tenant_id) do
+    Enum.count(state.grants, fn {_grant_id, grant} -> grant[:tenant_id] == tenant_id end)
   end
 
   defp tenant_queue_full?(state, tenant_id, max_queued_per_tenant) do
@@ -1300,7 +1315,8 @@ defmodule Orchard.Inference.QueueManager do
       terminal_metadata: nil,
       terminal_result: nil,
       terminal_retry_ref: nil,
-      terminal_retry_after_ms: config.poll_interval_ms
+      terminal_retry_after_ms: config.poll_interval_ms,
+      max_active_per_tenant: config.max_active_per_tenant
     }
 
     {ticket, put_entry(entry, state)}
@@ -1461,7 +1477,8 @@ defmodule Orchard.Inference.QueueManager do
       terminal_metadata: nil,
       terminal_result: nil,
       terminal_retry_ref: nil,
-      terminal_retry_after_ms: config.poll_interval_ms
+      terminal_retry_after_ms: config.poll_interval_ms,
+      max_active_per_tenant: config.max_active_per_tenant
     }
 
     {ticket, entry}
@@ -1516,6 +1533,9 @@ defmodule Orchard.Inference.QueueManager do
         {:removed, disconnect_queued_entry(entry, state)}
 
       not lane_has_capacity?(lane) or lane_blocked?(lane) ->
+        scan_tenant_ring(ring, state, scanned + 1, next_ring_index(ring, index))
+
+      not tenant_active_capacity?(state, entry, entry) ->
         scan_tenant_ring(ring, state, scanned + 1, next_ring_index(ring, index))
 
       true ->

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -254,7 +254,8 @@ defmodule Orchard.Inference.QueueManager do
         {ticket, state} = enqueue_request(request, config, state)
         {:reply, {:queued, ticket}, state}
 
-      active_capacity?(lane, config.capacity) and tenant_active_capacity?(state, request, config) and
+      active_capacity?(lane, config.capacity) and
+        tenant_active_capacity?(state, request, config) and
           not queue_key_has_queued_entries?(state, request.queue_key) ->
         {grant, state} = grant_immediate(request, config, state)
         {:reply, {:ok, grant}, state}

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -1199,7 +1199,8 @@ defmodule Orchard.Inference.QueueManager do
       model_id: model_id,
       version: version,
       caller_pid: Map.get(attrs, :caller_pid, self()),
-      max_active_per_tenant: normalize_max_active_per_tenant(Map.get(attrs, :max_active_per_tenant)),
+      max_active_per_tenant:
+        normalize_max_active_per_tenant(Map.get(attrs, :max_active_per_tenant)),
       queue_key: queue_key(model_id, version)
     }
   end

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -234,6 +234,8 @@ defmodule Orchard.Inference.QueueManager do
   def handle_call(:reset, _from, state), do: {:reply, :ok, reset_state(state)}
 
   def handle_call({:acquire, request, config}, {_waiter_pid, _tag}, state) do
+    config = queue_config_for_request(config, request)
+
     state =
       request.queue_key
       |> prune_recovered_grants(state)
@@ -271,6 +273,7 @@ defmodule Orchard.Inference.QueueManager do
   end
 
   def handle_call({:requeue, %Grant{} = grant, request, config}, _from, state) do
+    config = queue_config_for_request(config, request)
     {result, state} = requeue_grant(grant, request, config, state)
     {:reply, result, state}
   end
@@ -1196,9 +1199,17 @@ defmodule Orchard.Inference.QueueManager do
       model_id: model_id,
       version: version,
       caller_pid: Map.get(attrs, :caller_pid, self()),
+      max_active_per_tenant: normalize_max_active_per_tenant(Map.get(attrs, :max_active_per_tenant)),
       queue_key: queue_key(model_id, version)
     }
   end
+
+  defp queue_config_for_request(config, %{max_active_per_tenant: limit})
+       when is_integer(limit) and limit > 0 do
+    %{config | max_active_per_tenant: limit}
+  end
+
+  defp queue_config_for_request(config, _request), do: config
 
   defp normalize_config(config) do
     config = Keyword.merge(Orchard.Inference.queue_admission_config(), config)

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -106,12 +106,13 @@ defmodule Orchard.Inference.QueueManager do
   @max_tenant_weight 100
 
   @type admission_request :: %{
-          request_id: Ecto.UUID.t() | String.t(),
-          public_id: String.t(),
-          tenant_id: Ecto.UUID.t() | String.t(),
-          model_id: String.t(),
-          version: String.t(),
-          caller_pid: pid()
+          required(:request_id) => Ecto.UUID.t() | String.t(),
+          required(:public_id) => String.t(),
+          required(:tenant_id) => Ecto.UUID.t() | String.t(),
+          required(:model_id) => String.t(),
+          required(:version) => String.t(),
+          optional(:max_active_per_tenant) => pos_integer() | nil,
+          optional(:caller_pid) => pid()
         }
 
   @type acquire_result ::

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -3,8 +3,9 @@ defmodule Orchard.Inference.QueueManager do
   BEAM-local controller admission owner for the bounded queue-first slice.
 
   The owner grants at most `capacity` active requests per `{model_id, version}`
-  lane, queues callers by tenant FIFO, and monitors queued callers so
-  disconnected clients cannot be scheduled later.
+  lane and, when configured or resolved from policy, at most the tenant active
+  request cap across all lanes. It queues callers by tenant FIFO and monitors
+  queued callers so disconnected clients cannot be scheduled later.
   Cross-tenant grants use weighted round-robin, and live scheduler saturation can
   requeue an active grant under its original queue deadline.
   """

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -318,8 +318,16 @@ defmodule Orchard.Inference.RequestOrchestrator do
       tenant_id: db_request.tenant_id,
       model_id: canonical.model_ref.model_id,
       version: canonical.model_ref.version,
+      max_active_per_tenant: tenant_active_limit(canonical),
       caller_pid: caller
     }
+  end
+
+  defp tenant_active_limit(canonical) do
+    case canonical.resolved_policy.max_active_requests do
+      limit when is_integer(limit) and limit > 0 -> limit
+      _other -> nil
+    end
   end
 
   defp await_queued_grant(db_request, ticket) do

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -899,10 +899,9 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     end
 
     @tag :db
-    test "SPEC.md §5.4 tenant active cap queues same-tenant chat completions despite scheduler capacity",
+    test "SPEC.md §5.4 tenant active cap queues same-tenant chat completions despite lane capacity",
          %{bundle: bundle} do
-      put_queue_admission_config!(max_active_per_tenant: 1)
-      put_capacity_two_scheduler!()
+      put_queue_admission_config!(capacity: 2, max_active_per_tenant: 1)
 
       put_blocking_runtime_adapter!(self(),
         worker_generation_mode: "batch",
@@ -954,9 +953,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       queued = request_with_queue_result!("chat-queue-tenant-active-cap-model@v1", "queued")
 
       assert_queue_metadata(immediate, "immediate", granted?: true)
-      assert immediate.scheduler_decision["queue_lane_capacity"] == 2
       assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
-      assert queued.scheduler_decision["queue_lane_capacity"] == 2
     end
 
     test "SPEC.md §7.2.7 returns top-level chat envelopes for busy and queue execute errors" do
@@ -1590,7 +1587,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       {"persist-non-stream-model", "v1"},
       {"tenant-scope-model", "v1"},
       {"chat-queue-overlap-model", "v1"},
-      {"chat-queue-capacity2-model", "v1"}
+      {"chat-queue-capacity2-model", "v1"},
+      {"chat-queue-tenant-active-cap-model", "v1"}
     ]
 
     cache_paths =

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -898,6 +898,67 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       end
     end
 
+    @tag :db
+    test "SPEC.md §5.4 tenant active cap queues same-tenant chat completions despite scheduler capacity",
+         %{bundle: bundle} do
+      put_queue_admission_config!(max_active_per_tenant: 1)
+      put_capacity_two_scheduler!()
+
+      put_blocking_runtime_adapter!(self(),
+        worker_generation_mode: "batch",
+        worker_max_concurrent_requests_per_model: 2,
+        test_only_allow_batch_admission_for_non_worker_adapters?: true
+      )
+
+      create_queue_model!(bundle, "chat-queue-tenant-active-cap-model")
+
+      %{token: token} = create_api_key_with_token!("chat-queue-tenant-active-cap")
+
+      params = %{
+        "model" => "chat-queue-tenant-active-cap-model@v1",
+        "messages" => [%{"role" => "user", "content" => "hello"}]
+      }
+
+      first = Task.async(fn -> post_chat(params, token) end)
+
+      assert_receive {:queue_admission_runtime_started, first_pid, first_request_id,
+                      "chat-queue-tenant-active-cap-model"},
+                     2_000
+
+      second = Task.async(fn -> post_chat(params, token) end)
+
+      assert wait_for_queued_request("chat-queue-tenant-active-cap-model@v1")
+
+      refute_receive {:queue_admission_runtime_started, _pid, _request_id,
+                      "chat-queue-tenant-active-cap-model"},
+                     100
+
+      send(first_pid, :queue_admission_runtime_release)
+      first_conn = Task.await(first, 5_000)
+
+      assert_receive {:queue_admission_runtime_started, second_pid, second_request_id,
+                      "chat-queue-tenant-active-cap-model"},
+                     2_000
+
+      assert first_conn.status == 200
+      refute second_request_id == first_request_id
+
+      send(second_pid, :queue_admission_runtime_release)
+      second_conn = Task.await(second, 5_000)
+
+      assert second_conn.status == 200
+
+      immediate =
+        request_with_queue_result!("chat-queue-tenant-active-cap-model@v1", "immediate")
+
+      queued = request_with_queue_result!("chat-queue-tenant-active-cap-model@v1", "queued")
+
+      assert_queue_metadata(immediate, "immediate", granted?: true)
+      assert immediate.scheduler_decision["queue_lane_capacity"] == 2
+      assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
+      assert queued.scheduler_decision["queue_lane_capacity"] == 2
+    end
+
     test "SPEC.md §7.2.7 returns top-level chat envelopes for busy and queue execute errors" do
       cases = [
         {:model_busy, 503, "server_error", "model_busy"},

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -493,6 +493,66 @@ defmodule Orchard.API.ResponsesControllerTest do
     end
   end
 
+  test "SPEC.md §5.4 tenant active cap queues same-tenant responses requests despite scheduler capacity",
+       %{bundle: bundle} do
+    put_queue_admission_config!(max_active_per_tenant: 1)
+    put_capacity_two_scheduler!()
+
+    put_blocking_runtime_adapter!(self(),
+      worker_generation_mode: "batch",
+      worker_max_concurrent_requests_per_model: 2,
+      test_only_allow_batch_admission_for_non_worker_adapters?: true
+    )
+
+    create_queue_model!(bundle, "responses-queue-tenant-active-cap-model")
+
+    %{token: token} = create_api_key_with_token!("responses-queue-tenant-active-cap")
+
+    params = %{
+      "model" => "responses-queue-tenant-active-cap-model@v1",
+      "input" => "hello"
+    }
+
+    first = Task.async(fn -> post_responses(params, token) end)
+
+    assert_receive {:queue_admission_runtime_started, first_pid, first_request_id,
+                    "responses-queue-tenant-active-cap-model"},
+                   2_000
+
+    second = Task.async(fn -> post_responses(params, token) end)
+
+    assert wait_for_queued_request("responses-queue-tenant-active-cap-model@v1")
+
+    refute_receive {:queue_admission_runtime_started, _pid, _request_id,
+                    "responses-queue-tenant-active-cap-model"},
+                   100
+
+    send(first_pid, :queue_admission_runtime_release)
+    first_conn = Task.await(first, 5_000)
+
+    assert_receive {:queue_admission_runtime_started, second_pid, second_request_id,
+                    "responses-queue-tenant-active-cap-model"},
+                   2_000
+
+    assert first_conn.status == 200
+    refute second_request_id == first_request_id
+
+    send(second_pid, :queue_admission_runtime_release)
+    second_conn = Task.await(second, 5_000)
+
+    assert second_conn.status == 200
+
+    immediate =
+      request_with_queue_result!("responses-queue-tenant-active-cap-model@v1", "immediate")
+
+    queued = request_with_queue_result!("responses-queue-tenant-active-cap-model@v1", "queued")
+
+    assert_queue_metadata(immediate, "immediate", granted?: true)
+    assert immediate.scheduler_decision["queue_lane_capacity"] == 2
+    assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
+    assert queued.scheduler_decision["queue_lane_capacity"] == 2
+  end
+
   test "SPEC.md §7.2.7 returns top-level sync responses envelopes for busy and queue execute errors" do
     cases = [
       {:model_busy, 503, "server_error", "model_busy"},

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -493,10 +493,9 @@ defmodule Orchard.API.ResponsesControllerTest do
     end
   end
 
-  test "SPEC.md §5.4 tenant active cap queues same-tenant responses requests despite scheduler capacity",
+  test "SPEC.md §5.4 tenant active cap queues same-tenant responses requests despite lane capacity",
        %{bundle: bundle} do
-    put_queue_admission_config!(max_active_per_tenant: 1)
-    put_capacity_two_scheduler!()
+    put_queue_admission_config!(capacity: 2, max_active_per_tenant: 1)
 
     put_blocking_runtime_adapter!(self(),
       worker_generation_mode: "batch",
@@ -548,9 +547,7 @@ defmodule Orchard.API.ResponsesControllerTest do
     queued = request_with_queue_result!("responses-queue-tenant-active-cap-model@v1", "queued")
 
     assert_queue_metadata(immediate, "immediate", granted?: true)
-    assert immediate.scheduler_decision["queue_lane_capacity"] == 2
     assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
-    assert queued.scheduler_decision["queue_lane_capacity"] == 2
   end
 
   test "SPEC.md §7.2.7 returns top-level sync responses envelopes for busy and queue execute errors" do
@@ -1368,7 +1365,8 @@ defmodule Orchard.API.ResponsesControllerTest do
           {"responses-replay-model", "v1"},
           {"responses-stream-model", "v1"},
           {"responses-queue-overlap-model", "v1"},
-          {"responses-queue-capacity2-model", "v1"}
+          {"responses-queue-capacity2-model", "v1"},
+          {"responses-queue-tenant-active-cap-model", "v1"}
         ],
         fn {model_id, version} ->
           cache_path = Path.join([models_root, model_id, version])

--- a/apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs
@@ -55,6 +55,7 @@ defmodule Orchard.Inference.CanonicalRequestSerializerTest do
           quota_id: "quota_1",
           routing_policy_id: "route_1",
           allowed_pool_ids: ["pool_1"],
+          max_active_requests: 2,
           residency_preference: :prefer_loaded
         }
       })
@@ -67,6 +68,7 @@ defmodule Orchard.Inference.CanonicalRequestSerializerTest do
     assert serialized["metadata"] == %{"trace_id" => "trace-1", "tags" => ["a", "b"]}
     assert serialized["sampling"]["stop"] == ["END"]
     assert serialized["resolved_policy"]["residency_preference"] == "prefer_loaded"
+    assert serialized["resolved_policy"]["max_active_requests"] == 2
 
     assert serialized["tooling"] == %{
              "tools" => [%{"name" => "calculator"}],

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -53,6 +53,54 @@ defmodule Orchard.Inference.QueueManagerTest do
     end)
   end
 
+  test "SPEC.md §5.3 tenant active cap queues same-tenant work despite placement capacity" do
+    tenant_id = Ecto.UUID.generate()
+    config = queue_config(capacity: 2, max_active_per_tenant: 1)
+
+    assert {:ok, grant} =
+             QueueManager.acquire(admission_request("req-tenant-active-a", tenant_id: tenant_id),
+               config: config
+             )
+
+    assert {:queued, ticket} =
+             QueueManager.acquire(admission_request("req-tenant-active-b", tenant_id: tenant_id),
+               config: config
+             )
+
+    awaiter = Task.async(fn -> QueueManager.await(ticket) end)
+    refute Task.yield(awaiter, 50)
+
+    assert :ok = QueueManager.release(grant)
+    assert {:ok, queued_grant} = Task.await(awaiter, 2_000)
+    assert queued_grant.queue_result == :queued
+
+    assert :ok = QueueManager.release(queued_grant)
+  end
+
+  test "SPEC.md §5.3 tenant active cap does not block another tenant with placement capacity" do
+    first_tenant_id = Ecto.UUID.generate()
+    second_tenant_id = Ecto.UUID.generate()
+    config = queue_config(capacity: 2, max_active_per_tenant: 1)
+
+    assert {:ok, first_grant} =
+             QueueManager.acquire(
+               admission_request("req-tenant-isolated-a", tenant_id: first_tenant_id),
+               config: config
+             )
+
+    assert {:ok, second_grant} =
+             QueueManager.acquire(
+               admission_request("req-tenant-isolated-b", tenant_id: second_tenant_id),
+               config: config
+             )
+
+    assert first_grant.queue_result == :immediate
+    assert second_grant.queue_result == :immediate
+
+    assert :ok = QueueManager.release(first_grant)
+    assert :ok = QueueManager.release(second_grant)
+  end
+
   test "SPEC.md §5.4 cross-tenant weighted round-robin grants one tenant turn at a time" do
     tenant_a = Ecto.UUID.generate()
     tenant_b = Ecto.UUID.generate()
@@ -1387,6 +1435,7 @@ defmodule Orchard.Inference.QueueManagerTest do
       [
         enabled: true,
         max_wait_ms: 500,
+        max_active_per_tenant: nil,
         max_queued_per_tenant: 32,
         poll_interval_ms: 1,
         capacity: 1,

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -972,6 +972,50 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert :ok = QueueManager.release(grant)
   end
 
+  test "SPEC.md §5.3 recovered active grants count against tenant concurrency" do
+    tenant_id = Ecto.UUID.generate()
+
+    recovered_request =
+      create_request!("req_queue_recovered_tenant_active",
+        tenant_id: tenant_id,
+        requested_model: "queue-model-a@v1",
+        state: :running,
+        scheduler_decision: %{
+          queueing_enabled: true,
+          queue_key: "queue-model-a@v1",
+          queue_result: "immediate",
+          queue_grant_id: "grant-recovered-tenant-active",
+          queue_granted_at: DateTime.utc_now() |> DateTime.to_iso8601()
+        }
+      )
+
+    manager = unique_manager_name()
+    start_supervised!({QueueManager, name: manager, owner_runtime: true})
+
+    assert {:queued, ticket} =
+             QueueManager.acquire(
+               admission_request("req-after-tenant-active-recovery",
+                 tenant_id: tenant_id,
+                 model_id: "queue-model-b"
+               ),
+               server: manager,
+               config: queue_config(capacity: 2, max_active_per_tenant: 1)
+             )
+
+    awaiter = Task.async(fn -> QueueManager.await(ticket) end)
+    assert wait_until(fn -> queue_entry_awaiting?(ticket, manager) end)
+    refute Task.yield(awaiter, 100)
+
+    assert {:ok, _request} =
+             Requests.mark_terminal(recovered_request, %{state: :completed, output_tokens: 1})
+
+    assert {:ok, grant} = Task.await(awaiter, 2_000)
+    assert grant.queue_result == :queued
+    assert grant.queue_key == "queue-model-b@v1"
+
+    assert :ok = QueueManager.release(grant, server: manager)
+  end
+
   test "reconstructed legacy in-flight lane remains occupied until terminal" do
     request =
       create_request!("req_queue_recovered_legacy",

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -101,6 +101,46 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert :ok = QueueManager.release(second_grant)
   end
 
+  test "SPEC.md §5.4 active-cap-blocked tenant does not block another tenant" do
+    first_tenant_id = Ecto.UUID.generate()
+    second_tenant_id = Ecto.UUID.generate()
+    config = queue_config(capacity: 2, max_active_per_tenant: 1)
+
+    assert {:ok, first_grant} =
+             QueueManager.acquire(
+               admission_request("req-tenant-lane-head-a", tenant_id: first_tenant_id),
+               config: config
+             )
+
+    assert {:queued, blocked_ticket} =
+             QueueManager.acquire(
+               admission_request("req-tenant-lane-head-b", tenant_id: first_tenant_id),
+               config: config
+             )
+
+    blocked_awaiter = Task.async(fn -> QueueManager.await(blocked_ticket) end)
+    assert wait_until(fn -> queue_entry_awaiting?(blocked_ticket) end)
+
+    assert {:queued, other_ticket} =
+             QueueManager.acquire(
+               admission_request("req-tenant-lane-head-c", tenant_id: second_tenant_id),
+               config: config
+             )
+
+    other_awaiter = Task.async(fn -> QueueManager.await(other_ticket) end)
+
+    assert {:ok, other_grant} = Task.await(other_awaiter, 2_000)
+    assert other_grant.queue_result == :queued
+    refute Task.yield(blocked_awaiter, 50)
+
+    assert :ok = QueueManager.release(first_grant)
+    assert {:ok, blocked_grant} = Task.await(blocked_awaiter, 2_000)
+    assert blocked_grant.queue_result == :queued
+
+    assert :ok = QueueManager.release(other_grant)
+    assert :ok = QueueManager.release(blocked_grant)
+  end
+
   test "SPEC.md §5.4 cross-tenant weighted round-robin grants one tenant turn at a time" do
     tenant_a = Ecto.UUID.generate()
     tenant_b = Ecto.UUID.generate()

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -106,39 +106,38 @@ defmodule Orchard.Inference.QueueManagerTest do
     second_tenant_id = Ecto.UUID.generate()
     config = queue_config(capacity: 2, max_active_per_tenant: 1)
 
-    assert {:ok, first_grant} =
-             QueueManager.acquire(
-               admission_request("req-tenant-lane-head-a", tenant_id: first_tenant_id),
-               config: config
-             )
+    with_queue_admission_config(config, fn ->
+      assert {:ok, first_grant} =
+               QueueManager.acquire(
+                 admission_request("req-tenant-lane-head-a", tenant_id: first_tenant_id)
+               )
 
-    assert {:queued, blocked_ticket} =
-             QueueManager.acquire(
-               admission_request("req-tenant-lane-head-b", tenant_id: first_tenant_id),
-               config: config
-             )
+      assert {:queued, blocked_ticket} =
+               QueueManager.acquire(
+                 admission_request("req-tenant-lane-head-b", tenant_id: first_tenant_id)
+               )
 
-    blocked_awaiter = Task.async(fn -> QueueManager.await(blocked_ticket) end)
-    assert wait_until(fn -> queue_entry_awaiting?(blocked_ticket) end)
+      blocked_awaiter = Task.async(fn -> QueueManager.await(blocked_ticket) end)
+      assert wait_until(fn -> queue_entry_awaiting?(blocked_ticket) end)
 
-    assert {:queued, other_ticket} =
-             QueueManager.acquire(
-               admission_request("req-tenant-lane-head-c", tenant_id: second_tenant_id),
-               config: config
-             )
+      assert {:queued, other_ticket} =
+               QueueManager.acquire(
+                 admission_request("req-tenant-lane-head-c", tenant_id: second_tenant_id)
+               )
 
-    other_awaiter = Task.async(fn -> QueueManager.await(other_ticket) end)
+      other_awaiter = Task.async(fn -> QueueManager.await(other_ticket) end)
 
-    assert {:ok, other_grant} = Task.await(other_awaiter, 2_000)
-    assert other_grant.queue_result == :queued
-    refute Task.yield(blocked_awaiter, 50)
+      assert {:ok, other_grant} = Task.await(other_awaiter, 2_000)
+      assert other_grant.queue_result == :queued
+      refute Task.yield(blocked_awaiter, 50)
 
-    assert :ok = QueueManager.release(first_grant)
-    assert {:ok, blocked_grant} = Task.await(blocked_awaiter, 2_000)
-    assert blocked_grant.queue_result == :queued
+      assert :ok = QueueManager.release(first_grant)
+      assert {:ok, blocked_grant} = Task.await(blocked_awaiter, 2_000)
+      assert blocked_grant.queue_result == :queued
 
-    assert :ok = QueueManager.release(other_grant)
-    assert :ok = QueueManager.release(blocked_grant)
+      assert :ok = QueueManager.release(other_grant)
+      assert :ok = QueueManager.release(blocked_grant)
+    end)
   end
 
   test "SPEC.md §5.4 cross-tenant weighted round-robin grants one tenant turn at a time" do
@@ -386,80 +385,63 @@ defmodule Orchard.Inference.QueueManagerTest do
   test "SPEC.md §5.4 weighted promotion skips tenants blocked by active cap" do
     tenant_a = Ecto.UUID.generate()
     tenant_b = Ecto.UUID.generate()
-    tenant_weights = %{tenant_a => 2, tenant_b => 1}
 
     config =
-      queue_config(capacity: 2, max_active_per_tenant: 1, tenant_weights: tenant_weights)
+      queue_config(max_active_per_tenant: 1, tenant_weights: %{tenant_a => 2, tenant_b => 1})
 
-    assert {:ok, active_a} =
-             QueueManager.acquire(
-               admission_request("req-weighted-active-cap-held",
-                 tenant_id: tenant_a,
-                 model_id: "queue-model-held"
-               ),
-               config: config
-             )
-
-    assert {:queued, ticket_a} =
-             QueueManager.acquire(
-               admission_request("req-weighted-active-cap-a",
-                 tenant_id: tenant_a,
-                 model_id: "queue-model-a"
-               ),
-               config:
-                 queue_config(
-                   capacity: 0,
-                   max_active_per_tenant: 1,
-                   tenant_weights: tenant_weights
+    with_queue_admission_config(config, fn ->
+      assert {:ok, active_a} =
+               QueueManager.acquire(
+                 admission_request("req-weighted-active-cap-held-a",
+                   tenant_id: tenant_a,
+                   model_id: "queue-model-a"
                  )
-             )
+               )
 
-    assert {:queued, ticket_b} =
-             QueueManager.acquire(
-               admission_request("req-weighted-active-cap-b",
-                 tenant_id: tenant_b,
-                 model_id: "queue-model-b"
-               ),
-               config: queue_config(capacity: 0, tenant_weights: tenant_weights)
-             )
+      assert {:ok, active_b} =
+               QueueManager.acquire(
+                 admission_request("req-weighted-active-cap-held-b",
+                   tenant_id: tenant_b,
+                   model_id: "queue-model-b"
+                 )
+               )
 
-    awaiter_a = start_result_awaiter(ticket_a, :tenant_a)
-    awaiter_b = start_result_awaiter(ticket_b, :tenant_b)
+      assert {:queued, ticket_a} =
+               QueueManager.acquire(
+                 admission_request("req-weighted-active-cap-a",
+                   tenant_id: tenant_a,
+                   model_id: "queue-model-a"
+                 )
+               )
 
-    assert wait_until(fn -> queue_entry_awaiting?(ticket_a) end)
-    assert wait_until(fn -> queue_entry_awaiting?(ticket_b) end)
+      assert {:queued, ticket_b} =
+               QueueManager.acquire(
+                 admission_request("req-weighted-active-cap-b",
+                   tenant_id: tenant_b,
+                   model_id: "queue-model-b"
+                 )
+               )
 
-    :sys.replace_state(QueueManager, fn state ->
-      lanes =
-        Map.new(state.lanes, fn {queue_key, lane} ->
-          {queue_key, Map.put(lane, :capacity, 1)}
-        end)
+      awaiter_a = await_and_hold(ticket_a, :tenant_a)
+      awaiter_b = await_and_hold(ticket_b, :tenant_b)
 
-      %{state | lanes: lanes}
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_a) end)
+      assert wait_until(fn -> queue_entry_awaiting?(ticket_b) end)
+
+      assert :ok = QueueManager.release(active_b)
+      assert_receive {:await_result, :tenant_b, {:ok, grant_b}}, 1_000
+      assert grant_b.queue_key == "queue-model-b@v1"
+      refute_receive {:await_result, :tenant_a, {:ok, _grant_a}}, 50
+
+      assert :ok = QueueManager.release(active_a)
+      assert_receive {:await_result, :tenant_a, {:ok, grant_a}}, 1_000
+      assert grant_a.queue_key == "queue-model-a@v1"
+
+      assert :ok = QueueManager.release(grant_a)
+      assert :ok = QueueManager.release(grant_b)
+      stop_awaiter(awaiter_a)
+      stop_awaiter(awaiter_b)
     end)
-
-    assert {:queued, trigger_ticket} =
-             QueueManager.acquire(
-               admission_request("req-weighted-active-cap-trigger",
-                 model_id: "queue-model-trigger"
-               ),
-               config: queue_config(capacity: 0, tenant_weights: tenant_weights)
-             )
-
-    assert_receive {:tenant_b, {:ok, grant_b}}, 1_000
-    assert grant_b.queue_key == "queue-model-b@v1"
-    refute_receive {:tenant_a, {:ok, _grant_a}}, 50
-
-    assert :ok = QueueManager.release(active_a)
-    assert_receive {:tenant_a, {:ok, grant_a}}, 1_000
-    assert grant_a.queue_key == "queue-model-a@v1"
-
-    assert :ok = QueueManager.abandon(trigger_ticket)
-    assert :ok = QueueManager.release(grant_a)
-    assert :ok = QueueManager.release(grant_b)
-
-    Process.exit(awaiter_a, :kill)
-    Process.exit(awaiter_b, :kill)
   end
 
   test "SPEC.md §3.6 immediate grant holder death releases lane before explicit release" do

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -383,6 +383,85 @@ defmodule Orchard.Inference.QueueManagerTest do
     end)
   end
 
+  test "SPEC.md §5.4 weighted promotion skips tenants blocked by active cap" do
+    tenant_a = Ecto.UUID.generate()
+    tenant_b = Ecto.UUID.generate()
+    tenant_weights = %{tenant_a => 2, tenant_b => 1}
+
+    config =
+      queue_config(capacity: 2, max_active_per_tenant: 1, tenant_weights: tenant_weights)
+
+    assert {:ok, active_a} =
+             QueueManager.acquire(
+               admission_request("req-weighted-active-cap-held",
+                 tenant_id: tenant_a,
+                 model_id: "queue-model-held"
+               ),
+               config: config
+             )
+
+    assert {:queued, ticket_a} =
+             QueueManager.acquire(
+               admission_request("req-weighted-active-cap-a",
+                 tenant_id: tenant_a,
+                 model_id: "queue-model-a"
+               ),
+               config:
+                 queue_config(
+                   capacity: 0,
+                   max_active_per_tenant: 1,
+                   tenant_weights: tenant_weights
+                 )
+             )
+
+    assert {:queued, ticket_b} =
+             QueueManager.acquire(
+               admission_request("req-weighted-active-cap-b",
+                 tenant_id: tenant_b,
+                 model_id: "queue-model-b"
+               ),
+               config: queue_config(capacity: 0, tenant_weights: tenant_weights)
+             )
+
+    awaiter_a = start_result_awaiter(ticket_a, :tenant_a)
+    awaiter_b = start_result_awaiter(ticket_b, :tenant_b)
+
+    assert wait_until(fn -> queue_entry_awaiting?(ticket_a) end)
+    assert wait_until(fn -> queue_entry_awaiting?(ticket_b) end)
+
+    :sys.replace_state(QueueManager, fn state ->
+      lanes =
+        Map.new(state.lanes, fn {queue_key, lane} ->
+          {queue_key, Map.put(lane, :capacity, 1)}
+        end)
+
+      %{state | lanes: lanes}
+    end)
+
+    assert {:queued, trigger_ticket} =
+             QueueManager.acquire(
+               admission_request("req-weighted-active-cap-trigger",
+                 model_id: "queue-model-trigger"
+               ),
+               config: queue_config(capacity: 0, tenant_weights: tenant_weights)
+             )
+
+    assert_receive {:tenant_b, {:ok, grant_b}}, 1_000
+    assert grant_b.queue_key == "queue-model-b@v1"
+    refute_receive {:tenant_a, {:ok, _grant_a}}, 50
+
+    assert :ok = QueueManager.release(active_a)
+    assert_receive {:tenant_a, {:ok, grant_a}}, 1_000
+    assert grant_a.queue_key == "queue-model-a@v1"
+
+    assert :ok = QueueManager.abandon(trigger_ticket)
+    assert :ok = QueueManager.release(grant_a)
+    assert :ok = QueueManager.release(grant_b)
+
+    Process.exit(awaiter_a, :kill)
+    Process.exit(awaiter_b, :kill)
+  end
+
   test "SPEC.md §3.6 immediate grant holder death releases lane before explicit release" do
     db_request = create_request!("req_queue_immediate_holder_death", state: :admitted)
 

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -1207,6 +1207,45 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end
   end
 
+  test "SPEC.md §5.3 tenant active cap queues despite spare model lane capacity", %{
+    bundle: bundle
+  } do
+    put_queue_admission_config(
+      enabled: true,
+      capacity: 2,
+      max_active_per_tenant: 1,
+      max_wait_ms: 1_000
+    )
+
+    model = create_active_model!(bundle, "request-orchestrator-tenant-active-cap")
+    canonical = canonical_request("request-orchestrator-tenant-active-cap", stream?: false)
+
+    assert {:ok, held_grant} = hold_queue_lane(canonical)
+
+    task = Task.async(fn -> RequestOrchestrator.execute(canonical, model) end)
+
+    try do
+      assert wait_until(fn -> request_state(canonical.public_id) == :queued end)
+
+      queued_request = Requests.get_request_by_public_id(canonical.public_id)
+      assert_queue_metadata(queued_request, "queued", queued?: true)
+      refute :scheduled in request_event_states(queued_request)
+
+      assert :ok = QueueManager.release(held_grant)
+      assert {:ok, ^canonical, events} = Task.await(task, 2_000)
+      assert Enum.any?(events, &InferenceEvent.terminal?/1)
+
+      request = Requests.get_request_by_public_id(canonical.public_id)
+      states = request_event_states(request)
+
+      assert state_before?(states, :queued, :scheduled)
+      assert_queue_metadata(request, "queued", queued?: true, granted?: true)
+    after
+      QueueManager.release(held_grant)
+      Task.shutdown(task, :brutal_kill)
+    end
+  end
+
   test "queue admission returns queue_full before scheduling when tenant cap is exhausted", %{
     bundle: bundle
   } do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -1246,6 +1246,45 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end
   end
 
+  test "SPEC.md §5.3 resolved tenant active policy limits queue admission", %{
+    bundle: bundle
+  } do
+    put_queue_admission_config(enabled: true, capacity: 2, max_wait_ms: 1_000)
+
+    model = create_active_model!(bundle, "request-orchestrator-policy-tenant-active-cap")
+
+    canonical =
+      canonical_request("request-orchestrator-policy-tenant-active-cap",
+        stream?: false,
+        resolved_policy: %{max_active_requests: 1}
+      )
+
+    assert {:ok, held_grant} = hold_queue_lane(canonical)
+
+    task = Task.async(fn -> RequestOrchestrator.execute(canonical, model) end)
+
+    try do
+      assert wait_until(fn -> request_state(canonical.public_id) == :queued end)
+
+      queued_request = Requests.get_request_by_public_id(canonical.public_id)
+      assert_queue_metadata(queued_request, "queued", queued?: true)
+      refute :scheduled in request_event_states(queued_request)
+
+      assert :ok = QueueManager.release(held_grant)
+      assert {:ok, ^canonical, events} = Task.await(task, 2_000)
+      assert Enum.any?(events, &InferenceEvent.terminal?/1)
+
+      request = Requests.get_request_by_public_id(canonical.public_id)
+      states = request_event_states(request)
+
+      assert state_before?(states, :queued, :scheduled)
+      assert_queue_metadata(request, "queued", queued?: true, granted?: true)
+    after
+      QueueManager.release(held_grant)
+      Task.shutdown(task, :brutal_kill)
+    end
+  end
+
   test "queue admission returns queue_full before scheduling when tenant cap is exhausted", %{
     bundle: bundle
   } do
@@ -2845,6 +2884,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     stop = Keyword.get(overrides, :stop, [])
     max_output_tokens = Keyword.get(overrides, :max_output_tokens)
     tooling = Keyword.get(overrides, :tooling, %{})
+    resolved_policy = Keyword.get(overrides, :resolved_policy, %{})
 
     CanonicalRequest.new(%{
       internal_id: Ecto.UUID.generate(),
@@ -2860,7 +2900,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       sampling: %{temperature: 1.0, top_p: 1.0, stop: stop, max_output_tokens: max_output_tokens},
       response_format: %{type: :text},
       tooling: tooling,
-      metadata: metadata
+      metadata: metadata,
+      resolved_policy: resolved_policy
     })
   end
 

--- a/apps/orchard_shared/lib/orchard/canonical_request.ex
+++ b/apps/orchard_shared/lib/orchard/canonical_request.ex
@@ -79,6 +79,7 @@ defmodule Orchard.CanonicalRequest do
     defstruct quota_id: nil,
               routing_policy_id: nil,
               allowed_pool_ids: [],
+              max_active_requests: nil,
               residency_preference: :allow_cold_load
 
     @type residency_preference :: :required_loaded | :prefer_loaded | :allow_cold_load
@@ -87,6 +88,7 @@ defmodule Orchard.CanonicalRequest do
             quota_id: String.t() | nil,
             routing_policy_id: String.t() | nil,
             allowed_pool_ids: [String.t()],
+            max_active_requests: pos_integer() | nil,
             residency_preference: residency_preference()
           }
   end
@@ -444,17 +446,19 @@ defmodule Orchard.CanonicalRequest do
              quota_id: quota_id,
              routing_policy_id: routing_policy_id,
              allowed_pool_ids: allowed_pool_ids,
+             max_active_requests: max_active_requests,
              residency_preference: preference
            }
          } = struct
        )
        when preference in [:required_loaded, :prefer_loaded, :allow_cold_load] do
     if valid_optional_binary?(quota_id) and valid_optional_binary?(routing_policy_id) and
-         valid_allowed_pool_ids?(allowed_pool_ids) do
+         valid_allowed_pool_ids?(allowed_pool_ids) and
+         valid_optional_positive_integer?(max_active_requests) do
       struct
     else
       raise ArgumentError,
-            "#{inspect(__MODULE__)} resolved_policy must include non-empty optional IDs and non-empty string allowed_pool_ids, got: #{inspect(struct.resolved_policy)}"
+            "#{inspect(__MODULE__)} resolved_policy must include non-empty optional IDs, non-empty string allowed_pool_ids, and optional positive max_active_requests, got: #{inspect(struct.resolved_policy)}"
     end
   end
 
@@ -511,6 +515,9 @@ defmodule Orchard.CanonicalRequest do
 
   defp valid_optional_binary?(nil), do: true
   defp valid_optional_binary?(value), do: is_binary(value) and value != ""
+
+  defp valid_optional_positive_integer?(nil), do: true
+  defp valid_optional_positive_integer?(value), do: is_integer(value) and value > 0
 
   defp valid_allowed_pool_ids?(allowed_pool_ids) when is_list(allowed_pool_ids),
     do: Enum.all?(allowed_pool_ids, &(is_binary(&1) and &1 != ""))

--- a/apps/orchard_shared/test/shared_domain_types_test.exs
+++ b/apps/orchard_shared/test/shared_domain_types_test.exs
@@ -53,6 +53,7 @@ defmodule OrchardSharedDomainTypesTest do
         admission: %Admission{timeout_ms: 30_000, queue_wait_ms: 5_000, max_cold_start_ms: 10_000},
         resolved_policy: %ResolvedPolicy{
           allowed_pool_ids: ["pool_1"],
+          max_active_requests: 2,
           residency_preference: :prefer_loaded
         }
       })
@@ -83,6 +84,7 @@ defmodule OrchardSharedDomainTypesTest do
            }
 
     assert updated.resolved_policy.residency_preference == :prefer_loaded
+    assert updated.resolved_policy.max_active_requests == 2
   end
 
   test "canonical request spec section 3.4 tooling defaults keep old callers valid" do
@@ -363,6 +365,17 @@ defmodule OrchardSharedDomainTypesTest do
         model_ref: %ModelRef{model_id: "mlx-community/phi-3", version: "main"},
         input_items: [42],
         resolved_policy: %ResolvedPolicy{allowed_pool_ids: [nil]}
+      })
+    end
+
+    assert_raise ArgumentError, fn ->
+      CanonicalRequest.new(%{
+        internal_id: "req_internal",
+        public_id: "req_public",
+        endpoint: :chat_completions,
+        tenant_id: "tenant_123",
+        model_ref: %ModelRef{model_id: "mlx-community/phi-3", version: "main"},
+        resolved_policy: %ResolvedPolicy{max_active_requests: 0}
       })
     end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,10 +74,12 @@ legacy tenant defaults until full RBAC and quota policy are complete.
 1. Client calls a public `/v1` endpoint on the controller.
 2. Controller authenticates, canonicalizes, renders/tokenizes, admits, and
    persists request state.
-3. Scheduler chooses a node/runtime target.
-4. Controller dispatches to a node agent.
-5. Node agent ensures a worker/model is ready and streams worker events back.
-6. Controller relays SSE/JSON to the client and finalizes usage/state.
+3. Queue admission grants immediately or waits when lane capacity, live
+   placement capacity, or tenant active concurrency is exhausted.
+4. Scheduler chooses a node/runtime target.
+5. Controller dispatches to a node agent.
+6. Node agent ensures a worker/model is ready and streams worker events back.
+7. Controller relays SSE/JSON to the client and finalizes usage/state.
 
 `/v1/responses` is the target canonical abstraction. `/v1/chat/completions` is
 the compatibility facade. See `SPEC.md` §3 and §7 for normative behavior.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -133,7 +133,7 @@ A tenant-scoped usage or concurrency limit applied during Admission and reconcil
 _Avoid_: Routing Policy, Scheduler Decision, rate limit only
 
 **Routing Policy**:
-A tenant or model policy input that constrains eligible pools, residency preference, cold-start behavior, queue wait, and priority before scheduling.
+A tenant or model policy input that constrains eligible pools, active request limits, residency preference, cold-start behavior, queue wait, and priority before scheduling.
 _Avoid_: Quota, Scheduler Decision
 
 **Audit Log**:
@@ -361,8 +361,8 @@ A scheduler suppression rule for repeatedly failing nodes or placements.
 _Avoid_: Node health
 
 **Queue**:
-A controller-owned wait path used after Admission when no Node or live placement capacity is immediately eligible.
-Each Tenant keeps FIFO order, and cross-tenant selection uses weighted round-robin.
+A controller-owned wait path used after Admission when work cannot be immediately granted because node or live placement capacity is unavailable or tenant active concurrency is exhausted.
+Each Tenant keeps FIFO order, and cross-tenant selection uses weighted round-robin that can skip capped tenants while preserving their FIFO order.
 _Avoid_: Global backlog, Request lifecycle state
 
 **Cluster Busy**:


### PR DESCRIPTION
## Intent

Validate and ship the tenant-active-queue-caps Orchard PR candidate. The change is intended to enforce tenant active concurrency caps across queue admission and promotion so same-tenant requests queue when configured tenant active limits are exhausted, including chat completions and responses API flows, QueueManager recovered in-flight grants after admission-owner restart, and weighted same-model queue promotion where one tenant blocked by its cap must not prevent another tenant from using available capacity. Preserve the SPEC.md-traceable policy field, regression coverage, and docs added by the candidate, and run the full no-mistakes pipeline including push, PR creation, and CI monitoring.

## What Changed

- Added `resolved_policy.max_active_requests` to the canonical request contract, serializer, shared domain type, and SPEC/docs so tenant active limits travel with admitted requests.
- Wired queue admission, requeue, promotion, and restart recovery to count tenant-owned active grants against configured or resolved caps while preserving per-model lane capacity.
- Expanded QueueManager, orchestrator, chat completions, responses, serializer, and shared-domain regressions for same-tenant queuing, capped-tenant promotion, and recovered in-flight grants.

## Risk Assessment

✅ Low: The changes are narrowly scoped to queue admission cap accounting, canonical request metadata, and regression coverage, and I did not find a material correctness or merge-blocking issue in the reviewed diff.

## Testing

After inspecting the changed surface, I handled local setup without persisting mise trust, fetched missing Mix deps, ran the focused tenant-cap selectors and full affected controller/shared test files successfully, generated and inspected reviewer-visible JSON evidence for API queueing, recovered in-flight grants, and same-model promotion, then removed generated `_build`, `deps`, and `tmp` artifacts and ended with a clean worktree.

<details>
<summary>Evidence: Tenant active queue cap evidence</summary>

<code>Evidence shows both `/v1/chat/completions` and `/v1/responses` returned 200s while the second same-tenant request stayed queued until the first released; it also records recovered in-flight grant cap accounting and same-model promotion past a cap-blocked tenant.</code>

```text
{
  "exercised_at": "2026-06-23T23:29:07.965887Z",
  "user_visible_api_flows": {
    "chat_completions": {
      "endpoint": "/v1/chat/completions",
      "model": "evidence-chat-tenant-active-cap-model@v1",
      "tenant_cap": 1,
      "lane_capacity": 2,
      "first_runtime_request_id": "chatcmpl-3e91b4fa-7c69-4691-b288-cdbf0934bc77",
      "second_runtime_request_id": "chatcmpl-55ab205f-580d-4b7e-94bc-7bcd0fd73560",
      "second_started_before_first_release": false,
      "queued_row_before_release": {
        "state": "queued",
        "public_id": "chatcmpl-55ab205f-580d-4b7e-94bc-7bcd0fd73560",
        "queue_key": "evidence-chat-tenant-active-cap-model@v1",
        "queue_result": "queued",
        "queued_at_present": true,
        "grant_id_present": false,
        "queue_wait_ms_is_integer": true
      },
      "first_http": {
        "status": 200,
        "body": {
          "choice_count": 1,
          "finish_reason": "stop",
          "id": "chatcmpl-3e91b4fa-7c69-4691-b288-cdbf0934bc77",
          "message_content": "queued ok",
          "object": "chat.completion",
          "usage": {
            "completion_tokens": 2,
            "prompt_tokens": 3,
            "total_tokens": 5
          }
        }
      },
      "second_http": {
        "status": 200,
        "body": {
          "choice_count": 1,
          "finish_reason": "stop",
          "id": "chatcmpl-55ab205f-580d-4b7e-94bc-7bcd0fd73560",
          "message_content": "queued ok",
          "object": "chat.completion",
          "usage": {
            "completion_tokens": 2,
            "prompt_tokens": 3,
            "total_tokens": 5
          }
        }
      },
      "persisted_requests": [
        {
          "state": "completed",
          "public_id": "chatcmpl-3e91b4fa-7c69-4691-b288-cdbf0934bc77",
          "queue_key": "evidence-chat-tenant-active-cap-model@v1",
          "queue_result": "immediate",
          "queued_at_present": false,
          "grant_id_present": true,
          "queue_wait_ms_is_integer": true
        },
        {
          "state": "completed",
          "public_id": "chatcmpl-55ab205f-580d-4b7e-94bc-7bcd0fd73560",
          "queue_key": "evidence-chat-tenant-active-cap-model@v1",
          "queue_result": "queued",
          "queued_at_present": true,
          "grant_id_present": true,
          "queue_wait_ms_is_integer": true
        }
      ]
    },
    "responses": {
      "endpoint": "/v1/responses",
      "model": "evidence-responses-tenant-active-cap-model@v1",
      "tenant_cap": 1,
      "lane_capacity": 2,
      "first_runtime_request_id": "resp_a2b72a30-a129-49c4-9432-9f8da8f1d42c",
      "second_runtime_request_id": "resp_02316bee-33ef-4855-8018-75529a263a0c",
      "second_started_before_first_release": false,
      "queued_row_before_release": {
        "state": "queued",
        "public_id": "resp_02316bee-33ef-4855-8018-75529a263a0c",
        "queue_key": "evidence-responses-tenant-active-cap-model@v1",
        "queue_result": "queued",
        "queued_at_present": true,
        "grant_id_present": false,
        "queue_wait_ms_is_integer": true
      },
      "first_http": {
        "status": 200,
        "body": {
          "id": "resp_a2b72a30-a129-49c4-9432-9f8da8f1d42c",
          "object": "response",
          "output_count": 1,
          "output_text": "queued ok",
          "usage": {
            "input_tokens": 3,
            "output_tokens": 2,
            "total_tokens": 5
          }
        }
      },
      "second_http": {
        "status": 200,
        "body": {
          "id": "resp_02316bee-33ef-4855-8018-75529a263a0c",
          "object": "response",
          "output_count": 1,
          "output_text": "queued ok",
          "usage": {
            "input_tokens": 3,
            "output_tokens": 2,
            "total_tokens": 5
          }
        }
      },
      "persisted_requests": [
        {
          "state": "completed",
          "public_id": "resp_a2b72a30-a129-49c4-9432-9f8da8f1d42c",
          "queue_key": "evidence-responses-tenant-active-cap-model@v1",
          "queue_result": "immediate",
          "queued_at_present": false,
          "grant_id_present": true,
          "queue_wait_ms_is_integer": true
        },
        {
          "state": "completed",
          "public_id": "resp_02316bee-33ef-4855-8018-75529a263a0c",
          "queue_key": "evidence-responses-tenant-active-cap-model@v1",
          "queue_result": "queued",
          "queued_at_present": true,
          "grant_id_present": true,
          "queue_wait_ms_is_integer": true
        }
      ]
    }
  },
  "queue_manager_flows": {
    "recovered_in_flight_grant": {
      "grant_before_terminal": "nil",
      "recovered_request_public_id": "evidence_recovered_tenant_active",
      "recovered_request_state_before_terminal": "running",
      "next_request_state_while_recovered_grant_active": "queued",
      "next_grant_after_terminal": {
        "queue_key": "evidence-recovered-b@v1",
        "queue_result": "queued"
      }
    },
    "same_model_weighted_promotion": {
      "model": "evidence-weighted-same-model@v1",
      "tenant_cap": 1,
      "lane_capacity": 2,
      "tenant_a_second_request_before_release": "nil",
      "tenant_b_promoted_while_tenant_a_blocked": {
        "queue_key": "evidence-weighted-same-model@v1",
        "queue_result": "queued"
      },
      "tenant_a_granted_after_active_release": {
        "queue_key": "evidence-weighted-same-model@v1",
        "queue_result": "queued"
      }
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch`
- `git diff --stat 72996376fa620ff243d8056552c79e1bf8c867c5 3bfc70bc82c5fb0b22414ffdab63cdacf056daf0`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix deps.get`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix test apps/orchard_controller/test/orchard/inference/queue_manager_test.exs:53 apps/orchard_controller/test/orchard/inference/queue_manager_test.exs:79 apps/orchard_controller/test/orchard/inference/queue_manager_test.exs:99 apps/orchard_controller/test/orchard/inference/queue_manager_test.exs:382 apps/orchard_controller/test/orchard/inference/queue_manager_test.exs:1073 apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1210 apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1249 apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs:902 apps/orchard_controller/test/orchard/api/responses_controller_test.exs:496 apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs apps/orchard_shared/test/shared_domain_types_test.exs`
- `TENANT_QUEUE_EVIDENCE_PATH=/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVVCC3A642RGR2W3ED8JWFH7/tenant_active_queue_caps_evidence.json MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix test /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVVCC3A642RGR2W3ED8JWFH7/tenant_active_queue_caps_evidence_test.exs`
- `sed -n '1,260p' /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVVCC3A642RGR2W3ED8JWFH7/tenant_active_queue_caps_evidence.json`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix test apps/orchard_controller/test/orchard/inference/queue_manager_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs apps/orchard_controller/test/orchard/api/responses_controller_test.exs apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs apps/orchard_shared/test/shared_domain_types_test.exs`
- `git ls-files _build deps tmp`
- `rm -rf _build deps tmp`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
