### PR TITLE
feat: add BEAM-first runtime endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ Clients (SDKs / curl / apps)
    Controller (Elixir/OTP)
    ├── Inference API    ── `/v1/responses` canonical, `/v1/chat/completions` facade
    ├── Auth / RBAC      ── tenant-scoped keys + quotas
-   ├── Scheduler        ── placement, queueing, fairness
-   ├── Dispatch         ── gRPC fan-out to nodes
+   ├── Scheduler        ── Runtime Endpoint selection, queueing, fairness
+   ├── Dispatch         ── Runtime Endpoint operations + stream relay
    └── Observability    ── Prometheus, OTel, structured logs
         │
-   gRPC / mTLS
+   Runtime Endpoint Interface
         │
-   Node Agent(s)
+   Current gRPC compatibility adapter
+        │
+   Node Agent Runtime Endpoint(s)
    ├── Model cache + verification
    ├── Worker supervisor
    └── MLX runtime (Apple Silicon native)
@@ -55,8 +57,11 @@ Clients (SDKs / curl / apps)
 
 **Key design rules:**
 
-- All durable state in Postgres. No distributed Erlang across machines.
-- All cross-node traffic over gRPC/mTLS. Workers never exposed on the network.
+- All durable state lives in Postgres.
+- Controller runtime execution uses the Runtime Endpoint Interface.
+- The current `NodeRuntimeService` gRPC path is a compatibility adapter, not the durable domain contract.
+- First-party BEAM communication is guarded for future use and must not become durable cluster truth.
+- Workers are local to node agents and are never exposed on the network.
 - Token streams always pass through the controller for governance and accounting.
 - HA-lite only: exactly one active leader, active/standby via Postgres advisory locks, no active/active consensus.
 
@@ -67,7 +72,7 @@ Clients (SDKs / curl / apps)
 | Language | Elixir/OTP (umbrella app) |
 | Database | Postgres |
 | Inference | MLX-LM runtime adapter managed by the node agent |
-| Internal RPC | gRPC over mTLS |
+| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter |
 | APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
 | Packaging | DMG, PKG, launchd |
 | CLI | `orchardctl` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -374,9 +374,10 @@ The controller-side chat-template renderer SHALL support Hugging Face's standard
 
 Tokenizer observability includes `[:orchard, :tokenizer, :prompt_token_ids_dispatched]` when capable workers receive controller-supplied IDs, `[:orchard, :tokenizer, :unsafe_mode_active]` when safe-mode falls back to legacy rendered-prompt dispatch, and `[:orchard, :tokenizer, :parity_drift]` when a capable worker rejects controller-supplied `prompt_token_ids` with `prompt_token_ids_length_mismatch`. The parity-drift event is an operator-visible invariant breach counter; it is emitted only for worker stream failures, not controller-synthesized timeout or cancellation failures.
 
-When `tokenizer_safe_mode_prefer_capable` is enabled and `tokenizer_safe_mode` is not `:off`, the multi-node scheduler MAY prefer workers whose live `StatusResponse.supports_prompt_token_ids` is `true`. This preference is a scheduler tie-breaker only; it is not dispatch authority and MUST NOT replace the per-request `EnsureModelLoadedResponse.worker_supports_prompt_token_ids` gate.
+When `tokenizer_safe_mode_prefer_capable` is enabled and `tokenizer_safe_mode` is not `:off`, the multi-node scheduler MAY prefer Runtime Endpoints whose live Runtime Endpoint Observation reports `supports_prompt_token_ids = true`.
+This preference is a scheduler tie-breaker only; it is not dispatch authority and MUST NOT replace the per-request Runtime Endpoint ensure-model-loaded result gate.
 
-Console Live Cluster diagnostics SHALL surface the latest observed live `StatusResponse.supports_prompt_token_ids` value per reachable runtime target so operators can assess mixed-version safe-tokenization risk; absence or `false` is rendered as legacy capability, not as a probe failure.
+Console Live Cluster diagnostics SHALL surface the latest observed live prompt-token-ID support value per reachable runtime target so operators can assess mixed-version safe-tokenization risk; absence or `false` is rendered as legacy capability, not as a probe failure.
 
 Console diagnostics SHALL surface observe-only, process-local safe-tokenization counters aggregated since counter process start (`control_token_in_user_content`, `detector_error`, `prompt_token_ids_dispatched` event count and accumulated token count, `unsafe_mode_active`, `parity_drift`, `catalog_drift`, and `safe_tokenization.degraded_no_manifest_catalog`). Counter values reset on counter process restart and MUST NOT influence scheduling, dispatch, admission, or readiness.
 
@@ -863,7 +864,7 @@ Node agent SHALL:
 * register with controller
 * renew node certificate
 * heartbeat every 2s
-* expose gRPC runtime endpoint
+* expose the current gRPC Runtime Endpoint compatibility service
 * download/verify model artifacts
 * manage worker subprocess lifecycle
 * report immediate state changes
@@ -1025,13 +1026,13 @@ Eligibility condition:
 available_memory_bytes >= required_bytes
 ```
 
-Node concurrency is not exceeded only when live `StatusResponse.active_request_count < StatusResponse.max_concurrency`.
-If `max_concurrency` is omitted or zero, schedulers SHALL interpret node capacity as `1`.
-Model placement concurrency is evaluated independently through a valid matching `RuntimeModelPlacement`.
-Both node-level aggregate capacity and requested-placement capacity must remain available for a loaded candidate to be eligible.
-Scheduler decisions MAY include `queue_lane_capacity` when live loaded-placement capacity or eligible cold-node capacity leaves room for the requested lane.
-Loaded candidate contribution SHALL be constrained by both requested-placement capacity and aggregate node capacity.
-Cold candidate contribution SHALL count only candidates with remaining aggregate node capacity.
+Endpoint node concurrency is not exceeded only when the live Runtime Endpoint Observation reports aggregate `active_request_count < max_concurrency`.
+If aggregate `max_concurrency` is omitted or zero, schedulers SHALL interpret endpoint node capacity as `1`.
+Model placement concurrency is evaluated independently through valid matching Placement Capacity.
+Both endpoint-level aggregate capacity and requested-placement capacity must remain available for a loaded candidate to be eligible.
+Scheduler decisions MAY include `queue_lane_capacity` when live loaded-placement capacity or eligible cold Runtime Endpoint capacity leaves room for the requested lane.
+Loaded candidate contribution SHALL be constrained by both requested-placement capacity and aggregate endpoint capacity.
+Cold candidate contribution SHALL count only candidates with remaining aggregate endpoint capacity.
 Omitted `queue_lane_capacity` means the controller queue must use its conservative configured capacity.
 
 ### 5.6 Candidate tiers
@@ -2444,9 +2445,9 @@ Runtime capacity and Placement Capacity observation semantics:
 * duplicate matching entries, malformed matching entries, non-matching entries, or `max_concurrency <= 0` SHALL make placement capacity unknown for that request
 * a valid matching placement observation SHALL NOT override exhausted node-level aggregate capacity
 * unknown placement capacity SHALL NOT prove eligibility for an already-active loaded-model candidate; an already-active loaded-model candidate MAY remain eligible only when exactly one valid matching entry reports `active_request_count < max_concurrency`
-* when multiple eligible candidates remain, the scheduler SHALL rank by the requested placement's active request count before health when a valid matching placement observation is available; otherwise it SHALL use node `active_request_count`
-* controller queue capacity MAY be refreshed from `StatusResponse` observations; loaded placement observations contribute only to their matching model/version lane, while cold/no-placement node observations contribute conservative source-scoped capacity for queued lanes without exceeding aggregate node capacity
-* stale, unavailable, non-loaded, invalid, exhausted, ineligible, or transport-failed observations SHALL clear their node-owned queue capacity sources instead of preserving stale admission capacity
+* when multiple eligible candidates remain, the scheduler SHALL rank by the requested placement's active request count before health when a valid matching placement observation is available; otherwise it SHALL use the endpoint aggregate `active_request_count`
+* controller queue capacity MAY be refreshed from Runtime Endpoint Observations; loaded placement observations contribute only to their matching model/version lane, while cold/no-placement endpoint observations contribute conservative source-scoped capacity for queued lanes without exceeding aggregate endpoint capacity
+* stale, unavailable, non-loaded, invalid, exhausted, ineligible, or transport-failed observations SHALL clear their endpoint-owned queue capacity sources instead of preserving stale admission capacity
 * node-agent request admission SHALL reject a new runtime request when aggregate active request count has reached the effective aggregate worker request limit, even if the requested model placement has remaining per-placement capacity
 * cancellation or terminal completion SHALL release aggregate node capacity so another loaded model can use the freed slot
 * stream generation mode SHALL report `max_concurrency = 1` at both node and placement levels
@@ -3138,7 +3139,7 @@ Supported join modes:
 
 ### 10.6 Internal transport
 
-Internal RPC SHALL use:
+Certificate-backed node lifecycle RPC and current gRPC compatibility transports SHALL use:
 
 * TLS 1.3
 * mutual TLS

--- a/SPEC.md
+++ b/SPEC.md
@@ -40,10 +40,14 @@ Supported deployment modes:
 ### 1.2 Core design rules
 
 * No Kubernetes.
-* No distributed Erlang cluster across machines.
 * No active/active controller mode in v1.
 * All durable state SHALL live in Postgres.
-* All cross-node control traffic SHALL use **gRPC over mTLS**.
+* Controller runtime execution SHALL use the Runtime Endpoint Interface.
+* Runtime Endpoint semantics are transport-independent.
+* The current gRPC/protobuf `NodeRuntimeService` is the compatibility transport for the first implementation and a candidate protocol for future non-BEAM adapters.
+* First-party Orchard Controller and Node Agent services MAY later use BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
+* Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
+* External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 * All public API traffic SHALL terminate at the controller.
 * Token streams SHALL always pass through the controller so governance, accounting, cancellation, and audit behavior are centralized.
 * Node agents SHALL be the only network-reachable component on worker nodes.
@@ -70,14 +74,23 @@ Supported deployment modes:
                      |  - Dispatch                   |
                      |  - Request FSMs               |
                      |  - Metrics/Tracing/Logs       |
-                     +---------+-----------+---------+
+                     +---------+-----------+-------------------+
                                |           |
-                        SQL / TLS          gRPC / mTLS
+                        SQL / TLS          Runtime Endpoint Interface
                                |           |
-                     +---------v--+   +---v--------------------+
-                     | Postgres    |   | Node Agent(s)         |
-                     | durable DB  |   | - Register/Heartbeat  |
-                     +------------ +   | - Model cache         |
+                     +---------v--+   +---v---------------------------+
+                     | Postgres    |   | Runtime Endpoint Adapter(s) |
+                     | durable DB  |   | - current gRPC compatibility|
+                     +------------ +   | - future first-party BEAM   |
+                                       | - future external/provider  |
+                                       +---+-------------------------+
+                                           |
+                                           | v1 first-party endpoint
+                                           |
+                                       +---v--------------------+
+                                       | Node Agent(s)         |
+                                       | - Register/Heartbeat  |
+                                       | - Model cache         |
                                        | - Worker supervisor   |
                                        | - Diagnostics         |
                                        +---+-------------------+
@@ -125,8 +138,8 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 | `Orchard.API`           | OTP app              | HTTP API surface: `/v1`, `/ops/v1`, `/admin/v1`              |
 | `Orchard.Auth`          | OTP app              | API key auth, service account auth, RBAC                     |
 | `Orchard.Admission`     | OTP app              | validation, tenant policy, quotas, idempotency               |
-| `Orchard.Scheduler`     | OTP app              | node selection, queueing, fairness, placement decisions      |
-| `Orchard.Dispatch`      | OTP app              | gRPC calls to node agents, stream fan-out to clients         |
+| `Orchard.Scheduler`     | OTP app              | Runtime Endpoint selection, queueing, fairness, placement decisions |
+| `Orchard.Dispatch`      | OTP app              | Runtime Endpoint operations, compatibility dispatch, stream fan-out to clients |
 | `Orchard.Catalog`       | OTP app              | model catalog, artifact manifests, routing policy resolution |
 | `Orchard.Nodes`         | OTP app              | node registry, lifecycle, heartbeat snapshots                |
 | `Orchard.Requests`      | OTP app              | per-request FSMs and request event logging                   |
@@ -188,7 +201,7 @@ The implementation SHOULD use an umbrella repository with separate Elixir releas
 
 ### 3.1 Controller runtime model
 
-The controller SHALL be a Phoenix/Plug HTTP service plus a gRPC server and gRPC client pool.
+The controller SHALL be a Phoenix/Plug HTTP service plus Runtime Endpoint clients and the configured internal service ingress for node lifecycle and compatibility transports.
 
 **Required listeners**
 
@@ -196,7 +209,7 @@ The controller SHALL be a Phoenix/Plug HTTP service plus a gRPC server and gRPC 
   * `direct_https`: controller terminates HTTPS, default `:8443`.
   * `reverse_proxy`: controller provides a local/private HTTP backend for an operator-managed TLS-terminating proxy.
   * `plain_http_localhost`: controller provides loopback HTTP only for local development or break-glass recovery.
-* `:8444` gRPC/mTLS for node registration/heartbeat/event ingress
+* `:8444` gRPC/mTLS for node registration/heartbeat/event ingress while the compatibility transport remains enabled
 * `:9464` Prometheus metrics endpoint
 
 **Required readiness conditions**
@@ -749,14 +762,15 @@ Node agent SHALL send heartbeats every 2 seconds with:
 }
 ```
 
-### 4.6.1 Hosted-tool capability and readiness observation
+### 4.6.1 Runtime Endpoint capability and readiness observation
 
 Hosted-tool observation SHALL remain distinct from heartbeat inventory in the current implementation slice.
 
 Rules:
 
-* the active implementation seam for hosted-tool observation SHALL be `NodeRuntimeService.GetStatus` returning `StatusResponse`
-* heartbeat payloads MAY carry equivalent hosted-tool data in a later slice, but controller-owned hosted-tool observation SHALL currently be derived from status-probe ingestion
+* the durable implementation seam for runtime status SHALL be a Runtime Endpoint Observation produced through the Runtime Endpoint Interface
+* the current gRPC Compatibility Adapter SHALL derive Runtime Endpoint Observations from `NodeRuntimeService.GetStatus` returning `StatusResponse`
+* heartbeat payloads MAY carry equivalent hosted-tool data in a later slice, but controller-owned hosted-tool observation SHALL currently be derived from Runtime Endpoint status-probe ingestion
 * this contract defines future hosted routing inputs only; it SHALL NOT by itself enable controller-owned hosted `/v1/responses` execution or any other hosted execution behavior
 
 Hosted-tool observation vocabulary:
@@ -768,28 +782,28 @@ Hosted-tool observation vocabulary:
 
 Compatibility and defaulting rules:
 
-* absent hosted-tool capability/readiness fields on `StatusResponse` SHALL mean the node advertises no hosted tools
+* absent hosted-tool capability/readiness fields on a Runtime Endpoint Observation SHALL mean the endpoint advertises no hosted tools
 * absent hosted-tool capability/readiness fields SHALL NOT be treated as a status-probe error
 * readiness without matching advertised capability for the same `tool://<name>@<version>` SHALL NOT make the node eligible for hosted routing
-* `supports_prompt_token_ids` indicates that the node's loaded worker can accept controller-supplied prompt token IDs on `ExecuteInferenceRequest`. Absence or `false` is treated as legacy capability, not as a probe failure. When `tokenizer_safe_mode_prefer_capable=true` and `tokenizer_safe_mode` is not `:off`, this live status-probe field MAY inform opt-in scheduler preference only; it is not dispatch authority.
-* absent or empty `runtime_memory_budgets` on `StatusResponse` SHALL mean no memory-budget observation is available
+* `supports_prompt_token_ids` indicates that the endpoint's loaded worker can accept controller-supplied prompt token IDs on the runtime execution request. Absence or `false` is treated as legacy capability, not as a probe failure. When `tokenizer_safe_mode_prefer_capable=true` and `tokenizer_safe_mode` is not `:off`, this live status-probe field MAY inform opt-in scheduler preference only; it is not dispatch authority.
+* absent or empty runtime memory budgets on a Runtime Endpoint Observation SHALL mean no memory-budget observation is available
 * absent or empty `runtime_memory_budgets` SHALL NOT be treated as a status-probe error
 * `runtime_memory_budgets` SHALL remain observe-only telemetry except for the Phase 4E scheduler-ranking guard defined in §5.7 and §7.5.3; it SHALL NOT affect node readiness, model admission, request admission, scheduling eligibility, hosted-tool eligibility, public error contracts, queue ordering, or memory-budget enforcement
 * when `memory_admission.enabled = true`, `Orchard.Scheduler.MultiNode` MAY use only `RuntimeMemoryBudget.status_code == "ok"` plus `headroom_available == true` as a positive, non-excluding ranking preference below loadedness, requested-placement active request count when known, health, live prefix-cache fingerprint match, historical cache affinity, and any enabled safe-tokenization capable-worker preference, and above deterministic `node_id`
 * absent, empty, stale, malformed, disabled, unavailable, invalid, device-info-failed, compute-failed, non-`ok`, or `headroom_available != true` memory telemetry SHALL be rank-neutral and fail open
 * current `RuntimeMemoryBudget.status_code` vocabulary is: `ok`, `disabled`, `device_info_unavailable`, `device_info_invalid`, `resident_memory_unavailable`, `compute_failed`, `invalid_status`
-* absent or empty `runtime_prefix_cache_statuses` on `StatusResponse` SHALL mean no prefix-cache observation is available
+* absent or empty runtime prefix-cache statuses on a Runtime Endpoint Observation SHALL mean no prefix-cache observation is available
 * absent or empty `runtime_prefix_cache_statuses` SHALL NOT be treated as a status-probe error
 * aggregate `runtime_prefix_cache_statuses` counters SHALL remain observe-only telemetry and SHALL NOT affect node readiness, model admission, request admission, scheduling eligibility, queue ordering, hosted-tool eligibility, or `worker_generation_mode`; the Phase 4C bounded HMAC fingerprint field MAY affect scheduler ranking only as the explicitly configured non-gating tie-breaker defined in §5.7 and §7.5.3
 * current `RuntimePrefixCacheStatus.status_code` vocabulary is: `ok`, `disabled`, `unavailable`, `error`, `invalid_status`
 * these status codes are observational only in this slice and SHALL NOT gate readiness, admission, or scheduling
-* `active_request_count` on `StatusResponse` SHALL report active runtime requests across the node
-* `max_concurrency` on `StatusResponse` SHALL report the aggregate runtime request capacity enforced by the node agent; omitted or zero values SHALL be treated conservatively as node capacity `1` by schedulers
-* absent or empty `runtime_model_placements` on `StatusResponse` SHALL mean no explicit per-placement capacity observation is available
-* absent or empty `runtime_model_placements` SHALL NOT be treated as a status-probe error
-* `runtime_model_placements` entries SHALL report controller-observed capacity for loaded model placements using `model_ref`, `active_request_count`, and `max_concurrency`; `max_concurrency <= 0`, malformed entries, duplicate matching entries, or non-matching entries SHALL be treated as unknown capacity
-* valid per-placement capacity SHALL NOT prove node eligibility when node-level `active_request_count >= max_concurrency`
-* unknown placement capacity SHALL NOT prove scheduler eligibility for an already-active node; `Orchard.Scheduler.MultiNode` MAY keep a matching loaded-model active candidate eligible only when exactly one valid matching `runtime_model_placements` entry reports `active_request_count < max_concurrency`
+* aggregate `active_request_count` on a Runtime Endpoint Observation, and on the current gRPC compatibility `StatusResponse`, SHALL report active runtime requests across the endpoint node
+* `max_concurrency` on the current gRPC compatibility `StatusResponse` SHALL report the aggregate runtime request capacity enforced by the node agent; omitted or zero values SHALL be treated conservatively as endpoint node capacity `1` by schedulers
+* absent or empty Placement Capacity on a Runtime Endpoint Observation, including absent or empty `runtime_model_placements` on the current gRPC compatibility `StatusResponse`, SHALL mean no explicit per-placement capacity observation is available
+* absent or empty Placement Capacity SHALL NOT be treated as a status-probe error
+* Placement Capacity entries SHALL report controller-observed capacity for loaded Model Placements using model reference, active request count, and max concurrency; `max_concurrency <= 0`, malformed entries, duplicate matching entries, or non-matching entries SHALL be treated as unknown capacity
+* valid per-placement capacity SHALL NOT prove endpoint eligibility when known aggregate node-level `active_request_count >= max_concurrency`
+* unknown Placement Capacity SHALL NOT prove scheduler eligibility for an already-active endpoint; `Orchard.Scheduler.MultiNode` MAY keep a matching loaded-model active candidate eligible only when exactly one valid matching Placement Capacity entry reports `active_request_count < max_concurrency`
 
 Effective readiness rules for future hosted routing:
 
@@ -798,7 +812,7 @@ Effective readiness rules for future hosted routing:
 * the node SHALL advertise matching static hosted-tool capability for the same `tool://<name>@<version>`
 * the node lifecycle state SHALL be `active`
 * node health SHALL be `healthy` or `degraded`
-* the node observation SHALL be fresh under Orchard's existing freshness thresholds
+* the Runtime Endpoint Observation SHALL be fresh under Orchard's existing freshness thresholds
 * dynamic readiness for that tool SHALL exist and have `ready = true`
 
 ### 4.7 Pool model
@@ -941,7 +955,7 @@ Admission accounting:
 
 ### 5.4 Queue model
 
-When a request cannot be granted immediately because no live node or placement capacity is available, or because the tenant active request cap is exhausted:
+When a request cannot be granted immediately because no live Runtime Endpoint, node, or placement capacity is available, or because the tenant active request cap is exhausted:
 
 * request enters tenant FIFO queue
 * max wait defaults to `3000 ms`
@@ -1105,7 +1119,7 @@ The score/bonus model above is the broader M4 scheduling contract. The current b
 Controller-side cache-affinity, safe-tokenization capable-worker preference, Phase 4D tie-only scoring, and memory-admission ranking for the bounded current implementation SHALL use the following late tie-break order among otherwise schedulable candidates in the same residency/load/health position:
 
 1. loaded model already present
-2. lower active request count for the requested placement when a valid matching `RuntimeModelPlacement` is available, otherwise lower node `active_request_count`
+2. lower active request count for the requested placement when valid matching Placement Capacity is available, otherwise lower endpoint aggregate `active_request_count`
 3. healthier node (`healthy` before `degraded`)
 4. live prefix-cache fingerprint match, only when both `cache_affinity.enabled=true` and `cache_affinity.live_fingerprint_match_enabled=true`
 5. historical cache-affinity match from recent completed placements, when cache affinity is enabled
@@ -1520,10 +1534,11 @@ The platform SHALL expose four API surfaces:
    * loopback HTTP only in degraded `plain_http_localhost` mode for local development or break-glass recovery
    * admin/tenant-admin auth
 
-4. **Internal Node/Worker API**
+4. **Runtime Endpoint and Worker Interfaces**
 
-   * controller↔node RPC
-   * gRPC over mTLS
+   * controller↔Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, and Placement Capacity
+   * current first implementation uses the gRPC Compatibility Adapter over mTLS
+   * Worker Runtime Interface remains local to the Node Agent
 
 ---
 
@@ -2053,16 +2068,37 @@ PATCH /admin/v1/observability
 
 ---
 
-### 7.5 Internal Node/Worker API
+### 7.5 Runtime Endpoint and Internal Worker Interfaces
 
-Protocol: **gRPC over HTTP/2 + TLS 1.3 + mTLS**
+Controller runtime execution SHALL use the Runtime Endpoint Interface.
+Runtime Endpoint semantics are transport-independent.
+The current gRPC/protobuf `NodeRuntimeService` is the gRPC Compatibility Adapter for the first implementation and a candidate protocol for future non-BEAM adapters.
+First-party Orchard Controller and Node Agent services MAY later use BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
+Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
+External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
+Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling history, request state, and operator-visible status.
+BEAM Distribution MUST NOT be treated as durable cluster truth.
 
-Required ports:
+Definitions:
+
+* **Runtime Endpoint**: the scheduler-selected execution boundary that can receive model runtime work from the Controller.
+* **Runtime Endpoint Interface**: the Controller-facing operations and observations for status, model readiness, model unloading, inference execution, cancellation, prefix-cache scoring, runtime telemetry, Placement Capacity, and streaming events.
+* **Runtime Endpoint Observation**: a durable Controller-recorded snapshot of endpoint status, capability, availability, placement, and capacity signals.
+* **Runtime Endpoint Availability**: the scheduler-facing availability of a Runtime Endpoint for new work, independent of whether the endpoint is backed by an Orchard-managed Node, external compute, or a provider integration.
+* **Placement Capacity**: a Runtime Endpoint Observation for a Model Placement that reports the model reference, active request count, and max concurrency.
+* **Worker Runtime**: the Node Agent-local process/protocol boundary for Python, MLX, and future non-BEAM model execution.
+* **gRPC Compatibility Adapter**: the adapter that maps Runtime Endpoint Interface semantics to and from `proto/cluster/v1` and `NodeRuntimeService`.
+
+Compatibility protocol: **gRPC over HTTP/2 + TLS 1.3 + mTLS**
+
+Compatibility ports:
 
 * controller gRPC ingress: `8444`
 * node agent gRPC ingress: `9444`
 
 #### 7.5.1 Controller-side service
+
+Controller-side node lifecycle RPC remains a first-party management surface while Runtime Endpoint execution moves behind the Runtime Endpoint Interface.
 
 ```proto
 service ClusterMembershipService {
@@ -2074,6 +2110,9 @@ service ClusterMembershipService {
 ```
 
 #### 7.5.2 Node-side service
+
+`NodeRuntimeService` is the current gRPC Compatibility Adapter service for Runtime Endpoint operations.
+The Controller domain code SHALL depend on Runtime Endpoint Interface semantics rather than generated protobuf request or response types.
 
 ```proto
 service NodeRuntimeService {
@@ -2088,6 +2127,9 @@ service NodeRuntimeService {
 ```
 
 #### 7.5.2a Worker-side service (node-agent ↔ worker)
