### PR TITLE
fix(orchard_controller): clear stale queue capacity on transport failures

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -10,6 +10,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   - Request timeout → sends CancelInference to the node
   - Caller process exit → sends CancelInference to the node
 
+  Transport failures during connect, pre-dispatch status, model load, or stream
+  execution are recorded through node inventory so stale capacity for the failed
+  target is cleared.
+
   Timing instrumentation logs one 'dispatch_timing' line per dispatch attempt,
   capturing cold/warm classification, stream timing, and outcome.
   """

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -777,9 +777,16 @@ defmodule Orchard.Nodes do
         Repo.rollback(:noop)
 
       health ->
-        node
-        |> Ecto.Changeset.change(health: health)
-        |> Repo.update!()
+        updated =
+          node
+          |> Ecto.Changeset.change(health: health)
+          |> Repo.update!()
+
+        unless queue_capacity_eligible_node?(updated) do
+          clear_node_queue_capacity_sources(updated)
+        end
+
+        updated
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -220,12 +220,13 @@ defmodule Orchard.Nodes do
   end
 
   @doc """
-  Records a transport-like failure for a target and persists health degradation.
+  Records a transport-like failure for a target and persists node health.
 
   Classifies the given `reason` and, if it matches a transport failure pattern,
-  delegates to `mark_target_unreachable/2`. Non-transport reasons are ignored.
-  Successful transport-failure marks also clear queue capacity sources owned by
-  the failed node so stale observations cannot wake queued requests.
+  marks the target unreachable. Non-transport reasons are ignored.
+  Successful transport-failure marks clear all queue capacity sources owned by
+  the failed node after the health transaction commits, so stale observations
+  cannot wake queued requests.
 
   Transport failure reasons:
   - `{:connect_failed, _}` - gRPC channel could not be established
@@ -259,6 +260,8 @@ defmodule Orchard.Nodes do
 
   Only updates health on an existing node. Does not insert new rows
   on failure-only observations. Preserves `state` and `last_heartbeat_at`.
+  When the resulting node is not queue-capacity eligible, stale node-owned
+  queue capacity sources are cleared after the health transaction commits.
 
   Returns:
   - `{:ok, %Node{}}` on successful mark

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -239,7 +239,7 @@ defmodule Orchard.Nodes do
   @spec record_transport_failure(keyword(), term(), DateTime.t()) :: {:ok, Node.t()} | :noop
   def record_transport_failure(target, reason, observed_at) do
     if transport_failure_reason?(reason) do
-      case mark_target_unreachable(target, observed_at) do
+      case mark_target_unreachable_without_queue_cleanup(target, observed_at) do
         {:ok, %Node{} = node} = result ->
           clear_node_queue_capacity_sources(node)
           result
@@ -250,6 +250,8 @@ defmodule Orchard.Nodes do
     else
       :noop
     end
+  rescue
+    _ -> :noop
   end
 
   @doc """
@@ -264,14 +266,25 @@ defmodule Orchard.Nodes do
   """
   @spec mark_target_unreachable(keyword(), DateTime.t()) :: {:ok, Node.t()} | :noop
   def mark_target_unreachable(target, observed_at) do
+    case mark_target_unreachable_without_queue_cleanup(target, observed_at) do
+      {:ok, %Node{} = node} = result ->
+        clear_ineligible_node_queue_capacity_sources(node)
+        result
+
+      :noop ->
+        :noop
+    end
+  rescue
+    _ -> :noop
+  end
+
+  defp mark_target_unreachable_without_queue_cleanup(target, observed_at) do
     with true <- repo_available?(),
          {:ok, host, port} <- validate_target(target) do
       execute_mark_unreachable(host, port, observed_at)
     else
       _ -> :noop
     end
-  rescue
-    _ -> :noop
   end
 
   # -- Observation Normalization --
@@ -433,6 +446,12 @@ defmodule Orchard.Nodes do
     :exit, reason ->
       Logger.debug("Queue capacity source clear for node exited: #{inspect(reason)}")
       :ok
+  end
+
+  defp clear_ineligible_node_queue_capacity_sources(%Node{} = node) do
+    unless queue_capacity_eligible_node?(node) do
+      clear_node_queue_capacity_sources(node)
+    end
   end
 
   defp clear_existing_target_queue_capacity_sources(target, observed_at) do
