### PR TITLE
feat(nodes): add cluster admission foundation

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -358,8 +358,9 @@ defmodule OrchardConsole.NodesLive do
   defp load_nodes_page(socket) do
     observed_at = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    # Runtime first: observe_status may persist a newly discovered node,
-    # so inventory queried second can show it in the same cycle.
+    # Runtime first: observe_status may refresh an existing node's inventory
+    # and lifecycle state (e.g. admitted -> active), so inventory queried
+    # second reflects it in the same cycle.
     cluster = fetch_runtime_cluster(observed_at)
     inventory = fetch_inventory()
     safe_tokenization_counters = fetch_safe_tokenization_counters()

--- a/apps/orchard_controller/lib/orchard/console/runtime.ex
+++ b/apps/orchard_controller/lib/orchard/console/runtime.ex
@@ -82,7 +82,8 @@ defmodule OrchardConsole.Runtime do
   Fetches a runtime status snapshot from the configured node.
 
   On success, also performs a best-effort `Orchard.Nodes.observe_status/3`
-  to persist node inventory data and refresh queue capacity.
+  to update trusted node inventory or record an admission candidate, and to
+  refresh queue capacity.
   Observation failures never convert a successful status read into an error
   snapshot.
 

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -8,6 +8,7 @@ defmodule Orchard.Governance do
 
   alias Ecto.Changeset
   alias Orchard.Governance.ApiClientProvisioning
+  alias Orchard.SchemaSupport
 
   alias Orchard.Governance.{
     ApiKey,
@@ -1226,15 +1227,7 @@ defmodule Orchard.Governance do
   defp maybe_iso8601(nil), do: nil
   defp maybe_iso8601(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
 
-  defp normalize_attrs(attrs) when is_map(attrs) do
-    Enum.reduce(attrs, %{}, fn
-      {key, value}, acc when is_atom(key) -> Map.put_new(acc, Atom.to_string(key), value)
-      {key, value}, acc -> Map.put(acc, key, value)
-    end)
-  end
-
-  defp normalize_attrs(attrs) when is_list(attrs), do: normalize_attrs(Enum.into(attrs, %{}))
-  defp normalize_attrs(_attrs), do: %{}
+  defp normalize_attrs(attrs), do: SchemaSupport.normalize_attrs(attrs)
 
   defp trim_string(value) when is_binary(value), do: String.trim(value)
   defp trim_string(value), do: value
@@ -1278,9 +1271,7 @@ defmodule Orchard.Governance do
 
   defp redact_api_key(%ApiKey{} = api_key), do: %ApiKey{api_key | secret_hash: nil}
 
-  defp utc_now do
-    DateTime.utc_now() |> DateTime.truncate(:microsecond)
-  end
+  defp utc_now, do: SchemaSupport.utc_now()
 
   defp unwrap_transaction_result({:ok, {:ok, value}}), do: {:ok, value}
 

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -433,6 +433,27 @@ defmodule Orchard.Governance do
 
   def audit_support_bundle_generated(_attrs), do: audit_support_bundle_generated(%{})
 
+  @spec insert_cluster_audit_log(map() | keyword()) ::
+          {:ok, AuditLog.t()} | {:error, Changeset.t()}
+  def insert_cluster_audit_log(attrs) do
+    attrs = normalize_attrs(attrs)
+
+    %AuditLog{}
+    |> audit_log_impl().changeset(%{
+      scope: "cluster",
+      tenant_id: nil,
+      api_key_id: nil,
+      actor_type: Map.get(attrs, "actor_type", "operator"),
+      actor_id: Map.get(attrs, "actor_id"),
+      action: Map.get(attrs, "action"),
+      target_type: Map.get(attrs, "target_type"),
+      target_id: Map.get(attrs, "target_id"),
+      occurred_at: Map.get(attrs, "occurred_at", utc_now()),
+      payload: Map.get(attrs, "payload", %{})
+    })
+    |> Repo.insert()
+  end
+
   @spec revoke_api_key(ApiKey.t() | Ecto.UUID.t()) ::
           {:ok, ApiKey.t()} | {:error, Changeset.t() | :api_key_not_found}
   @spec revoke_api_key(ApiKey.t() | Ecto.UUID.t(), keyword()) ::

--- a/apps/orchard_controller/lib/orchard/governance/audit_log.ex
+++ b/apps/orchard_controller/lib/orchard/governance/audit_log.ex
@@ -18,6 +18,7 @@ defmodule Orchard.Governance.AuditLog do
   @type t :: %__MODULE__{}
 
   schema "audit_logs" do
+    field(:scope, :string, default: "tenant")
     field(:actor_type, :string)
     field(:actor_id, :string)
     field(:action, :string)
@@ -34,6 +35,7 @@ defmodule Orchard.Governance.AuditLog do
   def changeset(audit_log, attrs) do
     audit_log
     |> cast(attrs, [
+      :scope,
       :tenant_id,
       :api_key_id,
       :actor_type,
@@ -44,8 +46,35 @@ defmodule Orchard.Governance.AuditLog do
       :occurred_at,
       :payload
     ])
-    |> validate_required([:tenant_id, :actor_type, :action, :target_type])
+    |> put_default_scope()
+    |> validate_required([:scope, :actor_type, :action, :target_type])
+    |> validate_inclusion(:scope, ["tenant", "cluster"])
+    |> validate_scope()
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:api_key_id)
+    |> check_constraint(:scope, name: :audit_logs_scope_tenant_consistency)
+  end
+
+  defp put_default_scope(changeset) do
+    case get_field(changeset, :scope) do
+      nil -> put_change(changeset, :scope, "tenant")
+      _scope -> changeset
+    end
+  end
+
+  defp validate_scope(changeset) do
+    scope = get_field(changeset, :scope)
+    tenant_id = get_field(changeset, :tenant_id)
+
+    case {scope, tenant_id} do
+      {"tenant", nil} ->
+        add_error(changeset, :tenant_id, "can't be blank")
+
+      {"cluster", tenant_id} when not is_nil(tenant_id) ->
+        add_error(changeset, :tenant_id, "must be blank")
+
+      _valid ->
+        changeset
+    end
   end
 end

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -2,16 +2,19 @@ defmodule Orchard.Nodes do
   @moduledoc """
   Persistence context for node inventory.
 
-  Provides observational node discovery (no join ceremony) - nodes are
-  automatically registered when a successful `GetStatus` response includes
-  valid `RuntimeNodeMetadata`.
+  Stores trusted node inventory and admission review state.
+
+  First-observed Runtime Endpoint metadata is persisted as admission candidate
+  evidence until a trusted node registration and explicit admission path exists.
   """
 
   import Ecto.Query
 
   require Logger
 
-  alias Orchard.Nodes.Node
+  alias Orchard.Governance
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
   alias Orchard.Nodes.ToolCapability
   alias Orchard.Nodes.ToolReadiness
   alias Orchard.Repo
@@ -132,6 +135,25 @@ defmodule Orchard.Nodes do
   def get_node!(id), do: Repo.get!(Node, id)
 
   @doc """
+  Lists node admission candidates ordered for operator review.
+  """
+  @spec list_admission_candidates(keyword()) :: [AdmissionCandidate.t()]
+  def list_admission_candidates(opts \\ []) do
+    category = Keyword.get(opts, :admission_category)
+
+    AdmissionCandidate
+    |> maybe_filter_candidate_category(category)
+    |> order_by([candidate], desc_nulls_last: candidate.last_observed_at, asc: candidate.id)
+    |> Repo.all()
+  end
+
+  @doc """
+  Fetches a node admission candidate by ID. Raises on not found.
+  """
+  @spec get_admission_candidate!(Ecto.UUID.t()) :: AdmissionCandidate.t()
+  def get_admission_candidate!(id), do: Repo.get!(AdmissionCandidate, id)
+
+  @doc """
   Looks up a node by its connection target.
 
   Accepts a target keyword list matching the scheduler/dispatch shape:
@@ -156,14 +178,16 @@ defmodule Orchard.Nodes do
   # -- Observational Write APIs --
 
   @doc """
-  Observes a successful Runtime Endpoint status observation and persists the node.
+  Observes a successful Runtime Endpoint status observation.
 
   Normalizes metadata from a Runtime Endpoint Observation, `StatusResponse`,
   or compatible map before resolving conflicts (identity, display_name,
-  staleness) and inserting or updating the node row.
+  staleness) and updating a trusted node row or admission candidate.
 
-  New nodes are inserted with `state: :active`. Updates preserve the
-  existing `state` (admin-managed).
+  First observations that do not match a trusted node create or update a
+  Runtime Endpoint Admission Candidate and return `:noop`.
+  Updates preserve admin-managed lifecycle except for `admitted -> active`
+  after a fresh healthy observation.
   Successful eligible observations also refresh source-scoped queue capacity
   from aggregate endpoint capacity and loaded placement statuses.
   Fresh invalid metadata, identity conflicts, ineligible nodes, and target
@@ -207,6 +231,114 @@ defmodule Orchard.Nodes do
     end
   rescue
     _ -> :noop
