### PR TITLE
docs: add Claude agent instruction import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,7 @@ See `packaging/pkg/README.md` for full PKG operator documentation and `packaging
 |------|---------|
 | SPEC.md | Normative build contract |
 | AGENTS.md | This file — agent operating guide |
+| CLAUDE.md | Claude Code import shim for AGENTS.md |
 | README.md | High-level product and roadmap overview |
 | CONTRIBUTING.md | Human collaborator workflow |
 | CONTEXT-MAP.md | Domain-modeling discovery map for glossary context |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+@AGENTS.md
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,1 @@
 @AGENTS.md
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ macOS. This repository is the collaborator-facing source of truth.
 1. `SPEC.md` is the top-level normative product/system contract.
 2. `README.md` explains what Orchard is and where to start.
 3. `CONTRIBUTING.md` explains human collaboration workflow.
-4. `AGENTS.md` explains automation and agent workflow.
+4. `AGENTS.md` explains automation and agent workflow; `CLAUDE.md` imports it for Claude Code.
 5. `docs/glossary/CONTEXT.md` defines shared Orchard product language.
 6. `docs/process.md` explains artifact lifecycle and review gates.
 7. `docs/decisions/**` records durable decisions not already fixed by `SPEC.md`.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ must be rewritten into this repo before it counts as Orchard truth.
 
 - [`SPEC.md`](SPEC.md) is the top-level normative build contract.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) explains human collaboration workflow.
-- [`AGENTS.md`](AGENTS.md) explains automation and agent workflow.
+- [`AGENTS.md`](AGENTS.md) is the canonical automation and agent workflow guide; [`CLAUDE.md`](CLAUDE.md) imports it for Claude Code.
 - [`docs/glossary/CONTEXT.md`](docs/glossary/CONTEXT.md) defines Orchard's shared product language.
 - [`docs/README.md`](docs/README.md) is the collaborator docs hub.
 - [`docs/architecture.md`](docs/architecture.md) explains repo and runtime boundaries.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ large spec sections.
 - [`glossary/CONTEXT.md`](glossary/CONTEXT.md) — shared vocabulary and
   glossary.
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — human collaborator workflow.
-- [`../AGENTS.md`](../AGENTS.md) — automation/agent workflow.
+- [`../AGENTS.md`](../AGENTS.md) - automation/agent workflow.
+  [`../CLAUDE.md`](../CLAUDE.md) imports it for Claude Code.
 
 ### I want to run it locally
 
@@ -30,7 +31,8 @@ large spec sections.
 ### I want to contribute code
 
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — human collaborator workflow.
-- [`../AGENTS.md`](../AGENTS.md) — automation/agent workflow and quality gates.
+- [`../AGENTS.md`](../AGENTS.md) - automation/agent workflow and quality gates.
+  [`../CLAUDE.md`](../CLAUDE.md) imports it for Claude Code.
 - [`process.md`](process.md) — artifact lifecycle and review gates.
 - [`code-quality.md`](code-quality.md) — Credo, ex_slop, and ex_dna policy.
 - [`../openspec/README.md`](../openspec/README.md) — OpenSpec change workflow
@@ -61,7 +63,7 @@ large spec sections.
 
 - Normative product/system behavior: `../SPEC.md`.
 - Human workflow: `../CONTRIBUTING.md`.
-- Agent workflow and validation: `../AGENTS.md`.
+- Agent workflow and validation: `../AGENTS.md`; `../CLAUDE.md` imports it for Claude Code.
 - OpenSpec change intent: `../openspec/README.md` and
   `../openspec/changes/<change-id>/`.
 - Artifact lifecycle: `process.md` and `../goals/README.md`.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -205,8 +205,9 @@ Common agent accelerators include:
 | Superpowers | Planning, debugging, verification discipline | Do not commit generated local plans unless rewritten as product docs |
 | Exa | Web research when current external facts are needed | Cite external sources in product-facing docs when relevant |
 
-Agents should follow `AGENTS.md` for when to use these tools. If an accelerator
-is unavailable, fall back to repo files, tests, and standard git commands
+Agents should follow `AGENTS.md` for when to use these tools.
+Claude Code reads that same guide through root `CLAUDE.md`.
+If an accelerator is unavailable, fall back to repo files, tests, and standard git commands
 without making the accelerator a collaborator requirement.
 
 For substantial agentic work, use RepoPrompt as a review and iteration layer


### PR DESCRIPTION
## Intent

Add a CLAUDE.md file so Claude Code picks up the same project instructions as other agents. The file is intentionally a single-line `@AGENTS.md` import rather than duplicated content: AGENTS.md is the canonical agent guide and source of truth, and the import keeps Claude Code aligned with it without the two files drifting. This is a docs-only addition of a previously-untracked file (CLAUDE.md was created locally and was not yet committed); no code, behavior, or SPEC impact. The @-import is a Claude Code feature; other agents already read AGENTS.md directly, so all agents converge on the same content.

## What Changed
- Added `CLAUDE.md` as a single-line `@AGENTS.md` import so Claude Code uses the canonical agent instructions.
- Updated repository guidance references in `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `docs/README.md`, and `docs/tooling.md` to describe `CLAUDE.md` as an import shim rather than a separate instruction source.

## Risk Assessment

✅ Low: The branch only adds a root-level `CLAUDE.md` pointer to the existing canonical `AGENTS.md`, with no code, behavior, or workflow divergence introduced.

## Testing

I checked the clean target state, inspected the docs-only diff, searched for relevant existing coverage, then produced a reviewer-readable transcript and byte-for-byte assertion showing `CLAUDE.md` resolves to the canonical `AGENTS.md`; no UI screenshot was applicable because this change has no rendered UI surface.

<details>
<summary>Evidence: Claude import evidence transcript</summary>

```text
Intent: Claude Code should pick up the canonical Orchard agent guide through a one-line CLAUDE.md import.

$ git diff --name-status 26bfadcdc9745df18da48b5a4b9443b94e9f6651..HEAD
A	CLAUDE.md

$ git diff 26bfadcdc9745df18da48b5a4b9443b94e9f6651..HEAD -- CLAUDE.md
diff --git a/CLAUDE.md b/CLAUDE.md
new file mode 100644
index 0000000..43c994c
--- /dev/null
+++ b/CLAUDE.md
@@ -0,0 +1 @@
+@AGENTS.md

$ sed -n "1l" CLAUDE.md
@AGENTS.md$

$ wc -l CLAUDE.md
       1 CLAUDE.md

$ od -An -tx1 -c CLAUDE.md
           40  41  47  45  4e  54  53  2e  6d  64  0a                    
           @   A   G   E   N   T   S   .   m   d  \n                    


Resolved import target: AGENTS.md

$ sed -n "1,8p" "$import_target"
# AGENTS.md — Orchard v2

Orchard is a sovereign on-prem LLM orchestration platform for Apple Silicon macOS. Elixir/OTP + Postgres.

## Build Contract

**SPEC.md** is the top-level normative Orchard build contract. Every
implementation decision must trace to `SPEC.md`, tests, product docs, a

Check: CLAUDE.md contains exactly @AGENTS.md followed by one newline, and the target file exists.

$ printf "@AGENTS.md\n" | cmp -s - CLAUDE.md && test -f AGENTS.md && printf "byte-for-byte pointer and import target verified\n"
byte-for-byte pointer and import target verified
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (5m30s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `CLAUDE.md:2` - The Claude import target exists and line 1 is `@AGENTS.md`, but `CLAUDE.md` is not literally a single-line file. It has a second blank line, and the byte dump ends with two newlines (`0a 0a`). Remove the extra blank line so the file is exactly the intended one-line import.
- `git diff --name-status 26bfadcdc9745df18da48b5a4b9443b94e9f6651..f56295ef517da17660d2adc4422aaf66c4d65eeb`
- `rg -n "CLAUDE\.md|AGENTS\.md|@AGENTS" . --glob '!deps/**' --glob '!_build/**'`
- `test -f AGENTS.md`
- `test "$(sed -n '1p' CLAUDE.md)" = "@AGENTS.md"`
- `test "$(wc -l < CLAUDE.md | tr -d ' ')" = "1"`
- <code>Created evidence transcript at `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1ADF8NCEFN92XWWHWEB640/claude-md-import-check.txt`</code>
- `git status --short`

🔧 Fix: Fix Claude import newline
✅ Re-checked - no issues remain.
- `git status --short`
- `git diff --stat 26bfadcdc9745df18da48b5a4b9443b94e9f6651..HEAD`
- `git diff --name-status 26bfadcdc9745df18da48b5a4b9443b94e9f6651..HEAD`
- `git diff 26bfadcdc9745df18da48b5a4b9443b94e9f6651..HEAD -- CLAUDE.md`
- `sed -n '1,20l' CLAUDE.md && wc -l CLAUDE.md && od -An -tx1 -c CLAUDE.md`
- `rg -n "CLAUDE\\.md|AGENTS\\.md|@AGENTS" . -g '!_build' -g '!deps' -g '!prompt-exports'`
- <code>Evidence transcript generation resolving `CLAUDE.md` to `AGENTS.md` at `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1ADF8NCEFN92XWWHWEB640/claude-import-evidence.txt`</code>
- `printf '@AGENTS.md\n' | cmp -s - CLAUDE.md && test -f AGENTS.md`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
