### PR TITLE
fix(orchard_controller): terminalize runtime orchestration failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Clients (SDKs / curl / apps)
 - Controller runtime execution uses the Runtime Endpoint Interface.
 - The current `NodeRuntimeService` gRPC path is a compatibility adapter, not the durable domain contract.
 - First-party BEAM communication is guarded for future use and must not become durable cluster truth.
+- Source-dev keeps the gRPC compatibility adapter until a BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
 - Workers are local to node agents and are never exposed on the network.
 - Token streams always pass through the controller for governance and accounting.
 - HA-lite only: exactly one active leader, active/standby via Postgres advisory locks, no active/active consensus.
@@ -72,7 +73,7 @@ Clients (SDKs / curl / apps)
 | Language | Elixir/OTP (umbrella app) |
 | Database | Postgres |
 | Inference | MLX-LM runtime adapter managed by the node agent |
-| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter |
+| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter; future BEAM adapter gated by accepted two-Mac smoke |
 | APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
 | Packaging | DMG, PKG, launchd |
 | CLI | `orchardctl` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -46,6 +46,7 @@ Supported deployment modes:
 * Runtime Endpoint semantics are transport-independent.
 * The current gRPC/protobuf `NodeRuntimeService` is the compatibility transport for the first implementation and a candidate protocol for future non-BEAM adapters.
 * First-party Orchard Controller and Node Agent services MAY later use BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
+* Source-dev SHALL keep the gRPC compatibility path as the Controller-to-Node Agent runtime transport on port `50071` until a BEAM Runtime Endpoint adapter exists and passes the accepted two-Mac smoke.
 * Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
 * External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 * All public API traffic SHALL terminate at the controller.
@@ -417,6 +418,7 @@ Rules:
 * `running` means node accepted and worker prefill began
 * `streaming` means at least one token or structured delta has been emitted
 * `interrupted` is used for controller/process failure after dispatch but before terminal reconciliation
+* once a request row has reached `validated`, scheduler or dispatch orchestration crashes MUST terminalize it as `failed` with durable `error_code = "orchestration_error"` and a sanitized public `internal_error`
 * once terminal, state is immutable
 
 ### 3.7 Durable-state write rules
