### PR TITLE
fix: start split-role gRPC wrappers without BEAM args

### DIFF
--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -10,11 +10,13 @@ defmodule OrchardCLI.DevScriptsTest do
 
     assert controller =~ "cd \"$REPO_ROOT/apps/orchard_controller\""
     assert controller =~ "exec iex \"${ORCHARD_BEAM_IEX_ARGS[@]}\" -S mix phx.server"
+    assert controller =~ "exec iex -S mix phx.server"
     refute controller =~ "apps/orchard_node_agent"
     refute controller =~ "mix run --no-halt"
 
     assert node_agent =~ "cd \"$REPO_ROOT/apps/orchard_node_agent\""
     assert node_agent =~ "exec iex \"${ORCHARD_BEAM_IEX_ARGS[@]}\" -S mix run --no-halt"
+    assert node_agent =~ "exec iex -S mix run --no-halt"
 
     assert dev =~ "exec iex -S mix phx.server"
     refute dev =~ "cd \"$REPO_ROOT/apps/orchard_controller\""

--- a/bin/dev-controller
+++ b/bin/dev-controller
@@ -53,4 +53,8 @@ echo "==> Starting Orchard dev controller (role: controller)"
 echo "==> HTTP endpoint: 127.0.0.1:${PORT:-4000}"
 echo "==> Runtime client targets: ${ORCHARD_RUNTIME_CLIENT_TARGETS}"
 cd "$REPO_ROOT/apps/orchard_controller"
-exec iex "${ORCHARD_BEAM_IEX_ARGS[@]}" -S mix phx.server
+if [[ "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT}" == "beam" ]]; then
+  exec iex "${ORCHARD_BEAM_IEX_ARGS[@]}" -S mix phx.server
+else
+  exec iex -S mix phx.server
+fi

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -63,4 +63,8 @@ echo "==> Starting Orchard dev node-agent (role: node-agent)"
 echo "==> gRPC endpoint: ${ORCHARD_NODE_AGENT_LISTEN_HOST}:${resolved_port}"
 echo "==> Worker executable: ${ORCHARD_WORKER_EXECUTABLE}"
 cd "$REPO_ROOT/apps/orchard_node_agent"
-exec iex "${ORCHARD_BEAM_IEX_ARGS[@]}" -S mix run --no-halt
+if [[ "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT}" == "beam" ]]; then
+  exec iex "${ORCHARD_BEAM_IEX_ARGS[@]}" -S mix run --no-halt
+else
+  exec iex -S mix run --no-halt
+fi

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -389,4 +389,34 @@ assert_succeeds "$TMP_ROOT/i-node.out" \
 assert_grep 'ERL_EPMD_ADDRESS=127.0.0.1' "$TMP_ROOT/i-node-iex.log"
 assert_grep '--name orchard_node_agent@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52172 inet_dist_listen_max 52172 -S mix run --no-halt' "$TMP_ROOT/i-node-iex.log"
 
