### PR TITLE
fix(orchard_controller): restore playground send submission

### DIFF
--- a/apps/orchard_controller/assets/js/app.js
+++ b/apps/orchard_controller/assets/js/app.js
@@ -273,8 +273,42 @@ Hooks.AutoScrollBottom = {
   }
 }
 
+function requestSubmitForm(form, submitter) {
+  if (!form) return false
+  if (submitter && submitter.disabled) return false
+
+  let validSubmitter = submitter && submitter.form === form ? submitter : undefined
+
+  if (typeof form.requestSubmit !== "function") return false
+
+  form.requestSubmit(validSubmitter)
+  return true
+}
+
 /**
- * SubmitOnModEnter — submits the enclosing form on Cmd/Ctrl+Enter.
+ * PlaygroundSubmitClick - routes Send clicks through LiveView form submission.
+ * Attach to a wrapper around `#playground-form`.
+ */
+Hooks.PlaygroundSubmitClick = {
+  mounted() {
+    this._onClick = (event) => {
+      let btn = event.target.closest("#playground-send")
+      if (!btn || !this.el.contains(btn) || btn.disabled) return
+
+      let form = btn.form || btn.closest("form")
+      if (requestSubmitForm(form, btn)) event.preventDefault()
+    }
+
+    this.el.addEventListener("click", this._onClick)
+  },
+
+  destroyed() {
+    this.el.removeEventListener("click", this._onClick)
+  }
+}
+
+/**
+ * SubmitOnModEnter - submits the enclosing form on Cmd/Ctrl+Enter.
  * Attach to a textarea with `phx-hook="SubmitOnModEnter"`.
  */
 Hooks.SubmitOnModEnter = {
@@ -285,15 +319,10 @@ Hooks.SubmitOnModEnter = {
         let form = this.el.closest("form")
         if (!form) return
 
-        // Respect the disabled state of the submit button
         let btn = form.querySelector("#playground-send")
         if (btn && btn.disabled) return
 
-        if (typeof form.requestSubmit === "function") {
-          form.requestSubmit(btn || undefined)
-        } else if (btn) {
-          btn.click()
-        }
+        if (!requestSubmitForm(form, btn) && btn) btn.click()
       }
     }
     this.el.addEventListener("keydown", this._onKeydown)

--- a/apps/orchard_controller/assets/js/app.js
+++ b/apps/orchard_controller/assets/js/app.js
@@ -273,6 +273,10 @@ Hooks.AutoScrollBottom = {
   }
 }
 
