### PR TITLE
fix(console): keep API client actions visible without horizontal scroll

### DIFF
--- a/apps/orchard_controller/assets/css/app.css
+++ b/apps/orchard_controller/assets/css/app.css
@@ -241,6 +241,16 @@
   overflow: hidden;
 }
 
+.sidebar-collapsed #console-license-badge {
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
+  overflow: hidden;
+  border-width: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .sidebar-collapsed #theme-toggle {
   flex-direction: column;
   gap: 0.125rem;

--- a/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
@@ -305,132 +305,11 @@ defmodule OrchardConsole.TenantDetailLive do
           <:title>API Clients</:title>
           <:subtitle>Non-interactive access, ownership context, and owned API Tokens.</:subtitle>
 
-          <.table id="tenant-api-clients-table" rows={@api_clients} row_id={&"api-client-#{&1.id}"}>
-            <:col :let={client} label="API Client" class="min-w-64">
-              <div class="space-y-1">
-                <div class="font-medium text-slate-900 dark:text-slate-100">{client.name}</div>
-                <p :if={present?(client.purpose)} class="text-xs text-slate-600 dark:text-slate-300">
-                  {client.purpose}
-                </p>
-                <p :if={present?(client.description)} class="text-xs text-slate-500 dark:text-slate-400">
-                  {client.description}
-                </p>
-              </div>
-            </:col>
-            <:col :let={client} label="Owner">
-              <div class="space-y-1">
-                <div :if={present?(client.owner_name)} class="font-medium text-slate-900 dark:text-slate-100">
-                  {client.owner_name}
-                </div>
-                <div class="text-sm text-slate-700 dark:text-slate-200">{client.owner_contact}</div>
-                <div :if={present?(client.team)} class="inline-flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
-                  <span class="font-medium uppercase tracking-wide">Team</span>
-                  <span>{client.team}</span>
-                </div>
-              </div>
-            </:col>
-            <:col :let={client} label="External Ref" mono>
-              {client.external_ref || "—"}
-            </:col>
-            <:col :let={client} label="Access / State" class="min-w-36">
-              <div class="space-y-1.5 text-xs">
-                <div class="flex flex-wrap items-center gap-1.5">
-                  <span class="font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Access</span>
-                  <.badge :if={inference_client_access?(client)} tone={:neutral}>Inference Client</.badge>
-                  <.badge :if={!inference_client_access?(client)} tone={:neutral}>No Access</.badge>
-                </div>
-                <div class="flex flex-wrap items-center gap-1.5">
-                  <span class="font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">State</span>
-                  <.badge :if={client.disabled_at == nil} tone={:success}>Active</.badge>
-                  <.badge :if={client.disabled_at != nil} tone={:neutral}>Disabled</.badge>
-                </div>
-                <div
-                  :if={client.disabled_at != nil}
-                  class="text-xs text-slate-500 dark:text-slate-400"
-                >
-                  Disabled <.local_time value={client.disabled_at} format={:datetime_minute} class="font-mono" />
-                </div>
-              </div>
-            </:col>
-            <:col :let={client} label="API Tokens" class="min-w-72">
-              <div id={"api-client-tokens-#{client.id}"} class="space-y-2">
-                <div
-                  :for={token <- client.api_keys}
-                  id={"api-client-token-#{token.id}"}
-                  class={[
-                    "space-y-1 text-sm",
-                    ApiKey.revoked?(token) && "opacity-75"
-                  ]}
-                >
-                  <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span class="font-medium text-slate-700 dark:text-slate-200">{token.name}</span>
-                    <span class="font-mono text-xs text-slate-500 dark:text-slate-400">{token.token_prefix}</span>
-                    <.api_token_status_badge api_key={token} />
-                    <.badge :if={client.disabled_at != nil && active_api_token?(token)} tone={:warning}>
-                      Blocked by client
-                    </.badge>
-                    <button
-                      :if={token.revoked_at == nil}
-                      id={"tenant-api-client-token-revoke-#{token.id}"}
-                      type="button"
-                      phx-click="revoke_api_key"
-                      phx-value-id={token.id}
-                      phx-disable-with="Revoking…"
-                      class="text-xs font-medium text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                    >
-                      Revoke
-                    </button>
-                  </div>
-                  <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
-                    <span>
-                      Created <.local_time
-                        id={"api-client-token-created-at-#{token.id}"}
-                        value={token.inserted_at}
-                        format={:datetime_minute}
-                        class="font-mono"
-                      />
-                    </span>
-                    <span>
-                      Last Used <.local_time
-                        id={"api-client-token-last-used-at-#{token.id}"}
-                        value={token.last_used_at}
-                        format={:datetime_minute}
-                        class="font-mono"
-                      />
-                    </span>
-                  </div>
-                </div>
-                <span
-                  :if={client.api_keys == []}
-                  class="text-sm text-slate-500 dark:text-slate-400"
-                >
-                  No API Tokens
-                </span>
-              </div>
-            </:col>
-
-            <:action :let={client}>
-              <.button
-                :if={client.disabled_at == nil}
-                id={"tenant-api-client-disable-#{client.id}"}
-                variant={:danger}
-                size={:sm}
-                phx-click="disable_api_client"
-                phx-value-id={client.id}
-                phx-disable-with="Disabling…"
-                data-confirm="Disable this API Client? Active owned API Tokens will be blocked, but tokens are not revoked."
-              >
-                Disable
-              </.button>
-              <span
-                :if={client.disabled_at != nil}
-                class="text-slate-400 dark:text-slate-500"
-              >
-                —
-              </span>
-            </:action>
-
-            <:empty>
+          <div
+            id="tenant-api-clients-list"
+            class="-mx-6 -my-4 divide-y divide-slate-200 dark:divide-slate-700"
+          >
+            <div :if={@api_clients == []} class="px-6 py-8">
               <.state_message
                 id="tenant-api-clients-empty-state"
                 kind={:empty}
