### PR TITLE
feat(orchard_cli): add node admission review CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,13 @@ An initial cluster-admin `/admin/v1` node-admission surface (candidate review, r
 The roadmap and target behavior are governed by `SPEC.md` §14.
 
 Some SPEC-required CLI paths are present before their milestone implementation:
-`orchardctl cluster init`, `orchardctl node join`, `orchardctl nodes admit`,
-and `orchardctl requests inspect` return command-specific deferred-status
-errors with the current supported path. `orchardctl support bundle create`
+`orchardctl cluster init`, `orchardctl node join`, and
+`orchardctl requests inspect` return command-specific deferred-status errors
+with the current supported path. `orchardctl nodes inspect`,
+`orchardctl nodes pending`, `orchardctl nodes admit`, and
+`orchardctl nodes reject` are implemented for the current node-admission-review
+slice, with stable JSON and human output, `--dry-run` previews, and
+`--yes`/`--reason` execution gating. `orchardctl support bundle create`
 creates a local diagnostic `.tar.gz` with bounded redacted logs, redacted
 config, service status, node snapshots, shared cluster-management node
 status, and request summaries.

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -12,8 +12,10 @@ This README is orientation only. Normative CLI requirements live in
 - Operator commands for environment, transport, migrations, status, start/stop,
   upgrades, tenants, API keys, API Client bulk provisioning, nodes, and models.
 - SPEC-required future command paths that return explicit deferred status until
-  their milestones land: `cluster init`, `node join`, `nodes admit`,
-  and `requests inspect`.
+  their milestones land: `cluster init`, `node join`, and `requests inspect`.
+- Node-admission-review commands (`nodes inspect`, `nodes pending`,
+  `nodes admit`, `nodes reject`) with stable JSON and human output, `--dry-run`
+  previews, and `--yes`/`--reason` execution gating.
 - Local diagnostic support bundle creation via `support bundle create`.
 - Bulk API Client provisioning through `api-clients bulk-provision`, including
   Dry Run, all-or-nothing Apply, output preflight, Key Rotation, and One-time

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -1,29 +1,12 @@
 defmodule OrchardCLI.Commands.Nodes do
   @moduledoc """
   CLI handler for `orchardctl nodes` commands.
-
-  Supports:
-    orchardctl nodes list
-    orchardctl nodes admit (deferred status; SPEC.md 11.9)
   """
 
-  alias Orchard.ClusterManagement.{NodeStatus, StatusBuilder}
+  alias Orchard.API.Admin.NodeAdmissionPresenter
+  alias Orchard.ClusterManagement.{ActionPreview, ActionPreviewBuilder, NodeStatus, StatusBuilder}
+  alias Orchard.ControlPlane
   alias Orchard.Nodes
-  alias OrchardCLI.Commands.Deferred
-
-  @deferred_commands [
-    %{
-      path: ["admit"],
-      usage: "orchardctl nodes admit",
-      summary: "Admit a pending node into the cluster (SPEC.md 11.9).",
-      status:
-        "Defined by SPEC.md 11.9 for node lifecycle work; not implemented in the current build.",
-      guidance: [
-        "Use orchardctl nodes list to inspect registered nodes that already report to the controller.",
-        "For current source-dev multi-node testing, configure ORCHARD_RUNTIME_CLIENT_TARGETS as documented in docs/local-dev.md."
-      ]
-    }
-  ]
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(args) do
@@ -31,13 +14,367 @@ defmodule OrchardCLI.Commands.Nodes do
       ["list"] -> run_list()
       ["list", "--json"] -> run_list_json()
       ["list", "--help"] -> {:ok, list_usage()}
-      ["admit" | rest] -> Deferred.run(["admit" | rest], deferred_spec())
       ["help"] -> {:ok, group_usage()}
       ["--help"] -> {:ok, group_usage()}
       [] -> {:error, group_usage(), 1}
-      _ -> {:error, group_usage(), 1}
+      [command | rest] -> run_command(command, rest)
     end
   end
+
+  defp run_command("inspect", rest), do: run_inspect(rest)
+  defp run_command("pending", rest), do: run_pending(rest)
+  defp run_command("admit", rest), do: run_admit(rest)
+  defp run_command("reject", rest), do: run_reject(rest)
+  defp run_command(_command, _rest), do: {:error, group_usage(), 1}
+
+  defp run_inspect(["--help"]), do: {:ok, inspect_usage()}
+  defp run_inspect(["help"]), do: {:ok, inspect_usage()}
+
+  defp run_inspect(args) do
+    with {:ok, %{id: node_id, json?: json?}} <- parse_inspect_args(args),
+         {:ok, node} <- Nodes.fetch_node(node_id) do
+      output = NodeAdmissionPresenter.node(node)
+      {:ok, render_node(output, json?)}
+    else
+      {:error, :node_not_found} -> {:error, "Error: node not found.", 1}
+      {:error, message, code} -> {:error, message, code}
+    end
+  end
+
+  defp run_pending(["--help"]), do: {:ok, pending_usage()}
+  defp run_pending(["help"]), do: {:ok, pending_usage()}
+
+  defp run_pending(args) do
+    with {:ok, %{json?: json?}} <- parse_pending_args(args) do
+      candidates = Nodes.list_admission_candidates()
+      output = NodeAdmissionPresenter.list_candidates(candidates)
+      {:ok, render_pending(output, json?)}
+    end
+  end
+
+  defp run_admit(["--help"]), do: {:ok, admit_usage()}
+  defp run_admit(["help"]), do: {:ok, admit_usage()}
+
+  defp run_admit(args) do
+    with {:ok, opts} <- parse_admit_args(args) do
+      preview = ActionPreviewBuilder.admit_node(opts.id, opts.attrs)
+
+      cond do
+        opts.dry_run? ->
+          {:ok, render_preview(preview, opts.json?)}
+
+        preview_blocked?(preview) or not opts.yes? ->
+          confirmation_error(preview, opts.json?, :admit)
+
+        true ->
+          execute_admit(opts)
+      end
+    end
+  end
+
+  defp run_reject(["--help"]), do: {:ok, reject_usage()}
+  defp run_reject(["help"]), do: {:ok, reject_usage()}
+
+  defp run_reject(args) do
+    with {:ok, opts} <- parse_reject_args(args) do
+      preview = ActionPreviewBuilder.reject_admission(opts.id, opts.attrs)
+
+      cond do
+        opts.dry_run? ->
+          {:ok, render_preview(preview, opts.json?)}
+
+        preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) ->
+          confirmation_error(preview, opts.json?, :reject)
+
+        true ->
+          execute_reject(opts)
+      end
+    end
+  end
+
+  defp execute_admit(opts) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, result} <- Nodes.admit_node(opts.id, opts.attrs) do
+      output = NodeAdmissionPresenter.admit_result(result)
+      {:ok, render_action_result(output, opts.json?)}
+    else
+      {:error, reason} -> action_error(reason, opts.json?)
+    end
+  end
+
+  defp execute_reject(opts) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, result} <- Nodes.reject_admission(opts.id, opts.attrs) do
+      output = NodeAdmissionPresenter.reject_result(result)
+      {:ok, render_action_result(output, opts.json?)}
+    else
+      {:error, reason} -> action_error(reason, opts.json?)
+    end
+  end
+
+  defp parse_inspect_args(args) do
+    case OptionParser.parse(args, strict: [json: :boolean, help: :boolean]) do
+      {opts, [node_id], []} ->
+        if Keyword.get(opts, :help, false) do
+          {:error, inspect_usage(), 0}
+        else
+          {:ok, %{id: node_id, json?: Keyword.get(opts, :json, false)}}
+        end
+
+      {_opts, _rest, [{flag, _value} | _unknown]} ->
+        unknown_option(flag)
+
+      _other ->
+        {:error, inspect_usage(), 1}
+    end
+  end
+
+  defp parse_pending_args(args) do
+    case OptionParser.parse(args, strict: [json: :boolean, help: :boolean]) do
+      {opts, [], []} ->
+        if Keyword.get(opts, :help, false) do
+          {:error, pending_usage(), 0}
+        else
+          {:ok, %{json?: Keyword.get(opts, :json, false)}}
+        end
+
+      {_opts, _rest, [{flag, _value} | _unknown]} ->
+        unknown_option(flag)
+
+      _other ->
+        {:error, pending_usage(), 1}
+    end
+  end
+
+  defp parse_admit_args(args) do
+    case OptionParser.parse(args, strict: admit_switches()) do
+      {opts, [node_id], []} ->
+        if Keyword.get(opts, :help, false) do
+          {:error, admit_usage(), 0}
+        else
+          {:ok,
+           %{
+             id: node_id,
+             json?: Keyword.get(opts, :json, false),
+             dry_run?: Keyword.get(opts, :dry_run, false),
+             yes?: Keyword.get(opts, :yes, false),
+             attrs: admission_attrs(opts)
+           }}
+        end
+
+      {_opts, _rest, [{flag, _value} | _unknown]} ->
+        unknown_option(flag)
+
+      _other ->
+        {:error, admit_usage(), 1}
+    end
+  end
+
+  defp parse_reject_args(args) do
+    case OptionParser.parse(args, strict: reject_switches()) do
+      {opts, [target_id], []} ->
+        if Keyword.get(opts, :help, false) do
+          {:error, reject_usage(), 0}
+        else
+          {:ok,
+           %{
+             id: target_id,
+             json?: Keyword.get(opts, :json, false),
+             dry_run?: Keyword.get(opts, :dry_run, false),
+             yes?: Keyword.get(opts, :yes, false),
+             attrs: reject_attrs(opts)
+           }}
+        end
+
+      {_opts, _rest, [{flag, _value} | _unknown]} ->
+        unknown_option(flag)
+
+      _other ->
+        {:error, reject_usage(), 1}
+    end
+  end
+
+  defp admit_switches do
+    [
+      dry_run: :boolean,
+      help: :boolean,
+      json: :boolean,
+      pool: :string,
+      pool_id: :string,
+      policy_ref: :string,
+      routing_policy_id: :string,
+      trust_evidence_ref: :string,
+      trust_ref: :string,
+      yes: :boolean
+    ]
+  end
+
+  defp reject_switches do
+    [
+      dry_run: :boolean,
+      help: :boolean,
+      json: :boolean,
+      reason: :string,
+      yes: :boolean
+    ]
+  end
+
+  defp admission_attrs(opts) do
+    %{}
+    |> put_opt(opts, :trust_evidence_ref)
+    |> put_opt(opts, :trust_ref)
+    |> put_opt(opts, :pool_id)
+    |> put_opt(opts, :pool)
+    |> put_opt(opts, :routing_policy_id)
+    |> put_opt(opts, :policy_ref)
+  end
+
+  defp reject_attrs(opts), do: put_opt(%{}, opts, :reason)
+
+  defp put_opt(attrs, opts, key) do
+    case Keyword.get(opts, key) do
+      nil -> attrs
+      value -> Map.put(attrs, Atom.to_string(key), value)
+    end
+  end
+
+  defp unknown_option(flag), do: {:error, "Unknown option: --#{flag}", 2}
+
+  defp confirmation_error(%ActionPreview{} = preview, true, _action) do
+    {:error, render_preview(preview, true), 2}
+  end
+
+  defp confirmation_error(%ActionPreview{} = preview, false, action) do
+    message =
+      if preview_blocked?(preview) do
+        "Error: #{action_name(action)} cannot execute because preview blockers are present."
+      else
+        "Error: #{action_name(action)} requires --yes before execution."
+      end
+
+    {:error, message <> "\n\n" <> render_preview(preview, false), 2}
+  end
+
+  defp action_name(:admit), do: "node admission"
+  defp action_name(:reject), do: "node admission rejection"
+
+  defp action_error(reason, true) do
+    {:error, Jason.encode!(%{object: "error", code: Atom.to_string(reason)}, pretty: true), 1}
+  end
+
+  defp action_error(reason, false), do: {:error, "Error: #{human_reason(reason)}", 1}
+
+  defp human_reason(:admission_not_pending), do: "admission is not pending."
+  defp human_reason(:admission_rejected), do: "admission rejection must be cleared first."
+  defp human_reason(:controller_standby), do: "this controller is in standby mode."
+  defp human_reason(:inventory_missing), do: "registered node inventory is missing."
+  defp human_reason(:node_not_found), do: "node was not found."
+  defp human_reason(:node_not_pending_admission), do: "node is not pending admission."
+  defp human_reason(:node_not_registered), do: "node is not registered."
+  defp human_reason(:policy_required), do: "required policy inputs are missing."
+  defp human_reason(:pool_required), do: "node pool assignment is required."
+  defp human_reason(:reason_required), do: "a nonblank rejection reason is required."
+  defp human_reason(:trust_not_established), do: "node trust evidence is required."
+  defp human_reason(reason), do: "#{reason}."
+
+  defp preview_blocked?(%ActionPreview{blockers: blockers}), do: blockers != []
+
+  defp reason_missing?(attrs) do
+    case Map.get(attrs, "reason") do
+      reason when is_binary(reason) -> String.trim(reason) == ""
+      _other -> true
+    end
+  end
+
+  defp render_node(node, true), do: encode_json(node)
+
+  defp render_node(node, false) do
+    status = node.status
+
+    Enum.join(
+      [
+        "Node #{node.id}",
+        "Display name: #{node.display_name}",
+        "Hostname: #{node.hostname}",
+        "State: #{node.state}",
+        "Health: #{node.health}",
+        "Admission: #{get_in(status, [:admission, :category])}",
+        "Scheduling: #{format_scheduling(get_in(status, [:scheduling]))}"
+      ],
+      "\n"
+    )
+  end
+
+  defp render_pending(%{data: []}, false), do: "No admission candidates pending review."
+  defp render_pending(output, true), do: encode_json(pending_payload(output))
+
+  defp render_pending(output, false) do
+    output.data
+    |> Enum.map_join("\n", fn candidate ->
+      status = candidate.status
+
+      "#{candidate.id}  #{candidate.admission_category}  #{candidate.target_ref || "-"}  " <>
+        "#{format_scheduling(get_in(status, [:scheduling]))}"
+    end)
+  end
+
+  defp pending_payload(output) do
+    %{
+      object: "cluster_management.node_admission_review",
+      contract_version: NodeStatus.contract_version(),
+      data: output.data
+    }
+  end
+
+  defp render_preview(%ActionPreview{} = preview, true) do
+    preview
+    |> ActionPreview.to_map()
+    |> encode_json()
+  end
+
+  defp render_preview(%ActionPreview{} = preview, false) do
+    map = ActionPreview.to_map(preview)
+
+    Enum.join(
+      [
+        "Action: #{map.action}",
+        "Target: #{get_in(map, [:target, :type])}:#{get_in(map, [:target, :id])}",
+        "Blockers: #{format_codes(map.blockers, :code)}",
+        "Confirmation requirements: #{format_codes(map.confirmation_requirements)}",
+        "Expected transition: #{get_in(map, [:expected_transition, :from]) || "-"} -> #{get_in(map, [:expected_transition, :to]) || "-"}"
+      ],
+      "\n"
+    )
+  end
+
+  defp render_action_result(output, true), do: encode_json(output)
+
+  defp render_action_result(%{action: "node_admission.admitted", node: node}, false) do
+    "Admitted node #{node.id}. State: #{node.state}."
+  end
+
+  defp render_action_result(%{action: "node_admission.rejected", candidate: candidate}, false) do
+    "Rejected admission candidate #{candidate.id}."
+  end
+
+  defp encode_json(payload), do: Jason.encode!(payload, pretty: true)
+
+  defp format_scheduling(nil), do: "unknown"
+
+  defp format_scheduling(%{eligible: true}), do: "eligible"
+
+  defp format_scheduling(%{reason_codes: codes}) do
+    "blocked (#{Enum.join(codes, ", ")})"
+  end
+
+  defp format_codes([], _key), do: "none"
+
+  defp format_codes(values, key) do
+    Enum.map_join(values, ", ", &Map.fetch!(&1, key))
+  end
+
+  defp format_codes([]), do: "none"
+  defp format_codes(values), do: Enum.join(values, ", ")
 
   # NOTE: list_nodes/0 and summary/0 gracefully degrade to []/zero when the
   # repo is unavailable. The CLI cannot distinguish "no nodes" from "DB down".