+  end
+
+  @doc """
+  Rejects a pending node admission candidate or lifecycle-managed pending node.
+  """
+  @spec reject_admission(Ecto.UUID.t(), map() | keyword(), keyword()) ::
+          {:ok,
+           %{
+             candidate: AdmissionCandidate.t(),
+             decision: AdmissionDecision.t(),
+             audit_log: AuditLog.t()
+           }}
+          | {:error, term()}
+  def reject_admission(candidate_or_node_id, attrs, opts \\ []) do
+    attrs = normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, target} <- lock_admission_target(candidate_or_node_id),
+           {:ok, reason} <- required_reason(attrs),
+           {:ok, candidate} <- reject_admission_target(target),
+           {:ok, audit_log} <-
+             insert_admission_audit_log(
+               "node_admission.rejected",
+               candidate,
+               admission_audit_payload(candidate, %{"reason" => reason}),
+               opts
+             ),
+           {:ok, decision} <-
+             insert_admission_decision(candidate, :rejected, reason, audit_log, %{}, opts) do
+        {:ok, %{candidate: candidate, decision: decision, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  @doc """
+  Clears a rejected admission candidate by appending a clearance decision.
+  """
+  @spec clear_admission_rejection(Ecto.UUID.t(), map() | keyword(), keyword()) ::
+          {:ok,
+           %{
+             candidate: AdmissionCandidate.t(),
+             decision: AdmissionDecision.t(),
+             audit_log: AuditLog.t()
+           }}
+          | {:error, term()}
+  def clear_admission_rejection(candidate_or_node_id, attrs \\ %{}, opts \\ []) do
+    attrs = normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, candidate} <- lock_rejected_candidate(candidate_or_node_id),
+           {:ok, restored} <- restore_candidate_pending_category(candidate),
+           {:ok, audit_log} <-
+             insert_admission_audit_log(
+               "node_admission.rejection_cleared",
+               restored,
+               admission_audit_payload(restored, attrs),
+               opts
+             ),
+           {:ok, decision} <-
+             insert_admission_decision(restored, :rejection_cleared, nil, audit_log, attrs, opts) do
+        {:ok, %{candidate: restored, decision: decision, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  @doc """
+  Admits a registered node without activating it.
+  """
+  @spec admit_node(Ecto.UUID.t(), map() | keyword(), keyword()) ::
+          {:ok, %{node: Node.t(), decision: AdmissionDecision.t(), audit_log: AuditLog.t()}}
+          | {:error, term()}
+  def admit_node(node_id, attrs \\ %{}, opts \\ []) do
+    attrs = normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, node} <- lock_node(node_id),
+           :ok <- ensure_node_admittable(node, attrs),
+           {:ok, candidate} <- get_or_create_candidate_for_node(node),
+           {:ok, admitted_node} <- update_node_state(node, :admitted),
+           {:ok, admitted_candidate} <- update_candidate_category(candidate, :admitted),
+           {:ok, audit_log} <-
+             insert_admission_audit_log(
+               "node_admission.admitted",
+               admitted_candidate,
+               admission_audit_payload(admitted_candidate, attrs),
+               opts
+             ),
+           {:ok, decision} <-
+             insert_admission_decision(
+               admitted_candidate,
+               :admitted,
+               nil,
+               audit_log,
+               attrs,
+               opts
+             ) do
+        {:ok, %{node: admitted_node, decision: decision, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
   end
 
   defp handle_observation_result(target, observed_at, result, status_response, opts) do
@@ -317,6 +449,7 @@ defmodule Orchard.Nodes do
   # -- Observation Normalization --
 
   defp normalize_observation(target, status_response, observed_at) do
+    endpoint_transport = target_transport(target)
     target = target_address(target)
     metadata = extract_metadata(status_response)
 
@@ -338,6 +471,7 @@ defmodule Orchard.Nodes do
          rpc_port: port,
          connect_host: connect_host(target),
          connect_port: connect_port(target),
+         endpoint_transport: endpoint_transport,
          health: derive_health(extract_runtime_health(status_response)),
          agent_version: non_empty_or(map_get(meta, :agent_version), nil),
          capabilities: build_capabilities(meta, status_response),
@@ -758,6 +892,7 @@ defmodule Orchard.Nodes do
       end
     end)
     |> case do
+      {:ok, :candidate_persisted} -> {:noop, :candidate_persisted}
       {:ok, node} -> {:ok, node}
       {:error, :identity_conflict} -> {:noop, :identity_conflict}
       {:error, :stale} -> {:noop, :stale}
@@ -857,15 +992,469 @@ defmodule Orchard.Nodes do
     |> Node.changeset(
       observation
       |> Map.delete(:id)
-      |> Map.put(:state, existing.state)
+      |> Map.put(:state, observed_state(existing, observation))
     )
     |> Repo.update!()
   end
 
   defp upsert_observation(_existing, observation) do
-    %Node{}
-    |> Node.changeset(Map.put(observation, :state, :active))
-    |> Repo.insert!()
+    upsert_observed_admission_candidate(observation)
+    :candidate_persisted
+  end
+
+  defp observed_state(%Node{state: :admitted}, %{health: :healthy}), do: :active
+  defp observed_state(%Node{} = existing, _observation), do: existing.state
+
+  defp upsert_observed_admission_candidate(observation) do
+    attrs = observed_candidate_attrs(observation)
+
+    case lock_open_observed_candidate(observation) do
+      %AdmissionCandidate{} = candidate ->
+        attrs = Map.put(attrs, :admission_category, candidate.admission_category)
+
+        candidate
+        |> AdmissionCandidate.changeset(attrs)
+        |> Repo.update!()
+
+      nil ->
+        %AdmissionCandidate{}
+        |> AdmissionCandidate.changeset(attrs)
+        |> Repo.insert!(
+          on_conflict:
+            {:replace,
+             [
+               :observed_identity,
+               :target_ref,
+               :endpoint_transport,
+               :endpoint_target,
+               :inventory,
+               :compatibility_evidence,
+               :last_observed_at,
+               :updated_at
+             ]},
+          conflict_target:
+            {:unsafe_fragment,
+             """
+             (source, endpoint_transport, endpoint_target, ((observed_identity->>'claimed_node_id')))
+             WHERE source = 'runtime_endpoint_observation'
+               AND admission_category IN ('pending_observed', 'rejected')
+               AND endpoint_transport IS NOT NULL
+               AND endpoint_target IS NOT NULL
+               AND observed_identity ? 'claimed_node_id'
+             """}
+        )
+    end
+  end
+
+  defp lock_open_observed_candidate(observation) do
+    claimed_node_id = observation.id
+    endpoint_target = endpoint_target(observation)
+
+    AdmissionCandidate
+    |> where([candidate], candidate.source == :runtime_endpoint_observation)
+    |> where([candidate], candidate.admission_category in [:pending_observed, :rejected])
+    |> where([candidate], candidate.endpoint_transport == ^observation.endpoint_transport)
+    |> where([candidate], candidate.endpoint_target == ^endpoint_target)
+    |> where(
+      [candidate],
+      fragment("?->>'claimed_node_id' = ?", candidate.observed_identity, ^claimed_node_id)
+    )
+    |> order_by([candidate], desc: candidate.updated_at)
+    |> limit(1)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+  end
+
+  defp observed_candidate_attrs(observation) do
+    %{
+      source: :runtime_endpoint_observation,
+      admission_category: :pending_observed,
+      observed_identity: observed_identity_snapshot(observation),
+      target_ref: endpoint_target(observation),
+      endpoint_transport: observation.endpoint_transport,
+      endpoint_target: endpoint_target(observation),
+      inventory: inventory_snapshot(observation),
+      compatibility_evidence: compatibility_snapshot(observation),
+      last_observed_at: observation.last_heartbeat_at
+    }
+  end
+
+  defp endpoint_target(observation) do
+    case {observation.connect_host, observation.connect_port} do
+      {host, port} when is_binary(host) and is_integer(port) -> "#{host}:#{port}"
+      _other -> "#{observation.advertise_addr}:#{observation.rpc_port}"
+    end
+  end
+
+  # -- Admission Decisions --
+
+  defp lock_admission_target(id) do
+    case lock_candidate(id) do
+      %AdmissionCandidate{} = candidate ->
+        {:ok, {:candidate, candidate}}
+
+      nil ->
+        case lock_node(id) do
+          {:ok, %Node{} = node} -> {:ok, {:node, node}}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp reject_admission_target({:candidate, %AdmissionCandidate{} = candidate}) do
+    if candidate.admission_category in [
+         :pending_observed,
+         :pending_provisioned,
+         :pending_registered
+       ] do
+      update_candidate_category(candidate, :rejected)
+    else
+      {:error, :admission_not_pending}
+    end
+  end
+
+  defp reject_admission_target({:node, %Node{state: state} = node})
+       when state in [:provisioned, :registered] do
+    with {:ok, candidate} <- get_or_create_candidate_for_node(node) do
+      reject_admission_target({:candidate, candidate})
+    end
+  end
+
+  defp reject_admission_target({:node, %Node{}}), do: {:error, :admission_not_pending}
+
+  defp lock_rejected_candidate(id) do
+    case lock_candidate(id) do
+      %AdmissionCandidate{admission_category: :rejected} = candidate ->
+        {:ok, candidate}
+
+      %AdmissionCandidate{} ->
+        {:error, :admission_not_rejected}
+
+      nil ->
+        lock_rejected_candidate_for_node(id)
+    end
+  end
+
+  defp lock_rejected_candidate_for_node(node_id) do
+    AdmissionCandidate
+    |> where([candidate], candidate.node_id == ^node_id)
+    |> where([candidate], candidate.admission_category == :rejected)
+    |> order_by([candidate], desc: candidate.updated_at)
+    |> limit(1)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+    |> case do
+      %AdmissionCandidate{} = candidate -> {:ok, candidate}
+      nil -> {:error, :admission_not_rejected}
+    end
+  end
+
+  defp restore_candidate_pending_category(%AdmissionCandidate{} = candidate) do
+    update_candidate_category(candidate, pending_category_for_source(candidate.source))
+  end
+
+  defp pending_category_for_source(:runtime_endpoint_observation), do: :pending_observed
+  defp pending_category_for_source(:provisioned_placeholder), do: :pending_provisioned
+  defp pending_category_for_source(:registered_node), do: :pending_registered
+
+  defp ensure_node_admittable(%Node{state: :registered} = node, attrs) do
+    case latest_admission_decision_for_node(node.id) do
+      %AdmissionDecision{decision: :rejected} -> {:error, :admission_rejected}
+      _other -> ensure_admission_inputs_present(node, attrs)
+    end
+  end
+
+  defp ensure_node_admittable(%Node{state: :provisioned}, _attrs),
+    do: {:error, :node_not_registered}
+
+  defp ensure_node_admittable(%Node{}, _attrs), do: {:error, :node_not_pending_admission}
+
+  defp ensure_admission_inputs_present(%Node{} = node, attrs) do
+    cond do
+      not registered_inventory_present?(node) ->
+        {:error, :inventory_missing}
+
+      blank_admission_input?(attrs, ["trust_evidence_ref", "trust_ref"]) ->
+        {:error, :trust_not_established}
+
+      blank_admission_input?(attrs, ["pool_id", "pool"]) ->
+        {:error, :pool_required}
+
+      blank_admission_input?(attrs, ["routing_policy_id", "policy_ref", "policy_inputs"]) ->
+        {:error, :policy_required}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp registered_inventory_present?(%Node{} = node) do
+    non_empty?(node.hostname) and non_empty?(node.display_name) and
+      routable_advertise_addr?(node.advertise_addr) and is_integer(node.rpc_port)
+  end
+
+  defp blank_admission_input?(attrs, keys) do
+    keys
+    |> Enum.map(&Map.get(attrs, &1))
+    |> Enum.all?(&blank_admission_value?/1)
+  end
+
+  defp blank_admission_value?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank_admission_value?(value) when is_map(value), do: map_size(value) == 0
+  defp blank_admission_value?(value) when is_list(value), do: value == []
+  defp blank_admission_value?(nil), do: true
+  defp blank_admission_value?(_value), do: false
+
+  defp latest_admission_decision_for_node(node_id) do
+    AdmissionDecision
+    |> where([decision], decision.node_id == ^node_id)
+    |> order_by([decision], desc: decision.decided_at, desc: decision.inserted_at)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  defp get_or_create_candidate_for_node(%Node{} = node) do
+    case lock_candidate_for_node(node.id) do
+      %AdmissionCandidate{} = candidate ->
+        {:ok, candidate}
+
+      nil ->
+        %AdmissionCandidate{}
+        |> AdmissionCandidate.changeset(candidate_attrs_for_node(node))
+        |> Repo.insert()
+    end
+  end
+
+  defp lock_candidate_for_node(node_id) do
+    AdmissionCandidate
+    |> where([candidate], candidate.node_id == ^node_id)
+    |> order_by([candidate], desc: candidate.updated_at)
+    |> limit(1)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+  end
+
+  defp lock_candidate(id) do
+    AdmissionCandidate
+    |> where([candidate], candidate.id == ^id)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+  end
+
+  defp lock_node(node_id) do
+    Node
+    |> where([node], node.id == ^node_id)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+    |> case do
+      %Node{} = node -> {:ok, node}
+      nil -> {:error, :node_not_found}
+    end
+  end
+
+  defp update_node_state(%Node{} = node, state) do
+    node
+    |> Ecto.Changeset.change(state: state)
+    |> Repo.update()
+  end
+
+  defp update_candidate_category(%AdmissionCandidate{} = candidate, category) do
+    candidate
+    |> Ecto.Changeset.change(admission_category: category)
+    |> Repo.update()
+  end
+
+  defp candidate_attrs_for_node(%Node{} = node) do
+    source = candidate_source_for_node(node)
+
+    %{
+      node_id: node.id,
+      source: source,
+      admission_category: pending_category_for_source(source),
+      observed_identity: node_identity_snapshot(node),
+      target_ref: node_target_ref(node),
+      endpoint_transport: :grpc,
+      endpoint_target: node_target_ref(node),
+      inventory: inventory_snapshot(node),
+      compatibility_evidence: compatibility_snapshot(node),
+      last_observed_at: node.last_heartbeat_at
+    }
+  end
+
+  defp observed_identity_snapshot(observation) do
+    sanitize_snapshot(%{
+      "claimed_node_id" => observation.id,
+      "display_name" => observation.display_name,
+      "hostname" => observation.hostname,
+      "agent_version" => observation.agent_version
+    })
+  end
+
+  defp node_identity_snapshot(%Node{} = node) do
+    sanitize_snapshot(%{
+      "node_id" => node.id,
+      "display_name" => node.display_name,
+      "hostname" => node.hostname,
+      "agent_version" => node.agent_version
+    })
+  end
+
+  defp inventory_snapshot(source) do
+    sanitize_snapshot(%{
+      "advertise_addr" => source.advertise_addr,
+      "rpc_port" => source.rpc_port,
+      "connect_host" => source.connect_host,
+      "connect_port" => source.connect_port,
+      "capabilities" => source.capabilities
+    })
+  end
+
+  defp compatibility_snapshot(source) do
+    sanitize_snapshot(%{
+      "health" => Atom.to_string(source.health),
+      "tool_readiness" => source.tool_readiness
+    })
+  end
+
+  defp candidate_source_for_node(%Node{state: :registered}), do: :registered_node
+  defp candidate_source_for_node(%Node{}), do: :provisioned_placeholder
+
+  defp node_target_ref(%Node{connect_host: host, connect_port: port})
+       when is_binary(host) and is_integer(port),
+       do: "#{host}:#{port}"
+
+  defp node_target_ref(%Node{advertise_addr: host, rpc_port: port}), do: "#{host}:#{port}"
+
+  defp insert_admission_audit_log(action, %AdmissionCandidate{} = candidate, payload, opts) do
+    Governance.insert_cluster_audit_log(%{
+      actor_type: audit_actor_type(opts),
+      actor_id: audit_actor_id(opts),
+      action: action,
+      target_type: "node_admission_candidate",
+      target_id: candidate.id,
+      occurred_at: utc_now(),
+      payload: payload
+    })
+  end
+
+  defp insert_admission_decision(
+         %AdmissionCandidate{} = candidate,
+         decision,
+         reason,
+         %AuditLog{} = audit_log,
+         metadata,
+         opts
+       ) do
+    %AdmissionDecision{}
+    |> AdmissionDecision.changeset(%{
+      candidate_id: candidate.id,
+      node_id: candidate.node_id,
+      decision: decision,
+      actor_type: audit_actor_type(opts),
+      actor_id: audit_actor_id(opts),
+      reason: reason,
+      observed_identity: candidate.observed_identity || %{},
+      target_ref: candidate.target_ref,
+      audit_log_id: audit_log.id,
+      metadata: sanitize_snapshot(metadata),
+      decided_at: utc_now()
+    })
+    |> Repo.insert()
+  end
+
+  defp admission_audit_payload(%AdmissionCandidate{} = candidate, extra) do
+    %{
+      "candidate_id" => candidate.id,
+      "node_id" => candidate.node_id,
+      "source" => Atom.to_string(candidate.source),
+      "admission_category" => Atom.to_string(candidate.admission_category),
+      "observed_identity" => candidate.observed_identity || %{},
+      "target_ref" => candidate.target_ref
+    }
+    |> Map.merge(sanitize_snapshot(extra))
+  end
+
+  defp required_reason(attrs) do
+    case attrs |> Map.get("reason") |> normalize_reason() do
+      nil -> {:error, :reason_required}
+      reason -> {:ok, reason}
+    end
+  end
+
+  defp normalize_reason(reason) when is_binary(reason) do
+    case String.trim(reason) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_reason(reason), do: reason
+
+  defp audit_actor_type(opts), do: opts |> Keyword.get(:actor_type, "operator") |> to_string()
+  defp audit_actor_id(opts), do: Keyword.get(opts, :actor_id)
+
+  defp utc_now, do: DateTime.utc_now()
+
+  defp unwrap_transaction_result({:ok, {:ok, value}}), do: {:ok, value}
+  defp unwrap_transaction_result({:ok, value}), do: value
+  defp unwrap_transaction_result({:error, reason}), do: {:error, reason}
+
+  defp maybe_filter_candidate_category(query, nil), do: query
+
+  defp maybe_filter_candidate_category(query, category) do
+    where(query, [candidate], candidate.admission_category == ^category)
+  end
+
+  defp normalize_attrs(attrs) when is_map(attrs) do
+    Enum.reduce(attrs, %{}, fn
+      {key, value}, acc when is_atom(key) -> Map.put(acc, Atom.to_string(key), value)
+      {key, value}, acc -> Map.put(acc, key, value)
+    end)
+  end
+
+  defp normalize_attrs(attrs) when is_list(attrs), do: normalize_attrs(Enum.into(attrs, %{}))
+  defp normalize_attrs(_attrs), do: %{}
+
+  defp sanitize_snapshot(value), do: sanitize_snapshot(value, 0)
+
+  defp sanitize_snapshot(value, depth) when depth >= 4 do
+    cond do
+      is_map(value) -> %{"truncated" => true}
+      is_list(value) -> ["truncated"]
+      is_binary(value) -> bound_string(value)
+      true -> value
+    end
+  end
+
+  defp sanitize_snapshot(value, depth) when is_map(value) do
+    value
+    |> Enum.take(40)
+    |> Map.new(fn {key, entry} -> {to_string(key), sanitize_snapshot(entry, depth + 1)} end)
+  end
+
+  defp sanitize_snapshot(value, depth) when is_list(value) do
+    value
+    |> Enum.take(40)
+    |> Enum.map(&sanitize_snapshot(&1, depth + 1))
+  end
+
+  defp sanitize_snapshot(value, _depth) when is_binary(value), do: bound_string(value)
+  defp sanitize_snapshot(value, _depth), do: value
+
+  defp bound_string(value) when byte_size(value) > 512 do
+    value
+    |> String.slice(0, 512)
+    |> trim_to_byte_size(512)
+  end
+
+  defp bound_string(value), do: value
+
+  defp trim_to_byte_size(value, max_bytes) when byte_size(value) <= max_bytes, do: value
+
+  defp trim_to_byte_size(value, max_bytes) do
+    value
+    |> String.slice(0..-2//1)
+    |> trim_to_byte_size(max_bytes)
   end
 
   defp target_match?(node, observation) do
@@ -1099,6 +1688,10 @@ defmodule Orchard.Nodes do
   defp metadata_value(metadata, key) do
     Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
   end
+
+  defp target_transport(%Target{transport: :grpc_compat}), do: :grpc
+  defp target_transport(%Target{transport: :beam}), do: :beam
+  defp target_transport(_target), do: :grpc
 
   defp target_address(%Target{transport: :grpc_compat, address: address}), do: address
   defp target_address(%Target{transport: :beam}), do: []

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -19,6 +19,12 @@ defmodule Orchard.Nodes do
   alias Orchard.Nodes.ToolReadiness
   alias Orchard.Repo
   alias Orchard.RuntimeEndpoint.{ModelRef, Observation, Placement, PlacementCapacity, Target}
+  alias Orchard.SchemaSupport
+
+  @snapshot_entry_limit 40
+  @snapshot_max_depth 4
+  @snapshot_string_limit_bytes 512
+  @snapshot_truncation_key "__orchard_snapshot_truncation__"
 
   # -- Read APIs --
 
@@ -1415,7 +1421,7 @@ defmodule Orchard.Nodes do
   defp audit_actor_type(opts), do: opts |> Keyword.get(:actor_type, "operator") |> to_string()
   defp audit_actor_id(opts), do: Keyword.get(opts, :actor_id)
 
-  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+  defp utc_now, do: SchemaSupport.utc_now()
 
   defp unwrap_transaction_result({:ok, {:ok, value}}), do: {:ok, value}
   defp unwrap_transaction_result({:ok, value}), do: value
@@ -1427,19 +1433,11 @@ defmodule Orchard.Nodes do
     where(query, [candidate], candidate.admission_category == ^category)
   end
 
-  defp normalize_attrs(attrs) when is_map(attrs) do
-    Enum.reduce(attrs, %{}, fn
-      {key, value}, acc when is_atom(key) -> Map.put_new(acc, Atom.to_string(key), value)
-      {key, value}, acc -> Map.put(acc, key, value)
-    end)
-  end
-
-  defp normalize_attrs(attrs) when is_list(attrs), do: normalize_attrs(Enum.into(attrs, %{}))
-  defp normalize_attrs(_attrs), do: %{}
+  defp normalize_attrs(attrs), do: SchemaSupport.normalize_attrs(attrs)
 
   defp sanitize_snapshot(value), do: sanitize_snapshot(value, 0)
 
-  defp sanitize_snapshot(value, depth) when depth >= 4 do
+  defp sanitize_snapshot(value, depth) when depth >= @snapshot_max_depth do
     cond do
       is_map(value) -> %{"truncated" => true}
       is_list(value) -> ["truncated"]
@@ -1449,24 +1447,52 @@ defmodule Orchard.Nodes do
   end
 
   defp sanitize_snapshot(value, depth) when is_map(value) do
-    value
-    |> Enum.take(40)
-    |> Map.new(fn {key, entry} -> {to_string(key), sanitize_snapshot(entry, depth + 1)} end)
+    entries = Enum.to_list(value)
+
+    if length(entries) > @snapshot_entry_limit do
+      entries
+      |> Enum.take(@snapshot_entry_limit - 1)
+      |> Map.new(&sanitize_snapshot_map_entry(&1, depth))
+      |> Map.put(@snapshot_truncation_key, snapshot_truncation_marker(:map, length(entries)))
+    else
+      Map.new(entries, &sanitize_snapshot_map_entry(&1, depth))
+    end
   end
 
   defp sanitize_snapshot(value, depth) when is_list(value) do
-    value
-    |> Enum.take(40)
-    |> Enum.map(&sanitize_snapshot(&1, depth + 1))
+    if length(value) > @snapshot_entry_limit do
+      retained =
+        value
+        |> Enum.take(@snapshot_entry_limit - 1)
+        |> Enum.map(&sanitize_snapshot(&1, depth + 1))
+
+      retained ++ [snapshot_truncation_marker(:list, length(value))]
+    else
+      Enum.map(value, &sanitize_snapshot(&1, depth + 1))
+    end
   end
 
   defp sanitize_snapshot(value, _depth) when is_binary(value), do: bound_string(value)
   defp sanitize_snapshot(value, _depth), do: value
 
-  defp bound_string(value) when byte_size(value) > 512 do
+  defp sanitize_snapshot_map_entry({key, entry}, depth) do
+    {to_string(key), sanitize_snapshot(entry, depth + 1)}
+  end
+
+  defp snapshot_truncation_marker(kind, original_count) do
+    %{
+      "truncated" => true,
+      "reason" => "entry_limit",
+      "kind" => Atom.to_string(kind),
+      "entry_limit" => @snapshot_entry_limit,
+      "original_count" => original_count
+    }
+  end
+
+  defp bound_string(value) when byte_size(value) > @snapshot_string_limit_bytes do
     value
-    |> String.slice(0, 512)
-    |> trim_to_byte_size(512)
+    |> String.slice(0, @snapshot_string_limit_bytes)
+    |> trim_to_byte_size(@snapshot_string_limit_bytes)
   end
 
   defp bound_string(value), do: value

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -1010,28 +1010,21 @@ defmodule Orchard.Nodes do
 
     case lock_open_observed_candidate(observation) do
       %AdmissionCandidate{} = candidate ->
-        attrs = Map.put(attrs, :admission_category, candidate.admission_category)
+        if fresh_candidate_observation?(candidate, observation) do
+          attrs = Map.put(attrs, :admission_category, candidate.admission_category)
 
-        candidate
-        |> AdmissionCandidate.changeset(attrs)
-        |> Repo.update!()
+          candidate
+          |> AdmissionCandidate.changeset(attrs)
+          |> Repo.update!()
+        else
+          candidate
+        end
 
       nil ->
         %AdmissionCandidate{}
         |> AdmissionCandidate.changeset(attrs)
         |> Repo.insert!(
-          on_conflict:
-            {:replace,
-             [
-               :observed_identity,
-               :target_ref,
-               :endpoint_transport,
-               :endpoint_target,
-               :inventory,
-               :compatibility_evidence,
-               :last_observed_at,
-               :updated_at
-             ]},
+          on_conflict: observed_candidate_conflict_update(),
           conflict_target:
             {:unsafe_fragment,
              """
@@ -1044,6 +1037,36 @@ defmodule Orchard.Nodes do
              """}
         )
     end
+  end
+
+  defp fresh_candidate_observation?(%AdmissionCandidate{last_observed_at: nil}, _observation),
+    do: true
+
+  defp fresh_candidate_observation?(
+         %AdmissionCandidate{last_observed_at: last_observed_at},
+         observation
+       ) do
+    DateTime.compare(last_observed_at, observation.last_heartbeat_at) == :lt
+  end
+
+  defp observed_candidate_conflict_update do
+    from(candidate in AdmissionCandidate,
+      where:
+        is_nil(candidate.last_observed_at) or
+          candidate.last_observed_at < fragment("EXCLUDED.last_observed_at"),
+      update: [
+        set: [
+          observed_identity: fragment("EXCLUDED.observed_identity"),
+          target_ref: fragment("EXCLUDED.target_ref"),
+          endpoint_transport: fragment("EXCLUDED.endpoint_transport"),
+          endpoint_target: fragment("EXCLUDED.endpoint_target"),
+          inventory: fragment("EXCLUDED.inventory"),
+          compatibility_evidence: fragment("EXCLUDED.compatibility_evidence"),
+          last_observed_at: fragment("EXCLUDED.last_observed_at"),
+          updated_at: fragment("EXCLUDED.updated_at")
+        ]
+      ]
+    )
   end
 
   defp lock_open_observed_candidate(observation) do
@@ -1190,8 +1213,16 @@ defmodule Orchard.Nodes do
 
   defp registered_inventory_present?(%Node{} = node) do
     non_empty?(node.hostname) and non_empty?(node.display_name) and
-      routable_advertise_addr?(node.advertise_addr) and is_integer(node.rpc_port)
+      node_has_routable_target?(node)
   end
+
+  defp node_has_routable_target?(%Node{} = node) do
+    (routable_advertise_addr?(node.advertise_addr) and is_integer(node.rpc_port)) or
+      routable_connect_target?(node.connect_host, node.connect_port)
+  end
+
+  defp routable_connect_target?(host, port),
+    do: routable_advertise_addr?(host) and is_integer(port)
 
   defp blank_admission_input?(attrs, keys) do
     keys

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -1375,25 +1375,16 @@ defmodule Orchard.Nodes do
   end
 
   defp required_reason(attrs) do
-    case attrs |> Map.get("reason") |> normalize_reason() do
+    case attrs |> Map.get("reason") |> AdmissionDecision.normalize_reason() do
       nil -> {:error, :reason_required}
       reason -> {:ok, reason}
     end
   end
 
-  defp normalize_reason(reason) when is_binary(reason) do
-    case String.trim(reason) do
-      "" -> nil
-      trimmed -> trimmed
-    end
-  end
-
-  defp normalize_reason(reason), do: reason
-
   defp audit_actor_type(opts), do: opts |> Keyword.get(:actor_type, "operator") |> to_string()
   defp audit_actor_id(opts), do: Keyword.get(opts, :actor_id)
 
-  defp utc_now, do: DateTime.utc_now()
+  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
 
   defp unwrap_transaction_result({:ok, {:ok, value}}), do: {:ok, value}
   defp unwrap_transaction_result({:ok, value}), do: value
@@ -1407,7 +1398,7 @@ defmodule Orchard.Nodes do
 
   defp normalize_attrs(attrs) when is_map(attrs) do
     Enum.reduce(attrs, %{}, fn
-      {key, value}, acc when is_atom(key) -> Map.put(acc, Atom.to_string(key), value)
+      {key, value}, acc when is_atom(key) -> Map.put_new(acc, Atom.to_string(key), value)
       {key, value}, acc -> Map.put(acc, key, value)
     end)
   end

--- a/apps/orchard_controller/lib/orchard/nodes/admission_candidate.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/admission_candidate.ex
@@ -1,0 +1,89 @@
+defmodule Orchard.Nodes.AdmissionCandidate do
+  @moduledoc """
+  Ecto schema for Runtime Endpoint admission review candidates.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Orchard.Nodes.Node
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @sources [:runtime_endpoint_observation, :provisioned_placeholder, :registered_node]
+  @admission_categories [
+    :pending_observed,
+    :pending_provisioned,
+    :pending_registered,
+    :rejected,
+    :admitted
+  ]
+  # `external` is reserved for future provider/runtime adapters. RuntimeEndpoint.Target
+  # currently supports first-party gRPC compatibility and BEAM targets only.
+  @endpoint_transports [:grpc, :beam, :external]
+
+  @type t :: %__MODULE__{}
+
+  schema "node_admission_candidates" do
+    field(:source, Ecto.Enum, values: @sources)
+    field(:admission_category, Ecto.Enum, values: @admission_categories)
+    field(:observed_identity, :map, default: %{})
+    field(:target_ref, :string)
+    field(:endpoint_transport, Ecto.Enum, values: @endpoint_transports)
+    field(:endpoint_target, :string)
+    field(:inventory, :map, default: %{})
+    field(:compatibility_evidence, :map, default: %{})
+    field(:last_observed_at, :utc_datetime_usec)
+
+    belongs_to(:node, Node)
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @spec sources() :: [atom()]
+  def sources, do: @sources
+
+  @spec admission_categories() :: [atom()]
+  def admission_categories, do: @admission_categories
+
+  @spec changeset(struct(), map()) :: Ecto.Changeset.t()
+  def changeset(candidate, attrs) do
+    candidate
+    |> cast(attrs, [
+      :node_id,
+      :source,
+      :admission_category,
+      :observed_identity,
+      :target_ref,
+      :endpoint_transport,
+      :endpoint_target,
+      :inventory,
+      :compatibility_evidence,
+      :last_observed_at
+    ])
+    |> validate_required([:source, :admission_category, :observed_identity, :inventory])
+    |> validate_required([:compatibility_evidence])
+    |> validate_observed_timestamp()
+    |> foreign_key_constraint(:node_id)
+    |> check_constraint(:source, name: :node_admission_candidates_source)
+    |> check_constraint(:admission_category, name: :node_admission_candidates_admission_category)
+    |> check_constraint(:endpoint_transport, name: :node_admission_candidates_endpoint_transport)
+    |> check_constraint(:last_observed_at, name: :node_admission_candidates_observed_timestamp)
+    |> unique_constraint(:observed_identity,
+      name: :idx_node_admission_candidates_open_observed_identity_unique
+    )
+  end
+
+  defp validate_observed_timestamp(changeset) do
+    source = get_field(changeset, :source)
+    last_observed_at = get_field(changeset, :last_observed_at)
+
+    if source == :runtime_endpoint_observation and is_nil(last_observed_at) do
+      add_error(changeset, :last_observed_at, "must be present for runtime observations")
+    else
+      changeset
+    end
+  end
+end

--- a/apps/orchard_controller/lib/orchard/nodes/admission_decision.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/admission_decision.ex
@@ -1,0 +1,82 @@
+defmodule Orchard.Nodes.AdmissionDecision do
+  @moduledoc """
+  Ecto schema for append-only node admission decisions.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Nodes.{AdmissionCandidate, Node}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @decisions [:rejected, :rejection_cleared, :admitted]
+
+  @type t :: %__MODULE__{}
+
+  schema "node_admission_decisions" do
+    field(:decision, Ecto.Enum, values: @decisions)
+    field(:actor_type, :string)
+    field(:actor_id, :string)
+    field(:reason, :string)
+    field(:observed_identity, :map, default: %{})
+    field(:target_ref, :string)
+    field(:metadata, :map, default: %{})
+    field(:decided_at, :utc_datetime_usec)
+
+    belongs_to(:candidate, AdmissionCandidate)
+    belongs_to(:node, Node)
+    belongs_to(:audit_log, AuditLog, type: :id)
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
+  end
+
+  @spec decisions() :: [atom()]
+  def decisions, do: @decisions
+
+  @spec changeset(struct(), map()) :: Ecto.Changeset.t()
+  def changeset(decision, attrs) do
+    decision
+    |> cast(attrs, [
+      :candidate_id,
+      :node_id,
+      :decision,
+      :actor_type,
+      :actor_id,
+      :reason,
+      :observed_identity,
+      :target_ref,
+      :audit_log_id,
+      :metadata,
+      :decided_at
+    ])
+    |> validate_required([:decision, :actor_type, :observed_identity, :metadata, :decided_at])
+    |> validate_rejection_reason()
+    |> foreign_key_constraint(:candidate_id)
+    |> foreign_key_constraint(:node_id)
+    |> foreign_key_constraint(:audit_log_id)
+  end
+
+  defp validate_rejection_reason(changeset) do
+    decision = get_field(changeset, :decision)
+    reason = changeset |> get_field(:reason) |> normalize_reason()
+
+    if decision == :rejected and is_nil(reason) do
+      add_error(changeset, :reason, "must be present for rejected admission")
+    else
+      put_change(changeset, :reason, reason)
+    end
+  end
+
+  defp normalize_reason(reason) when is_binary(reason) do
+    case String.trim(reason) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_reason(reason), do: reason
+end

--- a/apps/orchard_controller/lib/orchard/nodes/admission_decision.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/admission_decision.ex
@@ -71,12 +71,13 @@ defmodule Orchard.Nodes.AdmissionDecision do
     end
   end
 
-  defp normalize_reason(reason) when is_binary(reason) do
+  @spec normalize_reason(term()) :: String.t() | nil | term()
+  def normalize_reason(reason) when is_binary(reason) do
     case String.trim(reason) do
       "" -> nil
       trimmed -> trimmed
     end
   end
 
-  defp normalize_reason(reason), do: reason
+  def normalize_reason(reason), do: reason
 end

--- a/apps/orchard_controller/lib/orchard/schema_support.ex
+++ b/apps/orchard_controller/lib/orchard/schema_support.ex
@@ -1,0 +1,19 @@
+defmodule Orchard.SchemaSupport do
+  @moduledoc """
+  Small shared helpers for context and schema boundary normalization.
+  """
+
+  @spec normalize_attrs(term()) :: map()
+  def normalize_attrs(attrs) when is_map(attrs) do
+    Enum.reduce(attrs, %{}, fn
+      {key, value}, acc when is_atom(key) -> Map.put_new(acc, Atom.to_string(key), value)
+      {key, value}, acc -> Map.put(acc, key, value)
+    end)
+  end
+
+  def normalize_attrs(attrs) when is_list(attrs), do: attrs |> Enum.into(%{}) |> normalize_attrs()
+  def normalize_attrs(_attrs), do: %{}
+
+  @spec utc_now() :: DateTime.t()
+  def utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+end

--- a/apps/orchard_controller/priv/repo/migrations/20260628000000_cluster_admission_foundation.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260628000000_cluster_admission_foundation.exs
@@ -200,7 +200,10 @@ defmodule Orchard.Repo.Migrations.ClusterAdmissionFoundation do
   end
 
   def down do
-    execute("DROP TRIGGER IF EXISTS node_admission_decisions_append_only ON node_admission_decisions")
+    execute(
+      "DROP TRIGGER IF EXISTS node_admission_decisions_append_only ON node_admission_decisions"
+    )
+
     execute("DROP FUNCTION IF EXISTS orchard_reject_node_admission_decision_mutation()")
 
     drop_if_exists(table(:node_admission_decisions))

--- a/apps/orchard_controller/priv/repo/migrations/20260628000000_cluster_admission_foundation.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260628000000_cluster_admission_foundation.exs
@@ -1,0 +1,231 @@
+defmodule Orchard.Repo.Migrations.ClusterAdmissionFoundation do
+  use Ecto.Migration
+
+  @legacy_tenant_id "00000000-0000-0000-0000-000000000000"
+
+  def up do
+    execute("""
+    CREATE TYPE node_admission_decision_kind AS ENUM (
+      'rejected',
+      'rejection_cleared',
+      'admitted'
+    )
+    """)
+
+    alter table(:audit_logs) do
+      add(:scope, :text, null: false, default: "tenant")
+    end
+
+    execute("ALTER TABLE audit_logs ALTER COLUMN tenant_id DROP NOT NULL")
+
+    create(
+      constraint(:audit_logs, :audit_logs_scope_tenant_consistency,
+        check:
+          "(scope = 'tenant' AND tenant_id IS NOT NULL) OR " <>
+            "(scope = 'cluster' AND tenant_id IS NULL)"
+      )
+    )
+
+    create(
+      index(:audit_logs, [:occurred_at],
+        name: :idx_audit_logs_cluster_occurred_at,
+        where: "scope = 'cluster'"
+      )
+    )
+
+    create table(:node_admission_candidates, primary_key: false) do
+      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:node_id, references(:nodes, type: :binary_id, on_delete: :nilify_all))
+      add(:source, :text, null: false)
+      add(:admission_category, :text, null: false)
+      add(:observed_identity, :map, null: false, default: %{})
+      add(:target_ref, :text)
+      add(:endpoint_transport, :text)
+      add(:endpoint_target, :text)
+      add(:inventory, :map, null: false, default: %{})
+      add(:compatibility_evidence, :map, null: false, default: %{})
+      add(:last_observed_at, :utc_datetime_usec)
+      add(:inserted_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+      add(:updated_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+    end
+
+    create(
+      constraint(:node_admission_candidates, :node_admission_candidates_source,
+        check:
+          "source IN (" <>
+            "'runtime_endpoint_observation', " <>
+            "'provisioned_placeholder', " <>
+            "'registered_node')"
+      )
+    )
+
+    create(
+      constraint(:node_admission_candidates, :node_admission_candidates_admission_category,
+        check:
+          "admission_category IN (" <>
+            "'pending_observed', " <>
+            "'pending_provisioned', " <>
+            "'pending_registered', " <>
+            "'rejected', " <>
+            "'admitted')"
+      )
+    )
+
+    create(
+      constraint(:node_admission_candidates, :node_admission_candidates_endpoint_transport,
+        check: "endpoint_transport IS NULL OR endpoint_transport IN ('grpc', 'beam', 'external')"
+      )
+    )
+
+    create(
+      constraint(:node_admission_candidates, :node_admission_candidates_observed_timestamp,
+        check: "source <> 'runtime_endpoint_observation' OR last_observed_at IS NOT NULL"
+      )
+    )
+
+    execute("""
+    CREATE INDEX idx_node_admission_candidates_category_observed
+    ON node_admission_candidates(admission_category, last_observed_at DESC NULLS LAST)
+    """)
+
+    create(
+      index(:node_admission_candidates, [:node_id],
+        name: :idx_node_admission_candidates_node,
+        where: "node_id IS NOT NULL"
+      )
+    )
+
+    execute("""
+    CREATE INDEX idx_node_admission_candidates_open_target_ref
+    ON node_admission_candidates(target_ref)
+    WHERE node_id IS NULL
+      AND target_ref IS NOT NULL
+      AND admission_category IN ('pending_observed', 'rejected')
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX idx_node_admission_candidates_open_observed_identity_unique
+    ON node_admission_candidates (
+      source,
+      endpoint_transport,
+      endpoint_target,
+      ((observed_identity->>'claimed_node_id'))
+    )
+    WHERE source = 'runtime_endpoint_observation'
+      AND admission_category IN ('pending_observed', 'rejected')
+      AND endpoint_transport IS NOT NULL
+      AND endpoint_target IS NOT NULL
+      AND observed_identity ? 'claimed_node_id'
+    """)
+
+    create table(:node_admission_decisions, primary_key: false) do
+      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
+
+      add(
+        :candidate_id,
+        references(:node_admission_candidates, type: :binary_id, on_delete: :nilify_all)
+      )
+
+      add(:node_id, references(:nodes, type: :binary_id, on_delete: :nilify_all))
+      add(:decision, :node_admission_decision_kind, null: false)
+      add(:actor_type, :text, null: false)
+      add(:actor_id, :text)
+      add(:reason, :text)
+      add(:observed_identity, :map, null: false, default: %{})
+      add(:target_ref, :text)
+      add(:audit_log_id, references(:audit_logs, type: :bigint, on_delete: :nilify_all))
+      add(:metadata, :map, null: false, default: %{})
+      add(:decided_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+      add(:inserted_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+    end
+
+    execute("""
+    CREATE INDEX idx_node_admission_decisions_candidate_decided
+    ON node_admission_decisions(candidate_id, decided_at DESC)
+    WHERE candidate_id IS NOT NULL
+    """)
+
+    execute("""
+    CREATE INDEX idx_node_admission_decisions_node_decided
+    ON node_admission_decisions(node_id, decided_at DESC)
+    WHERE node_id IS NOT NULL
+    """)
+
+    create(
+      index(:node_admission_decisions, [:audit_log_id],
+        name: :idx_node_admission_decisions_audit_log,
+        where: "audit_log_id IS NOT NULL"
+      )
+    )
+
+    execute("""
+    CREATE FUNCTION orchard_reject_node_admission_decision_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'node_admission_decisions is append-only';
+      END IF;
+
+      IF pg_trigger_depth() > 1
+         AND OLD.id IS NOT DISTINCT FROM NEW.id
+         AND OLD.decision IS NOT DISTINCT FROM NEW.decision
+         AND OLD.actor_type IS NOT DISTINCT FROM NEW.actor_type
+         AND OLD.actor_id IS NOT DISTINCT FROM NEW.actor_id
+         AND OLD.reason IS NOT DISTINCT FROM NEW.reason
+         AND OLD.observed_identity IS NOT DISTINCT FROM NEW.observed_identity
+         AND OLD.target_ref IS NOT DISTINCT FROM NEW.target_ref
+         AND OLD.metadata IS NOT DISTINCT FROM NEW.metadata
+         AND OLD.decided_at IS NOT DISTINCT FROM NEW.decided_at
+         AND OLD.inserted_at IS NOT DISTINCT FROM NEW.inserted_at
+         AND (NEW.candidate_id IS NULL OR NEW.candidate_id IS NOT DISTINCT FROM OLD.candidate_id)
+         AND (NEW.node_id IS NULL OR NEW.node_id IS NOT DISTINCT FROM OLD.node_id)
+         AND (NEW.audit_log_id IS NULL OR NEW.audit_log_id IS NOT DISTINCT FROM OLD.audit_log_id)
+      THEN
+        RETURN NEW;
+      END IF;
+
+      RAISE EXCEPTION 'node_admission_decisions is append-only';
+    END;
+    $$
+    """)
+
+    execute("""
+    CREATE TRIGGER node_admission_decisions_append_only
+    BEFORE UPDATE OR DELETE ON node_admission_decisions
+    FOR EACH ROW
+    EXECUTE FUNCTION orchard_reject_node_admission_decision_mutation()
+    """)
+  end
+
+  def down do
+    execute("DROP TRIGGER IF EXISTS node_admission_decisions_append_only ON node_admission_decisions")
+    execute("DROP FUNCTION IF EXISTS orchard_reject_node_admission_decision_mutation()")
+
+    drop_if_exists(table(:node_admission_decisions))
+    drop_if_exists(table(:node_admission_candidates))
+    drop_if_exists(index(:audit_logs, [:occurred_at], name: :idx_audit_logs_cluster_occurred_at))
+    drop_if_exists(constraint(:audit_logs, :audit_logs_scope_tenant_consistency))
+
+    execute("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")
+
+    execute("""
+    UPDATE audit_logs
+    SET tenant_id = '#{@legacy_tenant_id}',
+        scope = 'tenant',
+        payload = COALESCE(payload, '{}'::jsonb) || '{"legacy_cluster_scope": true}'::jsonb
+    WHERE scope = 'cluster'
+    """)
+
+    execute("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
+
+    alter table(:audit_logs) do
+      remove(:scope)
+    end
+
+    execute("ALTER TABLE audit_logs ALTER COLUMN tenant_id SET NOT NULL")
+
+    execute("DROP TYPE IF EXISTS node_admission_decision_kind")
+  end
+end

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -370,6 +370,13 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
     test "on_node_resolved callback exit does not abort dispatch or observation", ctx do
       configure_stub(%{status: {:ok, full_status(@other_uuid)}})
 
+      insert_target_node!(ctx.schedule.runtime_client_target,
+        id: @other_uuid,
+        display_name: "test-node",
+        hostname: "test.local",
+        rpc_port: 50_071
+      )
+
       callback = fn _node_id ->
         exit({:noproc, {GenServer, :call, [:queue_manager, :mark, 5_000]}})
       end
@@ -411,6 +418,13 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
         |> full_status()
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
+
+      insert_target_node!(target,
+        id: @valid_uuid,
+        display_name: "test-node",
+        hostname: "test.local",
+        rpc_port: 50_071
+      )
 
       assert {:ok, _node} =
                Orchard.Nodes.observe_status(target, healthy_status, DateTime.utc_now())

--- a/apps/orchard_controller/test/orchard/governance/foundation_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/foundation_test.exs
@@ -120,6 +120,75 @@ defmodule Orchard.Governance.FoundationTest do
                target_type: ["can't be blank"]
              } = errors_on(changeset)
     end
+
+    test "cluster-scoped audit records require no tenant" do
+      assert {:ok, audit_log} =
+               Governance.insert_cluster_audit_log(%{
+                 action: "node_admission.rejected",
+                 target_type: "node_admission_candidate",
+                 target_id: Ecto.UUID.generate(),
+                 payload: %{"surface" => "test"}
+               })
+
+      assert audit_log.scope == "cluster"
+      assert audit_log.tenant_id == nil
+      assert audit_log.actor_type == "operator"
+      assert audit_log.payload == %{"surface" => "test"}
+
+      changeset =
+        AuditLog.changeset(%AuditLog{}, %{
+          scope: "cluster",
+          tenant_id: Governance.legacy_tenant_id(),
+          actor_type: "operator",
+          action: "cluster.write",
+          target_type: "cluster"
+        })
+
+      assert %{tenant_id: ["must be blank"]} = errors_on(changeset)
+    end
+
+    test "cluster-scoped audit records return validation errors for missing required fields" do
+      assert {:error, changeset} = Governance.insert_cluster_audit_log(%{})
+
+      assert %{
+               action: ["can't be blank"],
+               target_type: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "cluster audit rows can be mapped before rollback restores tenant_id not null" do
+      assert {:ok, audit_log} =
+               Governance.insert_cluster_audit_log(%{
+                 action: "node_admission.rejected",
+                 target_type: "node_admission_candidate",
+                 target_id: Ecto.UUID.generate(),
+                 payload: %{"surface" => "rollback-test"}
+               })
+
+      Repo.query!("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")
+      {:ok, legacy_tenant_id} = Ecto.UUID.dump(Governance.legacy_tenant_id())
+
+      Repo.query!(
+        """
+        UPDATE audit_logs
+        SET tenant_id = $1,
+            scope = 'tenant',
+            payload = COALESCE(payload, '{}'::jsonb) || '{"legacy_cluster_scope": true}'::jsonb
+        WHERE scope = 'cluster'
+        """,
+        [legacy_tenant_id]
+      )
+
+      Repo.query!("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
+      Repo.query!("ALTER TABLE audit_logs ALTER COLUMN tenant_id SET NOT NULL")
+
+      reloaded = Repo.get!(AuditLog, audit_log.id)
+
+      assert reloaded.scope == "tenant"
+      assert reloaded.tenant_id == Governance.legacy_tenant_id()
+      assert reloaded.payload["legacy_cluster_scope"] == true
+      assert reloaded.payload["surface"] == "rollback-test"
+    end
   end
 
   defp create_tenant!(slug) do

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -32,9 +32,10 @@ defmodule Orchard.NodesTest do
 
   import ExUnit.CaptureLog
 
+  alias Orchard.Governance.AuditLog
   alias Orchard.Inference.QueueManager
   alias Orchard.Nodes
-  alias Orchard.Nodes.Node
+  alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
   alias Orchard.RuntimeEndpoint.GrpcCompatibilityMapper
   alias Orchard.RuntimeEndpoint.{ModelRef, Observation, Placement, PlacementCapacity, Target}
 
@@ -67,7 +68,52 @@ defmodule Orchard.NodesTest do
     |> Repo.insert!()
   end
 
+  defp insert_node_from_status!(target, status, overrides \\ %{}) do
+    metadata = status_metadata(status)
+    target = status_target(target)
+
+    attrs =
+      %{
+        id: metadata_value(metadata, :node_id),
+        hostname: metadata_value(metadata, :hostname),
+        display_name: metadata_value(metadata, :display_name),
+        advertise_addr: metadata_value(metadata, :listen_host),
+        rpc_port: metadata_value(metadata, :listen_port),
+        connect_host: Keyword.get(target, :host),
+        connect_port: Keyword.get(target, :port),
+        state: :active,
+        health: :healthy,
+        capabilities: %{},
+        tool_readiness: %{}
+      }
+      |> Map.merge(overrides)
+
+    Repo.get(Node, attrs.id) || insert_node!(attrs)
+  end
+
+  defp status_metadata(%Observation{metadata: metadata}), do: metadata
+  defp status_metadata(%{node_metadata: metadata}), do: metadata
+
+  defp status_target(%Target{transport: :grpc_compat, address: address}), do: address
+  defp status_target(%Target{transport: :beam}), do: []
+  defp status_target(target), do: target
+
+  defp metadata_value(metadata, key) do
+    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
+  end
+
   defp make_target(host, port), do: [host: host, port: port]
+
+  defp admission_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        trust_evidence_ref: "registration-audit:#{Ecto.UUID.generate()}",
+        pool_id: Ecto.UUID.generate(),
+        routing_policy_id: Ecto.UUID.generate()
+      },
+      overrides
+    )
+  end
 
   defp tool_ref(name, version), do: "tool://#{name}@#{version}"
 
@@ -443,10 +489,521 @@ defmodule Orchard.NodesTest do
     end
   end
 
-  # -- observe_status/3 insert --
+  # -- admission candidates --
 
-  describe "observe_status/3 insert" do
-    test "valid metadata inserts node as active" do
+  describe "admission candidates" do
+    test "SPEC.md §4.2 and §7.5.4 first observation creates candidate, not active node" do
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.1", 9444)
+      observed_at = DateTime.utc_now()
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "candidate-node",
+          hostname: "candidate-host.local",
+          listen_host: "10.0.0.1",
+          listen_port: 9444
+        })
+
+      assert :noop = Nodes.observe_status(target, status, observed_at)
+      assert Repo.get(Node, node_id) == nil
+
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+      assert candidate.source == :runtime_endpoint_observation
+      assert candidate.admission_category == :pending_observed
+      assert candidate.observed_identity["claimed_node_id"] == node_id
+      assert candidate.observed_identity["display_name"] == "candidate-node"
+      assert candidate.target_ref == "10.0.0.1:9444"
+      assert candidate.endpoint_target == "10.0.0.1:9444"
+      assert candidate.inventory["capabilities"]["supports_prompt_token_ids"] == false
+      assert candidate.last_observed_at == DateTime.truncate(observed_at, :microsecond)
+    end
+
+    test "SPEC.md §4.2 duplicate observations reuse one observed candidate" do
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.19", 9444)
+      first_observed_at = DateTime.utc_now()
+      second_observed_at = DateTime.add(first_observed_at, 1, :second)
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "duplicate-candidate-node",
+          hostname: "duplicate-candidate.local",
+          listen_host: "10.0.0.19",
+          listen_port: 9444
+        })
+
+      assert :noop = Nodes.observe_status(target, status, first_observed_at)
+      assert :noop = Nodes.observe_status(target, status, second_observed_at)
+
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+      assert candidate.observed_identity["claimed_node_id"] == node_id
+      assert candidate.admission_category == :pending_observed
+      assert candidate.last_observed_at == DateTime.truncate(second_observed_at, :microsecond)
+    end
+
+    test "SPEC.md §4.2 open observed candidate identity is unique in the database" do
+      node_id = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+
+      attrs = %{
+        source: :runtime_endpoint_observation,
+        admission_category: :pending_observed,
+        observed_identity: %{"claimed_node_id" => node_id},
+        target_ref: "10.0.0.20:9444",
+        endpoint_transport: :grpc,
+        endpoint_target: "10.0.0.20:9444",
+        inventory: %{},
+        compatibility_evidence: %{},
+        last_observed_at: now
+      }
+
+      assert {:ok, _candidate} =
+               %AdmissionCandidate{}
+               |> AdmissionCandidate.changeset(attrs)
+               |> Repo.insert()
+
+      assert {:error, changeset} =
+               %AdmissionCandidate{}
+               |> AdmissionCandidate.changeset(attrs)
+               |> Repo.insert()
+
+      assert %{observed_identity: ["has already been taken"]} = errors_on(changeset)
+
+      assert {:ok, _candidate} =
+               %AdmissionCandidate{}
+               |> AdmissionCandidate.changeset(%{
+                 attrs
+                 | observed_identity: %{"claimed_node_id" => Ecto.UUID.generate()}
+               })
+               |> Repo.insert()
+    end
+
+    test "SPEC.md §4.2 multibyte observed metadata is UTF-8 safe and byte bounded" do
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.24", 9444)
+      multibyte = String.duplicate("界", 300)
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "utf8-candidate",
+          hostname: "utf8-candidate.local",
+          listen_host: "10.0.0.24",
+          listen_port: 9444,
+          agent_version: multibyte
+        })
+        |> put_in([:hosted_tool_capabilities], [
+          hosted_tool_capability(multibyte, "2026-06-28", "mcp")
+        ])
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+
+      agent_version = candidate.observed_identity["agent_version"]
+
+      hosted_tool_name =
+        candidate.inventory["capabilities"]["hosted_tools"] |> hd() |> Map.fetch!("name")
+
+      assert String.valid?(agent_version)
+      assert String.valid?(hosted_tool_name)
+      assert byte_size(agent_version) <= 512
+      assert byte_size(hosted_tool_name) <= 512
+      assert agent_version != ""
+      assert hosted_tool_name != ""
+    end
+
+    test "SPEC.md §4.3 pending admission rejection is auditable and not decommissioning" do
+      target = make_target("10.0.0.12", 9444)
+
+      status =
+        make_status_response(%{
+          display_name: "reject-candidate",
+          hostname: "reject-candidate.local",
+          listen_host: "10.0.0.12",
+          listen_port: 9444
+        })
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      [candidate] = Nodes.list_admission_candidates()
+
+      assert {:ok, result} =
+               Nodes.reject_admission(
+                 candidate.id,
+                 %{reason: "identity not approved"},
+                 actor_type: "operator",
+                 actor_id: "admin@example.test"
+               )
+
+      assert result.candidate.admission_category == :rejected
+      assert result.decision.decision == :rejected
+      assert result.decision.reason == "identity not approved"
+      assert result.decision.candidate_id == candidate.id
+      assert result.decision.audit_log_id == result.audit_log.id
+      assert %AuditLog{} = result.audit_log
+      assert result.audit_log.scope == "cluster"
+      assert result.audit_log.tenant_id == nil
+      assert result.audit_log.action == "node_admission.rejected"
+    end
+
+    test "SPEC.md §4.3 node-id rejection is pending-only and does not duplicate decisions" do
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-double-reject",
+          hostname: "registered-double-reject.local",
+          advertise_addr: "10.0.0.21",
+          rpc_port: 9444
+        })
+
+      assert {:ok, _rejected} =
+               Nodes.reject_admission(node.id, %{reason: "first rejection"})
+
+      assert {:error, :admission_not_pending} =
+               Nodes.reject_admission(node.id, %{reason: "second rejection"})
+
+      decisions =
+        AdmissionDecision
+        |> where([decision], decision.node_id == ^node.id)
+        |> where([decision], decision.decision == :rejected)
+        |> Repo.all()
+
+      assert length(decisions) == 1
+    end
+
+    test "SPEC.md §4.3 rejected observed candidate remains rejected after later observation" do
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.15", 9444)
+      observed_at = DateTime.utc_now()
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "rejected-observed",
+          hostname: "rejected-observed.local",
+          listen_host: "10.0.0.15",
+          listen_port: 9444
+        })
+
+      assert :noop = Nodes.observe_status(target, status, observed_at)
+      [candidate] = Nodes.list_admission_candidates()
+
+      assert {:ok, rejected} =
+               Nodes.reject_admission(candidate.id, %{reason: "not trusted"})
+
+      assert rejected.candidate.admission_category == :rejected
+
+      later = DateTime.add(observed_at, 1, :second)
+      assert :noop = Nodes.observe_status(target, status, later)
+
+      assert [refreshed] = Nodes.list_admission_candidates()
+      assert refreshed.id == candidate.id
+      assert refreshed.admission_category == :rejected
+      assert refreshed.last_observed_at == DateTime.truncate(later, :microsecond)
+    end
+
+    test "SPEC.md §4.2 first BEAM observation creates a BEAM admission candidate" do
+      node_id = Ecto.UUID.generate()
+      target = Target.beam(node_id, address: :orchard_node_agent@localhost)
+      observed_at = DateTime.utc_now()
+
+      observation =
+        Observation.new(%{
+          endpoint_id: target.id,
+          target: target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 1,
+          metadata: %{
+            node_id: node_id,
+            display_name: "beam-candidate",
+            hostname: "beam-candidate.local",
+            listen_host: "10.0.0.16",
+            listen_port: 9444
+          },
+          health: %{ready: true},
+          placements: []
+        })
+
+      assert :noop = Nodes.observe_status(target, observation, observed_at)
+      assert Repo.get(Node, node_id) == nil
+
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+      assert candidate.source == :runtime_endpoint_observation
+      assert candidate.admission_category == :pending_observed
+      assert candidate.endpoint_transport == :beam
+      assert candidate.endpoint_target == "10.0.0.16:9444"
+      assert candidate.observed_identity["claimed_node_id"] == node_id
+    end
+
+    test "SPEC.md §4.3 rejection clear appends history before registered node admission" do
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-for-admission",
+          hostname: "registered-for-admission.local",
+          advertise_addr: "10.0.0.13",
+          rpc_port: 9444
+        })
+
+      assert {:ok, rejected} =
+               Nodes.reject_admission(node.id, %{reason: "waiting for approval"})
+
+      assert Repo.get!(Node, node.id).state == :registered
+      assert {:error, :admission_rejected} = Nodes.admit_node(node.id)
+
+      assert {:ok, cleared} =
+               Nodes.clear_admission_rejection(rejected.candidate.id, %{surface: "test"})
+
+      assert cleared.candidate.admission_category == :pending_registered
+      assert {:ok, admitted} = Nodes.admit_node(node.id, admission_attrs())
+      assert admitted.node.state == :admitted
+      assert admitted.decision.decision == :admitted
+
+      decisions =
+        AdmissionDecision
+        |> where([decision], decision.node_id == ^node.id)
+        |> order_by([decision], asc: decision.inserted_at)
+        |> Repo.all()
+        |> Enum.map(& &1.decision)
+
+      assert decisions == [:rejected, :rejection_cleared, :admitted]
+    end
+
+    test "SPEC.md §4.2 registered node admission fails closed without required inputs" do
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-inputs",
+          hostname: "registered-inputs.local",
+          advertise_addr: "10.0.0.17",
+          rpc_port: 9444
+        })
+
+      assert {:error, :trust_not_established} = Nodes.admit_node(node.id)
+
+      assert {:error, :pool_required} =
+               Nodes.admit_node(node.id, %{trust_evidence_ref: "registration-audit:test"})
+
+      assert {:error, :policy_required} =
+               Nodes.admit_node(node.id, %{
+                 trust_evidence_ref: "registration-audit:test",
+                 pool_id: Ecto.UUID.generate()
+               })
+    end
+
+    test "SPEC.md §4.3 admission decisions reject direct updates" do
+      target = make_target("10.0.0.18", 9444)
+
+      status =
+        make_status_response(%{
+          display_name: "append-only-candidate",
+          hostname: "append-only-candidate.local",
+          listen_host: "10.0.0.18",
+          listen_port: 9444
+        })
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      [candidate] = Nodes.list_admission_candidates()
+
+      assert {:ok, result} =
+               Nodes.reject_admission(candidate.id, %{reason: "append-only test"})
+
+      {:ok, decision_id} = Ecto.UUID.dump(result.decision.id)
+
+      assert_raise Postgrex.Error, ~r/node_admission_decisions is append-only/, fn ->
+        Repo.query!(
+          "UPDATE node_admission_decisions SET reason = 'mutated' WHERE id = $1",
+          [decision_id]
+        )
+      end
+    end
+
+    test "SPEC.md §4.3 admission decisions reject direct deletes" do
+      target = make_target("10.0.0.23", 9444)
+
+      status =
+        make_status_response(%{
+          display_name: "append-only-delete-candidate",
+          hostname: "append-only-delete-candidate.local",
+          listen_host: "10.0.0.23",
+          listen_port: 9444
+        })
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      [candidate] = Nodes.list_admission_candidates()
+
+      assert {:ok, result} =
+               Nodes.reject_admission(candidate.id, %{reason: "append-only delete test"})
+
+      {:ok, decision_id} = Ecto.UUID.dump(result.decision.id)
+
+      assert_raise Postgrex.Error, ~r/node_admission_decisions is append-only/, fn ->
+        Repo.query!("DELETE FROM node_admission_decisions WHERE id = $1", [decision_id])
+      end
+    end
+
+    test "SPEC.md §4.3 admission decisions allow FK retention nullification" do
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-fk-nullify",
+          hostname: "registered-fk-nullify.local",
+          advertise_addr: "10.0.0.22",
+          rpc_port: 9444
+        })
+
+      assert {:ok, result} =
+               Nodes.reject_admission(node.id, %{reason: "fk nullify test"})
+
+      decision_id = result.decision.id
+
+      Repo.delete!(result.candidate)
+
+      decision = Repo.get!(AdmissionDecision, decision_id)
+      assert decision.candidate_id == nil
+      assert decision.node_id == node.id
+      assert decision.audit_log_id == result.audit_log.id
+
+      Repo.delete!(node)
+
+      decision = Repo.get!(AdmissionDecision, decision_id)
+      assert decision.candidate_id == nil
+      assert decision.node_id == nil
+      assert decision.audit_log_id == result.audit_log.id
+
+      Repo.query!("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")
+
+      try do
+        Repo.delete!(result.audit_log)
+      after
+        Repo.query!("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
+      end
+
+      decision = Repo.get!(AdmissionDecision, decision_id)
+      assert decision.candidate_id == nil
+      assert decision.node_id == nil
+      assert decision.audit_log_id == nil
+      assert decision.reason == "fk nullify test"
+    end
+
+    test "SPEC.md §4.3 admission decisions reject direct reference rewrites" do
+      target = make_target("10.0.0.25", 9444)
+
+      status =
+        make_status_response(%{
+          display_name: "append-only-reference-candidate",
+          hostname: "append-only-reference-candidate.local",
+          listen_host: "10.0.0.25",
+          listen_port: 9444
+        })
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      [candidate] = Nodes.list_admission_candidates()
+
+      assert {:ok, result} =
+               Nodes.reject_admission(candidate.id, %{reason: "reference rewrite test"})
+
+      other_candidate =
+        %AdmissionCandidate{}
+        |> AdmissionCandidate.changeset(%{
+          source: :runtime_endpoint_observation,
+          admission_category: :pending_observed,
+          observed_identity: %{"claimed_node_id" => Ecto.UUID.generate()},
+          target_ref: "10.0.0.26:9444",
+          endpoint_transport: :grpc,
+          endpoint_target: "10.0.0.26:9444",
+          inventory: %{},
+          compatibility_evidence: %{},
+          last_observed_at: DateTime.utc_now()
+        })
+        |> Repo.insert!()
+
+      other_node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-reference-target",
+          hostname: "registered-reference-target.local",
+          advertise_addr: "10.0.0.27",
+          rpc_port: 9444
+        })
+
+      assert {:ok, other_audit_log} =
+               Orchard.Governance.insert_cluster_audit_log(%{
+                 action: "node_admission.rejected",
+                 target_type: "node",
+                 target_id: other_node.id,
+                 payload: %{}
+               })
+
+      {:ok, decision_id} = Ecto.UUID.dump(result.decision.id)
+      {:ok, other_candidate_id} = Ecto.UUID.dump(other_candidate.id)
+      {:ok, other_node_id} = Ecto.UUID.dump(other_node.id)
+
+      assert_raise Postgrex.Error, ~r/node_admission_decisions is append-only/, fn ->
+        Repo.query!(
+          "UPDATE node_admission_decisions SET candidate_id = NULL WHERE id = $1",
+          [decision_id]
+        )
+      end
+
+      assert_raise Postgrex.Error, ~r/node_admission_decisions is append-only/, fn ->
+        Repo.query!(
+          "UPDATE node_admission_decisions SET candidate_id = $2 WHERE id = $1",
+          [decision_id, other_candidate_id]
+        )
+      end
+
+      assert_raise Postgrex.Error, ~r/node_admission_decisions is append-only/, fn ->
+        Repo.query!(
+          "UPDATE node_admission_decisions SET node_id = $2 WHERE id = $1",
+          [decision_id, other_node_id]
+        )
+      end
+
+      assert_raise Postgrex.Error, ~r/node_admission_decisions is append-only/, fn ->
+        Repo.query!(
+          "UPDATE node_admission_decisions SET audit_log_id = $2 WHERE id = $1",
+          [decision_id, other_audit_log.id]
+        )
+      end
+    end
+
+    test "SPEC.md §4.3 admitted node becomes active after fresh healthy observation" do
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-activation",
+          hostname: "registered-activation.local",
+          advertise_addr: "10.0.0.14",
+          rpc_port: 9444
+        })
+
+      assert {:ok, admitted} = Nodes.admit_node(node.id, admission_attrs())
+      assert admitted.node.state == :admitted
+
+      target = make_target("10.0.0.14", 9444)
+
+      status =
+        make_status_response(%{
+          node_id: node.id,
+          display_name: "registered-activation",
+          hostname: "registered-activation.local",
+          listen_host: "10.0.0.14",
+          listen_port: 9444
+        })
+
+      assert {:ok, active} = Nodes.observe_status(target, status, DateTime.utc_now())
+      assert active.state == :active
+    end
+  end
+
+  # -- observe_status/3 trusted update --
+
+  describe "observe_status/3 trusted update" do
+    test "valid metadata updates active node" do
       node_id = Ecto.UUID.generate()
       target = make_target("10.0.0.1", 9444)
       now = DateTime.utc_now()
