### PR TITLE
feat: add BEAM runtime endpoint adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Clients (SDKs / curl / apps)
         │
    Runtime Endpoint Interface
         │
-   Current gRPC compatibility adapter
+   Runtime Endpoint adapter(s)
+   ├── gRPC compatibility adapter (current default)
+   └── first-party BEAM adapter (default-off rollout)
         │
    Node Agent Runtime Endpoint(s)
    ├── Model cache + verification
@@ -60,8 +62,8 @@ Clients (SDKs / curl / apps)
 - All durable state lives in Postgres.
 - Controller runtime execution uses the Runtime Endpoint Interface.
 - The current `NodeRuntimeService` gRPC path is a compatibility adapter, not the durable domain contract.
-- First-party BEAM communication is guarded for future use and must not become durable cluster truth.
-- Source-dev keeps the gRPC compatibility adapter until a BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
+- First-party BEAM communication is implemented behind explicit guardrails and must not become durable cluster truth.
+- Source-dev uses the gRPC compatibility adapter by default until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is promoted.
 - Workers are local to node agents and are never exposed on the network.
 - Token streams always pass through the controller for governance and accounting.
 - HA-lite only: exactly one active leader, active/standby via Postgres advisory locks, no active/active consensus.
@@ -73,7 +75,7 @@ Clients (SDKs / curl / apps)
 | Language | Elixir/OTP (umbrella app) |
 | Database | Postgres |
 | Inference | MLX-LM runtime adapter managed by the node agent |
-| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter; future BEAM adapter gated by accepted two-Mac smoke |
+| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter and default-off first-party BEAM adapter gated by accepted two-Mac smoke |
 | APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
 | Packaging | DMG, PKG, launchd |
 | CLI | `orchardctl` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,10 +44,11 @@ Supported deployment modes:
 * All durable state SHALL live in Postgres.
 * Controller runtime execution SHALL use the Runtime Endpoint Interface.
 * Runtime Endpoint semantics are transport-independent.
-* The current gRPC/protobuf `NodeRuntimeService` is the compatibility transport for the first implementation and a candidate protocol for future non-BEAM adapters.
-* First-party Orchard Controller and Node Agent services MAY later use BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
-* Source-dev SHALL keep the gRPC compatibility path as the Controller-to-Node Agent runtime transport on port `50071` until a BEAM Runtime Endpoint adapter exists and passes the accepted two-Mac smoke.
+* The gRPC/protobuf `NodeRuntimeService` remains the compatibility transport and a candidate protocol for future non-BEAM adapters.
+* First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
+* Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is explicitly promoted.
 * Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
+* BEAM Runtime Endpoint targets MUST carry a valid BEAM node-name address (`service@host`) as an atom or binary; a configured `node_id`, when present, MUST be a UUID and MUST match observed endpoint metadata before scheduler or dispatch may trust that candidate identity.
 * External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 * All public API traffic SHALL terminate at the controller.
 * Token streams SHALL always pass through the controller so governance, accounting, cancellation, and audit behavior are centralized.
@@ -82,7 +83,7 @@ Supported deployment modes:
                      +---------v--+   +---v---------------------------+
                      | Postgres    |   | Runtime Endpoint Adapter(s) |
                      | durable DB  |   | - current gRPC compatibility|
-                     +------------ +   | - future first-party BEAM   |
+                     +------------ +   | - default-off BEAM          |
                                        | - future external/provider  |
                                        +---+-------------------------+
                                            |
@@ -998,6 +999,7 @@ Valid loaded-placement observations MAY add source-scoped capacity for the match
 Eligible cold/no-placement node observations MAY add conservative source-scoped capacity for queued model/version lanes, bounded by aggregate node concurrency and by one unreserved cold slot per lane per node observation.
 Live capacity source refreshes SHALL be allowed to wake queued requests without a new admission event.
 Stale, unavailable, non-loaded, invalid, exhausted, ineligible, or transport-failed node and placement observations SHALL NOT inflate queue admission capacity and SHALL clear any stale capacity source owned by that node or target.
+BEAM Runtime Endpoint observations MAY refresh queue capacity only when the target resolves back to the same persisted node identity; address-only or mismatched BEAM observations SHALL NOT publish queue capacity.
 
 ### 5.5 Eligibility filter
 
@@ -2080,11 +2082,12 @@ PATCH /admin/v1/observability
 
 Controller runtime execution SHALL use the Runtime Endpoint Interface.
 Runtime Endpoint semantics are transport-independent.
-The current gRPC/protobuf `NodeRuntimeService` is the gRPC Compatibility Adapter for the first implementation and a candidate protocol for future non-BEAM adapters.
-First-party Orchard Controller and Node Agent services MAY later use BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
-Source-dev SHALL keep the gRPC compatibility path as the Controller-to-Node Agent runtime transport on port `50071` until a BEAM Runtime Endpoint adapter exists and passes the accepted two-Mac smoke.
+The gRPC/protobuf `NodeRuntimeService` remains the gRPC Compatibility Adapter and a candidate protocol for future non-BEAM adapters.
+First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
+Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is explicitly promoted.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
 Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
+BEAM Runtime Endpoint targets MUST carry a valid BEAM node-name address (`service@host`) as an atom or binary; a configured `node_id`, when present, MUST be a UUID and MUST match observed endpoint metadata before scheduler or dispatch may trust that candidate identity.
 External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling history, request state, and operator-visible status.
 BEAM Distribution MUST NOT be treated as durable cluster truth.
@@ -2457,6 +2460,7 @@ Runtime capacity and Placement Capacity observation semantics:
 * when multiple eligible candidates remain, the scheduler SHALL rank by the requested placement's active request count before health when a valid matching placement observation is available; otherwise it SHALL use the endpoint aggregate `active_request_count`
 * controller queue capacity MAY be refreshed from Runtime Endpoint Observations; loaded placement observations contribute only to their matching model/version lane, while cold/no-placement endpoint observations contribute conservative source-scoped capacity for queued lanes without exceeding aggregate endpoint capacity
 * stale, unavailable, non-loaded, invalid, exhausted, ineligible, or transport-failed observations SHALL clear their endpoint-owned queue capacity sources instead of preserving stale admission capacity
+* BEAM Runtime Endpoint observations MAY refresh queue capacity only when the target resolves back to the same persisted node identity; address-only or mismatched BEAM observations SHALL NOT publish queue capacity
 * node-agent request admission SHALL reject a new runtime request when aggregate active request count has reached the effective aggregate worker request limit, even if the requested model placement has remaining per-placement capacity
 * cancellation or terminal completion SHALL release aggregate node capacity so another loaded model can use the freed slot
 * stream generation mode SHALL report `max_concurrency = 1` at both node and placement levels

--- a/apps/orchard_controller/README.md
+++ b/apps/orchard_controller/README.md
@@ -16,6 +16,8 @@ This README is orientation only. Normative behavior lives in
 - `Orchard.Repo` migrations and Postgres-backed controller state.
 - Request canonicalization, tokenization orchestration, admission, scheduling,
   dispatch, lifecycle persistence, and public response serialization.
+- Runtime Endpoint client adapters, including the gRPC compatibility adapter and
+  default-off first-party BEAM adapter.
 
 ## Does not own
 

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -28,7 +28,15 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   alias Orchard.Inference
   alias Orchard.Inference.ModelLoadFailure
   alias Orchard.InferenceEvent
-  alias Orchard.RuntimeEndpoint.{GrpcCompatibilityMapper, Observation, Operation, Target}
+
+  alias Orchard.RuntimeEndpoint.{
+    BeamIdentity,
+    GrpcCompatibilityMapper,
+    Observation,
+    Operation,
+    Target
+  }
+
   alias Orchard.SentryContext
   alias Orchard.Tokenizer.Telemetry
 
@@ -257,28 +265,31 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp do_dispatch_with_channel(%{} = context) do
-    {model_load_request, metrics} =
-      probe_and_resolve_node(
-        context.client,
-        context.channel,
-        context.target,
-        context.model_load_request,
-        context.on_node_resolved,
-        context.metrics
-      )
+    case probe_and_resolve_node(
+           context.client,
+           context.channel,
+           context.target,
+           context.model_load_request,
+           context.on_node_resolved,
+           context.metrics
+         ) do
+      {:ok, model_load_request, metrics} ->
+        context = %{context | model_load_request: model_load_request, metrics: metrics}
+        ensure_start = System.monotonic_time(:millisecond)
+        put_ensure_model_load_started_context(metrics)
 
-    context = %{context | model_load_request: model_load_request, metrics: metrics}
-    ensure_start = System.monotonic_time(:millisecond)
-    put_ensure_model_load_started_context(metrics)
+        context.client
+        |> ensure_loaded_for_dispatch(
+          context.channel,
+          context.target,
+          model_load_request,
+          context.model_load_timeout
+        )
+        |> handle_ensure_result(context, ensure_start)
 
-    context.client
-    |> ensure_loaded_for_dispatch(
-      context.channel,
-      context.target,
-      model_load_request,
-      context.model_load_timeout
-    )
-    |> handle_ensure_result(context, ensure_start)
+      {:error, reason, metrics} ->
+        handle_dispatch_result({:error, {:dispatch_failed, reason}}, metrics, context.target)
+    end
   end
 
   defp ensure_loaded_for_dispatch(client, channel, target, model_load_request, model_load_timeout) do
@@ -361,8 +372,6 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     {:error, {:model_load_failed, ModelLoadFailure.from_transport_reason(:node_unavailable)}}
   end
 
-  # Pre-dispatch status probe: best-effort node identity resolution.
-  # Never aborts dispatch on failure.
   defp probe_and_resolve_node(
          client,
          channel,
@@ -373,56 +382,76 @@ defmodule Orchard.Dispatch.RequestDispatcher do
        ) do
     case client.status(channel, timeout: @status_probe_timeout_ms) do
       {:ok, response} ->
-        observed_at = DateTime.utc_now()
-        observation = normalize_status_observation(target, response)
-
-        {resolved_node_id, model_load_request, metrics} =
-          case extract_node_id(observation) do
-            {:ok, node_id} ->
-              metrics = %{metrics | node_id: node_id}
-              put_node_resolved_context(metrics, target)
-              {node_id, %{model_load_request | node_id: node_id}, metrics}
-
-            :error ->
-              {nil, model_load_request, metrics}
-          end
-
-        try do
-          Orchard.Nodes.observe_status(observation_target(target), observation, observed_at)
-        rescue
-          error ->
-            Logger.warning("Node observation failed during dispatch probe: #{inspect(error)}")
-        end
-
-        if is_binary(resolved_node_id) do
-          invoke_callback_safe(on_node_resolved, resolved_node_id)
-        end
-
-        {model_load_request, metrics}
+        resolve_probe_status(response, target, model_load_request, on_node_resolved, metrics)
 
       {:error, reason} ->
-        # Probe failure is non-fatal, but we still record transport reachability
-        # best-effort for node health.
         mark_transport_failure(target, reason)
-        {model_load_request, metrics}
+        {:ok, model_load_request, metrics}
     end
   rescue
     error ->
       Logger.warning("Status probe failed unexpectedly: #{inspect(error)}")
-      {model_load_request, metrics}
+      {:ok, model_load_request, metrics}
   end
 
-  defp extract_node_id(%Observation{} = observation) do
-    observation
-    |> Observation.node_id()
-    |> extract_node_id()
+  defp resolve_probe_status(response, target, model_load_request, on_node_resolved, metrics) do
+    observed_at = DateTime.utc_now()
+    observation = normalize_status_observation(target, response)
+
+    case BeamIdentity.resolve_candidate_node_id(target, observation) do
+      {:rejected, reason} ->
+        {:error, reason, metrics}
+
+      identity_result ->
+        persist_resolved_probe(
+          identity_result,
+          target,
+          observation,
+          observed_at,
+          model_load_request,
+          on_node_resolved,
+          metrics
+        )
+    end
   end
 
-  defp extract_node_id(node_id) when is_binary(node_id) do
-    Ecto.UUID.cast(node_id)
+  defp persist_resolved_probe(
+         identity_result,
+         target,
+         observation,
+         observed_at,
+         model_load_request,
+         on_node_resolved,
+         metrics
+       ) do
+    {resolved_node_id, model_load_request, metrics} =
+      resolved_probe_identity(identity_result, target, model_load_request, metrics)
+
+    observe_probe_status(target, observation, observed_at)
+
+    if is_binary(resolved_node_id) do
+      invoke_callback_safe(on_node_resolved, resolved_node_id)
+    end
+
+    {:ok, model_load_request, metrics}
   end
 
-  defp extract_node_id(_), do: :error
+  defp observe_probe_status(target, observation, observed_at) do
+    Orchard.Nodes.observe_status(observation_target(target), observation, observed_at)
+  rescue
+    error ->
+      Logger.warning("Node observation failed during dispatch probe: #{inspect(error)}")
+  end
+
+  defp resolved_probe_identity({:ok, node_id}, target, model_load_request, metrics) do
+    metrics = %{metrics | node_id: node_id}
+    put_node_resolved_context(metrics, target)
+    {node_id, %{model_load_request | node_id: node_id}, metrics}
+  end
+
+  defp resolved_probe_identity(:missing, _target, model_load_request, metrics) do
+    {nil, model_load_request, metrics}
+  end
 
   defp invoke_callback_safe(nil, _node_id), do: :ok
 

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -149,6 +149,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   - `:request_id` - the canonical request ID
   - `:request_timeout_ms` - maximum wall-clock time for the entire dispatch
 
+  BEAM schedules may omit `:runtime_client_target`.
+  If a configured BEAM target node ID conflicts with observed endpoint metadata,
+  dispatch fails before model load rather than trusting the mismatched identity.
+
   `execute_request` is the protobuf compatibility `ExecuteInferenceRequest` to map into a Runtime Endpoint operation.
 
   `model_load_request` is the protobuf compatibility `EnsureModelLoadedRequest` to map into a Runtime Endpoint operation.

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -261,9 +261,22 @@ defmodule Orchard.Inference do
   end
 
   defp auto_scheduler do
-    case runtime_client_targets() do
-      targets when length(targets) > 1 -> Orchard.Scheduler.MultiNode
-      _ -> Orchard.Scheduler.SingleNode
+    cond do
+      explicit_runtime_endpoint_targets?() ->
+        Orchard.Scheduler.MultiNode
+
+      length(runtime_client_targets()) > 1 ->
+        Orchard.Scheduler.MultiNode
+
+      true ->
+        Orchard.Scheduler.SingleNode
+    end
+  end
+
+  defp explicit_runtime_endpoint_targets? do
+    case config()[:runtime_endpoint_targets] do
+      targets when is_list(targets) and targets != [] -> true
+      _other -> false
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -273,6 +273,6 @@ defmodule Orchard.Inference do
     end)
   end
 
-  defp runtime_endpoint_target(%Target{} = target), do: target
+  defp runtime_endpoint_target(%Target{} = target), do: Target.normalize(target)
   defp runtime_endpoint_target(target), do: Target.normalize(target)
 end

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -212,11 +212,25 @@ defmodule Orchard.Inference do
     end
   end
 
+  @doc """
+  Returns the configured Runtime Endpoint client adapter.
+
+  Defaults to the gRPC compatibility adapter.
+  Set `:runtime_endpoint_client_impl` to `Orchard.RuntimeEndpoint.BeamClient`
+  only with explicit Runtime Endpoint targets.
+  """
   @spec runtime_endpoint_client() :: module()
   def runtime_endpoint_client do
     config()[:runtime_endpoint_client_impl] || Orchard.RuntimeEndpoint.GrpcCompatibilityClient
   end
 
+  @doc """
+  Returns normalized Runtime Endpoint targets for scheduler and dispatch.
+
+  Explicit `:runtime_endpoint_targets` override legacy
+  `:runtime_client_targets`, allow BEAM targets, and force endpoint-aware
+  scheduling even when only one target is configured.
+  """
   @spec runtime_endpoint_targets() :: [Target.t()]
   def runtime_endpoint_targets do
     case config()[:runtime_endpoint_targets] do

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -219,10 +219,18 @@ defmodule Orchard.Inference do
 
   @spec runtime_endpoint_targets() :: [Target.t()]
   def runtime_endpoint_targets do
-    runtime_client_targets()
-    |> Enum.reject(&is_nil/1)
-    |> Enum.map(&runtime_endpoint_target/1)
-    |> Enum.uniq_by(& &1.id)
+    case config()[:runtime_endpoint_targets] do
+      targets when is_list(targets) and targets != [] ->
+        targets
+        |> Enum.map(&runtime_endpoint_target/1)
+        |> Enum.uniq_by(& &1.id)
+
+      _other ->
+        runtime_client_targets()
+        |> Enum.reject(&is_nil/1)
+        |> Enum.map(&runtime_endpoint_target/1)
+        |> Enum.uniq_by(& &1.id)
+    end
   end
 
   @spec request_timeout_ms() :: pos_integer() | nil
@@ -266,5 +274,5 @@ defmodule Orchard.Inference do
   end
 
   defp runtime_endpoint_target(%Target{} = target), do: target
-  defp runtime_endpoint_target(target), do: Target.grpc_compat(target)
+  defp runtime_endpoint_target(target), do: Target.normalize(target)
 end

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -135,15 +135,15 @@ defmodule Orchard.Nodes do
   Looks up a node by its connection target.
 
   Accepts a target keyword list matching the scheduler/dispatch shape:
-  `[host: "127.0.0.1", port: 50071]`.
+  `[host: "127.0.0.1", port: 50071]`, or a Runtime Endpoint target.
 
   Returns `nil` when no match, target is malformed, or repo is unavailable.
   """
-  @spec lookup_by_target(keyword()) :: Node.t() | nil
+  @spec lookup_by_target(keyword() | Target.t()) :: Node.t() | nil
   def lookup_by_target(target) do
     with true <- repo_available?(),
-         {:ok, host, port} <- validate_target(target) do
-      lookup_node_by_target(host, port)
+         {:ok, target_lookup} <- target_lookup(target) do
+      lookup_node_by_target_lookup(target_lookup)
     else
       _ -> nil
     end
@@ -285,8 +285,8 @@ defmodule Orchard.Nodes do
 
   defp mark_target_unreachable_without_queue_cleanup(target, observed_at) do
     with true <- repo_available?(),
-         {:ok, host, port} <- validate_target(target) do
-      execute_mark_unreachable(host, port, observed_at)
+         {:ok, target_lookup} <- target_lookup(target) do
+      execute_mark_unreachable(target_lookup, observed_at)
     else
       _ -> :noop
     end
@@ -467,9 +467,9 @@ defmodule Orchard.Nodes do
   end
 
   defp clear_existing_target_queue_capacity_sources(target, observed_at) do
-    case validate_target(target) do
-      {:ok, host, port} ->
-        case lookup_node_by_target(host, port) do
+    case target_lookup(target) do
+      {:ok, target_lookup} ->
+        case lookup_node_by_target_lookup(target_lookup) do
           %Node{} = node -> clear_fresh_target_queue_capacity_sources(node, observed_at)
           nil -> :ok
         end
@@ -839,9 +839,9 @@ defmodule Orchard.Nodes do
 
   # -- Mark Unreachable --
 
-  defp execute_mark_unreachable(host, port, observed_at) do
+  defp execute_mark_unreachable(target_lookup, observed_at) do
     Repo.transaction(fn ->
-      case fetch_node_for_transport_update(host, port) do
+      case fetch_node_for_transport_update(target_lookup) do
         nil ->
           Repo.rollback(:noop)
 
@@ -855,9 +855,16 @@ defmodule Orchard.Nodes do
     end
   end
 
-  defp fetch_node_for_transport_update(host, port) do
+  defp fetch_node_for_transport_update({:connect_target, host, port}) do
     fetch_node_by_connect_target(host, port) ||
       fetch_legacy_node_by_advertise_target(host, port)
+  end
+
+  defp fetch_node_for_transport_update({:node_id, node_id}) do
+    Node
+    |> where([n], n.id == ^node_id)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
   end
 
   defp update_transport_failure_health(%Node{} = node, observed_at) do
@@ -906,13 +913,47 @@ defmodule Orchard.Nodes do
     is_pid(pid) and Process.alive?(pid)
   end
 
-  defp validate_target(target) do
+  defp target_lookup(%Target{transport: :beam} = target) do
+    case target_node_id_lookup(target) do
+      {:ok, _lookup} = result -> result
+      :error -> target_metadata_lookup(target.metadata)
+    end
+  end
+
+  defp target_lookup(target), do: connection_target_lookup(target)
+
+  defp target_node_id_lookup(%Target{node_id: node_id}) when is_binary(node_id) do
+    case Ecto.UUID.cast(node_id) do
+      {:ok, node_id} -> {:ok, {:node_id, node_id}}
+      :error -> :error
+    end
+  end
+
+  defp target_node_id_lookup(_target), do: :error
+
+  defp target_metadata_lookup(%{} = metadata) do
+    host =
+      metadata_value(metadata, :connect_host) ||
+        metadata_value(metadata, :host) ||
+        metadata_value(metadata, :listen_host)
+
+    port =
+      metadata_value(metadata, :connect_port) ||
+        metadata_value(metadata, :port) ||
+        metadata_value(metadata, :listen_port)
+
+    connection_target_lookup(host: host, port: port)
+  end
+
+  defp target_metadata_lookup(_metadata), do: :error
+
+  defp connection_target_lookup(target) do
     target = target_address(target)
     host = Keyword.get(target, :host)
     port = Keyword.get(target, :port)
 
     if is_binary(host) and host != "" and is_integer(port) and port in 1..65_535 do
-      {:ok, host, port}
+      {:ok, {:connect_target, host, port}}
     else
       :error
     end
@@ -948,9 +989,13 @@ defmodule Orchard.Nodes do
 
   defp map_get(_map, key) when is_atom(key), do: nil
 
-  defp lookup_node_by_target(host, port) do
+  defp lookup_node_by_target_lookup({:connect_target, host, port}) do
     lookup_node_by_connect_target(host, port) ||
       lookup_legacy_node_by_advertise_target(host, port)
+  end
+
+  defp lookup_node_by_target_lookup({:node_id, node_id}) do
+    Repo.get(Node, node_id)
   end
 
   defp lookup_node_by_connect_target(host, port) do
@@ -1021,6 +1066,7 @@ defmodule Orchard.Nodes do
   end
 
   defp target_address(%Target{transport: :grpc_compat, address: address}), do: address
+  defp target_address(%Target{transport: :beam}), do: []
   defp target_address(target), do: target
 
   defp valid_connect_target?(host, port), do: non_empty?(host) and is_integer(port)

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -136,6 +136,8 @@ defmodule Orchard.Nodes do
 
   Accepts a target keyword list matching the scheduler/dispatch shape:
   `[host: "127.0.0.1", port: 50071]`, or a Runtime Endpoint target.
+  BEAM Runtime Endpoint targets resolve by configured `node_id` first, then by
+  target metadata containing a connect/listen host and port.
 
   Returns `nil` when no match, target is malformed, or repo is unavailable.
   """
@@ -166,6 +168,8 @@ defmodule Orchard.Nodes do
   from aggregate endpoint capacity and loaded placement statuses.
   Fresh invalid metadata, identity conflicts, ineligible nodes, and target
   failures clear stale queue capacity sources for that node/target.
