### PR TITLE
feat(cluster_management): add shared cluster status and reason-code contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Some SPEC-required CLI paths are present before their milestone implementation:
 and `orchardctl requests inspect` return command-specific deferred-status
 errors with the current supported path. `orchardctl support bundle create`
 creates a local diagnostic `.tar.gz` with bounded redacted logs, redacted
-config, service status, node snapshots, and request summaries.
+config, service status, node snapshots, shared cluster-management node
+status, and request summaries.
 
 ## Spec
 

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -7,6 +7,7 @@ defmodule OrchardCLI.Commands.Nodes do
     orchardctl nodes admit (deferred status; SPEC.md 11.9)
   """
 
+  alias Orchard.ClusterManagement.{NodeStatus, StatusBuilder}
   alias Orchard.Nodes
   alias OrchardCLI.Commands.Deferred
 
@@ -28,6 +29,7 @@ defmodule OrchardCLI.Commands.Nodes do
   def run(args) do
     case args do
       ["list"] -> run_list()
+      ["list", "--json"] -> run_list_json()
       ["list", "--help"] -> {:ok, list_usage()}
       ["admit" | rest] -> Deferred.run(["admit" | rest], deferred_spec())
       ["help"] -> {:ok, group_usage()}
@@ -52,6 +54,19 @@ defmodule OrchardCLI.Commands.Nodes do
       table = format_table(nodes)
       {:ok, summary_line <> "\n\n" <> table}
     end
+  end
+
+  defp run_list_json do
+    nodes = Nodes.list_nodes()
+
+    payload = %{
+      object: "cluster_management.node_status_list",
+      contract_version: NodeStatus.contract_version(),
+      data: StatusBuilder.node_status_maps(nodes),
+      summary: Nodes.summary()
+    }
+
+    {:ok, Jason.encode!(payload, pretty: true)}
   end
 
   # ---------------------------------------------------------------------------
@@ -155,7 +170,7 @@ defmodule OrchardCLI.Commands.Nodes do
   defp list_usage do
     Enum.join(
       [
-        "Usage: orchardctl nodes list",
+        "Usage: orchardctl nodes list [--json]",
         "",
         "Lists all registered nodes with state, health, and agent version."
       ],

--- a/apps/orchard_cli/lib/orchard_cli/commands/support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/support.ex
@@ -1,6 +1,7 @@
 defmodule OrchardCLI.Commands.Support do
   @moduledoc false
 
+  alias Orchard.ClusterManagement.{NodeStatus, StatusBuilder}
   alias OrchardCLI.Commands.{LifecycleSupport, Status}
 
   @default_support_root "/Library/Application Support/Orchard"
@@ -312,9 +313,18 @@ defmodule OrchardCLI.Commands.Support do
 
   defp nodes_snapshot(runtime) do
     safe_snapshot(fn ->
+      nodes = runtime.list_nodes.()
+      summary = runtime.nodes_summary.()
+
       %{
-        summary: runtime.nodes_summary.(),
-        nodes: Enum.map(runtime.list_nodes.(), &node_summary/1)
+        summary: summary,
+        nodes: Enum.map(nodes, &node_summary/1),
+        cluster_management_status: %{
+          object: "cluster_management.node_status_list",
+          contract_version: NodeStatus.contract_version(),
+          data: StatusBuilder.node_status_maps(nodes),
+          summary: summary
+        }
       }
     end)
   end

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -2,6 +2,7 @@ defmodule OrchardCLI.Commands.NodesTest do
   use ExUnit.Case, async: false
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.ClusterManagement.StatusBuilder
   alias Orchard.Nodes.Node
   alias Orchard.Repo
   alias OrchardCLI.Commands.Nodes, as: NodesCmd
@@ -116,6 +117,28 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert output =~ "Summary: total=1 healthy=0 degraded=0 unhealthy=0 unreachable=1"
       assert output =~ "ghost-node"
       assert output =~ "unreachable"
+    end
+
+    test "json output derives status data from shared cluster management structures" do
+      node =
+        insert_node!(
+          display_name: "json-node",
+          state: :registered,
+          health: :healthy,
+          last_heartbeat_at: DateTime.utc_now()
+        )
+
+      assert {:ok, output} = NodesCmd.run(["list", "--json"])
+      decoded = Jason.decode!(output)
+      expected_status = StatusBuilder.node_status_map(node) |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["object"] == "cluster_management.node_status_list"
+      assert decoded["contract_version"] == "orchard.cluster_management.status.v1"
+      assert decoded["data"] == [expected_status]
+
+      assert get_in(decoded, ["data", Access.at(0), "scheduling", "reason_codes"]) == [
+               "node_not_admitted"
+             ]
     end
   end
 

--- a/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/support_test.exs
@@ -121,6 +121,18 @@ defmodule OrchardCLI.Commands.SupportTest do
     assert get_in(nodes, ["data", "summary", "total"]) == 1
     assert get_in(nodes, ["data", "nodes", Access.at(0), "display_name"]) == "node-a"
 
+    assert get_in(nodes, ["data", "cluster_management_status", "object"]) ==
+             "cluster_management.node_status_list"
+
+    assert get_in(nodes, [
+             "data",
+             "cluster_management_status",
+             "data",
+             Access.at(0),
+             "scheduling",
+             "reason_codes"
+           ]) == ["node_observation_stale"]
+
     requests = read_json!(extract_dir, "diagnostics/requests.json")
     assert requests["status"] == "ok"
     assert get_in(requests, ["data", "summary", "total"]) == 2

--- a/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
@@ -3,6 +3,7 @@ defmodule Orchard.API.Admin.NodeAdmissionPresenter do
   JSON presenters for Admin API node admission resources.
   """
 
+  alias Orchard.ClusterManagement.StatusBuilder
   alias Orchard.Governance.AuditLog
   alias Orchard.Nodes
   alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
@@ -43,6 +44,7 @@ defmodule Orchard.API.Admin.NodeAdmissionPresenter do
       last_observed_at: iso8601(candidate.last_observed_at),
       inserted_at: iso8601(candidate.inserted_at),
       updated_at: iso8601(candidate.updated_at),
+      status: StatusBuilder.candidate_status_map(candidate, latest_decision: latest_decision),
       latest_decision: decision(latest_decision)
     }
   end
@@ -80,6 +82,8 @@ defmodule Orchard.API.Admin.NodeAdmissionPresenter do
   end
 
   defp present_node(%Node{} = node) do
+    latest_decision = Nodes.latest_admission_decision_for_node(node.id)
+
     %{
       object: "node",
       id: node.id,
@@ -97,14 +101,9 @@ defmodule Orchard.API.Admin.NodeAdmissionPresenter do
       last_heartbeat_at: iso8601(node.last_heartbeat_at),
       inserted_at: iso8601(node.inserted_at),
       updated_at: iso8601(node.updated_at),
-      latest_decision: latest_node_decision(node)
+      status: StatusBuilder.node_status_map(node, latest_decision: latest_decision),
+      latest_decision: decision(latest_decision)
     }
-  end
-
-  defp latest_node_decision(%Node{id: id}) do
-    id
-    |> Nodes.latest_admission_decision_for_node()
-    |> decision()
   end
 
   defp decision(nil), do: nil

--- a/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
@@ -215,8 +215,9 @@ defmodule Orchard.ClusterManagement.StatusBuilder do
   defp add_health_reason(reasons, _health), do: [:node_health_unhealthy | reasons]
 
   defp add_freshness_reason(reasons, :fresh), do: reasons
+  defp add_freshness_reason(reasons, :stale), do: reasons
   defp add_freshness_reason(reasons, :unknown), do: reasons
-  defp add_freshness_reason(reasons, _freshness), do: [:node_observation_stale | reasons]
+  defp add_freshness_reason(reasons, :unreachable), do: [:node_observation_stale | reasons]
 
   defp candidate_scheduling(%AdmissionCandidate{admission_category: :pending_observed}) do
     %{eligible: false, reason_codes: [:node_not_registered, :trust_not_established]}