@@ -460,6 +1017,7 @@ defmodule Orchard.NodesTest do
           listen_port: 9444
         })
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, now)
       assert node.id == node_id
       assert node.state == :active
@@ -485,6 +1043,7 @@ defmodule Orchard.NodesTest do
           listen_port: 50_071
         })
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, now)
       assert node.advertise_addr == "0.0.0.0"
       assert node.rpc_port == 50_071
@@ -496,6 +1055,7 @@ defmodule Orchard.NodesTest do
       target = make_target("10.0.0.2", 9444)
       status = make_status_response(%{listen_host: "10.0.0.2"}, nil)
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.health == :healthy
     end
@@ -504,6 +1064,7 @@ defmodule Orchard.NodesTest do
       target = make_target("10.0.0.3", 9444)
       status = make_status_response(%{listen_host: "10.0.0.3"}, %{ready: false})
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.health == :unhealthy
     end
@@ -517,6 +1078,7 @@ defmodule Orchard.NodesTest do
           health_code: "SLOW"
         })
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.health == :degraded
     end
@@ -527,6 +1089,7 @@ defmodule Orchard.NodesTest do
       status =
         make_status_response(%{listen_host: "10.0.0.5", worker_backend: "mlx"})
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
 
       assert node.capabilities == %{
@@ -545,6 +1108,7 @@ defmodule Orchard.NodesTest do
         make_status_response(%{listen_host: "10.0.0.50", worker_backend: "mlx"})
         |> Map.put(:supports_prompt_token_ids, true)
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.capabilities["supports_prompt_token_ids"] == true
     end
@@ -556,6 +1120,7 @@ defmodule Orchard.NodesTest do
         make_status_response(%{listen_host: "10.0.0.51", worker_backend: "mlx"})
         |> Map.put(:supports_prompt_token_ids, false)
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.capabilities["supports_prompt_token_ids"] == false
     end
@@ -566,6 +1131,7 @@ defmodule Orchard.NodesTest do
       status =
         make_status_response(%{listen_host: "10.0.0.6", worker_backend: ""})
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.capabilities == %{"supports_prompt_token_ids" => false, "hosted_tools" => []}
       assert node.tool_readiness == %{}
@@ -599,6 +1165,7 @@ defmodule Orchard.NodesTest do
         ]
       }
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
 
       assert node.capabilities == %{
@@ -639,6 +1206,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.id == node_id
     end
@@ -665,6 +1233,7 @@ defmodule Orchard.NodesTest do
         ]
       }
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
 
       assert node.capabilities["hosted_tools"] == [
@@ -703,6 +1272,7 @@ defmodule Orchard.NodesTest do
         ]
       }
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
 
       assert node.capabilities["hosted_tools"] == [
@@ -743,6 +1313,7 @@ defmodule Orchard.NodesTest do
           agent_version: "0.2.0"
         })
 