+  BEAM Runtime Endpoint observations refresh queue capacity only when the
+  target resolves back to the same persisted node identity.
 
   Options:
   - `:reserve_unassigned_node_grants?` - reserve unassigned active grants

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -262,6 +262,24 @@ defmodule Orchard.Nodes do
   end
 
   @doc """
+  Clears queue capacity sources owned by an existing target without changing health.
+
+  Use this for fresh identity rejections where the target was reachable enough
+  to report status, but its observation must not remain an admission authority.
+  Cleanup is still freshness-gated against the target's last heartbeat.
+  """
+  @spec clear_target_queue_capacity_sources(keyword() | Target.t(), DateTime.t()) :: :ok
+  def clear_target_queue_capacity_sources(target, observed_at) do
+    if repo_available?() do
+      clear_existing_target_queue_capacity_sources(target, observed_at)
+    else
+      :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  @doc """
   Marks a node as unreachable by target address.
 
   Only updates health on an existing node. Does not insert new rows

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -208,7 +208,7 @@ defmodule Orchard.Nodes do
   defp handle_observation_result(target, observed_at, result, status_response, opts) do
     case result do
       {:ok, node} ->
-        refresh_observed_queue_capacities(node, status_response, opts)
+        refresh_observed_queue_capacities(target, node, status_response, opts)
         {:ok, node}
 
       {:noop, :identity_conflict} ->
@@ -409,12 +409,13 @@ defmodule Orchard.Nodes do
     |> ToolReadiness.persist_all()
   end
 
-  defp refresh_observed_queue_capacities(%Node{} = node, status_response, opts) do
+  defp refresh_observed_queue_capacities(target, %Node{} = node, status_response, opts) do
     queue_manager = Orchard.Inference.queue_manager()
     placement_source = {:node, node.id, :placement}
     cold_source = {:node, node.id, :cold}
 
-    if queue_capacity_eligible_node?(node) and
+    if queue_capacity_refresh_target?(target, node) and
+         queue_capacity_eligible_node?(node) and
          queue_capacity_eligible_observation?(status_response) do
       queue_manager.refresh_node_capacity_sources(%{
         clear_sources: node_queue_capacity_sources(node),
@@ -442,6 +443,18 @@ defmodule Orchard.Nodes do
       Logger.debug("Queue capacity refresh from node observation exited: #{inspect(reason)}")
       :ok
   end
+
+  defp queue_capacity_refresh_target?(%Target{transport: :beam} = target, %Node{id: node_id}) do
+    case target_lookup(target) do
+      {:ok, target_lookup} ->
+        match?(%Node{id: ^node_id}, lookup_node_by_target_lookup(target_lookup))
+
+      :error ->
+        false
+    end
+  end
+
+  defp queue_capacity_refresh_target?(_target, _node), do: true
 
   defp clear_node_queue_capacity_sources(%Node{} = node, opts \\ []) do
     queue_manager = Orchard.Inference.queue_manager()

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
@@ -15,20 +15,28 @@ defmodule Orchard.RuntimeEndpoint.BeamClient do
   @default_server_module Orchard.Node.RuntimeEndpoint
 
   @impl true
-  def connect(%Target{transport: :beam} = target) do
-    with :ok <- validate_beam_enabled(),
-         {:ok, node} <- target_node(target),
-         :ok <- ensure_connected(node) do
-      {:ok, %__MODULE__{node: node, target: target, server_module: server_module(target)}}
+  def connect(%Target{} = target) do
+    target = Target.normalize(target)
+
+    case target.transport do
+      :beam -> connect_beam(target)
+      transport -> {:error, {:unsupported_transport, transport}}
     end
   end
-
-  def connect(%Target{} = target), do: {:error, {:unsupported_transport, target.transport}}
 
   def connect(target) when is_list(target) or is_map(target) do
     target
     |> Target.normalize()
     |> connect()
+  end
+
+  defp connect_beam(%Target{transport: :beam} = target) do
+    with {:ok, config} <- validate_beam_enabled(),
+         :ok <- validate_beam_target(config, target),
+         {:ok, node} <- target_node(target),
+         :ok <- ensure_connected(node) do
+      {:ok, %__MODULE__{node: node, target: target, server_module: server_module(target)}}
+    end
   end
 
   @impl true
@@ -122,18 +130,20 @@ defmodule Orchard.RuntimeEndpoint.BeamClient do
   defp validate_beam_enabled do
     cond do
       BeamConfig.config()[:enabled] == true ->
-        BeamConfig.validate_enabled() |> validation_result()
+        BeamConfig.validate_enabled()
 
       Code.ensure_loaded?(Mix) and Mix.env() != :prod ->
-        :ok
+        {:ok, nil}
 
       true ->
         {:error, :beam_distribution_disabled}
     end
   end
 
-  defp validation_result({:ok, _config}), do: :ok
-  defp validation_result({:error, reason}), do: {:error, reason}
+  defp validate_beam_target(nil, _target), do: :ok
+
+  defp validate_beam_target(%BeamConfig{} = config, target),
+    do: BeamConfig.validate_target(config, target)
 
   defp target_node(%Target{address: node}) when is_atom(node), do: {:ok, node}
 

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
@@ -1,6 +1,12 @@
 defmodule Orchard.RuntimeEndpoint.BeamClient do
   @moduledoc """
   Runtime Endpoint client backed by first-party BEAM Distribution.
+
+  Releases and `:prod` require explicit BEAM guardrail configuration before
+  connecting.
+  Source-dev and test may use the adapter without enabled guardrails for local
+  endpoint validation, but targets are still normalized and BEAM node addresses
+  are validated at the client boundary.
   """
 
   @behaviour Orchard.RuntimeEndpoint.Client

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
@@ -1,0 +1,219 @@
+defmodule Orchard.RuntimeEndpoint.BeamClient do
+  @moduledoc """
+  Runtime Endpoint client backed by first-party BEAM Distribution.
+  """
+
+  @behaviour Orchard.RuntimeEndpoint.Client
+
+  alias Orchard.RuntimeEndpoint.{BeamConfig, Operation, Target}
+
+  defstruct [:node, :target, :server_module]
+
+  @type t :: %__MODULE__{node: node(), target: Target.t(), server_module: module()}
+
+  @default_timeout 5_000
+  @default_server_module Orchard.Node.RuntimeEndpoint
+
+  @impl true
+  def connect(%Target{transport: :beam} = target) do
+    with :ok <- validate_beam_enabled(),
+         {:ok, node} <- target_node(target),
+         :ok <- ensure_connected(node) do
+      {:ok, %__MODULE__{node: node, target: target, server_module: server_module(target)}}
+    end
+  end
+
+  def connect(%Target{} = target), do: {:error, {:unsupported_transport, target.transport}}
+
+  def connect(target) when is_list(target) or is_map(target) do
+    target
+    |> Target.normalize()
+    |> connect()
+  end
+
+  @impl true
+  def disconnect(%__MODULE__{}), do: :ok
+
+  @impl true
+  def status(%__MODULE__{target: target} = connection, opts \\ []) do
+    rpc(connection, :status, [target, opts], opts)
+  end
+
+  @impl true
+  def ensure_model_loaded(
+        %__MODULE__{} = connection,
+        %Operation.EnsureModelLoadedRequest{} = request,
+        opts \\ []
+      ) do
+    rpc(connection, :ensure_model_loaded, [request, opts], opts)
+  end
+
+  @impl true
+  def unload_model(
+        %__MODULE__{} = connection,
+        %Operation.UnloadModelRequest{} = request,
+        opts \\ []
+      ) do
+    rpc(connection, :unload_model, [request, opts], opts)
+  end
+
+  @impl true
+  def execute_inference(
+        %__MODULE__{} = connection,
+        %Operation.ExecuteRequest{} = request,
+        opts \\ []
+      ) do
+    owner = Keyword.get(opts, :owner, self())
+    stream_ref = make_ref()
+
+    {:ok, _pid} =
+      Task.start(fn ->
+        case rpc(connection, :execute_inference, [request, owner, stream_ref, opts], opts) do
+          {:ok, _remote_ref} -> :ok
+          {:error, reason} -> send(owner, {:runtime_endpoint_done, stream_ref, {:error, reason}})
+        end
+      end)
+
+    {:ok, stream_ref}
+  end
+
+  @impl true
+  def cancel_inference(
+        %__MODULE__{} = connection,
+        %Operation.CancelRequest{} = request,
+        opts \\ []
+      ) do
+    rpc(connection, :cancel_inference, [request, opts], opts)
+  end
+
+  @impl true
+  def score_prefix_cache(target_or_connection, request, opts \\ [])
+
+  def score_prefix_cache(
+        %__MODULE__{} = connection,
+        %Operation.PrefixCacheScoreRequest{} = request,
+        opts
+      ) do
+    case rpc(connection, :score_prefix_cache, [request, opts], opts) do
+      {:ok, result} -> {:ok, result}
+      {:error, reason} -> {:ok, failed_prefix_cache_score(reason)}
+    end
+  end
+
+  def score_prefix_cache(%Target{} = target, %Operation.PrefixCacheScoreRequest{} = request, opts) do
+    case connect(target) do
+      {:ok, connection} -> score_prefix_cache(connection, request, opts)
+      {:error, reason} -> {:ok, failed_prefix_cache_score(reason)}
+    end
+  end
+
+  def score_prefix_cache(target, %Operation.PrefixCacheScoreRequest{} = request, opts)
+      when is_list(target) or is_map(target) do
+    target
+    |> Target.normalize()
+    |> score_prefix_cache(request, opts)
+  end
+
+  # BEAM connections must validate guardrails when enabled. When BEAM is not
+  # enabled, only source-dev (Mix present, non-:prod) may proceed for local-node
+  # tests; releases (where Mix is absent) and :prod require explicit enablement.
+  # `Mix.env/0` is unavailable in a packaged release, so it is never called at
+  # runtime here.
+  defp validate_beam_enabled do
+    cond do
+      BeamConfig.config()[:enabled] == true ->
+        BeamConfig.validate_enabled() |> validation_result()
+
+      Code.ensure_loaded?(Mix) and Mix.env() != :prod ->
+        :ok
+
+      true ->
+        {:error, :beam_distribution_disabled}
+    end
+  end
+
+  defp validation_result({:ok, _config}), do: :ok
+  defp validation_result({:error, reason}), do: {:error, reason}
+
+  defp target_node(%Target{address: node}) when is_atom(node), do: {:ok, node}
+
+  defp target_node(%Target{address: address}) when is_binary(address) do
+    {:ok, String.to_existing_atom(address)}
+  rescue
+    ArgumentError -> {:error, :unknown_beam_node}
+  end
+
+  defp target_node(%Target{address: address}), do: {:error, {:invalid_beam_node, address}}
+
+  defp ensure_connected(node) when node == node(), do: :ok
+
+  defp ensure_connected(node) do
+    if node() == :nonode@nohost do
+      {:error, :beam_distribution_unavailable}
+    else
+      case Node.ping(node) do
+        :pong -> :ok
+        :pang -> {:error, :node_unavailable}
+      end
+    end
+  end
+
+  if Mix.env() == :test do
+    defp server_module(%Target{metadata: %{server_module: module}}) when is_atom(module),
+      do: module
+
+    defp server_module(%Target{metadata: %{"server_module" => module}}) when is_atom(module),
+      do: module
+  end
+
+  defp server_module(_target), do: @default_server_module
+
+  defp rpc(%__MODULE__{node: node} = connection, function, args, _opts) when node == node() do
+    safe_apply(connection.server_module, function, args)
+  end
+
+  defp rpc(%__MODULE__{} = connection, function, args, opts) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    connection.node
+    |> :rpc.call(connection.server_module, function, args, timeout)
+    |> normalize_rpc_result()
+  end
+
+  defp normalize_rpc_result({:badrpc, :nodedown}), do: {:error, :node_unavailable}
+  defp normalize_rpc_result({:badrpc, {:EXIT, :nodedown}}), do: {:error, :node_unavailable}
+  defp normalize_rpc_result({:badrpc, :timeout}), do: {:error, :node_timeout}
+
+  defp normalize_rpc_result({:badrpc, reason}),
+    do: {:error, {:beam_rpc_error, safe_reason(reason)}}
+
+  defp normalize_rpc_result(result), do: result
+
+  defp safe_apply(module, function, args) do
+    apply(module, function, args)
+  rescue
+    _error -> {:error, {:beam_rpc_error, :remote_error}}
+  catch
+    :exit, _reason -> {:error, {:beam_rpc_error, :remote_error}}
+    _kind, _reason -> {:error, {:beam_rpc_error, :remote_error}}
+  end
+
+  defp failed_prefix_cache_score(reason) do
+    %Operation.PrefixCacheScoreResult{
+      status_code: prefix_cache_status_code(reason),
+      status_message: "prefix cache score unavailable",
+      resident_fingerprint_match: false,
+      score_tier: "unknown",
+      session_started_unix_ms: 0
+    }
+  end
+
+  defp prefix_cache_status_code(:node_timeout), do: "timeout"
+  defp prefix_cache_status_code(:node_unavailable), do: "unavailable"
+  defp prefix_cache_status_code(:beam_distribution_unavailable), do: "unavailable"
+  defp prefix_cache_status_code(_reason), do: "error"
+
+  defp safe_reason(reason) when is_atom(reason), do: reason
+  defp safe_reason({kind, _detail}) when is_atom(kind), do: kind
+  defp safe_reason(_reason), do: :remote_error
+end

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_config.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_config.ex
@@ -3,6 +3,10 @@ defmodule Orchard.RuntimeEndpoint.BeamConfig do
   Guardrail validation for future first-party BEAM Runtime Endpoint transport.
   """
 
+  import Bitwise
+
+  alias Orchard.RuntimeEndpoint.Target
+
   defstruct enabled: false,
             node_name: nil,
             cookie_file: nil,
@@ -22,6 +26,15 @@ defmodule Orchard.RuntimeEndpoint.BeamConfig do
   @type error ::
           :beam_distribution_disabled
           | {:invalid_beam_distribution_config, [atom()]}
+
+  @type target_error ::
+          :beam_distribution_unavailable
+          | :beam_node_identity_mismatch
+          | :invalid_beam_target_address
+          | :beam_target_service_not_admitted
+          | :beam_target_outside_allowed_cidrs
+
+  @type cidr :: {:inet.ip_address(), non_neg_integer()}
 
   @spec config() :: keyword()
   def config do
@@ -52,6 +65,28 @@ defmodule Orchard.RuntimeEndpoint.BeamConfig do
     end
   end
 
+  @spec validate_target(t(), Target.t(), keyword()) :: :ok | {:error, target_error()}
+  def validate_target(config, target, opts \\ [])
+
+  def validate_target(%__MODULE__{enabled: false}, _target, _opts), do: :ok
+
+  def validate_target(
+        %__MODULE__{enabled: true} = config,
+        %Target{transport: :beam} = target,
+        opts
+      ) do
+    current_node = Keyword.get(opts, :current_node, node())
+
+    with :ok <- require_current_node(config, current_node),
+         {:ok, service, host} <- beam_service_host(target.address),
+         :ok <- require_admitted_service(config, service) do
+      require_allowed_host(config, host)
+    end
+  end
+
+  def validate_target(%__MODULE__{enabled: true}, %Target{}, _opts),
+    do: {:error, :invalid_beam_target_address}
+
   defp validate_enabled_attrs(attrs, _env) do
     errors =
       []
@@ -59,6 +94,7 @@ defmodule Orchard.RuntimeEndpoint.BeamConfig do
       |> require_non_empty(attrs, :cookie_file, :missing_cookie_file)
       |> require_restricted_list(attrs, :admitted_services, :missing_admitted_services)
       |> require_restricted_list(attrs, :allowed_cidrs, :missing_allowed_cidrs)
+      |> require_valid_cidrs(attrs, :allowed_cidrs)
       |> require_list_without_global_cidrs(attrs, :allowed_cidrs)
       |> require_restricted_listen_host(attrs)
 
@@ -79,6 +115,57 @@ defmodule Orchard.RuntimeEndpoint.BeamConfig do
     }
   end
 
+  defp require_current_node(_config, :nonode@nohost),
+    do: {:error, :beam_distribution_unavailable}
+
+  defp require_current_node(%__MODULE__{node_name: node_name}, current_node)
+       when is_atom(current_node) do
+    if Atom.to_string(current_node) == node_name do
+      :ok
+    else
+      {:error, :beam_node_identity_mismatch}
+    end
+  end
+
+  defp require_current_node(_config, _current_node), do: {:error, :beam_node_identity_mismatch}
+
+  defp beam_service_host(address) when is_atom(address) do
+    address
+    |> Atom.to_string()
+    |> beam_service_host()
+  end
+
+  defp beam_service_host(address) when is_binary(address) do
+    case String.split(address, "@") do
+      [service, host] when service != "" and host != "" -> {:ok, service, host}
+      _other -> {:error, :invalid_beam_target_address}
+    end
+  end
+
+  defp beam_service_host(_address), do: {:error, :invalid_beam_target_address}
+
+  defp require_admitted_service(%__MODULE__{admitted_services: services}, service) do
+    if service in services do
+      :ok
+    else
+      {:error, :beam_target_service_not_admitted}
+    end
+  end
+
+  defp require_allowed_host(%__MODULE__{allowed_cidrs: cidrs}, host) do
+    case parse_ip(host) do
+      {:ok, ip} ->
+        if Enum.any?(cidrs, &cidr_contains?(&1, ip)) do
+          :ok
+        else
+          {:error, :beam_target_outside_allowed_cidrs}
+        end
+
+      :error ->
+        {:error, :beam_target_outside_allowed_cidrs}
+    end
+  end
+
   defp require_non_empty(errors, attrs, key, error) do
     if non_empty_string?(value(attrs, key)), do: errors, else: [error | errors]
   end
@@ -93,10 +180,20 @@ defmodule Orchard.RuntimeEndpoint.BeamConfig do
     end
   end
 
+  defp require_valid_cidrs(errors, attrs, key) do
+    cidrs = list_value(attrs, key)
+
+    if cidrs != [] and Enum.any?(cidrs, &(parse_cidr(&1) == :error)) do
+      [:invalid_allowed_cidr | errors]
+    else
+      errors
+    end
+  end
+
   defp require_list_without_global_cidrs(errors, attrs, key) do
     cidrs = list_value(attrs, key)
 
-    if Enum.any?(cidrs, &(&1 in ["0.0.0.0/0", "::/0"])) do
+    if Enum.any?(cidrs, &global_cidr?/1) do
       [:global_beam_distribution_cidr | errors]
     else
       errors
@@ -113,6 +210,62 @@ defmodule Orchard.RuntimeEndpoint.BeamConfig do
 
   defp attrs_map(attrs) when is_list(attrs), do: Map.new(attrs)
   defp attrs_map(%{} = attrs), do: attrs
+
+  defp cidr_contains?(cidr, ip) do
+    case parse_cidr(cidr) do
+      {:ok, parsed_cidr} -> ip_in_cidr?(ip, parsed_cidr)
+      :error -> false
+    end
+  end
+
+  defp global_cidr?(cidr) do
+    case parse_cidr(cidr) do
+      {:ok, {_ip, 0}} -> true
+      _other -> false
+    end
+  end
+
+  defp parse_cidr(cidr) when is_binary(cidr) do
+    with [ip_string, prefix_string] <- String.split(cidr, "/", parts: 2),
+         {:ok, ip} <- parse_ip(ip_string),
+         {prefix, ""} <- Integer.parse(prefix_string),
+         true <- prefix >= 0 and prefix <= ip_bits(ip) do
+      {:ok, {ip, prefix}}
+    else
+      _other -> :error
+    end
+  end
+
+  defp parse_cidr(_cidr), do: :error
+
+  defp parse_ip(value) do
+    value
+    |> String.to_charlist()
+    |> :inet.parse_address()
+    |> case do
+      {:ok, ip} -> {:ok, ip}
+      {:error, _reason} -> :error
+    end
+  end
+
+  defp ip_in_cidr?(ip, {network, prefix}) when tuple_size(ip) == tuple_size(network) do
+    bits = ip_bits(ip)
+    mask = ((1 <<< prefix) - 1) <<< (bits - prefix)
+    (ip_to_integer(ip) &&& mask) == (ip_to_integer(network) &&& mask)
+  end
+
+  defp ip_in_cidr?(_ip, _cidr), do: false
+
+  defp ip_bits(ip) when tuple_size(ip) == 4, do: 32
+  defp ip_bits(ip) when tuple_size(ip) == 8, do: 128
+
+  defp ip_to_integer(ip) when tuple_size(ip) == 4 do
+    Enum.reduce(Tuple.to_list(ip), 0, fn octet, acc -> acc * 256 + octet end)
+  end
+
+  defp ip_to_integer(ip) when tuple_size(ip) == 8 do
+    Enum.reduce(Tuple.to_list(ip), 0, fn segment, acc -> acc * 65_536 + segment end)
+  end
 
   defp enabled?(attrs), do: value(attrs, :enabled) == true
 

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_config.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_config.ex
@@ -1,6 +1,9 @@
 defmodule Orchard.RuntimeEndpoint.BeamConfig do
   @moduledoc """
-  Guardrail validation for future first-party BEAM Runtime Endpoint transport.
+  Guardrail validation for first-party BEAM Runtime Endpoint transport.
+
+  Enabled BEAM transport requires an identity-bound local node, admitted target
+  services, restricted listen host, and allowed target CIDRs.
   """
 
   import Bitwise

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_identity.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_identity.ex
@@ -1,0 +1,58 @@
+defmodule Orchard.RuntimeEndpoint.BeamIdentity do
+  @moduledoc false
+
+  alias Orchard.RuntimeEndpoint.{Observation, Target}
+
+  @spec resolve_candidate_node_id(Target.t() | term(), Observation.t()) ::
+          {:ok, String.t()} | :missing | {:rejected, :beam_node_identity_mismatch}
+  def resolve_candidate_node_id(
+        %Target{transport: :beam, node_id: node_id},
+        %Observation{} = observation
+      )
+      when is_binary(node_id) do
+    configured_node_id = valid_node_id(node_id)
+    observed_node_id = metadata_node_id(observation)
+
+    cond do
+      configured_node_id == nil -> :missing
+      observed_node_id == configured_node_id -> {:ok, configured_node_id}
+      true -> {:rejected, :beam_node_identity_mismatch}
+    end
+  end
+
+  def resolve_candidate_node_id(%Target{transport: :beam}, %Observation{} = observation) do
+    case metadata_node_id(observation) do
+      nil -> :missing
+      node_id -> {:ok, node_id}
+    end
+  end
+
+  def resolve_candidate_node_id(_target, %Observation{} = observation) do
+    case valid_node_id(Observation.node_id(observation)) do
+      nil -> :missing
+      node_id -> {:ok, node_id}
+    end
+  end
+
+  @spec metadata_node_id(Observation.t()) :: String.t() | nil
+  def metadata_node_id(%Observation{metadata: metadata}) when is_map(metadata) do
+    metadata
+    |> metadata_value(:node_id)
+    |> valid_node_id()
+  end
+
+  def metadata_node_id(_observation), do: nil
+
+  defp valid_node_id(node_id) when is_binary(node_id) do
+    case Ecto.UUID.cast(node_id) do
+      {:ok, id} -> id
+      :error -> nil
+    end
+  end
+
+  defp valid_node_id(_node_id), do: nil
+
+  defp metadata_value(metadata, key) do
+    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
+  end
+end

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -180,7 +180,6 @@ defmodule Orchard.Scheduler.MultiNode do
           %{
             strategy: :multi_node,
             request_id: request.public_id,
-            runtime_client_target: dispatch_target(selected.target),
             runtime_endpoint_target: selected.target,
             request_timeout_ms: Inference.request_timeout_ms(),
             model_load_timeout_ms: Inference.model_load_timeout_ms(),
@@ -189,6 +188,7 @@ defmodule Orchard.Scheduler.MultiNode do
             queue_lane_capacity: queue_lane_capacity(available_candidates),
             selected_tier: if(selected.loaded_model?, do: "loaded", else: "cold")
           }