+
+The Worker Runtime Interface remains Node Agent-local.
+The Controller communicates with the Runtime Endpoint, not directly with Worker Runtime subprocesses.
 
 ```proto
 service WorkerRuntimeService {
@@ -2363,9 +2405,10 @@ Runtime memory-budget wire semantics:
 * `estimated_headroom_bytes` SHALL NOT be used as a threshold, continuous score, request-rejection input, or operator-tunable memory admission knob in this slice
 * scheduler memory eligibility SHALL continue to use the scheduler/model/node inputs defined elsewhere in this spec; Phase 4E promotes only the hard-coded `status_code = ok` plus `headroom_available = true` case to a non-excluding scheduler-ranking preference
 
-Runtime prefix-cache wire semantics:
+Runtime prefix-cache observation semantics:
 
-* `StatusResponse.runtime_prefix_cache_statuses` SHALL report observe-only aggregate prefix-cache snapshots for loaded runtime/model paths through the existing `GetStatus` probe
+* Runtime Endpoint Observations SHALL report observe-only aggregate prefix-cache snapshots for loaded runtime/model paths
+* the current gRPC Compatibility Adapter maps those observations to and from `StatusResponse.runtime_prefix_cache_statuses` through the existing `GetStatus` probe
 * `prefix_cache_scoring.ranking_mode` defaults to `:observe_only`; in observe-only mode Orchard MAY issue a bounded `ScorePrefixCache` RPC only for the already-selected candidate, after ranking, and at most once per request
 * when `prefix_cache_scoring.ranking_mode = :tie_only`, Orchard MAY additionally score only the challenger in the leading rank-equivalence group (equal on current ranking elements except final deterministic `node_id`, including any enabled safe-tokenization capable-worker preference), with total scored candidates capped at 2 per request (incumbent + challenger)
 * tie-only mode SHALL NOT introduce top-N scoring, all-candidate scoring, prompt-byte fan-out, token-ID fan-out, or parallel score fan-out
@@ -2386,16 +2429,17 @@ Runtime prefix-cache wire semantics:
 * in `:tie_only` mode, score MAY affect ranking only as a bounded conditional step before final deterministic `node_id`, only for the leading rank-equivalence group (all current ranking elements equal except `node_id`, including any enabled safe-tokenization capable-worker preference), and only when an authoritative resident challenger (`status_code = "ok"`, `resident_fingerprint_match = true`, `score_tier = "resident_fingerprint"`) is compared against a comparable `ok` non-resident incumbent (`status_code = "ok"`, `resident_fingerprint_match = false`, `score_tier` is `"no_match"` or `"recent_fingerprint_only"`)
 * in `:tie_only` mode, deterministic `node_id` ordering remains the fallback whenever promotion conditions are not met; any non-`ok`, timeout, `UNIMPLEMENTED`/`unsupported_version`, missing, malformed, or transport-failure score outcome for either incumbent or challenger SHALL preserve base order fail-open and SHALL never be surfaced as tenant-facing request errors
 
-Runtime capacity wire semantics:
+Runtime capacity and Placement Capacity observation semantics:
 
 * `WorkerStatusResponse.active_request_count` SHALL report active `Generate` calls in that worker process
 * `WorkerStatusResponse.max_concurrency` SHALL report the worker's effective overlapping `Generate` capacity; omitted or zero values SHALL be treated as worker capacity `1` by the node agent
 * `StatusResponse.active_request_count` SHALL report aggregate active runtime requests across all loaded models on the node
 * `StatusResponse.max_concurrency` SHALL report the aggregate runtime request capacity that the node agent will enforce across loaded models
 * omitted or zero `StatusResponse.max_concurrency` SHALL mean aggregate capacity is unknown or legacy; schedulers SHALL treat it conservatively as node capacity `1`
-* `StatusResponse.runtime_model_placements` SHALL report active request count and max concurrency for each loaded runtime/model path through the existing `GetStatus` probe
-* omitted or empty `runtime_model_placements` SHALL mean no explicit per-placement capacity observation is available
-* omitted or empty `runtime_model_placements` SHALL NOT be treated as a node status error, readiness failure, admission failure, model-admission failure, or scheduler-eligibility failure for otherwise idle candidates
+* Runtime Endpoint Observations SHALL report active request count and max concurrency for each loaded runtime/model path as Placement Capacity
+* the current gRPC Compatibility Adapter maps Placement Capacity to and from `StatusResponse.runtime_model_placements` through the existing `GetStatus` probe
+* omitted or empty Placement Capacity SHALL mean no explicit per-placement capacity observation is available
+* omitted or empty Placement Capacity SHALL NOT be treated as an endpoint status error, readiness failure, admission failure, model-admission failure, or scheduler-eligibility failure for otherwise idle candidates
 * a matching placement capacity observation is valid only when exactly one entry matches the requested `model_ref`, `active_request_count >= 0`, and `max_concurrency > 0`
 * duplicate matching entries, malformed matching entries, non-matching entries, or `max_concurrency <= 0` SHALL make placement capacity unknown for that request
 * a valid matching placement observation SHALL NOT override exhausted node-level aggregate capacity

--- a/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
@@ -1,7 +1,9 @@
 defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
   @moduledoc """
-  Real gRPC client for controller → node-agent dispatch over the
-  `NodeRuntimeService` contract.
+  Low-level gRPC transport client for the `NodeRuntimeService` compatibility protocol.
+
+  Controller code should prefer `Orchard.RuntimeEndpoint.Client` implementations
+  for transport-independent runtime operations.
   """
 
   alias Orchard.Cluster.V1.{
@@ -15,7 +17,8 @@ defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
     ScorePrefixCacheRequest,
     ScorePrefixCacheResponse,
     StatusRequest,
-    StatusResponse
+    StatusResponse,
+    UnloadModelRequest
   }
 
   alias Orchard.InferenceEvent
@@ -74,6 +77,18 @@ defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
 
     case NodeRuntimeService.Stub.ensure_model_loaded(channel, request, timeout: timeout) do
       {:ok, %EnsureModelLoadedResponse{} = response} -> {:ok, response}
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
+  @doc "Ask the node-agent to unload a model."
+  @spec unload_model(GRPC.Channel.t(), UnloadModelRequest.t(), keyword()) ::
+          {:ok, Ack.t()} | {:error, term()}
+  def unload_model(channel, %UnloadModelRequest{} = request, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, @rpc_timeout_ms)
+
+    case NodeRuntimeService.Stub.unload_model(channel, request, timeout: timeout) do
+      {:ok, %Ack{} = response} -> {:ok, response}
       {:error, reason} -> {:error, normalize_error(reason)}
     end
   end

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -223,7 +223,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       {:ok, channel} ->
         dispatch_with_channel(Map.put(context, :channel, channel))
 
-      {:error, {:connect_failed, _reason} = reason} ->
+      {:error, reason} ->
         handle_dispatch_connect_failure(target, reason, context.metrics)
     end
   end

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -20,14 +20,13 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   alias Orchard.Cluster.V1.{
     EnsureModelLoadedRequest,
-    EnsureModelLoadedResponse,
     ExecuteInferenceRequest
   }
 
-  alias Orchard.Dispatch.GrpcNodeRuntimeClient, as: DefaultClient
   alias Orchard.Inference
   alias Orchard.Inference.ModelLoadFailure
   alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.{GrpcCompatibilityMapper, Observation, Operation, Target}
   alias Orchard.SentryContext
   alias Orchard.Tokenizer.Telemetry
 
@@ -152,7 +151,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
                            Called when the pre-dispatch status probe discovers a
                            valid node UUID. Synchronous, lightweight, observational only.
                            Exceptions and exits are logged and ignored; return value is ignored.
-  - `:client_impl` - gRPC client module (default: `GrpcNodeRuntimeClient`)
+  - `:client_impl` - Runtime Endpoint client module
+                     (default: `Inference.runtime_endpoint_client/0`)
 
   Returns `{:ok, events}` with the list of all events received (including terminal),
   or `{:error, reason}` if dispatch fails before streaming begins.
@@ -169,14 +169,14 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         %EnsureModelLoadedRequest{} = model_load_request,
         opts \\ []
       ) do
-    target = Map.fetch!(schedule, :runtime_client_target)
+    target = runtime_endpoint_target(schedule)
     request_id = Map.fetch!(schedule, :request_id)
     timeout_ms = Map.fetch!(schedule, :request_timeout_ms)
     model_load_timeout = Map.get(schedule, :model_load_timeout_ms, 120_000)
     caller = Keyword.get(opts, :caller, self())
     event_handler = Keyword.get(opts, :event_handler)
     on_node_resolved = Keyword.get(opts, :on_node_resolved)
-    client = Keyword.get(opts, :client_impl, DefaultClient)
+    client = Keyword.get(opts, :client_impl, Inference.runtime_endpoint_client())
 
     # Initialize timing metrics
     metrics =
@@ -352,9 +352,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     case client.status(channel, timeout: @status_probe_timeout_ms) do
       {:ok, response} ->
         observed_at = DateTime.utc_now()
+        observation = normalize_status_observation(target, response)
 
         {resolved_node_id, model_load_request, metrics} =
-          case extract_node_id(response) do
+          case extract_node_id(observation) do
             {:ok, node_id} ->
               metrics = %{metrics | node_id: node_id}
               put_node_resolved_context(metrics, target)
@@ -365,7 +366,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
           end
 
         try do
-          Orchard.Nodes.observe_status(target, response, observed_at)
+          Orchard.Nodes.observe_status(observation_target(target), observation, observed_at)
         rescue
           error ->
             Logger.warning("Node observation failed during dispatch probe: #{inspect(error)}")
@@ -389,7 +390,13 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       {model_load_request, metrics}
   end
 
-  defp extract_node_id(%{node_metadata: %{node_id: node_id}}) when is_binary(node_id) do
+  defp extract_node_id(%Observation{} = observation) do
+    observation
+    |> Observation.node_id()
+    |> extract_node_id()
+  end
+
+  defp extract_node_id(node_id) when is_binary(node_id) do
     Ecto.UUID.cast(node_id)
   end
 
@@ -408,8 +415,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp do_ensure_model_loaded(client, channel, target, request, timeout_ms) do
-    case client.ensure_model_loaded(channel, request, timeout: timeout_ms) do
-      {:ok, %EnsureModelLoadedResponse{} = response} ->
+    case client.ensure_model_loaded(channel, ensure_model_loaded_operation(request),
+           timeout: timeout_ms
+         ) do
+      {:ok, %Operation.EnsureModelLoadedResult{} = response} ->
         case normalize_placement_state(response.placement_state) do
           :loaded ->
             {:ok,
@@ -419,7 +428,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
              }}
 
           :failed ->
-            {:error, ModelLoadFailure.from_response(response)}
+            {:error, ModelLoadFailure.from_result(response)}
 
           {:unexpected, placement_state} ->
             {:error,
@@ -451,7 +460,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   # supports_prompt_token_ids persisted under Nodes capabilities is observational
   # inventory from status probes and must not be used as dispatch eligibility
-  # authority. EnsureModelLoadedResponse is the authoritative capability gate.
+  # authority. The Runtime Endpoint ensure-model-loaded result is the
+  # authoritative capability gate.
   defp gate_prompt_token_ids(request, ensure_result, schedule, model_load_request) do
     mode = Inference.tokenizer_safe_mode()
     prompt_token_ids = request.prompt_token_ids || []
@@ -515,8 +525,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   defp normalize_placement_state(:PLACEMENT_STATE_LOADED), do: :loaded
   defp normalize_placement_state(7), do: :loaded
+  defp normalize_placement_state(:loaded), do: :loaded
   defp normalize_placement_state(:PLACEMENT_STATE_FAILED), do: :failed
   defp normalize_placement_state(10), do: :failed
+  defp normalize_placement_state(:failed), do: :failed
   defp normalize_placement_state(other), do: {:unexpected, other}
 
   defp do_execute_and_stream(
@@ -532,12 +544,14 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     caller_ref = Process.monitor(caller)
     timer_ref = start_timeout_timer(timeout_ms)
 
-    {:ok, task_ref} = client.execute_inference(channel, request, owner: self())
+    execute_request = execute_operation(request)
+    {:ok, task_ref} = client.execute_inference(channel, execute_request, owner: self())
 
     loop_ctx = %{
       caller_ref: caller_ref,
       channel: channel,
       client: client,
+      controller_session_id: execute_request.controller_session_id,
       event_handler: event_handler,
       metrics: metrics,
       target: target,
@@ -566,7 +580,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     request_id = metrics.request_id
 
     receive do
-      {:dispatch_event, ^task_ref, ^request_id, %InferenceEvent{} = event} ->
+      {:runtime_endpoint_event, ^task_ref, ^request_id, %InferenceEvent{} = event} ->
         handler_result = emit_event(event, request_id, event_handler)
         events = [event | events]
         metrics = update_metrics_for_event(metrics, event)
@@ -577,7 +591,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
           cancelled_by_handler?(handler_result) ->
             put_cancel_sent_context(metrics, :client_disconnect)
-            _ = client.cancel_inference(channel, request_id)
+            _ = cancel_inference(client, channel, request_id, loop_ctx.controller_session_id)
 
             drain_until_terminal_or_done(
               %{loop_ctx | metrics: metrics},
@@ -589,10 +603,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
             receive_loop(%{loop_ctx | metrics: metrics}, events)
         end
 
-      {:dispatch_done, ^task_ref, :ok} ->
+      {:runtime_endpoint_done, ^task_ref, :ok} ->
         {:ok, Enum.reverse(events), metrics}
 
-      {:dispatch_done, ^task_ref, {:error, reason}} ->
+      {:runtime_endpoint_done, ^task_ref, {:error, reason}} ->
         mark_transport_failure(target, reason)
 
         if events == [] do
@@ -618,12 +632,12 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
       {:dispatch_timeout, ^timer_ref} ->
         put_cancel_sent_context(metrics, :timeout)
-        _ = client.cancel_inference(channel, request_id)
+        _ = cancel_inference(client, channel, request_id, loop_ctx.controller_session_id)
         drain_until_terminal_or_done(%{loop_ctx | metrics: metrics}, events, :timeout)
 
       {:DOWN, ^caller_ref, :process, _pid, _reason} ->
         put_cancel_sent_context(metrics, :caller_disconnect)
-        _ = client.cancel_inference(channel, request_id)
+        _ = cancel_inference(client, channel, request_id, loop_ctx.controller_session_id)
         drain_until_terminal_or_done(%{loop_ctx | metrics: metrics}, events, :caller_disconnect)
     end
   end
@@ -635,7 +649,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     request_id = metrics.request_id
 
     receive do
-      {:dispatch_event, ^task_ref, ^request_id, %InferenceEvent{} = event} ->
+      {:runtime_endpoint_event, ^task_ref, ^request_id, %InferenceEvent{} = event} ->
         emit_event(event, request_id, event_handler)
         events = [event | events]
         metrics = update_metrics_for_event(metrics, event)
@@ -646,7 +660,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
           drain_until_terminal_or_done(%{loop_ctx | metrics: metrics}, events, cancel_reason)
         end
 
-      {:dispatch_done, ^task_ref, _result} ->
+      {:runtime_endpoint_done, ^task_ref, _result} ->
         # Stream ended without a terminal event after cancel.
         # Synthesize a terminal event so the caller always gets one.
         timeout_event =
@@ -832,9 +846,74 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     |> compact_nil_values()
   end
 
+  defp target_host(%Target{transport: :grpc_compat, address: address}), do: target_host(address)
   defp target_host(target) when is_list(target), do: Keyword.get(target, :host)
   defp target_host(%{} = target), do: Map.get(target, :host) || Map.get(target, "host")
   defp target_host(_target), do: nil
+
+  defp runtime_endpoint_target(schedule) do
+    case Map.get(schedule, :runtime_endpoint_target) do
+      %Target{} = target ->
+        target
+
+      nil ->
+        schedule
+        |> Map.fetch!(:runtime_client_target)
+        |> Target.grpc_compat()
+    end
+  end
+
+  defp observation_target(%Target{transport: :grpc_compat, address: address}), do: address
+  defp observation_target(target), do: target
+
+  defp normalize_status_observation(_target, %Observation{} = observation), do: observation
+
+  defp normalize_status_observation(target, %{} = status_response) do
+    GrpcCompatibilityMapper.observation_from_status(target, status_response)
+  end
+
+  defp ensure_model_loaded_operation(%EnsureModelLoadedRequest{} = request) do
+    Operation.EnsureModelLoadedRequest.new!(
+      node_id: blank_to_nil(request.node_id),
+      model_ref: %{model_id: request.model_id, version: request.version},
+      artifact_sha256: blank_to_nil(request.artifact_sha256),
+      preload: request.preload,
+      deadline_unix_ms: zero_to_nil(request.deadline_unix_ms),
+      artifact_source_uri: blank_to_nil(request.artifact_source_uri)
+    )
+  end
+
+  defp execute_operation(%ExecuteInferenceRequest{} = request) do
+    Operation.ExecuteRequest.new!(
+      request_id: request.request_id,
+      controller_session_id: request.controller_session_id,
+      model_ref: %{model_id: request.model_id, version: request.version},
+      rendered_prompt_utf8: request.rendered_prompt_utf8,
+      input_tokens: request.input_tokens,
+      params: request.params || %{},
+      deadline_unix_ms: zero_to_nil(request.deadline_unix_ms),
+      metadata_json: request.metadata_json || "{}",
+      cache_affinity_fingerprint: blank_to_nil(request.cache_affinity_fingerprint),
+      prompt_token_ids: request.prompt_token_ids || []
+    )
+  end
+
+  defp cancel_inference(client, channel, request_id, controller_session_id) do
+    client.cancel_inference(
+      channel,
+      Operation.CancelRequest.new!(
+        request_id: request_id,
+        controller_session_id: controller_session_id
+      )
+    )
+  end
+
+  defp blank_to_nil(value) when value in [nil, ""], do: nil
+  defp blank_to_nil(value), do: value
+
+  defp zero_to_nil(0), do: nil
+  defp zero_to_nil(nil), do: nil
+  defp zero_to_nil(value), do: value
 
   defp compact_nil_values(map) do
     Map.reject(map, fn {_key, value} -> is_nil(value) end)

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -131,16 +131,17 @@ defmodule Orchard.Dispatch.RequestDispatcher do
              {:model_load_failed, ModelLoadFailure.t()} | {:dispatch_failed, term()} | term()}
 
   @doc """
-  Dispatch an inference request to a node and stream events back to the caller.
+  Dispatch an inference request to a Runtime Endpoint and stream events back to the caller.
 
   `schedule` is the map returned by the configured scheduler containing:
-  - `:runtime_client_target` - `[host: ..., port: ...]` for the node-agent
+  - `:runtime_endpoint_target` - typed Runtime Endpoint target for new schedulers
+  - `:runtime_client_target` - legacy `[host: ..., port: ...]` gRPC compatibility target
   - `:request_id` - the canonical request ID
   - `:request_timeout_ms` - maximum wall-clock time for the entire dispatch
 
-  `execute_request` is the protobuf `ExecuteInferenceRequest` to send.
+  `execute_request` is the protobuf compatibility `ExecuteInferenceRequest` to map into a Runtime Endpoint operation.
 
-  `model_load_request` is the protobuf `EnsureModelLoadedRequest` to send.
+  `model_load_request` is the protobuf compatibility `EnsureModelLoadedRequest` to map into a Runtime Endpoint operation.
 
   Options:
   - `:caller` - PID to monitor for disconnect (default: `self()`)

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -904,7 +904,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       Operation.CancelRequest.new!(
         request_id: request_id,
         controller_session_id: controller_session_id
-      )
+      ),
+      []
     )
   end
 

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -7,6 +7,7 @@ defmodule Orchard.Inference do
 
   alias Orchard.Inference.{CacheAffinity, QueueManager}
   alias Orchard.Requests.Supervisor, as: RequestsSupervisor
+  alias Orchard.RuntimeEndpoint.Target
 
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(init_arg \\ []) do
@@ -211,6 +212,19 @@ defmodule Orchard.Inference do
     end
   end
 
+  @spec runtime_endpoint_client() :: module()
+  def runtime_endpoint_client do
+    config()[:runtime_endpoint_client_impl] || Orchard.RuntimeEndpoint.GrpcCompatibilityClient
+  end
+
+  @spec runtime_endpoint_targets() :: [Target.t()]
+  def runtime_endpoint_targets do
+    runtime_client_targets()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&runtime_endpoint_target/1)
+    |> Enum.uniq_by(& &1.id)
+  end
+
   @spec request_timeout_ms() :: pos_integer() | nil
   def request_timeout_ms, do: config()[:request_timeout_ms]
 
@@ -250,4 +264,7 @@ defmodule Orchard.Inference do
       {Keyword.get(target, :host), Keyword.get(target, :port)}
     end)
   end
+
+  defp runtime_endpoint_target(%Target{} = target), do: target
+  defp runtime_endpoint_target(target), do: Target.grpc_compat(target)
 end

--- a/apps/orchard_controller/lib/orchard/inference/model_load_failure.ex
+++ b/apps/orchard_controller/lib/orchard/inference/model_load_failure.ex
@@ -2,17 +2,20 @@ defmodule Orchard.Inference.ModelLoadFailure do
   @moduledoc """
   Controller-side model load failure normalization and API mapping.
 
-  Converts `EnsureModelLoadedResponse` proto failure fields and transport-level
-  gRPC errors into a structured failure value used by the orchestrator and API
+  Converts Runtime Endpoint ensure-model-loaded results, legacy
+  `EnsureModelLoadedResponse` proto failure fields, and transport-level errors
+  into a structured failure value used by the orchestrator and API
   layer for HTTP status selection, SSE error envelopes, and persistence.
 
   This module operates at the controller boundary — it never sees raw node-agent
   error reasons. It normalizes only:
+  - Runtime Endpoint result fields (`failure_category`, `failure_code`, `failure_message`)
   - Proto response fields (`failure_category`, `failure_code`, `failure_message`)
-  - Transport errors from `GrpcNodeRuntimeClient` (`:node_unavailable`, `:node_timeout`, etc.)
+  - Transport errors from Runtime Endpoint clients (`:node_unavailable`, `:node_timeout`, etc.)
   """
 
   alias Orchard.Cluster.V1.EnsureModelLoadedResponse
+  alias Orchard.RuntimeEndpoint.Operation
 
   @enforce_keys [:category, :code, :message]
   defstruct [:category, :code, :message]
@@ -52,6 +55,25 @@ defmodule Orchard.Inference.ModelLoadFailure do
     message =
       if trusted? do
         normalize_message(response.failure_message, default_message)
+      else
+        default_message
+      end
+
+    %__MODULE__{category: category, code: code, message: message}
+  end
+
+  @doc """
+  Extracts a failure struct from a Runtime Endpoint ensure-model-loaded result.
+  """
+  @spec from_result(Operation.EnsureModelLoadedResult.t()) :: t()
+  def from_result(%Operation.EnsureModelLoadedResult{} = result) do
+    {category, trusted?} = normalize_result_category(result.failure_category)
+    {default_code, default_message} = defaults_for_category(category)
+    code = normalize_code(result.failure_code, default_code)
+
+    message =
+      if trusted? do
+        normalize_message(result.failure_message, default_message)
       else
         default_message
       end
@@ -194,6 +216,19 @@ defmodule Orchard.Inference.ModelLoadFailure do
   defp normalize_category(6), do: {:internal, true}
   # UNSPECIFIED, unknown values, nil — untrusted
   defp normalize_category(_), do: {:internal, false}
+
+  defp normalize_result_category(category)
+       when category in [
+              :model_invalid,
+              :acquisition_failed,
+              :runtime_unavailable,
+              :timeout,
+              :resource_exhausted,
+              :internal
+            ],
+       do: {category, true}
+
+  defp normalize_result_category(_category), do: {:internal, false}
 
   defp normalize_code(code, default) when is_binary(code) do
     trimmed = String.trim(code)

--- a/apps/orchard_controller/lib/orchard/inference/model_load_failure.ex
+++ b/apps/orchard_controller/lib/orchard/inference/model_load_failure.ex
@@ -84,7 +84,7 @@ defmodule Orchard.Inference.ModelLoadFailure do
   @doc """
   Converts a transport-level error reason into a failure struct.
 
-  Accepts the normalized error shapes from `GrpcNodeRuntimeClient.ensure_model_loaded/3`.
+  Accepts normalized error shapes from Runtime Endpoint clients.
   """
   @spec from_transport_reason(term()) :: t()
   def from_transport_reason(:node_unavailable) do

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -752,9 +752,18 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   defp strip_scheduler_runtime_metadata(schedule) do
     schedule
+    |> strip_runtime_endpoint_metadata()
     |> strip_prefix_cache_metadata()
     |> strip_memory_admission_metadata()
   end
+
+  defp strip_runtime_endpoint_metadata(schedule) do
+    Map.reject(schedule, fn {key, _value} -> runtime_endpoint_metadata_key?(key) end)
+  end
+
+  defp runtime_endpoint_metadata_key?(:runtime_endpoint_target), do: true
+  defp runtime_endpoint_metadata_key?("runtime_endpoint_target"), do: true
+  defp runtime_endpoint_metadata_key?(_key), do: false
 
   defp strip_prefix_cache_metadata(schedule) do
     Map.reject(schedule, fn {key, _value} -> prefix_cache_metadata_key?(key) end)

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -154,16 +154,16 @@ defmodule Orchard.Nodes do
   # -- Observational Write APIs --
 
   @doc """
-  Observes a successful status response and persists the node.
+  Observes a successful Runtime Endpoint status observation and persists the node.
 
-  Normalizes metadata from a `StatusResponse` (or compatible map),
-  resolves conflicts (identity, display_name, staleness), and inserts
-  or updates the node row.
+  Normalizes metadata from a Runtime Endpoint Observation, `StatusResponse`,
+  or compatible map before resolving conflicts (identity, display_name,
+  staleness) and inserting or updating the node row.
 
   New nodes are inserted with `state: :active`. Updates preserve the
   existing `state` (admin-managed).
   Successful eligible observations also refresh source-scoped queue capacity
-  from aggregate node capacity and loaded placement statuses.
+  from aggregate endpoint capacity and loaded placement statuses.
   Fresh invalid metadata, identity conflicts, ineligible nodes, and target
   failures clear stale queue capacity sources for that node/target.
 

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -15,7 +15,7 @@ defmodule Orchard.Nodes do
   alias Orchard.Nodes.ToolCapability
   alias Orchard.Nodes.ToolReadiness
   alias Orchard.Repo
-  alias Orchard.RuntimeEndpoint.{Observation, Target}
+  alias Orchard.RuntimeEndpoint.{ModelRef, Observation, Placement, PlacementCapacity, Target}
 
   # -- Read APIs --
 
@@ -421,8 +421,8 @@ defmodule Orchard.Nodes do
         placement_source: placement_source,
         cold_source: cold_source,
         node_id: node.id,
-        node_active: non_negative_integer(map_get(status_response, :active_request_count), 0),
-        node_max: positive_integer(map_get(status_response, :max_concurrency), 1),
+        node_active: observed_node_active(status_response),
+        node_max: observed_node_max(status_response),
         placements: placement_observations(status_response),
         reserve_unassigned_node_grants?:
           Keyword.get(opts, :reserve_unassigned_node_grants?, true),
@@ -518,6 +518,12 @@ defmodule Orchard.Nodes do
 
   defp extract_runtime_model_placements(_status_response), do: []
 
+  defp placement_observations(%Observation{placements: placements}) do
+    placements
+    |> Enum.reduce(%{}, &put_runtime_endpoint_placement_observation/2)
+    |> Enum.map(fn {{model_id, version}, status} -> {model_id, version, status} end)
+  end
+
   defp placement_observations(status_response) do
     runtime_observations =
       status_response
@@ -538,6 +544,41 @@ defmodule Orchard.Nodes do
       observations
     end
   end
+
+  defp put_runtime_endpoint_placement_observation(%Placement{} = placement, observations) do
+    case runtime_endpoint_placement_ref(placement) do
+      {:ok, model_id, version} ->
+        status = runtime_endpoint_placement_status(placement)
+        Map.update(observations, {model_id, version}, status, fn _existing -> :ambiguous end)
+
+      :error ->
+        observations
+    end
+  end
+
+  defp put_runtime_endpoint_placement_observation(_placement, observations), do: observations
+
+  defp runtime_endpoint_placement_ref(%Placement{
+         model_ref: %ModelRef{model_id: model_id, version: version}
+       })
+       when is_binary(model_id) and model_id != "" and is_binary(version) and version != "",
+       do: {:ok, model_id, version}
+
+  defp runtime_endpoint_placement_ref(_placement), do: :error
+
+  defp runtime_endpoint_placement_status(%Placement{
+         state: state,
+         capacity: %PlacementCapacity{
+           status: :known,
+           active_request_count: active,
+           max_concurrency: max
+         }
+       })
+       when state in [:loaded, "loaded", :PLACEMENT_STATE_LOADED] do
+    %{active_request_count: active, max_concurrency: max}
+  end
+
+  defp runtime_endpoint_placement_status(%Placement{}), do: :unavailable
 
   defp extract_loaded_models(%{loaded_models: models}) when is_list(models), do: models
   defp extract_loaded_models(%{"loaded_models" => models}) when is_list(models), do: models
@@ -623,6 +664,18 @@ defmodule Orchard.Nodes do
       _other -> 0
     end
   end
+
+  defp observed_node_active(%Observation{aggregate_active_request_count: active}),
+    do: non_negative_integer(active, 0)
+
+  defp observed_node_active(status_response),
+    do: non_negative_integer(map_get(status_response, :active_request_count), 0)
+
+  defp observed_node_max(%Observation{aggregate_max_concurrency: max}),
+    do: positive_integer(max, 1)
+
+  defp observed_node_max(status_response),
+    do: positive_integer(map_get(status_response, :max_concurrency), 1)
 
   defp positive_integer(value, _default) when is_integer(value) and value > 0, do: value
   defp positive_integer(_value, default), do: default

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -15,6 +15,7 @@ defmodule Orchard.Nodes do
   alias Orchard.Nodes.ToolCapability
   alias Orchard.Nodes.ToolReadiness
   alias Orchard.Repo
+  alias Orchard.RuntimeEndpoint.{Observation, Target}
 
   # -- Read APIs --
 
@@ -177,7 +178,7 @@ defmodule Orchard.Nodes do
   - `:noop` when metadata is missing/invalid, repo unavailable,
     observation is stale, or an identity conflict is detected
   """
-  @spec observe_status(keyword(), map() | struct(), DateTime.t()) ::
+  @spec observe_status(keyword() | Target.t(), map() | struct(), DateTime.t()) ::
           {:ok, Node.t()} | :noop
   @spec observe_status(keyword(), map() | struct(), DateTime.t(), keyword()) ::
           {:ok, Node.t()} | :noop
@@ -237,7 +238,8 @@ defmodule Orchard.Nodes do
   - `{:ok, %Node{}}` when health was updated
   - `:noop` for non-transport reasons, unknown targets, or repo unavailable
   """
-  @spec record_transport_failure(keyword(), term(), DateTime.t()) :: {:ok, Node.t()} | :noop
+  @spec record_transport_failure(keyword() | Target.t(), term(), DateTime.t()) ::
+          {:ok, Node.t()} | :noop
   def record_transport_failure(target, reason, observed_at) do
     if transport_failure_reason?(reason) do
       case mark_target_unreachable_without_queue_cleanup(target, observed_at) do
@@ -267,7 +269,7 @@ defmodule Orchard.Nodes do
   - `{:ok, %Node{}}` on successful mark
   - `:noop` when target is unknown, stale, malformed, or repo unavailable
   """
-  @spec mark_target_unreachable(keyword(), DateTime.t()) :: {:ok, Node.t()} | :noop
+  @spec mark_target_unreachable(keyword() | Target.t(), DateTime.t()) :: {:ok, Node.t()} | :noop
   def mark_target_unreachable(target, observed_at) do
     case mark_target_unreachable_without_queue_cleanup(target, observed_at) do
       {:ok, %Node{} = node} = result ->
@@ -293,6 +295,7 @@ defmodule Orchard.Nodes do
   # -- Observation Normalization --
 
   defp normalize_observation(target, status_response, observed_at) do
+    target = target_address(target)
     metadata = extract_metadata(status_response)
 
     with {:metadata, %{} = meta} <- {:metadata, metadata},
@@ -328,10 +331,15 @@ defmodule Orchard.Nodes do
   defp extract_metadata(%{node_metadata: meta}), do: meta
   defp extract_metadata(%{"node_metadata" => nil}), do: nil
   defp extract_metadata(%{"node_metadata" => meta}), do: meta
+
+  defp extract_metadata(%Observation{metadata: metadata}) when is_map(metadata),
+    do: observation_metadata(metadata)
+
   defp extract_metadata(_), do: nil
 
   defp extract_runtime_health(%{runtime_health: health}), do: health
   defp extract_runtime_health(%{"runtime_health" => health}), do: health
+  defp extract_runtime_health(%Observation{health: health}) when is_map(health), do: health
   defp extract_runtime_health(_), do: nil
 
   defp resolve_display_name(meta) do
@@ -840,6 +848,7 @@ defmodule Orchard.Nodes do
   end
 
   defp validate_target(target) do
+    target = target_address(target)
     host = Keyword.get(target, :host)
     port = Keyword.get(target, :port)
 
@@ -850,10 +859,12 @@ defmodule Orchard.Nodes do
     end
   end
 
-  defp target_host(target), do: Keyword.get(target, :host, "")
-  defp target_port(target), do: Keyword.get(target, :port)
+  defp target_host(target), do: target |> target_address() |> Keyword.get(:host, "")
+  defp target_port(target), do: target |> target_address() |> Keyword.get(:port)
 
   defp connect_host(target) do
+    target = target_address(target)
+
     case Keyword.get(target, :host) do
       host when is_binary(host) and host != "" -> host
       _other -> nil
@@ -861,6 +872,8 @@ defmodule Orchard.Nodes do
   end
 
   defp connect_port(target) do
+    target = target_address(target)
+
     case Keyword.get(target, :port) do
       port when is_integer(port) and port in 1..65_535 -> port
       _other -> nil
@@ -931,6 +944,25 @@ defmodule Orchard.Nodes do
 
   defp non_empty?(value), do: is_binary(value) and value != ""
   defp non_empty_or(value, fallback), do: if(non_empty?(value), do: value, else: fallback)
+
+  defp observation_metadata(metadata) do
+    %{
+      node_id: metadata_value(metadata, :node_id),
+      display_name: metadata_value(metadata, :display_name),
+      hostname: metadata_value(metadata, :hostname),
+      agent_version: metadata_value(metadata, :agent_version),
+      listen_host: metadata_value(metadata, :listen_host),
+      listen_port: metadata_value(metadata, :listen_port),
+      worker_backend: metadata_value(metadata, :worker_backend)
+    }
+  end
+
+  defp metadata_value(metadata, key) do
+    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
+  end
+
+  defp target_address(%Target{transport: :grpc_compat, address: address}), do: address
+  defp target_address(target), do: target
 
   defp valid_connect_target?(host, port), do: non_empty?(host) and is_integer(port)
 

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -414,7 +414,8 @@ defmodule Orchard.Nodes do
     placement_source = {:node, node.id, :placement}
     cold_source = {:node, node.id, :cold}
 
-    if queue_capacity_eligible_node?(node) do
+    if queue_capacity_eligible_node?(node) and
+         queue_capacity_eligible_observation?(status_response) do
       queue_manager.refresh_node_capacity_sources(%{
         clear_sources: node_queue_capacity_sources(node),
         node_source: {:node, node.id},
@@ -508,6 +509,11 @@ defmodule Orchard.Nodes do
        do: true
 
   defp queue_capacity_eligible_node?(%Node{}), do: false
+
+  defp queue_capacity_eligible_observation?(%Observation{availability: availability}),
+    do: availability in [:available, :degraded]
+
+  defp queue_capacity_eligible_observation?(_status_response), do: true
 
   defp node_queue_capacity_sources(%Node{} = node),
     do: [{:node, node.id}, {:node, node.id, :placement}, {:node, node.id, :cold}]

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_config.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_config.ex
@@ -1,0 +1,149 @@
+defmodule Orchard.RuntimeEndpoint.BeamConfig do
+  @moduledoc """
+  Guardrail validation for future first-party BEAM Runtime Endpoint transport.
+  """
+
+  defstruct enabled: false,
+            node_name: nil,
+            cookie_file: nil,
+            listen_host: nil,
+            admitted_services: [],
+            allowed_cidrs: []
+
+  @type t :: %__MODULE__{
+          enabled: boolean(),
+          node_name: String.t() | nil,
+          cookie_file: String.t() | nil,
+          listen_host: String.t() | nil,
+          admitted_services: [String.t()],
+          allowed_cidrs: [String.t()]
+        }
+
+  @type error ::
+          :beam_distribution_disabled
+          | {:invalid_beam_distribution_config, [atom()]}
+
+  @spec config() :: keyword()
+  def config do
+    :orchard_controller
+    |> Application.get_env(:runtime_endpoint, [])
+    |> Keyword.get(:beam, [])
+  end
+
+  @spec validate(keyword() | map(), atom()) :: {:ok, t()} | {:error, error()}
+  def validate(config \\ config(), env \\ runtime_env()) do
+    attrs = attrs_map(config)
+
+    if enabled?(attrs) do
+      validate_enabled_attrs(attrs, env)
+    else
+      {:ok, %__MODULE__{enabled: false}}
+    end
+  end
+
+  @spec validate_enabled(keyword() | map(), atom()) :: {:ok, t()} | {:error, error()}
+  def validate_enabled(config \\ config(), env \\ runtime_env()) do
+    attrs = attrs_map(config)
+
+    if enabled?(attrs) do
+      validate_enabled_attrs(attrs, env)
+    else
+      {:error, :beam_distribution_disabled}
+    end
+  end
+
+  defp validate_enabled_attrs(attrs, _env) do
+    errors =
+      []
+      |> require_non_empty(attrs, :node_name, :missing_node_name)
+      |> require_non_empty(attrs, :cookie_file, :missing_cookie_file)
+      |> require_restricted_list(attrs, :admitted_services, :missing_admitted_services)
+      |> require_restricted_list(attrs, :allowed_cidrs, :missing_allowed_cidrs)
+      |> require_list_without_global_cidrs(attrs, :allowed_cidrs)
+      |> require_restricted_listen_host(attrs)
+
+    case errors do
+      [] -> {:ok, struct_from_attrs(attrs)}
+      _ -> {:error, {:invalid_beam_distribution_config, Enum.reverse(errors)}}
+    end
+  end
+
+  defp struct_from_attrs(attrs) do
+    %__MODULE__{
+      enabled: true,
+      node_name: string_value(attrs, :node_name),
+      cookie_file: string_value(attrs, :cookie_file),
+      listen_host: string_value(attrs, :listen_host),
+      admitted_services: list_value(attrs, :admitted_services),
+      allowed_cidrs: list_value(attrs, :allowed_cidrs)
+    }
+  end
+
+  defp require_non_empty(errors, attrs, key, error) do
+    if non_empty_string?(value(attrs, key)), do: errors, else: [error | errors]
+  end
+
+  defp require_restricted_list(errors, attrs, key, error) do
+    values = list_value(attrs, key)
+
+    if values != [] and Enum.all?(values, &non_empty_string?/1) do
+      errors
+    else
+      [error | errors]
+    end
+  end
+
+  defp require_list_without_global_cidrs(errors, attrs, key) do
+    cidrs = list_value(attrs, key)
+
+    if Enum.any?(cidrs, &(&1 in ["0.0.0.0/0", "::/0"])) do
+      [:global_beam_distribution_cidr | errors]
+    else
+      errors
+    end
+  end
+
+  defp require_restricted_listen_host(errors, attrs) do
+    case value(attrs, :listen_host) do
+      host when host in ["0.0.0.0", "::"] -> [:unrestricted_listen_host | errors]
+      host when is_binary(host) and host != "" -> errors
+      _ -> [:missing_listen_host | errors]
+    end
+  end
+
+  defp attrs_map(attrs) when is_list(attrs), do: Map.new(attrs)
+  defp attrs_map(%{} = attrs), do: attrs
+
+  defp enabled?(attrs), do: value(attrs, :enabled) == true
+
+  defp string_value(attrs, key) do
+    case value(attrs, key) do
+      value when is_binary(value) -> value
+      _ -> nil
+    end
+  end
+
+  defp list_value(attrs, key) do
+    case value(attrs, key) do
+      values when is_list(values) -> values
+      nil -> []
+      value -> [value]
+    end
+  end
+
+  defp value(attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
+
+  defp non_empty_string?(value), do: is_binary(value) and value != ""
+
+  defp runtime_env do
+    if Code.ensure_loaded?(Mix), do: Mix.env(), else: :prod
+  end
+end

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/client.ex
@@ -1,0 +1,41 @@
+defmodule Orchard.RuntimeEndpoint.Client do
+  @moduledoc """
+  Controller-facing Runtime Endpoint client behavior.
+
+  Implementations may use gRPC, BEAM Distribution, or another transport.
+  Callers exchange transport-independent Runtime Endpoint domain structs.
+
+  Streaming implementations send messages to the process in `:owner`:
+
+    * `{:runtime_endpoint_event, stream_ref, request_id, event}`
+    * `{:runtime_endpoint_done, stream_ref, :ok | {:error, reason}}`
+  """
+
+  alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.{Observation, Operation, Target}
+
+  @type connection :: term()
+  @type stream_ref :: reference()
+
+  @callback connect(Target.t() | keyword()) :: {:ok, connection()} | {:error, term()}
+  @callback disconnect(connection()) :: :ok
+  @callback status(connection(), keyword()) :: {:ok, Observation.t()} | {:error, term()}
+  @callback ensure_model_loaded(connection(), Operation.EnsureModelLoadedRequest.t(), keyword()) ::
+              {:ok, Operation.EnsureModelLoadedResult.t()} | {:error, term()}
+  @callback unload_model(connection(), Operation.UnloadModelRequest.t(), keyword()) ::
+              {:ok, Operation.Ack.t()} | {:error, term()}
+  @callback execute_inference(connection(), Operation.ExecuteRequest.t(), keyword()) ::
+              {:ok, stream_ref()}
+  @callback cancel_inference(connection(), Operation.CancelRequest.t(), keyword()) ::
+              :ok | {:error, term()}
+  @callback score_prefix_cache(
+              Target.t() | connection(),
+              Operation.PrefixCacheScoreRequest.t(),
+              keyword()
+            ) ::
+              {:ok, Operation.PrefixCacheScoreResult.t()} | {:error, term()}
+
+  @type stream_event_message ::
+          {:runtime_endpoint_event, stream_ref(), String.t(), InferenceEvent.t()}
+  @type stream_done_message :: {:runtime_endpoint_done, stream_ref(), :ok | {:error, term()}}
+end

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_client.ex
@@ -20,6 +20,8 @@ defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityClient do
     end
   end
 
+  def connect(%Target{} = target), do: {:error, {:unsupported_transport, target.transport}}
+
   def connect(target) when is_list(target) or is_map(target) do
     target
     |> GrpcCompatibilityMapper.normalize_target()

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_client.ex
@@ -1,0 +1,150 @@
+defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityClient do
+  @moduledoc """
+  Runtime Endpoint client backed by the gRPC `NodeRuntimeService` compatibility protocol.
+  """
+
+  @behaviour Orchard.RuntimeEndpoint.Client
+
+  alias Orchard.Cluster.V1.ScorePrefixCacheRequest
+  alias Orchard.Dispatch.GrpcNodeRuntimeClient, as: TransportClient
+  alias Orchard.RuntimeEndpoint.{GrpcCompatibilityMapper, Operation, Target}
+
+  defstruct [:channel, :target]
+
+  @type t :: %__MODULE__{channel: GRPC.Channel.t(), target: Target.t()}
+
+  @impl true
+  def connect(%Target{transport: :grpc_compat} = target) do
+    with {:ok, channel} <- TransportClient.connect(target.address) do
+      {:ok, %__MODULE__{channel: channel, target: target}}
+    end
+  end
+
+  def connect(target) when is_list(target) or is_map(target) do
+    target
+    |> GrpcCompatibilityMapper.normalize_target()
+    |> connect()
+  end
+
+  @impl true
+  def disconnect(%__MODULE__{channel: channel}) do
+    TransportClient.disconnect(channel)
+  end
+
+  @impl true
+  def status(%__MODULE__{channel: channel, target: target}, opts \\ []) do
+    with {:ok, response} <- TransportClient.status(channel, opts) do
+      {:ok, GrpcCompatibilityMapper.observation_from_status(target, response)}
+    end
+  end
+
+  @impl true
+  def ensure_model_loaded(
+        %__MODULE__{channel: channel},
+        %Operation.EnsureModelLoadedRequest{} = request,
+        opts \\ []
+      ) do
+    request = GrpcCompatibilityMapper.ensure_model_loaded_request_to_proto(request)
+
+    with {:ok, response} <- TransportClient.ensure_model_loaded(channel, request, opts) do
+      {:ok, GrpcCompatibilityMapper.ensure_model_loaded_result_from_response(response)}
+    end
+  end
+
+  @impl true
+  def unload_model(
+        %__MODULE__{channel: channel},
+        %Operation.UnloadModelRequest{} = request,
+        opts \\ []
+      ) do
+    request = GrpcCompatibilityMapper.unload_model_request_to_proto(request)
+
+    with {:ok, response} <- TransportClient.unload_model(channel, request, opts) do
+      {:ok, GrpcCompatibilityMapper.ack_from_response(response)}
+    end
+  end
+
+  @impl true
+  def execute_inference(
+        %__MODULE__{channel: channel},
+        %Operation.ExecuteRequest{} = request,
+        opts \\ []
+      ) do
+    owner = Keyword.get(opts, :owner, self())
+    runtime_ref = make_ref()
+    request = GrpcCompatibilityMapper.execute_request_to_proto(request)
+
+    {:ok, _pid} =
+      Task.start(fn ->
+        relay_execute_stream(channel, request, owner, runtime_ref, opts)
+      end)
+
+    {:ok, runtime_ref}
+  end
+
+  @impl true
+  def cancel_inference(connection, request, opts \\ [])
+
+  def cancel_inference(
+        %__MODULE__{channel: channel},
+        %Operation.CancelRequest{} = request,
+        _opts
+      ) do
+    TransportClient.cancel_inference(channel, request.request_id, request.controller_session_id)
+  end
+
+  def cancel_inference(%__MODULE__{channel: channel}, request_id, controller_session_id)
+      when is_binary(request_id) do
+    TransportClient.cancel_inference(channel, request_id, controller_session_id)
+  end
+
+  @impl true
+  def score_prefix_cache(target_or_connection, request, opts \\ [])
+
+  def score_prefix_cache(
+        target_or_connection,
+        %Operation.PrefixCacheScoreRequest{} = request,
+        opts
+      ) do
+    target = target_from(target_or_connection)
+    proto_request = GrpcCompatibilityMapper.prefix_cache_score_request_to_proto(request)
+
+    with {:ok, response} <-
+           TransportClient.score_prefix_cache(target.address, proto_request, opts) do
+      {:ok, GrpcCompatibilityMapper.prefix_cache_score_result_from_response(response)}
+    end
+  end
+
+  def score_prefix_cache(target_or_connection, %ScorePrefixCacheRequest{} = request, opts) do
+    target = target_from(target_or_connection)
+
+    with {:ok, response} <- TransportClient.score_prefix_cache(target.address, request, opts) do
+      {:ok, GrpcCompatibilityMapper.prefix_cache_score_result_from_response(response)}
+    end
+  end
+
+  defp relay_execute_stream(channel, request, owner, runtime_ref, opts) do
+    relay_opts =
+      opts
+      |> Keyword.delete(:owner)
+      |> Keyword.put(:owner, self())
+
+    {:ok, transport_ref} = TransportClient.execute_inference(channel, request, relay_opts)
+    relay_stream_messages(owner, runtime_ref, transport_ref)
+  end
+
+  defp relay_stream_messages(owner, runtime_ref, transport_ref) do
+    receive do
+      {:dispatch_event, ^transport_ref, request_id, event} ->
+        send(owner, {:runtime_endpoint_event, runtime_ref, request_id, event})
+        relay_stream_messages(owner, runtime_ref, transport_ref)
+
+      {:dispatch_done, ^transport_ref, result} ->
+        send(owner, {:runtime_endpoint_done, runtime_ref, result})
+    end
+  end
+
+  defp target_from(%__MODULE__{target: target}), do: target
+  defp target_from(%Target{} = target), do: target
+  defp target_from(target), do: GrpcCompatibilityMapper.normalize_target(target)
+end

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_mapper.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_mapper.ex
@@ -41,6 +41,7 @@ defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityMapper do
       worker_state: normalize_worker_state(value(response, :worker_state)),
       aggregate_active_request_count:
         non_negative_integer(value(response, :active_request_count)),
+      aggregate_max_concurrency: value(response, :max_concurrency),
       metadata: metadata,
       health: health_from_response(value(response, :runtime_health)),
       placements: placements_from_status(response),

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_mapper.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_mapper.ex
@@ -1,0 +1,433 @@
+defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityMapper do
+  @moduledoc """
+  Maps the gRPC `NodeRuntimeService` compatibility protocol to Runtime Endpoint structs.
+  """
+
+  alias Orchard.Cluster.V1.{
+    Ack,
+    EnsureModelLoadedRequest,
+    EnsureModelLoadedResponse,
+    ExecuteInferenceRequest,
+    GenerationParams,
+    RuntimeHealth,
+    RuntimeModelPlacement,
+    RuntimeNodeMetadata,
+    ScorePrefixCacheRequest,
+    ScorePrefixCacheResponse,
+    StatusResponse,
+    UnloadModelRequest
+  }
+
+  alias Orchard.RuntimeEndpoint.{
+    ModelRef,
+    Observation,
+    Operation,
+    Placement,
+    PlacementCapacity,
+    Target
+  }
+
+  @spec observation_from_status(Target.t() | keyword() | nil, StatusResponse.t() | map()) ::
+          Observation.t()
+  def observation_from_status(target, %{} = response) do
+    target = normalize_target(target)
+    metadata = metadata_from_response(response)
+
+    Observation.new(%{
+      endpoint_id: endpoint_id(target, metadata),
+      target: target,
+      observed_at: DateTime.utc_now(),
+      availability: availability_from_response(response),
+      worker_state: normalize_worker_state(value(response, :worker_state)),
+      aggregate_active_request_count:
+        non_negative_integer(value(response, :active_request_count)),
+      metadata: metadata,
+      health: health_from_response(value(response, :runtime_health)),
+      placements: placements_from_status(response),
+      hosted_tool_capabilities: list_value(response, :hosted_tool_capabilities),
+      hosted_tool_readiness: list_value(response, :hosted_tool_readiness),
+      runtime_memory_budgets: list_value(response, :runtime_memory_budgets),
+      runtime_prefix_cache_statuses: list_value(response, :runtime_prefix_cache_statuses),
+      supports_prompt_token_ids: value(response, :supports_prompt_token_ids) == true
+    })
+  end
+
+  @spec ensure_model_loaded_request_to_proto(Operation.EnsureModelLoadedRequest.t()) ::
+          EnsureModelLoadedRequest.t()
+  def ensure_model_loaded_request_to_proto(%Operation.EnsureModelLoadedRequest{} = request) do
+    %EnsureModelLoadedRequest{
+      node_id: request.node_id || "",
+      model_id: request.model_ref.model_id,
+      version: request.model_ref.version,
+      artifact_sha256: request.artifact_sha256 || "",
+      preload: request.preload,
+      deadline_unix_ms: request.deadline_unix_ms || 0,
+      artifact_source_uri: request.artifact_source_uri || ""
+    }
+  end
+
+  @spec ensure_model_loaded_result_from_response(EnsureModelLoadedResponse.t()) ::
+          Operation.EnsureModelLoadedResult.t()
+  def ensure_model_loaded_result_from_response(%EnsureModelLoadedResponse{} = response) do
+    %Operation.EnsureModelLoadedResult{
+      already_loaded: response.already_loaded,
+      placement_state: normalize_placement_state(response.placement_state),
+      failure_category: normalize_failure_category(response.failure_category),
+      failure_code: empty_to_nil(response.failure_code),
+      failure_message: empty_to_nil(response.failure_message),
+      worker_supports_prompt_token_ids: response.worker_supports_prompt_token_ids
+    }
+  end
+
+  @spec unload_model_request_to_proto(Operation.UnloadModelRequest.t()) :: UnloadModelRequest.t()
+  def unload_model_request_to_proto(%Operation.UnloadModelRequest{} = request) do
+    %UnloadModelRequest{
+      model_id: request.model_ref.model_id,
+      version: request.model_ref.version,
+      force: request.force,
+      evict: request.evict
+    }
+  end
+
+  @spec ack_from_response(Ack.t()) :: Operation.Ack.t()
+  def ack_from_response(%Ack{} = response) do
+    %Operation.Ack{ok: response.ok, message: response.message || ""}
+  end
+
+  @spec execute_request_to_proto(Operation.ExecuteRequest.t()) :: ExecuteInferenceRequest.t()
+  def execute_request_to_proto(%Operation.ExecuteRequest{} = request) do
+    %ExecuteInferenceRequest{
+      request_id: request.request_id,
+      controller_session_id: request.controller_session_id,
+      model_id: request.model_ref.model_id,
+      version: request.model_ref.version,
+      rendered_prompt_utf8: request.rendered_prompt_utf8,
+      input_tokens: request.input_tokens,
+      params: generation_params_to_proto(request.params),
+      deadline_unix_ms: request.deadline_unix_ms || 0,
+      metadata_json: request.metadata_json || "{}",
+      cache_affinity_fingerprint: request.cache_affinity_fingerprint || "",
+      prompt_token_ids: request.prompt_token_ids || []
+    }
+  end
+
+  @spec cancel_request_to_proto(Operation.CancelRequest.t()) ::
+          Orchard.Cluster.V1.CancelInferenceRequest.t()
+  def cancel_request_to_proto(%Operation.CancelRequest{} = request) do
+    %Orchard.Cluster.V1.CancelInferenceRequest{
+      request_id: request.request_id,
+      controller_session_id: request.controller_session_id
+    }
+  end
+
+  @spec prefix_cache_score_request_to_proto(Operation.PrefixCacheScoreRequest.t()) ::
+          ScorePrefixCacheRequest.t()
+  def prefix_cache_score_request_to_proto(%Operation.PrefixCacheScoreRequest{} = request) do
+    %ScorePrefixCacheRequest{
+      request_id: request.request_id,
+      controller_session_id: request.controller_session_id,
+      model_ref: model_ref_to_proto(request.model_ref),
+      cache_affinity_fingerprint: request.cache_affinity_fingerprint,
+      deadline_unix_ms: request.deadline_unix_ms || 0
+    }
+  end
+
+  @spec prefix_cache_score_result_from_response(ScorePrefixCacheResponse.t()) ::
+          Operation.PrefixCacheScoreResult.t()
+  def prefix_cache_score_result_from_response(%ScorePrefixCacheResponse{} = response) do
+    %Operation.PrefixCacheScoreResult{
+      status_code: response.status_code || "unknown",
+      status_message: response.status_message || "",
+      resident_fingerprint_match: response.resident_fingerprint_match,
+      score_tier: response.score_tier || "unknown",
+      session_started_unix_ms: non_negative_integer(response.session_started_unix_ms)
+    }
+  end
+
+  @spec model_ref_to_proto(ModelRef.t()) :: Orchard.Cluster.V1.ModelRef.t()
+  def model_ref_to_proto(%ModelRef{} = model_ref) do
+    %Orchard.Cluster.V1.ModelRef{
+      model_id: model_ref.model_id,
+      version: model_ref.version
+    }
+  end
+
+  @spec model_ref_from_proto(map() | nil) :: ModelRef.t() | nil
+  def model_ref_from_proto(nil), do: nil
+
+  def model_ref_from_proto(%{} = model_ref) do
+    case ModelRef.new(model_ref) do
+      {:ok, normalized} -> normalized
+      {:error, :invalid_model_ref} -> nil
+    end
+  end
+
+  @spec normalize_target(Target.t() | keyword() | map() | nil) :: Target.t() | nil
+  def normalize_target(%Target{} = target), do: target
+
+  def normalize_target(target) when is_list(target) or is_map(target) do
+    Target.grpc_compat(target)
+  end
+
+  def normalize_target(nil), do: nil
+
+  defp metadata_from_response(%{} = response) do
+    response
+    |> value(:node_metadata)
+    |> metadata_from_proto()
+  end
+
+  defp metadata_from_proto(%RuntimeNodeMetadata{} = metadata) do
+    %{
+      node_id: empty_to_nil(metadata.node_id),
+      display_name: empty_to_nil(metadata.display_name),
+      hostname: empty_to_nil(metadata.hostname),
+      agent_version: empty_to_nil(metadata.agent_version),
+      listen_host: empty_to_nil(metadata.listen_host),
+      listen_port: non_negative_integer(metadata.listen_port),
+      worker_backend: empty_to_nil(metadata.worker_backend)
+    }
+    |> compact_nil_values()
+  end
+
+  defp metadata_from_proto(nil), do: %{}
+
+  defp metadata_from_proto(%{} = metadata) do
+    metadata
+    |> Map.take([
+      :node_id,
+      "node_id",
+      :display_name,
+      "display_name",
+      :hostname,
+      "hostname",
+      :agent_version,
+      "agent_version",
+      :listen_host,
+      "listen_host",
+      :listen_port,
+      "listen_port",
+      :worker_backend,
+      "worker_backend"
+    ])
+    |> Enum.reduce(%{}, fn {key, value}, acc ->
+      Map.put(acc, normalize_metadata_key(key), value)
+    end)
+    |> compact_nil_values()
+  end
+
+  defp availability_from_response(%{} = response) do
+    case value(response, :runtime_health) do
+      %RuntimeHealth{ready: true} -> :available
+      %RuntimeHealth{ready: false} -> :degraded
+      %{ready: true} -> :available
+      %{"ready" => true} -> :available
+      %{ready: false} -> :degraded
+      %{"ready" => false} -> :degraded
+      nil -> :available
+      _other -> :unknown
+    end
+  end
+
+  defp health_from_response(%RuntimeHealth{} = health) do
+    %{
+      ready: health.ready,
+      health_code: empty_to_nil(health.health_code),
+      health_message: empty_to_nil(health.health_message),
+      affected_model: model_ref_from_proto(health.affected_model)
+    }
+    |> compact_nil_values()
+  end
+
+  defp health_from_response(nil), do: %{}
+
+  defp health_from_response(%{} = health) do
+    %{
+      ready: value(health, :ready),
+      health_code: empty_to_nil(value(health, :health_code)),
+      health_message: empty_to_nil(value(health, :health_message)),
+      affected_model: model_ref_from_proto(value(health, :affected_model))
+    }
+    |> compact_nil_values()
+  end
+
+  defp placements_from_status(%{} = response) do
+    placements = list_value(response, :runtime_model_placements)
+
+    response
+    |> list_value(:loaded_models)
+    |> Enum.flat_map(fn proto_ref ->
+      case model_ref_from_proto(proto_ref) do
+        %ModelRef{} = model_ref ->
+          [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity: placement_capacity(model_ref, placements)
+            })
+          ]
+
+        nil ->
+          []
+      end
+    end)
+  end
+
+  defp placement_capacity(%ModelRef{} = model_ref, placements) do
+    matches = Enum.filter(placements, &model_ref_matches?(&1, model_ref))
+
+    case matches do
+      [placement] ->
+        PlacementCapacity.new(%{
+          model_ref: model_ref,
+          active_request_count: value(placement, :active_request_count),
+          max_concurrency: value(placement, :max_concurrency),
+          source: :grpc_compatibility_status
+        })
+
+      [] ->
+        PlacementCapacity.unknown(model_ref, :grpc_compatibility_status)
+
+      _duplicates ->
+        PlacementCapacity.new(%{
+          model_ref: model_ref,
+          active_request_count: :duplicate,
+          max_concurrency: :duplicate,
+          source: :duplicate_grpc_compatibility_status
+        })
+    end
+  end
+
+  defp model_ref_matches?(%RuntimeModelPlacement{} = placement, %ModelRef{} = model_ref) do
+    ModelRef.equal?(placement.model_ref, model_ref)
+  end
+
+  defp model_ref_matches?(%{} = placement, %ModelRef{} = model_ref) do
+    placement
+    |> value(:model_ref)
+    |> ModelRef.equal?(model_ref)
+  end
+
+  defp model_ref_matches?(_placement, _model_ref), do: false
+
+  defp normalize_worker_state(:WORKER_STATE_STARTING), do: :starting
+  defp normalize_worker_state(:WORKER_STATE_IDLE), do: :idle
+  defp normalize_worker_state(:WORKER_STATE_BUSY), do: :busy
+  defp normalize_worker_state(:WORKER_STATE_STOPPING), do: :stopping
+  defp normalize_worker_state(:WORKER_STATE_FAILED), do: :failed
+  defp normalize_worker_state(:WORKER_STATE_STOPPED), do: :stopped
+  defp normalize_worker_state(:WORKER_STATE_UNSPECIFIED), do: :unknown
+  defp normalize_worker_state(1), do: :starting
+  defp normalize_worker_state(2), do: :idle
+  defp normalize_worker_state(3), do: :busy
+  defp normalize_worker_state(4), do: :stopping
+  defp normalize_worker_state(5), do: :failed
+  defp normalize_worker_state(6), do: :stopped
+  defp normalize_worker_state(_other), do: :unknown
+
+  defp normalize_placement_state(:PLACEMENT_STATE_ABSENT), do: :absent
+  defp normalize_placement_state(:PLACEMENT_STATE_DOWNLOADING), do: :downloading
+  defp normalize_placement_state(:PLACEMENT_STATE_DOWNLOADED), do: :downloaded
+  defp normalize_placement_state(:PLACEMENT_STATE_VERIFYING), do: :verifying
+  defp normalize_placement_state(:PLACEMENT_STATE_CACHED), do: :cached
+  defp normalize_placement_state(:PLACEMENT_STATE_LOADING), do: :loading
+  defp normalize_placement_state(:PLACEMENT_STATE_LOADED), do: :loaded
+  defp normalize_placement_state(:PLACEMENT_STATE_UNLOADING), do: :unloading
+  defp normalize_placement_state(:PLACEMENT_STATE_EVICTED), do: :evicted
+  defp normalize_placement_state(:PLACEMENT_STATE_FAILED), do: :failed
+  defp normalize_placement_state(:PLACEMENT_STATE_UNSPECIFIED), do: :unknown
+  defp normalize_placement_state(1), do: :absent
+  defp normalize_placement_state(2), do: :downloading
+  defp normalize_placement_state(3), do: :downloaded
+  defp normalize_placement_state(4), do: :verifying
+  defp normalize_placement_state(5), do: :cached
+  defp normalize_placement_state(6), do: :loading
+  defp normalize_placement_state(7), do: :loaded
+  defp normalize_placement_state(8), do: :unloading
+  defp normalize_placement_state(9), do: :evicted
+  defp normalize_placement_state(10), do: :failed
+  defp normalize_placement_state(_other), do: :unknown
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_MODEL_INVALID), do: :model_invalid
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_ACQUISITION_FAILED),
+    do: :acquisition_failed
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_RUNTIME_UNAVAILABLE),
+    do: :runtime_unavailable
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_TIMEOUT), do: :timeout
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_RESOURCE_EXHAUSTED),
+    do: :resource_exhausted
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_INTERNAL), do: :internal
+  defp normalize_failure_category(_other), do: nil
+
+  defp generation_params_to_proto(%GenerationParams{} = params), do: params
+
+  defp generation_params_to_proto(%{} = params) do
+    %GenerationParams{
+      max_output_tokens: non_negative_integer(value(params, :max_output_tokens)),
+      temperature: float_value(value(params, :temperature)),
+      top_p: float_value(value(params, :top_p)),
+      stop_sequences: list_value(params, :stop_sequences),
+      tools_json: value(params, :tools_json) || "",
+      tool_choice_json: value(params, :tool_choice_json) || ""
+    }
+  end
+
+  defp generation_params_to_proto(_params), do: %GenerationParams{}
+
+  defp endpoint_id(%Target{id: id}, _metadata) when is_binary(id) and id != "", do: id
+
+  defp endpoint_id(_target, %{node_id: node_id}) when is_binary(node_id) and node_id != "",
+    do: "node:#{node_id}"
+
+  defp endpoint_id(_target, _metadata), do: nil
+
+  defp normalize_metadata_key(key) when key in [:node_id, "node_id"], do: :node_id
+  defp normalize_metadata_key(key) when key in [:display_name, "display_name"], do: :display_name
+  defp normalize_metadata_key(key) when key in [:hostname, "hostname"], do: :hostname
+
+  defp normalize_metadata_key(key) when key in [:agent_version, "agent_version"],
+    do: :agent_version
+
+  defp normalize_metadata_key(key) when key in [:listen_host, "listen_host"], do: :listen_host
+  defp normalize_metadata_key(key) when key in [:listen_port, "listen_port"], do: :listen_port
+
+  defp normalize_metadata_key(key) when key in [:worker_backend, "worker_backend"],
+    do: :worker_backend
+
+  defp list_value(attrs, key) do
+    case value(attrs, key) do
+      list when is_list(list) -> list
+      nil -> []
+      other -> [other]
+    end
+  end
+
+  defp value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
+
+  defp empty_to_nil(value) when value in [nil, ""], do: nil
+  defp empty_to_nil(value), do: value
+
+  defp non_negative_integer(value) when is_integer(value) and value >= 0, do: value
+  defp non_negative_integer(_value), do: 0
+
+  defp float_value(value) when is_float(value), do: value
+  defp float_value(value) when is_integer(value), do: value / 1
+  defp float_value(_value), do: 0.0
+
+  defp compact_nil_values(map) do
+    Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  end
+end

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -35,12 +35,19 @@ defmodule Orchard.Scheduler.MultiNode do
   """
 
   alias Orchard.CanonicalRequest
-  alias Orchard.Cluster.V1.ModelRef, as: RPCModelRef
-  alias Orchard.Cluster.V1.ScorePrefixCacheRequest
-  alias Orchard.Dispatch.GrpcNodeRuntimeClient
   alias Orchard.Inference
   alias Orchard.Inference.CacheAffinity
   alias Orchard.Nodes
+
+  alias Orchard.RuntimeEndpoint.{
+    GrpcCompatibilityMapper,
+    ModelRef,
+    Observation,
+    Operation,
+    PlacementCapacity,
+    Target
+  }
+
   alias Orchard.Runtime.{MemoryBudget, PrefixCacheScore, PrefixCacheStatus}
   alias Orchard.Scheduler.SingleNode
 
@@ -68,14 +75,13 @@ defmodule Orchard.Scheduler.MultiNode do
   Schedule with injectable options for testing.
 
   Options:
-  - `:status_client` - module implementing `connect/1`, `status/2`, `disconnect/1`,
-    and (for prefix-cache scoring) `score_prefix_cache/3`
-    (default: `GrpcNodeRuntimeClient`)
+  - `:status_client` - module implementing the Runtime Endpoint client callbacks
+    (default: `Inference.runtime_endpoint_client/0`)
   - `:status_timeout_ms` - timeout for each status probe (default: #{@default_status_timeout_ms})
   - `:observed_at` - timestamp for observations (default: `DateTime.utc_now()`)
   """
   def schedule(%CanonicalRequest{} = request, opts) when is_list(opts) do
-    targets = Inference.runtime_client_targets()
+    targets = Inference.runtime_endpoint_targets()
 
     if targets == [] do
       fallback_schedule(request, targets, opts)
@@ -87,7 +93,7 @@ defmodule Orchard.Scheduler.MultiNode do
   # -- Internal --
 
   defp schedule_multi(request, targets, opts) do
-    client = Keyword.get(opts, :status_client, GrpcNodeRuntimeClient)
+    client = Keyword.get(opts, :status_client, Inference.runtime_endpoint_client())
     timeout = Keyword.get(opts, :status_timeout_ms, @default_status_timeout_ms)
     observed_at = Keyword.get(opts, :observed_at, DateTime.utc_now())
 
@@ -172,7 +178,8 @@ defmodule Orchard.Scheduler.MultiNode do
           %{
             strategy: :multi_node,
             request_id: request.public_id,
-            runtime_client_target: selected.target,
+            runtime_client_target: dispatch_target(selected.target),
+            runtime_endpoint_target: selected.target,
             request_timeout_ms: Inference.request_timeout_ms(),
             model_load_timeout_ms: Inference.model_load_timeout_ms(),
             node_id: selected.node_id,
@@ -199,40 +206,40 @@ defmodule Orchard.Scheduler.MultiNode do
         try do
           case client.status(channel, timeout: timeout) do
             {:ok, response} ->
-              # Persist observation best-effort
-              Nodes.observe_status(target, response, observed_at,
+              observation = normalize_status_observation(target, response)
+
+              Nodes.observe_status(observation_target(target), observation, observed_at,
                 reserve_unassigned_node_grants?: true,
                 reserve_unassigned_source_grants?: true
               )
 
-              # Extract node_id from metadata - skip if missing/invalid
-              case extract_valid_node_id(response) do
+              case extract_valid_node_id(observation) do
                 nil ->
                   nil
 
                 node_id ->
-                  loaded_model? = model_loaded?(response, request)
+                  loaded_model? = model_loaded?(observation, request)
 
                   %{
                     node_id: node_id,
                     target: target,
                     loaded_model?: loaded_model?,
-                    active_request_count: response.active_request_count || 0,
+                    active_request_count: observation.aggregate_active_request_count,
                     max_concurrency: node_max_concurrency(response),
-                    supports_prompt_token_ids: prompt_token_ids_supported?(response)
+                    supports_prompt_token_ids: observation.supports_prompt_token_ids
                   }
                   |> maybe_put_model_placement_capacity(
-                    model_placement_capacity_for(response, request.model_ref, loaded_model?)
+                    model_placement_capacity_for(observation, request.model_ref, loaded_model?)
                   )
                   |> maybe_put_prefix_cache_status(
-                    prefix_cache_status_for(response, request.model_ref)
+                    prefix_cache_status_for(observation, request.model_ref)
                   )
-                  |> maybe_put_memory_budget(memory_budget_for(response, request.model_ref))
+                  |> maybe_put_memory_budget(memory_budget_for(observation, request.model_ref))
               end
 
             {:error, reason} ->
               # Persist transport-like probe failures best-effort
-              Nodes.record_transport_failure(target, reason, observed_at)
+              Nodes.record_transport_failure(observation_target(target), reason, observed_at)
               nil
           end
         after
@@ -241,7 +248,7 @@ defmodule Orchard.Scheduler.MultiNode do
 
       {:error, reason} ->
         # Persist transport-like connect failures best-effort
-        Nodes.record_transport_failure(target, reason, observed_at)
+        Nodes.record_transport_failure(observation_target(target), reason, observed_at)
         nil
     end
   end
@@ -256,6 +263,11 @@ defmodule Orchard.Scheduler.MultiNode do
        do: active >= max
 
   defp node_concurrency_full?(_candidate), do: false
+
+  defp placement_capacity_full?(%{
+         model_placement_capacity: %PlacementCapacity{status: :known} = capacity
+       }),
+       do: PlacementCapacity.full?(capacity)
 
   defp placement_capacity_full?(%{
          model_placement_capacity: %{active_request_count: active, max_concurrency: max}
@@ -330,7 +342,13 @@ defmodule Orchard.Scheduler.MultiNode do
     end
   end
 
-  defp extract_valid_node_id(%{node_metadata: %{node_id: node_id}}) when is_binary(node_id) do
+  defp extract_valid_node_id(%Observation{} = observation) do
+    observation
+    |> Observation.node_id()
+    |> extract_valid_node_id()
+  end
+
+  defp extract_valid_node_id(node_id) when is_binary(node_id) do
     case Ecto.UUID.cast(node_id) do
       {:ok, id} -> id
       :error -> nil
@@ -339,23 +357,17 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp extract_valid_node_id(_), do: nil
 
-  defp model_loaded?(%{loaded_models: models}, %CanonicalRequest{model_ref: model_ref})
-       when is_list(models) do
-    Enum.any?(models, fn m ->
-      to_string(Map.get(m, :model_id, "")) == model_ref.model_id and
-        to_string(Map.get(m, :version, "")) == model_ref.version
-    end)
+  defp model_loaded?(%Observation{} = observation, %CanonicalRequest{model_ref: model_ref}) do
+    Observation.loaded_placement(observation, runtime_model_ref(model_ref)) != nil
   end
 
   defp model_loaded?(_, _), do: false
 
-  defp prompt_token_ids_supported?(%{supports_prompt_token_ids: true}), do: true
-  defp prompt_token_ids_supported?(%{"supports_prompt_token_ids" => true}), do: true
-  defp prompt_token_ids_supported?(_response), do: false
-
-  defp prefix_cache_status_for(response, %CanonicalRequest.ModelRef{} = model_ref) do
-    response
-    |> Map.get(:runtime_prefix_cache_statuses, [])
+  defp prefix_cache_status_for(
+         %Observation{} = observation,
+         %CanonicalRequest.ModelRef{} = model_ref
+       ) do
+    observation.runtime_prefix_cache_statuses
     |> find_prefix_cache_status(model_ref)
     |> PrefixCacheStatus.normalize_for_scheduler()
   end
@@ -363,8 +375,6 @@ defmodule Orchard.Scheduler.MultiNode do
   defp find_prefix_cache_status(statuses, model_ref) when is_list(statuses) do
     Enum.find(statuses, &prefix_cache_model_ref_matches?(&1, model_ref))
   end
-
-  defp find_prefix_cache_status(_statuses, _model_ref), do: nil
 
   defp prefix_cache_model_ref_matches?(status, model_ref) when is_map(status) do
     case Map.get(status, :model_ref) || Map.get(status, "model_ref") do
@@ -383,17 +393,14 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp prefix_cache_model_ref_matches?(_status, _model_ref), do: false
 
-  defp memory_budget_for(response, %CanonicalRequest.ModelRef{} = model_ref) do
-    response
-    |> Map.get(:runtime_memory_budgets, [])
+  defp memory_budget_for(%Observation{} = observation, %CanonicalRequest.ModelRef{} = model_ref) do
+    observation.runtime_memory_budgets
     |> find_memory_budget(model_ref)
   end
 
   defp find_memory_budget(budgets, model_ref) when is_list(budgets) do
     Enum.find(budgets, &memory_budget_model_ref_matches?(&1, model_ref))
   end
-
-  defp find_memory_budget(_budgets, _model_ref), do: nil
 
   defp memory_budget_model_ref_matches?(budget, model_ref) when is_map(budget) do
     case Map.get(budget, :model_ref) || Map.get(budget, "model_ref") do
@@ -412,54 +419,15 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp memory_budget_model_ref_matches?(_budget, _model_ref), do: false
 
-  defp model_placement_capacity_for(_response, _model_ref, false), do: nil
+  defp model_placement_capacity_for(_observation, _model_ref, false), do: nil
 
-  defp model_placement_capacity_for(response, %CanonicalRequest.ModelRef{} = model_ref, true) do
-    response
-    |> Map.get(:runtime_model_placements, [])
-    |> matching_model_placements(model_ref)
-    |> case do
-      [placement] -> valid_model_placement_capacity(placement)
-      _none_or_ambiguous -> nil
-    end
+  defp model_placement_capacity_for(
+         %Observation{} = observation,
+         %CanonicalRequest.ModelRef{} = model_ref,
+         true
+       ) do
+    Observation.placement_capacity_for(observation, runtime_model_ref(model_ref))
   end
-
-  defp matching_model_placements(placements, model_ref) when is_list(placements),
-    do: Enum.filter(placements, &model_placement_matches?(&1, model_ref))
-
-  defp matching_model_placements(_placements, _model_ref), do: []
-
-  defp model_placement_matches?(placement, model_ref) when is_map(placement) do
-    case Map.get(placement, :model_ref) || Map.get(placement, "model_ref") do
-      %{model_id: model_id, version: version}
-      when is_binary(model_id) and is_binary(version) ->
-        model_id == model_ref.model_id and version == model_ref.version
-
-      %{"model_id" => model_id, "version" => version}
-      when is_binary(model_id) and is_binary(version) ->
-        model_id == model_ref.model_id and version == model_ref.version
-
-      _other ->
-        false
-    end
-  end
-
-  defp model_placement_matches?(_placement, _model_ref), do: false
-
-  defp valid_model_placement_capacity(placement) when is_map(placement) do
-    active =
-      Map.get(placement, :active_request_count) || Map.get(placement, "active_request_count")
-
-    max = Map.get(placement, :max_concurrency) || Map.get(placement, "max_concurrency")
-
-    if is_integer(active) and active >= 0 and is_integer(max) and max > 0 do
-      %{active_request_count: active, max_concurrency: max}
-    else
-      nil
-    end
-  end
-
-  defp valid_model_placement_capacity(_placement), do: nil
 
   defp maybe_put_model_placement_capacity(map, nil), do: map
 
@@ -599,13 +567,10 @@ defmodule Orchard.Scheduler.MultiNode do
     timeout_ms = scoring_context.timeout_ms
 
     response =
-      %ScorePrefixCacheRequest{
+      %Operation.PrefixCacheScoreRequest{
         request_id: request.public_id,
         controller_session_id: request.internal_id,
-        model_ref: %RPCModelRef{
-          model_id: request.model_ref.model_id,
-          version: request.model_ref.version
-        },
+        model_ref: runtime_model_ref(request.model_ref),
         cache_affinity_fingerprint: scoring_context.fingerprint,
         deadline_unix_ms: System.system_time(:millisecond) + timeout_ms
       }
@@ -760,6 +725,9 @@ defmodule Orchard.Scheduler.MultiNode do
     "#{Keyword.get(target, :host, "unknown")}:#{Keyword.get(target, :port, "unknown")}"
   end
 
+  defp prefix_cache_score_target(%Target{} = target),
+    do: prefix_cache_score_target(target.address)
+
   defp prefix_cache_score_target(_target), do: "unknown"
 
   defp maybe_put_memory_admission(map, _selected, false), do: map
@@ -832,7 +800,10 @@ defmodule Orchard.Scheduler.MultiNode do
   end
 
   defp active_request_rank(%{
-         model_placement_capacity: %{active_request_count: active_request_count}
+         model_placement_capacity: %PlacementCapacity{
+           status: :known,
+           active_request_count: active_request_count
+         }
        })
        when is_integer(active_request_count) and active_request_count >= 0,
        do: active_request_count
@@ -880,10 +851,26 @@ defmodule Orchard.Scheduler.MultiNode do
   # When targets is empty or has multiple entries, use the implicit singular
   # fallback (no single deterministic target to pass).
   defp fallback_schedule(request, [single_target], opts) do
-    SingleNode.default_schedule(request, single_target, opts)
+    SingleNode.default_schedule(request, dispatch_target(single_target), opts)
   end
 
   defp fallback_schedule(request, _targets, opts) do
     SingleNode.default_schedule(request, SingleNode.target(), opts)
   end
+
+  defp normalize_status_observation(_target, %Observation{} = observation), do: observation
+
+  defp normalize_status_observation(target, %{} = status_response) do
+    GrpcCompatibilityMapper.observation_from_status(target, status_response)
+  end
+
+  defp runtime_model_ref(%CanonicalRequest.ModelRef{} = model_ref) do
+    ModelRef.new!(model_ref.model_id, model_ref.version)
+  end
+
+  defp dispatch_target(%Target{transport: :grpc_compat, address: address}), do: address
+  defp dispatch_target(target), do: target
+
+  defp observation_target(%Target{transport: :grpc_compat, address: address}), do: address
+  defp observation_target(target), do: target
 end

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -225,7 +225,7 @@ defmodule Orchard.Scheduler.MultiNode do
                     target: target,
                     loaded_model?: loaded_model?,
                     active_request_count: observation.aggregate_active_request_count,
-                    max_concurrency: node_max_concurrency(response),
+                    max_concurrency: node_max_concurrency(observation),
                     supports_prompt_token_ids: observation.supports_prompt_token_ids
                   }
                   |> maybe_put_model_placement_capacity(
@@ -277,7 +277,16 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp placement_capacity_full?(_candidate), do: false
 
-  defp active_without_known_capacity?(%{model_placement_capacity: _capacity}), do: false
+  defp active_without_known_capacity?(%{
+         model_placement_capacity: %PlacementCapacity{status: :known}
+       }),
+       do: false
+
+  defp active_without_known_capacity?(%{
+         model_placement_capacity: %{active_request_count: active, max_concurrency: max}
+       })
+       when is_integer(active) and active >= 0 and is_integer(max) and max > 0,
+       do: false
 
   defp active_without_known_capacity?(%{loaded_model?: true, active_request_count: count})
        when is_integer(count) and count > 0,
@@ -302,6 +311,26 @@ defmodule Orchard.Scheduler.MultiNode do
       _capacity -> 1
     end
   end
+
+  defp effective_model_capacity_for_queue(%{
+         active_request_count: node_active,
+         max_concurrency: node_max,
+         model_placement_capacity: %PlacementCapacity{
+           status: :known,
+           active_request_count: model_active,
+           max_concurrency: placement_max
+         }
+       })
+       when is_integer(node_active) and is_integer(node_max) and is_integer(model_active) and
+              is_integer(placement_max) do
+    remaining_node_capacity = max(node_max - node_active, 0)
+    min(placement_max, max(model_active, 0) + remaining_node_capacity)
+  end
+
+  defp effective_model_capacity_for_queue(%{
+         model_placement_capacity: %PlacementCapacity{}
+       }),
+       do: 1
 
   defp effective_model_capacity_for_queue(%{
          active_request_count: node_active,
@@ -335,8 +364,8 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp node_has_available_capacity?(_candidate), do: true
 
-  defp node_max_concurrency(response) do
-    case Map.get(response, :max_concurrency) || Map.get(response, "max_concurrency") do
+  defp node_max_concurrency(%Observation{aggregate_max_concurrency: value}) do
+    case value do
       value when is_integer(value) and value > 0 -> value
       _other -> 1
     end

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -223,6 +223,7 @@ defmodule Orchard.Scheduler.MultiNode do
                   %{
                     node_id: node_id,
                     target: target,
+                    availability: observation.availability,
                     loaded_model?: loaded_model?,
                     active_request_count: observation.aggregate_active_request_count,
                     max_concurrency: node_max_concurrency(observation),
@@ -254,9 +255,15 @@ defmodule Orchard.Scheduler.MultiNode do
   end
 
   defp candidate_full?(candidate) do
-    node_concurrency_full?(candidate) or placement_capacity_full?(candidate) or
+    runtime_endpoint_unavailable?(candidate) or node_concurrency_full?(candidate) or
+      placement_capacity_full?(candidate) or
       active_without_known_capacity?(candidate)
   end
+
+  defp runtime_endpoint_unavailable?(%{availability: availability}),
+    do: availability not in [:available, :degraded]
+
+  defp runtime_endpoint_unavailable?(_candidate), do: false
 
   defp node_concurrency_full?(%{active_request_count: active, max_concurrency: max})
        when is_integer(active) and is_integer(max) and max > 0,

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs
@@ -24,7 +24,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest.StubClient do
   end
 
   def disconnect(_channel), do: :ok
-  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts \\ []), do: :ok
 
   def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{} = request, _opts \\ []) do
     send(config().capture_pid, {:captured_ensure_model_loaded_request, request})

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs
@@ -4,12 +4,12 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest.StubClient do
 
   alias Orchard.Cluster.V1.{
     EnsureModelLoadedRequest,
-    EnsureModelLoadedResponse,
     ExecuteInferenceRequest,
     StatusResponse
   }
 
   alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.Operation
 
   def registry_name, do: @registry
 
@@ -24,34 +24,34 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest.StubClient do
   end
 
   def disconnect(_channel), do: :ok
-  def cancel_inference(_channel, _request_id), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
 
-  def ensure_model_loaded(_channel, %EnsureModelLoadedRequest{} = request, _opts \\ []) do
+  def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{} = request, _opts \\ []) do
     send(config().capture_pid, {:captured_ensure_model_loaded_request, request})
 
     {:ok,
-     %EnsureModelLoadedResponse{
+     %Operation.EnsureModelLoadedResult{
        already_loaded: false,
-       placement_state: :PLACEMENT_STATE_LOADED,
+       placement_state: :loaded,
        worker_supports_prompt_token_ids: config().worker_supports_prompt_token_ids
      }}
   end
 
-  def execute_inference(_channel, %ExecuteInferenceRequest{} = request, opts \\ []) do
+  def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts \\ []) do
     owner = Keyword.get(opts, :owner, self())
     ref = make_ref()
     send(config().capture_pid, {:captured_execute_request, request})
 
     spawn(fn ->
-      send(owner, {:dispatch_event, ref, request.request_id, InferenceEvent.accepted(0)})
+      send(owner, {:runtime_endpoint_event, ref, request.request_id, InferenceEvent.accepted(0)})
 
       send(
         owner,
-        {:dispatch_event, ref, request.request_id,
+        {:runtime_endpoint_event, ref, request.request_id,
          InferenceEvent.completed(:finish_reason_stop, nil)}
       )
 
-      send(owner, {:dispatch_done, ref, :ok})
+      send(owner, {:runtime_endpoint_done, ref, :ok})
     end)
 
     {:ok, ref}
@@ -68,6 +68,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
 
   alias Orchard.Cluster.V1.{EnsureModelLoadedRequest, ExecuteInferenceRequest}
   alias Orchard.Dispatch.RequestDispatcher
+  alias Orchard.RuntimeEndpoint.Operation
 
   @stub_client Orchard.Dispatch.DispatchCapabilityGateTest.StubClient
   @prompt_ids [101, 102, 103]
@@ -92,7 +93,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     assert metadata.worker_supports_prompt_token_ids == true
 
     assert_receive {:captured_execute_request,
-                    %ExecuteInferenceRequest{prompt_token_ids: @prompt_ids}}
+                    %Operation.ExecuteRequest{prompt_token_ids: @prompt_ids}}
   end
 
   test "safe-mode on with capable worker strips empty prompt_token_ids silently" do
@@ -106,7 +107,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
 
     refute_receive {^dispatched_ref, [:orchard, :tokenizer, :prompt_token_ids_dispatched], _, _}
     refute_receive {^unsafe_ref, [:orchard, :tokenizer, :unsafe_mode_active], _, _}
-    assert_receive {:captured_execute_request, %ExecuteInferenceRequest{prompt_token_ids: []}}
+    assert_receive {:captured_execute_request, %Operation.ExecuteRequest{prompt_token_ids: []}}
   end
 
   test "safe-mode on strips prompt_token_ids for legacy workers and emits unsafe fallback telemetry" do
@@ -122,7 +123,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
 
     assert metadata.reason == :legacy_worker_no_capability
     assert metadata.model_id == "test/model"
-    assert_receive {:captured_execute_request, %ExecuteInferenceRequest{prompt_token_ids: []}}
+    assert_receive {:captured_execute_request, %Operation.ExecuteRequest{prompt_token_ids: []}}
   end
 
   test "safe-mode off strips prompt_token_ids silently" do
@@ -136,7 +137,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
 
     refute_receive {^dispatched_ref, [:orchard, :tokenizer, :prompt_token_ids_dispatched], _, _}
     refute_receive {^unsafe_ref, [:orchard, :tokenizer, :unsafe_mode_active], _, _}
-    assert_receive {:captured_execute_request, %ExecuteInferenceRequest{prompt_token_ids: []}}
+    assert_receive {:captured_execute_request, %Operation.ExecuteRequest{prompt_token_ids: []}}
   end
 
   test "safe-mode reject refuses legacy workers without dispatching execute" do
@@ -149,7 +150,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
       assert metadata.model_id == "test/model"
     end)
 
-    refute_receive {:captured_execute_request, %ExecuteInferenceRequest{}}
+    refute_receive {:captured_execute_request, %Operation.ExecuteRequest{}}
   end
 
   test "safe-mode reject refuses requests missing prompt_token_ids before ensure_model_loaded" do
@@ -163,8 +164,10 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
       assert metadata.model_id == "test/model"
     end)
 
-    refute_receive {:captured_ensure_model_loaded_request, %EnsureModelLoadedRequest{}}, 200
-    refute_receive {:captured_execute_request, %ExecuteInferenceRequest{}}, 200
+    refute_receive {:captured_ensure_model_loaded_request, %Operation.EnsureModelLoadedRequest{}},
+                   200
+
+    refute_receive {:captured_execute_request, %Operation.ExecuteRequest{}}, 200
   end
 
   test "safe-mode reject missing prompt_token_ids short-circuits before connect and probe" do
@@ -180,8 +183,11 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
 
     refute_receive :connect_called, 200
     refute_receive :status_called, 200
-    refute_receive {:captured_ensure_model_loaded_request, %EnsureModelLoadedRequest{}}, 200
-    refute_receive {:captured_execute_request, %ExecuteInferenceRequest{}}, 200
+
+    refute_receive {:captured_ensure_model_loaded_request, %Operation.EnsureModelLoadedRequest{}},
+                   200
+
+    refute_receive {:captured_execute_request, %Operation.ExecuteRequest{}}, 200
   end
 
   test "safe-mode reject keeps prompt_token_ids for capable workers and emits dispatch telemetry" do
@@ -198,7 +204,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     assert metadata.model_id == "test/model"
 
     assert_receive {:captured_execute_request,
-                    %ExecuteInferenceRequest{prompt_token_ids: @prompt_ids}}
+                    %Operation.ExecuteRequest{prompt_token_ids: @prompt_ids}}
   end
 
   defp configure_stub(overrides) do

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_parity_drift_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_parity_drift_test.exs
@@ -4,13 +4,13 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest.StubClient do
 
   alias Orchard.Cluster.V1.{
     EnsureModelLoadedRequest,
-    EnsureModelLoadedResponse,
     ExecuteInferenceRequest,
     RuntimeNodeMetadata,
     StatusResponse
   }
 
   alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.Operation
 
   @node_id "550e8400-e29b-41d4-a716-446655440000"
 
@@ -26,30 +26,30 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest.StubClient do
   end
 
   def disconnect(_channel), do: :ok
-  def cancel_inference(_channel, _request_id), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
 
-  def ensure_model_loaded(_channel, %EnsureModelLoadedRequest{} = request, _opts \\ []) do
+  def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{} = request, _opts \\ []) do
     send(config().capture_pid, {:captured_ensure_model_loaded_request, request})
 
     {:ok,
-     %EnsureModelLoadedResponse{
+     %Operation.EnsureModelLoadedResult{
        already_loaded: false,
-       placement_state: :PLACEMENT_STATE_LOADED,
+       placement_state: :loaded,
        worker_supports_prompt_token_ids: true
      }}
   end
 
-  def execute_inference(_channel, %ExecuteInferenceRequest{} = request, opts \\ []) do
+  def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts \\ []) do
     owner = Keyword.get(opts, :owner, self())
     ref = make_ref()
     send(config().capture_pid, {:captured_execute_request, request})
 
     spawn(fn ->
-      send(owner, {:dispatch_event, ref, request.request_id, InferenceEvent.accepted(0)})
+      send(owner, {:runtime_endpoint_event, ref, request.request_id, InferenceEvent.accepted(0)})
 
       send(
         owner,
-        {:dispatch_event, ref, request.request_id,
+        {:runtime_endpoint_event, ref, request.request_id,
          InferenceEvent.failed(
            "prompt_token_ids_length_mismatch",
            config().worker_message,
@@ -57,7 +57,7 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest.StubClient do
          )}
       )
 
-      send(owner, {:dispatch_done, ref, :ok})
+      send(owner, {:runtime_endpoint_done, ref, :ok})
     end)
 
     {:ok, ref}
@@ -75,6 +75,7 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest do
   alias Orchard.Cluster.V1.{EnsureModelLoadedRequest, ExecuteInferenceRequest}
   alias Orchard.Dispatch.RequestDispatcher
   alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.Operation
 
   @stub_client Orchard.Dispatch.DispatchParityDriftTest.StubClient
   @event [:orchard, :tokenizer, :parity_drift]
@@ -128,10 +129,10 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest do
     refute Map.has_key?(metadata, :expected_len)
     refute Map.has_key?(metadata, :actual_len)
 
-    assert_receive {:captured_ensure_model_loaded_request, %EnsureModelLoadedRequest{}}
+    assert_receive {:captured_ensure_model_loaded_request, %Operation.EnsureModelLoadedRequest{}}
 
     assert_receive {:captured_execute_request,
-                    %ExecuteInferenceRequest{prompt_token_ids: @prompt_ids}}
+                    %Operation.ExecuteRequest{prompt_token_ids: @prompt_ids}}
   end
 
   test "does not emit parity_drift telemetry for synthesized terminal mismatch failures" do

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_parity_drift_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_parity_drift_test.exs
@@ -26,7 +26,7 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest.StubClient do
   end
 
   def disconnect(_channel), do: :ok
-  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts \\ []), do: :ok
 
   def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{} = request, _opts \\ []) do
     send(config().capture_pid, {:captured_ensure_model_loaded_request, request})

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -4,11 +4,11 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
 
   alias Orchard.Cluster.V1.{
     EnsureModelLoadedRequest,
-    EnsureModelLoadedResponse,
     ExecuteInferenceRequest
   }
 
   alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.Operation
 
   @doc false
   def registry_name, do: @registry
@@ -19,7 +19,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
     config().status
   end
 
-  def ensure_model_loaded(_channel, %EnsureModelLoadedRequest{} = request, _opts \\ []) do
+  def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{} = request, _opts \\ []) do
     config = config()
 
     if config.capture_pid do
@@ -27,12 +27,12 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
     end
 
     case config.ensure_model_loaded do
-      {:ok, %EnsureModelLoadedResponse{} = response} -> {:ok, response}
+      {:ok, %Operation.EnsureModelLoadedResult{} = response} -> {:ok, response}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  def execute_inference(_channel, %ExecuteInferenceRequest{} = request, opts \\ []) do
+  def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts \\ []) do
     owner = Keyword.get(opts, :owner, self())
     ref = make_ref()
 
@@ -42,23 +42,23 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
 
       case config().execute do
         :success ->
-          send(owner, {:dispatch_event, ref, request.request_id, accepted})
-          send(owner, {:dispatch_event, ref, request.request_id, completed})
-          send(owner, {:dispatch_done, ref, :ok})
+          send(owner, {:runtime_endpoint_event, ref, request.request_id, accepted})
+          send(owner, {:runtime_endpoint_event, ref, request.request_id, completed})
+          send(owner, {:runtime_endpoint_done, ref, :ok})
 
         {:error, reason} ->
-          send(owner, {:dispatch_done, ref, {:error, reason}})
+          send(owner, {:runtime_endpoint_done, ref, {:error, reason}})
 
         {:accepted_then_error, reason} ->
-          send(owner, {:dispatch_event, ref, request.request_id, accepted})
-          send(owner, {:dispatch_done, ref, {:error, reason}})
+          send(owner, {:runtime_endpoint_event, ref, request.request_id, accepted})
+          send(owner, {:runtime_endpoint_done, ref, {:error, reason}})
       end
     end)
 
     {:ok, ref}
   end
 
-  def cancel_inference(_channel, _request_id), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
   def disconnect(_channel), do: :ok
 
   defp config do
@@ -85,13 +85,13 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
 
   alias Orchard.Cluster.V1.{
     EnsureModelLoadedRequest,
-    EnsureModelLoadedResponse,
     ExecuteInferenceRequest
   }
 
   alias Orchard.Dispatch.RequestDispatcher
   alias Orchard.Inference.QueueManager
   alias Orchard.Nodes.Node
+  alias Orchard.RuntimeEndpoint.Operation
 
   @valid_uuid "550e8400-e29b-41d4-a716-446655440000"
   @other_uuid "660f9511-f30c-52e5-b827-557766551111"
@@ -140,9 +140,9 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       status: {:ok, old_agent_status()},
       ensure_model_loaded:
         {:ok,
-         %EnsureModelLoadedResponse{
+         %Operation.EnsureModelLoadedResult{
            already_loaded: false,
-           placement_state: :PLACEMENT_STATE_LOADED
+           placement_state: :loaded
          }},
       execute: :success,
       capture_pid: self()

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -35,12 +35,14 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
   def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts \\ []) do
     owner = Keyword.get(opts, :owner, self())
     ref = make_ref()
+    execute = config().execute
+    parent = self()
 
     spawn(fn ->
       accepted = InferenceEvent.accepted(System.system_time(:millisecond))
       completed = InferenceEvent.completed(:finish_reason_stop, nil)
 
-      case config().execute do
+      case execute do
         :success ->
           send(owner, {:runtime_endpoint_event, ref, request.request_id, accepted})
           send(owner, {:runtime_endpoint_event, ref, request.request_id, completed})
@@ -52,13 +54,43 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
         {:accepted_then_error, reason} ->
           send(owner, {:runtime_endpoint_event, ref, request.request_id, accepted})
           send(owner, {:runtime_endpoint_done, ref, {:error, reason}})
+
+        :accepted_until_cancel ->
+          Registry.register(@registry, {:stream, request.request_id}, {owner, ref})
+          send(parent, {:stream_registered, ref})
+          send(owner, {:runtime_endpoint_event, ref, request.request_id, accepted})
+
+          receive do
+            :finish_after_cancel ->
+              send(owner, {:runtime_endpoint_done, ref, :ok})
+          after
+            1_000 ->
+              :ok
+          end
       end
     end)
+
+    if execute == :accepted_until_cancel do
+      receive do
+        {:stream_registered, ^ref} -> :ok
+      after
+        100 -> :ok
+      end
+    end
 
     {:ok, ref}
   end
 
-  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{} = request, opts) do
+    send(config().capture_pid, {:cancel_inference_called, request, opts})
+
+    @registry
+    |> Registry.lookup({:stream, request.request_id})
+    |> Enum.each(fn {pid, _value} -> send(pid, :finish_after_cancel) end)
+
+    :ok
+  end
+
   def disconnect(_channel), do: :ok
 
   defp config do
@@ -485,6 +517,24 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
   end
 
   describe "Sentry cancellation enrichment" do
+    test "cancellation calls runtime endpoint cancel with opts", ctx do
+      configure_stub(%{execute: :accepted_until_cancel})
+      schedule = %{ctx.schedule | request_timeout_ms: 1}
+
+      assert {:ok, events} =
+               RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
+                 client_impl: @stub_client
+               )
+
+      assert_receive {:cancel_inference_called,
+                      %Operation.CancelRequest{
+                        request_id: "req-probe-test",
+                        controller_session_id: "probe-test-session"
+                      }, []}
+
+      assert Enum.any?(events, &Orchard.InferenceEvent.terminal?/1)
+    end
+
     test "handler cancellation records cancel and synthesized terminal breadcrumbs", ctx do
       enable_controller_sentry()
       configure_stub(%{execute: {:accepted_then_error, :client_closed}})

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -530,6 +530,27 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       assert marked.health == :degraded
     end
 
+    test "runtime endpoint connect error marks target degraded and returns sanitized failure",
+         ctx do
+      insert_target_node!(ctx.schedule.runtime_client_target)
+      configure_stub(%{connect: {:error, :node_unavailable}})
+
+      assert {:error, {:model_load_failed, failure}} =
+               RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
+                 client_impl: @stub_client
+               )
+
+      assert failure.code == "node_unavailable"
+
+      marked =
+        Repo.get_by!(Node,
+          advertise_addr: Keyword.fetch!(ctx.schedule.runtime_client_target, :host),
+          rpc_port: Keyword.fetch!(ctx.schedule.runtime_client_target, :port)
+        )
+
+      assert marked.health == :degraded
+    end
+
     test "connect failure marks bind-all advertised node by actual connect target", ctx do
       target = ctx.schedule.runtime_client_target
 

--- a/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
@@ -28,7 +28,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest.StubClient do
   end
 
   def disconnect(_channel), do: :ok
-  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts \\ []), do: :ok
 
   def ensure_model_loaded(
         {:stub_channel, target},

--- a/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
@@ -3,13 +3,13 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest.StubClient do
 
   alias Orchard.Cluster.V1.{
     EnsureModelLoadedRequest,
-    EnsureModelLoadedResponse,
     ExecuteInferenceRequest,
     RuntimeNodeMetadata,
     StatusResponse
   }
 
   alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.Operation
 
   def connect(target) do
     key = target_key(target)
@@ -28,11 +28,11 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest.StubClient do
   end
 
   def disconnect(_channel), do: :ok
-  def cancel_inference(_channel, _request_id), do: :ok
+  def cancel_inference(_channel, %Operation.CancelRequest{}), do: :ok
 
   def ensure_model_loaded(
         {:stub_channel, target},
-        %EnsureModelLoadedRequest{} = request,
+        %Operation.EnsureModelLoadedRequest{} = request,
         _opts \\ []
       ) do
     key = target_key(target)
@@ -44,14 +44,18 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest.StubClient do
     send(capture_pid(), {:captured_ensure_model_loaded_target, key, request})
 
     {:ok,
-     %EnsureModelLoadedResponse{
+     %Operation.EnsureModelLoadedResult{
        already_loaded: false,
-       placement_state: :PLACEMENT_STATE_LOADED,
+       placement_state: :loaded,
        worker_supports_prompt_token_ids: response.supports_prompt_token_ids
      }}
   end
 
-  def execute_inference({:stub_channel, target}, %ExecuteInferenceRequest{} = request, opts \\ []) do
+  def execute_inference(
+        {:stub_channel, target},
+        %Operation.ExecuteRequest{} = request,
+        opts \\ []
+      ) do
     key = target_key(target)
     owner = Keyword.get(opts, :owner, self())
     ref = make_ref()
@@ -59,18 +63,22 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest.StubClient do
     send(capture_pid(), {:captured_execute_request, key, request})
 
     spawn(fn ->
-      send(owner, {:dispatch_event, ref, request.request_id, InferenceEvent.accepted(0)})
+      send(owner, {:runtime_endpoint_event, ref, request.request_id, InferenceEvent.accepted(0)})
 
       send(
         owner,
-        {:dispatch_event, ref, request.request_id,
+        {:runtime_endpoint_event, ref, request.request_id,
          InferenceEvent.completed(:finish_reason_stop, nil)}
       )
 
-      send(owner, {:dispatch_done, ref, :ok})
+      send(owner, {:runtime_endpoint_done, ref, :ok})
     end)
 
     {:ok, ref}
+  end
+
+  defp target_key(%Orchard.RuntimeEndpoint.Target{transport: :grpc_compat, address: address}) do
+    target_key(address)
   end
 
   defp target_key(target) do
@@ -117,6 +125,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
   alias Orchard.ModelManifest
   alias Orchard.ModelManifest.{ChatTemplate, RuntimeRequirements, SafeTokenization, Tokenizer}
   alias Orchard.Nodes.Node
+  alias Orchard.RuntimeEndpoint.Operation
   alias Orchard.Scheduler.MultiNode
   alias Orchard.Tokenizer.Client
 
@@ -185,7 +194,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
     assert metadata.node_id == schedule.node_id
 
     assert_receive {:captured_execute_request, ^selected_target,
-                    %ExecuteInferenceRequest{prompt_token_ids: @prompt_ids}}
+                    %Operation.ExecuteRequest{prompt_token_ids: @prompt_ids}}
 
     refute_receive {^unsafe_ref, [:orchard, :tokenizer, :unsafe_mode_active], _, _}, 200
     refute_receive {^drift_ref, [:orchard, :tokenizer, :parity_drift], _, _}, 200
@@ -243,9 +252,9 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
     assert_receive {^dispatched_ref, [:orchard, :tokenizer, :prompt_token_ids_dispatched], _, _}
 
     assert_receive {:captured_execute_request, ^capable_target,
-                    %ExecuteInferenceRequest{prompt_token_ids: @prompt_ids}}
+                    %Operation.ExecuteRequest{prompt_token_ids: @prompt_ids}}
 
-    refute_received {:captured_execute_request, ^legacy_target, %ExecuteInferenceRequest{}}
+    refute_received {:captured_execute_request, ^legacy_target, %Operation.ExecuteRequest{}}
     refute_receive {^unsafe_ref, [:orchard, :tokenizer, :unsafe_mode_active], _, _}, 200
   end
 
@@ -276,7 +285,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
     assert metadata.worker_supports_prompt_token_ids == false
 
     assert_receive {:captured_execute_request, ^legacy_target,
-                    %ExecuteInferenceRequest{prompt_token_ids: []}}
+                    %Operation.ExecuteRequest{prompt_token_ids: []}}
   end
 
   test "manifest drift telemetry fires in safe-mode off fixture coverage" do
@@ -412,6 +421,10 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
       |> Enum.sort_by(&{Keyword.fetch!(&1, :host), Keyword.fetch!(&1, :port)})
 
     put_inference(runtime_client_targets: targets)
+  end
+
+  defp target_key(%Orchard.RuntimeEndpoint.Target{transport: :grpc_compat, address: address}) do
+    target_key(address)
   end
 
   defp target_key(target) do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -23,6 +23,30 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler do
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointTargetScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
+  alias Orchard.RuntimeEndpoint.Target
+
+  def schedule(%CanonicalRequest{} = request) do
+    with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
+      target =
+        Target.grpc_compat(%{
+          host: "127.0.0.1",
+          port: 50_071,
+          metadata: %{
+            bearer_token: "must-not-persist-runtime-target",
+            tenant_hint: "tenant-secret"
+          }
+        })
+
+      {:ok, Map.put(schedule, :runtime_endpoint_target, target)}
+    end
+  end
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.StubCacheAffinityScheduler do
   @behaviour Orchard.Scheduler.SingleNode
 
@@ -769,6 +793,25 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert request.scheduler_decision["candidate_count"] == 2
     assert request.scheduler_decision["selected_tier"] == "loaded"
     assert request.scheduler_decision["node_id"] == scheduled_node_id()
+  end
+
+  test "execute/3 strips dispatch-only runtime endpoint target metadata", %{bundle: bundle} do
+    put_runtime_endpoint_target_scheduler_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-runtime-target")
+    canonical = canonical_request("request-orchestrator-runtime-target", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    decision = request.scheduler_decision
+
+    assert decision["strategy"] == "multi_node"
+    assert decision["runtime_client_target"] == %{"host" => "127.0.0.1", "port" => 50_071}
+    refute Map.has_key?(decision, "runtime_endpoint_target")
+    refute inspect(decision) =~ "must-not-persist-runtime-target"
+    refute inspect(decision) =~ "tenant-secret"
   end
 
   test "execute/3 persists sanitized prefix-cache scheduler fields only when enabled", %{
@@ -2786,6 +2829,18 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
           [host: "127.0.0.2", port: 50_072]
         ],
         scheduler_impl: Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+  end
+
+  defp put_runtime_endpoint_target_scheduler_config do
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.merge(
+        runtime_client_targets: [[host: "127.0.0.1", port: 50_071]],
+        scheduler_impl:
+          Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointTargetScheduler
       )
 
     Application.put_env(:orchard_controller, :inference, inference)

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -35,6 +35,7 @@ defmodule Orchard.NodesTest do
   alias Orchard.Inference.QueueManager
   alias Orchard.Nodes
   alias Orchard.Nodes.Node
+  alias Orchard.RuntimeEndpoint.GrpcCompatibilityMapper
 
   # -- Helpers --
 
@@ -1772,6 +1773,57 @@ defmodule Orchard.NodesTest do
       assert grant.queue_result == :queued
 
       assert :ok = QueueManager.release(grant)
+    end
+
+    test "SPEC.md §5.5 runtime endpoint observation refreshes placement queue capacity" do
+      QueueManager.reset()
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-observation-placement-a",
+                   "observation-placement"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-observation-placement-b",
+                   "observation-placement"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter = start_holding_awaiter(first_ticket, :first_observation_placement_result)
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+      target = make_target("10.0.0.93", 9444)
+
+      status =
+        make_status_response(%{listen_host: "10.0.0.93", listen_port: 9444})
+        |> Map.put(:active_request_count, 0)
+        |> Map.put(:max_concurrency, 2)
+        |> Map.put(:loaded_models, [%{model_id: "observation-placement", version: "v1"}])
+        |> Map.put(:runtime_model_placements, [
+          %{
+            model_ref: %{model_id: "observation-placement", version: "v1"},
+            active_request_count: 0,
+            max_concurrency: 2
+          }
+        ])
+
+      observation = GrpcCompatibilityMapper.observation_from_status(target, status)
+
+      assert {:ok, _node} = Nodes.observe_status(target, observation, DateTime.utc_now())
+      assert_receive {:first_observation_placement_result, {:ok, first_grant}}, 2_000
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert second_grant.queue_result == :queued
+      assert second_grant.queue_key == "observation-placement@v1"
+
+      assert :ok = QueueManager.release(first_grant)
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
     end
 
     test "SPEC.md §5.4 exhausted placement status does not publish queued capacity" do

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -1826,6 +1826,69 @@ defmodule Orchard.NodesTest do
       send(first_awaiter, :stop)
     end
 
+    test "SPEC.md §5.5 unavailable runtime endpoint observation clears queue capacity" do
+      QueueManager.reset()
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-unavailable-observation-a",
+                   "unavailable-observation"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-node-unavailable-observation-b",
+                   "unavailable-observation"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter =
+        start_holding_awaiter(first_ticket, :first_unavailable_observation_result)
+
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+      target = make_target("10.0.0.94", 9444)
+      observed_at = DateTime.utc_now()
+
+      status =
+        make_status_response(%{listen_host: "10.0.0.94", listen_port: 9444})
+        |> Map.put(:active_request_count, 0)
+        |> Map.put(:max_concurrency, 1)
+        |> Map.put(:runtime_model_placements, [])
+
+      observation = GrpcCompatibilityMapper.observation_from_status(target, status)
+
+      assert {:ok, _node} = Nodes.observe_status(target, observation, observed_at)
+      assert_receive {:first_unavailable_observation_result, {:ok, first_grant}}, 2_000
+      refute Task.yield(second_awaiter, 50)
+
+      unavailable_observation = %{observation | availability: :unavailable}
+
+      assert {:ok, _node} =
+               Nodes.observe_status(
+                 target,
+                 unavailable_observation,
+                 DateTime.add(observed_at, 1, :second)
+               )
+
+      assert :ok = QueueManager.release(first_grant)
+      refute Task.yield(second_awaiter, 100)
+
+      assert {:ok, _node} =
+               Nodes.observe_status(target, observation, DateTime.add(observed_at, 2, :second))
+
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert second_grant.queue_result == :queued
+      assert second_grant.queue_key == "unavailable-observation@v1"
+
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
+    end
+
     test "SPEC.md §5.4 exhausted placement status does not publish queued capacity" do
       QueueManager.reset()
 

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/beam_config_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/beam_config_test.exs
@@ -1,0 +1,62 @@
+defmodule Orchard.RuntimeEndpoint.BeamConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.RuntimeEndpoint.BeamConfig
+
+  test "disabled config validates as disabled" do
+    assert {:ok, %BeamConfig{enabled: false}} = BeamConfig.validate([], :prod)
+  end
+
+  test "validate_enabled fails closed when BEAM distribution is disabled" do
+    assert {:error, :beam_distribution_disabled} = BeamConfig.validate_enabled([], :prod)
+  end
+
+  test "enabled config requires identity, admission, and network restrictions" do
+    assert {:error, {:invalid_beam_distribution_config, errors}} =
+             BeamConfig.validate_enabled([enabled: true], :prod)
+
+    assert :missing_node_name in errors
+    assert :missing_cookie_file in errors
+    assert :missing_admitted_services in errors
+    assert :missing_allowed_cidrs in errors
+    assert :missing_listen_host in errors
+  end
+
+  test "enabled config rejects globally open network settings" do
+    assert {:error, {:invalid_beam_distribution_config, errors}} =
+             BeamConfig.validate_enabled(
+               [
+                 enabled: true,
+                 node_name: "orchard_controller@controller.local",
+                 cookie_file: "/Library/Application Support/Orchard/secrets/beam.cookie",
+                 admitted_services: ["orchard_node_agent"],
+                 allowed_cidrs: ["0.0.0.0/0"],
+                 listen_host: "0.0.0.0"
+               ],
+               :prod
+             )
+
+    assert :global_beam_distribution_cidr in errors
+    assert :unrestricted_listen_host in errors
+  end
+
+  test "enabled config validates when identity, admission, and network restrictions are explicit" do
+    assert {:ok, config} =
+             BeamConfig.validate_enabled(
+               [
+                 enabled: true,
+                 node_name: "orchard_controller@controller.local",
+                 cookie_file: "/Library/Application Support/Orchard/secrets/beam.cookie",
+                 admitted_services: ["orchard_node_agent"],
+                 allowed_cidrs: ["10.0.0.0/24"],
+                 listen_host: "10.0.0.10"
+               ],
+               :prod
+             )
+
+    assert config.enabled
+    assert config.node_name == "orchard_controller@controller.local"
+    assert config.admitted_services == ["orchard_node_agent"]
+    assert config.allowed_cidrs == ["10.0.0.0/24"]
+  end
+end

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs
@@ -1,0 +1,11 @@
+defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityClientTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.RuntimeEndpoint.{GrpcCompatibilityClient, Target}
+
+  test "connect rejects unsupported runtime endpoint target transports" do
+    target = Target.beam("node-1", address: :node_one)
+
+    assert {:error, {:unsupported_transport, :beam}} = GrpcCompatibilityClient.connect(target)
+  end
+end

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_mapper_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_mapper_test.exs
@@ -1,0 +1,318 @@
+defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityMapperTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Cluster.V1.{
+    Ack,
+    EnsureModelLoadedResponse,
+    GenerationParams,
+    RuntimeHealth,
+    RuntimeModelPlacement,
+    RuntimeNodeMetadata,
+    ScorePrefixCacheResponse,
+    StatusResponse
+  }
+
+  alias Orchard.Cluster.V1.ModelRef, as: RPCModelRef
+
+  alias Orchard.RuntimeEndpoint.{
+    GrpcCompatibilityMapper,
+    Observation,
+    Operation,
+    PlacementCapacity,
+    Target
+  }
+
+  @model_id "mlx-community/phi-3"
+  @version "main"
+
+  test "maps status response placements to runtime endpoint observations" do
+    node_id = Ecto.UUID.generate()
+    target = Target.grpc_compat(host: "127.0.0.1", port: 50_071)
+
+    response =
+      status_response(
+        node_id: node_id,
+        worker_state: :WORKER_STATE_BUSY,
+        active_request_count: 3,
+        loaded_models: [rpc_model_ref()],
+        runtime_health: %RuntimeHealth{ready: true, health_code: "ok"},
+        runtime_model_placements: [
+          %RuntimeModelPlacement{
+            model_ref: rpc_model_ref(),
+            active_request_count: 1,
+            max_concurrency: 2
+          }
+        ],
+        supports_prompt_token_ids: true
+      )
+
+    observation = GrpcCompatibilityMapper.observation_from_status(target, response)
+
+    assert observation.endpoint_id == "grpc_compat:127.0.0.1:50071"
+    assert observation.target == target
+    assert observation.availability == :available
+    assert observation.worker_state == :busy
+    assert observation.aggregate_active_request_count == 3
+    assert observation.metadata.node_id == node_id
+    assert observation.health.ready == true
+    assert observation.supports_prompt_token_ids == true
+
+    assert [placement] = observation.placements
+    assert placement.model_ref == domain_model_ref()
+    assert placement.state == :loaded
+
+    assert %PlacementCapacity{
+             status: :known,
+             active_request_count: 1,
+             max_concurrency: 2,
+             source: :grpc_compatibility_status
+           } = placement.capacity
+
+    assert PlacementCapacity.spare?(placement.capacity)
+  end
+
+  test "maps loaded placement without placement capacity as unknown" do
+    observation =
+      GrpcCompatibilityMapper.observation_from_status(
+        [host: "127.0.0.1", port: 50_071],
+        status_response(loaded_models: [rpc_model_ref()])
+      )
+
+    capacity = Observation.placement_capacity_for(observation, domain_model_ref())
+
+    assert capacity.status == :unknown
+    refute PlacementCapacity.spare?(capacity)
+    refute PlacementCapacity.full?(capacity)
+  end
+
+  test "duplicate, malformed, and nonmatching placement capacity cannot prove spare capacity" do
+    cases = [
+      {
+        [
+          %RuntimeModelPlacement{
+            model_ref: rpc_model_ref(),
+            active_request_count: 0,
+            max_concurrency: 2
+          },
+          %RuntimeModelPlacement{
+            model_ref: rpc_model_ref(),
+            active_request_count: 1,
+            max_concurrency: 2
+          }
+        ],
+        :invalid
+      },
+      {
+        [
+          %{
+            model_ref: %{model_id: @model_id, version: @version},
+            active_request_count: "1",
+            max_concurrency: 2
+          }
+        ],
+        :invalid
+      },
+      {
+        [
+          %RuntimeModelPlacement{
+            model_ref: %RPCModelRef{model_id: "other-model", version: @version},
+            active_request_count: 0,
+            max_concurrency: 2
+          }
+        ],
+        :unknown
+      }
+    ]
+
+    for {placements, expected_status} <- cases do
+      observation =
+        GrpcCompatibilityMapper.observation_from_status(
+          [host: "127.0.0.1", port: 50_071],
+          status_response(
+            loaded_models: [rpc_model_ref()],
+            runtime_model_placements: placements
+          )
+        )
+
+      capacity = Observation.placement_capacity_for(observation, domain_model_ref())
+
+      assert capacity.status == expected_status
+      refute PlacementCapacity.spare?(capacity)
+    end
+  end
+
+  test "maps ensure model loaded requests and responses" do
+    request =
+      Operation.EnsureModelLoadedRequest.new!(
+        model_ref: %{model_id: @model_id, version: @version},
+        node_id: "node-1",
+        artifact_sha256: "sha",
+        preload: true,
+        deadline_unix_ms: 123,
+        artifact_source_uri: "file:///models/phi"
+      )
+
+    proto = GrpcCompatibilityMapper.ensure_model_loaded_request_to_proto(request)
+
+    assert proto.node_id == "node-1"
+    assert proto.model_id == @model_id
+    assert proto.version == @version
+    assert proto.artifact_sha256 == "sha"
+    assert proto.preload == true
+    assert proto.deadline_unix_ms == 123
+    assert proto.artifact_source_uri == "file:///models/phi"
+
+    loaded =
+      GrpcCompatibilityMapper.ensure_model_loaded_result_from_response(%EnsureModelLoadedResponse{
+        already_loaded: true,
+        placement_state: :PLACEMENT_STATE_LOADED,
+        worker_supports_prompt_token_ids: true
+      })
+
+    assert loaded.already_loaded == true
+    assert loaded.placement_state == :loaded
+    assert loaded.worker_supports_prompt_token_ids == true
+
+    failed =
+      GrpcCompatibilityMapper.ensure_model_loaded_result_from_response(%EnsureModelLoadedResponse{
+        placement_state: :PLACEMENT_STATE_FAILED,
+        failure_category: :MODEL_LOAD_FAILURE_CATEGORY_RESOURCE_EXHAUSTED,
+        failure_code: "oom",
+        failure_message: "not enough memory"
+      })
+
+    assert failed.placement_state == :failed
+    assert failed.failure_category == :resource_exhausted
+    assert failed.failure_code == "oom"
+    assert failed.failure_message == "not enough memory"
+  end
+
+  test "maps execute inference requests" do
+    request =
+      Operation.ExecuteRequest.new!(
+        request_id: "req-1",
+        controller_session_id: "session-1",
+        model_ref: %{model_id: @model_id, version: @version},
+        rendered_prompt_utf8: "hello",
+        input_tokens: 2,
+        params: %{
+          max_output_tokens: 16,
+          temperature: 0.2,
+          top_p: 0.9,
+          stop_sequences: ["stop"],
+          tools_json: "{}",
+          tool_choice_json: "{\"type\":\"auto\"}"
+        },
+        deadline_unix_ms: 456,
+        metadata_json: "{\"tenant\":\"default\"}",
+        cache_affinity_fingerprint: "fp",
+        prompt_token_ids: [1, 2, 3]
+      )
+
+    proto = GrpcCompatibilityMapper.execute_request_to_proto(request)
+
+    assert proto.request_id == "req-1"
+    assert proto.controller_session_id == "session-1"
+    assert proto.model_id == @model_id
+    assert proto.version == @version
+    assert proto.rendered_prompt_utf8 == "hello"
+    assert proto.input_tokens == 2
+
+    assert proto.params == %GenerationParams{
+             max_output_tokens: 16,
+             temperature: 0.2,
+             top_p: 0.9,
+             stop_sequences: ["stop"],
+             tools_json: "{}",
+             tool_choice_json: "{\"type\":\"auto\"}"
+           }
+
+    assert proto.deadline_unix_ms == 456
+    assert proto.metadata_json == "{\"tenant\":\"default\"}"
+    assert proto.cache_affinity_fingerprint == "fp"
+    assert proto.prompt_token_ids == [1, 2, 3]
+  end
+
+  test "maps prefix cache score requests and responses" do
+    request =
+      Operation.PrefixCacheScoreRequest.new!(
+        request_id: "req-score",
+        controller_session_id: "session-score",
+        model_ref: %{model_id: @model_id, version: @version},
+        cache_affinity_fingerprint: "fingerprint",
+        deadline_unix_ms: 789
+      )
+
+    proto = GrpcCompatibilityMapper.prefix_cache_score_request_to_proto(request)
+
+    assert proto.request_id == "req-score"
+    assert proto.controller_session_id == "session-score"
+    assert proto.model_ref == rpc_model_ref()
+    assert proto.cache_affinity_fingerprint == "fingerprint"
+    assert proto.deadline_unix_ms == 789
+
+    result =
+      GrpcCompatibilityMapper.prefix_cache_score_result_from_response(%ScorePrefixCacheResponse{
+        status_code: "ok",
+        status_message: "resident",
+        resident_fingerprint_match: true,
+        score_tier: "resident_fingerprint",
+        session_started_unix_ms: 999
+      })
+
+    assert result.status_code == "ok"
+    assert result.status_message == "resident"
+    assert result.resident_fingerprint_match == true
+    assert result.score_tier == "resident_fingerprint"
+    assert result.session_started_unix_ms == 999
+  end
+
+  test "maps unload requests and acks" do
+    request =
+      Operation.UnloadModelRequest.new!(
+        model_ref: %{model_id: @model_id, version: @version},
+        force: true,
+        evict: true
+      )
+
+    proto = GrpcCompatibilityMapper.unload_model_request_to_proto(request)
+
+    assert proto.model_id == @model_id
+    assert proto.version == @version
+    assert proto.force == true
+    assert proto.evict == true
+
+    assert %Operation.Ack{ok: true, message: "done"} =
+             GrpcCompatibilityMapper.ack_from_response(%Ack{ok: true, message: "done"})
+  end
+
+  defp status_response(opts) do
+    node_id = Keyword.get(opts, :node_id, Ecto.UUID.generate())
+
+    %StatusResponse{
+      worker_state: Keyword.get(opts, :worker_state, :WORKER_STATE_IDLE),
+      loaded_models: Keyword.get(opts, :loaded_models, []),
+      active_request_count: Keyword.get(opts, :active_request_count, 0),
+      node_metadata: %RuntimeNodeMetadata{
+        node_id: node_id,
+        display_name: "node-#{String.slice(node_id, 0, 8)}",
+        hostname: "node.local",
+        agent_version: "0.1.0",
+        listen_host: "127.0.0.1",
+        listen_port: 50_071,
+        worker_backend: "mlx"
+      },
+      runtime_health: Keyword.get(opts, :runtime_health),
+      runtime_model_placements: Keyword.get(opts, :runtime_model_placements, []),
+      supports_prompt_token_ids: Keyword.get(opts, :supports_prompt_token_ids, false)
+    }
+  end
+
+  defp rpc_model_ref do
+    %RPCModelRef{model_id: @model_id, version: @version}
+  end
+
+  defp domain_model_ref do
+    %Orchard.RuntimeEndpoint.ModelRef{model_id: @model_id, version: @version}
+  end
+end

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -595,6 +595,31 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.candidate_count == 1
     end
 
+    test "uses runtime endpoint observation aggregate capacity for active cold target" do
+      put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
+      node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      target = Target.grpc_compat(host: "10.0.0.1", port: 50_061)
+
+      observation =
+        GrpcCompatibilityMapper.observation_from_status(
+          target,
+          make_status(node.id,
+            host: "10.0.0.1",
+            port: 50_061,
+            active_request_count: 1,
+            max_concurrency: 2
+          )
+        )
+
+      stub_probe("10.0.0.1", 50_061, observation)
+
+      assert {:ok, schedule} = MultiNode.schedule(canonical_request(), status_client: StubClient)
+      assert schedule.strategy == :multi_node
+      assert schedule.node_id == node.id
+      assert schedule.selected_tier == "cold"
+      assert schedule.candidate_count == 1
+    end
+
     test "returns cluster_busy for one live cold target at aggregate capacity" do
       put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -10,6 +10,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
   alias Orchard.Inference.CacheAffinity
   alias Orchard.Inference.QueueManager
   alias Orchard.Nodes.Node
+  alias Orchard.RuntimeEndpoint.{GrpcCompatibilityMapper, Target}
   alias Orchard.Scheduler.MultiNode
 
   # -- Stub Status Client --
@@ -24,7 +25,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     Target key is `{host, port}`.
     """
     def connect(target) do
-      key = {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
+      key = target_key(target)
 
       case Process.get({:stub_connect, key}) do
         nil -> {:ok, target}
@@ -33,7 +34,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     end
 
     def status(target, opts) do
-      key = {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
+      key = target_key(target)
       calls = Process.get(:stub_status_calls, [])
       Process.put(:stub_status_calls, [{key, opts} | calls])
 
@@ -48,7 +49,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     def disconnect(_channel), do: :ok
 
     def score_prefix_cache(target, request, _opts) do
-      key = {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
+      key = target_key(target)
       calls = Process.get(:stub_score_calls, [])
       Process.put(:stub_score_calls, [{key, request} | calls])
 
@@ -57,6 +58,14 @@ defmodule Orchard.Scheduler.MultiNodeTest do
         {:error, _reason} = error -> error
         response -> {:ok, response}
       end
+    end
+
+    defp target_key(%Orchard.RuntimeEndpoint.Target{transport: :grpc_compat, address: address}) do
+      target_key(address)
+    end
+
+    defp target_key(target) do
+      {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
     end
   end
 
@@ -649,6 +658,37 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.node_id == node_b.id
       assert schedule.selected_tier == "loaded"
       assert schedule.candidate_count == 2
+    end
+
+    test "consumes runtime endpoint observations and preserves legacy dispatch target" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+      endpoint_target = Target.grpc_compat(host: "10.0.0.1", port: 50_061)
+
+      observation =
+        GrpcCompatibilityMapper.observation_from_status(
+          endpoint_target,
+          make_status(node_a.id,
+            host: "10.0.0.1",
+            port: 50_061,
+            loaded_models: [%{model_id: "test-model", version: "v1"}],
+            runtime_model_placements: [model_placement("test-model", "v1", 0, 2)]
+          )
+        )
+
+      stub_probe("10.0.0.1", 50_061, observation)
+      stub_probe("10.0.0.2", 50_062, make_status(node_b.id, host: "10.0.0.2", port: 50_062))
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request("test-model", "v1"),
+                 status_client: StubClient
+               )
+
+      assert schedule.strategy == :multi_node
+      assert schedule.node_id == node_a.id
+      assert schedule.runtime_endpoint_target == endpoint_target
+      assert schedule.runtime_client_target == [host: "10.0.0.1", port: 50_061]
+      assert schedule.selected_tier == "loaded"
     end
 
     test "hosted tool capability and readiness data do not change inference ranking" do

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -620,6 +620,31 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.candidate_count == 1
     end
 
+    test "SPEC.md §7.5 excludes unavailable runtime endpoint observations" do
+      put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
+      node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      target = Target.grpc_compat(host: "10.0.0.1", port: 50_061)
+
+      observation =
+        %{
+          GrpcCompatibilityMapper.observation_from_status(
+            target,
+            make_status(node.id,
+              host: "10.0.0.1",
+              port: 50_061,
+              active_request_count: 0,
+              max_concurrency: 16
+            )
+          )
+          | availability: :unavailable
+        }
+
+      stub_probe("10.0.0.1", 50_061, observation)
+
+      assert {:error, :cluster_busy} =
+               MultiNode.schedule(canonical_request(), status_client: StubClient)
+    end
+
     test "returns cluster_busy for one live cold target at aggregate capacity" do
       put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})

--- a/apps/orchard_node_agent/README.md
+++ b/apps/orchard_node_agent/README.md
@@ -1,8 +1,7 @@
 # orchard_node_agent
 
-Node-agent release for Orchard's worker-node boundary. It exposes the internal
-node runtime endpoint, reports node/runtime status, manages model acquisition and
-cache state, and supervises local worker subprocesses.
+Node-agent release for Orchard's worker-node boundary.
+It exposes the current gRPC Runtime Endpoint compatibility service, reports node/runtime status, manages model acquisition and cache state, and supervises local worker subprocesses.
 
 This README is orientation only. Normative behavior lives in
 [`../../SPEC.md`](../../SPEC.md); repo/runtime boundaries are mapped in
@@ -10,7 +9,7 @@ This README is orientation only. Normative behavior lives in
 
 ## Owns
 
-- Node-local runtime service behavior used by the controller.
+- Node-local Runtime Endpoint compatibility behavior used by the controller.
 - Model acquisition/cache/load coordination on a node.
 - Worker process supervision and node-local diagnostics/status reporting.
 - Runtime aggregate node and placement capacity telemetry.

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -39,6 +39,8 @@ defmodule OrchardNodeAgentTest do
   alias Orchard.Node.Supervisor, as: NodeSupervisor
   alias Orchard.Node.WorkerSupervisor
   alias Orchard.NodeAgent.Supervisor, as: NodeAgentSupervisor
+  alias Orchard.RuntimeEndpoint.ModelRef, as: RuntimeModelRef
+  alias Orchard.RuntimeEndpoint.{Observation, PlacementCapacity, Target}
 
   @test_model_id "mlx-community/phi-3"
   @test_version "main"
@@ -1303,6 +1305,7 @@ defmodule OrchardNodeAgentTest do
     assert String.ends_with?(runtime[:models_root], "/tmp/test/models")
     assert String.starts_with?(runtime[:worker_socket_dir], "/tmp/ot-")
     assert String.ends_with?(runtime[:worker_socket_dir], "/ws")
+    assert String.length(Node.worker_socket_path(@test_model_id, @test_version)) < 104
 
     assert String.ends_with?(
              runtime[:worker_executable],
@@ -2827,9 +2830,10 @@ defmodule OrchardNodeAgentTest do
     end
   end
 
-  test "batch mode accepts two same-model gRPC streams and reports active placement capacity", %{
-    bundle: bundle
-  } do
+  test "batch mode accepts two same-model gRPC compatibility runtime endpoint streams and reports active placement capacity",
+       %{
+         bundle: bundle
+       } do
     with_runtime_config(
       [
         runtime_adapter_impl: BlockingRuntimeAdapter,
@@ -2866,6 +2870,12 @@ defmodule OrchardNodeAgentTest do
             assert placement.active_request_count == 2
             assert placement.max_concurrency == 2
 
+            capacity = runtime_endpoint_capacity(status)
+            assert capacity.active_request_count == 2
+            assert capacity.max_concurrency == 2
+            assert PlacementCapacity.full?(capacity)
+            refute PlacementCapacity.spare?(capacity)
+
             send_release(Map.fetch!(refs, request_id1))
             send_release(Map.fetch!(refs, request_id2))
 
@@ -2883,6 +2893,12 @@ defmodule OrchardNodeAgentTest do
 
             assert final_placement.active_request_count == 0
             assert final_placement.max_concurrency == 2
+
+            final_capacity = runtime_endpoint_capacity(final_status)
+            assert final_capacity.active_request_count == 0
+            assert final_capacity.max_concurrency == 2
+            assert PlacementCapacity.spare?(final_capacity)
+            refute PlacementCapacity.full?(final_capacity)
           after
             try do
               best_effort_release_generation_refs([request_id1, request_id2])
@@ -2896,7 +2912,7 @@ defmodule OrchardNodeAgentTest do
     )
   end
 
-  test "batch mode cancel drains one gRPC stream and frees same-model capacity", %{
+  test "batch mode cancel drains one runtime endpoint stream and frees same-model capacity", %{
     bundle: bundle
   } do
     with_runtime_config(
@@ -2936,6 +2952,10 @@ defmodule OrchardNodeAgentTest do
             assert placement.active_request_count == 2
             assert placement.max_concurrency == 2
 
+            capacity = runtime_endpoint_capacity(status)
+            assert PlacementCapacity.full?(capacity)
+            refute PlacementCapacity.spare?(capacity)
+
             assert {:ok, %{ok: true, message: "cancel accepted"}} =
                      NodeRuntimeStub.cancel_inference(channel, %CancelInferenceRequest{
                        request_id: request_id1,
@@ -2946,10 +2966,10 @@ defmodule OrchardNodeAgentTest do
 
             wait_until(fn ->
               status = grpc_status_snapshot()
-              placement = runtime_model_placement!(status, @test_model_id, @test_version)
+              capacity = runtime_endpoint_capacity(status)
 
-              status.active_request_count == 1 and placement.active_request_count == 1 and
-                placement.max_concurrency == 2
+              status.active_request_count == 1 and capacity.active_request_count == 1 and
+                capacity.max_concurrency == 2 and PlacementCapacity.spare?(capacity)
             end)
 
             assert %{^request_id2 => _generation_ref} =
@@ -2971,6 +2991,10 @@ defmodule OrchardNodeAgentTest do
               assert refreshed_placement.active_request_count == 2
               assert refreshed_placement.max_concurrency == 2
 
+              refreshed_capacity = runtime_endpoint_capacity(refreshed_status)
+              assert PlacementCapacity.full?(refreshed_capacity)
+              refute PlacementCapacity.spare?(refreshed_capacity)
+
               send_release(Map.fetch!(refs, request_id2))
               send_release(Map.fetch!(refs, request_id3))
 
@@ -2979,10 +3003,10 @@ defmodule OrchardNodeAgentTest do
 
               wait_until(fn ->
                 status = grpc_status_snapshot()
-                placement = runtime_model_placement!(status, @test_model_id, @test_version)
+                capacity = runtime_endpoint_capacity(status)
 
-                status.active_request_count == 0 and placement.active_request_count == 0 and
-                  placement.max_concurrency == 2
+                status.active_request_count == 0 and capacity.active_request_count == 0 and
+                  capacity.max_concurrency == 2 and PlacementCapacity.spare?(capacity)
               end)
             after
               best_effort_release_generation_refs([request_id2, request_id3])
@@ -3014,7 +3038,12 @@ defmodule OrchardNodeAgentTest do
                    max_concurrency: 1
                  }
                ]
-             } = NodeStatus.current()
+             } = status = NodeStatus.current()
+
+      capacity = runtime_endpoint_capacity(status)
+      assert capacity.active_request_count == 0
+      assert capacity.max_concurrency == 1
+      assert PlacementCapacity.spare?(capacity)
     end)
   end
 
@@ -3041,7 +3070,12 @@ defmodule OrchardNodeAgentTest do
                      max_concurrency: 1
                    }
                  ]
-               } = NodeStatus.current()
+               } = status = NodeStatus.current()
+
+        capacity = runtime_endpoint_capacity(status)
+        assert capacity.active_request_count == 0
+        assert capacity.max_concurrency == 1
+        assert PlacementCapacity.spare?(capacity)
       end
     )
   end
@@ -3071,7 +3105,12 @@ defmodule OrchardNodeAgentTest do
                      max_concurrency: 2
                    }
                  ]
-               } = NodeStatus.current()
+               } = status = NodeStatus.current()
+
+        capacity = runtime_endpoint_capacity(status)
+        assert capacity.active_request_count == 1
+        assert capacity.max_concurrency == 2
+        assert PlacementCapacity.spare?(capacity)
 
         assert %{ok: true} = NodeStatus.cancel_request(request.request_id)
       end
@@ -4565,6 +4604,37 @@ defmodule OrchardNodeAgentTest do
     else
       refs
     end
+  end
+
+  defp runtime_endpoint_capacity(%StatusResponse{} = status) do
+    status
+    |> runtime_endpoint_observation()
+    |> Observation.placement_capacity_for(runtime_endpoint_model_ref())
+  end
+
+  defp runtime_endpoint_observation(%StatusResponse{} = status) do
+    Observation.new(%{
+      target: Target.beam(Node.node_id() || "test-node"),
+      aggregate_active_request_count: status.active_request_count,
+      worker_state: status.worker_state,
+      placements: Enum.map(status.runtime_model_placements, &runtime_endpoint_placement/1)
+    })
+  end
+
+  defp runtime_endpoint_placement(placement) do
+    %{
+      model_ref: placement.model_ref,
+      state: :loaded,
+      capacity: %{
+        active_request_count: placement.active_request_count,
+        max_concurrency: placement.max_concurrency,
+        source: :node_agent_status
+      }
+    }
+  end
+
+  defp runtime_endpoint_model_ref do
+    RuntimeModelRef.new!(@test_model_id, @test_version)
   end
 
   defp runtime_model_placement!(%StatusResponse{} = status, model_id, version) do

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/model_ref.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/model_ref.ex
@@ -1,0 +1,61 @@
+defmodule Orchard.RuntimeEndpoint.ModelRef do
+  @moduledoc """
+  Transport-independent model identity used by Runtime Endpoint contracts.
+  """
+
+  @enforce_keys [:model_id, :version]
+  defstruct model_id: nil, version: nil
+
+  @type t :: %__MODULE__{model_id: String.t(), version: String.t()}
+
+  @spec new(String.t(), String.t()) :: {:ok, t()} | {:error, :invalid_model_ref}
+  def new(model_id, version)
+      when is_binary(model_id) and model_id != "" and is_binary(version) and version != "" do
+    {:ok, %__MODULE__{model_id: model_id, version: version}}
+  end
+
+  def new(_model_id, _version), do: {:error, :invalid_model_ref}
+
+  @spec new(t() | map()) :: {:ok, t()} | {:error, :invalid_model_ref}
+  def new(%__MODULE__{} = model_ref), do: new(model_ref.model_id, model_ref.version)
+
+  def new(%{} = attrs) do
+    new(value(attrs, :model_id), value(attrs, :version))
+  end
+
+  def new(_attrs), do: {:error, :invalid_model_ref}
+
+  @spec new!(String.t(), String.t()) :: t()
+  def new!(model_id, version) do
+    case new(model_id, version) do
+      {:ok, model_ref} ->
+        model_ref
+
+      {:error, :invalid_model_ref} ->
+        raise ArgumentError, "model_ref requires non-empty model_id and version"
+    end
+  end
+
+  @spec new!(t() | map()) :: t()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, model_ref} ->
+        model_ref
+
+      {:error, :invalid_model_ref} ->
+        raise ArgumentError, "model_ref requires non-empty model_id and version"
+    end
+  end
+
+  @spec equal?(t() | map() | nil, t() | map() | nil) :: boolean()
+  def equal?(left, right) do
+    with {:ok, left_ref} <- new(left),
+         {:ok, right_ref} <- new(right) do
+      left_ref.model_id == right_ref.model_id and left_ref.version == right_ref.version
+    else
+      _ -> false
+    end
+  end
+
+  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/model_ref.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/model_ref.ex
@@ -57,5 +57,13 @@ defmodule Orchard.RuntimeEndpoint.ModelRef do
     end
   end
 
-  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  defp value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
 end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/observation.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/observation.ex
@@ -11,6 +11,7 @@ defmodule Orchard.RuntimeEndpoint.Observation do
             availability: :unknown,
             worker_state: :unknown,
             aggregate_active_request_count: 0,
+            aggregate_max_concurrency: nil,
             metadata: %{},
             health: %{},
             placements: [],
@@ -28,6 +29,7 @@ defmodule Orchard.RuntimeEndpoint.Observation do
           availability: availability(),
           worker_state: term(),
           aggregate_active_request_count: non_neg_integer(),
+          aggregate_max_concurrency: pos_integer() | nil,
           metadata: map(),
           health: map(),
           placements: [Placement.t()],
@@ -49,6 +51,7 @@ defmodule Orchard.RuntimeEndpoint.Observation do
       availability: value(attrs, :availability) || :unknown,
       worker_state: value(attrs, :worker_state) || :unknown,
       aggregate_active_request_count: aggregate_active_request_count(attrs),
+      aggregate_max_concurrency: aggregate_max_concurrency(attrs),
       metadata: map_value(attrs, :metadata),
       health: map_value(attrs, :health),
       placements: Enum.map(list_value(attrs, :placements), &normalize_placement/1),
@@ -110,6 +113,20 @@ defmodule Orchard.RuntimeEndpoint.Observation do
     end
   end
 
+  defp aggregate_max_concurrency(attrs) do
+    case aggregate_max_concurrency_value(attrs) do
+      count when is_integer(count) and count > 0 -> count
+      _ -> nil
+    end
+  end
+
+  defp aggregate_max_concurrency_value(attrs) do
+    case value(attrs, :aggregate_max_concurrency) do
+      nil -> value(attrs, :max_concurrency)
+      value -> value
+    end
+  end
+
   defp map_value(attrs, key) do
     case value(attrs, key) do
       %{} = map -> map
@@ -126,5 +143,13 @@ defmodule Orchard.RuntimeEndpoint.Observation do
     end
   end
 
-  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  defp value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
 end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/observation.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/observation.ex
@@ -1,0 +1,130 @@
+defmodule Orchard.RuntimeEndpoint.Observation do
+  @moduledoc """
+  Transport-independent Runtime Endpoint status observation.
+  """
+
+  alias Orchard.RuntimeEndpoint.{ModelRef, Placement, PlacementCapacity, Target}
+
+  defstruct endpoint_id: nil,
+            target: nil,
+            observed_at: nil,
+            availability: :unknown,
+            worker_state: :unknown,
+            aggregate_active_request_count: 0,
+            metadata: %{},
+            health: %{},
+            placements: [],
+            hosted_tool_capabilities: [],
+            hosted_tool_readiness: [],
+            runtime_memory_budgets: [],
+            runtime_prefix_cache_statuses: [],
+            supports_prompt_token_ids: false
+
+  @type availability :: :unknown | :available | :unavailable | :degraded | atom()
+  @type t :: %__MODULE__{
+          endpoint_id: String.t() | nil,
+          target: Target.t() | nil,
+          observed_at: term(),
+          availability: availability(),
+          worker_state: term(),
+          aggregate_active_request_count: non_neg_integer(),
+          metadata: map(),
+          health: map(),
+          placements: [Placement.t()],
+          hosted_tool_capabilities: [term()],
+          hosted_tool_readiness: [term()],
+          runtime_memory_budgets: [term()],
+          runtime_prefix_cache_statuses: [term()],
+          supports_prompt_token_ids: boolean()
+        }
+
+  @spec new(map() | keyword()) :: t()
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    %__MODULE__{
+      endpoint_id: value(attrs, :endpoint_id),
+      target: value(attrs, :target),
+      observed_at: value(attrs, :observed_at),
+      availability: value(attrs, :availability) || :unknown,
+      worker_state: value(attrs, :worker_state) || :unknown,
+      aggregate_active_request_count: aggregate_active_request_count(attrs),
+      metadata: map_value(attrs, :metadata),
+      health: map_value(attrs, :health),
+      placements: Enum.map(list_value(attrs, :placements), &normalize_placement/1),
+      hosted_tool_capabilities: list_value(attrs, :hosted_tool_capabilities),
+      hosted_tool_readiness: list_value(attrs, :hosted_tool_readiness),
+      runtime_memory_budgets: list_value(attrs, :runtime_memory_budgets),
+      runtime_prefix_cache_statuses: list_value(attrs, :runtime_prefix_cache_statuses),
+      supports_prompt_token_ids: value(attrs, :supports_prompt_token_ids) == true
+    }
+  end
+
+  @spec node_id(t()) :: String.t() | nil
+  def node_id(%__MODULE__{target: %Target{node_id: node_id}})
+      when is_binary(node_id) and node_id != "",
+      do: node_id
+
+  def node_id(%__MODULE__{metadata: metadata}) when is_map(metadata) do
+    value(metadata, :node_id)
+  end
+
+  @spec loaded_placement(t(), ModelRef.t() | map()) :: Placement.t() | nil
+  def loaded_placement(%__MODULE__{placements: placements}, model_ref) do
+    Enum.find(placements, fn placement ->
+      Placement.loaded?(placement) and ModelRef.equal?(placement.model_ref, model_ref)
+    end)
+  end
+
+  @spec placement_capacity_for(t(), ModelRef.t() | map()) :: PlacementCapacity.t()
+  def placement_capacity_for(%__MODULE__{placements: placements}, model_ref) do
+    matching =
+      Enum.filter(placements, fn placement ->
+        ModelRef.equal?(placement.model_ref, model_ref)
+      end)
+
+    case matching do
+      [%Placement{capacity: %PlacementCapacity{} = capacity}] ->
+        capacity
+
+      [] ->
+        PlacementCapacity.unknown(model_ref, :not_observed)
+
+      _duplicates ->
+        PlacementCapacity.new(%{
+          model_ref: model_ref,
+          active_request_count: :duplicate,
+          max_concurrency: :duplicate,
+          source: :duplicate_observation
+        })
+    end
+  end
+
+  defp normalize_placement(%Placement{} = placement), do: placement
+  defp normalize_placement(%{} = attrs), do: Placement.new(attrs)
+
+  defp aggregate_active_request_count(attrs) do
+    case value(attrs, :aggregate_active_request_count) do
+      count when is_integer(count) and count >= 0 -> count
+      _ -> 0
+    end
+  end
+
+  defp map_value(attrs, key) do
+    case value(attrs, key) do
+      %{} = map -> map
+      nil -> %{}
+      other -> %{raw_value: other}
+    end
+  end
+
+  defp list_value(attrs, key) do
+    case value(attrs, key) do
+      list when is_list(list) -> list
+      nil -> []
+      other -> [other]
+    end
+  end
+
+  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/operation.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/operation.ex
@@ -297,7 +297,15 @@ defmodule Orchard.RuntimeEndpoint.Operation do
   end
 
   @spec value(map(), atom()) :: term()
-  def value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  def value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
 
   @spec map_value(map(), atom()) :: map()
   def map_value(attrs, key) do

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/operation.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/operation.ex
@@ -1,0 +1,354 @@
+defmodule Orchard.RuntimeEndpoint.Operation do
+  @moduledoc """
+  Operation structs exchanged through the Runtime Endpoint Interface.
+  """
+
+  defmodule Ack do
+    @moduledoc false
+
+    defstruct ok: false, message: ""
+
+    @type t :: %__MODULE__{ok: boolean(), message: String.t()}
+  end
+
+  defmodule EnsureModelLoadedRequest do
+    @moduledoc false
+
+    alias Orchard.RuntimeEndpoint.{ModelRef, Operation}
+
+    @enforce_keys [:model_ref]
+    defstruct model_ref: nil,
+              node_id: nil,
+              artifact_sha256: nil,
+              preload: false,
+              deadline_unix_ms: nil,
+              artifact_source_uri: nil,
+              metadata: %{}
+
+    @type t :: %__MODULE__{
+            model_ref: ModelRef.t(),
+            node_id: String.t() | nil,
+            artifact_sha256: String.t() | nil,
+            preload: boolean(),
+            deadline_unix_ms: non_neg_integer() | nil,
+            artifact_source_uri: String.t() | nil,
+            metadata: map()
+          }
+
+    @spec new!(map() | keyword()) :: t()
+    def new!(attrs) when is_list(attrs), do: attrs |> Map.new() |> new!()
+
+    def new!(%{} = attrs) do
+      %__MODULE__{
+        model_ref: ModelRef.new!(Operation.value(attrs, :model_ref)),
+        node_id: Operation.value(attrs, :node_id),
+        artifact_sha256:
+          Operation.optional_binary!(Operation.value(attrs, :artifact_sha256), :artifact_sha256),
+        preload: Operation.value(attrs, :preload) == true,
+        deadline_unix_ms:
+          Operation.optional_non_neg_integer!(
+            Operation.value(attrs, :deadline_unix_ms),
+            :deadline_unix_ms
+          ),
+        artifact_source_uri:
+          Operation.optional_binary!(
+            Operation.value(attrs, :artifact_source_uri),
+            :artifact_source_uri
+          ),
+        metadata: Operation.map_value(attrs, :metadata)
+      }
+    end
+  end
+
+  defmodule EnsureModelLoadedResult do
+    @moduledoc false
+
+    defstruct already_loaded: false,
+              placement_state: :unknown,
+              failure_category: nil,
+              failure_code: nil,
+              failure_message: nil,
+              worker_supports_prompt_token_ids: false
+
+    @type t :: %__MODULE__{
+            already_loaded: boolean(),
+            placement_state: atom() | String.t(),
+            failure_category: atom() | String.t() | nil,
+            failure_code: String.t() | nil,
+            failure_message: String.t() | nil,
+            worker_supports_prompt_token_ids: boolean()
+          }
+  end
+
+  defmodule UnloadModelRequest do
+    @moduledoc false
+
+    alias Orchard.RuntimeEndpoint.{ModelRef, Operation}
+
+    @enforce_keys [:model_ref]
+    defstruct model_ref: nil, force: false, evict: false, deadline_unix_ms: nil, metadata: %{}
+
+    @type t :: %__MODULE__{
+            model_ref: ModelRef.t(),
+            force: boolean(),
+            evict: boolean(),
+            deadline_unix_ms: non_neg_integer() | nil,
+            metadata: map()
+          }
+
+    @spec new!(map() | keyword()) :: t()
+    def new!(attrs) when is_list(attrs), do: attrs |> Map.new() |> new!()
+
+    def new!(%{} = attrs) do
+      %__MODULE__{
+        model_ref: ModelRef.new!(Operation.value(attrs, :model_ref)),
+        force: Operation.value(attrs, :force) == true,
+        evict: Operation.value(attrs, :evict) == true,
+        deadline_unix_ms:
+          Operation.optional_non_neg_integer!(
+            Operation.value(attrs, :deadline_unix_ms),
+            :deadline_unix_ms
+          ),
+        metadata: Operation.map_value(attrs, :metadata)
+      }
+    end
+  end
+
+  defmodule ExecuteRequest do
+    @moduledoc false
+
+    alias Orchard.RuntimeEndpoint.{ModelRef, Operation}
+
+    @enforce_keys [
+      :request_id,
+      :controller_session_id,
+      :model_ref,
+      :rendered_prompt_utf8,
+      :input_tokens
+    ]
+    defstruct request_id: nil,
+              controller_session_id: nil,
+              model_ref: nil,
+              rendered_prompt_utf8: "",
+              input_tokens: 0,
+              params: %{},
+              deadline_unix_ms: nil,
+              metadata_json: "{}",
+              cache_affinity_fingerprint: nil,
+              prompt_token_ids: nil,
+              artifact_sha256: nil,
+              artifact_source_uri: nil,
+              preload: false
+
+    @type t :: %__MODULE__{
+            request_id: String.t(),
+            controller_session_id: String.t(),
+            model_ref: ModelRef.t(),
+            rendered_prompt_utf8: binary(),
+            input_tokens: non_neg_integer(),
+            params: map(),
+            deadline_unix_ms: non_neg_integer() | nil,
+            metadata_json: binary(),
+            cache_affinity_fingerprint: String.t() | nil,
+            prompt_token_ids: [non_neg_integer()] | nil,
+            artifact_sha256: String.t() | nil,
+            artifact_source_uri: String.t() | nil,
+            preload: boolean()
+          }
+
+    @spec new!(map() | keyword()) :: t()
+    def new!(attrs) when is_list(attrs), do: attrs |> Map.new() |> new!()
+
+    def new!(%{} = attrs) do
+      %__MODULE__{
+        request_id: Operation.non_empty_binary!(Operation.value(attrs, :request_id), :request_id),
+        controller_session_id:
+          Operation.non_empty_binary!(
+            Operation.value(attrs, :controller_session_id),
+            :controller_session_id
+          ),
+        model_ref: ModelRef.new!(Operation.value(attrs, :model_ref)),
+        rendered_prompt_utf8:
+          Operation.binary!(Operation.value(attrs, :rendered_prompt_utf8), :rendered_prompt_utf8),
+        input_tokens:
+          Operation.non_neg_integer!(Operation.value(attrs, :input_tokens), :input_tokens),
+        params: Operation.map_value(attrs, :params),
+        deadline_unix_ms:
+          Operation.optional_non_neg_integer!(
+            Operation.value(attrs, :deadline_unix_ms),
+            :deadline_unix_ms
+          ),
+        metadata_json:
+          Operation.binary!(Operation.value(attrs, :metadata_json) || "{}", :metadata_json),
+        cache_affinity_fingerprint:
+          Operation.optional_binary!(
+            Operation.value(attrs, :cache_affinity_fingerprint),
+            :cache_affinity_fingerprint
+          ),
+        prompt_token_ids:
+          Operation.optional_token_ids!(Operation.value(attrs, :prompt_token_ids)),
+        artifact_sha256:
+          Operation.optional_binary!(Operation.value(attrs, :artifact_sha256), :artifact_sha256),
+        artifact_source_uri:
+          Operation.optional_binary!(
+            Operation.value(attrs, :artifact_source_uri),
+            :artifact_source_uri
+          ),
+        preload: Operation.value(attrs, :preload) == true
+      }
+    end
+  end
+
+  defmodule CancelRequest do
+    @moduledoc false
+
+    alias Orchard.RuntimeEndpoint.Operation
+
+    @enforce_keys [:request_id, :controller_session_id]
+    defstruct request_id: nil, controller_session_id: nil, metadata: %{}
+
+    @type t :: %__MODULE__{
+            request_id: String.t(),
+            controller_session_id: String.t(),
+            metadata: map()
+          }
+
+    @spec new!(map() | keyword()) :: t()
+    def new!(attrs) when is_list(attrs), do: attrs |> Map.new() |> new!()
+
+    def new!(%{} = attrs) do
+      %__MODULE__{
+        request_id: Operation.non_empty_binary!(Operation.value(attrs, :request_id), :request_id),
+        controller_session_id:
+          Operation.non_empty_binary!(
+            Operation.value(attrs, :controller_session_id),
+            :controller_session_id
+          ),
+        metadata: Operation.map_value(attrs, :metadata)
+      }
+    end
+  end
+
+  defmodule PrefixCacheScoreRequest do
+    @moduledoc false
+
+    alias Orchard.RuntimeEndpoint.{ModelRef, Operation}
+
+    @enforce_keys [:request_id, :controller_session_id, :model_ref, :cache_affinity_fingerprint]
+    defstruct request_id: nil,
+              controller_session_id: nil,
+              model_ref: nil,
+              cache_affinity_fingerprint: nil,
+              deadline_unix_ms: nil,
+              metadata: %{}
+
+    @type t :: %__MODULE__{
+            request_id: String.t(),
+            controller_session_id: String.t(),
+            model_ref: ModelRef.t(),
+            cache_affinity_fingerprint: String.t(),
+            deadline_unix_ms: non_neg_integer() | nil,
+            metadata: map()
+          }
+
+    @spec new!(map() | keyword()) :: t()
+    def new!(attrs) when is_list(attrs), do: attrs |> Map.new() |> new!()
+
+    def new!(%{} = attrs) do
+      %__MODULE__{
+        request_id: Operation.non_empty_binary!(Operation.value(attrs, :request_id), :request_id),
+        controller_session_id:
+          Operation.non_empty_binary!(
+            Operation.value(attrs, :controller_session_id),
+            :controller_session_id
+          ),
+        model_ref: ModelRef.new!(Operation.value(attrs, :model_ref)),
+        cache_affinity_fingerprint:
+          Operation.non_empty_binary!(
+            Operation.value(attrs, :cache_affinity_fingerprint),
+            :cache_affinity_fingerprint
+          ),
+        deadline_unix_ms:
+          Operation.optional_non_neg_integer!(
+            Operation.value(attrs, :deadline_unix_ms),
+            :deadline_unix_ms
+          ),
+        metadata: Operation.map_value(attrs, :metadata)
+      }
+    end
+  end
+
+  defmodule PrefixCacheScoreResult do
+    @moduledoc false
+
+    defstruct status_code: "unknown",
+              status_message: "",
+              resident_fingerprint_match: false,
+              score_tier: "unknown",
+              session_started_unix_ms: 0
+
+    @type t :: %__MODULE__{
+            status_code: String.t(),
+            status_message: String.t(),
+            resident_fingerprint_match: boolean(),
+            score_tier: String.t(),
+            session_started_unix_ms: non_neg_integer()
+          }
+  end
+
+  @spec value(map(), atom()) :: term()
+  def value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+
+  @spec map_value(map(), atom()) :: map()
+  def map_value(attrs, key) do
+    case value(attrs, key) do
+      %{} = map -> map
+      nil -> %{}
+      other -> raise ArgumentError, "#{key} must be a map, got: #{inspect(other)}"
+    end
+  end
+
+  @spec non_empty_binary!(term(), atom()) :: String.t()
+  def non_empty_binary!(value, _key) when is_binary(value) and value != "", do: value
+
+  def non_empty_binary!(value, key),
+    do: raise(ArgumentError, "#{key} must be a non-empty binary, got: #{inspect(value)}")
+
+  @spec binary!(term(), atom()) :: binary()
+  def binary!(value, _key) when is_binary(value), do: value
+
+  def binary!(value, key),
+    do: raise(ArgumentError, "#{key} must be a binary, got: #{inspect(value)}")
+
+  @spec optional_binary!(term(), atom()) :: String.t() | nil
+  def optional_binary!(nil, _key), do: nil
+  def optional_binary!(value, key), do: binary!(value, key)
+
+  @spec non_neg_integer!(term(), atom()) :: non_neg_integer()
+  def non_neg_integer!(value, _key) when is_integer(value) and value >= 0, do: value
+
+  def non_neg_integer!(value, key),
+    do: raise(ArgumentError, "#{key} must be a non-negative integer, got: #{inspect(value)}")
+
+  @spec optional_non_neg_integer!(term(), atom()) :: non_neg_integer() | nil
+  def optional_non_neg_integer!(nil, _key), do: nil
+  def optional_non_neg_integer!(value, key), do: non_neg_integer!(value, key)
+
+  @spec optional_token_ids!(term()) :: [non_neg_integer()] | nil
+  def optional_token_ids!(nil), do: nil
+
+  def optional_token_ids!(token_ids) when is_list(token_ids) do
+    if Enum.all?(token_ids, &(is_integer(&1) and &1 >= 0)) do
+      token_ids
+    else
+      raise ArgumentError, "prompt_token_ids must be a list of non-negative integers"
+    end
+  end
+
+  def optional_token_ids!(token_ids),
+    do:
+      raise(
+        ArgumentError,
+        "prompt_token_ids must be a list of non-negative integers, got: #{inspect(token_ids)}"
+      )
+end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/placement.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/placement.ex
@@ -72,5 +72,13 @@ defmodule Orchard.RuntimeEndpoint.Placement do
     end
   end
 
-  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  defp value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
 end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/placement.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/placement.ex
@@ -1,0 +1,76 @@
+defmodule Orchard.RuntimeEndpoint.Placement do
+  @moduledoc """
+  Runtime Endpoint model placement state and capacity.
+  """
+
+  alias Orchard.RuntimeEndpoint.{ModelRef, PlacementCapacity}
+
+  @enforce_keys [:model_ref, :state]
+  defstruct model_ref: nil,
+            state: :unknown,
+            capacity: nil,
+            last_used_at: nil,
+            diagnostics: %{}
+
+  @type state ::
+          :unknown
+          | :unavailable
+          | :cached
+          | :loaded
+          | :provider_available
+          | :failed
+          | :loading
+          | atom()
+  @type t :: %__MODULE__{
+          model_ref: ModelRef.t(),
+          state: state(),
+          capacity: PlacementCapacity.t(),
+          last_used_at: term(),
+          diagnostics: map()
+        }
+
+  @spec new(map() | keyword()) :: t()
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    model_ref = ModelRef.new!(value(attrs, :model_ref))
+    capacity = normalize_capacity(value(attrs, :capacity), model_ref)
+
+    %__MODULE__{
+      model_ref: model_ref,
+      state: value(attrs, :state) || :unknown,
+      capacity: capacity,
+      last_used_at: value(attrs, :last_used_at),
+      diagnostics: diagnostics(attrs)
+    }
+  end
+
+  @spec loaded?(t()) :: boolean()
+  def loaded?(%__MODULE__{state: state})
+      when state in [:loaded, "loaded", :PLACEMENT_STATE_LOADED],
+      do: true
+
+  def loaded?(%__MODULE__{}), do: false
+
+  defp normalize_capacity(%PlacementCapacity{} = capacity, _model_ref), do: capacity
+  defp normalize_capacity(nil, model_ref), do: PlacementCapacity.unknown(model_ref, :not_observed)
+
+  defp normalize_capacity(%{} = attrs, model_ref) do
+    attrs
+    |> Map.put_new(:model_ref, model_ref)
+    |> PlacementCapacity.new()
+  end
+
+  defp normalize_capacity(_capacity, model_ref),
+    do: PlacementCapacity.unknown(model_ref, :invalid_capacity)
+
+  defp diagnostics(attrs) do
+    case value(attrs, :diagnostics) do
+      %{} = diagnostics -> diagnostics
+      nil -> %{}
+      other -> %{raw_diagnostics: other}
+    end
+  end
+
+  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/placement_capacity.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/placement_capacity.ex
@@ -90,5 +90,13 @@ defmodule Orchard.RuntimeEndpoint.PlacementCapacity do
     end
   end
 
-  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  defp value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
 end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/placement_capacity.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/placement_capacity.ex
@@ -1,0 +1,94 @@
+defmodule Orchard.RuntimeEndpoint.PlacementCapacity do
+  @moduledoc """
+  Scheduler-visible capacity for one Runtime Endpoint model placement.
+  """
+
+  alias Orchard.RuntimeEndpoint.ModelRef
+
+  defstruct model_ref: nil,
+            active_request_count: nil,
+            max_concurrency: nil,
+            status: :unknown,
+            source: :unknown,
+            diagnostics: %{}
+
+  @type status :: :known | :unknown | :invalid
+  @type t :: %__MODULE__{
+          model_ref: ModelRef.t() | nil,
+          active_request_count: non_neg_integer() | term(),
+          max_concurrency: pos_integer() | term(),
+          status: status(),
+          source: atom() | String.t(),
+          diagnostics: map()
+        }
+
+  @spec new(map() | keyword()) :: t()
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    model_ref = normalize_model_ref(value(attrs, :model_ref))
+    active_request_count = value(attrs, :active_request_count)
+    max_concurrency = value(attrs, :max_concurrency)
+
+    %__MODULE__{
+      model_ref: model_ref,
+      active_request_count: active_request_count,
+      max_concurrency: max_concurrency,
+      status: capacity_status(model_ref, active_request_count, max_concurrency),
+      source: value(attrs, :source) || :unknown,
+      diagnostics: diagnostics(attrs)
+    }
+  end
+
+  @spec unknown(ModelRef.t() | map(), atom() | String.t()) :: t()
+  def unknown(model_ref, source \\ :unknown) do
+    new(%{model_ref: model_ref, source: source})
+  end
+
+  @spec full?(t()) :: boolean()
+  def full?(%__MODULE__{status: :known, active_request_count: active, max_concurrency: max}),
+    do: active >= max
+
+  def full?(%__MODULE__{}), do: false
+
+  @spec spare?(t()) :: boolean()
+  def spare?(%__MODULE__{status: :known, active_request_count: active, max_concurrency: max}),
+    do: active < max
+
+  def spare?(%__MODULE__{}), do: false
+
+  @spec known?(t()) :: boolean()
+  def known?(%__MODULE__{status: :known}), do: true
+  def known?(%__MODULE__{}), do: false
+
+  defp normalize_model_ref(%ModelRef{} = model_ref), do: model_ref
+
+  defp normalize_model_ref(model_ref) do
+    case ModelRef.new(model_ref) do
+      {:ok, normalized} -> normalized
+      {:error, :invalid_model_ref} -> nil
+    end
+  end
+
+  defp capacity_status(nil, _active_request_count, _max_concurrency), do: :invalid
+
+  defp capacity_status(_model_ref, nil, nil), do: :unknown
+
+  defp capacity_status(_model_ref, active_request_count, max_concurrency)
+       when is_integer(active_request_count) and active_request_count >= 0 and
+              is_integer(max_concurrency) and
+              max_concurrency > 0,
+       do: :known
+
+  defp capacity_status(_model_ref, _active_request_count, _max_concurrency), do: :invalid
+
+  defp diagnostics(attrs) do
+    case value(attrs, :diagnostics) do
+      %{} = diagnostics -> diagnostics
+      nil -> %{}
+      other -> %{raw_diagnostics: other}
+    end
+  end
+
+  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -68,5 +68,13 @@ defmodule Orchard.RuntimeEndpoint.Target do
     end
   end
 
-  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  defp value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
 end

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -1,0 +1,72 @@
+defmodule Orchard.RuntimeEndpoint.Target do
+  @moduledoc """
+  Addressable Runtime Endpoint target selected by the scheduler.
+  """
+
+  @enforce_keys [:id, :transport, :address]
+  defstruct id: nil,
+            transport: nil,
+            address: nil,
+            node_id: nil,
+            metadata: %{}
+
+  @type transport :: :grpc_compat | :beam
+  @type t :: %__MODULE__{
+          id: String.t(),
+          transport: transport(),
+          address: term(),
+          node_id: String.t() | nil,
+          metadata: map()
+        }
+
+  @spec grpc_compat(keyword() | map()) :: t()
+  def grpc_compat(target) do
+    attrs = attrs_map(target)
+    host = value(attrs, :host)
+    port = value(attrs, :port)
+
+    unless is_binary(host) and is_integer(port) and port > 0 do
+      raise ArgumentError,
+            "grpc compatibility target requires binary host and positive integer port"
+    end
+
+    %__MODULE__{
+      id: "grpc_compat:#{host}:#{port}",
+      transport: :grpc_compat,
+      address: [host: host, port: port],
+      node_id: value(attrs, :node_id),
+      metadata: metadata(attrs)
+    }
+  end
+
+  @spec beam(String.t(), keyword() | map()) :: t()
+  def beam(node_id, opts \\ [])
+
+  def beam(node_id, opts) when is_binary(node_id) and node_id != "" do
+    attrs = attrs_map(opts)
+
+    %__MODULE__{
+      id: value(attrs, :id) || "beam:#{node_id}",
+      transport: :beam,
+      address: value(attrs, :address) || node_id,
+      node_id: node_id,
+      metadata: metadata(attrs)
+    }
+  end
+
+  def beam(_node_id, _opts),
+    do: raise(ArgumentError, "beam target requires a non-empty binary node_id")
+
+  defp attrs_map(attrs) when is_list(attrs), do: Map.new(attrs)
+  defp attrs_map(%{} = attrs), do: attrs
+
+  defp metadata(attrs) do
+    case value(attrs, :metadata) do
+      %{} = metadata -> metadata
+      nil -> %{}
+      other -> %{raw_metadata: other}
+    end
+  end
+
+  defp value(%{} = attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+end

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -24,6 +24,21 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     refute PlacementCapacity.full?(capacity)
   end
 
+  test "placement capacity preserves explicit zero values" do
+    capacity =
+      PlacementCapacity.new(%{
+        "active_request_count" => 1,
+        model_ref: ModelRef.new!("mlx-community/phi-3", "main"),
+        active_request_count: 0,
+        max_concurrency: 2,
+        source: :compatibility_status
+      })
+
+    assert capacity.status == :known
+    assert capacity.active_request_count == 0
+    assert PlacementCapacity.spare?(capacity)
+  end
+
   test "known placement capacity can prove full capacity" do
     capacity =
       PlacementCapacity.new(%{
@@ -109,5 +124,29 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     assert request.model_ref == model_ref
     assert request.prompt_token_ids == [1, 2, 3]
     assert request.preload
+  end
+
+  test "operation constructors preserve explicit false and zero values" do
+    model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+
+    load_request =
+      Operation.EnsureModelLoadedRequest.new!(%{
+        "preload" => true,
+        model_ref: model_ref,
+        preload: false
+      })
+
+    execute_request =
+      Operation.ExecuteRequest.new!(%{
+        "input_tokens" => 4,
+        request_id: "req_123",
+        controller_session_id: "session_123",
+        model_ref: model_ref,
+        rendered_prompt_utf8: "",
+        input_tokens: 0
+      })
+
+    refute load_request.preload
+    assert execute_request.input_tokens == 0
   end
 end

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -1,0 +1,113 @@
+defmodule Orchard.RuntimeEndpoint.DomainTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.RuntimeEndpoint.{
+    ModelRef,
+    Observation,
+    Operation,
+    Placement,
+    PlacementCapacity,
+    Target
+  }
+
+  test "known placement capacity can prove spare capacity" do
+    capacity =
+      PlacementCapacity.new(%{
+        model_ref: ModelRef.new!("mlx-community/phi-3", "main"),
+        active_request_count: 1,
+        max_concurrency: 2,
+        source: :compatibility_status
+      })
+
+    assert capacity.status == :known
+    assert PlacementCapacity.spare?(capacity)
+    refute PlacementCapacity.full?(capacity)
+  end
+
+  test "known placement capacity can prove full capacity" do
+    capacity =
+      PlacementCapacity.new(%{
+        model_ref: ModelRef.new!("mlx-community/phi-3", "main"),
+        active_request_count: 2,
+        max_concurrency: 2,
+        source: :compatibility_status
+      })
+
+    assert capacity.status == :known
+    assert PlacementCapacity.full?(capacity)
+    refute PlacementCapacity.spare?(capacity)
+  end
+
+  test "unknown placement capacity cannot prove eligibility" do
+    capacity =
+      PlacementCapacity.new(%{
+        model_ref: ModelRef.new!("mlx-community/phi-3", "main"),
+        source: :missing_compatibility_status
+      })
+
+    assert capacity.status == :unknown
+    refute PlacementCapacity.spare?(capacity)
+    refute PlacementCapacity.full?(capacity)
+  end
+
+  test "malformed placement capacity is invalid and cannot prove eligibility" do
+    capacity =
+      PlacementCapacity.new(%{
+        model_ref: ModelRef.new!("mlx-community/phi-3", "main"),
+        active_request_count: "1",
+        max_concurrency: 0,
+        source: :malformed
+      })
+
+    assert capacity.status == :invalid
+    refute PlacementCapacity.spare?(capacity)
+    refute PlacementCapacity.full?(capacity)
+  end
+
+  test "runtime endpoint observations expose loaded placement capacity" do
+    model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+
+    observation =
+      Observation.new(%{
+        target: Target.grpc_compat(host: "127.0.0.1", port: 50_061),
+        placements: [
+          %{
+            model_ref: model_ref,
+            state: :loaded,
+            capacity: %{
+              active_request_count: 1,
+              max_concurrency: 2,
+              source: :compatibility_status
+            }
+          }
+        ]
+      })
+
+    assert %Placement{} = Observation.loaded_placement(observation, model_ref)
+
+    assert PlacementCapacity.spare?(Observation.placement_capacity_for(observation, model_ref))
+  end
+
+  test "operation constructors validate scalar request shape without enforcing policy" do
+    model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+
+    request =
+      Operation.ExecuteRequest.new!(%{
+        request_id: "req_123",
+        controller_session_id: "session_123",
+        model_ref: model_ref,
+        rendered_prompt_utf8: "hello",
+        input_tokens: 1,
+        params: %{max_output_tokens: 4},
+        metadata_json: "{}",
+        prompt_token_ids: [1, 2, 3],
+        artifact_sha256: "sha256:abc",
+        artifact_source_uri: "file:///models/phi-3",
+        preload: true
+      })
+
+    assert request.model_ref == model_ref
+    assert request.prompt_token_ids == [1, 2, 3]
+    assert request.preload
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -46,6 +46,16 @@ config :orchard_controller,
        :inference,
        Orchard.Config.M1RuntimeDefaults.controller_inference(orchard_support_root)
 
+config :orchard_controller, :runtime_endpoint,
+  beam: [
+    enabled: false,
+    node_name: nil,
+    cookie_file: nil,
+    admitted_services: [],
+    allowed_cidrs: [],
+    listen_host: nil
+  ]
+
 config :orchard_controller,
        :hf,
        Orchard.Config.M1RuntimeDefaults.hf()

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,12 +5,14 @@ Code.require_file("m1_runtime_defaults.exs", __DIR__)
 repo_root = Path.expand("..", __DIR__)
 test_root = Path.join([repo_root, "tmp", "test"])
 
-test_root_hash =
+worker_socket_dir_hash =
   :crypto.hash(:sha256, repo_root)
   |> Base.url_encode64(padding: false)
   |> binary_part(0, 8)
 
-worker_socket_dir = Path.join(["/tmp", "ot-" <> test_root_hash, "ws"])
+# Python gRPC rejects Unix socket paths above roughly 103 bytes on macOS.
+# Keep test worker sockets under a short, worktree-specific root.
+worker_socket_dir = Path.join(["/tmp", "ot-" <> worker_socket_dir_hash, "ws"])
 
 config :orchard_controller, Orchard.Repo,
   username: System.get_env("PGUSER") || "postgres",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,11 @@ The target topology is:
 Public clients
   -> Controller (Phoenix/Elixir public APIs, Console, admission, scheduling)
      -> Postgres for durable state and coordination
-     -> Node Agent(s) over internal gRPC/mTLS
+     -> Runtime Endpoint Interface
+        -> current gRPC compatibility adapter
+        -> future first-party BEAM adapter
+        -> future external/provider adapters
+     -> Node Agent(s)
         -> Worker Runtime subprocesses for local MLX inference
 ```
 