+      insert_node_from_status!(target, status)
       assert {:ok, updated} = Nodes.observe_status(target, status, later)
       assert updated.id == existing.id
       assert updated.display_name == "updated-name"
@@ -763,6 +1334,7 @@ defmodule Orchard.NodesTest do
           listen_port: 9444
         })
 
+      insert_node_from_status!(target, status)
       assert {:ok, updated} = Nodes.observe_status(target, status, later)
       assert updated.state == :cordoned
     end
@@ -793,8 +1365,11 @@ defmodule Orchard.NodesTest do
           }
         ])
 
+      target = make_target("10.0.0.52", 9444)
+      insert_node_from_status!(target, status)
+
       assert {:ok, _node} =
-               Nodes.observe_status(make_target("10.0.0.52", 9444), status, DateTime.utc_now())
+               Nodes.observe_status(target, status, DateTime.utc_now())
 
       assert {:ok, grant} = Task.await(awaiter, 2_000)
       assert grant.queue_result == :queued
@@ -824,8 +1399,11 @@ defmodule Orchard.NodesTest do
       status_a =
         placement_status("10.0.0.53", "aggregate-model", max_concurrency: 1)
 
+      target_a = make_target("10.0.0.53", 9444)
+      insert_node_from_status!(target_a, status_a)
+
       assert {:ok, node_a} =