@@ -777,16 +796,9 @@ defmodule Orchard.Nodes do
         Repo.rollback(:noop)
 
       health ->
-        updated =
-          node
-          |> Ecto.Changeset.change(health: health)
-          |> Repo.update!()
-
-        unless queue_capacity_eligible_node?(updated) do
-          clear_node_queue_capacity_sources(updated)
-        end
-
-        updated
+        node
+        |> Ecto.Changeset.change(health: health)
+        |> Repo.update!()
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -28,6 +28,10 @@ defmodule Orchard.Scheduler.MultiNode do
   Successful schedules include `:queue_lane_capacity`, derived from loaded
   candidates with live node and placement room plus eligible cold candidates
   with remaining aggregate node capacity.
+
+  Transport-like probe and connect failures are recorded through node inventory
+  so failed targets stop contributing stale queue capacity before queued work is
+  promoted.
   """
 
   alias Orchard.CanonicalRequest

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -2504,6 +2504,62 @@ defmodule Orchard.NodesTest do
       assert marked.health == :unreachable
     end
 
+    test "SPEC.md §5.5 unreachable transport failure clears stale cold queue capacity" do
+      QueueManager.reset()
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-node-unreachable-capacity-a", "unreachable-model"),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-node-unreachable-capacity-b", "unreachable-model"),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter = start_holding_awaiter(first_ticket, :first_unreachable_capacity_result)
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.68", 9444)
+      heartbeat_at = DateTime.utc_now()
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          listen_host: "10.0.0.68",
+          listen_port: 9444
+        })
+        |> Map.put(:active_request_count, 0)
+        |> Map.put(:max_concurrency, 1)
+        |> Map.put(:runtime_model_placements, [])
+
+      assert {:ok, _node} = Nodes.observe_status(target, status, heartbeat_at)
+      assert_receive {:first_unreachable_capacity_result, {:ok, first_grant}}, 2_000
+      refute Task.yield(second_awaiter, 50)
+
+      unreachable_at =
+        DateTime.add(heartbeat_at, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+
+      assert {:ok, unreachable_node} = Nodes.mark_target_unreachable(target, unreachable_at)
+      assert unreachable_node.health == :unreachable
+
+      assert :ok = QueueManager.release(first_grant)
+      refute Task.yield(second_awaiter, 100)
+
+      restored_at = DateTime.add(unreachable_at, 1, :second)
+
+      assert {:ok, restored_node} = Nodes.observe_status(target, status, restored_at)
+      assert restored_node.health == :healthy
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert second_grant.queue_result == :queued
+      assert second_grant.queue_key == "unreachable-model@v1"
+
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
+    end
+
     test "marks nodes with nil heartbeat as unreachable" do
       insert_node!(%{
         advertise_addr: "10.0.0.52",

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -14,6 +14,19 @@ defmodule Orchard.NodesTest.ExitingQueueManager do
   end
 end
 
+defmodule Orchard.NodesTest.TransactionProbeQueueManager do
+  def refresh_node_capacity_sources(_observation), do: :ok
+
+  def clear_capacity_sources(sources, opts) do
+    send(
+      Process.get(:nodes_test_queue_probe_pid),
+      {:queue_capacity_clear, sources, opts, Orchard.Repo.in_transaction?()}
+    )
+
+    :ok
+  end
+end
+
 defmodule Orchard.NodesTest do
   use Orchard.DataCase, async: false
 
@@ -2502,6 +2515,38 @@ defmodule Orchard.NodesTest do
                Nodes.mark_target_unreachable(make_target("10.0.0.51", 9444), observed_at)
 
       assert marked.health == :unreachable
+    end
+
+    test "unreachable queue cleanup runs after health transaction commits" do
+      Process.put(:nodes_test_queue_probe_pid, self())
+      put_queue_manager_impl(Orchard.NodesTest.TransactionProbeQueueManager)
+      hb_time = DateTime.utc_now()
+
+      node =
+        insert_node!(%{
+          advertise_addr: "10.0.0.67",
+          rpc_port: 9444,
+          health: :healthy,
+          last_heartbeat_at: hb_time
+        })
+
+      observed_at = DateTime.add(hb_time, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+
+      assert {:ok, marked} =
+               Nodes.mark_target_unreachable(make_target("10.0.0.67", 9444), observed_at)
+
+      assert marked.health == :unreachable
+
+      assert_receive {:queue_capacity_clear, sources, opts, false}
+
+      assert Enum.sort(sources) ==
+               Enum.sort([
+                 {:node, node.id},
+                 {:node, node.id, :cold},
+                 {:node, node.id, :placement}
+               ])
+
+      assert Keyword.fetch!(opts, :promote?) == true
     end
 
     test "SPEC.md §5.5 unreachable transport failure clears stale cold queue capacity" do

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -2560,6 +2560,74 @@ defmodule Orchard.NodesTest do
       send(first_awaiter, :stop)
     end
 
+    test "SPEC.md §5.5 scheduler transport failure clears stale cold queue capacity" do
+      QueueManager.reset()
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-scheduler-transport-capacity-a",
+                   "transport-failure-model"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-scheduler-transport-capacity-b",
+                   "transport-failure-model"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter = start_holding_awaiter(first_ticket, :first_transport_capacity_result)
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.69", 9444)
+      heartbeat_at = DateTime.utc_now()
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          listen_host: "10.0.0.69",
+          listen_port: 9444
+        })
+        |> Map.put(:active_request_count, 0)
+        |> Map.put(:max_concurrency, 1)
+        |> Map.put(:runtime_model_placements, [])
+
+      assert {:ok, _node} = Nodes.observe_status(target, status, heartbeat_at)
+      assert_receive {:first_transport_capacity_result, {:ok, first_grant}}, 2_000
+      refute Task.yield(second_awaiter, 50)
+
+      unreachable_at =
+        DateTime.add(heartbeat_at, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+
+      assert {:ok, unreachable_node} =
+               Nodes.record_transport_failure(
+                 target,
+                 {:connect_failed, :econnrefused},
+                 unreachable_at
+               )
+
+      assert unreachable_node.health == :unreachable
+
+      assert :ok = QueueManager.release(first_grant)
+      refute Task.yield(second_awaiter, 100)
+
+      restored_at = DateTime.add(unreachable_at, 1, :second)
+
+      assert {:ok, restored_node} = Nodes.observe_status(target, status, restored_at)
+      assert restored_node.health == :healthy
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert second_grant.queue_result == :queued
+      assert second_grant.queue_key == "transport-failure-model@v1"
+
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
+    end
+
     test "marks nodes with nil heartbeat as unreachable" do
       insert_node!(%{
         advertise_addr: "10.0.0.52",

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -2628,6 +2628,65 @@ defmodule Orchard.NodesTest do
       send(first_awaiter, :stop)
     end
 
+    test "SPEC.md §5.5 scheduler transport failure clears stale placement queue capacity" do
+      QueueManager.reset()
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-scheduler-placement-failure-a",
+                   "transport-placement-model"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-scheduler-placement-failure-b",
+                   "transport-placement-model"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter = start_holding_awaiter(first_ticket, :first_transport_placement_result)
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+      target = make_target("10.0.0.70", 9444)
+      heartbeat_at = DateTime.utc_now()
+
+      status = placement_status("10.0.0.70", "transport-placement-model", max_concurrency: 1)
+
+      assert {:ok, _node} = Nodes.observe_status(target, status, heartbeat_at)
+      assert_receive {:first_transport_placement_result, {:ok, first_grant}}, 2_000
+      refute Task.yield(second_awaiter, 50)
+
+      unreachable_at =
+        DateTime.add(heartbeat_at, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+
+      assert {:ok, unreachable_node} =
+               Nodes.record_transport_failure(
+                 target,
+                 {:connect_failed, :econnrefused},
+                 unreachable_at
+               )
+
+      assert unreachable_node.health == :unreachable
+
+      assert :ok = QueueManager.release(first_grant)
+      refute Task.yield(second_awaiter, 100)
+
+      restored_at = DateTime.add(unreachable_at, 1, :second)
+
+      assert {:ok, restored_node} = Nodes.observe_status(target, status, restored_at)
+      assert restored_node.health == :healthy
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert second_grant.queue_result == :queued
+      assert second_grant.queue_key == "transport-placement-model@v1"
+
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
+    end
+
     test "marks nodes with nil heartbeat as unreachable" do
       insert_node!(%{
         advertise_addr: "10.0.0.52",

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -116,6 +116,33 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     }
   end
 
+  defp queue_config(overrides) do
+    Keyword.merge(
+      [
+        enabled: true,
+        capacity: 1,
+        max_queued_per_tenant: 32,
+        max_wait_ms: 1_000
+      ],
+      overrides
+    )
+  end
+
+  defp start_holding_awaiter(ticket, tag) do
+    parent = self()
+
+    spawn(fn ->
+      result = QueueManager.await(ticket)
+      send(parent, {tag, result})
+
+      receive do
+        :stop -> :ok
+      after
+        5_000 -> :ok
+      end
+    end)
+  end
+
   defp insert_node!(overrides) do
     unique = System.unique_integer([:positive])
 
@@ -3497,6 +3524,72 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       # Node A marked unreachable (stale heartbeat beyond threshold)
       reloaded = Repo.get!(Node, node_a.id)
       assert reloaded.health == :unreachable
+    end
+
+    test "SPEC.md §5.5 scheduler connect failure clears stale cold queue capacity" do
+      QueueManager.reset()
+      stale_hb = DateTime.add(DateTime.utc_now(), -120_000, :millisecond)
+      observed_at = DateTime.utc_now()
+      model_id = "scheduler-connect-clear-model"
+
+      node_a =
+        insert_node!(%{
+          advertise_addr: "10.0.0.1",
+          rpc_port: 50_061,
+          health: :healthy,
+          last_heartbeat_at: stale_hb
+        })
+
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-scheduler-connect-clear-a", model_id),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-scheduler-connect-clear-b", model_id),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter = start_holding_awaiter(first_ticket, :first_scheduler_clear_result)
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+
+      assert :ok =
+               QueueManager.refresh_capacity(model_id, "v1", 1, source: {:node, node_a.id, :cold})
+
+      assert_receive {:first_scheduler_clear_result, {:ok, first_grant}}, 2_000
+      refute Task.yield(second_awaiter, 50)
+
+      stub_connect_failure("10.0.0.1", 50_061, {:connect_failed, :econnrefused})
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(model_id),
+                 status_client: StubClient,
+                 observed_at: observed_at
+               )
+
+      assert schedule.strategy == :multi_node
+      assert schedule.node_id == node_b.id
+      assert Repo.get!(Node, node_a.id).health == :unreachable
+
+      assert :ok = QueueManager.release(first_grant)
+      refute Task.yield(second_awaiter, 100)
+
+      assert :ok = QueueManager.refresh_capacity(model_id, "v1", 1, source: {:test, :restore})
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert second_grant.queue_key == "#{model_id}@v1"
+
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
     end
 
     test "successful probe with missing metadata does NOT mutate failure health" do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,8 @@ model loading/generation details. Public clients never talk to workers directly.
 Node-agent status is also the live source for aggregate node capacity and loaded-model placement capacity, including active requests and max concurrency.
 Aggregate capacity is the conservative limit the node agent enforces across loaded workers, while each loaded placement reports its own active count and capacity.
 The controller scheduler uses that capacity telemetry to avoid dispatching to full nodes or full same-model placements.
-Controller queue admission also consumes fresh node observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted nodes and clearing stale sources on invalid, ineligible, unavailable, or failed observations.
+Controller queue admission also consumes fresh node observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted nodes.
+Invalid, ineligible, unavailable, or transport-failed observations clear stale node-owned capacity sources before queued work can be promoted.
 
 Cluster RPC and worker RPC are separate contracts:
 

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -363,7 +363,8 @@ _Avoid_: Node health
 **Queue**:
 A controller-owned wait path used after Admission when work cannot be immediately granted because live node or placement capacity is unavailable, node or placement concurrency is exhausted, or tenant active concurrency is exhausted.
 Each Tenant keeps FIFO order, and cross-tenant selection uses weighted round-robin that can skip capped tenants while preserving their FIFO order.
-Fresh node observations can wake queued work by adding source-scoped loaded-placement or cold/no-placement capacity; stale or failed observations clear their source capacity.
+Fresh node observations can wake queued work by adding source-scoped loaded-placement or cold/no-placement capacity.
+Stale, ineligible, or transport-failed observations clear node-owned capacity sources so queued work is not promoted against failed targets.
 _Avoid_: Global backlog, Request lifecycle state
 
 **Cluster Busy**:
@@ -398,6 +399,7 @@ _Avoid_: Catalog State, durable placement record, model manifest metadata
 Live node-agent status for aggregate runtime capacity on one node, including `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`.
 The scheduler uses it to exclude nodes that have exhausted aggregate request slots before considering per-placement capacity.
 Queue admission uses eligible node observations to bound cold/no-placement wakeups and to keep active source reservations from being double-counted across queued lanes.
+Transport-failed or newly ineligible nodes clear node-owned aggregate, cold, and placement sources instead of retaining stale capacity.
 _Avoid_: Tenant quota, durable Node inventory capacity, model-specific capacity
 
 **Prefix-cache Score**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -213,6 +213,7 @@ The node agent also enforces aggregate active request capacity across loaded mod
 The node-agent reports aggregate capacity through `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`.
 It reports live placement capacity through `StatusResponse.runtime_model_placements` as `active_request_count` and `max_concurrency`.
 The controller uses those fresh status observations both for scheduler candidate filtering and for queue wakeups from loaded-placement or cold/no-placement capacity.
+Transport failures and ineligible node observations clear node-owned queue capacity sources so queued work is not promoted against stale loaded-placement or cold/no-placement slots.
 Stream mode reports max concurrency as `1` at both node and placement levels.
 
 #### Controller Multi-Node (Source Dev)


### PR DESCRIPTION
## Intent

Najib asked to run no-mistakes on the Orchard transport-stale-capacity candidate after PRs #10-#13 merged. The goal is to validate the deliberate re-split of this branch onto current origin/main, preserving the corrected upstream tenant queue caps, node-agent aggregate concurrency, scheduler capacity, and cold queue wakeup stack while replaying only GNHF 57-60. The intended behavior is that scheduler and node transport failures clear stale loaded-placement and cold queue-capacity contributions when a node becomes unreachable, so queued inference work is not promoted against ineligible nodes. The branch should stay narrow: use the existing QueueManager node source cleanup helpers from the corrected stack, touch only Nodes transport-failure cleanup plus focused Nodes and MultiNode regressions, and avoid reintroducing older upstream cold queue wakeup or scheduler-capacity commits.

## What Changed

- Updated `Orchard.Nodes` transport-failure handling to clear node-owned aggregate, cold, and loaded-placement queue capacity sources after the unreachable health transaction commits.
- Added focused `Nodes` and `MultiNode` regressions covering stale cold capacity, stale loaded-placement capacity, scheduler-reported failures, and cleanup ordering.
- Refreshed architecture, glossary, and local-dev docs to describe transport-failed and ineligible node queue-capacity cleanup.

## Risk Assessment

✅ Low: The change is narrow, keeps QueueManager side effects outside the row-locking transaction, and the production behavior is covered by focused regressions with no material review findings.

## Testing

After an initial `mise` trust setup block was handled with per-command trust, the focused stale-capacity regressions and both affected test files passed, and the CLI evidence transcript demonstrated a scheduler connect failure marking the stale node unreachable, clearing its cold-capacity source, keeping the second queued request pending after the stale grant release, and allowing it only after fresh capacity was restored.

<details>
<summary>Evidence: transport stale capacity CLI evidence</summary>

<code>setup model=&#34;evidence-stale-capacity-model@v1&#34; stale_node=&#34;748133e0-a903-4980-9c5d-b86d1d60b626&#34; fallback_node=&#34;4697109e-3850-4ad5-a9f4-49070d70aa12&#34; stale_node_initial_health=:healthy&#10;queued_before_capacity first_queue_key=&#34;evidence-stale-capacity-model@v1&#34; second_queue_key=&#34;evidence-stale-capacity-model@v1&#34; queued_lanes=[]&#10;stale_capacity_promoted_first_request grant_result=:queued grant_queue_key=&#34;evidence-stale-capacity-model@v1&#34; source_lanes_before_failure=[{&#34;evidence-stale-capacity-model&#34;, &#34;v1&#34;}] second_request_pending=true&#10;scheduler_transport_failure schedule_strategy=:multi_node selected_node=&#34;4697109e-3850-4ad5-a9f4-49070d70aa12&#34; stale_node_health=:unreachable stale_source_lanes_after_failure=[]&#10;after_releasing_stale_grant second_request_pending=true stale_source_lanes_after_release=[]&#10;fresh_capacity_restores_progress second_grant_result=:queued second_grant_queue_key=&#34;evidence-stale-capacity-model@v1&#34; stale_node_final_health=:unreachable&#10;result=pass</code>

```text
setup model="evidence-stale-capacity-model@v1" stale_node="748133e0-a903-4980-9c5d-b86d1d60b626" fallback_node="4697109e-3850-4ad5-a9f4-49070d70aa12" stale_node_initial_health=:healthy
queued_before_capacity first_queue_key="evidence-stale-capacity-model@v1" second_queue_key="evidence-stale-capacity-model@v1" queued_lanes=[]
stale_capacity_promoted_first_request grant_result=:queued grant_queue_key="evidence-stale-capacity-model@v1" source_lanes_before_failure=[{"evidence-stale-capacity-model", "v1"}] second_request_pending=true
scheduler_transport_failure schedule_strategy=:multi_node selected_node="4697109e-3850-4ad5-a9f4-49070d70aa12" stale_node_health=:unreachable stale_source_lanes_after_failure=[]
after_releasing_stale_grant second_request_pending=true stale_source_lanes_after_release=[]
fresh_capacity_restores_progress second_grant_result=:queued second_grant_queue_key="evidence-stale-capacity-model@v1" stale_node_final_health=:unreachable
result=pass
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/nodes.ex:786` - `clear_node_queue_capacity_sources/1` performs a QueueManager GenServer call and can promote queued work, but this call now runs inside the `Repo.transaction/1` that also holds the node row `FOR UPDATE` lock. Move the capacity cleanup to after the transaction returns `{:ok, node}` so queue side effects cannot block the DB transaction or run before the health update commits.

🔧 Fix: Move queue cleanup after health transaction
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat c3e4ccb81f31fc0e73418b088f55649eb9c52c54..HEAD`
- `git diff --name-only c3e4ccb81f31fc0e73418b088f55649eb9c52c54..HEAD`
- `rg -n "scheduler connect failure clears stale cold queue capacity|scheduler transport failure clears stale cold queue capacity|scheduler transport failure clears stale placement queue capacity|unreachable transport failure clears stale cold queue capacity|unreachable queue cleanup runs after health transaction commits" apps/orchard_controller/test/orchard/nodes_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs`
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/nodes_test.exs:2520 apps/orchard_controller/test/orchard/nodes_test.exs:2552 apps/orchard_controller/test/orchard/nodes_test.exs:2608 apps/orchard_controller/test/orchard/nodes_test.exs:2676 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:3529` blocked before ExUnit because the worktree-local `mise.toml` was untrusted</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix --version`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix test apps/orchard_controller/test/orchard/nodes_test.exs:2520 apps/orchard_controller/test/orchard/nodes_test.exs:2552 apps/orchard_controller/test/orchard/nodes_test.exs:2608 apps/orchard_controller/test/orchard/nodes_test.exs:2676 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:3529`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix test apps/orchard_controller/test/orchard/nodes_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs`
- `MIX_ENV=test MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix run -e 'IO.puts("mix_run_smoke=ok")'`
- <code>created `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVXX22BG453MHZ4Q4Y34B597/transport_stale_capacity_demo.exs`</code>
- `set -o pipefail; MIX_ENV=test MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix run /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVXX22BG453MHZ4Q4Y34B597/transport_stale_capacity_demo.exs | tee /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVXX22BG453MHZ4Q4Y34B597/transport_stale_capacity_demo.txt`
- `rm -rf _build tmp; git status --short; git status --short --ignored | sed -n '1,40p'; find . -maxdepth 2 \( -name _build -o -name tmp \) -print`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
