### PR TITLE
feat(orchard_controller): surface BEAM runtime diagnostics in Console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,7 +289,7 @@ start `mise exec -- bin/dev-node-agent` on the worker host with
 When to bypass `bin/dev`:
 - `mise exec -- iex -S mix` — BEAM without HTTP server (one-off scripts, migrations)
 - `mise exec -- iex -S mix phx.server` — manual server start with custom env vars
-- `mise exec -- mix test` — test suite (uses its own DB and port 50071 via `test.exs`)
+- `mise exec -- mix test` - test suite (uses its own DB and defaults to port 50071 via `test.exs`; override with `ORCHARD_TEST_NODE_AGENT_PORT` when another worktree owns that port)
 
 See `docs/local-dev.md` for full environment setup and configuration.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -47,6 +47,7 @@ Supported deployment modes:
 * The gRPC/protobuf `NodeRuntimeService` remains the compatibility transport and a candidate protocol for future non-BEAM adapters.
 * First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
 * Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is explicitly promoted.
+* Console live runtime diagnostics SHALL use the configured Runtime Endpoint target list; explicit BEAM Runtime Endpoint targets SHALL take precedence over legacy gRPC runtime client targets.
 * Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
 * BEAM Runtime Endpoint targets MUST carry a valid BEAM node-name address (`service@host`) as an atom or binary; a configured `node_id`, when present, MUST be a UUID and MUST match observed endpoint metadata before scheduler or dispatch may trust that candidate identity.
 * External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