-               Nodes.observe_status(make_target("10.0.0.53", 9444), status_a, DateTime.utc_now())
+               Nodes.observe_status(target_a, status_a, DateTime.utc_now())
 
       assert_receive {:first_aggregate_result, {:ok, first_grant}}, 2_000
       assert :ok = QueueManager.mark_grant_node(first_grant, node_a.id)
@@ -834,8 +1412,11 @@ defmodule Orchard.NodesTest do
       status_b =
         placement_status("10.0.0.54", "aggregate-model", max_concurrency: 1)
 
+      target_b = make_target("10.0.0.54", 9444)
+      insert_node_from_status!(target_b, status_b)
+
       assert {:ok, _node} =
-               Nodes.observe_status(make_target("10.0.0.54", 9444), status_b, DateTime.utc_now())
+               Nodes.observe_status(target_b, status_b, DateTime.utc_now())
 
       assert_receive {:second_aggregate_result, {:ok, second_grant}}, 2_000
 
@@ -873,6 +1454,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:active_request_count, 1)
         |> Map.put(:max_concurrency, 2)
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, DateTime.utc_now())
 
       assert_receive {:first_node_cap_result, {:ok, first_grant}}, 2_000
@@ -880,6 +1462,7 @@ defmodule Orchard.NodesTest do
 
       refreshed_status = Map.put(status, :active_request_count, 0)
 