@@ -564,6 +566,8 @@ Future `/v1/responses` terminal projection rules are:
 11. finalize usage/accounting
 12. append terminal request event + audit entries
 ```
+
+After step 5, internal scheduler or dispatch orchestration failures SHALL skip the remaining runtime steps, append a terminal failed request event, and preserve sanitized public error mapping.
 
 ### 3.9 Idempotency
 
@@ -1175,6 +1179,9 @@ Retry rule:
 * only if failure occurs **before first token emitted**
 * retry must choose a different node if one exists
 * after first token, no automatic retry
+
+Runtime Endpoint disconnect and channel cleanup failures are cleanup-only failures.
+They SHALL be logged best-effort and MUST NOT overwrite an otherwise successful scheduler probe or dispatch result.
 
 ### 5.10 Circuit breakers
 
@@ -2075,6 +2082,8 @@ Controller runtime execution SHALL use the Runtime Endpoint Interface.
 Runtime Endpoint semantics are transport-independent.
 The current gRPC/protobuf `NodeRuntimeService` is the gRPC Compatibility Adapter for the first implementation and a candidate protocol for future non-BEAM adapters.
 First-party Orchard Controller and Node Agent services MAY later use BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
+Source-dev SHALL keep the gRPC compatibility path as the Controller-to-Node Agent runtime transport on port `50071` until a BEAM Runtime Endpoint adapter exists and passes the accepted two-Mac smoke.
+The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
 Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
 External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling history, request state, and operator-visible status.

--- a/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
@@ -46,7 +46,7 @@ defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
     end
   end
 
-  @doc "Disconnect a gRPC channel."
+  @doc "Disconnect a gRPC channel best-effort and return `:ok`."
   @spec disconnect(GRPC.Channel.t()) :: :ok
   def disconnect(channel) do
     case GRPC.Stub.disconnect(channel) do

--- a/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
@@ -24,6 +24,8 @@ defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
   alias Orchard.InferenceEvent
   alias Orchard.Runtime.PrefixCacheScore
 
+  require Logger
+
   @rpc_timeout_ms 5_000
 
   @doc """
@@ -51,6 +53,18 @@ defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
       {:ok, _channel} -> :ok
       {:error, _reason} -> :ok
     end
+  rescue
+    error ->
+      Logger.warning("gRPC disconnect failed: #{exception_name(error)}")
+      :ok
+  catch
+    :exit, _reason ->
+      Logger.warning("gRPC disconnect exited")
+      :ok
+
+    _kind, _reason ->
+      Logger.warning("gRPC disconnect threw")
+      :ok
   end
 
   @doc """
@@ -270,6 +284,8 @@ defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
   defp normalize_score_transport_error(_reason) do
     score_response("error")
   end
+
+  defp exception_name(%{__struct__: module}) when is_atom(module), do: Atom.to_string(module)
 
   defp score_response(status_code) do
     normalized = PrefixCacheScore.normalize_for_scheduler(%{status_code: status_code})

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -232,7 +232,24 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp dispatch_with_channel(%{client: client, channel: channel} = context) do
     do_dispatch_with_channel(context)
   after
+    disconnect_best_effort(client, channel)
+  end
+
+  defp disconnect_best_effort(client, channel) do
     client.disconnect(channel)
+    :ok
+  rescue
+    error ->
+      Logger.warning("Runtime endpoint disconnect failed: #{exception_name(error)}")
+      :ok
+  catch
+    :exit, _reason ->
+      Logger.warning("Runtime endpoint disconnect exited")
+      :ok
+
+    _kind, _reason ->
+      Logger.warning("Runtime endpoint disconnect threw")
+      :ok
   end
 
   defp do_dispatch_with_channel(%{} = context) do
@@ -710,9 +727,11 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   rescue
     error ->
       Logger.warning(
-        "Failed to mark target transport failure for #{inspect(target)}: #{inspect(error)}"
+        "Failed to mark runtime endpoint transport failure: #{exception_name(error)}"
       )
   end
+
+  defp exception_name(%{__struct__: module}) when is_atom(module), do: Atom.to_string(module)
 
   defp emit_event(_event, _request_id, nil), do: :ok
 

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -13,6 +13,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   Transport failures during connect, pre-dispatch status, model load, or stream
   execution are recorded through node inventory so stale capacity for the failed
   target is cleared.
+  Runtime Endpoint disconnect cleanup is best-effort and does not override the
+  dispatch outcome.
 
   Timing instrumentation logs one 'dispatch_timing' line per dispatch attempt,
   capturing cold/warm classification, stream timing, and outcome.
@@ -157,6 +159,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   Returns `{:ok, events}` with the list of all events received (including terminal),
   or `{:error, reason}` if dispatch fails before streaming begins.
+  Runtime Endpoint disconnect cleanup failures are logged and ignored after the
+  dispatch outcome is known.
   """
   @spec dispatch(
           schedule :: map(),

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -27,6 +27,7 @@ defmodule Orchard.Inference.ChatError do
           | :request_cancelled
           | :request_interrupted
           | :request_failed
+          | :orchestration_crash
           | :internal
 
   @type mapping :: %{
@@ -114,6 +115,9 @@ defmodule Orchard.Inference.ChatError do
   def from_execute_error({kind, detail})
       when kind in [:model_busy, :cluster_busy, :queue_full, :queue_timeout],
       do: build_admission_error(kind, nil, detail)
+
+  def from_execute_error({:orchestration_crash, metadata}),
+    do: build(:orchestration_crash, detail: metadata)
 
   def from_execute_error(reason), do: build(:internal, detail: reason)
 
@@ -298,6 +302,16 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def api_mapping(%__MODULE__{kind: :orchestration_crash}) do
+    %{
+      status: :internal_server_error,
+      type: "api_error",
+      code: "internal_error",
+      message: "Internal error",
+      param: nil
+    }
+  end
+
   def api_mapping(%__MODULE__{kind: :internal, detail: detail}) do
     %{
       status: :internal_server_error,
@@ -333,6 +347,15 @@ defmodule Orchard.Inference.ChatError do
   end
 
   def sse_mapping(%__MODULE__{kind: :internal}) do
+    %{
+      type: "server_error",
+      code: "internal_error",
+      message: "Internal error",
+      param: nil
+    }
+  end
+
+  def sse_mapping(%__MODULE__{kind: :orchestration_crash}) do
     %{
       type: "server_error",
       code: "internal_error",
@@ -420,6 +443,15 @@ defmodule Orchard.Inference.ChatError do
       http_status: 500,
       error_code: error.source_code || "internal_error",
       error_message: error.source_message || "Inference failed"
+    }
+  end
+
+  def terminal_attrs(%__MODULE__{kind: :orchestration_crash}) do
+    %{
+      state: :failed,
+      http_status: 500,
+      error_code: "orchestration_error",
+      error_message: "Runtime orchestration failed"
     }
   end
 

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -4,6 +4,8 @@ defmodule Orchard.Inference.ChatError do
 
   Centralizes client-safe HTTP/SSE mappings and durable terminal request attrs so
   the public API and console paths stay behavior-aligned.
+  Internal orchestration crashes keep public payloads generic while storing a
+  durable `orchestration_error` terminal reason.
   """
 
   alias Orchard.Inference.ModelLoadFailure

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -1,6 +1,10 @@
 defmodule Orchard.Inference.RequestOrchestrator do
   @moduledoc """
   Executes the shared durable request lifecycle for prepared canonical requests.
+
+  Once a request has been persisted and validated, scheduler and dispatch
+  orchestration crashes are converted into durable failed terminal outcomes so
+  requests do not remain active without a runtime owner.
   """
 
   alias Orchard.CanonicalRequest

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -668,7 +668,32 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp schedule_request(canonical) do
+    case call_scheduler(canonical) do
+      {:ok, schedule} when is_map(schedule) ->
+        {:ok, schedule}
+
+      {:error, _reason} = error ->
+        error
+
+      _other ->
+        {:error, orchestration_crash(:scheduler, :invalid_return)}
+    end
+  end
+
+  defp call_scheduler(canonical) do
     Inference.scheduler().schedule(canonical)
+  rescue
+    error ->
+      log_warn("scheduler crashed: #{exception_name(error)}")
+      {:error, orchestration_crash(:scheduler, {:exception, error})}
+  catch
+    :exit, _reason ->
+      log_warn("scheduler exited")
+      {:error, orchestration_crash(:scheduler, :exit)}
+
+    _kind, _reason ->
+      log_warn("scheduler threw")
+      {:error, orchestration_crash(:scheduler, :throw)}
   end
 
   defp scheduler_persistence_metadata(schedule) do
@@ -827,13 +852,14 @@ defmodule Orchard.Inference.RequestOrchestrator do
       maybe_mark_grant_node(queue_grant, map_value(schedule, :node_id), promote?: false)
 
       result =
-        RequestDispatcher.dispatch(
+        dispatch_request(
           schedule,
           execute_request,
           model_load_request,
-          caller: caller,
-          event_handler: wrapped_handler,
-          on_node_resolved: build_node_resolved_callback(db_request.id, queue_grant)
+          caller,
+          wrapped_handler,
+          db_request.id,
+          queue_grant
         )
 
       first_token_at = Process.get(capture_key)
@@ -846,6 +872,45 @@ defmodule Orchard.Inference.RequestOrchestrator do
       Process.delete(capture_key)
     end
   end
+
+  defp dispatch_request(
+         schedule,
+         execute_request,
+         model_load_request,
+         caller,
+         wrapped_handler,
+         request_id,
+         queue_grant
+       ) do
+    opts = [
+      caller: caller,
+      event_handler: wrapped_handler,
+      on_node_resolved: build_node_resolved_callback(request_id, queue_grant)
+    ]
+
+    dispatch = &RequestDispatcher.dispatch/4
+
+    dispatch.(schedule, execute_request, model_load_request, opts)
+    |> normalize_dispatch_result()
+  rescue
+    error ->
+      log_warn("dispatch crashed: #{exception_name(error)}")
+      {:error, orchestration_crash(:dispatch, {:exception, error})}
+  catch
+    :exit, _reason ->
+      log_warn("dispatch exited")
+      {:error, orchestration_crash(:dispatch, :exit)}
+
+    _kind, _reason ->
+      log_warn("dispatch threw")
+      {:error, orchestration_crash(:dispatch, :throw)}
+  end
+
+  defp normalize_dispatch_result({:ok, _events} = success), do: success
+  defp normalize_dispatch_result({:error, _reason} = error), do: error
+
+  defp normalize_dispatch_result(_other),
+    do: {:error, orchestration_crash(:dispatch, :invalid_return)}
 
   defp wrap_event_handler_for_first_token(downstream_handler, capture_key, queue_grant) do
     fn request_id, event ->
@@ -1122,7 +1187,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp advance_fsm_best_effort_terminal(request_id, state) do
-    try_advance(request_id, state)
+    try_advance_terminal(request_id, state)
   end
 
   defp try_advance(request_id, state) do
@@ -1131,6 +1196,31 @@ defmodule Orchard.Inference.RequestOrchestrator do
       {:error, :not_found} -> :ok
       {:error, :already_terminal} -> :ok
       {:error, error} -> log_warn("FSM advance to #{state} failed: #{inspect(error)}")
+    end
+  end
+
+  defp try_advance_terminal(request_id, state) do
+    case advance_fsm(request_id, state) do
+      :ok -> :ok
+      {:error, :not_found} -> append_terminal_state_event(request_id, state)
+      {:error, :already_terminal} -> :ok
+      {:error, error} -> log_warn("FSM terminal advance to #{state} failed: #{inspect(error)}")
+    end
+  end
+
+  defp append_terminal_state_event(request_id, state) do
+    attrs = %{
+      event_type: "state_transition",
+      state: state,
+      payload: %{to_state: to_string(state), source: "request_orchestrator_terminal_fallback"}
+    }
+
+    case Requests.append_request_event(request_id, attrs) do
+      {:ok, _event} ->
+        :ok
+
+      {:error, error} ->
+        log_warn("FSM terminal fallback event for #{state} failed: #{inspect(error)}")
     end
   end
 
@@ -1661,6 +1751,17 @@ defmodule Orchard.Inference.RequestOrchestrator do
       log_warn("canonical_request serialization failed: #{Exception.message(error)}")
       {:error, {:canonical_request_serialization_failed, Exception.message(error)}}
   end
+
+  defp orchestration_crash(phase, {:exception, error}) do
+    {:orchestration_crash,
+     %{phase: phase, category: :exception, exception: exception_name(error)}}
+  end
+
+  defp orchestration_crash(phase, category) do
+    {:orchestration_crash, %{phase: phase, category: category}}
+  end
+
+  defp exception_name(%{__struct__: module}) when is_atom(module), do: Atom.to_string(module)
 
   defp log_warn(message) do
     require Logger

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/client.ex
@@ -9,6 +9,10 @@ defmodule Orchard.RuntimeEndpoint.Client do
 
     * `{:runtime_endpoint_event, stream_ref, request_id, event}`
     * `{:runtime_endpoint_done, stream_ref, :ok | {:error, reason}}`
+
+  Disconnect is cleanup-only. Callers treat disconnect failures as best-effort
+  cleanup and preserve the status, scheduling, or dispatch outcome already
+  produced by the Runtime Endpoint operation.
   """
 
   alias Orchard.InferenceEvent

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -32,6 +32,8 @@ defmodule Orchard.Scheduler.MultiNode do
   Transport-like probe and connect failures are recorded through node inventory
   so failed targets stop contributing stale queue capacity before queued work is
   promoted.
+  Probe disconnect cleanup is best-effort and does not remove an otherwise valid
+  candidate or change the scheduling outcome.
   """
 
   alias Orchard.CanonicalRequest

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -244,7 +244,7 @@ defmodule Orchard.Scheduler.MultiNode do
               nil
           end
         after
-          client.disconnect(channel)
+          disconnect_best_effort(client, channel)
         end
 
       {:error, reason} ->
@@ -252,6 +252,23 @@ defmodule Orchard.Scheduler.MultiNode do
         Nodes.record_transport_failure(observation_target(target), reason, observed_at)
         nil
     end
+  end
+
+  defp disconnect_best_effort(client, channel) do
+    client.disconnect(channel)
+    :ok
+  rescue
+    error ->
+      Logger.warning("Runtime endpoint disconnect failed: #{exception_name(error)}")
+      :ok
+  catch
+    :exit, _reason ->
+      Logger.warning("Runtime endpoint disconnect exited")
+      :ok
+
+    _kind, _reason ->
+      Logger.warning("Runtime endpoint disconnect threw")
+      :ok
   end
 
   defp candidate_full?(candidate) do
@@ -392,6 +409,8 @@ defmodule Orchard.Scheduler.MultiNode do
   end
 
   defp extract_valid_node_id(_), do: nil
+
+  defp exception_name(%{__struct__: module}) when is_atom(module), do: Atom.to_string(module)
 
   defp model_loaded?(%Observation{} = observation, %CanonicalRequest{model_ref: model_ref}) do
     Observation.loaded_placement(observation, runtime_model_ref(model_ref)) != nil

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -1,3 +1,51 @@
+defmodule Orchard.Dispatch.DispatchTest.DisconnectRaisingClient do
+  @moduledoc false
+
+  alias Orchard.Cluster.V1.StatusResponse
+  alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.Operation
+
+  def connect(_target), do: {:ok, :disconnect_raising_channel}
+
+  def status(_channel, _opts \\ []), do: {:ok, %StatusResponse{}}
+
+  def disconnect(_channel) do
+    raise FunctionClauseError, module: __MODULE__, function: :disconnect, arity: 1
+  end
+
+  def ensure_model_loaded(
+        _channel,
+        %Operation.EnsureModelLoadedRequest{},
+        _opts \\ []
+      ) do
+    {:ok,
+     %Operation.EnsureModelLoadedResult{
+       already_loaded: false,
+       placement_state: :loaded,
+       worker_supports_prompt_token_ids: true
+     }}
+  end
+
+  def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts \\ []) do
+    owner = Keyword.get(opts, :owner, self())
+    ref = make_ref()
+
+    send(owner, {:runtime_endpoint_event, ref, request.request_id, InferenceEvent.accepted(0)})
+
+    send(
+      owner,
+      {:runtime_endpoint_event, ref, request.request_id,
+       InferenceEvent.completed(:finish_reason_stop, nil)}
+    )
+
+    send(owner, {:runtime_endpoint_done, ref, :ok})
+
+    {:ok, ref}
+  end
+
+  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts \\ []), do: :ok
+end
+
 defmodule Orchard.Dispatch.DispatchTest do
   @moduledoc """
   Tests for R6: single-node dispatch and cancellation.
@@ -159,6 +207,20 @@ defmodule Orchard.Dispatch.DispatchTest do
         |> Enum.map(& &1.event.delta)
 
       assert deltas == ["orchard ", "ready"]
+    end
+
+    test "returns streamed events when disconnect cleanup raises", %{bundle: bundle} do
+      schedule = build_schedule("req-dispatch-cleanup-raises")
+      execute = execute_request("req-dispatch-cleanup-raises")
+      model_load = model_load_request(bundle)
+
+      assert {:ok, events} =
+               RequestDispatcher.dispatch(schedule, execute, model_load,
+                 client_impl: Orchard.Dispatch.DispatchTest.DisconnectRaisingClient
+               )
+
+      assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted, :completed]
+      assert List.last(events) |> InferenceEvent.terminal?()
     end
 
     test "Sentry controller enrichment records sparse dispatch context", %{bundle: bundle} do

--- a/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
@@ -305,6 +305,36 @@ defmodule Orchard.Inference.ChatErrorTest do
            }
   end
 
+  test "orchestration crash execute errors stay generic across public and durable mappings" do
+    error =
+      ChatError.from_execute_error(
+        {:orchestration_crash,
+         %{phase: :scheduler, category: :exception, exception: "Elixir.FunctionClauseError"}}
+      )
+
+    assert ChatError.api_mapping(error) == %{
+             status: :internal_server_error,
+             type: "api_error",
+             code: "internal_error",
+             message: "Internal error",
+             param: nil
+           }
+
+    assert ChatError.sse_mapping(error) == %{
+             type: "server_error",
+             code: "internal_error",
+             message: "Internal error",
+             param: nil
+           }
+
+    assert ChatError.terminal_attrs(error) == %{
+             state: :failed,
+             http_status: 500,
+             error_code: "orchestration_error",
+             error_message: "Runtime orchestration failed"
+           }
+  end
+
   test "generic execute errors preserve JSON inspect details but SSE stays sanitized" do
     error = ChatError.from_execute_error({:terminal_persist_failed, :boom})
 

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -3390,7 +3390,7 @@ defmodule Orchard.Inference.QueueManagerTest do
     end)
   end
 
-  defp wait_until(fun, attempts \\ 50)
+  defp wait_until(fun, attempts \\ 150)
   defp wait_until(_fun, 0), do: false
 
   defp wait_until(fun, attempts) do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -351,6 +351,24 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler do
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+
+  def schedule(%CanonicalRequest{}) do
+    raise FunctionClauseError, module: __MODULE__, function: :schedule, arity: 1
+  end
+end
+
+defmodule Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseRuntimeClient do
+  @moduledoc false
+
+  def connect(_target) do
+    raise FunctionClauseError, module: __MODULE__, function: :connect, arity: 1
+  end
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.StubLiveCapacityScheduler do
   @behaviour Orchard.Scheduler.SingleNode
 
@@ -1227,6 +1245,54 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     refute :admitted in states
     refute :queued in states
     refute Map.has_key?(request.scheduler_decision, "queueing_enabled")
+  end
+
+  test "execute/3 terminalizes a validated request when scheduling crashes", %{bundle: bundle} do
+    put_queue_admission_config(enabled: false)
+    put_function_clause_scheduler_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-scheduler-crash")
+    canonical = canonical_request("request-orchestrator-scheduler-crash", stream?: false)
+
+    assert {:error,
+            {:orchestration_crash,
+             %{phase: :scheduler, category: :exception, exception: "Elixir.FunctionClauseError"}}} =
+             RequestOrchestrator.execute(canonical, model)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    states = request_event_states(request)
+
+    assert request.state == :failed
+    assert request.node_id == nil
+    assert request.error_code == "orchestration_error"
+    assert request.error_message == "Runtime orchestration failed"
+    assert :validated in states
+    assert :failed in states
+    assert state_before?(states, :validated, :failed)
+    refute :scheduled in states
+  end
+
+  test "execute/3 terminalizes a validated request when dispatch crashes", %{bundle: bundle} do
+    put_queue_admission_config(enabled: false)
+    put_function_clause_runtime_client_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-dispatch-crash")
+    canonical = canonical_request("request-orchestrator-dispatch-crash", stream?: false)
+
+    assert {:error,
+            {:orchestration_crash,
+             %{phase: :dispatch, category: :exception, exception: "Elixir.FunctionClauseError"}}} =
+             RequestOrchestrator.execute(canonical, model)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    states = request_event_states(request)
+
+    assert request.state == :failed
+    assert request.error_code == "orchestration_error"
+    assert request.error_message == "Runtime orchestration failed"
+    assert state_before?(states, :validated, :failed)
+    assert :scheduled in states
+    assert :dispatching in states
   end
 
   test "queue admission enabled records immediate grant metadata before dispatch", %{
@@ -2851,6 +2917,27 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       Application.fetch_env!(:orchard_controller, :inference)
       |> Keyword.merge(
         scheduler_impl: Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+  end
+
+  defp put_function_clause_scheduler_config do
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.merge(
+        scheduler_impl: Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseScheduler
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+  end
+
+  defp put_function_clause_runtime_client_config do
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.merge(
+        runtime_endpoint_client_impl:
+          Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseRuntimeClient
       )
 
     Application.put_env(:orchard_controller, :inference, inference)

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -77,6 +77,20 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     def disconnect(channel), do: StubClient.disconnect(channel)
   end
 
+  defmodule StubClientDisconnectRaises do
+    @moduledoc false
+
+    def connect(target), do: StubClient.connect(target)
+    def status(target, opts), do: StubClient.status(target, opts)
+
+    def disconnect(_channel) do
+      raise FunctionClauseError, module: __MODULE__, function: :disconnect, arity: 1
+    end
+
+    def score_prefix_cache(target, request, opts),
+      do: StubClient.score_prefix_cache(target, request, opts)
+  end
+
   defmodule StubClientRaiseScore do
     @moduledoc false
 
@@ -708,6 +722,46 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.node_id == node_b.id
       assert schedule.selected_tier == "loaded"
       assert schedule.candidate_count == 2
+    end
+
+    test "keeps probe candidates when disconnect cleanup raises" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(node_a.id,
+          host: "10.0.0.1",
+          port: 50_061,
+          loaded_models: [%{model_id: "test-model", version: "v1"}]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id, host: "10.0.0.2", port: 50_062)
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      log =
+        capture_log(fn ->
+          assert {:ok, schedule} =
+                   MultiNode.schedule(request, status_client: StubClientDisconnectRaises)
+
+          send(self(), {:schedule, schedule})
+        end)
+
+      assert log =~ "Runtime endpoint disconnect failed"
+      assert_receive {:schedule, schedule}
+      assert schedule.strategy == :multi_node
+      assert schedule.node_id == node_a.id
+      assert schedule.selected_tier == "loaded"
+      assert schedule.candidate_count == 2
+      assert Repo.get!(Node, node_a.id).health == :healthy
+      assert Repo.get!(Node, node_b.id).health == :healthy
     end
 
     test "consumes runtime endpoint observations and preserves legacy dispatch target" do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ Public clients
      -> Postgres for durable state and coordination
      -> Runtime Endpoint Interface
         -> current gRPC compatibility adapter
-        -> future first-party BEAM adapter
+        -> future first-party BEAM adapter after accepted source-dev smoke
         -> future external/provider adapters
      -> Node Agent(s)
         -> Worker Runtime subprocesses for local MLX inference
@@ -52,6 +52,7 @@ Core design rules from `SPEC.md`:
 - the Controller dispatches model runtime work through the Runtime Endpoint Interface;
 - the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
 - first-party BEAM communication requires explicit production guardrails before it can be enabled;
+- source-dev keeps the gRPC compatibility adapter until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke;
 - node agents are the v1 first-party Runtime Endpoint boundary;
 - worker runtimes are local subprocesses, not public services;
 - Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling, and request state.
@@ -101,6 +102,7 @@ Aggregate capacity is the conservative limit the node agent enforces across load
 The controller scheduler uses that capacity telemetry to avoid dispatching to full endpoints or full same-model placements.
 Controller queue admission also consumes fresh Runtime Endpoint Observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted endpoints.
 Invalid, ineligible, unavailable, or transport-failed observations clear stale endpoint-owned capacity sources before queued work can be promoted.
+Scheduler and dispatch orchestration crashes after request validation terminalize the durable request as a failed `orchestration_error` with sanitized public error payloads instead of leaving it active.
 
 Runtime Endpoint and worker runtime contracts are separate:
 

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -38,6 +38,11 @@ Existing `proto/cluster/v1` work should be demoted from the default first-party 
 Placement Capacity is a first-class Runtime Endpoint observation and must be exposed by the interface independently of transport.
 Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove eligibility for an active loaded placement.
 
+The BEAM Runtime Endpoint adapter is the intended primary source-dev Controller-to-Node Agent path once the adapter exists and passes the accepted two-Mac smoke.
+Until that gate passes, current source-dev continues to use the gRPC Compatibility Adapter on port `50071` as the compatibility and fallback path.
+The accepted smoke gate requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
+Do not remove gRPC compatibility before the BEAM adapter passes that smoke.
+
 Keep the Worker Runtime Interface separate.
 The Node Agent may continue to use a local worker protocol for Python/MLX subprocesses.
 The BEAM-first decision applies to first-party Controller-to-Node Agent communication.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -60,6 +60,7 @@ _Avoid_: Redis, Kafka, distributed Erlang state
 
 **BEAM Distribution**:
 The live Orchard communication and monitoring layer between first-party Elixir services.
+In source-dev, it becomes the primary Runtime Endpoint transport only after the BEAM adapter passes the accepted two-Mac smoke.
 In packaged production, BEAM Distribution is limited to admitted first-party Orchard services.
 _Avoid_: Durable cluster truth, database replacement, public API, external provider integration
 
@@ -181,6 +182,7 @@ _Avoid_: Job, task, request-step observation, public response status
 
 **Request FSM**:
 The lifecycle state machine for an active Request from receipt through terminal outcome.
+Scheduler or dispatch orchestration crashes after validation terminalize the Request as failed with `orchestration_error`.
 _Avoid_: Queue state
 
 **Request Event**:
@@ -395,6 +397,7 @@ _Avoid_: persisted Scheduler Decision metadata, tenant-facing error contract
 
 **Dispatch**:
 The Controller-to-Runtime Endpoint handoff after scheduling that ensures a model is loaded and starts inference execution.
+Runtime Endpoint disconnect cleanup is best-effort and does not define the dispatch outcome.
 _Avoid_: Scheduler Decision
 
 **Circuit Breaker**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -227,6 +227,8 @@ Stream mode reports max concurrency as `1` at both node and placement levels.
 The current source-dev slice includes default-off BEAM Runtime Endpoint guardrail config under `:orchard_controller, :runtime_endpoint, beam: [...]`.
 This validates future first-party BEAM transport admission settings only.
 It does not implement or enable a live BEAM Runtime Endpoint adapter, and there is no supported source-dev env var surface for it in this slice.
+The accepted target is for BEAM Runtime Endpoint transport to become the primary source-dev Controller-to-Node Agent path after the adapter exists and passes the two-Mac smoke.
+Until that gate passes, source-dev keeps using the gRPC compatibility adapter on port `50071`.
 
 If enabled directly in application config for future work, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
 The `listen_host` must not be `0.0.0.0` or `::`, and `allowed_cidrs` must not contain `0.0.0.0/0` or `::/0`.
@@ -842,4 +844,5 @@ mise exec -- iex -S mix phx.server
   quota policy remain incomplete
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
 - Live BEAM Runtime Endpoint transport is not implemented in source dev; current source dev uses the gRPC compatibility adapter
+- BEAM Runtime Endpoint transport becomes the primary source-dev path only after the adapter exists and passes the accepted two-Mac smoke
 - Model import from local filesystem only (no remote download)

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -229,6 +229,7 @@ This validates future first-party BEAM transport admission settings only.
 It does not implement or enable a live BEAM Runtime Endpoint adapter, and there is no supported source-dev env var surface for it in this slice.
 The accepted target is for BEAM Runtime Endpoint transport to become the primary source-dev Controller-to-Node Agent path after the adapter exists and passes the two-Mac smoke.
 Until that gate passes, source-dev keeps using the gRPC compatibility adapter on port `50071`.
+The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
 
 If enabled directly in application config for future work, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
 The `listen_host` must not be `0.0.0.0` or `::`, and `allowed_cidrs` must not contain `0.0.0.0/0` or `::/0`.
@@ -420,10 +421,12 @@ needed for the stub backend; source dev resolves it to stream mode when unset.
 
 ### Verification
 
-1. Both nodes should appear in `/console/nodes` with distinct display names
-2. Cluster summary should show 2 configured targets
-3. Playground inference should attribute requests to specific nodes
-4. Killing the remote node-agent should transition its health to
+1. Both nodes should appear in `/console/nodes` with distinct display names and reachable status
+2. `GET /v1/models` should return `200`
+3. `POST /v1/chat/completions` should complete through the Console Playground or an equivalent API request
+4. Cluster summary should show 2 configured targets
+5. Playground inference should attribute requests to specific nodes
+6. Killing the remote node-agent should transition its health to
    degraded/unreachable
 
 ### Troubleshooting

--- a/openspec/changes/beam-first-runtime-endpoints/design.md
+++ b/openspec/changes/beam-first-runtime-endpoints/design.md
@@ -17,8 +17,10 @@ The Worker Runtime remains a local process/protocol boundary owned by the Node A
 - Define Runtime Endpoint as the Controller-selected execution boundary.
 - Define Runtime Endpoint Interface as transport-independent runtime semantics.
 - Add guardrails for future BEAM Distribution between first-party Controller and Node Agent services.
+- Keep source-dev on gRPC compatibility until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
 - Keep Runtime Endpoint Observations durable in Postgres for operator-visible state and scheduling inputs.
 - Preserve `gnhf/objective-fully-impl-369718` concurrency semantics while moving controller domain code to Runtime Endpoint semantics.
+- Preserve durable request terminalization when scheduler or dispatch orchestration crashes.
 - Keep external compute and provider integrations behind future Runtime Endpoint adapters.
 - Keep `proto/cluster/v1` available as a future adapter or compatibility protocol instead of deleting it immediately.
 
@@ -46,6 +48,7 @@ That keeps v1 terminology simple, but it makes future Cloud VM, high-performance
 The Controller should depend on a Runtime Endpoint Interface for status, model readiness, inference execution, cancellation, runtime telemetry, Placement Capacity, and prefix-cache scoring.
 This slice should introduce the interface and keep the current first-party path behind a gRPC Compatibility Adapter.
 A later first-party implementation can use BEAM Distribution.
+Source-dev should promote BEAM Runtime Endpoint transport only after the adapter exists and the accepted two-Mac smoke passes.
 Future non-BEAM implementations can use provider APIs, gRPC/protobuf, or other adapter protocols.
 
 Alternative considered: keep `NodeRuntimeService` as the core interface.
@@ -80,6 +83,7 @@ The `gnhf` work shows it drives visible concurrency, `cluster_busy`, and queue b
 
 `proto/cluster/v1` and `NodeRuntimeService` should no longer be the durable Controller domain contract.
 They remain the current compatibility transport and may remain as future adapter protocol artifacts.
+Until the BEAM adapter passes the accepted two-Mac smoke, source-dev keeps this gRPC compatibility path on port `50071`.
 
 Alternative considered: delete the proto surface during the pivot.
 That creates avoidable churn and removes a useful candidate protocol for future non-BEAM Runtime Endpoint adapters.
@@ -101,15 +105,20 @@ Mitigation: first recast them as Runtime Endpoint contract tests, then keep or r
 Risk: The term `cluster_busy` may feel stale after Runtime Endpoint modeling.
 Mitigation: keep the name for compatibility and define it as live Runtime Endpoint capacity exhaustion.
 
+Risk: Internal scheduler or dispatch crashes can strand already-validated requests.
+Mitigation: terminalize those crashes as failed `orchestration_error` requests with generic public error payloads.
+
 ## Migration Plan
 
 1. Update `SPEC.md`, architecture docs, and glossary to define Runtime Endpoint, Runtime Endpoint Interface, Runtime Endpoint Observation, Runtime Endpoint Availability, Placement Capacity, and first-party BEAM Distribution constraints.
 2. Introduce a Controller-facing Runtime Endpoint Interface, current gRPC Compatibility Adapter, and BEAM guardrail validation.
 3. Adapt scheduler and dispatch code to depend on Runtime Endpoint semantics instead of the low-level gRPC client module.
 4. Preserve and adapt the `gnhf` queue, placement capacity, and `cluster_busy` behavior after the gnhf baseline is chosen.
-5. Recast current gRPC integration tests as Runtime Endpoint Interface contract tests.
-6. Keep a smaller adapter or compatibility test suite if gRPC remains available for future external endpoints.
-7. Validate OpenSpec, compile, lint, Dialyzer, tests, and coverage under the repo workflow before handoff.
+5. Keep source-dev on gRPC compatibility until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
+6. Terminalize scheduler and dispatch orchestration crashes as generic failed requests.
+7. Recast current gRPC integration tests as Runtime Endpoint Interface contract tests.
+8. Keep a smaller adapter or compatibility test suite if gRPC remains available for future external endpoints.
+9. Validate OpenSpec, compile, lint, Dialyzer, tests, and coverage under the repo workflow before handoff.
 
 Rollback is architectural rather than runtime.
 If the BEAM-first path proves unsafe, keep the Runtime Endpoint Interface and continue binding the first-party adapter to gRPC while preserving the transport-independent domain model.

--- a/openspec/changes/beam-first-runtime-endpoints/proposal.md
+++ b/openspec/changes/beam-first-runtime-endpoints/proposal.md
@@ -12,10 +12,12 @@ The architecture should make Orchard's runtime execution semantics transport-ind
 - Treat the first-party Node Agent as Orchard's v1 Runtime Endpoint implementation.
 - Add BEAM Distribution guardrail validation for future live communication and monitoring between first-party Orchard Elixir services.
 - Keep the current gRPC/protobuf `NodeRuntimeService` path as an explicit Runtime Endpoint compatibility adapter for this implementation slice.
+- Keep source-dev on the gRPC compatibility adapter until a BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
 - Keep Postgres as Orchard's durable persistence and coordination store.
 - Keep Worker Runtime as a local Node Agent-owned process/protocol boundary for Python/MLX execution.
 - Demote `proto/cluster/v1` and `NodeRuntimeService` from the durable Controller domain contract to an explicit compatibility adapter and possible future non-BEAM adapter protocol.
 - Preserve the latest `gnhf/objective-fully-impl-369718` concurrency semantics around Placement Capacity, conservative scheduler eligibility, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, and weighted round-robin.
+- Terminalize scheduler and dispatch orchestration crashes as generic failed requests rather than leaving validated requests active.
 - Require production BEAM Distribution to be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
 - Keep external compute, appliance-style accelerators, cloud VMs, high-performance compute nodes, and paid provider integrations outside the BEAM mesh behind future Runtime Endpoint adapters.
 
@@ -36,6 +38,7 @@ The architecture should make Orchard's runtime execution semantics transport-ind
 - Requires updates to `SPEC.md` sections that mandated no distributed Erlang across machines and gRPC over mTLS for all cross-node control traffic at the base of this change.
 - Requires updates to architecture docs and glossary terms that bound internal runtime communication to gRPC/mTLS at the base of this change.
 - Affects controller dispatch, scheduler, request orchestration, queue admission, node-agent runtime status, and runtime telemetry tests.
+- Affects request lifecycle documentation for scheduler and dispatch crash terminalization.
 - Affects current gRPC/protobuf artifacts under `proto/cluster/v1/` and generated cluster bindings by wrapping them as adapter or compatibility transport status.
 - Does not remove the local Worker Runtime protocol boundary.
 - Does not merge `gnhf/objective-fully-impl-369718`, but the accepted architecture must preserve and adapt its concurrency behavior.

--- a/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
@@ -108,6 +108,30 @@ This preserves the incoming `gnhf/objective-fully-impl-369718` behavior around `
 - **WHEN** queue admission is disabled and scheduling returns `cluster_busy`
 - **THEN** the request fails immediately with the existing `cluster_busy` public error mapping
 
