### PR TITLE
fix(orchard_node_agent): shorten source-dev worker socket paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Clients (SDKs / curl / apps)
 - Controller runtime execution uses the Runtime Endpoint Interface.
 - The current `NodeRuntimeService` gRPC path is a compatibility adapter, not the durable domain contract.
 - First-party BEAM communication is implemented behind explicit guardrails and must not become durable cluster truth.
-- Source-dev uses the gRPC compatibility adapter by default until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is promoted.
+- Source-dev uses the gRPC compatibility adapter by default until BEAM Runtime Endpoint transport is explicitly promoted after accepted two-Mac smoke evidence.
 - Source-dev BEAM is available only through the explicit split-role `bin/dev-controller` and `bin/dev-node-agent` flow while all-in-one `bin/dev` remains the gRPC default.
+- Explicit Source-dev BEAM mode does not automatically retry a failed request through gRPC compatibility.
 - Workers are local to node agents and are never exposed on the network.
 - Token streams always pass through the controller for governance and accounting.
 - HA-lite only: exactly one active leader, active/standby via Postgres advisory locks, no active/active consensus.
@@ -76,7 +77,7 @@ Clients (SDKs / curl / apps)
 | Language | Elixir/OTP (umbrella app) |
 | Database | Postgres |
 | Inference | MLX-LM runtime adapter managed by the node agent |
-| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter and explicit split-role first-party BEAM mode gated from default promotion by accepted two-Mac smoke |
+| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter, explicit split-role first-party BEAM mode, and recorded two-Mac smoke evidence awaiting separate default promotion |
 | APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
 | Packaging | DMG, PKG, launchd |
 | CLI | `orchardctl` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -46,7 +46,9 @@ Supported deployment modes:
 * Runtime Endpoint semantics are transport-independent.
 * The gRPC/protobuf `NodeRuntimeService` remains the compatibility transport and a candidate protocol for future non-BEAM adapters.
 * First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
-* Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is explicitly promoted.
+* Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until BEAM Runtime Endpoint transport is explicitly promoted in a separate change.
+* Accepted two-Mac smoke evidence SHALL exist before BEAM Runtime Endpoint transport is promoted as the source-dev default.
+* When BEAM Runtime Endpoint transport is explicitly selected, Orchard MUST NOT retry the same request through gRPC compatibility as an automatic fallback.
 * Console live runtime diagnostics SHALL use the configured Runtime Endpoint target list; explicit BEAM Runtime Endpoint targets SHALL take precedence over legacy gRPC runtime client targets.
 * Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
 * BEAM Runtime Endpoint targets MUST carry a valid BEAM node-name address (`service@host`) as an atom or binary; a configured `node_id`, when present, MUST be a UUID and MUST match observed endpoint metadata before scheduler or dispatch may trust that candidate identity.
@@ -2085,8 +2087,10 @@ Controller runtime execution SHALL use the Runtime Endpoint Interface.
 Runtime Endpoint semantics are transport-independent.
 The gRPC/protobuf `NodeRuntimeService` remains the gRPC Compatibility Adapter and a candidate protocol for future non-BEAM adapters.
 First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
-Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is explicitly promoted.
+Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until BEAM Runtime Endpoint transport is explicitly promoted in a separate change.
+Accepted two-Mac smoke evidence SHALL exist before BEAM Runtime Endpoint transport is promoted as the source-dev default.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
+When BEAM Runtime Endpoint transport is explicitly selected, Orchard MUST NOT retry the same request through gRPC compatibility as an automatic fallback.
 Console live runtime diagnostics SHALL use the configured Runtime Endpoint target list.
 Explicit BEAM Runtime Endpoint targets SHALL take precedence over legacy gRPC runtime client targets for Console probes.
 Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.

--- a/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
@@ -125,6 +125,25 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert runtime[:worker_generation_mode] == "stream"
   end
 
