### PR TITLE
feat(admin): add cluster-admin node admission API

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Building from spec.
 The current source tree includes authenticated
 `/v1/models`, `/v1/chat/completions`, a bounded `/v1/responses` slice, tenant-direct API Tokens, and bulk API Client provisioning for service-account-owned API Tokens.
 Full M2 quota behavior remains in progress.
+An initial cluster-admin `/admin/v1` node-admission surface (candidate review, rejection, rejection clearance, and admission) is present ahead of its M3 milestone, but is not yet operator-usable because cluster bootstrap and first-admin credential provisioning are not yet implemented.
 The roadmap and target behavior are governed by `SPEC.md` §14.
 
 Some SPEC-required CLI paths are present before their milestone implementation:

--- a/apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex
@@ -10,6 +10,27 @@ defmodule Orchard.API.Admin.NodeAdmissionController do
   alias Orchard.ControlPlane
   alias Orchard.Nodes
 
+  @reserved_request_metadata_keys MapSet.new([
+                                    "admission_category",
+                                    "audit_log_id",
+                                    "candidate_id",
+                                    "compatibility_evidence",
+                                    "decided_at",
+                                    "decision",
+                                    "endpoint",
+                                    "endpoint_target",
+                                    "endpoint_transport",
+                                    "id",
+                                    "inserted_at",
+                                    "inventory",
+                                    "last_observed_at",
+                                    "node_id",
+                                    "observed_identity",
+                                    "source",
+                                    "target_ref",
+                                    "updated_at"
+                                  ])
+
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     json(conn, NodeAdmissionPresenter.list_candidates(Nodes.list_admission_candidates()))
@@ -72,7 +93,9 @@ defmodule Orchard.API.Admin.NodeAdmissionController do
   defp request_attrs(%Plug.Conn{body_params: %Plug.Conn.Unfetched{}}), do: %{}
 
   defp request_attrs(%Plug.Conn{body_params: body_params}) when is_map(body_params) do
-    Map.drop(body_params, ["candidate_id", "node_id"])
+    Map.reject(body_params, fn {key, _value} ->
+      MapSet.member?(@reserved_request_metadata_keys, key)
+    end)
   end
 
   defp request_attrs(_conn), do: %{}