+      insert_node_from_status!(target, refreshed_status)
       assert {:ok, _node} = Nodes.observe_status(target, refreshed_status, DateTime.utc_now())
       assert_receive {:second_node_cap_result, {:ok, second_grant}}, 2_000
 
@@ -929,6 +1512,7 @@ defmodule Orchard.NodesTest do
           }
         ])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, observed_at)
 
       {granted_lane, first_grant} =
@@ -995,6 +1579,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, DateTime.utc_now())
       refute Task.yield(awaiter, 100)
 
@@ -1030,6 +1615,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:active_request_count, 0)
         |> Map.put(:max_concurrency, 1)
 
+      insert_node_from_status!(target, initial_status)
       assert {:ok, _node} = Nodes.observe_status(target, initial_status, observed_at)
       assert_receive {:first_observed_source_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -1084,6 +1670,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, initial_status)
       assert {:ok, _node} = Nodes.observe_status(target, initial_status, observed_at)
       assert_receive {:first_unobserved_source_result, {:ok, first_grant}}, 2_000
       refute_receive {:second_unobserved_source_result, _result}, 50
@@ -1146,6 +1733,7 @@ defmodule Orchard.NodesTest do
           }
         ])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, DateTime.utc_now())
 
       assert_receive {:first_multislot_result, {:ok, first_grant}}, 2_000
@@ -1195,6 +1783,7 @@ defmodule Orchard.NodesTest do
           }
         ])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, observed_at)
 
       assert_receive {:first_head_order_result, {:ok, first_grant}}, 2_000
@@ -1230,11 +1819,13 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, full_status)
       assert {:ok, _node} = Nodes.observe_status(target, full_status, DateTime.utc_now())
       refute Task.yield(awaiter, 100)
 
       available_status = Map.put(full_status, :active_request_count, 0)
 
+      insert_node_from_status!(target, available_status)
       assert {:ok, _node} = Nodes.observe_status(target, available_status, DateTime.utc_now())
       assert {:ok, grant} = Task.await(awaiter, 2_000)
       assert grant.queue_result == :queued
@@ -1268,6 +1859,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 4)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert_receive {:first_cold_one_slot_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 100)
@@ -1307,6 +1899,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, observed_at)
 
       {granted_lane, first_grant} =
@@ -1366,6 +1959,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert_receive {:first_release_cold_lane_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -1398,6 +1992,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, initial_status)
       assert {:ok, _node} = Nodes.observe_status(target, initial_status, observed_at)
       assert_receive {:first_empty_source_result, {:ok, first_grant}}, 2_000
       assert :ok = QueueManager.mark_capacity_source_observed(first_grant)
@@ -1451,6 +2046,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, observed_at)
 
       {granted_lane, first_grant} =
@@ -1519,6 +2115,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert_receive {:first_repeat_cold_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -1559,8 +2156,11 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      target_a = make_target("10.0.0.65", 9444)
+      insert_node_from_status!(target_a, status_a)
+
       assert {:ok, node_a} =
-               Nodes.observe_status(make_target("10.0.0.65", 9444), status_a, DateTime.utc_now())
+               Nodes.observe_status(target_a, status_a, DateTime.utc_now())
 
       assert_receive {:first_cold_aggregate_result, {:ok, first_grant}}, 2_000
       assert :ok = QueueManager.mark_grant_node(first_grant, node_a.id)
@@ -1572,8 +2172,11 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      target_b = make_target("10.0.0.66", 9444)
+      insert_node_from_status!(target_b, status_b)
+
       assert {:ok, _node} =
-               Nodes.observe_status(make_target("10.0.0.66", 9444), status_b, DateTime.utc_now())
+               Nodes.observe_status(target_b, status_b, DateTime.utc_now())
 
       assert_receive {:second_cold_aggregate_result, {:ok, second_grant}}, 2_000
 
@@ -1609,6 +2212,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.health == :degraded
       assert {:ok, grant} = Task.await(awaiter, 2_000)
@@ -1650,6 +2254,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, updated} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert updated.state == :cordoned
       refute Task.yield(awaiter, 100)
@@ -1660,6 +2265,7 @@ defmodule Orchard.NodesTest do
 
       later = DateTime.add(DateTime.utc_now(), 1, :second)
 
+      insert_node_from_status!(target, status)
       assert {:ok, active_node} = Nodes.observe_status(target, status, later)
       assert active_node.state == :active
       assert {:ok, grant} = Task.await(awaiter, 2_000)
@@ -1721,6 +2327,7 @@ defmodule Orchard.NodesTest do
 
       later = DateTime.add(DateTime.utc_now(), 1, :second)
 
+      insert_node_from_status!(target, healthy_status)
       assert {:ok, cordoned_node} = Nodes.observe_status(target, healthy_status, later)
       assert cordoned_node.state == :cordoned
       assert :ok = QueueManager.release(first_grant)
@@ -1732,6 +2339,7 @@ defmodule Orchard.NodesTest do
 
       newest = DateTime.add(later, 1, :second)
 
+      insert_node_from_status!(target, healthy_status)
       assert {:ok, _active_node} = Nodes.observe_status(target, healthy_status, newest)
       assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
       assert second_grant.queue_result == :queued
@@ -1759,6 +2367,7 @@ defmodule Orchard.NodesTest do
       invalid_status =
         placement_status("10.0.0.58", "invalid-cap-model", max_concurrency: 0)
 
+      insert_node_from_status!(target, invalid_status)
       assert {:ok, _node} = Nodes.observe_status(target, invalid_status, DateTime.utc_now())
       refute Task.yield(awaiter, 100)
 
@@ -1769,6 +2378,7 @@ defmodule Orchard.NodesTest do
           1
         )
 
+      insert_node_from_status!(target, valid_status)
       assert {:ok, _node} = Nodes.observe_status(target, valid_status, DateTime.utc_now())
       assert {:ok, grant} = Task.await(awaiter, 2_000)
       assert grant.queue_result == :queued
@@ -1816,6 +2426,7 @@ defmodule Orchard.NodesTest do
 
       observation = GrpcCompatibilityMapper.observation_from_status(target, status)
 
+      insert_node_from_status!(target, observation)
       assert {:ok, _node} = Nodes.observe_status(target, observation, DateTime.utc_now())
       assert_receive {:first_observation_placement_result, {:ok, first_grant}}, 2_000
       assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
@@ -1875,6 +2486,7 @@ defmodule Orchard.NodesTest do
           ]
         })
 
+      insert_node_from_status!(target, observation)
       assert {:ok, node} = Nodes.observe_status(target, observation, DateTime.utc_now())
       assert node.id == node_id
       assert node.advertise_addr == "10.0.0.95"
@@ -1940,6 +2552,7 @@ defmodule Orchard.NodesTest do
           ]
         })
 
+      insert_node_from_status!(target, observation)
       assert {:ok, node} = Nodes.observe_status(target, observation, DateTime.utc_now())
       assert node.id == node_id
       assert {:error, :queue_timeout, metadata} = Task.await(awaiter, 2_000)
@@ -1982,6 +2595,7 @@ defmodule Orchard.NodesTest do
 
       observation = GrpcCompatibilityMapper.observation_from_status(target, status)
 
+      insert_node_from_status!(target, observation)
       assert {:ok, _node} = Nodes.observe_status(target, observation, observed_at)
       assert_receive {:first_unavailable_observation_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2027,6 +2641,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> put_in([:runtime_model_placements, Access.at(0), :active_request_count], 1)
 
+      insert_node_from_status!(target, full_status)
       assert {:ok, _node} = Nodes.observe_status(target, full_status, DateTime.utc_now())
       refute Task.yield(awaiter, 100)
 
@@ -2035,6 +2650,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:active_request_count, 0)
         |> put_in([:runtime_model_placements, Access.at(0), :active_request_count], 0)
 
+      insert_node_from_status!(target, available_status)
       assert {:ok, _node} = Nodes.observe_status(target, available_status, DateTime.utc_now())
       assert {:ok, grant} = Task.await(awaiter, 2_000)
       assert grant.queue_result == :queued
@@ -2065,6 +2681,7 @@ defmodule Orchard.NodesTest do
         placement_status("10.0.0.55", "clear-model", max_concurrency: 1)
 
       target = make_target("10.0.0.55", 9444)
+      insert_node_from_status!(target, loaded_status)
       assert {:ok, _node} = Nodes.observe_status(target, loaded_status, DateTime.utc_now())
       assert_receive {:first_clear_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2076,6 +2693,7 @@ defmodule Orchard.NodesTest do
           :PLACEMENT_STATE_CACHED
         )
 
+      insert_node_from_status!(target, cached_status)
       assert {:ok, _node} = Nodes.observe_status(target, cached_status, DateTime.utc_now())
       assert :ok = QueueManager.release(first_grant)
       refute Task.yield(second_awaiter, 100)
@@ -2087,6 +2705,7 @@ defmodule Orchard.NodesTest do
           :PLACEMENT_STATE_LOADED
         )
 
+      insert_node_from_status!(target, reloaded_status)
       assert {:ok, _node} = Nodes.observe_status(target, reloaded_status, DateTime.utc_now())
       assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
       assert second_grant.queue_result == :queued
@@ -2116,16 +2735,19 @@ defmodule Orchard.NodesTest do
       target = make_target("10.0.0.57", 9444)
       loaded_status = placement_status("10.0.0.57", "omitted-model", max_concurrency: 1)
 
+      insert_node_from_status!(target, loaded_status)
       assert {:ok, _node} = Nodes.observe_status(target, loaded_status, DateTime.utc_now())
       assert_receive {:first_omitted_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
 
       omitted_status = Map.put(loaded_status, :runtime_model_placements, [])
 
+      insert_node_from_status!(target, omitted_status)
       assert {:ok, _node} = Nodes.observe_status(target, omitted_status, DateTime.utc_now())
       assert :ok = QueueManager.release(first_grant)
       refute Task.yield(second_awaiter, 100)
 
+      insert_node_from_status!(target, loaded_status)
       assert {:ok, _node} = Nodes.observe_status(target, loaded_status, DateTime.utc_now())
       assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
       assert second_grant.queue_result == :queued
@@ -2154,6 +2776,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:loaded_models, [%{model_id: "loaded-missing", version: "v1"}])
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, missing_placement_status)
       assert {:ok, _node} = Nodes.observe_status(target, missing_placement_status, observed_at)
       refute Task.yield(awaiter, 100)
 
@@ -2226,6 +2849,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, DateTime.add(observed_at, 1))
       assert_receive {:first_stale_metadata_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2360,6 +2984,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, valid_status)
       assert {:ok, _node} = Nodes.observe_status(target, valid_status, DateTime.utc_now())
       assert_receive {:first_identity_conflict_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2442,6 +3067,7 @@ defmodule Orchard.NodesTest do
           listen_port: 50_071
         })
 
+      insert_node_from_status!(target, status)
       assert {:ok, node} = Nodes.observe_status(target, status, DateTime.utc_now())
       assert node.id == different_id
       assert node.advertise_addr == "0.0.0.0"
@@ -2547,6 +3173,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, valid_status)
       assert {:ok, _node} = Nodes.observe_status(target, valid_status, DateTime.utc_now())
       assert_receive {:first_invalid_metadata_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2627,6 +3254,7 @@ defmodule Orchard.NodesTest do
           |> Map.put(:max_concurrency, 1)
           |> Map.put(:runtime_model_placements, [])
 
+        insert_node_from_status!(target, valid_status)
         assert {:ok, _node} = Nodes.observe_status(target, valid_status, DateTime.utc_now())
         assert_receive {{:first_invalid_map_result, ^suffix}, {:ok, first_grant}}, 2_000
         refute Task.yield(second_awaiter, 50)
@@ -2815,6 +3443,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, heartbeat_at)
       assert_receive {:first_unreachable_capacity_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2830,6 +3459,7 @@ defmodule Orchard.NodesTest do
 
       restored_at = DateTime.add(unreachable_at, 1, :second)
 
+      insert_node_from_status!(target, status)
       assert {:ok, restored_node} = Nodes.observe_status(target, status, restored_at)
       assert restored_node.health == :healthy
       assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
@@ -2877,6 +3507,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, heartbeat_at)
       assert_receive {:first_transport_capacity_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2898,6 +3529,7 @@ defmodule Orchard.NodesTest do
 
       restored_at = DateTime.add(unreachable_at, 1, :second)
 
+      insert_node_from_status!(target, status)
       assert {:ok, restored_node} = Nodes.observe_status(target, status, restored_at)
       assert restored_node.health == :healthy
       assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
@@ -2936,6 +3568,7 @@ defmodule Orchard.NodesTest do
 
       status = placement_status("10.0.0.70", "transport-placement-model", max_concurrency: 1)
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, heartbeat_at)
       assert_receive {:first_transport_placement_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)
@@ -2957,6 +3590,7 @@ defmodule Orchard.NodesTest do
 
       restored_at = DateTime.add(unreachable_at, 1, :second)
 
+      insert_node_from_status!(target, status)
       assert {:ok, restored_node} = Nodes.observe_status(target, status, restored_at)
       assert restored_node.health == :healthy
       assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
@@ -3184,6 +3818,7 @@ defmodule Orchard.NodesTest do
         |> Map.put(:max_concurrency, 1)
         |> Map.put(:runtime_model_placements, [])
 
+      insert_node_from_status!(target, status)
       assert {:ok, _node} = Nodes.observe_status(target, status, observed_at)
       assert_receive {:first_failure_clear_result, {:ok, first_grant}}, 2_000
       refute Task.yield(second_awaiter, 50)

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -49,7 +49,7 @@ defmodule Orchard.NodesTest do
         id: Ecto.UUID.generate(),
         hostname: "host-#{unique}.local",
         display_name: "node-#{unique}",
-        advertise_addr: "10.0.0.#{rem(unique, 255)}",
+        advertise_addr: unique_advertise_addr(unique),
         rpc_port: 9444,
         state: :active,
         health: :healthy,
@@ -58,6 +58,14 @@ defmodule Orchard.NodesTest do
       },
       overrides
     )
+  end
+
+  defp unique_advertise_addr(unique) do
+    second_octet = unique |> div(65_536) |> rem(256)
+    third_octet = unique |> div(256) |> rem(256)
+    fourth_octet = rem(unique, 254) + 1
+
+    "10.#{second_octet}.#{third_octet}.#{fourth_octet}"
   end
 
   defp insert_node!(overrides) do
@@ -544,6 +552,54 @@ defmodule Orchard.NodesTest do
       assert candidate.last_observed_at == DateTime.truncate(second_observed_at, :microsecond)
     end
 
+    test "SPEC.md §4.2 stale duplicate observations preserve newer candidate evidence" do
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.33", 9444)
+      newer_observed_at = DateTime.utc_now()
+      older_observed_at = DateTime.add(newer_observed_at, -30, :second)
+
+      newer_status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "newer-candidate-node",
+          hostname: "newer-candidate.local",
+          listen_host: "10.0.0.33",
+          listen_port: 9444,
+          agent_version: "0.3.0"
+        })
+
+      older_status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "older-candidate-node",
+          hostname: "older-candidate.local",
+          listen_host: "10.0.0.33",
+          listen_port: 9444,
+          agent_version: "0.1.0"
+        })
+
+      equal_timestamp_status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "equal-candidate-node",
+          hostname: "equal-candidate.local",
+          listen_host: "10.0.0.33",
+          listen_port: 9444,
+          agent_version: "0.2.0"
+        })
+
+      assert :noop = Nodes.observe_status(target, newer_status, newer_observed_at)
+      assert :noop = Nodes.observe_status(target, older_status, older_observed_at)
+      assert :noop = Nodes.observe_status(target, equal_timestamp_status, newer_observed_at)
+
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+      assert candidate.observed_identity["claimed_node_id"] == node_id
+      assert candidate.observed_identity["display_name"] == "newer-candidate-node"
+      assert candidate.observed_identity["hostname"] == "newer-candidate.local"
+      assert candidate.observed_identity["agent_version"] == "0.3.0"
+      assert candidate.last_observed_at == DateTime.truncate(newer_observed_at, :microsecond)
+    end
+
     test "SPEC.md §4.2 open observed candidate identity is unique in the database" do
       node_id = Ecto.UUID.generate()
       now = DateTime.utc_now()
@@ -792,6 +848,23 @@ defmodule Orchard.NodesTest do
                  trust_evidence_ref: "registration-audit:test",
                  pool_id: Ecto.UUID.generate()
                })