@@ -45,9 +49,12 @@ Core design rules from `SPEC.md`:
 - all durable state lives in Postgres;
 - public API traffic terminates at the controller;
 - token streams pass through the controller;
-- node agents are the network-reachable worker-node boundary;
+- the Controller dispatches model runtime work through the Runtime Endpoint Interface;
+- the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
+- first-party BEAM communication requires explicit production guardrails before it can be enabled;
+- node agents are the v1 first-party Runtime Endpoint boundary;
 - worker runtimes are local subprocesses, not public services;
-- cross-node control traffic uses gRPC over mTLS in the target product.
+- Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling, and request state.
 
 ## Repository map
 
@@ -56,10 +63,10 @@ Core design rules from `SPEC.md`:
 | `apps/orchard_controller/` | Controller release: public APIs, Console, Repo, admission, scheduling, dispatch, governance, observability surfaces. |
 | `apps/orchard_node_agent/` | Node-agent release: node-local runtime endpoint, model acquisition/cache, worker supervision, status/diagnostics. |
 | `apps/orchard_cli/` | `orchardctl` CLI: operator/admin automation for source dev and packaged installs. |
-| `apps/orchard_shared/` | Shared generated proto modules, domain structs, helpers, licensing/build metadata. |
+| `apps/orchard_shared/` | Shared generated proto modules, Runtime Endpoint domain structs, helpers, licensing/build metadata. |
 | `native/orchard_tokenizer/` | Python helper for prompt rendering, exact token counts, and safe-tokenization support. |
 | `native/orchard_worker_mlx/` | Python MLX worker runtime package and node-agent ↔ worker proto. |