@@ -441,8 +320,167 @@ defmodule OrchardConsole.TenantDetailLive do
                   Use orchardctl bulk provisioning to create API Clients and one-time API Token output.
                 </:action>
               </.state_message>
-            </:empty>
-          </.table>
+            </div>
+
+            <article
+              :for={client <- @api_clients}
+              id={"api-client-#{client.id}"}
+              class="px-6 py-4"
+            >
+              <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div class="min-w-0 flex-1 space-y-4">
+                  <div class="space-y-1">
+                    <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <h3 class="min-w-0 break-words font-medium text-slate-900 dark:text-slate-100">
+                        {client.name}
+                      </h3>
+                      <.badge :if={client.disabled_at == nil} tone={:success}>Active</.badge>
+                      <.badge :if={client.disabled_at != nil} tone={:neutral}>Disabled</.badge>
+                    </div>
+                    <p :if={present?(client.purpose)} class="break-words text-xs text-slate-600 dark:text-slate-300">
+                      {client.purpose}
+                    </p>
+                    <p :if={present?(client.description)} class="break-words text-xs text-slate-500 dark:text-slate-400">
+                      {client.description}
+                    </p>
+                  </div>
+
+                  <.detail_grid
+                    gap_class="gap-x-6 gap-y-3"
+                    class="grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
+                  >
+                    <.detail_field id={"api-client-owner-#{client.id}"} label="Owner">
+                      <div :if={present?(client.owner_name)} class="break-words font-medium">
+                        {client.owner_name}
+                      </div>
+                      <div class="break-all text-slate-700 dark:text-slate-200">
+                        {client.owner_contact}
+                      </div>
+                      <div
+                        :if={present?(client.team)}
+                        class="mt-1 flex min-w-0 max-w-full flex-wrap items-center gap-x-1 gap-y-0.5 text-xs text-slate-500 dark:text-slate-400"
+                      >
+                        <span class="font-medium uppercase tracking-wide">Team</span>
+                        <span class="min-w-0 break-words">{client.team}</span>
+                      </div>
+                    </.detail_field>
+                    <.detail_field
+                      id={"api-client-external-ref-#{client.id}"}
+                      label="External Ref"
+                      mono
+                      break_all
+                    >
+                      {client.external_ref || "None"}
+                    </.detail_field>
+                    <.detail_field id={"api-client-access-#{client.id}"} label="Access">
+                      <div class="flex flex-wrap items-center gap-1.5">
+                        <.badge :if={inference_client_access?(client)} tone={:neutral}>
+                          Inference Client
+                        </.badge>
+                        <.badge :if={!inference_client_access?(client)} tone={:neutral}>
+                          No Access
+                        </.badge>
+                      </div>
+                    </.detail_field>
+                    <.detail_field id={"api-client-state-#{client.id}"} label="State">
+                      <div class="space-y-1.5">
+                        <div class="flex flex-wrap items-center gap-1.5">
+                          <.badge :if={client.disabled_at == nil} tone={:success}>Active</.badge>
+                          <.badge :if={client.disabled_at != nil} tone={:neutral}>Disabled</.badge>
+                        </div>
+                        <div
+                          :if={client.disabled_at != nil}
+                          class="text-xs text-slate-500 dark:text-slate-400"
+                        >
+                          Disabled <.local_time value={client.disabled_at} format={:datetime_minute} class="font-mono" />
+                        </div>
+                      </div>
+                    </.detail_field>
+                  </.detail_grid>
+
+                  <div
+                    id={"api-client-tokens-#{client.id}"}
+                    class="space-y-2 rounded-md border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/60"
+                  >
+                    <div class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      API Tokens
+                    </div>
+                    <div
+                      :for={token <- client.api_keys}
+                      id={"api-client-token-#{token.id}"}
+                      class={[
+                        "space-y-1 text-sm",
+                        ApiKey.revoked?(token) && "opacity-75"
+                      ]}
+                    >
+                      <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <span class="min-w-0 max-w-full break-words font-medium text-slate-700 dark:text-slate-200">
+                          {token.name}
+                        </span>
+                        <span class="break-all font-mono text-xs text-slate-500 dark:text-slate-400">
+                          {token.token_prefix}
+                        </span>
+                        <.api_token_status_badge api_key={token} />
+                        <.badge :if={client.disabled_at != nil && active_api_token?(token)} tone={:warning}>
+                          Blocked by client
+                        </.badge>
+                        <button
+                          :if={token.revoked_at == nil}
+                          id={"tenant-api-client-token-revoke-#{token.id}"}
+                          type="button"
+                          phx-click="revoke_api_key"
+                          phx-value-id={token.id}
+                          phx-disable-with="Revoking…"
+                          class="text-xs font-medium text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                        >
+                          Revoke
+                        </button>
+                      </div>
+                      <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+                        <span>
+                          Created <.local_time
+                            id={"api-client-token-created-at-#{token.id}"}
+                            value={token.inserted_at}
+                            format={:datetime_minute}
+                            class="font-mono"
+                          />
+                        </span>
+                        <span>
+                          Last Used <.local_time
+                            id={"api-client-token-last-used-at-#{token.id}"}
+                            value={token.last_used_at}
+                            format={:datetime_minute}
+                            class="font-mono"
+                          />
+                        </span>
+                      </div>
+                    </div>
+                    <span
+                      :if={client.api_keys == []}
+                      class="text-sm text-slate-500 dark:text-slate-400"
+                    >
+                      No API Tokens
+                    </span>
+                  </div>
+                </div>
+
+                <div class="flex shrink-0 items-center justify-start md:justify-end">
+                  <.button
+                    :if={client.disabled_at == nil}
+                    id={"tenant-api-client-disable-#{client.id}"}
+                    variant={:danger}
+                    size={:sm}
+                    phx-click="disable_api_client"
+                    phx-value-id={client.id}
+                    phx-disable-with="Disabling…"
+                    data-confirm="Disable this API Client? Active owned API Tokens will be blocked, but tokens are not revoked."
+                  >
+                    Disable
+                  </.button>
+                </div>
+              </div>
+            </article>
+          </div>
         </.card>
       </div>
     </div>