+    end
+
+    test "SPEC.md §4.2 registered node admission accepts bind-all inventory with connect target" do
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-bind-all",
+          hostname: "registered-bind-all.local",
+          advertise_addr: "0.0.0.0",
+          rpc_port: 50_071,
+          connect_host: "100.90.207.78",
+          connect_port: 50_071
+        })
+
+      assert {:ok, admitted} = Nodes.admit_node(node.id, admission_attrs())
+      assert admitted.node.state == :admitted
+      assert admitted.decision.decision == :admitted
     end
 
     test "SPEC.md §4.3 admission decisions reject direct updates" do

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -671,6 +671,135 @@ defmodule Orchard.NodesTest do
       assert hosted_tool_name != ""
     end
 
+    test "SPEC.md §4.2 observed candidate list snapshots mark count truncation" do
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.25", 9444)
+
+      tools =
+        for index <- 1..41 do
+          hosted_tool_capability("tool-#{index}", "2026-06-28", "mcp")
+        end
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "truncated-list-candidate",
+          hostname: "truncated-list-candidate.local",
+          listen_host: "10.0.0.25",
+          listen_port: 9444
+        })
+        |> Map.put(:hosted_tool_capabilities, tools)
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+
+      hosted_tools = candidate.inventory["capabilities"]["hosted_tools"]
+      marker = List.last(hosted_tools)
+
+      assert length(hosted_tools) == 40
+
+      assert marker == %{
+               "truncated" => true,
+               "reason" => "entry_limit",
+               "kind" => "list",
+               "entry_limit" => 40,
+               "original_count" => 41
+             }
+
+      refute Enum.any?(hosted_tools, &match?(%{"name" => "tool-41"}, &1))
+    end
+
+    test "SPEC.md §4.2 observed candidate list snapshots at count cap stay unmarked" do
+      node_id = Ecto.UUID.generate()
+      target = make_target("10.0.0.26", 9444)
+
+      tools =
+        for index <- 1..40 do
+          hosted_tool_capability("complete-tool-#{index}", "2026-06-28", "mcp")
+        end
+
+      status =
+        make_status_response(%{
+          node_id: node_id,
+          display_name: "complete-list-candidate",
+          hostname: "complete-list-candidate.local",
+          listen_host: "10.0.0.26",
+          listen_port: 9444
+        })
+        |> Map.put(:hosted_tool_capabilities, tools)
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+
+      hosted_tools = candidate.inventory["capabilities"]["hosted_tools"]
+
+      assert length(hosted_tools) == 40
+      refute Enum.any?(hosted_tools, &Map.has_key?(&1, "truncated"))
+    end
+
+    test "SPEC.md §4.3 admission decision map snapshots mark count truncation" do
+      target = make_target("10.0.0.27", 9444)
+
+      status =
+        make_status_response(%{
+          display_name: "truncated-map-candidate",
+          hostname: "truncated-map-candidate.local",
+          listen_host: "10.0.0.27",
+          listen_port: 9444
+        })
+
+      oversized_metadata =
+        1..41
+        |> Enum.map(fn index -> {"evidence_#{index}", "value-#{index}"} end)
+        |> Map.new()
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      [candidate] = Nodes.list_admission_candidates()
+      assert {:ok, rejected} = Nodes.reject_admission(candidate.id, %{reason: "needs review"})
+
+      assert {:ok, cleared} =
+               Nodes.clear_admission_rejection(rejected.candidate.id, oversized_metadata)
+
+      marker = cleared.decision.metadata["__orchard_snapshot_truncation__"]
+
+      assert map_size(cleared.decision.metadata) == 40
+
+      assert marker == %{
+               "truncated" => true,
+               "reason" => "entry_limit",
+               "kind" => "map",
+               "entry_limit" => 40,
+               "original_count" => 41
+             }
+    end
+
+    test "SPEC.md §4.3 admission decision map snapshots at count cap stay unmarked" do
+      target = make_target("10.0.0.28", 9444)
+
+      status =
+        make_status_response(%{
+          display_name: "complete-map-candidate",
+          hostname: "complete-map-candidate.local",
+          listen_host: "10.0.0.28",
+          listen_port: 9444
+        })
+
+      complete_metadata =
+        1..40
+        |> Enum.map(fn index -> {"evidence_#{index}", "value-#{index}"} end)
+        |> Map.new()
+
+      assert :noop = Nodes.observe_status(target, status, DateTime.utc_now())
+      [candidate] = Nodes.list_admission_candidates()
+      assert {:ok, rejected} = Nodes.reject_admission(candidate.id, %{reason: "needs review"})
+
+      assert {:ok, cleared} =
+               Nodes.clear_admission_rejection(rejected.candidate.id, complete_metadata)
+
+      assert map_size(cleared.decision.metadata) == 40
+      refute Map.has_key?(cleared.decision.metadata, "__orchard_snapshot_truncation__")
+    end
+
     test "SPEC.md §4.3 pending admission rejection is auditable and not decommissioning" do
       target = make_target("10.0.0.12", 9444)
 

--- a/apps/orchard_controller/test/orchard/repo/migrations/governance_db_foundation_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/governance_db_foundation_test.exs
@@ -137,6 +137,8 @@ defmodule Orchard.Repo.Migrations.GovernanceDbFoundationTest do
   end
 
   defp run_down_sql do
+    Repo.query!("DROP TABLE IF EXISTS node_admission_decisions")
+    Repo.query!("DROP TABLE IF EXISTS node_admission_candidates")
     Repo.query!("DROP TABLE IF EXISTS provisioning_batches")
     Repo.query!("DROP TABLE IF EXISTS role_bindings")
 

--- a/apps/orchard_controller/test/orchard/repo/migrations/node_inventory_foundation_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/node_inventory_foundation_test.exs
@@ -123,6 +123,8 @@ defmodule Orchard.Repo.Migrations.NodeInventoryFoundationTest do
   end
 
   defp run_down_sql do
+    Repo.query!("DROP TABLE IF EXISTS node_admission_decisions")
+    Repo.query!("DROP TABLE IF EXISTS node_admission_candidates")
     Repo.query!("DROP TABLE IF EXISTS nodes")
     Repo.query!("DROP TYPE IF EXISTS node_health")
     Repo.query!("DROP TYPE IF EXISTS node_state")

--- a/openspec/changes/cluster-management-ux-foundation/design.md
+++ b/openspec/changes/cluster-management-ux-foundation/design.md
@@ -7,8 +7,8 @@ Orchard targets one to four Apple Silicon macOS nodes, with all durable state in
 `SPEC.md` §7.3 and §7.4 split operator actions from admin actions.
 `SPEC.md` §7.5 says Runtime Endpoint observations are transport-independent and Postgres remains durable truth for inventory, lifecycle state, observations, scheduling history, request state, and operator-visible status.
 
-The current source tree has useful foundations but does not yet implement the full lifecycle UX.
-`apps/orchard_controller/lib/orchard/nodes.ex` describes observational node discovery and inserts new nodes from successful Runtime Endpoint observations with `state: :active`.
+The pre-implementation source tree had useful foundations but did not yet implement the full lifecycle UX.
+`apps/orchard_controller/lib/orchard/nodes.ex` described observational node discovery and inserted new nodes from successful Runtime Endpoint observations with `state: :active`.
 `apps/orchard_controller/lib/orchard/console/nodes_live.ex` renders persisted inventory and live Runtime Endpoint diagnostics, but it does not yet expose pending admission review or safe lifecycle actions.
 `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex` supports `orchardctl nodes list`, while `orchardctl nodes admit` is a deferred command.
 `apps/orchard_cli/lib/orchard_cli/commands/support.ex` already has a redacted support bundle flow that can become the shared diagnostics foundation.

--- a/openspec/changes/cluster-management-ux-foundation/proposal.md
+++ b/openspec/changes/cluster-management-ux-foundation/proposal.md
@@ -2,7 +2,7 @@
 
 Orchard's cluster management surface is approaching the point where operators need one coherent answer across Console, CLI, Operator API, Admin API, scheduler explanations, diagnostics, and support bundles.
 `SPEC.md` already defines node lifecycle, health, scheduler eligibility, Runtime Endpoint observations, operator APIs, admin APIs, diagnostics, support bundles, and HA-lite leadership.
-Current implementation reality is not yet aligned with the full contract: `Orchard.Nodes` still performs observational node discovery from successful Runtime Endpoint status reads and inserts new nodes as `active`, while `orchardctl nodes admit` and `orchardctl cluster init` are deferred.
+Before this change, implementation reality was not yet aligned with the full contract: `Orchard.Nodes` performed observational node discovery from successful Runtime Endpoint status reads and inserted new nodes as `active`, while `orchardctl nodes admit` and `orchardctl cluster init` were deferred.
 This change defines the operator-facing UX contract before implementation so the next code slices reconcile that gap deliberately instead of growing disconnected Console and CLI behavior.
 
 ## What Changes

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -7,17 +7,17 @@
 
 ## 2. Node Lifecycle And Admission
 
-- [ ] 2.1 Change first-observed Runtime Endpoint node persistence so new nodes are not inserted as `active` without explicit admission.
-- [ ] 2.2 Add observed admission candidate persistence through `node_admission_candidates` for first-observed Runtime Endpoint observations that do not match an existing provisioned placeholder or registered node, including retention-safe snapshot fields for linked candidates, nullable observation timestamps for unobserved review rows, and non-unique target-reference lookup.
-- [ ] 2.3 Add reconciliation logic that prevents observed candidates from being represented as `provisioned` without an admin-created placeholder or as `registered` without `RegisterNode` or equivalent trust proof.
-- [ ] 2.4 Add pending-admission category handling without adding a lifecycle enum that is absent from `SPEC.md`.
-- [ ] 2.5 Preserve observed inventory, target metadata, and compatibility evidence for pending admission review.
-- [ ] 2.6 Block admission execution for observed candidates and provisioned placeholders until registration inventory, trust evidence, pool assignment, and required policy inputs are present.
-- [ ] 2.7 Implement and test rejected-admission persistence semantics through `node_admission_decisions` with actor, decided timestamp, reason, observed identity or node reference, target reference when applicable, retention-safe snapshot fields, and audit event reference.
+- [x] 2.1 Change first-observed Runtime Endpoint node persistence so new nodes are not inserted as `active` without explicit admission.
+- [x] 2.2 Add observed admission candidate persistence through `node_admission_candidates` for first-observed Runtime Endpoint observations that do not match an existing provisioned placeholder or registered node, including retention-safe snapshot fields for linked candidates, nullable observation timestamps for unobserved review rows, and non-unique target-reference lookup.
+- [x] 2.3 Add reconciliation logic that prevents observed candidates from being represented as `provisioned` without an admin-created placeholder or as `registered` without `RegisterNode` or equivalent trust proof.
+- [x] 2.4 Add pending-admission category handling without adding a lifecycle enum that is absent from `SPEC.md`.
+- [x] 2.5 Preserve observed inventory, target metadata, and compatibility evidence for pending admission review.
+- [x] 2.6 Block admission execution for observed candidates and provisioned placeholders until registration inventory, trust evidence, pool assignment, and required policy inputs are present.
+- [x] 2.7 Implement and test rejected-admission persistence semantics through `node_admission_decisions` with actor, decided timestamp, reason, observed identity or node reference, target reference when applicable, retention-safe snapshot fields, and audit event reference.
 - [ ] 2.8 Implement Admin API admission and pending-admission rejection semantics with cluster-scoped audit events.
-- [ ] 2.9 Implement explicit admin clear or new-registration handling before re-admission after rejection.
-- [ ] 2.10 Preserve existing admitted node rows through migration or explicit compatibility handling.
-- [ ] 2.11 Add regression tests for `SPEC.md` §4.2, §4.3, and §7.5.4 lifecycle behavior.
+- [x] 2.9 Implement explicit admin clear or new-registration handling before re-admission after rejection.
+- [x] 2.10 Preserve existing admitted node rows through migration or explicit compatibility handling.
+- [x] 2.11 Add regression tests for `SPEC.md` §4.2, §4.3, and §7.5.4 lifecycle behavior.
 
 ## 3. Shared Status And Reason Codes
 


### PR DESCRIPTION
## Intent

Implement the Orchard cluster admission foundation slice for SPEC and OpenSpec cluster-management-ux-foundation tasks 2.1-2.11. Persist admission candidates and append-only admission decisions, use cluster-scoped audit semantics, make first observed runtime endpoints create pending observed candidates rather than trusted active Nodes, preserve rejection, clear, and readmission guardrails, fail closed for admission without explicit pool, policy, trust, and inventory readiness metadata, and add regression coverage for SPEC sections 4.2, 4.3, and 7.5.4. This run includes the SPEC-aligned correction that node_admission_decisions candidate_id, node_id, and audit_log_id use ON DELETE SET NULL / Ecto nilify_all, while the append-only trigger still rejects DELETE, semantic UPDATEs, direct reference rewrites, and direct reference nullification; it only permits FK-triggered non-null to null cleanup for those reference columns. This PR intentionally leaves Admin API, CLI, and Console route wiring for the next slice. It also intentionally keeps external as a reserved admission persistence value for future provider/runtime adapters without broadening Orchard.RuntimeEndpoint.Target or first-party schedulable runtime-target support, and leaves MultiNode configured-target live-probe gating as a later scheduler contract slice. Please keep generated gate reports plain ASCII.

## What Changed

- Added admission persistence to `Orchard.Nodes`: new `AdmissionCandidate` and `AdmissionDecision` schemas plus a migration with an append-only decisions trigger (rejects DELETE, semantic UPDATEs, and direct reference rewrites/nullification) while `candidate_id`, `node_id`, and `audit_log_id` use `ON DELETE SET NULL` / `nilify_all` to permit FK-triggered cleanup; `external` is reserved as a future admission value without broadening `RuntimeEndpoint.Target`.
- Changed observation behavior so a first-observed runtime endpoint now persists a `pending_observed` candidate and `observe_status` returns `:noop` instead of inserting an `:active` node; the only path to `:active` is `admitted -> active` on a fresh healthy observation, with admission failing closed unless explicit pool, policy, trust, and inventory-readiness metadata is present, and rejection/clear/readmission guardrails preserved.
- Wired cluster-scoped audit semantics through `Orchard.Governance`/`AuditLog`, consolidated duplicated admission helpers, and added SPEC 4.2/4.3/7.5.4 regression coverage across `nodes_test`, `governance/foundation_test`, and probe-compatibility tests; Admin API, CLI, and Console route wiring are intentionally deferred to the next slice.

## Risk Assessment

⚠️ Medium: A large, foundational change introducing new admission tables, a custom plpgsql append-only trigger, a partial-unique-index upsert, and a deliberate shift of first-observed endpoints from auto-active nodes to pending candidates — well-structured and extensively regression-tested with the prior review finding resolved, but the new DB trigger semantics and admission behavior change warrant human awareness before merge.

## Testing

Baseline targeted suites for the changed surface pass: nodes_test.exs (118), the governance/probe/migration foundation files (33), and a consolidated re-run (128). The initial run showed 17 failures, but these were not code defects — the harness-provisioned worktree test DB held committed rows (1 node, 3 candidates, 3 decisions, 3 audit logs, timestamps hours before this run) that leaked past the per-test Ecto sandbox into "empty DB" assertions. Diagnosing it surfaced that a single dual-stack homebrew Postgres serves both ::1 and 127.0.0.1, and that bare `mix ecto.migrate/drop/create` target the dev env, so I reset and re-migrated the test DB with MIX_ENV=test/PGHOST=127.0.0.1/PGDATABASE_TEST and all tests went green. Because this slice intentionally ships no Admin API/CLI/Console wiring, the operator-facing surface is the persisted DB state and DB-enforced guardrails; I captured that directly as a plain-ASCII transcript (admission_evidence.txt) driving the real domain API against live Postgres, showing pending-candidate creation (no auto-admit), cluster-scoped auditable rejection, the append-only trigger rejecting DELETE/UPDATE/ref-rewrite, FK retention nullify preserving the decision row, fail-closed admission, and the reject→clear→readmit append-only history. There is no rendered UI to screenshot since this is a backend persistence/trigger change. After capturing evidence I truncated the test DB back to zero rows and confirmed the worktree git status is clean; evidence files reside only in the dedicated evidence directory.

<details>
<summary>Evidence: Cluster admission foundation — live Postgres behavior transcript</summary>

