### PR TITLE
docs: add README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Orchard
 
+[![Elixir 1.20.0-otp-29](https://img.shields.io/badge/Elixir-1.20.0--otp--29-4B275F)](docs/tooling.md)
+[![Erlang/OTP 29.0.2](https://img.shields.io/badge/Erlang%2FOTP-29.0.2-A90533)](docs/tooling.md)
+[![mise pinned](https://img.shields.io/badge/toolchain-mise--pinned-0F766E)](mise.toml)
+[![OpenSpec strict validation](https://img.shields.io/badge/OpenSpec-strict%20validation-2563EB)](openspec/README.md)
+
 **Your LLMs. Your hardware. Your rules.**
 
 Orchard is a sovereign on-prem LLM orchestration platform for 1–4 Apple Silicon macOS machines. It runs inference on your own hardware, behind your own firewall, with no cloud dependency.


### PR DESCRIPTION
## Summary

- Add README badges for the pinned Elixir and Erlang/OTP toolchain.
- Add badges for mise-pinned tooling and the repo OpenSpec strict validation workflow.
- Avoid CI, release, package, and public license badges because this checkout has no workflows, no release/package signal, and no LICENSE file.

## Validation

- `git diff --check`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
- `mise exec -- node -e '...'` README badge Markdown/link-target sanity check

Note: `mise trust` was run for this Codex worktree before validation, matching the repo setup guidance.