--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -210,6 +210,8 @@ defmodule OrchardConsole.TenantDetailLiveTest do
 
       {:ok, view, html} = live(conn, "/console/tenants/#{tenant.id}")
 
+      assert has_element?(view, "#tenant-api-clients-list")
+      assert has_element?(view, "#api-client-#{api_client.id}")
       assert html =~ "console-client"
       assert html =~ "Owner Example"
       assert html =~ "owner@example.com"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,7 +1,7 @@
 # DESIGN.md — Orchard Console Tactical UI Contract
 
 **Status:** Active (v2)
-**Last Updated:** 2026-05-11
+**Last Updated:** 2026-06-28
 **Audience:** AI coding agents and contributors generating or modifying Console UI.
 
 This document is the tactical, component-level design contract for the Orchard
@@ -277,6 +277,7 @@ Notes:
   keeps its existing classes, including the badge wrapper's `bg-slate-50
   dark:bg-slate-900/60`. The badge now reads as a tinted chip *inside* the
   recessed rail; this is intended.
+  In the collapsed rail the badge hides cleanly; see section 5.3.
 
 ### 5.2 Sidebar Nav Items (`sidebar_nav/1`)
 
@@ -326,12 +327,13 @@ Disabled items keep their `aria-disabled="true"` (when not active) and
 `title="<label> — coming soon"` from the existing `sidebar_nav/1`
 implementation. Do not add hover styling to the disabled span.
 
-### 5.3 Collapse Behavior (Unchanged)
+### 5.3 Collapse Behavior
 
 - The `sidebar-label`, `console-sidebar-version`, and `sidebar-toggle-icon`
   rules in `app.css` (`#console-sidebar { width / min-width }`,