+# J: split-role gRPC entrypoints do not require BEAM IEx args.
+GRPC_ENTRYPOINT_REPO="$TMP_ROOT/grpc-entrypoint-repo"
+mkdir -p "$GRPC_ENTRYPOINT_REPO/bin/lib" "$GRPC_ENTRYPOINT_REPO/apps/orchard_controller" "$GRPC_ENTRYPOINT_REPO/apps/orchard_node_agent"
+cp "$REPO_ROOT/bin/dev-controller" "$GRPC_ENTRYPOINT_REPO/bin/dev-controller"
+cp "$REPO_ROOT/bin/dev-node-agent" "$GRPC_ENTRYPOINT_REPO/bin/dev-node-agent"
+chmod +x "$GRPC_ENTRYPOINT_REPO/bin/dev-controller" "$GRPC_ENTRYPOINT_REPO/bin/dev-node-agent"
+: > "$GRPC_ENTRYPOINT_REPO/mix.exs"
+cat > "$GRPC_ENTRYPOINT_REPO/bin/lib/source-dev-beam.sh" <<'SH'
+#!/usr/bin/env bash
+orchard_source_dev_beam_bootstrap() {
+  export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+  export ORCHARD_SOURCE_DEV_ROLE="$1"
+}
+SH
+
+: > "$TMP_ROOT/j-controller-mix.log"
+assert_succeeds "$TMP_ROOT/j-controller.out" \
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/j-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/j-controller-iex.log" "$GRPC_ENTRYPOINT_REPO/bin/dev-controller"
+assert_grep 'mix called: ecto.create --quiet' "$TMP_ROOT/j-controller-mix.log"
+assert_grep '-S mix phx.server' "$TMP_ROOT/j-controller-iex.log"
+assert_no_grep '--name' "$TMP_ROOT/j-controller-iex.log"
+assert_no_grep '--erl' "$TMP_ROOT/j-controller-iex.log"
+
+: > "$TMP_ROOT/j-node-mix.log"
+assert_succeeds "$TMP_ROOT/j-node.out" \
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/j-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/j-node-iex.log" "$GRPC_ENTRYPOINT_REPO/bin/dev-node-agent"
+assert_grep '-S mix run --no-halt' "$TMP_ROOT/j-node-iex.log"
+assert_no_grep '--name' "$TMP_ROOT/j-node-iex.log"
+assert_no_grep '--erl' "$TMP_ROOT/j-node-iex.log"
+
 printf 'source-dev BEAM bootstrap tests passed\n'


### PR DESCRIPTION
## Summary

Fixes the post-merge PR #30 smoke blocker where the documented split-role gRPC wrappers could expand `ORCHARD_BEAM_IEX_ARGS[@]` under `set -u` even though BEAM-specific IEx args are intentionally absent in gRPC mode.

Changes:
- `bin/dev-node-agent` uses plain `iex -S mix run --no-halt` in gRPC mode and keeps BEAM args only for `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`.
- `bin/dev-controller` uses plain `iex -S mix phx.server` in gRPC mode and keeps BEAM args only for BEAM mode.
- Adds a shell regression proving gRPC split-role entrypoints do not require BEAM IEx args while existing BEAM flag checks still pass.

## Validation

Passed:
- `bash scripts/test-source-dev-beam-bootstrap.sh`
- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix test apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `mise exec -- mix test`

Not run:
- `mise exec -- mix test --cover`, because this is a tiny wrapper-only shell fix and the default suite plus focused shell regression cover the changed behavior.

## Smoke

Wrapper-based two-Mac gRPC smoke passed on branch commit `c0d700e0db37d98d69dcde5575093bb72474df4c`.

Remote mawarduri node-agent used `bin/dev-node-agent` from a throwaway clone:

```bash
ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0 \
ORCHARD_NODE_AGENT_LISTEN_PORT=50071 \
ORCHARD_WORKER_BACKEND=stub \
ORCHARD_NODE_DISPLAY_NAME=mawarduri-wrapper-smoke \
mise exec -- bin/dev-node-agent
```

Local controller used `bin/dev-controller`:

```bash
PGDATABASE=orchard_wrapper_smoke \
PORT=4011 \
ORCHARD_RUNTIME_CLIENT_TARGETS=100.70.81.109:50071 \
ORCHARD_NODE_DISPLAY_NAME=local-wrapper-smoke \
mise exec -- bin/dev-controller
```

Observed evidence:
- `mawarduri` listened on `100.70.81.109:50071` through the wrapper.
- Local controller was live on `127.0.0.1:4011` through the wrapper.
- `OrchardConsole.Runtime.cluster_snapshot(timeout: 5000)` reached the remote target.
- `node_admission_candidates` row was created with `admission_category = pending_observed`.
- Candidate `target_ref` was `100.70.81.109:50071`.
- Candidate `node_id` was `nil`.
- `nodes` count remained `0`, so no active trusted node was auto-created.
- Cleanup removed the remote temp clone/logs, closed remote `50071`, stopped local `4011`, and dropped isolated DB `orchard_wrapper_smoke`.