-| `proto/cluster/v1/` | Controller ↔ node-agent cluster RPC proto source. |
+| `proto/cluster/v1/` | Current gRPC compatibility transport and future-adapter proto source for Controller ↔ node-agent runtime operations. |
 | `packaging/` | PKG, launchd, reserved DMG/container assets, signing/build runbooks. |
 | `docs/` | Contributor-facing orientation, tooling, process, design, and durable decisions subordinate to `SPEC.md`. |
 
@@ -76,9 +83,9 @@ legacy tenant defaults until full RBAC and quota policy are complete.
 1. Client calls a public `/v1` endpoint on the controller.
 2. Controller authenticates, canonicalizes, renders/tokenizes, admits, and
    persists request state.
-3. Queue admission grants immediately or waits when lane capacity, live node capacity, live requested-model or placement capacity, or tenant active concurrency is exhausted.
-4. Scheduler chooses a node/runtime target.
-5. Controller dispatches to a node agent.
+3. Queue admission grants immediately or waits when lane capacity, live Runtime Endpoint capacity, live requested-model or placement capacity, or tenant active concurrency is exhausted.
+4. Scheduler chooses a Runtime Endpoint.
+5. Controller dispatches through the Runtime Endpoint Interface.
 6. Node agent ensures a worker/model is ready and streams worker events back.
 7. Controller relays SSE/JSON to the client and finalizes usage/state.
 
