### PR TITLE
feat: add source-dev BEAM operating model

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Clients (SDKs / curl / apps)
 - The current `NodeRuntimeService` gRPC path is a compatibility adapter, not the durable domain contract.
 - First-party BEAM communication is implemented behind explicit guardrails and must not become durable cluster truth.
 - Source-dev uses the gRPC compatibility adapter by default until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is promoted.
+- Source-dev BEAM is available only through the explicit split-role `bin/dev-controller` and `bin/dev-node-agent` flow while all-in-one `bin/dev` remains the gRPC default.
 - Workers are local to node agents and are never exposed on the network.
 - Token streams always pass through the controller for governance and accounting.
 - HA-lite only: exactly one active leader, active/standby via Postgres advisory locks, no active/active consensus.
@@ -75,7 +76,7 @@ Clients (SDKs / curl / apps)
 | Language | Elixir/OTP (umbrella app) |
 | Database | Postgres |
 | Inference | MLX-LM runtime adapter managed by the node agent |
-| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter and default-off first-party BEAM adapter gated by accepted two-Mac smoke |
+| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter and explicit split-role first-party BEAM mode gated from default promotion by accepted two-Mac smoke |
 | APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
 | Packaging | DMG, PKG, launchd |
 | CLI | `orchardctl` |

--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -32,4 +32,16 @@ defmodule OrchardCLI.DevScriptsTest do
     assert dev =~ "pgrep -f orchard-worker-mlx"
     assert node_agent =~ "pgrep -f orchard-worker-mlx"
   end
+
+  test "source-dev BEAM bootstrap shell contract stays wired into Mix tests" do
+    script = Path.join(@repo_root, "scripts/test-source-dev-beam-bootstrap.sh")
+
+    assert {output, 0} =
+             System.cmd("bash", [script],
+               cd: @repo_root,
+               stderr_to_stdout: true
+             )
+
+    assert output =~ "source-dev BEAM bootstrap tests passed"
+  end
 end

--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -9,12 +9,12 @@ defmodule OrchardCLI.DevScriptsTest do
     node_agent = File.read!(Path.join(@repo_root, "bin/dev-node-agent"))
 
     assert controller =~ "cd \"$REPO_ROOT/apps/orchard_controller\""
-    assert controller =~ "exec iex -S mix phx.server"
+    assert controller =~ "exec iex \"${ORCHARD_BEAM_IEX_ARGS[@]}\" -S mix phx.server"
     refute controller =~ "apps/orchard_node_agent"
     refute controller =~ "mix run --no-halt"
 
     assert node_agent =~ "cd \"$REPO_ROOT/apps/orchard_node_agent\""
-    assert node_agent =~ "exec iex -S mix run --no-halt"
+    assert node_agent =~ "exec iex \"${ORCHARD_BEAM_IEX_ARGS[@]}\" -S mix run --no-halt"
 
     assert dev =~ "exec iex -S mix phx.server"
     refute dev =~ "cd \"$REPO_ROOT/apps/orchard_controller\""

--- a/apps/orchard_controller/README.md
+++ b/apps/orchard_controller/README.md
@@ -29,6 +29,8 @@ This README is orientation only. Normative behavior lives in
 
 ## Local work
 
-Run source dev from the umbrella root with `mise exec -- bin/dev`. For setup and
-validation commands, see [`../../docs/local-dev.md`](../../docs/local-dev.md)
-and [`../../docs/tooling.md`](../../docs/tooling.md).
+Run all-in-one source dev from the umbrella root with `mise exec -- bin/dev`.
+Use `mise exec -- bin/dev-controller` only for split-role controller work.
+For setup, BEAM or gRPC split-role flows, and validation commands, see
+[`../../docs/local-dev.md`](../../docs/local-dev.md) and
+[`../../docs/tooling.md`](../../docs/tooling.md).

--- a/apps/orchard_controller/lib/orchard/config/runtime_target_parser.ex
+++ b/apps/orchard_controller/lib/orchard/config/runtime_target_parser.ex
@@ -1,11 +1,14 @@
 defmodule Orchard.Config.RuntimeTargetParser do
   @moduledoc """
-  Pure parser for `ORCHARD_RUNTIME_CLIENT_TARGETS` environment variable.
+  Pure parser for the gRPC compatibility `ORCHARD_RUNTIME_CLIENT_TARGETS`
+  environment variable.
 
   Extracted from `config/runtime.exs` to enable direct unit testing
   of malformed input rejection.
 
   Format: comma-separated `host:port` pairs.
+  BEAM Runtime Endpoint node names belong to `ORCHARD_RUNTIME_ENDPOINT_TARGETS`
+  and are intentionally rejected here.
   Example: `"127.0.0.1:50071,100.86.198.38:50061"`
   """
 

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -945,24 +945,38 @@ defmodule Orchard.Scheduler.MultiNode do
   end
 
   defp fallback_schedule(request, [%Target{} = single_target], _opts) do
-    {:ok,
-     %{
-       strategy: :single_node,
-       request_id: request.public_id,
-       runtime_endpoint_target: single_target,
-       request_timeout_ms: Inference.request_timeout_ms(),
-       model_load_timeout_ms: Inference.model_load_timeout_ms(),
-       node_id: runtime_endpoint_node_id(single_target)
-     }}
+    runtime_endpoint_fallback_schedule(request, single_target)
   end
 
   defp fallback_schedule(request, [single_target], opts) do
     SingleNode.default_schedule(request, dispatch_target(single_target), opts)
   end
 
+  defp fallback_schedule(request, [%Target{} | _] = targets, opts) do
+    case Enum.find(targets, &runtime_endpoint_fallback_target?/1) do
+      nil -> SingleNode.default_schedule(request, SingleNode.target(), opts)
+      %Target{} = target -> runtime_endpoint_fallback_schedule(request, target)
+    end
+  end
+
   defp fallback_schedule(request, _targets, opts) do
     SingleNode.default_schedule(request, SingleNode.target(), opts)
   end
+
+  defp runtime_endpoint_fallback_schedule(request, target) do
+    {:ok,
+     %{
+       strategy: :single_node,
+       request_id: request.public_id,
+       runtime_endpoint_target: target,
+       request_timeout_ms: Inference.request_timeout_ms(),
+       model_load_timeout_ms: Inference.model_load_timeout_ms(),
+       node_id: runtime_endpoint_node_id(target)
+     }}
+  end
+
+  defp runtime_endpoint_fallback_target?(%Target{transport: :grpc_compat}), do: false
+  defp runtime_endpoint_fallback_target?(%Target{}), do: true
 
   defp normalize_status_observation(_target, %Observation{} = observation), do: observation
 

--- a/apps/orchard_controller/test/orchard/config/runtime_target_parser_test.exs
+++ b/apps/orchard_controller/test/orchard/config/runtime_target_parser_test.exs
@@ -42,6 +42,12 @@ defmodule Orchard.Config.RuntimeTargetParserTest do
              ]
     end
 
+    test "rejects BEAM node names because this parser is gRPC host:port only" do
+      assert_raise RuntimeError, ~r/invalid host:port segment/, fn ->
+        RuntimeTargetParser.parse_csv!("orchard_node_agent@127.0.0.1", @env_name)
+      end
+    end
+
     test "raises on missing port" do
       assert_raise RuntimeError, ~r/invalid host:port segment/, fn ->
         RuntimeTargetParser.parse_csv!("host-only", @env_name)

--- a/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
+++ b/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
@@ -52,6 +52,17 @@ defmodule Orchard.Config.SourceDevBeamTest do
       end
     end
 
+    test "rejects unspecified target hosts" do
+      for target <- ["orchard_node_agent@0.0.0.0", "orchard_node_agent@::"] do
+        assert_raise RuntimeError, ~r/must not use unspecified or wildcard BEAM hosts/, fn ->
+          SourceDevBeam.controller_beam_targets!(
+            target,
+            "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+          )
+        end
+      end
+    end
+
     test "rejects unsupported target services" do
       assert_raise RuntimeError, ~r/unsupported BEAM target service/, fn ->
         SourceDevBeam.controller_beam_targets!(
@@ -102,6 +113,24 @@ defmodule Orchard.Config.SourceDevBeamTest do
                admitted_services: ["orchard_node_agent"],
                allowed_cidrs: ["127.0.0.1/32", "10.0.0.2/32"]
              ]
+    end
+
+    test "rejects unspecified local controller hosts" do
+      targets =
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@127.0.0.1",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+
+      for node_name <- ["orchard_controller@0.0.0.0", "orchard_controller@::"] do
+        assert_raise RuntimeError, ~r/must not use unspecified or wildcard BEAM hosts/, fn ->
+          SourceDevBeam.beam_guardrail_config!(
+            node_name,
+            "/tmp/orchard-cookie",
+            targets
+          )
+        end
+      end
     end
   end
 end

--- a/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
+++ b/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
@@ -25,7 +25,7 @@ defmodule Orchard.Config.SourceDevBeamTest do
   end
 
   describe "controller_beam_targets!/2" do
-    test "parses comma-separated BEAM node-name targets with IP-literal hosts" do
+    test "parses comma-separated BEAM node-name targets with IPv4-literal hosts" do
       assert SourceDevBeam.controller_beam_targets!(
                " orchard_node_agent@127.0.0.1 , orchard_node_agent@10.0.0.2 ",
                "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
@@ -44,7 +44,7 @@ defmodule Orchard.Config.SourceDevBeamTest do
     end
 
     test "rejects hostname target hosts" do
-      assert_raise RuntimeError, ~r/requires IP-literal BEAM target hosts/, fn ->
+      assert_raise RuntimeError, ~r/requires IPv4-literal BEAM target hosts/, fn ->
         SourceDevBeam.controller_beam_targets!(
           "orchard_node_agent@worker.local",
           "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
@@ -52,14 +52,28 @@ defmodule Orchard.Config.SourceDevBeamTest do
       end
     end
 
+    test "rejects IPv6 target hosts" do
+      assert_raise RuntimeError, ~r/requires IPv4-literal BEAM target hosts/, fn ->
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@::1",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+      end
+    end
+
     test "rejects unspecified target hosts" do
-      for target <- ["orchard_node_agent@0.0.0.0", "orchard_node_agent@::"] do
-        assert_raise RuntimeError, ~r/must not use unspecified or wildcard BEAM hosts/, fn ->
-          SourceDevBeam.controller_beam_targets!(
-            target,
-            "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
-          )
-        end
+      assert_raise RuntimeError, ~r/must not use unspecified or wildcard BEAM hosts/, fn ->
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@0.0.0.0",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+      end
+
+      assert_raise RuntimeError, ~r/requires IPv4-literal BEAM target hosts/, fn ->
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@::",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
       end
     end
 
@@ -115,6 +129,22 @@ defmodule Orchard.Config.SourceDevBeamTest do
              ]
     end
 
+    test "rejects IPv6 local controller hosts" do
+      targets =
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@127.0.0.1",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+
+      assert_raise RuntimeError, ~r/requires IPv4-literal local controller host/, fn ->
+        SourceDevBeam.beam_guardrail_config!(
+          "orchard_controller@::1",
+          "/tmp/orchard-cookie",
+          targets
+        )
+      end
+    end
+
     test "rejects unspecified local controller hosts" do
       targets =
         SourceDevBeam.controller_beam_targets!(
@@ -122,15 +152,31 @@ defmodule Orchard.Config.SourceDevBeamTest do
           "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
         )
 
-      for node_name <- ["orchard_controller@0.0.0.0", "orchard_controller@::"] do
-        assert_raise RuntimeError, ~r/must not use unspecified or wildcard BEAM hosts/, fn ->
-          SourceDevBeam.beam_guardrail_config!(
-            node_name,
-            "/tmp/orchard-cookie",
-            targets
-          )
-        end
+      assert_raise RuntimeError, ~r/must not use unspecified or wildcard BEAM hosts/, fn ->
+        SourceDevBeam.beam_guardrail_config!(
+          "orchard_controller@0.0.0.0",
+          "/tmp/orchard-cookie",
+          targets
+        )
       end
+    end
+
+    test "rejects unsupported local controller service" do
+      targets =
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@127.0.0.1",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+
+      assert_raise RuntimeError,
+                   ~r/local controller BEAM node service must start with orchard_controller/,
+                   fn ->
+                     SourceDevBeam.beam_guardrail_config!(
+                       "orchard_node_agent@127.0.0.1",
+                       "/tmp/orchard-cookie",
+                       targets
+                     )
+                   end
     end
   end
 end

--- a/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
+++ b/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
@@ -1,0 +1,93 @@
+Code.require_file(Path.expand("../../../../../config/source_dev_beam.exs", __DIR__))
+
+defmodule Orchard.Config.SourceDevBeamTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Config.SourceDevBeam
+
+  describe "transport!/1" do
+    test "defaults unset and blank transport to gRPC" do
+      assert SourceDevBeam.transport!(nil) == :grpc
+      assert SourceDevBeam.transport!("") == :grpc
+      assert SourceDevBeam.transport!("   ") == :grpc
+    end
+
+    test "accepts explicit grpc and beam modes" do
+      assert SourceDevBeam.transport!("grpc") == :grpc
+      assert SourceDevBeam.transport!("beam") == :beam
+    end
+
+    test "rejects unknown modes" do
+      assert_raise RuntimeError, ~r/ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc\|beam/, fn ->
+        SourceDevBeam.transport!("http")
+      end
+    end
+  end
+
+  describe "controller_beam_targets!/2" do
+    test "parses comma-separated BEAM node-name targets with IP-literal hosts" do
+      assert SourceDevBeam.controller_beam_targets!(
+               " orchard_node_agent@127.0.0.1 , orchard_node_agent@10.0.0.2 ",
+               "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+             ) == [
+               %{
+                 transport: :beam,
+                 address: "orchard_node_agent@127.0.0.1",
+                 metadata: %{source_dev: true}
+               },
+               %{
+                 transport: :beam,
+                 address: "orchard_node_agent@10.0.0.2",
+                 metadata: %{source_dev: true}
+               }
+             ]
+    end
+
+    test "rejects hostname target hosts" do
+      assert_raise RuntimeError, ~r/requires IP-literal BEAM target hosts/, fn ->
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@worker.local",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+      end
+    end
+
+    test "rejects unsupported target services" do
+      assert_raise RuntimeError, ~r/unsupported BEAM target service/, fn ->
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_controller@127.0.0.1",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+      end
+    end
+
+    test "requires at least one target" do
+      assert_raise RuntimeError, ~r/at least one BEAM target/, fn ->
+        SourceDevBeam.controller_beam_targets!(nil, "ORCHARD_RUNTIME_ENDPOINT_TARGETS")
+      end
+    end
+  end
+
+  describe "beam_guardrail_config!/3" do
+    test "derives listen host and allowed CIDRs from source-dev BEAM targets" do
+      targets =
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@127.0.0.1,orchard_node_agent@127.0.0.1,orchard_node_agent@10.0.0.2",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+        )
+
+      assert SourceDevBeam.beam_guardrail_config!(
+               "orchard_controller@127.0.0.1",
+               "/tmp/orchard-cookie",
+               targets
+             ) == [
+               enabled: true,
+               node_name: "orchard_controller@127.0.0.1",
+               cookie_file: "/tmp/orchard-cookie",
+               listen_host: "127.0.0.1",
+               admitted_services: ["orchard_node_agent"],
+               allowed_cidrs: ["127.0.0.1/32", "10.0.0.2/32"]
+             ]
+    end
+  end
+end

--- a/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
+++ b/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
@@ -68,6 +68,20 @@ defmodule Orchard.Config.SourceDevBeamTest do
     end
   end
 
+  describe "validate_transport_role!/2" do
+    test "rejects all-in-one BEAM mode" do
+      assert_raise RuntimeError, ~r/all_in_one BEAM source-dev mode is not supported/, fn ->
+        SourceDevBeam.validate_transport_role!(:beam, :all_in_one)
+      end
+    end
+
+    test "accepts split-role BEAM mode and all-in-one gRPC mode" do
+      assert SourceDevBeam.validate_transport_role!(:beam, :controller) == :ok
+      assert SourceDevBeam.validate_transport_role!(:beam, :node_agent) == :ok
+      assert SourceDevBeam.validate_transport_role!(:grpc, :all_in_one) == :ok
+    end
+  end
+
   describe "beam_guardrail_config!/3" do
     test "derives listen host and allowed CIDRs from source-dev BEAM targets" do
       targets =

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -376,7 +376,7 @@ defmodule OrchardConsole.NodesLiveTest.RuntimeBeamTargetStub do
   @moduledoc false
   @node_id "550e8400-e29b-41d4-a716-446655440000"
   @target Orchard.RuntimeEndpoint.Target.beam(@node_id,
-            address: :orchard_node_agent_smoke@mawarduri
+            address: :"orchard_node_agent@127.0.0.1"
           )
 
   def cluster_snapshot(_opts \\ []) do
@@ -808,16 +808,17 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ ~s(id="nodes-runtime-card-127-0-0-1-50071")
     end
 
-    test "renders BEAM Runtime Endpoint targets with readable labels and stable DOM ids", %{
-      conn: conn
-    } do
+    test "renders source-dev BEAM Runtime Endpoint targets with readable labels and stable DOM ids",
+         %{
+           conn: conn
+         } do
       put_runtime_stub(OrchardConsole.NodesLiveTest.RuntimeBeamTargetStub)
 
       {:ok, view, html} = live(conn, "/console/nodes")
 
-      assert html =~ ~s(id="nodes-runtime-card-beam-orchard-node-agent-smoke-mawarduri")
+      assert html =~ ~s(id="nodes-runtime-card-beam-orchard-node-agent-127-0-0-1")
       assert html =~ "beam-node"
-      assert html =~ "orchard_node_agent_smoke@mawarduri"
+      assert html =~ "orchard_node_agent@127.0.0.1"
 
       summary = element(view, "#nodes-live-cluster-card") |> render()
       assert summary =~ "1 target(s) configured"

--- a/apps/orchard_controller/test/orchard/console/runtime_test.exs
+++ b/apps/orchard_controller/test/orchard/console/runtime_test.exs
@@ -1026,6 +1026,58 @@ defmodule OrchardConsole.RuntimeTest do
       refute_received {:legacy_client_called, ^beam_target}
     end
 
+    test "source-dev BEAM target maps use active Runtime Endpoint client and ignore legacy targets" do
+      node_id = "550e8400-e29b-41d4-a716-446655440000"
+
+      source_dev_target = %{
+        transport: :beam,
+        address: "orchard_node_agent@127.0.0.1",
+        metadata: %{source_dev: true}
+      }
+
+      expected_target = Target.normalize(source_dev_target)
+      legacy_target = [host: "10.0.0.9", port: 50_061]
+
+      put_console(runtime_client_impl: __MODULE__.LegacyPoisonClient)
+
+      put_inference(
+        runtime_endpoint_client_impl: __MODULE__.StubClient,
+        runtime_endpoint_targets: [source_dev_target],
+        runtime_client_targets: [legacy_target]
+      )
+
+      stub_client(
+        target_responses: %{
+          {:beam, :"orchard_node_agent@127.0.0.1"} => [
+            connect: {:ok, :source_dev_beam_ch},
+            status:
+              {:ok,
+               %{
+                 worker_state: :WORKER_STATE_IDLE,
+                 loaded_models: [],
+                 active_request_count: 0,
+                 node_metadata: %{node_id: node_id, display_name: "source-dev-beam-node"},
+                 runtime_health: %{ready: true}
+               }},
+            disconnect: :ok
+          ]
+        }
+      )
+
+      assert [
+               %{
+                 target: ^expected_target,
+                 status: :ok,
+                 node_metadata: %{display_name: "source-dev-beam-node"}
+               }
+             ] =
+               Runtime.cluster_snapshot()
+
+      assert_received {:connect_called, ^expected_target}
+      refute_received {:connect_called, ^legacy_target}
+      refute_received {:legacy_client_called, _target}
+    end
+
     test "legacy Console runtime client receives keyword gRPC address from Runtime Endpoint target" do
       target = Target.grpc_compat(host: "127.0.0.1", port: 50_071)
       legacy_address = [host: "127.0.0.1", port: 50_071]

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -13,7 +13,15 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
   @doc false
   def registry_name, do: @registry
 
-  def connect(_target), do: config().connect
+  def connect(target) do
+    config = config()
+
+    if config.capture_pid do
+      send(config.capture_pid, {:connect_called, target})
+    end
+
+    config.connect
+  end
 
   def status(_channel, _opts \\ []) do
     config().status
@@ -474,7 +482,78 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
     end
   end
 
-  describe "BEAM target identity guard" do
+  describe "BEAM Runtime Endpoint dispatch" do
+    test "uses the explicit BEAM target and never falls back to the legacy gRPC target", ctx do
+      beam_target = Target.beam(@valid_uuid, address: :"orchard_node_agent@127.0.0.1")
+      legacy_target = [host: "127.0.0.1", port: 59_999]
+
+      schedule =
+        ctx.schedule
+        |> Map.put(:runtime_endpoint_target, beam_target)
+        |> Map.put(:runtime_client_target, legacy_target)
+
+      configure_stub(%{connect: {:error, {:rpc_exit, :nodedown}}})
+
+      assert {:error, {:model_load_failed, failure}} =
+               RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
+                 client_impl: @stub_client
+               )
+
+      assert failure.code == "node_unavailable"
+      assert_received {:connect_called, ^beam_target}
+      refute_received {:connect_called, ^legacy_target}
+      refute_received {:ensure_model_loaded_called, _request}
+    end
+
+    test "returns BEAM RPC failures without retrying the legacy gRPC target", ctx do
+      beam_target = Target.beam(@valid_uuid, address: :"orchard_node_agent@127.0.0.1")
+      legacy_target = [host: "127.0.0.1", port: 59_999]
+
+      schedule =
+        ctx.schedule
+        |> Map.put(:runtime_endpoint_target, beam_target)
+        |> Map.put(:runtime_client_target, legacy_target)
+
+      configure_stub(%{
+        status: {:ok, full_status(@valid_uuid)},
+        ensure_model_loaded: {:error, :node_unavailable}
+      })
+
+      assert {:error, {:model_load_failed, failure}} =
+               RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
+                 client_impl: @stub_client
+               )
+
+      assert failure.code == "node_unavailable"
+      assert_received {:connect_called, ^beam_target}
+      refute_received {:connect_called, ^legacy_target}
+      assert_received {:ensure_model_loaded_called, _request}
+    end
+
+    test "returns BEAM stream failures without retrying the legacy gRPC target", ctx do
+      beam_target = Target.beam(@valid_uuid, address: :"orchard_node_agent@127.0.0.1")
+      legacy_target = [host: "127.0.0.1", port: 59_999]
+
+      schedule =
+        ctx.schedule
+        |> Map.put(:runtime_endpoint_target, beam_target)
+        |> Map.put(:runtime_client_target, legacy_target)
+
+      configure_stub(%{
+        status: {:ok, full_status(@valid_uuid)},
+        execute: {:error, :node_timeout}
+      })
+
+      assert {:error, {:dispatch_failed, :node_timeout}} =
+               RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
+                 client_impl: @stub_client
+               )
+
+      assert_received {:connect_called, ^beam_target}
+      refute_received {:connect_called, ^legacy_target}
+      assert_received {:ensure_model_loaded_called, _request}
+    end
+
     test "dispatch fails closed before observe or ensure when live metadata disagrees", ctx do
       target = Target.beam(@valid_uuid, address: :orchard_node_agent@localhost)
 

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -289,7 +289,7 @@ defmodule Orchard.InferenceTest do
     end
 
     test "dev.exs beam controller mode rejects hostname endpoint targets" do
-      assert_raise RuntimeError, ~r/requires IP-literal BEAM target hosts/, fn ->
+      assert_raise RuntimeError, ~r/requires IPv4-literal BEAM target hosts/, fn ->
         read_dev_controller_inference!(%{
           "ORCHARD_SOURCE_DEV_ROLE" => "controller",
           "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
@@ -367,7 +367,7 @@ defmodule Orchard.InferenceTest do
     end
 
     test "dev.exs beam controller mode rejects local controller node names with hostnames" do
-      assert_raise RuntimeError, ~r/requires IP-literal local controller host/, fn ->
+      assert_raise RuntimeError, ~r/requires IPv4-literal local controller host/, fn ->
         read_dev_controller_config!(%{
           "ORCHARD_SOURCE_DEV_ROLE" => "controller",
           "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -238,6 +238,136 @@ defmodule Orchard.InferenceTest do
     end
   end
 
+  describe "source-dev runtime endpoint transport config" do
+    test "dev.exs preserves gRPC compatibility behavior when transport is unset or explicit grpc" do
+      for transport <- [nil, "grpc"] do
+        inference =
+          read_dev_controller_inference!(%{
+            "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => transport,
+            "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@127.0.0.1",
+            "ORCHARD_RUNTIME_CLIENT_TARGETS" => "10.0.0.1:50071"
+          })
+
+        refute Keyword.has_key?(inference, :runtime_endpoint_client_impl)
+        refute Keyword.has_key?(inference, :runtime_endpoint_targets)
+
+        assert Keyword.fetch!(inference, :runtime_client_targets) == [
+                 [host: "10.0.0.1", port: 50_071]
+               ]
+      end
+    end
+
+    test "dev.exs beam controller mode configures BEAM client and endpoint targets" do
+      inference =
+        read_dev_controller_inference!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@127.0.0.1",
+          "ORCHARD_RUNTIME_CLIENT_TARGETS" => "10.0.0.1:50071"
+        })
+
+      assert Keyword.fetch!(inference, :runtime_endpoint_client_impl) ==
+               Orchard.RuntimeEndpoint.BeamClient
+
+      assert [
+               %{
+                 transport: :beam,
+                 address: "orchard_node_agent@127.0.0.1",
+                 metadata: %{source_dev: true}
+               }
+             ] = Keyword.fetch!(inference, :runtime_endpoint_targets)
+
+      assert Keyword.fetch!(inference, :runtime_client_targets) == [
+               [host: "10.0.0.1", port: 50_071]
+             ]
+    end
+
+    test "dev.exs rejects invalid runtime endpoint transport values" do
+      assert_raise RuntimeError, ~r/ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc\|beam/, fn ->
+        read_dev_controller_inference!(%{"ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "http"})
+      end
+    end
+
+    test "dev.exs beam controller mode rejects hostname endpoint targets" do
+      assert_raise RuntimeError, ~r/requires IP-literal BEAM target hosts/, fn ->
+        read_dev_controller_inference!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@worker.local"
+        })
+      end
+    end
+
+    test "dev.exs beam controller mode requires endpoint targets" do
+      assert_raise RuntimeError,
+                   ~r/ORCHARD_RUNTIME_ENDPOINT_TARGETS.*at least one BEAM target/,
+                   fn ->
+                     read_dev_controller_inference!(%{
+                       "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+                       "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+                       "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => nil
+                     })
+                   end
+    end
+
+    test "dev.exs beam node-agent role does not require controller endpoint targets" do
+      inference =
+        read_dev_controller_inference!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "node_agent",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => nil
+        })
+
+      refute Keyword.has_key?(inference, :runtime_endpoint_client_impl)
+      refute Keyword.has_key?(inference, :runtime_endpoint_targets)
+    end
+
+    test "dev.exs beam controller mode configures source-dev BEAM guardrails" do
+      controller_config =
+        read_dev_controller_config!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" =>
+            "orchard_node_agent@127.0.0.1,orchard_node_agent@10.0.0.2",
+          "ORCHARD_BEAM_NODE_NAME" => "orchard_controller@127.0.0.1",
+          "ORCHARD_BEAM_COOKIE_FILE" => "/tmp/orchard-dev-cookie"
+        })
+
+      assert Keyword.fetch!(controller_config, :runtime_endpoint)[:beam] == [
+               enabled: true,
+               node_name: "orchard_controller@127.0.0.1",
+               cookie_file: "/tmp/orchard-dev-cookie",
+               listen_host: "127.0.0.1",
+               admitted_services: ["orchard_node_agent"],
+               allowed_cidrs: ["127.0.0.1/32", "10.0.0.2/32"]
+             ]
+    end
+
+    test "dev.exs beam controller mode rejects local controller node names with wrong services" do
+      assert_raise RuntimeError,
+                   ~r/local controller BEAM node service must start with orchard_controller/,
+                   fn ->
+                     read_dev_controller_config!(%{
+                       "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+                       "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+                       "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@127.0.0.1",
+                       "ORCHARD_BEAM_NODE_NAME" => "orchard_node_agent@127.0.0.1"
+                     })
+                   end
+    end
+
+    test "dev.exs beam controller mode rejects local controller node names with hostnames" do
+      assert_raise RuntimeError, ~r/requires IP-literal local controller host/, fn ->
+        read_dev_controller_config!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@127.0.0.1",
+          "ORCHARD_BEAM_NODE_NAME" => "orchard_controller@localhost"
+        })
+      end
+    end
+  end
+
   describe "tokenizer_safe_mode/0" do
     test "defaults to :off when not configured" do
       config = Application.fetch_env!(:orchard_controller, :inference)