--- a/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
@@ -1,0 +1,314 @@
+defmodule Orchard.ClusterManagement.StatusBuilder do
+  @moduledoc """
+  Controller-owned translation into shared cluster-management status structures.
+  """
+
+  alias Orchard.ClusterManagement.NodeStatus
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
+
+  @admitted_states [:admitted, :active, :cordoned, :draining, :maintenance, :decommissioning]
+  @unschedulable_states [
+    :admitted,
+    :cordoned,
+    :draining,
+    :maintenance,
+    :decommissioning,
+    :removed
+  ]
+
+  @spec node_status(Node.t() | map(), keyword()) :: NodeStatus.t()
+  def node_status(node, opts \\ [])
+
+  def node_status(%Node{} = node, opts) do
+    latest_decision =
+      Keyword.get_lazy(opts, :latest_decision, fn ->
+        Nodes.latest_admission_decision_for_node(node.id)
+      end)
+
+    NodeStatus.new!(%{
+      resource: %{type: :node, id: node.id},
+      lifecycle: %{state: node.state},
+      admission: %{
+        category: node_admission_category(node, latest_decision),
+        source: :registered_node,
+        latest_decision: decision_name(latest_decision)
+      },
+      health: %{status: node.health || :unreachable},
+      freshness: %{
+        status: freshness(node.last_heartbeat_at),
+        observed_at: node.last_heartbeat_at,
+        source: :heartbeat
+      },
+      transport: %{status: :unknown},
+      runtime: %{status: :unknown, health_code: nil, health_message: nil},
+      compatibility: %{status: :unknown},
+      scheduling: scheduling(node),
+      warnings: []
+    })
+  end
+
+  def node_status(%{} = node, opts) do
+    NodeStatus.new!(%{
+      resource: %{type: :node, id: node_field(node, :id)},
+      lifecycle: %{state: node_field(node, :state)},
+      admission: %{
+        category: node_admission_category(node, Keyword.get(opts, :latest_decision)),
+        source: :registered_node,
+        latest_decision: decision_name(Keyword.get(opts, :latest_decision))
+      },
+      health: %{status: node_field(node, :health) || :unreachable},
+      freshness: %{
+        status: freshness(node_field(node, :last_heartbeat_at)),
+        observed_at: node_field(node, :last_heartbeat_at),
+        source: :heartbeat
+      },
+      transport: %{status: :unknown},
+      runtime: %{status: :unknown, health_code: nil, health_message: nil},
+      compatibility: %{status: :unknown},
+      scheduling: scheduling(node),
+      warnings: []
+    })
+  end
+
+  @spec node_status_map(Node.t() | map(), keyword()) :: map()
+  def node_status_map(node, opts \\ []) do
+    node
+    |> node_status(opts)
+    |> NodeStatus.to_map()
+  end
+
+  @spec candidate_status(AdmissionCandidate.t(), keyword()) :: NodeStatus.t()
+  def candidate_status(%AdmissionCandidate{} = candidate, opts \\ []) do
+    latest_decision =
+      Keyword.get_lazy(opts, :latest_decision, fn ->
+        Nodes.latest_admission_decision_for_candidate(candidate.id)
+      end)
+
+    NodeStatus.new!(%{
+      resource: %{type: :admission_candidate, id: candidate.id},
+      lifecycle: %{state: nil},
+      admission: %{
+        category: candidate.admission_category,
+        source: candidate.source,
+        latest_decision: decision_name(latest_decision)
+      },
+      health: %{status: :unknown},
+      freshness: %{
+        status: freshness(candidate.last_observed_at),
+        observed_at: candidate.last_observed_at,
+        source: :runtime_endpoint_observation
+      },
+      transport: candidate_transport(candidate),
+      runtime: %{status: :unknown, health_code: nil, health_message: nil},
+      compatibility: candidate_compatibility(candidate),
+      scheduling: candidate_scheduling(candidate),
+      warnings: []
+    })
+  end
+
+  @spec candidate_status_map(AdmissionCandidate.t(), keyword()) :: map()
+  def candidate_status_map(%AdmissionCandidate{} = candidate, opts \\ []) do
+    candidate
+    |> candidate_status(opts)
+    |> NodeStatus.to_map()
+  end
+
+  @spec runtime_target_status(map()) :: NodeStatus.t()
+  def runtime_target_status(%{} = target) do
+    NodeStatus.new!(%{
+      resource: %{type: :runtime_target, id: target_ref(target)},
+      lifecycle: %{state: nil},
+      admission: %{category: nil, source: nil, latest_decision: nil},
+      health: %{status: runtime_health_status(target)},
+      freshness: %{status: :unknown, observed_at: nil, source: nil},
+      transport: runtime_transport(target),
+      runtime: runtime_readiness(target),
+      compatibility: runtime_compatibility(target),
+      scheduling: %{eligible: false, reason_codes: []},
+      warnings: runtime_warnings(target)
+    })
+  end
+
+  @spec runtime_target_status_map(map()) :: map()
+  def runtime_target_status_map(%{} = target) do
+    target
+    |> runtime_target_status()
+    |> NodeStatus.to_map()
+  end
+
+  @spec node_status_maps([Node.t() | map()]) :: [map()]
+  def node_status_maps(nodes), do: Enum.map(nodes, &node_status_map/1)
+
+  defp node_admission_category(_node, %AdmissionDecision{decision: :rejected}), do: :rejected
+  defp node_admission_category(%Node{state: :provisioned}, _decision), do: :pending_provisioned
+  defp node_admission_category(%Node{state: :registered}, _decision), do: :pending_registered
+
+  defp node_admission_category(%Node{state: state}, _decision) when state in @admitted_states,
+    do: :admitted
+
+  defp node_admission_category(%Node{state: :removed}, _decision), do: :removed
+
+  defp node_admission_category(%{} = node, decision) do
+    node_admission_category(%Node{state: node_field(node, :state)}, decision)
+  end
+
+  defp decision_name(%AdmissionDecision{decision: decision}), do: decision
+  defp decision_name(_decision), do: nil
+
+  defp scheduling(%Node{} = node) do
+    reason_codes = scheduling_reason_codes(node)
+    %{eligible: reason_codes == [], reason_codes: reason_codes}
+  end
+
+  defp scheduling(%{} = node) do
+    reason_codes = scheduling_reason_codes(node)
+    %{eligible: reason_codes == [], reason_codes: reason_codes}
+  end
+
+  defp scheduling_reason_codes(%Node{} = node) do
+    []
+    |> add_state_reason(node.state)
+    |> add_health_reason(node.health)
+    |> add_freshness_reason(freshness(node.last_heartbeat_at))
+    |> Enum.uniq()
+    |> Enum.reverse()
+  end
+
+  defp scheduling_reason_codes(%{} = node) do
+    []
+    |> add_state_reason(node_field(node, :state))
+    |> add_health_reason(node_field(node, :health))
+    |> add_freshness_reason(freshness(node_field(node, :last_heartbeat_at)))
+    |> Enum.uniq()
+    |> Enum.reverse()
+  end
+
+  defp add_state_reason(reasons, :active), do: reasons
+  defp add_state_reason(reasons, :provisioned), do: [:node_not_registered | reasons]
+  defp add_state_reason(reasons, :registered), do: [:node_not_admitted | reasons]
+
+  defp add_state_reason(reasons, state) when state in @unschedulable_states,
+    do: [:node_not_active | reasons]
+
+  defp add_state_reason(reasons, _state), do: [:inventory_missing | reasons]
+
+  defp add_health_reason(reasons, :healthy), do: reasons
+  defp add_health_reason(reasons, :degraded), do: reasons
+  defp add_health_reason(reasons, :unreachable), do: [:node_health_unreachable | reasons]
+  defp add_health_reason(reasons, :unhealthy), do: [:node_health_unhealthy | reasons]
+  defp add_health_reason(reasons, _health), do: [:node_health_unhealthy | reasons]
+
+  defp add_freshness_reason(reasons, :fresh), do: reasons
+  defp add_freshness_reason(reasons, :unknown), do: reasons
+  defp add_freshness_reason(reasons, _freshness), do: [:node_observation_stale | reasons]
+
+  defp candidate_scheduling(%AdmissionCandidate{admission_category: :pending_observed}) do
+    %{eligible: false, reason_codes: [:node_not_registered, :trust_not_established]}
+  end
+
+  defp candidate_scheduling(%AdmissionCandidate{admission_category: :pending_provisioned}) do
+    %{eligible: false, reason_codes: [:node_not_registered]}
+  end
+
+  defp candidate_scheduling(%AdmissionCandidate{admission_category: :pending_registered}) do
+    %{eligible: false, reason_codes: [:node_not_admitted]}
+  end
+
+  defp candidate_scheduling(%AdmissionCandidate{admission_category: :rejected}) do
+    %{eligible: false, reason_codes: [:node_not_admitted]}
+  end
+
+  defp candidate_scheduling(_candidate),
+    do: %{eligible: false, reason_codes: [:node_not_admitted]}
+
+  defp candidate_transport(%AdmissionCandidate{endpoint_transport: nil}) do
+    %{status: :target_unconfigured}
+  end
+
+  defp candidate_transport(%AdmissionCandidate{source: :runtime_endpoint_observation}) do
+    %{status: :reachable}
+  end
+
+  defp candidate_transport(_candidate), do: %{status: :unknown}
+
+  defp candidate_compatibility(%AdmissionCandidate{compatibility_evidence: evidence})
+       when is_map(evidence) and map_size(evidence) > 0 do
+    %{status: :partial_metadata}
+  end
+
+  defp candidate_compatibility(_candidate), do: %{status: :unknown}
+
+  defp freshness(nil), do: :unknown
+
+  defp freshness(%DateTime{} = observed_at) do
+    age_ms = DateTime.diff(DateTime.utc_now(), observed_at, :millisecond)
+
+    cond do
+      age_ms <= Orchard.Inference.node_freshness_threshold_ms() -> :fresh
+      age_ms <= Orchard.Inference.node_unreachable_threshold_ms() -> :stale
+      true -> :unreachable
+    end
+  end
+
+  defp freshness(_observed_at), do: :unknown
+
+  defp runtime_transport(%{status: :ok}), do: %{status: :reachable}
+  defp runtime_transport(%{status: :timeout}), do: %{status: :timeout}
+
+  defp runtime_transport(%{code: code})
+       when code in ["identity_mismatch", "runtime_identity_mismatch"],
+       do: %{status: :identity_mismatch}
+
+  defp runtime_transport(%{status: :unavailable}), do: %{status: :connect_failed}
+  defp runtime_transport(%{target: nil}), do: %{status: :target_unconfigured}
+  defp runtime_transport(_target), do: %{status: :unknown}
+
+  defp runtime_readiness(%{
+         runtime_health: %{ready: true, health_code: code, health_message: message}
+       }) do
+    %{status: :ready, health_code: code, health_message: message}
+  end
+
+  defp runtime_readiness(%{
+         runtime_health: %{ready: false, health_code: code, health_message: message}
+       }) do
+    %{status: :not_ready, health_code: code, health_message: message}
+  end
+
+  defp runtime_readiness(_target), do: %{status: :unknown, health_code: nil, health_message: nil}
+
+  defp runtime_compatibility(%{status: status}) when status != :ok, do: %{status: :unknown}
+
+  defp runtime_compatibility(%{node_metadata: nil, runtime_health: nil}) do
+    %{status: :legacy_metadata}
+  end
+
+  defp runtime_compatibility(%{node_metadata: nil}), do: %{status: :partial_metadata}
+  defp runtime_compatibility(%{runtime_health: nil}), do: %{status: :partial_metadata}
+  defp runtime_compatibility(_target), do: %{status: :compatible}
+
+  defp runtime_health_status(%{runtime_health: %{ready: true}}), do: :healthy
+  defp runtime_health_status(%{runtime_health: %{ready: false}}), do: :unhealthy
+  defp runtime_health_status(%{status: :unavailable}), do: :unreachable
+  defp runtime_health_status(_target), do: :unknown
+
+  defp runtime_warnings(%{status: :ok} = target) do
+    case runtime_compatibility(target) do
+      %{status: status} when status in [:legacy_metadata, :partial_metadata] ->
+        [%{code: Atom.to_string(status), message: nil, metadata: %{}}]
+
+      _compatibility ->
+        []
+    end
+  end
+
+  defp runtime_warnings(_target), do: []
+
+  defp target_ref(%{target_ref: ref}) when is_binary(ref) and ref != "", do: ref
+  defp target_ref(%{target_label: label}) when is_binary(label) and label != "", do: label
+  defp target_ref(%{target_dom_id: id}) when is_binary(id) and id != "", do: id
+  defp target_ref(_target), do: nil
+
+  defp node_field(%{} = node, key), do: Map.get(node, key) || Map.get(node, Atom.to_string(key))
+end

--- a/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
@@ -138,7 +138,20 @@ defmodule Orchard.ClusterManagement.StatusBuilder do
   end
 
   @spec node_status_maps([Node.t() | map()]) :: [map()]
-  def node_status_maps(nodes), do: Enum.map(nodes, &node_status_map/1)
+  def node_status_maps(nodes) do
+    decisions =
+      nodes
+      |> Enum.map(&node_id/1)
+      |> Enum.reject(&is_nil/1)
+      |> Nodes.latest_admission_decisions_for_nodes()
+
+    Enum.map(nodes, fn node ->
+      node_status_map(node, latest_decision: Map.get(decisions, node_id(node)))
+    end)
+  end
+
+  defp node_id(%Node{id: id}), do: id
+  defp node_id(%{} = node), do: node_field(node, :id)
 
   defp node_admission_category(_node, %AdmissionDecision{decision: :rejected}), do: :rejected
   defp node_admission_category(%Node{state: :provisioned}, _decision), do: :pending_provisioned
@@ -148,6 +161,8 @@ defmodule Orchard.ClusterManagement.StatusBuilder do
     do: :admitted
 
   defp node_admission_category(%Node{state: :removed}, _decision), do: :removed
+
+  defp node_admission_category(%Node{}, _decision), do: :pending_registered
 
   defp node_admission_category(%{} = node, decision) do
     node_admission_category(%Node{state: node_field(node, :state)}, decision)
@@ -243,10 +258,12 @@ defmodule Orchard.ClusterManagement.StatusBuilder do
 
   defp freshness(%DateTime{} = observed_at) do
     age_ms = DateTime.diff(DateTime.utc_now(), observed_at, :millisecond)
+    freshness_ms = Orchard.Inference.node_freshness_threshold_ms()
+    unreachable_ms = Orchard.Inference.node_unreachable_threshold_ms()
 
     cond do
-      age_ms <= Orchard.Inference.node_freshness_threshold_ms() -> :fresh
-      age_ms <= Orchard.Inference.node_unreachable_threshold_ms() -> :stale
+      age_ms <= min(freshness_ms, unreachable_ms) -> :fresh
+      age_ms <= max(freshness_ms, unreachable_ms) -> :stale
       true -> :unreachable
     end
   end

--- a/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex
@@ -185,7 +185,7 @@ defmodule Orchard.ClusterManagement.StatusBuilder do
     []
     |> add_state_reason(node.state)
     |> add_health_reason(node.health)
-    |> add_freshness_reason(freshness(node.last_heartbeat_at))
+    |> add_freshness_reason(node.last_heartbeat_at)
     |> Enum.uniq()
     |> Enum.reverse()
   end