@@ -95,9 +102,10 @@ The controller scheduler uses that capacity telemetry to avoid dispatching to fu
 Controller queue admission also consumes fresh node observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted nodes.
 Invalid, ineligible, unavailable, or transport-failed observations clear stale node-owned capacity sources before queued work can be promoted.
 
-Cluster RPC and worker RPC are separate contracts:
+Runtime Endpoint and worker runtime contracts are separate:
 
-- `proto/cluster/v1/` describes controller ↔ node-agent messages/services.
+- `proto/cluster/v1/` describes the current controller ↔ node-agent gRPC compatibility transport.
+- Runtime Endpoint domain structs describe the Controller-facing scheduler and dispatch contract.
 - `native/orchard_worker_mlx/proto/` describes node-agent ↔ worker messages/services.
 
 ### Persistence and coordination

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,11 +96,11 @@ the compatibility facade. See `SPEC.md` §3 and §7 for normative behavior.
 
 The node agent owns worker subprocess lifecycle. The worker runtime owns local
 model loading/generation details. Public clients never talk to workers directly.
-Node-agent status is also the live source for aggregate node capacity and loaded-model placement capacity, including active requests and max concurrency.
+Node-agent status is mapped into Runtime Endpoint Observations for aggregate endpoint capacity and loaded-model Placement Capacity, including active requests and max concurrency.
 Aggregate capacity is the conservative limit the node agent enforces across loaded workers, while each loaded placement reports its own active count and capacity.