@@ -379,7 +380,7 @@ Tokenizer observability includes `[:orchard, :tokenizer, :prompt_token_ids_dispa
 When `tokenizer_safe_mode_prefer_capable` is enabled and `tokenizer_safe_mode` is not `:off`, the multi-node scheduler MAY prefer Runtime Endpoints whose live Runtime Endpoint Observation reports `supports_prompt_token_ids = true`.
 This preference is a scheduler tie-breaker only; it is not dispatch authority and MUST NOT replace the per-request Runtime Endpoint ensure-model-loaded result gate.
 
-Console Live Cluster diagnostics SHALL surface the latest observed live prompt-token-ID support value per reachable runtime target so operators can assess mixed-version safe-tokenization risk; absence or `false` is rendered as legacy capability, not as a probe failure.
+Console Live Cluster diagnostics SHALL surface the latest observed live prompt-token-ID support value per reachable Runtime Endpoint target so operators can assess mixed-version safe-tokenization risk; absence or `false` is rendered as legacy capability, not as a probe failure.
 
 Console diagnostics SHALL surface observe-only, process-local safe-tokenization counters aggregated since counter process start (`control_token_in_user_content`, `detector_error`, `prompt_token_ids_dispatched` event count and accumulated token count, `unsafe_mode_active`, `parity_drift`, `catalog_drift`, and `safe_tokenization.degraded_no_manifest_catalog`). Counter values reset on counter process restart and MUST NOT influence scheduling, dispatch, admission, or readiness.
 
@@ -2086,6 +2087,8 @@ The gRPC/protobuf `NodeRuntimeService` remains the gRPC Compatibility Adapter an
 First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
 Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is explicitly promoted.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
+Console live runtime diagnostics SHALL use the configured Runtime Endpoint target list.
+Explicit BEAM Runtime Endpoint targets SHALL take precedence over legacy gRPC runtime client targets for Console probes.
 Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
 BEAM Runtime Endpoint targets MUST carry a valid BEAM node-name address (`service@host`) as an atom or binary; a configured `node_id`, when present, MUST be a UUID and MUST match observed endpoint metadata before scheduler or dispatch may trust that candidate identity.
 External Runtime Endpoints MUST NOT join the first-party BEAM mesh.

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -12,6 +12,7 @@ defmodule OrchardConsole.NodesLive do
   require Logger
 
   alias Orchard.Nodes
+  alias Orchard.RuntimeEndpoint.Target
 
   @default_refresh_interval_ms 5_000
   @safe_tokenization_counter_keys [
@@ -592,17 +593,49 @@ defmodule OrchardConsole.NodesLive do
     }
   end
 
-  defp target_label(target) do
+  defp target_label(%Target{transport: :grpc_compat, address: address}), do: target_label(address)
+
+  defp target_label(%Target{transport: :beam, address: address}) do
+    beam_address_label(address)
+  end
+
+  defp target_label(target) when is_list(target) do
     host = to_string(Keyword.get(target, :host, "?"))
     port = Keyword.get(target, :port)
     format_host_port(host, port)
   end
 
-  defp target_dom_id(target) do
+  defp target_label(%{host: host, port: port}) do
+    format_host_port(to_string(host), port)
+  end
+
+  defp target_label(_target), do: "unknown"
+
+  defp target_dom_id(%Target{transport: :grpc_compat, address: address}),
+    do: target_dom_id(address)
+
+  defp target_dom_id(%Target{transport: :beam, address: address}) do
+    "beam-#{beam_address_label(address)}"
+    |> sanitize_dom_id()
+  end
+
+  defp target_dom_id(target) when is_list(target) do
     host = to_string(Keyword.get(target, :host, "unknown"))
     port = Keyword.get(target, :port, 0)
-    raw = "#{host}-#{port}"
+    sanitize_dom_id("#{host}-#{port}")
+  end
 
+  defp target_dom_id(%{host: host, port: port}) do
+    sanitize_dom_id("#{host}-#{port}")
+  end
+
+  defp target_dom_id(_target), do: "unknown"
+
+  defp beam_address_label(address) when is_atom(address), do: Atom.to_string(address)
+  defp beam_address_label(address) when is_binary(address), do: address
+  defp beam_address_label(_address), do: "unknown"
+
+  defp sanitize_dom_id(raw) do
     raw
     |> String.replace(~r/[^a-zA-Z0-9]+/, "-")
     |> String.trim_leading("-")

--- a/apps/orchard_controller/lib/orchard/console/runtime.ex
+++ b/apps/orchard_controller/lib/orchard/console/runtime.ex
@@ -2,16 +2,19 @@ defmodule OrchardConsole.Runtime do
   @moduledoc """
   Console-facing wrapper for controller → node runtime status snapshots.
 
-  Wraps `Orchard.Dispatch.GrpcNodeRuntimeClient` connect/status/disconnect
-  into a single `snapshot/0` call that normalizes protobuf enums, sorts
-  loaded models, and returns operator-safe error snapshots.
+  Wraps the configured Runtime Endpoint client connect/status/disconnect flow
+  into a single `snapshot/0` call that normalizes endpoint observations or
+  legacy status responses, sorts loaded models, and returns operator-safe
+  error snapshots.
 
-  The underlying client module is injectable via `:runtime_client_impl`
-  in the `:orchard_controller, :console` config for testing.
+  The underlying client module is injectable via `:runtime_endpoint_client_impl`
+  or the legacy `:runtime_client_impl` in the `:orchard_controller, :console`
+  config for testing.
   """
 
   alias Orchard.Inference
   alias Orchard.Runtime.PrefixCacheStatus
+  alias Orchard.RuntimeEndpoint.{Observation, Placement, Target}
 
   @type worker_state :: :starting | :idle | :busy | :stopping | :failed | :stopped | :unknown
 
@@ -91,7 +94,7 @@ defmodule OrchardConsole.Runtime do
   def snapshot, do: snapshot([])
 
   @type cluster_target_snapshot :: %{
-          target: keyword(),
+          target: Target.t() | keyword(),
           status: :ok | :unavailable | :timeout | :error,
           message: String.t() | nil,
           worker_state: worker_state(),
@@ -108,14 +111,14 @@ defmodule OrchardConsole.Runtime do
   @doc """
   Probes all configured runtime targets and returns an ordered list of snapshots.
 
-  Each entry corresponds to one target from `Inference.runtime_client_targets/0`.
+  Each entry corresponds to one target from `Inference.runtime_endpoint_targets/0`.
   Successful probes trigger best-effort `observe_status/3` via the existing
   `snapshot/1` path, including queue capacity refresh.
   Per-target failures are isolated - one failed target never aborts the cluster
   result.
 
   Options:
-  - `:targets` - explicit ordered target list (default: `Inference.runtime_client_targets/0`)
+  - `:targets` - explicit ordered target list (default: `Inference.runtime_endpoint_targets/0`)
   - `:observed_at` - shared timestamp for all probes (default: `DateTime.utc_now()`)
   - `:timeout` - forwarded to each `snapshot/1` call
   """
@@ -124,7 +127,7 @@ defmodule OrchardConsole.Runtime do
 
   @spec cluster_snapshot(keyword()) :: [cluster_target_snapshot()]
   def cluster_snapshot(opts) do
-    targets = Keyword.get(opts, :targets, Inference.runtime_client_targets())
+    targets = Keyword.get(opts, :targets, Inference.runtime_endpoint_targets())
     observed_at = Keyword.get(opts, :observed_at, DateTime.utc_now())
     timeout = opts[:timeout]
 
@@ -181,44 +184,59 @@ defmodule OrchardConsole.Runtime do
   Fetches a runtime status snapshot with optional overrides.
 
   Options:
-  - `:target` - override runtime target (default: from inference config)
+  - `:target` - override runtime target (default: first Runtime Endpoint target)
   - `:observed_at` - override observation timestamp (default: `DateTime.utc_now()`)
   - `:timeout` - status RPC timeout in milliseconds (default: client default)
   """
   @spec snapshot(keyword()) :: {:ok, snapshot()} | {:error, error_snapshot()}
   def snapshot(opts) do
-    client = runtime_client_impl()
-    target = Keyword.get(opts, :target, Inference.runtime_client_target())
+    target = Keyword.get_lazy(opts, :target, &default_runtime_target/0)
+    client = runtime_client_impl(target)
     observed_at = Keyword.get(opts, :observed_at, DateTime.utc_now())
     status_opts = if timeout = opts[:timeout], do: [timeout: timeout], else: []
 
+    snapshot_target(client, target, observed_at, status_opts)
+  end
+
+  defp default_runtime_target do
+    case Inference.runtime_endpoint_targets() do
+      [target | _] -> target
+      [] -> nil
+    end
+  end
+
+  defp snapshot_target(_client, nil, _observed_at, _status_opts) do
+    {:error,
+     error_snapshot(:error, "runtime_target_unconfigured", "runtime target is not configured")}
+  end
+
+  defp snapshot_target(client, target, observed_at, status_opts) do
     case safe_connect(client, target) do
       {:ok, channel} ->
-        try do
-          case safe_status(client, channel, status_opts, target) do
-            {:ok, response} ->
-              observe_status_best_effort(target, response, observed_at)
-              {:ok, normalize_response(response)}
+        read_target_status(client, channel, target, observed_at, status_opts)
 
-            {:error, reason} ->
-              {:error, error_snapshot_for(reason)}
-          end
-        after
-          safe_disconnect(client, channel, target)
-        end
-
-      {:error, {:connect_failed, _reason}} ->
-        {:error, error_snapshot(:unavailable, "node_unavailable", "node runtime is unavailable")}
-
-      {:error, _reason} ->
-        {:error, error_snapshot(:error, "runtime_error", "node status request failed")}
+      {:error, reason} ->
+        {:error, error_snapshot_for(reason)}
     end
+  end
+
+  defp read_target_status(client, channel, target, observed_at, status_opts) do
+    case safe_status(client, channel, status_opts, target) do
+      {:ok, response} ->
+        observe_status_best_effort(target, response, observed_at)
+        {:ok, normalize_response(response)}
+
+      {:error, reason} ->
+        {:error, error_snapshot_for(reason)}
+    end
+  after
+    safe_disconnect(client, channel, target)
   end
 
   # ---------------------------------------------------------------------------
   # Safe transport wrappers
   #
-  # gRPC client calls can exit (e.g., GenServer call to a dead process) or
+  # Runtime client calls can exit (e.g., GenServer call to a dead process) or
   # raise unexpectedly. These wrappers ensure transport-layer instability
   # is always converted to tagged error tuples so callers never crash.
   # ---------------------------------------------------------------------------
@@ -274,6 +292,20 @@ defmodule OrchardConsole.Runtime do
   # Response normalization
   # ---------------------------------------------------------------------------
 
+  defp normalize_response(%Observation{} = observation) do
+    %{
+      worker_state: normalize_worker_state(observation.worker_state),
+      loaded_models: normalize_observation_loaded_models(observation),
+      active_request_count: normalize_count(observation.aggregate_active_request_count),
+      node_metadata: normalize_node_metadata(observation),
+      runtime_health: normalize_runtime_health(observation),
+      supports_prompt_token_ids: observation.supports_prompt_token_ids == true,
+      runtime_memory_budgets: normalize_runtime_memory_budgets(observation),
+      runtime_memory_budgets_truncated_count: runtime_memory_budgets_truncated_count(observation),
+      runtime_prefix_cache_statuses: normalize_runtime_prefix_cache_statuses(observation)
+    }
+  end
+
   defp normalize_response(response) do
     %{
       worker_state: normalize_worker_state(response.worker_state),
@@ -295,6 +327,9 @@ defmodule OrchardConsole.Runtime do
   defp normalize_worker_state(:WORKER_STATE_STOPPING), do: :stopping
   defp normalize_worker_state(:WORKER_STATE_FAILED), do: :failed
   defp normalize_worker_state(:WORKER_STATE_STOPPED), do: :stopped
+  defp normalize_worker_state(state) when state in [:starting, :idle, :busy], do: state
+  defp normalize_worker_state(state) when state in [:stopping, :failed, :stopped], do: state
+  defp normalize_worker_state(:unknown), do: :unknown
   # Integer fallbacks for forward compatibility
   defp normalize_worker_state(1), do: :starting
   defp normalize_worker_state(2), do: :idle
@@ -317,6 +352,24 @@ defmodule OrchardConsole.Runtime do
 
   defp normalize_loaded_models(_), do: []
 
+  defp normalize_observation_loaded_models(%Observation{placements: placements})
+       when is_list(placements) do
+    placements
+    |> Enum.filter(&Placement.loaded?/1)
+    |> Enum.map(&loaded_model_from_placement/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort_by(&{&1.model_id, &1.version})
+  end
+
+  defp normalize_observation_loaded_models(_observation), do: []
+
+  defp loaded_model_from_placement(%Placement{model_ref: %{model_id: model_id, version: version}})
+       when is_binary(model_id) and model_id != "" and is_binary(version) and version != "" do
+    %{model_id: model_id, version: version}
+  end
+
+  defp loaded_model_from_placement(_placement), do: nil
+
   defp normalize_count(n) when is_integer(n) and n >= 0, do: n
   defp normalize_count(_), do: 0
 
@@ -327,6 +380,11 @@ defmodule OrchardConsole.Runtime do
   # ---------------------------------------------------------------------------
   # Node metadata / runtime health normalization
   # ---------------------------------------------------------------------------
+
+  defp normalize_node_metadata(%Observation{metadata: metadata}) when metadata == %{}, do: nil
+
+  defp normalize_node_metadata(%Observation{metadata: metadata}) when is_map(metadata),
+    do: do_normalize_metadata(metadata)
 
   defp normalize_node_metadata(%{node_metadata: nil}), do: nil
 
@@ -346,6 +404,11 @@ defmodule OrchardConsole.Runtime do
       worker_backend: non_empty_string(Map.get(meta, :worker_backend))
     }
   end
+
+  defp normalize_runtime_health(%Observation{health: health}) when health == %{}, do: nil
+
+  defp normalize_runtime_health(%Observation{health: health}) when is_map(health),
+    do: do_normalize_health(health)
 
   defp normalize_runtime_health(%{runtime_health: nil}), do: nil
 
@@ -497,11 +560,39 @@ defmodule OrchardConsole.Runtime do
   # Error snapshots
   # ---------------------------------------------------------------------------
 
+  defp error_snapshot_for({:connect_failed, _reason}),
+    do: error_snapshot(:unavailable, "node_unavailable", "node runtime is unavailable")
+
   defp error_snapshot_for(:node_unavailable),
     do: error_snapshot(:unavailable, "node_unavailable", "node runtime is unavailable")
 
   defp error_snapshot_for(:node_timeout),
     do: error_snapshot(:timeout, "node_timeout", "node status request timed out")
+
+  defp error_snapshot_for(:beam_distribution_unavailable),
+    do:
+      error_snapshot(
+        :unavailable,
+        "beam_distribution_unavailable",
+        "BEAM distribution is unavailable"
+      )
+
+  defp error_snapshot_for(:beam_distribution_disabled),
+    do:
+      error_snapshot(
+        :unavailable,
+        "beam_distribution_disabled",
+        "BEAM distribution is disabled"
+      )
+
+  defp error_snapshot_for(:unknown_beam_node),
+    do: error_snapshot(:unavailable, "unknown_beam_node", "BEAM node is unavailable")
+
+  defp error_snapshot_for({:unsupported_transport, _transport}),
+    do: error_snapshot(:error, "unsupported_runtime_transport", "node status request failed")
+
+  defp error_snapshot_for({:beam_rpc_error, _reason}),
+    do: error_snapshot(:error, "beam_rpc_error", "node status request failed")
 
   defp error_snapshot_for({:rpc_error, status, _message}) when is_atom(status),
     do: error_snapshot(:error, "rpc_#{status}", "node status request failed")
@@ -533,9 +624,19 @@ defmodule OrchardConsole.Runtime do
   # Config seam
   # ---------------------------------------------------------------------------
 
-  defp runtime_client_impl do
-    Application.get_env(:orchard_controller, :console, [])
-    |> Keyword.get(:runtime_client_impl, Orchard.Dispatch.GrpcNodeRuntimeClient)
+  defp runtime_client_impl(%Target{transport: :beam}) do
+    console_config = Application.get_env(:orchard_controller, :console, [])
+
+    console_config[:runtime_endpoint_client_impl] ||
+      Inference.runtime_endpoint_client()
+  end
+
+  defp runtime_client_impl(_target) do
+    console_config = Application.get_env(:orchard_controller, :console, [])
+
+    console_config[:runtime_endpoint_client_impl] ||
+      console_config[:runtime_client_impl] ||
+      Inference.runtime_endpoint_client()
   end
 
   defp nodes_impl do

--- a/apps/orchard_controller/lib/orchard/console/runtime.ex
+++ b/apps/orchard_controller/lib/orchard/console/runtime.ex
@@ -127,7 +127,7 @@ defmodule OrchardConsole.Runtime do
 
   @spec cluster_snapshot(keyword()) :: [cluster_target_snapshot()]
   def cluster_snapshot(opts) do
-    targets = Keyword.get(opts, :targets, Inference.runtime_endpoint_targets())
+    targets = Keyword.get_lazy(opts, :targets, &Inference.runtime_endpoint_targets/0)
     observed_at = Keyword.get(opts, :observed_at, DateTime.utc_now())
     timeout = opts[:timeout]
 
@@ -191,11 +191,11 @@ defmodule OrchardConsole.Runtime do
   @spec snapshot(keyword()) :: {:ok, snapshot()} | {:error, error_snapshot()}
   def snapshot(opts) do
     target = Keyword.get_lazy(opts, :target, &default_runtime_target/0)
-    client = runtime_client_impl(target)
+    {client, client_target} = runtime_client(target)
     observed_at = Keyword.get(opts, :observed_at, DateTime.utc_now())
     status_opts = if timeout = opts[:timeout], do: [timeout: timeout], else: []
 
-    snapshot_target(client, target, observed_at, status_opts)
+    snapshot_target(client, target, client_target, observed_at, status_opts)
   end
 
   defp default_runtime_target do
@@ -205,13 +205,13 @@ defmodule OrchardConsole.Runtime do
     end
   end
 
-  defp snapshot_target(_client, nil, _observed_at, _status_opts) do
+  defp snapshot_target(_client, nil, _client_target, _observed_at, _status_opts) do
     {:error,
      error_snapshot(:error, "runtime_target_unconfigured", "runtime target is not configured")}
   end
 
-  defp snapshot_target(client, target, observed_at, status_opts) do
-    case safe_connect(client, target) do
+  defp snapshot_target(client, target, client_target, observed_at, status_opts) do
+    case safe_connect(client, client_target, target) do
       {:ok, channel} ->
         read_target_status(client, channel, target, observed_at, status_opts)
 
@@ -241,8 +241,8 @@ defmodule OrchardConsole.Runtime do
   # is always converted to tagged error tuples so callers never crash.
   # ---------------------------------------------------------------------------
 
-  defp safe_connect(client, target) do
-    client.connect(target)
+  defp safe_connect(client, client_target, target) do
+    client.connect(client_target)
   catch
     kind, reason ->
       require Logger
@@ -624,19 +624,44 @@ defmodule OrchardConsole.Runtime do
   # Config seam
   # ---------------------------------------------------------------------------
 
-  defp runtime_client_impl(%Target{transport: :beam}) do
+  defp runtime_client(%Target{transport: :beam} = target) do
     console_config = Application.get_env(:orchard_controller, :console, [])
 
-    console_config[:runtime_endpoint_client_impl] ||
-      Inference.runtime_endpoint_client()
+    client =
+      console_config[:runtime_endpoint_client_impl] ||
+        Inference.runtime_endpoint_client()
+
+    {client, target}
   end
 
-  defp runtime_client_impl(_target) do
+  defp runtime_client(%Target{transport: :grpc_compat, address: address} = target) do
     console_config = Application.get_env(:orchard_controller, :console, [])
 
-    console_config[:runtime_endpoint_client_impl] ||
-      console_config[:runtime_client_impl] ||
-      Inference.runtime_endpoint_client()
+    cond do
+      client = console_config[:runtime_endpoint_client_impl] ->
+        {client, target}
+
+      client = console_config[:runtime_client_impl] ->
+        {client, address}
+
+      true ->
+        {Inference.runtime_endpoint_client(), target}
+    end
+  end
+
+  defp runtime_client(target) do
+    console_config = Application.get_env(:orchard_controller, :console, [])
+
+    cond do
+      client = console_config[:runtime_endpoint_client_impl] ->
+        {client, target}
+
+      client = console_config[:runtime_client_impl] ->
+        {client, target}
+
+      true ->
+        {Inference.runtime_endpoint_client(), target}
+    end
   end
 
   defp nodes_impl do

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -225,7 +225,8 @@ defmodule Orchard.Inference do
   end
 
   @doc """
-  Returns normalized Runtime Endpoint targets for scheduler and dispatch.
+  Returns normalized Runtime Endpoint targets for scheduler, dispatch, and
+  Console live diagnostics.
 
   Explicit `:runtime_endpoint_targets` override legacy
   `:runtime_client_targets`, allow BEAM targets, and force endpoint-aware

--- a/apps/orchard_controller/test/application_test.exs
+++ b/apps/orchard_controller/test/application_test.exs
@@ -103,7 +103,7 @@ defmodule OrchardApplicationTest do
 
     assert inference[:tokenizer_mode] == :fake
     assert inference[:request_timeout_ms] == 5_000
-    assert inference[:runtime_client_target] == [host: "127.0.0.1", port: 50_071]
+    assert inference[:runtime_client_target] == test_runtime_client_target()
     assert Path.type(inference[:artifacts_root]) == :absolute
     assert String.ends_with?(inference[:artifacts_root], "/tmp/test/bundles")
 
@@ -157,5 +157,14 @@ defmodule OrchardApplicationTest do
       :ok -> :ok
       {:error, {:not_started, :orchard_controller}} -> :ok
     end
+  end
+
+  defp test_runtime_client_target do
+    [host: "127.0.0.1", port: test_node_agent_port()]
+  end
+
+  defp test_node_agent_port do
+    System.get_env("ORCHARD_TEST_NODE_AGENT_PORT", "50071")
+    |> String.to_integer()
   end
 end

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -372,6 +372,65 @@ defmodule OrchardConsole.NodesLiveTest.RuntimeMultiTargetStub do
   end
 end
 
+defmodule OrchardConsole.NodesLiveTest.RuntimeBeamTargetStub do
+  @moduledoc false
+  @node_id "550e8400-e29b-41d4-a716-446655440000"
+  @target Orchard.RuntimeEndpoint.Target.beam(@node_id,
+            address: :orchard_node_agent_smoke@mawarduri
+          )
+
+  def cluster_snapshot(_opts \\ []) do
+    [
+      %{
+        target: @target,
+        status: :ok,
+        message: nil,
+        worker_state: :idle,
+        loaded_models: [%{model_id: "model-beam", version: "v1"}],
+        active_request_count: 0,
+        node_metadata: %{
+          node_id: @node_id,
+          display_name: "beam-node",
+          hostname: "mawarduri.local",
+          listen_host: "100.70.81.109",
+          listen_port: 50_071,
+          agent_version: "0.2.0",
+          worker_backend: "stub"
+        },
+        runtime_health: %{ready: true, health_code: nil, health_message: nil, affected_model: nil},
+        supports_prompt_token_ids: true
+      }
+    ]
+  end
+end
+
+defmodule OrchardConsole.NodesLiveTest.RuntimeGrpcMapTargetStub do
+  @moduledoc false
+
+  @target %Orchard.RuntimeEndpoint.Target{
+    id: "grpc_compat:127.0.0.9:50071",
+    transport: :grpc_compat,
+    address: %{host: "127.0.0.9", port: 50_071, metadata: %{token: "must-not-render"}},
+    metadata: %{}
+  }
+
+  def cluster_snapshot(_opts \\ []) do
+    [
+      %{
+        target: @target,
+        status: :ok,
+        message: nil,
+        worker_state: :idle,
+        loaded_models: [],
+        active_request_count: 0,
+        node_metadata: nil,
+        runtime_health: %{ready: true, health_code: nil, health_message: nil, affected_model: nil},
+        supports_prompt_token_ids: false
+      }
+    ]
+  end
+end
+
 defmodule OrchardConsole.NodesLiveTest.DiscoveryRuntimeClient do
   @moduledoc false
   @discovery_uuid "770fa622-a41c-63f6-c938-668877662222"
@@ -747,6 +806,34 @@ defmodule OrchardConsole.NodesLiveTest do
 
       # DOM id based on target host:port
       assert html =~ ~s(id="nodes-runtime-card-127-0-0-1-50071")
+    end
+
+    test "renders BEAM Runtime Endpoint targets with readable labels and stable DOM ids", %{
+      conn: conn
+    } do
+      put_runtime_stub(OrchardConsole.NodesLiveTest.RuntimeBeamTargetStub)
+
+      {:ok, view, html} = live(conn, "/console/nodes")
+
+      assert html =~ ~s(id="nodes-runtime-card-beam-orchard-node-agent-smoke-mawarduri")
+      assert html =~ "beam-node"
+      assert html =~ "orchard_node_agent_smoke@mawarduri"
+
+      summary = element(view, "#nodes-live-cluster-card") |> render()
+      assert summary =~ "1 target(s) configured"
+      assert summary =~ "1 reachable"
+    end
+
+    test "renders map-backed gRPC Runtime Endpoint targets without leaking metadata", %{
+      conn: conn
+    } do
+      put_runtime_stub(OrchardConsole.NodesLiveTest.RuntimeGrpcMapTargetStub)
+
+      {:ok, _view, html} = live(conn, "/console/nodes")
+
+      assert html =~ ~s(id="nodes-runtime-card-127-0-0-9-50071")
+      assert html =~ "127.0.0.9:50071"
+      refute html =~ "must-not-render"
     end
 
     test "renders prompt-token capability badge for capable target", %{conn: conn} do

--- a/apps/orchard_controller/test/orchard/console/runtime_test.exs
+++ b/apps/orchard_controller/test/orchard/console/runtime_test.exs
@@ -2,11 +2,13 @@ defmodule OrchardConsole.RuntimeTest do
   use ExUnit.Case, async: false
 
   alias Orchard.Runtime.PrefixCacheStatus
+  alias Orchard.RuntimeEndpoint.{Observation, Target}
   alias OrchardConsole.Runtime
   import Orchard.TestSupport.RepoHelpers
 
   setup do
     previous = Application.get_env(:orchard_controller, :console, [])
+    previous_inference = Application.fetch_env!(:orchard_controller, :inference)
 
     Application.put_env(
       :orchard_controller,
@@ -16,7 +18,11 @@ defmodule OrchardConsole.RuntimeTest do
       |> Keyword.put(:nodes_impl, __MODULE__.StubNodes)
     )
 
-    on_exit(fn -> Application.put_env(:orchard_controller, :console, previous) end)
+    on_exit(fn ->
+      Application.put_env(:orchard_controller, :console, previous)
+      Application.put_env(:orchard_controller, :inference, previous_inference)
+    end)
+
     :ok
   end
 
@@ -840,7 +846,7 @@ defmodule OrchardConsole.RuntimeTest do
       # Support per-target scripted responses via :target_responses map
       case Keyword.get(stubs, :target_responses) do
         responses when is_map(responses) and target != nil ->
-          target_key = {Keyword.get(target, :host), Keyword.get(target, :port)}
+          target_key = target_response_key(target)
 
           case Map.get(responses, target_key) do
             nil -> Keyword.fetch!(stubs, key)
@@ -852,10 +858,36 @@ defmodule OrchardConsole.RuntimeTest do
       end
     end
 
+    defp target_response_key(%Orchard.RuntimeEndpoint.Target{
+           transport: :grpc_compat,
+           address: address
+         }) do
+      target_response_key(address)
+    end
+
+    defp target_response_key(%Orchard.RuntimeEndpoint.Target{transport: :beam, address: address}) do
+      {:beam, address}
+    end
+
+    defp target_response_key(target) when is_list(target) do
+      {Keyword.get(target, :host), Keyword.get(target, :port)}
+    end
+
     defp get_stub_pid do
       [{pid, _stubs}] = Registry.lookup(OrchardConsole.RuntimeTest.StubRegistry, :stubs)
       pid
     end
+  end
+
+  defmodule LegacyPoisonClient do
+    def connect(target) do
+      [{pid, _stubs}] = Registry.lookup(OrchardConsole.RuntimeTest.StubRegistry, :stubs)
+      send(pid, {:legacy_client_called, target})
+      {:error, :legacy_client_used}
+    end
+
+    def status(_channel, _opts \\ []), do: {:error, :legacy_client_used}
+    def disconnect(_channel), do: :ok
   end
 
   defmodule StubNodes do
@@ -887,6 +919,140 @@ defmodule OrchardConsole.RuntimeTest do
   end
 
   describe "cluster_snapshot/0,1" do
+    test "defaults to explicit Runtime Endpoint targets instead of legacy gRPC targets" do
+      node_id = "550e8400-e29b-41d4-a716-446655440000"
+      beam_target = Target.beam(node_id, address: :orchard_node_agent_smoke@localhost)
+      legacy_target = [host: "10.0.0.1", port: 50_061]
+
+      put_inference(
+        runtime_endpoint_client_impl: __MODULE__.StubClient,
+        runtime_endpoint_targets: [beam_target],
+        runtime_client_targets: [legacy_target]
+      )
+
+      stub_client(
+        target_responses: %{
+          {:beam, :orchard_node_agent_smoke@localhost} => [
+            connect: {:ok, :beam_ch},
+            status:
+              {:ok,
+               %{
+                 worker_state: :WORKER_STATE_IDLE,
+                 loaded_models: [],
+                 active_request_count: 0,
+                 node_metadata: %{
+                   node_id: node_id,
+                   display_name: "beam-node",
+                   hostname: "beam.local",
+                   listen_host: "127.0.0.1",
+                   listen_port: 50_071,
+                   agent_version: "0.1.0",
+                   worker_backend: "stub"
+                 },
+                 runtime_health: %{ready: true}
+               }},
+            disconnect: :ok
+          ]
+        }
+      )
+
+      assert [
+               %{target: ^beam_target, status: :ok, node_metadata: %{display_name: "beam-node"}}
+             ] = Runtime.cluster_snapshot()
+
+      assert_received {:connect_called, ^beam_target}
+      refute_received {:connect_called, ^legacy_target}
+    end
+
+    test "BEAM Runtime Endpoint targets ignore stale legacy Console runtime client override" do
+      node_id = "550e8400-e29b-41d4-a716-446655440000"
+      beam_target = Target.beam(node_id, address: :orchard_node_agent_smoke@localhost)
+
+      put_console(runtime_client_impl: __MODULE__.LegacyPoisonClient)
+
+      put_inference(
+        runtime_endpoint_client_impl: __MODULE__.StubClient,
+        runtime_endpoint_targets: [beam_target]
+      )
+
+      stub_client(
+        target_responses: %{
+          {:beam, :orchard_node_agent_smoke@localhost} => [
+            connect: {:ok, :beam_ch},
+            status:
+              {:ok,
+               %{
+                 worker_state: :WORKER_STATE_IDLE,
+                 loaded_models: [],
+                 active_request_count: 0,
+                 node_metadata: %{node_id: node_id, display_name: "beam-node"},
+                 runtime_health: %{ready: true}
+               }},
+            disconnect: :ok
+          ]
+        }
+      )
+
+      assert {:ok, snapshot} = Runtime.snapshot()
+      assert snapshot.node_metadata.display_name == "beam-node"
+      assert_received {:connect_called, ^beam_target}
+      refute_received {:legacy_client_called, ^beam_target}
+    end
+
+    test "normalizes Runtime Endpoint observations returned by the configured client" do
+      node_id = "550e8400-e29b-41d4-a716-446655440000"
+      target = Target.beam(node_id, address: :orchard_node_agent_smoke@localhost)
+
+      put_inference(runtime_endpoint_client_impl: __MODULE__.StubClient)
+
+      observation =
+        Observation.new(%{
+          endpoint_id: "beam:#{node_id}",
+          target: target,
+          availability: :available,
+          worker_state: :idle,
+          aggregate_active_request_count: 2,
+          metadata: %{
+            node_id: node_id,
+            display_name: "beam-observed",
+            hostname: "beam.local",
+            listen_host: "127.0.0.1",
+            listen_port: 50_071,
+            agent_version: "0.2.0",
+            worker_backend: "stub"
+          },
+          health: %{ready: true, health_code: nil, health_message: nil, affected_model: nil},
+          placements: [
+            %{
+              model_ref: %{model_id: "mlx-community/phi-3", version: "main"},
+              state: :loaded
+            }
+          ],
+          supports_prompt_token_ids: true
+        })
+
+      stub_client(
+        target_responses: %{
+          {:beam, :orchard_node_agent_smoke@localhost} => [
+            connect: {:ok, :beam_ch},
+            status: {:ok, observation},
+            disconnect: :ok
+          ]
+        }
+      )
+
+      assert {:ok, snapshot} = Runtime.snapshot(target: target)
+
+      assert snapshot.worker_state == :idle
+      assert snapshot.active_request_count == 2
+      assert snapshot.node_metadata.display_name == "beam-observed"
+      assert snapshot.runtime_health.ready == true
+      assert snapshot.supports_prompt_token_ids == true
+      assert snapshot.loaded_models == [%{model_id: "mlx-community/phi-3", version: "main"}]
+
+      assert_received {:observe_status_called, ^target, ^observation, _observed_at}
+    end
+
     test "probes all targets in config order" do
       target_a = [host: "127.0.0.1", port: 50_071]
       target_b = [host: "10.0.0.2", port: 50_061]
@@ -1410,5 +1576,15 @@ defmodule OrchardConsole.RuntimeTest do
       },
       attrs
     )
+  end
+
+  defp put_inference(opts) do
+    previous = Application.fetch_env!(:orchard_controller, :inference)
+    Application.put_env(:orchard_controller, :inference, Keyword.merge(previous, opts))
+  end
+
+  defp put_console(opts) do
+    previous = Application.fetch_env!(:orchard_controller, :console)
+    Application.put_env(:orchard_controller, :console, Keyword.merge(previous, opts))
   end
 end

--- a/apps/orchard_controller/test/orchard/console/runtime_test.exs
+++ b/apps/orchard_controller/test/orchard/console/runtime_test.exs
@@ -818,9 +818,9 @@ defmodule OrchardConsole.RuntimeTest do
       dispatch_stub(:status)
     end
 
-    def disconnect({:stub_channel, _target, channel}) do
+    def disconnect({:stub_channel, target, channel}) do
       send(get_stub_pid(), {:disconnect_called, channel})
-      dispatch_stub(:disconnect)
+      dispatch_stub(:disconnect, target)
     end
 
     def disconnect(channel) do
@@ -888,6 +888,33 @@ defmodule OrchardConsole.RuntimeTest do
 
     def status(_channel, _opts \\ []), do: {:error, :legacy_client_used}
     def disconnect(_channel), do: :ok
+  end
+
+  defmodule LegacyStrictClient do
+    def connect(target) when is_list(target) do
+      [{pid, _stubs}] = Registry.lookup(OrchardConsole.RuntimeTest.StubRegistry, :stubs)
+      send(pid, {:legacy_client_called, target})
+      {:ok, :legacy_channel}
+    end
+
+    def connect(target) do
+      [{pid, _stubs}] = Registry.lookup(OrchardConsole.RuntimeTest.StubRegistry, :stubs)
+      send(pid, {:legacy_client_called, target})
+      raise ArgumentError, "legacy client requires keyword target"
+    end
+
+    def status(:legacy_channel, _opts \\ []) do
+      {:ok,
+       %{
+         worker_state: :WORKER_STATE_IDLE,
+         loaded_models: [],
+         active_request_count: 0,
+         node_metadata: %{node_id: "legacy-node", display_name: "legacy-grpc"},
+         runtime_health: %{ready: true}
+       }}
+    end
+
+    def disconnect(:legacy_channel), do: :ok
   end
 
   defmodule StubNodes do
@@ -997,6 +1024,44 @@ defmodule OrchardConsole.RuntimeTest do
       assert snapshot.node_metadata.display_name == "beam-node"
       assert_received {:connect_called, ^beam_target}
       refute_received {:legacy_client_called, ^beam_target}
+    end
+
+    test "legacy Console runtime client receives keyword gRPC address from Runtime Endpoint target" do
+      target = Target.grpc_compat(host: "127.0.0.1", port: 50_071)
+      legacy_address = [host: "127.0.0.1", port: 50_071]
+
+      put_console(runtime_client_impl: __MODULE__.LegacyStrictClient)
+      put_inference(runtime_endpoint_targets: [target])
+      stub_client([])
+
+      assert [
+               %{target: ^target, status: :ok, node_metadata: %{display_name: "legacy-grpc"}}
+             ] = Runtime.cluster_snapshot()
+
+      assert_received {:legacy_client_called, ^legacy_address}
+      assert_received {:observe_status_called, ^target, _response, _observed_at}
+    end
+
+    test "explicit cluster targets avoid evaluating default Runtime Endpoint config" do
+      target = [host: "127.0.0.1", port: 50_071]
+
+      put_inference(
+        runtime_endpoint_targets: [
+          [transport: :beam, node_id: "not-a-uuid", address: :orchard_node_agent_smoke@localhost]
+        ]
+      )
+
+      stub_client(
+        target_responses: %{
+          {"127.0.0.1", 50_071} => [
+            connect: {:ok, :explicit_ch},
+            status: {:ok, status_response()},
+            disconnect: :ok
+          ]
+        }
+      )
+
+      assert [%{target: ^target, status: :ok}] = Runtime.cluster_snapshot(targets: [target])
     end
 
     test "normalizes Runtime Endpoint observations returned by the configured client" do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -27,15 +27,18 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointTargetSch
   @behaviour Orchard.Scheduler.SingleNode
 
   alias Orchard.CanonicalRequest
+  alias Orchard.Inference
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
   alias Orchard.RuntimeEndpoint.Target
 
   def schedule(%CanonicalRequest{} = request) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
+      runtime_target = Inference.runtime_client_target()
+
       target =
         Target.grpc_compat(%{
-          host: "127.0.0.1",
-          port: 50_071,
+          host: Keyword.fetch!(runtime_target, :host),
+          port: Keyword.fetch!(runtime_target, :port),
           metadata: %{
             bearer_token: "must-not-persist-runtime-target",
             tenant_hint: "tenant-secret"
@@ -826,7 +829,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     decision = request.scheduler_decision
 
     assert decision["strategy"] == "multi_node"
-    assert decision["runtime_client_target"] == %{"host" => "127.0.0.1", "port" => 50_071}
+    assert decision["runtime_client_target"] == runtime_client_target_map()
     refute Map.has_key?(decision, "runtime_endpoint_target")
     refute inspect(decision) =~ "must-not-persist-runtime-target"
     refute inspect(decision) =~ "tenant-secret"
@@ -993,7 +996,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     assert decision["strategy"] == "multi_node"
     assert decision["node_id"] == promoted_scheduler.promoted_node_id()
-    assert decision["runtime_client_target"] == %{"host" => "127.0.0.1", "port" => 50_071}
+    assert decision["runtime_client_target"] == runtime_client_target_map()
     assert decision["selected_tier"] == "cold"
     assert decision["selected_cache_tier"] == "no_hint"
     assert decision["cache_affinity_selected_match"] == false
@@ -2910,6 +2913,15 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       )
 
     Application.put_env(:orchard_controller, :inference, inference)
+  end
+
+  defp runtime_client_target_map do
+    runtime_target = Orchard.Inference.runtime_client_target()
+
+    %{
+      "host" => Keyword.fetch!(runtime_target, :host),
+      "port" => Keyword.fetch!(runtime_target, :port)
+    }
   end
 
   defp put_unreachable_scheduler_config do

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -80,7 +80,7 @@ defmodule Orchard.InferenceTest do
     assert {:ok, schedule} = SingleNode.schedule(request)
     assert schedule.strategy == :single_node
     assert schedule.request_id == request.public_id
-    assert schedule.runtime_client_target == [host: "127.0.0.1", port: 50_071]
+    assert schedule.runtime_client_target == test_runtime_client_target()
     assert schedule.request_timeout_ms == 5_000
     assert schedule.model_load_timeout_ms == 5_000
 
@@ -696,6 +696,7 @@ defmodule Orchard.InferenceTest do
   end
 
   describe "SingleNode backward compatibility" do
+    @tag :db
     test "SingleNode.schedule/1 always uses singular target even when plural differs" do
       put_inference(
         runtime_client_targets: [
@@ -721,7 +722,7 @@ defmodule Orchard.InferenceTest do
       with_repo_unregistered(fn ->
         assert {:ok, schedule} = SingleNode.schedule(request)
         assert schedule.strategy == :single_node
-        assert schedule.runtime_client_target == [host: "127.0.0.1", port: 50_071]
+        assert schedule.runtime_client_target == test_runtime_client_target()
         assert schedule.request_timeout_ms == 5_000
         assert schedule.model_load_timeout_ms == 5_000
         assert schedule.node_id == nil
@@ -732,6 +733,15 @@ defmodule Orchard.InferenceTest do
   defp put_inference(overrides) do
     config = Application.fetch_env!(:orchard_controller, :inference)
     Application.put_env(:orchard_controller, :inference, Keyword.merge(config, overrides))
+  end
+
+  defp test_runtime_client_target do
+    [host: "127.0.0.1", port: test_node_agent_port()]
+  end
+
+  defp test_node_agent_port do
+    System.get_env("ORCHARD_TEST_NODE_AGENT_PORT", "50071")
+    |> String.to_integer()
   end
 
   defp read_runtime_controller_inference!(overrides) do

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -1330,7 +1330,7 @@ defmodule OrchardNodeAgentTest do
     runtime = Application.fetch_env!(:orchard_node_agent, :runtime)
 
     assert runtime[:fake_runtime?]
-    assert runtime[:listen_address] == [host: "127.0.0.1", port: 50_071]
+    assert runtime[:listen_address] == test_listen_address()
     assert Path.type(runtime[:models_root]) == :absolute
     assert Path.type(runtime[:worker_socket_dir]) == :absolute
     assert Path.type(runtime[:worker_executable]) == :absolute
@@ -1359,7 +1359,7 @@ defmodule OrchardNodeAgentTest do
     assert runtime[:worker_memory_budget_overhead_bytes] == 1_073_741_824
 
     assert Node.listen_host() == "127.0.0.1"
-    assert Node.listen_port() == 50_071
+    assert Node.listen_port() == test_node_agent_port()
     assert Node.fake_runtime?()
     assert Node.runtime_adapter_impl() == Orchard.Node.FakeRuntimeAdapter
     assert Node.worker_backend() == "stub"
@@ -5478,6 +5478,15 @@ defmodule OrchardNodeAgentTest do
     if Code.ensure_loaded?(Sentry.Context) do
       Sentry.Context.clear_all()
     end
+  end
+
+  defp test_listen_address do
+    [host: "127.0.0.1", port: test_node_agent_port()]
+  end
+
+  defp test_node_agent_port do
+    System.get_env("ORCHARD_TEST_NODE_AGENT_PORT", "50071")
+    |> String.to_integer()
   end
 
   defp restore_sentry_enrichment(nil),

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,15 @@ Code.require_file("m1_runtime_defaults.exs", __DIR__)
 repo_root = Path.expand("..", __DIR__)
 test_root = Path.join([repo_root, "tmp", "test"])
 
+test_node_agent_port =
+  case Integer.parse(System.get_env("ORCHARD_TEST_NODE_AGENT_PORT") || "50071") do
+    {port, ""} when port in 1..65_535 ->
+      port
+
+    _ ->
+      raise "ORCHARD_TEST_NODE_AGENT_PORT must be an integer between 1 and 65535"
+  end
+
 worker_socket_dir_hash =
   :crypto.hash(:sha256, repo_root)
   |> Base.url_encode64(padding: false)
@@ -32,7 +41,7 @@ config :orchard_controller,
       tokenizer_mode: :fake,
       tokenizer_executable:
         Path.join([repo_root, "native", "orchard_tokenizer", "bin", "orchard-tokenizer"]),
-      runtime_client_target: [host: "127.0.0.1", port: 50_071],
+      runtime_client_target: [host: "127.0.0.1", port: test_node_agent_port],
       request_timeout_ms: 5_000,
       model_load_timeout_ms: 5_000
     ),
@@ -44,7 +53,7 @@ config :orchard_node_agent,
       Orchard.Config.M1RuntimeDefaults.node_runtime(test_root),
       node_id: "00000000-0000-4000-a000-000000000001",
       display_name: "test-node",
-      listen_address: [host: "127.0.0.1", port: 50_071],
+      listen_address: [host: "127.0.0.1", port: test_node_agent_port],
       worker_socket_dir: worker_socket_dir,
       worker_executable:
         Path.join([repo_root, "native", "orchard_worker_mlx", "bin", "orchard-worker-mlx"]),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,7 @@ Core design rules from `SPEC.md`:
 - the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
 - first-party BEAM communication is implemented behind explicit guardrails and remains default-off until rollout gates allow it;
 - source-dev uses the gRPC compatibility adapter by default until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is promoted;
+- Console live runtime diagnostics use the same configured Runtime Endpoint target list as scheduler and dispatch, with explicit BEAM targets taking precedence over legacy gRPC runtime client targets;
 - BEAM Runtime Endpoint targets validate BEAM node-name addresses and configured node UUIDs before scheduler or dispatch trusts endpoint identity;
 - node agents are the v1 first-party Runtime Endpoint boundary;
 - worker runtimes are local subprocesses, not public services;
@@ -104,6 +105,7 @@ The controller scheduler uses that capacity telemetry to avoid dispatching to fu
 Controller queue admission also consumes fresh Runtime Endpoint Observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted endpoints.
 Invalid, ineligible, unavailable, or transport-failed observations clear stale endpoint-owned capacity sources before queued work can be promoted.
 For BEAM Runtime Endpoint observations, queue capacity is published only when the target resolves back to the same persisted node identity.
+Console Nodes live diagnostics probe the configured Runtime Endpoint targets rather than a separate legacy gRPC-only target list.
 Scheduler and dispatch orchestration crashes after request validation terminalize the durable request as a failed `orchestration_error` with sanitized public error payloads instead of leaving it active.
 
 Runtime Endpoint and worker runtime contracts are separate:

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -40,6 +40,7 @@ Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove 
 The BEAM Runtime Endpoint adapter is the intended primary source-dev Controller-to-Node Agent path once it passes the accepted two-Mac smoke.
 Until that gate passes, current source-dev continues to use the gRPC Compatibility Adapter on port `50071` as the compatibility and fallback path.
 The accepted smoke gate requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
+Console Nodes live diagnostics use the configured Runtime Endpoint target list, so explicit BEAM Runtime Endpoint targets take precedence over legacy gRPC runtime client targets during that smoke.
 Do not remove gRPC compatibility before the BEAM adapter passes that smoke.
 
 Keep the Worker Runtime Interface separate.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -226,6 +226,9 @@ Stream mode reports max concurrency as `1` at both node and placement levels.
 
 These env vars configure only the gRPC compatibility target path.
 Explicit BEAM Runtime Endpoint targets are application config only in this slice.
+Console Nodes live runtime diagnostics follow the active Runtime Endpoint target source.
+When explicit BEAM `runtime_endpoint_targets` are configured, Console probes those BEAM targets through the configured Runtime Endpoint client.
+Keep `ORCHARD_RUNTIME_CLIENT_TARGETS` alongside BEAM targets only when deliberately comparing or exercising the gRPC compatibility fallback.
 
 #### Runtime Endpoint BEAM Guardrails
 
@@ -234,22 +237,32 @@ The adapter is implemented behind explicit application config, but source dev ke
 There is no supported source-dev env var surface for BEAM target selection in this slice.
 The accepted target is for BEAM Runtime Endpoint transport to become the primary source-dev Controller-to-Node Agent path after that smoke passes.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
+Console Nodes uses the same Runtime Endpoint targets as scheduler and dispatch.
+For a BEAM-only smoke, duplicate gRPC `ORCHARD_RUNTIME_CLIENT_TARGETS` are no longer required just to make Console Nodes show both Macs.
 
 Application-config opt-in uses the Runtime Endpoint client and target keys under `:orchard_controller, :inference`.
 
 ```elixir