+          |> maybe_put_runtime_client_target(selected.target)
           |> maybe_put_prefix_cache_status(Map.get(selected, :prefix_cache_status))
           |> maybe_put_prefix_cache_fingerprint_match(
             selected,
@@ -924,6 +924,15 @@ defmodule Orchard.Scheduler.MultiNode do
   defp runtime_model_ref(%CanonicalRequest.ModelRef{} = model_ref) do
     ModelRef.new!(model_ref.model_id, model_ref.version)
   end
+
+  defp maybe_put_runtime_client_target(schedule, %Target{
+         transport: :grpc_compat,
+         address: address
+       }) do
+    Map.put(schedule, :runtime_client_target, address)
+  end
+
+  defp maybe_put_runtime_client_target(schedule, _target), do: schedule
 
   defp dispatch_target(%Target{transport: :grpc_compat, address: address}), do: address
   defp dispatch_target(target), do: target

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -24,10 +24,15 @@ defmodule Orchard.Scheduler.MultiNode do
   Returns `{:error, :cluster_busy}` when live probes joined to persisted schedulable
   nodes, but every joined candidate has exhausted capacity or is an active
   loaded-model candidate with unknown placement capacity.
+  BEAM observations whose configured node identity conflicts with observed
+  metadata also fail closed as `:cluster_busy` instead of falling back to a
+  different identity.
 
   Successful schedules include `:queue_lane_capacity`, derived from loaded
   candidates with live node and placement room plus eligible cold candidates
   with remaining aggregate node capacity.
+  gRPC compatibility schedules include legacy `:runtime_client_target`;
+  BEAM schedules carry only `:runtime_endpoint_target`.
 
   Transport-like probe and connect failures are recorded through node inventory
   so failed targets stop contributing stale queue capacity before queued work is

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -106,10 +106,19 @@ defmodule Orchard.Scheduler.MultiNode do
     # - Worst-case latency is cumulative (N × timeout_ms) but acceptable at this scale
     # Future: parallel probing via Task.async_stream or cached observations
     # within freshness window for larger clusters.
-    probe_results =
+    probe_outcomes =
       targets
       |> Enum.map(&probe_target(&1, client, timeout, observed_at, request))
       |> Enum.reject(&is_nil/1)
+
+    probe_results =
+      Enum.flat_map(probe_outcomes, fn
+        {:candidate, candidate} -> [candidate]
+        {:rejected, _reason} -> []
+      end)
+
+    beam_identity_rejected? =
+      Enum.any?(probe_outcomes, &match?({:rejected, :beam_node_identity_mismatch}, &1))
 
     # Join with persistent schedulable nodes
     schedulable_map =
@@ -123,17 +132,20 @@ defmodule Orchard.Scheduler.MultiNode do
 
     available_candidates = Enum.reject(candidates, &candidate_full?/1)
 
-    cond do
-      candidates == [] and probe_results == [] ->
-        fallback_schedule(request, targets, Keyword.put(opts, :probe_status?, false))
+    case selection_state(
+           candidates,
+           available_candidates,
+           probe_outcomes,
+           opts,
+           beam_identity_rejected?
+         ) do
+      {:fallback, fallback_opts} ->
+        fallback_schedule(request, targets, fallback_opts)
 
-      candidates == [] ->
-        fallback_schedule(request, targets, opts)
+      {:error, reason} ->
+        {:error, reason}
 
-      available_candidates == [] ->
-        {:error, :cluster_busy}
-
-      true ->
+      :select_candidate ->
         cache_affinity_config = Inference.cache_affinity_config()
 
         {affinity_candidates, affinity_context} =
@@ -202,6 +214,27 @@ defmodule Orchard.Scheduler.MultiNode do
     end
   end
 
+  defp selection_state([], _available_candidates, [], opts, _beam_identity_rejected?),
+    do: {:fallback, Keyword.put(opts, :probe_status?, false)}
+
+  defp selection_state([], _available_candidates, _probe_outcomes, _opts, true),
+    do: {:error, :cluster_busy}
+
+  defp selection_state([], _available_candidates, _probe_outcomes, opts, false),
+    do: {:fallback, opts}
+
+  defp selection_state(_candidates, [], _probe_outcomes, _opts, _beam_identity_rejected?),
+    do: {:error, :cluster_busy}
+
+  defp selection_state(
+         _candidates,
+         _available_candidates,
+         _probe_outcomes,
+         _opts,
+         _beam_identity_rejected?
+       ),
+       do: :select_candidate
+
   defp probe_target(target, client, timeout, observed_at, request) do
     case client.connect(target) do
       {:ok, channel} ->
@@ -215,29 +248,33 @@ defmodule Orchard.Scheduler.MultiNode do
                 reserve_unassigned_source_grants?: true
               )
 
-              case extract_valid_node_id(observation) do
-                nil ->
+              case candidate_node_id(target, observation) do
+                :missing ->
                   nil
 
-                node_id ->
+                {:rejected, reason} ->
+                  {:rejected, reason}
+
+                {:ok, node_id} ->
                   loaded_model? = model_loaded?(observation, request)
 
-                  %{
-                    node_id: node_id,
-                    target: schedule_target(target, node_id),
-                    availability: observation.availability,
-                    loaded_model?: loaded_model?,
-                    active_request_count: observation.aggregate_active_request_count,
-                    max_concurrency: node_max_concurrency(observation),
-                    supports_prompt_token_ids: observation.supports_prompt_token_ids
-                  }
-                  |> maybe_put_model_placement_capacity(
-                    model_placement_capacity_for(observation, request.model_ref, loaded_model?)
-                  )
-                  |> maybe_put_prefix_cache_status(
-                    prefix_cache_status_for(observation, request.model_ref)
-                  )
-                  |> maybe_put_memory_budget(memory_budget_for(observation, request.model_ref))
+                  {:candidate,
+                   %{
+                     node_id: node_id,
+                     target: schedule_target(target, node_id),
+                     availability: observation.availability,
+                     loaded_model?: loaded_model?,
+                     active_request_count: observation.aggregate_active_request_count,
+                     max_concurrency: node_max_concurrency(observation),
+                     supports_prompt_token_ids: observation.supports_prompt_token_ids
+                   }
+                   |> maybe_put_model_placement_capacity(
+                     model_placement_capacity_for(observation, request.model_ref, loaded_model?)
+                   )
+                   |> maybe_put_prefix_cache_status(
+                     prefix_cache_status_for(observation, request.model_ref)
+                   )
+                   |> maybe_put_memory_budget(memory_budget_for(observation, request.model_ref))}
               end
 
             {:error, reason} ->
@@ -395,6 +432,45 @@ defmodule Orchard.Scheduler.MultiNode do
       value when is_integer(value) and value > 0 -> value
       _other -> 1
     end
+  end
+
+  defp candidate_node_id(
+         %Target{transport: :beam, node_id: node_id},
+         %Observation{} = observation
+       )
+       when is_binary(node_id) do
+    configured_node_id = extract_valid_node_id(node_id)
+    observed_node_id = observed_metadata_node_id(observation)
+
+    cond do
+      configured_node_id == nil -> :missing
+      observed_node_id == configured_node_id -> {:ok, configured_node_id}
+      true -> {:rejected, :beam_node_identity_mismatch}
+    end
+  end
+
+  defp candidate_node_id(%Target{transport: :beam}, %Observation{} = observation) do
+    case observed_metadata_node_id(observation) do
+      nil -> :missing
+      node_id -> {:ok, node_id}
+    end
+  end
+
+  defp candidate_node_id(_target, %Observation{} = observation) do
+    case extract_valid_node_id(observation) do
+      nil -> :missing
+      node_id -> {:ok, node_id}
+    end
+  end
+
+  defp observed_metadata_node_id(%Observation{metadata: metadata}) when is_map(metadata) do
+    metadata
+    |> metadata_value(:node_id)
+    |> extract_valid_node_id()
+  end
+
+  defp metadata_value(metadata, key) do
+    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
   end
 
   defp extract_valid_node_id(%Observation{} = observation) do

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -254,6 +254,11 @@ defmodule Orchard.Scheduler.MultiNode do
                   nil
 
                 {:rejected, reason} ->
+                  Nodes.clear_target_queue_capacity_sources(
+                    observation_target(target),
+                    observed_at
+                  )
+
                   {:rejected, reason}
 
                 {:ok, node_id} ->

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -42,6 +42,7 @@ defmodule Orchard.Scheduler.MultiNode do
   alias Orchard.Nodes
 
   alias Orchard.RuntimeEndpoint.{
+    BeamIdentity,
     GrpcCompatibilityMapper,
     ModelRef,
     Observation,
@@ -243,12 +244,7 @@ defmodule Orchard.Scheduler.MultiNode do
             {:ok, response} ->
               observation = normalize_status_observation(target, response)
 
-              Nodes.observe_status(observation_target(target), observation, observed_at,
-                reserve_unassigned_node_grants?: true,
-                reserve_unassigned_source_grants?: true
-              )
-
-              case candidate_node_id(target, observation) do
+              case BeamIdentity.resolve_candidate_node_id(target, observation) do
                 :missing ->
                   nil
 
@@ -256,6 +252,11 @@ defmodule Orchard.Scheduler.MultiNode do
                   {:rejected, reason}
 
                 {:ok, node_id} ->
+                  Nodes.observe_status(observation_target(target), observation, observed_at,
+                    reserve_unassigned_node_grants?: true,
+                    reserve_unassigned_source_grants?: true
+                  )
+
                   loaded_model? = model_loaded?(observation, request)
 
                   {:candidate,
@@ -433,60 +434,6 @@ defmodule Orchard.Scheduler.MultiNode do
       _other -> 1
     end
   end
-
-  defp candidate_node_id(
-         %Target{transport: :beam, node_id: node_id},
-         %Observation{} = observation
-       )
-       when is_binary(node_id) do
-    configured_node_id = extract_valid_node_id(node_id)
-    observed_node_id = observed_metadata_node_id(observation)
-
-    cond do
-      configured_node_id == nil -> :missing
-      observed_node_id == configured_node_id -> {:ok, configured_node_id}
-      true -> {:rejected, :beam_node_identity_mismatch}
-    end
-  end
-
-  defp candidate_node_id(%Target{transport: :beam}, %Observation{} = observation) do
-    case observed_metadata_node_id(observation) do
-      nil -> :missing
-      node_id -> {:ok, node_id}
-    end
-  end
-
-  defp candidate_node_id(_target, %Observation{} = observation) do
-    case extract_valid_node_id(observation) do
-      nil -> :missing
-      node_id -> {:ok, node_id}
-    end
-  end
-
-  defp observed_metadata_node_id(%Observation{metadata: metadata}) when is_map(metadata) do
-    metadata
-    |> metadata_value(:node_id)
-    |> extract_valid_node_id()
-  end
-
-  defp metadata_value(metadata, key) do
-    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
-  end
-
-  defp extract_valid_node_id(%Observation{} = observation) do
-    observation
-    |> Observation.node_id()
-    |> extract_valid_node_id()
-  end
-
-  defp extract_valid_node_id(node_id) when is_binary(node_id) do
-    case Ecto.UUID.cast(node_id) do
-      {:ok, id} -> id
-      :error -> nil
-    end
-  end
-
-  defp extract_valid_node_id(_), do: nil
 
   defp schedule_target(%Target{transport: :beam, node_id: nil} = target, node_id),
     do: %{target | node_id: node_id}

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -224,7 +224,7 @@ defmodule Orchard.Scheduler.MultiNode do
 
                   %{
                     node_id: node_id,
-                    target: target,
+                    target: schedule_target(target, node_id),
                     availability: observation.availability,
                     loaded_model?: loaded_model?,
                     active_request_count: observation.aggregate_active_request_count,
@@ -411,6 +411,11 @@ defmodule Orchard.Scheduler.MultiNode do
   end
 
   defp extract_valid_node_id(_), do: nil
+
+  defp schedule_target(%Target{transport: :beam, node_id: nil} = target, node_id),
+    do: %{target | node_id: node_id}
+
+  defp schedule_target(target, _node_id), do: target
 
   defp exception_name(%{__struct__: module}) when is_atom(module), do: Atom.to_string(module)
 

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -902,11 +902,22 @@ defmodule Orchard.Scheduler.MultiNode do
 
   # -- Helpers --
 
-  # When there is exactly one unique target, pass it explicitly to
-  # SingleNode.default_schedule/2 so the fallback uses the actual target
-  # from the plural config, not the separate singular runtime_client_target.
-  # When targets is empty or has multiple entries, use the implicit singular
-  # fallback (no single deterministic target to pass).
+  defp fallback_schedule(request, [%Target{transport: :grpc_compat} = single_target], opts) do
+    SingleNode.default_schedule(request, dispatch_target(single_target), opts)
+  end
+
+  defp fallback_schedule(request, [%Target{} = single_target], _opts) do
+    {:ok,
+     %{
+       strategy: :single_node,
+       request_id: request.public_id,
+       runtime_endpoint_target: single_target,
+       request_timeout_ms: Inference.request_timeout_ms(),
+       model_load_timeout_ms: Inference.model_load_timeout_ms(),
+       node_id: runtime_endpoint_node_id(single_target)
+     }}
+  end
+
   defp fallback_schedule(request, [single_target], opts) do
     SingleNode.default_schedule(request, dispatch_target(single_target), opts)
   end
@@ -936,6 +947,13 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp dispatch_target(%Target{transport: :grpc_compat, address: address}), do: address
   defp dispatch_target(target), do: target
+
+  defp runtime_endpoint_node_id(%Target{} = target) do
+    case Nodes.lookup_by_target(target) do
+      %{id: id} -> id
+      nil -> nil
+    end
+  end
 
   defp observation_target(%Target{transport: :grpc_compat, address: address}), do: address
   defp observation_target(target), do: target

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -123,7 +123,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
   alias Orchard.Dispatch.RequestDispatcher
   alias Orchard.Inference.QueueManager
   alias Orchard.Nodes.Node
-  alias Orchard.RuntimeEndpoint.Operation
+  alias Orchard.RuntimeEndpoint.{Operation, Target}
 
   @valid_uuid "550e8400-e29b-41d4-a716-446655440000"
   @other_uuid "660f9511-f30c-52e5-b827-557766551111"
@@ -471,6 +471,27 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
 
       assert_received {:ensure_model_loaded_called, req}
       assert req.node_id == @valid_uuid
+    end
+  end
+
+  describe "BEAM target identity guard" do
+    test "dispatch fails closed before observe or ensure when live metadata disagrees", ctx do
+      target = Target.beam(@valid_uuid, address: :orchard_node_agent@localhost)
+
+      schedule =
+        ctx.schedule
+        |> Map.put(:runtime_endpoint_target, target)
+        |> Map.delete(:runtime_client_target)
+
+      configure_stub(%{status: {:ok, full_status(@other_uuid)}})
+
+      assert {:error, {:dispatch_failed, :beam_node_identity_mismatch}} =
+               RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
+                 client_impl: @stub_client
+               )
+
+      refute_received {:ensure_model_loaded_called, _request}
+      assert Repo.get(Node, @other_uuid) == nil
     end
   end
 

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -7,6 +7,7 @@ defmodule Orchard.InferenceTest do
   alias Orchard.Inference
   alias Orchard.Inference.ChatOrchestrator
   alias Orchard.Models
+  alias Orchard.RuntimeEndpoint.Target
   alias Orchard.Scheduler.{MultiNode, SingleNode}
   alias Orchard.Tokenizer.Client
 
@@ -206,6 +207,32 @@ defmodule Orchard.InferenceTest do
       clean = Keyword.delete(config, :node_unreachable_threshold_ms)
       Application.put_env(:orchard_controller, :inference, clean)
       assert Inference.node_unreachable_threshold_ms() == 15_000
+    end
+  end
+
+  describe "runtime_endpoint_targets/0" do
+    test "defaults to gRPC compatibility targets from legacy runtime client config" do
+      put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
+
+      assert [%Target{transport: :grpc_compat, address: [host: "10.0.0.1", port: 50_061]}] =
+               Inference.runtime_endpoint_targets()
+    end
+
+    test "explicit Runtime Endpoint targets opt into BEAM without changing legacy fallback" do
+      put_inference(
+        runtime_client_targets: [[host: "10.0.0.1", port: 50_061]],
+        runtime_endpoint_targets: [
+          %{transport: :beam, node_id: "node-1", address: :orchard_node_agent@localhost}
+        ]
+      )
+
+      assert [
+               %Target{
+                 transport: :beam,
+                 node_id: "node-1",
+                 address: :orchard_node_agent@localhost
+               }
+             ] = Inference.runtime_endpoint_targets()
     end
   end
 

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -666,6 +666,22 @@ defmodule Orchard.InferenceTest do
       assert Inference.scheduler() == SingleNode
     end
 
+    test "SPEC.md §7.5 explicit Runtime Endpoint targets use endpoint-aware scheduling when singular" do
+      put_inference(
+        runtime_endpoint_targets: [
+          %{
+            transport: :beam,
+            id: "source-dev-node-agent",
+            address: :orchard_node_agent@localhost
+          }
+        ],
+        runtime_client_targets: [],
+        scheduler_impl: nil
+      )
+
+      assert Inference.scheduler() == MultiNode
+    end
+
     test "explicit scheduler override wins over auto-selection" do
       put_inference(
         runtime_client_targets: [

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -219,17 +219,19 @@ defmodule Orchard.InferenceTest do
     end
 
     test "explicit Runtime Endpoint targets opt into BEAM without changing legacy fallback" do
+      node_id = "550e8400-e29b-41d4-a716-446655440000"
+
       put_inference(
         runtime_client_targets: [[host: "10.0.0.1", port: 50_061]],
         runtime_endpoint_targets: [
-          %{transport: :beam, node_id: "node-1", address: :orchard_node_agent@localhost}
+          %{transport: :beam, node_id: node_id, address: :orchard_node_agent@localhost}
         ]
       )
 
       assert [
                %Target{
                  transport: :beam,
-                 node_id: "node-1",
+                 node_id: ^node_id,
                  address: :orchard_node_agent@localhost
                }
              ] = Inference.runtime_endpoint_targets()

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -1886,6 +1886,66 @@ defmodule Orchard.NodesTest do
       assert :ok = QueueManager.release(grant)
     end
 
+    test "SPEC.md §5.5 address-only BEAM observation does not publish uncleared capacity" do
+      QueueManager.reset()
+
+      node_id = Ecto.UUID.generate()
+      model_ref = ModelRef.new!("beam-address-only-placement", "v1")
+
+      target =
+        Target.normalize(
+          transport: :beam,
+          id: "source-dev-node-agent",
+          address: :orchard_node_agent@localhost
+        )
+
+      assert {:queued, ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-beam-address-only-placement",
+                   "beam-address-only-placement"
+                 ),
+                 config: queue_config(capacity: 0, max_wait_ms: 100)
+               )
+
+      awaiter = Task.async(fn -> QueueManager.await(ticket) end)
+
+      observation =
+        Observation.new(%{
+          endpoint_id: target.id,
+          target: target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 1,
+          metadata: %{
+            node_id: node_id,
+            display_name: "beam-address-only-node",
+            hostname: "beam-address-only.local",
+            listen_host: "10.0.0.96",
+            listen_port: 9444
+          },
+          health: %{ready: true},
+          placements: [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity:
+                PlacementCapacity.new(%{
+                  model_ref: model_ref,
+                  active_request_count: 0,
+                  max_concurrency: 1,
+                  source: :beam_runtime_endpoint_status
+                })
+            })
+          ]
+        })
+
+      assert {:ok, node} = Nodes.observe_status(target, observation, DateTime.utc_now())
+      assert node.id == node_id
+      assert {:error, :queue_timeout, metadata} = Task.await(awaiter, 2_000)
+      assert metadata.queue_result == :queue_timeout
+    end
+
     test "SPEC.md §5.5 unavailable runtime endpoint observation clears queue capacity" do
       QueueManager.reset()
 

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -36,6 +36,7 @@ defmodule Orchard.NodesTest do
   alias Orchard.Nodes
   alias Orchard.Nodes.Node
   alias Orchard.RuntimeEndpoint.GrpcCompatibilityMapper
+  alias Orchard.RuntimeEndpoint.{ModelRef, Observation, Placement, PlacementCapacity, Target}
 
   # -- Helpers --
 
@@ -1826,6 +1827,65 @@ defmodule Orchard.NodesTest do
       send(first_awaiter, :stop)
     end
 
+    test "SPEC.md §5.5 BEAM runtime endpoint observation persists node capacity" do
+      QueueManager.reset()
+
+      node_id = Ecto.UUID.generate()
+      model_ref = ModelRef.new!("beam-observation-placement", "v1")
+      target = Target.beam(node_id, address: :orchard_node_agent@localhost)
+
+      assert {:queued, ticket} =
+               QueueManager.acquire(
+                 queue_admission_request(
+                   "req-beam-observation-placement",
+                   "beam-observation-placement"
+                 ),
+                 config: queue_config(capacity: 0)
+               )
+
+      awaiter = Task.async(fn -> QueueManager.await(ticket) end)
+
+      observation =
+        Observation.new(%{
+          endpoint_id: target.id,
+          target: target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 1,
+          metadata: %{
+            node_id: node_id,
+            display_name: "beam-observation-node",
+            hostname: "beam-observation.local",
+            listen_host: "10.0.0.95",
+            listen_port: 9444
+          },
+          health: %{ready: true},
+          placements: [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity:
+                PlacementCapacity.new(%{
+                  model_ref: model_ref,
+                  active_request_count: 0,
+                  max_concurrency: 1,
+                  source: :beam_runtime_endpoint_status
+                })
+            })
+          ]
+        })
+
+      assert {:ok, node} = Nodes.observe_status(target, observation, DateTime.utc_now())
+      assert node.id == node_id
+      assert node.advertise_addr == "10.0.0.95"
+      assert node.rpc_port == 9444
+
+      assert {:ok, grant} = Task.await(awaiter, 2_000)
+      assert grant.queue_key == "beam-observation-placement@v1"
+
+      assert :ok = QueueManager.release(grant)
+    end
+
     test "SPEC.md §5.5 unavailable runtime endpoint observation clears queue capacity" do
       QueueManager.reset()
 
@@ -3147,6 +3207,61 @@ defmodule Orchard.NodesTest do
 
       assert_receive {^tag, {:ok, grant}}, 2_000
       assert :ok = QueueManager.release(grant)
+    end
+
+    test "SPEC.md §5.5 BEAM transport failure clears stale queue capacity sources" do
+      QueueManager.reset()
+
+      node_id = Ecto.UUID.generate()
+      model_id = "beam-failure-clear-model"
+      observed_at = DateTime.utc_now()
+
+      insert_node!(%{
+        id: node_id,
+        advertise_addr: "10.0.0.80",
+        rpc_port: 9444,
+        health: :healthy,
+        last_heartbeat_at: observed_at
+      })
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-beam-failure-clear-a", model_id),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-beam-failure-clear-b", model_id),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter = start_holding_awaiter(first_ticket, :first_beam_failure_clear_result)
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+
+      assert :ok =
+               QueueManager.refresh_capacity(model_id, "v1", 1, source: {:node, node_id, :cold})
+
+      assert_receive {:first_beam_failure_clear_result, {:ok, first_grant}}, 2_000
+      refute Task.yield(second_awaiter, 50)
+
+      target = Target.beam(node_id, address: :orchard_node_agent@localhost)
+
+      assert {:ok, marked} =
+               Nodes.record_transport_failure(
+                 target,
+                 :node_timeout,
+                 DateTime.add(observed_at, 1, :second)
+               )
+
+      assert marked.health == :degraded
+      assert :ok = QueueManager.release(first_grant)
+      refute Task.yield(second_awaiter, 100)
+
+      assert :ok = QueueManager.refresh_capacity(model_id, "v1", 1, source: {:test, :restore})
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
     end
 
     test "swallows QueueManager clear exits after marking transport failure" do

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
@@ -4,6 +4,8 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
   alias Orchard.InferenceEvent
   alias Orchard.RuntimeEndpoint.{BeamClient, ModelRef, Observation, Operation, Target}
 