@@ -194,7 +194,7 @@ defmodule Orchard.ClusterManagement.StatusBuilder do
     []
     |> add_state_reason(node_field(node, :state))
     |> add_health_reason(node_field(node, :health))
-    |> add_freshness_reason(freshness(node_field(node, :last_heartbeat_at)))
+    |> add_freshness_reason(node_field(node, :last_heartbeat_at))
     |> Enum.uniq()
     |> Enum.reverse()
   end
@@ -214,10 +214,20 @@ defmodule Orchard.ClusterManagement.StatusBuilder do
   defp add_health_reason(reasons, :unhealthy), do: [:node_health_unhealthy | reasons]
   defp add_health_reason(reasons, _health), do: [:node_health_unhealthy | reasons]
 
-  defp add_freshness_reason(reasons, :fresh), do: reasons
-  defp add_freshness_reason(reasons, :stale), do: reasons
-  defp add_freshness_reason(reasons, :unknown), do: reasons
-  defp add_freshness_reason(reasons, :unreachable), do: [:node_observation_stale | reasons]
+  defp add_freshness_reason(reasons, last_heartbeat_at) do
+    if schedulable_observation?(last_heartbeat_at) do
+      reasons
+    else
+      [:node_observation_stale | reasons]
+    end
+  end
+
+  defp schedulable_observation?(%DateTime{} = observed_at) do
+    age_ms = DateTime.diff(DateTime.utc_now(), observed_at, :millisecond)
+    age_ms <= Orchard.Inference.node_freshness_threshold_ms()
+  end
+
+  defp schedulable_observation?(_observed_at), do: false
 
   defp candidate_scheduling(%AdmissionCandidate{admission_category: :pending_observed}) do
     %{eligible: false, reason_codes: [:node_not_registered, :trust_not_established]}

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -13,6 +13,7 @@ defmodule OrchardConsole.NodesLive do
 
   alias Orchard.Nodes
   alias Orchard.RuntimeEndpoint.Target