--- a/apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex
@@ -1,0 +1,145 @@
+defmodule Orchard.API.Admin.NodeAdmissionController do
+  @moduledoc """
+  Admin API endpoints for node admission review and execution.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Orchard.API.Admin.NodeAdmissionPresenter
+  alias Orchard.API.AdminErrorHelpers
+  alias Orchard.ControlPlane
+  alias Orchard.Nodes
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    json(conn, NodeAdmissionPresenter.list_candidates(Nodes.list_admission_candidates()))
+  end
+
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show(conn, %{"candidate_id" => candidate_id}) do
+    case Nodes.fetch_admission_candidate(candidate_id) do
+      {:ok, candidate} ->
+        json(conn, NodeAdmissionPresenter.candidate(candidate))
+
+      {:error, reason} ->
+        send_error(conn, reason)
+    end
+  end
+
+  @spec reject(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def reject(conn, %{"candidate_id" => candidate_id}) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, result} <-
+           Nodes.reject_admission_candidate(candidate_id, request_attrs(conn), audit_opts(conn)) do
+      json(conn, NodeAdmissionPresenter.reject_result(result))
+    else
+      {:error, reason} -> send_error(conn, reason)
+    end
+  end
+
+  @spec clear_rejection(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def clear_rejection(conn, %{"candidate_id" => candidate_id}) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, result} <-
+           Nodes.clear_admission_candidate_rejection(
+             candidate_id,
+             request_attrs(conn),
+             audit_opts(conn)
+           ) do
+      json(conn, NodeAdmissionPresenter.clear_rejection_result(result))
+    else
+      {:error, reason} -> send_error(conn, reason)
+    end
+  end
+
+  @spec admit(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def admit(conn, %{"node_id" => node_id}) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, result} <- Nodes.admit_node(node_id, request_attrs(conn), audit_opts(conn)) do
+      json(conn, NodeAdmissionPresenter.admit_result(result))
+    else
+      {:error, reason} -> send_error(conn, reason)
+    end
+  end
+
+  defp audit_opts(conn) do
+    [
+      actor_type: "operator",
+      actor_id: conn.assigns[:service_account_id] || conn.assigns[:principal_id]
+    ]
+  end
+
+  defp request_attrs(%Plug.Conn{body_params: %Plug.Conn.Unfetched{}}), do: %{}
+
+  defp request_attrs(%Plug.Conn{body_params: body_params}) when is_map(body_params) do
+    Map.drop(body_params, ["candidate_id", "node_id"])
+  end
+
+  defp request_attrs(_conn), do: %{}
+
+  defp send_error(conn, :candidate_not_found) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :not_found,
+      "candidate_not_found",
+      "Node admission candidate was not found."
+    )
+  end
+
+  defp send_error(conn, :node_not_found) do
+    AdminErrorHelpers.send_error(conn, :not_found, "node_not_found", "Node was not found.")
+  end
+
+  defp send_error(conn, :reason_required) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :bad_request,
+      "reason_required",
+      "A nonblank rejection reason is required."
+    )
+  end
+
+  defp send_error(conn, :controller_standby) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :service_unavailable,
+      "controller_standby",
+      "This controller is in standby mode."
+    )
+  end
+
+  defp send_error(conn, reason)
+       when reason in [
+              :admission_not_pending,
+              :admission_not_rejected,
+              :admission_rejected,
+              :node_not_registered,
+              :node_not_pending_admission,
+              :inventory_missing,
+              :trust_not_established,
+              :pool_required,
+              :policy_required
+            ] do
+    reason = Atom.to_string(reason)
+    AdminErrorHelpers.send_error(conn, :conflict, reason, conflict_message(reason))
+  end
+
+  defp send_error(conn, _reason) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :internal_server_error,
+      "admin_api_error",
+      "Admin API request failed."
+    )
+  end
+
+  defp conflict_message("admission_not_pending"), do: "Admission is not pending."
+  defp conflict_message("admission_not_rejected"), do: "Admission is not rejected."
+  defp conflict_message("admission_rejected"), do: "Admission rejection must be cleared first."
+  defp conflict_message("node_not_registered"), do: "Node is not registered."
+  defp conflict_message("node_not_pending_admission"), do: "Node is not pending admission."
+  defp conflict_message("inventory_missing"), do: "Registered node inventory is missing."
+  defp conflict_message("trust_not_established"), do: "Node trust evidence is required."
+  defp conflict_message("pool_required"), do: "Node pool assignment is required."
+  defp conflict_message("policy_required"), do: "Required policy inputs are missing."
+end

--- a/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
@@ -1,0 +1,145 @@
+defmodule Orchard.API.Admin.NodeAdmissionPresenter do
+  @moduledoc """
+  JSON presenters for Admin API node admission resources.
+  """
+
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
+
+  @spec list_candidates([AdmissionCandidate.t()]) :: map()
+  def list_candidates(candidates) do
+    latest_decisions =
+      candidates
+      |> Enum.map(& &1.id)
+      |> Nodes.latest_admission_decisions_for_candidates()
+
+    %{
+      object: "list",
+      data: Enum.map(candidates, &candidate(&1, Map.get(latest_decisions, &1.id)))
+    }
+  end
+
+  @spec candidate(AdmissionCandidate.t()) :: map()
+  def candidate(%AdmissionCandidate{} = candidate) do
+    candidate(candidate, Nodes.latest_admission_decision_for_candidate(candidate.id))
+  end
+
+  defp candidate(%AdmissionCandidate{} = candidate, latest_decision) do
+    %{
+      object: "node_admission_candidate",
+      id: candidate.id,
+      node_id: candidate.node_id,
+      source: atom_string(candidate.source),
+      admission_category: atom_string(candidate.admission_category),
+      observed_identity: candidate.observed_identity || %{},
+      target_ref: candidate.target_ref,
+      endpoint: %{
+        transport: atom_string(candidate.endpoint_transport),
+        target: candidate.endpoint_target
+      },
+      inventory: candidate.inventory || %{},
+      compatibility_evidence: candidate.compatibility_evidence || %{},
+      last_observed_at: iso8601(candidate.last_observed_at),
+      inserted_at: iso8601(candidate.inserted_at),
+      updated_at: iso8601(candidate.updated_at),
+      latest_decision: decision(latest_decision)
+    }
+  end
+
+  @spec reject_result(map()) :: map()
+  def reject_result(result), do: candidate_action_result("node_admission.rejected", result)
+
+  @spec clear_rejection_result(map()) :: map()
+  def clear_rejection_result(result),
+    do: candidate_action_result("node_admission.rejection_cleared", result)
+
+  @spec admit_result(map()) :: map()
+  def admit_result(%{node: %Node{} = node, decision: decision, audit_log: audit_log}) do
+    %{
+      object: "node_admission_action_result",
+      action: "node_admission.admitted",
+      node: present_node(node),
+      decision: decision(decision),
+      audit_log: audit_log(audit_log)
+    }
+  end
+
+  defp candidate_action_result(action, %{
+         candidate: %AdmissionCandidate{} = candidate,
+         decision: decision,
+         audit_log: audit_log
+       }) do
+    %{
+      object: "node_admission_action_result",
+      action: action,
+      candidate: candidate(candidate, decision),
+      decision: decision(decision),
+      audit_log: audit_log(audit_log)
+    }
+  end
+
+  defp present_node(%Node{} = node) do
+    %{
+      object: "node",
+      id: node.id,
+      hostname: node.hostname,
+      display_name: node.display_name,
+      advertise_addr: node.advertise_addr,
+      rpc_port: node.rpc_port,
+      connect_host: node.connect_host,
+      connect_port: node.connect_port,
+      state: atom_string(node.state),
+      health: atom_string(node.health),
+      capabilities: node.capabilities || %{},
+      tool_readiness: node.tool_readiness || %{},
+      agent_version: node.agent_version,
+      last_heartbeat_at: iso8601(node.last_heartbeat_at),
+      inserted_at: iso8601(node.inserted_at),
+      updated_at: iso8601(node.updated_at),
+      latest_decision: latest_node_decision(node)
+    }
+  end
+
+  defp latest_node_decision(%Node{id: id}) do
+    id
+    |> Nodes.latest_admission_decision_for_node()
+    |> decision()
+  end
+
+  defp decision(nil), do: nil
+
+  defp decision(%AdmissionDecision{} = decision) do
+    %{
+      object: "node_admission_decision",
+      id: decision.id,
+      candidate_id: decision.candidate_id,
+      node_id: decision.node_id,
+      decision: atom_string(decision.decision),
+      actor_type: decision.actor_type,
+      actor_id: decision.actor_id,
+      reason: decision.reason,
+      observed_identity: decision.observed_identity || %{},
+      target_ref: decision.target_ref,
+      audit_log_id: decision.audit_log_id,
+      metadata: decision.metadata || %{},
+      decided_at: iso8601(decision.decided_at),
+      inserted_at: iso8601(decision.inserted_at)
+    }
+  end
+
+  defp audit_log(%AuditLog{} = audit_log) do
+    %{
+      id: audit_log.id,
+      scope: audit_log.scope,
+      action: audit_log.action
+    }
+  end
+
+  defp atom_string(nil), do: nil
+  defp atom_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp atom_string(value), do: value
+
+  defp iso8601(nil), do: nil
+  defp iso8601(%DateTime{} = value), do: DateTime.to_iso8601(value)
+end

--- a/apps/orchard_controller/lib/orchard/api/admin_error_helpers.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin_error_helpers.ex
@@ -1,0 +1,23 @@
+defmodule Orchard.API.AdminErrorHelpers do
+  @moduledoc """
+  Stable JSON error envelope for Admin API surfaces.
+  """
+
+  import Phoenix.Controller, only: [json: 2]
+  import Plug.Conn, only: [put_status: 2]
+
+  @spec send_error(Plug.Conn.t(), atom() | integer(), String.t(), String.t(), keyword()) ::
+          Plug.Conn.t()
+  def send_error(conn, status, code, message, opts \\ []) do
+    error =
+      %{code: code, message: message}
+      |> maybe_put_details(Keyword.get(opts, :details))
+
+    conn
+    |> put_status(status)
+    |> json(%{error: error})
+  end
+
+  defp maybe_put_details(error, nil), do: error
+  defp maybe_put_details(error, details), do: Map.put(error, :details, details)
+end

--- a/apps/orchard_controller/lib/orchard/api/admin_request_context.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin_request_context.ex
@@ -1,0 +1,87 @@
+defmodule Orchard.API.AdminRequestContext do
+  @moduledoc """
+  Plug that resolves and authorizes `/admin/v1/*` caller context.
+  """
+
+  @behaviour Plug
+
+  alias Orchard.API.AdminErrorHelpers
+  alias Orchard.Governance
+
+  @invalid_api_key_message "Invalid API key provided."
+  @admin_required_message "Admin API requires a cluster-scoped admin API Client token."
+
+  @impl Plug
+  @spec init(Keyword.t()) :: Keyword.t()
+  def init(opts), do: opts
+
+  @impl Plug
+  @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    case bearer_token(conn) do
+      {:ok, token} ->
+        authenticate_request(conn, token)
+
+      {:error, reason} ->
+        conn
+        |> audit_auth_failure(nil, reason)
+        |> send_auth_error()
+    end
+  end
+
+  defp authenticate_request(conn, token) do
+    case Governance.authenticate_api_key(token) do
+      {:ok, auth_context} ->
+        Governance.touch_api_key_last_used(auth_context.api_key_id)
+        authorize_request(conn, auth_context)
+
+      {:error, reason} ->
+        conn
+        |> audit_auth_failure(token, reason)
+        |> send_auth_error()
+    end
+  end
+
+  defp authorize_request(conn, auth_context) do
+    case Governance.authorize_admin_api(auth_context) do
+      :ok ->
+        conn
+        |> Plug.Conn.assign(:tenant_id, auth_context.tenant_id)
+        |> Plug.Conn.assign(:principal_type, auth_context.principal_type)
+        |> Plug.Conn.assign(:principal_id, auth_context.principal_id)
+        |> Plug.Conn.assign(:service_account_id, auth_context.service_account_id)
+        |> Plug.Conn.assign(:api_key_id, auth_context.api_key_id)
+
+      {:error, :admin_required} ->
+        send_admin_required_error(conn)
+    end
+  end
+
+  defp bearer_token(conn) do
+    case Plug.Conn.get_req_header(conn, "authorization") do
+      [header] -> parse_bearer_header(header)
+      [] -> {:error, :missing_header}
+      _headers -> {:error, :malformed_header}
+    end
+  end
+
+  defp parse_bearer_header("Bearer " <> token) when token != "", do: {:ok, token}
+  defp parse_bearer_header(_header), do: {:error, :malformed_header}
+
+  defp audit_auth_failure(conn, token, reason) do
+    Governance.audit_api_key_auth_failure(token, reason)
+    conn
+  end
+
+  defp send_auth_error(conn) do
+    conn
+    |> AdminErrorHelpers.send_error(:unauthorized, "invalid_api_key", @invalid_api_key_message)
+    |> Plug.Conn.halt()
+  end
+
+  defp send_admin_required_error(conn) do
+    conn
+    |> AdminErrorHelpers.send_error(:forbidden, "admin_required", @admin_required_message)
+    |> Plug.Conn.halt()
+  end
+end

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -15,6 +15,11 @@ defmodule Orchard.API.Router do
     plug(Orchard.API.LicensePlug)
   end
 
+  pipeline :admin_api do
+    plug(:accepts, ["json"])
+    plug(Orchard.API.AdminRequestContext)
+  end
+
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)
@@ -44,6 +49,22 @@ defmodule Orchard.API.Router do
     get("/models", ModelsController, :index)
     post("/chat/completions", ChatCompletionsController, :create)
     post("/responses", ResponsesController, :create)
+  end
+
+  scope "/admin/v1", Orchard.API.Admin do
+    pipe_through(:admin_api)
+
+    get("/node-admission/candidates", NodeAdmissionController, :index)
+    get("/node-admission/candidates/:candidate_id", NodeAdmissionController, :show)
+    post("/node-admission/candidates/:candidate_id/reject", NodeAdmissionController, :reject)
+
+    post(
+      "/node-admission/candidates/:candidate_id/clear-rejection",
+      NodeAdmissionController,
+      :clear_rejection
+    )
+
+    post("/nodes/:node_id/admit", NodeAdmissionController, :admit)
   end
 
   # Console — LiveView operator UI

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -1,0 +1,23 @@
+defmodule Orchard.ControlPlane do
+  @moduledoc """
+  Small control-plane write gate for leader-only mutation paths.
+  """
+
+  @type write_path :: atom()
+  @type write_error :: :controller_standby
+
+  @spec authorize_write_path(write_path()) :: :ok | {:error, write_error()}
+  def authorize_write_path(_path) do
+    case configured_role() do
+      :standby -> {:error, :controller_standby}
+      "standby" -> {:error, :controller_standby}
+      _role -> :ok
+    end
+  end
+
+  defp configured_role do
+    :orchard_controller
+    |> Application.get_env(:control_plane, [])
+    |> Keyword.get(:role, :single_controller)
+  end
+end

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -36,7 +36,8 @@ defmodule Orchard.Governance do
           api_key_id: Ecto.UUID.t()
         }
   @type api_key_auth_error :: :invalid_api_key | :api_key_revoked | :api_key_expired
-  @type authorization_error :: :api_client_disabled | :missing_inference_client_access
+  @type authorization_error ::
+          :api_client_disabled | :missing_inference_client_access | :admin_required
   @type auth_failure_reason :: :missing_header | :malformed_header | api_key_auth_error
 
   @spec legacy_tenant_id() :: Ecto.UUID.t()
@@ -297,6 +298,22 @@ defmodule Orchard.Governance do
     |> unwrap_transaction_result()
   end
 
+  @spec ensure_cluster_admin_access(ServiceAccount.t() | Ecto.UUID.t(), keyword()) ::
+          {:ok, RoleBinding.t()} | {:error, Changeset.t() | :api_client_not_found}
+  def ensure_cluster_admin_access(service_account_or_id, opts \\ []) do
+    Repo.transaction(fn ->
+      with {:ok, api_client} <- resolve_api_client(service_account_or_id),
+           {:ok, role_binding, created?} <- ensure_cluster_admin_role_binding(api_client),
+           {:ok, _audit_log} <-
+             maybe_insert_role_binding_audit_log(api_client, role_binding, created?, opts) do
+        {:ok, role_binding}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
   @spec has_inference_client_access?(
           ServiceAccount.t() | Ecto.UUID.t(),
           Tenant.t() | Ecto.UUID.t()
@@ -308,6 +325,14 @@ defmodule Orchard.Governance do
       inference_client_role_binding_exists?(api_client.id, tenant.id)
     else
       _ -> false
+    end
+  end
+
+  @spec has_cluster_admin_access?(ServiceAccount.t() | Ecto.UUID.t()) :: boolean()
+  def has_cluster_admin_access?(service_account_or_id) do
+    case resolve_api_client(service_account_or_id) do
+      {:ok, api_client} -> cluster_admin_role_binding_exists?(api_client.id)
+      {:error, _reason} -> false
     end
   end
 
@@ -329,6 +354,22 @@ defmodule Orchard.Governance do
       {:error, _reason} -> {:error, :missing_inference_client_access}
     end
   end
+
+  @spec authorize_admin_api(api_key_auth_result()) :: :ok | {:error, :admin_required}
+  def authorize_admin_api(%{
+        principal_type: :service_account,
+        principal_id: service_account_id
+      }) do
+    with {:ok, api_client} <- resolve_api_client(service_account_id),
+         false <- ServiceAccount.disabled?(api_client),
+         true <- cluster_admin_role_binding_exists?(api_client.id) do
+      :ok
+    else
+      _ -> {:error, :admin_required}
+    end
+  end
+
+  def authorize_admin_api(_auth_context), do: {:error, :admin_required}
 
   @spec bulk_validate_api_clients([map()], keyword()) ::
           {:ok, ApiClientProvisioning.plan()}
@@ -846,6 +887,16 @@ defmodule Orchard.Governance do
     end
   end
 
+  defp ensure_cluster_admin_role_binding(%ServiceAccount{} = api_client) do
+    case fetch_cluster_admin_role_binding(api_client.id) do
+      %RoleBinding{} = role_binding ->
+        {:ok, role_binding, false}
+
+      nil ->
+        insert_cluster_admin_role_binding(api_client)
+    end
+  end
+
   defp insert_inference_client_role_binding(%ServiceAccount{} = api_client, %Tenant{} = tenant) do
     %RoleBinding{}
     |> RoleBinding.changeset(%{
@@ -856,8 +907,35 @@ defmodule Orchard.Governance do
     })
     |> Repo.insert()
     |> case do
-      {:ok, role_binding} -> {:ok, role_binding, true}
-      {:error, changeset} -> {:error, changeset}
+      {:ok, role_binding} ->
+        {:ok, role_binding, true}
+
+      {:error, changeset} ->
+        case fetch_inference_client_role_binding(api_client.id, tenant.id) do
+          %RoleBinding{} = role_binding -> {:ok, role_binding, false}
+          nil -> {:error, changeset}
+        end
+    end
+  end
+
+  defp insert_cluster_admin_role_binding(%ServiceAccount{} = api_client) do
+    %RoleBinding{}
+    |> RoleBinding.changeset(%{
+      principal_type: :service_account,
+      principal_id: api_client.id,
+      role: :admin,
+      tenant_scope_id: nil
+    })
+    |> Repo.insert()
+    |> case do
+      {:ok, role_binding} ->
+        {:ok, role_binding, true}
+
+      {:error, changeset} ->
+        case fetch_cluster_admin_role_binding(api_client.id) do
+          %RoleBinding{} = role_binding -> {:ok, role_binding, false}
+          nil -> {:error, changeset}
+        end
     end
   end
 
@@ -875,6 +953,22 @@ defmodule Orchard.Governance do
       role: :inference_client,
       tenant_scope_id: tenant_id
     )
+  end
+
+  defp cluster_admin_role_binding_exists?(service_account_id) do
+    case fetch_cluster_admin_role_binding(service_account_id) do
+      %RoleBinding{} -> true
+      nil -> false
+    end
+  end
+
+  defp fetch_cluster_admin_role_binding(service_account_id) do
+    RoleBinding
+    |> where([role_binding], role_binding.principal_type == :service_account)
+    |> where([role_binding], role_binding.principal_id == ^service_account_id)
+    |> where([role_binding], role_binding.role == :admin)
+    |> where([role_binding], is_nil(role_binding.tenant_scope_id))
+    |> Repo.one()
   end
 
   defp fetch_api_key_by_prefix(token_prefix) do
@@ -1134,26 +1228,37 @@ defmodule Orchard.Governance do
          true,
          opts
        ) do
+    scope_attrs = role_binding_audit_scope_attrs(role_binding)
+
     %AuditLog{}
-    |> audit_log_impl().changeset(%{
-      tenant_id: role_binding.tenant_scope_id,
-      api_key_id: nil,
-      actor_type: audit_actor_type(opts),
-      actor_id: audit_actor_id(opts),
-      action: "role_binding.created",
-      target_type: "role_binding",
-      target_id: role_binding.id,
-      occurred_at: utc_now(),
-      payload:
-        %{
-          "principal_type" => "service_account",
-          "principal_id" => api_client.id,
-          "role" => "inference_client",
-          "tenant_scope_id" => role_binding.tenant_scope_id
-        }
-        |> put_audit_context_payload(opts)
-    })
+    |> audit_log_impl().changeset(
+      Map.merge(scope_attrs, %{
+        api_key_id: nil,
+        actor_type: audit_actor_type(opts),
+        actor_id: audit_actor_id(opts),
+        action: "role_binding.created",
+        target_type: "role_binding",
+        target_id: role_binding.id,
+        occurred_at: utc_now(),
+        payload:
+          %{
+            "principal_type" => "service_account",
+            "principal_id" => api_client.id,
+            "role" => Atom.to_string(role_binding.role),
+            "tenant_scope_id" => role_binding.tenant_scope_id
+          }
+          |> put_audit_context_payload(opts)
+      })
+    )
     |> Repo.insert()
+  end
+
+  defp role_binding_audit_scope_attrs(%RoleBinding{tenant_scope_id: nil}) do
+    %{scope: "cluster", tenant_id: nil}
+  end
+
+  defp role_binding_audit_scope_attrs(%RoleBinding{tenant_scope_id: tenant_scope_id}) do
+    %{scope: "tenant", tenant_id: tenant_scope_id}
   end
 
   defp insert_tenant_audit_log(%Tenant{} = tenant, action, occurred_at) do

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -919,23 +919,34 @@ defmodule Orchard.Governance do
   end
 
   defp insert_cluster_admin_role_binding(%ServiceAccount{} = api_client) do
-    %RoleBinding{}
-    |> RoleBinding.changeset(%{
-      principal_type: :service_account,
-      principal_id: api_client.id,
-      role: :admin,
-      tenant_scope_id: nil
-    })
-    |> Repo.insert()
+    attempted =
+      %RoleBinding{}
+      |> RoleBinding.changeset(%{
+        principal_type: :service_account,
+        principal_id: api_client.id,
+        role: :admin,
+        tenant_scope_id: nil
+      })
+
+    attempted
+    |> Repo.insert(
+      on_conflict: :nothing,
+      conflict_target:
+        {:unsafe_fragment, "(principal_type, principal_id, role) WHERE tenant_scope_id IS NULL"},
+      returning: true
+    )
     |> case do
-      {:ok, role_binding} ->
-        {:ok, role_binding, true}
+      {:ok, %RoleBinding{} = attempted_role_binding} ->
+        case fetch_cluster_admin_role_binding(api_client.id) do
+          %RoleBinding{} = role_binding ->
+            {:ok, role_binding, role_binding.id == attempted_role_binding.id}
+
+          nil ->
+            {:error, attempted}
+        end
 
       {:error, changeset} ->
-        case fetch_cluster_admin_role_binding(api_client.id) do
-          %RoleBinding{} = role_binding -> {:ok, role_binding, false}
-          nil -> {:error, changeset}
-        end
+        {:error, changeset}
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/governance/role_binding.ex
+++ b/apps/orchard_controller/lib/orchard/governance/role_binding.ex
@@ -43,6 +43,7 @@ defmodule Orchard.Governance.RoleBinding do
     |> check_constraint(:role, name: :role_bindings_role_check)
     |> check_constraint(:tenant_scope_id, name: :role_bindings_inference_client_tenant_scope)
     |> unique_constraint(:role, name: :idx_role_bindings_unique_assignment)
+    |> unique_constraint(:role, name: :idx_role_bindings_unique_cluster_assignment)
     |> foreign_key_constraint(:tenant_scope_id)
   end
 end

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -141,6 +141,19 @@ defmodule Orchard.Nodes do
   def get_node!(id), do: Repo.get!(Node, id)
 
   @doc """