+  @node_id "550e8400-e29b-41d4-a716-446655440000"
+
   defmodule Server do
     alias Orchard.RuntimeEndpoint.{Observation, Operation}
 
@@ -50,7 +52,7 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
 
   test "serves Runtime Endpoint operations over the BEAM client contract" do
     model_ref = ModelRef.new!("mlx-community/phi-3", "main")
-    target = Target.beam("node-1", address: node(), metadata: %{server_module: Server})
+    target = Target.beam(@node_id, address: node(), metadata: %{server_module: Server})
 
     assert {:ok, connection} = BeamClient.connect(target)
     assert {:ok, %Observation{availability: :available}} = BeamClient.status(connection, [])
@@ -101,7 +103,7 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
 
   test "prefix-cache scoring fails open when a BEAM target is unavailable" do
     model_ref = ModelRef.new!("mlx-community/phi-3", "main")
-    target = Target.beam("node-1", address: :definitely_missing@localhost)
+    target = Target.beam(@node_id, address: :definitely_missing@localhost)
 
     request = %Operation.PrefixCacheScoreRequest{
       request_id: "req_1",
@@ -116,7 +118,7 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
 
   test "local BEAM server startup failures send dispatcher-safe completion" do
     model_ref = ModelRef.new!("mlx-community/phi-3", "main")
-    target = Target.beam("node-1", address: node(), metadata: %{server_module: RaisingServer})
+    target = Target.beam(@node_id, address: node(), metadata: %{server_module: RaisingServer})
     assert {:ok, connection} = BeamClient.connect(target)
 
     request = %Operation.ExecuteRequest{
@@ -135,7 +137,7 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
 
   test "prefix-cache scoring fails open when a local BEAM server raises" do
     model_ref = ModelRef.new!("mlx-community/phi-3", "main")
-    target = Target.beam("node-1", address: node(), metadata: %{server_module: RaisingServer})
+    target = Target.beam(@node_id, address: node(), metadata: %{server_module: RaisingServer})
     assert {:ok, connection} = BeamClient.connect(target)
 
     request = %Operation.PrefixCacheScoreRequest{

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
@@ -1,10 +1,20 @@
 defmodule Orchard.RuntimeEndpoint.BeamClientTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Orchard.InferenceEvent
   alias Orchard.RuntimeEndpoint.{BeamClient, ModelRef, Observation, Operation, Target}
 
   @node_id "550e8400-e29b-41d4-a716-446655440000"
+
+  setup do
+    previous_config = Application.get_env(:orchard_controller, :runtime_endpoint)
+
+    on_exit(fn ->
+      restore_runtime_endpoint_config(previous_config)
+    end)
+
+    :ok
+  end
 
   defmodule Server do
     alias Orchard.RuntimeEndpoint.{Observation, Operation}
@@ -48,6 +58,35 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
     target = Target.grpc_compat(host: "127.0.0.1", port: 50_071)
 
     assert {:error, {:unsupported_transport, :grpc_compat}} = BeamClient.connect(target)
+  end
+
+  test "SPEC.md §7.5 connect normalizes prebuilt BEAM targets at the client boundary" do
+    target = %Target{
+      id: "source-dev-node-agent",
+      transport: :beam,
+      address: Atom.to_string(node()),
+      node_id: @node_id,
+      metadata: %{server_module: Server}
+    }
+
+    assert {:ok, %BeamClient{target: %Target{address: address}}} = BeamClient.connect(target)
+    assert address == node()
+  end
+
+  test "SPEC.md §7.5 enabled config applies guardrails before local BEAM RPC" do
+    put_beam_config(
+      enabled: true,
+      node_name: "orchard_controller@10.0.0.5",
+      cookie_file: "/Library/Application Support/Orchard/secrets/beam.cookie",
+      admitted_services: ["orchard_node_agent"],
+      allowed_cidrs: ["10.0.0.0/24"],
+      listen_host: "10.0.0.5"
+    )
+
+    target = Target.beam(@node_id, address: node(), metadata: %{server_module: Server})
+
+    assert {:error, reason} = BeamClient.connect(target)
+    assert reason in [:beam_distribution_unavailable, :beam_node_identity_mismatch]
   end
 
   test "serves Runtime Endpoint operations over the BEAM client contract" do
@@ -149,5 +188,17 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
 
     assert {:ok, %Operation.PrefixCacheScoreResult{status_code: "error"}} =
              BeamClient.score_prefix_cache(connection, request, [])
+  end
+
+  defp put_beam_config(config) do
+    Application.put_env(:orchard_controller, :runtime_endpoint, beam: config)
+  end
+
+  defp restore_runtime_endpoint_config(nil) do
+    Application.delete_env(:orchard_controller, :runtime_endpoint)
+  end
+
+  defp restore_runtime_endpoint_config(config) do
+    Application.put_env(:orchard_controller, :runtime_endpoint, config)
   end
 end

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
@@ -1,0 +1,151 @@
+defmodule Orchard.RuntimeEndpoint.BeamClientTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.{BeamClient, ModelRef, Observation, Operation, Target}
+
+  defmodule Server do
+    alias Orchard.RuntimeEndpoint.{Observation, Operation}
+
+    def status(target, _opts) do
+      {:ok, Observation.new(endpoint_id: target.id, target: target, availability: :available)}
+    end
+
+    def ensure_model_loaded(%Operation.EnsureModelLoadedRequest{}, _opts) do
+      {:ok, %Operation.EnsureModelLoadedResult{already_loaded: true, placement_state: :loaded}}
+    end
+
+    def unload_model(%Operation.UnloadModelRequest{}, _opts) do
+      {:ok, %Operation.Ack{ok: true, message: "unloaded"}}
+    end
+
+    def execute_inference(%Operation.ExecuteRequest{} = request, owner, stream_ref, _opts) do
+      send(
+        owner,
+        {:runtime_endpoint_event, stream_ref, request.request_id,
+         Orchard.InferenceEvent.accepted(1)}
+      )
+
+      send(owner, {:runtime_endpoint_done, stream_ref, :ok})
+      {:ok, self()}
+    end
+
+    def cancel_inference(%Operation.CancelRequest{}, _opts), do: :ok
+
+    def score_prefix_cache(%Operation.PrefixCacheScoreRequest{}, _opts) do
+      {:ok, %Operation.PrefixCacheScoreResult{status_code: "ok", score_tier: "resident"}}
+    end
+  end
+
+  defmodule RaisingServer do
+    def execute_inference(_request, _owner, _stream_ref, _opts), do: raise("boom")
+    def score_prefix_cache(_request, _opts), do: raise("boom")
+  end
+
+  test "connect rejects unsupported target transports" do
+    target = Target.grpc_compat(host: "127.0.0.1", port: 50_071)
+
+    assert {:error, {:unsupported_transport, :grpc_compat}} = BeamClient.connect(target)
+  end
+
+  test "serves Runtime Endpoint operations over the BEAM client contract" do
+    model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+    target = Target.beam("node-1", address: node(), metadata: %{server_module: Server})
+
+    assert {:ok, connection} = BeamClient.connect(target)
+    assert {:ok, %Observation{availability: :available}} = BeamClient.status(connection, [])
+
+    load_request = %Operation.EnsureModelLoadedRequest{model_ref: model_ref}
+
+    assert {:ok, %{already_loaded: true, placement_state: :loaded}} =
+             BeamClient.ensure_model_loaded(connection, load_request, [])
+
+    unload_request = %Operation.UnloadModelRequest{model_ref: model_ref}
+
+    assert {:ok, %Operation.Ack{ok: true}} =
+             BeamClient.unload_model(connection, unload_request, [])
+
+    execute_request = %Operation.ExecuteRequest{
+      request_id: "req_1",
+      controller_session_id: "session_1",
+      model_ref: model_ref,
+      rendered_prompt_utf8: "hello",
+      input_tokens: 1
+    }
+
+    assert {:ok, stream_ref} =
+             BeamClient.execute_inference(connection, execute_request, owner: self())
+
+    assert_receive {:runtime_endpoint_event, ^stream_ref, "req_1", %InferenceEvent{}}
+    assert_receive {:runtime_endpoint_done, ^stream_ref, :ok}
+
+    cancel_request = %Operation.CancelRequest{
+      request_id: "req_1",
+      controller_session_id: "session_1"
+    }
+
+    assert :ok = BeamClient.cancel_inference(connection, cancel_request, [])
+
+    score_request = %Operation.PrefixCacheScoreRequest{
+      request_id: "req_1",
+      controller_session_id: "session_1",
+      model_ref: model_ref,
+      cache_affinity_fingerprint: "fingerprint"
+    }
+
+    assert {:ok, %Operation.PrefixCacheScoreResult{status_code: "ok", score_tier: "resident"}} =
+             BeamClient.score_prefix_cache(connection, score_request, [])
+
+    assert :ok = BeamClient.disconnect(connection)
+  end
+
+  test "prefix-cache scoring fails open when a BEAM target is unavailable" do
+    model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+    target = Target.beam("node-1", address: :definitely_missing@localhost)
+
+    request = %Operation.PrefixCacheScoreRequest{
+      request_id: "req_1",
+      controller_session_id: "session_1",
+      model_ref: model_ref,
+      cache_affinity_fingerprint: "fingerprint"
+    }
+
+    assert {:ok, %Operation.PrefixCacheScoreResult{status_code: "unavailable"}} =
+             BeamClient.score_prefix_cache(target, request, [])
+  end
+
+  test "local BEAM server startup failures send dispatcher-safe completion" do
+    model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+    target = Target.beam("node-1", address: node(), metadata: %{server_module: RaisingServer})
+    assert {:ok, connection} = BeamClient.connect(target)
+
+    request = %Operation.ExecuteRequest{
+      request_id: "req_1",
+      controller_session_id: "session_1",
+      model_ref: model_ref,
+      rendered_prompt_utf8: "hello",
+      input_tokens: 1
+    }
+
+    assert {:ok, stream_ref} = BeamClient.execute_inference(connection, request, owner: self())
+
+    assert_receive {:runtime_endpoint_done, ^stream_ref,
+                    {:error, {:beam_rpc_error, :remote_error}}}
+  end
+
+  test "prefix-cache scoring fails open when a local BEAM server raises" do
+    model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+    target = Target.beam("node-1", address: node(), metadata: %{server_module: RaisingServer})
+    assert {:ok, connection} = BeamClient.connect(target)
+
+    request = %Operation.PrefixCacheScoreRequest{
+      request_id: "req_1",
+      controller_session_id: "session_1",
+      model_ref: model_ref,
+      cache_affinity_fingerprint: "fingerprint"
+    }
+
+    assert {:ok, %Operation.PrefixCacheScoreResult{status_code: "error"}} =
+             BeamClient.score_prefix_cache(connection, request, [])
+  end
+end

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/beam_config_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/beam_config_test.exs
@@ -1,7 +1,10 @@
 defmodule Orchard.RuntimeEndpoint.BeamConfigTest do
   use ExUnit.Case, async: true
 
-  alias Orchard.RuntimeEndpoint.BeamConfig
+  alias Orchard.RuntimeEndpoint.{BeamConfig, Target}
+
+  @node_id "550e8400-e29b-41d4-a716-446655440000"
+  @controller_node :"orchard_controller@10.0.0.5"
 
   test "disabled config validates as disabled" do
     assert {:ok, %BeamConfig{enabled: false}} = BeamConfig.validate([], :prod)
@@ -40,6 +43,23 @@ defmodule Orchard.RuntimeEndpoint.BeamConfigTest do
     assert :unrestricted_listen_host in errors
   end
 
+  test "SPEC.md §7.5 enabled config rejects malformed allowed CIDRs" do
+    assert {:error, {:invalid_beam_distribution_config, errors}} =
+             BeamConfig.validate_enabled(
+               [
+                 enabled: true,
+                 node_name: "orchard_controller@controller.local",
+                 cookie_file: "/Library/Application Support/Orchard/secrets/beam.cookie",
+                 admitted_services: ["orchard_node_agent"],
+                 allowed_cidrs: ["not-a-cidr"],
+                 listen_host: "10.0.0.10"
+               ],
+               :prod
+             )
+
+    assert :invalid_allowed_cidr in errors
+  end
+
   test "enabled config validates when identity, admission, and network restrictions are explicit" do
     assert {:ok, config} =
              BeamConfig.validate_enabled(
@@ -58,5 +78,58 @@ defmodule Orchard.RuntimeEndpoint.BeamConfigTest do
     assert config.node_name == "orchard_controller@controller.local"
     assert config.admitted_services == ["orchard_node_agent"]
     assert config.allowed_cidrs == ["10.0.0.0/24"]
+  end
+
+  test "SPEC.md §7.5 target guardrails enforce current node identity" do
+    config = enabled_config!()
+    target = beam_target("orchard_node_agent@10.0.0.42")
+
+    assert :ok = BeamConfig.validate_target(config, target, current_node: @controller_node)
+
+    assert {:error, :beam_node_identity_mismatch} =
+             BeamConfig.validate_target(config, target,
+               current_node: :"other_controller@10.0.0.5"
+             )
+  end
+
+  test "SPEC.md §7.5 target guardrails enforce admitted service membership" do
+    config = enabled_config!()
+    target = beam_target("external_provider@10.0.0.42")
+
+    assert {:error, :beam_target_service_not_admitted} =
+             BeamConfig.validate_target(config, target, current_node: @controller_node)
+  end
+
+  test "SPEC.md §7.5 target guardrails enforce allowed CIDR membership" do
+    config = enabled_config!()
+    target = beam_target("orchard_node_agent@10.1.0.42")
+
+    assert {:error, :beam_target_outside_allowed_cidrs} =
+             BeamConfig.validate_target(config, target, current_node: @controller_node)
+  end
+
+  defp enabled_config! do
+    {:ok, config} =
+      BeamConfig.validate_enabled(
+        [
+          enabled: true,
+          node_name: Atom.to_string(@controller_node),
+          cookie_file: "/Library/Application Support/Orchard/secrets/beam.cookie",
+          admitted_services: ["orchard_node_agent"],
+          allowed_cidrs: ["10.0.0.0/24"],
+          listen_host: "10.0.0.5"
+        ],
+        :prod
+      )
+
+    config
+  end
+
+  defp beam_target(address) do
+    Target.normalize(%{
+      transport: :beam,
+      node_id: @node_id,
+      address: address
+    })
   end
 end

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs
@@ -4,7 +4,7 @@ defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityClientTest do
   alias Orchard.RuntimeEndpoint.{GrpcCompatibilityClient, Target}
 
   test "connect rejects unsupported runtime endpoint target transports" do
-    target = Target.beam("node-1", address: :node_one)
+    target = Target.beam("550e8400-e29b-41d4-a716-446655440000", address: :node_one)
 
     assert {:error, {:unsupported_transport, :beam}} = GrpcCompatibilityClient.connect(target)
   end

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs
@@ -4,7 +4,7 @@ defmodule Orchard.RuntimeEndpoint.GrpcCompatibilityClientTest do
   alias Orchard.RuntimeEndpoint.{GrpcCompatibilityClient, Target}
 
   test "connect rejects unsupported runtime endpoint target transports" do
-    target = Target.beam("550e8400-e29b-41d4-a716-446655440000", address: :node_one)
+    target = Target.beam("550e8400-e29b-41d4-a716-446655440000", address: :node_one@localhost)
 
     assert {:error, {:unsupported_transport, :beam}} = GrpcCompatibilityClient.connect(target)
   end

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -884,9 +884,9 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.selected_tier == "loaded"
     end
 
-    test "SPEC.md §7.5 rejects configured BEAM observations with mismatched metadata identity" do
+    test "SPEC.md §7.5 rejects configured BEAM observations before persisting mismatched metadata identity" do
       configured_node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
-      reported_node = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+      reported_node_id = Ecto.UUID.generate()
       endpoint_target = Target.beam(configured_node.id, address: :orchard_node_agent@localhost)
       model_ref = Orchard.RuntimeEndpoint.ModelRef.new!("test-model", "v1")
 
@@ -898,11 +898,11 @@ defmodule Orchard.Scheduler.MultiNodeTest do
           aggregate_active_request_count: 0,
           aggregate_max_concurrency: 2,
           metadata: %{
-            node_id: reported_node.id,
-            display_name: reported_node.display_name,
-            hostname: reported_node.hostname,
-            listen_host: reported_node.advertise_addr,
-            listen_port: reported_node.rpc_port
+            node_id: reported_node_id,
+            display_name: "reported-beam-mismatch",
+            hostname: "reported-beam-mismatch.local",
+            listen_host: "10.0.0.2",
+            listen_port: 50_062
           },
           health: %{ready: true},
           placements: [
@@ -927,6 +927,8 @@ defmodule Orchard.Scheduler.MultiNodeTest do
                MultiNode.schedule(canonical_request("test-model", "v1"),
                  status_client: StubClient
                )
+
+      assert Repo.get(Node, reported_node_id) == nil
     end
 
     test "address-only BEAM schedules carry observed node identity for failure cleanup" do

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -884,6 +884,51 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.selected_tier == "loaded"
     end
 
+    test "SPEC.md §7.5 rejects configured BEAM observations with mismatched metadata identity" do
+      configured_node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      reported_node = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+      endpoint_target = Target.beam(configured_node.id, address: :orchard_node_agent@localhost)
+      model_ref = Orchard.RuntimeEndpoint.ModelRef.new!("test-model", "v1")
+
+      observation =
+        Observation.new(%{
+          endpoint_id: endpoint_target.id,
+          target: endpoint_target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 2,
+          metadata: %{
+            node_id: reported_node.id,
+            display_name: reported_node.display_name,
+            hostname: reported_node.hostname,
+            listen_host: reported_node.advertise_addr,
+            listen_port: reported_node.rpc_port
+          },
+          health: %{ready: true},
+          placements: [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity:
+                PlacementCapacity.new(%{
+                  model_ref: model_ref,
+                  active_request_count: 0,
+                  max_concurrency: 2,
+                  source: :beam_runtime_endpoint_status
+                })
+            })
+          ]
+        })
+
+      put_inference(runtime_endpoint_targets: [endpoint_target], runtime_client_targets: [])
+      stub_probe(endpoint_target, observation)
+
+      assert {:error, :cluster_busy} =
+               MultiNode.schedule(canonical_request("test-model", "v1"),
+                 status_client: StubClient
+               )
+    end
+
     test "address-only BEAM schedules carry observed node identity for failure cleanup" do
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
 

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -10,7 +10,15 @@ defmodule Orchard.Scheduler.MultiNodeTest do
   alias Orchard.Inference.CacheAffinity
   alias Orchard.Inference.QueueManager
   alias Orchard.Nodes.Node
-  alias Orchard.RuntimeEndpoint.{GrpcCompatibilityMapper, Target}
+
+  alias Orchard.RuntimeEndpoint.{
+    GrpcCompatibilityMapper,
+    Observation,
+    Placement,
+    PlacementCapacity,
+    Target
+  }
+
   alias Orchard.Scheduler.MultiNode
 
   # -- Stub Status Client --
@@ -60,11 +68,15 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       end
     end
 
-    defp target_key(%Orchard.RuntimeEndpoint.Target{transport: :grpc_compat, address: address}) do
+    def target_key(%Orchard.RuntimeEndpoint.Target{transport: :grpc_compat, address: address}) do
       target_key(address)
     end
 
-    defp target_key(target) do
+    def target_key(%Orchard.RuntimeEndpoint.Target{transport: :beam, id: id}) do
+      {:beam, id}
+    end
+
+    def target_key(target) do
       {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
     end
   end
@@ -234,6 +246,10 @@ defmodule Orchard.Scheduler.MultiNodeTest do
 
   defp stub_probe(host, port, response) do
     Process.put({:stub_status, {host, port}}, response)
+  end
+
+  defp stub_probe(%Target{} = target, response) do
+    Process.put({:stub_status, StubClient.target_key(target)}, response)
   end
 
   defp stub_connect_failure(host, port, reason) do
@@ -792,6 +808,56 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.node_id == node_a.id
       assert schedule.runtime_endpoint_target == endpoint_target
       assert schedule.runtime_client_target == [host: "10.0.0.1", port: 50_061]
+      assert schedule.selected_tier == "loaded"
+    end
+
+    test "consumes BEAM runtime endpoint observations without legacy dispatch target" do
+      node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      endpoint_target = Target.beam(node.id, address: :orchard_node_agent@localhost)
+      model_ref = Orchard.RuntimeEndpoint.ModelRef.new!("test-model", "v1")
+
+      observation =
+        Observation.new(%{
+          endpoint_id: endpoint_target.id,
+          target: endpoint_target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 2,
+          metadata: %{
+            node_id: node.id,
+            display_name: node.display_name,
+            hostname: node.hostname,
+            listen_host: node.advertise_addr,
+            listen_port: node.rpc_port
+          },
+          health: %{ready: true},
+          placements: [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity:
+                PlacementCapacity.new(%{
+                  model_ref: model_ref,
+                  active_request_count: 0,
+                  max_concurrency: 2,
+                  source: :beam_runtime_endpoint_status
+                })
+            })
+          ]
+        })
+
+      put_inference(runtime_endpoint_targets: [endpoint_target], runtime_client_targets: [])
+      stub_probe(endpoint_target, observation)
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request("test-model", "v1"),
+                 status_client: StubClient
+               )
+
+      assert schedule.strategy == :multi_node
+      assert schedule.node_id == node.id
+      assert schedule.runtime_endpoint_target == endpoint_target
+      refute Map.has_key?(schedule, :runtime_client_target)
       assert schedule.selected_tier == "loaded"
     end
 

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -931,6 +931,100 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert Repo.get(Node, reported_node_id) == nil
     end
 
+    test "SPEC.md §5.5 BEAM identity rejection clears stale cold queue capacity" do
+      QueueManager.reset()
+      stale_hb = DateTime.add(DateTime.utc_now(), -120_000, :millisecond)
+      observed_at = DateTime.utc_now()
+      model_id = "beam-identity-clear-model"
+
+      configured_node =
+        insert_node!(%{
+          advertise_addr: "10.0.0.1",
+          rpc_port: 50_061,
+          health: :healthy,
+          last_heartbeat_at: stale_hb
+        })
+
+      reported_node_id = Ecto.UUID.generate()
+      endpoint_target = Target.beam(configured_node.id, address: :orchard_node_agent@localhost)
+      model_ref = Orchard.RuntimeEndpoint.ModelRef.new!(model_id, "v1")
+
+      assert {:queued, first_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-beam-identity-clear-a", model_id),
+                 config: queue_config(capacity: 0)
+               )
+
+      assert {:queued, second_ticket} =
+               QueueManager.acquire(
+                 queue_admission_request("req-beam-identity-clear-b", model_id),
+                 config: queue_config(capacity: 0)
+               )
+
+      first_awaiter = start_holding_awaiter(first_ticket, :first_beam_identity_clear_result)
+      second_awaiter = Task.async(fn -> QueueManager.await(second_ticket) end)
+
+      assert :ok =
+               QueueManager.refresh_capacity(model_id, "v1", 1,
+                 source: {:node, configured_node.id, :cold}
+               )
+
+      assert_receive {:first_beam_identity_clear_result, {:ok, first_grant}}, 2_000
+      refute Task.yield(second_awaiter, 50)
+
+      observation =
+        Observation.new(%{
+          endpoint_id: endpoint_target.id,
+          target: endpoint_target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 2,
+          metadata: %{
+            node_id: reported_node_id,
+            display_name: "reported-beam-mismatch",
+            hostname: "reported-beam-mismatch.local",
+            listen_host: "10.0.0.2",
+            listen_port: 50_062
+          },
+          health: %{ready: true},
+          placements: [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity:
+                PlacementCapacity.new(%{
+                  model_ref: model_ref,
+                  active_request_count: 0,
+                  max_concurrency: 2,
+                  source: :beam_runtime_endpoint_status
+                })
+            })
+          ]
+        })
+
+      put_inference(runtime_endpoint_targets: [endpoint_target], runtime_client_targets: [])
+      stub_probe(endpoint_target, observation)
+
+      assert {:error, :cluster_busy} =
+               MultiNode.schedule(canonical_request(model_id),
+                 status_client: StubClient,
+                 observed_at: observed_at
+               )
+
+      assert Repo.get(Node, reported_node_id) == nil
+      assert QueueManager.active_capacity_source_lanes({:node, configured_node.id, :cold}) == []
+
+      assert :ok = QueueManager.release(first_grant)
+      refute Task.yield(second_awaiter, 100)
+
+      assert :ok = QueueManager.refresh_capacity(model_id, "v1", 1, source: {:test, :restore})
+      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert second_grant.queue_key == "#{model_id}@v1"
+
+      assert :ok = QueueManager.release(second_grant)
+      send(first_awaiter, :stop)
+    end
+
     test "address-only BEAM schedules carry observed node identity for failure cleanup" do
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
 

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -884,6 +884,68 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.selected_tier == "loaded"
     end
 