@@ -66,12 +403,8 @@ defmodule OrchardCLI.Commands.Nodes do
       summary: Nodes.summary()
     }
 
-    {:ok, Jason.encode!(payload, pretty: true)}
+    {:ok, encode_json(payload)}
   end
-
-  # ---------------------------------------------------------------------------
-  # Summary formatting
-  # ---------------------------------------------------------------------------
 
   defp format_summary(summary) do
     by_health = summary.by_health
@@ -83,10 +416,6 @@ defmodule OrchardCLI.Commands.Nodes do
       "unhealthy=#{by_health[:unhealthy] || 0} " <>
       "unreachable=#{by_health[:unreachable] || 0}"
   end
-
-  # ---------------------------------------------------------------------------
-  # Table formatting
-  # ---------------------------------------------------------------------------
 
   @columns [
     {:id, "NODE ID"},
@@ -101,8 +430,6 @@ defmodule OrchardCLI.Commands.Nodes do
   defp format_table(nodes) do
     rows = Enum.map(nodes, &format_row/1)
     headers = Enum.map(@columns, fn {_key, header} -> header end)
-
-    # Compute column widths
     all_rows = [headers | rows]
 
     widths =
@@ -113,7 +440,6 @@ defmodule OrchardCLI.Commands.Nodes do
         |> Enum.max()
       end)
 
-    # Render
     header_line = format_row_cells(headers, widths)
     separator = Enum.map_join(widths, "  ", &String.duplicate("-", &1))
     data_lines = Enum.map_join(rows, "\n", &format_row_cells(&1, widths))
@@ -133,14 +459,12 @@ defmodule OrchardCLI.Commands.Nodes do
 
   defp format_field(:last_heartbeat_at, node) do
     case node.last_heartbeat_at do
-      nil -> "—"
+      nil -> "-"
       %DateTime{} = dt -> DateTime.to_iso8601(dt)
     end
   end
 
-  defp format_field(:agent_version, node) do
-    node.agent_version || "—"
-  end
+  defp format_field(:agent_version, node), do: node.agent_version || "-"
 
   defp format_row_cells(cells, widths) do
     cells
@@ -148,24 +472,21 @@ defmodule OrchardCLI.Commands.Nodes do
     |> Enum.map_join("  ", fn {cell, width} -> String.pad_trailing(cell, width) end)
   end
 
-  # ---------------------------------------------------------------------------
-  # Usage
-  # ---------------------------------------------------------------------------
-
   defp group_usage do
     Enum.join(
       [
         "Usage: orchardctl nodes <command>",
         "",
         "Commands:",
-        "  list   List registered nodes",
-        "  admit  Admit a pending node into the cluster (SPEC.md 11.9; not implemented)"
+        "  list     List registered nodes",
+        "  inspect  Inspect one node",
+        "  pending  Review pending or rejected node admission candidates",
+        "  admit    Admit a registered pending node into the cluster",
+        "  reject   Reject pending node admission"
       ],
       "\n"
     )
   end
-
-  defp deferred_spec, do: %{name: "nodes", commands: @deferred_commands}
 
   defp list_usage do
     Enum.join(
@@ -173,6 +494,52 @@ defmodule OrchardCLI.Commands.Nodes do
         "Usage: orchardctl nodes list [--json]",
         "",
         "Lists all registered nodes with state, health, and agent version."
+      ],
+      "\n"
+    )
+  end
+
+  defp inspect_usage do
+    Enum.join(
+      [
+        "Usage: orchardctl nodes inspect <node-id> [--json]",
+        "",
+        "Shows one node with shared cluster-management status categories."
+      ],
+      "\n"
+    )
+  end
+
+  defp pending_usage do
+    Enum.join(
+      [
+        "Usage: orchardctl nodes pending [--json]",
+        "",
+        "Lists admission candidates pending review or rejected for review follow-up."
+      ],
+      "\n"
+    )
+  end
+
+  defp admit_usage do
+    Enum.join(
+      [
+        "Usage: orchardctl nodes admit <node-id> [--dry-run] [--json] [--yes] --trust-evidence-ref REF --pool-id ID --routing-policy-id ID",
+        "",
+        "Previews or admits a registered pending node.",
+        "Execution requires --yes and a preview with no blockers."
+      ],
+      "\n"
+    )
+  end
+
+  defp reject_usage do
+    Enum.join(
+      [
+        "Usage: orchardctl nodes reject <node-id|candidate-id> [--dry-run] [--json] [--yes] --reason REASON",
+        "",
+        "Previews or rejects pending node admission.",
+        "Execution requires --yes, --reason, and a preview with no blockers."
       ],
       "\n"
     )

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -7,6 +7,7 @@ defmodule OrchardCLI.Commands.Nodes do
   alias Orchard.ClusterManagement.{ActionPreview, ActionPreviewBuilder, NodeStatus, StatusBuilder}
   alias Orchard.ControlPlane
   alias Orchard.Nodes
+  alias Orchard.Nodes.AdmissionCandidate
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(args) do
@@ -46,7 +47,11 @@ defmodule OrchardCLI.Commands.Nodes do
 
   defp run_pending(args) do
     with {:ok, %{json?: json?}} <- parse_pending_args(args) do
-      candidates = Nodes.list_admission_candidates()
+      candidates =
+        Nodes.list_admission_candidates(
+          admission_category: AdmissionCandidate.review_categories()
+        )
+
       output = NodeAdmissionPresenter.list_candidates(candidates)
       {:ok, render_pending(output, json?)}
     end
@@ -64,7 +69,7 @@ defmodule OrchardCLI.Commands.Nodes do
           {:ok, render_preview(preview, opts.json?)}
 
         preview_blocked?(preview) or not opts.yes? ->
-          confirmation_error(preview, opts.json?, :admit)
+          confirmation_error(preview, opts, :admit)
 
         true ->
           execute_admit(opts)
@@ -84,7 +89,7 @@ defmodule OrchardCLI.Commands.Nodes do
           {:ok, render_preview(preview, opts.json?)}
 
         preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) ->
-          confirmation_error(preview, opts.json?, :reject)
+          confirmation_error(preview, opts, :reject)
 
         true ->
           execute_reject(opts)
@@ -240,29 +245,44 @@ defmodule OrchardCLI.Commands.Nodes do
 
   defp unknown_option(flag), do: {:error, "Unknown option: --#{flag}", 2}
 
-  defp confirmation_error(%ActionPreview{} = preview, true, _action) do
+  defp confirmation_error(%ActionPreview{} = preview, %{json?: true}, _action) do
     {:error, render_preview(preview, true), 2}
   end
 
-  defp confirmation_error(%ActionPreview{} = preview, false, action) do
-    message =
-      if preview_blocked?(preview) do
-        "Error: #{action_name(action)} cannot execute because preview blockers are present."
-      else
-        "Error: #{action_name(action)} requires --yes before execution."
-      end
-
+  defp confirmation_error(%ActionPreview{} = preview, opts, action) do
+    message = confirmation_message(preview, opts, action)
     {:error, message <> "\n\n" <> render_preview(preview, false), 2}
+  end
+
+  defp confirmation_message(preview, opts, action) do
+    cond do
+      preview_blocked?(preview) ->
+        "Error: #{action_name(action)} cannot execute because preview blockers are present."
+
+      not opts.yes? ->
+        "Error: #{action_name(action)} requires --yes before execution."
+
+      true ->
+        "Error: #{action_name(action)} requires a nonblank --reason before execution."
+    end
   end
 
   defp action_name(:admit), do: "node admission"
   defp action_name(:reject), do: "node admission rejection"
 
-  defp action_error(reason, true) do
+  defp action_error(reason, true) when is_atom(reason) do
     {:error, Jason.encode!(%{object: "error", code: Atom.to_string(reason)}, pretty: true), 1}
   end
 
-  defp action_error(reason, false), do: {:error, "Error: #{human_reason(reason)}", 1}
+  defp action_error(_reason, true) do
+    {:error, Jason.encode!(%{object: "error", code: "action_failed"}, pretty: true), 1}
+  end
+
+  defp action_error(reason, false) when is_atom(reason),
+    do: {:error, "Error: #{human_reason(reason)}", 1}
+
+  defp action_error(_reason, false),
+    do: {:error, "Error: the admission action could not be completed.", 1}
 
   defp human_reason(:admission_not_pending), do: "admission is not pending."
   defp human_reason(:admission_rejected), do: "admission rejection must be cleared first."

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -65,18 +65,23 @@ defmodule OrchardCLI.Commands.Nodes do
 
   defp run_admit(args) do
     case parse_admit_args(args) do
+      {:ok, %{dry_run?: true} = opts} ->
+        preview =
+          guarded_preview(
+            fn -> ActionPreviewBuilder.admit_node(opts.id, opts.attrs) end,
+            :admit,
+            opts.id
+          )
+
+        {:ok, render_preview(preview, opts.json?)}
+
       {:ok, opts} ->
         preview = ActionPreviewBuilder.admit_node(opts.id, opts.attrs)
 