@@ -766,9 +896,13 @@ defmodule Orchard.InferenceTest do
   end
 
   defp read_dev_controller_inference!(overrides) do
+    read_dev_controller_config!(overrides)
+    |> Keyword.fetch!(:inference)
+  end
+
+  defp read_dev_controller_config!(overrides) do
     read_config!(dev_config_path(), :dev, overrides)
     |> Keyword.fetch!(:orchard_controller)
-    |> Keyword.fetch!(:inference)
   end
 
   defp read_config!(path, env, env_overrides) do

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -310,6 +310,16 @@ defmodule Orchard.InferenceTest do
                    end
     end
 
+    test "dev.exs rejects all-in-one BEAM mode" do
+      assert_raise RuntimeError, ~r/all_in_one.*BEAM source-dev mode/, fn ->
+        read_dev_controller_inference!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "all_in_one",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@127.0.0.1"
+        })
+      end
+    end
+
     test "dev.exs beam node-agent role does not require controller endpoint targets" do
       inference =
         read_dev_controller_inference!(%{

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -607,6 +607,33 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert status_calls() == [{{:beam, target.id}, [timeout: 17]}]
     end
 
+    test "source-dev BEAM target maps emit runtime endpoint schedules without legacy targets" do
+      target_map = %{
+        transport: :beam,
+        address: "orchard_node_agent@127.0.0.1",
+        metadata: %{source_dev: true}
+      }
+
+      target = Target.normalize(target_map)
+
+      put_inference(
+        runtime_endpoint_targets: [target_map],
+        runtime_client_targets: [[host: "10.0.0.9", port: 50_061]],
+        runtime_client_target: [host: "127.0.0.1", port: 50_071]
+      )
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(),
+                 status_client: StubClient,
+                 status_timeout_ms: 17
+               )
+
+      assert schedule.strategy == :single_node
+      assert schedule.runtime_endpoint_target == target
+      refute Map.has_key?(schedule, :runtime_client_target)
+      assert status_calls() == [{{:beam, target.id}, [timeout: 17]}]
+    end
+
     test "returns cluster_busy for one live full target instead of bypassing capacity checks" do
       put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -634,6 +634,43 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert status_calls() == [{{:beam, target.id}, [timeout: 17]}]
     end
 
+    test "multi-target BEAM all-probe failure preserves Runtime Endpoint selection" do
+      target_a =
+        Target.normalize(
+          transport: :beam,
+          address: "orchard_node_agent@127.0.0.1",
+          metadata: %{source_dev: true}
+        )
+
+      target_b =
+        Target.normalize(
+          transport: :beam,
+          address: "orchard_node_agent@10.0.0.2",
+          metadata: %{source_dev: true}
+        )
+
+      put_inference(
+        runtime_endpoint_targets: [target_a, target_b],
+        runtime_client_targets: [[host: "10.0.0.9", port: 50_061]],
+        runtime_client_target: [host: "127.0.0.1", port: 50_071]
+      )
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(),
+                 status_client: StubClient,
+                 status_timeout_ms: 17
+               )
+
+      assert schedule.strategy == :single_node
+      assert schedule.runtime_endpoint_target == target_a
+      refute Map.has_key?(schedule, :runtime_client_target)
+
+      assert status_calls() == [
+               {{:beam, target_a.id}, [timeout: 17]},
+               {{:beam, target_b.id}, [timeout: 17]}
+             ]
+    end
+
     test "returns cluster_busy for one live full target instead of bypassing capacity checks" do
       put_inference(runtime_client_targets: [[host: "10.0.0.1", port: 50_061]])
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})

--- a/apps/orchard_node_agent/README.md
+++ b/apps/orchard_node_agent/README.md
@@ -25,6 +25,8 @@ This README is orientation only. Normative behavior lives in
 
 ## Local work
 
-Use `mise exec -- bin/dev-node-agent` for source-dev worker hosts. For split-role
-setup and validation commands, see [`../../docs/local-dev.md`](../../docs/local-dev.md)
+Use `mise exec -- bin/dev-node-agent` for source-dev worker hosts.
+For gRPC split-role testing, configure `ORCHARD_NODE_AGENT_LISTEN_HOST` and the controller's `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+For BEAM split-role testing, configure `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`, `ORCHARD_BEAM_NODE_NAME`, and the shared cookie surface documented in local-dev.
+For setup and validation commands, see [`../../docs/local-dev.md`](../../docs/local-dev.md)
 and [`../../docs/tooling.md`](../../docs/tooling.md).

--- a/apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs
@@ -47,6 +47,34 @@ defmodule Orchard.Node.RuntimeEndpointMapperTest do
              capacity
   end
 