+### Requirement: Runtime Orchestration Failure Terminalization
+After a durable request reaches validation, scheduler or dispatch orchestration failures SHALL terminalize the request instead of leaving it active.
+The durable request SHALL fail with `error_code = "orchestration_error"` and `error_message = "Runtime orchestration failed"`.
+Public HTTP and SSE error payloads SHALL stay sanitized with `internal_error`.
+Runtime Endpoint disconnect cleanup failures SHALL be logged best-effort and MUST NOT overwrite an otherwise successful scheduler probe or dispatch result.
+
+#### Scenario: Scheduler crashes after validation
+- **WHEN** a validated request encounters an exception, exit, throw, or invalid return from the scheduler
+- **THEN** the request reaches terminal state `failed`
+- **THEN** no scheduled request state is required
+- **THEN** the public error payload is generic
+
+#### Scenario: Dispatch crashes after scheduling
+- **WHEN** a scheduled request encounters an exception, exit, throw, or invalid return from dispatch
+- **THEN** the request reaches terminal state `failed`
+- **THEN** the request retains scheduled and dispatching lifecycle evidence when those states were reached
+- **THEN** the public error payload is generic
+
+#### Scenario: Runtime Endpoint cleanup fails
+- **WHEN** a scheduler probe or dispatch attempt has already produced its operation result
+- **AND** disconnect cleanup fails
+- **THEN** Orchard keeps the operation result
+- **THEN** cleanup failure is logged best-effort
+
 ### Requirement: Worker Runtime Boundary Preservation
 The Worker Runtime Interface SHALL remain separate from the Runtime Endpoint Interface.
 The Node Agent SHALL continue to own local Worker Runtime lifecycle, model loading, active request accounting, cancellation, diagnostics, and cleanup.