+  Fetches a node by ID for API surfaces that need stable not-found errors.
+  """
+  @spec fetch_node(Ecto.UUID.t()) :: {:ok, Node.t()} | {:error, :node_not_found}
+  def fetch_node(id) do
+    with {:ok, id} <- normalize_uuid(id, :node_not_found) do
+      case Repo.get(Node, id) do
+        %Node{} = node -> {:ok, node}
+        nil -> {:error, :node_not_found}
+      end
+    end
+  end
+
+  @doc """
   Lists node admission candidates ordered for operator review.
   """
   @spec list_admission_candidates(keyword()) :: [AdmissionCandidate.t()]
@@ -158,6 +171,20 @@ defmodule Orchard.Nodes do
   """
   @spec get_admission_candidate!(Ecto.UUID.t()) :: AdmissionCandidate.t()
   def get_admission_candidate!(id), do: Repo.get!(AdmissionCandidate, id)
+
+  @doc """
+  Fetches a node admission candidate by ID for API surfaces.
+  """
+  @spec fetch_admission_candidate(Ecto.UUID.t()) ::
+          {:ok, AdmissionCandidate.t()} | {:error, :candidate_not_found}
+  def fetch_admission_candidate(id) do
+    with {:ok, id} <- normalize_uuid(id, :candidate_not_found) do
+      case Repo.get(AdmissionCandidate, id) do
+        %AdmissionCandidate{} = candidate -> {:ok, candidate}
+        nil -> {:error, :candidate_not_found}
+      end
+    end
+  end
 
   @doc """
   Looks up a node by its connection target.
@@ -275,6 +302,41 @@ defmodule Orchard.Nodes do
   end
 
   @doc """
+  Rejects a pending node admission candidate by candidate ID only.
+  """
+  @spec reject_admission_candidate(Ecto.UUID.t(), map() | keyword(), keyword()) ::
+          {:ok,
+           %{
+             candidate: AdmissionCandidate.t(),
+             decision: AdmissionDecision.t(),
+             audit_log: AuditLog.t()
+           }}
+          | {:error, term()}
+  def reject_admission_candidate(candidate_id, attrs, opts \\ []) do
+    attrs = normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, candidate} <- lock_candidate_by_id(candidate_id),
+           {:ok, reason} <- required_reason(attrs),
+           {:ok, candidate} <- reject_admission_target({:candidate, candidate}),
+           {:ok, audit_log} <-
+             insert_admission_audit_log(
+               "node_admission.rejected",
+               candidate,
+               admission_audit_payload(candidate, %{"reason" => reason}),
+               opts
+             ),
+           {:ok, decision} <-
+             insert_admission_decision(candidate, :rejected, reason, audit_log, %{}, opts) do
+        {:ok, %{candidate: candidate, decision: decision, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  @doc """
   Clears a rejected admission candidate by appending a clearance decision.
   """
   @spec clear_admission_rejection(Ecto.UUID.t(), map() | keyword(), keyword()) ::
@@ -290,6 +352,40 @@ defmodule Orchard.Nodes do
 
     Repo.transaction(fn ->
       with {:ok, candidate} <- lock_rejected_candidate(candidate_or_node_id),
+           {:ok, restored} <- restore_candidate_pending_category(candidate),
+           {:ok, audit_log} <-
+             insert_admission_audit_log(
+               "node_admission.rejection_cleared",
+               restored,
+               admission_audit_payload(restored, attrs),
+               opts
+             ),
+           {:ok, decision} <-
+             insert_admission_decision(restored, :rejection_cleared, nil, audit_log, attrs, opts) do
+        {:ok, %{candidate: restored, decision: decision, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  @doc """
+  Clears a rejected node admission candidate by candidate ID only.
+  """
+  @spec clear_admission_candidate_rejection(Ecto.UUID.t(), map() | keyword(), keyword()) ::
+          {:ok,
+           %{
+             candidate: AdmissionCandidate.t(),
+             decision: AdmissionDecision.t(),
+             audit_log: AuditLog.t()
+           }}
+          | {:error, term()}
+  def clear_admission_candidate_rejection(candidate_id, attrs \\ %{}, opts \\ []) do
+    attrs = normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, candidate} <- lock_rejected_candidate_by_id(candidate_id),
            {:ok, restored} <- restore_candidate_pending_category(candidate),
            {:ok, audit_log} <-
              insert_admission_audit_log(
@@ -345,6 +441,48 @@ defmodule Orchard.Nodes do
       end
     end)
     |> unwrap_transaction_result()
+  end
+
+  @doc """
+  Returns the latest admission decision for a candidate.
+  """
+  @spec latest_admission_decision_for_candidate(Ecto.UUID.t()) :: AdmissionDecision.t() | nil
+  def latest_admission_decision_for_candidate(candidate_id) do
+    case normalize_uuid(candidate_id, :candidate_not_found) do
+      {:ok, candidate_id} ->
+        AdmissionDecision
+        |> where([decision], decision.candidate_id == ^candidate_id)
+        |> order_by([decision], desc: decision.decided_at, desc: decision.inserted_at)
+        |> limit(1)
+        |> Repo.one()
+
+      {:error, :candidate_not_found} ->
+        nil
+    end
+  end
+
+  @doc """
+  Returns the latest admission decisions keyed by candidate ID.
+  """
+  @spec latest_admission_decisions_for_candidates([Ecto.UUID.t()]) :: %{
+          optional(Ecto.UUID.t()) => AdmissionDecision.t()
+        }
+  def latest_admission_decisions_for_candidates(candidate_ids) do
+    candidate_ids
+    |> normalize_uuid_list()
+    |> do_latest_admission_decisions_for_candidates()
+  end
+
+  defp do_latest_admission_decisions_for_candidates([]), do: %{}
+
+  defp do_latest_admission_decisions_for_candidates(candidate_ids) do
+    AdmissionDecision
+    |> where([decision], decision.candidate_id in ^candidate_ids)
+    |> order_by([decision], desc: decision.decided_at, desc: decision.inserted_at)
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn decision, decisions_by_candidate ->
+      Map.put_new(decisions_by_candidate, decision.candidate_id, decision)
+    end)
   end
 
   defp handle_observation_result(target, observed_at, result, status_response, opts) do
@@ -1130,6 +1268,17 @@ defmodule Orchard.Nodes do
     end
   end
 
+  defp lock_candidate_by_id(candidate_id) do
+    with {:ok, candidate_id} <- normalize_uuid(candidate_id, :candidate_not_found) do
+      candidate_id
+      |> lock_candidate()
+      |> case do
+        %AdmissionCandidate{} = candidate -> {:ok, candidate}
+        nil -> {:error, :candidate_not_found}
+      end
+    end
+  end
+
   defp reject_admission_target({:candidate, %AdmissionCandidate{} = candidate}) do
     if candidate.admission_category in [
          :pending_observed,
@@ -1161,6 +1310,18 @@ defmodule Orchard.Nodes do
 
       nil ->
         lock_rejected_candidate_for_node(id)
+    end
+  end
+
+  defp lock_rejected_candidate_by_id(candidate_id) do
+    with {:ok, candidate} <- lock_candidate_by_id(candidate_id) do
+      case candidate do
+        %AdmissionCandidate{admission_category: :rejected} = candidate ->
+          {:ok, candidate}
+
+        %AdmissionCandidate{} ->
+          {:error, :admission_not_rejected}
+      end
     end
   end
 
@@ -1242,7 +1403,18 @@ defmodule Orchard.Nodes do
   defp blank_admission_value?(nil), do: true
   defp blank_admission_value?(_value), do: false
 
-  defp latest_admission_decision_for_node(node_id) do
+  @doc """
+  Returns the latest admission decision for a node.
+  """
+  @spec latest_admission_decision_for_node(Ecto.UUID.t()) :: AdmissionDecision.t() | nil
+  def latest_admission_decision_for_node(node_id) do
+    case normalize_uuid(node_id, :node_not_found) do
+      {:ok, node_id} -> do_latest_admission_decision_for_node(node_id)
+      {:error, :node_not_found} -> nil
+    end
+  end
+
+  defp do_latest_admission_decision_for_node(node_id) do
     AdmissionDecision
     |> where([decision], decision.node_id == ^node_id)
     |> order_by([decision], desc: decision.decided_at, desc: decision.inserted_at)
@@ -1279,13 +1451,15 @@ defmodule Orchard.Nodes do
   end
 
   defp lock_node(node_id) do
-    Node
-    |> where([node], node.id == ^node_id)
-    |> lock("FOR UPDATE")
-    |> Repo.one()
-    |> case do
-      %Node{} = node -> {:ok, node}
-      nil -> {:error, :node_not_found}
+    with {:ok, node_id} <- normalize_uuid(node_id, :node_not_found) do
+      Node
+      |> where([node], node.id == ^node_id)
+      |> lock("FOR UPDATE")
+      |> Repo.one()
+      |> case do
+        %Node{} = node -> {:ok, node}
+        nil -> {:error, :node_not_found}
+      end
     end
   end
 
@@ -1434,6 +1608,24 @@ defmodule Orchard.Nodes do
   end
 
   defp normalize_attrs(attrs), do: SchemaSupport.normalize_attrs(attrs)
+
+  defp normalize_uuid(value, error) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, error}
+    end
+  end
+
+  defp normalize_uuid_list(values) do
+    values
+    |> Enum.flat_map(fn value ->
+      case Ecto.UUID.cast(value) do
+        {:ok, uuid} -> [uuid]
+        :error -> []
+      end
+    end)
+    |> Enum.uniq()
+  end
 
   defp sanitize_snapshot(value), do: sanitize_snapshot(value, 0)
 

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -141,19 +141,6 @@ defmodule Orchard.Nodes do
   def get_node!(id), do: Repo.get!(Node, id)
 
   @doc """
-  Fetches a node by ID for API surfaces that need stable not-found errors.
-  """
-  @spec fetch_node(Ecto.UUID.t()) :: {:ok, Node.t()} | {:error, :node_not_found}
-  def fetch_node(id) do
-    with {:ok, id} <- normalize_uuid(id, :node_not_found) do
-      case Repo.get(Node, id) do
-        %Node{} = node -> {:ok, node}
-        nil -> {:error, :node_not_found}
-      end
-    end
-  end
-
-  @doc """
   Lists node admission candidates ordered for operator review.
   """
   @spec list_admission_candidates(keyword()) :: [AdmissionCandidate.t()]
@@ -278,27 +265,7 @@ defmodule Orchard.Nodes do
            }}
           | {:error, term()}
   def reject_admission(candidate_or_node_id, attrs, opts \\ []) do
-    attrs = normalize_attrs(attrs)
-
-    Repo.transaction(fn ->
-      with {:ok, target} <- lock_admission_target(candidate_or_node_id),
-           {:ok, reason} <- required_reason(attrs),
-           {:ok, candidate} <- reject_admission_target(target),
-           {:ok, audit_log} <-
-             insert_admission_audit_log(
-               "node_admission.rejected",
-               candidate,
-               admission_audit_payload(candidate, %{"reason" => reason}),
-               opts
-             ),
-           {:ok, decision} <-
-             insert_admission_decision(candidate, :rejected, reason, audit_log, %{}, opts) do
-        {:ok, %{candidate: candidate, decision: decision, audit_log: audit_log}}
-      else
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
-    |> unwrap_transaction_result()
+    do_reject_admission(fn -> lock_admission_target(candidate_or_node_id) end, attrs, opts)
   end
 
   @doc """