+    test "address-only BEAM schedules carry observed node identity for failure cleanup" do
+      node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+
+      endpoint_target =
+        Target.normalize(
+          transport: :beam,
+          id: "source-dev-node-agent",
+          address: :orchard_node_agent@localhost
+        )
+
+      model_ref = Orchard.RuntimeEndpoint.ModelRef.new!("test-model", "v1")
+
+      observation =
+        Observation.new(%{
+          endpoint_id: endpoint_target.id,
+          target: endpoint_target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 2,
+          metadata: %{
+            node_id: node.id,
+            display_name: node.display_name,
+            hostname: node.hostname,
+            listen_host: node.advertise_addr,
+            listen_port: node.rpc_port
+          },
+          health: %{ready: true},
+          placements: [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity:
+                PlacementCapacity.new(%{
+                  model_ref: model_ref,
+                  active_request_count: 0,
+                  max_concurrency: 2,
+                  source: :beam_runtime_endpoint_status
+                })
+            })
+          ]
+        })
+
+      put_inference(runtime_endpoint_targets: [endpoint_target], runtime_client_targets: [])
+      stub_probe(endpoint_target, observation)
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request("test-model", "v1"),
+                 status_client: StubClient
+               )
+
+      node_id = node.id
+
+      assert schedule.node_id == node.id
+
+      assert %Target{
+               id: "source-dev-node-agent",
+               transport: :beam,
+               address: :orchard_node_agent@localhost,
+               node_id: ^node_id
+             } = schedule.runtime_endpoint_target
+    end
+
     test "hosted tool capability and readiness data do not change inference ranking" do
       node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
       node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -584,6 +584,29 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert status_calls() == [{{"127.0.0.1", 1}, [timeout: 17]}]
     end
 
+    test "single BEAM target fallback emits a runtime endpoint schedule" do
+      node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      target = Target.beam(node.id, address: :orchard_node_agent@localhost)
+
+      put_inference(
+        runtime_endpoint_targets: [target],
+        runtime_client_targets: [],
+        runtime_client_target: [host: "127.0.0.1", port: 50_071]
+      )
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(),
+                 status_client: StubClient,
+                 status_timeout_ms: 17
+               )
+
+      assert schedule.strategy == :single_node
+      assert schedule.runtime_endpoint_target == target
+      refute Map.has_key?(schedule, :runtime_client_target)
+      assert schedule.node_id == node.id
+      assert status_calls() == [{{:beam, target.id}, [timeout: 17]}]
+    end
+
     test "returns cluster_busy for one live full target instead of bypassing capacity checks" do
       put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})

--- a/apps/orchard_node_agent/README.md
+++ b/apps/orchard_node_agent/README.md
@@ -1,7 +1,7 @@
 # orchard_node_agent
 
 Node-agent release for Orchard's worker-node boundary.
-It exposes the current gRPC Runtime Endpoint compatibility service, reports node/runtime status, manages model acquisition and cache state, and supervises local worker subprocesses.
+It exposes the current gRPC Runtime Endpoint compatibility service and default-off BEAM Runtime Endpoint facade, reports node/runtime status, manages model acquisition and cache state, and supervises local worker subprocesses.
 
 This README is orientation only. Normative behavior lives in
 [`../../SPEC.md`](../../SPEC.md); repo/runtime boundaries are mapped in
@@ -9,7 +9,8 @@ This README is orientation only. Normative behavior lives in
 
 ## Owns
 
-- Node-local Runtime Endpoint compatibility behavior used by the controller.
+- Node-local Runtime Endpoint behavior used by the controller through gRPC
+  compatibility and first-party BEAM adapters.
 - Model acquisition/cache/load coordination on a node.
 - Worker process supervision and node-local diagnostics/status reporting.
 - Runtime aggregate node and placement capacity telemetry.

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint.ex
@@ -48,8 +48,10 @@ defmodule Orchard.Node.RuntimeEndpoint do
 
   @spec cancel_inference(Operation.CancelRequest.t(), keyword()) :: :ok | {:error, term()}
   def cancel_inference(%Operation.CancelRequest{} = request, _opts \\ []) do
-    _ack = Status.cancel_request(request.request_id, request.controller_session_id)
-    :ok
+    request.request_id
+    |> Status.cancel_request(request.controller_session_id)
+    |> RuntimeEndpointMapper.ack_from_response()
+    |> cancel_result()
   end
 
   @spec score_prefix_cache(Operation.PrefixCacheScoreRequest.t(), keyword()) ::
@@ -127,6 +129,11 @@ defmodule Orchard.Node.RuntimeEndpoint do
   defp accepted_event do
     InferenceEvent.accepted(System.system_time(:millisecond))
   end
+
+  defp cancel_result(%Operation.Ack{ok: true}), do: :ok
+
+  defp cancel_result(%Operation.Ack{ok: false, message: message}),
+    do: {:error, {:cancel_rejected, message}}
 
   defp send_failed(owner, stream_ref, request_id, reason) do
     code = RuntimeServer.safe_failure_reason_code(reason)

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint.ex
@@ -1,0 +1,151 @@
+defmodule Orchard.Node.RuntimeEndpoint do
+  @moduledoc """
+  First-party BEAM Runtime Endpoint facade served by the Node Agent.
+  """
+
+  alias Orchard.InferenceEvent
+  alias Orchard.Node.{RuntimeEndpointMapper, RuntimeServer, Status}
+  alias Orchard.RuntimeEndpoint.{Operation, Target}
+
+  @task_supervisor Orchard.Node.RuntimeEndpointTaskSupervisor
+
+  @spec status(Target.t() | nil, keyword()) :: {:ok, Orchard.RuntimeEndpoint.Observation.t()}
+  def status(target \\ nil, _opts \\ []) do
+    {:ok, RuntimeEndpointMapper.observation_from_status(target, Status.current())}
+  end
+
+  @spec ensure_model_loaded(Operation.EnsureModelLoadedRequest.t(), keyword()) ::
+          {:ok, Operation.EnsureModelLoadedResult.t()}
+  def ensure_model_loaded(%Operation.EnsureModelLoadedRequest{} = request, _opts \\ []) do
+    response =
+      request
+      |> RuntimeEndpointMapper.ensure_model_loaded_request_to_proto()
+      |> Status.ensure_model_loaded()
+
+    {:ok, RuntimeEndpointMapper.ensure_model_loaded_result_from_response(response)}
+  end
+
+  @spec unload_model(Operation.UnloadModelRequest.t(), keyword()) :: {:ok, Operation.Ack.t()}
+  def unload_model(%Operation.UnloadModelRequest{} = request, _opts \\ []) do
+    response =
+      request
+      |> RuntimeEndpointMapper.unload_model_request_to_proto()
+      |> Status.unload_model()
+
+    {:ok, RuntimeEndpointMapper.ack_from_response(response)}
+  end
+
+  @spec execute_inference(Operation.ExecuteRequest.t(), pid(), reference(), keyword()) ::
+          {:ok, pid()} | {:error, term()}
+  def execute_inference(%Operation.ExecuteRequest{} = request, owner, stream_ref, opts \\ [])
+      when is_pid(owner) and is_reference(stream_ref) do
+    proto_request = RuntimeEndpointMapper.execute_request_to_proto(request)
+
+    Task.Supervisor.start_child(task_supervisor(opts), fn ->
+      execute_stream(proto_request, owner, stream_ref)
+    end)
+  end
+
+  @spec cancel_inference(Operation.CancelRequest.t(), keyword()) :: :ok | {:error, term()}
+  def cancel_inference(%Operation.CancelRequest{} = request, _opts \\ []) do
+    _ack = Status.cancel_request(request.request_id, request.controller_session_id)
+    :ok
+  end
+
+  @spec score_prefix_cache(Operation.PrefixCacheScoreRequest.t(), keyword()) ::
+          {:ok, Operation.PrefixCacheScoreResult.t()}
+  def score_prefix_cache(%Operation.PrefixCacheScoreRequest{} = request, _opts \\ []) do
+    response =
+      request
+      |> RuntimeEndpointMapper.prefix_cache_score_request_to_proto()
+      |> Status.score_prefix_cache()
+
+    {:ok, RuntimeEndpointMapper.prefix_cache_score_result_from_response(response)}
+  end
+
+  defp execute_stream(request, owner, stream_ref) do
+    owner_ref = Process.monitor(owner)
+
+    try do
+      do_execute_stream(request, owner, owner_ref, stream_ref)
+    rescue
+      _error ->
+        send(
+          owner,
+          {:runtime_endpoint_done, stream_ref, {:error, :runtime_endpoint_stream_failed}}
+        )
+    catch
+      :exit, _reason ->
+        send(
+          owner,
+          {:runtime_endpoint_done, stream_ref, {:error, :runtime_endpoint_stream_failed}}
+        )
+    after
+      Process.demonitor(owner_ref, [:flush])
+    end
+  end
+
+  defp do_execute_stream(request, owner, owner_ref, stream_ref) do
+    case Status.prepare_request(request, self()) do
+      :ok ->
+        send(owner, {:runtime_endpoint_event, stream_ref, request.request_id, accepted_event()})
+        start_prepared_request(request, owner, owner_ref, stream_ref)
+
+      {:error, reason} ->
+        send_failed(owner, stream_ref, request.request_id, reason)
+        send(owner, {:runtime_endpoint_done, stream_ref, :ok})
+    end
+  end
+
+  defp start_prepared_request(request, owner, owner_ref, stream_ref) do
+    case Status.start_request(request) do
+      :ok ->
+        forward_runtime_events(owner, owner_ref, stream_ref, request.request_id)
+
+      {:error, reason} ->
+        send_failed(owner, stream_ref, request.request_id, reason)
+        send(owner, {:runtime_endpoint_done, stream_ref, :ok})
+    end
+  end
+
+  defp forward_runtime_events(owner, owner_ref, stream_ref, request_id) do
+    receive do
+      {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+        :ok
+
+      {:node_runtime_event, ^request_id, %InferenceEvent{} = event} ->
+        send(owner, {:runtime_endpoint_event, stream_ref, request_id, event})
+
+        if InferenceEvent.terminal?(event) do
+          send(owner, {:runtime_endpoint_done, stream_ref, :ok})
+        else
+          forward_runtime_events(owner, owner_ref, stream_ref, request_id)
+        end
+    end
+  end
+
+  defp accepted_event do
+    InferenceEvent.accepted(System.system_time(:millisecond))
+  end
+
+  defp send_failed(owner, stream_ref, request_id, reason) do
+    code = RuntimeServer.safe_failure_reason_code(reason)
+    message = failure_message(code)
+
+    send(
+      owner,
+      {:runtime_endpoint_event, stream_ref, request_id,
+       InferenceEvent.failed(code, message, false)}
+    )
+  end
+
+  defp failure_message("model_busy"), do: "model already has an active request"
+  defp failure_message("model_not_loaded"), do: "model is not loaded"
+  defp failure_message("request_already_active"), do: "request is already active"
+  defp failure_message("request_not_prepared"), do: "request is not prepared"
+  defp failure_message("worker_unavailable"), do: "worker process became unavailable"
+  defp failure_message("license_invalid"), do: "node-agent license invalid"
+  defp failure_message(_code), do: "runtime request failed"
+
+  defp task_supervisor(opts), do: Keyword.get(opts, :task_supervisor, @task_supervisor)
+end

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint.ex
@@ -1,6 +1,10 @@
 defmodule Orchard.Node.RuntimeEndpoint do
   @moduledoc """
   First-party BEAM Runtime Endpoint facade served by the Node Agent.
+
+  The facade maps transport-independent Runtime Endpoint operations onto the
+  existing node-agent status, model lifecycle, request execution, cancellation,
+  and prefix-cache scoring paths.
   """
 
   alias Orchard.InferenceEvent

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint_mapper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_endpoint_mapper.ex
@@ -1,0 +1,303 @@
+defmodule Orchard.Node.RuntimeEndpointMapper do
+  @moduledoc false
+
+  alias Orchard.Cluster.V1.{
+    Ack,
+    EnsureModelLoadedRequest,
+    EnsureModelLoadedResponse,
+    ExecuteInferenceRequest,
+    GenerationParams,
+    RuntimeHealth,
+    RuntimeNodeMetadata,
+    ScorePrefixCacheRequest,
+    ScorePrefixCacheResponse,
+    StatusResponse,
+    UnloadModelRequest
+  }
+
+  alias Orchard.RuntimeEndpoint.{
+    ModelRef,
+    Observation,
+    Operation,
+    Placement,
+    PlacementCapacity,
+    Target
+  }
+
+  @spec observation_from_status(Target.t() | nil, StatusResponse.t()) :: Observation.t()
+  def observation_from_status(target, %StatusResponse{} = response) do
+    metadata = metadata_from_proto(response.node_metadata)
+
+    Observation.new(%{
+      endpoint_id: endpoint_id(target, metadata),
+      target: target,
+      observed_at: DateTime.utc_now(),
+      availability: availability_from_response(response.runtime_health),
+      worker_state: normalize_worker_state(response.worker_state),
+      aggregate_active_request_count: non_negative_integer(response.active_request_count),
+      aggregate_max_concurrency: response.max_concurrency,
+      metadata: metadata,
+      health: health_from_response(response.runtime_health),
+      placements: placements_from_status(response),
+      hosted_tool_capabilities: response.hosted_tool_capabilities,
+      hosted_tool_readiness: response.hosted_tool_readiness,
+      runtime_memory_budgets: response.runtime_memory_budgets,
+      runtime_prefix_cache_statuses: response.runtime_prefix_cache_statuses,
+      supports_prompt_token_ids: response.supports_prompt_token_ids
+    })
+  end
+
+  @spec ensure_model_loaded_request_to_proto(Operation.EnsureModelLoadedRequest.t()) ::
+          EnsureModelLoadedRequest.t()
+  def ensure_model_loaded_request_to_proto(%Operation.EnsureModelLoadedRequest{} = request) do
+    %EnsureModelLoadedRequest{
+      node_id: request.node_id || "",
+      model_id: request.model_ref.model_id,
+      version: request.model_ref.version,
+      artifact_sha256: request.artifact_sha256 || "",
+      preload: request.preload,
+      deadline_unix_ms: request.deadline_unix_ms || 0,
+      artifact_source_uri: request.artifact_source_uri || ""
+    }
+  end
+
+  @spec ensure_model_loaded_result_from_response(EnsureModelLoadedResponse.t()) ::
+          Operation.EnsureModelLoadedResult.t()
+  def ensure_model_loaded_result_from_response(%EnsureModelLoadedResponse{} = response) do
+    %Operation.EnsureModelLoadedResult{
+      already_loaded: response.already_loaded,
+      placement_state: normalize_placement_state(response.placement_state),
+      failure_category: normalize_failure_category(response.failure_category),
+      failure_code: empty_to_nil(response.failure_code),
+      failure_message: empty_to_nil(response.failure_message),
+      worker_supports_prompt_token_ids: response.worker_supports_prompt_token_ids
+    }
+  end
+
+  @spec unload_model_request_to_proto(Operation.UnloadModelRequest.t()) :: UnloadModelRequest.t()
+  def unload_model_request_to_proto(%Operation.UnloadModelRequest{} = request) do
+    %UnloadModelRequest{
+      model_id: request.model_ref.model_id,
+      version: request.model_ref.version,
+      force: request.force,
+      evict: request.evict
+    }
+  end
+
+  @spec ack_from_response(Ack.t()) :: Operation.Ack.t()
+  def ack_from_response(%Ack{} = response) do
+    %Operation.Ack{ok: response.ok, message: response.message || ""}
+  end
+
+  @spec execute_request_to_proto(Operation.ExecuteRequest.t()) :: ExecuteInferenceRequest.t()
+  def execute_request_to_proto(%Operation.ExecuteRequest{} = request) do
+    %ExecuteInferenceRequest{
+      request_id: request.request_id,
+      controller_session_id: request.controller_session_id,
+      model_id: request.model_ref.model_id,
+      version: request.model_ref.version,
+      rendered_prompt_utf8: request.rendered_prompt_utf8,
+      input_tokens: request.input_tokens,
+      params: generation_params_to_proto(request.params),
+      deadline_unix_ms: request.deadline_unix_ms || 0,
+      metadata_json: request.metadata_json || "{}",
+      cache_affinity_fingerprint: request.cache_affinity_fingerprint || "",
+      prompt_token_ids: request.prompt_token_ids || []
+    }
+  end
+
+  @spec prefix_cache_score_request_to_proto(Operation.PrefixCacheScoreRequest.t()) ::
+          ScorePrefixCacheRequest.t()
+  def prefix_cache_score_request_to_proto(%Operation.PrefixCacheScoreRequest{} = request) do
+    %ScorePrefixCacheRequest{
+      request_id: request.request_id,
+      controller_session_id: request.controller_session_id,
+      model_ref: model_ref_to_proto(request.model_ref),
+      cache_affinity_fingerprint: request.cache_affinity_fingerprint,
+      deadline_unix_ms: request.deadline_unix_ms || 0
+    }
+  end
+
+  @spec prefix_cache_score_result_from_response(ScorePrefixCacheResponse.t()) ::
+          Operation.PrefixCacheScoreResult.t()
+  def prefix_cache_score_result_from_response(%ScorePrefixCacheResponse{} = response) do
+    %Operation.PrefixCacheScoreResult{
+      status_code: response.status_code || "unknown",
+      status_message: response.status_message || "",
+      resident_fingerprint_match: response.resident_fingerprint_match,
+      score_tier: response.score_tier || "unknown",
+      session_started_unix_ms: non_negative_integer(response.session_started_unix_ms)
+    }
+  end
+
+  defp model_ref_to_proto(%ModelRef{} = model_ref) do
+    %Orchard.Cluster.V1.ModelRef{model_id: model_ref.model_id, version: model_ref.version}
+  end
+
+  defp model_ref_from_proto(nil), do: nil
+
+  defp model_ref_from_proto(%{} = model_ref) do
+    case ModelRef.new(model_ref) do
+      {:ok, normalized} -> normalized
+      {:error, :invalid_model_ref} -> nil
+    end
+  end
+
+  defp metadata_from_proto(%RuntimeNodeMetadata{} = metadata) do
+    %{
+      node_id: empty_to_nil(metadata.node_id),
+      display_name: empty_to_nil(metadata.display_name),
+      hostname: empty_to_nil(metadata.hostname),
+      agent_version: empty_to_nil(metadata.agent_version),
+      listen_host: empty_to_nil(metadata.listen_host),
+      listen_port: non_negative_integer(metadata.listen_port),
+      worker_backend: empty_to_nil(metadata.worker_backend)
+    }
+    |> compact_nil_values()
+  end
+
+  defp metadata_from_proto(nil), do: %{}
+
+  defp availability_from_response(%RuntimeHealth{ready: true}), do: :available
+  defp availability_from_response(%RuntimeHealth{ready: false}), do: :degraded
+  defp availability_from_response(nil), do: :available
+  defp availability_from_response(_health), do: :unknown
+
+  defp health_from_response(%RuntimeHealth{} = health) do
+    %{
+      ready: health.ready,
+      health_code: empty_to_nil(health.health_code),
+      health_message: empty_to_nil(health.health_message),
+      affected_model: model_ref_from_proto(health.affected_model)
+    }
+    |> compact_nil_values()
+  end
+
+  defp health_from_response(nil), do: %{}
+
+  defp placements_from_status(%StatusResponse{} = response) do
+    Enum.flat_map(response.loaded_models, fn proto_ref ->
+      case model_ref_from_proto(proto_ref) do
+        %ModelRef{} = model_ref ->
+          [
+            Placement.new(%{
+              model_ref: model_ref,
+              state: :loaded,
+              capacity: placement_capacity(model_ref, response.runtime_model_placements)
+            })
+          ]
+
+        nil ->
+          []
+      end
+    end)
+  end
+
+  defp placement_capacity(%ModelRef{} = model_ref, placements) do
+    case Enum.filter(placements, &ModelRef.equal?(&1.model_ref, model_ref)) do
+      [placement] ->
+        PlacementCapacity.new(%{
+          model_ref: model_ref,
+          active_request_count: placement.active_request_count,
+          max_concurrency: placement.max_concurrency,
+          source: :beam_runtime_endpoint_status
+        })
+
+      [] ->
+        PlacementCapacity.unknown(model_ref, :beam_runtime_endpoint_status)
+
+      _duplicates ->
+        PlacementCapacity.new(%{
+          model_ref: model_ref,
+          active_request_count: :duplicate,
+          max_concurrency: :duplicate,
+          source: :duplicate_beam_runtime_endpoint_status
+        })
+    end
+  end
+
+  defp normalize_worker_state(:WORKER_STATE_STARTING), do: :starting
+  defp normalize_worker_state(:WORKER_STATE_IDLE), do: :idle
+  defp normalize_worker_state(:WORKER_STATE_BUSY), do: :busy
+  defp normalize_worker_state(:WORKER_STATE_STOPPING), do: :stopping
+  defp normalize_worker_state(:WORKER_STATE_FAILED), do: :failed
+  defp normalize_worker_state(:WORKER_STATE_STOPPED), do: :stopped
+  defp normalize_worker_state(_state), do: :unknown
+
+  defp normalize_placement_state(:PLACEMENT_STATE_ABSENT), do: :absent
+  defp normalize_placement_state(:PLACEMENT_STATE_DOWNLOADING), do: :downloading
+  defp normalize_placement_state(:PLACEMENT_STATE_DOWNLOADED), do: :downloaded
+  defp normalize_placement_state(:PLACEMENT_STATE_VERIFYING), do: :verifying
+  defp normalize_placement_state(:PLACEMENT_STATE_CACHED), do: :cached
+  defp normalize_placement_state(:PLACEMENT_STATE_LOADING), do: :loading
+  defp normalize_placement_state(:PLACEMENT_STATE_LOADED), do: :loaded
+  defp normalize_placement_state(:PLACEMENT_STATE_UNLOADING), do: :unloading
+  defp normalize_placement_state(:PLACEMENT_STATE_EVICTED), do: :evicted
+  defp normalize_placement_state(:PLACEMENT_STATE_FAILED), do: :failed
+  defp normalize_placement_state(_state), do: :unknown
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_MODEL_INVALID), do: :model_invalid
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_ACQUISITION_FAILED),
+    do: :acquisition_failed
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_RUNTIME_UNAVAILABLE),
+    do: :runtime_unavailable
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_TIMEOUT), do: :timeout
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_RESOURCE_EXHAUSTED),
+    do: :resource_exhausted
+
+  defp normalize_failure_category(:MODEL_LOAD_FAILURE_CATEGORY_INTERNAL), do: :internal
+  defp normalize_failure_category(_category), do: nil
+
+  defp generation_params_to_proto(%GenerationParams{} = params), do: params
+
+  defp generation_params_to_proto(%{} = params) do
+    %GenerationParams{
+      max_output_tokens: non_negative_integer(value(params, :max_output_tokens)),
+      temperature: float_value(value(params, :temperature)),
+      top_p: float_value(value(params, :top_p)),
+      stop_sequences: list_value(params, :stop_sequences),
+      tools_json: value(params, :tools_json) || "",
+      tool_choice_json: value(params, :tool_choice_json) || ""
+    }
+  end
+
+  defp generation_params_to_proto(_params), do: %GenerationParams{}
+
+  defp endpoint_id(%Target{id: id}, _metadata) when is_binary(id) and id != "", do: id
+
+  defp endpoint_id(_target, %{node_id: node_id}) when is_binary(node_id) and node_id != "",
+    do: "node:#{node_id}"
+
+  defp endpoint_id(_target, _metadata), do: nil
+
+  defp value(%{} = attrs, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.fetch!(attrs, key)
+      Map.has_key?(attrs, string_key) -> Map.fetch!(attrs, string_key)
+      true -> nil
+    end
+  end
+
+  defp list_value(attrs, key) do
+    case value(attrs, key) do
+      values when is_list(values) -> values
+      nil -> []
+      value -> [value]
+    end
+  end
+
+  defp empty_to_nil(value) when value in [nil, ""], do: nil
+  defp empty_to_nil(value), do: value
+  defp non_negative_integer(value) when is_integer(value) and value >= 0, do: value
+  defp non_negative_integer(_value), do: 0
+  defp float_value(value) when is_float(value), do: value
+  defp float_value(value) when is_integer(value), do: value / 1
+  defp float_value(_value), do: 0.0
+  defp compact_nil_values(map), do: Map.reject(map, fn {_key, value} -> is_nil(value) end)
+end

--- a/apps/orchard_node_agent/lib/orchard/node/supervisor.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/supervisor.ex
@@ -24,6 +24,7 @@ defmodule Orchard.Node.Supervisor do
       ModelManager,
       {Task.Supervisor, name: Orchard.Node.ModelLoadTaskSupervisor},
       WorkerSupervisor,
+      {Task.Supervisor, name: Orchard.Node.RuntimeEndpointTaskSupervisor},
       Supervisor.child_spec({GRPC.Server.Supervisor, grpc_server_opts()}, id: @grpc_server_id)
     ]
 