--- a/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
@@ -130,3 +130,21 @@ This changes the role of the gRPC contract currently described in `SPEC.md` sect
 #### Scenario: Future adapter uses gRPC
 - **WHEN** a future Runtime Endpoint adapter needs a stable non-BEAM protocol
 - **THEN** the existing gRPC/protobuf work may be reused or evolved as an adapter protocol
+
+### Requirement: Source-dev BEAM Primary Rollout
+Orchard SHALL treat the first-party BEAM Runtime Endpoint adapter as the intended primary source-dev Controller-to-Node Agent path only after the adapter is implemented and passes the accepted two-Mac smoke.
+Until that gate passes, current source-dev SHALL keep the gRPC compatibility path as the compatibility and fallback path on port `50071`.
+
+#### Scenario: BEAM adapter passes the source-dev smoke gate
+- **WHEN** the BEAM Runtime Endpoint adapter exists and the accepted two-Mac smoke passes
+- **THEN** Orchard may promote BEAM Runtime Endpoint transport to the primary source-dev Controller-to-Node Agent path
+
+#### Scenario: BEAM adapter has not passed the source-dev smoke gate
+- **WHEN** the BEAM Runtime Endpoint adapter is absent or has not passed the accepted two-Mac smoke
+- **THEN** Orchard keeps using the gRPC compatibility path for source-dev Controller-to-Node Agent communication
+
+#### Scenario: Source-dev smoke gate is evaluated
+- **WHEN** the accepted two-Mac source-dev smoke is run
+- **THEN** Console Nodes shows local and remote Node Agents reachable
+- **THEN** `GET /v1/models` returns `200`
+- **THEN** `POST /v1/chat/completions` completes through the Console Playground or an equivalent API request