-runtime_endpoint_client_impl: Orchard.RuntimeEndpoint.BeamClient,
-runtime_endpoint_targets: [
-  %{
-    transport: :beam,
-    node_id: "<node-uuid>",
-    address: :orchard_node_agent@localhost
-  }
-]
+config :orchard_controller, :inference,
+  runtime_endpoint_client_impl: Orchard.RuntimeEndpoint.BeamClient,
+  runtime_endpoint_targets: [
+    %{
+      transport: :beam,
+      node_id: "<local-node-uuid>",
+      address: :orchard_node_agent_smoke@tamingsari
+    },
+    %{
+      transport: :beam,
+      node_id: "<remote-node-uuid>",
+      address: :orchard_node_agent_smoke@mawarduri
+    }
+  ]
 ```
 
 BEAM target `address` is required and must be a valid BEAM node name (`service@host`) as an atom or binary.
 Configured BEAM target `node_id` values are optional for address-only discovery, but when present they must be UUIDs and must match observed Node Agent metadata.
+Do not set `:orchard_controller, :console, :runtime_client_impl` for BEAM diagnostics.
+That legacy test seam is only for the gRPC compatibility path; BEAM diagnostics use `:runtime_endpoint_client_impl`.
 When BEAM guardrails are enabled directly in application config, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
 The `listen_host` must not be `0.0.0.0` or `::`, and `allowed_cidrs` must not contain `0.0.0.0/0` or `::/0`.
 Allowed CIDRs must parse as IP CIDR ranges, the running BEAM node name must match configured `node_name`, BEAM target services must be listed in `admitted_services`, and BEAM target hosts must fall inside `allowed_cidrs`.
@@ -449,6 +462,10 @@ needed for the stub backend; source dev resolves it to stream mode when unset.
 6. Killing the remote node-agent should transition its health to
    degraded/unreachable
 
+For BEAM Runtime Endpoint smoke tests, configure `runtime_endpoint_client_impl` and `runtime_endpoint_targets` instead of relying on `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+The `/console/nodes` Live Cluster panel should reflect the BEAM target list.
+If the gRPC compatibility path is intentionally configured at the same time, treat it as a fallback or comparison path rather than the Console diagnostics source.
+
 ### Troubleshooting
 
 | Symptom | Cause | Fix |