-The controller scheduler uses that capacity telemetry to avoid dispatching to full nodes or full same-model placements.
-Controller queue admission also consumes fresh node observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted nodes.
-Invalid, ineligible, unavailable, or transport-failed observations clear stale node-owned capacity sources before queued work can be promoted.
+The controller scheduler uses that capacity telemetry to avoid dispatching to full endpoints or full same-model placements.
+Controller queue admission also consumes fresh Runtime Endpoint Observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted endpoints.
+Invalid, ineligible, unavailable, or transport-failed observations clear stale endpoint-owned capacity sources before queued work can be promoted.
 
 Runtime Endpoint and worker runtime contracts are separate:
 

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
-`SPEC.md` currently defines cross-node control traffic as gRPC over mTLS and forbids distributed Erlang across machines.
+Before this decision, `SPEC.md` defined cross-node control traffic as gRPC over mTLS and forbade distributed Erlang across machines.
 That direction was chosen while Orchard's cluster boundary was still being worked out.
 The current architecture uses Elixir for both the Controller and first-party Node Agent, while Python/MLX remains a local Worker Runtime detail behind the Node Agent.
 The latest `gnhf/objective-fully-impl-369718` work strengthens concurrent inference behavior with live placement capacity, conservative scheduler eligibility, `cluster_busy` requeue semantics, and queue fairness.
@@ -18,20 +18,21 @@ The key ambiguity is whether the Node Agent is a protocol-isolated runtime endpo
 
 Model Orchard scheduling around transport-independent Runtime Endpoints.
 The v1 Runtime Endpoint is the first-party Node Agent.