@@ -313,27 +280,7 @@ defmodule Orchard.Nodes do
            }}
           | {:error, term()}
   def reject_admission_candidate(candidate_id, attrs, opts \\ []) do
-    attrs = normalize_attrs(attrs)
-
-    Repo.transaction(fn ->
-      with {:ok, candidate} <- lock_candidate_by_id(candidate_id),
-           {:ok, reason} <- required_reason(attrs),
-           {:ok, candidate} <- reject_admission_target({:candidate, candidate}),
-           {:ok, audit_log} <-
-             insert_admission_audit_log(
-               "node_admission.rejected",
-               candidate,
-               admission_audit_payload(candidate, %{"reason" => reason}),
-               opts
-             ),
-           {:ok, decision} <-
-             insert_admission_decision(candidate, :rejected, reason, audit_log, %{}, opts) do
-        {:ok, %{candidate: candidate, decision: decision, audit_log: audit_log}}
-      else
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
-    |> unwrap_transaction_result()
+    do_reject_admission(fn -> lock_candidate_target(candidate_id) end, attrs, opts)
   end
 
   @doc """
@@ -348,26 +295,11 @@ defmodule Orchard.Nodes do
            }}
           | {:error, term()}
   def clear_admission_rejection(candidate_or_node_id, attrs \\ %{}, opts \\ []) do
-    attrs = normalize_attrs(attrs)
-
-    Repo.transaction(fn ->
-      with {:ok, candidate} <- lock_rejected_candidate(candidate_or_node_id),
-           {:ok, restored} <- restore_candidate_pending_category(candidate),
-           {:ok, audit_log} <-
-             insert_admission_audit_log(
-               "node_admission.rejection_cleared",
-               restored,
-               admission_audit_payload(restored, attrs),
-               opts
-             ),
-           {:ok, decision} <-
-             insert_admission_decision(restored, :rejection_cleared, nil, audit_log, attrs, opts) do
-        {:ok, %{candidate: restored, decision: decision, audit_log: audit_log}}
-      else
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
-    |> unwrap_transaction_result()
+    do_clear_admission_rejection(
+      fn -> lock_rejected_candidate(candidate_or_node_id) end,
+      attrs,
+      opts
+    )
   end
 
   @doc """
@@ -382,26 +314,11 @@ defmodule Orchard.Nodes do
            }}
           | {:error, term()}
   def clear_admission_candidate_rejection(candidate_id, attrs \\ %{}, opts \\ []) do