--- a/apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs
@@ -14,7 +14,7 @@ defmodule Orchard.Node.RuntimeEndpointMapperTest do
   alias Orchard.RuntimeEndpoint.{ModelRef, Observation, Operation, PlacementCapacity, Target}
 
   test "maps node-agent status to Runtime Endpoint observation with placement capacity" do
-    target = Target.beam("node-1", address: :node_one@localhost)
+    target = Target.beam("550e8400-e29b-41d4-a716-446655440000", address: :node_one@localhost)
     model_ref = %RPCModelRef{model_id: "mlx-community/phi-3", version: "main"}
 
     response = %StatusResponse{

--- a/apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs
@@ -1,0 +1,67 @@
+defmodule Orchard.Node.RuntimeEndpointMapperTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Cluster.V1.{
+    RuntimeHealth,
+    RuntimeModelPlacement,
+    RuntimeNodeMetadata,
+    ScorePrefixCacheResponse,
+    StatusResponse
+  }
+
+  alias Orchard.Cluster.V1.ModelRef, as: RPCModelRef
+  alias Orchard.Node.RuntimeEndpointMapper
+  alias Orchard.RuntimeEndpoint.{ModelRef, Observation, Operation, PlacementCapacity, Target}
+
+  test "maps node-agent status to Runtime Endpoint observation with placement capacity" do
+    target = Target.beam("node-1", address: :node_one@localhost)
+    model_ref = %RPCModelRef{model_id: "mlx-community/phi-3", version: "main"}
+
+    response = %StatusResponse{
+      worker_state: :WORKER_STATE_IDLE,
+      loaded_models: [model_ref],
+      active_request_count: 1,
+      max_concurrency: 2,
+      node_metadata: %RuntimeNodeMetadata{node_id: "node-1", hostname: "worker.local"},
+      runtime_health: %RuntimeHealth{ready: true, health_code: "ok"},
+      runtime_model_placements: [
+        %RuntimeModelPlacement{model_ref: model_ref, active_request_count: 1, max_concurrency: 2}
+      ],
+      supports_prompt_token_ids: true
+    }
+
+    observation = RuntimeEndpointMapper.observation_from_status(target, response)
+    runtime_model_ref = ModelRef.new!("mlx-community/phi-3", "main")
+
+    capacity = Observation.placement_capacity_for(observation, runtime_model_ref)
+
+    assert observation.target == target
+    assert observation.availability == :available
+    assert observation.worker_state == :idle
+    assert observation.aggregate_active_request_count == 1
+    assert observation.aggregate_max_concurrency == 2
+    assert observation.metadata.node_id == "node-1"
+    assert observation.supports_prompt_token_ids
+
+    assert %PlacementCapacity{status: :known, active_request_count: 1, max_concurrency: 2} =
+             capacity
+  end
+
+  test "maps prefix-cache score responses to Runtime Endpoint operation results" do
+    response = %ScorePrefixCacheResponse{
+      status_code: "ok",
+      status_message: "resident",
+      resident_fingerprint_match: true,
+      score_tier: "resident",
+      session_started_unix_ms: 123
+    }
+
+    assert %Operation.PrefixCacheScoreResult{
+             status_code: "ok",
+             status_message: "resident",
+             resident_fingerprint_match: true,
+             score_tier: "resident",
+             session_started_unix_ms: 123
+           } = RuntimeEndpointMapper.prefix_cache_score_result_from_response(response)
+  end
+end

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -4881,7 +4881,7 @@ defmodule OrchardNodeAgentTest do
 
   defp runtime_endpoint_observation(%StatusResponse{} = status) do
     Observation.new(%{
-      target: Target.beam(Node.node_id() || "test-node"),
+      target: Target.beam("550e8400-e29b-41d4-a716-446655440000", address: node()),
       aggregate_active_request_count: status.active_request_count,
       worker_state: status.worker_state,
       placements: Enum.map(status.runtime_model_placements, &runtime_endpoint_placement/1)

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -305,6 +305,37 @@ defmodule OrchardNodeAgentTest do
     def finish_generation(adapter_state, _generation_ref, _opts), do: adapter_state
   end
 
+  defmodule FailingCancelAdapter do
+    @behaviour Orchard.Node.RuntimeAdapter
+
+    alias Orchard.Cluster.V1.ExecuteInferenceRequest
+    alias Orchard.Cluster.V1.ModelRef
+
+    @impl true
+    def get_status(adapter_state, opts),
+      do: BlockingRuntimeAdapter.get_status(adapter_state, opts)
+
+    @impl true
+    def load_model(%ModelRef{} = model_ref, opts),
+      do: BlockingRuntimeAdapter.load_model(model_ref, opts)
+
+    @impl true
+    def unload_model(adapter_state, opts),
+      do: BlockingRuntimeAdapter.unload_model(adapter_state, opts)
+
+    @impl true
+    def start_generation(adapter_state, %ExecuteInferenceRequest{} = request, opts),
+      do: BlockingRuntimeAdapter.start_generation(adapter_state, request, opts)
+
+    @impl true
+    def cancel_generation(adapter_state, _generation_ref, _opts),
+      do: {:error, {:simulated_cancel_failure, map_size(adapter_state.generations)}}
+
+    @impl true
+    def finish_generation(adapter_state, generation_ref, opts),
+      do: BlockingRuntimeAdapter.finish_generation(adapter_state, generation_ref, opts)
+  end
+
   defmodule MemoryBudgetRuntimeAdapter do
     @behaviour Orchard.Node.RuntimeAdapter
 
@@ -2865,6 +2896,33 @@ defmodule OrchardNodeAgentTest do
 
       assert_receive {:runtime_endpoint_done, ^stream_ref2, :ok}, 1_000
       wait_until(fn -> NodeStatus.current().active_request_count == 0 end)
+    end)
+  end
+
+  test "BEAM Runtime Endpoint cancel reports rejected acknowledgements", %{bundle: bundle} do
+    with_runtime_adapter(FailingCancelAdapter, fn ->
+      assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+               NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+      request = beam_execute_request("req-beam-cancel-rejected", bundle)
+      stream_ref = make_ref()
+
+      assert {:ok, _pid} = NodeRuntimeEndpoint.execute_inference(request, self(), stream_ref)
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref, "req-beam-cancel-rejected",
+                      %OrchardInferenceEvent{event: %OrchardInferenceEvent.Accepted{}}},
+                     1_000
+
+      cancel_request =
+        Operation.CancelRequest.new!(%{
+          request_id: request.request_id,
+          controller_session_id: request.controller_session_id
+        })
+
+      assert {:error, {:cancel_rejected, message}} =
+               NodeRuntimeEndpoint.cancel_inference(cancel_request)
+
+      assert message =~ "simulated_cancel_failure"
     end)
   end
 

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -32,6 +32,7 @@ defmodule OrchardNodeAgentTest do
   alias Orchard.ModelManifest.Tokenizer
   alias Orchard.Node
   alias Orchard.Node.ModelManager
+  alias Orchard.Node.RuntimeEndpoint, as: NodeRuntimeEndpoint
   alias Orchard.Node.RuntimeServer
   alias Orchard.Node.SentryTelemetryBridge
   alias Orchard.Node.SharedContract
@@ -40,7 +41,7 @@ defmodule OrchardNodeAgentTest do
   alias Orchard.Node.WorkerSupervisor
   alias Orchard.NodeAgent.Supervisor, as: NodeAgentSupervisor
   alias Orchard.RuntimeEndpoint.ModelRef, as: RuntimeModelRef
-  alias Orchard.RuntimeEndpoint.{Observation, PlacementCapacity, Target}
+  alias Orchard.RuntimeEndpoint.{Observation, Operation, PlacementCapacity, Target}
 
   @test_model_id "mlx-community/phi-3"
   @test_version "main"
@@ -2708,6 +2709,214 @@ defmodule OrchardNodeAgentTest do
     end)
   end
 
+  test "BEAM Runtime Endpoint streams model_busy failure without Accepted when model is busy",
+       %{bundle: bundle} do
+    with_runtime_adapter(BlockingRuntimeAdapter, fn ->
+      assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+               NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+      request1 = execute_inference_request("req-beam-busy-first")
+      assert :ok = NodeStatus.prepare_request(request1, self())
+      assert :ok = NodeStatus.start_request(request1)
+
+      wait_until(fn -> NodeStatus.current().active_request_count == 1 end)
+
+      stream_ref = make_ref()
+
+      request2 = %Operation.ExecuteRequest{
+        request_id: "req-beam-busy-second",
+        controller_session_id: "session-beam-busy-second",
+        model_ref: RuntimeModelRef.new!(@test_model_id, @test_version),
+        rendered_prompt_utf8: "hello",
+        input_tokens: 1
+      }
+
+      assert {:ok, _pid} = NodeRuntimeEndpoint.execute_inference(request2, self(), stream_ref)
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref, "req-beam-busy-second",
+                      %OrchardInferenceEvent{
+                        event: %OrchardInferenceEvent.Failed{code: "model_busy"}
+                      }},
+                     1_000
+
+      refute_receive {:runtime_endpoint_event, ^stream_ref, "req-beam-busy-second",
+                      %OrchardInferenceEvent{
+                        event: %OrchardInferenceEvent.Accepted{}
+                      }},
+                     100
+
+      assert_receive {:runtime_endpoint_done, ^stream_ref, :ok}, 1_000
+
+      generation_ref = get_blocking_generation_ref()
+      send_release(generation_ref)
+
+      assert_receive {:node_runtime_event, "req-beam-busy-first",
+                      %OrchardInferenceEvent{event: %OrchardInferenceEvent.OutputTextDelta{}}},
+                     1_000
+
+      assert_receive {:node_runtime_event, "req-beam-busy-first",
+                      %OrchardInferenceEvent{event: %OrchardInferenceEvent.Completed{}}},
+                     1_000
+    end)
+  end
+
+  test "BEAM Runtime Endpoint streams accepted delta completed and done", %{bundle: bundle} do
+    with_runtime_adapter(BlockingRuntimeAdapter, fn ->
+      assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+               NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+      request = beam_execute_request("req-beam-happy-stream", bundle)
+      stream_ref = make_ref()
+
+      assert {:ok, _pid} = NodeRuntimeEndpoint.execute_inference(request, self(), stream_ref)
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref, "req-beam-happy-stream",
+                      %OrchardInferenceEvent{
+                        event: %OrchardInferenceEvent.Accepted{accepted_at_unix_ms: accepted_at}
+                      }},
+                     1_000
+
+      assert is_integer(accepted_at)
+      assert accepted_at > 0
+
+      wait_until(fn -> NodeStatus.current().active_request_count == 1 end)
+      refs = wait_for_generation_refs([request.request_id])
+      send_release(Map.fetch!(refs, request.request_id))
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref, "req-beam-happy-stream",
+                      %OrchardInferenceEvent{
+                        event: %OrchardInferenceEvent.OutputTextDelta{delta: "released"}
+                      }},
+                     1_000
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref, "req-beam-happy-stream",
+                      %OrchardInferenceEvent{
+                        event: %OrchardInferenceEvent.Completed{} = completed
+                      }},
+                     1_000
+
+      assert completed.finish_reason == :finish_reason_stop
+
+      assert completed.usage == %OrchardInferenceEvent.Usage{
+               input_tokens: 2,
+               output_tokens: 1,
+               total_tokens: 3
+             }
+
+      assert_receive {:runtime_endpoint_done, ^stream_ref, :ok}, 1_000
+      wait_until(fn -> NodeStatus.current().active_request_count == 0 end)
+    end)
+  end
+
+  test "BEAM Runtime Endpoint cancel releases same-model capacity", %{bundle: bundle} do
+    with_runtime_adapter(BlockingRuntimeAdapter, fn ->
+      assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+               NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+      request1 = beam_execute_request("req-beam-cancel-first", bundle)
+      stream_ref1 = make_ref()
+
+      assert {:ok, _pid} = NodeRuntimeEndpoint.execute_inference(request1, self(), stream_ref1)
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref1, "req-beam-cancel-first",
+                      %OrchardInferenceEvent{event: %OrchardInferenceEvent.Accepted{}}},
+                     1_000
+
+      wait_until(fn -> NodeStatus.current().active_request_count == 1 end)
+
+      cancel_request =
+        Operation.CancelRequest.new!(%{
+          request_id: request1.request_id,
+          controller_session_id: request1.controller_session_id
+        })
+
+      assert :ok = NodeRuntimeEndpoint.cancel_inference(cancel_request)
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref1, "req-beam-cancel-first",
+                      %OrchardInferenceEvent{
+                        event: %OrchardInferenceEvent.Failed{code: "cancelled"}
+                      }},
+                     1_000
+
+      assert_receive {:runtime_endpoint_done, ^stream_ref1, :ok}, 1_000
+      wait_until(fn -> NodeStatus.current().active_request_count == 0 end)
+
+      request2 = beam_execute_request("req-beam-cancel-second", bundle)
+      stream_ref2 = make_ref()
+
+      assert {:ok, _pid} = NodeRuntimeEndpoint.execute_inference(request2, self(), stream_ref2)
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref2, "req-beam-cancel-second",
+                      %OrchardInferenceEvent{event: %OrchardInferenceEvent.Accepted{}}},
+                     1_000
+
+      refs = wait_for_generation_refs([request2.request_id])
+      send_release(Map.fetch!(refs, request2.request_id))
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref2, "req-beam-cancel-second",
+                      %OrchardInferenceEvent{
+                        event: %OrchardInferenceEvent.OutputTextDelta{delta: "released"}
+                      }},
+                     1_000
+
+      assert_receive {:runtime_endpoint_event, ^stream_ref2, "req-beam-cancel-second",
+                      %OrchardInferenceEvent{event: %OrchardInferenceEvent.Completed{}}},
+                     1_000
+
+      assert_receive {:runtime_endpoint_done, ^stream_ref2, :ok}, 1_000
+      wait_until(fn -> NodeStatus.current().active_request_count == 0 end)
+    end)
+  end
+
+  test "BEAM Runtime Endpoint owner death releases same-model capacity", %{bundle: bundle} do
+    with_runtime_adapter(BlockingRuntimeAdapter, fn ->
+      assert %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED} =
+               NodeStatus.ensure_model_loaded(ensure_model_loaded_request(bundle))
+
+      parent = self()
+      request = beam_execute_request("req-beam-owner-death", bundle)
+      stream_ref = make_ref()
+
+      owner_pid =
+        spawn(fn ->
+          result = NodeRuntimeEndpoint.execute_inference(request, self(), stream_ref)
+          send(parent, {:beam_owner_execute_result, result})
+
+          receive do
+            {:runtime_endpoint_event, ^stream_ref, "req-beam-owner-death",
+             %OrchardInferenceEvent{event: %OrchardInferenceEvent.Accepted{}}} ->
+              send(parent, :beam_owner_stream_accepted)
+              Process.sleep(:infinity)
+          after
+            5_000 -> send(parent, :beam_owner_stream_timeout)
+          end
+        end)
+
+      try do
+        assert_receive {:beam_owner_execute_result, {:ok, stream_pid}}, 1_000
+        stream_monitor = Process.monitor(stream_pid)
+
+        assert_receive :beam_owner_stream_accepted, 1_000
+        wait_until(fn -> NodeStatus.current().active_request_count == 1 end)
+
+        Process.exit(owner_pid, :kill)
+
+        assert_receive {:DOWN, ^stream_monitor, :process, ^stream_pid, _reason}, 1_000
+
+        wait_until(fn ->
+          status = NodeStatus.current()
+          capacity = runtime_endpoint_capacity(status)
+
+          status.active_request_count == 0 and capacity.active_request_count == 0 and
+            capacity.max_concurrency == 1 and PlacementCapacity.spare?(capacity)
+        end)
+      after
+        if Process.alive?(owner_pid), do: Process.exit(owner_pid, :kill)
+        best_effort_release_generation_refs([request.request_id])
+      end
+    end)
+  end
+
   test "batch mode allows two active requests and rejects the third at prepare time",
        %{bundle: bundle} do
     with_runtime_config(
@@ -4875,6 +5084,19 @@ defmodule OrchardNodeAgentTest do
       deadline_unix_ms: System.system_time(:millisecond) + 5_000,
       metadata_json: ~s({"source":"test"})
     }
+  end
+
+  defp beam_execute_request(request_id, bundle) do
+    Operation.ExecuteRequest.new!(%{
+      request_id: request_id,
+      controller_session_id: "controller-session-1",
+      model_ref: RuntimeModelRef.new!(bundle.model_id, bundle.version),
+      rendered_prompt_utf8: "hello orchard",
+      input_tokens: 2,
+      params: %{max_output_tokens: 16},
+      deadline_unix_ms: System.system_time(:millisecond) + 5_000,
+      metadata_json: ~s({"source":"test"})
+    })
   end
 
   defp with_hard_mode_license(fun) when is_function(fun, 0) do

--- a/apps/orchard_shared/README.md
+++ b/apps/orchard_shared/README.md
@@ -10,7 +10,8 @@ This README is orientation only. Normative shared contracts live in
 ## Owns
 
 - Generated Elixir modules for `proto/cluster/v1/` under `lib/cluster/v1/`.
-- Shared domain structs and mappers used across releases.
+- Shared Runtime Endpoint domain structs, target normalization, and mappers used
+  across releases.
 - Shared filesystem/path, build metadata, licensing, manifest, and Sentry helper
   modules when they are release-neutral.
 

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -118,7 +118,16 @@ defmodule Orchard.RuntimeEndpoint.Target do
     raise ArgumentError, "beam target address must be an atom or binary node name"
   end
 
-  defp normalize_beam_address(address) when is_atom(address), do: address
+  defp normalize_beam_address(address) when is_atom(address) do
+    node_name = Atom.to_string(address)
+
+    unless valid_beam_node_name?(node_name) do
+      raise ArgumentError,
+            "beam target address must be a valid node name, got: #{inspect(address)}"
+    end
+
+    address
+  end
 
   defp normalize_beam_address(address) when is_binary(address) do
     unless valid_beam_node_name?(address) do

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -70,13 +70,29 @@ defmodule Orchard.RuntimeEndpoint.Target do
     do: raise(ArgumentError, "beam target requires a non-empty binary node_id")
 
   defp beam_target(attrs) do
-    node_id = value(attrs, :node_id) || value(attrs, :id) || value(attrs, :address)
-    address = normalize_beam_address(value(attrs, :address) || node_id)
-    beam(to_string(node_id), Map.put(attrs, :address, address))
+    node_id = normalize_optional_node_id(value(attrs, :node_id))
+    address = normalize_beam_address(value(attrs, :address))
+
+    %__MODULE__{
+      id: to_string(value(attrs, :id) || default_beam_id(node_id, address)),
+      transport: :beam,
+      address: address,
+      node_id: node_id,
+      metadata: metadata(attrs)
+    }
   end
 
   defp normalize_transport(transport) when transport in [:beam, "beam"], do: :beam
   defp normalize_transport(_transport), do: :grpc_compat
+
+  defp normalize_optional_node_id(nil), do: nil
+
+  defp normalize_optional_node_id(node_id) when is_binary(node_id) and node_id != "",
+    do: node_id
+
+  defp normalize_optional_node_id(_node_id) do
+    raise ArgumentError, "beam target node_id must be a non-empty binary when provided"
+  end
 
   defp normalize_beam_address(address) when is_atom(address), do: address
 
@@ -93,6 +109,9 @@ defmodule Orchard.RuntimeEndpoint.Target do
     raise ArgumentError,
           "beam target address must be an atom or binary node name, got: #{inspect(address)}"
   end