-        cond do
-          opts.dry_run? ->
-            {:ok, render_preview(preview, opts.json?)}
-
-          preview_blocked?(preview) or not opts.yes? ->
-            confirmation_error(preview, opts, :admit)
-
-          true ->
-            execute_admit(opts)
+        if preview_blocked?(preview) or not opts.yes? do
+          confirmation_error(preview, opts, :admit)
+        else
+          execute_admit(opts)
         end
 
       {:help, usage} ->
@@ -92,18 +97,23 @@ defmodule OrchardCLI.Commands.Nodes do
 
   defp run_reject(args) do
     case parse_reject_args(args) do
+      {:ok, %{dry_run?: true} = opts} ->
+        preview =
+          guarded_preview(
+            fn -> ActionPreviewBuilder.reject_admission(opts.id, opts.attrs) end,
+            :reject,
+            opts.id
+          )
+
+        {:ok, render_preview(preview, opts.json?)}
+
       {:ok, opts} ->
         preview = ActionPreviewBuilder.reject_admission(opts.id, opts.attrs)
 
-        cond do
-          opts.dry_run? ->
-            {:ok, render_preview(preview, opts.json?)}
-
-          preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) ->
-            confirmation_error(preview, opts, :reject)
-
-          true ->
-            execute_reject(opts)
+        if preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) do
+          confirmation_error(preview, opts, :reject)
+        else
+          execute_reject(opts)
         end
 
       {:help, usage} ->
@@ -147,6 +157,10 @@ defmodule OrchardCLI.Commands.Nodes do
       end,
       []
     )
+  end
+
+  defp guarded_preview(build_fun, action, target_id) do
+    guarded_read(build_fun, ActionPreviewBuilder.not_found_preview(action, target_id))
   end
 
   defp guarded_read(fun, fallback) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -243,7 +243,7 @@ defmodule OrchardCLI.Commands.Nodes do
     end
   end
 
-  defp unknown_option(flag), do: {:error, "Unknown option: --#{flag}", 2}
+  defp unknown_option(flag), do: {:error, "Unknown option: #{flag}", 2}
 
   defp confirmation_error(%ActionPreview{} = preview, %{json?: true}, _action) do
     {:error, render_preview(preview, true), 2}

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -33,11 +33,12 @@ defmodule OrchardCLI.Commands.Nodes do
 
   defp run_inspect(args) do
     with {:ok, %{id: node_id, json?: json?}} <- parse_inspect_args(args),
-         {:ok, node} <- Nodes.fetch_node(node_id) do
+         {:ok, node} <- guarded_fetch_node(node_id) do
       output = NodeAdmissionPresenter.node(node)
       {:ok, render_node(output, json?)}
     else
       {:error, :node_not_found} -> {:error, "Error: node not found.", 1}
+      {:help, usage} -> {:ok, usage}
       {:error, message, code} -> {:error, message, code}
     end
   end
@@ -46,14 +47,16 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_pending(["help"]), do: {:ok, pending_usage()}
 
   defp run_pending(args) do
-    with {:ok, %{json?: json?}} <- parse_pending_args(args) do
-      candidates =
-        Nodes.list_admission_candidates(
-          admission_category: AdmissionCandidate.review_categories()
-        )
+    case parse_pending_args(args) do
+      {:ok, %{json?: json?}} ->
+        output = NodeAdmissionPresenter.list_candidates(guarded_pending_candidates())
+        {:ok, render_pending(output, json?)}
 
-      output = NodeAdmissionPresenter.list_candidates(candidates)
-      {:ok, render_pending(output, json?)}
+      {:help, usage} ->
+        {:ok, usage}
+
+      {:error, message, code} ->
+        {:error, message, code}
     end
   end
 
@@ -61,19 +64,26 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_admit(["help"]), do: {:ok, admit_usage()}
 
   defp run_admit(args) do
-    with {:ok, opts} <- parse_admit_args(args) do
-      preview = ActionPreviewBuilder.admit_node(opts.id, opts.attrs)
+    case parse_admit_args(args) do
+      {:ok, opts} ->
+        preview = ActionPreviewBuilder.admit_node(opts.id, opts.attrs)
 
-      cond do
-        opts.dry_run? ->
-          {:ok, render_preview(preview, opts.json?)}
+        cond do
+          opts.dry_run? ->
+            {:ok, render_preview(preview, opts.json?)}
 
-        preview_blocked?(preview) or not opts.yes? ->
-          confirmation_error(preview, opts, :admit)
+          preview_blocked?(preview) or not opts.yes? ->
+            confirmation_error(preview, opts, :admit)
 
-        true ->
-          execute_admit(opts)
-      end
+          true ->
+            execute_admit(opts)
+        end
+
+      {:help, usage} ->
+        {:ok, usage}
+
+      {:error, message, code} ->
+        {:error, message, code}
     end
   end
 
@@ -81,19 +91,26 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_reject(["help"]), do: {:ok, reject_usage()}
 
   defp run_reject(args) do
-    with {:ok, opts} <- parse_reject_args(args) do
-      preview = ActionPreviewBuilder.reject_admission(opts.id, opts.attrs)
+    case parse_reject_args(args) do
+      {:ok, opts} ->
+        preview = ActionPreviewBuilder.reject_admission(opts.id, opts.attrs)
 
-      cond do
-        opts.dry_run? ->
-          {:ok, render_preview(preview, opts.json?)}
+        cond do
+          opts.dry_run? ->
+            {:ok, render_preview(preview, opts.json?)}
 
-        preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) ->
-          confirmation_error(preview, opts, :reject)
+          preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) ->
+            confirmation_error(preview, opts, :reject)
 
-        true ->
-          execute_reject(opts)
-      end
+          true ->
+            execute_reject(opts)
+        end
+
+      {:help, usage} ->
+        {:ok, usage}
+
+      {:error, message, code} ->
+        {:error, message, code}
     end
   end
 
@@ -117,11 +134,42 @@ defmodule OrchardCLI.Commands.Nodes do
     end
   end
 
+  defp guarded_fetch_node(node_id) do
+    guarded_read(fn -> Nodes.fetch_node(node_id) end, {:error, :node_not_found})
+  end
+
+  defp guarded_pending_candidates do
+    guarded_read(
+      fn ->
+        Nodes.list_admission_candidates(
+          admission_category: AdmissionCandidate.review_categories()
+        )
+      end,
+      []
+    )
+  end
+
+  defp guarded_read(fun, fallback) do
+    if repo_available?() do
+      fun.()
+    else
+      fallback
+    end
+  rescue
+    _exception in [DBConnection.ConnectionError, DBConnection.OwnershipError, Postgrex.Error] ->
+      fallback
+  end
+
+  defp repo_available? do
+    pid = Process.whereis(Orchard.Repo)
+    is_pid(pid) and Process.alive?(pid)
+  end
+
   defp parse_inspect_args(args) do
     case OptionParser.parse(args, strict: [json: :boolean, help: :boolean]) do
       {opts, [node_id], []} ->
         if Keyword.get(opts, :help, false) do
-          {:error, inspect_usage(), 0}
+          {:help, inspect_usage()}
         else
           {:ok, %{id: node_id, json?: Keyword.get(opts, :json, false)}}
         end
@@ -138,7 +186,7 @@ defmodule OrchardCLI.Commands.Nodes do
     case OptionParser.parse(args, strict: [json: :boolean, help: :boolean]) do
       {opts, [], []} ->
         if Keyword.get(opts, :help, false) do
-          {:error, pending_usage(), 0}
+          {:help, pending_usage()}
         else
           {:ok, %{json?: Keyword.get(opts, :json, false)}}
         end
@@ -155,7 +203,7 @@ defmodule OrchardCLI.Commands.Nodes do
     case OptionParser.parse(args, strict: admit_switches()) do
       {opts, [node_id], []} ->
         if Keyword.get(opts, :help, false) do