+  test "maps source-dev BEAM target address shape into observation identity" do
+    target =
+      Target.beam("550e8400-e29b-41d4-a716-446655440000",
+        address: :"orchard_node_agent@127.0.0.1",
+        metadata: %{source_dev: true}
+      )
+
+    response = %StatusResponse{
+      node_metadata: %RuntimeNodeMetadata{
+        node_id: "node-source-dev",
+        hostname: "127.0.0.1",
+        listen_host: "127.0.0.1"
+      },
+      runtime_health: %RuntimeHealth{ready: true, health_code: "ok"}
+    }
+
+    observation = RuntimeEndpointMapper.observation_from_status(target, response)
+
+    assert observation.endpoint_id == target.id
+    assert observation.target == target
+    assert observation.target.address == :"orchard_node_agent@127.0.0.1"
+    assert observation.target.metadata.source_dev
+    assert observation.metadata.node_id == "node-source-dev"
+    assert observation.metadata.hostname == "127.0.0.1"
+    assert observation.metadata.listen_host == "127.0.0.1"
+    assert observation.availability == :available
+  end
+
   test "maps prefix-cache score responses to Runtime Endpoint operation results" do
     response = %ScorePrefixCacheResponse{
       status_code: "ok",

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -4,8 +4,10 @@ defmodule Orchard.RuntimeEndpoint.Target do
 
   gRPC compatibility targets use `[host: ..., port: ...]` addresses.
   BEAM targets use BEAM node-name addresses such as
-  `:orchard_node_agent@localhost` and may carry a persisted Orchard node UUID
-  for identity checks.
+  `:orchard_node_agent@localhost` or `"orchard_node_agent@127.0.0.1"` and may
+  carry a persisted Orchard node UUID for identity checks.
+  Source-dev env parsing applies the narrower IPv4-literal operating-model
+  rules before these targets reach this domain struct.
   """
 
   @enforce_keys [:id, :transport, :address]
@@ -32,6 +34,8 @@ defmodule Orchard.RuntimeEndpoint.Target do
   Targets without an explicit transport remain gRPC compatibility targets.
   BEAM targets require an atom or binary BEAM node-name address and reject
   malformed configured node IDs.
+  Host policy beyond valid `service@host` shape belongs to the caller's
+  transport config.
   """
   @spec normalize(t() | keyword() | map()) :: t()
   def normalize(%__MODULE__{transport: :beam} = target) do

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/target.ex
@@ -168,8 +168,15 @@ defmodule Orchard.RuntimeEndpoint.Target do
   defp default_beam_id(nil, address) when is_atom(address), do: "beam:#{Atom.to_string(address)}"
 
   defp valid_beam_node_name?(address) do
-    byte_size(address) in 3..255 and String.match?(address, ~r/^[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+$/)
+    byte_size(address) in 3..255 and
+      case String.split(address, "@") do
+        [service, host] -> valid_beam_service?(service) and valid_beam_host?(host)
+        _other -> false
+      end
   end
+
+  defp valid_beam_service?(service), do: String.match?(service, ~r/^[A-Za-z0-9_.-]+$/)
+  defp valid_beam_host?(host), do: String.match?(host, ~r/^[^\s@]+$/)
 
   defp attrs_map(attrs) when is_list(attrs), do: Map.new(attrs)
   defp attrs_map(%{} = attrs), do: attrs

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs
@@ -125,6 +125,26 @@ defmodule Orchard.RuntimeEndpoint.DomainTest do
     assert beam_target.metadata == %{role: :node_agent}
   end
 
+  test "BEAM target normalization accepts IP-literal BEAM node-name hosts" do
+    ipv4_target =
+      Target.normalize(%{
+        transport: :beam,
+        id: "source-dev-ipv4",
+        address: "orchard_node_agent@127.0.0.1"
+      })
+
+    assert ipv4_target.address == :"orchard_node_agent@127.0.0.1"
+
+    ipv6_target =
+      Target.normalize(%{
+        transport: :beam,
+        id: "source-dev-ipv6",
+        address: "orchard_node_agent@::1"
+      })
+
+    assert ipv6_target.address == :"orchard_node_agent@::1"
+  end
+
   test "BEAM target normalization keeps node_id nil unless explicitly configured" do
     target =
       Target.normalize(%{

--- a/bin/dev
+++ b/bin/dev
@@ -14,6 +14,17 @@ cd "$REPO_ROOT"
 command -v mix >/dev/null || { echo "error: mix not found on PATH" >&2; exit 1; }
 
 export MIX_ENV=dev
+export ORCHARD_SOURCE_DEV_ROLE=all_in_one
+
+runtime_endpoint_transport="${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-}"
+runtime_endpoint_transport="${runtime_endpoint_transport#"${runtime_endpoint_transport%%[![:space:]]*}"}"
+runtime_endpoint_transport="${runtime_endpoint_transport%"${runtime_endpoint_transport##*[![:space:]]}"}"
+
+if [[ "$runtime_endpoint_transport" == "beam" ]]; then
+  echo "error: all-in-one bin/dev does not support BEAM source-dev mode yet" >&2
+  echo "error: use bin/dev-controller and bin/dev-node-agent for ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam" >&2
+  exit 64
+fi
 
 # ---------------------------------------------------------------------------
 # Resolve dev runtime port (default 50071, avoids packaged BEAM on 50061).

--- a/bin/dev
+++ b/bin/dev
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# bin/dev — Idempotent dev environment startup for Orchard.
+# bin/dev — Idempotent all-in-one dev environment startup for Orchard.
 # Creates/migrates the dev DB, sets the dev gRPC port, starts the Phoenix server.
 # Safe to run repeatedly. Works alongside the packaged production BEAM on 50061.
+# Explicit BEAM Runtime Endpoint mode belongs to bin/dev-controller + bin/dev-node-agent.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/bin/dev-controller
+++ b/bin/dev-controller
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # bin/dev-controller — Source-dev controller role startup for Orchard.
 # Creates/migrates the dev DB, sets the dev gRPC target port, starts Phoenix.
-# Use ORCHARD_RUNTIME_CLIENT_TARGETS for multi-host source-dev clusters.
+# Use ORCHARD_RUNTIME_CLIENT_TARGETS for gRPC compatibility targets.
+# Use ORCHARD_RUNTIME_ENDPOINT_TARGETS with ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
+# for split-role BEAM Runtime Endpoint targets.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/bin/dev-controller
+++ b/bin/dev-controller
@@ -14,6 +14,7 @@ cd "$REPO_ROOT"
 command -v mix >/dev/null || { echo "error: mix not found on PATH" >&2; exit 1; }
 
 export MIX_ENV=dev
+export ORCHARD_SOURCE_DEV_ROLE=controller
 
 # Resolve dev runtime port (default 50071, avoids packaged BEAM on 50061).
 # Supports both env var names for parity with config/runtime.exs.
@@ -37,6 +38,9 @@ export ORCHARD_NODE_AGENT_LISTEN_PORT="$resolved_port"
 export ORCHARD_RUNTIME_CLIENT_PORT="$resolved_port"
 export ORCHARD_RUNTIME_CLIENT_TARGETS="${ORCHARD_RUNTIME_CLIENT_TARGETS:-127.0.0.1:${resolved_port}}"
 
+source "$REPO_ROOT/bin/lib/source-dev-beam.sh"
+orchard_source_dev_beam_bootstrap controller "$REPO_ROOT"
+
 # Bootstrap dev database. The controller owns the schema.
 echo "==> Ensuring dev database..."
 mix ecto.create --quiet
@@ -47,4 +51,4 @@ echo "==> Starting Orchard dev controller (role: controller)"
 echo "==> HTTP endpoint: 127.0.0.1:${PORT:-4000}"
 echo "==> Runtime client targets: ${ORCHARD_RUNTIME_CLIENT_TARGETS}"
 cd "$REPO_ROOT/apps/orchard_controller"
-exec iex -S mix phx.server
+exec iex "${ORCHARD_BEAM_IEX_ARGS[@]}" -S mix phx.server

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -14,6 +14,7 @@ cd "$REPO_ROOT"
 command -v mix >/dev/null || { echo "error: mix not found on PATH" >&2; exit 1; }
 
 export MIX_ENV=dev
+export ORCHARD_SOURCE_DEV_ROLE=node_agent
 
 # Resolve dev runtime port (default 50071, avoids packaged BEAM on 50061).
 # Supports both env var names for parity with config/runtime.exs.
@@ -42,6 +43,9 @@ if [[ ! -x "$ORCHARD_WORKER_EXECUTABLE" ]]; then
   echo "warning: ORCHARD_WORKER_EXECUTABLE is not executable: $ORCHARD_WORKER_EXECUTABLE" >&2
 fi
 
+source "$REPO_ROOT/bin/lib/source-dev-beam.sh"
+orchard_source_dev_beam_bootstrap node_agent "$REPO_ROOT"
+
 # Kill orphaned MLX workers from prior sessions.
 orphans=$(pgrep -f orchard-worker-mlx 2>/dev/null || true)
 if [[ -n "$orphans" ]]; then
@@ -56,4 +60,4 @@ echo "==> Starting Orchard dev node-agent (role: node-agent)"
 echo "==> gRPC endpoint: ${ORCHARD_NODE_AGENT_LISTEN_HOST}:${resolved_port}"
 echo "==> Worker executable: ${ORCHARD_WORKER_EXECUTABLE}"
 cd "$REPO_ROOT/apps/orchard_node_agent"
-exec iex -S mix run --no-halt
+exec iex "${ORCHARD_BEAM_IEX_ARGS[@]}" -S mix run --no-halt

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -3,7 +3,10 @@ set -euo pipefail
 
 # bin/dev-node-agent — Source-dev node-agent role startup for Orchard.
 # Starts only the node-agent app from source; no DB create/migrate, no Phoenix.
-# Set ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0 for LAN/Tailscale testing.
+# For gRPC compatibility testing, set ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0
+# on LAN/Tailscale worker hosts.
+# For BEAM Runtime Endpoint testing, set ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
+# and an ORCHARD_BEAM_NODE_NAME with the host's IPv4 address.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -79,6 +79,7 @@ orchard_source_dev_beam_bootstrap() {
   local dist_interface
   dist_interface="$(orchard_source_dev_beam_inet_dist_interface "$node_host")" || return $?
 
+  orchard_source_dev_beam_preflight_epmd "$node_host" "$epmd_port" || return $?
   orchard_source_dev_beam_prepare_home "$role" "$repo_root" "$cookie_file" || return $?
 
   ORCHARD_BEAM_IEX_ARGS=(
@@ -143,6 +144,11 @@ orchard_source_dev_beam_validate_node_name() {
       ;;
   esac
 
+  if orchard_source_dev_beam_ip_is_unspecified "$host"; then
+    echo "error: ORCHARD_BEAM_NODE_NAME host must not be an unspecified or wildcard address" >&2
+    return 64
+  fi
+
   if ! orchard_source_dev_beam_is_ip_literal "$host"; then
     echo "error: ORCHARD_BEAM_NODE_NAME host must be an IP literal" >&2
     return 64
@@ -174,6 +180,33 @@ PY
       fi
     done
     return 0
+  fi
+
+  return 1
+}
+
+orchard_source_dev_beam_ip_is_unspecified() {
+  local host="$1"
+
+  case "$host" in
+    0.0.0.0|::|0:0:0:0:0:0:0:0)
+      return 0
+      ;;
+  esac
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$host" <<'PY'
+import ipaddress
+import sys
+
+try:
+    addr = ipaddress.ip_address(sys.argv[1])
+except ValueError:
+    raise SystemExit(1)
+
+raise SystemExit(0 if addr.is_unspecified else 1)
+PY
+    return $?
   fi
 
   return 1
@@ -217,6 +250,118 @@ PY
 
   echo "error: ORCHARD_BEAM_NODE_NAME host cannot be converted to inet_dist_use_interface" >&2
   return 64
+}
+
+orchard_source_dev_beam_preflight_epmd() {
+  local host="$1"
+  local port="$2"
+
+  if ! command -v epmd >/dev/null 2>&1; then
+    echo "error: epmd not found on PATH; run through the pinned Erlang toolchain" >&2
+    return 69
+  fi
+
+  if orchard_source_dev_beam_epmd_running "$port"; then
+    orchard_source_dev_beam_verify_epmd_listener "$host" "$port"
+    return $?
+  fi
+
+  if ! epmd -daemon -address "$host" -port "$port" >/dev/null 2>&1; then
+    echo "error: failed to start address-constrained EPMD on $host:$port" >&2
+    return 69
+  fi
+
+  orchard_source_dev_beam_verify_epmd_listener "$host" "$port"
+}
+
+orchard_source_dev_beam_epmd_running() {
+  local port="$1"
+  epmd -port "$port" -names >/dev/null 2>&1
+}
+
+orchard_source_dev_beam_verify_epmd_listener() {
+  local host="$1"
+  local port="$2"
+  local listeners listener matched attempts status
+
+  listeners=""
+  attempts=0
+  status=1
+  while (( attempts < 20 )); do
+    if listeners="$(orchard_source_dev_beam_epmd_listener_hosts "$port")"; then
+      status=0
+      if [[ -n "$listeners" ]]; then
+        break
+      fi
+    else
+      status=$?
+    fi
+
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+
+  if (( status != 0 )); then
+    echo "error: unable to verify EPMD listener on port $port; stop any existing EPMD with ERL_EPMD_PORT=$port epmd -kill, then rerun" >&2
+    return 69
+  elif [[ -z "$listeners" ]]; then
+    echo "error: unable to find EPMD listener on port $port after preflight" >&2
+    return 69
+  fi
+
+  matched=0
+  while IFS= read -r listener; do
+    if orchard_source_dev_beam_listener_is_wildcard "$listener"; then
+      echo "error: EPMD listener on port $port is wildcard-bound; stop it with ERL_EPMD_PORT=$port epmd -kill, then rerun" >&2
+      return 69
+    fi
+
+    if [[ "$listener" == "$host" ]]; then
+      matched=1
+    fi
+  done <<< "$listeners"
+
+  if (( matched == 0 )); then
+    echo "error: EPMD listener on port $port is not bound to $host; stop existing EPMD with ERL_EPMD_PORT=$port epmd -kill, then rerun" >&2
+    return 69
+  fi
+}
+
+orchard_source_dev_beam_epmd_listener_hosts() {
+  local port="$1"
+  local output
+
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 1
+  fi
+
+  output="$(lsof -nP -a -iTCP:"$port" -sTCP:LISTEN -c epmd 2>/dev/null)" || return 1
+
+  printf '%s\n' "$output" | awk '
+    / TCP / {
+      endpoint = $0
+      sub(/^.* TCP /, "", endpoint)
+      sub(/ .*/, "", endpoint)
+      if (endpoint ~ /^\[/) {
+        sub(/^\[/, "", endpoint)
+        sub(/\]:[0-9]+$/, "", endpoint)
+      } else {
+        sub(/:[0-9]+$/, "", endpoint)
+      }
+      print endpoint
+    }
+  '
+}
+
+orchard_source_dev_beam_listener_is_wildcard() {
+  case "$1" in
+    ""|"*"|0.0.0.0|::)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 orchard_source_dev_beam_prepare_cookie() {

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -489,8 +489,17 @@ orchard_source_dev_beam_validate_cookie_file() {
 orchard_source_dev_beam_cookie_is_owner_only() {
   local cookie_file="$1"
   local mode
-  mode="$(stat -f '%Lp' "$cookie_file" 2>/dev/null || stat -c '%a' "$cookie_file")"
-  mode="$(printf '%03d' "$mode")"
+
+  if mode="$(stat -c '%a' "$cookie_file" 2>/dev/null)"; then
+    :
+  elif mode="$(stat -f '%Lp' "$cookie_file" 2>/dev/null)"; then
+    :
+  else
+    return 1
+  fi
+
+  [[ "$mode" =~ ^[0-7]+$ ]] || return 1
+  mode="00$mode"
   [[ "${mode: -2}" == "00" ]]
 }
 

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# Shared source-dev BEAM bootstrap for split-role Orchard scripts.
+
+orchard_source_dev_beam_bootstrap() {
+  local role="$1"
+  local repo_root="$2"
+
+  ORCHARD_BEAM_IEX_ARGS=()
+
+  local transport
+  transport="$(orchard_source_dev_beam_trim "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-}")"
+  case "$transport" in
+    ""|grpc)
+      export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT="grpc"
+      export ORCHARD_SOURCE_DEV_ROLE="$role"
+      return 0
+      ;;
+    beam)
+      export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT="beam"
+      ;;
+    *)
+      echo "error: ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc|beam, got: $transport" >&2
+      return 64
+      ;;
+  esac
+
+  export ORCHARD_SOURCE_DEV_ROLE="$role"
+
+  local node_name
+  node_name="$(orchard_source_dev_beam_default_node_name "$role")"
+  node_name="${ORCHARD_BEAM_NODE_NAME:-$node_name}"
+  orchard_source_dev_beam_validate_node_name "$role" "$node_name" || return $?
+  export ORCHARD_BEAM_NODE_NAME="$node_name"
+
+  local cookie_file
+  cookie_file="${ORCHARD_BEAM_COOKIE_FILE:-$repo_root/tmp/dev/beam.cookie}"
+  orchard_source_dev_beam_prepare_cookie "$cookie_file" "${ORCHARD_BEAM_COOKIE_FILE+x}" || return $?
+  export ORCHARD_BEAM_COOKIE_FILE="$cookie_file"
+
+  local epmd_port
+  epmd_port="${ORCHARD_BEAM_EPMD_PORT:-4369}"
+  orchard_source_dev_beam_validate_port "ORCHARD_BEAM_EPMD_PORT" "$epmd_port" || return $?
+  export ORCHARD_BEAM_EPMD_PORT="$epmd_port"
+  export ERL_EPMD_PORT="$epmd_port"
+
+  local dist_min="${ORCHARD_BEAM_DIST_PORT_MIN:-}"
+  local dist_max="${ORCHARD_BEAM_DIST_PORT_MAX:-}"
+  if [[ -z "$dist_min" && -z "$dist_max" ]]; then
+    case "$role" in
+      controller)
+        dist_min=52171
+        dist_max=52171
+        ;;
+      node_agent)
+        dist_min=52172
+        dist_max=52172
+        ;;
+      *)
+        echo "error: unsupported source-dev role: $role" >&2
+        return 64
+        ;;
+    esac
+  elif [[ -z "$dist_min" || -z "$dist_max" ]]; then
+    echo "error: ORCHARD_BEAM_DIST_PORT_MIN and ORCHARD_BEAM_DIST_PORT_MAX must be set together" >&2
+    return 64
+  fi
+
+  orchard_source_dev_beam_validate_port "ORCHARD_BEAM_DIST_PORT_MIN" "$dist_min" || return $?
+  orchard_source_dev_beam_validate_port "ORCHARD_BEAM_DIST_PORT_MAX" "$dist_max" || return $?
+  if (( dist_min > dist_max )); then
+    echo "error: ORCHARD_BEAM_DIST_PORT_MIN must be less than or equal to ORCHARD_BEAM_DIST_PORT_MAX" >&2
+    return 64
+  fi
+  export ORCHARD_BEAM_DIST_PORT_MIN="$dist_min"
+  export ORCHARD_BEAM_DIST_PORT_MAX="$dist_max"
+
+  orchard_source_dev_beam_prepare_home "$role" "$repo_root" "$cookie_file" || return $?
+
+  ORCHARD_BEAM_IEX_ARGS=(
+    --name "$node_name"
+    --erl "-kernel inet_dist_listen_min $dist_min inet_dist_listen_max $dist_max"
+  )
+
+  echo "==> Runtime endpoint transport: beam" >&2
+  echo "==> BEAM node name: $node_name" >&2
+  echo "==> BEAM cookie file: $cookie_file" >&2
+  echo "==> BEAM EPMD port: $epmd_port" >&2
+  echo "==> BEAM distribution port range: $dist_min..$dist_max" >&2
+}
+
+orchard_source_dev_beam_default_node_name() {
+  case "$1" in
+    controller)
+      printf '%s\n' 'orchard_controller@127.0.0.1'
+      ;;
+    node_agent)
+      printf '%s\n' 'orchard_node_agent@127.0.0.1'
+      ;;
+    *)
+      echo "error: unsupported source-dev role: $1" >&2
+      return 64
+      ;;
+  esac
+}
+
+orchard_source_dev_beam_validate_node_name() {
+  local role="$1"
+  local node_name="$2"
+  local service host rest
+
+  IFS='@' read -r service host rest <<< "$node_name"
+  if [[ -z "${service:-}" || -z "${host:-}" || -n "${rest:-}" ]]; then
+    echo "error: ORCHARD_BEAM_NODE_NAME must be a long BEAM node name in service@ip form" >&2
+    return 64
+  fi
+
+  if [[ ! "$service" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+    echo "error: ORCHARD_BEAM_NODE_NAME service contains invalid characters" >&2
+    return 64
+  fi
+
+  case "$role" in
+    controller)
+      if [[ "$service" != orchard_controller* ]]; then
+        echo "error: controller BEAM node service must start with orchard_controller" >&2
+        return 64
+      fi
+      ;;
+    node_agent)
+      if [[ "$service" != orchard_node_agent* ]]; then
+        echo "error: node-agent BEAM node service must start with orchard_node_agent" >&2
+        return 64
+      fi
+      ;;
+    *)
+      echo "error: unsupported source-dev role: $role" >&2
+      return 64
+      ;;
+  esac
+
+  if ! orchard_source_dev_beam_is_ip_literal "$host"; then
+    echo "error: ORCHARD_BEAM_NODE_NAME host must be an IP literal" >&2
+    return 64
+  fi
+}
+
+orchard_source_dev_beam_is_ip_literal() {
+  local host="$1"
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$host" <<'PY'
+import ipaddress
+import sys
+
+try:
+    ipaddress.ip_address(sys.argv[1])
+except ValueError:
+    raise SystemExit(1)
+PY
+    return $?
+  fi
+
+  if [[ "$host" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    local IFS='.'
+    local part
+    for part in $host; do
+      if (( part > 255 )); then
+        return 1
+      fi
+    done
+    return 0
+  fi
+
+  return 1
+}
+
+orchard_source_dev_beam_prepare_cookie() {
+  local cookie_file="$1"
+  local explicit_marker="$2"
+
+  if [[ -n "$explicit_marker" ]]; then
+    orchard_source_dev_beam_validate_cookie_file "$cookie_file" || return $?
+    return 0
+  fi
+
+  if [[ ! -e "$cookie_file" ]]; then
+    orchard_source_dev_beam_create_cookie_file "$cookie_file" || return $?
+  fi
+
+  orchard_source_dev_beam_validate_cookie_file "$cookie_file"
+}
+
+orchard_source_dev_beam_create_cookie_file() {
+  local cookie_file="$1"
+  local cookie_dir lock_dir wait_count status
+
+  cookie_dir="$(dirname "$cookie_file")"
+  mkdir -p "$cookie_dir"
+  lock_dir="$cookie_file.lock"
+  wait_count=0
+
+  until mkdir "$lock_dir" 2>/dev/null; do
+    if (( wait_count >= 200 )); then
+      echo "error: timed out waiting for source-dev BEAM cookie lock: $lock_dir" >&2
+      return 75
+    fi
+
+    sleep 0.05
+    wait_count=$((wait_count + 1))
+  done
+
+  status=0
+  if [[ ! -e "$cookie_file" ]]; then
+    orchard_source_dev_beam_write_cookie_file "$cookie_file" || status=$?
+  fi
+
+  rmdir "$lock_dir"
+  return "$status"
+}
+
+orchard_source_dev_beam_write_cookie_file() {
+  local cookie_file="$1"
+  local cookie_dir tmp_file cookie old_umask
+
+  cookie_dir="$(dirname "$cookie_file")"
+  cookie="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+  if [[ -z "$cookie" ]]; then
+    echo "error: failed to generate source-dev BEAM cookie material" >&2
+    return 70
+  fi
+
+  tmp_file="$cookie_dir/.beam.cookie.$$"
+  old_umask="$(umask)"
+  umask 077
+  printf '%s\n' "$cookie" > "$tmp_file"
+  umask "$old_umask"
+  chmod 600 "$tmp_file"
+  mv "$tmp_file" "$cookie_file"
+}
+
+orchard_source_dev_beam_validate_cookie_file() {
+  local cookie_file="$1"
+
+  if [[ ! -f "$cookie_file" ]]; then
+    echo "error: ORCHARD_BEAM_COOKIE_FILE must point to an existing regular file" >&2
+    return 64
+  fi
+
+  if [[ ! -s "$cookie_file" ]]; then
+    echo "error: ORCHARD_BEAM_COOKIE_FILE must not be empty" >&2
+    return 64
+  fi
+
+  if ! orchard_source_dev_beam_cookie_is_owner_only "$cookie_file"; then
+    echo "error: ORCHARD_BEAM_COOKIE_FILE must be owner-only" >&2
+    return 64
+  fi
+}
+
+orchard_source_dev_beam_cookie_is_owner_only() {
+  local cookie_file="$1"
+  local mode
+  mode="$(stat -f '%Lp' "$cookie_file" 2>/dev/null || stat -c '%a' "$cookie_file")"
+  mode="$(printf '%03d' "$mode")"
+  [[ "${mode: -2}" == "00" ]]
+}
+
+orchard_source_dev_beam_prepare_home() {
+  local role="$1"
+  local repo_root="$2"
+  local cookie_file="$3"
+  local original_home beam_home
+
+  original_home="${HOME:-$repo_root/tmp/dev/home}"
+  export MIX_HOME="${MIX_HOME:-$original_home/.mix}"
+  export HEX_HOME="${HEX_HOME:-$original_home/.hex}"
+
+  beam_home="$repo_root/tmp/dev/beam-home/$role"
+  mkdir -p "$beam_home"
+  cp "$cookie_file" "$beam_home/.erlang.cookie"
+  chmod 600 "$beam_home/.erlang.cookie"
+  export HOME="$beam_home"
+}
+
+orchard_source_dev_beam_validate_port() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]] || (( value < 1 || value > 65535 )); then
+    echo "error: $name must be an integer from 1 to 65535" >&2
+    return 64
+  fi
+}
+
+orchard_source_dev_beam_trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s\n' "$value"
+}

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -82,6 +82,7 @@ orchard_source_dev_beam_bootstrap() {
   orchard_source_dev_beam_preflight_epmd "$node_host" "$epmd_port" || return $?
   orchard_source_dev_beam_prepare_home "$role" "$repo_root" "$cookie_file" || return $?
 
+  # shellcheck disable=SC2034 # Consumed by caller scripts after this file is sourced.
   ORCHARD_BEAM_IEX_ARGS=(
     --name "$node_name"
     --erl "-kernel inet_dist_use_interface $dist_interface inet_dist_listen_min $dist_min inet_dist_listen_max $dist_max"

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -127,8 +127,8 @@ orchard_source_dev_beam_validate_node_name() {
       fi
       ;;
     node_agent)
-      if [[ "$service" != orchard_node_agent* ]]; then
-        echo "error: node-agent BEAM node service must start with orchard_node_agent" >&2
+      if [[ "$service" != orchard_node_agent ]]; then
+        echo "error: node-agent BEAM node service must be exactly orchard_node_agent" >&2
         return 64
       fi
       ;;

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -116,7 +116,7 @@ orchard_source_dev_beam_validate_node_name() {
 
   IFS='@' read -r service host rest <<< "$node_name"
   if [[ -z "${service:-}" || -z "${host:-}" || -n "${rest:-}" ]]; then
-    echo "error: ORCHARD_BEAM_NODE_NAME must be a long BEAM node name in service@ip form" >&2
+    echo "error: ORCHARD_BEAM_NODE_NAME must be a long BEAM node name in service@ipv4 form" >&2
     return 64
   fi
 
@@ -144,18 +144,18 @@ orchard_source_dev_beam_validate_node_name() {
       ;;
   esac
 
+  if ! orchard_source_dev_beam_is_ipv4_literal "$host"; then
+    echo "error: ORCHARD_BEAM_NODE_NAME host must be an IPv4 literal" >&2
+    return 64
+  fi
+
   if orchard_source_dev_beam_ip_is_unspecified "$host"; then
     echo "error: ORCHARD_BEAM_NODE_NAME host must not be an unspecified or wildcard address" >&2
     return 64
   fi
-
-  if ! orchard_source_dev_beam_is_ip_literal "$host"; then
-    echo "error: ORCHARD_BEAM_NODE_NAME host must be an IP literal" >&2
-    return 64
-  fi
 }
 
-orchard_source_dev_beam_is_ip_literal() {
+orchard_source_dev_beam_is_ipv4_literal() {
   local host="$1"
 
   if command -v python3 >/dev/null 2>&1; then
@@ -164,9 +164,11 @@ import ipaddress
 import sys
 
 try:
-    ipaddress.ip_address(sys.argv[1])
+    addr = ipaddress.ip_address(sys.argv[1])
 except ValueError:
     raise SystemExit(1)
+
+raise SystemExit(0 if addr.version == 4 else 1)
 PY
     return $?
   fi
@@ -189,7 +191,7 @@ orchard_source_dev_beam_ip_is_unspecified() {
   local host="$1"
 
   case "$host" in
-    0.0.0.0|::|0:0:0:0:0:0:0:0)
+    0.0.0.0)
       return 0
       ;;
   esac
@@ -202,6 +204,9 @@ import sys
 try:
     addr = ipaddress.ip_address(sys.argv[1])
 except ValueError:
+    raise SystemExit(1)
+
+if addr.version != 4:
     raise SystemExit(1)
 
 raise SystemExit(0 if addr.is_unspecified else 1)
@@ -221,13 +226,10 @@ import ipaddress
 import sys
 
 addr = ipaddress.ip_address(sys.argv[1])
-if addr.version == 4:
-    parts = [str(part) for part in addr.packed]
-else:
-    parts = [
-        str(int.from_bytes(addr.packed[index:index + 2], "big"))
-        for index in range(0, 16, 2)
-    ]
+if addr.version != 4:
+    raise SystemExit(1)
+
+parts = [str(part) for part in addr.packed]
 
 print("{" + ",".join(parts) + "}")
 PY
@@ -318,7 +320,15 @@ orchard_source_dev_beam_verify_epmd_listener() {
 
     if [[ "$listener" == "$host" ]]; then
       matched=1
+      continue
     fi
+
+    if orchard_source_dev_beam_listener_is_loopback "$listener"; then
+      continue
+    fi
+
+    echo "error: EPMD listener on port $port is not constrained to $host; stop existing EPMD with ERL_EPMD_PORT=$port epmd -kill, then rerun" >&2
+    return 69
   done <<< "$listeners"
 
   if (( matched == 0 )); then
@@ -356,6 +366,34 @@ orchard_source_dev_beam_epmd_listener_hosts() {
 orchard_source_dev_beam_listener_is_wildcard() {
   case "$1" in
     ""|"*"|0.0.0.0|::)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+orchard_source_dev_beam_listener_is_loopback() {
+  local listener="$1"
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$listener" <<'PY'
+import ipaddress
+import sys
+
+try:
+    addr = ipaddress.ip_address(sys.argv[1])
+except ValueError:
+    raise SystemExit(1)
+
+raise SystemExit(0 if addr.is_loopback else 1)
+PY
+    return $?
+  fi
+
+  case "$listener" in
+    127.*|::1|0:0:0:0:0:0:0:1)
       return 0
       ;;
     *)

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -26,10 +26,11 @@ orchard_source_dev_beam_bootstrap() {
 
   export ORCHARD_SOURCE_DEV_ROLE="$role"
 
-  local node_name
+  local node_name node_host
   node_name="$(orchard_source_dev_beam_default_node_name "$role")"
   node_name="${ORCHARD_BEAM_NODE_NAME:-$node_name}"
   orchard_source_dev_beam_validate_node_name "$role" "$node_name" || return $?
+  node_host="${node_name#*@}"
   export ORCHARD_BEAM_NODE_NAME="$node_name"
 
   local cookie_file
@@ -42,6 +43,7 @@ orchard_source_dev_beam_bootstrap() {
   orchard_source_dev_beam_validate_port "ORCHARD_BEAM_EPMD_PORT" "$epmd_port" || return $?
   export ORCHARD_BEAM_EPMD_PORT="$epmd_port"
   export ERL_EPMD_PORT="$epmd_port"
+  export ERL_EPMD_ADDRESS="$node_host"
 
   local dist_min="${ORCHARD_BEAM_DIST_PORT_MIN:-}"
   local dist_max="${ORCHARD_BEAM_DIST_PORT_MAX:-}"
@@ -74,11 +76,14 @@ orchard_source_dev_beam_bootstrap() {
   export ORCHARD_BEAM_DIST_PORT_MIN="$dist_min"
   export ORCHARD_BEAM_DIST_PORT_MAX="$dist_max"
 
+  local dist_interface
+  dist_interface="$(orchard_source_dev_beam_inet_dist_interface "$node_host")" || return $?
+
   orchard_source_dev_beam_prepare_home "$role" "$repo_root" "$cookie_file" || return $?
 
   ORCHARD_BEAM_IEX_ARGS=(
     --name "$node_name"
-    --erl "-kernel inet_dist_listen_min $dist_min inet_dist_listen_max $dist_max"
+    --erl "-kernel inet_dist_use_interface $dist_interface inet_dist_listen_min $dist_min inet_dist_listen_max $dist_max"
   )
 
   echo "==> Runtime endpoint transport: beam" >&2
@@ -172,6 +177,46 @@ PY
   fi
 
   return 1
+}
+
+orchard_source_dev_beam_inet_dist_interface() {
+  local host="$1"
+
+  if command -v python3 >/dev/null 2>&1; then
+    if python3 - "$host" <<'PY'
+import ipaddress
+import sys
+
+addr = ipaddress.ip_address(sys.argv[1])
+if addr.version == 4:
+    parts = [str(part) for part in addr.packed]
+else:
+    parts = [
+        str(int.from_bytes(addr.packed[index:index + 2], "big"))
+        for index in range(0, 16, 2)
+    ]
+
+print("{" + ",".join(parts) + "}")
+PY
+    then
+      return 0
+    fi
+
+    echo "error: ORCHARD_BEAM_NODE_NAME host cannot be converted to inet_dist_use_interface" >&2
+    return 64
+  fi
+
+  if [[ "$host" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    local a b c d rest
+    IFS='.' read -r a b c d rest <<< "$host"
+    if [[ -n "${a:-}" && -n "${b:-}" && -n "${c:-}" && -n "${d:-}" && -z "${rest:-}" ]]; then
+      printf '{%s,%s,%s,%s}\n' "$a" "$b" "$c" "$d"
+      return 0
+    fi
+  fi
+
+  echo "error: ORCHARD_BEAM_NODE_NAME host cannot be converted to inet_dist_use_interface" >&2
+  return 64
 }
 
 orchard_source_dev_beam_prepare_cookie() {

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -136,6 +136,11 @@ source_dev_role =
 runtime_endpoint_transport =
   Orchard.Config.SourceDevBeam.transport!(System.get_env("ORCHARD_RUNTIME_ENDPOINT_TRANSPORT"))
 
+Orchard.Config.SourceDevBeam.validate_transport_role!(
+  runtime_endpoint_transport,
+  source_dev_role
+)
+
 beam_runtime_endpoint_targets =
   if runtime_endpoint_transport == :beam and source_dev_role == :controller do
     Orchard.Config.SourceDevBeam.controller_beam_targets!(

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,6 +1,7 @@
 import Config
 
 Code.require_file("m1_runtime_defaults.exs", __DIR__)
+Code.require_file("source_dev_beam.exs", __DIR__)
 
 repo_root = Path.expand("..", __DIR__)
 dev_root = Path.join([repo_root, "tmp", "dev"])
@@ -128,6 +129,37 @@ parse_runtime_targets = fn env_name ->
 end
 
 dev_runtime_targets = parse_runtime_targets.("ORCHARD_RUNTIME_CLIENT_TARGETS")
+
+source_dev_role =
+  Orchard.Config.SourceDevBeam.source_dev_role(System.get_env("ORCHARD_SOURCE_DEV_ROLE"))
+
+runtime_endpoint_transport =
+  Orchard.Config.SourceDevBeam.transport!(System.get_env("ORCHARD_RUNTIME_ENDPOINT_TRANSPORT"))
+
+beam_runtime_endpoint_targets =
+  if runtime_endpoint_transport == :beam and source_dev_role == :controller do
+    Orchard.Config.SourceDevBeam.controller_beam_targets!(
+      System.get_env("ORCHARD_RUNTIME_ENDPOINT_TARGETS")
+    )
+  else
+    []
+  end
+
+beam_controller_node_name =
+  System.get_env("ORCHARD_BEAM_NODE_NAME") || "orchard_controller@127.0.0.1"
+
+beam_cookie_file =
+  System.get_env("ORCHARD_BEAM_COOKIE_FILE") || Path.join(dev_root, "beam.cookie")
+
+runtime_endpoint_inference_config =
+  if beam_runtime_endpoint_targets == [] do
+    []
+  else
+    [
+      runtime_endpoint_client_impl: Orchard.RuntimeEndpoint.BeamClient,
+      runtime_endpoint_targets: beam_runtime_endpoint_targets
+    ]
+  end
 
 controller_inference_defaults = Orchard.Config.M1RuntimeDefaults.controller_inference(dev_root)
 cache_affinity_defaults = Keyword.fetch!(controller_inference_defaults, :cache_affinity)
@@ -323,20 +355,33 @@ config :orchard_controller, Orchard.Repo,
 config :orchard_controller,
   inference:
     Keyword.merge(
-      controller_inference_defaults,
-      runtime_client_target: [host: dev_runtime_client_host, port: dev_runtime_port],
-      runtime_client_targets: dev_runtime_targets,
-      tokenizer_executable:
-        System.get_env("ORCHARD_TOKENIZER_EXECUTABLE") ||
-          Path.join([repo_root, "native", "orchard_tokenizer", "bin", "orchard-tokenizer"]),
-      tokenizer_safe_mode: env_tokenizer_safe_mode.("ORCHARD_TOKENIZER_SAFE_MODE", :off),
-      tokenizer_safe_mode_prefer_capable:
-        env_bool.("ORCHARD_TOKENIZER_SAFE_MODE_PREFER_CAPABLE", false),
-      cache_affinity: cache_affinity_config,
-      cache_introspection: cache_introspection_config,
-      prefix_cache_scoring: prefix_cache_scoring_config,
-      memory_admission: memory_admission_config
+      Keyword.merge(
+        controller_inference_defaults,
+        runtime_client_target: [host: dev_runtime_client_host, port: dev_runtime_port],
+        runtime_client_targets: dev_runtime_targets,
+        tokenizer_executable:
+          System.get_env("ORCHARD_TOKENIZER_EXECUTABLE") ||
+            Path.join([repo_root, "native", "orchard_tokenizer", "bin", "orchard-tokenizer"]),
+        tokenizer_safe_mode: env_tokenizer_safe_mode.("ORCHARD_TOKENIZER_SAFE_MODE", :off),
+        tokenizer_safe_mode_prefer_capable:
+          env_bool.("ORCHARD_TOKENIZER_SAFE_MODE_PREFER_CAPABLE", false),
+        cache_affinity: cache_affinity_config,
+        cache_introspection: cache_introspection_config,
+        prefix_cache_scoring: prefix_cache_scoring_config,
+        memory_admission: memory_admission_config
+      ),
+      runtime_endpoint_inference_config
     )
+
+if beam_runtime_endpoint_targets != [] do
+  config :orchard_controller, :runtime_endpoint,
+    beam:
+      Orchard.Config.SourceDevBeam.beam_guardrail_config!(
+        beam_controller_node_name,
+        beam_cookie_file,
+        beam_runtime_endpoint_targets
+      )
+end
 
 config :orchard_node_agent,
   runtime:

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -95,7 +95,9 @@ dev_runtime_client_host =
 dev_node_agent_listen_host =
   System.get_env("ORCHARD_NODE_AGENT_LISTEN_HOST") || "127.0.0.1"
 
-# Inline parser for ORCHARD_RUNTIME_CLIENT_TARGETS (comma-separated host:port).
+# Inline parser for gRPC-only ORCHARD_RUNTIME_CLIENT_TARGETS
+# (comma-separated host:port).
+# Source-dev BEAM targets use ORCHARD_RUNTIME_ENDPOINT_TARGETS instead.
 # Intentionally inline — RuntimeTargetParser may not be compiled when dev.exs
 # evaluates on clean builds. Mirrors RuntimeTargetParser.parse_csv!/2 semantics.
 # SYNC NOTE: if RuntimeTargetParser parse rules change, update this parser too.

--- a/config/source_dev_beam.exs
+++ b/config/source_dev_beam.exs
@@ -135,6 +135,7 @@ defmodule Orchard.Config.SourceDevBeam do
   defp require_local_controller_ip_literal!(host, node_name) do
     case :inet.parse_address(String.to_charlist(host)) do
       {:ok, ip} when tuple_size(ip) in [4, 8] ->
+        reject_unspecified_ip!(ip, @node_name_env, node_name)
         :ok
 
       {:error, _reason} ->
@@ -145,13 +146,21 @@ defmodule Orchard.Config.SourceDevBeam do
   defp ip_and_cidr_suffix!(host, env_name, segment) do
     case :inet.parse_address(String.to_charlist(host)) do
       {:ok, ip} when tuple_size(ip) == 4 ->
+        reject_unspecified_ip!(ip, env_name, segment)
         {ip, 32}
 
       {:ok, ip} when tuple_size(ip) == 8 ->
+        reject_unspecified_ip!(ip, env_name, segment)
         {ip, 128}
 
       {:error, _reason} ->
         raise "environment variable #{env_name} requires IP-literal BEAM target hosts, got segment #{inspect(segment)}"
+    end
+  end
+
+  defp reject_unspecified_ip!(ip, env_name, segment) do
+    if ip |> Tuple.to_list() |> Enum.all?(&(&1 == 0)) do
+      raise "environment variable #{env_name} must not use unspecified or wildcard BEAM hosts, got segment #{inspect(segment)}"
     end
   end
 

--- a/config/source_dev_beam.exs
+++ b/config/source_dev_beam.exs
@@ -86,7 +86,7 @@ defmodule Orchard.Config.SourceDevBeam do
       raise "environment variable #{@node_name_env} local controller BEAM node service must start with orchard_controller"
     end
 
-    require_local_controller_ip_literal!(host, node_name)
+    require_local_controller_ipv4_literal!(host, node_name)
     {service, host}
   end
 
@@ -97,7 +97,7 @@ defmodule Orchard.Config.SourceDevBeam do
       raise "environment variable #{env_name} has unsupported BEAM target service in segment #{inspect(segment)}"
     end
 
-    require_ip_literal!(host, env_name, segment)
+    require_ipv4_literal!(host, env_name, segment)
 
     %{
       transport: :beam,
@@ -110,8 +110,8 @@ defmodule Orchard.Config.SourceDevBeam do
     targets
     |> Enum.map(fn %{address: address} ->
       {_service, host} = beam_service_host!(address, @targets_env)
-      {ip, cidr_suffix} = ip_and_cidr_suffix!(host, @targets_env, address)
-      {ip, "#{host}/#{cidr_suffix}"}
+      ip = parse_ipv4!(host, @targets_env, address)
+      {ip, "#{host}/32"}
     end)
     |> Enum.uniq_by(fn {ip, _cidr} -> ip end)
     |> Enum.map(fn {_ip, cidr} -> cidr end)
@@ -127,35 +127,33 @@ defmodule Orchard.Config.SourceDevBeam do
     end
   end
 
-  defp require_ip_literal!(host, env_name, segment) do
-    ip_and_cidr_suffix!(host, env_name, segment)
+  defp require_ipv4_literal!(host, env_name, segment) do
+    parse_ipv4!(host, env_name, segment)
     :ok
   end
 
-  defp require_local_controller_ip_literal!(host, node_name) do
-    case :inet.parse_address(String.to_charlist(host)) do
-      {:ok, ip} when tuple_size(ip) in [4, 8] ->
-        reject_unspecified_ip!(ip, @node_name_env, node_name)
-        :ok
+  defp require_local_controller_ipv4_literal!(host, node_name) do
+    parse_ipv4!(host, @node_name_env, node_name)
+    :ok
+  end
+
+  defp parse_ipv4!(host, env_name, segment) do
+    case :inet.parse_ipv4strict_address(String.to_charlist(host)) do
+      {:ok, ip} ->
+        reject_unspecified_ip!(ip, env_name, segment)
+        ip
 
       {:error, _reason} ->
-        raise "environment variable #{@node_name_env} requires IP-literal local controller host, got #{inspect(node_name)}"
+        raise_ipv4_error!(env_name, segment)
     end
   end
 
-  defp ip_and_cidr_suffix!(host, env_name, segment) do
-    case :inet.parse_address(String.to_charlist(host)) do
-      {:ok, ip} when tuple_size(ip) == 4 ->
-        reject_unspecified_ip!(ip, env_name, segment)
-        {ip, 32}
+  defp raise_ipv4_error!(@node_name_env, node_name) do
+    raise "environment variable #{@node_name_env} requires IPv4-literal local controller host, got #{inspect(node_name)}"
+  end
 
-      {:ok, ip} when tuple_size(ip) == 8 ->
-        reject_unspecified_ip!(ip, env_name, segment)
-        {ip, 128}
-
-      {:error, _reason} ->
-        raise "environment variable #{env_name} requires IP-literal BEAM target hosts, got segment #{inspect(segment)}"
-    end
+  defp raise_ipv4_error!(env_name, segment) do
+    raise "environment variable #{env_name} requires IPv4-literal BEAM target hosts, got segment #{inspect(segment)}"
   end
 
   defp reject_unspecified_ip!(ip, env_name, segment) do

--- a/config/source_dev_beam.exs
+++ b/config/source_dev_beam.exs
@@ -1,0 +1,167 @@
+defmodule Orchard.Config.SourceDevBeam do
+  @moduledoc false
+
+  @transport_env "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT"
+  @targets_env "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+  @role_env "ORCHARD_SOURCE_DEV_ROLE"
+  @node_name_env "ORCHARD_BEAM_NODE_NAME"
+
+  def transport!(value) do
+    case optional_trimmed(value) do
+      nil ->
+        :grpc
+
+      "grpc" ->
+        :grpc
+
+      "beam" ->
+        :beam
+
+      other ->
+        raise "environment variable #{@transport_env} must be grpc|beam, got: #{inspect(other)}"
+    end
+  end
+
+  def source_dev_role(value) do
+    case optional_trimmed(value) do
+      nil ->
+        :controller
+
+      "controller" ->
+        :controller
+
+      "node_agent" ->
+        :node_agent
+
+      "all_in_one" ->
+        :all_in_one
+
+      other ->
+        raise "environment variable #{@role_env} must be controller|node_agent|all_in_one, got: #{inspect(other)}"
+    end
+  end
+
+  def controller_beam_targets!(value, env_name \\ @targets_env) do
+    targets =
+      value
+      |> csv_segments()
+      |> Enum.map(&beam_target!(&1, env_name))
+
+    case targets do
+      [] ->
+        raise "environment variable #{env_name} must include at least one BEAM target for controller BEAM source-dev mode"
+
+      _ ->
+        targets
+    end
+  end
+
+  def beam_guardrail_config!(node_name, cookie_file, targets) do
+    {_service, listen_host} = local_controller_service_host!(node_name)
+
+    [
+      enabled: true,
+      node_name: node_name,
+      cookie_file: cookie_file,
+      listen_host: listen_host,
+      admitted_services: ["orchard_node_agent"],
+      allowed_cidrs: allowed_cidrs(targets)
+    ]
+  end
+
+  defp local_controller_service_host!(node_name) do
+    {service, host} = beam_service_host!(node_name, @node_name_env)
+
+    unless service =~ ~r/^[A-Za-z0-9_.-]+$/ do
+      raise "environment variable #{@node_name_env} local controller BEAM node service contains invalid characters"
+    end
+
+    unless String.starts_with?(service, "orchard_controller") do
+      raise "environment variable #{@node_name_env} local controller BEAM node service must start with orchard_controller"
+    end
+
+    require_local_controller_ip_literal!(host, node_name)
+    {service, host}
+  end
+
+  defp beam_target!(segment, env_name) do
+    {service, host} = beam_service_host!(segment, env_name)
+
+    unless service == "orchard_node_agent" do
+      raise "environment variable #{env_name} has unsupported BEAM target service in segment #{inspect(segment)}"
+    end
+
+    require_ip_literal!(host, env_name, segment)
+
+    %{
+      transport: :beam,
+      address: "#{service}@#{host}",
+      metadata: %{source_dev: true}
+    }
+  end
+
+  defp allowed_cidrs(targets) do
+    targets
+    |> Enum.map(fn %{address: address} ->
+      {_service, host} = beam_service_host!(address, @targets_env)
+      {ip, cidr_suffix} = ip_and_cidr_suffix!(host, @targets_env, address)
+      {ip, "#{host}/#{cidr_suffix}"}
+    end)
+    |> Enum.uniq_by(fn {ip, _cidr} -> ip end)
+    |> Enum.map(fn {_ip, cidr} -> cidr end)
+  end
+
+  defp beam_service_host!(value, env_name) do
+    case String.split(to_string(value), "@") do
+      [service, host] when service != "" and host != "" ->
+        {service, host}
+
+      _ ->
+        raise "environment variable #{env_name} has invalid BEAM node-name segment #{inspect(value)}"
+    end
+  end
+
+  defp require_ip_literal!(host, env_name, segment) do
+    ip_and_cidr_suffix!(host, env_name, segment)
+    :ok
+  end
+
+  defp require_local_controller_ip_literal!(host, node_name) do
+    case :inet.parse_address(String.to_charlist(host)) do
+      {:ok, ip} when tuple_size(ip) in [4, 8] ->
+        :ok
+
+      {:error, _reason} ->
+        raise "environment variable #{@node_name_env} requires IP-literal local controller host, got #{inspect(node_name)}"
+    end
+  end
+
+  defp ip_and_cidr_suffix!(host, env_name, segment) do
+    case :inet.parse_address(String.to_charlist(host)) do
+      {:ok, ip} when tuple_size(ip) == 4 ->
+        {ip, 32}
+
+      {:ok, ip} when tuple_size(ip) == 8 ->
+        {ip, 128}
+
+      {:error, _reason} ->
+        raise "environment variable #{env_name} requires IP-literal BEAM target hosts, got segment #{inspect(segment)}"
+    end
+  end
+
+  defp csv_segments(nil), do: []
+
+  defp csv_segments(value) when is_binary(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp optional_trimmed(nil), do: nil
+
+  defp optional_trimmed(value) when is_binary(value) do
+    value = String.trim(value)
+    if value == "", do: nil, else: value
+  end
+end

--- a/config/source_dev_beam.exs
+++ b/config/source_dev_beam.exs
@@ -41,6 +41,12 @@ defmodule Orchard.Config.SourceDevBeam do
     end
   end
 
+  def validate_transport_role!(:beam, :all_in_one) do
+    raise "all_in_one BEAM source-dev mode is not supported; use bin/dev-controller and bin/dev-node-agent"
+  end
+
+  def validate_transport_role!(_transport, _source_dev_role), do: :ok
+
   def controller_beam_targets!(value, env_name \\ @targets_env) do
     targets =
       value

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ Public clients
      -> Postgres for durable state and coordination
      -> Runtime Endpoint Interface
         -> current gRPC compatibility adapter
-        -> default-off first-party BEAM adapter, promoted after accepted source-dev smoke
+        -> explicit split-role first-party BEAM adapter, promoted after accepted source-dev smoke
         -> future external/provider adapters
      -> Node Agent(s)
         -> Worker Runtime subprocesses for local MLX inference
@@ -53,6 +53,7 @@ Core design rules from `SPEC.md`:
 - the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
 - first-party BEAM communication is implemented behind explicit guardrails and remains default-off until rollout gates allow it;
 - source-dev uses the gRPC compatibility adapter by default until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is promoted;
+- explicit source-dev BEAM mode runs only through split-role `bin/dev-controller` and `bin/dev-node-agent` launches, not all-in-one `bin/dev`;
 - Console live runtime diagnostics use the same configured Runtime Endpoint target list as scheduler and dispatch, with explicit BEAM targets taking precedence over legacy gRPC runtime client targets;
 - BEAM Runtime Endpoint targets validate BEAM node-name addresses and configured node UUIDs before scheduler or dispatch trusts endpoint identity;
 - node agents are the v1 first-party Runtime Endpoint boundary;

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -39,11 +39,12 @@ Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove 
 
 The BEAM Runtime Endpoint adapter is the intended primary source-dev Controller-to-Node Agent path once it passes the accepted two-Mac smoke.
 Until that gate passes, current source-dev continues to use the gRPC Compatibility Adapter on port `50071` as the compatibility path.
-The Source-dev BEAM Operating Model uses long BEAM node names with IP-literal hosts, explicit shared cookie material, bounded distribution networking, and BEAM-specific Runtime Endpoint target variables rather than legacy gRPC runtime client variables.
+The Source-dev BEAM Operating Model uses long BEAM node names with IPv4-literal hosts, explicit shared cookie material, bounded distribution networking, and BEAM-specific Runtime Endpoint target variables rather than legacy gRPC runtime client variables.
+The current implementation exposes that model through explicit split-role `bin/dev-controller` and `bin/dev-node-agent` launches while all-in-one `bin/dev` remains the gRPC default and rejects explicit BEAM mode.
 Same-host source dev may generate a repo-local `tmp/dev/beam.cookie` file, while two-Mac source dev must provision the same cookie material on both Macs.
 Packaged or release runtime configuration must not inherit the repo-local cookie model; it should use runtime secret injection such as release cookie configuration.
 Cookie files must be `0600` or stricter and must not be printed in logs or templates.
-Guarded source-dev BEAM targets require IP-literal host parts for CIDR validation.
+Guarded source-dev BEAM targets require IPv4-literal host parts for CIDR validation.
 When BEAM Runtime Endpoint mode is selected, BEAM connection failure must fail visibly rather than automatically falling back to gRPC for the same request.
 gRPC remains an explicitly selected compatibility mode, not an implicit fallback behind BEAM mode.
 Promotion starts with split-role `bin/dev-controller` and `bin/dev-node-agent` before changing all-in-one `bin/dev`.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -67,7 +67,8 @@ _Avoid_: Durable cluster truth, database replacement, public API, external provi
 
 **Source-dev BEAM Operating Model**:
 The source-development distribution profile for first-party Controller-to-Node Agent BEAM Runtime Endpoint communication.
-It uses long BEAM node names with IP-literal hosts, explicit shared cookie material, bounded distribution networking, explicit BEAM target configuration, no automatic gRPC fallback, and split-role promotion before all-in-one source dev.
+It uses long BEAM node names with IPv4-literal hosts, explicit shared cookie material, bounded distribution networking, explicit BEAM target configuration, no automatic gRPC fallback, and split-role promotion before all-in-one source dev.
+The current implementation exposes this through explicit `bin/dev-controller` and `bin/dev-node-agent` source-dev launches while `bin/dev` remains the gRPC default.
 _Avoid_: Production BEAM security model, ambient `.erlang.cookie`, implicit fallback, durable cluster truth
 
 **All-in-One Deployment**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -253,8 +253,8 @@ CLI scaffolding for these variables is deferred to a separate change.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` | `grpc` | Runtime Endpoint transport selector. Use `beam` for split-role BEAM source dev. |
-| `ORCHARD_RUNTIME_ENDPOINT_TARGETS` | _(empty)_ | Controller-only comma-separated BEAM target list. Each target must be `orchard_node_agent@<ip-literal>`. |
-| `ORCHARD_BEAM_NODE_NAME` | `orchard_controller@127.0.0.1` or `orchard_node_agent@127.0.0.1` | Long BEAM node name for the current split-role VM. The host part must be an IP literal. |
+| `ORCHARD_RUNTIME_ENDPOINT_TARGETS` | _(empty)_ | Controller-only comma-separated BEAM target list. Each target must be `orchard_node_agent@<ipv4-literal>`. |
+| `ORCHARD_BEAM_NODE_NAME` | `orchard_controller@127.0.0.1` or `orchard_node_agent@127.0.0.1` | Long BEAM node name for the current split-role VM. The host part must be an IPv4 literal. |
 | `ORCHARD_BEAM_COOKIE_FILE` | `tmp/dev/beam.cookie` | Cookie file path. Same-host source dev generates it when absent. Two-Mac source dev must provision the same cookie material on each Mac. |
 | `ORCHARD_BEAM_DIST_PORT_MIN` | `52171` for controller, `52172` for node-agent | Lower bound for the BEAM distribution listener port range. Set both min and max together when overriding. |
 | `ORCHARD_BEAM_DIST_PORT_MAX` | `52171` for controller, `52172` for node-agent | Upper bound for the BEAM distribution listener port range. Set both min and max together when overriding. |
@@ -290,9 +290,9 @@ For same-host mode, the controller defaults to `orchard_controller@127.0.0.1` an
 The node-agent defaults to `orchard_node_agent@127.0.0.1` and distribution port `52172`.
 Both roles use `ERL_EPMD_PORT=4369` unless `ORCHARD_BEAM_EPMD_PORT` is set.
 
-Two-Mac BEAM source-dev mode requires explicit IP-literal node names and the same cookie material on every participating Mac.
+Two-Mac BEAM source-dev mode requires explicit IPv4-literal node names and the same cookie material on every participating Mac.
 Do not use hostnames such as `worker.local` for BEAM target hosts in this slice.
-Use Tailscale IPv4 addresses or another trusted private IP-literal address.
+Use Tailscale IPv4 addresses or another trusted private IPv4-literal address.
 Provision the cookie out of band without pasting the cookie value into docs, tickets, chat, shell history, or evidence files.
 
 From one Mac, create the cookie file if you are not using an existing secret manager output:
@@ -316,17 +316,17 @@ If you override `ORCHARD_BEAM_EPMD_PORT`, `ORCHARD_BEAM_DIST_PORT_MIN`, or `ORCH
 A quick reachability check after the roles start is:
 
 ```bash
-nc -vz <worker-ip> 4369
-nc -vz <worker-ip> 52172
-nc -vz <controller-ip> 4369
-nc -vz <controller-ip> 52171
+nc -vz <worker-ipv4> 4369
+nc -vz <worker-ipv4> 52172
+nc -vz <controller-ipv4> 4369
+nc -vz <controller-ipv4> 52171
 ```
 
 For BEAM Runtime Endpoint RPC evidence from the controller IEx session, use the configured target through the BEAM client.
 This checks the Runtime Endpoint adapter path rather than the legacy gRPC compatibility path.
 
 ```elixir
-target = %{transport: :beam, address: "orchard_node_agent@<worker-ip>"}
+target = %{transport: :beam, address: "orchard_node_agent@<worker-ipv4>"}
 {:ok, conn} = Orchard.RuntimeEndpoint.BeamClient.connect(target)
 {:ok, observation} = Orchard.RuntimeEndpoint.BeamClient.status(conn)
 observation
@@ -567,7 +567,7 @@ Do not commit cookie material, raw local evidence logs, or machine-specific path
 
 ```bash
 ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
-ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<controller-ip> \
+ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<controller-ipv4> \
 ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
 ORCHARD_WORKER_BACKEND=stub \
 ORCHARD_NODE_DISPLAY_NAME=<controller-node-agent-label> \
@@ -578,7 +578,7 @@ mise exec -- bin/dev-node-agent
 
 ```bash
 ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
-ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<worker-ip> \
+ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<worker-ipv4> \
 ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
 ORCHARD_WORKER_BACKEND=stub \
 ORCHARD_NODE_DISPLAY_NAME=<worker-label> \
@@ -589,8 +589,8 @@ mise exec -- bin/dev-node-agent
 
 ```bash
 ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
-ORCHARD_RUNTIME_ENDPOINT_TARGETS="orchard_node_agent@<controller-ip>,orchard_node_agent@<worker-ip>" \
-ORCHARD_BEAM_NODE_NAME=orchard_controller@<controller-ip> \
+ORCHARD_RUNTIME_ENDPOINT_TARGETS="orchard_node_agent@<controller-ipv4>,orchard_node_agent@<worker-ipv4>" \
+ORCHARD_BEAM_NODE_NAME=orchard_controller@<controller-ipv4> \
 ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
 ORCHARD_NODE_DISPLAY_NAME=<controller-label> \
 mise exec -- bin/dev-controller
@@ -605,7 +605,7 @@ If you override the EPMD or distribution port variables, use the same values in 
 For a remote Runtime Endpoint RPC check from the controller IEx session:
 
 ```elixir
-target = %{transport: :beam, address: "orchard_node_agent@<worker-ip>"}
+target = %{transport: :beam, address: "orchard_node_agent@<worker-ipv4>"}
 {:ok, conn} = Orchard.RuntimeEndpoint.BeamClient.connect(target)
 {:ok, observation} = Orchard.RuntimeEndpoint.BeamClient.status(conn)
 observation
@@ -636,11 +636,11 @@ Default promotion remains deferred to a future OpenSpec change even after the sm
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | gRPC controller shows 1 target | `ORCHARD_RUNTIME_CLIENT_TARGETS` unset or malformed | Check env var, use `host:port,host:port` format. |
-| BEAM controller exits before Mix starts | `ORCHARD_RUNTIME_ENDPOINT_TARGETS` is empty, malformed, or uses a hostname | Use comma-separated `orchard_node_agent@<ip-literal>` targets. |
+| BEAM controller exits before Mix starts | `ORCHARD_RUNTIME_ENDPOINT_TARGETS` is empty, malformed, or uses a hostname or IPv6 address | Use comma-separated `orchard_node_agent@<ipv4-literal>` targets. |
 | All-in-one `bin/dev` rejects BEAM mode | `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` was set with the all-in-one entrypoint | Use `bin/dev-controller` and `bin/dev-node-agent` for BEAM mode. |
-| BEAM node-name validation fails | `ORCHARD_BEAM_NODE_NAME` is not `service@ip` or uses the wrong role service | Use `orchard_controller@<controller-ip>` for the controller and exactly `orchard_node_agent@<node-ip>` for node-agents. |
+| BEAM node-name validation fails | `ORCHARD_BEAM_NODE_NAME` is not `service@ipv4` or uses the wrong role service | Use `orchard_controller@<controller-ipv4>` for the controller and exactly `orchard_node_agent@<node-ipv4>` for node-agents. |
 | BEAM cookie validation fails | Cookie file is missing, empty, or group/world-readable | Create or copy the cookie file, then run `chmod 600 tmp/dev/beam.cookie`. |
-| BEAM `connect` returns `:pang` or `:unknown_beam_node` | EPMD cannot resolve the target, the target node is not running, or the cookie does not match | Check `ERL_EPMD_PORT`, node names, cookie digest match, and `nc -vz <target-ip> 4369`. |
+| BEAM `connect` returns `:pang` or `:unknown_beam_node` | EPMD cannot resolve the target, the target node is not running, or the cookie does not match | Check `ERL_EPMD_PORT`, node names, cookie digest match, and `nc -vz <target-ipv4> 4369`. |
 | BEAM RPC times out or is unreachable | Distribution listener port is blocked | Check TCP `52171` for the controller and TCP `52172` for node-agents, or check your overridden range. |
 | BEAM Console shows stale gRPC expectations | gRPC targets were configured as a comparison path | Use Console Runtime Endpoint target diagnostics and remember that `ORCHARD_RUNTIME_CLIENT_TARGETS` is not a BEAM fallback. |
 | Remote gRPC node-agent unreachable | Listen host still `127.0.0.1` | Set `ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0` for the gRPC compatibility flow. |

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -638,7 +638,7 @@ Default promotion remains deferred to a future OpenSpec change even after the sm
 | gRPC controller shows 1 target | `ORCHARD_RUNTIME_CLIENT_TARGETS` unset or malformed | Check env var, use `host:port,host:port` format. |
 | BEAM controller exits before Mix starts | `ORCHARD_RUNTIME_ENDPOINT_TARGETS` is empty, malformed, or uses a hostname | Use comma-separated `orchard_node_agent@<ip-literal>` targets. |
 | All-in-one `bin/dev` rejects BEAM mode | `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` was set with the all-in-one entrypoint | Use `bin/dev-controller` and `bin/dev-node-agent` for BEAM mode. |
-| BEAM node-name validation fails | `ORCHARD_BEAM_NODE_NAME` is not `service@ip` or uses the wrong role prefix | Use `orchard_controller@<controller-ip>` for the controller and `orchard_node_agent@<node-ip>` for node-agents. |
+| BEAM node-name validation fails | `ORCHARD_BEAM_NODE_NAME` is not `service@ip` or uses the wrong role service | Use `orchard_controller@<controller-ip>` for the controller and exactly `orchard_node_agent@<node-ip>` for node-agents. |
 | BEAM cookie validation fails | Cookie file is missing, empty, or group/world-readable | Create or copy the cookie file, then run `chmod 600 tmp/dev/beam.cookie`. |
 | BEAM `connect` returns `:pang` or `:unknown_beam_node` | EPMD cannot resolve the target, the target node is not running, or the cookie does not match | Check `ERL_EPMD_PORT`, node names, cookie digest match, and `nc -vz <target-ip> 4369`. |
 | BEAM RPC times out or is unreachable | Distribution listener port is blocked | Check TCP `52171` for the controller and TCP `52172` for node-agents, or check your overridden range. |

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1058,6 +1058,7 @@ mise exec -- iex -S mix phx.server
 - Public `/v1/*` API routes require tenant-scoped Bearer API keys; full RBAC and
   quota policy remain incomplete
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
-- Live BEAM Runtime Endpoint transport is implemented behind default-off application config; default source dev uses the gRPC compatibility adapter
+- Explicit split-role BEAM Runtime Endpoint mode is implemented for `bin/dev-controller` and `bin/dev-node-agent`; default source dev still uses the gRPC compatibility adapter
+- All-in-one `bin/dev` rejects explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
 - BEAM Runtime Endpoint transport becomes the primary source-dev path only after it passes the accepted two-Mac smoke
 - Model import from local filesystem only (no remote download)

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -232,40 +232,113 @@ When explicit BEAM Runtime Endpoint targets are configured, Console probes those
 Keep `ORCHARD_RUNTIME_CLIENT_TARGETS` alongside BEAM targets only when deliberately comparing the gRPC compatibility path.
 Do not rely on automatic gRPC fallback when BEAM mode is selected.
 
-#### Runtime Endpoint BEAM Guardrails
+#### Source-dev BEAM Runtime Endpoint Split-role Mode
 
-The current source-dev slice includes a default-off BEAM Runtime Endpoint adapter, Node Agent facade, and guardrail config under `:orchard_controller, :runtime_endpoint, beam: [...]`.
-The adapter is implemented behind explicit application config, but source dev keeps using the gRPC compatibility adapter on port `50071` until the accepted two-Mac smoke passes.
-There is no implemented source-dev env var surface for BEAM target selection in this slice.
-The accepted Source-dev BEAM Operating Model uses long BEAM node names with IP-literal hosts, explicit shared cookie material, bounded distribution networking, and BEAM-specific Runtime Endpoint target variables.
-The intended env surface is separate from legacy gRPC runtime client variables:
+Source dev now supports an explicit BEAM Runtime Endpoint mode for split-role launches.
+The default source-dev path is still gRPC compatibility on port `50071`.
+Unset `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` or set it to `grpc` to keep the existing gRPC path.
+Set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` only with `bin/dev-controller` and `bin/dev-node-agent`.
+All-in-one `bin/dev` intentionally rejects explicit BEAM mode and remains the gRPC default.
+
+The BEAM source-dev env surface is separate from the legacy gRPC compatibility target surface.
+`ORCHARD_RUNTIME_CLIENT_TARGETS` remains gRPC compatibility-only and accepts only `host:port` targets.
+`ORCHARD_RUNTIME_ENDPOINT_TARGETS` is BEAM target-only when BEAM mode is selected and accepts BEAM node names such as `orchard_node_agent@100.x.y.z`.
+`ORCHARD_RUNTIME_ENDPOINT_TARGETS` does not configure gRPC targets.
+`ORCHARD_RUNTIME_CLIENT_TARGETS` does not configure BEAM targets.
+When BEAM mode is selected, BEAM configuration, guardrail, connection, identity, and Runtime Endpoint RPC failures fail visibly.
+The controller does not automatically retry the same request through gRPC.
+`orchardctl env init` does not render this BEAM env surface yet.
+CLI scaffolding for these variables is deferred to a separate change.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` | `grpc` until promotion | Runtime Endpoint transport selector, with `beam` selecting the BEAM Runtime Endpoint adapter |
-| `ORCHARD_RUNTIME_ENDPOINT_TARGETS` | _(empty)_ | Comma-separated BEAM Runtime Endpoint target list using BEAM node names such as `orchard_node_agent@100.x.y.z` |
-| `ORCHARD_BEAM_NODE_NAME` | role-derived after implementation | Long BEAM node name for the current source-dev VM |
-| `ORCHARD_BEAM_COOKIE_FILE` | `tmp/dev/beam.cookie` for same-host source dev | Explicit cookie file path; two-Mac source dev must provision the same cookie material on both Macs |
-| `ORCHARD_BEAM_DIST_PORT_MIN` | implementation-defined | Lower bound for the BEAM distribution listener port range |
-| `ORCHARD_BEAM_DIST_PORT_MAX` | implementation-defined | Upper bound for the BEAM distribution listener port range |
-| `ORCHARD_BEAM_EPMD_PORT` | `4369` | EPMD port for source-dev node discovery |
+| `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` | `grpc` | Runtime Endpoint transport selector. Use `beam` for split-role BEAM source dev. |
+| `ORCHARD_RUNTIME_ENDPOINT_TARGETS` | _(empty)_ | Controller-only comma-separated BEAM target list. Each target must be `orchard_node_agent@<ip-literal>`. |
+| `ORCHARD_BEAM_NODE_NAME` | `orchard_controller@127.0.0.1` or `orchard_node_agent@127.0.0.1` | Long BEAM node name for the current split-role VM. The host part must be an IP literal. |
+| `ORCHARD_BEAM_COOKIE_FILE` | `tmp/dev/beam.cookie` | Cookie file path. Same-host source dev generates it when absent. Two-Mac source dev must provision the same cookie material on each Mac. |
+| `ORCHARD_BEAM_DIST_PORT_MIN` | `52171` for controller, `52172` for node-agent | Lower bound for the BEAM distribution listener port range. Set both min and max together when overriding. |
+| `ORCHARD_BEAM_DIST_PORT_MAX` | `52171` for controller, `52172` for node-agent | Upper bound for the BEAM distribution listener port range. Set both min and max together when overriding. |
+| `ORCHARD_BEAM_EPMD_PORT` | `4369` | EPMD port for source-dev node discovery. |
 
-Same-host source dev may generate `tmp/dev/beam.cookie` if absent.
-Two-Mac source dev must copy or provision the same cookie material to both Macs.
-Cookie files must be `0600` or stricter and must not be printed.
-Packaged or release runtime configuration must not inherit the repo-local cookie model; use runtime secret injection such as release cookie configuration instead.
-Guarded source-dev BEAM targets require IP-literal host parts for CIDR validation.
-Hostname target support is deferred.
-When BEAM Runtime Endpoint mode is selected, BEAM connection failure must fail visibly rather than automatically falling back to gRPC for the same request.
-gRPC remains an explicitly selected compatibility mode.
-BEAM promotion starts with split-role `bin/dev-controller` and `bin/dev-node-agent` before changing all-in-one `bin/dev`.
-The accepted smoke requires remote BEAM Runtime Endpoint RPC evidence, Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
-Before flipping source-dev defaults, record durable smoke evidence in a sanitized repo document such as `docs/investigations/source-dev-beam-smoke-<date>.md`, including date, commit, sanitized hosts, commands, target node names, pass/fail checklist, and remote Runtime Endpoint RPC evidence.
-The committed evidence must not include cookie material, credentials, raw local evidence logs, local tool session identifiers, or machine-specific filesystem paths.
-Console Nodes live runtime diagnostics use the same Runtime Endpoint targets as scheduler and dispatch.
-For a BEAM-only smoke, duplicate gRPC `ORCHARD_RUNTIME_CLIENT_TARGETS` are no longer required just to make Console Nodes show both Macs.
+The split-role scripts print non-secret startup diagnostics for the BEAM node name, cookie file path, EPMD port, and distribution port range.
+They never print cookie contents.
+Explicit cookie files must exist, be regular files, be non-empty, and be owner-only before Mix starts.
+Owner-only means mode `0600` or stricter.
+Same-host default cookie generation writes `tmp/dev/beam.cookie` with mode `0600`.
+The helper copies the selected cookie into a private per-role BEAM home under `tmp/dev/beam-home/` so Erlang can read `.erlang.cookie` without using the contributor's normal home directory.
+Packaged or release runtime configuration must not inherit this repo-local cookie model.
+Use release secret injection for packaged distributed BEAM cookie material instead.
 
-Application-config opt-in uses the Runtime Endpoint client and target keys under `:orchard_controller, :inference`.
+Same-host BEAM split-role smoke can run from two terminals in the same checkout.
+Start the node-agent first:
+
+```bash
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+ORCHARD_WORKER_BACKEND=stub \
+mise exec -- bin/dev-node-agent
+```
+
+Then start the controller:
+
+```bash
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@127.0.0.1 \
+mise exec -- bin/dev-controller
+```
+
+For same-host mode, the controller defaults to `orchard_controller@127.0.0.1` and distribution port `52171`.
+The node-agent defaults to `orchard_node_agent@127.0.0.1` and distribution port `52172`.
+Both roles use `ERL_EPMD_PORT=4369` unless `ORCHARD_BEAM_EPMD_PORT` is set.
+
+Two-Mac BEAM source-dev mode requires explicit IP-literal node names and the same cookie material on every participating Mac.
+Do not use hostnames such as `worker.local` for BEAM target hosts in this slice.
+Use Tailscale IPv4 addresses or another trusted private IP-literal address.
+Provision the cookie out of band without pasting the cookie value into docs, tickets, chat, shell history, or evidence files.
+
+From one Mac, create the cookie file if you are not using an existing secret manager output:
+
+```bash
+umask 077
+mkdir -p tmp/dev
+openssl rand -hex 32 > tmp/dev/beam.cookie
+chmod 600 tmp/dev/beam.cookie
+shasum -a 256 tmp/dev/beam.cookie
+```
+
+Copy the file to the same repo-relative path on each participating Mac through a trusted channel such as `scp` over Tailscale.
+After copying, run `chmod 600 tmp/dev/beam.cookie` on each Mac.
+Verify that the SHA-256 digests match without showing or committing the cookie contents.
+The durable smoke note may say that cookie digests matched, but it must not include the cookie value.
+
+EPMD and the bounded distribution ports must be reachable between the BEAM hosts.
+For the defaults, allow TCP `4369`, controller TCP `52171`, and node-agent TCP `52172` between the participating private IPs.
+If you override `ORCHARD_BEAM_EPMD_PORT`, `ORCHARD_BEAM_DIST_PORT_MIN`, or `ORCHARD_BEAM_DIST_PORT_MAX`, update the firewall and smoke notes to match.
+A quick reachability check after the roles start is:
+
+```bash
+nc -vz <worker-ip> 4369
+nc -vz <worker-ip> 52172
+nc -vz <controller-ip> 4369
+nc -vz <controller-ip> 52171
+```
+
+For BEAM Runtime Endpoint RPC evidence from the controller IEx session, use the configured target through the BEAM client.
+This checks the Runtime Endpoint adapter path rather than the legacy gRPC compatibility path.
+
+```elixir
+target = %{transport: :beam, address: "orchard_node_agent@<worker-ip>"}
+{:ok, conn} = Orchard.RuntimeEndpoint.BeamClient.connect(target)
+{:ok, observation} = Orchard.RuntimeEndpoint.BeamClient.status(conn)
+observation
+```
+
+Console Nodes live runtime diagnostics use the same Runtime Endpoint target list as scheduler and dispatch.
+For a BEAM-only smoke, do not duplicate `ORCHARD_RUNTIME_CLIENT_TARGETS` just to make Console Nodes show both Macs.
+If `ORCHARD_RUNTIME_CLIENT_TARGETS` is also set, treat it as an explicit gRPC comparison path only.
+It is not a fallback path for BEAM request failures.
+
+Application-config opt-in still uses the Runtime Endpoint client and target keys under `:orchard_controller, :inference`.
+Source-dev BEAM env parsing writes equivalent target maps when the controller starts in BEAM mode.
 
 ```elixir
 config :orchard_controller, :inference,
@@ -273,24 +346,17 @@ config :orchard_controller, :inference,
   runtime_endpoint_targets: [
     %{
       transport: :beam,
-      node_id: "<local-node-uuid>",
-      address: :orchard_node_agent_smoke@tamingsari
-    },
-    %{
-      transport: :beam,
-      node_id: "<remote-node-uuid>",
-      address: :orchard_node_agent_smoke@mawarduri
+      address: "orchard_node_agent@100.64.1.10",
+      metadata: %{source_dev: true}
     }
   ]
 ```
 
-BEAM target `address` is required and must be a valid BEAM node name (`service@host`) as an atom or binary.
-Configured BEAM target `node_id` values are optional for address-only discovery, but when present they must be UUIDs and must match observed Node Agent metadata.
-Do not set `:orchard_controller, :console, :runtime_client_impl` for BEAM diagnostics.
-That legacy test seam is only for the gRPC compatibility path; BEAM diagnostics use `:runtime_endpoint_client_impl`.
-When BEAM guardrails are enabled directly in application config, guardrail validation requires non-empty `node_name`, `cookie_file`, `listen_host`, `admitted_services`, and `allowed_cidrs`.
-The `listen_host` must not be `0.0.0.0` or `::`, and `allowed_cidrs` must not contain `0.0.0.0/0` or `::/0`.
-Allowed CIDRs must parse as IP CIDR ranges, the running BEAM node name must match configured `node_name`, BEAM target services must be listed in `admitted_services`, and BEAM target hosts must fall inside `allowed_cidrs`.
+When source-dev BEAM mode is configured through env vars, `config/dev.exs` also enables BEAM guardrails under `:orchard_controller, :runtime_endpoint, beam: [...]`.
+Guardrail validation requires a matching controller node name, a cookie file path, the controller listen IP, admitted `orchard_node_agent` services, and per-target CIDRs derived from the BEAM target IPs.
+The `listen_host` must not be `0.0.0.0` or `::`.
+Allowed CIDRs must not contain `0.0.0.0/0` or `::/0`.
+BEAM target services must be admitted and BEAM target hosts must fall inside `allowed_cidrs`.
 
 #### Packaged Controller Transport (release only)
 
@@ -440,71 +506,150 @@ operator workflow, permission expectations, and external certificate setup.
 
 ## Two-Node Source-Dev Cluster Testing
 
-Single-node remains the default. To opt into 2-node source-dev testing
-with a remote machine (e.g., Tamingsari as node-agent, mawarduri as
-controller):
+Single-node remains the default.
+Use the gRPC compatibility flow when you want the stable default source-dev path.
+Use the BEAM Runtime Endpoint flow when you are validating the explicit split-role BEAM operating model.
 
-`orchardctl cluster init`, `orchardctl node join`, and
-`orchardctl nodes admit` are SPEC-required future node-lifecycle commands. In
-this build they return deferred status; use the env-var split-role flow below
-for source-dev cluster testing.
+`orchardctl cluster init`, `orchardctl node join`, and `orchardctl nodes admit` are SPEC-required future node-lifecycle commands.
+In this build they return deferred status.
+Use the env-var split-role flows below for source-dev cluster testing.
 
-### Controller host (mawarduri)
+### gRPC compatibility flow
+
+The gRPC compatibility flow keeps all-in-one `bin/dev` on the controller Mac and starts one remote node-agent.
+It uses `ORCHARD_RUNTIME_CLIENT_TARGETS` as a comma-separated `host:port` list.
+This variable is gRPC-only and is not used by BEAM Runtime Endpoint mode.
+
+#### Controller host
 
 ```bash
 ORCHARD_RUNTIME_CLIENT_TARGETS="127.0.0.1:50071,<remote-tailscale-ip>:50071" \
-  ORCHARD_NODE_DISPLAY_NAME=mawarduri \
+  ORCHARD_NODE_DISPLAY_NAME=<controller-label> \
   mise exec -- bin/dev
 ```
 
-The local node-agent still binds to `127.0.0.1:50071`. The controller targets
-both local and remote nodes. The scheduler auto-selects `MultiNode` when it
-sees >1 target. Use the Tailscale IPv4 address (`100.x.y.z`) — IPv6 addresses
-are not supported in the target list.
+The local node-agent still binds to `127.0.0.1:50071`.
+The controller targets both local and remote gRPC nodes.
+The scheduler auto-selects `MultiNode` when it sees more than one target.
+Use a Tailscale IPv4 address such as `100.x.y.z` in the target list.
+IPv6 addresses are not supported in the gRPC compatibility target list.
 
-### Remote node-agent host (Tamingsari)
+#### Remote node-agent host
 
 ```bash
 ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0 \
   ORCHARD_NODE_AGENT_LISTEN_PORT=50071 \
   ORCHARD_WORKER_BACKEND=stub \
-  ORCHARD_NODE_DISPLAY_NAME=tamingsari \
+  ORCHARD_NODE_DISPLAY_NAME=<worker-label> \
   mise exec -- bin/dev-node-agent
 ```
 
-The node-agent boots standalone — no Postgres, controller, or asset watchers
-needed. Use `stub` backend for cluster mechanics testing; switch to `mlx` when
-real inference is required. No `ORCHARD_WORKER_GENERATION_MODE` override is
-needed for the stub backend; source dev resolves it to stream mode when unset.
+The node-agent boots standalone.
+It does not need Postgres, the controller, or asset watchers.
+Use the `stub` backend for cluster mechanics testing.
+Switch to `mlx` when real inference is required.
+No `ORCHARD_WORKER_GENERATION_MODE` override is needed for the stub backend.
+Source dev resolves stub mode to stream mode when the variable is unset.
+
+### BEAM Runtime Endpoint flow
+
+The BEAM flow uses named distributed BEAM nodes and `ORCHARD_RUNTIME_ENDPOINT_TARGETS`.
+Do not use `ORCHARD_RUNTIME_CLIENT_TARGETS` for BEAM target selection.
+The accepted two-Mac smoke should include a controller-side node-agent and a remote node-agent when validating local and remote Console reachability.
+Start the node-agents first, then start the controller.
+
+Provision the same `tmp/dev/beam.cookie` file on every participating Mac before starting the two-Mac BEAM flow.
+Keep the cookie mode at `0600` or stricter.
+Verify matching cookie files by comparing SHA-256 digests, not by printing cookie contents.
+Do not commit cookie material, raw local evidence logs, or machine-specific paths.
+
+#### Controller Mac local node-agent terminal
+
+```bash
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<controller-ip> \
+ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
+ORCHARD_WORKER_BACKEND=stub \
+ORCHARD_NODE_DISPLAY_NAME=<controller-node-agent-label> \
+mise exec -- bin/dev-node-agent
+```
+
+#### Remote node-agent Mac terminal
+
+```bash
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<worker-ip> \
+ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
+ORCHARD_WORKER_BACKEND=stub \
+ORCHARD_NODE_DISPLAY_NAME=<worker-label> \
+mise exec -- bin/dev-node-agent
+```
+
+#### Controller Mac controller terminal
+
+```bash
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+ORCHARD_RUNTIME_ENDPOINT_TARGETS="orchard_node_agent@<controller-ip>,orchard_node_agent@<worker-ip>" \
+ORCHARD_BEAM_NODE_NAME=orchard_controller@<controller-ip> \
+ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
+ORCHARD_NODE_DISPLAY_NAME=<controller-label> \
+mise exec -- bin/dev-controller
+```
+
+The default controller distribution port is TCP `52171`.
+The default node-agent distribution port is TCP `52172`.
+The default EPMD port is TCP `4369`.
+Those ports must be reachable between the participating private IPs.
+If you override the EPMD or distribution port variables, use the same values in your firewall rules and smoke notes.
+
+For a remote Runtime Endpoint RPC check from the controller IEx session:
+
+```elixir
+target = %{transport: :beam, address: "orchard_node_agent@<worker-ip>"}
+{:ok, conn} = Orchard.RuntimeEndpoint.BeamClient.connect(target)
+{:ok, observation} = Orchard.RuntimeEndpoint.BeamClient.status(conn)
+observation
+```
+
+This check exercises the BEAM Runtime Endpoint adapter.
+It does not prove the gRPC compatibility path.
+It should fail visibly if EPMD, distribution ports, cookies, target identity, or guardrails are wrong.
+It should not fall back to gRPC.
 
 ### Verification
 
-1. Both nodes should appear in `/console/nodes` with distinct display names and reachable status
-2. `GET /v1/models` should return `200`
-3. `POST /v1/chat/completions` should complete through the Console Playground or an equivalent API request
-4. Cluster summary should show 2 configured targets
-5. Playground inference should attribute requests to specific nodes
-6. Killing the remote node-agent should transition its health to
-   degraded/unreachable
+1. Console Nodes should show the configured Runtime Endpoint targets with distinct display names and reachable status.
+2. The BEAM smoke should include both the controller-side node-agent and the remote node-agent when validating local and remote reachability.
+3. `GET /v1/models` should return `200`.
+4. `POST /v1/chat/completions` should complete through the Console Playground or an equivalent API request.
+5. Cluster summary should show the configured target count for the selected transport.
+6. Playground inference should attribute requests to specific nodes when the scheduler has multiple eligible targets.
+7. Killing the remote node-agent should transition its health to degraded or unreachable.
 
-For BEAM Runtime Endpoint smoke tests, configure the BEAM Runtime Endpoint target surface instead of relying on `ORCHARD_RUNTIME_CLIENT_TARGETS`.
-The `/console/nodes` Live Cluster panel should reflect the BEAM target list.
-The accepted smoke evidence must include remote BEAM Runtime Endpoint RPC evidence, Console reachability, `GET /v1/models`, and `POST /v1/chat/completions`.
-If the gRPC compatibility path is intentionally configured at the same time, treat it as an explicit comparison path rather than an automatic fallback.
+Do not create `docs/investigations/source-dev-beam-smoke-<date>.md` unless a real two-Mac BEAM smoke has actually been run.
+When that evidence is added, sanitize host labels, commands, node names, pass/fail status, and Runtime Endpoint RPC evidence.
+The evidence must not include cookie material, credentials, raw logs, prompt exports, local tool session identifiers, DSNs, or machine-specific filesystem paths.
+Default promotion remains deferred to a future OpenSpec change even after the smoke evidence gate passes.
 
 ### Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| gRPC controller shows 1 target | `ORCHARD_RUNTIME_CLIENT_TARGETS` unset or malformed | Check env var, use `host:port,host:port` format |
-| BEAM Console shows gRPC targets | `runtime_endpoint_targets` not configured or legacy Console client override still active | Configure `runtime_endpoint_client_impl` and `runtime_endpoint_targets`; remove `:orchard_controller, :console, :runtime_client_impl` for BEAM diagnostics |
-| Remote node-agent unreachable | Listen host still `127.0.0.1` | Set `ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0` |
-| Remote node fails on MLX | mise toolchain not installed or no `uv sync` | Use `ORCHARD_WORKER_BACKEND=stub` or run `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx` |
-| Port conflict on remote | Another BEAM on same port | Change `ORCHARD_NODE_AGENT_LISTEN_PORT` |
+| gRPC controller shows 1 target | `ORCHARD_RUNTIME_CLIENT_TARGETS` unset or malformed | Check env var, use `host:port,host:port` format. |
+| BEAM controller exits before Mix starts | `ORCHARD_RUNTIME_ENDPOINT_TARGETS` is empty, malformed, or uses a hostname | Use comma-separated `orchard_node_agent@<ip-literal>` targets. |
+| All-in-one `bin/dev` rejects BEAM mode | `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` was set with the all-in-one entrypoint | Use `bin/dev-controller` and `bin/dev-node-agent` for BEAM mode. |
+| BEAM node-name validation fails | `ORCHARD_BEAM_NODE_NAME` is not `service@ip` or uses the wrong role prefix | Use `orchard_controller@<controller-ip>` for the controller and `orchard_node_agent@<node-ip>` for node-agents. |
+| BEAM cookie validation fails | Cookie file is missing, empty, or group/world-readable | Create or copy the cookie file, then run `chmod 600 tmp/dev/beam.cookie`. |
+| BEAM `connect` returns `:pang` or `:unknown_beam_node` | EPMD cannot resolve the target, the target node is not running, or the cookie does not match | Check `ERL_EPMD_PORT`, node names, cookie digest match, and `nc -vz <target-ip> 4369`. |
+| BEAM RPC times out or is unreachable | Distribution listener port is blocked | Check TCP `52171` for the controller and TCP `52172` for node-agents, or check your overridden range. |
+| BEAM Console shows stale gRPC expectations | gRPC targets were configured as a comparison path | Use Console Runtime Endpoint target diagnostics and remember that `ORCHARD_RUNTIME_CLIENT_TARGETS` is not a BEAM fallback. |
+| Remote gRPC node-agent unreachable | Listen host still `127.0.0.1` | Set `ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0` for the gRPC compatibility flow. |
+| Remote node fails on MLX | mise toolchain not installed or no `uv sync` | Use `ORCHARD_WORKER_BACKEND=stub` or run `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx`. |
+| Port conflict on remote gRPC node-agent | Another BEAM or node-agent owns the gRPC port | Change `ORCHARD_NODE_AGENT_LISTEN_PORT`. |
 
-> **Security note:** Binding to `0.0.0.0` exposes the gRPC server on all
-> interfaces. Use only on trusted networks (Tailscale, private LAN). Source-dev
-> gRPC has no TLS — Tailscale provides wire encryption.
+> **Security note:** Binding gRPC to `0.0.0.0` exposes the gRPC server on all interfaces.
+> Use it only on trusted networks such as Tailscale or a private LAN.
+> Source-dev gRPC has no TLS, so rely on the private network for wire encryption.
 
 ## Testing
 

--- a/openspec/changes/source-dev-beam-operating-model/design.md
+++ b/openspec/changes/source-dev-beam-operating-model/design.md
@@ -2,7 +2,7 @@
 
 Orchard already models Controller runtime execution through the Runtime Endpoint Interface, and `SPEC.md` §1.2 and §7.5 allow default-off BEAM Distribution for admitted first-party Controller and Node Agent services.
 The existing BEAM Runtime Endpoint adapter assumes that BEAM Distribution has already been started with compatible node names, cookies, network reachability, and target addresses.
-Current source-dev entrypoints still boot unnamed Mix VMs and configure the legacy gRPC compatibility target list.
+Before this change, source-dev entrypoints still booted unnamed Mix VMs and configured the legacy gRPC compatibility target list.
 
 This design turns the accepted BEAM-first Runtime Endpoint direction into an apply-ready source-dev operating model.
 It is intentionally narrower than production BEAM Distribution hardening.
@@ -22,7 +22,6 @@ All-in-one `bin/dev` remains on the current gRPC compatibility default until a s
 
 **Non-Goals:**
 
-- Do not implement product code, scripts, runtime config, tests, or documentation updates in this proposal package.
 - Do not update `orchardctl env init` to render the Source-dev BEAM env surface in this implementation slice; defer CLI scaffolding to a separate change.
 - Do not flip all-in-one `bin/dev` from gRPC compatibility to BEAM Runtime Endpoint mode.
 - Do not remove the gRPC Compatibility Adapter.
@@ -34,7 +33,7 @@ All-in-one `bin/dev` remains on the current gRPC compatibility default until a s
 
 ### Split-role source dev is the first BEAM operating target
 
-BEAM Runtime Endpoint mode should be implemented first for `bin/dev-controller` and `bin/dev-node-agent`.
+BEAM Runtime Endpoint mode is implemented first for `bin/dev-controller` and `bin/dev-node-agent`.
 Both processes must start as named distributed BEAM nodes when BEAM transport is selected.
 This keeps the validation path close to the real distributed source-dev topology and avoids hiding operational defects inside an all-in-one VM.
 
@@ -64,7 +63,8 @@ It also makes failures harder to diagnose because the configured Runtime Endpoin
 
 ### Distribution networking is bounded and visible
 
-Source-dev BEAM mode should set an explicit EPMD port policy, defaulting to TCP `4369`, and a configured distribution listener port range through `ORCHARD_BEAM_DIST_PORT_MIN` and `ORCHARD_BEAM_DIST_PORT_MAX`.
+Source-dev BEAM mode sets an explicit EPMD port policy, defaulting to TCP `4369`, and a configured distribution listener port range through `ORCHARD_BEAM_DIST_PORT_MIN` and `ORCHARD_BEAM_DIST_PORT_MAX`.
+The implementation defaults the controller distribution range to TCP `52171..52171` and the node-agent range to TCP `52172..52172`.
 Startup output may show node name, cookie file path, EPMD port, and distribution port range.
 Startup output must not show cookie contents.
 The two-Mac smoke runbook must state that both EPMD and the bounded distribution listener range must be reachable over the trusted source-dev network.
@@ -132,8 +132,9 @@ Rollback is configuration-based during implementation.
 Contributors can return to the existing source-dev gRPC compatibility path by selecting or leaving the compatibility transport in place.
 No data migration is expected because this operating model does not change Postgres schema or durable request data.
 
-## Open Questions
+## Resolved Implementation Notes
 
-- What exact default source-dev distribution port range should implementation choose for same-host and two-Mac workflows?
-- Should the implementation provide a helper command to copy or verify cookie material across two Macs, or should that remain documented manual setup?
-- Should automated distributed BEAM tests use multiple OS processes in the Elixir suite, or remain a smoke-only validation until the launch helper is stable?
+- Source-dev BEAM uses TCP `52171` for the controller distribution listener and TCP `52172` for node-agent distribution listeners by default.
+- Cross-Mac cookie provisioning remains a documented manual setup step; this slice does not add a copy or secret-manager helper.
+- Automated coverage uses config tests and a shell bootstrap harness for launch behavior.
+  Real two-Mac distributed Runtime Endpoint evidence remains the smoke gate tracked in tasks 5.4 and 5.5.

--- a/openspec/changes/source-dev-beam-operating-model/design.md
+++ b/openspec/changes/source-dev-beam-operating-model/design.md
@@ -14,7 +14,7 @@ All-in-one `bin/dev` remains on the current gRPC compatibility default until a s
 **Goals:**
 
 - Define the source-dev launch policy for BEAM Runtime Endpoint mode on `bin/dev-controller` and `bin/dev-node-agent`.
-- Define long-name BEAM node naming, IP-literal target hosts, explicit cookie material, bounded distribution ports, and EPMD policy for source dev.
+- Define long-name BEAM node naming, IPv4-literal target hosts, explicit cookie material, bounded distribution ports, and EPMD policy for source dev.
 - Define the BEAM Runtime Endpoint env/config surface separately from the legacy gRPC compatibility target surface.
 - Define visible failure behavior when BEAM mode is selected.
 - Define the smoke-evidence gate required before source-dev defaults can be promoted.
@@ -41,10 +41,10 @@ This keeps the validation path close to the real distributed source-dev topology
 Alternative considered: change all-in-one `bin/dev` first.
 That is simpler to run, but it would not prove remote BEAM Distribution, cookie sharing, EPMD reachability, or remote Runtime Endpoint RPC behavior.
 
-### Source-dev BEAM uses long node names with IP-literal hosts
+### Source-dev BEAM uses long node names with IPv4-literal hosts
 
 Source-dev BEAM node names should use long-name format, such as `orchard_controller@100.x.y.z` and `orchard_node_agent@100.x.y.z`.
-Guarded BEAM Runtime Endpoint targets should require the host part to be an IP literal.
+Guarded BEAM Runtime Endpoint targets should require the host part to be an IPv4 literal.
 This keeps CIDR guardrail validation deterministic and avoids source-dev ambiguity around hostname resolution, local DNS, Bonjour, split-horizon names, and different network interfaces.
 
 Alternative considered: accept short names or arbitrary hostnames.
@@ -105,7 +105,7 @@ Those tests are useful, but they do not prove the source-dev operating model acr
 Risk: Source-dev BEAM mode can fail for local networking reasons unrelated to Runtime Endpoint code.
 Mitigation: keep EPMD and distribution ports explicit, print non-secret startup diagnostics, and document the smoke reachability checklist.
 
-Risk: Requiring IP-literal hosts is less ergonomic than hostnames.
+Risk: Requiring IPv4-literal hosts is less ergonomic than hostnames or IPv6 literals.
 Mitigation: treat hostname target support as a later enhancement after resolution and CIDR guardrail behavior are specified.
 
 Risk: Same-host generated cookie files can be confused with production secret handling.
@@ -124,7 +124,7 @@ Mitigation: record the commit with the smoke evidence and require new evidence b
 3. Implement explicit cookie-file generation or validation, strict permissions, and secret-safe diagnostics.
 4. Add BEAM node-name, EPMD, and distribution-port launch flags for split-role source-dev processes.
 5. Wire BEAM Runtime Endpoint target selection from `ORCHARD_RUNTIME_ENDPOINT_TARGETS` while leaving `ORCHARD_RUNTIME_CLIENT_TARGETS` scoped to gRPC compatibility.
-6. Add unit and integration coverage for parsing, cookie validation, node-name validation, IP-literal target rules, no automatic fallback, and split-role launch behavior.
+6. Add unit and integration coverage for parsing, cookie validation, node-name validation, IPv4-literal target rules, no automatic fallback, and split-role launch behavior.
 7. Run the two-Mac smoke and record durable evidence before proposing any default promotion.
 8. Propose any change to all-in-one `bin/dev` or default source-dev transport separately after the evidence gate passes.
 

--- a/openspec/changes/source-dev-beam-operating-model/proposal.md
+++ b/openspec/changes/source-dev-beam-operating-model/proposal.md
@@ -1,7 +1,8 @@
 ## Why
 
-Orchard has a default-off BEAM Runtime Endpoint adapter, but source-dev still boots unnamed Mix VMs and configures only gRPC-shaped runtime targets.
-A collaborator-reviewable operating model is needed before builders add split-role BEAM bootstrap, cookie handling, distribution networking, and BEAM-specific Runtime Endpoint target configuration.
+Orchard has a default-off BEAM Runtime Endpoint adapter.
+Before this change, source-dev still booted unnamed Mix VMs and configured only gRPC-shaped runtime targets.
+A collaborator-reviewable operating model is needed for split-role BEAM bootstrap, cookie handling, distribution networking, and BEAM-specific Runtime Endpoint target configuration.
 
 ## What Changes
 
@@ -12,7 +13,7 @@ A collaborator-reviewable operating model is needed before builders add split-ro
 - Require sanitized durable two-Mac smoke evidence under `docs/investigations/source-dev-beam-smoke-<date>.md` before any source-dev default promotion.
 - Preserve all-in-one `bin/dev` on the current gRPC compatibility default in this change.
 - Preserve gRPC compatibility as an explicitly selected adapter.
-- Exclude product code, script, and runtime config implementation from this proposal package.
+- Include the source-dev code, scripts, runtime config, tests, and documentation needed for the explicit split-role operating model.
 - Exclude production or packaged BEAM Distribution hardening, external Runtime Endpoint adapters, and any change to Postgres as Orchard's durable cluster truth.
 
 ## Capabilities
@@ -30,6 +31,6 @@ A collaborator-reviewable operating model is needed before builders add split-ro
 ## Impact
 
 - SPEC.md impact: this change proposes behavior for the source-dev Runtime Endpoint operating model under the accepted BEAM-first Runtime Endpoint direction, without changing production packaging behavior or durable cluster truth.
-- Affects future implementation work in `bin/dev-controller`, `bin/dev-node-agent`, source-dev config parsing, BEAM Runtime Endpoint target selection, cookie validation, distributed-node launch flags, tests, and local-dev documentation.
+- Affects implementation work in `bin/dev-controller`, `bin/dev-node-agent`, source-dev config parsing, BEAM Runtime Endpoint target selection, cookie validation, distributed-node launch flags, tests, and local-dev documentation.
 - Does not affect public inference APIs, request semantics, scheduler ranking policy, persisted schema, packaged launchd services, or Worker Runtime protocol behavior directly.
 - Depends on the accepted direction in ADR 0001, `docs/decisions/0001-runtime-endpoints-beam-first.md`; the sibling `beam-first-runtime-endpoints` OpenSpec change remains companion architecture context, not an accepted capability spec dependency.

--- a/openspec/changes/source-dev-beam-operating-model/proposal.md
+++ b/openspec/changes/source-dev-beam-operating-model/proposal.md
@@ -6,7 +6,7 @@ A collaborator-reviewable operating model is needed before builders add split-ro
 ## What Changes
 
 - Define the Source-dev BEAM Operating Model for split-role `bin/dev-controller` and `bin/dev-node-agent` launches.
-- Require named distributed BEAM nodes, long BEAM node names with IP-literal hosts, explicit shared cookie material, and bounded source-dev distribution networking when BEAM mode is selected.
+- Require named distributed BEAM nodes, long BEAM node names with IPv4-literal hosts, explicit shared cookie material, and bounded source-dev distribution networking when BEAM mode is selected.
 - Define a BEAM-specific source-dev env/config surface using `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT`, `ORCHARD_RUNTIME_ENDPOINT_TARGETS`, and `ORCHARD_BEAM_*` variables, while deferring `orchardctl env init` scaffolding for that surface to a separate CLI change.
 - Keep `ORCHARD_RUNTIME_CLIENT_TARGETS` scoped to the gRPC Compatibility Adapter and prevent BEAM mode from silently falling back to gRPC for the same request.
 - Require sanitized durable two-Mac smoke evidence under `docs/investigations/source-dev-beam-smoke-<date>.md` before any source-dev default promotion.

--- a/openspec/changes/source-dev-beam-operating-model/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/source-dev-beam-operating-model/specs/runtime-endpoints/spec.md
@@ -16,13 +16,14 @@ This refines the source-dev BEAM rollout rules in `SPEC.md` §1.2 and §7.5.
 - **THEN** Orchard keeps using the current gRPC compatibility runtime transport on source-dev port `50071`
 
 ### Requirement: Source-dev BEAM Node Names
-Source-dev BEAM node names SHALL use long-name format with IP-literal host parts for guarded BEAM Runtime Endpoint targets.
-Controller nodes SHALL use role-identifying names such as `orchard_controller@<ip>`.
-Node Agent nodes SHALL use role-identifying names such as `orchard_node_agent@<ip>`.
+Source-dev BEAM node names SHALL use long-name format with IPv4-literal host parts for guarded BEAM Runtime Endpoint targets.
+Controller nodes SHALL use role-identifying names such as `orchard_controller@<ipv4>`.
+Node Agent nodes SHALL use role-identifying names such as `orchard_node_agent@<ipv4>`.
 Source-dev BEAM target hostnames SHALL be rejected until hostname resolution and CIDR guardrail behavior are specified in a later change.
+Source-dev BEAM IPv6 target hosts SHALL be rejected until IPv6 distribution launch flags and guardrail behavior are specified in a later change.
 This refines BEAM Runtime Endpoint target rules in `SPEC.md` §1.2 and §7.5.
 
-#### Scenario: BEAM target uses IP-literal host
+#### Scenario: BEAM target uses IPv4-literal host
 - **WHEN** `ORCHARD_RUNTIME_ENDPOINT_TARGETS` contains `orchard_node_agent@100.64.1.10` in Source-dev BEAM mode
 - **THEN** Orchard accepts the target as a BEAM node-name address for guardrail validation
 

--- a/openspec/changes/source-dev-beam-operating-model/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/source-dev-beam-operating-model/specs/runtime-endpoints/spec.md
@@ -4,6 +4,7 @@
 Orchard SHALL support Source-dev BEAM Runtime Endpoint mode first for the split-role `bin/dev-controller` and `bin/dev-node-agent` entrypoints.
 When Source-dev BEAM mode is selected, both split-role processes SHALL start as named distributed BEAM nodes before Runtime Endpoint work is attempted.
 All-in-one `bin/dev` SHALL remain on the current gRPC compatibility default in this change.
+All-in-one `bin/dev` SHALL reject explicit Source-dev BEAM mode before starting Mix.
 This refines the source-dev BEAM rollout rules in `SPEC.md` §1.2 and §7.5.
 
 #### Scenario: Split-role BEAM mode starts distributed nodes
@@ -15,10 +16,15 @@ This refines the source-dev BEAM rollout rules in `SPEC.md` §1.2 and §7.5.
 - **WHEN** a contributor starts all-in-one `bin/dev` without selecting Source-dev BEAM mode
 - **THEN** Orchard keeps using the current gRPC compatibility runtime transport on source-dev port `50071`
 
+#### Scenario: All-in-one dev rejects BEAM mode
+- **WHEN** a contributor starts all-in-one `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
+- **THEN** Orchard rejects the launch before running Mix
+- **THEN** the contributor is directed to use `bin/dev-controller` and `bin/dev-node-agent`
+
 ### Requirement: Source-dev BEAM Node Names
 Source-dev BEAM node names SHALL use long-name format with IPv4-literal host parts for guarded BEAM Runtime Endpoint targets.
-Controller nodes SHALL use role-identifying names such as `orchard_controller@<ipv4>`.
-Node Agent nodes SHALL use role-identifying names such as `orchard_node_agent@<ipv4>`.
+Controller nodes SHALL use role-identifying services that start with `orchard_controller`, such as `orchard_controller@<ipv4>`.
+Node Agent nodes SHALL use the exact role-identifying service `orchard_node_agent`, such as `orchard_node_agent@<ipv4>`.
 Source-dev BEAM target hostnames SHALL be rejected until hostname resolution and CIDR guardrail behavior are specified in a later change.
 Source-dev BEAM IPv6 target hosts SHALL be rejected until IPv6 distribution launch flags and guardrail behavior are specified in a later change.
 This refines BEAM Runtime Endpoint target rules in `SPEC.md` §1.2 and §7.5.
@@ -62,6 +68,7 @@ This refines the first-party BEAM Distribution rules in `SPEC.md` §1.2 and §7.
 Source-dev BEAM mode SHALL define explicit distribution networking settings.
 `ORCHARD_BEAM_EPMD_PORT` SHALL select the source-dev EPMD port and SHALL default to `4369` when unset.
 `ORCHARD_BEAM_DIST_PORT_MIN` and `ORCHARD_BEAM_DIST_PORT_MAX` SHALL bound the BEAM distribution listener port range.
+When unset, the controller distribution listener range SHALL default to `52171..52171` and the node-agent distribution listener range SHALL default to `52172..52172`.
 The two-Mac smoke procedure SHALL document reachability requirements for EPMD and the configured distribution listener range.
 This refines Runtime Endpoint transport requirements in `SPEC.md` §1.2 and §7.5.
 
@@ -75,7 +82,7 @@ This refines Runtime Endpoint transport requirements in `SPEC.md` §1.2 and §7.
 
 ### Requirement: Source-dev Runtime Endpoint Env Surface
 Source-dev Runtime Endpoint transport selection SHALL use `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT`.
-Source-dev BEAM Runtime Endpoint targets SHALL come from `ORCHARD_RUNTIME_ENDPOINT_TARGETS` and SHALL use BEAM node-name addresses.
+Controller Source-dev BEAM Runtime Endpoint targets SHALL come from `ORCHARD_RUNTIME_ENDPOINT_TARGETS` and SHALL use BEAM node-name addresses.
 Source-dev BEAM node bootstrap SHALL use `ORCHARD_BEAM_NODE_NAME`, `ORCHARD_BEAM_COOKIE_FILE`, `ORCHARD_BEAM_DIST_PORT_MIN`, `ORCHARD_BEAM_DIST_PORT_MAX`, and `ORCHARD_BEAM_EPMD_PORT`.
 `ORCHARD_RUNTIME_CLIENT_TARGETS` SHALL remain scoped to gRPC Compatibility Adapter `host:port` targets and SHALL NOT be interpreted as BEAM Runtime Endpoint targets.
 This refines the transport-independent Runtime Endpoint target rules in `SPEC.md` §1.2, §4.6.1, and §7.5.

--- a/openspec/changes/source-dev-beam-operating-model/tasks.md
+++ b/openspec/changes/source-dev-beam-operating-model/tasks.md
@@ -1,60 +1,60 @@
 ## 1. Source-dev Configuration Surface
 
-- [ ] 1.1 Add source-dev parsing for `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` with explicit `grpc` and `beam` modes.
-- [ ] 1.2 Add source-dev parsing for `ORCHARD_RUNTIME_ENDPOINT_TARGETS` as BEAM node-name targets when transport is `beam`.
-- [ ] 1.3 Keep `ORCHARD_RUNTIME_CLIENT_TARGETS` scoped to gRPC Compatibility Adapter `host:port` targets.
-- [ ] 1.4 Add source-dev parsing for `ORCHARD_BEAM_NODE_NAME`, `ORCHARD_BEAM_COOKIE_FILE`, `ORCHARD_BEAM_DIST_PORT_MIN`, `ORCHARD_BEAM_DIST_PORT_MAX`, and `ORCHARD_BEAM_EPMD_PORT`.
-- [ ] 1.5 Add validation that Source-dev BEAM target host parts are IP literals and reject hostname targets for this slice.
+- [x] 1.1 Add source-dev parsing for `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` with explicit `grpc` and `beam` modes.
+- [x] 1.2 Add source-dev parsing for `ORCHARD_RUNTIME_ENDPOINT_TARGETS` as BEAM node-name targets when transport is `beam`.
+- [x] 1.3 Keep `ORCHARD_RUNTIME_CLIENT_TARGETS` scoped to gRPC Compatibility Adapter `host:port` targets.
+- [x] 1.4 Add source-dev parsing for `ORCHARD_BEAM_NODE_NAME`, `ORCHARD_BEAM_COOKIE_FILE`, `ORCHARD_BEAM_DIST_PORT_MIN`, `ORCHARD_BEAM_DIST_PORT_MAX`, and `ORCHARD_BEAM_EPMD_PORT`.
+- [x] 1.5 Add validation that Source-dev BEAM target host parts are IP literals and reject hostname targets for this slice.
 
 ## 2. Split-role BEAM Bootstrap
 
-- [ ] 2.1 Add a shared source-dev shell bootstrap helper for BEAM launch flags used by `bin/dev-controller` and `bin/dev-node-agent`.
-- [ ] 2.2 Update `bin/dev-controller` to start as a named distributed BEAM node when Source-dev BEAM mode is selected.
-- [ ] 2.3 Update `bin/dev-node-agent` to start as a named distributed BEAM node when Source-dev BEAM mode is selected.
-- [ ] 2.4 Preserve all-in-one `bin/dev` on the gRPC compatibility default in this implementation slice.
-- [ ] 2.5 Print non-secret startup diagnostics for BEAM node name, cookie file path, EPMD port, and distribution port range.
-- [ ] 2.6 Defer `orchardctl env init` rendering of the Source-dev BEAM env surface to a separate CLI scaffolding change; this implementation slice must not imply that `orchardctl env init` emits BEAM variables.
+- [x] 2.1 Add a shared source-dev shell bootstrap helper for BEAM launch flags used by `bin/dev-controller` and `bin/dev-node-agent`.
+- [x] 2.2 Update `bin/dev-controller` to start as a named distributed BEAM node when Source-dev BEAM mode is selected.
+- [x] 2.3 Update `bin/dev-node-agent` to start as a named distributed BEAM node when Source-dev BEAM mode is selected.
+- [x] 2.4 Preserve all-in-one `bin/dev` on the gRPC compatibility default in this implementation slice.
+- [x] 2.5 Print non-secret startup diagnostics for BEAM node name, cookie file path, EPMD port, and distribution port range.
+- [x] 2.6 Defer `orchardctl env init` rendering of the Source-dev BEAM env surface to a separate CLI scaffolding change; this implementation slice must not imply that `orchardctl env init` emits BEAM variables.
 
 ## 3. Cookie And Distribution Networking
 
-- [ ] 3.1 Implement same-host source-dev creation of `tmp/dev/beam.cookie` when BEAM mode is selected and no explicit cookie file exists.
-- [ ] 3.2 Validate that BEAM cookie files exist, are non-empty, and have mode `0600` or stricter before Runtime Endpoint work is attempted.
-- [ ] 3.3 Ensure cookie contents are never printed in logs, generated templates, diagnostics, or startup output.
-- [ ] 3.4 Apply `ORCHARD_BEAM_EPMD_PORT` with default `4369` for Source-dev BEAM launches.
-- [ ] 3.5 Apply `ORCHARD_BEAM_DIST_PORT_MIN` and `ORCHARD_BEAM_DIST_PORT_MAX` as bounded distribution listener settings for Source-dev BEAM launches.
-- [ ] 3.6 Reject invalid distribution port ranges before Runtime Endpoint work is attempted.
+- [x] 3.1 Implement same-host source-dev creation of `tmp/dev/beam.cookie` when BEAM mode is selected and no explicit cookie file exists.
+- [x] 3.2 Validate that BEAM cookie files exist, are non-empty, and have mode `0600` or stricter before Runtime Endpoint work is attempted.
+- [x] 3.3 Ensure cookie contents are never printed in logs, generated templates, diagnostics, or startup output.
+- [x] 3.4 Apply `ORCHARD_BEAM_EPMD_PORT` with default `4369` for Source-dev BEAM launches.
+- [x] 3.5 Apply `ORCHARD_BEAM_DIST_PORT_MIN` and `ORCHARD_BEAM_DIST_PORT_MAX` as bounded distribution listener settings for Source-dev BEAM launches.
+- [x] 3.6 Reject invalid distribution port ranges before Runtime Endpoint work is attempted.
 
 ## 4. Runtime Endpoint Wiring And Failure Behavior
 
-- [ ] 4.1 Wire Source-dev BEAM mode to `Orchard.RuntimeEndpoint.BeamClient` through Runtime Endpoint Interface configuration.
-- [ ] 4.2 Wire parsed BEAM targets into `:orchard_controller, :inference, :runtime_endpoint_targets` without reading `ORCHARD_RUNTIME_CLIENT_TARGETS`.
-- [ ] 4.3 Preserve gRPC Compatibility Adapter configuration when `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` is unset or explicitly `grpc`.
-- [ ] 4.4 Ensure BEAM configuration, guardrail, connection, target identity, and Runtime Endpoint RPC failures do not automatically retry the same request through gRPC.
-- [ ] 4.5 Ensure Console Nodes diagnostics use the active Runtime Endpoint target list and BEAM client when BEAM mode is selected.
+- [x] 4.1 Wire Source-dev BEAM mode to `Orchard.RuntimeEndpoint.BeamClient` through Runtime Endpoint Interface configuration.
+- [x] 4.2 Wire parsed BEAM targets into `:orchard_controller, :inference, :runtime_endpoint_targets` without reading `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+- [x] 4.3 Preserve gRPC Compatibility Adapter configuration when `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` is unset or explicitly `grpc`.
+- [x] 4.4 Ensure BEAM configuration, guardrail, connection, target identity, and Runtime Endpoint RPC failures do not automatically retry the same request through gRPC.
+- [x] 4.5 Ensure Console Nodes diagnostics use the active Runtime Endpoint target list and BEAM client when BEAM mode is selected.
 
 ## 5. Documentation And Smoke Evidence
 
-- [ ] 5.1 Update `docs/local-dev.md` with the implemented Source-dev BEAM split-role launch commands and troubleshooting guidance.
-- [ ] 5.2 Document two-Mac cookie provisioning and verification without committing cookie material.
-- [ ] 5.3 Document EPMD and bounded distribution port reachability requirements for the two-Mac smoke.
+- [x] 5.1 Update `docs/local-dev.md` with the implemented Source-dev BEAM split-role launch commands and troubleshooting guidance.
+- [x] 5.2 Document two-Mac cookie provisioning and verification without committing cookie material.
+- [x] 5.3 Document EPMD and bounded distribution port reachability requirements for the two-Mac smoke.
 - [ ] 5.4 Run the two-Mac Source-dev BEAM smoke and record durable evidence in `docs/investigations/source-dev-beam-smoke-<date>.md` with date, commit, sanitized hosts, commands, controller and node-agent BEAM node names, and remote Runtime Endpoint RPC evidence.
 - [ ] 5.5 Record Console Nodes reachability for local and remote Node Agents, `GET /v1/models` returning `200`, and `POST /v1/chat/completions` completing through Console Playground or an equivalent API request.
-- [ ] 5.6 Defer any source-dev default promotion or all-in-one `bin/dev` BEAM default change to a separate OpenSpec change after the smoke evidence gate passes.
+- [x] 5.6 Defer any source-dev default promotion or all-in-one `bin/dev` BEAM default change to a separate OpenSpec change after the smoke evidence gate passes.
 
 ## 6. Tests And Validation
 
-- [ ] 6.1 Add unit tests for source-dev Runtime Endpoint transport parsing and BEAM target parsing.
-- [ ] 6.2 Add tests that `ORCHARD_RUNTIME_CLIENT_TARGETS` remains gRPC compatibility-only and is not interpreted as a BEAM target source.
-- [ ] 6.3 Add tests for IP-literal BEAM target host validation and hostname rejection.
-- [ ] 6.4 Add tests for cookie file existence, non-empty content, strict permissions, and secret-safe diagnostics.
-- [ ] 6.5 Add tests for invalid EPMD or distribution port configuration.
-- [ ] 6.6 Add tests proving BEAM mode failures do not automatically fall back to gRPC for the same request.
-- [ ] 6.7 Add split-role bootstrap tests or smoke harness coverage for named distributed BEAM nodes where practical.
-- [ ] 6.8 Run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate source-dev-beam-operating-model --type change --strict --no-interactive`.
-- [ ] 6.9 Run `mise exec -- mix format`.
-- [ ] 6.10 Run `mise exec -- mix compile --warnings-as-errors`.
-- [ ] 6.11 Run `mise exec -- mix credo --strict`.
-- [ ] 6.12 Run `mise exec -- mix dialyzer`.
-- [ ] 6.13 Run `mise exec -- mix test`.
-- [ ] 6.14 Run `mise exec -- mix test --cover`.
+- [x] 6.1 Add unit tests for source-dev Runtime Endpoint transport parsing and BEAM target parsing.
+- [x] 6.2 Add tests that `ORCHARD_RUNTIME_CLIENT_TARGETS` remains gRPC compatibility-only and is not interpreted as a BEAM target source.
+- [x] 6.3 Add tests for IP-literal BEAM target host validation and hostname rejection.
+- [x] 6.4 Add tests for cookie file existence, non-empty content, strict permissions, and secret-safe diagnostics.
+- [x] 6.5 Add tests for invalid EPMD or distribution port configuration.
+- [x] 6.6 Add tests proving BEAM mode failures do not automatically fall back to gRPC for the same request.
+- [x] 6.7 Add split-role bootstrap tests or smoke harness coverage for named distributed BEAM nodes where practical.
+- [x] 6.8 Run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate source-dev-beam-operating-model --type change --strict --no-interactive`.
+- [x] 6.9 Run `mise exec -- mix format`.
+- [x] 6.10 Run `mise exec -- mix compile --warnings-as-errors`.
+- [x] 6.11 Run `mise exec -- mix credo --strict`.
+- [x] 6.12 Run `mise exec -- mix dialyzer`.
+- [x] 6.13 Run `mise exec -- mix test`.
+- [x] 6.14 Run `mise exec -- mix test --cover`.
 - [ ] 6.15 After spec sync or archive, review generated specs for placeholder prose such as `Purpose TBD`.

--- a/openspec/changes/source-dev-beam-operating-model/tasks.md
+++ b/openspec/changes/source-dev-beam-operating-model/tasks.md
@@ -57,4 +57,4 @@
 - [x] 6.12 Run `mise exec -- mix dialyzer`.
 - [x] 6.13 Run `mise exec -- mix test`.
 - [x] 6.14 Run `mise exec -- mix test --cover`.
-- [ ] 6.15 After spec sync or archive, review generated specs for placeholder prose such as `Purpose TBD`.
+- [x] 6.15 After spec sync or archive, review generated specs for placeholder prose such as `Purpose TBD`.

--- a/openspec/changes/source-dev-beam-operating-model/tasks.md
+++ b/openspec/changes/source-dev-beam-operating-model/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 Add source-dev parsing for `ORCHARD_RUNTIME_ENDPOINT_TARGETS` as BEAM node-name targets when transport is `beam`.
 - [x] 1.3 Keep `ORCHARD_RUNTIME_CLIENT_TARGETS` scoped to gRPC Compatibility Adapter `host:port` targets.
 - [x] 1.4 Add source-dev parsing for `ORCHARD_BEAM_NODE_NAME`, `ORCHARD_BEAM_COOKIE_FILE`, `ORCHARD_BEAM_DIST_PORT_MIN`, `ORCHARD_BEAM_DIST_PORT_MAX`, and `ORCHARD_BEAM_EPMD_PORT`.
-- [x] 1.5 Add validation that Source-dev BEAM target host parts are IP literals and reject hostname targets for this slice.
+- [x] 1.5 Add validation that Source-dev BEAM target host parts are IPv4 literals and reject hostname and IPv6 targets for this slice.
 
 ## 2. Split-role BEAM Bootstrap
 
@@ -45,7 +45,7 @@
 
 - [x] 6.1 Add unit tests for source-dev Runtime Endpoint transport parsing and BEAM target parsing.
 - [x] 6.2 Add tests that `ORCHARD_RUNTIME_CLIENT_TARGETS` remains gRPC compatibility-only and is not interpreted as a BEAM target source.
-- [x] 6.3 Add tests for IP-literal BEAM target host validation and hostname rejection.
+- [x] 6.3 Add tests for IPv4-literal BEAM target host validation and hostname or IPv6 rejection.
 - [x] 6.4 Add tests for cookie file existence, non-empty content, strict permissions, and secret-safe diagnostics.
 - [x] 6.5 Add tests for invalid EPMD or distribution port configuration.
 - [x] 6.6 Add tests proving BEAM mode failures do not automatically fall back to gRPC for the same request.

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -166,8 +166,13 @@ assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IP literal' "$TMP_ROOT
   run_helper controller "$TMP_ROOT/repo-e2-invalid-ipv6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@::::
 assert_fails_with 'controller BEAM node service must start with orchard_controller' "$TMP_ROOT/e3.out" \
   run_helper controller "$TMP_ROOT/repo-e3" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_node_agent@127.0.0.1
-assert_fails_with 'node-agent BEAM node service must start with orchard_node_agent' "$TMP_ROOT/e4.out" \
+assert_fails_with 'node-agent BEAM node service must be exactly orchard_node_agent' "$TMP_ROOT/e4.out" \
   run_helper node_agent "$TMP_ROOT/repo-e4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@127.0.0.1
+assert_succeeds "$TMP_ROOT/e4-exact.out" \
+  run_helper node_agent "$TMP_ROOT/repo-e4-exact" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_node_agent@127.0.0.1
+assert_grep 'node=orchard_node_agent@127.0.0.1' "$TMP_ROOT/e4-exact.out"
+assert_fails_with 'node-agent BEAM node service must be exactly orchard_node_agent' "$TMP_ROOT/e4-suffix.out" \
+  run_helper node_agent "$TMP_ROOT/repo-e4-suffix" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_node_agent_dev@127.0.0.1
 assert_fails_with 'ORCHARD_BEAM_NODE_NAME service contains invalid characters' "$TMP_ROOT/e5-space.out" \
   run_helper controller "$TMP_ROOT/repo-e5-space" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME='orchard_controller bad@127.0.0.1'
 assert_fails_with 'ORCHARD_BEAM_NODE_NAME service contains invalid characters' "$TMP_ROOT/e5-slash.out" \

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HELPER="$REPO_ROOT/bin/lib/source-dev-beam.sh"
 TMP_ROOT="$(mktemp -d)"
+DEFAULT_TOOLS="$TMP_ROOT/tools-default"
+EPMD_CALL_LOG="$TMP_ROOT/epmd-calls.log"
 cleanup() {
   rm -rf "$TMP_ROOT"
 }
@@ -78,8 +80,9 @@ run_helper() {
   local repo_root="$2"
   shift 2
   env -i \
-    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    PATH="$DEFAULT_TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
     HOME="$TMP_ROOT/home" \
+    FAKE_EPMD_CALL_LOG="$EPMD_CALL_LOG" \
     "$@" \
     bash -c 'set -euo pipefail; source "$1"; orchard_source_dev_beam_bootstrap "$2" "$3"; printf "transport=%s\n" "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-unset}"; printf "node=%s\n" "${ORCHARD_BEAM_NODE_NAME:-unset}"; printf "cookie=%s\n" "${ORCHARD_BEAM_COOKIE_FILE:-unset}"; printf "epmd=%s\n" "${ORCHARD_BEAM_EPMD_PORT:-unset}"; printf "epmd_address=%s\n" "${ERL_EPMD_ADDRESS:-unset}"; printf "dist=%s..%s\n" "${ORCHARD_BEAM_DIST_PORT_MIN:-unset}" "${ORCHARD_BEAM_DIST_PORT_MAX:-unset}"; printf "home=%s\n" "$HOME"; printf "mix_home=%s\n" "${MIX_HOME:-unset}"; printf "hex_home=%s\n" "${HEX_HOME:-unset}"; printf "args=%s\n" "${ORCHARD_BEAM_IEX_ARGS[*]-}"' \
       bash "$HELPER" "$role" "$repo_root"
@@ -91,6 +94,42 @@ if [[ ! -f "$HELPER" ]]; then
 fi
 
 mkdir -p "$TMP_ROOT/home"
+mkdir -p "$DEFAULT_TOOLS"
+
+cat > "$DEFAULT_TOOLS/epmd" <<'SH'
+#!/bin/sh
+if [ -n "${FAKE_EPMD_CALL_LOG:-}" ]; then
+  printf 'epmd %s\n' "$*" >> "$FAKE_EPMD_CALL_LOG"
+fi
+
+case " $* " in
+  *" -names "*)
+    exit "${FAKE_EPMD_NAMES_EXIT:-1}"
+    ;;
+  *" -daemon "*)
+    exit "${FAKE_EPMD_DAEMON_EXIT:-0}"
+    ;;
+esac
+
+exit 0
+SH
+
+cat > "$DEFAULT_TOOLS/lsof" <<'SH'
+#!/bin/sh
+if [ "${FAKE_LSOF_EXIT:-0}" -ne 0 ]; then
+  exit "$FAKE_LSOF_EXIT"
+fi
+
+if [ -n "${FAKE_LSOF_OUTPUT:-}" ]; then
+  printf '%s\n' "$FAKE_LSOF_OUTPUT"
+  exit 0
+fi
+
+printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
+printf 'epmd 100 user 3u IPv4 0t0 TCP %s:%s (LISTEN)\n' "${ERL_EPMD_ADDRESS:-127.0.0.1}" "${ERL_EPMD_PORT:-4369}"
+SH
+
+chmod +x "$DEFAULT_TOOLS/epmd" "$DEFAULT_TOOLS/lsof"
 
 # A: unset or grpc mode is a no-op for IEx distribution args.
 assert_succeeds "$TMP_ROOT/a0.out" run_helper controller "$TMP_ROOT/repo-a0"
@@ -116,6 +155,7 @@ assert_grep 'epmd_address=127.0.0.1' "$TMP_ROOT/b.out"
 assert_grep 'dist=52171..52171' "$TMP_ROOT/b.out"
 assert_grep '--name orchard_controller@127.0.0.1' "$TMP_ROOT/b.out"
 assert_grep 'inet_dist_use_interface {127,0,0,1}' "$TMP_ROOT/b.out"
+assert_grep 'epmd -daemon -address 127.0.0.1 -port 4369' "$EPMD_CALL_LOG"
 assert_no_grep "$(cat "$COOKIE_B")" "$TMP_ROOT/b.out"
 
 # C: node-agent BEAM mode gets its own role default node and distribution port.
@@ -167,6 +207,10 @@ assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IP literal' "$TMP_ROOT
   run_helper controller "$TMP_ROOT/repo-e2" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@localhost
 assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IP literal' "$TMP_ROOT/e2-invalid-ipv6.out" \
   run_helper controller "$TMP_ROOT/repo-e2-invalid-ipv6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@::::
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must not be an unspecified or wildcard address' "$TMP_ROOT/e2-wildcard-v4.out" \
+  run_helper controller "$TMP_ROOT/repo-e2-wildcard-v4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@0.0.0.0
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must not be an unspecified or wildcard address' "$TMP_ROOT/e2-wildcard-v6.out" \
+  run_helper controller "$TMP_ROOT/repo-e2-wildcard-v6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@::
 assert_fails_with 'controller BEAM node service must start with orchard_controller' "$TMP_ROOT/e3.out" \
   run_helper controller "$TMP_ROOT/repo-e3" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_node_agent@127.0.0.1
 assert_fails_with 'node-agent BEAM node service must be exactly orchard_node_agent' "$TMP_ROOT/e4.out" \
@@ -198,6 +242,12 @@ assert_fails_with 'ORCHARD_BEAM_DIST_PORT_MIN must be less than or equal to ORCH
 assert_succeeds "$TMP_ROOT/f4.out" run_helper controller "$TMP_ROOT/repo-f4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_EPMD_PORT=4370 ORCHARD_BEAM_DIST_PORT_MIN=52180 ORCHARD_BEAM_DIST_PORT_MAX=52181
 assert_grep 'epmd=4370' "$TMP_ROOT/f4.out"
 assert_grep 'dist=52180..52181' "$TMP_ROOT/f4.out"
+assert_fails_with 'EPMD listener on port 4369 is wildcard-bound' "$TMP_ROOT/f5.out" \
+  run_helper controller "$TMP_ROOT/repo-f5" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam FAKE_EPMD_NAMES_EXIT=0 FAKE_LSOF_OUTPUT='epmd 100 user 3u IPv4 0t0 TCP *:4369 (LISTEN)'
+assert_fails_with 'EPMD listener on port 4369 is not bound to 127.0.0.1' "$TMP_ROOT/f6.out" \
+  run_helper controller "$TMP_ROOT/repo-f6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam FAKE_EPMD_NAMES_EXIT=0 FAKE_LSOF_OUTPUT='epmd 100 user 3u IPv4 0t0 TCP 10.0.0.2:4369 (LISTEN)'
+assert_succeeds "$TMP_ROOT/f7.out" \
+  run_helper controller "$TMP_ROOT/repo-f7" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam FAKE_EPMD_NAMES_EXIT=0 FAKE_LSOF_OUTPUT='epmd 100 user 3u IPv4 0t0 TCP 127.0.0.1:4369 (LISTEN)'
 
 # G: the helper rejects unknown transport values early.
 assert_fails_with 'ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc|beam' "$TMP_ROOT/g.out" \
@@ -248,7 +298,9 @@ cat > "$TOOLS_I/pgrep" <<'SH'
 #!/bin/sh
 exit 1
 SH
-chmod +x "$TOOLS_I/mix" "$TOOLS_I/iex" "$TOOLS_I/pgrep"
+cp "$DEFAULT_TOOLS/epmd" "$TOOLS_I/epmd"
+cp "$DEFAULT_TOOLS/lsof" "$TOOLS_I/lsof"
+chmod +x "$TOOLS_I/mix" "$TOOLS_I/iex" "$TOOLS_I/pgrep" "$TOOLS_I/epmd" "$TOOLS_I/lsof"
 
 CONTROLLER_REPO="$TMP_ROOT/controller-entrypoint"
 mkdir -p "$CONTROLLER_REPO"

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -200,16 +200,18 @@ assert_succeeds "$TMP_ROOT/d4.out" run_helper controller "$TMP_ROOT/repo-d4" ORC
 assert_grep "cookie=$STRICT_COOKIE" "$TMP_ROOT/d4.out"
 assert_no_grep 'fixture-cookie' "$TMP_ROOT/d4.out"
 
-# E: BEAM node names must be role-appropriate long names with IP-literal hosts.
+# E: BEAM node names must be role-appropriate long names with IPv4-literal hosts.
 assert_fails_with 'ORCHARD_BEAM_NODE_NAME must be a long BEAM node name' "$TMP_ROOT/e1.out" \
   run_helper controller "$TMP_ROOT/repo-e1" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller
-assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IP literal' "$TMP_ROOT/e2.out" \
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IPv4 literal' "$TMP_ROOT/e2.out" \
   run_helper controller "$TMP_ROOT/repo-e2" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@localhost
-assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IP literal' "$TMP_ROOT/e2-invalid-ipv6.out" \
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IPv4 literal' "$TMP_ROOT/e2-invalid-ipv6.out" \
   run_helper controller "$TMP_ROOT/repo-e2-invalid-ipv6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@::::
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IPv4 literal' "$TMP_ROOT/e2-ipv6.out" \
+  run_helper node_agent "$TMP_ROOT/repo-e2-ipv6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_node_agent@::1
 assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must not be an unspecified or wildcard address' "$TMP_ROOT/e2-wildcard-v4.out" \
   run_helper controller "$TMP_ROOT/repo-e2-wildcard-v4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@0.0.0.0
-assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must not be an unspecified or wildcard address' "$TMP_ROOT/e2-wildcard-v6.out" \
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IPv4 literal' "$TMP_ROOT/e2-wildcard-v6.out" \
   run_helper controller "$TMP_ROOT/repo-e2-wildcard-v6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@::
 assert_fails_with 'controller BEAM node service must start with orchard_controller' "$TMP_ROOT/e3.out" \
   run_helper controller "$TMP_ROOT/repo-e3" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_node_agent@127.0.0.1
@@ -244,10 +246,14 @@ assert_grep 'epmd=4370' "$TMP_ROOT/f4.out"
 assert_grep 'dist=52180..52181' "$TMP_ROOT/f4.out"
 assert_fails_with 'EPMD listener on port 4369 is wildcard-bound' "$TMP_ROOT/f5.out" \
   run_helper controller "$TMP_ROOT/repo-f5" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam FAKE_EPMD_NAMES_EXIT=0 FAKE_LSOF_OUTPUT='epmd 100 user 3u IPv4 0t0 TCP *:4369 (LISTEN)'
-assert_fails_with 'EPMD listener on port 4369 is not bound to 127.0.0.1' "$TMP_ROOT/f6.out" \
+assert_fails_with 'EPMD listener on port 4369 is not constrained to 127.0.0.1' "$TMP_ROOT/f6.out" \
   run_helper controller "$TMP_ROOT/repo-f6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam FAKE_EPMD_NAMES_EXIT=0 FAKE_LSOF_OUTPUT='epmd 100 user 3u IPv4 0t0 TCP 10.0.0.2:4369 (LISTEN)'
 assert_succeeds "$TMP_ROOT/f7.out" \
   run_helper controller "$TMP_ROOT/repo-f7" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam FAKE_EPMD_NAMES_EXIT=0 FAKE_LSOF_OUTPUT='epmd 100 user 3u IPv4 0t0 TCP 127.0.0.1:4369 (LISTEN)'
+assert_fails_with 'EPMD listener on port 4369 is not constrained to 127.0.0.1' "$TMP_ROOT/f8.out" \
+  run_helper controller "$TMP_ROOT/repo-f8" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam FAKE_EPMD_NAMES_EXIT=0 FAKE_LSOF_OUTPUT='COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+epmd 100 user 3u IPv4 0t0 TCP 127.0.0.1:4369 (LISTEN)
+epmd 100 user 4u IPv4 0t0 TCP 10.0.0.2:4369 (LISTEN)'
 
 # G: the helper rejects unknown transport values early.
 assert_fails_with 'ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc|beam' "$TMP_ROOT/g.out" \

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -81,7 +81,7 @@ run_helper() {
     PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
     HOME="$TMP_ROOT/home" \
     "$@" \
-    bash -c 'set -euo pipefail; source "$1"; orchard_source_dev_beam_bootstrap "$2" "$3"; printf "transport=%s\n" "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-unset}"; printf "node=%s\n" "${ORCHARD_BEAM_NODE_NAME:-unset}"; printf "cookie=%s\n" "${ORCHARD_BEAM_COOKIE_FILE:-unset}"; printf "epmd=%s\n" "${ORCHARD_BEAM_EPMD_PORT:-unset}"; printf "dist=%s..%s\n" "${ORCHARD_BEAM_DIST_PORT_MIN:-unset}" "${ORCHARD_BEAM_DIST_PORT_MAX:-unset}"; printf "home=%s\n" "$HOME"; printf "mix_home=%s\n" "${MIX_HOME:-unset}"; printf "hex_home=%s\n" "${HEX_HOME:-unset}"; printf "args=%s\n" "${ORCHARD_BEAM_IEX_ARGS[*]-}"' \
+    bash -c 'set -euo pipefail; source "$1"; orchard_source_dev_beam_bootstrap "$2" "$3"; printf "transport=%s\n" "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-unset}"; printf "node=%s\n" "${ORCHARD_BEAM_NODE_NAME:-unset}"; printf "cookie=%s\n" "${ORCHARD_BEAM_COOKIE_FILE:-unset}"; printf "epmd=%s\n" "${ORCHARD_BEAM_EPMD_PORT:-unset}"; printf "epmd_address=%s\n" "${ERL_EPMD_ADDRESS:-unset}"; printf "dist=%s..%s\n" "${ORCHARD_BEAM_DIST_PORT_MIN:-unset}" "${ORCHARD_BEAM_DIST_PORT_MAX:-unset}"; printf "home=%s\n" "$HOME"; printf "mix_home=%s\n" "${MIX_HOME:-unset}"; printf "hex_home=%s\n" "${HEX_HOME:-unset}"; printf "args=%s\n" "${ORCHARD_BEAM_IEX_ARGS[*]-}"' \
       bash "$HELPER" "$role" "$repo_root"
 }
 
@@ -112,8 +112,10 @@ assert_grep 'node=orchard_controller@127.0.0.1' "$TMP_ROOT/b.out"
 assert_grep "cookie=$COOKIE_B" "$TMP_ROOT/b.out"
 assert_files_equal "$COOKIE_B" "$REPO_B/tmp/dev/beam-home/controller/.erlang.cookie"
 assert_grep 'epmd=4369' "$TMP_ROOT/b.out"
+assert_grep 'epmd_address=127.0.0.1' "$TMP_ROOT/b.out"
 assert_grep 'dist=52171..52171' "$TMP_ROOT/b.out"
 assert_grep '--name orchard_controller@127.0.0.1' "$TMP_ROOT/b.out"
+assert_grep 'inet_dist_use_interface {127,0,0,1}' "$TMP_ROOT/b.out"
 assert_no_grep "$(cat "$COOKIE_B")" "$TMP_ROOT/b.out"
 
 # C: node-agent BEAM mode gets its own role default node and distribution port.
@@ -122,6 +124,7 @@ assert_succeeds "$TMP_ROOT/c.out" run_helper node_agent "$REPO_C" ORCHARD_RUNTIM
 assert_grep 'node=orchard_node_agent@127.0.0.1' "$TMP_ROOT/c.out"
 assert_grep 'dist=52172..52172' "$TMP_ROOT/c.out"
 assert_grep '--name orchard_node_agent@127.0.0.1' "$TMP_ROOT/c.out"
+assert_grep 'inet_dist_use_interface {127,0,0,1}' "$TMP_ROOT/c.out"
 
 # C2: concurrent split-role bootstrap from a clean checkout stages the final default cookie for both roles.
 REPO_C2="$TMP_ROOT/repo-c2"
@@ -181,6 +184,9 @@ assert_fails_with 'ORCHARD_BEAM_NODE_NAME service contains invalid characters' "
   run_helper controller "$TMP_ROOT/repo-e5-colon" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME='orchard_controller:dev@127.0.0.1'
 assert_succeeds "$TMP_ROOT/e5.out" run_helper controller "$TMP_ROOT/repo-e5" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller_dev@127.0.0.1
 assert_grep 'node=orchard_controller_dev@127.0.0.1' "$TMP_ROOT/e5.out"
+assert_succeeds "$TMP_ROOT/e6.out" run_helper controller "$TMP_ROOT/repo-e6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@192.0.2.10
+assert_grep 'epmd_address=192.0.2.10' "$TMP_ROOT/e6.out"
+assert_grep 'inet_dist_use_interface {192,0,2,10}' "$TMP_ROOT/e6.out"
 
 # F: EPMD and distribution ports are validated before Mix starts.
 assert_fails_with 'ORCHARD_BEAM_EPMD_PORT must be an integer from 1 to 65535' "$TMP_ROOT/f1.out" \
@@ -234,7 +240,8 @@ exit 0
 SH
 cat > "$TOOLS_I/iex" <<'SH'
 #!/bin/sh
-printf '%s\n' "$*" > "$IEX_ARG_LOG"
+printf 'ERL_EPMD_ADDRESS=%s\n' "${ERL_EPMD_ADDRESS:-unset}" > "$IEX_ARG_LOG"
+printf '%s\n' "$*" >> "$IEX_ARG_LOG"
 exit 0
 SH
 cat > "$TOOLS_I/pgrep" <<'SH'
@@ -250,12 +257,14 @@ assert_succeeds "$TMP_ROOT/i-controller.out" \
   env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-controller-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@127.0.0.1 "$ENTRYPOINT_REPO/bin/dev-controller"
 assert_grep 'mix called: ecto.create --quiet' "$TMP_ROOT/i-controller-mix.log"
 assert_grep 'mix called: ecto.migrate --quiet' "$TMP_ROOT/i-controller-mix.log"
-assert_grep '--name orchard_controller@127.0.0.1 --erl -kernel inet_dist_listen_min 52171 inet_dist_listen_max 52171 -S mix phx.server' "$TMP_ROOT/i-controller-iex.log"
+assert_grep 'ERL_EPMD_ADDRESS=127.0.0.1' "$TMP_ROOT/i-controller-iex.log"
+assert_grep '--name orchard_controller@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52171 inet_dist_listen_max 52171 -S mix phx.server' "$TMP_ROOT/i-controller-iex.log"
 assert_grep 'BEAM cookie file:' "$TMP_ROOT/i-controller.out"
 
 : > "$TMP_ROOT/i-node-mix.log"
 assert_succeeds "$TMP_ROOT/i-node.out" \
   env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-node-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam "$ENTRYPOINT_REPO/bin/dev-node-agent"
-assert_grep '--name orchard_node_agent@127.0.0.1 --erl -kernel inet_dist_listen_min 52172 inet_dist_listen_max 52172 -S mix run --no-halt' "$TMP_ROOT/i-node-iex.log"
+assert_grep 'ERL_EPMD_ADDRESS=127.0.0.1' "$TMP_ROOT/i-node-iex.log"
+assert_grep '--name orchard_node_agent@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52172 inet_dist_listen_max 52172 -S mix run --no-halt' "$TMP_ROOT/i-node-iex.log"
 
 printf 'source-dev BEAM bootstrap tests passed\n'

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -78,13 +78,18 @@ assert_mode() {
 run_helper() {
   local role="$1"
   local repo_root="$2"
+  local probe_script
   shift 2
+
+  # shellcheck disable=SC2016 # Expanded by the child bash -c process.
+  probe_script='set -euo pipefail; source "$1"; orchard_source_dev_beam_bootstrap "$2" "$3"; printf "transport=%s\n" "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-unset}"; printf "node=%s\n" "${ORCHARD_BEAM_NODE_NAME:-unset}"; printf "cookie=%s\n" "${ORCHARD_BEAM_COOKIE_FILE:-unset}"; printf "epmd=%s\n" "${ORCHARD_BEAM_EPMD_PORT:-unset}"; printf "epmd_address=%s\n" "${ERL_EPMD_ADDRESS:-unset}"; printf "dist=%s..%s\n" "${ORCHARD_BEAM_DIST_PORT_MIN:-unset}" "${ORCHARD_BEAM_DIST_PORT_MAX:-unset}"; printf "home=%s\n" "$HOME"; printf "mix_home=%s\n" "${MIX_HOME:-unset}"; printf "hex_home=%s\n" "${HEX_HOME:-unset}"; printf "args=%s\n" "${ORCHARD_BEAM_IEX_ARGS[*]-}"'
+
   env -i \
     PATH="$DEFAULT_TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
     HOME="$TMP_ROOT/home" \
     FAKE_EPMD_CALL_LOG="$EPMD_CALL_LOG" \
     "$@" \
-    bash -c 'set -euo pipefail; source "$1"; orchard_source_dev_beam_bootstrap "$2" "$3"; printf "transport=%s\n" "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-unset}"; printf "node=%s\n" "${ORCHARD_BEAM_NODE_NAME:-unset}"; printf "cookie=%s\n" "${ORCHARD_BEAM_COOKIE_FILE:-unset}"; printf "epmd=%s\n" "${ORCHARD_BEAM_EPMD_PORT:-unset}"; printf "epmd_address=%s\n" "${ERL_EPMD_ADDRESS:-unset}"; printf "dist=%s..%s\n" "${ORCHARD_BEAM_DIST_PORT_MIN:-unset}" "${ORCHARD_BEAM_DIST_PORT_MAX:-unset}"; printf "home=%s\n" "$HOME"; printf "mix_home=%s\n" "${MIX_HOME:-unset}"; printf "hex_home=%s\n" "${HEX_HOME:-unset}"; printf "args=%s\n" "${ORCHARD_BEAM_IEX_ARGS[*]-}"' \
+    bash -c "$probe_script" \
       bash "$HELPER" "$role" "$repo_root"
 }
 

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Focused tests for the source-dev BEAM shell bootstrap contract.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/bin/lib/source-dev-beam.sh"
+TMP_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+assert_grep() {
+  local pattern="$1"
+  local file="$2"
+  grep -F -- "$pattern" "$file" >/dev/null
+}
+
+assert_no_grep() {
+  local pattern="$1"
+  local file="$2"
+  if grep -F -- "$pattern" "$file" >/dev/null; then
+    echo "unexpected match for $pattern" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local pattern="$1"
+  local out="$2"
+  shift 2
+  if "$@" >"$out" 2>&1; then
+    echo "expected command to fail with: $pattern" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+  assert_grep "$pattern" "$out"
+}
+
+assert_succeeds() {
+  local out="$1"
+  shift
+  if ! "$@" >"$out" 2>&1; then
+    echo "expected command to succeed" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+}
+
+assert_files_equal() {
+  local left="$1"
+  local right="$2"
+  if ! cmp -s "$left" "$right"; then
+    echo "expected files to match: $left $right" >&2
+    echo "--- $left" >&2
+    cat "$left" >&2
+    echo "--- $right" >&2
+    cat "$right" >&2
+    exit 1
+  fi
+}
+
+assert_mode() {
+  local expected="$1"
+  local path="$2"
+  local actual
+  actual="$(stat -f '%Lp' "$path" 2>/dev/null || stat -c '%a' "$path")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "expected $path mode $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+run_helper() {
+  local role="$1"
+  local repo_root="$2"
+  shift 2
+  env -i \
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    HOME="$TMP_ROOT/home" \
+    "$@" \
+    bash -c 'set -euo pipefail; source "$1"; orchard_source_dev_beam_bootstrap "$2" "$3"; printf "transport=%s\n" "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-unset}"; printf "node=%s\n" "${ORCHARD_BEAM_NODE_NAME:-unset}"; printf "cookie=%s\n" "${ORCHARD_BEAM_COOKIE_FILE:-unset}"; printf "epmd=%s\n" "${ORCHARD_BEAM_EPMD_PORT:-unset}"; printf "dist=%s..%s\n" "${ORCHARD_BEAM_DIST_PORT_MIN:-unset}" "${ORCHARD_BEAM_DIST_PORT_MAX:-unset}"; printf "home=%s\n" "$HOME"; printf "mix_home=%s\n" "${MIX_HOME:-unset}"; printf "hex_home=%s\n" "${HEX_HOME:-unset}"; printf "args=%s\n" "${ORCHARD_BEAM_IEX_ARGS[*]-}"' \
+      bash "$HELPER" "$role" "$repo_root"
+}
+
+if [[ ! -f "$HELPER" ]]; then
+  echo "helper not found: bin/lib/source-dev-beam.sh" >&2
+  exit 1
+fi
+
+mkdir -p "$TMP_ROOT/home"
+
+# A: unset or grpc mode is a no-op for IEx distribution args.
+assert_succeeds "$TMP_ROOT/a0.out" run_helper controller "$TMP_ROOT/repo-a0"
+assert_grep 'transport=grpc' "$TMP_ROOT/a0.out"
+assert_grep 'node=unset' "$TMP_ROOT/a0.out"
+assert_grep 'args=' "$TMP_ROOT/a0.out"
+assert_succeeds "$TMP_ROOT/a.out" run_helper controller "$TMP_ROOT/repo-a" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+assert_grep 'transport=grpc' "$TMP_ROOT/a.out"
+assert_grep 'node=unset' "$TMP_ROOT/a.out"
+assert_grep 'args=' "$TMP_ROOT/a.out"
+
+# B: controller BEAM mode creates the same-host default cookie with strict permissions.
+REPO_B="$TMP_ROOT/repo-b"
+assert_succeeds "$TMP_ROOT/b.out" run_helper controller "$REPO_B" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
+COOKIE_B="$REPO_B/tmp/dev/beam.cookie"
+[[ -s "$COOKIE_B" ]] || { echo "expected non-empty cookie at $COOKIE_B" >&2; exit 1; }
+assert_mode 600 "$COOKIE_B"
+assert_grep 'node=orchard_controller@127.0.0.1' "$TMP_ROOT/b.out"
+assert_grep "cookie=$COOKIE_B" "$TMP_ROOT/b.out"
+assert_files_equal "$COOKIE_B" "$REPO_B/tmp/dev/beam-home/controller/.erlang.cookie"
+assert_grep 'epmd=4369' "$TMP_ROOT/b.out"
+assert_grep 'dist=52171..52171' "$TMP_ROOT/b.out"
+assert_grep '--name orchard_controller@127.0.0.1' "$TMP_ROOT/b.out"
+assert_no_grep "$(cat "$COOKIE_B")" "$TMP_ROOT/b.out"
+
+# C: node-agent BEAM mode gets its own role default node and distribution port.
+REPO_C="$TMP_ROOT/repo-c"
+assert_succeeds "$TMP_ROOT/c.out" run_helper node_agent "$REPO_C" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
+assert_grep 'node=orchard_node_agent@127.0.0.1' "$TMP_ROOT/c.out"
+assert_grep 'dist=52172..52172' "$TMP_ROOT/c.out"
+assert_grep '--name orchard_node_agent@127.0.0.1' "$TMP_ROOT/c.out"
+
+# C2: concurrent split-role bootstrap from a clean checkout stages the final default cookie for both roles.
+REPO_C2="$TMP_ROOT/repo-c2"
+run_helper controller "$REPO_C2" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam >"$TMP_ROOT/c2-controller.out" 2>&1 &
+pid_controller=$!
+run_helper node_agent "$REPO_C2" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam >"$TMP_ROOT/c2-node.out" 2>&1 &
+pid_node=$!
+wait "$pid_controller"
+wait "$pid_node"
+COOKIE_C2="$REPO_C2/tmp/dev/beam.cookie"
+assert_mode 600 "$COOKIE_C2"
+assert_files_equal "$COOKIE_C2" "$REPO_C2/tmp/dev/beam-home/controller/.erlang.cookie"
+assert_files_equal "$COOKIE_C2" "$REPO_C2/tmp/dev/beam-home/node_agent/.erlang.cookie"
+
+# D: explicit cookie files must exist, be non-empty, and owner-only.
+MISSING_COOKIE="$TMP_ROOT/missing.cookie"
+assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE must point to an existing regular file' "$TMP_ROOT/d1.out" \
+  run_helper controller "$TMP_ROOT/repo-d1" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_COOKIE_FILE="$MISSING_COOKIE"
+EMPTY_COOKIE="$TMP_ROOT/empty.cookie"
+: > "$EMPTY_COOKIE"
+chmod 600 "$EMPTY_COOKIE"
+assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE must not be empty' "$TMP_ROOT/d2.out" \
+  run_helper controller "$TMP_ROOT/repo-d2" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_COOKIE_FILE="$EMPTY_COOKIE"
+WEAK_COOKIE="$TMP_ROOT/weak.cookie"
+printf 'fixture-cookie\n' > "$WEAK_COOKIE"
+chmod 644 "$WEAK_COOKIE"
+assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE must be owner-only' "$TMP_ROOT/d3.out" \
+  run_helper controller "$TMP_ROOT/repo-d3" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_COOKIE_FILE="$WEAK_COOKIE"
+STRICT_COOKIE="$TMP_ROOT/strict.cookie"
+printf 'fixture-cookie\n' > "$STRICT_COOKIE"
+chmod 600 "$STRICT_COOKIE"
+assert_succeeds "$TMP_ROOT/d4.out" run_helper controller "$TMP_ROOT/repo-d4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_COOKIE_FILE="$STRICT_COOKIE"
+assert_grep "cookie=$STRICT_COOKIE" "$TMP_ROOT/d4.out"
+assert_no_grep 'fixture-cookie' "$TMP_ROOT/d4.out"
+
+# E: BEAM node names must be role-appropriate long names with IP-literal hosts.
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME must be a long BEAM node name' "$TMP_ROOT/e1.out" \
+  run_helper controller "$TMP_ROOT/repo-e1" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IP literal' "$TMP_ROOT/e2.out" \
+  run_helper controller "$TMP_ROOT/repo-e2" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@localhost
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME host must be an IP literal' "$TMP_ROOT/e2-invalid-ipv6.out" \
+  run_helper controller "$TMP_ROOT/repo-e2-invalid-ipv6" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@::::
+assert_fails_with 'controller BEAM node service must start with orchard_controller' "$TMP_ROOT/e3.out" \
+  run_helper controller "$TMP_ROOT/repo-e3" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_node_agent@127.0.0.1
+assert_fails_with 'node-agent BEAM node service must start with orchard_node_agent' "$TMP_ROOT/e4.out" \
+  run_helper node_agent "$TMP_ROOT/repo-e4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller@127.0.0.1
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME service contains invalid characters' "$TMP_ROOT/e5-space.out" \
+  run_helper controller "$TMP_ROOT/repo-e5-space" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME='orchard_controller bad@127.0.0.1'
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME service contains invalid characters' "$TMP_ROOT/e5-slash.out" \
+  run_helper node_agent "$TMP_ROOT/repo-e5-slash" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME='orchard_node_agent/@127.0.0.1'
+assert_fails_with 'ORCHARD_BEAM_NODE_NAME service contains invalid characters' "$TMP_ROOT/e5-colon.out" \
+  run_helper controller "$TMP_ROOT/repo-e5-colon" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME='orchard_controller:dev@127.0.0.1'
+assert_succeeds "$TMP_ROOT/e5.out" run_helper controller "$TMP_ROOT/repo-e5" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_NODE_NAME=orchard_controller_dev@127.0.0.1
+assert_grep 'node=orchard_controller_dev@127.0.0.1' "$TMP_ROOT/e5.out"
+
+# F: EPMD and distribution ports are validated before Mix starts.
+assert_fails_with 'ORCHARD_BEAM_EPMD_PORT must be an integer from 1 to 65535' "$TMP_ROOT/f1.out" \
+  run_helper controller "$TMP_ROOT/repo-f1" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_EPMD_PORT=70000
+assert_fails_with 'ORCHARD_BEAM_DIST_PORT_MIN and ORCHARD_BEAM_DIST_PORT_MAX must be set together' "$TMP_ROOT/f2.out" \
+  run_helper controller "$TMP_ROOT/repo-f2" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_DIST_PORT_MIN=52180
+assert_fails_with 'ORCHARD_BEAM_DIST_PORT_MIN must be less than or equal to ORCHARD_BEAM_DIST_PORT_MAX' "$TMP_ROOT/f3.out" \
+  run_helper controller "$TMP_ROOT/repo-f3" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_DIST_PORT_MIN=52182 ORCHARD_BEAM_DIST_PORT_MAX=52181
+assert_succeeds "$TMP_ROOT/f4.out" run_helper controller "$TMP_ROOT/repo-f4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_EPMD_PORT=4370 ORCHARD_BEAM_DIST_PORT_MIN=52180 ORCHARD_BEAM_DIST_PORT_MAX=52181
+assert_grep 'epmd=4370' "$TMP_ROOT/f4.out"
+assert_grep 'dist=52180..52181' "$TMP_ROOT/f4.out"
+
+# G: the helper rejects unknown transport values early.
+assert_fails_with 'ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc|beam' "$TMP_ROOT/g.out" \
+  run_helper controller "$TMP_ROOT/repo-g" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=http
+
+ENTRYPOINT_REPO="$TMP_ROOT/entrypoint-repo"
+mkdir -p "$ENTRYPOINT_REPO/bin/lib" "$ENTRYPOINT_REPO/apps/orchard_controller" "$ENTRYPOINT_REPO/apps/orchard_node_agent"
+cp "$REPO_ROOT/bin/dev" "$ENTRYPOINT_REPO/bin/dev"
+cp "$REPO_ROOT/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-controller"
+cp "$REPO_ROOT/bin/dev-node-agent" "$ENTRYPOINT_REPO/bin/dev-node-agent"
+cp "$HELPER" "$ENTRYPOINT_REPO/bin/lib/source-dev-beam.sh"
+chmod +x "$ENTRYPOINT_REPO/bin/dev" "$ENTRYPOINT_REPO/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-node-agent"
+: > "$ENTRYPOINT_REPO/mix.exs"
+
+# H: all-in-one bin/dev rejects explicit BEAM mode before running Mix.
+TOOLS_H="$TMP_ROOT/tools-h"
+mkdir -p "$TOOLS_H"
+cat > "$TOOLS_H/mix" <<'SH'
+#!/bin/sh
+printf 'mix called: %s\n' "$*" >> "$MIX_CALL_LOG"
+exit 0
+SH
+chmod +x "$TOOLS_H/mix"
+: > "$TMP_ROOT/h-mix.log"
+assert_fails_with 'all-in-one bin/dev does not support BEAM source-dev mode yet' "$TMP_ROOT/h.out" \
+  env -i PATH="$TOOLS_H:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/h-mix.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=' beam ' "$ENTRYPOINT_REPO/bin/dev"
+if [[ -s "$TMP_ROOT/h-mix.log" ]]; then
+  echo "bin/dev should reject BEAM mode before running mix" >&2
+  cat "$TMP_ROOT/h-mix.log" >&2
+  exit 1
+fi
+
+# I: split-role entrypoints pass named-node BEAM launch flags to IEx.
+TOOLS_I="$TMP_ROOT/tools-i"
+mkdir -p "$TOOLS_I"
+cat > "$TOOLS_I/mix" <<'SH'
+#!/bin/sh
+printf 'mix called: %s\n' "$*" >> "$MIX_CALL_LOG"
+exit 0
+SH
+cat > "$TOOLS_I/iex" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" > "$IEX_ARG_LOG"
+exit 0
+SH
+cat > "$TOOLS_I/pgrep" <<'SH'
+#!/bin/sh
+exit 1
+SH
+chmod +x "$TOOLS_I/mix" "$TOOLS_I/iex" "$TOOLS_I/pgrep"
+
+CONTROLLER_REPO="$TMP_ROOT/controller-entrypoint"
+mkdir -p "$CONTROLLER_REPO"
+: > "$TMP_ROOT/i-controller-mix.log"
+assert_succeeds "$TMP_ROOT/i-controller.out" \
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-controller-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@127.0.0.1 "$ENTRYPOINT_REPO/bin/dev-controller"
+assert_grep 'mix called: ecto.create --quiet' "$TMP_ROOT/i-controller-mix.log"
+assert_grep 'mix called: ecto.migrate --quiet' "$TMP_ROOT/i-controller-mix.log"
+assert_grep '--name orchard_controller@127.0.0.1 --erl -kernel inet_dist_listen_min 52171 inet_dist_listen_max 52171 -S mix phx.server' "$TMP_ROOT/i-controller-iex.log"
+assert_grep 'BEAM cookie file:' "$TMP_ROOT/i-controller.out"
+
+: > "$TMP_ROOT/i-node-mix.log"
+assert_succeeds "$TMP_ROOT/i-node.out" \
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-node-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam "$ENTRYPOINT_REPO/bin/dev-node-agent"
+assert_grep '--name orchard_node_agent@127.0.0.1 --erl -kernel inet_dist_listen_min 52172 inet_dist_listen_max 52172 -S mix run --no-halt' "$TMP_ROOT/i-node-iex.log"
+
+printf 'source-dev BEAM bootstrap tests passed\n'

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -198,9 +198,37 @@ printf 'fixture-cookie\n' > "$WEAK_COOKIE"
 chmod 644 "$WEAK_COOKIE"
 assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE must be owner-only' "$TMP_ROOT/d3.out" \
   run_helper controller "$TMP_ROOT/repo-d3" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_COOKIE_FILE="$WEAK_COOKIE"
+FAKE_GNU_STAT_DIR="$TMP_ROOT/fake-gnu-stat-bin"
+mkdir -p "$FAKE_GNU_STAT_DIR"
+cat > "$FAKE_GNU_STAT_DIR/stat" <<'STAT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-c" ]]; then
+  printf '644\n'
+  exit 0
+fi
+if [[ "${1:-}" == "-f" ]]; then
+  printf '100\n'
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+STAT
+chmod +x "$FAKE_GNU_STAT_DIR/stat"
+assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE must be owner-only' "$TMP_ROOT/d3-fake-gnu-stat.out" \
+  run_helper controller "$TMP_ROOT/repo-d3-fake-gnu-stat" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam PATH="$FAKE_GNU_STAT_DIR:/usr/bin:/bin:/usr/sbin:/sbin" ORCHARD_BEAM_COOKIE_FILE="$WEAK_COOKIE"
 STRICT_COOKIE="$TMP_ROOT/strict.cookie"
 printf 'fixture-cookie\n' > "$STRICT_COOKIE"
 chmod 600 "$STRICT_COOKIE"
+FAKE_NON_OCTAL_STAT_DIR="$TMP_ROOT/fake-non-octal-stat-bin"
+mkdir -p "$FAKE_NON_OCTAL_STAT_DIR"
+cat > "$FAKE_NON_OCTAL_STAT_DIR/stat" <<'STAT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'not-octal\n'
+STAT
+chmod +x "$FAKE_NON_OCTAL_STAT_DIR/stat"
+assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE must be owner-only' "$TMP_ROOT/d3-non-octal-stat.out" \
+  run_helper controller "$TMP_ROOT/repo-d3-non-octal-stat" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam PATH="$FAKE_NON_OCTAL_STAT_DIR:/usr/bin:/bin:/usr/sbin:/sbin" ORCHARD_BEAM_COOKIE_FILE="$STRICT_COOKIE"
 assert_succeeds "$TMP_ROOT/d4.out" run_helper controller "$TMP_ROOT/repo-d4" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_BEAM_COOKIE_FILE="$STRICT_COOKIE"
 assert_grep "cookie=$STRICT_COOKIE" "$TMP_ROOT/d4.out"
 assert_no_grep 'fixture-cookie' "$TMP_ROOT/d4.out"

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -68,7 +68,21 @@ assert_mode() {
   local expected="$1"
   local path="$2"
   local actual
-  actual="$(stat -f '%Lp' "$path" 2>/dev/null || stat -c '%a' "$path")"
+
+  if actual="$(stat -c '%a' "$path" 2>/dev/null)"; then
+    :
+  elif actual="$(stat -f '%Lp' "$path" 2>/dev/null)"; then
+    :
+  else
+    echo "unable to read $path mode" >&2
+    exit 1
+  fi
+
+  if [[ ! "$actual" =~ ^[0-7]+$ ]]; then
+    echo "expected $path mode $expected, got non-octal output: $actual" >&2
+    exit 1
+  fi
+
   if [[ "$actual" != "$expected" ]]; then
     echo "expected $path mode $expected, got $actual" >&2
     exit 1
@@ -219,6 +233,23 @@ assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE must be owner-only' "$TMP_ROOT/d3-fa
 STRICT_COOKIE="$TMP_ROOT/strict.cookie"
 printf 'fixture-cookie\n' > "$STRICT_COOKIE"
 chmod 600 "$STRICT_COOKIE"
+FAKE_ASSERT_MODE_GNU_STAT_DIR="$TMP_ROOT/fake-assert-mode-gnu-stat-bin"
+mkdir -p "$FAKE_ASSERT_MODE_GNU_STAT_DIR"
+cat > "$FAKE_ASSERT_MODE_GNU_STAT_DIR/stat" <<'STAT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-c" ]]; then
+  printf '600\n'
+  exit 0
+fi
+if [[ "${1:-}" == "-f" ]]; then
+  printf 'filesystem-blocks-not-mode\n'
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+STAT
+chmod +x "$FAKE_ASSERT_MODE_GNU_STAT_DIR/stat"
+PATH="$FAKE_ASSERT_MODE_GNU_STAT_DIR:/usr/bin:/bin:/usr/sbin:/sbin" assert_mode 600 "$STRICT_COOKIE"
 FAKE_NON_OCTAL_STAT_DIR="$TMP_ROOT/fake-non-octal-stat-bin"
 mkdir -p "$FAKE_NON_OCTAL_STAT_DIR"
 cat > "$FAKE_NON_OCTAL_STAT_DIR/stat" <<'STAT'


### PR DESCRIPTION
## Intent

Implement the OpenSpec source-dev BEAM operating model for Orchard so source development can run split controller and node-agent BEAM roles with explicit environment parsing and safe defaults. The change wires source-dev BEAM config, adds bin/dev-controller and bin/dev-node-agent bootstrap behavior, preserves all-in-one bin/dev on the gRPC runtime default, rejects BEAM-specific distributed runtime flags in all-in-one mode, adds cookie generation and validation with race-safe default cookie creation, validates EPMD and distribution ports, and keeps diagnostics secret-safe. It also adds regressions proving runtime dispatch, scheduler, Console Runtime, Console Nodes, and node-agent endpoint mapping do not silently fall back when runtime targets are unreachable. Documentation and OpenSpec tasks were updated, with real two-Mac source-dev smoke evidence intentionally deferred by leaving tasks 5.4 and 5.5 unchecked.

## What Changed

- Adds explicit source-dev BEAM Runtime Endpoint mode for split controller and node-agent roles, wiring BEAM target parsing, BeamClient config, guardrails, and all-in-one `bin/dev` rejection while preserving gRPC as the default path.
- Adds shared BEAM bootstrap support for `bin/dev-controller` and `bin/dev-node-agent`, including named-node launch args, cookie creation and validation, EPMD preflight, IPv4/interface binding, bounded distribution ports, and secret-safe diagnostics.
- Hardens scheduler, dispatch, Console, runtime endpoint mapping, docs, OpenSpec tasks, and regression coverage so BEAM target failures do not silently fall back to gRPC.

## Risk Assessment

⚠️ Medium: No material merge-blocking issues were found, but this is a nontrivial source-dev startup and networking path with real distributed smoke evidence still deferred.

## Testing

The bootstrap contract passed; the first Mix run was blocked by mise trust, then the same focused test set passed with an environment-only trust override. I also produced CLI dry-run evidence and a no-fallback trace summary; no screenshot was captured because the changed Console files are tests only, not UI source or layout changes.

<details>
<summary>Evidence: Source-dev BEAM CLI transcript</summary>

```text
Source-dev BEAM CLI evidence

Actual all-in-one bin/dev with ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
error: all-in-one bin/dev does not support BEAM source-dev mode yet
error: use bin/dev-controller and bin/dev-node-agent for ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
mix_called_before_rejection=no

Split-role controller dry-run
==> Runtime endpoint transport: beam
==> BEAM node name: orchard_controller@127.0.0.1
==> BEAM cookie file: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW24H36B7F8K1T9SSFQNY102/source-dev-beam-cli-sandbox/entrypoint-repo/tmp/dev/beam.cookie
==> BEAM EPMD port: 4369
==> BEAM distribution port range: 52171..52171
==> Ensuring dev database...
==> Starting Orchard dev controller (role: controller)
==> HTTP endpoint: 127.0.0.1:4000
==> Runtime client targets: 127.0.0.1:50071

controller_mix_calls
mix called: ecto.create --quiet
mix called: ecto.migrate --quiet
controller_iex_invocation
ERL_EPMD_ADDRESS=127.0.0.1
--name orchard_controller@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52171 inet_dist_listen_max 52171 -S mix phx.server

Split-role node-agent dry-run
warning: ORCHARD_WORKER_EXECUTABLE is not executable: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW24H36B7F8K1T9SSFQNY102/source-dev-beam-cli-sandbox/entrypoint-repo/native/orchard_worker_mlx/bin/orchard-worker-mlx
==> Runtime endpoint transport: beam
==> BEAM node name: orchard_node_agent@127.0.0.1
==> BEAM cookie file: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW24H36B7F8K1T9SSFQNY102/source-dev-beam-cli-sandbox/entrypoint-repo/tmp/dev/beam.cookie
==> BEAM EPMD port: 4369
==> BEAM distribution port range: 52172..52172
==> Starting Orchard dev node-agent (role: node-agent)
==> gRPC endpoint: 127.0.0.1:50071
==> Worker executable: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW24H36B7F8K1T9SSFQNY102/source-dev-beam-cli-sandbox/entrypoint-repo/native/orchard_worker_mlx/bin/orchard-worker-mlx

node_agent_mix_calls
node_agent_iex_invocation
ERL_EPMD_ADDRESS=127.0.0.1
--name orchard_node_agent@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52172 inet_dist_listen_max 52172 -S mix run --no-halt

Cookie and EPMD checks
default_cookie_mode=600
controller_cookie_mode=600
node_agent_cookie_mode=600
controller_cookie_matches_default=yes
node_agent_cookie_matches_default=yes
epmd_calls
epmd -port 4369 -names
epmd -daemon -address 127.0.0.1 -port 4369
epmd -port 4369 -names
epmd -daemon -address 127.0.0.1 -port 4369
cookie_secret_in_transcript=no
```
</details>
<details>
<summary>Evidence: No-fallback regression trace summary</summary>

```text
  * test live runtime renders source-dev BEAM Runtime Endpoint targets with readable labels and stable DOM ids (197.4ms) [L#811]
  * test BEAM Runtime Endpoint dispatch returns BEAM RPC failures without retrying the legacy gRPC target (37.9ms) [L#508]
  * test BEAM Runtime Endpoint dispatch uses the explicit BEAM target and never falls back to the legacy gRPC target (0.3ms) [L#486]
  * test BEAM Runtime Endpoint dispatch returns BEAM stream failures without retrying the legacy gRPC target (9.0ms) [L#533]
  * test cluster_snapshot/0,1 source-dev BEAM target maps use active Runtime Endpoint client and ignore legacy targets (1.5ms) [L#1029]
  * test single-node delegation multi-target BEAM all-probe failure preserves Runtime Endpoint selection (7.8ms) [L#637]
  * test single-node delegation source-dev BEAM target maps emit runtime endpoint schedules without legacy targets (3.7ms) [L#610]
Result: 7 passed, 235 excluded
  * test maps source-dev BEAM target address shape into observation identity (2.0ms) [L#50]
Result: 1 passed, 2 excluded
```
</details>
<details>
<summary>Evidence: No-fallback regression full trace</summary>

```text
==> orchard_controller
Running ExUnit with seed: 673598, max_cases: 1
Excluding tags: [:test]
Including tags: [location: {"test/orchard/dispatch/probe_compatibility_test.exs", 486}, location: {"test/orchard/dispatch/probe_compatibility_test.exs", 508}, location: {"test/orchard/dispatch/probe_compatibility_test.exs", 533}, location: {"test/orchard/scheduler/multi_node_test.exs", 610}, location: {"test/orchard/scheduler/multi_node_test.exs", 637}, location: {"test/orchard/console/runtime_test.exs", 1029}, location: {"test/orchard/console/nodes_live_test.exs", 811}]


OrchardConsole.NodesLiveTest [test/orchard/console/nodes_live_test.exs]
  * test cluster_snapshot exit does not crash LiveView inventory renders correctly despite cluster exit [L#1379]  * test cluster_snapshot exit does not crash LiveView inventory renders correctly despite cluster exit (excluded) [L#1379]
  * test memory telemetry guardrails memory telemetry alone does not change health labels or summary counts [L#1130]  * test memory telemetry guardrails memory telemetry alone does not change health labels or summary counts (excluded) [L#1130]
  * test freshness shows freshness row with timestamp after load [L#1295]  * test freshness shows freshness row with timestamp after load (excluded) [L#1295]
  * test mixed legacy and modern cluster cluster summary counts prompt-token-capable reachable workers [L#1226]  * test mixed legacy and modern cluster cluster summary counts prompt-token-capable reachable workers (excluded) [L#1226]
  * test live runtime renders map-backed gRPC Runtime Endpoint targets without leaking metadata [L#828]  * test live runtime renders map-backed gRPC Runtime Endpoint targets without leaking metadata (excluded) [L#828]
  * test safe tokenization telemetry counters HTTP dead mount renders non-zero safe tokenization counters [L#952]  * test safe tokenization telemetry counters HTTP dead mount renders non-zero safe tokenization counters (excluded) [L#952]
  * test summary strip counts reflect inserted nodes by health [L#716]  * test summary strip counts reflect inserted nodes by health (excluded) [L#716]
  * test multi-target cluster prompt-token summary denominator excludes unavailable targets [L#1069]  * test multi-target cluster prompt-token summary denominator excludes unavailable targets (excluded) [L#1069]
  * test safe tokenization telemetry counters raising counter provider fails open and keeps Live Cluster rendering [L#1005]  * test safe tokenization telemetry counters raising counter provider fails open and keeps Live Cluster rendering (excluded) [L#1005]
  * test runtime unavailable shows per-target error while inventory still renders [L#1248]  * test runtime unavailable shows per-target error while inventory still renders (excluded) [L#1248]
  * test compatibility warning shown for legacy snapshot (per-target) [L#1084]  * test compatibility warning shown for legacy snapshot (per-target) (excluded) [L#1084]
  * test memory telemetry guardrails malformed memory telemetry rows fail open as advisory rows [L#1157]  * test memory telemetry guardrails malformed memory telemetry rows fail open as advisory rows (excluded) [L#1157]
  * test live runtime does not render prompt-token capability badge for unavailable target [L#864]  * test live runtime does not render prompt-token capability badge for unavailable target (excluded) [L#864]
  * test compatibility warning not shown when runtime is unavailable [L#1108]  * test compatibility warning not shown when runtime is unavailable (excluded) [L#1108]
  * test memory telemetry guardrails oversized memory telemetry stays bounded at the LiveView seam [L#1171]  * test memory telemetry guardrails oversized memory telemetry stays bounded at the LiveView seam (excluded) [L#1171]
  * test GET /console/nodes hard mode keeps nodes diagnostics reachable [L#631]  * test GET /console/nodes hard mode keeps nodes diagnostics reachable (excluded) [L#631]
  * test safe tokenization telemetry counters partial prompt-token counter preserves valid count and defaults token count [L#976]  * test safe tokenization telemetry counters partial prompt-token counter preserves valid count and defaults token count (excluded) [L#976]
  * test safe tokenization telemetry counters renders non-zero unsafe signals with warning and error tones [L#927]  * test safe tokenization telemetry counters renders non-zero unsafe signals with warning and error tones (excluded) [L#927]
  * test GET /console/nodes has correct page title [L#671]  * test GET /console/nodes has correct page title (excluded) [L#671]
  * test memory telemetry guardrails runtime unavailable without memory budgets still renders safely [L#1147]  * test memory telemetry guardrails runtime unavailable without memory budgets still renders safely (excluded) [L#1147]
  * test same-cycle discovery runtime-first load order surfaces newly discovered node on first render [L#1320]  * test same-cycle discovery runtime-first load order surfaces newly discovered node on first render (excluded) [L#1320]
  * test mixed legacy and modern cluster cluster summary counts based on reachability not metadata [L#1215]  * test mixed legacy and modern cluster cluster summary counts based on reachability not metadata (excluded) [L#1215]
  * test safe tokenization telemetry counters counters do not affect health, compatibility, or prompt-token summaries [L#1018]  * test safe tokenization telemetry counters counters do not affect health, compatibility, or prompt-token summaries (excluded) [L#1018]
  * test sidebar Nodes nav item exists and is active [L#683]  * test sidebar Nodes nav item exists and is active (excluded) [L#683]
  * test freshness disconnected render shows waiting text without LocalTime hook [L#1304]  * test freshness disconnected render shows waiting text without LocalTime hook (excluded) [L#1304]
  * test inventory table renders persisted rows [L#739]  * test inventory table renders persisted rows (excluded) [L#739]
  * test live runtime per-target card renders with stable DOM id [L#804]  * test live runtime per-target card renders with stable DOM id (excluded) [L#804]
  * test multi-target cluster cluster summary reflects mixed results [L#1059]  * test multi-target cluster cluster summary reflects mixed results (excluded) [L#1059]
  * test safe tokenization telemetry counters renders process-local observe-only zero counters [L#909]  * test safe tokenization telemetry counters renders process-local observe-only zero counters (excluded) [L#909]
  * test live runtime shows worker state, backend, and loaded models on full snapshot [L#779]  * test live runtime shows worker state, backend, and loaded models on full snapshot (excluded) [L#779]
  * test refresh polling via :refresh_nodes updates the page [L#1279]  * test refresh polling via :refresh_nodes updates the page (excluded) [L#1279]
  * test compatibility warning shown for partial snapshot (per-target) [L#1093]  * test compatibility warning shown for partial snapshot (per-target) (excluded) [L#1093]
  * test cluster_snapshot exit does not crash LiveView refresh after exit does not crash LiveView [L#1365]  * test cluster_snapshot exit does not crash LiveView refresh after exit does not crash LiveView (excluded) [L#1365]
  * test live runtime renders observe-only memory telemetry empty state when budgets are absent [L#875]  * test live runtime renders observe-only memory telemetry empty state when budgets are absent (excluded) [L#875]
  * test compatibility warning memory telemetry does not change compatibility classification [L#1116]  * test compatibility warning memory telemetry does not change compatibility classification (excluded) [L#1116]
  * test summary strip shows zero-filled counts when no nodes exist [L#706]  * test summary strip shows zero-filled counts when no nodes exist (excluded) [L#706]
  * test cluster_snapshot raise does not crash LiveView mount succeeds and renders cluster error state [L#1392]  * test cluster_snapshot raise does not crash LiveView mount succeeds and renders cluster error state (excluded) [L#1392]
  * test multi-target cluster renders one card per target, mixed succ

... [37771 bytes truncated] ...

ng [L#3379]  * test multi-node scheduling keeps capable-worker preference below live prefix-cache fingerprint matching (excluded) [L#3379]
  * test multi-node scheduling SPEC.md §5.5 reports cold-tier queue capacity from eligible node concurrency [L#1435]  * test multi-node scheduling SPEC.md §5.5 reports cold-tier queue capacity from eligible node concurrency (excluded) [L#1435]
  * test single-node delegation uses runtime endpoint observation aggregate capacity for active cold target [L#715]  * test single-node delegation uses runtime endpoint observation aggregate capacity for active cold target (excluded) [L#715]
  * test multi-node scheduling keeps memory admission below historical cache-affinity [L#3030]  * test multi-node scheduling keeps memory admission below historical cache-affinity (excluded) [L#3030]
  * test single-node delegation delegates to SingleNode when only one target configured [L#528]  * test single-node delegation delegates to SingleNode when only one target configured (excluded) [L#528]
  * test multi-node scheduling does not let memory admission outrank health [L#3158]  * test multi-node scheduling does not let memory admission outrank health (excluded) [L#3158]
  * test multi-node scheduling returns dispatch-compatible schedule map [L#3677]  * test multi-node scheduling returns dispatch-compatible schedule map (excluded) [L#3677]
  * test multi-node scheduling SPEC.md §5.5 excludes active loaded node with invalid matching placement max concurrency [L#1635]  * test multi-node scheduling SPEC.md §5.5 excludes active loaded node with invalid matching placement max concurrency (excluded) [L#1635]
  * test multi-node scheduling uses cache-affinity as a tie-breaker for otherwise equivalent candidates [L#1988]  * test multi-node scheduling uses cache-affinity as a tie-breaker for otherwise equivalent candidates (excluded) [L#1988]
  * test multi-node scheduling still schedules deterministically when all workers are legacy [L#3492]  * test multi-node scheduling still schedules deterministically when all workers are legacy (excluded) [L#3492]
  * test multi-node scheduling keeps prompt-token capability rank-neutral when safe mode is off [L#3306]  * test multi-node scheduling keeps prompt-token capability rank-neutral when safe mode is off (excluded) [L#3306]
  * test multi-node scheduling prefers prompt-token-capable worker when opt-in flag and safe mode are enabled [L#3252]  * test multi-node scheduling prefers prompt-token-capable worker when opt-in flag and safe mode are enabled (excluded) [L#3252]
  * test multi-node scheduling prefix cache scoring probes only the selected candidate when enabled [L#2199]  * test multi-node scheduling prefix cache scoring probes only the selected candidate when enabled (excluded) [L#2199]
  * test multi-node scheduling breaks ties by node_id [L#1861]  * test multi-node scheduling breaks ties by node_id (excluded) [L#1861]
  * test edge case: all nodes unreachable falls back to SingleNode when all persisted nodes are unreachable [L#3844]  * test edge case: all nodes unreachable falls back to SingleNode when all persisted nodes are unreachable (excluded) [L#3844]
  * test multi-node scheduling hosted tool capability and readiness data do not change inference ranking [L#1154]  * test multi-node scheduling hosted tool capability and readiness data do not change inference ranking (excluded) [L#1154]
  * test single-node delegation returns cluster_busy for one live cold target at aggregate capacity [L#765]  * test single-node delegation returns cluster_busy for one live cold target at aggregate capacity (excluded) [L#765]
  * test multi-node scheduling SPEC.md §7.5 rejects configured BEAM observations before persisting mismatched metadata identity [L#951]  * test multi-node scheduling SPEC.md §7.5 rejects configured BEAM observations before persisting mismatched metadata identity (excluded) [L#951]
  * test multi-node scheduling tie-only scoring preserves incumbent when both candidates are authoritative resident [L#2446]  * test multi-node scheduling tie-only scoring preserves incumbent when both candidates are authoritative resident (excluded) [L#2446]
  * test single-node delegation forwards status client options to no-candidate fallback [L#536]  * test single-node delegation forwards status client options to no-candidate fallback (excluded) [L#536]
  * test multi-node scheduling uses memory admission only as an enabled positive tie-breaker [L#2970]  * test multi-node scheduling uses memory admission only as an enabled positive tie-breaker (excluded) [L#2970]
  * test edge case: mixed legacy and modern agents schedules to modern node when legacy returns no metadata [L#3885]  * test edge case: mixed legacy and modern agents schedules to modern node when legacy returns no metadata (excluded) [L#3885]
  * test multi-node scheduling ignores stale cache-affinity placements [L#3574]  * test multi-node scheduling ignores stale cache-affinity placements (excluded) [L#3574]
  * test multi-node scheduling SPEC.md §5.5 constrains queue admission capacity by node max concurrency [L#1343]  * test multi-node scheduling SPEC.md §5.5 constrains queue admission capacity by node max concurrency (excluded) [L#1343]
  * test multi-node scheduling keeps memory admission below live prefix-cache fingerprint matching [L#3073]  * test multi-node scheduling keeps memory admission below live prefix-cache fingerprint matching (excluded) [L#3073]
  * test multi-node scheduling tie-only scoring caps leading tie scoring to two candidates [L#2530]  * test multi-node scheduling tie-only scoring caps leading tie scoring to two candidates (excluded) [L#2530]
  * test multi-node scheduling tie-only scoring treats recent_fingerprint_only incumbent as comparable non-resident [L#2402]  * test multi-node scheduling tie-only scoring treats recent_fingerprint_only incumbent as comparable non-resident (excluded) [L#2402]
  * test multi-node scheduling keeps capable-worker preference below historical cache-affinity [L#3332]  * test multi-node scheduling keeps capable-worker preference below historical cache-affinity (excluded) [L#3332]
  * test multi-node scheduling consumes BEAM runtime endpoint observations without legacy dispatch target [L#901]  * test multi-node scheduling consumes BEAM runtime endpoint observations without legacy dispatch target (excluded) [L#901]
  * test multi-node scheduling prefix cache scoring normalizes unsupported client versions without affecting selection [L#2822]  * test multi-node scheduling prefix cache scoring normalizes unsupported client versions without affecting selection (excluded) [L#2822]
  * test single-node delegation multi-target BEAM all-probe failure preserves Runtime Endpoint selection [L#637]  * test single-node delegation multi-target BEAM all-probe failure preserves Runtime Endpoint selection (7.8ms) [L#637]
  * test single-node delegation source-dev BEAM target maps emit runtime endpoint schedules without legacy targets [L#610]  * test single-node delegation source-dev BEAM target maps emit runtime endpoint schedules without legacy targets (3.7ms) [L#610]

Finished in 1.9 seconds (0.00s async, 1.9s sync)

Result: 7 passed, 235 excluded
==> orchard_node_agent
Running ExUnit with seed: 673598, max_cases: 1
Excluding tags: [:test]
Including tags: [location: {"test/orchard/node/runtime_endpoint_mapper_test.exs", 50}]


Orchard.Node.RuntimeEndpointMapperTest [test/orchard/node/runtime_endpoint_mapper_test.exs]
  * test maps node-agent status to Runtime Endpoint observation with placement capacity [L#16]  * test maps node-agent status to Runtime Endpoint observation with placement capacity (excluded) [L#16]
  * test maps prefix-cache score responses to Runtime Endpoint operation results [L#78]  * test maps prefix-cache score responses to Runtime Endpoint operation results (excluded) [L#78]
  * test maps source-dev BEAM target address shape into observation identity [L#50]  * test maps source-dev BEAM target address shape into observation identity (2.0ms) [L#50]

Finished in 0.04 seconds (0.04s async, 0.00s sync)

Result: 1 passed, 2 excluded
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (5) ✅</summary>

- 🚨 `config/dev.exs:160` - BEAM mode can now install multiple explicit Runtime Endpoint targets, but the all-probes-failed multi-target path in MultiNode still falls through to the generic SingleNode gRPC fallback. With two BEAM node agents configured, if both BEAM probes fail the scheduler returns a legacy single-node schedule instead of failing visibly or preserving a BEAM target, which violates the no automatic gRPC fallback contract. Add an explicit non-gRPC Runtime Endpoint fallback/error path for this case and cover the multi-target all-failed scenario.

🔧 Fix: Prevent BEAM multi-target gRPC fallback
3 issues (1 error, 2 warnings) still open:
- 🚨 `config/dev.exs:140` - Explicit BEAM mode is only handled for the controller role. If dev config is evaluated with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` and `ORCHARD_SOURCE_DEV_ROLE=all_in_one`, the BEAM target list stays empty, `runtime_endpoint_inference_config` stays empty, and the controller silently uses the legacy gRPC path. Reject `:all_in_one` with BEAM in `config/dev.exs` as well, not only in `bin/dev`.
- ⚠️ `bin/lib/source-dev-beam.sh:130` - The node-agent bootstrap accepts any service starting with `orchard_node_agent`, but the controller-side BEAM target parser and guardrails admit only the exact `orchard_node_agent` service. A node-agent can start as `orchard_node_agent_dev@&lt;ip&gt;` and then be impossible to target through the documented env surface. Decide whether suffixed services are supported, then align bootstrap validation, target parsing, docs, and guardrails.
- ⚠️ `scripts/test-source-dev-beam-bootstrap.sh:1` - This new bootstrap regression suite is standalone and is not invoked by `make test`, `make check-elixir`, or an ExUnit wrapper, so the standard validation path can pass while the shell bootstrap contract regresses. Wire it into a repo validation target or a Mix test that executes the script.

🔧 Fix: Harden source-dev BEAM validation
1 warning still open:
- ⚠️ `bin/lib/source-dev-beam.sh:81` - The BEAM bootstrap validates `ORCHARD_BEAM_NODE_NAME` as `service@ip` and configures guardrails with that host, but the actual IEx launch only constrains the distribution port range. Erlang distribution and EPMD can still bind on wildcard interfaces, so the default `...@127.0.0.1` source-dev run may expose EPMD/distribution outside loopback. Bind distribution with `inet_dist_use_interface` and constrain EPMD to the validated node-name host before launching IEx.

🔧 Fix: Bind source-dev BEAM interfaces
2 warnings still open:
- ⚠️ `bin/lib/source-dev-beam.sh:46` - `ERL_EPMD_ADDRESS` only constrains EPMD when a new daemon is started; if port 4369 already has an EPMD daemon from a prior shell, BEAM mode silently reuses it and can remain wildcard-bound despite the loopback/default-host guard. Add a preflight that starts or verifies an address-constrained EPMD for the selected port, or fails with a clear remediation when an existing daemon cannot be trusted.
- ⚠️ `bin/lib/source-dev-beam.sh:146` - The node-name host validator accepts unspecified IP literals like `0.0.0.0` or `::`, and those values are then fed into `ERL_EPMD_ADDRESS` and `inet_dist_use_interface`. That lets a misapplied gRPC-style wildcard host expose source-dev BEAM distribution broadly; reject unspecified/wildcard addresses in the shell bootstrap and the BEAM target parser.

🔧 Fix: Harden source-dev BEAM EPMD preflight
2 issues (1 error, 1 warning) still open:
- 🚨 `bin/lib/source-dev-beam.sh:319` - The EPMD preflight accepts an existing daemon as soon as one listener equals the requested host. A default `127.0.0.1` run will still pass if EPMD is also listening on a concrete non-loopback address like `10.0.0.2`, so the loopback source-dev mode can reuse an exposed EPMD. Reject listeners that are neither the requested host nor loopback, and add a regression with both `127.0.0.1` and an extra private IP in the fake `lsof` output.
- ⚠️ `bin/lib/source-dev-beam.sh:85` - The source-dev parser accepts IPv6 BEAM hosts, but the IEx launch args never add `-proto_dist inet6_tcp`. OTP documents IPv6 distribution as requiring that protocol, so `orchard_node_agent@::1` can be accepted into config and guardrails while the node still starts with the default IPv4 distribution. Decide whether this slice should reject IPv6 hosts or add the IPv6 distribution flag with coverage.

🔧 Fix: Harden source-dev BEAM IPv4 validation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash scripts/test-source-dev-beam-bootstrap.sh`
- <code>`mise exec -- mix test apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs apps/orchard_controller/test/orchard/config/runtime_target_parser_test.exs apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs apps/orchard_controller/test/orchard/inference_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs apps/orchard_controller/test/orchard/console/runtime_test.exs apps/orchard_controller/test/orchard/console/nodes_live_test.exs` (initial setup attempt blocked by untrusted mise config)</code>
- `env MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KW24H36B7F8K1T9SSFQNY102/mise.toml mise exec -- mix test apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs apps/orchard_controller/test/orchard/config/runtime_target_parser_test.exs apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs apps/orchard_controller/test/orchard/inference_test.exs apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs apps/orchard_controller/test/orchard/console/runtime_test.exs apps/orchard_controller/test/orchard/console/nodes_live_test.exs`
- `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW24H36B7F8K1T9SSFQNY102/source-dev-beam-cli-evidence.sh`
- `env MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KW24H36B7F8K1T9SSFQNY102/mise.toml mise exec -- mix test --trace apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs:486 apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs:508 apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs:533 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:610 apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:637 apps/orchard_controller/test/orchard/console/runtime_test.exs:1029 apps/orchard_controller/test/orchard/console/nodes_live_test.exs:811 apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs:50`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