+/**
+ * requestSubmitForm - submits through the browser form contract.
+ * Returns false when submission should fall back or stay suppressed.
+ */
 function requestSubmitForm(form, submitter) {
   if (!form) return false
   if (submitter && submitter.disabled) return false
@@ -287,7 +291,7 @@ function requestSubmitForm(form, submitter) {
 
 /**
  * PlaygroundSubmitClick - routes Send clicks through LiveView form submission.
- * Attach to a wrapper around `#playground-form`.
+ * Attach to the wrapper that contains `#playground-form` and `#playground-send`.
  */
 Hooks.PlaygroundSubmitClick = {
   mounted() {

--- a/apps/orchard_controller/lib/orchard/console/playground_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground_live.ex
@@ -710,77 +710,80 @@ defmodule OrchardConsole.PlaygroundLive do
               title={@run_error.message}
             />
 
-            <.simple_form
-              id="playground-form"
-              for={@form}
-              phx-change="validate"
-              phx-submit="submit"
-            >
-              <.input
-                id="playground-model"
-                field={@form[:model]}
-                type="select"
-                label="Model"
-                size={:lg}
-                options={Enum.map(@models, &{&1.label, &1.value})}
-                errors={List.wrap(@form_errors[:model])}
-                disabled={@active_run != nil}
-              />
-              <p
-                :if={present_text?(@form[:model].value)}
-                id="playground-model-selected"
-                aria-live="polite"
-                class="-mt-3 font-mono text-xs text-slate-500 dark:text-slate-400 break-all"
+            <div id="playground-submit-controls" phx-hook="PlaygroundSubmitClick">
+              <.simple_form
+                id="playground-form"
+                for={@form}
+                phx-change="validate"
+                phx-submit="submit"
               >
-                Selected: {@form[:model].value}
-              </p>
-              <.input
-                id="playground-system"
-                field={@form[:system]}
-                type="textarea"
-                label="System prompt (optional)"
-                size={:lg}
-                rows={2}
-                disabled={@active_run != nil}
-              />
-              <div id="playground-sample-prompts" class="flex flex-wrap items-center gap-2">
-                <span class="text-xs text-slate-500 dark:text-slate-400">Sample prompts:</span>
-                <.button
-                  :for={sample <- sample_prompts()}
-                  id={"playground-sample-prompt-#{sample.id}"}
-                  type="button"
-                  variant={:secondary}
-                  size={:sm}
-                  phx-click="apply_sample_prompt"
-                  phx-value-sample_id={sample.id}
+                <.input
+                  id="playground-model"
+                  field={@form[:model]}
+                  type="select"
+                  label="Model"
+                  size={:lg}
+                  options={Enum.map(@models, &{&1.label, &1.value})}
+                  errors={List.wrap(@form_errors[:model])}
                   disabled={@active_run != nil}
+                />
+                <p
+                  :if={present_text?(@form[:model].value)}
+                  id="playground-model-selected"
+                  aria-live="polite"
+                  class="-mt-3 font-mono text-xs text-slate-500 dark:text-slate-400 break-all"
                 >
-                  {sample.label}
-                </.button>
-              </div>
-              <.input
-                id="playground-prompt"
-                field={@form[:prompt]}
-                type="textarea"
-                label="Message"
-                size={:lg}
-                rows={3}
-                errors={List.wrap(@form_errors[:prompt])}
-                phx-hook="SubmitOnModEnter"
-              />
-              <p id="playground-submit-hint" class="-mt-2 text-xs text-slate-500 dark:text-slate-400">
-                Press Cmd/Ctrl + Enter to send.
-              </p>
-              <:actions>
-                <.button
-                  id="playground-send"
-                  type="submit"
-                  disabled={@active_run != nil || @models == []}
-                >
-                  Send
-                </.button>
-              </:actions>
-            </.simple_form>
+                  Selected: {@form[:model].value}
+                </p>
+                <.input
+                  id="playground-system"
+                  field={@form[:system]}
+                  type="textarea"
+                  label="System prompt (optional)"
+                  size={:lg}
+                  rows={2}
+                  disabled={@active_run != nil}
+                />
+                <div id="playground-sample-prompts" class="flex flex-wrap items-center gap-2">
+                  <span class="text-xs text-slate-500 dark:text-slate-400">Sample prompts:</span>
+                  <.button
+                    :for={sample <- sample_prompts()}
+                    id={"playground-sample-prompt-#{sample.id}"}
+                    type="button"
+                    variant={:secondary}
+                    size={:sm}
+                    phx-click="apply_sample_prompt"
+                    phx-value-sample_id={sample.id}
+                    disabled={@active_run != nil}
+                  >
+                    {sample.label}
+                  </.button>
+                </div>
+                <.input
+                  id="playground-prompt"
+                  field={@form[:prompt]}
+                  type="textarea"
+                  label="Message"
+                  size={:lg}
+                  rows={3}
+                  errors={List.wrap(@form_errors[:prompt])}
+                  phx-hook="SubmitOnModEnter"
+                />
+                <p id="playground-submit-hint" class="-mt-2 text-xs text-slate-500 dark:text-slate-400">
+                  Press Cmd/Ctrl + Enter to send.
+                </p>
+                <:actions>
+                  <.button
+                    id="playground-send"
+                    type="submit"
+                    form="playground-form"
+                    disabled={@active_run != nil || @models == []}
+                  >
+                    Send
+                  </.button>
+                </:actions>
+              </.simple_form>
+            </div>
           </div>
         </.card>
 

--- a/apps/orchard_controller/test/orchard/console/playground_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_live_test.exs
@@ -564,10 +564,18 @@ defmodule OrchardConsole.PlaygroundLiveTest do
       assert html =~ ~s(data-auto-scroll="true")
     end
 
-    test "prompt textarea has submit shortcut hook and hint", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/console/playground")
+    test "send button keeps browser submit contract", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/console/playground")
 
-      assert html =~ ~s(phx-hook="SubmitOnModEnter")
+      assert has_element?(view, ~s|#playground-submit-controls[phx-hook="PlaygroundSubmitClick"]|)
+      assert has_element?(view, "#playground-form")
+      assert has_element?(view, ~s|#playground-send[type="submit"][form="playground-form"]|)
+    end
+
+    test "prompt textarea has submit shortcut hook and hint", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/console/playground")
+
+      assert has_element?(view, ~s|#playground-prompt[phx-hook="SubmitOnModEnter"]|)
       assert html =~ "playground-submit-hint"
       assert html =~ "Cmd/Ctrl + Enter"
     end

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -620,12 +620,16 @@ For each pair of `{light, dark} × {sidebar-expanded, sidebar-collapsed}`:
 
 **Form input wells (Playground)**
 
-- [ ] `<.input type="select">` model selector — well + caret visually
+- [ ] `<.input type="select">` model selector - well + caret visually
   consistent.
-- [ ] `<.input type="textarea">` system prompt — well treatment scales to
+- [ ] `<.input type="textarea">` system prompt - well treatment scales to
   multi-line.
-- [ ] `<.input type="textarea">` main message — well treatment scales to
+- [ ] `<.input type="textarea">` main message - well treatment scales to
   large height; the `SubmitOnModEnter` hook still fires.
+- [ ] Send remains a submit control for `#playground-form`; click submission
+  routes through `PlaygroundSubmitClick` and respects disabled state.
+- [ ] Cmd/Ctrl + Enter uses the same browser submit path as Send and respects
+  disabled state.
 - [ ] Disabled state legible. Verify via existing component paths or
   short-lived local-only attribute toggles in devtools; do not commit
   fixture-only UI states.


### PR DESCRIPTION
## Intent

Fix the Orchard Console Playground send button so clicking Send reliably submits the LiveView form in the browser while preserving the existing Cmd/Ctrl+Enter shortcut and disabled-state behavior. The change routes the rendered Send control through the Playground form submission contract, adds a small JS hook/helper for click and keyboard submission, and adds regression coverage for the browser submit contract so the Playground can send prompts again without changing product behavior beyond restoring the intended submit action.

## What Changed
- Restores the Playground Send button as a browser submit control for `#playground-form`, including the explicit form association needed after LiveView rendering.
- Adds a `PlaygroundSubmitClick` hook and shared `requestSubmitForm` helper so Send clicks and Cmd/Ctrl+Enter submit through the same browser form path while respecting disabled state.
- Adds regression assertions for the Playground submit contract and updates `docs/DESIGN.md` with the matching browser-walk checks.

## Risk Assessment

✅ Low: The change is narrowly scoped to the Playground submit control and preserves the existing form submit and disabled-state paths without introducing a material regression I could substantiate from the diff and surrounding code.

## Testing

After resolving setup-only blockers from untrusted `mise.toml` and missing local dependencies without persisting trust, the focused submit-contract tests and the full Playground LiveView test file passed; rendered Chrome/Playwright verification showed Send enabled with an active model, click submit and Cmd+Enter both reached real LiveView `submit` events, controls disabled during active runs, completion re-enabled Send, and screenshots plus JSON evidence were saved with no browser console or request failures.

- Evidence: Initial Playground with enabled Send (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F27S2JMPCVFQJDM6R9PZ7/playground-initial-enabled.png</code>)
- Evidence: Click submit with controls disabled during active run (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F27S2JMPCVFQJDM6R9PZ7/playground-click-during-submit-disabled.png</code>)
- Evidence: Click submit completed transcript (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F27S2JMPCVFQJDM6R9PZ7/playground-click-completed.png</code>)
- Evidence: Cmd+Enter shortcut completed transcript (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F27S2JMPCVFQJDM6R9PZ7/playground-shortcut-completed.png</code>)
<details>
<summary>Evidence: Browser submit verification summary</summary>

```text
{
  "browser": "Google Chrome headless via Playwright",
  "url": "http://localhost:4017/console/playground",
  "initialState": {
    "pageUrl": "http://localhost:4017/console/playground",
    "title": "Playground",
    "notBlank": true,
    "hasFrameworkOverlay": false,
    "liveViewConnected": true,
    "sendDisabled": false,
    "formId": "playground-form",
    "sendType": "submit",
    "promptHook": "SubmitOnModEnter",
    "submitHook": "PlaygroundSubmitClick",
    "selectedModelVisible": true,
    "shortcutHintVisible": true
  },
  "duringClickState": {
    "sendDisabled": true,
    "resetDisabled": true,
    "userVisible": true,
    "assistantWaiting": true,
    "transcriptAutoScroll": "true"
  },
  "afterClickState": {
    "sendDisabled": false,
    "statusCompleted": true,
    "userVisible": true,
    "assistantVisible": true,
    "requestIdVisible": true
  },
  "shortcutDuringState": {
    "sendDisabled": true,
    "resetDisabled": true,
    "userVisible": true
  },
  "afterShortcutState": {
    "sendDisabled": false,
    "statusCompleted": true,
    "userVisible": true,
    "assistantVisible": true,
    "shortcutHintVisible": true
  },
  "consoleMessages": [],
  "failedRequests": [],
  "ok": true
}
```
</details>
<details>
<summary>Evidence: LiveView submit events</summary>

```text
Observed LiveView events from the temporary evidence server:
HANDLE EVENT "submit" with prompt "Click submit evidence"
HANDLE EVENT "submit" with prompt "Shortcut submit evidence"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Browser plugin setup attempt: connected runtime, attempted `agent.browsers.get(&#34;iab&#34;)`, read `bootstrap-troubleshooting`, and confirmed `agent.browsers.list()` returned `[]`, so rendered validation used Playwright fallback.</code>
- `ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- mix deps.get`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- mix test apps/orchard_controller/test/orchard/console/playground_live_test.exs:568 apps/orchard_controller/test/orchard/console/playground_live_test.exs:576`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- npm ci --ignore-scripts`
- <code>`MISE_TRUSTED_CONFIG_PATHS=&#34;/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KW1F27S2JMPCVFQJDM6R9PZ7/mise.toml&#34; mise exec -- mix assets.build` from `apps/orchard_controller`</code>
- <code>`MIX_ENV=test ... mise exec -- mix run --no-start -e &#39;&lt;temporary PlaygroundBrowserEvidence server&gt;&#39;` at `http://localhost:4017/console/playground`</code>
- <code>Playwright with installed Google Chrome: loaded Playground, verified LiveView connected, clicked `#playground-send`, captured disabled active-run state, waited for completed transcript, reset, submitted again with `Meta+Enter`, and captured completed shortcut state.</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" mise exec -- mix test apps/orchard_controller/test/orchard/console/playground_live_test.exs`
- <code>Final cleanup/readback: removed generated `_build`, `deps`, `node_modules`, and `apps/orchard_controller/priv/static/assets`; confirmed `git status --short --ignored` was clean and the evidence server was stopped.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