-    attrs = normalize_attrs(attrs)
-
-    Repo.transaction(fn ->
-      with {:ok, candidate} <- lock_rejected_candidate_by_id(candidate_id),
-           {:ok, restored} <- restore_candidate_pending_category(candidate),
-           {:ok, audit_log} <-
-             insert_admission_audit_log(
-               "node_admission.rejection_cleared",
-               restored,
-               admission_audit_payload(restored, attrs),
-               opts
-             ),
-           {:ok, decision} <-
-             insert_admission_decision(restored, :rejection_cleared, nil, audit_log, attrs, opts) do
-        {:ok, %{candidate: restored, decision: decision, audit_log: audit_log}}
-      else
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
-    |> unwrap_transaction_result()
+    do_clear_admission_rejection(
+      fn -> lock_rejected_candidate_by_id(candidate_id) end,
+      attrs,
+      opts
+    )
   end
 
   @doc """
@@ -1255,6 +1172,53 @@ defmodule Orchard.Nodes do
 
   # -- Admission Decisions --
 
+  defp do_reject_admission(lock_target, attrs, opts) do
+    attrs = normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, target} <- lock_target.(),
+           {:ok, reason} <- required_reason(attrs),
+           {:ok, candidate} <- reject_admission_target(target),
+           {:ok, audit_log} <-
+             insert_admission_audit_log(
+               "node_admission.rejected",
+               candidate,
+               admission_audit_payload(candidate, %{"reason" => reason}),
+               opts
+             ),
+           {:ok, decision} <-
+             insert_admission_decision(candidate, :rejected, reason, audit_log, %{}, opts) do
+        {:ok, %{candidate: candidate, decision: decision, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  defp do_clear_admission_rejection(lock_candidate, attrs, opts) do
+    attrs = normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, candidate} <- lock_candidate.(),
+           {:ok, restored} <- restore_candidate_pending_category(candidate),
+           {:ok, audit_log} <-
+             insert_admission_audit_log(
+               "node_admission.rejection_cleared",
+               restored,
+               admission_audit_payload(restored, attrs),
+               opts
+             ),
+           {:ok, decision} <-
+             insert_admission_decision(restored, :rejection_cleared, nil, audit_log, attrs, opts) do
+        {:ok, %{candidate: restored, decision: decision, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
   defp lock_admission_target(id) do
     case lock_candidate(id) do
       %AdmissionCandidate{} = candidate ->
@@ -1276,6 +1240,12 @@ defmodule Orchard.Nodes do
         %AdmissionCandidate{} = candidate -> {:ok, candidate}
         nil -> {:error, :candidate_not_found}
       end
+    end
+  end
+
+  defp lock_candidate_target(candidate_id) do
+    with {:ok, candidate} <- lock_candidate_by_id(candidate_id) do
+      {:ok, {:candidate, candidate}}
     end
   end
 

--- a/apps/orchard_controller/priv/repo/migrations/20260630070000_cluster_admin_role_binding_unique_index.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260630070000_cluster_admin_role_binding_unique_index.exs
@@ -1,0 +1,12 @@
+defmodule Orchard.Repo.Migrations.ClusterAdminRoleBindingUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    create(
+      unique_index(:role_bindings, [:principal_type, :principal_id, :role],
+        name: :idx_role_bindings_unique_cluster_assignment,
+        where: "tenant_scope_id IS NULL"
+      )
+    )
+  end
+end

--- a/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
@@ -1,0 +1,440 @@
+defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
+  use Orchard.ConnCase, async: false
+
+  import Ecto.Query
+
+  alias Orchard.API.Router
+  alias Orchard.Governance
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
+  alias Orchard.Repo
+
+  describe "Admin API node admission" do
+    @describetag :db
+
+    test "SPEC.md §7.4 lists and shows admission candidates with latest decision metadata" do
+      token = admin_token!("admin-node-admission-list")
+      candidate = insert_candidate!(target_ref: "10.0.0.44:50071")
+
+      assert {:ok, _result} =
+               Nodes.reject_admission_candidate(candidate.id, %{reason: "review later"})
+
+      list_conn = admin_json(:get, "/admin/v1/node-admission/candidates", token)
+      assert list_conn.status == 200
+
+      assert %{"object" => "list", "data" => [listed]} = Jason.decode!(list_conn.resp_body)
+      assert listed["id"] == candidate.id
+      assert listed["object"] == "node_admission_candidate"
+      assert listed["latest_decision"]["decision"] == "rejected"
+
+      show_conn =
+        admin_json(:get, "/admin/v1/node-admission/candidates/#{candidate.id}", token)
+
+      assert show_conn.status == 200
+      assert Jason.decode!(show_conn.resp_body)["id"] == candidate.id
+    end
+
+    test "candidate show returns 404 for unknown candidates" do
+      token = admin_token!("admin-node-admission-show-missing")
+
+      conn =
+        admin_json(
+          :get,
+          "/admin/v1/node-admission/candidates/#{Ecto.UUID.generate()}",
+          token
+        )
+
+      assert conn.status == 404
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "candidate_not_found"
+    end
+
+    test "reject requires a nonblank reason" do
+      token = admin_token!("admin-node-admission-reason")
+      candidate = insert_candidate!()
+
+      conn =
+        admin_json(
+          :post,
+          "/admin/v1/node-admission/candidates/#{candidate.id}/reject",
+          token,
+          %{"reason" => "  "}
+        )
+
+      assert conn.status == 400
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "reason_required"
+    end
+
+    test "reject and clear append decisions and cluster audit logs" do
+      token = admin_token!("admin-node-admission-reject-clear")
+      candidate = insert_candidate!(target_ref: "10.0.0.45:50071")
+
+      reject_conn =
+        admin_json(
+          :post,
+          "/admin/v1/node-admission/candidates/#{candidate.id}/reject",
+          token,
+          %{"reason" => "identity mismatch"}
+        )
+
+      assert reject_conn.status == 200
+      rejected = Jason.decode!(reject_conn.resp_body)
+      assert rejected["action"] == "node_admission.rejected"
+      assert rejected["candidate"]["admission_category"] == "rejected"
+      assert rejected["decision"]["reason"] == "identity mismatch"
+      assert rejected["audit_log"]["scope"] == "cluster"
+
+      clear_conn =
+        admin_json(
+          :post,
+          "/admin/v1/node-admission/candidates/#{candidate.id}/clear-rejection",
+          token,
+          %{"surface" => "admin-api-test"}
+        )
+
+      assert clear_conn.status == 200
+      cleared = Jason.decode!(clear_conn.resp_body)
+      assert cleared["action"] == "node_admission.rejection_cleared"
+      assert cleared["candidate"]["admission_category"] == "pending_observed"
+      assert cleared["decision"]["metadata"] == %{"surface" => "admin-api-test"}
+      refute Map.has_key?(cleared["decision"]["metadata"], "candidate_id")
+
+      decisions =
+        AdmissionDecision
+        |> where([decision], decision.candidate_id == ^candidate.id)
+        |> order_by([decision], asc: decision.inserted_at)
+        |> Repo.all()
+        |> Enum.map(& &1.decision)
+
+      assert decisions == [:rejected, :rejection_cleared]
+
+      assert Repo.aggregate(
+               from(audit_log in AuditLog,
+                 where:
+                   audit_log.scope == "cluster" and
+                     audit_log.target_type == "node_admission_candidate" and
+                     audit_log.target_id == ^candidate.id
+               ),
+               :count,
+               :id
+             ) == 2
+    end
+
+    test "candidate reject route does not fall back to a node with the same UUID" do
+      token = admin_token!("admin-node-admission-no-fallback")
+
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "same-id-node",
+          hostname: "same-id-node.local"
+        })
+
+      conn =
+        admin_json(
+          :post,
+          "/admin/v1/node-admission/candidates/#{node.id}/reject",
+          token,
+          %{"reason" => "must not affect node"}
+        )
+
+      assert conn.status == 404
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "candidate_not_found"
+
+      assert [] =
+               Repo.all(from(decision in AdmissionDecision, where: decision.node_id == ^node.id))
+    end
+
+    test "candidate clear route does not fall back to a node with the same UUID" do
+      token = admin_token!("admin-node-admission-clear-no-fallback")
+
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "same-id-clear-node",
+          hostname: "same-id-clear-node.local"
+        })
+
+      conn =
+        admin_json(
+          :post,
+          "/admin/v1/node-admission/candidates/#{node.id}/clear-rejection",
+          token,
+          %{}
+        )
+
+      assert conn.status == 404
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "candidate_not_found"
+
+      assert [] =
+               Repo.all(from(decision in AdmissionDecision, where: decision.node_id == ^node.id))
+    end
+
+    test "admit rejects observed-only candidates and provisioned nodes" do
+      token = admin_token!("admin-node-admission-blockers")
+      candidate = insert_candidate!()
+
+      observed_conn =
+        admin_json(:post, "/admin/v1/nodes/#{candidate.id}/admit", token, admission_attrs())
+
+      assert observed_conn.status == 404
+      assert Jason.decode!(observed_conn.resp_body)["error"]["code"] == "node_not_found"
+
+      node =
+        insert_node!(%{
+          state: :provisioned,
+          display_name: "provisioned-node",
+          hostname: "provisioned-node.local"
+        })
+
+      provisioned_conn =
+        admin_json(:post, "/admin/v1/nodes/#{node.id}/admit", token, admission_attrs())
+
+      assert provisioned_conn.status == 409
+      assert Jason.decode!(provisioned_conn.resp_body)["error"]["code"] == "node_not_registered"
+    end
+
+    test "admit enforces rejection clear, inventory, trust, pool, and policy blockers" do
+      token = admin_token!("admin-node-admission-input-blockers")
+
+      rejected_node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "rejected-node",
+          hostname: "rejected-node.local"
+        })
+
+      assert {:ok, _rejected} =
+               Nodes.reject_admission(rejected_node.id, %{reason: "hold admission"})
+
+      rejected_conn =
+        admin_json(:post, "/admin/v1/nodes/#{rejected_node.id}/admit", token, admission_attrs())
+
+      assert rejected_conn.status == 409
+      assert Jason.decode!(rejected_conn.resp_body)["error"]["code"] == "admission_rejected"
+
+      missing_inventory =
+        insert_node!(%{
+          state: :registered,
+          advertise_addr: "0.0.0.0",
+          display_name: "missing-inventory-node",
+          hostname: "missing-inventory-node.local"
+        })
+
+      inventory_conn =
+        admin_json(
+          :post,
+          "/admin/v1/nodes/#{missing_inventory.id}/admit",
+          token,
+          admission_attrs()
+        )
+
+      assert inventory_conn.status == 409
+      assert Jason.decode!(inventory_conn.resp_body)["error"]["code"] == "inventory_missing"
+
+      registered =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-blocker-node",
+          hostname: "registered-blocker-node.local"
+        })
+
+      trust_conn = admin_json(:post, "/admin/v1/nodes/#{registered.id}/admit", token, %{})
+      assert trust_conn.status == 409
+      assert Jason.decode!(trust_conn.resp_body)["error"]["code"] == "trust_not_established"
+
+      pool_conn =
+        admin_json(
+          :post,
+          "/admin/v1/nodes/#{registered.id}/admit",
+          token,
+          %{"trust_evidence_ref" => "registration-audit:test"}
+        )
+
+      assert pool_conn.status == 409
+      assert Jason.decode!(pool_conn.resp_body)["error"]["code"] == "pool_required"
+
+      policy_conn =
+        admin_json(
+          :post,
+          "/admin/v1/nodes/#{registered.id}/admit",
+          token,
+          %{
+            "trust_evidence_ref" => "registration-audit:test",
+            "pool_id" => Ecto.UUID.generate()
+          }
+        )
+
+      assert policy_conn.status == 409
+      assert Jason.decode!(policy_conn.resp_body)["error"]["code"] == "policy_required"
+    end
+
+    test "admit transitions a registered trusted node to admitted and writes cluster audit" do
+      token = admin_token!("admin-node-admission-admit")
+
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-admit-node",
+          hostname: "registered-admit-node.local"
+        })
+
+      conn = admin_json(:post, "/admin/v1/nodes/#{node.id}/admit", token, admission_attrs())
+
+      assert conn.status == 200
+      body = Jason.decode!(conn.resp_body)
+      assert body["action"] == "node_admission.admitted"
+      assert body["node"]["state"] == "admitted"
+      assert body["decision"]["decision"] == "admitted"
+      assert body["decision"]["metadata"]["trust_evidence_ref"] == "registration-audit:test"
+      refute Map.has_key?(body["decision"]["metadata"], "node_id")
+      assert body["audit_log"]["scope"] == "cluster"
+      assert Repo.get!(Node, node.id).state == :admitted
+    end
+
+    test "stored snapshot truncation markers are preserved in candidate responses" do
+      token = admin_token!("admin-node-admission-truncation")
+
+      marker = %{
+        "truncated" => true,
+        "reason" => "entry_limit",
+        "kind" => "map",
+        "entry_limit" => 40,
+        "original_count" => 41
+      }
+
+      candidate =
+        insert_candidate!(
+          inventory: %{
+            "__orchard_snapshot_truncation__" => marker,
+            "retained" => "value"
+          }
+        )
+
+      conn = admin_json(:get, "/admin/v1/node-admission/candidates/#{candidate.id}", token)
+
+      assert conn.status == 200
+      body = Jason.decode!(conn.resp_body)
+      assert body["inventory"]["__orchard_snapshot_truncation__"] == marker
+    end
+
+    test "controller standby fails closed before mutation or audit writes" do
+      token = admin_token!("admin-node-admission-standby")
+      candidate = insert_candidate!()
+      previous = Application.get_env(:orchard_controller, :control_plane)
+
+      Application.put_env(:orchard_controller, :control_plane, role: :standby)
+
+      on_exit(fn ->
+        if is_nil(previous) do
+          Application.delete_env(:orchard_controller, :control_plane)
+        else
+          Application.put_env(:orchard_controller, :control_plane, previous)
+        end
+      end)
+
+      conn =
+        admin_json(
+          :post,
+          "/admin/v1/node-admission/candidates/#{candidate.id}/reject",
+          token,
+          %{"reason" => "standby should not mutate"}
+        )
+
+      assert conn.status == 503
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "controller_standby"
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
+
+      assert Repo.aggregate(
+               from(audit_log in AuditLog,
+                 where:
+                   audit_log.target_type == "node_admission_candidate" and
+                     audit_log.target_id == ^candidate.id
+               ),
+               :count,
+               :id
+             ) == 0
+    end
+  end
+
+  defp admin_json(method, path, token, params \\ %{}) do
+    method
+    |> build_conn(path)
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> Map.put(:params, params)
+    |> Map.put(:body_params, params)
+    |> Router.call(Router.init([]))
+  end
+
+  defp admin_token!(slug) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+
+    {:ok, api_client} =
+      Governance.upsert_api_client(tenant, %{
+        name: "#{slug}-client",
+        owner_contact: "owner@example.com"
+      })
+
+    {:ok, _role_binding} = Governance.ensure_cluster_admin_access(api_client)
+    {:ok, %{token: token}} = Governance.create_api_client_api_token(api_client, %{name: "admin"})
+    token
+  end
+
+  defp insert_candidate!(overrides \\ []) do
+    unique = System.unique_integer([:positive])
+
+    attrs =
+      %{
+        source: :runtime_endpoint_observation,
+        admission_category: :pending_observed,
+        observed_identity: %{
+          "claimed_node_id" => Ecto.UUID.generate(),
+          "display_name" => "candidate-#{unique}",
+          "hostname" => "candidate-#{unique}.local"
+        },
+        target_ref: "10.0.0.#{rem(unique, 200) + 1}:50071",
+        endpoint_transport: :grpc,
+        endpoint_target: "10.0.0.#{rem(unique, 200) + 1}:50071",
+        inventory: %{"capabilities" => %{}},
+        compatibility_evidence: %{"health" => "healthy"},
+        last_observed_at: DateTime.utc_now()
+      }
+      |> Map.merge(Map.new(overrides))
+
+    %AdmissionCandidate{}
+    |> AdmissionCandidate.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  defp insert_node!(overrides) do
+    unique = System.unique_integer([:positive])
+
+    attrs =
+      %{
+        id: Ecto.UUID.generate(),
+        hostname: "node-#{unique}.local",
+        display_name: "node-#{unique}",
+        advertise_addr: "10.20.#{rem(unique, 200)}.#{rem(unique, 250) + 1}",
+        rpc_port: 50_071,
+        state: :active,
+        health: :healthy,
+        capabilities: %{},
+        tool_readiness: %{}
+      }
+      |> Map.merge(overrides)
+
+    %Node{}
+    |> Node.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  defp admission_attrs do
+    %{
+      "trust_evidence_ref" => "registration-audit:test",
+      "pool_id" => Ecto.UUID.generate(),
+      "routing_policy_id" => Ecto.UUID.generate()
+    }
+  end
+end

--- a/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
@@ -89,7 +89,7 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
           :post,
           "/admin/v1/node-admission/candidates/#{candidate.id}/clear-rejection",
           token,
-          %{"surface" => "admin-api-test"}
+          malicious_metadata(%{"surface" => "admin-api-test"})
         )
 
       assert clear_conn.status == 200
@@ -98,6 +98,13 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
       assert cleared["candidate"]["admission_category"] == "pending_observed"
       assert cleared["decision"]["metadata"] == %{"surface" => "admin-api-test"}
       refute Map.has_key?(cleared["decision"]["metadata"], "candidate_id")
+
+      clear_audit_log = Repo.get!(AuditLog, cleared["audit_log"]["id"])
+      assert clear_audit_log.payload["source"] == "runtime_endpoint_observation"
+      assert clear_audit_log.payload["admission_category"] == "pending_observed"
+      assert clear_audit_log.payload["target_ref"] == "10.0.0.45:50071"
+      assert clear_audit_log.payload["observed_identity"] == candidate.observed_identity
+      assert clear_audit_log.payload["surface"] == "admin-api-test"
 
       decisions =
         AdmissionDecision
@@ -279,7 +286,13 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
           hostname: "registered-admit-node.local"
         })
 
-      conn = admin_json(:post, "/admin/v1/nodes/#{node.id}/admit", token, admission_attrs())
+      conn =
+        admin_json(
+          :post,
+          "/admin/v1/nodes/#{node.id}/admit",
+          token,
+          malicious_metadata(admission_attrs())
+        )
 
       assert conn.status == 200
       body = Jason.decode!(conn.resp_body)
@@ -288,7 +301,17 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
       assert body["decision"]["decision"] == "admitted"
       assert body["decision"]["metadata"]["trust_evidence_ref"] == "registration-audit:test"
       refute Map.has_key?(body["decision"]["metadata"], "node_id")
+      refute Map.has_key?(body["decision"]["metadata"], "source")
+      refute Map.has_key?(body["decision"]["metadata"], "observed_identity")
       assert body["audit_log"]["scope"] == "cluster"
+
+      audit_log = Repo.get!(AuditLog, body["audit_log"]["id"])
+      assert audit_log.payload["source"] == "registered_node"
+      assert audit_log.payload["admission_category"] == "admitted"
+      assert audit_log.payload["node_id"] == node.id
+      assert audit_log.payload["observed_identity"]["node_id"] == node.id
+      assert audit_log.payload["target_ref"] != "spoofed-target"
+
       assert Repo.get!(Node, node.id).state == :admitted
     end
 
@@ -436,5 +459,16 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
       "pool_id" => Ecto.UUID.generate(),
       "routing_policy_id" => Ecto.UUID.generate()
     }
+  end
+
+  defp malicious_metadata(attrs) do
+    Map.merge(attrs, %{
+      "source" => "spoofed-source",
+      "admission_category" => "spoofed-category",
+      "observed_identity" => %{"claimed_node_id" => "spoofed-node"},
+      "target_ref" => "spoofed-target",
+      "candidate_id" => Ecto.UUID.generate(),
+      "node_id" => Ecto.UUID.generate()
+    })
   end
 end

--- a/apps/orchard_controller/test/orchard/api/admin_request_context_test.exs
+++ b/apps/orchard_controller/test/orchard/api/admin_request_context_test.exs
@@ -1,0 +1,211 @@
+defmodule Orchard.API.AdminRequestContextTest do
+  use Orchard.ConnCase, async: false
+
+  alias Orchard.API.AdminRequestContext
+  alias Orchard.Governance
+  alias Orchard.Governance.RoleBinding
+  alias Orchard.Repo
+
+  describe "AdminRequestContext plug" do
+    @describetag :db
+
+    test "SPEC.md §7.4 authorizes service-account-owned cluster admin tokens" do
+      %{api_client: api_client, api_key: api_key, token: token, tenant: tenant} =
+        create_api_client_token!("admin-context-authorized", role: :admin)
+
+      conn =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> AdminRequestContext.call([])
+
+      refute conn.halted
+      assert conn.assigns[:tenant_id] == tenant.id
+      assert conn.assigns[:principal_type] == :service_account
+      assert conn.assigns[:principal_id] == api_client.id
+      assert conn.assigns[:service_account_id] == api_client.id
+      assert conn.assigns[:api_key_id] == api_key.id
+    end
+
+    test "rejects missing, malformed, invalid, revoked, and expired tokens with 401" do
+      assert_admin_auth_error(build_conn(:get, "/admin/v1/node-admission/candidates"), 401)
+
+      malformed =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Token nope")
+
+      assert_admin_auth_error(malformed, 401)
+
+      invalid =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer orchard_sk_invalid.invalid")
+
+      assert_admin_auth_error(invalid, 401)
+
+      %{api_key: api_key, token: revoked_token} =
+        create_api_client_token!("admin-context-revoked", role: :admin)
+
+      assert {:ok, _revoked} = Governance.revoke_api_key(api_key.id)
+
+      revoked =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{revoked_token}")
+
+      assert_admin_auth_error(revoked, 401)
+
+      expired_at =
+        DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:microsecond)
+
+      %{token: expired_token} =
+        create_api_client_token!("admin-context-expired", role: :admin, expires_at: expired_at)
+
+      expired =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{expired_token}")
+
+      assert_admin_auth_error(expired, 401)
+    end
+
+    test "rejects tenant-direct keys and non-admin service-account tokens with 403" do
+      %{token: tenant_token} = create_tenant_token!("admin-context-tenant-direct")
+
+      tenant_direct =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{tenant_token}")
+
+      assert_admin_required(tenant_direct)
+
+      %{token: inference_token} =
+        create_api_client_token!("admin-context-inference", role: :inference_client)
+
+      inference =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{inference_token}")
+
+      assert_admin_required(inference)
+
+      %{token: operator_token} =
+        create_api_client_token!("admin-context-operator", role: :operator)
+
+      operator =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{operator_token}")
+
+      assert_admin_required(operator)
+
+      %{token: tenant_admin_token} =
+        create_api_client_token!("admin-context-tenant-admin", role: :tenant_admin)
+
+      tenant_admin =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{tenant_admin_token}")
+
+      assert_admin_required(tenant_admin)
+    end
+
+    test "rejects disabled API Clients with otherwise valid admin tokens" do
+      %{token: token} =
+        create_api_client_token!("admin-context-disabled", role: :admin, disabled?: true)
+
+      conn =
+        build_conn(:get, "/admin/v1/node-admission/candidates")
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      assert_admin_required(conn)
+    end
+  end
+
+  defp assert_admin_auth_error(conn, status) do
+    conn = AdminRequestContext.call(conn, [])
+
+    assert conn.halted
+    assert conn.status == status
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "error" => %{
+               "code" => "invalid_api_key",
+               "message" => "Invalid API key provided."
+             }
+           }
+  end
+
+  defp assert_admin_required(conn) do
+    conn = AdminRequestContext.call(conn, [])
+
+    assert conn.halted
+    assert conn.status == 403
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "error" => %{
+               "code" => "admin_required",
+               "message" => "Admin API requires a cluster-scoped admin API Client token."
+             }
+           }
+  end
+
+  defp create_tenant_token!(slug) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+
+    {:ok, %{api_key: api_key, token: token}} =
+      Governance.create_api_key(tenant, %{name: "Primary"})
+
+    %{tenant: tenant, api_key: api_key, token: token}
+  end
+
+  defp create_api_client_token!(slug, opts) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+
+    {:ok, api_client} =
+      Governance.upsert_api_client(tenant, %{
+        name: "#{slug}-client",
+        owner_contact: "owner@example.com"
+      })
+
+    grant_role!(api_client, tenant, Keyword.fetch!(opts, :role))
+
+    token_attrs =
+      %{name: "Primary"}
+      |> maybe_put(:expires_at, Keyword.get(opts, :expires_at))
+
+    {:ok, %{api_key: api_key, token: token}} =
+      Governance.create_api_client_api_token(api_client, token_attrs)
+
+    if Keyword.get(opts, :disabled?, false) do
+      {:ok, _disabled} = Governance.disable_api_client(tenant, api_client)
+    end
+
+    %{tenant: tenant, api_client: api_client, api_key: api_key, token: token}
+  end
+
+  defp grant_role!(api_client, _tenant, :admin) do
+    {:ok, _role_binding} = Governance.ensure_cluster_admin_access(api_client)
+  end
+
+  defp grant_role!(api_client, tenant, :inference_client) do
+    {:ok, _role_binding} = Governance.ensure_inference_client_access(api_client, tenant)
+  end
+
+  defp grant_role!(api_client, _tenant, :operator) do
+    %RoleBinding{}
+    |> RoleBinding.changeset(%{
+      principal_type: :service_account,
+      principal_id: api_client.id,
+      role: :operator,
+      tenant_scope_id: nil
+    })
+    |> Repo.insert!()
+  end
+
+  defp grant_role!(api_client, tenant, :tenant_admin) do
+    %RoleBinding{}
+    |> RoleBinding.changeset(%{
+      principal_type: :service_account,
+      principal_id: api_client.id,
+      role: :tenant_admin,
+      tenant_scope_id: tenant.id
+    })
+    |> Repo.insert!()
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/apps/orchard_controller/test/orchard/governance/governance_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/governance_test.exs
@@ -287,6 +287,65 @@ defmodule Orchard.GovernanceTest do
       assert %{role: ["has already been taken"]} = errors_on(changeset)
     end
 
+    test "concurrent cluster admin grants stay idempotent and write one audit row" do
+      tenant = create_tenant!("tenant-cluster-admin-race")
+      api_client = create_api_client!(tenant, "cluster-admin-race-client")
+      start_ref = make_ref()
+      parent = self()
+
+      task = fn actor_id ->
+        Task.async(fn ->
+          Sandbox.allow(Repo, parent, self())
+          send(parent, {:ready, self()})
+
+          receive do
+            ^start_ref -> Governance.ensure_cluster_admin_access(api_client, actor_id: actor_id)
+          end
+        end)
+      end
+
+      task_one = task.("cluster-admin-race-one")
+      task_two = task.("cluster-admin-race-two")
+
+      assert_receive {:ready, _pid}, 1_000
+      assert_receive {:ready, _pid}, 1_000
+
+      send(task_one.pid, start_ref)
+      send(task_two.pid, start_ref)
+
+      results = [Task.await(task_one, 5_000), Task.await(task_two, 5_000)]
+
+      assert Enum.all?(results, &match?({:ok, %RoleBinding{}}, &1))
+
+      role_binding_ids =
+        Enum.map(results, fn {:ok, role_binding} -> role_binding.id end)
+
+      assert Enum.uniq(role_binding_ids) |> length() == 1
+      [role_binding_id] = Enum.uniq(role_binding_ids)
+
+      assert Repo.aggregate(
+               from(role_binding in RoleBinding,
+                 where:
+                   role_binding.principal_type == :service_account and
+                     role_binding.principal_id == ^api_client.id and
+                     role_binding.role == :admin and
+                     is_nil(role_binding.tenant_scope_id)
+               ),
+               :count,
+               :id
+             ) == 1
+
+      assert Repo.aggregate(
+               from(audit_log in AuditLog,
+                 where:
+                   audit_log.action == "role_binding.created" and
+                     audit_log.target_id == ^role_binding_id
+               ),
+               :count,
+               :id
+             ) == 1
+    end
+
     test "denies tenant-direct, inference-only, and disabled API Client tokens" do
       tenant = create_tenant!("tenant-cluster-admin-denied")
 

--- a/apps/orchard_controller/test/orchard/governance/governance_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/governance_test.exs
@@ -37,7 +37,7 @@ defmodule Orchard.GovernanceTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance
-  alias Orchard.Governance.{ApiKey, ApiKeySecret, AuditLog, Tenant}
+  alias Orchard.Governance.{ApiKey, ApiKeySecret, AuditLog, RoleBinding, Tenant}
 
   describe "create_tenant/1" do
     test "creates a tenant, ignores caller-supplied ids, and writes one audit row" do
@@ -209,6 +209,111 @@ defmodule Orchard.GovernanceTest do
       assert {:ok, _disabled} = Governance.disable_api_client(tenant, api_client)
 
       refute Governance.has_active_api_keys?()
+    end
+  end
+
+  describe "cluster-scoped admin access" do
+    test "creates a cluster-scoped admin role binding and audit event" do
+      tenant = create_tenant!("tenant-cluster-admin")
+      api_client = create_api_client!(tenant, "cluster-admin-client")
+
+      assert {:ok, role_binding} =
+               Governance.ensure_cluster_admin_access(api_client, actor_id: "setup@example.test")
+
+      assert role_binding.principal_type == :service_account
+      assert role_binding.principal_id == api_client.id
+      assert role_binding.role == :admin
+      assert role_binding.tenant_scope_id == nil
+      assert Governance.has_cluster_admin_access?(api_client)
+
+      audit_log =
+        Repo.one!(
+          from(audit_log in AuditLog,
+            where:
+              audit_log.action == "role_binding.created" and
+                audit_log.target_id == ^role_binding.id
+          )
+        )
+
+      assert audit_log.scope == "cluster"
+      assert audit_log.tenant_id == nil
+      assert audit_log.actor_id == "setup@example.test"
+
+      assert audit_log.payload == %{
+               "principal_type" => "service_account",
+               "principal_id" => api_client.id,
+               "role" => "admin",
+               "tenant_scope_id" => nil
+             }
+    end
+
+    test "is idempotent and authorizes only enabled service-account cluster admins" do
+      tenant = create_tenant!("tenant-cluster-admin-auth")
+      api_client = create_api_client!(tenant, "cluster-admin-auth-client")
+
+      assert {:ok, first} = Governance.ensure_cluster_admin_access(api_client)
+      assert {:ok, second} = Governance.ensure_cluster_admin_access(api_client)
+      assert first.id == second.id
+
+      {:ok, %{token: token}} =
+        Governance.create_api_client_api_token(api_client, %{name: "admin"})
+
+      {:ok, auth_context} = Governance.authenticate_api_key(token)
+
+      assert :ok = Governance.authorize_admin_api(auth_context)
+
+      assert Repo.aggregate(
+               from(role_binding in RoleBinding,
+                 where:
+                   role_binding.principal_type == :service_account and
+                     role_binding.principal_id == ^api_client.id and
+                     role_binding.role == :admin and
+                     is_nil(role_binding.tenant_scope_id)
+               ),
+               :count,
+               :id
+             ) == 1
+
+      assert {:error, changeset} =
+               %RoleBinding{}
+               |> RoleBinding.changeset(%{
+                 principal_type: :service_account,
+                 principal_id: api_client.id,
+                 role: :admin,
+                 tenant_scope_id: nil
+               })
+               |> Repo.insert()
+
+      assert %{role: ["has already been taken"]} = errors_on(changeset)
+    end
+
+    test "denies tenant-direct, inference-only, and disabled API Client tokens" do
+      tenant = create_tenant!("tenant-cluster-admin-denied")
+
+      {:ok, %{token: tenant_token}} = Governance.create_api_key(tenant, %{name: "tenant"})
+      {:ok, tenant_auth} = Governance.authenticate_api_key(tenant_token)
+      assert {:error, :admin_required} = Governance.authorize_admin_api(tenant_auth)
+
+      inference_client = create_api_client!(tenant, "inference-only-client")
+
+      assert {:ok, _role_binding} =
+               Governance.ensure_inference_client_access(inference_client, tenant)
+
+      {:ok, %{token: inference_token}} =
+        Governance.create_api_client_api_token(inference_client, %{name: "inference"})
+
+      {:ok, inference_auth} = Governance.authenticate_api_key(inference_token)
+      assert {:error, :admin_required} = Governance.authorize_admin_api(inference_auth)
+
+      disabled_client = create_api_client!(tenant, "disabled-admin-client")
+      assert {:ok, _role_binding} = Governance.ensure_cluster_admin_access(disabled_client)
+
+      {:ok, %{token: disabled_token}} =
+        Governance.create_api_client_api_token(disabled_client, %{name: "disabled"})
+
+      assert {:ok, _disabled} = Governance.disable_api_client(tenant, disabled_client)
+      {:ok, disabled_auth} = Governance.authenticate_api_key(disabled_token)
+      assert {:error, :admin_required} = Governance.authorize_admin_api(disabled_auth)
     end
   end
 

--- a/docs/decisions/0004-admin-api-cluster-admin-auth.md
+++ b/docs/decisions/0004-admin-api-cluster-admin-auth.md
@@ -1,0 +1,15 @@
+# Admin API uses service-account-owned cluster admin tokens
+
+Accepted.
+
+Admin API requests are cluster control-plane operations and require a service-account-owned API Token whose owning API Client is enabled and has a cluster-scoped `admin` RoleBinding.
+The required RoleBinding has `principal_type = :service_account`, `principal_id = service_account.id`, `role = :admin`, and `tenant_scope_id = nil`.
+Tenant-direct API Keys do not authorize Admin API access.
+Tenant-scoped Access Levels such as `inference_client` and `tenant_admin` do not authorize Admin API access.
+The `operator` role does not authorize Admin API access unless a future decision explicitly grants a narrower operator surface.
+
+This keeps public inference credentials, tenant-scoped automation credentials, and cluster administration credentials separate.
+It also makes API Client disablement the single kill switch for service-account-owned Admin API tokens.
+
+The first Admin API admission slice may seed admin credentials in tests and local setup code.
+The operator-facing first-admin and cluster bootstrap workflow remains a separate `orchardctl cluster init`, bootstrap-token, or provisioning slice.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -95,6 +95,11 @@ _Avoid_: Secondary active controller
 A Postgres coordination lock used by Orchard for exclusive leadership and ownership of single-writer tasks.
 _Avoid_: Distributed lock service
 
+**Leader-only Write Path**:
+A mutating operation that may execute only on the Active Leader in HA-lite mode and must fail closed on a Standby Controller.
+Examples include node admission rejection, rejection clearance, admission, decommissioning, and the related cluster-scoped audit events.
+_Avoid_: best-effort write, local-controller write
+
 ### APIs and Product Surfaces
 
 **Public Inference API**:
@@ -217,6 +222,11 @@ _Avoid_: Dry Run, partial import, best-effort import
 A named permission set assignable to principals for cluster, operator, tenant-admin, or inference-client access.
 Product-facing label: Access Level.
 _Avoid_: credential, API Key, ad hoc permission flag
+
+**Cluster-scoped Admin Role**:
+An RBAC Role assignment that grants a Service Account full cluster access through Admin API surfaces without a Tenant scope.
+Tenant-direct API Keys do not imply this role.
+_Avoid_: tenant admin, inference client, local dev admin
 
 **Inference Client**:
 An Access Level that permits a principal to call public inference endpoints for its Organization.

--- a/docs/investigations/cluster-admission-admin-api-slice-plan.md
+++ b/docs/investigations/cluster-admission-admin-api-slice-plan.md
@@ -114,6 +114,7 @@ Use `503` for `controller_standby`.
 Initial stable error codes should include:
 
 ```text
+invalid_api_key
 admin_required
 candidate_not_found
 node_not_found

--- a/docs/investigations/cluster-admission-admin-api-slice-plan.md
+++ b/docs/investigations/cluster-admission-admin-api-slice-plan.md
@@ -1,0 +1,273 @@
+# Cluster Admission Admin API Slice Plan
+
+## Status
+
+Ready for implementation after Najib approval.
+This is a planning artifact for the next cluster-management implementation slice after PR #31.
+It intentionally does not implement product code.
+
+The working branch is `najibninaba/plan-cluster-admission-admin-api-slice` from `origin/main` at `5e2956164a79dc528f7740624061ef1066fea460`.
+RepoPrompt Oracle review was run against the Orchard worktree and agreed with the slice after tightening candidate-only route semantics, Admin API auth, and HA-lite wording.
+Web research used official Phoenix router pipeline documentation, OWASP API authorization guidance, and NIST zero-trust guidance.
+Exa was not available in this Codex tool surface, so web search was used instead.
+
+## Recommended Slice
+
+Implement OpenSpec task `2.8`: Admin API admission and pending-admission rejection semantics with cluster-scoped audit events.
+
+The slice should expose the first `/admin/v1` node-admission API surface, wire real Admin API authorization, preserve the admission-candidate evidence model from PR #30, and keep enough response shape stability for later CLI and Console parity.
+
+## Scope
+
+Add an Admin API router pipeline under `/admin/v1`.
+This pipeline must be separate from the public inference pipeline and must not reuse `authorize_public_inference/1`.
+
+Add Admin API authentication and authorization for Bearer API Keys.
+The token must resolve to a service-account-owned API Token.
+The owning API Client must be enabled.
+The API Client must have a cluster-scoped `admin` RoleBinding with `tenant_scope_id == nil`.
+Tenant-direct API Keys, tenant-scoped `inference_client`, `tenant_admin`, `operator`, disabled service accounts, expired tokens, revoked tokens, and malformed tokens must fail closed.
+
+Add a small governance helper for checking or ensuring cluster-scoped admin access.
+The implementation should follow the existing `ensure_inference_client_access/3` and `has_inference_client_access?/2` shape where it fits, but admin access is cluster-scoped and must not require a Tenant scope.
+
+Add a narrow leader-only write gate for Admin API control-plane mutations.
+In current single-controller and source-dev mode it may return `:ok`.
+When HA-lite standby state is represented, the gate must fail closed with one stable external Admin API error code.
+Use `controller_standby` as the external error code with HTTP `503 Service Unavailable`.
+Do not claim complete HA-lite enforcement until first-observed candidate creation and other non-Admin write paths are also covered.
+
+Implement these endpoints:
+
+```text
+GET  /admin/v1/node-admission/candidates
+GET  /admin/v1/node-admission/candidates/:candidate_id
+POST /admin/v1/node-admission/candidates/:candidate_id/reject
+POST /admin/v1/node-admission/candidates/:candidate_id/clear-rejection
+POST /admin/v1/nodes/:node_id/admit
+```
+
+Candidate-route mutations must be candidate-only.
+Do not call context functions in a way that allows a missing `candidate_id` to fall back to a Node row with the same UUID.
+Add candidate-only context functions or route-level locking that returns `candidate_not_found` for candidate routes.
+
+Node admission remains node-only.
+Observed-only Runtime Endpoint Admission Candidates must not be directly admitted.
+Admin admission execution requires a registered trusted Node with inventory, pool, and required policy inputs.
+Successful admission transitions `registered -> admitted`, not `active`.
+
+## Response Contract
+
+List responses should use:
+
+```json
+{
+  "object": "list",
+  "data": []
+}
+```
+
+Candidate responses should expose sanitized stored evidence and decision metadata:
+
+```json
+{
+  "object": "node_admission_candidate",
+  "id": "uuid",
+  "node_id": null,
+  "source": "runtime_endpoint_observation",
+  "admission_category": "pending_observed",
+  "observed_identity": {},
+  "target_ref": "host:port",
+  "endpoint": {
+    "transport": "grpc",
+    "target": "host:port"
+  },
+  "inventory": {},
+  "compatibility_evidence": {},
+  "last_observed_at": "2026-06-29T00:00:00Z",
+  "inserted_at": "2026-06-29T00:00:00Z",
+  "updated_at": "2026-06-29T00:00:00Z",
+  "latest_decision": null
+}
+```
+
+Mutation responses should include the changed resource, the appended Admission Decision, and a compact audit reference:
+
+```json
+{
+  "object": "node_admission_action_result",
+  "action": "node_admission.rejected",
+  "candidate": {},
+  "decision": {},
+  "audit_log": {
+    "id": 123,
+    "scope": "cluster",
+    "action": "node_admission.rejected"
+  }
+}
+```
+
+Present stored `observed_identity`, `inventory`, `compatibility_evidence`, and decision metadata as stored.
+Do not re-sanitize already stored snapshots on read, because that could hide or alter explicit `__orchard_snapshot_truncation__` markers from PR #30.
+
+Admin API errors should use stable JSON with `error.code`, `error.message`, and optional `error.details`.
+Use `401` for missing, malformed, invalid, expired, or revoked Bearer tokens.
+Use `403` for tenant-direct tokens, disabled service accounts, missing cluster admin role, or wrong role.
+Use `404` for missing candidates or nodes.
+Use `409` for lifecycle or admission blockers.
+Use `503` for `controller_standby`.
+
+Initial stable error codes should include:
+
+```text
+admin_required
+candidate_not_found
+node_not_found
+reason_required
+admission_not_pending
+admission_not_rejected
+admission_rejected
+node_not_registered
+node_not_pending_admission
+inventory_missing
+trust_not_established
+pool_required
+policy_required
+controller_standby
+```
+
+## Likely Files
+
+Likely new or changed controller files:
+
+```text
+apps/orchard_controller/lib/orchard/api/router.ex
+apps/orchard_controller/lib/orchard/api/admin_request_context.ex
+apps/orchard_controller/lib/orchard/api/admin_error_helpers.ex
+apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex
+apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
+apps/orchard_controller/lib/orchard/control_plane.ex
+apps/orchard_controller/lib/orchard/governance.ex
+apps/orchard_controller/lib/orchard/nodes.ex
+```
+
+Likely test files:
+
+```text
+apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
+apps/orchard_controller/test/orchard/api/admin_request_context_test.exs
+apps/orchard_controller/test/orchard/governance/governance_test.exs
+apps/orchard_controller/test/orchard/nodes_test.exs
+```
+
+OpenSpec files may need small task or spec clarifications only if implementation discovers a contract mismatch:
+
+```text
+openspec/changes/cluster-management-ux-foundation/tasks.md
+openspec/changes/cluster-management-ux-foundation/specs/cluster-management-ux/spec.md
+```
+
+## Validation Plan
+
+Run focused tests first:
+
+```text
+mise exec -- mix test apps/orchard_controller/test/orchard/api/admin_request_context_test.exs
+mise exec -- mix test apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
+mise exec -- mix test apps/orchard_controller/test/orchard/nodes_test.exs
+mise exec -- mix test apps/orchard_controller/test/orchard/governance
+```
+
+Run OpenSpec validation before implementation handoff:
+
+```text
+OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate cluster-management-ux-foundation --type change --strict --no-interactive
+```
+
+Run the Elixir quality workflow from the umbrella root:
+
+```text
+mise exec -- mix format
+mise exec -- mix compile --warnings-as-errors
+mise exec -- mix credo --strict
+mise exec -- mix dialyzer
+mise exec -- mix test
+mise exec -- mix test --cover
+```
+
+After implementation, repeat the documented two-Mac gRPC smoke using mawarduri:
+
+```text
+mise exec -- bin/dev-node-agent
+mise exec -- bin/dev-controller
+```
+
+The smoke should still show first-observed Runtime Endpoints persisting as `pending_observed` candidates, `nodes` count staying `0`, and no trusted active Node being auto-created.
+
+## Required Tests
+
+Admin API auth tests:
+
+```text
+missing token returns 401
+malformed token returns 401
+invalid token returns 401
+expired token returns 401
+revoked token returns 401
+tenant-direct API Key returns 403 admin_required
+service-account token with only inference_client returns 403 admin_required
+service-account token with operator role returns 403 admin_required
+disabled API Client returns 403 admin_required
+service-account token with cluster-scoped admin role succeeds
+```
+
+Admission route tests:
+
+```text
+admin can list candidates
+admin can show candidate
+candidate show returns 404 candidate_not_found
+candidate reject requires nonblank normalized reason
+candidate reject appends Admission Decision and cluster audit log
+candidate clear-rejection appends Admission Decision and cluster audit log
+candidate reject route does not fall back to a Node with the same UUID
+candidate clear route does not fall back to a Node with the same UUID
+node admit rejects observed-only candidates
+node admit rejects provisioned nodes
+node admit rejects rejected nodes
+node admit rejects registered nodes missing inventory
+node admit rejects registered nodes missing trust
+node admit rejects registered nodes missing pool or policy inputs
+node admit transitions registered trusted node to admitted
+node admit writes Admission Decision and cluster audit log
+stored snapshot truncation markers are preserved in API responses
+controller_standby returns 503 before mutating admission state or audit logs
+```
+
+## Out Of Scope
+
+Do not implement `orchardctl nodes admit`.
+Do not implement Console pending admission UX.
+Do not implement action previews.
+Do not implement shared scheduler explanation UI.
+Do not implement `POST /admin/v1/nodes/provision`.
+Do not implement `POST /admin/v1/nodes/:node_id/decommission`.
+Do not implement `/admin/v1/bootstrap-tokens`.
+Do not implement `orchardctl cluster init`.
+Do not implement first-admin credential provisioning.
+Do not implement full HA-lite failover, leadership transfer, standby read-only UX, or leader election.
+Do not change observed Runtime Endpoint behavior back to auto-created active Nodes.
+
+## Risks And Open Questions
+
+First-admin provisioning is a deployability gap.
+It is not a task 2.8 blocker, but release notes and handoff must avoid presenting the Admin API as fully operator-usable until `cluster init`, bootstrap tokens, or another provisioning path exists.
+
+Leader-only write-path compliance is partial in this slice.
+Admin API mutations can be gated now, but first-observed candidate creation through Runtime Endpoint observation is also leader-only per `SPEC.md` and should be covered by a later HA-lite write-path slice or included only if the implementation explicitly expands scope.
+
+Admin API response envelopes should be treated as a contract for CLI and Console.
+Changing them later will create avoidable parity work.
+
+Cluster-scoped Admin API auth now has a durable ADR in `docs/decisions/0004-admin-api-cluster-admin-auth.md`.
+If implementation finds `SPEC.md` text that conflicts with that ADR, treat the PR as blocked until the conflict is reconciled.

--- a/docs/investigations/cluster-admission-admin-api-slice-plan.md
+++ b/docs/investigations/cluster-admission-admin-api-slice-plan.md
@@ -2,14 +2,8 @@
 
 ## Status
 
-Ready for implementation after Najib approval.
-This is a planning artifact for the next cluster-management implementation slice after PR #31.
-It intentionally does not implement product code.
-
-The working branch is `najibninaba/plan-cluster-admission-admin-api-slice` from `origin/main` at `5e2956164a79dc528f7740624061ef1066fea460`.
-RepoPrompt Oracle review was run against the Orchard worktree and agreed with the slice after tightening candidate-only route semantics, Admin API auth, and HA-lite wording.
-Web research used official Phoenix router pipeline documentation, OWASP API authorization guidance, and NIST zero-trust guidance.
-Exa was not available in this Codex tool surface, so web search was used instead.
+Accepted implementation plan for the initial cluster-management Admin API node-admission slice.
+The implemented slice covers OpenSpec task `2.8` and preserves the explicit out-of-scope boundaries below for later CLI, Console, bootstrap, and diagnostics work.
 
 ## Recommended Slice
 

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -14,7 +14,7 @@
 - [x] 2.5 Preserve observed inventory, target metadata, and compatibility evidence for pending admission review.
 - [x] 2.6 Block admission execution for observed candidates and provisioned placeholders until registration inventory, trust evidence, pool assignment, and required policy inputs are present.
 - [x] 2.7 Implement and test rejected-admission persistence semantics through `node_admission_decisions` with actor, decided timestamp, reason, observed identity or node reference, target reference when applicable, retention-safe snapshot fields, and audit event reference.
-- [ ] 2.8 Implement Admin API admission and pending-admission rejection semantics with cluster-scoped audit events.
+- [x] 2.8 Implement Admin API admission and pending-admission rejection semantics with cluster-scoped audit events.
 - [x] 2.9 Implement explicit admin clear or new-registration handling before re-admission after rejection.
 - [x] 2.10 Preserve existing admitted node rows through migration or explicit compatibility handling.
 - [x] 2.11 Add regression tests for `SPEC.md` §4.2, §4.3, and §7.5.4 lifecycle behavior.


### PR DESCRIPTION
## Intent

Address the four actionable Codex review comments on Orchard PR #32 without expanding scope: update the cluster admission Admin API investigation doc so it no longer claims the implemented slice is future-only, remove local planning-tool provenance from that durable doc, preserve canonical node-admission audit evidence by filtering reserved request metadata keys before clear/admit metadata reaches decisions and audit payloads, and make cluster-admin RoleBinding grants idempotent under concurrent duplicate attempts by avoiding failed-insert refetch inside an aborted Postgres transaction. Keep the OpenSpec task 2.8 Admin API behavior unchanged and preserve candidate-only admission semantics.

## What Changed

- Adds a new `/admin/v1` API surface for node admission: a `NodeAdmissionController` plus presenter and router `:admin_api` pipeline exposing candidate list/show/reject/clear-rejection and `nodes/:id/admit` endpoints, fronted by an `AdminRequestContext` plug that authenticates bearer tokens, requires cluster-admin authorization, and emits auth-failure audit events.
- Backs the endpoints with admission logic in `Orchard.Nodes` (candidate listing/fetch, reject, clear-rejection, and `admit_node`), a new `Orchard.ControlPlane.authorize_write_path/1` standby write gate, and `Governance` cluster-admin RoleBinding authorization made idempotent via `on_conflict` plus a new unique-index migration; reserved request-metadata keys are filtered out before clear/admit attrs reach decisions and audit payloads.
- Documents the slice with decision record 0004, glossary/README/OpenSpec task updates and an investigation plan doc, and adds controller, admin-request-context, and governance test suites.

## Risk Assessment

✅ Low: A well-bounded, well-tested admin API slice with correct idempotency, fail-closed auth, and audit-evidence protection; the only findings are minor internal consistency/maintainability notes with no functional bug.

## Testing

Set up the worktree test DB (mise trust, deps.get, ecto.create/migrate against orchard_test_nm_2b20bc518d75) and ran the two affected suites (62 passed). Since unit passes alone aren't sufficient evidence and this is an Admin API change, I wrote a temporary evidence test that exercises the real Router with spoofed reserved metadata and dumped the genuine request body, API response, and persisted audit payloads to the evidence directory — showing spoofed source/node_id/observed_identity/target_ref dropped from decision metadata while canonical audit evidence (registered_node, real node_id/observed_identity, real target_ref) is preserved for both admit and clear-rejection. A concurrent-grant transcript shows both calls succeeding, returning the same role-binding id, and persisting exactly one role binding and one audit row. The doc change was verified by inspection and grep. The temp test was removed and the working tree is clean; no visual UI surface is involved (this is a JSON Admin API + durable doc), so artifacts are API/DB JSON transcripts rather than screenshots.

<details>
<summary>Evidence: Admit endpoint: spoofed reserved keys stripped from decision metadata, canonical audit evidence preserved</summary>

`Request sent source/node_id/observed_identity/target_ref=spoofed-*; API decision_metadata returns only pool_id/routing_policy_id/trust_evidence_ref; persisted audit payload: source=registered_node, node_id=<real>, observed_identity.node_id=<real>, target_ref=10.20.122.123:50071 (not spoofed-target). All assertions true.`

```text
{
  "node_id": "399ba066-979a-49df-becc-0bdf93e751e6",
  "scenario": "POST /admin/v1/nodes/:node_id/admit with attacker-supplied reserved keys",
  "request_body_sent_by_caller": {
    "admission_category": "spoofed-category",
    "candidate_id": "39c536d7-bfca-4539-a76f-36c176518501",
    "node_id": "cbe71408-b595-45ec-a584-62d9c0a9412f",
    "observed_identity": {
      "claimed_node_id": "spoofed-node"
    },
    "pool_id": "320f59f4-fa7e-4e21-912f-d7659e03c5ea",
    "routing_policy_id": "702005a3-3cdd-4a79-a8fd-7c7c13fe68a4",
    "source": "spoofed-source",
    "target_ref": "spoofed-target",
    "trust_evidence_ref": "registration-audit:test"
  },
  "api_response": {
    "status": 200,
    "node_state": "admitted",
    "decision_metadata": {
      "pool_id": "320f59f4-fa7e-4e21-912f-d7659e03c5ea",
      "routing_policy_id": "702005a3-3cdd-4a79-a8fd-7c7c13fe68a4",
      "trust_evidence_ref": "registration-audit:test"
    },
    "audit_scope": "cluster"
  },
  "persisted_audit_log_payload": {
    "admission_category": "admitted",
    "candidate_id": "c588d90c-6170-4502-9a37-4ddfeac0b54e",
    "node_id": "399ba066-979a-49df-becc-0bdf93e751e6",
    "observed_identity": {
      "agent_version": null,
      "display_name": "registered-admit-node",
      "hostname": "registered-admit-node.local",
      "node_id": "399ba066-979a-49df-becc-0bdf93e751e6"
    },
    "pool_id": "320f59f4-fa7e-4e21-912f-d7659e03c5ea",
    "routing_policy_id": "702005a3-3cdd-4a79-a8fd-7c7c13fe68a4",
    "source": "registered_node",
    "target_ref": "10.20.122.123:50071",
    "trust_evidence_ref": "registration-audit:test"
  },
  "assertions": {
    "spoofed_keys_dropped_from_decision_metadata": true,
    "canonical_audit_source_preserved": true,
    "canonical_audit_node_id_preserved": true,
    "canonical_audit_observed_identity_preserved": true,
    "spoofed_target_ref_rejected": true
  }
}
```
</details>
<details>
<summary>Evidence: Clear-rejection endpoint: only caller-safe surface key kept, observed-candidate audit evidence preserved</summary>

`Request included spoofed reserved keys + surface=admin-api-test; decision_metadata == {"surface":"admin-api-test"}; persisted audit payload: source=runtime_endpoint_observation, target_ref=10.0.0.45:50071, observed_identity=<real candidate identity>. All assertions true.`

```text
{
  "scenario": "POST /admin/v1/node-admission/candidates/:id/clear-rejection with attacker-supplied reserved keys",
  "request_body_sent_by_caller": {
    "admission_category": "spoofed-category",
    "candidate_id": "f4e98f4c-3bd0-481a-936c-7f6608ae4830",
    "node_id": "441250d8-c485-40b1-8d90-2e181a510a92",
    "observed_identity": {
      "claimed_node_id": "spoofed-node"
    },
    "source": "spoofed-source",
    "surface": "admin-api-test",
    "target_ref": "spoofed-target"
  },
  "api_response": {
    "status": 200,
    "decision_metadata": {
      "surface": "admin-api-test"
    },
    "admission_category": "pending_observed"
  },
  "persisted_audit_log_payload": {
    "admission_category": "pending_observed",
    "candidate_id": "ff6668be-c427-4419-a081-f47e9c40b351",
    "node_id": null,
    "observed_identity": {
      "claimed_node_id": "c952c08b-1b4d-4781-9f5e-c0a867e49f30",
      "display_name": "candidate-12930",
      "hostname": "candidate-12930.local"
    },
    "source": "runtime_endpoint_observation",
    "surface": "admin-api-test",
    "target_ref": "10.0.0.45:50071"
  },
  "assertions": {
    "canonical_audit_source_preserved": true,
    "decision_metadata_is_only_caller_safe_surface": true,
    "canonical_target_ref_preserved": true,
    "canonical_observed_identity_preserved": true
  },
  "candidate_id": "ff6668be-c427-4419-a081-f47e9c40b351"
}
```
</details>
<details>
<summary>Evidence: Concurrent cluster-admin grants idempotent: one role binding, one audit row</summary>

`Two concurrent ensure_cluster_admin_access/2 calls both return {:ok, RoleBinding} with the same id; persisted_cluster_admin_role_binding_count=1; persisted_role_binding_created_audit_count=1. All assertions true.`

```text
{
  "scenario": "Two concurrent Governance.ensure_cluster_admin_access/2 calls for the same API client",
  "assertions": {
    "both_calls_succeeded": true,
    "single_role_binding_persisted": true,
    "single_audit_row_written": true,
    "both_calls_observed_same_role_binding": true
  },
  "api_client_id": "89af5c81-1138-494a-a8a2-dd0e934ebef5",
  "both_calls_returned": [
    {
      "tag": "ok",
      "role_binding_id": "b53778ab-713e-46f6-9a7f-32c6db1aedd8"
    },
    {
      "tag": "ok",
      "role_binding_id": "b53778ab-713e-46f6-9a7f-32c6db1aedd8"
    }
  ],
  "distinct_role_binding_ids_returned": [
    "b53778ab-713e-46f6-9a7f-32c6db1aedd8"
  ],
  "persisted_cluster_admin_role_binding_count": 1,
  "persisted_role_binding_created_audit_count": 1
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/governance.ex:914` - This branch fixes cluster-admin duplicate inserts with `on_conflict: :nothing` (insert_cluster_admin_role_binding, line 933) specifically to avoid failed-insert-then-refetch, yet the same branch changes `insert_inference_client_role_binding` to use exactly that failed-insert-&gt;refetch pattern (line 914). Both are actually safe: Ecto wraps a constraint-mapped insert in a SAVEPOINT inside a transaction, so the refetch does not run in an aborted transaction, and Postgres blocks the losing concurrent inserter until the winner commits so the refetch sees the committed row. The concern is the inconsistency, not correctness — two different idempotency strategies for the same problem in one diff invites a future reader to assume one path is buggy. Consider unifying (now that `idx_role_bindings_unique_cluster_assignment` is mapped on the changeset, the cluster path could use the simpler refetch, or both could use `on_conflict: :nothing`).
- ℹ️ `apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex:13` - `@reserved_request_metadata_keys` is a hand-maintained denylist that must stay in sync with the canonical keys built by `Nodes.admission_audit_payload/2` (candidate_id, node_id, source, admission_category, observed_identity, target_ref). It correctly covers them today (with a malicious_metadata regression test), but it is a denylist guarding audit-evidence integrity: if a future canonical audit-payload key is added without also adding it here, callers can again clobber audit evidence via request metadata. Consider deriving the reserved set from a shared source or adding a test that asserts every canonical audit-payload key is present in the denylist.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/governance/governance_test.exs apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs` (62 passed, against worktree DB orchard_test_nm_2b20bc518d75)</code>
- <code>Authored and ran a temporary evidence test driving the real `Orchard.API.Router` admit + clear-rejection endpoints with attacker-supplied reserved metadata keys; captured API response + persisted `AuditLog.payload` to JSON (3 passed, temp test then removed)</code>
- <code>Ran the concurrent `Governance.ensure_cluster_admin_access/2` scenario capturing returned role-binding ids and persisted role-binding/audit-row counts</code>
- <code>Verified `ensure_cluster_admin_access` wraps insert+refetch in `Repo.transaction` (governance.ex:304), confirming the old refetch ran inside an aborted txn and the `on_conflict: :nothing` fix avoids it</code>
- <code>Verified doc Status section and grep-confirmed removal of RepoPrompt/Oracle/Exa/Codex/branch-hash provenance in `docs/investigations/cluster-admission-admin-api-slice-plan.md`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