-  `.sidebar-collapsed` overrides, reduced-motion media query) are not
-  modified in v2.
+  `.sidebar-collapsed` overrides, reduced-motion media query) are unchanged
+  from v2.
+- `#console-license-badge` collapses out of view in `.sidebar-collapsed` mode via an `app.css` rule (`max-height` / `opacity` / `margin` / `border` / `padding` reset) that mirrors `console-sidebar-version`, so the full license chip does not crowd the 4.5rem collapsed rail.
 - The icon column at `h-5 w-5 flex-shrink-0` is kept on every nav item so
   collapsed-state alignment continues to work.
 - Active `aria-current="page"` is set by `sidebar_nav/1` and must remain.


### PR DESCRIPTION
## Intent

Fix the Console Organization detail API Clients management UI so Disable and token Revoke actions stay visible and usable without horizontal scrolling at normal desktop widths.

## What Changed

- Replaced the wide API Clients table with a responsive stacked list on the tenant detail page.
- Preserved existing LiveView behavior, element IDs, tenant scoping, disable/revoke events, and secret handling.
- Wrapped long provisioning-controlled values so names, owners, external refs, and token prefixes cannot push actions offscreen.
- Hid the collapsed-sidebar license badge cleanly and documented that behavior in `docs/DESIGN.md`.
- Added focused LiveView coverage for the stacked API Clients list rendering.

## Verification

- `mise exec -- mix test apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs` passed: 23 tests.
- `mise exec -- mix format` passed.
- `mise exec -- mix compile --warnings-as-errors` passed.
- `mise exec -- mix credo --strict` passed.
- `mise exec -- mix dialyzer` passed.
- `mise exec -- mix test` passed across the umbrella.
- `mise exec -- mix test --cover` passed across the umbrella.
- `git diff --check` passed.
- No Mistakes completed with `checks-passed`; its generated review notes were triaged with RP Oracle and treated as non-blocking.

## Browser Evidence

Seeded a dev Organization with normal, long-value, and disabled API Clients, then verified the real LiveView page in browser automation.

- 1280x720 expanded sidebar: no horizontal overflow, Disable/Revoke actions visible, no plaintext token secret in DOM.
- 1024x720 collapsed sidebar: no page overflow beyond expected `sr-only` accessibility helper, actions visible, license badge hidden cleanly.
- 768x844 collapsed sidebar: API Clients section fits with actions visible.
- 430x844 narrow check: API Clients section fits and actions remain visible; page-level overflow still exists from the pre-existing Organization API Tokens table, outside this API Clients fix.
- Live Revoke smoke on seeded data changed a token from Active to Revoked and removed its Revoke control.