+  alias OrchardConsole.NodesPageData
 
   @default_refresh_interval_ms 5_000
   @safe_tokenization_counter_keys [
@@ -378,6 +379,7 @@ defmodule OrchardConsole.NodesLive do
       inventory: %{
         status: :loading,
         rows: [],
+        statuses: [],
         summary: %{
           total: nil,
           by_health: %{healthy: nil, degraded: nil, unhealthy: nil, unreachable: nil}
@@ -646,12 +648,13 @@ defmodule OrchardConsole.NodesLive do
   defp fetch_inventory do
     rows = Nodes.list_nodes()
     summary = Nodes.summary()
-    %{status: :ok, rows: rows, summary: summary, message: nil}
+    NodesPageData.inventory(rows, summary)
   rescue
     _ ->
       %{
         status: :error,
         rows: [],
+        statuses: [],
         summary: %{total: 0, by_health: %{healthy: 0, degraded: 0, unhealthy: 0, unreachable: 0}},
         message: "Node inventory unavailable."
       }

--- a/apps/orchard_controller/lib/orchard/console/nodes_page_data.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_page_data.ex
@@ -1,0 +1,18 @@
+defmodule OrchardConsole.NodesPageData do
+  @moduledoc """
+  Builds Console nodes page data from shared cluster-management status structures.
+  """
+
+  alias Orchard.ClusterManagement.StatusBuilder
+
+  @spec inventory([struct()], map()) :: map()
+  def inventory(rows, summary) when is_list(rows) and is_map(summary) do
+    %{
+      status: :ok,
+      rows: rows,
+      summary: summary,
+      statuses: StatusBuilder.node_status_maps(rows),
+      message: nil
+    }
+  end
+end

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -3,6 +3,8 @@ defmodule Orchard.ControlPlane do
   Small control-plane write gate for leader-only mutation paths.
   """
 
+  alias Orchard.ClusterManagement.HALiteStatus
+
   @type write_path :: atom()
   @type write_error :: :controller_standby
 
@@ -15,9 +17,37 @@ defmodule Orchard.ControlPlane do
     end
   end
 
+  @spec read_only_status() :: HALiteStatus.t()
+  def read_only_status do
+    role = normalized_role(configured_role())
+
+    HALiteStatus.new!(%{
+      deployment_mode: deployment_mode(role),
+      controller_role: role,
+      advisory_lock_status: :unknown,
+      standby_write_path_behavior: standby_write_path_behavior(role)
+    })
+  end
+
   defp configured_role do
     :orchard_controller
     |> Application.get_env(:control_plane, [])
     |> Keyword.get(:role, :single_controller)
   end
+
+  defp normalized_role(:leader), do: :leader
+  defp normalized_role("leader"), do: :leader
+  defp normalized_role(:standby), do: :standby
+  defp normalized_role("standby"), do: :standby
+  defp normalized_role(:single_controller), do: :single_controller
+  defp normalized_role("single_controller"), do: :single_controller
+  defp normalized_role(_role), do: :unknown
+
+  defp deployment_mode(:leader), do: :ha_lite
+  defp deployment_mode(:standby), do: :ha_lite
+  defp deployment_mode(:single_controller), do: :single_controller
+  defp deployment_mode(_role), do: :unknown
+
+  defp standby_write_path_behavior(:standby), do: "writes_return_503_controller_standby"
+  defp standby_write_path_behavior(_role), do: "writes_allowed_when_authorized"
 end

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -1,6 +1,7 @@
 defmodule Orchard.ControlPlane do
   @moduledoc """
-  Small control-plane write gate for leader-only mutation paths.
+  Small control-plane write gate for leader-only mutation paths, plus read-only
+  HA-lite control-plane status.
   """
 
   alias Orchard.ClusterManagement.HALiteStatus

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -387,18 +387,30 @@ defmodule Orchard.Nodes do
   def latest_admission_decisions_for_candidates(candidate_ids) do
     candidate_ids
     |> normalize_uuid_list()
-    |> do_latest_admission_decisions_for_candidates()
+    |> latest_admission_decisions_by(:candidate_id)
   end
 
-  defp do_latest_admission_decisions_for_candidates([]), do: %{}
+  @doc """
+  Returns the latest admission decisions keyed by node ID.
+  """
+  @spec latest_admission_decisions_for_nodes([Ecto.UUID.t()]) :: %{
+          optional(Ecto.UUID.t()) => AdmissionDecision.t()
+        }
+  def latest_admission_decisions_for_nodes(node_ids) do
+    node_ids
+    |> normalize_uuid_list()
+    |> latest_admission_decisions_by(:node_id)
+  end
 
-  defp do_latest_admission_decisions_for_candidates(candidate_ids) do
+  defp latest_admission_decisions_by([], _key), do: %{}
+
+  defp latest_admission_decisions_by(ids, key) do
     AdmissionDecision
-    |> where([decision], decision.candidate_id in ^candidate_ids)
+    |> where([decision], field(decision, ^key) in ^ids)
     |> order_by([decision], desc: decision.decided_at, desc: decision.inserted_at)
     |> Repo.all()
-    |> Enum.reduce(%{}, fn decision, decisions_by_candidate ->
-      Map.put_new(decisions_by_candidate, decision.candidate_id, decision)
+    |> Enum.reduce(%{}, fn decision, decisions ->
+      Map.put_new(decisions, Map.get(decision, key), decision)
     end)
   end
 

--- a/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
@@ -27,6 +27,9 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
       assert listed["id"] == candidate.id
       assert listed["object"] == "node_admission_candidate"
       assert listed["latest_decision"]["decision"] == "rejected"
+      assert listed["status"]["object"] == "cluster_management.node_status"
+      assert listed["status"]["admission"]["category"] == "rejected"
+      assert listed["status"]["scheduling"]["reason_codes"] == ["node_not_admitted"]
 
       show_conn =
         admin_json(:get, "/admin/v1/node-admission/candidates/#{candidate.id}", token)

--- a/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
+++ b/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
@@ -1,0 +1,118 @@
+defmodule Orchard.ClusterManagement.StatusBuilderTest do
+  use Orchard.DataCase, async: false
+
+  alias Orchard.ClusterManagement.StatusBuilder
+  alias Orchard.Nodes.AdmissionCandidate
+  alias Orchard.Nodes.Node
+  alias Orchard.Repo
+
+  describe "node status" do
+    test "active fresh healthy node is schedulable" do
+      node =
+        insert_node!(%{
+          state: :active,
+          health: :healthy,
+          last_heartbeat_at: DateTime.utc_now()
+        })
+
+      status = StatusBuilder.node_status_map(node)
+
+      assert status.scheduling.eligible == true
+      assert status.scheduling.reason_codes == []
+      assert status.lifecycle.state == "active"
+      assert status.admission.category == "admitted"
+      assert status.freshness.status == "fresh"
+    end
+
+    test "registered node is not admitted and not schedulable" do
+      node =
+        insert_node!(%{
+          state: :registered,
+          health: :healthy,
+          last_heartbeat_at: DateTime.utc_now()
+        })
+
+      status = StatusBuilder.node_status_map(node)
+
+      assert status.admission.category == "pending_registered"
+      assert status.scheduling.eligible == false
+      assert status.scheduling.reason_codes == ["node_not_admitted"]
+    end
+
+    test "stale active node reports observation freshness reason" do
+      node =
+        insert_node!(%{
+          state: :active,
+          health: :healthy,
+          last_heartbeat_at: DateTime.add(DateTime.utc_now(), -120, :second)
+        })
+
+      status = StatusBuilder.node_status_map(node)
+
+      assert status.scheduling.eligible == false
+      assert "node_observation_stale" in status.scheduling.reason_codes
+      assert status.freshness.status == "unreachable"
+    end
+  end
+
+  describe "candidate status" do
+    test "observed admission candidate is never schedulable" do
+      candidate = insert_candidate!()
+
+      status = StatusBuilder.candidate_status_map(candidate)
+
+      assert status.resource.type == "admission_candidate"
+      assert status.admission.category == "pending_observed"
+      assert status.lifecycle.state == nil
+      assert status.transport.status == "reachable"
+      assert status.scheduling.eligible == false
+      assert status.scheduling.reason_codes == ["node_not_registered", "trust_not_established"]
+    end
+  end
+
+  defp insert_node!(overrides) do
+    unique = System.unique_integer([:positive])
+
+    attrs =
+      %{
+        id: Ecto.UUID.generate(),
+        hostname: "node-#{unique}.local",
+        display_name: "node-#{unique}",
+        advertise_addr: "10.30.#{rem(unique, 200)}.#{rem(unique, 250) + 1}",
+        rpc_port: 50_071,
+        state: :active,
+        health: :healthy,
+        capabilities: %{},
+        tool_readiness: %{}
+      }
+      |> Map.merge(overrides)
+
+    %Node{}
+    |> Node.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  defp insert_candidate! do
+    unique = System.unique_integer([:positive])
+
+    attrs = %{
+      source: :runtime_endpoint_observation,
+      admission_category: :pending_observed,
+      observed_identity: %{
+        "claimed_node_id" => Ecto.UUID.generate(),
+        "display_name" => "candidate-#{unique}",
+        "hostname" => "candidate-#{unique}.local"
+      },
+      target_ref: "10.0.0.#{rem(unique, 200) + 1}:50071",
+      endpoint_transport: :grpc,
+      endpoint_target: "10.0.0.#{rem(unique, 200) + 1}:50071",
+      inventory: %{"capabilities" => %{}},
+      compatibility_evidence: %{"metadata" => "partial"},
+      last_observed_at: DateTime.utc_now()
+    }
+
+    %AdmissionCandidate{}
+    |> AdmissionCandidate.changeset(attrs)
+    |> Repo.insert!()
+  end
+end

--- a/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
+++ b/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
@@ -78,6 +78,27 @@ defmodule Orchard.ClusterManagement.StatusBuilderTest do
       )
     end
 
+    test "heartbeat past the freshness cutoff is ineligible even when unreachable threshold is longer" do
+      with_inference_overrides(
+        [node_freshness_threshold_ms: 15_000, node_unreachable_threshold_ms: 60_000],
+        fn ->
+          node =
+            insert_node!(%{
+              state: :active,
+              health: :healthy,
+              last_heartbeat_at: DateTime.add(DateTime.utc_now(), -30, :second)
+            })
+
+          status = StatusBuilder.node_status_map(node)
+
+          assert status.freshness.status == "stale"
+          assert status.scheduling.eligible == false
+          assert "node_observation_stale" in status.scheduling.reason_codes
+          assert Nodes.schedulable_nodes() == []
+        end
+      )
+    end
+
     test "unknown node state resolves without infinite recursion" do
       status =
         StatusBuilder.node_status_map(%{

--- a/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
+++ b/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
@@ -2,9 +2,12 @@ defmodule Orchard.ClusterManagement.StatusBuilderTest do
   use Orchard.DataCase, async: false
 
   alias Orchard.ClusterManagement.StatusBuilder
+  alias Orchard.Nodes
   alias Orchard.Nodes.AdmissionCandidate
   alias Orchard.Nodes.Node
   alias Orchard.Repo
+
+  import Orchard.TestSupport.ToolRegistryTestSupport, only: [with_inference_overrides: 2]
 
   describe "node status" do
     test "active fresh healthy node is schedulable" do
@@ -52,6 +55,47 @@ defmodule Orchard.ClusterManagement.StatusBuilderTest do
       assert status.scheduling.eligible == false
       assert "node_observation_stale" in status.scheduling.reason_codes
       assert status.freshness.status == "unreachable"
+    end
+
+    test "heartbeat between the two thresholds is reported as stale" do
+      with_inference_overrides(
+        [node_freshness_threshold_ms: 30_000, node_unreachable_threshold_ms: 15_000],
+        fn ->
+          node =
+            insert_node!(%{
+              state: :active,
+              health: :healthy,
+              last_heartbeat_at: DateTime.add(DateTime.utc_now(), -20, :second)
+            })
+
+          status = StatusBuilder.node_status_map(node)
+
+          assert status.freshness.status == "stale"
+        end
+      )
+    end
+
+    test "unknown node state resolves without infinite recursion" do
+      status =
+        StatusBuilder.node_status_map(%{
+          id: Ecto.UUID.generate(),
+          state: nil,
+          health: :healthy,
+          last_heartbeat_at: DateTime.utc_now()
+        })
+
+      assert status.admission.category == "pending_registered"
+    end
+
+    test "node_status_maps threads batched admission decisions" do
+      node = insert_node!(%{state: :registered, health: :healthy})
+
+      assert {:ok, _rejected} =
+               Nodes.reject_admission(node.id, %{reason: "needs review"})
+
+      assert [status] = StatusBuilder.node_status_maps([node])
+      assert status.admission.category == "rejected"
+      assert status.admission.latest_decision == "rejected"
     end
   end
 

--- a/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
+++ b/apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs
@@ -57,7 +57,7 @@ defmodule Orchard.ClusterManagement.StatusBuilderTest do
       assert status.freshness.status == "unreachable"
     end
 
-    test "heartbeat between the two thresholds is reported as stale" do
+    test "heartbeat between the two thresholds is reported as stale but remains schedulable" do
       with_inference_overrides(
         [node_freshness_threshold_ms: 30_000, node_unreachable_threshold_ms: 15_000],
         fn ->
@@ -71,6 +71,9 @@ defmodule Orchard.ClusterManagement.StatusBuilderTest do
           status = StatusBuilder.node_status_map(node)
 
           assert status.freshness.status == "stale"
+          assert status.scheduling.eligible == true
+          assert status.scheduling.reason_codes == []
+          assert Enum.map(Nodes.schedulable_nodes(), & &1.id) == [node.id]
         end
       )
     end

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -599,7 +599,10 @@ defmodule OrchardConsole.NodesLiveTest do
 
   alias __MODULE__.RuntimeOversizedMemoryBudgetRowsStub
   alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.ClusterManagement.StatusBuilder
+  alias Orchard.Nodes
   alias Orchard.Repo
+  alias OrchardConsole.NodesPageData
 
   @moduletag :live
   @moduletag :db
@@ -755,6 +758,24 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ "active"
       assert html =~ "healthy"
       assert html =~ "0.1.0"
+    end
+
+    test "page data derives inventory statuses from shared cluster management structures" do
+      node =
+        insert_node!(
+          display_name: "console-status-node",
+          state: :registered,
+          health: :healthy,
+          last_heartbeat_at: DateTime.utc_now()
+        )
+
+      page_data = NodesPageData.inventory([node], Nodes.summary())
+
+      assert page_data.statuses == [StatusBuilder.node_status_map(node)]
+
+      assert get_in(page_data.statuses, [Access.at(0), :scheduling, :reason_codes]) == [
+               "node_not_admitted"
+             ]
     end
   end
 

--- a/apps/orchard_shared/lib/orchard/cluster_management/action_preview.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/action_preview.ex
@@ -44,7 +44,6 @@ defmodule Orchard.ClusterManagement.ActionPreview do
              :confirmation_requirement,
              value(attrs, :confirmation_requirements)
            ),
-         :ok <- reject_confirmation_blockers(blockers),
          {:ok, scheduler_eligibility} <- scheduler_eligibility(attrs) do
       {:ok,
        %__MODULE__{
@@ -141,15 +140,6 @@ defmodule Orchard.ClusterManagement.ActionPreview do
   end
 
   defp coded_entry(_entry, _vocabulary, _fixed), do: {:error, :entry_must_be_map}
-
-  defp reject_confirmation_blockers(blockers) do
-    confirmation_codes = ReasonCodes.confirmation_requirement_codes()
-
-    case Enum.find(blockers, &(&1.code in confirmation_codes)) do
-      nil -> :ok
-      blocker -> {:error, {:confirmation_requirement_used_as_blocker, blocker.code}}
-    end
-  end
 
   defp string_map(nil, defaults), do: defaults
 

--- a/apps/orchard_shared/lib/orchard/cluster_management/action_preview.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/action_preview.ex
@@ -1,0 +1,177 @@
+defmodule Orchard.ClusterManagement.ActionPreview do
+  @moduledoc """
+  Side-effect-free action preview contract for cluster-management actions.
+  """
+
+  alias Orchard.ClusterManagement.{ReasonCodes, Value}
+
+  @object "cluster_management.action_preview"
+  @contract_version "orchard.cluster_management.action_preview.v1"
+
+  defstruct object: @object,
+            contract_version: @contract_version,
+            action: nil,
+            target: %{type: nil, id: nil},
+            current: %{},
+            active_request_count: nil,
+            scheduler_eligibility: %{eligible: false, reason_codes: []},
+            blockers: [],
+            warnings: [],
+            consequence_codes: [],
+            confirmation_requirements: [],
+            expected_transition: %{from: nil, to: nil},
+            audit_action: nil,
+            confirmation_required: false
+
+  @type t :: %__MODULE__{}
+
+  @spec object() :: String.t()
+  def object, do: @object
+
+  @spec contract_version() :: String.t()
+  def contract_version, do: @contract_version
+
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, term()}
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    with {:ok, blockers} <- coded_entries(value(attrs, :blockers), :action_blocker, true),
+         {:ok, warnings} <- coded_entries(value(attrs, :warnings), nil, false),
+         {:ok, consequence_codes} <-
+           ReasonCodes.validate_codes(:consequence, value(attrs, :consequence_codes)),
+         {:ok, confirmation_requirements} <-
+           ReasonCodes.validate_codes(
+             :confirmation_requirement,
+             value(attrs, :confirmation_requirements)
+           ),
+         :ok <- reject_confirmation_blockers(blockers),
+         {:ok, scheduler_eligibility} <- scheduler_eligibility(attrs) do
+      {:ok,
+       %__MODULE__{
+         action: Value.normalize_string(value(attrs, :action)),
+         target: string_map(value(attrs, :target), %{type: nil, id: nil}),
+         current: map_value_or_empty(value(attrs, :current)),
+         active_request_count: active_request_count(value(attrs, :active_request_count)),
+         scheduler_eligibility: scheduler_eligibility,
+         blockers: blockers,
+         warnings: warnings,
+         consequence_codes: consequence_codes,
+         confirmation_requirements: confirmation_requirements,
+         expected_transition:
+           string_map(value(attrs, :expected_transition), %{from: nil, to: nil}),
+         audit_action: Value.normalize_string(value(attrs, :audit_action)),
+         confirmation_required: value(attrs, :confirmation_required) == true
+       }}
+    end
+  end
+
+  @spec new!(map() | keyword()) :: t()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, preview} -> preview
+      {:error, reason} -> raise ArgumentError, "invalid action preview: #{inspect(reason)}"
+    end
+  end
+
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = preview) do
+    %{
+      object: preview.object,
+      contract_version: preview.contract_version,
+      action: preview.action,
+      target: Value.json_value(preview.target),
+      current: Value.json_value(preview.current),
+      active_request_count: preview.active_request_count,
+      scheduler_eligibility: Value.json_value(preview.scheduler_eligibility),
+      blockers: Enum.map(preview.blockers, &Value.json_value/1),
+      warnings: Enum.map(preview.warnings, &Value.json_value/1),
+      consequence_codes: preview.consequence_codes,
+      confirmation_requirements: preview.confirmation_requirements,
+      expected_transition: Value.json_value(preview.expected_transition),
+      audit_action: preview.audit_action,
+      confirmation_required: preview.confirmation_required
+    }
+  end
+
+  defp scheduler_eligibility(attrs) do
+    scheduling = value(attrs, :scheduler_eligibility) || %{}
+
+    with {:ok, codes} <-
+           ReasonCodes.validate_codes(:scheduler_rejection, map_value(scheduling, :reason_codes)) do
+      {:ok, %{eligible: map_value(scheduling, :eligible) == true, reason_codes: codes}}
+    end
+  end
+
+  defp coded_entries(nil, _vocabulary, _fixed), do: {:ok, []}
+
+  defp coded_entries(entries, vocabulary, fixed) when is_list(entries) do
+    entries
+    |> Enum.reduce_while({:ok, []}, fn entry, {:ok, acc} ->
+      case coded_entry(entry, vocabulary, fixed) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      error -> error
+    end
+  end
+
+  defp coded_entries(_entries, _vocabulary, _fixed), do: {:error, :entries_must_be_list}
+
+  defp coded_entry(entry, vocabulary, fixed) when is_map(entry) do
+    code = ReasonCodes.normalize_code(map_value(entry, :code))
+
+    cond do
+      is_nil(code) ->
+        {:error, :entry_code_required}
+
+      fixed and not ReasonCodes.valid?(vocabulary, code) ->
+        {:error, {:unknown_code, vocabulary, code}}
+
+      true ->
+        {:ok,
+         %{
+           code: code,
+           message: Value.normalize_string(map_value(entry, :message)),
+           metadata: map_value_or_empty(map_value(entry, :metadata))
+         }}
+    end
+  end
+
+  defp coded_entry(_entry, _vocabulary, _fixed), do: {:error, :entry_must_be_map}
+
+  defp reject_confirmation_blockers(blockers) do
+    confirmation_codes = ReasonCodes.confirmation_requirement_codes()
+
+    case Enum.find(blockers, &(&1.code in confirmation_codes)) do
+      nil -> :ok
+      blocker -> {:error, {:confirmation_requirement_used_as_blocker, blocker.code}}
+    end
+  end
+
+  defp string_map(nil, defaults), do: defaults
+
+  defp string_map(map, defaults) when is_map(map) do
+    Enum.reduce(defaults, %{}, fn {key, default}, acc ->
+      Map.put(acc, key, Value.normalize_string(map_value(map, key)) || default)
+    end)
+  end
+
+  defp string_map(_value, defaults), do: defaults
+
+  defp map_value_or_empty(value) when is_map(value), do: value
+  defp map_value_or_empty(_value), do: %{}
+
+  defp active_request_count(count) when is_integer(count) and count >= 0, do: count
+  defp active_request_count(_count), do: nil
+
+  defp value(attrs, key), do: map_value(attrs, key)
+
+  defp map_value(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp map_value(_map, _key), do: nil
+end

--- a/apps/orchard_shared/lib/orchard/cluster_management/ha_lite_status.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/ha_lite_status.ex
@@ -1,0 +1,104 @@
+defmodule Orchard.ClusterManagement.HALiteStatus do
+  @moduledoc """
+  Read-only HA-lite control-plane status contract.
+  """
+
+  @object "cluster_management.ha_lite_status"
+  @contract_version "orchard.cluster_management.ha_lite_status.v1"
+
+  @deployment_modes ~w(single_controller ha_lite unknown)
+  @controller_roles ~w(leader standby single_controller unknown)
+  @lock_statuses ~w(held not_held unavailable unknown)
+
+  alias Orchard.ClusterManagement.Value
+
+  defstruct object: @object,
+            contract_version: @contract_version,
+            deployment_mode: "unknown",
+            this_controller_identity: nil,
+            controller_role: "unknown",
+            leader_identity: nil,
+            advisory_lock_status: "unknown",
+            lock_age_ms: nil,
+            last_renewed_at: nil,
+            standby_write_path_behavior: "unknown",
+            last_observed_leadership_error: nil
+
+  @type t :: %__MODULE__{}
+
+  @spec object() :: String.t()
+  def object, do: @object
+
+  @spec contract_version() :: String.t()
+  def contract_version, do: @contract_version
+
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, term()}
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    with {:ok, deployment_mode} <-
+           status_value(attrs, :deployment_mode, @deployment_modes, "unknown"),
+         {:ok, controller_role} <-
+           status_value(attrs, :controller_role, @controller_roles, "unknown"),
+         {:ok, advisory_lock_status} <-
+           status_value(attrs, :advisory_lock_status, @lock_statuses, "unknown") do
+      {:ok,
+       %__MODULE__{
+         deployment_mode: deployment_mode,
+         this_controller_identity:
+           Value.normalize_string(value(attrs, :this_controller_identity)),
+         controller_role: controller_role,
+         leader_identity: Value.normalize_string(value(attrs, :leader_identity)),
+         advisory_lock_status: advisory_lock_status,
+         lock_age_ms: lock_age_ms(value(attrs, :lock_age_ms)),
+         last_renewed_at: value(attrs, :last_renewed_at),
+         standby_write_path_behavior:
+           Value.normalize_string(value(attrs, :standby_write_path_behavior)) || "unknown",
+         last_observed_leadership_error:
+           Value.normalize_string(value(attrs, :last_observed_leadership_error))
+       }}
+    end
+  end
+
+  @spec new!(map() | keyword()) :: t()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, status} -> status
+      {:error, reason} -> raise ArgumentError, "invalid HA-lite status: #{inspect(reason)}"
+    end
+  end
+
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = status) do
+    %{
+      object: status.object,
+      contract_version: status.contract_version,
+      deployment_mode: status.deployment_mode,
+      this_controller_identity: status.this_controller_identity,
+      controller_role: status.controller_role,
+      leader_identity: status.leader_identity,
+      advisory_lock_status: status.advisory_lock_status,
+      lock_age_ms: status.lock_age_ms,
+      last_renewed_at: Value.json_value(status.last_renewed_at),
+      standby_write_path_behavior: status.standby_write_path_behavior,
+      last_observed_leadership_error: status.last_observed_leadership_error
+    }
+  end
+
+  defp status_value(attrs, key, allowed_values, default) do
+    value = Value.normalize_string(value(attrs, key)) || default
+
+    if value in allowed_values do
+      {:ok, value}
+    else
+      {:error, {:unknown_status, key, value}}
+    end
+  end
+
+  defp lock_age_ms(value) when is_integer(value) and value >= 0, do: value
+  defp lock_age_ms(_value), do: nil
+
+  defp value(attrs, key) do
+    Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  end
+end

--- a/apps/orchard_shared/lib/orchard/cluster_management/node_status.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/node_status.ex
@@ -1,0 +1,197 @@
+defmodule Orchard.ClusterManagement.NodeStatus do
+  @moduledoc """
+  Shared node and runtime-target status contract for cluster-management surfaces.
+  """
+
+  alias Orchard.ClusterManagement.{ReasonCodes, Value}
+
+  @object "cluster_management.node_status"
+  @contract_version "orchard.cluster_management.status.v1"
+
+  @resource_types ~w(node admission_candidate runtime_target cluster)
+  @freshness_values ~w(fresh stale unreachable unknown)
+  @transport_values ~w(reachable timeout connect_failed identity_mismatch target_unconfigured unknown)
+  @runtime_values ~w(ready not_ready unsupported unknown)
+  @compatibility_values ~w(compatible legacy_metadata partial_metadata version_skew unsupported_version unknown)
+
+  defstruct object: @object,
+            contract_version: @contract_version,
+            resource: %{type: nil, id: nil},
+            lifecycle: %{state: nil},
+            admission: %{category: nil, source: nil, latest_decision: nil},
+            health: %{status: "unknown"},
+            freshness: %{status: "unknown", observed_at: nil, source: nil},
+            transport: %{status: "unknown"},
+            runtime: %{status: "unknown", health_code: nil, health_message: nil},
+            compatibility: %{status: "unknown"},
+            scheduling: %{eligible: false, reason_codes: []},
+            warnings: []
+
+  @type t :: %__MODULE__{}
+
+  @spec object() :: String.t()
+  def object, do: @object
+
+  @spec contract_version() :: String.t()
+  def contract_version, do: @contract_version
+
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, term()}
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    with {:ok, resource} <- resource(attrs),
+         {:ok, freshness} <-
+           category(attrs, :freshness, @freshness_values, %{
+             status: "unknown",
+             observed_at: nil,
+             source: nil
+           }),
+         {:ok, transport} <- category(attrs, :transport, @transport_values, %{status: "unknown"}),
+         {:ok, runtime} <-
+           category(attrs, :runtime, @runtime_values, %{
+             status: "unknown",
+             health_code: nil,
+             health_message: nil
+           }),
+         {:ok, compatibility} <-
+           category(attrs, :compatibility, @compatibility_values, %{status: "unknown"}),
+         {:ok, scheduling} <- scheduling(attrs),
+         {:ok, warnings} <- warnings(value(attrs, :warnings)) do
+      {:ok,
+       %__MODULE__{
+         resource: resource,
+         lifecycle: string_map(value(attrs, :lifecycle), %{state: nil}),
+         admission:
+           string_map(value(attrs, :admission), %{
+             category: nil,
+             source: nil,
+             latest_decision: nil
+           }),
+         health: string_map(value(attrs, :health), %{status: "unknown"}),
+         freshness: freshness,
+         transport: transport,
+         runtime: runtime,
+         compatibility: compatibility,
+         scheduling: scheduling,
+         warnings: warnings
+       }}
+    end
+  end
+
+  @spec new!(map() | keyword()) :: t()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, status} -> status
+      {:error, reason} -> raise ArgumentError, "invalid node status: #{inspect(reason)}"
+    end
+  end
+
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = status) do
+    %{
+      object: status.object,
+      contract_version: status.contract_version,
+      resource: json_map(status.resource),
+      lifecycle: json_map(status.lifecycle),
+      admission: json_map(status.admission),
+      health: json_map(status.health),
+      freshness: json_map(status.freshness),
+      transport: json_map(status.transport),
+      runtime: json_map(status.runtime),
+      compatibility: json_map(status.compatibility),
+      scheduling: json_map(status.scheduling),
+      warnings: Enum.map(status.warnings, &json_map/1)
+    }
+  end
+
+  defp resource(attrs) do
+    resource = string_map(value(attrs, :resource), %{type: nil, id: nil})
+    type = Map.get(resource, :type)
+
+    if is_nil(type) or type in @resource_types do
+      {:ok, resource}
+    else
+      {:error, {:unknown_resource_type, type}}
+    end
+  end
+
+  defp category(attrs, key, values, defaults) do
+    category = string_map(value(attrs, key), defaults)
+    status = Map.get(category, :status)
+
+    if is_nil(status) or status in values do
+      {:ok, category}
+    else
+      {:error, {:unknown_status, key, status}}
+    end
+  end
+
+  defp scheduling(attrs) do
+    scheduling = value(attrs, :scheduling) || %{}
+    reason_codes = map_value(scheduling, :reason_codes)
+
+    with {:ok, codes} <- ReasonCodes.validate_codes(:scheduler_rejection, reason_codes) do
+      {:ok,
+       %{
+         eligible: map_value(scheduling, :eligible) == true,
+         reason_codes: codes
+       }}
+    end
+  end
+
+  defp warnings(nil), do: {:ok, []}
+
+  defp warnings(warnings) when is_list(warnings) do
+    warnings
+    |> Enum.reduce_while({:ok, []}, fn warning, {:ok, acc} ->
+      case warning(warning) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      error -> error
+    end
+  end
+
+  defp warnings(_warnings), do: {:error, :warnings_must_be_list}
+
+  defp warning(warning) when is_map(warning) do
+    normalized = string_map(warning, %{code: nil, message: nil, metadata: %{}})
+
+    case normalized.code do
+      code when is_binary(code) and code != "" -> {:ok, normalized}
+      _other -> {:error, :warning_code_required}
+    end
+  end
+
+  defp warning(_warning), do: {:error, :warning_must_be_map}
+
+  defp string_map(nil, defaults), do: defaults
+
+  defp string_map(map, defaults) when is_map(map) do
+    Enum.reduce(defaults, %{}, fn {key, default}, acc ->
+      Map.put(acc, key, normalize_value(map_value(map, key), default))
+    end)
+  end
+
+  defp string_map(_value, defaults), do: defaults
+
+  defp json_map(map) when is_map(map) do
+    Map.new(map, fn {key, value} -> {key, Value.json_value(value)} end)
+  end
+
+  defp normalize_value(nil, default), do: default
+  defp normalize_value(%DateTime{} = value, _default), do: value
+  defp normalize_value(value, _default) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_value(value, _default), do: value
+
+  defp value(attrs, key), do: map_value(attrs, key)
+
+  defp map_value(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp map_value(_map, _key), do: nil
+end

--- a/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
@@ -1,0 +1,160 @@
+defmodule Orchard.ClusterManagement.ReasonCodes do
+  @moduledoc """
+  Fixed cluster-management reason-code vocabularies.
+  """
+
+  @scheduler_rejection_codes ~w(
+    inventory_missing
+    node_not_admitted
+    node_not_active
+    node_not_registered
+    node_health_unreachable
+    node_health_unhealthy
+    node_observation_stale
+    transport_unreachable
+    runtime_not_ready
+    runtime_identity_mismatch
+    version_incompatible
+    pool_not_allowed
+    model_format_unsupported
+    model_not_available_on_node
+    insufficient_memory
+    node_concurrency_exhausted
+    placement_concurrency_exhausted
+    placement_suppressed
+    node_circuit_breaker_open
+    model_load_suppressed
+    policy_required
+    pool_required
+    queue_lane_capacity_unavailable
+    trust_not_established
+    unknown_capacity
+  )
+
+  @scheduler_skip_codes ~w(
+    lower_tier_not_considered
+    not_scored_after_selection
+    not_applicable_to_request
+    candidate_limit_reached
+  )
+
+  @action_blocker_codes ~w(
+    requires_admin
+    requires_operator
+    node_not_found
+    node_not_pending_admission
+    node_not_admitted
+    node_not_active
+    node_not_registered
+    node_unreachable
+    inventory_missing
+    drain_already_running
+    decommission_already_running
+    maintenance_requires_drain
+    ha_standby_write_blocked
+    cluster_lock_unavailable
+    version_incompatible
+    pool_required
+    policy_required
+    trust_not_established
+  )
+
+  @confirmation_requirement_codes ~w(
+    requires_yes_flag
+    requires_typed_node_id
+    requires_reason
+    requires_drain_consequence_acknowledgement
+    requires_decommission_consequence_acknowledgement
+  )
+
+  @consequence_codes ~w(
+    active_requests_present
+    would_cancel_active_requests
+    existing_requests_continue_until_deadline
+  )
+
+  @support_scope_codes ~w(
+    cluster
+    node
+    request
+    scheduler_decision
+    runtime_endpoint
+    control_plane
+    ha_lite
+  )
+
+  @vocabularies %{
+    scheduler_rejection: @scheduler_rejection_codes,
+    scheduler_skip: @scheduler_skip_codes,
+    action_blocker: @action_blocker_codes,
+    confirmation_requirement: @confirmation_requirement_codes,
+    consequence: @consequence_codes,
+    support_scope: @support_scope_codes
+  }
+
+  @type vocabulary ::
+          :scheduler_rejection
+          | :scheduler_skip
+          | :action_blocker
+          | :confirmation_requirement
+          | :consequence
+          | :support_scope
+
+  @spec scheduler_rejection_codes() :: [String.t()]
+  def scheduler_rejection_codes, do: @scheduler_rejection_codes
+
+  @spec scheduler_skip_codes() :: [String.t()]
+  def scheduler_skip_codes, do: @scheduler_skip_codes
+
+  @spec action_blocker_codes() :: [String.t()]
+  def action_blocker_codes, do: @action_blocker_codes
+
+  @spec confirmation_requirement_codes() :: [String.t()]
+  def confirmation_requirement_codes, do: @confirmation_requirement_codes
+
+  @spec consequence_codes() :: [String.t()]
+  def consequence_codes, do: @consequence_codes
+
+  @spec support_scope_codes() :: [String.t()]
+  def support_scope_codes, do: @support_scope_codes
+
+  @spec normalize_code(term()) :: String.t() | nil
+  def normalize_code(nil), do: nil
+  def normalize_code(code) when is_atom(code), do: Atom.to_string(code)
+
+  def normalize_code(code) when is_binary(code) do
+    case String.trim(code) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  def normalize_code(_code), do: nil
+
+  @spec valid?(vocabulary(), term()) :: boolean()
+  def valid?(vocabulary, code) do
+    normalized = normalize_code(code)
+    is_binary(normalized) and normalized in Map.fetch!(@vocabularies, vocabulary)
+  end
+
+  @spec normalize_codes([term()] | term()) :: [String.t()]
+  def normalize_codes(codes) when is_list(codes) do
+    codes
+    |> Enum.map(&normalize_code/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def normalize_codes(nil), do: []
+  def normalize_codes(code), do: normalize_codes([code])
+
+  @spec validate_codes(vocabulary(), [term()] | term()) ::
+          {:ok, [String.t()]} | {:error, {:unknown_code, vocabulary(), term()}}
+  def validate_codes(vocabulary, codes) do
+    normalized_codes = normalize_codes(codes)
+
+    case Enum.find(normalized_codes, &(not valid?(vocabulary, &1))) do
+      nil -> {:ok, normalized_codes}
+      unknown -> {:error, {:unknown_code, vocabulary, unknown}}
+    end
+  end
+end

--- a/apps/orchard_shared/lib/orchard/cluster_management/scheduler_explanation.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/scheduler_explanation.ex
@@ -1,0 +1,146 @@
+defmodule Orchard.ClusterManagement.SchedulerExplanation do
+  @moduledoc """
+  Shared scheduler explanation contract with fixed candidate reason codes.
+  """
+
+  alias Orchard.ClusterManagement.{ReasonCodes, Value}
+
+  @object "cluster_management.scheduler_explanation"
+  @contract_version "orchard.cluster_management.scheduler_explanation.v1"
+
+  defstruct object: @object,
+            contract_version: @contract_version,
+            request_id: nil,
+            selected_node_id: nil,
+            selection_tier: nil,
+            scored_candidates: [],
+            rejected_candidates: [],
+            skipped_candidates: []
+
+  @type t :: %__MODULE__{}
+
+  @spec object() :: String.t()
+  def object, do: @object
+
+  @spec contract_version() :: String.t()
+  def contract_version, do: @contract_version
+
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, term()}
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    with {:ok, scored} <- candidates(value(attrs, :scored_candidates), :scored),
+         {:ok, rejected} <- candidates(value(attrs, :rejected_candidates), :rejected),
+         {:ok, skipped} <- candidates(value(attrs, :skipped_candidates), :skipped) do
+      {:ok,
+       %__MODULE__{
+         request_id: Value.normalize_string(value(attrs, :request_id)),
+         selected_node_id: Value.normalize_string(value(attrs, :selected_node_id)),
+         selection_tier: Value.normalize_string(value(attrs, :selection_tier)),
+         scored_candidates: scored,
+         rejected_candidates: rejected,
+         skipped_candidates: skipped
+       }}
+    end
+  end
+
+  @spec new!(map() | keyword()) :: t()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, explanation} -> explanation
+      {:error, reason} -> raise ArgumentError, "invalid scheduler explanation: #{inspect(reason)}"
+    end
+  end
+
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = explanation) do
+    %{
+      object: explanation.object,
+      contract_version: explanation.contract_version,
+      request_id: explanation.request_id,
+      selected_node_id: explanation.selected_node_id,
+      selection_tier: explanation.selection_tier,
+      scored_candidates: Enum.map(explanation.scored_candidates, &Value.json_value/1),
+      rejected_candidates: Enum.map(explanation.rejected_candidates, &Value.json_value/1),
+      skipped_candidates: Enum.map(explanation.skipped_candidates, &Value.json_value/1)
+    }
+  end
+
+  @spec validate_map(map()) :: :ok | {:error, term()}
+  def validate_map(map) when is_map(map) do
+    case new(map) do
+      {:ok, _explanation} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def validate_map(_map), do: {:error, :scheduler_explanation_must_be_map}
+
+  defp candidates(nil, _kind), do: {:ok, []}
+
+  defp candidates(candidates, kind) when is_list(candidates) do
+    candidates
+    |> Enum.reduce_while({:ok, []}, fn candidate, {:ok, acc} ->
+      case candidate(candidate, kind) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      error -> error
+    end
+  end
+
+  defp candidates(_candidates, kind), do: {:error, {:candidates_must_be_list, kind}}
+
+  defp candidate(candidate, kind) when is_map(candidate) do
+    with {:ok, reason_codes} <- reason_codes(candidate, kind) do
+      {:ok,
+       %{
+         node_id: Value.normalize_string(map_value(candidate, :node_id)),
+         target_ref: Value.normalize_string(map_value(candidate, :target_ref)),
+         eligible: map_value(candidate, :eligible) == true,
+         tier: Value.normalize_string(map_value(candidate, :tier)),
+         score: map_value(candidate, :score),
+         components: map_value_or_empty(map_value(candidate, :components)),
+         diagnostics: map_value_or_empty(map_value(candidate, :diagnostics)),
+         reason_codes: reason_codes
+       }}
+    end
+  end
+
+  defp candidate(_candidate, kind), do: {:error, {:candidate_must_be_map, kind}}
+
+  defp reason_codes(candidate, :rejected) do
+    validate_required_codes(
+      candidate,
+      :scheduler_rejection,
+      :rejected_candidate_reason_codes_required
+    )
+  end
+
+  defp reason_codes(candidate, :skipped) do
+    validate_required_codes(candidate, :scheduler_skip, :skipped_candidate_reason_codes_required)
+  end
+
+  defp reason_codes(candidate, :scored) do
+    ReasonCodes.validate_codes(:scheduler_rejection, map_value(candidate, :reason_codes))
+  end
+
+  defp validate_required_codes(candidate, vocabulary, empty_reason) do
+    case ReasonCodes.validate_codes(vocabulary, map_value(candidate, :reason_codes)) do
+      {:ok, []} -> {:error, empty_reason}
+      other -> other
+    end
+  end
+
+  defp map_value_or_empty(value) when is_map(value), do: value
+  defp map_value_or_empty(_value), do: %{}
+
+  defp value(attrs, key), do: map_value(attrs, key)
+
+  defp map_value(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+end

--- a/apps/orchard_shared/lib/orchard/cluster_management/value.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/value.ex
@@ -1,0 +1,29 @@
+defmodule Orchard.ClusterManagement.Value do
+  @moduledoc false
+
+  @spec normalize_string(term()) :: String.t() | nil
+  def normalize_string(nil), do: nil
+  def normalize_string(value) when is_atom(value), do: Atom.to_string(value)
+
+  def normalize_string(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  def normalize_string(_value), do: nil
+
+  @spec json_value(term()) :: term()
+  def json_value(nil), do: nil
+  def json_value(value) when is_boolean(value), do: value
+  def json_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  def json_value(value) when is_atom(value), do: Atom.to_string(value)
+
+  def json_value(value) when is_map(value) do
+    Map.new(value, fn {key, val} -> {key, json_value(val)} end)
+  end
+
+  def json_value(values) when is_list(values), do: Enum.map(values, &json_value/1)
+  def json_value(value), do: value
+end

--- a/apps/orchard_shared/test/fixtures/cluster_management/action_preview_v1.json
+++ b/apps/orchard_shared/test/fixtures/cluster_management/action_preview_v1.json
@@ -1,0 +1,53 @@
+{
+  "object": "cluster_management.action_preview",
+  "contract_version": "orchard.cluster_management.action_preview.v1",
+  "action": "node_admission.admit",
+  "target": {
+    "type": "node",
+    "id": "550e8400-e29b-41d4-a716-446655440000"
+  },
+  "current": {
+    "lifecycle": {
+      "state": "registered"
+    },
+    "health": {
+      "status": "healthy"
+    },
+    "freshness": {
+      "status": "fresh"
+    }
+  },
+  "active_request_count": 0,
+  "scheduler_eligibility": {
+    "eligible": false,
+    "reason_codes": [
+      "node_not_admitted"
+    ]
+  },
+  "blockers": [
+    {
+      "code": "policy_required",
+      "message": "Admission requires policy inputs.",
+      "metadata": {}
+    }
+  ],
+  "warnings": [
+    {
+      "code": "legacy_metadata",
+      "message": "Runtime metadata is partial.",
+      "metadata": {}
+    }
+  ],
+  "consequence_codes": [
+    "existing_requests_continue_until_deadline"
+  ],
+  "confirmation_requirements": [
+    "requires_reason"
+  ],
+  "expected_transition": {
+    "from": "registered",
+    "to": "admitted"
+  },
+  "audit_action": "node_admission.admit",
+  "confirmation_required": true
+}

--- a/apps/orchard_shared/test/fixtures/cluster_management/ha_lite_status_v1.json
+++ b/apps/orchard_shared/test/fixtures/cluster_management/ha_lite_status_v1.json
@@ -1,0 +1,13 @@
+{
+  "object": "cluster_management.ha_lite_status",
+  "contract_version": "orchard.cluster_management.ha_lite_status.v1",
+  "deployment_mode": "ha_lite",
+  "this_controller_identity": "controller-a",
+  "controller_role": "standby",
+  "leader_identity": "controller-b",
+  "advisory_lock_status": "not_held",
+  "lock_age_ms": 1200,
+  "last_renewed_at": "2026-07-01T00:00:00Z",
+  "standby_write_path_behavior": "writes_return_503_controller_standby",
+  "last_observed_leadership_error": null
+}

--- a/apps/orchard_shared/test/fixtures/cluster_management/node_status_v1.json
+++ b/apps/orchard_shared/test/fixtures/cluster_management/node_status_v1.json
@@ -1,0 +1,40 @@
+{
+  "object": "cluster_management.node_status",
+  "contract_version": "orchard.cluster_management.status.v1",
+  "resource": {
+    "type": "node",
+    "id": "550e8400-e29b-41d4-a716-446655440000"
+  },
+  "lifecycle": {
+    "state": "active"
+  },
+  "admission": {
+    "category": "admitted",
+    "source": "registered_node",
+    "latest_decision": "admitted"
+  },
+  "health": {
+    "status": "healthy"
+  },
+  "freshness": {
+    "status": "fresh",
+    "observed_at": "2026-07-01T00:00:00Z",
+    "source": "heartbeat"
+  },
+  "transport": {
+    "status": "reachable"
+  },
+  "runtime": {
+    "status": "ready",
+    "health_code": null,
+    "health_message": null
+  },
+  "compatibility": {
+    "status": "compatible"
+  },
+  "scheduling": {
+    "eligible": true,
+    "reason_codes": []
+  },
+  "warnings": []
+}

--- a/apps/orchard_shared/test/fixtures/cluster_management/scheduler_explanation_v1.json
+++ b/apps/orchard_shared/test/fixtures/cluster_management/scheduler_explanation_v1.json
@@ -1,0 +1,49 @@
+{
+  "object": "cluster_management.scheduler_explanation",
+  "contract_version": "orchard.cluster_management.scheduler_explanation.v1",
+  "request_id": "resp_01J00000000000000000000000",
+  "selected_node_id": "550e8400-e29b-41d4-a716-446655440000",
+  "selection_tier": "loaded",
+  "scored_candidates": [
+    {
+      "node_id": "550e8400-e29b-41d4-a716-446655440000",
+      "target_ref": "127.0.0.1:50071",
+      "eligible": true,
+      "tier": "loaded",
+      "score": 842,
+      "components": {
+        "health_bonus": 30
+      },
+      "diagnostics": {},
+      "reason_codes": []
+    }
+  ],
+  "rejected_candidates": [
+    {
+      "node_id": "660e8400-e29b-41d4-a716-446655440000",
+      "target_ref": "127.0.0.2:50071",
+      "eligible": false,
+      "tier": "loaded",
+      "score": null,
+      "components": {},
+      "diagnostics": {},
+      "reason_codes": [
+        "node_not_active"
+      ]
+    }
+  ],
+  "skipped_candidates": [
+    {
+      "node_id": "770e8400-e29b-41d4-a716-446655440000",
+      "target_ref": "127.0.0.3:50071",
+      "eligible": false,
+      "tier": "cached",
+      "score": null,
+      "components": {},
+      "diagnostics": {},
+      "reason_codes": [
+        "lower_tier_not_considered"
+      ]
+    }
+  ]
+}

--- a/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
+++ b/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
@@ -1,0 +1,120 @@
+defmodule Orchard.ClusterManagement.ContractTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.ClusterManagement.{
+    ActionPreview,
+    HALiteStatus,
+    NodeStatus,
+    ReasonCodes,
+    SchedulerExplanation
+  }
+
+  @fixture_dir Path.expand("../../fixtures/cluster_management", __DIR__)
+
+  test "reason-code vocabularies expose accepted fixed codes" do
+    assert "node_not_active" in ReasonCodes.scheduler_rejection_codes()
+    assert "lower_tier_not_considered" in ReasonCodes.scheduler_skip_codes()
+    assert "node_not_pending_admission" in ReasonCodes.action_blocker_codes()
+    assert "requires_reason" in ReasonCodes.confirmation_requirement_codes()
+    assert "active_requests_present" in ReasonCodes.consequence_codes()
+    assert "ha_lite" in ReasonCodes.support_scope_codes()
+  end
+
+  test "node status golden fixture matches shared JSON contract" do
+    fixture = fixture!("node_status_v1.json")
+    assert {:ok, status} = NodeStatus.new(fixture)
+    assert fixture == json_round_trip(NodeStatus.to_map(status))
+  end
+
+  test "action preview golden fixture separates blockers, warnings, consequences, and confirmations" do
+    fixture = fixture!("action_preview_v1.json")
+    assert {:ok, preview} = ActionPreview.new(fixture)
+
+    rendered = json_round_trip(ActionPreview.to_map(preview))
+
+    assert fixture == rendered
+    assert [%{"code" => "policy_required"}] = rendered["blockers"]
+    assert [%{"code" => "legacy_metadata"}] = rendered["warnings"]
+    assert rendered["consequence_codes"] == ["existing_requests_continue_until_deadline"]
+    assert rendered["confirmation_requirements"] == ["requires_reason"]
+  end
+
+  test "scheduler explanation golden fixture validates fixed rejected and skipped codes" do
+    fixture = fixture!("scheduler_explanation_v1.json")
+    assert {:ok, explanation} = SchedulerExplanation.new(fixture)
+    assert fixture == json_round_trip(SchedulerExplanation.to_map(explanation))
+  end
+
+  test "HA-lite golden fixture matches shared JSON contract" do
+    fixture = fixture!("ha_lite_status_v1.json")
+    assert {:ok, status} = HALiteStatus.new(fixture)
+    assert fixture == json_round_trip(HALiteStatus.to_map(status))
+  end
+
+  test "node status rejects unknown scheduling reason codes" do
+    assert {:error, {:unknown_code, :scheduler_rejection, "surprise_reason"}} =
+             NodeStatus.new(%{
+               resource: %{type: :node, id: "node-1"},
+               scheduling: %{eligible: false, reason_codes: ["surprise_reason"]}
+             })
+  end
+
+  test "scheduler explanation rejects free-text-only rejected candidates" do
+    assert {:error, :rejected_candidate_reason_codes_required} =
+             SchedulerExplanation.new(%{
+               rejected_candidates: [
+                 %{
+                   node_id: "node-1",
+                   message: "node is not active",
+                   reason_codes: []
+                 }
+               ]
+             })
+  end
+
+  test "scheduler explanation rejects unknown rejected candidate codes" do
+    assert {:error, {:unknown_code, :scheduler_rejection, "made_up"}} =
+             SchedulerExplanation.new(%{
+               rejected_candidates: [
+                 %{node_id: "node-1", reason_codes: ["made_up"]}
+               ]
+             })
+  end
+
+  test "scheduler explanation keeps skipped candidates out of rejection vocabulary" do
+    assert {:error, {:unknown_code, :scheduler_skip, "node_not_active"}} =
+             SchedulerExplanation.new(%{
+               skipped_candidates: [
+                 %{node_id: "node-1", reason_codes: ["node_not_active"]}
+               ]
+             })
+  end
+
+  test "action preview rejects confirmation requirements masquerading as blockers" do
+    assert {:error, {:unknown_code, :action_blocker, "requires_reason"}} =
+             ActionPreview.new(%{
+               blockers: [%{code: "requires_reason"}],
+               confirmation_requirements: []
+             })
+  end
+
+  test "action preview rejects unknown consequence codes" do
+    assert {:error, {:unknown_code, :consequence, "restart_everything"}} =
+             ActionPreview.new(%{
+               consequence_codes: ["restart_everything"]
+             })
+  end
+
+  defp fixture!(name) do
+    @fixture_dir
+    |> Path.join(name)
+    |> File.read!()
+    |> Jason.decode!()
+  end
+
+  defp json_round_trip(map) do
+    map
+    |> Jason.encode!()
+    |> Jason.decode!()
+  end
+end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ product/system/build contract.
   `orchardctl` but return deferred-status errors with the current supported
   path. `orchardctl support bundle create` creates a local diagnostic archive
   with bounded redacted logs, redacted config, service status, node snapshots,
-  and request summaries.
+  shared cluster-management node status, and request summaries.
 
 When this guide and `SPEC.md` disagree, treat the branch as blocked until the
 conflict is reconciled. `SPEC.md` wins until explicitly updated.

--- a/docs/decisions/0005-shared-cluster-management-contract.md
+++ b/docs/decisions/0005-shared-cluster-management-contract.md
@@ -1,0 +1,17 @@
+# Shared cluster-management contract
+
+Accepted.
+
+Cluster-management status categories, scheduler reason codes, action-preview codes, scheduler-explanation shapes, and HA-lite read-only status belong in `orchard_shared`.
+Controller code translates persisted inventory, admission candidates, runtime observations, scheduler evaluations, and control-plane state into those shared structures.
+Admin API, future Operator API, CLI JSON, Console assigns, support bundles, and tests consume the shared structures rather than inventing local reason vocabularies.
+This decision does not require the full Operator API route set, Console pending-admission workflow, or support bundle v2 archive format to land in the same slice.
+It does allow scheduler code to attach additive `scheduler_explanation` metadata to persisted scheduler decisions so support and future Operator API surfaces have a real producer.
+
+This keeps machine-readable cluster-management semantics stable across human and programmatic surfaces while allowing each surface to keep its own presentation.
+Human-readable messages may change, but fixed reason codes and documented status categories are the client contract.
+
+The trade-off is an extra controller builder layer between persistence/runtime state and rendered JSON.
+That layer is deliberate because `orchard_shared` must not depend on Ecto schemas, Phoenix presenters, Console LiveViews, CLI commands, or support-bundle writers.
+
+SPEC.md impact: no change required.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -380,6 +380,11 @@ _Avoid_: Runtime Endpoint Availability, Node Health, heartbeat freshness
 The observed condition of a Node, independent of its operator-controlled lifecycle state.
 _Avoid_: Node Lifecycle State, operator action
 
+**Cluster Management Status**:
+A shared operator-facing status contract that separates lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and HA-lite read-only signals.
+It is a cross-surface status vocabulary, not a replacement for the Node Lifecycle State machine.
+_Avoid_: Node Lifecycle State, Node Health, Console-only status label
+
 **Runtime Endpoint Availability**:
 The scheduler-facing availability of a Runtime Endpoint for new work, independent of whether the endpoint is backed by an Orchard-managed Node, external compute, or a provider integration.
 _Avoid_: Node Lifecycle State, durable cluster truth, provider billing status
@@ -485,6 +490,11 @@ _Avoid_: Quota, Routing Policy, Scheduler Explanation, tenant-facing error reaso
 **Scheduler Explanation**:
 Operator-facing reasoning for selected and rejected scheduling candidates.
 _Avoid_: persisted Scheduler Decision metadata, tenant-facing error contract
+
+**Scheduler Reason Code**:
+A stable machine-readable identifier explaining why a scheduler candidate was rejected or skipped.
+It is the programmatic contract; human-readable scheduler messages are explanatory and may change.
+_Avoid_: free-text reason, tenant-facing error message
 
 **Skipped Scheduler Candidate**:
 A scheduler candidate omitted from scoring or rejection for a stable non-error reason such as lower-priority tier selection or candidate-budget limits.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -992,11 +992,14 @@ sudo launchctl kickstart -k system/com.orchard.node-agent
 `orchardctl requests inspect` is a SPEC-required diagnostics path that returns
 deferred status in this build. `orchardctl support bundle create` creates a
 local diagnostic `.tar.gz` containing bounded redacted logs, redacted config,
-service status, node snapshots, and request summaries; use `--support-root` and
+service status, node snapshots, shared cluster-management node status, and
+request summaries; use `--support-root` and
 `--output` to point it at an isolated source-dev fixture. Use
 `--max-log-bytes` to cap each retained log tail and `--json` when scripting
 bundle creation. It records `support_bundle.generated` only when the controller
-Repo is already available. Console request views, health/readiness endpoints,
+Repo is already available. `orchardctl nodes list --json` emits the same shared
+cluster-management node status contract for scripting node inventory checks.
+Console request views, health/readiness endpoints,
 and controller or node-agent logs remain useful for interactive source-dev
 diagnostics.
 

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -31,7 +31,7 @@
 
 ## 4. CLI Parity
 
-- [ ] 4.1 Implement `orchardctl nodes list --json` with separated status categories.
+- [x] 4.1 Implement `orchardctl nodes list --json` with separated status categories.
 - [ ] 4.2 Implement `orchardctl nodes inspect <node-id> --json`.
 - [ ] 4.3 Implement `orchardctl nodes pending` or an equivalent admission-review command.
 - [ ] 4.4 Implement `orchardctl nodes admit <node-id>` with dry-run and JSON preview support.

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -21,13 +21,13 @@
 
 ## 3. Shared Status And Reason Codes
 
-- [ ] 3.1 Add shared domain structures for lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and HA-lite read-only status.
-- [ ] 3.2 Add fixed scheduler explanation rejection codes and action preview blocker codes.
+- [x] 3.1 Add shared domain structures for lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and HA-lite read-only status.
+- [x] 3.2 Add fixed scheduler explanation rejection codes and action preview blocker codes.
 - [ ] 3.3 Ensure reason codes are used by Operator API, Admin API, CLI, Console, support bundles, and tests.
-- [ ] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
-- [ ] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
-- [ ] 3.6 Ensure action preview schema fixtures include separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements` fields.
-- [ ] 3.7 Add parity tests proving CLI JSON and Console data assigns derive from the same domain structures.
+- [x] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
+- [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
+- [x] 3.6 Ensure action preview schema fixtures include separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements` fields.
+- [x] 3.7 Add parity tests proving CLI JSON and Console data assigns derive from the same domain structures.
 
 ## 4. CLI Parity
 


### PR DESCRIPTION
## Intent

Reduce PR #35 residual risk by addressing only the two No Mistakes PR-body items. First, keep the 15-30 second heartbeat window as an operator-facing stale freshness display state while preserving scheduler eligibility parity with Nodes.schedulable_nodes/0: stale active healthy nodes inside the freshness threshold should remain eligible with no node_observation_stale scheduling reason; only unreachable observations should add the scheduler-blocking node_observation_stale code. Add a regression test proving stale displays distinctly while remaining schedulable and aligned with Nodes.schedulable_nodes/0. Second, remove the inert ActionPreview reject_confirmation_blockers guard because strict action-blocker validation already rejects confirmation requirement codes before that guard can run. Keep scope tight: do not add scheduler explanation production, Console pending-admission UX, bootstrap workflows, or other cluster-management changes.

## What Changed

- Add a shared `Orchard.ClusterManagement` contract in `orchard_shared` — versioned `NodeStatus`, `HaLiteStatus`, `ActionPreview`, `SchedulerExplanation`, and `ReasonCodes` structs backed by `v1` JSON schema fixtures and a `contract_test` that pins serialization; `ActionPreview` validates action blockers strictly so confirmation-requirement codes are rejected up front.
- Add controller `StatusBuilder` that projects node and cluster-management records into the shared status contract, wired through `Orchard.Nodes` (including a new `latest_admission_decisions_for_nodes/1` query), `ControlPlane.read_only_status/0`, the node-admission presenter, and the Console nodes page; the CLI gains `orchardctl nodes list --json` plus reason-code-aware `nodes`/`support` output.
- Gate the scheduler-blocking `:node_observation_stale` reason on the unreachable-freshness cutoff so a stale-but-fresh active node surfaces a distinct display state while staying eligible in parity with `Nodes.schedulable_nodes/0`, with regression coverage in `status_builder_test`; refresh `docs/decisions/0005`, architecture/glossary/local-dev docs, and the OpenSpec tasks list.

## Risk Assessment

✅ Low: The change is a well-bounded contract-foundation slice whose every wired surface (CLI, support bundle, Admin presenter, Console) is tested, with regression coverage proving both the freshness-display/scheduler-eligibility parity against Nodes.schedulable_nodes/0 and the removed action-blocker guard; the only gaps are deliberately unwired scaffolding functions.

## Testing

Ran the targeted regression tests for both PR items (status_builder_test.exs and contract_test.exs) plus the broader cluster-management, Console nodes, and CLI nodes suites — all green. To show the behavior as an operator/API consumer actually experiences it (this is a backend status-contract change with no new UI surface — the freshness display state already existed), I built a sandboxed evidence harness that prints the serialized cluster-management status contract: it confirms a 20s-stale node renders freshness "stale" while staying schedulable and present in schedulable_nodes/0, a past-freshness-cutoff node renders "stale" but is blocked with node_observation_stale and excluded from schedulable_nodes/0, and a confirmation code sent as an action blocker is rejected by strict validation before any guard. That transcript is saved as the evidence artifact; no visual/screenshot artifact applies since the change is contract/serialization logic rather than a rendered surface.

<details>
<summary>Evidence: Operator-facing cluster-management status contract transcript (both freshness scenarios + ActionPreview rejection)</summary>

<code>ITEM 1a STALE DISPLAY, STILL SCHEDULABLE (freshness=30s gate, unreachable=15s, heartbeat 20s old):&#10;freshness.status = &#34;stale&#34; scheduling.eligible = true reason_codes = []&#10;Nodes.schedulable_nodes/0 includes node? true&#10;&#10;ITEM 1b PAST FRESHNESS CUTOFF, BLOCKED (freshness=15s gate, unreachable=60s, heartbeat 30s old):&#10;freshness.status = &#34;stale&#34; scheduling.eligible = false reason_codes = [&#34;node_observation_stale&#34;]&#10;Nodes.schedulable_nodes/0 result: [] (parity)&#10;&#10;ITEM 2 STRICT VALIDATION REJECTS CONFIRMATION-AS-BLOCKER:&#10;ActionPreview.new(blockers: [requires_reason]) =&gt; {:error, {:unknown_code, :action_blocker, &#34;requires_reason&#34;}}&#10;ActionPreview.new(valid blocker + confirmation_requirement) =&gt; ok? true</code>

```text
==> orchard_controller
Running ExUnit with seed: 925530, max_cases: 16


================ ITEM 1a: STALE DISPLAY, STILL SCHEDULABLE ================
Config: freshness_threshold=30s (scheduling gate), unreachable=15s
Node heartbeat age: 20s ago (past display-stale cutoff, inside scheduling gate)

freshness.status         = "stale"   <- operator sees STALE
scheduling.eligible      = true   <- still schedulable
scheduling.reason_codes  = []   <- no node_observation_stale
Nodes.schedulable_nodes/0 includes this node? true

================ ITEM 1b: PAST FRESHNESS CUTOFF, BLOCKED ================
Config: freshness_threshold=15s (scheduling gate), unreachable=60s
Node heartbeat age: 30s ago (past scheduling gate, inside unreachable window)

freshness.status         = "stale"   <- operator sees STALE (display)
scheduling.eligible      = false   <- blocked from scheduling
scheduling.reason_codes  = ["node_observation_stale"]   <- node_observation_stale added
Nodes.schedulable_nodes/0 result: []   <- empty (parity)

================ ITEM 2: STRICT VALIDATION REJECTS CONFIRMATION-AS-BLOCKER ================
A confirmation-requirement code passed as an action blocker is rejected by
strict action-blocker validation BEFORE any confirmation guard could run.

ActionPreview.new(blockers: [requires_reason]) => {:error, {:unknown_code, :action_blocker, "requires_reason"}}
ActionPreview.new(valid blocker + confirmation_requirement) => ok? true
=========================================================================================

.
Finished in 0.08 seconds (0.00s async, 0.08s sync)

Result: 1 passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex:267` - The scheduler-eligibility parity that this PR promises with Nodes.schedulable_nodes/0 holds only when node_freshness_threshold_ms &gt;= node_unreachable_threshold_ms. schedulable_nodes/0 excludes nodes whose heartbeat age exceeds node_freshness_threshold_ms, but StatusBuilder only adds the scheduler-blocking :node_observation_stale code when freshness/1 returns :unreachable — i.e. when age exceeds max(freshness_ms, unreachable_ms) (status_builder.ex:220,267). Both thresholds are independently operator-configurable via ORCHARD_NODE_FRESHNESS_THRESHOLD_MS / ORCHARD_NODE_UNREACHABLE_THRESHOLD_MS (config/runtime.exs:814-815) with no invariant enforced. Under the default (30000 &gt;= 15000) they coincide, but if an operator sets unreachable longer than freshness (arguably the more intuitive ordering), any node whose heartbeat age falls in (freshness_ms, unreachable_ms] is dropped by schedulable_nodes/0 yet reported as scheduling.eligible == true by the status contract — a false operator-facing &#39;schedulable&#39; signal contradicting the stated parity. Consider gating :node_observation_stale on the freshness_ms cutoff directly (or documenting/enforcing freshness_ms &gt;= unreachable_ms).

🔧 Fix: gate scheduling freshness on freshness_ms to match schedulable_nodes
2 infos still open:
- ℹ️ `apps/orchard_controller/lib/orchard/cluster_management/status_builder.ex:118` - `runtime_target_status/1` and `runtime_target_status_map/1` (plus their `runtime_transport`/`runtime_readiness`/`runtime_compatibility`/`runtime_health_status`/`runtime_warnings`/`target_ref` helper chain, ~50 lines) have no production callers and no direct test coverage. The branching logic here (e.g. transport clause ordering where `%{status: :ok}` short-circuits before the `identity_mismatch` code check) could regress silently when a future runtime-target surface wires it. This is intended contract scaffolding per docs/decisions/0005, so it is not a merge blocker — noting the coverage gap only.
- ℹ️ `apps/orchard_controller/lib/orchard/control_plane.ex:22` - `Orchard.ControlPlane.read_only_status/0` is new production code (role normalization + deployment-mode/standby-behavior mapping) with no caller and no test; only the underlying `HALiteStatus` struct is exercised via the shared contract test. Same deliberate-scaffolding rationale as the runtime-target builder (future Operator API producer per decision 0005); informational.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`PGDATABASE_TEST=orchard_test_nm_2b20bc518d75 mise exec -- mix test apps/orchard_shared/test/orchard/cluster_management/contract_test.exs` (11 passed; includes contract_test.exs:93 &#39;action preview rejects confirmation requirements masquerading as blockers&#39;)</code>
- <code>`PGDATABASE_TEST=orchard_test_nm_2b20bc518d75 mise exec -- mix test apps/orchard_controller/test/orchard/cluster_management/status_builder_test.exs` (8 passed; includes status_builder_test.exs:60 stale-but-schedulable + :81 past-cutoff-blocked, both asserting Nodes.schedulable_nodes/0 parity)</code>
- <code>Broader affected slice: `mix test apps/orchard_shared/test/orchard/cluster_management/ apps/orchard_controller/test/orchard/cluster_management/ apps/orchard_controller/test/orchard/console/nodes_live_test.exs apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs` (61 + 11 passed)</code>
- <code>Authored and ran a temporary DataCase-sandboxed evidence harness that inserted active/healthy nodes at 20s and 30s heartbeat ages under two freshness/unreachable threshold configs and printed the real StatusBuilder.node_status_map contract, Nodes.schedulable_nodes/0 results, and ActionPreview.new/1 rejection; captured output then removed the harness (worktree verified clean via `git status --porcelain`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