--- a/openspec/changes/beam-first-runtime-endpoints/tasks.md
+++ b/openspec/changes/beam-first-runtime-endpoints/tasks.md
@@ -6,6 +6,7 @@
 - [x] 1.4 Update `SPEC.md` to keep Worker Runtime as a Node Agent-local boundary.
 - [x] 1.5 Update `docs/architecture.md` and glossary docs to match accepted Runtime Endpoint language.
 - [x] 1.6 Decide and document which `proto/cluster/v1` artifacts remain as adapter or compatibility protocol inputs.
+- [x] 1.7 Record the source-dev BEAM-primary rollout gate and gRPC fallback policy.
 
 ## 2. Runtime Endpoint Interface
 

--- a/openspec/changes/beam-first-runtime-endpoints/tasks.md
+++ b/openspec/changes/beam-first-runtime-endpoints/tasks.md
@@ -25,6 +25,7 @@
 - [x] 3.5 Preserve timeout, caller disconnect, cancellation, streaming event, and terminal event behavior during dispatch.
 - [x] 3.6 Preserve queue-enabled post-grant `cluster_busy` requeue under the original queue deadline.
 - [x] 3.7 Preserve queue-disabled `cluster_busy` as an immediate public failure.
+- [x] 3.8 Terminalize scheduler and dispatch orchestration crashes with generic failed request outcomes.
 
 ## 4. Node Agent And Worker Runtime Boundary
 