+  test "dev.exs keeps worker sockets under a short worktree-specific root" do
+    runtime =
+      read_dev_config!(%{})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert String.starts_with?(runtime[:worker_socket_dir], "/tmp/od-")
+    assert String.ends_with?(runtime[:worker_socket_dir], "/ws")
+  end
+
+  test "dev.exs parses ORCHARD_WORKER_SOCKET_DIR" do
+    runtime =
+      read_dev_config!(%{"ORCHARD_WORKER_SOCKET_DIR" => "/tmp/orchard-worker-sockets"})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:worker_socket_dir] == "/tmp/orchard-worker-sockets"
+  end
+
   test "dev.exs explicit generation mode overrides stub backend default" do
     runtime =
       read_dev_config!(%{

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -279,6 +279,17 @@ memory_admission_config =
 
 node_runtime_defaults = Orchard.Config.M1RuntimeDefaults.node_runtime(dev_root)
 
+worker_socket_dir_hash =
+  :crypto.hash(:sha256, repo_root)
+  |> Base.url_encode64(padding: false)
+  |> binary_part(0, 8)
+
+# Python gRPC rejects Unix socket paths above roughly 103 bytes on macOS.
+# Keep source-dev worker sockets under a short, worktree-specific root.
+worker_socket_dir =
+  System.get_env("ORCHARD_WORKER_SOCKET_DIR") ||
+    Path.join(["/tmp", "od-" <> worker_socket_dir_hash, "ws"])
+
 worker_backend =
   env_optional_string.("ORCHARD_WORKER_BACKEND") ||
     Keyword.fetch!(node_runtime_defaults, :worker_backend)
@@ -398,6 +409,7 @@ config :orchard_node_agent,
       worker_executable:
         System.get_env("ORCHARD_WORKER_EXECUTABLE") ||
           Path.join([repo_root, "native", "orchard_worker_mlx", "bin", "orchard-worker-mlx"]),
+      worker_socket_dir: worker_socket_dir,
       worker_backend: worker_backend,
       worker_prefix_cache_mode: worker_prefix_cache_mode,
       worker_generation_mode: worker_generation_mode,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ Public clients
      -> Postgres for durable state and coordination
      -> Runtime Endpoint Interface
         -> current gRPC compatibility adapter
-        -> explicit split-role first-party BEAM adapter, promoted after accepted source-dev smoke
+        -> explicit split-role first-party BEAM adapter, eligible for promotion after accepted source-dev smoke evidence
         -> future external/provider adapters
      -> Node Agent(s)
         -> Worker Runtime subprocesses for local MLX inference
@@ -51,9 +51,10 @@ Core design rules from `SPEC.md`:
 - token streams pass through the controller;
 - the Controller dispatches model runtime work through the Runtime Endpoint Interface;
 - the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
-- first-party BEAM communication is implemented behind explicit guardrails and remains default-off until rollout gates allow it;
-- source-dev uses the gRPC compatibility adapter by default until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke and is promoted;
+- first-party BEAM communication is implemented behind explicit guardrails and remains default-off until explicit promotion;
+- source-dev uses the gRPC compatibility adapter by default until BEAM Runtime Endpoint transport is explicitly promoted after accepted two-Mac smoke evidence;
 - explicit source-dev BEAM mode runs only through split-role `bin/dev-controller` and `bin/dev-node-agent` launches, not all-in-one `bin/dev`;
+- explicit source-dev BEAM mode does not automatically fall back to gRPC compatibility for the same request;
 - Console live runtime diagnostics use the same configured Runtime Endpoint target list as scheduler and dispatch, with explicit BEAM targets taking precedence over legacy gRPC runtime client targets;
 - BEAM Runtime Endpoint targets validate BEAM node-name addresses and configured node UUIDs before scheduler or dispatch trusts endpoint identity;
 - node agents are the v1 first-party Runtime Endpoint boundary;

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -37,8 +37,9 @@ Existing `proto/cluster/v1` work should be demoted from the default first-party 
 Placement Capacity is a first-class Runtime Endpoint observation and must be exposed by the interface independently of transport.
 Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove eligibility for an active loaded placement.
 
-The BEAM Runtime Endpoint adapter is the intended primary source-dev Controller-to-Node Agent path once it passes the accepted two-Mac smoke.
-Until that gate passes, current source-dev continues to use the gRPC Compatibility Adapter on port `50071` as the compatibility path.
+The BEAM Runtime Endpoint adapter is eligible to become the primary source-dev Controller-to-Node Agent path after accepted two-Mac smoke evidence and explicit promotion.
+The accepted smoke evidence is recorded in `docs/investigations/source-dev-beam-smoke-2026-06-27.md`.
+Until a separate promotion change is accepted, current source-dev continues to use the gRPC Compatibility Adapter on port `50071` as the explicitly selected compatibility path.
 The Source-dev BEAM Operating Model uses long BEAM node names with IPv4-literal hosts, explicit shared cookie material, bounded distribution networking, and BEAM-specific Runtime Endpoint target variables rather than legacy gRPC runtime client variables.
 The current implementation exposes that model through explicit split-role `bin/dev-controller` and `bin/dev-node-agent` launches while all-in-one `bin/dev` remains the gRPC default and rejects explicit BEAM mode.
 Same-host source dev may generate a repo-local `tmp/dev/beam.cookie` file, while two-Mac source dev must provision the same cookie material on both Macs.
@@ -49,10 +50,10 @@ When BEAM Runtime Endpoint mode is selected, BEAM connection failure must fail v
 gRPC remains an explicitly selected compatibility mode, not an implicit fallback behind BEAM mode.
 Promotion starts with split-role `bin/dev-controller` and `bin/dev-node-agent` before changing all-in-one `bin/dev`.
 The accepted smoke gate requires remote BEAM Runtime Endpoint RPC evidence, Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
-Before flipping source-dev defaults, record durable smoke evidence in a sanitized repo document such as `docs/investigations/source-dev-beam-smoke-<date>.md`, including date, commit, sanitized hosts, commands, target node names, pass/fail checklist, and remote Runtime Endpoint RPC evidence.
+Before flipping source-dev defaults, keep durable smoke evidence in a sanitized repo document such as `docs/investigations/source-dev-beam-smoke-<date>.md`, including date, commit, sanitized hosts, commands, target node names, pass/fail checklist, and remote Runtime Endpoint RPC evidence.
 The committed evidence must not include cookie material, credentials, raw local evidence logs, local tool session identifiers, or machine-specific filesystem paths.
 Console Nodes live diagnostics use the configured Runtime Endpoint target list, so explicit BEAM Runtime Endpoint targets take precedence over legacy gRPC runtime client targets during that smoke.
-Do not remove gRPC compatibility before the BEAM adapter passes that smoke.
+Do not remove gRPC compatibility before BEAM Runtime Endpoint transport is explicitly promoted after that smoke.
 
 Keep the Worker Runtime Interface separate.
 The Node Agent may continue to use a local worker protocol for Python/MLX subprocesses.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -61,7 +61,7 @@ _Avoid_: Redis, Kafka, distributed Erlang state
 **BEAM Distribution**:
 The live Orchard communication and monitoring layer between first-party Elixir services.
 The default-off BEAM Runtime Endpoint adapter exists for first-party Controller-to-Node Agent communication.
-In source-dev, it becomes the primary Runtime Endpoint transport only after the BEAM adapter passes the accepted two-Mac smoke and is promoted.
+In source-dev, it becomes the primary Runtime Endpoint transport only after accepted two-Mac smoke evidence and explicit promotion.
 In packaged production, BEAM Distribution is limited to admitted first-party Orchard services.
 _Avoid_: Durable cluster truth, database replacement, public API, external provider integration
 

--- a/docs/investigations/source-dev-beam-smoke-2026-06-27.md
+++ b/docs/investigations/source-dev-beam-smoke-2026-06-27.md
@@ -1,0 +1,155 @@
+# Source-dev BEAM Two-Mac Smoke - 2026-06-27
+
+## Summary
+
+Result: passed.
+
+This smoke validated explicit Source-dev BEAM Runtime Endpoint mode across two Macs before considering a later change that promotes BEAM as the source-dev default.
+It did not change the default source-dev transport.
+It did not rely on automatic gRPC fallback.
+
+Smoke date: 2026-06-27.
+Smoke time: 2026-06-27T02:42:21Z.
+Repo commit at smoke start: `995879a13710ba39ec22c316d91ca5b3f356c2ec`.
+Smoke worktree also included the branch patch that keeps source-dev worker Unix sockets under a short `/tmp/od-<hash>/ws` root.
+
+## Hosts
+
+Controller host: `tamingsari`.
+Local node-agent host: `tamingsari`.
+Remote node-agent host: `mawarduri`.
+
+Controller BEAM node name: `orchard_controller@100.90.207.78`.
+Local node-agent BEAM node name: `orchard_node_agent@100.90.207.78`.
+Remote node-agent BEAM node name: `orchard_node_agent@100.70.81.109`.
+
+The run used an alternate EPMD port, `43690`, because the remote Mac already had default EPMD and packaged Orchard state on the standard port.
+The shared BEAM cookie was provisioned from a local transient file to the remote worktree and verified by digest comparison.
+Cookie contents and API token material are intentionally omitted.
+
+## Launch Commands
+
+The remote node agent was started on `mawarduri` with this sanitized command shape:
+
+```bash
+ssh -tt mawarduri env \
+  ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+  ORCHARD_BEAM_EPMD_PORT=43690 \
+  ORCHARD_BEAM_NODE_NAME=orchard_node_agent@100.70.81.109 \
+  ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
+  ORCHARD_WORKER_BACKEND=stub \
+  ORCHARD_NODE_DISPLAY_NAME=mawarduri-smoke \
+  mise exec -C <remote-worktree> -- bin/dev-node-agent
+```
+
+The local node agent was started on `tamingsari` with this sanitized command shape:
+
+```bash
+env \
+  ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+  ORCHARD_BEAM_EPMD_PORT=43690 \
+  ORCHARD_BEAM_NODE_NAME=orchard_node_agent@100.90.207.78 \
+  ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
+  ORCHARD_WORKER_BACKEND=stub \
+  ORCHARD_NODE_DISPLAY_NAME=tamingsari-node-smoke \
+  mise exec -- bin/dev-node-agent
+```
+
+The controller was started on `tamingsari` with this sanitized command shape:
+
+```bash
+env \
+  ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
+  ORCHARD_BEAM_EPMD_PORT=43690 \
+  ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@100.90.207.78,orchard_node_agent@100.70.81.109 \
+  ORCHARD_BEAM_NODE_NAME=orchard_controller@100.90.207.78 \
+  ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
+  ORCHARD_NODE_DISPLAY_NAME=tamingsari-controller-smoke \
+  mise exec -- bin/dev-controller
+```
+
+## Runtime Endpoint RPC Evidence
+
+The controller called the BEAM Runtime Endpoint client against both configured node-agent targets.
+
+```elixir
+alias Orchard.RuntimeEndpoint.{BeamClient, Observation, Target}
+
+[
+  {"tamingsari", "orchard_node_agent@100.90.207.78"},
+  {"mawarduri", "orchard_node_agent@100.70.81.109"}
+]
+|> Enum.map(fn {label, address} ->
+  target = Target.normalize(%{transport: :beam, address: address, id: "beam:" <> address})
+  {:ok, connection} = BeamClient.connect(target)
+  {:ok, observation} = BeamClient.status(connection, timeout: 10_000)
+
+  {
+    label,
+    Atom.to_string(target.address),
+    observation.availability,
+    observation.worker_state,
+    Observation.node_id(observation),
+    length(observation.placements),
+    observation.supports_prompt_token_ids
+  }
+end)
+```
+
+The result was:
+
+```elixir
+[
+  {"tamingsari", "orchard_node_agent@100.90.207.78", :available, :idle,
+   "e640079f-6786-482e-9b1a-5cc0b361872c", 1, true},
+  {"mawarduri", "orchard_node_agent@100.70.81.109", :available, :idle,
+   "9ec667b3-14bc-437d-80bc-f0d0bc210acb", 0, false}
+]
+```
+
+Both Runtime Endpoint targets were reachable over BEAM Distribution.
+The local target reported one loaded placement after the chat completion run.
+The remote target reported no loaded models, which matched the scheduler choosing the local placement for the request.
+
+## Model And API Evidence
+
+The model probe used `mlx-community/Llama-3.2-1B-Instruct-4bit@08231374eeacb049a0eade7922910865b8fce912`.
+The same model bundle was available on both Macs before the smoke.
+
+`GET /v1/models` returned `200` through the authenticated API.
+
+```json
+{"object":"list","count":4,"llama":"mlx-community/Llama-3.2-1B-Instruct-4bit@08231374eeacb049a0eade7922910865b8fce912"}
+```
+
+`POST /v1/chat/completions` returned `200` through the authenticated API using the same model.
+
+```json
+{"id":"chatcmpl-661f4591-5160-41ab-a911-8a188af174d6","model":"mlx-community/Llama-3.2-1B-Instruct-4bit@08231374eeacb049a0eade7922910865b8fce912","content":"mlx ready","finish_reason":"stop"}
+```
+
+The controller dispatch timing log reported outcome `ok` for that request.
+The local node-agent worker logs showed the source-dev worker socket path under `/tmp/od-<hash>/ws` and completed stub worker generation.
+
+## Console Evidence
+
+The Console Nodes page was verified in a connected browser session against `http://127.0.0.1:4000/console/nodes`.
+The page title was `Nodes`.
+The connected LiveView reported `2 target(s) configured, 2 reachable`.
+
+The `tamingsari` BEAM runtime card used `orchard_node_agent@100.90.207.78`.
+It reported `Idle`, `Healthy`, `Prompt IDs: capable`, backend `stub`, and the Llama model placement.
+
+The `mawarduri` BEAM runtime card used `orchard_node_agent@100.70.81.109`.
+It reported `Idle`, `Healthy`, `Prompt IDs: legacy`, backend `stub`, and no loaded models.
+
+The transient screenshot was saved under `tmp/dev/console-nodes.png` during the run and is intentionally not committed.
+
+## Residual Notes
+
+The run logged stale node identity conflict warnings for the legacy `127.0.0.1:50071` advertised target in the local development database.
+Those warnings did not prevent BEAM Runtime Endpoint RPC, Console reachability, model listing, or chat completion.
+They should be cleaned up or suppressed separately if they keep confusing Console smoke output.
+
+The accepted gate now has two-Mac BEAM smoke evidence, but default promotion still belongs in a separate OpenSpec change.
+gRPC compatibility remains explicitly selectable and remains the current source-dev default until that later promotion is approved.

--- a/docs/investigations/source-dev-beam-smoke-2026-06-27.md
+++ b/docs/investigations/source-dev-beam-smoke-2026-06-27.md
@@ -10,18 +10,18 @@ It did not rely on automatic gRPC fallback.
 
 Smoke date: 2026-06-27.
 Smoke time: 2026-06-27T02:42:21Z.
-Repo commit at smoke start: `995879a13710ba39ec22c316d91ca5b3f356c2ec`.
-Smoke worktree also included the branch patch that keeps source-dev worker Unix sockets under a short `/tmp/od-<hash>/ws` root.
+Tested code state: base commit `995879a13710ba39ec22c316d91ca5b3f356c2ec` plus the local branch patch that keeps source-dev worker Unix sockets under a short `/tmp/od-<hash>/ws` root.
+No Runtime Endpoint transport implementation files differed from the base commit during the smoke.
 
 ## Hosts
 
-Controller host: `tamingsari`.
-Local node-agent host: `tamingsari`.
-Remote node-agent host: `mawarduri`.
+Controller host: `controller-mac`.
+Local node-agent host: `controller-mac`.
+Remote node-agent host: `remote-worker-mac`.
 
-Controller BEAM node name: `orchard_controller@100.90.207.78`.
-Local node-agent BEAM node name: `orchard_node_agent@100.90.207.78`.
-Remote node-agent BEAM node name: `orchard_node_agent@100.70.81.109`.
+Controller BEAM node name: `orchard_controller@192.0.2.10`.
+Local node-agent BEAM node name: `orchard_node_agent@192.0.2.10`.
+Remote node-agent BEAM node name: `orchard_node_agent@192.0.2.20`.
 
 The run used an alternate EPMD port, `43690`, because the remote Mac already had default EPMD and packaged Orchard state on the standard port.
 The shared BEAM cookie was provisioned from a local transient file to the remote worktree and verified by digest comparison.
@@ -29,42 +29,42 @@ Cookie contents and API token material are intentionally omitted.
 
 ## Launch Commands
 
-The remote node agent was started on `mawarduri` with this sanitized command shape:
+The remote node agent was started on `remote-worker-mac` with this sanitized command shape:
 
 ```bash
-ssh -tt mawarduri env \
+ssh -tt remote-worker-mac env \
   ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
   ORCHARD_BEAM_EPMD_PORT=43690 \
-  ORCHARD_BEAM_NODE_NAME=orchard_node_agent@100.70.81.109 \
+  ORCHARD_BEAM_NODE_NAME=orchard_node_agent@192.0.2.20 \
   ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
   ORCHARD_WORKER_BACKEND=stub \
-  ORCHARD_NODE_DISPLAY_NAME=mawarduri-smoke \
+  ORCHARD_NODE_DISPLAY_NAME=remote-worker-mac-smoke \
   mise exec -C <remote-worktree> -- bin/dev-node-agent
 ```
 
-The local node agent was started on `tamingsari` with this sanitized command shape:
+The local node agent was started on `controller-mac` with this sanitized command shape:
 
 ```bash
 env \
   ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
   ORCHARD_BEAM_EPMD_PORT=43690 \
-  ORCHARD_BEAM_NODE_NAME=orchard_node_agent@100.90.207.78 \
+  ORCHARD_BEAM_NODE_NAME=orchard_node_agent@192.0.2.10 \
   ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
   ORCHARD_WORKER_BACKEND=stub \
-  ORCHARD_NODE_DISPLAY_NAME=tamingsari-node-smoke \
+  ORCHARD_NODE_DISPLAY_NAME=controller-mac-node-smoke \
   mise exec -- bin/dev-node-agent
 ```
 
-The controller was started on `tamingsari` with this sanitized command shape:
+The controller was started on `controller-mac` with this sanitized command shape:
 
 ```bash
 env \
   ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
   ORCHARD_BEAM_EPMD_PORT=43690 \
-  ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@100.90.207.78,orchard_node_agent@100.70.81.109 \
-  ORCHARD_BEAM_NODE_NAME=orchard_controller@100.90.207.78 \
+  ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@192.0.2.10,orchard_node_agent@192.0.2.20 \
+  ORCHARD_BEAM_NODE_NAME=orchard_controller@192.0.2.10 \
   ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
-  ORCHARD_NODE_DISPLAY_NAME=tamingsari-controller-smoke \
+  ORCHARD_NODE_DISPLAY_NAME=controller-mac-controller-smoke \
   mise exec -- bin/dev-controller
 ```
 
@@ -76,8 +76,8 @@ The controller called the BEAM Runtime Endpoint client against both configured n
 alias Orchard.RuntimeEndpoint.{BeamClient, Observation, Target}
 
 [
-  {"tamingsari", "orchard_node_agent@100.90.207.78"},
-  {"mawarduri", "orchard_node_agent@100.70.81.109"}
+  {"controller-mac", "orchard_node_agent@192.0.2.10"},
+  {"remote-worker-mac", "orchard_node_agent@192.0.2.20"}
 ]
 |> Enum.map(fn {label, address} ->
   target = Target.normalize(%{transport: :beam, address: address, id: "beam:" <> address})
@@ -100,9 +100,9 @@ The result was:
 
 ```elixir
 [
-  {"tamingsari", "orchard_node_agent@100.90.207.78", :available, :idle,
+  {"controller-mac", "orchard_node_agent@192.0.2.10", :available, :idle,
    "e640079f-6786-482e-9b1a-5cc0b361872c", 1, true},
-  {"mawarduri", "orchard_node_agent@100.70.81.109", :available, :idle,
+  {"remote-worker-mac", "orchard_node_agent@192.0.2.20", :available, :idle,
    "9ec667b3-14bc-437d-80bc-f0d0bc210acb", 0, false}
 ]
 ```
@@ -137,10 +137,10 @@ The Console Nodes page was verified in a connected browser session against `http
 The page title was `Nodes`.
 The connected LiveView reported `2 target(s) configured, 2 reachable`.
 
-The `tamingsari` BEAM runtime card used `orchard_node_agent@100.90.207.78`.
+The `controller-mac` BEAM runtime card used `orchard_node_agent@192.0.2.10`.
 It reported `Idle`, `Healthy`, `Prompt IDs: capable`, backend `stub`, and the Llama model placement.
 
-The `mawarduri` BEAM runtime card used `orchard_node_agent@100.70.81.109`.
+The `remote-worker-mac` BEAM runtime card used `orchard_node_agent@192.0.2.20`.
 It reported `Idle`, `Healthy`, `Prompt IDs: legacy`, backend `stub`, and no loaded models.
 
 The transient screenshot was saved under `tmp/dev/console-nodes.png` during the run and is intentionally not committed.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -191,7 +191,7 @@ ELIXIR
 | `ORCHARD_NODE_AGENT_LISTEN_PORT` | `50071` (source dev) / `50061` (packaged) | gRPC listen port |
 | `ORCHARD_RUNTIME_CLIENT_PORT` | Same as listen port | Controller gRPC client port (must match listen port) |
 | `ORCHARD_MODELS_ROOT` | `tmp/dev/models` | Model artifact storage |
-| `ORCHARD_WORKER_SOCKET_DIR` | `tmp/dev/data/worker-sockets` | Worker UDS directory |
+| `ORCHARD_WORKER_SOCKET_DIR` | `/tmp/od-<hash>/ws` | Worker UDS directory |
 | `ORCHARD_WORKER_EXECUTABLE` | `native/orchard_worker_mlx/bin/orchard-worker-mlx` (repo-root) | Worker binary path. Override via env var; default resolves from repo root in source-dev mode. |
 | `ORCHARD_WORKER_BACKEND` | `mlx` | Worker backend (`mlx` or `stub`) |
 | `ORCHARD_WORKER_GENERATION_MODE` | `batch` for `mlx`, `stream` for unset `stub` | Worker generation runtime (`stream` or `batch`). Leave unset when using the stub backend. |
@@ -206,6 +206,8 @@ bin/dev-node-agent` after changing them. Use `ORCHARD_WORKER_BACKEND=stub` for
 cluster mechanics or rollback testing when real MLX inference is not required;
 when `ORCHARD_WORKER_GENERATION_MODE` is unset, the stub backend resolves to
 stream mode automatically.
+By default, source-dev worker Unix sockets live under a short, worktree-specific `/tmp/od-<hash>/ws` directory to avoid macOS Unix socket path length limits.
+Set `ORCHARD_WORKER_SOCKET_DIR` to override that location.
 `ORCHARD_FAKE_RUNTIME` is a release/runtime config knob; source-dev tests use
 the fake runtime through `config/test.exs`, not a dev env override.
 Batch generation mode can admit multiple same-model requests up to the worker-reported limit.
@@ -393,15 +395,16 @@ on transport modes, truthy/falsy values, and validation behavior.
 
 ### Dev Directory Structure
 
-Dev mode uses `tmp/dev/` under the repo root:
+Dev mode uses `tmp/dev/` under the repo root for model and controller data:
 
 ```
 tmp/dev/
 ├── bundles/           # Imported model artifacts (controller)
 ├── models/            # Model files (node-agent)
-└── data/
-    └── worker-sockets/ # Worker Unix domain sockets
+└── data/              # Source-dev runtime data
 ```
+
+Worker Unix domain sockets default to `/tmp/od-<hash>/ws`, outside the repo tree, and can be overridden with `ORCHARD_WORKER_SOCKET_DIR`.
 
 ## API Endpoints
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -238,6 +238,7 @@ Do not rely on automatic gRPC fallback when BEAM mode is selected.
 
 Source dev now supports an explicit BEAM Runtime Endpoint mode for split-role launches.
 The default source-dev path is still gRPC compatibility on port `50071`.
+Accepted two-Mac smoke evidence is recorded in `docs/investigations/source-dev-beam-smoke-2026-06-27.md`, but default promotion remains a separate change.
 Unset `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` or set it to `grpc` to keep the existing gRPC path.
 Set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` only with `bin/dev-controller` and `bin/dev-node-agent`.
 All-in-one `bin/dev` intentionally rejects explicit BEAM mode and remains the gRPC default.
@@ -1063,5 +1064,5 @@ mise exec -- iex -S mix phx.server
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
 - Explicit split-role BEAM Runtime Endpoint mode is implemented for `bin/dev-controller` and `bin/dev-node-agent`; default source dev still uses the gRPC compatibility adapter
 - All-in-one `bin/dev` rejects explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
-- BEAM Runtime Endpoint transport becomes the primary source-dev path only after it passes the accepted two-Mac smoke
+- BEAM Runtime Endpoint transport becomes the primary source-dev path only through a separate promotion after accepted two-Mac smoke evidence
 - Model import from local filesystem only (no remote download)

--- a/openspec/changes/beam-first-runtime-endpoints/design.md
+++ b/openspec/changes/beam-first-runtime-endpoints/design.md
@@ -17,7 +17,7 @@ The Worker Runtime remains a local process/protocol boundary owned by the Node A
 - Define Runtime Endpoint as the Controller-selected execution boundary.
 - Define Runtime Endpoint Interface as transport-independent runtime semantics.
 - Add guardrails for default-off BEAM Distribution between first-party Controller and Node Agent services.
-- Keep source-dev on gRPC compatibility until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
+- Keep source-dev on gRPC compatibility until a separate promotion change selects BEAM as the default, with accepted two-Mac smoke evidence required before that promotion.
 - Keep Runtime Endpoint Observations durable in Postgres for operator-visible state and scheduling inputs.
 - Preserve `gnhf/objective-fully-impl-369718` concurrency semantics while moving controller domain code to Runtime Endpoint semantics.
 - Preserve durable request terminalization when scheduler or dispatch orchestration crashes.
@@ -48,7 +48,7 @@ That keeps v1 terminology simple, but it makes future Cloud VM, high-performance
 The Controller should depend on a Runtime Endpoint Interface for status, model readiness, inference execution, cancellation, runtime telemetry, Placement Capacity, and prefix-cache scoring.
 This slice should introduce the interface and keep the current first-party path behind a gRPC Compatibility Adapter.
 A later first-party implementation can use BEAM Distribution.
-Source-dev should promote BEAM Runtime Endpoint transport only after the accepted two-Mac smoke passes.
+Source-dev should promote BEAM Runtime Endpoint transport only after accepted two-Mac smoke evidence exists and a separate promotion change is accepted.
 Future non-BEAM implementations can use provider APIs, gRPC/protobuf, or other adapter protocols.
 
 Alternative considered: keep `NodeRuntimeService` as the core interface.
@@ -83,7 +83,7 @@ The `gnhf` work shows it drives visible concurrency, `cluster_busy`, and queue b
 
 `proto/cluster/v1` and `NodeRuntimeService` should no longer be the durable Controller domain contract.
 They remain the current compatibility transport and may remain as future adapter protocol artifacts.
-Until the BEAM adapter passes the accepted two-Mac smoke, source-dev keeps this gRPC compatibility path on port `50071`.
+Until BEAM Runtime Endpoint transport is explicitly promoted after accepted two-Mac smoke evidence, source-dev keeps this gRPC compatibility path on port `50071`.
 
 Alternative considered: delete the proto surface during the pivot.
 That creates avoidable churn and removes a useful candidate protocol for future non-BEAM Runtime Endpoint adapters.
@@ -114,7 +114,7 @@ Mitigation: terminalize those crashes as failed `orchestration_error` requests w
 2. Introduce a Controller-facing Runtime Endpoint Interface, current gRPC Compatibility Adapter, and BEAM guardrail validation.
 3. Adapt scheduler and dispatch code to depend on Runtime Endpoint semantics instead of the low-level gRPC client module.
 4. Preserve and adapt the `gnhf` queue, placement capacity, and `cluster_busy` behavior after the gnhf baseline is chosen.
-5. Keep source-dev on gRPC compatibility until the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
+5. Keep source-dev on gRPC compatibility until a separate promotion change selects BEAM as the default, with accepted two-Mac smoke evidence required before that promotion.
 6. Terminalize scheduler and dispatch orchestration crashes as generic failed requests.
 7. Recast current gRPC integration tests as Runtime Endpoint Interface contract tests.
 8. Keep a smaller adapter or compatibility test suite if gRPC remains available for future external endpoints.

--- a/openspec/changes/beam-first-runtime-endpoints/proposal.md
+++ b/openspec/changes/beam-first-runtime-endpoints/proposal.md
@@ -12,7 +12,7 @@ The architecture should make Orchard's runtime execution semantics transport-ind
 - Treat the first-party Node Agent as Orchard's v1 Runtime Endpoint implementation.
 - Add BEAM Distribution guardrail validation for default-off live communication and monitoring between first-party Orchard Elixir services.
 - Keep the current gRPC/protobuf `NodeRuntimeService` path as an explicit Runtime Endpoint compatibility adapter for this implementation slice.
-- Keep source-dev on the gRPC compatibility adapter until a BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke.
+- Keep source-dev on the gRPC compatibility adapter until a separate promotion change selects BEAM as the default, with accepted two-Mac smoke evidence required before that promotion.
 - Keep Postgres as Orchard's durable persistence and coordination store.
 - Keep Worker Runtime as a local Node Agent-owned process/protocol boundary for Python/MLX execution.
 - Demote `proto/cluster/v1` and `NodeRuntimeService` from the durable Controller domain contract to an explicit compatibility adapter and possible future non-BEAM adapter protocol.

--- a/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
@@ -167,16 +167,16 @@ This changes the role of the gRPC contract currently described in `SPEC.md` sect
 - **THEN** the existing gRPC/protobuf work may be reused or evolved as an adapter protocol
 
 ### Requirement: Source-dev BEAM Primary Rollout
-Orchard SHALL treat the first-party BEAM Runtime Endpoint adapter as the intended primary source-dev Controller-to-Node Agent path only after it passes the accepted two-Mac smoke.
-Until that gate passes, current source-dev SHALL keep the gRPC compatibility path as the explicit compatibility transport on port `50071`.
+Orchard SHALL treat the first-party BEAM Runtime Endpoint adapter as eligible for primary source-dev Controller-to-Node Agent transport only after accepted two-Mac smoke evidence exists.
+Until a separate promotion change selects BEAM Runtime Endpoint transport as the source-dev default, current source-dev SHALL keep the gRPC compatibility path as the default and explicit compatibility transport on port `50071`.
 This compatibility transport is not an automatic same-request fallback when BEAM mode has been explicitly selected.
 
-#### Scenario: BEAM adapter passes the source-dev smoke gate
-- **WHEN** the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke
+#### Scenario: BEAM adapter has accepted smoke evidence
+- **WHEN** accepted two-Mac smoke evidence exists for the BEAM Runtime Endpoint adapter
 - **THEN** Orchard may promote BEAM Runtime Endpoint transport to the primary source-dev Controller-to-Node Agent path
 
-#### Scenario: BEAM adapter has not passed the source-dev smoke gate
-- **WHEN** the BEAM Runtime Endpoint adapter has not passed the accepted two-Mac smoke
+#### Scenario: BEAM adapter has not been promoted as the source-dev default
+- **WHEN** no separate promotion change has selected BEAM Runtime Endpoint transport as the source-dev default
 - **THEN** Orchard keeps using the gRPC compatibility path by default for source-dev Controller-to-Node Agent communication
 - **THEN** BEAM-mode requests do not automatically retry through gRPC compatibility after a BEAM transport failure
 

--- a/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md
@@ -168,7 +168,8 @@ This changes the role of the gRPC contract currently described in `SPEC.md` sect
 
 ### Requirement: Source-dev BEAM Primary Rollout
 Orchard SHALL treat the first-party BEAM Runtime Endpoint adapter as the intended primary source-dev Controller-to-Node Agent path only after it passes the accepted two-Mac smoke.
-Until that gate passes, current source-dev SHALL keep the gRPC compatibility path as the compatibility and fallback path on port `50071`.
+Until that gate passes, current source-dev SHALL keep the gRPC compatibility path as the explicit compatibility transport on port `50071`.
+This compatibility transport is not an automatic same-request fallback when BEAM mode has been explicitly selected.
 
 #### Scenario: BEAM adapter passes the source-dev smoke gate
 - **WHEN** the BEAM Runtime Endpoint adapter passes the accepted two-Mac smoke
@@ -176,7 +177,8 @@ Until that gate passes, current source-dev SHALL keep the gRPC compatibility pat
 
 #### Scenario: BEAM adapter has not passed the source-dev smoke gate
 - **WHEN** the BEAM Runtime Endpoint adapter has not passed the accepted two-Mac smoke
-- **THEN** Orchard keeps using the gRPC compatibility path for source-dev Controller-to-Node Agent communication
+- **THEN** Orchard keeps using the gRPC compatibility path by default for source-dev Controller-to-Node Agent communication
+- **THEN** BEAM-mode requests do not automatically retry through gRPC compatibility after a BEAM transport failure
 
 #### Scenario: Source-dev smoke gate is evaluated
 - **WHEN** the accepted two-Mac source-dev smoke is run

--- a/openspec/changes/beam-first-runtime-endpoints/tasks.md
+++ b/openspec/changes/beam-first-runtime-endpoints/tasks.md
@@ -6,7 +6,7 @@
 - [x] 1.4 Update `SPEC.md` to keep Worker Runtime as a Node Agent-local boundary.
 - [x] 1.5 Update `docs/architecture.md` and glossary docs to match accepted Runtime Endpoint language.
 - [x] 1.6 Decide and document which `proto/cluster/v1` artifacts remain as adapter or compatibility protocol inputs.
-- [x] 1.7 Record the source-dev BEAM-primary rollout gate and gRPC fallback policy.
+- [x] 1.7 Record the source-dev BEAM-primary rollout gate and explicit gRPC compatibility transport policy.
 
 ## 2. Runtime Endpoint Interface
 

--- a/openspec/changes/source-dev-beam-operating-model/tasks.md
+++ b/openspec/changes/source-dev-beam-operating-model/tasks.md
@@ -37,8 +37,8 @@
 - [x] 5.1 Update `docs/local-dev.md` with the implemented Source-dev BEAM split-role launch commands and troubleshooting guidance.
 - [x] 5.2 Document two-Mac cookie provisioning and verification without committing cookie material.
 - [x] 5.3 Document EPMD and bounded distribution port reachability requirements for the two-Mac smoke.
-- [ ] 5.4 Run the two-Mac Source-dev BEAM smoke and record durable evidence in `docs/investigations/source-dev-beam-smoke-<date>.md` with date, commit, sanitized hosts, commands, controller and node-agent BEAM node names, and remote Runtime Endpoint RPC evidence.
-- [ ] 5.5 Record Console Nodes reachability for local and remote Node Agents, `GET /v1/models` returning `200`, and `POST /v1/chat/completions` completing through Console Playground or an equivalent API request.
+- [x] 5.4 Run the two-Mac Source-dev BEAM smoke and record durable evidence in `docs/investigations/source-dev-beam-smoke-<date>.md` with date, commit, sanitized hosts, commands, controller and node-agent BEAM node names, and remote Runtime Endpoint RPC evidence.
+- [x] 5.5 Record Console Nodes reachability for local and remote Node Agents, `GET /v1/models` returning `200`, and `POST /v1/chat/completions` completing through Console Playground or an equivalent API request.
 - [x] 5.6 Defer any source-dev default promotion or all-in-one `bin/dev` BEAM default change to a separate OpenSpec change after the smoke evidence gate passes.
 
 ## 6. Tests And Validation


### PR DESCRIPTION
## Intent

After PR #21 merged, verify the remaining OpenSpec gate before making BEAM Runtime Endpoint the source-dev default and demoting gRPC compatibility. Run a real two-Mac Source-dev BEAM smoke across tamingsari and mawarduri via Tailscale SSH, including BEAM Runtime Endpoint RPC evidence, model/API checks, and connected Console Nodes reachability. Record sanitized durable evidence in the repo without committing cookie material, API tokens, raw transient logs, local prompt exports, or screenshots. Mark the remaining OpenSpec tasks complete only after evidence exists, clarify that gRPC compatibility is an explicit selected transport rather than automatic same-request fallback when BEAM mode is selected, and keep default promotion for a later OpenSpec change. During the smoke, a macOS Unix socket path length failure surfaced in the long worktree; fix that source-dev-only by giving worker sockets a short worktree-specific /tmp root while preserving ORCHARD_WORKER_SOCKET_DIR override and adding regression tests.

## What Changed
- Configures source-dev worker sockets to use a short worktree-specific `/tmp/od-<hash>/ws` default while preserving `ORCHARD_WORKER_SOCKET_DIR`, with node-agent regression coverage for the runtime env resolution.
- Records sanitized source-dev BEAM smoke evidence covering BEAM Runtime Endpoint RPC checks, model/API checks, and connected Console Nodes reachability.
- Updates SPEC, architecture, local-dev, glossary, ADR, and OpenSpec materials to clarify BEAM Runtime Endpoint source-dev behavior and gRPC as an explicitly selected compatibility transport.

## Risk Assessment

✅ Low: The change is narrowly scoped to source-dev socket configuration plus documentation/OpenSpec evidence, and I did not find a substantiated branch-introduced correctness or safety issue.

## Testing

After resolving isolated-worktree setup with per-command mise trust and `mix deps.get`, the focused runtime config ExUnit file passed, both touched OpenSpec changes validated strictly, the dev config probe showed `/tmp/od-mxy9tm3i/ws` with a 19-byte path and preserved `ORCHARD_WORKER_SOCKET_DIR`, and the smoke-doc audit confirmed the durable BEAM RPC, model/API, Console reachability, no-fallback, no-default-promotion, and no-committed-screenshot claims. No UI screenshot was captured because the target diff does not change UI code and the committed smoke record intentionally omits transient screenshots; generated `deps/` and `_build/` were removed before handoff.

<details>
<summary>Evidence: Dev worker socket config evidence</summary>

```text
probe=Config.Reader.read!(config/dev.exs, env: :dev)
default_worker_socket_dir=/tmp/od-mxy9tm3i/ws
default_worker_socket_dir_bytes=19
default_starts_with_tmp_od=true
default_ends_with_ws=true
override_worker_socket_dir=/tmp/orchard-worker-sockets
override_preserved=true
```
</details>
<details>
<summary>Evidence: Source-dev BEAM smoke doc audit</summary>

```text
audited_doc=docs/investigations/source-dev-beam-smoke-2026-06-27.md
selected_evidence_lines:
5:Result: passed.
8:It did not change the default source-dev transport.
9:It did not rely on automatic gRPC fallback.
28:Cookie contents and API token material are intentionally omitted.
71:## Runtime Endpoint RPC Evidence
110:Both Runtime Endpoint targets were reachable over BEAM Distribution.
119:`GET /v1/models` returned `200` through the authenticated API.
125:`POST /v1/chat/completions` returned `200` through the authenticated API using the same model.
138:The connected LiveView reported `2 target(s) configured, 2 reachable`.
146:The transient screenshot was saved under `tmp/dev/console-nodes.png` during the run and is intentionally not committed.
155:gRPC compatibility remains explicitly selectable and remains the current source-dev default until that later promotion is approved.

changed_openspec_no_fallback_lines:
openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md:172:This compatibility transport is not an automatic same-request fallback when BEAM mode has been explicitly selected.
openspec/changes/beam-first-runtime-endpoints/specs/runtime-endpoints/spec.md:181:- **THEN** BEAM-mode requests do not automatically retry through gRPC compatibility after a BEAM transport failure
openspec/changes/source-dev-beam-operating-model/specs/runtime-endpoints/spec.md:103:gRPC compatibility SHALL remain available only when explicitly selected as the runtime transport.
openspec/changes/source-dev-beam-operating-model/specs/runtime-endpoints/spec.md:111:#### Scenario: gRPC compatibility is explicitly selected
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `config/dev.exs:291` - The dev default now resolves worker sockets to `/tmp/od-&lt;hash&gt;/ws`, but `docs/local-dev.md` still documents `tmp/dev/data/worker-sockets` as the source-dev default and in the dev tree. Update the docs so operators do not follow the old long-path default that this change is meant to avoid.
- ⚠️ `docs/investigations/source-dev-beam-smoke-2026-06-27.md:22` - The smoke artifact records real-looking hostnames and Tailscale IPs in BEAM node names and commands, despite the repo guidance requiring sanitized host labels, node names, commands, and RPC evidence. Replace these with stable placeholders before treating this as committed durable evidence.
- ⚠️ `docs/investigations/source-dev-beam-smoke-2026-06-27.md:13` - The evidence says the smoke ran at commit `995879a...` while also relying on an uncommitted branch patch. Since tasks 5.4/5.5 are now marked complete, the artifact should identify the exact tested code state, such as the final branch commit or an explicit commit-plus-patch reference.

🔧 Fix: Sanitize smoke evidence and socket docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 995879a13710ba39ec22c316d91ca5b3f356c2ec..7cc028404360a653ba45880b4fd8c7cf0c1396be --stat --name-status`
- <code>`mise exec -- mix test apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs` - initial setup attempt hit untrusted mise config</code>
- <code>`MISE_TRUSTED_CONFIG_PATHS=&#34;$PWD&#34; mise exec -- mix test apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs` - retry reached Mix and found missing deps</code>
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix deps.get`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix test apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs`
- `OPENSPEC_TELEMETRY=0 MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- npm run openspec -- validate source-dev-beam-operating-model --type change --strict --no-interactive`
- `OPENSPEC_TELEMETRY=0 MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- npm run openspec -- validate beam-first-runtime-endpoints --type change --strict --no-interactive`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- mix run --no-start -e '<Config.Reader dev worker_socket_dir probe>' | tee /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW3QNMS0DC3ZCD2TMWVRJ5YH/dev-worker-socket-config.txt`
- <code>`rg` evidence audit over `docs/investigations/source-dev-beam-smoke-2026-06-27.md` and changed OpenSpec runtime-endpoint specs, saved to `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KW3QNMS0DC3ZCD2TMWVRJ5YH/source-dev-beam-smoke-doc-audit.txt`</code>
- <code>`rm -rf _build deps` then `git status --short` and generated-artifact check</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