@@ -467,6 +484,9 @@ needed for the stub backend; source dev resolves it to stream mode when unset.
 ```bash
 # Full test suite (uses fake runtime, no GPU needed)
 mise exec -- mix test
+
+# If another worktree already owns the default test node-agent port
+ORCHARD_TEST_NODE_AGENT_PORT=50171 mise exec -- mix test
 
 # With coverage
 mise exec -- mix test --cover

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -237,7 +237,7 @@ The adapter is implemented behind explicit application config, but source dev ke
 There is no supported source-dev env var surface for BEAM target selection in this slice.
 The accepted target is for BEAM Runtime Endpoint transport to become the primary source-dev Controller-to-Node Agent path after that smoke passes.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
-Console Nodes uses the same Runtime Endpoint targets as scheduler and dispatch.
+Console Nodes live runtime diagnostics use the same Runtime Endpoint targets as scheduler and dispatch.
 For a BEAM-only smoke, duplicate gRPC `ORCHARD_RUNTIME_CLIENT_TARGETS` are no longer required just to make Console Nodes show both Macs.
 
 Application-config opt-in uses the Runtime Endpoint client and target keys under `:orchard_controller, :inference`.
@@ -470,7 +470,8 @@ If the gRPC compatibility path is intentionally configured at the same time, tre
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Controller shows 1 target | `ORCHARD_RUNTIME_CLIENT_TARGETS` unset or malformed | Check env var, use `host:port,host:port` format |
+| gRPC controller shows 1 target | `ORCHARD_RUNTIME_CLIENT_TARGETS` unset or malformed | Check env var, use `host:port,host:port` format |
+| BEAM Console shows gRPC targets | `runtime_endpoint_targets` not configured or legacy Console client override still active | Configure `runtime_endpoint_client_impl` and `runtime_endpoint_targets`; remove `:orchard_controller, :console, :runtime_client_impl` for BEAM diagnostics |
 | Remote node-agent unreachable | Listen host still `127.0.0.1` | Set `ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0` |
 | Remote node fails on MLX | mise toolchain not installed or no `uv sync` | Use `ORCHARD_WORKER_BACKEND=stub` or run `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx` |
 | Port conflict on remote | Another BEAM on same port | Change `ORCHARD_NODE_AGENT_LISTEN_PORT` |


### PR DESCRIPTION
## Intent

Validate the current Console BEAM diagnostics work on codex/console-beam-diagnostics. The goal is to make Orchard Console use explicit Runtime Endpoint targets for runtime snapshots, especially BEAM node-agent endpoints, instead of accidentally falling back to stale legacy gRPC runtime client settings. The change should preserve legacy target compatibility where tests and configuration still require it, add focused regression coverage for BEAM target observation and Console node diagnostics, and update local development documentation for the source-dev controller/node-agent ports and runtime target configuration. This validation should ensure the implementation remains spec-traceable, does not broaden product behavior beyond diagnostics/runtime endpoint selection, and keeps existing Orchard quality gates green.

## What Changed
- Surface Console node runtime diagnostics from explicit Runtime Endpoint targets, including BEAM node-agent endpoints, instead of relying on stale legacy gRPC client settings.
- Preserve compatibility for legacy gRPC runtime client target configuration while keeping explicit-target snapshot callers isolated from invalid global Runtime Endpoint config.
- Add regression coverage for Console runtime snapshots, node diagnostics, inference target behavior, and related node-agent compatibility paths, plus sync SPEC and local-dev docs with the BEAM-first runtime endpoint flow.

## Risk Assessment

✅ Low: The follow-up fixes address the previously identified target-shape and eager-default issues, and the remaining changes are narrowly scoped to Console runtime endpoint diagnostics, labeling, focused test coverage, and local-dev documentation.

## Testing

Focused Console/runtime tests passed, browser evidence showed Console Nodes using the BEAM Runtime Endpoint target while ignoring stale legacy gRPC config, full `mix test` passed, and generated worktree artifacts from testing were cleaned up; no linters, formatters, or static analysis tools were run.

- Evidence: Console Nodes BEAM target desktop screenshot (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F8AA77QFJRHKV02YPG2XE/console-nodes-beam-target-desktop.png</code>)
- Evidence: Console Nodes BEAM target mobile screenshot (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F8AA77QFJRHKV02YPG2XE/console-nodes-beam-target-mobile.png</code>)
<details>
<summary>Evidence: Console Nodes BEAM target browser checks</summary>

```text
{
  "browser_path": "regular Playwright fallback; in-app Browser list was empty; used existing Google Chrome executable",
  "runtime_path": "OrchardConsole.Runtime with runtime_endpoint_client_impl BEAM stub, explicit runtime_endpoint_targets, and poison legacy runtime_client_impl configured",
  "url": "http://127.0.0.1:4103/console/nodes",
  "title": "Nodes",
  "page_identity_ok": true,
  "not_blank_ok": true,
  "no_framework_overlay_ok": true,
  "console_health": {
    "errors": [],
    "warnings": [],
    "page_errors": []
  },
  "beam_target_visible": true,
  "stale_legacy_grpc_target_absent": true,
  "stable_dom_id_visible": true,
  "node_inventory_visible": true,
  "cluster_summary_visible": true,
  "refresh_interaction_ok": true,
  "prompt_id_capable_visible": true,
  "screenshot_desktop": "/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F8AA77QFJRHKV02YPG2XE/console-nodes-beam-target-desktop.png",
  "screenshot_mobile": "/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW1F8AA77QFJRHKV02YPG2XE/console-nodes-beam-target-mobile.png",
  "mobile_beam_target_visible": true
}
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (21m19s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/console/runtime.ex:638` - The legacy `:runtime_client_impl` path now receives `%Orchard.RuntimeEndpoint.Target{}` values from `default_runtime_target/0`. Existing legacy clients such as `Orchard.Dispatch.GrpcNodeRuntimeClient` still expect a `[host: ..., port: ...]` keyword target, so configuring the documented legacy seam makes Console diagnostics raise or show cluster unavailable instead of preserving gRPC compatibility. Unwrap `:grpc_compat` targets to their address when using `:runtime_client_impl`, or route legacy clients through the compatibility adapter.
- ℹ️ `apps/orchard_controller/lib/orchard/console/runtime.ex:130` - `Inference.runtime_endpoint_targets()` is evaluated even when callers pass explicit `:targets`, so `cluster_snapshot(targets: ...)` can still fail because of unrelated invalid global Runtime Endpoint config. Use `Keyword.get_lazy/3` or `Keyword.fetch/2` so explicit-target callers stay isolated.

🔧 Fix: Fix Console runtime target compatibility
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `apps/orchard_node_agent/test/orchard_node_agent_test.exs:4228` - One cold combined focused run timed out in `single-flight deadline compatibility no timer leaks or stale timeout messages after restart`, but the exact test, the full node-agent file, and the later full `mix test` suite all passed. Treat this as a non-reproduced timing flake if it recurs.
- <code>`ORCHARD_TEST_NODE_AGENT_PORT=50173 mise exec -- mix test apps/orchard_controller/test/orchard/console/runtime_test.exs apps/orchard_controller/test/orchard/console/nodes_live_test.exs apps/orchard_controller/test/orchard/inference_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/application_test.exs apps/orchard_node_agent/test/orchard_node_agent_test.exs` - setup failed before tests because mise did not trust this worktree config.</code>
- <code>`MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; ORCHARD_TEST_NODE_AGENT_PORT=50173 mise exec -- mix test apps/orchard_controller/test/orchard/console/runtime_test.exs apps/orchard_controller/test/orchard/console/nodes_live_test.exs apps/orchard_controller/test/orchard/inference_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/application_test.exs apps/orchard_node_agent/test/orchard_node_agent_test.exs` - controller portion passed; node-agent file had one timeout before retry.</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" ORCHARD_TEST_NODE_AGENT_PORT=50173 mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs:4228`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" ORCHARD_TEST_NODE_AGENT_PORT=50173 mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" ORCHARD_TEST_NODE_AGENT_PORT=50173 mise exec -- mix test apps/orchard_controller/test/orchard/console/runtime_test.exs apps/orchard_controller/test/orchard/console/nodes_live_test.exs apps/orchard_controller/test/orchard/inference_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/application_test.exs`
- <code>`MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; mise exec -- npm ci` and `MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD/mise.toml&#34; mise exec -- mix assets.build` for browser evidence setup only.</code>
- <code>Browser fallback check with Playwright using existing Google Chrome: loaded `http://127.0.0.1:4103/console/nodes`, real `OrchardConsole.Runtime`, explicit BEAM Runtime Endpoint target, poison legacy gRPC client, clicked `Refresh now`, verified no browser console errors/warnings, and captured screenshots/JSON evidence.</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD/mise.toml" ORCHARD_TEST_NODE_AGENT_PORT=50173 mise exec -- mix test`
- <code>Cleanup: removed generated `_build`, `node_modules`, Console static assets, native `.venv` directories, Python `__pycache__`, and `tmp`; evidence files were left in the requested evidence directory.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