-For first-party Runtime Endpoints, prefer BEAM Distribution as the live communication and monitoring layer between Elixir services.
+For first-party Runtime Endpoints, keep BEAM Distribution as the preferred future live communication and monitoring layer between Elixir services once the adapter exists.
 Limit BEAM Distribution to first-party Orchard Runtime Endpoints.
 External or provider-backed Runtime Endpoints must integrate through explicit Runtime Endpoint adapters and provider-appropriate protocols.
 
 Keep Postgres as the durable persistence and coordination store.
 BEAM Distribution must not become durable cluster truth.
-Use BEAM Distribution for live first-party communication, monitoring, and fast session failure signals.
+Use BEAM Distribution for future live first-party communication, monitoring, and fast session failure signals after explicit adapter work.
 Persist Runtime Endpoint Observations in Postgres for inventory, lifecycle, availability, scheduling, and operator-visible history.
 A connected BEAM node is not automatically schedulable.
 Production BEAM Distribution must be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
 External Runtime Endpoints must not join the BEAM mesh.
 
 Keep the Runtime Endpoint Interface independent of a transport protocol.
-The first implementation can be an Elixir behaviour backed by BEAM Distribution.
+The first implementation slice defines an Elixir behaviour backed by the current gRPC Compatibility Adapter.
+A later implementation can add a first-party BEAM adapter behind the same Runtime Endpoint Interface.
 Future Runtime Endpoint adapters may target external compute, cloud VMs, high-performance compute nodes, appliance-style accelerators, or paid provider integrations.
 Existing `proto/cluster/v1` work should be demoted from the default first-party Controller-to-Node Agent path to a possible future adapter protocol.
 Placement Capacity is a first-class Runtime Endpoint observation and must be exposed by the interface independently of transport.
@@ -44,14 +45,14 @@ It does not remove the local process/protocol boundary between the Node Agent an
 
 ## Consequences
 
-This removes gRPC/protobuf as the default Controller-to-Node Agent abstraction for first-party Elixir services.
+This removes gRPC/protobuf as the durable Controller-to-Node Agent domain abstraction for first-party Elixir services.
 It reduces transport duplication, generated-code surface, and domain-to-proto translation for the v1 path.
 It keeps OTP semantics close to the Orchard services that already run on the BEAM.
 
 The design still preserves an extension point for non-BEAM Runtime Endpoints.
 Those endpoints should integrate through Runtime Endpoint adapters rather than forcing the first-party v1 path through an external-service protocol.
 It also avoids extending BEAM trust to endpoints Orchard does not fully own.
-The existing cluster proto surface should not be deleted solely because the first-party path moves to BEAM Distribution.
+The existing cluster proto surface should not be deleted solely because the durable domain model moves to Runtime Endpoint semantics or a later first-party path moves to BEAM Distribution.
 It may still become useful for external Runtime Endpoint adapters or compatibility bridges.
 
 Node lifecycle remains first-party and Node-specific.
@@ -65,7 +66,7 @@ Keep the existing `cluster_busy` error name for now, but define it as live Runti
 
 ## SPEC.md impact
 
-Update required in `SPEC.md` sections that mandate no distributed Erlang across machines, gRPC over mTLS for all cross-node control traffic, Internal Node/Worker API language, node scheduling, node lifecycle, and model placement.
-The update should also reconcile the incoming gnhf concurrency semantics around Placement Capacity, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, weighted round-robin, and unknown-capacity fail-closed behavior.
+The `SPEC.md` update replaces prior gRPC-only runtime execution language with Runtime Endpoint semantics, current gRPC compatibility transport, future guarded BEAM transport, node scheduling, node lifecycle, and model placement.
+The update also reconciles the incoming gnhf concurrency semantics around Placement Capacity, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, weighted round-robin, and unknown-capacity fail-closed behavior.
 The OpenSpec change should treat `gnhf/objective-fully-impl-369718` as an architecture input and preservation dependency, not as implementation scope to merge inside the proposal.
-This ADR does not by itself change the normative build contract.
+This ADR records the decision rationale; `SPEC.md` remains the normative build contract.

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -1,0 +1,71 @@
+# ADR: Beam-first Runtime Endpoints
+
+## Status
+
+Proposed
+
+## Context
+
+`SPEC.md` currently defines cross-node control traffic as gRPC over mTLS and forbids distributed Erlang across machines.
+That direction was chosen while Orchard's cluster boundary was still being worked out.
+The current architecture uses Elixir for both the Controller and first-party Node Agent, while Python/MLX remains a local Worker Runtime detail behind the Node Agent.
+The latest `gnhf/objective-fully-impl-369718` work strengthens concurrent inference behavior with live placement capacity, conservative scheduler eligibility, `cluster_busy` requeue semantics, and queue fairness.
+Those semantics should be treated as target architecture inputs even though their current representation is gRPC/protobuf-shaped.
+
+The key ambiguity is whether the Node Agent is a protocol-isolated runtime endpoint that happens to be implemented in Elixir, or a first-party Orchard BEAM participant that owns node-local execution.
+
+## Decision
+
+Model Orchard scheduling around transport-independent Runtime Endpoints.
+The v1 Runtime Endpoint is the first-party Node Agent.
+For first-party Runtime Endpoints, prefer BEAM Distribution as the live communication and monitoring layer between Elixir services.
+Limit BEAM Distribution to first-party Orchard Runtime Endpoints.
+External or provider-backed Runtime Endpoints must integrate through explicit Runtime Endpoint adapters and provider-appropriate protocols.
+
+Keep Postgres as the durable persistence and coordination store.
+BEAM Distribution must not become durable cluster truth.
+Use BEAM Distribution for live first-party communication, monitoring, and fast session failure signals.
+Persist Runtime Endpoint Observations in Postgres for inventory, lifecycle, availability, scheduling, and operator-visible history.
+A connected BEAM node is not automatically schedulable.
+Production BEAM Distribution must be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
+External Runtime Endpoints must not join the BEAM mesh.
+
+Keep the Runtime Endpoint Interface independent of a transport protocol.
+The first implementation can be an Elixir behaviour backed by BEAM Distribution.
+Future Runtime Endpoint adapters may target external compute, cloud VMs, high-performance compute nodes, appliance-style accelerators, or paid provider integrations.
+Existing `proto/cluster/v1` work should be demoted from the default first-party Controller-to-Node Agent path to a possible future adapter protocol.
+Placement Capacity is a first-class Runtime Endpoint observation and must be exposed by the interface independently of transport.
+Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove eligibility for an active loaded placement.
+
+Keep the Worker Runtime Interface separate.
+The Node Agent may continue to use a local worker protocol for Python/MLX subprocesses.
+The BEAM-first decision applies to first-party Controller-to-Node Agent communication.
+It does not remove the local process/protocol boundary between the Node Agent and non-BEAM Worker Runtimes.
+
+## Consequences
+
+This removes gRPC/protobuf as the default Controller-to-Node Agent abstraction for first-party Elixir services.
+It reduces transport duplication, generated-code surface, and domain-to-proto translation for the v1 path.
+It keeps OTP semantics close to the Orchard services that already run on the BEAM.
+
+The design still preserves an extension point for non-BEAM Runtime Endpoints.
+Those endpoints should integrate through Runtime Endpoint adapters rather than forcing the first-party v1 path through an external-service protocol.
+It also avoids extending BEAM trust to endpoints Orchard does not fully own.
+The existing cluster proto surface should not be deleted solely because the first-party path moves to BEAM Distribution.
+It may still become useful for external Runtime Endpoint adapters or compatibility bridges.
+
+Node lifecycle remains first-party and Node-specific.
+Runtime Endpoint Availability becomes the scheduler-facing availability concept for both first-party and future external endpoints.
+Runtime Endpoint Observations remain durable scheduler and operator inputs even when live first-party communication uses BEAM monitoring.
+Model Placement becomes scoped to Runtime Endpoints rather than only Nodes.
+Placement Capacity becomes a Runtime Endpoint Observation rather than a protobuf-specific `runtime_model_placements` field.
+The queue and scheduling semantics from `gnhf/objective-fully-impl-369718` should be preserved while adapting their transport-specific shell.
+The conservative unknown-capacity rule is part of that behavior, not a gRPC artifact.
+Keep the existing `cluster_busy` error name for now, but define it as live Runtime Endpoint capacity exhaustion rather than a transport-specific node-cluster failure.
+
+## SPEC.md impact
+
+Update required in `SPEC.md` sections that mandate no distributed Erlang across machines, gRPC over mTLS for all cross-node control traffic, Internal Node/Worker API language, node scheduling, node lifecycle, and model placement.
+The update should also reconcile the incoming gnhf concurrency semantics around Placement Capacity, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, weighted round-robin, and unknown-capacity fail-closed behavior.
+The OpenSpec change should treat `gnhf/objective-fully-impl-369718` as an architecture input and preservation dependency, not as implementation scope to merge inside the proposal.
+This ADR does not by itself change the normative build contract.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -37,8 +37,14 @@ The central control-plane service that owns public APIs, governance, admission, 
 _Avoid_: Worker, node agent
 
 **Node Agent**:
-The node-local control endpoint that manages node registration, status, model cache, worker supervision, diagnostics, and runtime access.
+The first-party node-local Orchard service that owns local runtime execution, model cache, worker supervision, diagnostics, status, and cleanup.
 _Avoid_: Controller agent, worker runtime
+
+**Runtime Endpoint**:
+A schedulable execution boundary that can receive model runtime work from the Controller through Orchard's runtime semantics.
+Orchard's v1 Runtime Endpoint is the first-party Node Agent; future Runtime Endpoints may be external compute or provider integrations.
+A Runtime Endpoint is not necessarily a Node.
+_Avoid_: Worker Runtime, transport protocol, durable cluster truth, managed Mac
 
 **Worker Runtime**:
 The local model execution process supervised by the Node Agent.
@@ -51,6 +57,11 @@ _Avoid_: Generic remote compute worker
 **Postgres**:
 Orchard's sole durable persistence and coordination store.
 _Avoid_: Redis, Kafka, distributed Erlang state
+
+**BEAM Distribution**:
+The live Orchard communication and monitoring layer between first-party Elixir services.
+In packaged production, BEAM Distribution is limited to admitted first-party Orchard services.
+_Avoid_: Durable cluster truth, database replacement, public API, external provider integration
 
 **All-in-One Deployment**:
 A deployment topology where one Mac runs the Controller, Node Agent, Worker Runtime, and Managed Database Mode.
@@ -98,9 +109,23 @@ _Avoid_: Admin API, Public Inference API, tenant/key mutation unless also admin
 The governance and configuration HTTP API surface for tenants, keys, quotas, models, routing, nodes, and observability settings.
 _Avoid_: Operator API, runtime support action
 
-**Internal Node/Worker API**:
-The private gRPC/mTLS RPC surface between the Controller, Node Agent, and Worker Runtime.
-_Avoid_: Public worker API, public/admin/operator HTTP API
+**Runtime Endpoint Interface**:
+The transport-independent Controller-facing execution semantics for scheduling, model readiness, inference execution, cancellation, status, and runtime telemetry.
+Placement Capacity is part of this interface's observation vocabulary.
+_Avoid_: Worker Runtime Interface, Node Lifecycle Interface, transport protocol
+
+**gRPC Compatibility Adapter**:
+The current adapter that maps Runtime Endpoint Interface semantics to `proto/cluster/v1` and `NodeRuntimeService`.
+It preserves today's gRPC/protobuf implementation while keeping the durable Controller domain contract transport-independent.
+_Avoid_: Runtime Endpoint Interface, Worker Runtime Interface, first-party BEAM mesh
+
+**Worker Runtime Interface**:
+The Node Agent-local execution process contract for loading models, generating output, reporting local worker status, and handling cancellation.
+_Avoid_: Runtime Endpoint Interface, Public Inference API, provider API
+
+**Node Lifecycle Interface**:
+The first-party Orchard node management semantics for node identity, join, health observation, maintenance, drain, and decommissioning.
+_Avoid_: Runtime Endpoint Interface, Worker Runtime Interface, scheduler ranking
 
 **Orchard Console**:
 The product-facing LiveView console for local and operator UI.
@@ -256,15 +281,23 @@ _Avoid_: Server when cluster role matters
 
 **Node Lifecycle State**:
 The operator-controlled lifecycle state that determines how a Node is allowed to participate in the cluster.
-_Avoid_: Node Health, heartbeat freshness
+_Avoid_: Runtime Endpoint Availability, Node Health, heartbeat freshness
 
 **Node Health**:
 The observed condition of a Node, independent of its operator-controlled lifecycle state.
 _Avoid_: Node Lifecycle State, operator action
 
+**Runtime Endpoint Availability**:
+The scheduler-facing availability of a Runtime Endpoint for new work, independent of whether the endpoint is backed by an Orchard-managed Node, external compute, or a provider integration.
+_Avoid_: Node Lifecycle State, durable cluster truth, provider billing status
+
+**Runtime Endpoint Observation**:
+A durable Controller-recorded snapshot of Runtime Endpoint status, capability, availability, and placement signals.
+_Avoid_: live BEAM session, durable cluster truth by itself, provider billing event
+
 **Heartbeat**:
-A periodic Node Agent status report used by the Controller to observe node health, inventory, workers, and placements.
-_Avoid_: Node Lifecycle State, readiness probe
+A periodic durable observation used by the Controller to record first-party Node Agent health, inventory, workers, placements, and Runtime Endpoint Availability.
+_Avoid_: Node Lifecycle State, readiness probe, live BEAM session
 
 **Node Pool**:
 A scheduling group where each v1 Node belongs to exactly one pool.
@@ -295,12 +328,16 @@ A model's global publication state in the Model Catalog, independent of node-loc
 _Avoid_: Placement State, loadedness
 
 **Model Placement**:
-The per-node residency, cache, and load state for a model artifact.
+The per-Runtime Endpoint residency, cache, availability, or load state for a model.
 _Avoid_: Catalog entry
 
 **Placement State**:
-A per-node model state describing whether an artifact is absent, cached, loaded, evicted, failed, or in transition.
+A per-Runtime Endpoint model state describing whether a model is unavailable, cached, loaded, provider-available, failed, or in transition.
 _Avoid_: Catalog State, tenant-visible model activation
+
+**Placement Capacity**:
+A first-class Runtime Endpoint Observation describing current active request count and maximum concurrency for a Model Placement.
+_Avoid_: Quota, durable capacity guarantee, transport field name
 
 **Model Bundle**:
 An offline-importable model artifact directory or archive supplied to Orchard with a Model Manifest.
@@ -337,15 +374,19 @@ The Controller component that evaluates eligible work, applies queue and ranking
 _Avoid_: Admission, Dispatch
 
 **Schedulable Node**:
-A Node eligible for new work because lifecycle, health, policy, capability, memory, concurrency, and breaker conditions allow it.
-_Avoid_: Healthy node
+A Node whose first-party Runtime Endpoint is eligible for new work because lifecycle, health, policy, capability, memory, concurrency, and breaker conditions allow it.
+_Avoid_: Healthy node, every Runtime Endpoint
+
+**Schedulable Runtime Endpoint**:
+A Runtime Endpoint eligible for new work because policy, capability, health, capacity, and breaker conditions allow it.
+_Avoid_: Node inventory, hardware host
 
 **Candidate Tier**:
 A scheduling group based on model residency, such as loaded, cached, or cold.
 _Avoid_: Node pool
 
 **Scheduler Decision**:
-The selected scheduling result and sanitized ranking metadata persisted with a Request.
+The selected Runtime Endpoint and sanitized ranking metadata persisted with a Request.
 _Avoid_: Quota, Routing Policy, Scheduler Explanation, tenant-facing error reason
 
 **Scheduler Explanation**:
@@ -353,7 +394,7 @@ Operator-facing reasoning for selected and rejected scheduling candidates.
 _Avoid_: persisted Scheduler Decision metadata, tenant-facing error contract
 
 **Dispatch**:
-The Controller-to-Node Agent handoff after scheduling that ensures a model is loaded and starts inference execution.
+The Controller-to-Runtime Endpoint handoff after scheduling that ensures a model is loaded and starts inference execution.
 _Avoid_: Scheduler Decision
 
 **Circuit Breaker**:

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -402,14 +402,14 @@ A scheduler suppression rule for repeatedly failing nodes or placements.
 _Avoid_: Node health
 
 **Queue**:
-A controller-owned wait path used after Admission when work cannot be immediately granted because live node or placement capacity is unavailable, node or placement concurrency is exhausted, or tenant active concurrency is exhausted.
+A controller-owned wait path used after Admission when work cannot be immediately granted because live Runtime Endpoint, node, or placement capacity is unavailable, placement or aggregate runtime concurrency is exhausted, or tenant active concurrency is exhausted.
 Each Tenant keeps FIFO order, and cross-tenant selection uses weighted round-robin that can skip capped tenants while preserving their FIFO order.
-Fresh node observations can wake queued work by adding source-scoped loaded-placement or cold/no-placement capacity.
-Stale, ineligible, or transport-failed observations clear node-owned capacity sources so queued work is not promoted against failed targets.
+Fresh Runtime Endpoint Observations can wake queued work by adding source-scoped loaded-placement or cold/no-placement capacity.
+Stale, unavailable, ineligible, or transport-failed observations clear endpoint-owned capacity sources so queued work is not promoted against failed targets.
 _Avoid_: Global backlog, Request lifecycle state
 
 **Cluster Busy**:
-A scheduler outcome meaning joined live candidates exist, but none can currently accept the request because node or placement capacity is exhausted, or because placement capacity is unknown for already-active candidates.
+A scheduler outcome meaning joined live Runtime Endpoint candidates exist, but none can currently accept the request because aggregate endpoint or placement capacity is exhausted, or because placement capacity is unknown for already-active candidates.
 With queue admission enabled, this can return the request to the same Queue deadline; otherwise it is a tenant-facing `503` capacity failure.
 _Avoid_: Transport failure, model not found, queue full
 
@@ -431,16 +431,17 @@ Runtime telemetry about prefix-cache configuration, counters, and bounded HMAC f
 _Avoid_: Readiness gate, admission gate, scheduler eligibility gate, tenant-facing signal, raw prompt or token data
 
 **Runtime Model Placement**:
-Live node-agent status for one loaded Model Placement, including `active_request_count` and `max_concurrency`.
+Compatibility-protocol status for one loaded Model Placement, including `active_request_count` and `max_concurrency`.
 The scheduler uses it only to prove same-model placement capacity and to rank by requested-placement load.
 Queue admission also uses valid loaded-placement observations to wake queued same-model work, and treats non-loaded, invalid, duplicate, or exhausted placement observations as unavailable capacity.
 _Avoid_: Catalog State, durable placement record, model manifest metadata
 
 **Runtime Node Capacity**:
-Live node-agent status for aggregate runtime capacity on one node, including `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`.
-The scheduler uses it to exclude nodes that have exhausted aggregate request slots before considering per-placement capacity.
-Queue admission uses eligible node observations to bound cold/no-placement wakeups and to keep active source reservations from being double-counted across queued lanes.
-Transport-failed or newly ineligible nodes clear node-owned aggregate, cold, and placement sources instead of retaining stale capacity.
+Runtime Endpoint Observation data for aggregate runtime capacity on one endpoint-backed node.
+The current gRPC Compatibility Adapter maps this from `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`.
+The scheduler uses it to exclude endpoint-backed nodes that have exhausted aggregate request slots before considering per-placement capacity.
+Queue admission uses eligible endpoint observations to bound cold/no-placement wakeups and to keep active source reservations from being double-counted across queued lanes.
+Transport-failed or newly ineligible endpoints clear endpoint-owned aggregate, cold, and placement sources instead of retaining stale capacity.
 _Avoid_: Tenant quota, durable Node inventory capacity, model-specific capacity
 
 **Prefix-cache Score**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -210,10 +210,9 @@ stream mode automatically.
 the fake runtime through `config/test.exs`, not a dev env override.
 Batch generation mode can admit multiple same-model requests up to the worker-reported limit.
 The node agent also enforces aggregate active request capacity across loaded models using the resolved worker limits, conservatively falling back to single-request capacity when worker status omits `max_concurrency`.
-The node-agent reports aggregate capacity through `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`.
-It reports live placement capacity through `StatusResponse.runtime_model_placements` as `active_request_count` and `max_concurrency`.
-The controller uses those fresh status observations both for scheduler candidate filtering and for queue wakeups from loaded-placement or cold/no-placement capacity.
-Transport failures and ineligible node observations clear node-owned queue capacity sources so queued work is not promoted against stale loaded-placement or cold/no-placement slots.
+The node-agent reports aggregate and placement capacity through the current gRPC compatibility status response.
+The controller maps that response into Runtime Endpoint Observations before multi-node scheduler candidate filtering and queue wakeups from loaded-placement or cold/no-placement capacity.
+Transport failures and ineligible Runtime Endpoint Observations clear endpoint-owned queue capacity sources so queued work is not promoted against stale loaded-placement or cold/no-placement slots.
 Stream mode reports max concurrency as `1` at both node and placement levels.
 
 #### Controller Multi-Node (Source Dev)
@@ -222,6 +221,15 @@ Stream mode reports max concurrency as `1` at both node and placement levels.
 |----------|---------|-------------|
 | `ORCHARD_RUNTIME_CLIENT_HOST` | `127.0.0.1` | Controller’s local gRPC target host |
 | `ORCHARD_RUNTIME_CLIENT_TARGETS` | _(empty)_ | Comma-separated `host:port` list for multi-node scheduling. When set with >1 target, the scheduler auto-selects `MultiNode`. |
+
+#### Runtime Endpoint BEAM Guardrails
+
+The current source-dev slice includes default-off BEAM Runtime Endpoint guardrail config under `:orchard_controller, :runtime_endpoint, beam: [...]`.
+This validates future first-party BEAM transport admission settings only.
+It does not implement or enable a live BEAM Runtime Endpoint adapter, and there is no supported source-dev env var surface for it in this slice.
+
+If enabled directly in application config for future work, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
+The `listen_host` must not be `0.0.0.0` or `::`, and `allowed_cidrs` must not contain `0.0.0.0/0` or `::/0`.
 
 #### Packaged Controller Transport (release only)
 
@@ -833,5 +841,5 @@ mise exec -- iex -S mix phx.server
 - Public `/v1/*` API routes require tenant-scoped Bearer API keys; full RBAC and
   quota policy remain incomplete
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
-- No distributed Erlang across machines
+- Live BEAM Runtime Endpoint transport is not implemented in source dev; current source dev uses the gRPC compatibility adapter
 - Model import from local filesystem only (no remote download)

--- a/docs/milestones/m1-single-node-inference.md
+++ b/docs/milestones/m1-single-node-inference.md
@@ -81,7 +81,7 @@ HTTP client
 - Request persistence before dispatch; terminal state persisted after (§3.7)
 - Terminal states are immutable (§3.6)
 - Unsupported parameters rejected with OpenAI-style errors (§7.2.4)
-- No distributed Erlang across machines (§1.2)
+- M1 used no distributed Erlang across machines under the then-current §1.2 constraint; current runtime transport direction lives in `SPEC.md` §1.2 and §7.5.
 
 ## In Scope
 

--- a/openspec/changes/beam-first-runtime-endpoints/.openspec.yaml
+++ b/openspec/changes/beam-first-runtime-endpoints/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/beam-first-runtime-endpoints/design.md
+++ b/openspec/changes/beam-first-runtime-endpoints/design.md
@@ -1,0 +1,121 @@
+## Context
+
+`SPEC.md` currently requires no distributed Erlang across machines and requires all cross-node control traffic to use gRPC over mTLS.
+That made sense while Orchard's runtime boundary was still being shaped, but the v1 first-party Controller and Node Agent are both Elixir services owned, packaged, and operated by Orchard.
+
+The latest concurrency work in `gnhf/objective-fully-impl-369718` adds important behavior that must survive this architectural pivot.
+It introduces live Placement Capacity, conservative scheduler eligibility, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, and weighted round-robin queue discipline.
+Those semantics are product behavior even though their current representation is `StatusResponse.runtime_model_placements` over gRPC.
+
+Postgres remains Orchard's durable persistence and coordination store.
+The Worker Runtime remains a local process/protocol boundary owned by the Node Agent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define Runtime Endpoint as the Controller-selected execution boundary.
+- Define Runtime Endpoint Interface as transport-independent runtime semantics.
+- Use BEAM Distribution for live first-party Controller-to-Node Agent communication and monitoring.
+- Keep Runtime Endpoint Observations durable in Postgres for operator-visible state and scheduling inputs.
+- Preserve `gnhf/objective-fully-impl-369718` concurrency semantics while replacing their first-party gRPC shell.
+- Keep external compute and provider integrations behind future Runtime Endpoint adapters.
+- Keep `proto/cluster/v1` available as a future adapter or compatibility protocol instead of deleting it immediately.
+
+**Non-Goals:**
+
+- Do not merge `gnhf/objective-fully-impl-369718` as part of this architecture proposal.
+- Do not implement external provider endpoints in this change.
+- Do not remove the local Worker Runtime protocol boundary.
+- Do not make BEAM Distribution durable cluster truth.
+- Do not allow external Runtime Endpoints to join the first-party BEAM mesh.
+
+## Decisions
+
+### Runtime Endpoint Becomes The Scheduler Target
+
+The Scheduler should select a Runtime Endpoint rather than a Node.
+A Node is a managed Apple Silicon Mac in Orchard inventory.
+A Runtime Endpoint is the execution boundary capable of receiving model runtime work.
+
+Alternative considered: keep scheduling centered on Nodes.
+That keeps v1 terminology simple, but it makes future Cloud VM, high-performance compute, appliance, or paid-provider execution targets look like fake Nodes.
+
+### Runtime Endpoint Interface Is Transport-Independent
+
+The Controller should depend on a Runtime Endpoint Interface for status, model readiness, inference execution, cancellation, runtime telemetry, Placement Capacity, and prefix-cache scoring.
+The first-party implementation should use BEAM Distribution.
+Future implementations can use provider APIs, gRPC/protobuf, or other adapter protocols.
+
+Alternative considered: keep `NodeRuntimeService` as the core interface.
+That preserves current code shape, but it keeps gRPC/protobuf as the ontology rather than an adapter.
+
+### BEAM Distribution Is First-Party Only
+
+BEAM Distribution should be limited to admitted first-party Orchard Elixir services.
+Production BEAM Distribution must be explicitly configured, identity-bound, network-restricted, and unavailable to external Runtime Endpoints.
+
+Alternative considered: use BEAM Distribution for every endpoint.
+That extends first-party trust to systems Orchard does not own and makes provider integration unsafe.
+
+### Postgres Remains Durable Truth
+
+BEAM Distribution provides live communication, monitoring, and fast failure signals.
+Postgres remains the durable store for inventory, lifecycle state, Runtime Endpoint Observations, scheduling history, request state, and operator-visible status.
+
+Alternative considered: use BEAM node connectivity as cluster truth.
+That would blur live session state with durable operator state and would weaken recovery after controller restart.
+
+### Placement Capacity Is First-Class Runtime Endpoint Observation
+
+Placement Capacity must be part of the Runtime Endpoint Interface.
+It includes the requested model placement, current active request count, and maximum concurrency.
+Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove eligibility for an active loaded placement.
+
+Alternative considered: keep Placement Capacity as scheduler-internal telemetry.
+The `gnhf` work shows it drives visible concurrency, `cluster_busy`, and queue behavior, so it belongs in the interface observation vocabulary.
+
+### gRPC Is Demoted, Not Deleted
+
+`proto/cluster/v1` and `NodeRuntimeService` should no longer be the default first-party Controller-to-Node Agent path.
+They may remain as future adapter or compatibility protocol artifacts.
+
+Alternative considered: delete the proto surface during the pivot.
+That creates avoidable churn and removes a useful candidate protocol for future non-BEAM Runtime Endpoint adapters.
+
+## Risks / Trade-offs
+
+Risk: BEAM Distribution security may be weaker than the prior mTLS story if treated casually.
+Mitigation: require explicit production configuration, identity binding, network restriction, and first-party admission before any BEAM node participates.
+
+Risk: Transport-neutral interfaces can become vague.
+Mitigation: specify concrete operations and observations, including Placement Capacity, cancellation, streaming events, status, availability, and scheduler-visible failure modes.
+
+Risk: The `gnhf` concurrency behavior may regress during transport adaptation.
+Mitigation: carry its scheduler, queue, public endpoint, and node-agent active-request regressions forward as Runtime Endpoint Interface tests.
+
+Risk: Existing gRPC tests may be deleted before replacement tests exist.
+Mitigation: first recast them as Runtime Endpoint contract tests, then keep or remove gRPC adapter tests based on whether the adapter remains supported.
+
+Risk: The term `cluster_busy` may feel stale after Runtime Endpoint modeling.
+Mitigation: keep the name for compatibility and define it as live Runtime Endpoint capacity exhaustion.
+
+## Migration Plan
+
+1. Update `SPEC.md`, architecture docs, and glossary to define Runtime Endpoint, Runtime Endpoint Interface, Runtime Endpoint Observation, Runtime Endpoint Availability, Placement Capacity, and first-party BEAM Distribution constraints.
+2. Introduce a Controller-facing Runtime Endpoint Interface and first-party BEAM implementation.
+3. Adapt scheduler and dispatch code to depend on Runtime Endpoint semantics instead of the gRPC client module.
+4. Preserve and adapt the `gnhf` queue, placement capacity, and `cluster_busy` behavior after the gnhf baseline is chosen.
+5. Recast current gRPC integration tests as Runtime Endpoint Interface contract tests.
+6. Keep a smaller adapter or compatibility test suite if gRPC remains available for future external endpoints.
+7. Validate OpenSpec, compile, lint, Dialyzer, tests, and coverage under the repo workflow before handoff.
+
+Rollback is architectural rather than runtime.
+If the BEAM-first path proves unsafe, keep the Runtime Endpoint Interface and bind the first-party adapter back to gRPC while preserving the transport-independent domain model.
+
+## Open Questions
+
+- What exact production BEAM Distribution identity mechanism will Orchard use for admitted first-party services?
+- Should `cluster_busy` eventually be renamed to `runtime_capacity_exhausted` or kept indefinitely for compatibility?
+- Which subset of `proto/cluster/v1` should remain generated after the first-party path moves to BEAM?
+- Should external Runtime Endpoint adapters be introduced as a later OpenSpec capability or as implementation slices under `runtime-endpoints`?

--- a/openspec/changes/beam-first-runtime-endpoints/design.md
+++ b/openspec/changes/beam-first-runtime-endpoints/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-`SPEC.md` currently requires no distributed Erlang across machines and requires all cross-node control traffic to use gRPC over mTLS.
+At the base of this change, `SPEC.md` requires no distributed Erlang across machines and requires all cross-node control traffic to use gRPC over mTLS.
 That made sense while Orchard's runtime boundary was still being shaped, but the v1 first-party Controller and Node Agent are both Elixir services owned, packaged, and operated by Orchard.
 
 The latest concurrency work in `gnhf/objective-fully-impl-369718` adds important behavior that must survive this architectural pivot.
@@ -16,9 +16,9 @@ The Worker Runtime remains a local process/protocol boundary owned by the Node A
 
 - Define Runtime Endpoint as the Controller-selected execution boundary.
 - Define Runtime Endpoint Interface as transport-independent runtime semantics.
-- Use BEAM Distribution for live first-party Controller-to-Node Agent communication and monitoring.
+- Add guardrails for future BEAM Distribution between first-party Controller and Node Agent services.
 - Keep Runtime Endpoint Observations durable in Postgres for operator-visible state and scheduling inputs.
-- Preserve `gnhf/objective-fully-impl-369718` concurrency semantics while replacing their first-party gRPC shell.
+- Preserve `gnhf/objective-fully-impl-369718` concurrency semantics while moving controller domain code to Runtime Endpoint semantics.
 - Keep external compute and provider integrations behind future Runtime Endpoint adapters.
 - Keep `proto/cluster/v1` available as a future adapter or compatibility protocol instead of deleting it immediately.
 
@@ -44,8 +44,9 @@ That keeps v1 terminology simple, but it makes future Cloud VM, high-performance
 ### Runtime Endpoint Interface Is Transport-Independent
 
 The Controller should depend on a Runtime Endpoint Interface for status, model readiness, inference execution, cancellation, runtime telemetry, Placement Capacity, and prefix-cache scoring.
-The first-party implementation should use BEAM Distribution.
-Future implementations can use provider APIs, gRPC/protobuf, or other adapter protocols.
+This slice should introduce the interface and keep the current first-party path behind a gRPC Compatibility Adapter.
+A later first-party implementation can use BEAM Distribution.
+Future non-BEAM implementations can use provider APIs, gRPC/protobuf, or other adapter protocols.
 
 Alternative considered: keep `NodeRuntimeService` as the core interface.
 That preserves current code shape, but it keeps gRPC/protobuf as the ontology rather than an adapter.
@@ -77,8 +78,8 @@ The `gnhf` work shows it drives visible concurrency, `cluster_busy`, and queue b
 
 ### gRPC Is Demoted, Not Deleted
 
-`proto/cluster/v1` and `NodeRuntimeService` should no longer be the default first-party Controller-to-Node Agent path.
-They may remain as future adapter or compatibility protocol artifacts.
+`proto/cluster/v1` and `NodeRuntimeService` should no longer be the durable Controller domain contract.
+They remain the current compatibility transport and may remain as future adapter protocol artifacts.
 
 Alternative considered: delete the proto surface during the pivot.
 That creates avoidable churn and removes a useful candidate protocol for future non-BEAM Runtime Endpoint adapters.
@@ -103,15 +104,15 @@ Mitigation: keep the name for compatibility and define it as live Runtime Endpoi
 ## Migration Plan
 
 1. Update `SPEC.md`, architecture docs, and glossary to define Runtime Endpoint, Runtime Endpoint Interface, Runtime Endpoint Observation, Runtime Endpoint Availability, Placement Capacity, and first-party BEAM Distribution constraints.
-2. Introduce a Controller-facing Runtime Endpoint Interface and first-party BEAM implementation.
-3. Adapt scheduler and dispatch code to depend on Runtime Endpoint semantics instead of the gRPC client module.
+2. Introduce a Controller-facing Runtime Endpoint Interface, current gRPC Compatibility Adapter, and BEAM guardrail validation.
+3. Adapt scheduler and dispatch code to depend on Runtime Endpoint semantics instead of the low-level gRPC client module.
 4. Preserve and adapt the `gnhf` queue, placement capacity, and `cluster_busy` behavior after the gnhf baseline is chosen.
 5. Recast current gRPC integration tests as Runtime Endpoint Interface contract tests.
 6. Keep a smaller adapter or compatibility test suite if gRPC remains available for future external endpoints.
 7. Validate OpenSpec, compile, lint, Dialyzer, tests, and coverage under the repo workflow before handoff.
 
 Rollback is architectural rather than runtime.