<code>SECTION A (SPEC 4.2/7.5.4): observe_status/3 -&gt; :noop; Repo.get(Node) -&gt; nil; persisted candidate source=:runtime_endpoint_observation admission_category=:pending_observed target_ref=&#34;10.20.0.1:9444&#34;&#10;SECTION B (SPEC 4.3): rejection -&gt; candidate=:rejected, decision=:rejected, audit action=node_admission.rejected scope=cluster tenant_id=nil, decision.audit_log_id==audit_log.id=true&#10;SECTION C (SPEC 4.3 append-only): direct DELETE / semantic UPDATE / direct ref nullify all REJECTED -&gt; &#39;node_admission_decisions is append-only&#39;&#10;SECTION D (FK retention nullify): delete candidate/node/audit_log -&gt; decision.candidate_id/node_id/audit_log_id become nil while reason=&#34;fk nullify demo&#34; row preserved&#10;SECTION E (SPEC 4.2 fail closed): admit(no inputs)-&gt;{:error,:trust_not_established}; +trust-&gt;{:error,:pool_required}; +pool-&gt;{:error,:policy_required}&#10;SECTION F (SPEC 4.3 reject-&gt;clear-&gt;readmit): blocked admit while rejected -&gt;{:error,:admission_rejected}; after clear admit -&gt; node.state=:admitted; append-only history [:rejected, :rejection_cleared, :admitted]</code>

```text

========== SECTION A: SPEC 4.2 / 7.5.4 ==========
First observed runtime endpoint becomes a PENDING candidate, not a trusted Node.

observe_status/3 returned: :noop   (:noop = no trusted node created)
Repo.get(Node, observed id): nil   (nil = NOT auto-admitted)
------------------------------------------------------------------------------
Persisted node_admission_candidates row:
  source              = :runtime_endpoint_observation
  admission_category  = :pending_observed
  claimed_node_id     = "228ff038-8aee-4f35-ab95-103e2fdc71dc"
  display_name        = "edge-1"
  target_ref          = "10.20.0.1:9444"
  endpoint_transport  = :grpc
  last_observed_at    = ~U[2026-06-28 15:26:11.469488Z]

========== SECTION B: SPEC 4.3 ==========
Pending-admission rejection is auditable, cluster-scoped, and append-only.

candidate.admission_category -> :rejected
decision.decision            -> :rejected
decision.reason              -> "identity not approved"
decision.actor_type/id       -> "operator" / "admin@example.test"
audit_log.action             -> "node_admission.rejected"
audit_log.scope              -> "cluster"   (cluster, not tenant)
audit_log.tenant_id          -> nil   (nil for cluster scope)
decision.audit_log_id == audit_log.id -> true

========== SECTION C: SPEC 4.3 (DB-enforced append-only) ==========
Postgres trigger rejects direct DELETE and semantic UPDATE of decisions.

direct DELETE          : REJECTED -> node_admission_decisions is append-only
semantic UPDATE reason : REJECTED -> node_admission_decisions is append-only
direct ref nullify     : REJECTED -> node_admission_decisions is append-only

========== SECTION D: SPEC-aligned FK retention nullify ==========
ON DELETE SET NULL cleanup is allowed; the decision row is preserved.

after reject: candidate_id=true node_id=true audit_log_id=true (all present)
delete candidate -> decision.candidate_id=nil node_id=true reason="fk nullify demo" (row preserved)
delete node      -> decision.node_id=nil reason="fk nullify demo" (row preserved)
delete audit_log -> decision.audit_log_id=nil reason="fk nullify demo" (row preserved)

========== SECTION E: SPEC 4.2 (fail closed) ==========
Admission fails closed until trust, pool, and policy metadata are present.

admit (no inputs)            -> {:error, :trust_not_established}
admit (trust only)          -> {:error, :pool_required}
admit (trust+pool)          -> {:error, :policy_required}

========== SECTION F: SPEC 4.3 (reject -> clear -> readmit) ==========
Re-admission after rejection requires explicit clear; history is append-only.

reject                       -> blocked admit? {:error, :admission_rejected}
clear + admit                -> node.state=:admitted decision=:admitted
append-only decision history -> [:rejected, :rejection_cleared, :admitted]
------------------------------------------------------------------------------
Restoring clean test DB state (TRUNCATE)...
DONE.
```
</details>
<details>
<summary>Evidence: Evidence driver script (re-runnable: MIX_ENV=test PGHOST=127.0.0.1 PGDATABASE_TEST=orchard_test_nm_2b20bc518d75 mix run)</summary>

```text
## Cluster admission foundation - end-to-end behavior evidence.
## Run: MIX_ENV=test mix run <this file>
## Exercises the real Orchard.Nodes domain API against live Postgres and prints
## the persisted state + DB-enforced guardrails an operator/next-slice API relies on.

alias Orchard.Repo
alias Orchard.Nodes
alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
alias Orchard.Governance.AuditLog
import Ecto.Query

case Repo.start_link() do
  {:ok, _} -> :ok
  {:error, {:already_started, _}} -> :ok
end

truncate = fn ->
  Repo.query!(
    "TRUNCATE node_admission_decisions, node_admission_candidates, nodes, audit_logs RESTART IDENTITY CASCADE"
  )
end

line = fn -> IO.puts(String.duplicate("-", 78)) end
truncate.()

insert_node = fn attrs ->
  base = %{
    id: Ecto.UUID.generate(),
    hostname: "h-#{System.unique_integer([:positive])}.local",
    display_name: "n-#{System.unique_integer([:positive])}",
    advertise_addr: "10.30.0.#{:erlang.unique_integer([:positive]) |> rem(250)}",
    rpc_port: 9444,
    state: :active,
    health: :healthy,
    capabilities: %{},
    tool_readiness: %{}
  }

  %Node{} |> Node.changeset(Map.merge(base, attrs)) |> Repo.insert!()
end

status = fn meta ->
  %{
    node_metadata:
      Map.merge(
        %{
          node_id: Ecto.UUID.generate(),
          display_name: "obs-node",
          hostname: "obs-host.local",
          agent_version: "0.1.0",
          listen_host: "10.20.0.1",
          listen_port: 9444,
          worker_backend: "mlx"
        },
        meta
      ),
    runtime_health: %{ready: true, health_code: "", health_message: ""}
  }
end

IO.puts("\n========== SECTION A: SPEC 4.2 / 7.5.4 ==========")
IO.puts("First observed runtime endpoint becomes a PENDING candidate, not a trusted Node.\n")

node_id = Ecto.UUID.generate()
target = [host: "10.20.0.1", port: 9444]
result = Nodes.observe_status(target, status.(%{node_id: node_id, display_name: "edge-1", listen_host: "10.20.0.1"}), DateTime.utc_now())

IO.puts("observe_status/3 returned: #{inspect(result)}   (:noop = no trusted node created)")
IO.puts("Repo.get(Node, observed id): #{inspect(Repo.get(Node, node_id))}   (nil = NOT auto-admitted)")
[cand] = Nodes.list_admission_candidates()
line.()
IO.puts("Persisted node_admission_candidates row:")
IO.puts("  source              = #{inspect(cand.source)}")
IO.puts("  admission_category  = #{inspect(cand.admission_category)}")
IO.puts("  claimed_node_id     = #{inspect(cand.observed_identity["claimed_node_id"])}")
IO.puts("  display_name        = #{inspect(cand.observed_identity["display_name"])}")
IO.puts("  target_ref          = #{inspect(cand.target_ref)}")
IO.puts("  endpoint_transport  = #{inspect(cand.endpoint_transport)}")
IO.puts("  last_observed_at    = #{inspect(cand.last_observed_at)}")

IO.puts("\n========== SECTION B: SPEC 4.3 ==========")
IO.puts("Pending-admission rejection is auditable, cluster-scoped, and append-only.\n")

{:ok, rej} =
  Nodes.reject_admission(cand.id, %{reason: "identity not approved"},
    actor_type: "operator",
    actor_id: "admin@example.test"
  )

IO.puts("candidate.admission_category -> #{inspect(rej.candidate.admission_category)}")
IO.puts("decision.decision            -> #{inspect(rej.decision.decision)}")
IO.puts("decision.reason              -> #{inspect(rej.decision.reason)}")
IO.puts("decision.actor_type/id       -> #{inspect(rej.decision.actor_type)} / #{inspect(rej.decision.actor_id)}")
IO.puts("audit_log.action             -> #{inspect(rej.audit_log.action)}")
IO.puts("audit_log.scope              -> #{inspect(rej.audit_log.scope)}   (cluster, not tenant)")
IO.puts("audit_log.tenant_id          -> #{inspect(rej.audit_log.tenant_id)}   (nil for cluster scope)")
IO.puts("decision.audit_log_id == audit_log.id -> #{rej.decision.audit_log_id == rej.audit_log.id}")

IO.puts("\n========== SECTION C: SPEC 4.3 (DB-enforced append-only) ==========")
IO.puts("Postgres trigger rejects direct DELETE and semantic UPDATE of decisions.\n")

{:ok, did} = Ecto.UUID.dump(rej.decision.id)

demo = fn label, sql, params ->
  try do
    Repo.query!(sql, params)
    IO.puts("#{label}: NO ERROR  <-- UNEXPECTED")
  rescue
    e in Postgrex.Error -> IO.puts("#{label}: REJECTED -> #{e.postgres.message}")
  end
end

demo.("direct DELETE          ", "DELETE FROM node_admission_decisions WHERE id = $1", [did])
demo.("semantic UPDATE reason ", "UPDATE node_admission_decisions SET reason = 'mutated' WHERE id = $1", [did])
demo.("direct ref nullify     ", "UPDATE node_admission_decisions SET candidate_id = NULL WHERE id = $1", [did])

IO.puts("\n========== SECTION D: SPEC-aligned FK retention nullify ==========")
IO.puts("ON DELETE SET NULL cleanup is allowed; the decision row is preserved.\n")

reg = insert_node.(%{state: :registered, display_name: "reg-fk", advertise_addr: "10.30.0.9"})
{:ok, fk} = Nodes.reject_admission(reg.id, %{reason: "fk nullify demo"})
decision_id = fk.decision.id
IO.puts("after reject: candidate_id=#{inspect(fk.decision.candidate_id != nil)} node_id=#{inspect(fk.decision.node_id != nil)} audit_log_id=#{inspect(fk.decision.audit_log_id != nil)} (all present)")

Repo.delete!(fk.candidate)
d = Repo.get!(AdmissionDecision, decision_id)
IO.puts("delete candidate -> decision.candidate_id=#{inspect(d.candidate_id)} node_id=#{inspect(d.node_id == reg.id)} reason=#{inspect(d.reason)} (row preserved)")

Repo.delete!(reg)
d = Repo.get!(AdmissionDecision, decision_id)
IO.puts("delete node      -> decision.node_id=#{inspect(d.node_id)} reason=#{inspect(d.reason)} (row preserved)")

Repo.query!("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")

try do
  Repo.delete!(fk.audit_log)
after
  Repo.query!("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
end

d = Repo.get!(AdmissionDecision, decision_id)
IO.puts("delete audit_log -> decision.audit_log_id=#{inspect(d.audit_log_id)} reason=#{inspect(d.reason)} (row preserved)")

IO.puts("\n========== SECTION E: SPEC 4.2 (fail closed) ==========")
IO.puts("Admission fails closed until trust, pool, and policy metadata are present.\n")

reg2 = insert_node.(%{state: :registered, display_name: "reg-inputs", advertise_addr: "10.30.0.17"})
IO.puts("admit (no inputs)            -> #{inspect(Nodes.admit_node(reg2.id))}")
IO.puts("admit (trust only)          -> #{inspect(Nodes.admit_node(reg2.id, %{trust_evidence_ref: "registration-audit:test"}))}")

IO.puts(
  "admit (trust+pool)          -> " <>
    inspect(Nodes.admit_node(reg2.id, %{trust_evidence_ref: "registration-audit:test", pool_id: Ecto.UUID.generate()}))
)

IO.puts("\n========== SECTION F: SPEC 4.3 (reject -> clear -> readmit) ==========")
IO.puts("Re-admission after rejection requires explicit clear; history is append-only.\n")

reg3 = insert_node.(%{state: :registered, display_name: "reg-readmit", advertise_addr: "10.30.0.21"})
{:ok, r1} = Nodes.reject_admission(reg3.id, %{reason: "waiting for approval"})
IO.puts("reject                       -> blocked admit? #{inspect(Nodes.admit_node(reg3.id))}")
{:ok, _c} = Nodes.clear_admission_rejection(r1.candidate.id, %{surface: "evidence"})
admit_attrs = %{trust_evidence_ref: "registration-audit:#{Ecto.UUID.generate()}", pool_id: Ecto.UUID.generate(), routing_policy_id: Ecto.UUID.generate()}
{:ok, adm} = Nodes.admit_node(reg3.id, admit_attrs)
IO.puts("clear + admit                -> node.state=#{inspect(adm.node.state)} decision=#{inspect(adm.decision.decision)}")

history =
  AdmissionDecision
  |> where([d], d.node_id == ^reg3.id)
  |> order_by([d], asc: d.inserted_at)
  |> Repo.all()
  |> Enum.map(& &1.decision)

IO.puts("append-only decision history -> #{inspect(history)}")

line.()
IO.puts("Restoring clean test DB state (TRUNCATE)...")
truncate.()
IO.puts("DONE.")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/nodes.ex:990` - Behavior change: first-observed Runtime Endpoints now persist as `pending_observed` admission candidates and `observe_status` returns `:noop` instead of inserting an `:active` node (nodes.ex:990-1006, upsert_observation/observed_state). The only production path to `:active` is now `admitted -&gt; active` on a fresh healthy observation, which requires `admit_node` on a `:registered` node. No code path in this slice creates `:registered`/`:provisioned` nodes, and the Admin API/CLI admission wiring is explicitly deferred (OpenSpec task 2.8 still unchecked). Net effect: on a fresh install, an observed node cannot become schedulable until the next slice lands. Existing `:active` nodes are unaffected. This is the intended SPEC 4.2/7.5.4 direction, surfaced so reviewers are aware of the cross-slice operational gap.
- ⚠️ `apps/orchard_controller/lib/orchard/nodes.ex:1408` - `Orchard.Nodes` reintroduces private helpers that already exist in `Orchard.Governance`, with subtle divergence: `normalize_attrs/1` (nodes.ex:1408 uses `Map.put` / overwrite vs governance.ex:1229 `Map.put_new` / first-wins) and `utc_now/0` (nodes.ex:1396 returns `DateTime.utc_now()` un-truncated vs governance.ex truncates to microsecond). `normalize_reason/1` is also duplicated between nodes.ex:1384 and AdmissionDecision.normalize_reason. The structural clones risk an ex_dna duplication finding (the gate AGENTS.md requires zero findings on) and the put/put_new divergence is an inconsistency waiting to bite. Consolidate into a shared helper module (e.g. an `Orchard.AttrNormalize`/snapshot util) rather than maintaining parallel copies.

🔧 Fix: consolidate duplicated admission helpers in Orchard.Nodes
1 info still open:
- ℹ️ `apps/orchard_controller/lib/orchard/nodes.ex:1422` - sanitize_snapshot/2 silently truncates maps and lists to the first 40 entries (lines 1422 and 1428) with no indication, unlike the depth&gt;=4 branch which marks {&#34;truncated&#34; =&gt; true}. These snapshots are the Runtime Endpoint Admission Candidate evidence operators use for trust decisions (e.g. compatibility_evidence.tool_readiness, inventory.capabilities.hosted_tools). A node advertising &gt;40 hosted tools or readiness entries would have entries dropped from the recorded evidence with no marker, so an operator reviewing the candidate cannot tell the evidence is incomplete. Bound is generous and the behavior is a deliberate defensive cap; flagging only so the inconsistency (depth-cap marks truncation, count-cap does not) is a conscious choice. A parallel {&#34;truncated&#34; =&gt; true} sentinel on the take(40) branches would close the gap.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mix test apps/orchard_controller/test/orchard/nodes_test.exs` — 118 passed (admission candidate persistence, rejection/clear/readmit, append-only and FK-nullify guardrails, fail-closed admission, BEAM/grpc observation)</code>
- <code>`mix test apps/orchard_controller/test/orchard/governance/foundation_test.exs apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs apps/orchard_controller/test/orchard/migrations/{governance_db_foundation_test,node_inventory_foundation_test}.exs` — 33 passed (cluster-scoped audit, probe compatibility, migration foundations)</code>
- <code>Consolidated re-run `mix test nodes_test.exs governance/foundation_test.exs` — 128 passed after DB reset</code>
- <code>Live-Postgres behavior transcript via `MIX_ENV=test mix run admission_evidence.exs` against Orchard.Nodes.{observe_status,reject_admission,clear_admission_rejection,admit_node} plus raw SQL DELETE/UPDATE to demonstrate the append-only trigger and ON DELETE SET NULL retention</code>
- <code>Environment fix: reset the worktree test DB (`orchard_test_nm_2b20bc518d75`) which had committed rows leaking into empty-DB assertions; required pinning PGHOST=127.0.0.1 + PGDATABASE_TEST + MIX_ENV=test (bare `mix ecto.*` targets the dev DB)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
