### PR TITLE
docs: document No Mistakes Opus configuration

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -203,7 +203,12 @@ Common agent accelerators include:
 | ast-grep | Structural search and refactors | Keep edits traceable to product files and tests |
 | Refero | UI and visual design research | Do not copy private research artifacts into product docs |
 | Superpowers | Planning, debugging, verification discipline | Do not commit generated local plans unless rewritten as product docs |
+| No Mistakes | Significant workstream validation, smoke checks, and push or PR gate driving | Configure the tool-owned `~/.no-mistakes/config.yaml`; do not commit gate repos, logs, evidence, prompt exports, or machine-specific paths |
 | Exa | Web research when current external facts are needed | Cite external sources in product-facing docs when relevant |
+
+No Mistakes is configured outside the repo in `~/.no-mistakes/config.yaml`.
+For Orchard agent workstreams, prefer the Claude native agent there when model selection is needed, because `agent_args_override` is a global-only No Mistakes setting.
+Use `no-mistakes doctor`, `no-mistakes axi`, and `no-mistakes axi run --help` as cheap smoke checks before starting an expensive gate run.
 
 Agents should follow `AGENTS.md` for when to use these tools.
 Claude Code reads that same guide through root `CLAUDE.md`.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -207,7 +207,7 @@ Common agent accelerators include:
 | Exa | Web research when current external facts are needed | Cite external sources in product-facing docs when relevant |
 
 No Mistakes is configured outside the repo in `~/.no-mistakes/config.yaml`.
-For Orchard agent workstreams, prefer the Claude native agent there when model selection is needed, because `agent_args_override` is a global-only No Mistakes setting.
+For significant Orchard No Mistakes gates, prefer the Claude native agent with the Opus model as the independent reviewer, because `agent_args_override` is a global-only No Mistakes setting.
 Use `no-mistakes doctor`, `no-mistakes axi`, and `no-mistakes axi run --help` as cheap smoke checks before starting an expensive gate run.
 
 Agents should follow `AGENTS.md` for when to use these tools.


### PR DESCRIPTION
## Summary

- Document No Mistakes as a local Orchard agent accelerator.
- Point future workstreams to the tool-owned `~/.no-mistakes/config.yaml` instead of a repo-local model config.
- Document that significant Orchard No Mistakes gates should prefer Claude Opus as the independent reviewer.
- Record the cheap No Mistakes smoke commands to run before starting an expensive gate.

## Local Configuration

- Updated `/Users/najib/.no-mistakes/config.yaml` locally to use `agent: claude`.
- Set `agent_args_override.claude` to `--model opus`.
- Kept the actual No Mistakes config file out of git.

## Validation

- `no-mistakes doctor` passed and found Claude at `/Users/najib/.local/bin/claude`.
- `no-mistakes axi` passed and reported no active run for `najibninaba/configure-no-mistakes-claude`.
- `no-mistakes axi run --help` passed.
- `claude --model opus --version` passed and returned `2.1.195 (Claude Code)`.
- `git diff --check` passed.

No full No Mistakes gate run was started.