@@ -47,6 +48,7 @@
 - [x] 6.2 Keep targeted gRPC adapter tests if the gRPC compatibility adapter remains supported.
 - [x] 6.3 Add scheduler tests for Runtime Endpoint Observations and Placement Capacity edge cases.
 - [x] 6.4 Add request orchestration tests for `cluster_busy` requeue and timeout behavior through the Runtime Endpoint Interface.
+- [x] 6.4a Add regression tests for scheduler crash, dispatch crash, and disconnect cleanup behavior.
 - [x] 6.5 Run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate beam-first-runtime-endpoints --type change --strict --no-interactive`.
 - [x] 6.6 Run `mise exec -- mix format`.
 - [x] 6.7 Run `mise exec -- mix compile --warnings-as-errors`.


### PR DESCRIPTION
## Intent

Start a new branch and worktree for the Orchard Mawarduri multi-node smoke follow-up; use RP Context Builder and Oracle for grounding; fix the stuck validated request path caused by scheduler or dispatch and gRPC disconnect crashes; add regression coverage so requests terminalize generically instead of staying validated; document the BEAM source-dev rollout gate while keeping gRPC compatibility until the accepted two-Mac smoke passes; run repo validation and open a PR.

## What Changed
- Converts scheduler, dispatch, runtime endpoint, and request orchestration crash paths into terminal chat/request errors so validated requests fail cleanly instead of staying stuck.
- Adds shared chat error normalization plus regression coverage for orchestrator, dispatcher, scheduler, queue manager, and chat error behavior.
- Updates SPEC, architecture, local-dev, decision, glossary, and OpenSpec docs to describe runtime failure semantics and the BEAM-first rollout gate while preserving the gRPC compatibility path.

## Risk Assessment

✅ Low: The change is narrowly scoped to terminalizing scheduler/dispatch crashes and best-effort disconnect cleanup, with focused regression coverage and no material introduced risks found in the reviewed diff.

## Testing

After fixing local setup without changing user/global mise state, the narrow regression tests and affected file suites passed. The API evidence drove `POST /v1/chat/completions` end-to-end and showed scheduler/dispatch crashes returning generic 500s with persisted `failed` requests, while a successful request still completed when disconnect cleanup raised; the docs readback confirmed the BEAM source-dev gate keeps gRPC compatibility until the accepted two-Mac smoke passes. Transient `deps`, `_build`, and `tmp/test` artifacts were removed from the worktree.

<details>
<summary>Evidence: API evidence summary</summary>

```text
scheduler_crash 500 failed orchestration_error -
dispatch_connect_crash 500 failed orchestration_error -
disconnect_cleanup_raises_after_success 200 completed ok orchard
```
</details>
<details>
<summary>Evidence: Full API orchestration evidence</summary>

```text
{
  "cases": [
    {
      "http": {
        "status": 500,
        "body": {
          "error": {
            "code": "internal_error",
            "message": "Internal error",
            "param": null,
            "type": "api_error"
          }
        },
        "content_type": [
          "application/json; charset=utf-8"
        ]
      },
      "name": "scheduler_crash",
      "persisted_request": {
        "state": "failed",
        "events": [
          {
            "state": "validated",
            "seq": 1,
            "event_type": "state_transition",
            "payload": {
              "to_state": "validated"
            }
          },
          {
            "state": "failed",
            "seq": 2,
            "event_type": "state_transition",
            "payload": {
              "to_state": "failed"
            }
          }
        ],
        "public_id": "chatcmpl-831c233c-e6bc-4ec4-8450-7250d3f29049",
        "requested_model": "evidence-scheduler-crash-17763@v1",
        "http_status": 500,
        "error_code": "orchestration_error",
        "error_message": "Runtime orchestration failed",
        "response_preview": null,
        "event_states": [
          "validated",
          "failed"
        ]
      }
    },
    {
      "http": {
        "status": 500,
        "body": {
          "error": {
            "code": "internal_error",
            "message": "Internal error",
            "param": null,
            "type": "api_error"
          }
        },
        "content_type": [
          "application/json; charset=utf-8"
        ]
      },
      "name": "dispatch_connect_crash",
      "persisted_request": {
        "state": "failed",
        "events": [
          {
            "state": "validated",
            "seq": 1,
            "event_type": "state_transition",
            "payload": {
              "to_state": "validated"
            }
          },
          {
            "state": "scheduled",
            "seq": 2,
            "event_type": "state_transition",
            "payload": {
              "to_state": "scheduled"
            }
          },
          {
            "state": "dispatching",
            "seq": 3,
            "event_type": "state_transition",
            "payload": {
              "to_state": "dispatching"
            }
          },
          {
            "state": null,
            "seq": 4,
            "event_type": "request_step.started",
            "payload": {
              "attempt": 1,
              "boundary": "pre_side_effect",
              "model_id": "evidence-dispatch-crash-324",
              "model_version": "v1",
              "parent_step_id": null,
              "result": {},
              "step_id": "inference_turn:t1:a1",
              "step_type": "inference_turn",
              "turn_index": 1
            }
          },
          {
            "state": null,
            "seq": 5,
            "event_type": "request_step.failed",
            "payload": {
              "attempt": 1,
              "boundary": "post_observation",
              "model_id": "evidence-dispatch-crash-324",
              "model_version": "v1",
              "parent_step_id": null,
              "result": {
                "error_code": "orchestration_error",
                "error_message": "Runtime orchestration failed",
                "http_status": 500
              },
              "step_id": "inference_turn:t1:a1",
              "step_type": "inference_turn",
              "turn_index": 1
            }
          },
          {
            "state": "failed",
            "seq": 6,
            "event_type": "state_transition",
            "payload": {
              "to_state": "failed"
            }
          }
        ],
        "public_id": "chatcmpl-133862d7-a84c-441e-9d31-e941c1231faf",
        "requested_model": "evidence-dispatch-crash-324@v1",
        "http_status": 500,
        "error_code": "orchestration_error",
        "error_message": "Runtime orchestration failed",
        "response_preview": null,
        "event_states": [
          "validated",
          "scheduled",
          "dispatching",
          null,
          null,
          "failed"
        ]
      }
    },
    {
      "http": {
        "status": 200,
        "body": {
          "choices": [
            {
              "finish_reason": "stop",
              "index": 0,
              "message": {
                "content": "orchard",
                "role": "assistant"
              }
            }
          ],
          "created": 1782375073,
          "id": "chatcmpl-0413bd51-2677-4db8-89d4-48133d7c4cb7",
          "model": "evidence-disconnect-cleanup-420@v1",
          "object": "chat.completion",
          "usage": {
            "completion_tokens": 0,
            "prompt_tokens": 0,
            "total_tokens": 0
          }
        },
        "content_type": [
          "application/json; charset=utf-8"
        ]
      },
      "name": "disconnect_cleanup_raises_after_success",
      "persisted_request": {
        "state": "completed",
        "events": [
          {
            "state": "validated",
            "seq": 1,
            "event_type": "state_transition",
            "payload": {
              "to_state": "validated"
            }
          },
          {
            "state": "scheduled",
            "seq": 2,
            "event_type": "state_transition",
            "payload": {
              "to_state": "scheduled"
            }
          },
          {
            "state": "dispatching",
            "seq": 3,
            "event_type": "state_transition",
            "payload": {
              "to_state": "dispatching"
            }
          },
          {
            "state": null,
            "seq": 4,
            "event_type": "request_step.started",
            "payload": {
              "attempt": 1,
              "boundary": "pre_side_effect",
              "model_id": "evidence-disconnect-cleanup-420",
              "model_version": "v1",
              "parent_step_id": null,
              "result": {},
              "step_id": "inference_turn:t1:a1",
              "step_type": "inference_turn",
              "turn_index": 1
            }
          },
          {
            "state": "running",
            "seq": 5,
            "event_type": "state_transition",
            "payload": {
              "to_state": "running"
            }
          },
          {
            "state": "streaming",
            "seq": 6,
            "event_type": "state_transition",
            "payload": {
              "to_state": "streaming"
            }
          },
          {
            "state": null,
            "seq": 7,
            "event_type": "request_step.completed",
            "payload": {
              "attempt": 1,
              "boundary": "post_observation",
              "model_id": "evidence-disconnect-cleanup-420",
              "model_version": "v1",
              "parent_step_id": null,
              "result": {
                "finish_reason": "stop",
                "http_status": 200,
                "input_tokens": 0,
                "output_tokens": 0
              },
              "step_id": "inference_turn:t1:a1",
              "step_type": "inference_turn",
              "turn_index": 1
            }
          },
          {
            "state": "completed",
            "seq": 8,
            "event_type": "state_transition",
            "payload": {
              "to_state": "completed"
            }
          }
        ],
        "public_id": "chatcmpl-0413bd51-2677-4db8-89d4-48133d7c4cb7",
        "requested_model": "evidence-disconnect-cleanup-420@v1",
        "http_status": 200,
        "error_code": null,
        "error_message": null,
        "response_preview": "orchard",
        "event_states": [
          "validated",
          "scheduled",
          "dispatching",
          null,
          "running",
          "streaming",
          null,
          "completed"
        ]
      }
    }
  ],
  "exercised_surface": "POST /v1/chat/completions through Orchard.API.Router"
}
```
</details>
<details>
<summary>Evidence: BEAM rollout gate readback</summary>

```text
docs/decisions/0001-runtime-endpoints-beam-first.md:41: BEAM adapter is primary only after accepted two-Mac smoke.
docs/decisions/0001-runtime-endpoints-beam-first.md:44: Do not remove gRPC compatibility before that smoke passes.
openspec/.../runtime-endpoints/spec.md:134-144: Source-dev BEAM Primary Rollout keeps gRPC compatibility until the gate passes.
docs/local-dev.md:847: BEAM transport becomes primary only after accepted two-Mac smoke.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1247 apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1275 apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs:209 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:724 apps/orchard_controller/test/orchard/inference/chat_error_test.exs:308` - initial setup check failed on mise trust guard.</code>
- <code>`MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; mise exec -- mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1247 apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1275 apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs:209 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:724 apps/orchard_controller/test/orchard/inference/chat_error_test.exs:308` - retry exposed missing deps.</code>
- <code>`MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; mise exec -- mix deps.get` - setup fix for isolated worktree.</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1247 apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs:1275 apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs:209 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:724 apps/orchard_controller/test/orchard/inference/chat_error_test.exs:308`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs apps/orchard_controller/test/orchard/inference/chat_error_test.exs apps/orchard_controller/test/orchard/inference/queue_manager_test.exs`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" MIX_ENV=test mise exec -- mix run --no-start /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVYWP80EZYSVY3HNH04ZMER2/api_orchestration_crash_evidence.exs > /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVYWP80EZYSVY3HNH04ZMER2/api_orchestration_crash_evidence.json 2> /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KVYWP80EZYSVY3HNH04ZMER2/api_orchestration_crash_evidence.stderr.log`
- `rg -n "BEAM Runtime Endpoint transport becomes|gRPC compatibility path|accepted two-Mac smoke|Do not remove gRPC compatibility|Source-dev BEAM Primary Rollout" docs/local-dev.md docs/decisions/0001-runtime-endpoints-beam-first.md openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md`
- <code>Cleanup: `rm -rf deps _build tmp/test`; verified with `git status --short` and `find . -maxdepth 2 \( -name _build -o -name deps -o -path ./tmp/test -o -name .elixir_ls \) -print`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
