### PR TITLE
fix: preserve console API client audit provenance

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2629,7 +2629,7 @@ create type request_state as enum (
 
 create type tenant_status as enum ('active', 'suspended', 'deleted');
 create type api_key_status as enum ('active', 'revoked', 'expired');
-create type actor_type as enum ('user', 'service_account', 'api_key', 'node', 'system');
+create type actor_type as enum ('user', 'operator', 'service_account', 'api_key', 'node', 'system');
 create type payload_capture_mode as enum ('none', 'metadata', 'full');
 ```
 
@@ -2870,20 +2870,22 @@ create table request_events (
 
 create table audit_logs (
   id bigserial primary key,
-  occurred_at timestamptz not null default now(),
+  tenant_id uuid not null references tenants(id),
+  api_key_id uuid references api_keys(id) on delete set null,
   actor_type actor_type not null,
-  actor_id text not null,
-  tenant_id uuid references tenants(id),
-  request_id uuid references requests(id),
+  actor_id text,
   action text not null,
-  resource_type text not null,
-  resource_id text not null,
-  outcome text not null,
-  remote_addr inet,
-  user_agent text,
-  details jsonb not null default '{}'::jsonb
+  target_type text not null,
+  target_id text,
+  occurred_at timestamptz not null default now(),
+  payload jsonb not null default '{}'::jsonb
 );
 ```
+
+Audit log `actor_type` SHALL identify the provenance class of the action.
+`operator` represents operator and admin product surfaces such as Orchard Console, Orchard CLI, Operator API, and Admin API actions.
+`actor_id` MAY be null for `system` actions and for local operator actions before Orchard has an authenticated first-class operator identity.
+Audit log `payload` MAY include `surface` to preserve the originating product surface, for example `console` or `cli`, when that context is useful for governance review.
 
 ### 8.3 Supplemental governance tables
 

--- a/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
@@ -8,6 +8,8 @@ defmodule OrchardConsole.TenantDetailLive do
   alias Orchard.Governance
   alias Orchard.Governance.{ApiKey, RoleBinding}
 
+  @console_audit_opts [actor_type: "operator", surface: "console"]
+
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     socket =
@@ -447,7 +449,7 @@ defmodule OrchardConsole.TenantDetailLive do
   end
 
   defp revoke_api_key(socket, api_key_id) do
-    case Governance.revoke_api_key(socket.assigns.tenant, api_key_id) do
+    case Governance.revoke_api_key(socket.assigns.tenant, api_key_id, @console_audit_opts) do
       {:ok, api_key} ->
         {:noreply,
          socket
@@ -478,7 +480,7 @@ defmodule OrchardConsole.TenantDetailLive do
   end
 
   defp disable_api_client(socket, api_client_id) do
-    case Governance.disable_api_client(socket.assigns.tenant, api_client_id) do
+    case Governance.disable_api_client(socket.assigns.tenant, api_client_id, @console_audit_opts) do
       {:ok, api_client} ->
         {:noreply,
          socket

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -149,19 +149,25 @@ defmodule Orchard.Governance do
     end
   end
 
-  @spec disable_api_client(Tenant.t() | Ecto.UUID.t(), ServiceAccount.t() | Ecto.UUID.t()) ::
+  @spec disable_api_client(
+          Tenant.t() | Ecto.UUID.t(),
+          ServiceAccount.t() | Ecto.UUID.t(),
+          keyword()
+        ) ::
           {:ok, ServiceAccount.t()}
           | {:error, Changeset.t() | :tenant_not_found | :api_client_not_found}
-  def disable_api_client(tenant_or_id, %ServiceAccount{id: service_account_id}),
-    do: disable_api_client(tenant_or_id, service_account_id)
+  def disable_api_client(tenant_or_id, service_account_or_id, opts \\ [])
 
-  def disable_api_client(tenant_or_id, service_account_id) do
+  def disable_api_client(tenant_or_id, %ServiceAccount{id: service_account_id}, opts),
+    do: disable_api_client(tenant_or_id, service_account_id, opts)
+
+  def disable_api_client(tenant_or_id, service_account_id, opts) do
     Repo.transaction(fn ->
       with {:ok, tenant} <- resolve_tenant(tenant_or_id),
            {:ok, service_account_id} <- normalize_service_account_id(service_account_id),
            {:ok, api_client} <- lock_api_client_for_tenant(tenant.id, service_account_id),
            {:ok, api_client, audit?} <- disable_locked_api_client(api_client),
-           {:ok, _audit_log} <- maybe_insert_disable_audit_log(api_client, audit?) do
+           {:ok, _audit_log} <- maybe_insert_disable_audit_log(api_client, audit?, opts) do
         {:ok, api_client}
       else
         {:error, reason} -> Repo.rollback(reason)
@@ -429,13 +435,17 @@ defmodule Orchard.Governance do
 
   @spec revoke_api_key(ApiKey.t() | Ecto.UUID.t()) ::
           {:ok, ApiKey.t()} | {:error, Changeset.t() | :api_key_not_found}
-  def revoke_api_key(%ApiKey{id: api_key_id}), do: revoke_api_key(api_key_id)
+  @spec revoke_api_key(ApiKey.t() | Ecto.UUID.t(), keyword()) ::
+          {:ok, ApiKey.t()} | {:error, Changeset.t() | :api_key_not_found}
+  def revoke_api_key(api_key_or_id, opts \\ [])
 
-  def revoke_api_key(api_key_id) do
+  def revoke_api_key(%ApiKey{id: api_key_id}, opts), do: revoke_api_key(api_key_id, opts)
+
+  def revoke_api_key(api_key_id, opts) when is_list(opts) do
     Repo.transaction(fn ->
       with {:ok, api_key_id} <- normalize_api_key_id(api_key_id),
            {:ok, api_key} <- lock_api_key(api_key_id),
-           {:ok, api_key} <- revoke_locked_api_key(api_key) do
+           {:ok, api_key} <- revoke_locked_api_key(api_key, opts) do
         {:ok, redact_api_key(api_key)}
       else
         {:error, reason} -> Repo.rollback(reason)
@@ -443,6 +453,44 @@ defmodule Orchard.Governance do
     end)
     |> unwrap_transaction_result()
   end
+
+  @spec revoke_api_key(Tenant.t() | Ecto.UUID.t(), ApiKey.t() | Ecto.UUID.t()) ::
+          {:ok, ApiKey.t()} | {:error, Changeset.t() | :tenant_not_found | :api_key_not_found}
+  @spec revoke_api_key(Tenant.t() | Ecto.UUID.t(), ApiKey.t() | Ecto.UUID.t(), keyword()) ::
+          {:ok, ApiKey.t()} | {:error, Changeset.t() | :tenant_not_found | :api_key_not_found}
+
+  def revoke_api_key(%Tenant{id: tenant_id}, api_key_or_id),
+    do: revoke_api_key(tenant_id, api_key_or_id, [])
+
+  def revoke_api_key(tenant_id, %ApiKey{id: api_key_id}),
+    do: revoke_api_key(tenant_id, api_key_id, [])
+
+  def revoke_api_key(tenant_id, api_key_id) when is_binary(tenant_id) and is_binary(api_key_id),
+    do: revoke_api_key(tenant_id, api_key_id, [])
+
+  def revoke_api_key(%Tenant{id: tenant_id}, api_key_or_id, opts),
+    do: revoke_api_key(tenant_id, api_key_or_id, opts)
+
+  def revoke_api_key(tenant_id, %ApiKey{id: api_key_id}, opts),
+    do: revoke_api_key(tenant_id, api_key_id, opts)
+
+  def revoke_api_key(tenant_id, api_key_id, opts)
+      when is_binary(tenant_id) and is_binary(api_key_id) do
+    Repo.transaction(fn ->
+      with {:ok, tenant_id} <- normalize_tenant_id(tenant_id),
+           {:ok, _tenant} <- fetch_tenant(tenant_id),
+           {:ok, api_key_id} <- normalize_api_key_id(api_key_id),
+           {:ok, api_key} <- lock_api_key_for_tenant(api_key_id, tenant_id),
+           {:ok, api_key} <- revoke_locked_api_key(api_key, opts) do
+        {:ok, redact_api_key(api_key)}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  def revoke_api_key(_tenant_id, _api_key_id, _opts), do: {:error, :tenant_not_found}
 
   @spec list_tenants() :: [Tenant.t()]
   def list_tenants do
@@ -517,31 +565,6 @@ defmodule Orchard.Governance do
       {:ok, api_keys}
     end
   end
-
-  @spec revoke_api_key(Tenant.t() | Ecto.UUID.t(), ApiKey.t() | Ecto.UUID.t()) ::
-          {:ok, ApiKey.t()} | {:error, Changeset.t() | :tenant_not_found | :api_key_not_found}
-  def revoke_api_key(%Tenant{id: tenant_id}, api_key_or_id),
-    do: revoke_api_key(tenant_id, api_key_or_id)
-
-  def revoke_api_key(tenant_id, %ApiKey{id: api_key_id}),
-    do: revoke_api_key(tenant_id, api_key_id)
-
-  def revoke_api_key(tenant_id, api_key_id) when is_binary(tenant_id) and is_binary(api_key_id) do
-    Repo.transaction(fn ->
-      with {:ok, tenant_id} <- normalize_tenant_id(tenant_id),
-           {:ok, _tenant} <- fetch_tenant(tenant_id),
-           {:ok, api_key_id} <- normalize_api_key_id(api_key_id),
-           {:ok, api_key} <- lock_api_key_for_tenant(api_key_id, tenant_id),
-           {:ok, api_key} <- revoke_locked_api_key(api_key) do
-        {:ok, redact_api_key(api_key)}
-      else
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
-    |> unwrap_transaction_result()
-  end
-
-  def revoke_api_key(_tenant_id, _api_key_id), do: {:error, :tenant_not_found}
 
   defp insert_tenant(attrs) do
     %Tenant{}
@@ -962,8 +985,6 @@ defmodule Orchard.Governance do
     end
   end
 
-  defp revoke_locked_api_key(api_key, opts \\ [])
-
   defp revoke_locked_api_key(%ApiKey{revoked_at: %DateTime{}} = api_key, _opts),
     do: {:ok, api_key}
 
@@ -1009,14 +1030,14 @@ defmodule Orchard.Governance do
     |> Repo.insert()
   end
 
-  defp maybe_insert_disable_audit_log(_api_client, false), do: {:ok, nil}
+  defp maybe_insert_disable_audit_log(_api_client, false, _opts), do: {:ok, nil}
 
-  defp maybe_insert_disable_audit_log(%ServiceAccount{} = api_client, true) do
+  defp maybe_insert_disable_audit_log(%ServiceAccount{} = api_client, true, opts) do
     insert_api_client_audit_log(
       api_client,
       "service_account.disabled",
       api_client.disabled_at,
-      []
+      opts
     )
   end
 
@@ -1175,6 +1196,7 @@ defmodule Orchard.Governance do
     payload
     |> maybe_put_payload("provisioning_batch_id", Keyword.get(opts, :provisioning_batch_id))
     |> maybe_put_payload("bulk_operation_ref", Keyword.get(opts, :bulk_operation_ref))
+    |> maybe_put_payload("surface", Keyword.get(opts, :surface))
   end
 
   defp maybe_put_payload(payload, _key, nil), do: payload

--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -6,6 +6,8 @@ defmodule OrchardConsole.TenantDetailLiveTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Repo
 
   @moduletag :live
   @moduletag :db
@@ -237,6 +239,11 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "Revoked API Token prod."
       assert html =~ "Revoked"
       refute has_element?(view, "#tenant-api-client-token-revoke-#{api_key.id}")
+
+      audit_log = Repo.get_by!(AuditLog, api_key_id: api_key.id, action: "api_key.revoked")
+      assert audit_log.actor_type == "operator"
+      assert audit_log.actor_id == nil
+      assert audit_log.payload["surface"] == "console"
     end
 
     test "revokes expired API Client-owned API Tokens from the Organization detail page", %{
@@ -275,6 +282,17 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "Disabled API Client console-client-disable."
       assert html =~ "Disabled"
       refute has_element?(view, "#tenant-api-client-disable-#{api_client.id}")
+
+      audit_log =
+        Repo.get_by!(AuditLog,
+          action: "service_account.disabled",
+          target_type: "service_account",
+          target_id: api_client.id
+        )
+
+      assert audit_log.actor_type == "operator"
+      assert audit_log.actor_id == nil
+      assert audit_log.payload["surface"] == "console"
     end
 
     test "shows error for cross-Organization API Client disable attempt", %{

--- a/apps/orchard_controller/test/orchard/governance/governance_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/governance_test.exs
@@ -457,6 +457,8 @@ defmodule Orchard.GovernanceTest do
 
       audit_log = audit_log!(api_key.id, "api_key.revoked")
       assert audit_log.occurred_at == revoked.revoked_at
+      assert audit_log.actor_type == "system"
+      assert audit_log.actor_id == nil
       assert count_audit_logs(api_key.id, "api_key.revoked") == 1
 
       assert {:ok, reloaded} = Governance.revoke_api_key(api_key.id)
@@ -519,6 +521,26 @@ defmodule Orchard.GovernanceTest do
       reloaded = Repo.get!(ApiKey, api_key.id)
       assert reloaded.revoked_at == nil
       assert count_audit_logs(api_key.id, "api_key.revoked") == 0
+    end
+  end
+
+  describe "disable_api_client/2" do
+    test "no-opts disable audit defaults to system actor" do
+      tenant = create_tenant!("tenant-disable-system-audit")
+      api_client = create_api_client!(tenant, "disable-system-client")
+
+      assert {:ok, disabled} = Governance.disable_api_client(tenant, api_client)
+      assert %DateTime{} = disabled.disabled_at
+
+      audit_log =
+        Repo.get_by!(AuditLog,
+          action: "service_account.disabled",
+          target_type: "service_account",
+          target_id: api_client.id
+        )
+
+      assert audit_log.actor_type == "system"
+      assert audit_log.actor_id == nil
     end
   end
 

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -145,6 +145,11 @@ _Avoid_: Shell scripts as product interface
 
 ### Governance
 
+**Operator**:
+A human or local administrative actor who configures, governs, or operates Orchard through Console, CLI, Operator API, or Admin API surfaces.
+An Operator is not a Service Account, API Client, API Key, or Tenant.
+_Avoid_: Service Account, API Client, API Key, Tenant
+
 **Tenant**:
 A governance boundary for model access, quotas, keys, retention, and usage accounting.
 Product-facing label: Organization.


### PR DESCRIPTION
## Summary

- Audit Console API Client token revoke and client disable actions as operator-initiated Console actions.
- Preserve system actor defaults for no-opts Governance calls.
- Keep tenant-scoped API key revoke behavior on the tenant-specific lookup path.

## Validation

- `ORCHARD_TEST_NODE_AGENT_PORT=50171 mise exec -- mix test apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs apps/orchard_controller/test/orchard/governance/governance_test.exs`
- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `ORCHARD_TEST_NODE_AGENT_PORT=50171 mise exec -- mix test`
- `ORCHARD_TEST_NODE_AGENT_PORT=50171 mise exec -- mix test --cover`
- `git diff --check`

Note: the first full-suite attempt exposed a fresh-worktree environment issue where `native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx` did not exist yet. A later test created the venv, and the full suite passed on rerun.