+
+  defp default_beam_id(node_id, _address) when is_binary(node_id), do: "beam:#{node_id}"
+  defp default_beam_id(nil, address) when is_atom(address), do: "beam:#{Atom.to_string(address)}"
 
   defp valid_beam_node_name?(address) do
     byte_size(address) in 3..255 and String.match?(address, ~r/^[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+$/)

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -10,6 +10,8 @@ defmodule Orchard.RuntimeEndpoint.Target do
             node_id: nil,
             metadata: %{}
 
+  @uuid_pattern ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
   @type transport :: :grpc_compat | :beam
   @type t :: %__MODULE__{
           id: String.t(),
@@ -20,6 +22,9 @@ defmodule Orchard.RuntimeEndpoint.Target do
         }
 
   @spec normalize(t() | keyword() | map()) :: t()
+  def normalize(%__MODULE__{transport: :beam} = target),
+    do: %{target | node_id: normalize_optional_node_id(target.node_id)}
+
   def normalize(%__MODULE__{} = target), do: target
 
   def normalize(target) when is_list(target) or is_map(target) do
@@ -56,6 +61,7 @@ defmodule Orchard.RuntimeEndpoint.Target do
 
   def beam(node_id, opts) when is_binary(node_id) and node_id != "" do
     attrs = attrs_map(opts)
+    node_id = normalize_required_node_id(node_id)
 
     %__MODULE__{
       id: value(attrs, :id) || "beam:#{node_id}",
@@ -67,7 +73,7 @@ defmodule Orchard.RuntimeEndpoint.Target do
   end
 
   def beam(_node_id, _opts),
-    do: raise(ArgumentError, "beam target requires a non-empty binary node_id")
+    do: raise(ArgumentError, "beam target node_id must be a UUID")
 
   defp beam_target(attrs) do
     node_id = normalize_optional_node_id(value(attrs, :node_id))
@@ -88,10 +94,18 @@ defmodule Orchard.RuntimeEndpoint.Target do
   defp normalize_optional_node_id(nil), do: nil
 
   defp normalize_optional_node_id(node_id) when is_binary(node_id) and node_id != "",
-    do: node_id
+    do: normalize_required_node_id(node_id)
 
   defp normalize_optional_node_id(_node_id) do
-    raise ArgumentError, "beam target node_id must be a non-empty binary when provided"
+    raise ArgumentError, "beam target node_id must be a UUID when provided"
+  end
+
+  defp normalize_required_node_id(node_id) do
+    if String.match?(node_id, @uuid_pattern) do
+      String.downcase(node_id)
+    else
+      raise ArgumentError, "beam target node_id must be a UUID"
+    end
   end
 
   defp normalize_beam_address(address) when is_atom(address), do: address

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -19,6 +19,18 @@ defmodule Orchard.RuntimeEndpoint.Target do
           metadata: map()
         }
 
+  @spec normalize(t() | keyword() | map()) :: t()
+  def normalize(%__MODULE__{} = target), do: target
+
+  def normalize(target) when is_list(target) or is_map(target) do
+    attrs = attrs_map(target)
+
+    case normalize_transport(value(attrs, :transport)) do
+      :beam -> beam_target(attrs)
+      :grpc_compat -> grpc_compat(attrs)
+    end
+  end
+
   @spec grpc_compat(keyword() | map()) :: t()
   def grpc_compat(target) do
     attrs = attrs_map(target)
@@ -56,6 +68,35 @@ defmodule Orchard.RuntimeEndpoint.Target do
 
   def beam(_node_id, _opts),
     do: raise(ArgumentError, "beam target requires a non-empty binary node_id")
+
+  defp beam_target(attrs) do
+    node_id = value(attrs, :node_id) || value(attrs, :id) || value(attrs, :address)
+    address = normalize_beam_address(value(attrs, :address) || node_id)
+    beam(to_string(node_id), Map.put(attrs, :address, address))
+  end
+
+  defp normalize_transport(transport) when transport in [:beam, "beam"], do: :beam
+  defp normalize_transport(_transport), do: :grpc_compat
+
+  defp normalize_beam_address(address) when is_atom(address), do: address
+
+  defp normalize_beam_address(address) when is_binary(address) do
+    unless valid_beam_node_name?(address) do
+      raise ArgumentError,
+            "beam target address must be a valid node name, got: #{inspect(address)}"
+    end
+
+    String.to_atom(address)
+  end
+
+  defp normalize_beam_address(address) do
+    raise ArgumentError,
+          "beam target address must be an atom or binary node name, got: #{inspect(address)}"
+  end
+
+  defp valid_beam_node_name?(address) do
+    byte_size(address) in 3..255 and String.match?(address, ~r/^[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+$/)
+  end
 
   defp attrs_map(attrs) when is_list(attrs), do: Map.new(attrs)
   defp attrs_map(%{} = attrs), do: attrs

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -1,6 +1,11 @@
 defmodule Orchard.RuntimeEndpoint.Target do
   @moduledoc """
   Addressable Runtime Endpoint target selected by the scheduler.
+
+  gRPC compatibility targets use `[host: ..., port: ...]` addresses.
+  BEAM targets use BEAM node-name addresses such as
+  `:orchard_node_agent@localhost` and may carry a persisted Orchard node UUID
+  for identity checks.
   """
 
   @enforce_keys [:id, :transport, :address]
@@ -21,6 +26,13 @@ defmodule Orchard.RuntimeEndpoint.Target do
           metadata: map()
         }
 
+  @doc """
+  Normalizes keyword, map, or prebuilt Runtime Endpoint targets.
+
+  Targets without an explicit transport remain gRPC compatibility targets.
+  BEAM targets require an atom or binary BEAM node-name address and reject
+  malformed configured node IDs.
+  """
   @spec normalize(t() | keyword() | map()) :: t()
   def normalize(%__MODULE__{transport: :beam} = target) do
     %{
@@ -41,6 +53,9 @@ defmodule Orchard.RuntimeEndpoint.Target do
     end
   end
 
+  @doc """
+  Builds a gRPC compatibility target from `:host` and `:port`.
+  """
   @spec grpc_compat(keyword() | map()) :: t()
   def grpc_compat(target) do
     attrs = attrs_map(target)
@@ -61,6 +76,12 @@ defmodule Orchard.RuntimeEndpoint.Target do
     }
   end
 
+  @doc """
+  Builds a BEAM Runtime Endpoint target for a persisted Orchard node UUID.
+
+  The `:address` option is required and must be an atom or binary BEAM node
+  name in `service@host` form.
+  """
   @spec beam(String.t(), keyword() | map()) :: t()
   def beam(node_id, opts \\ [])
 

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -22,8 +22,13 @@ defmodule Orchard.RuntimeEndpoint.Target do
         }
 
   @spec normalize(t() | keyword() | map()) :: t()
-  def normalize(%__MODULE__{transport: :beam} = target),
-    do: %{target | node_id: normalize_optional_node_id(target.node_id)}
+  def normalize(%__MODULE__{transport: :beam} = target) do
+    %{
+      target
+      | address: normalize_beam_address(target.address),
+        node_id: normalize_optional_node_id(target.node_id)
+    }
+  end
 
   def normalize(%__MODULE__{} = target), do: target
 
@@ -62,11 +67,12 @@ defmodule Orchard.RuntimeEndpoint.Target do
   def beam(node_id, opts) when is_binary(node_id) and node_id != "" do
     attrs = attrs_map(opts)
     node_id = normalize_required_node_id(node_id)
+    address = normalize_beam_address(value(attrs, :address))
 
     %__MODULE__{
       id: value(attrs, :id) || "beam:#{node_id}",
       transport: :beam,
-      address: value(attrs, :address) || node_id,
+      address: address,
       node_id: node_id,
       metadata: metadata(attrs)
     }
@@ -106,6 +112,10 @@ defmodule Orchard.RuntimeEndpoint.Target do
     else
       raise ArgumentError, "beam target node_id must be a UUID"
     end
+  end
+
+  defp normalize_beam_address(nil) do
+    raise ArgumentError, "beam target address must be an atom or binary node name"
   end
 
   defp normalize_beam_address(address) when is_atom(address), do: address

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -139,6 +139,21 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     assert target.address == :orchard_node_agent@localhost
   end
 
+  test "prebuilt BEAM target normalization validates and normalizes address" do
+    node_id = "550e8400-e29b-41d4-a716-446655440000"
+
+    target =
+      Target.normalize(%Target{
+        id: "source-dev-node-agent",
+        transport: :beam,
+        address: "orchard_node_agent@localhost",
+        node_id: node_id
+      })
+
+    assert target.address == :orchard_node_agent@localhost
+    assert target.node_id == node_id
+  end
+
   test "runtime endpoint observations prefer metadata node identity without target node_id" do
     node_id = "550e8400-e29b-41d4-a716-446655440000"
 
@@ -176,6 +191,12 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
         address: :orchard_node_agent@localhost,
         node_id: "node-1"
       })
+    end
+  end
+
+  test "BEAM target construction requires explicit address" do
+    assert_raise ArgumentError, fn ->
+      Target.beam("550e8400-e29b-41d4-a716-446655440000")
     end
   end
 

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -210,6 +210,16 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     end
   end
 
+  test "target normalization rejects malformed atom BEAM node names" do
+    assert_raise ArgumentError, fn ->
+      Target.normalize(
+        transport: :beam,
+        node_id: "550e8400-e29b-41d4-a716-446655440000",
+        address: :not_a_node
+      )
+    end
+  end
+
   test "operation constructors validate scalar request shape without enforcing policy" do
     model_ref = ModelRef.new!("mlx-community/phi-3", "main")
 

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -103,6 +103,32 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     assert PlacementCapacity.spare?(Observation.placement_capacity_for(observation, model_ref))
   end
 
+  test "target normalization preserves default gRPC fallback and admits explicit BEAM targets" do
+    grpc_target = Target.normalize(host: "127.0.0.1", port: 50_071)
+
+    assert grpc_target.transport == :grpc_compat
+    assert grpc_target.address == [host: "127.0.0.1", port: 50_071]
+
+    beam_target =
+      Target.normalize(%{
+        transport: :beam,
+        node_id: "node-1",
+        address: :orchard_node_agent@localhost,
+        metadata: %{role: :node_agent}
+      })
+
+    assert beam_target.transport == :beam
+    assert beam_target.node_id == "node-1"
+    assert beam_target.address == :orchard_node_agent@localhost
+    assert beam_target.metadata == %{role: :node_agent}
+  end
+
+  test "target normalization rejects malformed configured BEAM node names" do
+    assert_raise ArgumentError, fn ->
+      Target.normalize(transport: :beam, node_id: "node-1", address: "not a node")
+    end
+  end
+
   test "operation constructors validate scalar request shape without enforcing policy" do
     model_ref = ModelRef.new!("mlx-community/phi-3", "main")
 

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -109,16 +109,18 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     assert grpc_target.transport == :grpc_compat
     assert grpc_target.address == [host: "127.0.0.1", port: 50_071]
 
+    node_id = "550e8400-e29b-41d4-a716-446655440000"
+
     beam_target =
       Target.normalize(%{
         transport: :beam,
-        node_id: "node-1",
+        node_id: node_id,
         address: :orchard_node_agent@localhost,
         metadata: %{role: :node_agent}
       })
 
     assert beam_target.transport == :beam
-    assert beam_target.node_id == "node-1"
+    assert beam_target.node_id == node_id
     assert beam_target.address == :orchard_node_agent@localhost
     assert beam_target.metadata == %{role: :node_agent}
   end
@@ -154,9 +156,36 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     assert Observation.node_id(observation) == node_id
   end
 
+  test "BEAM target normalization rejects configured non-UUID node_id values" do
+    assert_raise ArgumentError, fn ->
+      Target.normalize(
+        transport: :beam,
+        node_id: "node-1",
+        address: :orchard_node_agent@localhost
+      )
+    end
+
+    assert_raise ArgumentError, fn ->
+      Target.beam("node-1", address: :orchard_node_agent@localhost)
+    end
+
+    assert_raise ArgumentError, fn ->
+      Target.normalize(%Target{
+        id: "source-dev-node-agent",
+        transport: :beam,
+        address: :orchard_node_agent@localhost,
+        node_id: "node-1"
+      })
+    end
+  end
+
   test "target normalization rejects malformed configured BEAM node names" do
     assert_raise ArgumentError, fn ->
-      Target.normalize(transport: :beam, node_id: "node-1", address: "not a node")
+      Target.normalize(
+        transport: :beam,
+        node_id: "550e8400-e29b-41d4-a716-446655440000",
+        address: "not a node"
+      )
     end
   end
 

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -123,6 +123,37 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     assert beam_target.metadata == %{role: :node_agent}
   end
 
+  test "BEAM target normalization keeps node_id nil unless explicitly configured" do
+    target =
+      Target.normalize(%{
+        transport: :beam,
+        id: "source-dev-node-agent",
+        address: :orchard_node_agent@localhost
+      })
+
+    assert target.id == "source-dev-node-agent"
+    assert target.transport == :beam
+    assert target.node_id == nil
+    assert target.address == :orchard_node_agent@localhost
+  end
+
+  test "runtime endpoint observations prefer metadata node identity without target node_id" do
+    node_id = "550e8400-e29b-41d4-a716-446655440000"
+
+    observation =
+      Observation.new(%{
+        target:
+          Target.normalize(%{
+            transport: :beam,
+            id: "source-dev-node-agent",
+            address: :orchard_node_agent@localhost
+          }),
+        metadata: %{node_id: node_id}
+      })
+
+    assert Observation.node_id(observation) == node_id
+  end
+
   test "target normalization rejects malformed configured BEAM node names" do
     assert_raise ArgumentError, fn ->
       Target.normalize(transport: :beam, node_id: "node-1", address: "not a node")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ Public clients
      -> Postgres for durable state and coordination
      -> Runtime Endpoint Interface
         -> current gRPC compatibility adapter
-        -> future first-party BEAM adapter after accepted source-dev smoke
+        -> default-off first-party BEAM adapter, promoted after accepted source-dev smoke
         -> future external/provider adapters
      -> Node Agent(s)
         -> Worker Runtime subprocesses for local MLX inference
@@ -51,8 +51,9 @@ Core design rules from `SPEC.md`:
 - token streams pass through the controller;
 - the Controller dispatches model runtime work through the Runtime Endpoint Interface;
 - the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
-- first-party BEAM communication requires explicit production guardrails before it can be enabled;
-- source-dev keeps the gRPC compatibility adapter until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke;
+- first-party BEAM communication is implemented behind explicit guardrails and remains default-off until rollout gates allow it;
+- source-dev uses the gRPC compatibility adapter by default until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is promoted;
+- BEAM Runtime Endpoint targets validate BEAM node-name addresses and configured node UUIDs before scheduler or dispatch trusts endpoint identity;
 - node agents are the v1 first-party Runtime Endpoint boundary;
 - worker runtimes are local subprocesses, not public services;
 - Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling, and request state.
@@ -102,12 +103,14 @@ Aggregate capacity is the conservative limit the node agent enforces across load
 The controller scheduler uses that capacity telemetry to avoid dispatching to full endpoints or full same-model placements.
 Controller queue admission also consumes fresh Runtime Endpoint Observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted endpoints.
 Invalid, ineligible, unavailable, or transport-failed observations clear stale endpoint-owned capacity sources before queued work can be promoted.
+For BEAM Runtime Endpoint observations, queue capacity is published only when the target resolves back to the same persisted node identity.
 Scheduler and dispatch orchestration crashes after request validation terminalize the durable request as a failed `orchestration_error` with sanitized public error payloads instead of leaving it active.
 
 Runtime Endpoint and worker runtime contracts are separate:
 
 - `proto/cluster/v1/` describes the current controller ↔ node-agent gRPC compatibility transport.
 - Runtime Endpoint domain structs describe the Controller-facing scheduler and dispatch contract.
+- `Orchard.RuntimeEndpoint.BeamClient` and `Orchard.Node.RuntimeEndpoint` provide the default-off first-party BEAM adapter and Node Agent facade.
 - `native/orchard_worker_mlx/proto/` describes node-agent ↔ worker messages/services.
 
 ### Persistence and coordination

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -18,27 +18,26 @@ The key ambiguity is whether the Node Agent is a protocol-isolated runtime endpo
 
 Model Orchard scheduling around transport-independent Runtime Endpoints.
 The v1 Runtime Endpoint is the first-party Node Agent.
-For first-party Runtime Endpoints, keep BEAM Distribution as the preferred future live communication and monitoring layer between Elixir services once the adapter exists.
+For first-party Runtime Endpoints, keep BEAM Distribution as the preferred live communication and monitoring layer between Elixir services when guardrails and rollout gates allow it.
 Limit BEAM Distribution to first-party Orchard Runtime Endpoints.
 External or provider-backed Runtime Endpoints must integrate through explicit Runtime Endpoint adapters and provider-appropriate protocols.
 
 Keep Postgres as the durable persistence and coordination store.
 BEAM Distribution must not become durable cluster truth.
-Use BEAM Distribution for future live first-party communication, monitoring, and fast session failure signals after explicit adapter work.
+Use BEAM Distribution for guarded live first-party communication, monitoring, and fast session failure signals.
 Persist Runtime Endpoint Observations in Postgres for inventory, lifecycle, availability, scheduling, and operator-visible history.
 A connected BEAM node is not automatically schedulable.
 Production BEAM Distribution must be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
 External Runtime Endpoints must not join the BEAM mesh.
 
 Keep the Runtime Endpoint Interface independent of a transport protocol.
-The first implementation slice defines an Elixir behaviour backed by the current gRPC Compatibility Adapter.
-A later implementation can add a first-party BEAM adapter behind the same Runtime Endpoint Interface.
+The implementation defines an Elixir behaviour with the current gRPC Compatibility Adapter and a default-off first-party BEAM adapter behind the same Runtime Endpoint Interface.
 Future Runtime Endpoint adapters may target external compute, cloud VMs, high-performance compute nodes, appliance-style accelerators, or paid provider integrations.
 Existing `proto/cluster/v1` work should be demoted from the default first-party Controller-to-Node Agent path to a possible future adapter protocol.
 Placement Capacity is a first-class Runtime Endpoint observation and must be exposed by the interface independently of transport.
 Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove eligibility for an active loaded placement.
 
-The BEAM Runtime Endpoint adapter is the intended primary source-dev Controller-to-Node Agent path once the adapter exists and passes the accepted two-Mac smoke.
+The BEAM Runtime Endpoint adapter is the intended primary source-dev Controller-to-Node Agent path once it passes the accepted two-Mac smoke.
 Until that gate passes, current source-dev continues to use the gRPC Compatibility Adapter on port `50071` as the compatibility and fallback path.
 The accepted smoke gate requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
 Do not remove gRPC compatibility before the BEAM adapter passes that smoke.
@@ -57,7 +56,7 @@ It keeps OTP semantics close to the Orchard services that already run on the BEA
 The design still preserves an extension point for non-BEAM Runtime Endpoints.
 Those endpoints should integrate through Runtime Endpoint adapters rather than forcing the first-party v1 path through an external-service protocol.
 It also avoids extending BEAM trust to endpoints Orchard does not fully own.
-The existing cluster proto surface should not be deleted solely because the durable domain model moves to Runtime Endpoint semantics or a later first-party path moves to BEAM Distribution.
+The existing cluster proto surface should not be deleted solely because the durable domain model moves to Runtime Endpoint semantics or the first-party path moves to BEAM Distribution.
 It may still become useful for external Runtime Endpoint adapters or compatibility bridges.
 
 Node lifecycle remains first-party and Node-specific.
@@ -71,7 +70,7 @@ Keep the existing `cluster_busy` error name for now, but define it as live Runti
 
 ## SPEC.md impact
 
-The `SPEC.md` update replaces prior gRPC-only runtime execution language with Runtime Endpoint semantics, current gRPC compatibility transport, future guarded BEAM transport, node scheduling, node lifecycle, and model placement.
+The `SPEC.md` update replaces prior gRPC-only runtime execution language with Runtime Endpoint semantics, current gRPC compatibility transport, guarded BEAM transport, node scheduling, node lifecycle, and model placement.
 The update also reconciles the incoming gnhf concurrency semantics around Placement Capacity, `cluster_busy`, queue requeue under the original deadline, tenant FIFO, weighted round-robin, and unknown-capacity fail-closed behavior.
 The OpenSpec change should treat `gnhf/objective-fully-impl-369718` as an architecture input and preservation dependency, not as implementation scope to merge inside the proposal.
 This ADR records the decision rationale; `SPEC.md` remains the normative build contract.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -60,7 +60,8 @@ _Avoid_: Redis, Kafka, distributed Erlang state
 
 **BEAM Distribution**:
 The live Orchard communication and monitoring layer between first-party Elixir services.
-In source-dev, it becomes the primary Runtime Endpoint transport only after the BEAM adapter passes the accepted two-Mac smoke.
+The default-off BEAM Runtime Endpoint adapter exists for first-party Controller-to-Node Agent communication.
+In source-dev, it becomes the primary Runtime Endpoint transport only after the BEAM adapter passes the accepted two-Mac smoke and is promoted.
 In packaged production, BEAM Distribution is limited to admitted first-party Orchard services.
 _Avoid_: Durable cluster truth, database replacement, public API, external provider integration
 
@@ -111,7 +112,7 @@ The governance and configuration HTTP API surface for tenants, keys, quotas, mod
 _Avoid_: Operator API, runtime support action
 
 **Runtime Endpoint Interface**:
-The transport-independent Controller-facing execution semantics for scheduling, model readiness, inference execution, cancellation, status, and runtime telemetry.
+The transport-independent Controller-facing execution semantics for scheduling, model readiness, inference execution, cancellation, status, prefix-cache scoring, and runtime telemetry.
 Placement Capacity is part of this interface's observation vocabulary.
 _Avoid_: Worker Runtime Interface, Node Lifecycle Interface, transport protocol
 
@@ -294,7 +295,7 @@ The scheduler-facing availability of a Runtime Endpoint for new work, independen
 _Avoid_: Node Lifecycle State, durable cluster truth, provider billing status
 
 **Runtime Endpoint Observation**:
-A durable Controller-recorded snapshot of Runtime Endpoint status, capability, availability, and placement signals.
+A durable Controller-recorded snapshot of Runtime Endpoint status, capability, availability, placement, and capacity signals.
 _Avoid_: live BEAM session, durable cluster truth by itself, provider billing event
 
 **Heartbeat**:
@@ -442,9 +443,11 @@ _Avoid_: Catalog State, durable placement record, model manifest metadata
 **Runtime Node Capacity**:
 Runtime Endpoint Observation data for aggregate runtime capacity on one endpoint-backed node.
 The current gRPC Compatibility Adapter maps this from `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`.
+The BEAM Node Agent facade maps the same node-agent status semantics into BEAM Runtime Endpoint Observations.
 The scheduler uses it to exclude endpoint-backed nodes that have exhausted aggregate request slots before considering per-placement capacity.
 Queue admission uses eligible endpoint observations to bound cold/no-placement wakeups and to keep active source reservations from being double-counted across queued lanes.
 Transport-failed or newly ineligible endpoints clear endpoint-owned aggregate, cold, and placement sources instead of retaining stale capacity.
+BEAM observations publish queue capacity only when the target resolves back to the same persisted node identity.
 _Avoid_: Tenant quota, durable Node inventory capacity, model-specific capacity
 
 **Prefix-cache Score**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -210,9 +210,11 @@ stream mode automatically.
 the fake runtime through `config/test.exs`, not a dev env override.
 Batch generation mode can admit multiple same-model requests up to the worker-reported limit.
 The node agent also enforces aggregate active request capacity across loaded models using the resolved worker limits, conservatively falling back to single-request capacity when worker status omits `max_concurrency`.
-The node-agent reports aggregate and placement capacity through the current gRPC compatibility status response.
-The controller maps that response into Runtime Endpoint Observations before multi-node scheduler candidate filtering and queue wakeups from loaded-placement or cold/no-placement capacity.
+The node-agent reports aggregate and placement capacity through Runtime Endpoint status.
+The default source-dev path maps the current gRPC compatibility status response into Runtime Endpoint Observations before multi-node scheduler candidate filtering and queue wakeups from loaded-placement or cold/no-placement capacity.
+When the BEAM adapter is explicitly configured, the Node Agent facade maps the same status semantics into BEAM Runtime Endpoint Observations.
 Transport failures and ineligible Runtime Endpoint Observations clear endpoint-owned queue capacity sources so queued work is not promoted against stale loaded-placement or cold/no-placement slots.
+BEAM observations publish queue capacity only when the target resolves back to the same persisted node identity.
 Stream mode reports max concurrency as `1` at both node and placement levels.
 
 #### Controller Multi-Node (Source Dev)
@@ -222,6 +224,9 @@ Stream mode reports max concurrency as `1` at both node and placement levels.
 | `ORCHARD_RUNTIME_CLIENT_HOST` | `127.0.0.1` | Controller’s local gRPC target host |
 | `ORCHARD_RUNTIME_CLIENT_TARGETS` | _(empty)_ | Comma-separated `host:port` list for multi-node scheduling. When set with >1 target, the scheduler auto-selects `MultiNode`. |
 