-If the BEAM-first path proves unsafe, keep the Runtime Endpoint Interface and bind the first-party adapter back to gRPC while preserving the transport-independent domain model.
+If the BEAM-first path proves unsafe, keep the Runtime Endpoint Interface and continue binding the first-party adapter to gRPC while preserving the transport-independent domain model.
 
 ## Open Questions
 

--- a/openspec/changes/beam-first-runtime-endpoints/proposal.md
+++ b/openspec/changes/beam-first-runtime-endpoints/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Orchard currently treats first-party Controller-to-Node Agent communication as a gRPC over mTLS product boundary even though both sides are first-party Elixir services.
+This adds transport and protobuf complexity before Orchard has a non-BEAM runtime endpoint that needs it.
+
+The architecture should make Orchard's runtime execution semantics transport-independent, use BEAM Distribution for admitted first-party Elixir Runtime Endpoints, keep Postgres as durable truth, and preserve the latest concurrent-inference semantics from `gnhf/objective-fully-impl-369718`.
+
+## What Changes
+
+- Introduce Runtime Endpoint as the schedulable execution boundary selected by the Controller.
+- Introduce a transport-independent Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, Placement Capacity, and scheduler observations.
+- Treat the first-party Node Agent as Orchard's v1 Runtime Endpoint implementation.
+- Prefer BEAM Distribution for live communication and monitoring between first-party Orchard Elixir services.
+- Keep Postgres as Orchard's durable persistence and coordination store.
+- Keep Worker Runtime as a local Node Agent-owned process/protocol boundary for Python/MLX execution.
+- Demote `proto/cluster/v1` and `NodeRuntimeService` from the default first-party Controller-to-Node Agent path to a possible future adapter or compatibility protocol.
+- Preserve the latest `gnhf/objective-fully-impl-369718` concurrency semantics around Placement Capacity, conservative scheduler eligibility, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, and weighted round-robin.
+- Require production BEAM Distribution to be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
+- Keep external compute, appliance-style accelerators, cloud VMs, high-performance compute nodes, and paid provider integrations outside the BEAM mesh behind future Runtime Endpoint adapters.
+
+## Capabilities
+
+### New Capabilities
+
+- `runtime-endpoints`: Defines Runtime Endpoint semantics, the transport-independent Runtime Endpoint Interface, first-party BEAM transport constraints, Placement Capacity observations, and the compatibility role of non-BEAM adapters.
+
+### Modified Capabilities
+
+- None.
+  No accepted OpenSpec capability specs exist yet.
+  This change updates `SPEC.md` behavior and supporting product docs after review.
+
+## Impact
+
+- Requires updates to `SPEC.md` sections that currently mandate no distributed Erlang across machines and gRPC over mTLS for all cross-node control traffic.
+- Requires updates to architecture docs and glossary terms that currently bind internal runtime communication to gRPC/mTLS.
+- Affects controller dispatch, scheduler, request orchestration, queue admission, node-agent runtime status, and runtime telemetry tests.
+- Affects current gRPC/protobuf artifacts under `proto/cluster/v1/` and generated cluster bindings by demoting them to adapter or compatibility status.
+- Does not remove the local Worker Runtime protocol boundary.
+- Does not merge `gnhf/objective-fully-impl-369718`, but the accepted architecture must preserve and adapt its concurrency behavior.

--- a/openspec/changes/beam-first-runtime-endpoints/proposal.md
+++ b/openspec/changes/beam-first-runtime-endpoints/proposal.md
@@ -1,19 +1,20 @@
 ## Why
 
-Orchard currently treats first-party Controller-to-Node Agent communication as a gRPC over mTLS product boundary even though both sides are first-party Elixir services.
+At the base of this change, Orchard treats first-party Controller-to-Node Agent communication as a gRPC over mTLS product boundary even though both sides are first-party Elixir services.
 This adds transport and protobuf complexity before Orchard has a non-BEAM runtime endpoint that needs it.
 
-The architecture should make Orchard's runtime execution semantics transport-independent, use BEAM Distribution for admitted first-party Elixir Runtime Endpoints, keep Postgres as durable truth, and preserve the latest concurrent-inference semantics from `gnhf/objective-fully-impl-369718`.
+The architecture should make Orchard's runtime execution semantics transport-independent, add guardrails for future BEAM Distribution between admitted first-party Elixir Runtime Endpoints, keep Postgres as durable truth, and preserve the latest concurrent-inference semantics from `gnhf/objective-fully-impl-369718`.
 
 ## What Changes
 
 - Introduce Runtime Endpoint as the schedulable execution boundary selected by the Controller.
 - Introduce a transport-independent Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, Placement Capacity, and scheduler observations.
 - Treat the first-party Node Agent as Orchard's v1 Runtime Endpoint implementation.
-- Prefer BEAM Distribution for live communication and monitoring between first-party Orchard Elixir services.
+- Add BEAM Distribution guardrail validation for future live communication and monitoring between first-party Orchard Elixir services.
+- Keep the current gRPC/protobuf `NodeRuntimeService` path as an explicit Runtime Endpoint compatibility adapter for this implementation slice.
 - Keep Postgres as Orchard's durable persistence and coordination store.
 - Keep Worker Runtime as a local Node Agent-owned process/protocol boundary for Python/MLX execution.
-- Demote `proto/cluster/v1` and `NodeRuntimeService` from the default first-party Controller-to-Node Agent path to a possible future adapter or compatibility protocol.
+- Demote `proto/cluster/v1` and `NodeRuntimeService` from the durable Controller domain contract to an explicit compatibility adapter and possible future non-BEAM adapter protocol.
 - Preserve the latest `gnhf/objective-fully-impl-369718` concurrency semantics around Placement Capacity, conservative scheduler eligibility, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, and weighted round-robin.
 - Require production BEAM Distribution to be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
 - Keep external compute, appliance-style accelerators, cloud VMs, high-performance compute nodes, and paid provider integrations outside the BEAM mesh behind future Runtime Endpoint adapters.
@@ -22,7 +23,7 @@ The architecture should make Orchard's runtime execution semantics transport-ind
 
 ### New Capabilities
 
-- `runtime-endpoints`: Defines Runtime Endpoint semantics, the transport-independent Runtime Endpoint Interface, first-party BEAM transport constraints, Placement Capacity observations, and the compatibility role of non-BEAM adapters.
+- `runtime-endpoints`: Defines Runtime Endpoint semantics, the transport-independent Runtime Endpoint Interface, first-party BEAM transport guardrails, Placement Capacity observations, and the compatibility role of the current gRPC adapter.
 
 ### Modified Capabilities
 
@@ -32,9 +33,9 @@ The architecture should make Orchard's runtime execution semantics transport-ind
 
 ## Impact
 
-- Requires updates to `SPEC.md` sections that currently mandate no distributed Erlang across machines and gRPC over mTLS for all cross-node control traffic.
-- Requires updates to architecture docs and glossary terms that currently bind internal runtime communication to gRPC/mTLS.
+- Requires updates to `SPEC.md` sections that mandated no distributed Erlang across machines and gRPC over mTLS for all cross-node control traffic at the base of this change.
+- Requires updates to architecture docs and glossary terms that bound internal runtime communication to gRPC/mTLS at the base of this change.
 - Affects controller dispatch, scheduler, request orchestration, queue admission, node-agent runtime status, and runtime telemetry tests.
-- Affects current gRPC/protobuf artifacts under `proto/cluster/v1/` and generated cluster bindings by demoting them to adapter or compatibility status.
+- Affects current gRPC/protobuf artifacts under `proto/cluster/v1/` and generated cluster bindings by wrapping them as adapter or compatibility transport status.
 - Does not remove the local Worker Runtime protocol boundary.
 - Does not merge `gnhf/objective-fully-impl-369718`, but the accepted architecture must preserve and adapt its concurrency behavior.

--- a/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
@@ -16,8 +16,8 @@ This changes the topology and scheduler language currently described in `SPEC.md
 
 ### Requirement: Transport-independent Runtime Endpoint Interface
 Orchard SHALL define a transport-independent Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, Placement Capacity, and scheduler observations.
-The Controller MUST depend on Runtime Endpoint semantics rather than direct gRPC/protobuf message semantics for first-party Node Agent communication.
-This supersedes the current first-party use of `NodeRuntimeService` in `SPEC.md` section 7.5 while preserving its logical operations.
+The Controller MUST depend on Runtime Endpoint semantics rather than direct gRPC/protobuf message semantics for scheduler and dispatch domain code.
+This wraps the current first-party use of `NodeRuntimeService` in `SPEC.md` section 7.5 behind a compatibility adapter while preserving its logical operations.
 
 #### Scenario: Controller requests inference through interface semantics
 - **WHEN** the Controller dispatches an inference request to a first-party Node Agent
@@ -27,15 +27,16 @@ This supersedes the current first-party use of `NodeRuntimeService` in `SPEC.md`
 - **WHEN** the first-party transport changes from gRPC to BEAM Distribution
 - **THEN** model readiness, inference execution, cancellation, status, and runtime telemetry semantics remain unchanged at the Runtime Endpoint Interface
 
-### Requirement: First-party BEAM Transport
-First-party Orchard Runtime Endpoints SHALL use BEAM Distribution as the preferred live communication and monitoring layer between admitted Elixir services.
+### Requirement: First-party BEAM Transport Guardrails
+Orchard SHALL validate first-party BEAM Distribution guardrails before any live BEAM Runtime Endpoint adapter can be enabled.
+First-party Orchard Runtime Endpoints MAY use BEAM Distribution as a future live communication and monitoring layer between admitted Elixir services.
 Production BEAM Distribution MUST be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
 External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
-This changes `SPEC.md` section 1.2, which currently forbids distributed Erlang across machines and requires all cross-node control traffic to use gRPC over mTLS.
+This changes the base `SPEC.md` section 1.2 language that forbids distributed Erlang across machines and requires all cross-node control traffic to use gRPC over mTLS.
 
-#### Scenario: First-party BEAM endpoint connects
-- **WHEN** an admitted first-party Node Agent participates in production runtime communication
-- **THEN** it communicates with the Controller through the configured first-party BEAM transport
+#### Scenario: First-party BEAM endpoint is enabled later
+- **WHEN** an admitted first-party Node Agent participates in production runtime communication through a future BEAM adapter
+- **THEN** it communicates with the Controller only through explicitly configured first-party BEAM transport
 - **THEN** the Controller still records durable Runtime Endpoint Observations in Postgres
 
 #### Scenario: External endpoint remains outside BEAM mesh

--- a/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
@@ -1,0 +1,131 @@
+## ADDED Requirements
+
+### Requirement: Runtime Endpoint Scheduling Boundary
+Orchard SHALL model the Controller-selected execution target as a Runtime Endpoint.
+The first-party v1 Runtime Endpoint SHALL be the Node Agent.
+A Runtime Endpoint MUST NOT be assumed to be a managed Orchard Node.
+This changes the topology and scheduler language currently described in `SPEC.md` sections 1.2, 1.3, 4, 5, and 7.5.
+
+#### Scenario: First-party Node Agent endpoint is selected
+- **WHEN** the Scheduler selects an Orchard-managed Apple Silicon Mac for inference work
+- **THEN** the selected execution target is represented as the Node Agent Runtime Endpoint for that Node
+
+#### Scenario: Future external endpoint is not a Node
+- **WHEN** a future provider-backed Runtime Endpoint is available to the Scheduler
+- **THEN** the endpoint is schedulable through Runtime Endpoint semantics without being represented as a managed Orchard Node
+
+### Requirement: Transport-independent Runtime Endpoint Interface
+Orchard SHALL define a transport-independent Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, Placement Capacity, and scheduler observations.
+The Controller MUST depend on Runtime Endpoint semantics rather than direct gRPC/protobuf message semantics for first-party Node Agent communication.
+This supersedes the current first-party use of `NodeRuntimeService` in `SPEC.md` section 7.5 while preserving its logical operations.
+
+#### Scenario: Controller requests inference through interface semantics
+- **WHEN** the Controller dispatches an inference request to a first-party Node Agent
+- **THEN** the dispatch uses Runtime Endpoint Interface operations for readiness, execution, streaming events, and cancellation
+
+#### Scenario: Transport adapter changes without semantic change
+- **WHEN** the first-party transport changes from gRPC to BEAM Distribution
+- **THEN** model readiness, inference execution, cancellation, status, and runtime telemetry semantics remain unchanged at the Runtime Endpoint Interface
+
+### Requirement: First-party BEAM Transport
+First-party Orchard Runtime Endpoints SHALL use BEAM Distribution as the preferred live communication and monitoring layer between admitted Elixir services.
+Production BEAM Distribution MUST be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
+External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
+This changes `SPEC.md` section 1.2, which currently forbids distributed Erlang across machines and requires all cross-node control traffic to use gRPC over mTLS.
+
+#### Scenario: First-party BEAM endpoint connects
+- **WHEN** an admitted first-party Node Agent participates in production runtime communication
+- **THEN** it communicates with the Controller through the configured first-party BEAM transport
+- **THEN** the Controller still records durable Runtime Endpoint Observations in Postgres
+
+#### Scenario: External endpoint remains outside BEAM mesh
+- **WHEN** a future provider-backed Runtime Endpoint is configured
+- **THEN** it integrates through a Runtime Endpoint adapter
+- **THEN** it does not join first-party BEAM Distribution
+
+### Requirement: Postgres Durable Runtime Truth
+Postgres SHALL remain Orchard's durable persistence and coordination store for inventory, lifecycle state, Runtime Endpoint Observations, request state, scheduling decisions, and operator-visible history.
+BEAM Distribution MUST NOT be treated as durable cluster truth.
+This preserves the durable coordination model described in `SPEC.md` sections 1.2, 3.3, and 3.7.
+
+#### Scenario: Live BEAM session exists
+- **WHEN** a first-party Node Agent has a live BEAM session with the Controller
+- **THEN** the Node Agent is not automatically schedulable
+- **THEN** scheduler eligibility still depends on durable policy, lifecycle state, availability, and fresh Runtime Endpoint Observations
+
+#### Scenario: Controller restarts
+- **WHEN** the Controller restarts after live BEAM sessions are lost
+- **THEN** durable request, node, endpoint, and scheduling state is recovered from Postgres
+
+### Requirement: Runtime Endpoint Observations
+The Controller SHALL record Runtime Endpoint Observations as durable snapshots of endpoint status, capability, availability, Placement Capacity, and placement signals.
+Runtime Endpoint Observations SHALL be transport-independent.
+This replaces the current first-party dependence on `StatusResponse` as the active observation seam in `SPEC.md` sections 4.6.1 and 7.5.
+
+#### Scenario: First-party status is observed
+- **WHEN** a Node Agent reports runtime status through the Runtime Endpoint Interface
+- **THEN** the Controller records a Runtime Endpoint Observation in Postgres using transport-independent fields
+
+#### Scenario: Transport-specific field is absent
+- **WHEN** a first-party BEAM Runtime Endpoint reports status without protobuf fields
+- **THEN** the Controller still records equivalent Runtime Endpoint Observation data
+
+### Requirement: Placement Capacity Observation
+Placement Capacity SHALL be a first-class Runtime Endpoint Observation for Model Placements.
+Placement Capacity SHALL include the model reference, active request count, and maximum concurrency for the placement.
+Unknown, malformed, duplicate, or nonmatching Placement Capacity MUST NOT prove scheduler eligibility for an active loaded placement.
+This preserves and generalizes the incoming `gnhf/objective-fully-impl-369718` `runtime_model_placements` behavior added around `SPEC.md` sections 4.6.1, 5.7, and 7.5.
+
+#### Scenario: Active loaded placement has spare capacity
+- **WHEN** exactly one matching Placement Capacity observation reports `active_request_count < max_concurrency`
+- **THEN** the Scheduler may keep that active loaded placement eligible for the requested work
+
+#### Scenario: Active loaded placement has unknown capacity
+- **WHEN** Placement Capacity is absent, malformed, duplicate, or nonmatching for an active loaded placement
+- **THEN** the Scheduler does not treat that placement as eligible based on capacity
+
+#### Scenario: Active loaded placement is full
+- **WHEN** matching Placement Capacity reports `active_request_count >= max_concurrency`
+- **THEN** the Scheduler treats that placement as currently unavailable for new work
+
+### Requirement: Cluster Busy Runtime Capacity Semantics
+Orchard SHALL retain the `cluster_busy` outcome name for now.
+`cluster_busy` SHALL mean live Runtime Endpoints exist, but no eligible Runtime Endpoint currently has capacity for the requested work.
+Queue-enabled `cluster_busy` after a queue grant SHALL be treated as waitable live Placement Capacity exhaustion under the original queue deadline.
+Queue-disabled `cluster_busy` SHALL remain an immediate failure.
+This preserves the incoming `gnhf/objective-fully-impl-369718` behavior around `SPEC.md` sections 5.4, 7.2.7, and 7.5.
+
+#### Scenario: Queue-enabled capacity exhaustion requeues
+- **WHEN** a queue-enabled request receives a queue grant and scheduling returns `cluster_busy`
+- **THEN** the Controller returns the request to the same queue lane under the original max queue wait deadline
+
+#### Scenario: Queue wait expires after cluster busy
+- **WHEN** no eligible Runtime Endpoint capacity appears before the original queue deadline
+- **THEN** the request terminates with `queue_timeout`
+
+#### Scenario: Queue disabled cluster busy
+- **WHEN** queue admission is disabled and scheduling returns `cluster_busy`
+- **THEN** the request fails immediately with the existing `cluster_busy` public error mapping
+
+### Requirement: Worker Runtime Boundary Preservation
+The Worker Runtime Interface SHALL remain separate from the Runtime Endpoint Interface.
+The Node Agent SHALL continue to own local Worker Runtime lifecycle, model loading, active request accounting, cancellation, diagnostics, and cleanup.
+This preserves `SPEC.md` sections 4.9, 4.10, and 7.5.2a.
+
+#### Scenario: Python MLX worker is used
+- **WHEN** a first-party Node Agent executes work through a Python/MLX Worker Runtime
+- **THEN** the Worker Runtime remains local to the Node Agent
+- **THEN** the Controller communicates with the Node Agent Runtime Endpoint rather than directly supervising the Worker Runtime
+
+### Requirement: gRPC Compatibility Demotion
+The existing `proto/cluster/v1` and `NodeRuntimeService` artifacts SHALL be demoted from the default first-party Controller-to-Node Agent path to a possible adapter or compatibility protocol.
+They MUST NOT be deleted solely because the first-party path becomes BEAM-first.
+This changes the role of the gRPC contract currently described in `SPEC.md` section 7.5.
+
+#### Scenario: First-party path is BEAM-first
+- **WHEN** the first-party Runtime Endpoint implementation uses BEAM Distribution
+- **THEN** `proto/cluster/v1` is not required for default first-party Controller-to-Node Agent communication
+
+#### Scenario: Future adapter uses gRPC
+- **WHEN** a future Runtime Endpoint adapter needs a stable non-BEAM protocol
+- **THEN** the existing gRPC/protobuf work may be reused or evolved as an adapter protocol

--- a/openspec/changes/beam-first-runtime-endpoints/tasks.md
+++ b/openspec/changes/beam-first-runtime-endpoints/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Update `SPEC.md` to replace first-party gRPC-only cross-node rules with Runtime Endpoint and BEAM-first first-party semantics.
 - [x] 1.2 Update `SPEC.md` to define Runtime Endpoint Observation, Runtime Endpoint Availability, Placement Capacity, and `cluster_busy` capacity semantics.
-- [x] 1.3 Update `SPEC.md` to keep Postgres as durable truth and BEAM Distribution as live first-party communication only.
+- [x] 1.3 Update `SPEC.md` to keep Postgres as durable truth and BEAM Distribution as guarded future first-party live communication only.
 - [x] 1.4 Update `SPEC.md` to keep Worker Runtime as a Node Agent-local boundary.
 - [x] 1.5 Update `docs/architecture.md` and glossary docs to match accepted Runtime Endpoint language.
 - [x] 1.6 Decide and document which `proto/cluster/v1` artifacts remain as adapter or compatibility protocol inputs.

--- a/openspec/changes/beam-first-runtime-endpoints/tasks.md
+++ b/openspec/changes/beam-first-runtime-endpoints/tasks.md
@@ -1,0 +1,56 @@
+## 1. Contract And Documentation
+
+- [x] 1.1 Update `SPEC.md` to replace first-party gRPC-only cross-node rules with Runtime Endpoint and BEAM-first first-party semantics.
+- [x] 1.2 Update `SPEC.md` to define Runtime Endpoint Observation, Runtime Endpoint Availability, Placement Capacity, and `cluster_busy` capacity semantics.
+- [x] 1.3 Update `SPEC.md` to keep Postgres as durable truth and BEAM Distribution as live first-party communication only.
+- [x] 1.4 Update `SPEC.md` to keep Worker Runtime as a Node Agent-local boundary.
+- [x] 1.5 Update `docs/architecture.md` and glossary docs to match accepted Runtime Endpoint language.
+- [x] 1.6 Decide and document which `proto/cluster/v1` artifacts remain as adapter or compatibility protocol inputs.
+
+## 2. Runtime Endpoint Interface
+
+- [x] 2.1 Define transport-independent Runtime Endpoint request, response, event, status, availability, and Placement Capacity domain types.
+- [x] 2.2 Define a Controller-facing Runtime Endpoint behaviour for status, ensure model loaded, unload model, execute inference, cancel inference, and prefix-cache scoring.
+- [ ] 2.3 Implement the first-party BEAM Runtime Endpoint adapter for Node Agent communication.
+- [x] 2.4 Add production guardrails for first-party BEAM Distribution configuration, identity binding, network restriction, and admitted-service membership.
+- [x] 2.5 Keep or adapt gRPC client/server modules only behind an explicit compatibility or future-adapter boundary.
+
+## 3. Scheduler, Dispatch, And Queue Behavior
+
+- [x] 3.1 Refactor `Orchard.Scheduler.MultiNode` to consume Runtime Endpoint Observations instead of gRPC `StatusResponse` structs.
+- [x] 3.2 Preserve conservative Placement Capacity behavior for active loaded placements with unknown, malformed, duplicate, or nonmatching capacity.
+- [x] 3.3 Preserve loadedness, lower active placement count, health, cache, safe-tokenization, memory, and deterministic tie-break ranking order.
+- [x] 3.4 Refactor dispatch so `RequestDispatcher` depends on the Runtime Endpoint Interface rather than a gRPC client module.
+- [x] 3.5 Preserve timeout, caller disconnect, cancellation, streaming event, and terminal event behavior during dispatch.
+- [x] 3.6 Preserve queue-enabled post-grant `cluster_busy` requeue under the original queue deadline.
+- [x] 3.7 Preserve queue-disabled `cluster_busy` as an immediate public failure.
+
+## 4. Node Agent And Worker Runtime Boundary
+
+- [ ] 4.1 Adapt Node Agent status and runtime operations to serve the first-party Runtime Endpoint Interface.
+- [x] 4.2 Preserve `ModelManager` ownership of active request accounting and Placement Capacity.
+- [x] 4.3 Preserve local Worker Runtime supervision, model loading, generation, cancellation, diagnostics, and cleanup.
+- [x] 4.4 Keep Python/MLX worker communication behind the Worker Runtime Interface.
+
+## 5. gnhf Concurrency Preservation
+
+- [x] 5.1 Choose the merge or rebase baseline for `gnhf/objective-fully-impl-369718` before implementation begins.
+- [x] 5.2 Preserve the gnhf capacity-2 concurrent inference behavior for `/v1/responses`.
+- [x] 5.3 Preserve the gnhf capacity-2 concurrent inference behavior for `/v1/chat/completions`.
+- [x] 5.4 Preserve tenant FIFO, weighted round-robin, same-lane bypass prevention, and grant requeue behavior in `QueueManager`.
+- [x] 5.5 Preserve public error mappings for `cluster_busy`, `queue_full`, and `queue_timeout`.
+
+## 6. Tests And Validation
+
+- [x] 6.1 Recast gRPC-specific node-agent capacity tests as Runtime Endpoint Interface contract tests.
+- [x] 6.2 Keep targeted gRPC adapter tests if the gRPC compatibility adapter remains supported.
+- [x] 6.3 Add scheduler tests for Runtime Endpoint Observations and Placement Capacity edge cases.
+- [x] 6.4 Add request orchestration tests for `cluster_busy` requeue and timeout behavior through the Runtime Endpoint Interface.
+- [x] 6.5 Run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate beam-first-runtime-endpoints --type change --strict --no-interactive`.
+- [x] 6.6 Run `mise exec -- mix format`.
+- [x] 6.7 Run `mise exec -- mix compile --warnings-as-errors`.
+- [x] 6.8 Run `mise exec -- mix credo --strict`.
+- [x] 6.9 Run `mise exec -- mix dialyzer`.
+- [x] 6.10 Run `mise exec -- mix test`.
+- [x] 6.11 Run `mise exec -- mix test --cover`.
+- [x] 6.12 After spec sync or archive, review generated specs for placeholder prose such as `Purpose TBD`.

--- a/proto/cluster/v1/runtime.proto
+++ b/proto/cluster/v1/runtime.proto
@@ -5,6 +5,9 @@ package cluster.v1;
 import "cluster/v1/common.proto";
 import "cluster/v1/events.proto";
 
+// Compatibility transport for Runtime Endpoint operations.
+// The transport-independent Runtime Endpoint Interface is the Controller
+// domain contract for runtime execution.
 service NodeRuntimeService {
   rpc GetStatus(StatusRequest) returns (StatusResponse);
   rpc EnsureModelLoaded(EnsureModelLoadedRequest) returns (EnsureModelLoadedResponse);


### PR DESCRIPTION
## Intent

Implement the first BEAM-first Runtime Endpoint slice for Orchard. The user wanted the durable Runtime Endpoint contract and first code slice, not the full first-party BEAM transport migration: define transport-independent Runtime Endpoint domain types and Controller behaviour, wrap the current gRPC NodeRuntimeService as an explicit compatibility adapter, refactor scheduler and dispatch to consume Runtime Endpoint observations and operations, preserve the merged gnhf placement-capacity and queue invariants including cluster_busy requeue semantics, add BEAM transport guardrail configuration without implementing the live BEAM adapter, keep Worker Runtime local to the Node Agent, and update SPEC.md, architecture, glossary, OpenSpec, ADR, and focused tests accordingly. During validation, also fix test-only issues discovered by the workflow: shorten test worker Unix socket paths for Python gRPC and clear cached Sentry license status at setup so boundary tests are isolated.

## What Changed
- Added transport-independent Runtime Endpoint domain types, Controller client behaviour, BEAM guardrail configuration, and a gRPC compatibility adapter/mapper for the existing NodeRuntimeService path.
- Refactored scheduler, node observation, request orchestration, and dispatch flows to consume Runtime Endpoint observations/operations while preserving placement-capacity, availability, cancellation, and queue requeue semantics.
- Updated SPEC.md, architecture/glossary/local-dev docs, OpenSpec change materials, and focused regression coverage for runtime endpoint configuration, mapping, scheduling, dispatch, node status, and node-agent boundaries.

## Risk Assessment

⚠️ Medium: The reviewed changes touch scheduler, dispatch, queue refresh, and Runtime Endpoint compatibility paths, so integration risk remains non-trivial even though I found no substantiated merge-blocking defects in the diff.

## Testing

Focused Runtime Endpoint, scheduler, dispatch, node-agent, OpenSpec, full umbrella tests, and coverage all passed. A temp evidence test produced reviewer-visible JSON demonstrating Runtime Endpoint scheduling, persisted observation state, `cluster_busy` capacity exhaustion, and BEAM guardrails; generated coverage/build artifacts were removed afterward.

<details>
<summary>Evidence: Runtime Endpoint scheduling evidence</summary>

<code>Shows scheduler selected `grpc_compat` Runtime Endpoint at `10.42.0.7:50071`, persisted healthy node capability, reported spare placement capacity, returned `cluster_busy` when exhausted, and rejected unsafe BEAM guardrails.</code>

```text
{
  "intent": "Runtime Endpoint first slice scheduling through transport-independent observations",
  "selected_target_transport": "grpc_compat",
  "selected_target_address": {
    "port": 50071,
    "host": "10.42.0.7"
  },
  "selected_node_id": "7d89b211-3f6c-40f4-861e-cf4f6f4c1066",
  "selected_tier": "loaded",
  "queue_lane_capacity": 2,
  "persisted_node_health": "healthy",
  "persisted_prompt_token_ids_capability": true,
  "spare_placement_capacity": {
    "status": "known",
    "full": false,
    "source": "evidence_observation",
    "max_concurrency": 2,
    "active_request_count": 1,
    "spare": true
  },
  "exhausted_capacity_result": "cluster_busy",
  "beam_guardrail_rejected": [
    "global_beam_distribution_cidr",
    "unrestricted_listen_host"
  ],
  "beam_guardrail_allowed": {
    "node_name": "orchard_controller@controller.local",
    "admitted_services": [
      "orchard_node_agent"
    ],
    "allowed_cidrs": [
      "10.42.0.0/24"
    ],
    "listen_host": "10.42.0.10"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 8 issues found → auto-fixed ✅</summary>

- ⚠️ `SPEC.md` - merge conflict rebasing onto origin/main
- ⚠️ `apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex` - merge conflict rebasing onto origin/main
- ⚠️ `apps/orchard_controller/lib/orchard/nodes.ex` - merge conflict rebasing onto origin/main
- ⚠️ `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex` - merge conflict rebasing onto origin/main
- ⚠️ `apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs` - merge conflict rebasing onto origin/main
- ⚠️ `apps/orchard_node_agent/test/orchard_node_agent_test.exs` - merge conflict rebasing onto origin/main
- ⚠️ `config/test.exs` - merge conflict rebasing onto origin/main
- ⚠️ `docs/architecture.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (3) ✅</summary>

- 🚨 `apps/orchard_shared/lib/orchard/runtime_endpoint/placement_capacity.ex:93` - `value/2` drops valid zero values because it falls back with `||`; `active_request_count: 0` becomes `nil`, so an idle loaded placement with positive `max_concurrency` is marked invalid instead of known spare capacity. Use key-preserving fetch logic here.
- 🚨 `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:228` - The default Runtime Endpoint client now returns `%Observation{}`, but the scheduler still derives aggregate `max_concurrency` from the raw response shape. Since `Observation` has no `:max_concurrency`, batch-capable nodes default to capacity 1 and get reported `cluster_busy` once any request is active.
- 🚨 `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:280` - Unknown or invalid `%PlacementCapacity{}` now still sets `:model_placement_capacity`, which makes `active_without_known_capacity?/1` return false. An active loaded candidate with absent/malformed placement capacity can be treated as eligible, violating the fail-closed placement-capacity rule.
- 🚨 `apps/orchard_controller/lib/orchard/nodes.ex:424` - `observe_status/4` now receives `%Observation{}` from the scheduler and dispatcher, but queue capacity refresh still reads legacy `:active_request_count`, `:max_concurrency`, and `:runtime_model_placements` fields. Runtime Endpoint observations therefore refresh queue sources as 0/1 with no placements, breaking loaded-placement and cold-capacity wakeups.
- ⚠️ `apps/orchard_shared/lib/orchard/runtime_endpoint/operation.ex:300` - This shared `value/2` helper also drops valid zero values; `Operation.ExecuteRequest.new!/1` will reject `input_tokens: 0` even though canonical requests allow non-negative token counts. Use the same key-preserving lookup pattern as the mapper helpers.

🔧 Fix: Fix runtime endpoint capacity observation handling
2 warnings still open:
- ⚠️ `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:223` - `probe_target/5` turns any Runtime Endpoint `Observation` with a valid node id into a schedulable candidate without checking `observation.availability`. A non-gRPC adapter could report `availability: :unavailable` with valid metadata/capacity and still be treated as eligible, so the new scheduler-facing availability field is not authoritative before the BEAM adapter arrives.
- ⚠️ `apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex:226` - `dispatch_after_preensure_gate/1` only handles `{:error, {:connect_failed, _}}` from `client.connect/1`, but the Runtime Endpoint client behaviour allows any `{:error, term()}`. A BEAM or test client returning another connect error, such as `:node_unavailable` or a guardrail failure, will raise a case clause instead of recording the failure and returning a dispatch error.

🔧 Fix: Honor runtime endpoint availability
3 warnings still open:
- ⚠️ `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:182` - `runtime_endpoint_target` now flows into the persisted scheduler decision, so the full `%Target{}` including arbitrary `metadata` can be stored and exposed in Console raw JSON. Persist only a sanitized endpoint id/transport summary, or strip this dispatch-only field before `Requests.record_schedule/2`.
- ⚠️ `apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex:902` - `RuntimeEndpoint.Client` requires `cancel_inference/3`, but dispatch calls `client.cancel_inference/2`; any conforming client without a default `/2` will crash on timeout or caller-disconnect cancellation. Call the callback with an explicit opts argument.
- ⚠️ `apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_client.ex:23` - Unsupported `%Target{}` transports hit the generic map clause, normalize back to the same target, and recurse forever. Add a non-`:grpc_compat` target clause that returns an explicit unsupported-transport error.

🔧 Fix: Fix Runtime Endpoint dispatch seams
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `mise exec -- mix test apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs apps/orchard_controller/test/orchard/runtime_endpoint/beam_config_test.exs apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_mapper_test.exs apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs apps/orchard_controller/test/orchard/dispatch/dispatch_parity_drift_test.exs apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs apps/orchard_controller/test/orchard/nodes_test.exs`
- `mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs`
- <code>`mise exec -- mix test /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVYB7A0S11WEBMJ5NQFH90Y8/runtime_endpoint_evidence_test.exs` from `apps/orchard_controller` after fixing the temp harness to use the app’s keyword-list runtime target config shape</code>
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate beam-first-runtime-endpoints --type change --strict --no-interactive`
- `mise exec -- mix test`
- `mise exec -- mix test --cover`
- <code>Cleaned generated worktree artifacts with `rm -rf apps/orchard_shared/cover apps/orchard_cli/cover apps/orchard_node_agent/cover _build/test apps/orchard_controller/_build/test-tmp`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