-          {:error, admit_usage(), 0}
+          {:help, admit_usage()}
         else
           {:ok,
            %{
@@ -179,7 +227,7 @@ defmodule OrchardCLI.Commands.Nodes do
     case OptionParser.parse(args, strict: reject_switches()) do
       {opts, [target_id], []} ->
         if Keyword.get(opts, :help, false) do
-          {:error, reject_usage(), 0}
+          {:help, reject_usage()}
         else
           {:ok,
            %{

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -1,3 +1,18 @@
+defmodule OrchardCLI.Commands.NodesTest.FailingAuditLog do
+  @moduledoc false
+
+  import Ecto.Changeset
+
+  alias Orchard.Governance.AuditLog
+
+  @spec changeset(AuditLog.t(), map()) :: Ecto.Changeset.t()
+  def changeset(%AuditLog{} = audit_log, _attrs) do
+    audit_log
+    |> change()
+    |> add_error(:action, "forced audit persistence failure")
+  end
+end
+
 defmodule OrchardCLI.Commands.NodesTest do
   use ExUnit.Case, async: false
 
@@ -6,6 +21,7 @@ defmodule OrchardCLI.Commands.NodesTest do
   alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
   alias Orchard.Repo
   alias OrchardCLI.Commands.Nodes, as: NodesCmd
+  alias OrchardCLI.Commands.NodesTest.FailingAuditLog
 
   setup do
     :ok = Sandbox.checkout(Repo)
@@ -194,6 +210,32 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert {:ok, output} = NodesCmd.run(["pending"])
       assert output =~ "No admission candidates pending review."
     end
+
+    test "json output lists pending and rejected candidates but omits admitted" do
+      pending = insert_candidate!(admission_category: :pending_observed)
+      rejected = insert_candidate!(admission_category: :rejected)
+      admitted = insert_candidate!(admission_category: :admitted)
+
+      assert {:ok, output} = NodesCmd.run(["pending", "--json"])
+      decoded = Jason.decode!(output)
+      ids = Enum.map(decoded["data"], & &1["id"])
+
+      assert pending.id in ids
+      assert rejected.id in ids
+      refute admitted.id in ids
+      refute Enum.any?(decoded["data"], &(&1["admission_category"] == "admitted"))
+    end
+
+    test "human output omits admitted candidates from review scope" do
+      pending = insert_candidate!(admission_category: :pending_observed)
+      admitted = insert_candidate!(admission_category: :admitted)
+
+      assert {:ok, output} = NodesCmd.run(["pending"])
+
+      assert output =~ pending.id
+      refute output =~ admitted.id
+      refute output =~ "admitted"
+    end
   end
 
   describe "admit" do
@@ -314,6 +356,58 @@ defmodule OrchardCLI.Commands.NodesTest do
 
       assert %AdmissionDecision{decision: :rejected} =
                Repo.get_by(AdmissionDecision, candidate_id: candidate.id)
+    end
+
+    test "yes without reason reports the missing reason rather than a missing --yes" do
+      candidate = insert_candidate!()
+
+      assert {:error, output, 2} = NodesCmd.run(["reject", candidate.id, "--yes"])
+
+      assert output =~ "requires a nonblank --reason before execution"
+      refute output =~ "requires --yes before execution"
+      assert output =~ "requires_reason"
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
+    end
+  end
+
+  describe "action persistence failures" do
+    setup do
+      Application.put_env(:orchard_controller, :governance_audit_log_impl, FailingAuditLog)
+      on_exit(fn -> Application.delete_env(:orchard_controller, :governance_audit_log_impl) end)
+      :ok
+    end
+
+    test "admit json surfaces a clean error when audit persistence fails" do
+      node = insert_node!(state: :registered, display_name: "admit-audit-fail-node")
+
+      assert {:error, output, 1} =
+               NodesCmd.run([
+                 "admit",
+                 node.id,
+                 "--yes",
+                 "--json",
+                 "--trust-evidence-ref",
+                 "registration-audit:test",
+                 "--pool-id",
+                 Ecto.UUID.generate(),
+                 "--routing-policy-id",
+                 Ecto.UUID.generate()
+               ])
+
+      decoded = Jason.decode!(output)
+      assert decoded["object"] == "error"
+      assert decoded["code"] == "action_failed"
+      assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "reject human output surfaces a clean error when audit persistence fails" do
+      candidate = insert_candidate!()
+
+      assert {:error, output, 1} =
+               NodesCmd.run(["reject", candidate.id, "--yes", "--reason", "identity mismatch"])
+
+      assert output =~ "the admission action could not be completed."
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
     end
   end
 

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -65,6 +65,28 @@ defmodule OrchardCLI.Commands.NodesTest do
     end
   end
 
+  describe "help flag on parsed commands" do
+    test "inspect --help with a node id prints usage to stdout with success" do
+      assert {:ok, msg} = NodesCmd.run(["inspect", Ecto.UUID.generate(), "--help"])
+      assert msg =~ "orchardctl nodes inspect"
+    end
+
+    test "pending --json --help prints usage to stdout with success" do
+      assert {:ok, msg} = NodesCmd.run(["pending", "--json", "--help"])
+      assert msg =~ "orchardctl nodes pending"
+    end
+
+    test "admit --help with a node id prints usage to stdout with success" do
+      assert {:ok, msg} = NodesCmd.run(["admit", Ecto.UUID.generate(), "--help"])
+      assert msg =~ "orchardctl nodes admit"
+    end
+
+    test "reject --help with a target id prints usage to stdout with success" do
+      assert {:ok, msg} = NodesCmd.run(["reject", Ecto.UUID.generate(), "--help"])
+      assert msg =~ "orchardctl nodes reject"
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # List command
   # ---------------------------------------------------------------------------
@@ -193,6 +215,15 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert message == "Unknown option: --bogus"
       refute message =~ "----"
     end
+
+    test "degrades to not found when the controller repo is unavailable" do
+      node = insert_node!(display_name: "inspect-repo-off-node")
+
+      with_repo_unavailable(fn ->
+        assert {:error, message, 1} = NodesCmd.run(["inspect", node.id, "--json"])
+        assert message =~ "node not found"
+      end)
+    end
   end
 
   describe "pending" do
@@ -243,6 +274,18 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert output =~ pending.id
       refute output =~ admitted.id
       refute output =~ "admitted"
+    end
+
+    test "degrades to empty review when the controller repo is unavailable" do
+      insert_candidate!()
+
+      with_repo_unavailable(fn ->
+        assert {:ok, output} = NodesCmd.run(["pending"])
+        assert output =~ "No admission candidates pending review."
+
+        assert {:ok, json} = NodesCmd.run(["pending", "--json"])
+        assert Jason.decode!(json)["data"] == []
+      end)
     end
   end
 
@@ -422,6 +465,17 @@ defmodule OrchardCLI.Commands.NodesTest do
   # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------
+
+  defp with_repo_unavailable(fun) do
+    repo_pid = Process.whereis(Repo)
+    Process.unregister(Repo)
+
+    try do
+      fun.()
+    after
+      Process.register(repo_pid, Repo)
+    end
+  end
 
   defp insert_node!(attrs) do
     unique = System.unique_integer([:positive])

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -185,6 +185,14 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert {:error, message, 1} = NodesCmd.run(["inspect", Ecto.UUID.generate(), "--json"])
       assert message =~ "node not found"
     end
+
+    test "unknown option reports the flag without doubled dashes" do
+      assert {:error, message, 2} =
+               NodesCmd.run(["inspect", Ecto.UUID.generate(), "--bogus"])
+
+      assert message == "Unknown option: --bogus"
+      refute message =~ "----"
+    end
   end
 
   describe "pending" do

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -3,7 +3,7 @@ defmodule OrchardCLI.Commands.NodesTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.ClusterManagement.StatusBuilder
-  alias Orchard.Nodes.Node
+  alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
   alias Orchard.Repo
   alias OrchardCLI.Commands.Nodes, as: NodesCmd
 
@@ -22,6 +22,10 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert {:error, msg, 1} = NodesCmd.run([])
       assert msg =~ "orchardctl nodes"
       assert msg =~ "list"
+      assert msg =~ "inspect"
+      assert msg =~ "pending"
+      assert msg =~ "admit"
+      assert msg =~ "reject"
     end
 
     test "--help returns group usage" do
@@ -92,8 +96,7 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert {:ok, output} = NodesCmd.run(["list"])
 
       assert output =~ "no-heartbeat-node"
-      # Two dashes: one for last_seen, one for agent_version
-      assert output =~ "\u2014"
+      assert output =~ "-"
     end
 
     test "multiple nodes render in table" do
@@ -142,6 +145,178 @@ defmodule OrchardCLI.Commands.NodesTest do
     end
   end
 
+  describe "inspect" do
+    test "json output renders one node with shared status categories" do
+      node =
+        insert_node!(
+          display_name: "inspect-node",
+          state: :registered,
+          health: :healthy,
+          last_heartbeat_at: DateTime.utc_now()
+        )
+
+      assert {:ok, output} = NodesCmd.run(["inspect", node.id, "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["object"] == "node"
+      assert decoded["id"] == node.id
+      assert decoded["status"]["object"] == "cluster_management.node_status"
+      assert decoded["status"]["admission"]["category"] == "pending_registered"
+      assert decoded["status"]["scheduling"]["reason_codes"] == ["node_not_admitted"]
+    end
+
+    test "missing node reports not found" do
+      assert {:error, message, 1} = NodesCmd.run(["inspect", Ecto.UUID.generate(), "--json"])
+      assert message =~ "node not found"
+    end
+  end
+
+  describe "pending" do
+    test "json output renders admission review candidates with shared status" do
+      candidate = insert_candidate!(target_ref: "10.0.0.44:50071")
+
+      assert {:ok, output} = NodesCmd.run(["pending", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["object"] == "cluster_management.node_admission_review"
+      assert decoded["contract_version"] == "orchard.cluster_management.status.v1"
+      assert [listed] = decoded["data"]
+      assert listed["id"] == candidate.id
+      assert listed["status"]["resource"]["type"] == "admission_candidate"
+
+      assert listed["status"]["scheduling"]["reason_codes"] == [
+               "node_not_registered",
+               "trust_not_established"
+             ]
+    end
+
+    test "human output shows empty admission review" do
+      assert {:ok, output} = NodesCmd.run(["pending"])
+      assert output =~ "No admission candidates pending review."
+    end
+  end
+
+  describe "admit" do
+    test "dry-run json reports blocker and confirmation requirement without mutation" do
+      node = insert_node!(state: :registered, display_name: "admit-preview-node")
+
+      assert {:ok, output} = NodesCmd.run(["admit", node.id, "--dry-run", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["object"] == "cluster_management.action_preview"
+      assert decoded["action"] == "node_admission.admit"
+      assert decoded["target"] == %{"type" => "node", "id" => node.id}
+      assert decoded["confirmation_requirements"] == ["requires_yes_flag"]
+
+      assert Enum.map(decoded["blockers"], & &1["code"]) == [
+               "trust_not_established",
+               "pool_required",
+               "policy_required"
+             ]
+
+      assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "json execution without yes returns preview instead of mutating" do
+      node = insert_node!(state: :registered, display_name: "admit-needs-yes-node")
+
+      assert {:error, output, 2} =
+               NodesCmd.run([
+                 "admit",
+                 node.id,
+                 "--json",
+                 "--trust-evidence-ref",
+                 "registration-audit:test",
+                 "--pool-id",
+                 Ecto.UUID.generate(),
+                 "--routing-policy-id",
+                 Ecto.UUID.generate()
+               ])
+
+      decoded = Jason.decode!(output)
+      assert decoded["confirmation_requirements"] == ["requires_yes_flag"]
+      assert decoded["blockers"] == []
+      assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "yes execution admits a registered node and emits action result json" do
+      node = insert_node!(state: :registered, display_name: "admit-execute-node")
+
+      assert {:ok, output} =
+               NodesCmd.run([
+                 "admit",
+                 node.id,
+                 "--yes",
+                 "--json",
+                 "--trust-evidence-ref",
+                 "registration-audit:test",
+                 "--pool-id",
+                 Ecto.UUID.generate(),
+                 "--routing-policy-id",
+                 Ecto.UUID.generate()
+               ])
+
+      decoded = Jason.decode!(output)
+      assert decoded["action"] == "node_admission.admitted"
+      assert decoded["node"]["id"] == node.id
+      assert decoded["node"]["state"] == "admitted"
+      assert decoded["audit_log"]["scope"] == "cluster"
+      assert Repo.get!(Node, node.id).state == :admitted
+    end
+  end
+
+  describe "reject" do
+    test "dry-run json reports reason and yes confirmation requirements" do
+      candidate = insert_candidate!()
+
+      assert {:ok, output} = NodesCmd.run(["reject", candidate.id, "--dry-run", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["action"] == "node_admission.reject"
+      assert decoded["target"] == %{"type" => "admission_candidate", "id" => candidate.id}
+      assert decoded["confirmation_requirements"] == ["requires_yes_flag", "requires_reason"]
+      assert decoded["blockers"] == []
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
+    end
+
+    test "json execution without yes returns preview and preserves candidate" do
+      candidate = insert_candidate!()
+
+      assert {:error, output, 2} =
+               NodesCmd.run(["reject", candidate.id, "--json", "--reason", "identity mismatch"])
+
+      decoded = Jason.decode!(output)
+      assert decoded["confirmation_requirements"] == ["requires_yes_flag"]
+      assert decoded["blockers"] == []
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
+    end
+
+    test "yes execution rejects candidate and records a decision" do
+      candidate = insert_candidate!()
+
+      assert {:ok, output} =
+               NodesCmd.run([
+                 "reject",
+                 candidate.id,
+                 "--yes",
+                 "--json",
+                 "--reason",
+                 "identity mismatch"
+               ])
+
+      decoded = Jason.decode!(output)
+      assert decoded["action"] == "node_admission.rejected"
+      assert decoded["candidate"]["id"] == candidate.id
+      assert decoded["candidate"]["admission_category"] == "rejected"
+      assert decoded["decision"]["reason"] == "identity mismatch"
+      assert decoded["audit_log"]["scope"] == "cluster"
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :rejected
+
+      assert %AdmissionDecision{decision: :rejected} =
+               Repo.get_by(AdmissionDecision, candidate_id: candidate.id)
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------
@@ -166,6 +341,30 @@ defmodule OrchardCLI.Commands.NodesTest do
 
     %Node{}
     |> Node.changeset(merged)
+    |> Repo.insert!()
+  end
+
+  defp insert_candidate!(attrs \\ []) do
+    unique = System.unique_integer([:positive])
+
+    defaults = %{
+      source: :runtime_endpoint_observation,
+      admission_category: :pending_observed,
+      observed_identity: %{
+        "claimed_node_id" => Ecto.UUID.generate(),
+        "display_name" => "candidate-#{unique}",
+        "hostname" => "candidate-#{unique}.local"
+      },
+      target_ref: "10.0.0.#{rem(unique, 200) + 1}:50071",
+      endpoint_transport: :grpc,
+      endpoint_target: "10.0.0.#{rem(unique, 200) + 1}:50071",
+      inventory: %{"capabilities" => %{}},
+      compatibility_evidence: %{"health" => "healthy"},
+      last_observed_at: DateTime.utc_now()
+    }
+
+    %AdmissionCandidate{}
+    |> AdmissionCandidate.changeset(Map.merge(defaults, Map.new(attrs)))
     |> Repo.insert!()
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -356,6 +356,21 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert decoded["audit_log"]["scope"] == "cluster"
       assert Repo.get!(Node, node.id).state == :admitted
     end
+
+    test "dry-run degrades to a not-found preview when the controller repo is unavailable" do
+      node = insert_node!(state: :registered, display_name: "admit-dry-run-repo-off")
+
+      with_repo_unavailable(fn ->
+        assert {:ok, output} = NodesCmd.run(["admit", node.id, "--dry-run", "--json"])
+        decoded = Jason.decode!(output)
+
+        assert decoded["action"] == "node_admission.admit"
+        assert decoded["target"] == %{"type" => "node", "id" => node.id}
+        assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_found"]
+      end)
+
+      assert Repo.get!(Node, node.id).state == :registered
+    end
   end
 
   describe "reject" do
@@ -417,6 +432,21 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert output =~ "requires a nonblank --reason before execution"
       refute output =~ "requires --yes before execution"
       assert output =~ "requires_reason"
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
+    end
+
+    test "dry-run degrades to a not-found preview when the controller repo is unavailable" do
+      candidate = insert_candidate!()
+
+      with_repo_unavailable(fn ->
+        assert {:ok, output} = NodesCmd.run(["reject", candidate.id, "--dry-run", "--json"])
+        decoded = Jason.decode!(output)
+
+        assert decoded["action"] == "node_admission.reject"
+        assert decoded["target"] == %{"type" => "node", "id" => candidate.id}
+        assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_found"]
+      end)
+
       assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
     end
   end

--- a/apps/orchard_cli/test/orchard_cli_test.exs
+++ b/apps/orchard_cli/test/orchard_cli_test.exs
@@ -96,7 +96,6 @@ defmodule OrchardCLITest do
     commands = [
       {Cluster, ["init"], "orchardctl cluster init"},
       {Node, ["join"], "orchardctl node join"},
-      {Nodes, ["admit"], "orchardctl nodes admit"},
       {Requests, ["inspect"], "orchardctl requests inspect"}
     ]
 
@@ -117,7 +116,6 @@ defmodule OrchardCLITest do
     commands = [
       ["cluster", "init"],
       ["node", "join"],
-      ["nodes", "admit"],
       ["requests", "inspect"]
     ]
 
@@ -149,6 +147,16 @@ defmodule OrchardCLITest do
       refute message =~ "M0 scaffold"
       refute message =~ "not implemented yet"
     end
+  end
+
+  test "nodes admit help documents the implemented admission command" do
+    assert {:ok, message} = Nodes.run(["admit", "--help"])
+
+    assert message =~ "Usage: orchardctl nodes admit <node-id>"
+    assert message =~ "--dry-run"
+    assert message =~ "--yes"
+    assert message =~ "--trust-evidence-ref"
+    refute message =~ "not implemented"
   end
 
   test "advertised deferred group help lists commands relative to group" do

--- a/apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin/node_admission_controller.ex
@@ -7,6 +7,7 @@ defmodule Orchard.API.Admin.NodeAdmissionController do
 
   alias Orchard.API.Admin.NodeAdmissionPresenter
   alias Orchard.API.AdminErrorHelpers
+  alias Orchard.ClusterManagement.ActionPreviewBuilder
   alias Orchard.ControlPlane
   alias Orchard.Nodes
 
@@ -17,6 +18,7 @@ defmodule Orchard.API.Admin.NodeAdmissionController do
                                     "compatibility_evidence",
                                     "decided_at",
                                     "decision",
+                                    "dry_run",
                                     "endpoint",
                                     "endpoint_target",
                                     "endpoint_transport",
@@ -49,12 +51,23 @@ defmodule Orchard.API.Admin.NodeAdmissionController do
 
   @spec reject(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def reject(conn, %{"candidate_id" => candidate_id}) do
-    with :ok <- ControlPlane.authorize_write_path(:node_admission),
-         {:ok, result} <-
-           Nodes.reject_admission_candidate(candidate_id, request_attrs(conn), audit_opts(conn)) do
-      json(conn, NodeAdmissionPresenter.reject_result(result))
+    attrs = request_attrs(conn)
+
+    if dry_run?(conn) do
+      json(
+        conn,
+        NodeAdmissionPresenter.action_preview(
+          ActionPreviewBuilder.reject_admission(candidate_id, attrs)
+        )
+      )
     else
-      {:error, reason} -> send_error(conn, reason)
+      with :ok <- ControlPlane.authorize_write_path(:node_admission),
+           {:ok, result} <-
+             Nodes.reject_admission_candidate(candidate_id, attrs, audit_opts(conn)) do
+        json(conn, NodeAdmissionPresenter.reject_result(result))
+      else
+        {:error, reason} -> send_error(conn, reason)
+      end
     end
   end
 
@@ -75,13 +88,30 @@ defmodule Orchard.API.Admin.NodeAdmissionController do
 
   @spec admit(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def admit(conn, %{"node_id" => node_id}) do
-    with :ok <- ControlPlane.authorize_write_path(:node_admission),
-         {:ok, result} <- Nodes.admit_node(node_id, request_attrs(conn), audit_opts(conn)) do
-      json(conn, NodeAdmissionPresenter.admit_result(result))
+    attrs = request_attrs(conn)
+
+    if dry_run?(conn) do
+      json(
+        conn,
+        NodeAdmissionPresenter.action_preview(ActionPreviewBuilder.admit_node(node_id, attrs))
+      )
     else
-      {:error, reason} -> send_error(conn, reason)
+      with :ok <- ControlPlane.authorize_write_path(:node_admission),
+           {:ok, result} <- Nodes.admit_node(node_id, attrs, audit_opts(conn)) do
+        json(conn, NodeAdmissionPresenter.admit_result(result))
+      else
+        {:error, reason} -> send_error(conn, reason)
+      end
     end
   end
+
+  defp dry_run?(%Plug.Conn{body_params: %Plug.Conn.Unfetched{}}), do: false
+
+  defp dry_run?(%Plug.Conn{body_params: body_params}) when is_map(body_params) do
+    Map.get(body_params, "dry_run") in [true, "true"]
+  end
+
+  defp dry_run?(_conn), do: false
 
   defp audit_opts(conn) do
     [

--- a/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
@@ -3,7 +3,7 @@ defmodule Orchard.API.Admin.NodeAdmissionPresenter do
   JSON presenters for Admin API node admission resources.
   """
 
-  alias Orchard.ClusterManagement.StatusBuilder
+  alias Orchard.ClusterManagement.{ActionPreview, StatusBuilder}
   alias Orchard.Governance.AuditLog
   alias Orchard.Nodes
   alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
@@ -25,6 +25,12 @@ defmodule Orchard.API.Admin.NodeAdmissionPresenter do
   def candidate(%AdmissionCandidate{} = candidate) do
     candidate(candidate, Nodes.latest_admission_decision_for_candidate(candidate.id))
   end
+
+  @spec node(Node.t()) :: map()
+  def node(%Node{} = node), do: present_node(node)
+
+  @spec action_preview(ActionPreview.t()) :: map()
+  def action_preview(%ActionPreview{} = preview), do: ActionPreview.to_map(preview)
 
   defp candidate(%AdmissionCandidate{} = candidate, latest_decision) do
     %{

--- a/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
@@ -1,0 +1,185 @@
+defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
+  @moduledoc """
+  Builds side-effect-free cluster-management action previews.
+  """
+
+  alias Orchard.ClusterManagement.{ActionPreview, StatusBuilder}
+  alias Orchard.ControlPlane
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{AdmissionCandidate, Node}
+
+  @spec admit_node(Ecto.UUID.t(), map() | keyword()) :: ActionPreview.t()
+  def admit_node(node_id, attrs \\ %{}) do
+    attrs = Map.new(attrs)
+
+    case Nodes.fetch_node(node_id) do
+      {:ok, %Node{} = node} ->
+        blockers =
+          []
+          |> add_write_path_blocker()
+          |> add_blockers(Nodes.admission_blocker_codes(node, attrs))
+
+        action_preview(%{
+          action: "node_admission.admit",
+          target: %{type: "node", id: node.id},
+          current: StatusBuilder.node_status_map(node),
+          scheduler_eligibility: scheduler_eligibility(node),
+          blockers: blockers,
+          confirmation_requirements: [:requires_yes_flag],
+          expected_transition: %{from: node.state, to: :admitted},
+          audit_action: "node_admission.admitted",
+          confirmation_required: true
+        })
+
+      {:error, :node_not_found} ->
+        missing_target_preview("node_admission.admit", "node", node_id, "node_admission.admitted")
+    end
+  end
+
+  @spec reject_admission(Ecto.UUID.t(), map() | keyword()) :: ActionPreview.t()
+  def reject_admission(candidate_or_node_id, attrs \\ %{}) do
+    attrs = Map.new(attrs)
+
+    case admission_rejection_target(candidate_or_node_id) do
+      {:candidate, %AdmissionCandidate{} = candidate} ->
+        reject_candidate_preview(candidate, attrs)
+
+      {:node, %Node{} = node} ->
+        reject_node_preview(node, attrs)
+
+      :not_found ->
+        missing_target_preview(
+          "node_admission.reject",
+          "node",
+          candidate_or_node_id,
+          "node_admission.rejected"
+        )
+    end
+  end
+
+  defp reject_candidate_preview(%AdmissionCandidate{} = candidate, attrs) do
+    blockers =
+      []
+      |> add_write_path_blocker()
+      |> add_blockers(candidate_rejection_blockers(candidate))
+
+    action_preview(%{
+      action: "node_admission.reject",
+      target: %{type: "admission_candidate", id: candidate.id},
+      current: StatusBuilder.candidate_status_map(candidate),
+      scheduler_eligibility: %{eligible: false, reason_codes: [:node_not_admitted]},
+      blockers: blockers,
+      confirmation_requirements: rejection_confirmation_requirements(attrs),
+      expected_transition: %{from: candidate.admission_category, to: :rejected},
+      audit_action: "node_admission.rejected",
+      confirmation_required: true
+    })
+  end
+
+  defp reject_node_preview(%Node{} = node, attrs) do
+    blockers =
+      []
+      |> add_write_path_blocker()
+      |> add_blockers(node_rejection_blockers(node))
+
+    action_preview(%{
+      action: "node_admission.reject",
+      target: %{type: "node", id: node.id},
+      current: StatusBuilder.node_status_map(node),
+      scheduler_eligibility: scheduler_eligibility(node),
+      blockers: blockers,
+      confirmation_requirements: rejection_confirmation_requirements(attrs),
+      expected_transition: %{from: node.state, to: :rejected},
+      audit_action: "node_admission.rejected",
+      confirmation_required: true
+    })
+  end
+
+  defp missing_target_preview(action, target_type, target_id, audit_action) do
+    action_preview(%{
+      action: action,
+      target: %{type: target_type, id: target_id},
+      current: %{},
+      scheduler_eligibility: %{eligible: false, reason_codes: []},
+      blockers: [:node_not_found],
+      confirmation_requirements: [:requires_yes_flag],
+      expected_transition: %{from: nil, to: nil},
+      audit_action: audit_action,
+      confirmation_required: true
+    })
+  end
+
+  defp admission_rejection_target(candidate_or_node_id) do
+    case Nodes.fetch_admission_candidate(candidate_or_node_id) do
+      {:ok, %AdmissionCandidate{} = candidate} ->
+        {:candidate, candidate}
+
+      {:error, :candidate_not_found} ->
+        case Nodes.fetch_node(candidate_or_node_id) do
+          {:ok, %Node{} = node} -> {:node, node}
+          {:error, :node_not_found} -> :not_found
+        end
+    end
+  end
+
+  defp candidate_rejection_blockers(%AdmissionCandidate{admission_category: category})
+       when category in [:pending_observed, :pending_provisioned, :pending_registered],
+       do: []
+
+  defp candidate_rejection_blockers(%AdmissionCandidate{}), do: [:node_not_pending_admission]
+
+  defp node_rejection_blockers(%Node{state: state}) when state in [:provisioned, :registered],
+    do: []
+
+  defp node_rejection_blockers(%Node{}), do: [:node_not_pending_admission]
+
+  defp rejection_confirmation_requirements(attrs) do
+    [:requires_yes_flag]
+    |> add_confirmation_requirement(:requires_reason, blank?(Map.get(attrs, "reason")))
+  end
+
+  defp add_confirmation_requirement(requirements, requirement, true),
+    do: requirements ++ [requirement]
+
+  defp add_confirmation_requirement(requirements, _requirement, false), do: requirements
+
+  defp scheduler_eligibility(%Node{} = node) do
+    node
+    |> StatusBuilder.node_status()
+    |> then(& &1.scheduling)
+  end
+
+  defp add_write_path_blocker(blockers) do
+    case ControlPlane.authorize_write_path(:node_admission) do
+      :ok -> blockers
+      {:error, :controller_standby} -> blockers ++ [:ha_standby_write_blocked]
+    end
+  end
+
+  defp add_blockers(blockers, more_blockers), do: blockers ++ List.wrap(more_blockers)
+
+  defp action_preview(attrs) do
+    attrs
+    |> Map.update!(:blockers, &blocker_entries/1)
+    |> ActionPreview.new!()
+  end
+
+  defp blocker_entries(blockers) do
+    blockers
+    |> Enum.uniq()
+    |> Enum.map(&%{code: &1, message: blocker_message(&1), metadata: %{}})
+  end
+
+  defp blocker_message(:ha_standby_write_blocked), do: "This controller is in standby mode."
+  defp blocker_message(:inventory_missing), do: "Registered node inventory is missing."
+  defp blocker_message(:node_not_found), do: "Node was not found."
+  defp blocker_message(:node_not_pending_admission), do: "Node is not pending admission."
+  defp blocker_message(:node_not_registered), do: "Node is not registered."
+  defp blocker_message(:policy_required), do: "Required policy inputs are missing."
+  defp blocker_message(:pool_required), do: "Node pool assignment is required."
+  defp blocker_message(:trust_not_established), do: "Node trust evidence is required."
+
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(nil), do: true
+  defp blank?(_value), do: false
+end

--- a/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
@@ -57,6 +57,15 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
     end
   end
 
+  @spec not_found_preview(:admit | :reject, Ecto.UUID.t()) :: ActionPreview.t()
+  def not_found_preview(:admit, node_id) do
+    missing_target_preview("node_admission.admit", "node", node_id, "node_admission.admitted")
+  end
+
+  def not_found_preview(:reject, target_id) do
+    missing_target_preview("node_admission.reject", "node", target_id, "node_admission.rejected")
+  end
+
   defp reject_candidate_preview(%AdmissionCandidate{} = candidate, attrs) do
     blockers =
       []

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -141,6 +141,19 @@ defmodule Orchard.Nodes do
   def get_node!(id), do: Repo.get!(Node, id)
 
   @doc """
+  Fetches a node by ID for API and CLI surfaces.
+  """
+  @spec fetch_node(Ecto.UUID.t()) :: {:ok, Node.t()} | {:error, :node_not_found}
+  def fetch_node(id) do
+    with {:ok, id} <- normalize_uuid(id, :node_not_found) do
+      case Repo.get(Node, id) do
+        %Node{} = node -> {:ok, node}
+        nil -> {:error, :node_not_found}
+      end
+    end
+  end
+
+  @doc """
   Lists node admission candidates ordered for operator review.
   """
   @spec list_admission_candidates(keyword()) :: [AdmissionCandidate.t()]
@@ -358,6 +371,22 @@ defmodule Orchard.Nodes do
       end
     end)
     |> unwrap_transaction_result()
+  end
+
+  @doc """
+  Returns shared action-preview blocker codes for node admission.
+  """
+  @spec admission_blocker_codes(Node.t(), map() | keyword()) :: [atom()]
+  def admission_blocker_codes(%Node{} = node, attrs \\ %{}) do
+    attrs = normalize_attrs(attrs)
+
+    case latest_admission_decision_for_node(node.id) do
+      %AdmissionDecision{decision: :rejected} ->
+        [:node_not_pending_admission]
+
+      _decision ->
+        do_admission_blocker_codes(node, attrs)
+    end
   end
 
   @doc """
@@ -1340,6 +1369,28 @@ defmodule Orchard.Nodes do
     do: {:error, :node_not_registered}
 
   defp ensure_node_admittable(%Node{}, _attrs), do: {:error, :node_not_pending_admission}
+
+  defp do_admission_blocker_codes(%Node{state: :provisioned}, _attrs),
+    do: [:node_not_registered]
+
+  defp do_admission_blocker_codes(%Node{state: :registered} = node, attrs) do
+    []
+    |> maybe_add_blocker(:inventory_missing, not registered_inventory_present?(node))
+    |> maybe_add_blocker(
+      :trust_not_established,
+      blank_admission_input?(attrs, ["trust_evidence_ref", "trust_ref"])
+    )
+    |> maybe_add_blocker(:pool_required, blank_admission_input?(attrs, ["pool_id", "pool"]))
+    |> maybe_add_blocker(
+      :policy_required,
+      blank_admission_input?(attrs, ["routing_policy_id", "policy_ref", "policy_inputs"])
+    )
+  end
+
+  defp do_admission_blocker_codes(%Node{}, _attrs), do: [:node_not_pending_admission]
+
+  defp maybe_add_blocker(blockers, blocker, true), do: blockers ++ [blocker]
+  defp maybe_add_blocker(blockers, _blocker, false), do: blockers
 
   defp ensure_admission_inputs_present(%Node{} = node, attrs) do
     cond do

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -1636,6 +1636,10 @@ defmodule Orchard.Nodes do
 
   defp maybe_filter_candidate_category(query, nil), do: query
 
+  defp maybe_filter_candidate_category(query, categories) when is_list(categories) do
+    where(query, [candidate], candidate.admission_category in ^categories)
+  end
+
   defp maybe_filter_candidate_category(query, category) do
     where(query, [candidate], candidate.admission_category == ^category)
   end

--- a/apps/orchard_controller/lib/orchard/nodes/admission_candidate.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/admission_candidate.ex
@@ -48,6 +48,11 @@ defmodule Orchard.Nodes.AdmissionCandidate do
   @spec admission_categories() :: [atom()]
   def admission_categories, do: @admission_categories
 
+  @review_categories [:pending_observed, :pending_provisioned, :pending_registered, :rejected]
+
+  @spec review_categories() :: [atom()]
+  def review_categories, do: @review_categories
+
   @spec changeset(struct(), map()) :: Ecto.Changeset.t()
   def changeset(candidate, attrs) do
     candidate

--- a/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs
@@ -68,6 +68,28 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
       assert Jason.decode!(conn.resp_body)["error"]["code"] == "reason_required"
     end
 
+    test "candidate reject dry-run returns shared action preview without mutation" do
+      token = admin_token!("admin-node-admission-reject-preview")
+      candidate = insert_candidate!()
+
+      conn =
+        admin_json(
+          :post,
+          "/admin/v1/node-admission/candidates/#{candidate.id}/reject",
+          token,
+          %{"dry_run" => true}
+        )
+
+      assert conn.status == 200
+      preview = Jason.decode!(conn.resp_body)
+      assert preview["object"] == "cluster_management.action_preview"
+      assert preview["action"] == "node_admission.reject"
+      assert preview["target"] == %{"type" => "admission_candidate", "id" => candidate.id}
+      assert preview["confirmation_requirements"] == ["requires_yes_flag", "requires_reason"]
+      assert preview["blockers"] == []
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
+    end
+
     test "reject and clear append decisions and cluster audit logs" do
       token = admin_token!("admin-node-admission-reject-clear")
       candidate = insert_candidate!(target_ref: "10.0.0.45:50071")
@@ -277,6 +299,40 @@ defmodule Orchard.API.Admin.NodeAdmissionControllerTest do
 
       assert policy_conn.status == 409
       assert Jason.decode!(policy_conn.resp_body)["error"]["code"] == "policy_required"
+    end
+
+    test "admit dry-run returns shared action preview blockers without mutation" do
+      token = admin_token!("admin-node-admission-admit-preview")
+
+      node =
+        insert_node!(%{
+          state: :registered,
+          display_name: "registered-admit-preview-node",
+          hostname: "registered-admit-preview-node.local"
+        })
+
+      conn =
+        admin_json(
+          :post,
+          "/admin/v1/nodes/#{node.id}/admit",
+          token,
+          %{"dry_run" => true}
+        )
+
+      assert conn.status == 200
+      preview = Jason.decode!(conn.resp_body)
+      assert preview["object"] == "cluster_management.action_preview"
+      assert preview["action"] == "node_admission.admit"
+      assert preview["target"] == %{"type" => "node", "id" => node.id}
+      assert preview["confirmation_requirements"] == ["requires_yes_flag"]
+
+      assert Enum.map(preview["blockers"], & &1["code"]) == [
+               "trust_not_established",
+               "pool_required",
+               "policy_required"
+             ]
+
+      assert Repo.get!(Node, node.id).state == :registered
     end
 
     test "admit transitions a registered trusted node to admitted and writes cluster audit" do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,10 +17,14 @@ product/system/build contract.
   `orchard-managed-postgres` helper is an operator-safe guard, not a runtime
   service.
 - **Current CLI limitation:** SPEC-required future paths such as
-  `orchardctl cluster init`, `orchardctl node join`,
-  `orchardctl nodes admit`, and `orchardctl requests inspect` are routed by
-  `orchardctl` but return deferred-status errors with the current supported
-  path. `orchardctl support bundle create` creates a local diagnostic archive
+  `orchardctl cluster init`, `orchardctl node join`, and
+  `orchardctl requests inspect` are routed by `orchardctl` but return
+  deferred-status errors with the current supported path.
+  `orchardctl nodes inspect`, `orchardctl nodes pending`,
+  `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for
+  the current node-admission-review slice, with stable JSON and human output,
+  `--dry-run` previews, and `--yes`/`--reason` execution gating.
+  `orchardctl support bundle create` creates a local diagnostic archive
   with bounded redacted logs, redacted config, service status, node snapshots,
   shared cluster-management node status, and request summaries.
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -532,8 +532,9 @@ Single-node remains the default.
 Use the gRPC compatibility flow when you want the stable default source-dev path.
 Use the BEAM Runtime Endpoint flow when you are validating the explicit split-role BEAM operating model.
 
-`orchardctl cluster init`, `orchardctl node join`, and `orchardctl nodes admit` are SPEC-required future node-lifecycle commands.
+`orchardctl cluster init` and `orchardctl node join` are SPEC-required future node-lifecycle commands.
 In this build they return deferred status.
+`orchardctl nodes inspect`, `orchardctl nodes pending`, `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for the current node-admission-review slice, with stable JSON and human output, `--dry-run` previews, and `--yes`/`--reason` execution gating.
 Use the env-var split-role flows below for source-dev cluster testing.
 
 ### gRPC compatibility flow

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -24,6 +24,7 @@
 - [x] 3.1 Add shared domain structures for lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and HA-lite read-only status.
 - [x] 3.2 Add fixed scheduler explanation rejection codes and action preview blocker codes.
 - [ ] 3.3 Ensure reason codes are used by Operator API, Admin API, CLI, Console, support bundles, and tests.
+  Note: CLI/Admin admission previews now use shared `ActionPreview` blocker and confirmation codes; Operator API, Console, and support bundles remain future slices.
 - [x] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
 - [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
 - [x] 3.6 Ensure action preview schema fixtures include separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements` fields.
@@ -32,10 +33,10 @@
 ## 4. CLI Parity
 
 - [x] 4.1 Implement `orchardctl nodes list --json` with separated status categories.
-- [ ] 4.2 Implement `orchardctl nodes inspect <node-id> --json`.
-- [ ] 4.3 Implement `orchardctl nodes pending` or an equivalent admission-review command.
-- [ ] 4.4 Implement `orchardctl nodes admit <node-id>` with dry-run and JSON preview support.
-- [ ] 4.5 Implement `orchardctl nodes reject <node-id|candidate-id>` with dry-run, JSON preview support, `--reason`, and required confirmation semantics aligned with Console and Admin API.
+- [x] 4.2 Implement `orchardctl nodes inspect <node-id> --json`.
+- [x] 4.3 Implement `orchardctl nodes pending` or an equivalent admission-review command.
+- [x] 4.4 Implement `orchardctl nodes admit <node-id>` with dry-run and JSON preview support.
+- [x] 4.5 Implement `orchardctl nodes reject <node-id|candidate-id>` with dry-run, JSON preview support, `--reason`, and required confirmation semantics aligned with Console and Admin API.
 - [ ] 4.6 Implement safe lifecycle commands for cordon, uncordon, drain, maintenance, resume, and decommission with dry-run, confirmation requirements, and JSON output.
 - [ ] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.


### PR DESCRIPTION
## Intent

Implement the next Orchard cluster-management CLI parity slice after PR #35. Add stable JSON and human CLI support for inspecting nodes, listing pending admission candidates, previewing and executing node admission, and previewing and executing node rejection with required --yes and rejection reason semantics. Keep the work narrowly aligned with SPEC.md and the cluster-management-ux-foundation OpenSpec, reuse the shared cluster-management status and ActionPreview contracts from the merged reason-code work, preserve existing nodes list --json behavior, avoid lifecycle actions and Console work outside this slice, update only genuinely completed OpenSpec tasks, and validate with focused tests, strict OpenSpec validation, the Elixir quality workflow, coverage, and No Mistakes before PR handoff. The first No Mistakes run applied review fixes for non-atom action errors, missing rejection reason messaging, and filtering nodes pending to pending/rejected review candidates; the final local tree at 088e686 has passed OpenSpec strict validation, mix format, compile --warnings-as-errors, Credo strict, Dialyzer, focused affected tests, full mix test, and mix test --cover.

## What Changed

- Add `orchardctl nodes inspect`, `nodes pending`, `nodes admit`, and `nodes reject` commands with stable JSON and human output, `--dry-run` previews, and `--yes`/`--reason` execution gating; preserve existing `nodes list --json` behavior and degrade the new read/preview paths to guarded output when the repo is unavailable.
- Introduce a shared `Orchard.ClusterManagement.ActionPreviewBuilder` for side-effect-free admit/reject previews, reused by the CLI and wired into the Admin API `admit`/`reject` controllers via a new `dry_run` branch; add supporting `Nodes.fetch_node/1`, `Nodes.admission_blocker_codes/2`, `AdmissionCandidate.review_categories/0`, list-category filtering, and presenter helpers.
- Reconcile README, CLI README, `docs/architecture.md`, `docs/local-dev.md`, and the cluster-management-ux-foundation OpenSpec tasks so the previously deferred `nodes admit` path (plus inspect/pending/reject) is documented as implemented, and add CLI and controller test coverage for the new commands and preview paths.

## Risk Assessment

✅ Low: The change is well-bounded, thoroughly tested, and prior review rounds already resolved the substantive correctness and degradation issues; the remaining item is a minor governance-attribution tradeoff, not a functional defect.

## Testing

Ran the baseline focused suites — the CLI nodes/parity tests (74 passed) and the admin node-admission controller tests (13 passed) — after creating/migrating the test database. To show the end-user surface rather than just internal return tuples, I produced a real CLI transcript by driving `orchardctl nodes` commands through the live command dispatcher against the test DB inside a sandbox connection: it demonstrates inspecting a node, listing pending admission candidates, previewing and executing admission (node moves registered→admitted with a recorded decision and cluster audit log), and previewing and executing rejection including both required-confirmation guard rails (--yes and a nonblank --reason, each exiting 2 without mutation). A follow-up inspect confirms the persisted admitted state, and psql confirms nothing leaked into the database. This is a CLI/JSON-output change with no rendered UI surface, so the reviewer-visible evidence is the captured CLI transcript rather than a screenshot. All exercised paths pass.

<details>
<summary>Evidence: orchardctl nodes end-to-end CLI transcript (full)</summary>

```text
=== orchardctl nodes CLI parity — end-to-end transcript ===
seeded registered node id:      86905228-3da0-45ca-83f9-b021a01a3abd
seeded pending candidate id:    d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c


--- 1. inspect a node (human + JSON) ---

$ orchardctl nodes inspect 86905228-3da0-45ca-83f9-b021a01a3abd
Node 86905228-3da0-45ca-83f9-b021a01a3abd
Display name: worker-alpha
Hostname: worker-alpha.local
State: registered
Health: healthy
Admission: pending_registered
Scheduling: blocked (node_not_admitted)
[exit: 0]

$ orchardctl nodes inspect 86905228-3da0-45ca-83f9-b021a01a3abd --json
{
  "id": "86905228-3da0-45ca-83f9-b021a01a3abd",
  "status": {
    "runtime": {
      "status": "unknown",
      "health_code": null,
      "health_message": null
    },
    "resource": {
      "id": "86905228-3da0-45ca-83f9-b021a01a3abd",
      "type": "node"
    },
    "warnings": [],
    "transport": {
      "status": "unknown"
    },
    "health": {
      "status": "healthy"
    },
    "object": "cluster_management.node_status",
    "contract_version": "orchard.cluster_management.status.v1",
    "admission": {
      "category": "pending_registered",
      "source": "registered_node",
      "latest_decision": null
    },
    "scheduling": {
      "eligible": false,
      "reason_codes": [
        "node_not_admitted"
      ]
    },
    "compatibility": {
      "status": "unknown"
    },
    "freshness": {
      "status": "fresh",
      "source": "heartbeat",
      "observed_at": "2026-07-02T08:58:26.370542Z"
    },
    "lifecycle": {
      "state": "registered"
    }
  },
  "state": "registered",
  "hostname": "worker-alpha.local",
  "display_name": "worker-alpha",
  "agent_version": "0.2.0",
  "capabilities": {},
  "advertise_addr": "10.0.0.21",
  "rpc_port": 50071,
  "health": "healthy",
  "last_heartbeat_at": "2026-07-02T08:58:26.370542Z",
  "object": "node",
  "connect_host": null,
  "connect_port": null,
  "inserted_at": "2026-07-02T08:58:26.380639Z",
  "tool_readiness": {},
  "updated_at": "2026-07-02T08:58:26.380639Z",
  "latest_decision": null
}
[exit: 0]


--- 2. list pending admission candidates (human + JSON) ---

$ orchardctl nodes pending
d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c  pending_observed  10.0.0.44:50071  blocked (node_not_registered, trust_not_established)
[exit: 0]

$ orchardctl nodes pending --json
{
  "data": [
    {
      "id": "d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c",
      "status": {
        "runtime": {
          "status": "unknown",
          "health_code": null,
          "health_message": null
        },
        "resource": {
          "id": "d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c",
          "type": "admission_candidate"
        },
        "warnings": [],
        "transport": {
          "status": "reachable"
        },
        "health": {
          "status": "unknown"
        },
        "object": "cluster_management.node_status",
        "contract_version": "orchard.cluster_management.status.v1",
        "admission": {
          "category": "pending_observed",
          "source": "runtime_endpoint_observation",
          "latest_decision": null
        },
        "scheduling": {
          "eligible": false,
          "reason_codes": [
            "node_not_registered",
            "trust_not_established"
          ]
        },
        "compatibility": {
          "status": "partial_metadata"
        },
        "freshness": {
          "status": "fresh",
          "source": "runtime_endpoint_observation",
          "observed_at": "2026-07-02T08:58:26.385924Z"
        },
        "lifecycle": {
          "state": null
        }
      },
      "source": "runtime_endpoint_observation",
      "node_id": null,
      "endpoint": {
        "target": "10.0.0.44:50071",
        "transport": "grpc"
      },
      "admission_category": "pending_observed",
      "observed_identity": {
        "claimed_node_id": "39414ad9-dd60-4507-9287-e7de7b5303ff",
        "display_name": "candidate-beta",
        "hostname": "candidate-beta.local"
      },
      "target_ref": "10.0.0.44:50071",
      "inventory": {
        "capabilities": {}
      },
      "compatibility_evidence": {
        "health": "healthy"
      },
      "last_observed_at": "2026-07-02T08:58:26.385924Z",
      "object": "node_admission_candidate",
      "inserted_at": "2026-07-02T08:58:26.385956Z",
      "updated_at": "2026-07-02T08:58:26.385956Z",
      "latest_decision": null
    }
  ],
  "object": "cluster_management.node_admission_review",
  "contract_version": "orchard.cluster_management.status.v1"
}
[exit: 0]


--- 3. admit: preview (dry-run) then execute ---

$ orchardctl nodes admit 86905228-3da0-45ca-83f9-b021a01a3abd --dry-run --json
{
  "action": "node_admission.admit",
  "target": {
    "id": "86905228-3da0-45ca-83f9-b021a01a3abd",
    "type": "node"
  },
  "warnings": [],
  "active_request_count": null,
  "current": {
    "runtime": {
      "status": "unknown",
      "health_code": null,
      "health_message": null
    },
    "resource": {
      "id": "86905228-3da0-45ca-83f9-b021a01a3abd",
      "type": "node"
    },
    "warnings": [],
    "transport": {
      "status": "unknown"
    },
    "health": {
      "status": "healthy"
    },
    "object": "cluster_management.node_status",
    "contract_version": "orchard.cluster_management.status.v1",
    "admission": {
      "category": "pending_registered",
      "source": "registered_node",
      "latest_decision": null
    },
    "scheduling": {
      "eligible": false,
      "reason_codes": [
        "node_not_admitted"
      ]
    },
    "compatibility": {
      "status": "unknown"
    },
    "freshness": {
      "status": "fresh",
      "source": "heartbeat",
      "observed_at": "2026-07-02T08:58:26.370542Z"
    },
    "lifecycle": {
      "state": "registered"
    }
  },
  "object": "cluster_management.action_preview",
  "contract_version": "orchard.cluster_management.action_preview.v1",
  "blockers": [
    {
      "code": "trust_not_established",
      "message": "Node trust evidence is required.",
      "metadata": {}
    },
    {
      "code": "pool_required",
      "message": "Node pool assignment is required.",
      "metadata": {}
    },
    {
      "code": "policy_required",
      "message": "Required policy inputs are missing.",
      "metadata": {}
    }
  ],
  "confirmation_requirements": [
    "requires_yes_flag"
  ],
  "expected_transition": {
    "to": "admitted",
    "from": "registered"
  },
  "consequence_codes": [],
  "audit_action": "node_admission.admitted",
  "confirmation_required": true,
  "scheduler_eligibility": {
    "eligible": false,
    "reason_codes": [
      "node_not_admitted"
    ]
  }
}
[exit: 0]

$ orchardctl nodes admit 86905228-3da0-45ca-83f9-b021a01a3abd --yes --json --trust-evidence-ref registration-audit:signed --pool-id ced9f04b-2da2-472c-9b96-425b42837643 --routing-policy-id f48f0637-c101-4c71-a6a1-fd91f477536b
{
  "node": {
    "id": "86905228-3da0-45ca-83f9-b021a01a3abd",
    "status": {
      "runtime": {
        "status": "unknown",
        "health_code": null,
        "health_message": null
      },
      "resource": {
        "id": "86905228-3da0-45ca-83f9-b021a01a3abd",
        "type": "node"
      },
      "warnings": [],
      "transport": {
        "status": "unknown"
      },
      "health": {
        "status": "healthy"
      },
      "object": "cluster_management.node_status",
      "contract_version": "orchard.cluster_management.status.v1",
      "admission": {
        "category": "admitted",
        "source": "registered_node",
        "latest_decision": "admitted"
      },
      "scheduling": {
        "eligible": false,
        "reason_codes": [
          "node_not_active"
        ]
      },
      "compatibility": {
        "status": "unknown"
      },
      "freshness": {
        "status": "fresh",
        "source": "heartbeat",
        "observed_at": "2026-07-02T08:58:26.370542Z"
      },
      "lifecycle": {
        "state": "admitted"
      }
    },
    "state": "admitted",
    "hostname": "worker-alpha.local",
    "display_name": "worker-alpha",
    "agent_version": "0.2.0",
    "capabilities": {},
    "advertise_addr": "10.0.0.21",
    "rpc_port": 50071,
    "health": "healthy",
    "last_heartbeat_at": "2026-07-02T08:58:26.370542Z",
    "object": "node",
    "connect_host": null,
    "connect_port": null,
    "inserted_at": "2026-07-02T08:58:26.380639Z",
    "tool_readiness": {},
    "updated_at": "2026-07-02T08:58:26.414744Z",
    "latest_decision": {
      "id": "40468d27-6664-4e6c-af2a-c170317a20f3",
      "reason": null,
      "metadata": {
        "pool_id": "ced9f04b-2da2-472c-9b96-425b42837643",
        "routing_policy_id": "f48f0637-c101-4c71-a6a1-fd91f477536b",
        "trust_evidence_ref": "registration-audit:signed"
      },
      "node_id": "86905228-3da0-45ca-83f9-b021a01a3abd",
      "observed_identity": {
        "agent_version": "0.2.0",
        "display_name": "worker-alpha",
        "hostname": "worker-alpha.local",
        "node_id": "86905228-3da0-45ca-83f9-b021a01a3abd"
      },
      "target_ref": "10.0.0.21:50071",
      "object": "node_admission_decision",
      "inserted_at": "2026-07-02T08:58:26.418780Z",
      "decision": "admitted",
      "actor_id": null,
      "actor_type": "operator",
      "audit_log_id": 17349,
      "candidate_id": "ed2a4922-c961-4cb5-9385-cfafd2a417d6",
      "decided_at": "2026-07-02T08:58:26.418752Z"
    }
  },
  "action": "node_admission.admitted",
  "object": "node_admission_action_result",
  "decision": {
    "id": "40468d27-6664-4e6c-af2a-c170317a20f3",
    "reason": null,
    "metadata": {
      "pool_id": "ced9f04b-2da2-472c-9b96-425b42837643",
      "routing_policy_id": "f48f0637-c101-4c71-a6a1-fd91f477536b",
      "trust_evidence_ref": "registration-audit:signed"
    },
    "node_id": "86905228-3da0-45ca-83f9-b021a01a3abd",
    "observed_identity": {
      "agent_version": "0.2.0",
      "display_name": "worker-alpha",
      "hostname": "worker-alpha.local",
      "node_id": "86905228-3da0-45ca-83f9-b021a01a3abd"
    },
    "target_ref": "10.0.0.21:50071",
    "object": "node_admission_decision",
    "inserted_at": "2026-07-02T08:58:26.418780Z",
    "decision": "admitted",
    "actor_id": null,
    "actor_type": "operator",
    "audit_log_id": 17349,
    "candidate_id": "ed2a4922-c961-4cb5-9385-cfafd2a417d6",
    "decided_at": "2026-07-02T08:58:26.418752Z"
  },
  "audit_log": {
    "id": 17349,
    "scope": "cluster",
    "action": "node_admission.admitted"
  }
}
[exit: 0]


--- 4. reject: preview, guard rails, then execute ---

$ orchardctl nodes reject d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c --dry-run --json
{
  "action": "node_admission.reject",
  "target": {
    "id": "d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c",
    "type": "admission_candidate"
  },
  "warnings": [],
  "active_request_count": null,
  "current": {
    "runtime": {
      "status": "unknown",
      "health_code": null,
      "health_message": null
    },
    "resource": {
      "id": "d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c",
      "type": "admission_candidate"
    },
    "warnings": [],
    "transport": {
      "status": "reachable"
    },
    "health": {
      "status": "unknown"
    },
    "object": "cluster_management.node_status",
    "contract_version": "orchard.cluster_management.status.v1",
    "admission": {
      "category": "pending_observed",
      "source": "runtime_endpoint_observation",
      "latest_decision": null
    },
    "scheduling": {
      "eligible": false,
      "reason_codes": [
        "node_not_registered",
        "trust_not_established"
      ]
    },
    "compatibility": {
      "status": "partial_metadata"
    },
    "freshness": {
      "status": "fresh",
      "source": "runtime_endpoint_observation",
      "observed_at": "2026-07-02T08:58:26.385924Z"
    },
    "lifecycle": {
      "state": null
    }
  },
  "object": "cluster_management.action_preview",
  "contract_version": "orchard.cluster_management.action_preview.v1",
  "blockers": [],
  "confirmation_requirements": [
    "requires_yes_flag",
    "requires_reason"
  ],
  "expected_transition": {
    "to": "rejected",
    "from": "pending_observed"
  },
  "consequence_codes": [],
  "audit_action": "node_admission.rejected",
  "confirmation_required": true,
  "scheduler_eligibility": {
    "eligible": false,
    "reason_codes": [
      "node_not_admitted"
    ]
  }
}
[exit: 0]

$ orchardctl nodes reject d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c --reason identity mismatch
Error: node admission rejection requires --yes before execution.

Action: node_admission.reject
Target: admission_candidate:d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c
Blockers: none
Confirmation requirements: requires_yes_flag
Expected transition: pending_observed -> rejected
[exit: 2]

$ orchardctl nodes reject d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c --yes
Error: node admission rejection requires a nonblank --reason before execution.

Action: node_admission.reject
Target: admission_candidate:d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c
Blockers: none
Confirmation requirements: requires_yes_flag, requires_reason
Expected transition: pending_observed -> rejected
[exit: 2]

$ orchardctl nodes reject d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c --yes --reason identity mismatch
Rejected admission candidate d5e5b2d7-e4f7-40f5-a5e4-2105e8702b9c.
[exit: 0]


--- 5. inspect the now-admitted node reflects admitted state ---

$ orchardctl nodes inspect 86905228-3da0-45ca-83f9-b021a01a3abd
Node 86905228-3da0-45ca-83f9-b021a01a3abd
Display name: worker-alpha
Hostname: worker-alpha.local
State: admitted
Health: healthy
Admission: admitted
Scheduling: blocked (node_not_active)
[exit: 0]

(sandbox connection checked in — no seeded rows persisted to orchard_test)
```
</details>
<details>
<summary>Evidence: Transcript generator script (sandbox-isolated, rolled back)</summary>

```text
# Generates a real orchardctl nodes CLI transcript against the test DB.
# Seeds a registered node + a pending admission candidate inside a
# transaction that is rolled back at the end, so no rows persist.
alias Ecto.Adapters.SQL.Sandbox
alias Orchard.Repo
alias Orchard.Nodes.{Node, AdmissionCandidate}

{:ok, _} = Application.ensure_all_started(:ecto_sql)
{:ok, _} = Application.ensure_all_started(:postgrex)
{:ok, _} = Repo.start_link()
# Sandbox checkout runs inside a transaction that is discarded on checkin,
# so nothing the CLI writes persists to orchard_test.
:ok = Sandbox.checkout(Repo)

uuid = fn -> Ecto.UUID.generate() end

render = fn
  {:ok, msg} -> {msg, 0}
  {:error, msg, code} -> {msg, code}
end

run = fn args ->
  {msg, code} = render.(OrchardCLI.Commands.Nodes.run(args))
  IO.puts("\n$ orchardctl " <> Enum.join(["nodes" | args], " "))
  IO.puts(msg)
  IO.puts("[exit: #{code}]")
end

node =
    %Node{}
    |> Node.changeset(%{
      id: uuid.(),
      hostname: "worker-alpha.local",
      display_name: "worker-alpha",
      advertise_addr: "10.0.0.21",
      rpc_port: 50071,
      state: :registered,
      health: :healthy,
      capabilities: %{},
      agent_version: "0.2.0",
      last_heartbeat_at: DateTime.utc_now()
    })
    |> Repo.insert!()

  candidate =
    %AdmissionCandidate{}
    |> AdmissionCandidate.changeset(%{
      source: :runtime_endpoint_observation,
      admission_category: :pending_observed,
      observed_identity: %{
        "claimed_node_id" => uuid.(),
        "display_name" => "candidate-beta",
        "hostname" => "candidate-beta.local"
      },
      target_ref: "10.0.0.44:50071",
      endpoint_transport: :grpc,
      endpoint_target: "10.0.0.44:50071",
      inventory: %{"capabilities" => %{}},
      compatibility_evidence: %{"health" => "healthy"},
      last_observed_at: DateTime.utc_now()
    })
    |> Repo.insert!()

  IO.puts("=== orchardctl nodes CLI parity — end-to-end transcript ===")
  IO.puts("seeded registered node id:      #{node.id}")
  IO.puts("seeded pending candidate id:    #{candidate.id}")

  IO.puts("\n\n--- 1. inspect a node (human + JSON) ---")
  run.(["inspect", node.id])
  run.(["inspect", node.id, "--json"])

  IO.puts("\n\n--- 2. list pending admission candidates (human + JSON) ---")
  run.(["pending"])
  run.(["pending", "--json"])

  IO.puts("\n\n--- 3. admit: preview (dry-run) then execute ---")
  run.(["admit", node.id, "--dry-run", "--json"])

  run.([
    "admit",
    node.id,
    "--yes",
    "--json",
    "--trust-evidence-ref",
    "registration-audit:signed",
    "--pool-id",
    uuid.(),
    "--routing-policy-id",
    uuid.()
  ])

  IO.puts("\n\n--- 4. reject: preview, guard rails, then execute ---")
  run.(["reject", candidate.id, "--dry-run", "--json"])
  # missing --yes returns preview, exit 2, no mutation
  run.(["reject", candidate.id, "--reason", "identity mismatch"])
  # --yes without --reason surfaces the reason requirement, exit 2
  run.(["reject", candidate.id, "--yes"])
  # full execution
  run.(["reject", candidate.id, "--yes", "--reason", "identity mismatch"])

  IO.puts("\n\n--- 5. inspect the now-admitted node reflects admitted state ---")
  run.(["inspect", node.id])

Sandbox.checkin(Repo)
IO.puts("\n(sandbox connection checked in — no seeded rows persisted to orchard_test)")
```
</details>
<details>
<summary>Evidence: Transcript highlights (human-readable surface + guard rails)</summary>

```text
$ orchardctl nodes inspect <node>
Node <id>
State: registered
Admission: pending_registered
Scheduling: blocked (node_not_admitted)
[exit: 0]

$ orchardctl nodes pending
<candidate> pending_observed 10.0.0.44:50071 blocked (node_not_registered, trust_not_established)
[exit: 0]

$ orchardctl nodes admit <node> --dry-run --json
blockers: trust_not_established, pool_required, policy_required
confirmation_requirements: [requires_yes_flag]
expected_transition: registered -> admitted (no mutation)
[exit: 0]

$ orchardctl nodes admit <node> --yes --json --trust-evidence-ref ... --pool-id ... --routing-policy-id ...
action: node_admission.admitted node.state: admitted audit_log.scope: cluster
[exit: 0]

$ orchardctl nodes reject <candidate> --reason "identity mismatch" # missing --yes
Error: node admission rejection requires --yes before execution.
[exit: 2]

$ orchardctl nodes reject <candidate> --yes # missing reason
Error: node admission rejection requires a nonblank --reason before execution.
[exit: 2]

$ orchardctl nodes reject <candidate> --yes --reason "identity mismatch"
Rejected admission candidate <candidate>.
[exit: 0]

$ orchardctl nodes inspect <node> # persisted state after admit
State: admitted Admission: admitted
[exit: 0]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex:246` - `unknown_option/1` builds the message as `&#34;Unknown option: --#{flag}&#34;`, but OptionParser returns invalid options already prefixed with dashes (e.g. `&#34;--json&#34;`). This yields malformed output like `Unknown option: ----json` for any unrecognized flag on `nodes inspect/pending/admit/reject`. It also diverges from the repo convention (see `apps/orchard_cli/lib/orchard_cli/commands/upgrade.ex:47`, which uses `&#34;Unknown option: #{option}&#34;` with no extra prefix). Drop the leading `--` in the interpolation.
- ⚠️ `README.md:173` - This change fully implements `orchardctl nodes admit` (plus reject/pending/inspect), but three product docs still describe `orchardctl nodes admit` as returning deferred-status errors / deferred status: README.md:173, docs/local-dev.md:535, and docs/architecture.md:21. Per AGENTS.md, doc/impl conflicts should be reconciled on the branch. Update these docs to reflect the now-implemented command.
- ℹ️ `apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex:173` - `blocker_message/1` has clauses for the 8 blocker codes produced today but no catch-all, while the shared `:action_blocker` vocabulary defines 18 codes (e.g. node_not_admitted, node_not_active, node_unreachable, cluster_lock_unavailable, version_incompatible). All currently-produced codes are covered, so there is no present crash, but adding any new blocker code path (e.g. the deferred lifecycle commands) without a matching message clause would raise FunctionClauseError. Consider a fallback clause.

🔧 Fix: fix nodes CLI unknown-option message and reconcile admit docs
2 infos still open:
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex:51` - New read commands do not degrade when the repo is unavailable, unlike `nodes list`. `run_pending` (line 51, `Nodes.list_admission_candidates/1`) and `run_inspect` (line 36, `Nodes.fetch_node/1`) issue plain `Repo` queries with no availability guard, and `OrchardCLI.main/2` has no top-level rescue. When Postgres is unreachable, `orchardctl nodes inspect`/`nodes pending` crash with a raw DBConnection stacktrace and a BEAM crash exit, whereas `nodes list` deliberately degrades to empty output via `Nodes.list_nodes/0`/`summary/0` (see the NOTE at nodes.ex:399-401). Decide whether the new read commands should degrade consistently or fail loudly on purpose.
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex:124` - Help-flag branches in `parse_inspect_args`/`parse_pending_args`/`parse_admit_args`/`parse_reject_args` return `{:error, usage(), 0}` (lines 124, 141, 158, 182), reachable via forms like `nodes admit &lt;id&gt; --help` or `nodes pending --json --help`. `handle_result/2` then prints usage to stderr and halts with exit code 0 — diverging from the sibling `--help`/`help` clauses that return `{:ok, usage()}` (stdout, success), and placing a non-`pos_integer` exit code inside an `{:error, ...}` tuple (violates the `command_result` contract). Return `{:ok, usage()}` from these branches so help goes to stdout with a success exit.

🔧 Fix: guard nodes read CLI on repo outage, fix help exit
1 info still open:
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex:69` - The admit/reject preview is built unconditionally and unguarded: run_admit (line 69, ActionPreviewBuilder.admit_node/2) and run_reject (line 96, ActionPreviewBuilder.reject_admission/2) both call into DB-backed Nodes.fetch_node/fetch_admission_candidate with no repo-availability guard and no top-level rescue in OrchardCLI.main. This means the read-only preview paths `orchardctl nodes admit &lt;id&gt; --dry-run` and `orchardctl nodes reject &lt;id&gt; --dry-run` crash with a raw DBConnection stacktrace and a BEAM crash exit when Postgres is unavailable — inconsistent with the degradation just added in this same change for `nodes inspect` and `nodes pending` via guarded_read/repo_available? (lines 137-166). Decide whether the dry-run/preview read paths should degrade consistently (e.g. wrap the ActionPreviewBuilder call in the same guard) or intentionally fail loudly for admission actions.

🔧 Fix: guard nodes admit/reject dry-run preview on repo outage
1 info still open:
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex:129` - CLI-executed admissions and rejections call `Nodes.admit_node(opts.id, opts.attrs)` (line 129) and `Nodes.reject_admission(opts.id, opts.attrs)` (line 139) with only two arguments, omitting the `audit_opts` keyword list. As a result the governance audit log and the persisted `AdmissionDecision` record `actor_type: &#34;operator&#34;` but `actor_id: nil`, whereas the Admin API path passes the operator&#39;s service-account/principal id via `audit_opts/1` (node_admission_controller.ex:116-121). This works today (actor_id is nullable and tests pass), but every admit/reject performed through `orchardctl` is unattributed in the audit trail for an audit-focused governance surface. Decide whether CLI-driven admission mutations should carry an operator identity, or whether unattributed local-CLI writes are the accepted trust model for this slice.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`ORCHARD_TEST_NODE_AGENT_PORT=50231 mix test apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs apps/orchard_cli/test/orchard_cli_test.exs` — 74 passed (list/inspect/pending/admit/reject, JSON + human, repo-outage degradation, audit-failure paths)</code>
- <code>`mix test apps/orchard_controller/test/orchard/api/admin/node_admission_controller_test.exs` — 13 passed</code>
- <code>Generated a real end-to-end CLI transcript via `mix run nodes_cli_transcript.exs` calling `OrchardCLI.Commands.Nodes.run/1` against the test DB: `nodes inspect` (human+JSON), `nodes pending` (human+JSON), `nodes admit --dry-run --json` then `nodes admit --yes ...`, `nodes reject --dry-run --json`, `nodes reject --reason` (no --yes → exit 2), `nodes reject --yes` (no reason → exit 2), `nodes reject --yes --reason ...`, and a follow-up `nodes inspect` confirming the admitted state</code>
- <code>Verified via psql that no seeded node/candidate rows persisted to `orchard_test` (sandbox rollback) and `git status` is clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