+These env vars configure only the gRPC compatibility target path.
+Explicit BEAM Runtime Endpoint targets are application config only in this slice.
+
 #### Runtime Endpoint BEAM Guardrails
 
 The current source-dev slice includes a default-off BEAM Runtime Endpoint adapter, Node Agent facade, and guardrail config under `:orchard_controller, :runtime_endpoint, beam: [...]`.
@@ -230,8 +235,24 @@ There is no supported source-dev env var surface for BEAM target selection in th
 The accepted target is for BEAM Runtime Endpoint transport to become the primary source-dev Controller-to-Node Agent path after that smoke passes.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
 
-If enabled directly in application config for future work, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
+Application-config opt-in uses the Runtime Endpoint client and target keys under `:orchard_controller, :inference`.
+
+```elixir
+runtime_endpoint_client_impl: Orchard.RuntimeEndpoint.BeamClient,
+runtime_endpoint_targets: [
+  %{
+    transport: :beam,
+    node_id: "<node-uuid>",
+    address: :orchard_node_agent@localhost
+  }
+]
+```
+
+BEAM target `address` is required and must be a valid BEAM node name (`service@host`) as an atom or binary.
+Configured BEAM target `node_id` values are optional for address-only discovery, but when present they must be UUIDs and must match observed Node Agent metadata.
+When BEAM guardrails are enabled directly in application config, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
 The `listen_host` must not be `0.0.0.0` or `::`, and `allowed_cidrs` must not contain `0.0.0.0/0` or `::/0`.
+Allowed CIDRs must parse as IP CIDR ranges, the running BEAM node name must match configured `node_name`, BEAM target services must be listed in `admitted_services`, and BEAM target hosts must fall inside `allowed_cidrs`.
 
 #### Packaged Controller Transport (release only)
 
@@ -813,8 +834,8 @@ All-in-one local boot (dev):
    - Runs pending migrations
    - Exports dev gRPC port (50071)
    - Starts `iex -S mix phx.server`
-   - Controller boots: Endpoint, Repo, Inference supervisor, gRPC client
-   - Node-agent boots: ModelManager, WorkerSupervisor, gRPC server
+   - Controller boots: Endpoint, Repo, Inference supervisor, Runtime Endpoint clients
+   - Node-agent boots: ModelManager, WorkerSupervisor, Runtime Endpoint task supervisor, gRPC server
 3. Import at least one model bundle with `OrchardCLI.main(["models", "import", "<path>", "--activate"])`
 4. Create a tenant and API key with `OrchardCLI.main(["tenants", ...])` and
    `OrchardCLI.main(["api-keys", ...])`
@@ -845,6 +866,6 @@ mise exec -- iex -S mix phx.server
 - Public `/v1/*` API routes require tenant-scoped Bearer API keys; full RBAC and
   quota policy remain incomplete
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
-- Live BEAM Runtime Endpoint transport is implemented behind default-off application config; current source dev uses the gRPC compatibility adapter
+- Live BEAM Runtime Endpoint transport is implemented behind default-off application config; default source dev uses the gRPC compatibility adapter
 - BEAM Runtime Endpoint transport becomes the primary source-dev path only after it passes the accepted two-Mac smoke
 - Model import from local filesystem only (no remote download)

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -224,11 +224,10 @@ Stream mode reports max concurrency as `1` at both node and placement levels.
 
 #### Runtime Endpoint BEAM Guardrails
 
-The current source-dev slice includes default-off BEAM Runtime Endpoint guardrail config under `:orchard_controller, :runtime_endpoint, beam: [...]`.
-This validates future first-party BEAM transport admission settings only.
-It does not implement or enable a live BEAM Runtime Endpoint adapter, and there is no supported source-dev env var surface for it in this slice.
-The accepted target is for BEAM Runtime Endpoint transport to become the primary source-dev Controller-to-Node Agent path after the adapter exists and passes the two-Mac smoke.
-Until that gate passes, source-dev keeps using the gRPC compatibility adapter on port `50071`.
+The current source-dev slice includes a default-off BEAM Runtime Endpoint adapter, Node Agent facade, and guardrail config under `:orchard_controller, :runtime_endpoint, beam: [...]`.
+The adapter is implemented behind explicit application config, but source dev keeps using the gRPC compatibility adapter on port `50071` until the accepted two-Mac smoke passes.
+There is no supported source-dev env var surface for BEAM target selection in this slice.
+The accepted target is for BEAM Runtime Endpoint transport to become the primary source-dev Controller-to-Node Agent path after that smoke passes.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
 
 If enabled directly in application config for future work, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
@@ -846,6 +845,6 @@ mise exec -- iex -S mix phx.server
 - Public `/v1/*` API routes require tenant-scoped Bearer API keys; full RBAC and
   quota policy remain incomplete
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
-- Live BEAM Runtime Endpoint transport is not implemented in source dev; current source dev uses the gRPC compatibility adapter
-- BEAM Runtime Endpoint transport becomes the primary source-dev path only after the adapter exists and passes the accepted two-Mac smoke
+- Live BEAM Runtime Endpoint transport is implemented behind default-off application config; current source dev uses the gRPC compatibility adapter
+- BEAM Runtime Endpoint transport becomes the primary source-dev path only after it passes the accepted two-Mac smoke
 - Model import from local filesystem only (no remote download)

--- a/openspec/changes/beam-first-runtime-endpoints/design.md
+++ b/openspec/changes/beam-first-runtime-endpoints/design.md
@@ -16,7 +16,7 @@ The Worker Runtime remains a local process/protocol boundary owned by the Node A
 
 - Define Runtime Endpoint as the Controller-selected execution boundary.
 - Define Runtime Endpoint Interface as transport-independent runtime semantics.
-- Add guardrails for future BEAM Distribution between first-party Controller and Node Agent services.
+- Add guardrails for default-off BEAM Distribution between first-party Controller and Node Agent services.
 - Keep source-dev on gRPC compatibility until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
 - Keep Runtime Endpoint Observations durable in Postgres for operator-visible state and scheduling inputs.
 - Preserve `gnhf/objective-fully-impl-369718` concurrency semantics while moving controller domain code to Runtime Endpoint semantics.
@@ -48,7 +48,7 @@ That keeps v1 terminology simple, but it makes future Cloud VM, high-performance
 The Controller should depend on a Runtime Endpoint Interface for status, model readiness, inference execution, cancellation, runtime telemetry, Placement Capacity, and prefix-cache scoring.
 This slice should introduce the interface and keep the current first-party path behind a gRPC Compatibility Adapter.
 A later first-party implementation can use BEAM Distribution.
-Source-dev should promote BEAM Runtime Endpoint transport only after the adapter exists and the accepted two-Mac smoke passes.
+Source-dev should promote BEAM Runtime Endpoint transport only after the accepted two-Mac smoke passes.
 Future non-BEAM implementations can use provider APIs, gRPC/protobuf, or other adapter protocols.
 
 Alternative considered: keep `NodeRuntimeService` as the core interface.

--- a/openspec/changes/beam-first-runtime-endpoints/proposal.md
+++ b/openspec/changes/beam-first-runtime-endpoints/proposal.md
@@ -3,14 +3,14 @@
 At the base of this change, Orchard treats first-party Controller-to-Node Agent communication as a gRPC over mTLS product boundary even though both sides are first-party Elixir services.
 This adds transport and protobuf complexity before Orchard has a non-BEAM runtime endpoint that needs it.
 
-The architecture should make Orchard's runtime execution semantics transport-independent, add guardrails for future BEAM Distribution between admitted first-party Elixir Runtime Endpoints, keep Postgres as durable truth, and preserve the latest concurrent-inference semantics from `gnhf/objective-fully-impl-369718`.
+The architecture should make Orchard's runtime execution semantics transport-independent, add guardrails for BEAM Distribution between admitted first-party Elixir Runtime Endpoints, keep Postgres as durable truth, and preserve the latest concurrent-inference semantics from `gnhf/objective-fully-impl-369718`.
 
 ## What Changes
 
 - Introduce Runtime Endpoint as the schedulable execution boundary selected by the Controller.
 - Introduce a transport-independent Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, Placement Capacity, and scheduler observations.
 - Treat the first-party Node Agent as Orchard's v1 Runtime Endpoint implementation.
-- Add BEAM Distribution guardrail validation for future live communication and monitoring between first-party Orchard Elixir services.
+- Add BEAM Distribution guardrail validation for default-off live communication and monitoring between first-party Orchard Elixir services.
 - Keep the current gRPC/protobuf `NodeRuntimeService` path as an explicit Runtime Endpoint compatibility adapter for this implementation slice.
 - Keep source-dev on the gRPC compatibility adapter until a BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
 - Keep Postgres as Orchard's durable persistence and coordination store.

--- a/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
@@ -28,16 +28,22 @@ This wraps the current first-party use of `NodeRuntimeService` in `SPEC.md` sect
 - **THEN** model readiness, inference execution, cancellation, status, and runtime telemetry semantics remain unchanged at the Runtime Endpoint Interface
 
 ### Requirement: First-party BEAM Transport Guardrails
-Orchard SHALL validate first-party BEAM Distribution guardrails before any live BEAM Runtime Endpoint adapter can be enabled.
-First-party Orchard Runtime Endpoints MAY use BEAM Distribution as a future live communication and monitoring layer between admitted Elixir services.
+Orchard SHALL validate first-party BEAM Distribution guardrails before production BEAM Runtime Endpoint transport can be enabled.
+First-party Orchard Runtime Endpoints MAY use BEAM Distribution as a default-off live communication and monitoring layer between admitted Elixir services.
 Production BEAM Distribution MUST be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
 External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 This changes the base `SPEC.md` section 1.2 language that forbids distributed Erlang across machines and requires all cross-node control traffic to use gRPC over mTLS.
 
-#### Scenario: First-party BEAM endpoint is enabled later
-- **WHEN** an admitted first-party Node Agent participates in production runtime communication through a future BEAM adapter
+#### Scenario: First-party BEAM endpoint is enabled
+- **WHEN** an admitted first-party Node Agent participates in production runtime communication through the BEAM adapter
 - **THEN** it communicates with the Controller only through explicitly configured first-party BEAM transport
 - **THEN** the Controller still records durable Runtime Endpoint Observations in Postgres
+
+#### Scenario: BEAM target identity is validated
+- **WHEN** a configured BEAM Runtime Endpoint target has a node-name address and node identity
+- **THEN** the address is validated as a BEAM node name
+- **THEN** the node identity is validated as a UUID
+- **THEN** scheduler and dispatch trust the identity only when observed endpoint metadata matches the configured identity
 
 #### Scenario: External endpoint remains outside BEAM mesh
 - **WHEN** a future provider-backed Runtime Endpoint is configured
@@ -70,6 +76,11 @@ This replaces the current first-party dependence on `StatusResponse` as the acti
 #### Scenario: Transport-specific field is absent
 - **WHEN** a first-party BEAM Runtime Endpoint reports status without protobuf fields
 - **THEN** the Controller still records equivalent Runtime Endpoint Observation data
+
+#### Scenario: Address-only BEAM observation lacks persisted identity proof
+- **WHEN** a BEAM Runtime Endpoint Observation is recorded from a target that cannot resolve back to the same persisted node identity
+- **THEN** the Controller does not publish queue capacity from that observation
+- **THEN** stale queue capacity sources for the unresolved target remain unavailable for promotion
 
 ### Requirement: Placement Capacity Observation
 Placement Capacity SHALL be a first-class Runtime Endpoint Observation for Model Placements.
@@ -156,15 +167,15 @@ This changes the role of the gRPC contract currently described in `SPEC.md` sect
 - **THEN** the existing gRPC/protobuf work may be reused or evolved as an adapter protocol
 
 ### Requirement: Source-dev BEAM Primary Rollout
-Orchard SHALL treat the first-party BEAM Runtime Endpoint adapter as the intended primary source-dev Controller-to-Node Agent path only after the adapter is implemented and passes the accepted two-Mac smoke.
+Orchard SHALL treat the first-party BEAM Runtime Endpoint adapter as the intended primary source-dev Controller-to-Node Agent path only after it passes the accepted two-Mac smoke.
 Until that gate passes, current source-dev SHALL keep the gRPC compatibility path as the compatibility and fallback path on port `50071`.
 
 #### Scenario: BEAM adapter passes the source-dev smoke gate
-- **WHEN** the BEAM Runtime Endpoint adapter exists and the accepted two-Mac smoke passes
+- **WHEN** the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke
 - **THEN** Orchard may promote BEAM Runtime Endpoint transport to the primary source-dev Controller-to-Node Agent path
 
 #### Scenario: BEAM adapter has not passed the source-dev smoke gate
-- **WHEN** the BEAM Runtime Endpoint adapter is absent or has not passed the accepted two-Mac smoke
+- **WHEN** the BEAM Runtime Endpoint adapter has not passed the accepted two-Mac smoke
 - **THEN** Orchard keeps using the gRPC compatibility path for source-dev Controller-to-Node Agent communication
 
 #### Scenario: Source-dev smoke gate is evaluated

--- a/openspec/changes/beam-first-runtime-endpoints/tasks.md
+++ b/openspec/changes/beam-first-runtime-endpoints/tasks.md
@@ -12,7 +12,7 @@
 
 - [x] 2.1 Define transport-independent Runtime Endpoint request, response, event, status, availability, and Placement Capacity domain types.
 - [x] 2.2 Define a Controller-facing Runtime Endpoint behaviour for status, ensure model loaded, unload model, execute inference, cancel inference, and prefix-cache scoring.
-- [ ] 2.3 Implement the first-party BEAM Runtime Endpoint adapter for Node Agent communication.
+- [x] 2.3 Implement the first-party BEAM Runtime Endpoint adapter for Node Agent communication.
 - [x] 2.4 Add production guardrails for first-party BEAM Distribution configuration, identity binding, network restriction, and admitted-service membership.
 - [x] 2.5 Keep or adapt gRPC client/server modules only behind an explicit compatibility or future-adapter boundary.
 
@@ -29,7 +29,7 @@
 
 ## 4. Node Agent And Worker Runtime Boundary
 
-- [ ] 4.1 Adapt Node Agent status and runtime operations to serve the first-party Runtime Endpoint Interface.
+- [x] 4.1 Adapt Node Agent status and runtime operations to serve the first-party Runtime Endpoint Interface.
 - [x] 4.2 Preserve `ModelManager` ownership of active request accounting and Placement Capacity.
 - [x] 4.3 Preserve local Worker Runtime supervision, model loading, generation, cancellation, diagnostics, and cleanup.
 - [x] 4.4 Keep Python/MLX worker communication behind the Worker Runtime Interface.

--- a/openspec/changes/beam-first-runtime-endpoints/tasks.md
+++ b/openspec/changes/beam-first-runtime-endpoints/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Update `SPEC.md` to replace first-party gRPC-only cross-node rules with Runtime Endpoint and BEAM-first first-party semantics.
 - [x] 1.2 Update `SPEC.md` to define Runtime Endpoint Observation, Runtime Endpoint Availability, Placement Capacity, and `cluster_busy` capacity semantics.
-- [x] 1.3 Update `SPEC.md` to keep Postgres as durable truth and BEAM Distribution as guarded future first-party live communication only.
+- [x] 1.3 Update `SPEC.md` to keep Postgres as durable truth and BEAM Distribution as guarded default-off first-party live communication only.
 - [x] 1.4 Update `SPEC.md` to keep Worker Runtime as a Node Agent-local boundary.
 - [x] 1.5 Update `docs/architecture.md` and glossary docs to match accepted Runtime Endpoint language.
 - [x] 1.6 Decide and document which `proto/cluster/v1` artifacts remain as adapter or compatibility protocol inputs.


### PR DESCRIPTION
## Intent

Implement and validate Orchard's BEAM-first runtime endpoint adapter for local source-dev/controller to node-agent communication, preserving the committed BEAM endpoint behavior while fixing the review findings before opening a PR. The branch now includes the prior no-mistakes fixes plus the final hardening: BEAM targets must normalize and validate their node address even when passed as prebuilt Target structs, Target.beam/1 must not silently accept a nil BEAM address, and address-only BEAM observations must not publish queue capacity unless the target can be resolved back to the same persisted node identity. Keep the Orchard SPEC.md and OpenSpec beam-first-runtime-endpoints contract intact, avoid unrelated refactors, and open the PR only after the no-mistakes review, tests, docs/lint gates, push, PR creation, and CI path are satisfied.

## What Changed

- Adds BEAM runtime endpoint support across the controller, node-agent, and shared target domain, including BEAM client/config/identity handling and node-agent endpoint mapping.
- Routes BEAM endpoint targets through inference scheduling, probing, dispatch, observation, and cleanup with fail-closed guardrails for address validation and node identity mismatches.
- Updates SPEC/OpenSpec, architecture/local-dev docs, and regression coverage for BEAM target normalization, scheduler fallback, node observation, endpoint mapping, and compatibility paths.

## Risk Assessment

⚠️ Medium: The branch is default-off and I found no merge-blocking issues, but it touches core scheduler, dispatch, node inventory, and BEAM transport identity paths, so residual integration risk is nontrivial.

## Testing

After an initial mise trust setup block, I reran with process-local trust, passed the targeted shared/controller/node-agent BEAM runtime endpoint tests plus dispatch/inference/gRPC compatibility selectors, and captured a MIX_ENV=test transcript showing prebuilt BEAM target normalization, nil address rejection, local BEAM client status, configured capacity publication, and address-only capacity withholding.

<details>
<summary>Evidence: BEAM runtime endpoint evidence transcript</summary>

<code>Orchard BEAM Runtime Endpoint evidence&#10;prebuilt target string address normalized to atom: :orchard_node_agent@localhost&#10;Target.beam/1 nil address rejection: beam target address must be an atom or binary node name&#10;BeamClient local source-dev status via prebuilt target: availability=available normalized_address=:nonode@nohost&#10;configured BEAM observation queue result: persisted_node=8f0b554d-7d7c-4915-81c2-63c0f6695584 grant=queued lane=beam-evidence-configured@v1&#10;address-only BEAM observation queue result: persisted_node=91c28365-0a33-447f-9c24-34bce44c5bce wait_result=queue_timeout lane=beam-evidence-address-only@v1&#10;address-only capacity withheld: true</code>

```text
Orchard BEAM Runtime Endpoint evidence
prebuilt target string address normalized to atom: :orchard_node_agent@localhost
Target.beam/1 nil address rejection: beam target address must be an atom or binary node name
BeamClient local source-dev status via prebuilt target: availability=available normalized_address=:nonode@nohost
configured BEAM observation queue result: persisted_node=8f0b554d-7d7c-4915-81c2-63c0f6695584 grant=queued lane=beam-evidence-configured@v1
address-only BEAM observation queue result: persisted_node=91c28365-0a33-447f-9c24-34bce44c5bce wait_result=queue_timeout lane=beam-evidence-address-only@v1
address-only capacity withheld: true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex:124` - Production BEAM enablement only checks that guardrail config is present, then allows `connect/1` to ping/RPC any target node reachable by the running BEAM cookie. This does not enforce current-node identity, admitted service, or allowed CIDR before live BEAM RPC, so the adapter should fail closed against the validated `BeamConfig` before production use.
- ⚠️ `apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex:18` - `connect/1` accepts a prebuilt BEAM `%Target{}` without calling `Target.normalize/1`, so direct callers still bypass the new address and node_id validation. Normalize the target at this boundary and store/use the normalized target.
- ⚠️ `apps/orchard_controller/lib/orchard/inference.ex:222` - Explicit `runtime_endpoint_targets` can now return BEAM targets, but default scheduler selection still keys off `runtime_client_targets/0`, and `SingleNode` still schedules only `runtime_client_target`. A single configured BEAM target is ignored unless `scheduler_impl: MultiNode` is also set, so confirm whether that extra opt-in is intentional or make the default scheduler path consume endpoint targets.

🔧 Fix: Harden BEAM endpoint guardrails and scheduling
2 issues (1 error, 1 warning) still open:
- 🚨 `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:218` - BEAM probe scheduling uses `Observation.node_id/1`, which prefers the configured target node_id over the node_id reported by the live BEAM status metadata. A target configured for node A can connect to a BEAM node reporting B, then schedule B&#39;s live capacity under persisted node A; require BEAM target node_id to match the observation metadata node_id before creating a candidate.
- ⚠️ `apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex:121` - `normalize_beam_address/1` accepts any atom without the `service@host` validation used for binary addresses, so atom callers still bypass the new BEAM target address validation. Validate `Atom.to_string(address)` before returning the atom.

🔧 Fix: Harden BEAM endpoint identity validation
3 issues (1 error, 2 warnings) still open:
- 🚨 `apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex:380` - Dispatch re-resolves node identity from the fresh status probe with `Observation.node_id/1`, which prefers the scheduled BEAM target&#39;s node_id and never compares it to live metadata. A target scheduled for node A can report node B at dispatch time and still run ensure/execute on B under A&#39;s attribution; apply the BEAM metadata mismatch check before observe/ensure/execute.
- ⚠️ `apps/orchard_controller/lib/orchard/nodes.ex:929` - Address-only BEAM targets can publish capacity after scheduling because `schedule_target/2` injects the observed node_id, but later connect/status failures use the original config target and `target_lookup/1` has no BEAM-address-to-node lookup. That leaves previously refreshed node capacity uncleared; either avoid publishing capacity for observed-only BEAM identities or persist a resolvable target identity for later failure cleanup.
- ⚠️ `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:246` - The scheduler writes the BEAM observation before checking configured target node_id against live metadata, so a target configured for node A but reporting B is rejected as a candidate while still inserting/updating B in node inventory. Move the BEAM identity check before `Nodes.observe_status/4` and skip or fail-closed on mismatches.

🔧 Fix: Harden BEAM endpoint identity guards
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch`
- `git diff --name-status 8f1259da1301c5fb6398c4f84bfd0c1bc45f453c..e192063fea5dc7b63ae7ce4233097416eaa8178b`
- `rg -n "Target\\.beam|beam_address|runtime endpoint|Runtime.*Endpoint|Endpoint" apps test config docs openspec SPEC.md`
- <code>Initial setup attempt: `mise exec -- mix test apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs apps/orchard_controller/test/orchard/runtime_endpoint/beam_config_test.exs apps/orchard_controller/test/orchard/nodes_test.exs:1830 apps/orchard_controller/test/orchard/nodes_test.exs:1889 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:587 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:837 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:889 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:927 apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs apps/orchard_node_agent/test/orchard_node_agent_test.exs:2794 apps/orchard_node_agent/test/orchard_node_agent_test.exs:2842` blocked before running tests because mise config was untrusted.</code>
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix test apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs apps/orchard_controller/test/orchard/runtime_endpoint/beam_config_test.exs apps/orchard_controller/test/orchard/nodes_test.exs:1830 apps/orchard_controller/test/orchard/nodes_test.exs:1889 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:587 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:837 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:889 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:927 apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs apps/orchard_node_agent/test/orchard_node_agent_test.exs:2794 apps/orchard_node_agent/test/orchard_node_agent_test.exs:2842`
- <code>`MIX_ENV=test MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix run --no-start -e &#39;...&#39;` manual Repo/QueueManager harness smoke check</code>
- `set -o pipefail; MIX_ENV=test MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix run --no-start /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW0KXEYXCTCEK2R1QMZYKGFV/beam_runtime_endpoint_evidence.exs | tee /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW0KXEYXCTCEK2R1QMZYKGFV/beam_runtime_endpoint_evidence.txt`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- mix test apps/orchard_controller/test/orchard/inference_test.exs:221 apps/orchard_controller/test/orchard/inference_test.exs:669 apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs:479 apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs:541 apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs:604 apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_client_test.exs apps/orchard_controller/test/orchard/nodes_test.exs:3308`
- `git status --short --branch`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
