### PR TITLE
feat(console): add node admission review UX

### DIFF
--- a/apps/orchard_controller/assets/css/app.css
+++ b/apps/orchard_controller/assets/css/app.css
@@ -205,6 +205,18 @@
    Console Shell — sidebar transitions
    ========================================================================== */
 
+#console-app,
+#console-shell {
+  width: 100vw;
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+#console-app {
+  position: fixed;
+  inset: 3px 0 0;
+}
+
 #console-sidebar {
   width: 16rem;
   min-width: 16rem;
@@ -273,6 +285,49 @@
 
 .sidebar-collapsed .sidebar-toggle-icon {
   transform: rotate(180deg);
+}
+
+@media (max-width: 639px) {
+  #console-sidebar {
+    width: 4.5rem;
+    min-width: 4.5rem;
+  }
+
+  #console-sidebar .sidebar-label {
+    opacity: 0;
+    width: 0;
+    overflow: hidden;
+  }
+
+  #console-sidebar .console-sidebar-version,
+  #console-sidebar #console-license-badge {
+    max-height: 0;
+    opacity: 0;
+    margin-bottom: 0;
+    overflow: hidden;
+    border-width: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  #console-sidebar #theme-toggle {
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  #console-sidebar #theme-toggle [data-theme-mode] {
+    width: 100%;
+    gap: 0;
+  }
+
+  #console-sidebar .logo-lockup {
+    gap: 0;
+    justify-content: center;
+  }
+
+  #sidebar-toggle {
+    display: none;
+  }
 }
 
 /* Respect reduced-motion preferences */

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -74,6 +74,8 @@ defmodule Orchard.API.Router do
     live_session :console, on_mount: [{OrchardConsole, :ensure_console_access}] do
       live("/", OrchardConsole.OverviewLive, :index)
       live("/nodes", OrchardConsole.NodesLive, :index)
+      live("/nodes/pending/:candidate_id", OrchardConsole.NodeDetailLive, :candidate)
+      live("/nodes/:node_id", OrchardConsole.NodeDetailLive, :node)
       live("/playground", OrchardConsole.PlaygroundLive, :index)
       live("/models", OrchardConsole.ModelsLive, :index)
       live("/model-hub", OrchardConsole.ModelHubLive, :index)

--- a/apps/orchard_controller/lib/orchard/console/layouts/app.html.heex
+++ b/apps/orchard_controller/lib/orchard/console/layouts/app.html.heex
@@ -61,7 +61,7 @@
   </aside>
 
   <%!-- Main content area --%>
-  <main class="flex-1 overflow-auto bg-slate-50 dark:bg-slate-900">
+  <main class="min-w-0 flex-1 overflow-x-hidden overflow-y-auto bg-slate-50 dark:bg-slate-900">
     <%!-- Page header --%>
     <header
       :if={assigns[:page_title]}

--- a/apps/orchard_controller/lib/orchard/console/layouts/root.html.heex
+++ b/apps/orchard_controller/lib/orchard/console/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full" data-theme={assigns[:initial_theme] || "system"}>
+<html lang="en" class="h-full overflow-hidden" data-theme={assigns[:initial_theme] || "system"}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -25,7 +25,7 @@
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
-  <body class="h-full bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-50 antialiased" data-lv-connected-once="false" data-lv-connection-state="connecting">
+  <body class="h-full overflow-hidden bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-50 antialiased" data-lv-connected-once="false" data-lv-connection-state="connecting">
     <!-- Brand bar: 3px gradient at top of viewport -->
     <div id="brand-bar" class="brand-bar h-[3px]"></div>
     {@inner_content}

--- a/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
@@ -1,0 +1,1192 @@
+defmodule OrchardConsole.NodeDetailLive do
+  @moduledoc """
+  Console detail drill-in for node inventory rows and admission candidates.
+  """
+
+  use OrchardConsole, :live_view
+
+  require Logger
+
+  alias Orchard.ClusterManagement.{ActionPreview, ActionPreviewBuilder, StatusBuilder}
+  alias Orchard.ControlPlane
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{AdmissionCandidate, Node}
+
+  @default_refresh_interval_ms 5_000
+  @pending_admission_categories ~w(pending_observed pending_provisioned pending_registered)
+
+  # ===========================================================================
+  # Lifecycle
+  # ===========================================================================
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     assign(socket,
+       page_title: "Node Detail",
+       active_nav: :nodes,
+       page_mode: :workspace,
+       target_kind: nil,
+       target_id: nil,
+       load_status: :loading,
+       record: nil,
+       status: nil,
+       latest_decision: nil,
+       action: nil,
+       refresh_timer: nil,
+       message: nil
+     )}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    {target_kind, target_id} = target_from_params(socket.assigns.live_action, params)
+
+    socket =
+      assign(socket,
+        target_kind: target_kind,
+        target_id: target_id,
+        load_status: :loading,
+        action: nil,
+        message: nil
+      )
+
+    if connected?(socket) do
+      {:noreply, socket |> cancel_refresh() |> load_detail() |> schedule_refresh()}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_info(:refresh_node_detail, socket) do
+    {:noreply, socket |> load_detail() |> schedule_refresh()}
+  end
+
+  @impl true
+  def handle_event("open_admit", _params, socket) do
+    if can_open_admit?(socket.assigns.target_kind, socket.assigns.record, socket.assigns.status) do
+      {:noreply, put_action(socket, :admit, default_action_inputs(:admit), false)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("open_reject", _params, socket) do
+    if can_open_reject?(socket.assigns.target_kind, socket.assigns.record, socket.assigns.status) do
+      {:noreply, put_action(socket, :reject, default_action_inputs(:reject), false)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("cancel_action", _params, socket) do
+    {:noreply, assign(socket, action: nil)}
+  end
+
+  def handle_event("action_change", %{"action" => params}, socket) do
+    action = socket.assigns.action
+    inputs = normalize_action_inputs(action.kind, params)
+    confirmed? = truthy?(Map.get(params, "confirmed"))
+
+    {:noreply, put_action(socket, action.kind, inputs, confirmed?)}
+  end
+
+  def handle_event("execute_action", %{"action" => params}, socket) do
+    action = socket.assigns.action
+    inputs = normalize_action_inputs(action.kind, params)
+    confirmed? = truthy?(Map.get(params, "confirmed"))
+
+    socket = put_action(socket, action.kind, inputs, confirmed?)
+
+    if action_executable?(socket.assigns.action) do
+      execute_action(socket, socket.assigns.action)
+    else
+      {:noreply,
+       put_action_error(socket, "Resolve blockers and confirm the preview before executing.")}
+    end
+  end
+
+  # ===========================================================================
+  # Render
+  # ===========================================================================
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="node-detail-page" class="space-y-6">
+      <.link
+        navigate={~p"/console/nodes"}
+        class="inline-flex items-center rounded-md px-2 py-1 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-navy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-sky-300 dark:focus-visible:ring-sky-400"
+      >
+        Back to Nodes
+      </.link>
+
+      <%= cond do %>
+        <% @load_status == :loading -> %>
+          <.state_message id="node-detail-loading" kind={:loading} layout={:panel} title="Loading node detail." />
+        <% @load_status == :not_found -> %>
+          <.state_message id="node-detail-not-found" kind={:empty} layout={:panel} title="Node detail not found." body={@message} />
+        <% @load_status == :error -> %>
+          <.state_message id="node-detail-error" kind={:error} layout={:panel} title="Node detail unavailable." body={@message} />
+        <% true -> %>
+          <div id="node-detail-content" class="space-y-6">
+            <div id="node-detail-header-card">
+              <.card>
+                <:title>{detail_title(@target_kind, @record)}</:title>
+                <:subtitle>{detail_subtitle(@target_kind, @record)}</:subtitle>
+                <:actions>
+                  <div class="flex flex-wrap justify-end gap-2">
+                    <.button
+                      :if={can_open_admit?(@target_kind, @record, @status)}
+                      id="node-detail-open-admit"
+                      variant={:primary}
+                      size={:sm}
+                      phx-click="open_admit"
+                    >
+                      Preview admit
+                    </.button>
+                    <.button
+                      :if={can_open_reject?(@target_kind, @record, @status)}
+                      id="node-detail-open-reject"
+                      variant={:danger}
+                      size={:sm}
+                      phx-click="open_reject"
+                    >
+                      Preview reject
+                    </.button>
+                  </div>
+                </:actions>
+
+                <div class="flex flex-wrap items-center gap-2">
+                  <.badge tone={admission_category_tone(status_value(@status, :admission, :category))}>
+                    {format_status_value(status_value(@status, :admission, :category))}
+                  </.badge>
+                  <.badge tone={health_tone(status_value(@status, :health, :status))}>
+                    {format_status_value(status_value(@status, :health, :status))}
+                  </.badge>
+                  <.badge tone={freshness_tone(status_value(@status, :freshness, :status))}>
+                    {format_status_value(status_value(@status, :freshness, :status))}
+                  </.badge>
+                  <span class="text-xs font-mono text-slate-500 dark:text-slate-400">
+                    {resource_id(@target_kind, @record)}
+                  </span>
+                </div>
+              </.card>
+            </div>
+
+            <div id="node-detail-status-groups" class="grid gap-4 lg:grid-cols-2">
+              <.status_group
+                id="node-detail-lifecycle"
+                title="Lifecycle"
+                badge={format_status_value(status_value(@status, :lifecycle, :state))}
+                tone={lifecycle_tone(status_value(@status, :lifecycle, :state))}
+              >
+                <.detail_grid id="node-detail-lifecycle-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-lifecycle-state" label="State" mono>
+                    {format_status_value(status_value(@status, :lifecycle, :state))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-resource-type" label="Resource" mono>
+                    {status_value(@status, :resource, :type)}
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+
+              <.status_group
+                id="node-detail-admission"
+                title="Admission"
+                badge={format_status_value(status_value(@status, :admission, :category))}
+                tone={admission_category_tone(status_value(@status, :admission, :category))}
+              >
+                <.detail_grid id="node-detail-admission-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-admission-category" label="Category" mono>
+                    {format_status_value(status_value(@status, :admission, :category))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-admission-source" label="Source" mono>
+                    {format_status_value(status_value(@status, :admission, :source))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-admission-latest" label="Latest Decision" mono>
+                    {format_status_value(status_value(@status, :admission, :latest_decision))}
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+
+              <.status_group
+                id="node-detail-health"
+                title="Health"
+                badge={format_status_value(status_value(@status, :health, :status))}
+                tone={health_tone(status_value(@status, :health, :status))}
+              >
+                <.detail_grid id="node-detail-health-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-health-status" label="Health" mono>
+                    {format_status_value(status_value(@status, :health, :status))}
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+
+              <.status_group
+                id="node-detail-freshness"
+                title="Freshness"
+                badge={format_status_value(status_value(@status, :freshness, :status))}
+                tone={freshness_tone(status_value(@status, :freshness, :status))}
+              >
+                <.detail_grid id="node-detail-freshness-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-freshness-status" label="Freshness" mono>
+                    {format_status_value(status_value(@status, :freshness, :status))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-freshness-source" label="Source" mono>
+                    {format_status_value(status_value(@status, :freshness, :source))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-freshness-observed" label="Observed At" mono>
+                    <.local_time
+                      :if={status_value(@status, :freshness, :observed_at)}
+                      value={status_value(@status, :freshness, :observed_at)}
+                      format={:datetime_second}
+                    />
+                    <span :if={!status_value(@status, :freshness, :observed_at)}>Never observed</span>
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+
+              <.status_group
+                id="node-detail-transport"
+                title="Transport"
+                badge={format_status_value(status_value(@status, :transport, :status))}
+                tone={transport_tone(status_value(@status, :transport, :status))}
+              >
+                <.detail_grid id="node-detail-transport-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-transport-status" label="Transport" mono>
+                    {format_status_value(status_value(@status, :transport, :status))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-target-ref" label="Target" mono break_all>
+                    {target_ref(@target_kind, @record)}
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+
+              <.status_group
+                id="node-detail-runtime"
+                title="Runtime"
+                badge={format_status_value(status_value(@status, :runtime, :status))}
+                tone={runtime_tone(status_value(@status, :runtime, :status))}
+              >
+                <.detail_grid id="node-detail-runtime-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-runtime-status" label="Runtime" mono>
+                    {format_status_value(status_value(@status, :runtime, :status))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-runtime-health-code" label="Health Code" mono>
+                    {format_optional(status_value(@status, :runtime, :health_code))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-runtime-message" label="Message">
+                    {format_optional(status_value(@status, :runtime, :health_message))}
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+
+              <.status_group
+                id="node-detail-compatibility"
+                title="Compatibility"
+                badge={format_status_value(status_value(@status, :compatibility, :status))}
+                tone={compatibility_tone(status_value(@status, :compatibility, :status))}
+              >
+                <.detail_grid id="node-detail-compatibility-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-compatibility-status" label="Compatibility" mono>
+                    {format_status_value(status_value(@status, :compatibility, :status))}
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+
+              <.status_group
+                id="node-detail-scheduling"
+                title="Scheduling"
+                badge={scheduling_badge(status_value(@status, :scheduling, :eligible))}
+                tone={scheduling_tone(status_value(@status, :scheduling, :eligible))}
+              >
+                <.detail_grid id="node-detail-scheduling-grid" class="sm:grid-cols-2">
+                  <.detail_field id="node-detail-scheduling-eligible" label="Eligible" mono>
+                    {scheduling_badge(status_value(@status, :scheduling, :eligible))}
+                  </.detail_field>
+                  <.detail_field id="node-detail-scheduling-codes" label="Reason Codes">
+                    <.code_list
+                      id="node-detail-scheduling-code-list"
+                      codes={status_value(@status, :scheduling, :reason_codes) || []}
+                      empty="No scheduler rejection codes."
+                    />
+                  </.detail_field>
+                </.detail_grid>
+              </.status_group>
+            </div>
+
+            <div id="node-detail-warnings-card">
+              <.card>
+                <:title>Warnings</:title>
+                <.coded_entry_list
+                  id="node-detail-warnings"
+                  entries={status_value(@status, :warnings)}
+                  empty="No warnings reported."
+                  tone={:warning}
+                />
+              </.card>
+            </div>
+
+            <div :if={@latest_decision} id="node-detail-latest-decision-card">
+              <.card variant={:secondary}>
+                <:title>Latest Admission Decision</:title>
+                <.detail_grid id="node-detail-latest-decision-grid" class="sm:grid-cols-3">
+                  <.detail_field id="node-detail-decision-kind" label="Decision" mono>
+                    {format_status_value(@latest_decision.decision)}
+                  </.detail_field>
+                  <.detail_field id="node-detail-decision-reason" label="Reason">
+                    {format_optional(@latest_decision.reason)}
+                  </.detail_field>
+                  <.detail_field id="node-detail-decision-at" label="Decided At" mono>
+                    <.local_time value={@latest_decision.decided_at} format={:datetime_second} />
+                  </.detail_field>
+                </.detail_grid>
+              </.card>
+            </div>
+
+            <div :if={@target_kind == :candidate} id="node-detail-candidate-evidence-card">
+              <.card>
+                <:title>Candidate Evidence</:title>
+                <:subtitle>Observed candidate evidence is preserved as review context.</:subtitle>
+                <div class="grid gap-4 lg:grid-cols-3">
+                  <.evidence_block
+                    id="node-detail-observed-identity"
+                    title="Observed Identity"
+                    rows={evidence_rows(@record.observed_identity)}
+                  />
+                  <.evidence_block
+                    id="node-detail-inventory-evidence"
+                    title="Inventory Snapshot"
+                    rows={evidence_rows(@record.inventory)}
+                  />
+                  <.evidence_block
+                    id="node-detail-compatibility-evidence"
+                    title="Compatibility Evidence"
+                    rows={evidence_rows(@record.compatibility_evidence)}
+                  />
+                </div>
+                <div :if={@record.node_id} class="mt-4">
+                  <.link
+                    navigate={~p"/console/nodes/#{@record.node_id}"}
+                    class="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium text-navy hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-sky-300 dark:hover:bg-slate-800 dark:focus-visible:ring-sky-400"
+                  >
+                    Review linked node
+                  </.link>
+                </div>
+              </.card>
+            </div>
+
+            <.action_preview_panel :if={@action} action={@action} />
+          </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  # ===========================================================================
+  # Data loading
+  # ===========================================================================
+
+  defp target_from_params(:candidate, %{"candidate_id" => candidate_id}),
+    do: {:candidate, candidate_id}
+
+  defp target_from_params(:node, %{"node_id" => node_id}), do: {:node, node_id}
+
+  defp load_detail(%{assigns: %{target_kind: :node, target_id: node_id}} = socket) do
+    case Nodes.fetch_node(node_id) do
+      {:ok, %Node{} = node} ->
+        latest_decision = Nodes.latest_admission_decision_for_node(node.id)
+        status = StatusBuilder.node_status_map(node, latest_decision: latest_decision)
+
+        socket
+        |> assign(
+          page_title: "#{node.display_name || node.hostname || "Node"} Detail",
+          load_status: :ok,
+          record: node,
+          status: status,
+          latest_decision: latest_decision,
+          message: nil
+        )
+        |> refresh_open_action()
+
+      {:error, :node_not_found} ->
+        assign(socket,
+          load_status: :not_found,
+          record: nil,
+          status: nil,
+          latest_decision: nil,
+          action: nil,
+          message: "The requested node inventory row was not found."
+        )
+    end
+  rescue
+    error ->
+      Logger.warning("Node detail load failed: #{inspect(error)}")
+      detail_error(socket)
+  catch
+    kind, reason ->
+      Logger.warning("Node detail load #{kind}: #{inspect(reason)}")
+      detail_error(socket)
+  end
+
+  defp load_detail(%{assigns: %{target_kind: :candidate, target_id: candidate_id}} = socket) do
+    case Nodes.fetch_admission_candidate(candidate_id) do
+      {:ok, %AdmissionCandidate{} = candidate} ->
+        latest_decision = Nodes.latest_admission_decision_for_candidate(candidate.id)
+        status = StatusBuilder.candidate_status_map(candidate, latest_decision: latest_decision)
+
+        socket
+        |> assign(
+          page_title: "#{candidate_display_label(candidate)} Detail",
+          load_status: :ok,
+          record: candidate,
+          status: status,
+          latest_decision: latest_decision,
+          message: nil
+        )
+        |> refresh_open_action()
+
+      {:error, :candidate_not_found} ->
+        assign(socket,
+          load_status: :not_found,
+          record: nil,
+          status: nil,
+          latest_decision: nil,
+          action: nil,
+          message: "The requested admission candidate was not found."
+        )
+    end
+  rescue
+    error ->
+      Logger.warning("Admission candidate detail load failed: #{inspect(error)}")
+      detail_error(socket)
+  catch
+    kind, reason ->
+      Logger.warning("Admission candidate detail load #{kind}: #{inspect(reason)}")
+      detail_error(socket)
+  end
+
+  defp detail_error(socket) do
+    assign(socket,
+      load_status: :error,
+      record: nil,
+      status: nil,
+      latest_decision: nil,
+      action: nil,
+      message: "Node detail could not be loaded."
+    )
+  end
+
+  defp refresh_open_action(%{assigns: %{action: nil}} = socket), do: socket
+
+  defp refresh_open_action(%{assigns: %{action: action}} = socket) do
+    put_action(socket, action.kind, action.inputs, action.confirmed)
+  end
+
+  # ===========================================================================
+  # Actions
+  # ===========================================================================
+
+  defp put_action(socket, kind, inputs, confirmed?) do
+    preview =
+      socket
+      |> build_action_preview(kind, inputs)
+      |> ActionPreview.to_map()
+
+    assign(socket,
+      action: %{
+        kind: kind,
+        inputs: inputs,
+        confirmed: confirmed?,
+        preview: preview,
+        error: nil
+      }
+    )
+  end
+
+  defp build_action_preview(
+         %{assigns: %{target_kind: :node, record: %Node{id: id}}},
+         :admit,
+         inputs
+       ) do
+    ActionPreviewBuilder.admit_node(id, inputs)
+  end
+
+  defp build_action_preview(
+         %{assigns: %{target_kind: :candidate, record: %AdmissionCandidate{id: id}}},
+         :reject,
+         inputs
+       ) do
+    ActionPreviewBuilder.reject_admission(id, inputs)
+  end
+
+  defp build_action_preview(
+         %{assigns: %{target_kind: :node, record: %Node{id: id}}},
+         :reject,
+         inputs
+       ) do
+    ActionPreviewBuilder.reject_admission(id, inputs)
+  end
+
+  defp execute_action(socket, %{kind: :admit, inputs: inputs}) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, _result} <- Nodes.admit_node(socket.assigns.record.id, inputs, audit_opts()) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Node admitted.")
+       |> assign(action: nil)
+       |> load_detail()}
+    else
+      {:error, reason} -> {:noreply, put_action_error(socket, error_message(reason))}
+    end
+  end
+
+  defp execute_action(%{assigns: %{target_kind: :candidate}} = socket, %{
+         kind: :reject,
+         inputs: inputs
+       }) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, _result} <-
+           Nodes.reject_admission_candidate(socket.assigns.record.id, inputs, audit_opts()) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Admission rejected.")
+       |> assign(action: nil)
+       |> load_detail()}
+    else
+      {:error, reason} -> {:noreply, put_action_error(socket, error_message(reason))}
+    end
+  end
+
+  defp execute_action(%{assigns: %{target_kind: :node}} = socket, %{kind: :reject, inputs: inputs}) do
+    with :ok <- ControlPlane.authorize_write_path(:node_admission),
+         {:ok, _result} <- Nodes.reject_admission(socket.assigns.record.id, inputs, audit_opts()) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Admission rejected.")
+       |> assign(action: nil)
+       |> load_detail()}
+    else
+      {:error, reason} -> {:noreply, put_action_error(socket, error_message(reason))}
+    end
+  end
+
+  defp put_action_error(%{assigns: %{action: action}} = socket, message) do
+    assign(socket, action: Map.put(action, :error, message))
+  end
+
+  defp audit_opts, do: [actor_type: "operator", actor_id: nil]
+
+  defp default_action_inputs(:admit) do
+    %{"trust_evidence_ref" => "", "pool_id" => "", "routing_policy_id" => ""}
+  end
+
+  defp default_action_inputs(:reject), do: %{"reason" => ""}
+
+  defp normalize_action_inputs(:admit, params) do
+    %{
+      "trust_evidence_ref" => Map.get(params, "trust_evidence_ref", ""),
+      "pool_id" => Map.get(params, "pool_id", ""),
+      "routing_policy_id" => Map.get(params, "routing_policy_id", "")
+    }
+  end
+
+  defp normalize_action_inputs(:reject, params) do
+    %{"reason" => Map.get(params, "reason", "")}
+  end
+
+  defp action_executable?(%{confirmed: true, preview: preview, kind: kind, inputs: inputs}) do
+    preview_entries(preview, :blockers) == [] and
+      not missing_required_input?(kind, preview, inputs)
+  end
+
+  defp action_executable?(_action), do: false
+
+  defp missing_required_input?(:reject, preview, inputs) do
+    "requires_reason" in preview_codes(preview, :confirmation_requirements) and
+      blank?(Map.get(inputs, "reason"))
+  end
+
+  defp missing_required_input?(_kind, _preview, _inputs), do: false
+
+  defp can_open_admit?(:node, %Node{}, status) do
+    status_value(status, :admission, :category) in ["pending_provisioned", "pending_registered"]
+  end
+
+  defp can_open_admit?(_target_kind, _record, _status), do: false
+
+  defp can_open_reject?(_target_kind, record, status)
+       when is_struct(record, Node) or is_struct(record, AdmissionCandidate) do
+    status_value(status, :admission, :category) in @pending_admission_categories
+  end
+
+  defp can_open_reject?(_target_kind, _record, _status), do: false
+
+  # ===========================================================================
+  # Display helpers
+  # ===========================================================================
+
+  defp detail_title(:node, %Node{} = node), do: node.display_name || node.hostname || node.id
+
+  defp detail_title(:candidate, %AdmissionCandidate{} = candidate),
+    do: candidate_display_label(candidate)
+
+  defp detail_title(_kind, _record), do: "Node Detail"
+
+  defp detail_subtitle(:node, %Node{} = node), do: "Node inventory row #{node.id}"
+
+  defp detail_subtitle(:candidate, %AdmissionCandidate{} = candidate),
+    do: "Admission candidate #{candidate.id}"
+
+  defp detail_subtitle(_kind, _record), do: nil
+
+  defp resource_id(:node, %Node{id: id}), do: "node #{id}"
+  defp resource_id(:candidate, %AdmissionCandidate{id: id}), do: "candidate #{id}"
+  defp resource_id(_kind, _record), do: "unknown"
+
+  defp target_ref(:node, %Node{} = node), do: format_host_port(node.advertise_addr, node.rpc_port)
+
+  defp target_ref(:candidate, %AdmissionCandidate{} = candidate) do
+    candidate.target_ref || candidate.endpoint_target || "Unconfigured"
+  end
+
+  defp target_ref(_kind, _record), do: "Unconfigured"
+
+  defp candidate_display_label(%AdmissionCandidate{observed_identity: identity} = candidate) do
+    [
+      map_get(identity, "display_name"),
+      map_get(identity, "hostname"),
+      map_get(identity, "claimed_node_id"),
+      candidate.target_ref,
+      candidate.endpoint_target,
+      candidate.id
+    ]
+    |> Enum.find(&present?/1)
+  end
+
+  defp status_value(status, :warnings) when is_map(status) do
+    case map_get(status, :warnings) do
+      warnings when is_list(warnings) -> warnings
+      _warnings -> []
+    end
+  end
+
+  defp status_value(status, group, key) when is_map(status) do
+    case map_get(status, group) do
+      group_status when is_map(group_status) -> map_get(group_status, key)
+      _group_status -> nil
+    end
+  end
+
+  defp status_value(_status, _group, _key), do: nil
+
+  defp preview_entries(preview, key) when is_map(preview) do
+    case map_get(preview, key) do
+      entries when is_list(entries) -> entries
+      _entries -> []
+    end
+  end
+
+  defp preview_codes(preview, key) when is_map(preview) do
+    case map_get(preview, key) do
+      codes when is_list(codes) -> codes
+      _codes -> []
+    end
+  end
+
+  defp preview_value(preview, key) when is_map(preview), do: map_get(preview, key)
+  defp preview_value(_preview, _key), do: nil
+
+  defp nested_preview_value(preview, group, key) when is_map(preview) do
+    case map_get(preview, group) do
+      group_value when is_map(group_value) -> map_get(group_value, key)
+      _group_value -> nil
+    end
+  end
+
+  defp evidence_rows(map) when is_map(map) do
+    map
+    |> Enum.map(fn {key, value} -> %{key: to_string(key), value: value} end)
+    |> Enum.sort_by(& &1.key)
+  end
+
+  defp evidence_rows(_value), do: []
+
+  defp map_get(map, key) when is_map(map) and is_atom(key) do
+    fetch_map_value(map, key, Atom.to_string(key))
+  end
+
+  defp map_get(map, key) when is_map(map) and is_binary(key) do
+    fetch_map_value(map, key, key_atom(key))
+  end
+
+  defp map_get(_map, _key), do: nil
+
+  defp fetch_map_value(map, key, fallback_key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> fetch_fallback_map_value(map, fallback_key)
+    end
+  end
+
+  defp fetch_fallback_map_value(_map, nil), do: nil
+
+  defp fetch_fallback_map_value(map, fallback_key) do
+    Map.get(map, fallback_key)
+  end
+
+  defp key_atom("display_name"), do: :display_name
+  defp key_atom("hostname"), do: :hostname
+  defp key_atom("claimed_node_id"), do: :claimed_node_id
+  defp key_atom(_key), do: nil
+
+  defp format_optional(value) when is_binary(value) and value != "", do: value
+  defp format_optional(nil), do: "Not reported"
+  defp format_optional(""), do: "Not reported"
+  defp format_optional(value), do: to_string(value)
+
+  defp format_status_value(nil), do: "unknown"
+
+  defp format_status_value(value) when is_atom(value) do
+    value
+    |> Atom.to_string()
+    |> format_status_value()
+  end
+
+  defp format_status_value(value) when is_binary(value) do
+    value
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp format_status_value(value), do: to_string(value)
+
+  defp format_data(nil), do: "Not reported"
+  defp format_data(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp format_data(value) when is_binary(value), do: value
+  defp format_data(value) when is_number(value) or is_boolean(value), do: to_string(value)
+  defp format_data(value), do: inspect(value, pretty: true, limit: 50)
+
+  defp format_host_port(host, port) when is_binary(host) and is_integer(port) do
+    if String.contains?(host, ":"),
+      do: "[#{host}]:#{port}",
+      else: "#{host}:#{port}"
+  end
+
+  defp format_host_port(_host, _port), do: "Unconfigured"
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(nil), do: false
+  defp present?(_value), do: true
+
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(nil), do: true
+  defp blank?(_value), do: false
+
+  defp truthy?(value), do: value in [true, "true", "on", "1", 1]
+
+  defp lifecycle_tone("active"), do: :success
+  defp lifecycle_tone(state) when state in ["cordoned", "draining", "maintenance"], do: :warning
+  defp lifecycle_tone("removed"), do: :neutral
+  defp lifecycle_tone(_state), do: :neutral
+
+  defp admission_category_tone("rejected"), do: :error
+  defp admission_category_tone("pending_registered"), do: :info
+  defp admission_category_tone("pending_provisioned"), do: :warning
+  defp admission_category_tone(_category), do: :neutral
+
+  defp health_tone("healthy"), do: :success
+  defp health_tone("degraded"), do: :warning
+  defp health_tone(status) when status in ["unhealthy", "unreachable"], do: :error
+  defp health_tone(_status), do: :neutral
+
+  defp freshness_tone("fresh"), do: :success
+  defp freshness_tone("stale"), do: :warning
+  defp freshness_tone("unreachable"), do: :error
+  defp freshness_tone(_status), do: :neutral
+
+  defp transport_tone("reachable"), do: :success
+  defp transport_tone("target_unconfigured"), do: :warning
+
+  defp transport_tone(status) when status in ["timeout", "connect_failed", "identity_mismatch"],
+    do: :error
+
+  defp transport_tone(_status), do: :neutral
+
+  defp runtime_tone("ready"), do: :success
+  defp runtime_tone("not_ready"), do: :error
+  defp runtime_tone(_status), do: :neutral
+
+  defp compatibility_tone("compatible"), do: :success
+
+  defp compatibility_tone(status)
+       when status in ["legacy_metadata", "partial_metadata", "version_skew"], do: :warning
+
+  defp compatibility_tone("unsupported_version"), do: :error
+  defp compatibility_tone(_status), do: :neutral
+
+  defp scheduling_badge(true), do: "Eligible"
+  defp scheduling_badge(false), do: "Blocked"
+  defp scheduling_badge(_value), do: "Unknown"
+
+  defp scheduling_tone(true), do: :success
+  defp scheduling_tone(false), do: :warning
+  defp scheduling_tone(_value), do: :neutral
+
+  defp action_title(:admit), do: "Admit Node Preview"
+  defp action_title(:reject), do: "Reject Admission Preview"
+
+  defp action_submit_label(:admit), do: "Admit node"
+  defp action_submit_label(:reject), do: "Reject admission"
+
+  defp action_variant(:reject), do: :danger
+  defp action_variant(_kind), do: :primary
+
+  defp action_panel_class(:reject),
+    do: "border-red-200 bg-red-50/40 dark:border-red-900/50 dark:bg-red-950/20"
+
+  defp action_panel_class(_kind), do: ""
+
+  defp action_explanation(:admit) do
+    "Execution revalidates admission blockers before mutating node state."
+  end
+
+  defp action_explanation(:reject) do
+    "Rejection records an admission decision and keeps the candidate visible for audit review."
+  end
+
+  defp error_message(:controller_standby), do: "This controller is in standby mode."
+  defp error_message(:candidate_not_found), do: "Node admission candidate was not found."
+  defp error_message(:node_not_found), do: "Node was not found."
+  defp error_message(:reason_required), do: "A nonblank rejection reason is required."
+  defp error_message(:admission_not_pending), do: "Admission is not pending."
+  defp error_message(:admission_not_rejected), do: "Admission is not rejected."
+  defp error_message(:admission_rejected), do: "Admission rejection must be cleared first."
+  defp error_message(:node_not_registered), do: "Node is not registered."
+  defp error_message(:node_not_pending_admission), do: "Node is not pending admission."
+  defp error_message(:inventory_missing), do: "Registered node inventory is missing."
+  defp error_message(:trust_not_established), do: "Node trust evidence is required."
+  defp error_message(:pool_required), do: "Node pool assignment is required."
+  defp error_message(:policy_required), do: "Required policy inputs are missing."
+  defp error_message(_reason), do: "Node admission action failed."
+
+  # ===========================================================================
+  # Refresh / config
+  # ===========================================================================
+
+  defp schedule_refresh(socket) do
+    ref = Process.send_after(self(), :refresh_node_detail, refresh_interval_ms())
+    assign(socket, refresh_timer: ref)
+  end
+
+  defp cancel_refresh(socket) do
+    case socket.assigns[:refresh_timer] do
+      ref when is_reference(ref) -> Process.cancel_timer(ref)
+      _ -> :ok
+    end
+
+    assign(socket, refresh_timer: nil)
+  end
+
+  defp refresh_interval_ms do
+    case console_config()[:refresh_interval_ms] do
+      n when is_integer(n) and n > 0 -> n
+      _ -> @default_refresh_interval_ms
+    end
+  end
+
+  defp console_config do
+    Application.get_env(:orchard_controller, :console, [])
+  end
+
+  # ===========================================================================
+  # Local components
+  # ===========================================================================
+
+  attr(:id, :string, required: true)
+  attr(:title, :string, required: true)
+  attr(:badge, :string, default: nil)
+  attr(:tone, :atom, default: :neutral)
+  slot(:inner_block, required: true)
+
+  defp status_group(assigns) do
+    ~H"""
+    <div id={@id}>
+      <.card padding={:sm}>
+        <:title>
+          <span class="flex flex-wrap items-center gap-2">
+            <span>{@title}</span>
+            <.badge :if={@badge} tone={@tone}>{@badge}</.badge>
+          </span>
+        </:title>
+        {render_slot(@inner_block)}
+      </.card>
+    </div>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:entries, :list, default: [])
+  attr(:empty, :string, required: true)
+  attr(:tone, :atom, default: :neutral)
+
+  defp coded_entry_list(assigns) do
+    ~H"""
+    <div id={@id}>
+      <p :if={@entries == []} class="text-sm text-slate-500 dark:text-slate-400">
+        {@empty}
+      </p>
+      <ul :if={@entries != []} class="space-y-2">
+        <li :for={entry <- @entries} class="flex flex-wrap items-start gap-2 text-sm">
+          <.code_chip code={map_get(entry, :code)} tone={@tone} />
+          <span class="text-slate-700 dark:text-slate-300">
+            {format_optional(map_get(entry, :message))}
+          </span>
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:codes, :list, default: [])
+  attr(:empty, :string, required: true)
+
+  defp code_list(assigns) do
+    ~H"""
+    <div id={@id}>
+      <p :if={@codes == []} class="text-sm text-slate-500 dark:text-slate-400">
+        {@empty}
+      </p>
+      <div :if={@codes != []} class="flex flex-wrap gap-2">
+        <.code_chip :for={code <- @codes} code={code} tone={:neutral} />
+      </div>
+    </div>
+    """
+  end
+
+  attr(:code, :any, required: true)
+  attr(:tone, :atom, default: :neutral)
+
+  defp code_chip(assigns) do
+    ~H"""
+    <span class={[
+      "inline-flex max-w-full items-center rounded border px-2 py-0.5 font-mono text-xs",
+      code_chip_class(@tone)
+    ]}>
+      {format_optional(@code)}
+    </span>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:title, :string, required: true)
+  attr(:rows, :list, default: [])
+
+  defp evidence_block(assigns) do
+    ~H"""
+    <div id={@id} class="rounded-lg border border-slate-200 bg-slate-50/60 p-3 dark:border-slate-700 dark:bg-slate-900/50">
+      <h3 class="text-sm font-medium text-slate-800 dark:text-slate-100">{@title}</h3>
+      <p :if={@rows == []} class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        No evidence reported.
+      </p>
+      <dl :if={@rows != []} class="mt-3 space-y-3">
+        <div :for={row <- @rows}>
+          <dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            {row.key}
+          </dt>
+          <dd class="mt-1 max-h-36 overflow-auto rounded border border-slate-200 bg-white p-2 font-mono text-xs text-slate-800 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200">
+            <pre class="whitespace-pre-wrap break-words">{format_data(row.value)}</pre>
+          </dd>
+        </div>
+      </dl>
+    </div>
+    """
+  end
+
+  attr(:action, :map, required: true)
+
+  defp action_preview_panel(assigns) do
+    ~H"""
+    <div id="node-admission-action-preview">
+      <.card class={action_panel_class(@action.kind)}>
+        <:title>{action_title(@action.kind)}</:title>
+        <:subtitle>{action_explanation(@action.kind)}</:subtitle>
+
+        <form id="admission-action-form" phx-change="action_change" phx-submit="execute_action" class="space-y-5">
+          <div id="action-preview-summary" class="grid gap-4 lg:grid-cols-3">
+            <.detail_grid id="action-preview-current" class="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-950">
+              <.detail_field id="action-preview-current-state" label="Current" mono>
+                {format_status_value(nested_preview_value(@action.preview, :current, :state))}
+              </.detail_field>
+              <.detail_field id="action-preview-active-requests" label="Active Requests" mono>
+                {format_optional(preview_value(@action.preview, :active_request_count))}
+              </.detail_field>
+            </.detail_grid>
+
+            <.detail_grid id="action-preview-scheduling" class="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-950">
+              <.detail_field id="action-preview-scheduling-state" label="Scheduler" mono>
+                {scheduling_badge(nested_preview_value(@action.preview, :scheduler_eligibility, :eligible))}
+              </.detail_field>
+              <.detail_field id="action-preview-scheduling-codes" label="Reason Codes">
+                <.code_list
+                  id="action-preview-scheduler-code-list"
+                  codes={nested_preview_value(@action.preview, :scheduler_eligibility, :reason_codes) || []}
+                  empty="No scheduler rejection codes."
+                />
+              </.detail_field>
+            </.detail_grid>
+
+            <.detail_grid id="action-preview-transition" class="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-950">
+              <.detail_field id="action-preview-transition-from" label="From" mono>
+                {format_status_value(nested_preview_value(@action.preview, :expected_transition, :from))}
+              </.detail_field>
+              <.detail_field id="action-preview-transition-to" label="To" mono>
+                {format_status_value(nested_preview_value(@action.preview, :expected_transition, :to))}
+              </.detail_field>
+              <.detail_field id="action-preview-audit-action" label="Audit Action" mono break_all>
+                {format_optional(preview_value(@action.preview, :audit_action))}
+              </.detail_field>
+            </.detail_grid>
+          </div>
+
+          <div class="grid gap-4 lg:grid-cols-2">
+            <div class="rounded-lg border border-red-200 bg-red-50/60 p-3 dark:border-red-900/50 dark:bg-red-950/20">
+              <h3 class="text-sm font-medium text-red-800 dark:text-red-200">Blockers</h3>
+              <div class="mt-2">
+                <.coded_entry_list
+                  id="action-preview-blockers"
+                  entries={preview_entries(@action.preview, :blockers)}
+                  empty="No blockers."
+                  tone={:error}
+                />
+              </div>
+            </div>
+            <div class="rounded-lg border border-amber-200 bg-amber-50/60 p-3 dark:border-amber-900/50 dark:bg-amber-950/20">
+              <h3 class="text-sm font-medium text-amber-800 dark:text-amber-200">Warnings</h3>
+              <div class="mt-2">
+                <.coded_entry_list
+                  id="action-preview-warnings"
+                  entries={preview_entries(@action.preview, :warnings)}
+                  empty="No warnings."
+                  tone={:warning}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div class="grid gap-4 lg:grid-cols-2">
+            <div>
+              <h3 class="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">
+                Consequences
+              </h3>
+              <.code_list
+                id="action-preview-consequence-codes"
+                codes={preview_codes(@action.preview, :consequence_codes)}
+                empty="No consequence codes."
+              />
+            </div>
+            <div>
+              <h3 class="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">
+                Confirmation Requirements
+              </h3>
+              <.code_list
+                id="action-preview-confirmation-requirements"
+                codes={preview_codes(@action.preview, :confirmation_requirements)}
+                empty="No confirmation requirements."
+              />
+            </div>
+          </div>
+
+          <div :if={@action.kind == :admit} id="action-admit-inputs" class="grid gap-4 md:grid-cols-3">
+            <.input
+              id="action-trust-evidence-ref"
+              name="action[trust_evidence_ref]"
+              value={@action.inputs["trust_evidence_ref"]}
+              label="Trust Evidence Reference"
+              placeholder="registration-audit:..."
+            />
+            <.input
+              id="action-pool-id"
+              name="action[pool_id]"
+              value={@action.inputs["pool_id"]}
+              label="Pool ID"
+              placeholder="pool identifier"
+            />
+            <.input
+              id="action-routing-policy-id"
+              name="action[routing_policy_id]"
+              value={@action.inputs["routing_policy_id"]}
+              label="Routing Policy ID"
+              placeholder="policy identifier"
+            />
+          </div>
+
+          <div :if={@action.kind == :reject} id="action-reject-inputs">
+            <.input
+              id="action-reason"
+              name="action[reason]"
+              type="textarea"
+              rows="3"
+              value={@action.inputs["reason"]}
+              label="Rejection Reason"
+              placeholder="Describe why this admission is being rejected."
+              errors={reject_reason_errors(@action)}
+            />
+          </div>
+
+          <div class="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/50">
+            <.input
+              id="action-confirmed"
+              name="action[confirmed]"
+              type="checkbox"
+              checked={@action.confirmed}
+              label="I reviewed the preview and understand this admission action."
+            />
+          </div>
+
+          <p :if={@action.error} id="action-preview-error" class="text-sm font-medium text-red-700 dark:text-red-300">
+            {@action.error}
+          </p>
+
+          <div class="flex flex-wrap justify-end gap-2">
+            <.button id="action-cancel" variant={:secondary} phx-click="cancel_action">
+              Cancel
+            </.button>
+            <.button
+              id="action-submit"
+              type="submit"
+              variant={action_variant(@action.kind)}
+              disabled={!action_executable?(@action)}
+            >
+              {action_submit_label(@action.kind)}
+            </.button>
+          </div>
+        </form>
+      </.card>
+    </div>
+    """
+  end
+
+  defp reject_reason_errors(%{kind: :reject, preview: preview, inputs: inputs}) do
+    if missing_required_input?(:reject, preview, inputs),
+      do: ["A nonblank rejection reason is required."],
+      else: []
+  end
+
+  defp reject_reason_errors(_action), do: []
+
+  defp code_chip_class(:error),
+    do:
+      "border-red-200 bg-red-100 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200"
+
+  defp code_chip_class(:warning),
+    do:
+      "border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+
+  defp code_chip_class(_tone),
+    do:
+      "border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+end

--- a/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
@@ -482,7 +482,12 @@ defmodule OrchardConsole.NodeDetailLive do
   defp refresh_open_action(%{assigns: %{action: nil}} = socket), do: socket
 
   defp refresh_open_action(%{assigns: %{action: action}} = socket) do
-    put_action(socket, action.kind, action.inputs, action.confirmed)
+    refreshed = put_action(socket, action.kind, action.inputs, action.confirmed)
+
+    case action.error do
+      nil -> refreshed
+      error -> put_action_error(refreshed, error)
+    end
   end
 
   # ===========================================================================

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -969,16 +969,16 @@ defmodule OrchardConsole.NodesLive do
 
   defp pending_source_tone(:runtime_endpoint_observation), do: :info
   defp pending_source_tone("runtime_endpoint_observation"), do: :info
-  defp pending_source_tone(:provisioned_node), do: :neutral
-  defp pending_source_tone("provisioned_node"), do: :neutral
+  defp pending_source_tone(:provisioned_placeholder), do: :neutral
+  defp pending_source_tone("provisioned_placeholder"), do: :neutral
   defp pending_source_tone(:registered_node), do: :info
   defp pending_source_tone("registered_node"), do: :info
   defp pending_source_tone(_source), do: :neutral
 
   defp pending_source_label(:runtime_endpoint_observation), do: "observed"
   defp pending_source_label("runtime_endpoint_observation"), do: "observed"
-  defp pending_source_label(:provisioned_node), do: "provisioned"
-  defp pending_source_label("provisioned_node"), do: "provisioned"
+  defp pending_source_label(:provisioned_placeholder), do: "provisioned"
+  defp pending_source_label("provisioned_placeholder"), do: "provisioned"
   defp pending_source_label(:registered_node), do: "registered"
   defp pending_source_label("registered_node"), do: "registered"
   defp pending_source_label(source), do: format_status_value(source)

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -12,6 +12,7 @@ defmodule OrchardConsole.NodesLive do
   require Logger
 
   alias Orchard.Nodes
+  alias Orchard.Nodes.AdmissionCandidate
   alias Orchard.RuntimeEndpoint.Target
   alias OrchardConsole.NodesPageData
 
@@ -93,10 +94,84 @@ defmodule OrchardConsole.NodesLive do
       </.card>
       </div>
 
+      <%!-- Admission Review Queue --%>
+      <div id="nodes-pending-admissions-card">
+      <.card>
+        <:title>Admission Review</:title>
+        <:subtitle>{pending_admissions_subtitle(@pending_admissions)}</:subtitle>
+
+        <%= cond do %>
+          <% @pending_admissions.status == :loading -> %>
+            <.state_message id="nodes-pending-loading" kind={:loading} layout={:compact} title="Loading pending admissions." />
+          <% @pending_admissions.status == :ok and @pending_admissions.rows == [] -> %>
+            <.state_message
+              id="nodes-pending-empty-state"
+              kind={:empty}
+              layout={:compact}
+              title="No admission review items."
+              body="New pending candidates and registered nodes will appear here; rejected records remain visible for audit after decisions."
+            />
+          <% @pending_admissions.status == :ok -> %>
+            <.table
+              id="nodes-pending-table"
+              rows={@pending_admissions.rows}
+              row_id={fn row -> "pending-admission-#{row.kind}-#{row.id}" end}
+            >
+              <:col :let={row} label="Identity" class="min-w-44">
+                <span class="font-medium text-slate-900 dark:text-slate-100">{row.display_label}</span>
+                <span
+                  :if={row.node_id && row.kind == :candidate}
+                  class="mt-1 block text-xs font-mono text-slate-500 dark:text-slate-400"
+                >
+                  linked node {row.node_id}
+                </span>
+              </:col>
+              <:col :let={row} label="Source" class="min-w-28" header_class="whitespace-nowrap">
+                <.badge tone={pending_source_tone(row.source)}>
+                  {pending_source_label(row.source)}
+                </.badge>
+              </:col>
+              <:col :let={row} label="Admission" class="min-w-32" header_class="whitespace-nowrap">
+                <.badge tone={admission_category_tone(row.admission_category)}>
+                  {format_status_value(row.admission_category)}
+                </.badge>
+              </:col>
+              <:col :let={row} label="Compatibility" class="min-w-32" header_class="whitespace-nowrap">
+                <.badge tone={compatibility_tone(status_value(row.status, :compatibility, :status))}>
+                  {format_status_value(status_value(row.status, :compatibility, :status))}
+                </.badge>
+              </:col>
+              <:col :let={row} label="Target" mono class="min-w-40 max-w-[16rem] break-all" header_class="whitespace-nowrap">
+                {format_pending_target(row)}
+              </:col>
+              <:col :let={row} label="Last Observed" mono class="min-w-40" header_class="whitespace-nowrap">
+                <.local_time
+                  :if={row.observed_at}
+                  value={row.observed_at}
+                  format={:datetime_second}
+                />
+                <span :if={!row.observed_at}>Never observed</span>
+              </:col>
+              <:action :let={row}>
+                <.link
+                  navigate={pending_detail_path(row)}
+                  class="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium text-navy hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-sky-300 dark:hover:bg-slate-800 dark:focus-visible:ring-sky-400"
+                >
+                  Review
+                </.link>
+              </:action>
+            </.table>
+          <% true -> %>
+            <.state_message id="nodes-pending-error" kind={:error} layout={:compact} title="Pending admissions unavailable." body={@pending_admissions.message} />
+          <% end %>
+      </.card>
+      </div>
+
       <%!-- Main Grid --%>
       <div class="grid gap-6 xl:grid-cols-12">
-        <%!-- Persisted Inventory Table --%>
         <div class="xl:col-span-8">
+          <div class="space-y-6">
+          <%!-- Persisted Inventory Table --%>
           <div id="nodes-inventory-card">
           <.card>
             <:title>Registered Nodes</:title>
@@ -115,7 +190,12 @@ defmodule OrchardConsole.NodesLive do
               <% @inventory.status == :ok -> %>
                 <.table id="nodes-table" rows={@inventory.rows} row_id={fn node -> "node-#{node.id}" end}>
                   <:col :let={node} label="Display Name">
-                    <span class="font-medium text-slate-900 dark:text-slate-100">{node.display_name}</span>
+                    <.link
+                      navigate={~p"/console/nodes/#{node.id}"}
+                      class="font-medium text-slate-900 hover:text-navy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-slate-100 dark:hover:text-sky-300 dark:focus-visible:ring-sky-400"
+                    >
+                      {node.display_name}
+                    </.link>
                   </:col>
                   <:col :let={node} label="Hostname" mono>{node.hostname}</:col>
                   <:col :let={node} label="Address" mono>{format_address(node)}</:col>
@@ -132,6 +212,7 @@ defmodule OrchardConsole.NodesLive do
                 <.state_message id="nodes-inventory-error" kind={:error} layout={:compact} title="Node inventory unavailable." body={@inventory.message} />
               <% end %>
           </.card>
+          </div>
           </div>
         </div>
 
@@ -364,11 +445,13 @@ defmodule OrchardConsole.NodesLive do
     # second reflects it in the same cycle.
     cluster = fetch_runtime_cluster(observed_at)
     inventory = fetch_inventory()
+    pending_admissions = fetch_pending_admissions(inventory.rows)
     safe_tokenization_counters = fetch_safe_tokenization_counters()
 
     assign(socket,
       cluster: cluster,
       inventory: inventory,
+      pending_admissions: pending_admissions,
       safe_tokenization_counters: safe_tokenization_counters,
       last_refreshed_at: observed_at
     )
@@ -384,6 +467,14 @@ defmodule OrchardConsole.NodesLive do
           total: nil,
           by_health: %{healthy: nil, degraded: nil, unhealthy: nil, unreachable: nil}
         },
+        message: nil
+      },
+      pending_admissions: %{
+        status: :loading,
+        rows: [],
+        count: nil,
+        pending_count: nil,
+        rejected_count: nil,
         message: nil
       },
       cluster: %{
@@ -660,6 +751,32 @@ defmodule OrchardConsole.NodesLive do
       }
   end
 
+  defp fetch_pending_admissions(nodes) do
+    candidates =
+      Nodes.list_admission_candidates(admission_category: AdmissionCandidate.review_categories())
+
+    NodesPageData.pending_admissions(candidates, nodes)
+  rescue
+    error ->
+      Logger.warning("Pending admission fetch failed: #{inspect(error)}")
+      pending_admissions_error_state()
+  catch
+    kind, reason ->
+      Logger.warning("Pending admission fetch #{kind}: #{inspect(reason)}")
+      pending_admissions_error_state()
+  end
+
+  defp pending_admissions_error_state do
+    %{
+      status: :error,
+      rows: [],
+      count: 0,
+      pending_count: 0,
+      rejected_count: 0,
+      message: "Pending admission candidates unavailable."
+    }
+  end
+
   defp fetch_safe_tokenization_counters do
     telemetry_counters_impl().snapshot()
     |> normalize_safe_tokenization_counters()
@@ -850,6 +967,39 @@ defmodule OrchardConsole.NodesLive do
 
   defp has_health_detail?(_), do: false
 
+  defp pending_source_tone(:runtime_endpoint_observation), do: :info
+  defp pending_source_tone("runtime_endpoint_observation"), do: :info
+  defp pending_source_tone(:provisioned_node), do: :neutral
+  defp pending_source_tone("provisioned_node"), do: :neutral
+  defp pending_source_tone(:registered_node), do: :info
+  defp pending_source_tone("registered_node"), do: :info
+  defp pending_source_tone(_source), do: :neutral
+
+  defp pending_source_label(:runtime_endpoint_observation), do: "observed"
+  defp pending_source_label("runtime_endpoint_observation"), do: "observed"
+  defp pending_source_label(:provisioned_node), do: "provisioned"
+  defp pending_source_label("provisioned_node"), do: "provisioned"
+  defp pending_source_label(:registered_node), do: "registered"
+  defp pending_source_label("registered_node"), do: "registered"
+  defp pending_source_label(source), do: format_status_value(source)
+
+  defp admission_category_tone(:rejected), do: :error
+  defp admission_category_tone("rejected"), do: :error
+  defp admission_category_tone(:pending_registered), do: :info
+  defp admission_category_tone("pending_registered"), do: :info
+  defp admission_category_tone(:pending_provisioned), do: :warning
+  defp admission_category_tone("pending_provisioned"), do: :warning
+  defp admission_category_tone(:pending_observed), do: :neutral
+  defp admission_category_tone("pending_observed"), do: :neutral
+  defp admission_category_tone(_category), do: :neutral
+
+  defp compatibility_tone("compatible"), do: :success
+  defp compatibility_tone("legacy_metadata"), do: :warning
+  defp compatibility_tone("partial_metadata"), do: :warning
+  defp compatibility_tone("version_skew"), do: :warning
+  defp compatibility_tone("unsupported_version"), do: :error
+  defp compatibility_tone(_status), do: :neutral
+
   # Observe-only memory telemetry display helpers.
   defp memory_budget_status_label(%{display_state: :invalid}), do: "invalid telemetry"
 
@@ -911,6 +1061,77 @@ defmodule OrchardConsole.NodesLive do
 
   defp format_count(nil), do: "\u2014"
   defp format_count(count) when is_integer(count), do: Integer.to_string(count)
+
+  defp pending_admissions_subtitle(%{
+         status: :ok,
+         pending_count: pending_count,
+         rejected_count: rejected_count
+       })
+       when is_integer(pending_count) and is_integer(rejected_count) do
+    [
+      pending_review_count_label(pending_count),
+      rejected_review_count_label(rejected_count)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+  end
+
+  defp pending_admissions_subtitle(%{status: :ok, count: count}) when is_integer(count) do
+    "#{count} admission review items."
+  end
+
+  defp pending_admissions_subtitle(%{status: :loading}), do: "Loading review queue."
+  defp pending_admissions_subtitle(_pending), do: "Review queue unavailable."
+
+  defp pending_review_count_label(0), do: "No pending decisions."
+  defp pending_review_count_label(1), do: "1 awaiting operator decision."
+  defp pending_review_count_label(count), do: "#{count} awaiting operator decision."
+
+  defp rejected_review_count_label(0), do: nil
+  defp rejected_review_count_label(1), do: "1 rejected record visible for audit."
+  defp rejected_review_count_label(count), do: "#{count} rejected records visible for audit."
+
+  defp pending_detail_path(%{kind: :candidate, id: id}), do: ~p"/console/nodes/pending/#{id}"
+  defp pending_detail_path(%{kind: :node, id: id}), do: ~p"/console/nodes/#{id}"
+
+  defp status_value(status, group, key) when is_map(status) do
+    case map_get(status, group) do
+      group_status when is_map(group_status) -> map_get(group_status, key)
+      _group_status -> nil
+    end
+  end
+
+  defp status_value(_status, _group, _key), do: nil
+
+  defp map_get(map, key) when is_map(map) and is_atom(key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp map_get(_map, _key), do: nil
+
+  defp format_status_value(nil), do: "unknown"
+
+  defp format_status_value(value) when is_atom(value) do
+    value
+    |> Atom.to_string()
+    |> format_status_value()
+  end
+
+  defp format_status_value(value) when is_binary(value) do
+    value
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp format_status_value(value), do: to_string(value)
+
+  defp format_pending_target(%{target_ref: target}) when is_binary(target) and target != "",
+    do: target
+
+  defp format_pending_target(_row), do: "Unconfigured"
 
   defp format_bytes(bytes) when is_integer(bytes) and bytes >= 0, do: "#{bytes} bytes"
 

--- a/apps/orchard_controller/lib/orchard/console/nodes_page_data.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_page_data.ex
@@ -4,6 +4,11 @@ defmodule OrchardConsole.NodesPageData do
   """
 
   alias Orchard.ClusterManagement.StatusBuilder
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{AdmissionCandidate, Node}
+
+  @pending_admission_categories [:pending_observed, :pending_provisioned, :pending_registered]
+  @pending_admission_category_strings Enum.map(@pending_admission_categories, &Atom.to_string/1)
 
   @spec inventory([struct()], map()) :: map()
   def inventory(rows, summary) when is_list(rows) and is_map(summary) do
@@ -15,4 +20,125 @@ defmodule OrchardConsole.NodesPageData do
       message: nil
     }
   end
+
+  @spec pending_admissions([AdmissionCandidate.t()], [Node.t()]) :: map()
+  def pending_admissions(candidates, nodes) when is_list(candidates) and is_list(nodes) do
+    candidate_decisions =
+      candidates
+      |> Enum.map(& &1.id)
+      |> Nodes.latest_admission_decisions_for_candidates()
+
+    node_decisions =
+      nodes
+      |> Enum.map(& &1.id)
+      |> Nodes.latest_admission_decisions_for_nodes()
+
+    candidate_node_ids =
+      candidates
+      |> Enum.map(& &1.node_id)
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    rows =
+      candidates
+      |> Enum.map(&candidate_row(&1, Map.get(candidate_decisions, &1.id)))
+      |> Kernel.++(
+        nodes
+        |> Enum.filter(&pending_node?/1)
+        |> Enum.reject(&MapSet.member?(candidate_node_ids, &1.id))
+        |> Enum.map(&node_row(&1, Map.get(node_decisions, &1.id)))
+      )
+      |> Enum.sort_by(&row_sort_key/1)
+
+    %{
+      status: :ok,
+      rows: rows,
+      count: length(rows),
+      pending_count: Enum.count(rows, &pending_admission_row?/1),
+      rejected_count: Enum.count(rows, &rejected_admission_row?/1),
+      message: nil
+    }
+  end
+
+  defp candidate_row(%AdmissionCandidate{} = candidate, latest_decision) do
+    status = StatusBuilder.candidate_status_map(candidate, latest_decision: latest_decision)
+
+    %{
+      kind: :candidate,
+      id: candidate.id,
+      node_id: candidate.node_id,
+      display_label: candidate_display_label(candidate),
+      source: candidate.source,
+      admission_category: candidate.admission_category,
+      target_ref: candidate.target_ref || candidate.endpoint_target,
+      observed_at: candidate.last_observed_at,
+      status: status
+    }
+  end
+
+  defp node_row(%Node{} = node, latest_decision) do
+    status = StatusBuilder.node_status_map(node, latest_decision: latest_decision)
+
+    %{
+      kind: :node,
+      id: node.id,
+      node_id: node.id,
+      display_label: node.display_name || node.hostname || node.id,
+      source: :registered_node,
+      admission_category: get_in(status, [:admission, :category]),
+      target_ref: format_host_port(node.advertise_addr, node.rpc_port),
+      observed_at: node.last_heartbeat_at,
+      status: status
+    }
+  end
+
+  defp pending_node?(%Node{state: state}), do: state in [:provisioned, :registered]
+
+  defp pending_admission_row?(%{admission_category: category}),
+    do:
+      category in @pending_admission_categories or category in @pending_admission_category_strings
+
+  defp rejected_admission_row?(%{admission_category: category}),
+    do: category in [:rejected, "rejected"]
+
+  defp candidate_display_label(%AdmissionCandidate{observed_identity: identity} = candidate) do
+    [
+      map_get(identity, "display_name"),
+      map_get(identity, "hostname"),
+      map_get(identity, "claimed_node_id"),
+      candidate.target_ref,
+      candidate.endpoint_target,
+      candidate.id
+    ]
+    |> Enum.find(&present?/1)
+  end
+
+  defp row_sort_key(%{observed_at: %DateTime{} = observed_at, display_label: label}) do
+    {-DateTime.to_unix(observed_at, :microsecond), to_string(label)}
+  end
+
+  defp row_sort_key(%{display_label: label}), do: {0, to_string(label)}
+
+  defp map_get(map, "display_name") when is_map(map),
+    do: Map.get(map, "display_name") || Map.get(map, :display_name)
+
+  defp map_get(map, "hostname") when is_map(map),
+    do: Map.get(map, "hostname") || Map.get(map, :hostname)
+
+  defp map_get(map, "claimed_node_id") when is_map(map),
+    do: Map.get(map, "claimed_node_id") || Map.get(map, :claimed_node_id)
+
+  defp map_get(_map, _key), do: nil
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(nil), do: false
+  defp present?(_value), do: true
+
+  defp format_host_port(host, port) when is_binary(host) and is_integer(port) do
+    if String.contains?(host, ":"),
+      do: "[#{host}]:#{port}",
+      else: "#{host}:#{port}"
+  end
+
+  defp format_host_port(_host, _port), do: nil
 end

--- a/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
@@ -171,6 +171,35 @@ defmodule OrchardConsole.NodeDetailLiveTest do
       assert render(view) =~ "Rejected"
       refute render(view) =~ "Preview reject"
     end
+
+    test "preserves execute-action error across periodic refresh", %{conn: conn} do
+      candidate = insert_candidate!(target_ref: "10.4.0.44:50071")
+
+      {:ok, view, _html} = live(conn, "/console/nodes/pending/#{candidate.id}")
+
+      view
+      |> element("#node-detail-open-reject")
+      |> render_click()
+
+      view
+      |> form("#admission-action-form", %{"action" => %{"reason" => "", "confirmed" => "true"}})
+      |> render_submit()
+
+      assert has_element?(
+               view,
+               "#action-preview-error",
+               "Resolve blockers and confirm the preview before executing."
+             )
+
+      send(view.pid, :refresh_node_detail)
+      _ = :sys.get_state(view.pid)
+
+      assert has_element?(
+               view,
+               "#action-preview-error",
+               "Resolve blockers and confirm the preview before executing."
+             )
+    end
   end
 
   defp insert_node!(attrs) do

--- a/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
@@ -1,0 +1,225 @@
+defmodule OrchardConsole.NodeDetailLiveTest do
+  use Orchard.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
+  alias Orchard.Repo
+
+  @moduletag :live
+  @moduletag :db
+
+  setup do
+    previous_console = Application.get_env(:orchard_controller, :console, [])
+    previous_control_plane = Application.get_env(:orchard_controller, :control_plane, [])
+
+    Application.put_env(
+      :orchard_controller,
+      :console,
+      Keyword.put(previous_console, :refresh_interval_ms, 60_000)
+    )
+
+    Application.put_env(:orchard_controller, :control_plane, role: :single_controller)
+
+    on_exit(fn ->
+      Application.put_env(:orchard_controller, :console, previous_console)
+      Application.put_env(:orchard_controller, :control_plane, previous_control_plane)
+    end)
+
+    Sandbox.mode(Repo, {:shared, self()})
+    :ok
+  end
+
+  describe "node detail drill-in" do
+    test "renders separated status groups and pending actions", %{conn: conn} do
+      node =
+        insert_node!(%{
+          display_name: "registered-detail-node",
+          state: :registered,
+          health: :healthy
+        })
+
+      {:ok, _view, html} = live(conn, "/console/nodes/#{node.id}")
+
+      assert html =~ "registered-detail-node"
+      assert html =~ "node-detail-lifecycle"
+      assert html =~ "node-detail-admission"
+      assert html =~ "node-detail-health"
+      assert html =~ "node-detail-freshness"
+      assert html =~ "node-detail-transport"
+      assert html =~ "node-detail-runtime"
+      assert html =~ "node-detail-compatibility"
+      assert html =~ "node-detail-scheduling"
+      assert html =~ "Blocked"
+      assert html =~ "node_not_admitted"
+      assert html =~ "Preview admit"
+      assert html =~ "Preview reject"
+    end
+
+    test "renders candidate evidence without exposing direct admit", %{conn: conn} do
+      candidate =
+        insert_candidate!(
+          observed_identity: %{
+            "display_name" => "candidate-detail-row",
+            "hostname" => "candidate-detail.local"
+          },
+          inventory: %{"capabilities" => %{"mlx" => true}},
+          compatibility_evidence: %{"metadata" => "partial"}
+        )
+
+      {:ok, _view, html} = live(conn, "/console/nodes/pending/#{candidate.id}")
+
+      assert html =~ "candidate-detail-row"
+      assert html =~ "Candidate Evidence"
+      assert html =~ "node-detail-observed-identity"
+      assert html =~ "node-detail-inventory-evidence"
+      assert html =~ "node-detail-compatibility-evidence"
+      assert html =~ "Preview reject"
+      refute html =~ "Preview admit"
+    end
+
+    test "renders not found state for missing candidates", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/console/nodes/pending/#{Ecto.UUID.generate()}")
+
+      assert html =~ "node-detail-not-found"
+      assert html =~ "The requested admission candidate was not found."
+    end
+  end
+
+  describe "admission action previews" do
+    test "previews and executes node admit with shared blockers and confirmation", %{conn: conn} do
+      node =
+        insert_node!(%{
+          display_name: "admit-detail-node",
+          state: :registered,
+          health: :healthy
+        })
+
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+
+      view
+      |> element("#node-detail-open-admit")
+      |> render_click()
+
+      html = render(view)
+      assert html =~ "Admit Node Preview"
+      assert html =~ "Blocked"
+      assert html =~ "trust_not_established"
+      assert html =~ "requires_yes_flag"
+
+      admission_attrs = %{
+        "action" => %{
+          "trust_evidence_ref" => "registration-audit:test",
+          "pool_id" => Ecto.UUID.generate(),
+          "routing_policy_id" => Ecto.UUID.generate(),
+          "confirmed" => "true"
+        }
+      }
+
+      view
+      |> form("#admission-action-form", admission_attrs)
+      |> render_change()
+
+      view
+      |> form("#admission-action-form", admission_attrs)
+      |> render_submit()
+
+      assert Repo.get!(Node, node.id).state == :admitted
+
+      assert %AdmissionDecision{decision: :admitted} =
+               Nodes.latest_admission_decision_for_node(node.id)
+
+      assert render(view) =~ "Admitted"
+    end
+
+    test "previews and executes candidate reject with required reason", %{conn: conn} do
+      candidate = insert_candidate!(target_ref: "10.4.0.22:50071")
+
+      {:ok, view, _html} = live(conn, "/console/nodes/pending/#{candidate.id}")
+
+      view
+      |> element("#node-detail-open-reject")
+      |> render_click()
+
+      html = render(view)
+      assert html =~ "Reject Admission Preview"
+      assert html =~ "requires_reason"
+      assert html =~ "A nonblank rejection reason is required."
+
+      reject_attrs = %{
+        "action" => %{
+          "reason" => "untrusted bootstrap source",
+          "confirmed" => "true"
+        }
+      }
+
+      view
+      |> form("#admission-action-form", reject_attrs)
+      |> render_change()
+
+      view
+      |> form("#admission-action-form", reject_attrs)
+      |> render_submit()
+
+      assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :rejected
+
+      assert %AdmissionDecision{decision: :rejected, reason: "untrusted bootstrap source"} =
+               Nodes.latest_admission_decision_for_candidate(candidate.id)
+
+      assert render(view) =~ "Rejected"
+      refute render(view) =~ "Preview reject"
+    end
+  end
+
+  defp insert_node!(attrs) do
+    unique = System.unique_integer([:positive])
+
+    defaults = %{
+      id: Ecto.UUID.generate(),
+      hostname: "detail-node-#{unique}.local",
+      display_name: "detail-node-#{unique}",
+      advertise_addr: "10.30.#{rem(unique, 200)}.#{rem(unique, 250) + 1}",
+      rpc_port: 50_071,
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      tool_readiness: %{},
+      agent_version: "0.1.0",
+      last_heartbeat_at: DateTime.utc_now()
+    }
+
+    merged = Map.merge(defaults, Map.new(attrs))
+
+    %Node{}
+    |> Node.changeset(merged)
+    |> Repo.insert!()
+  end
+
+  defp insert_candidate!(attrs) do
+    unique = System.unique_integer([:positive])
+
+    defaults = %{
+      source: :runtime_endpoint_observation,
+      admission_category: :pending_observed,
+      observed_identity: %{
+        "claimed_node_id" => Ecto.UUID.generate(),
+        "display_name" => "candidate-#{unique}",
+        "hostname" => "candidate-#{unique}.local"
+      },
+      target_ref: "10.5.0.#{rem(unique, 200) + 1}:50071",
+      endpoint_transport: :grpc,
+      endpoint_target: "10.5.0.#{rem(unique, 200) + 1}:50071",
+      inventory: %{"capabilities" => %{}},
+      compatibility_evidence: %{"metadata" => "partial"},
+      last_observed_at: DateTime.utc_now()
+    }
+
+    merged = Map.merge(defaults, Map.new(attrs))
+
+    %AdmissionCandidate{}
+    |> AdmissionCandidate.changeset(merged)
+    |> Repo.insert!()
+  end
+end

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -713,6 +713,20 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ "/console/nodes/#{node.id}"
     end
 
+    test "labels provisioned-placeholder candidates with the short source badge", %{conn: conn} do
+      insert_candidate!(
+        source: :provisioned_placeholder,
+        admission_category: :pending_provisioned,
+        observed_identity: %{"display_name" => "provisioned-review-candidate"}
+      )
+
+      {:ok, _view, html} = live(conn, "/console/nodes")
+
+      assert html =~ "provisioned-review-candidate"
+      assert html =~ "Pending provisioned"
+      refute html =~ "Provisioned placeholder"
+    end
+
     test "keeps rejected admission records visible as audit records", %{conn: conn} do
       candidate =
         insert_candidate!(

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -601,6 +601,7 @@ defmodule OrchardConsole.NodesLiveTest do
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.ClusterManagement.StatusBuilder
   alias Orchard.Nodes
+  alias Orchard.Nodes.AdmissionCandidate
   alias Orchard.Repo
   alias OrchardConsole.NodesPageData
 
@@ -637,6 +638,7 @@ defmodule OrchardConsole.NodesLiveTest do
       {:ok, _view, html} = live(conn, "/console/nodes")
 
       assert html =~ "Inventory Summary"
+      assert html =~ "Admission Review"
       assert html =~ "Registered Nodes"
       assert html =~ "Live Cluster"
     end
@@ -675,6 +677,97 @@ defmodule OrchardConsole.NodesLiveTest do
       {:ok, _view, html} = live(conn, "/console/nodes")
 
       assert html =~ "Nodes \u2014 Orchard Console"
+    end
+
+    test "renders pending admission candidates above registered inventory", %{conn: conn} do
+      candidate =
+        insert_candidate!(
+          observed_identity: %{
+            "display_name" => "join-review-candidate",
+            "hostname" => "join-review.local"
+          },
+          target_ref: "10.10.10.44:50071"
+        )
+
+      {:ok, _view, html} = live(conn, "/console/nodes")
+
+      assert html =~ "nodes-pending-admissions-card"
+      assert html =~ "join-review-candidate"
+      assert html =~ "Pending observed"
+      assert html =~ "10.10.10.44:50071"
+      assert html =~ "/console/nodes/pending/#{candidate.id}"
+    end
+
+    test "renders registered nodes awaiting admission in the pending queue", %{conn: conn} do
+      node =
+        insert_node!(%{
+          display_name: "registered-review-node",
+          state: :registered,
+          health: :healthy
+        })
+
+      {:ok, _view, html} = live(conn, "/console/nodes")
+
+      assert html =~ "registered-review-node"
+      assert html =~ "Pending registered"
+      assert html =~ "/console/nodes/#{node.id}"
+    end
+
+    test "keeps rejected admission records visible as audit records", %{conn: conn} do
+      candidate =
+        insert_candidate!(
+          admission_category: :rejected,
+          observed_identity: %{"display_name" => "rejected-review-candidate"}
+        )
+
+      {:ok, _view, html} = live(conn, "/console/nodes")
+
+      assert html =~ "Admission Review"
+      assert html =~ "No pending decisions."
+      assert html =~ "1 rejected record visible for audit."
+      assert html =~ "rejected-review-candidate"
+      assert html =~ "Rejected"
+      assert html =~ "/console/nodes/pending/#{candidate.id}"
+    end
+  end
+
+  describe "pending admission page data" do
+    test "combines candidates and pending lifecycle nodes with shared status maps" do
+      candidate = insert_candidate!(admission_category: :pending_observed)
+
+      node =
+        insert_node!(%{
+          display_name: "pending-node-page-data",
+          state: :registered,
+          health: :healthy
+        })
+
+      page = NodesPageData.pending_admissions([candidate], [node])
+
+      assert page.status == :ok
+      assert page.count == 2
+      assert page.pending_count == 2
+      assert page.rejected_count == 0
+      assert Enum.map(page.rows, & &1.kind) |> Enum.sort() == [:candidate, :node]
+
+      candidate_row = Enum.find(page.rows, &(&1.kind == :candidate))
+      node_row = Enum.find(page.rows, &(&1.kind == :node))
+
+      assert candidate_row.status.admission.category == "pending_observed"
+      assert candidate_row.status.resource.type == "admission_candidate"
+      assert node_row.status.admission.category == "pending_registered"
+      assert node_row.status.resource.type == "node"
+    end
+
+    test "separates pending and rejected review counts" do
+      pending_candidate = insert_candidate!(admission_category: :pending_observed)
+      rejected_candidate = insert_candidate!(admission_category: :rejected)
+
+      page = NodesPageData.pending_admissions([pending_candidate, rejected_candidate], [])
+
+      assert page.count == 2
+      assert page.pending_count == 1
+      assert page.rejected_count == 1
     end
   end
 
@@ -1491,6 +1584,32 @@ defmodule OrchardConsole.NodesLiveTest do
 
     %Orchard.Nodes.Node{}
     |> Orchard.Nodes.Node.changeset(merged)
+    |> Repo.insert!()
+  end
+
+  defp insert_candidate!(attrs) do
+    unique = System.unique_integer([:positive])
+
+    defaults = %{
+      source: :runtime_endpoint_observation,
+      admission_category: :pending_observed,
+      observed_identity: %{
+        "claimed_node_id" => Ecto.UUID.generate(),
+        "display_name" => "candidate-#{unique}",
+        "hostname" => "candidate-#{unique}.local"
+      },
+      target_ref: "10.0.0.#{rem(unique, 200) + 1}:50071",
+      endpoint_transport: :grpc,
+      endpoint_target: "10.0.0.#{rem(unique, 200) + 1}:50071",
+      inventory: %{"capabilities" => %{}},
+      compatibility_evidence: %{"metadata" => "partial"},
+      last_observed_at: DateTime.utc_now()
+    }
+
+    merged = Map.merge(defaults, Map.new(attrs))
+
+    %AdmissionCandidate{}
+    |> AdmissionCandidate.changeset(merged)
     |> Repo.insert!()
   end
 end

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -350,6 +350,9 @@ implementation. Do not add hover styling to the disabled span.
   existing radii (`rounded-lg` where already set). Do not introduce
   `rounded-xl` or `rounded-2xl` in v2.
 - Sidebar nav row padding is `px-3 py-2`. Do not change in v2.
+- Below the `sm` breakpoint, the Console sidebar uses the collapsed rail tokens by default and hides the manual expand/collapse toggle.
+- Desktop and tablet widths keep the existing expanded-by-default sidebar with manual collapse behavior.
+- The Console root clips document-level horizontal overflow; wide tables or logs must own their own local horizontal scroll region.
 
 ### 6.1 Page Width Modes
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -670,8 +670,10 @@ contract first.
   is reserved, not yet used).
 - Page-header, breadcrumb, status pill, modal, toast/flash, badge, or button
   restyling beyond what already exists.
-- Mobile sidebar / responsive collapse below `lg`. The rail is desktop-only
-  in v2.
+- Off-canvas / drawer mobile navigation with a hamburger toggle. Below the
+  `sm` breakpoint the rail auto-collapses to the icon-only tokens and hides
+  the manual toggle (see §5.3 and §6); a hidden-by-default drawer pattern
+  remains out of scope in v2.
 - Animated entrance/exit transitions for inputs, nav items, or rail.
 - Component library swap (Headless UI, Radix, etc.).
 - A LiveView component split (`Orchard.Console.UI.Input` etc.).

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -24,7 +24,9 @@
 - [x] 3.1 Add shared domain structures for lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and HA-lite read-only status.
 - [x] 3.2 Add fixed scheduler explanation rejection codes and action preview blocker codes.
 - [ ] 3.3 Ensure reason codes are used by Operator API, Admin API, CLI, Console, support bundles, and tests.
-  Note: CLI/Admin admission previews now use shared `ActionPreview` blocker and confirmation codes; Operator API, Console, and support bundles remain future slices.
+  Note: CLI/Admin admission previews now use shared `ActionPreview` blocker and confirmation codes.
+  Console pending admission queue, detail drill-in, and admit/reject preview panels now render shared status, scheduler, blocker, warning, consequence, and confirmation codes for this slice.
+  Operator API and support bundles remain future slices.
 - [x] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
 - [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
 - [x] 3.6 Ensure action preview schema fixtures include separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements` fields.
@@ -43,9 +45,11 @@
 
 ## 5. Console Nodes UX
 
-- [ ] 5.1 Add a pending admission queue to the Console Nodes workspace.
-- [ ] 5.2 Add node detail drill-in that preserves separate lifecycle, health, freshness, transport, runtime, compatibility, scheduling, and warning groups.
+- [x] 5.1 Add a pending admission queue to the Console Nodes workspace.
+- [x] 5.2 Add node detail drill-in that preserves separate lifecycle, health, freshness, transport, runtime, compatibility, scheduling, and warning groups.
 - [ ] 5.3 Add action preview dialogs for admit, reject pending admission, cordon, uncordon, drain, maintenance, resume, and decommission.
+  Note: this slice implements Console admit and reject pending admission preview panels using the shared `ActionPreview` contract.
+  Full lifecycle action previews and any reusable dialog primitive remain future work.
 - [ ] 5.4 Add scheduler explanation views with selected candidate, skipped candidates, fixed reason codes, and sanitized diagnostics.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
 - [ ] 5.6 Add read-only HA-lite control-plane status.


### PR DESCRIPTION
## Intent

Implement Orchard Console admission review UX slice for cluster-management-ux-foundation: pending admission review queue, node and candidate detail drill-in, admit and reject dry-run preview panels using shared ActionPreview/Admin API semantics, OpenSpec task updates, responsive browser verification, and no scheduler explanations or lifecycle actions beyond admit/reject.

## What Changed

- Added a pending admission review queue to the Nodes workspace (`nodes_live.ex`, new `nodes_page_data.ex`) that surfaces registered nodes awaiting admission plus observed/provisioned candidates with source and compatibility badges.
- Added node and candidate detail drill-in (`node_detail_live.ex`, new `/console/nodes/:id` and `/console/nodes/pending/:id` routes) with admit/reject dry-run preview panels built on the shared ActionPreview/Admin API semantics — blockers, confirmation flags, transition, and latest-decision display — and no lifecycle actions beyond admit/reject; auto-refresh now preserves execute-action error banners and the provisioned candidate renders its intended "provisioned" source label.
- Converted the console root layout into a fixed app-shell with main-pane scrolling (`root.html.heex`, `app.css` `#console-app`), added LiveView tests for both new views, and reconciled `docs/DESIGN.md` and the OpenSpec `cluster-management-ux-foundation` task notes.

## Risk Assessment

✅ Low: The change is additive, well-bounded, and thoroughly tested; the DB-mutating admit/reject paths are gated by write-path auth and confirmation/blocker revalidation, the two prior-round findings are fixed with regression tests, and I found no reachable correctness defects — only benign cross-module helper duplication.

## Testing

Ran the two new console LiveView test files (65 passing) as the automated baseline, then produced product-level evidence by seeding a dev database and driving the actual rendered Console in a browser: screenshots of the admission review queue, node and candidate detail drill-ins, the shared-ActionPreview admit and reject dry-run panels, and an actual reject executed through the UI that persisted a rejection decision to Postgres (verified by query) and updated the live queue counts, plus a responsive mobile capture showing the collapsed sidebar rail. Everything works as intended and only admit/reject actions are surfaced; no defects found. Server, browser session, and transient built assets were torn down and the working tree left clean.

- Evidence: Admission review queue (/console/nodes, desktop) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWHHFPVR8Q8N95YC19ETZSHM/01-nodes-admission-review-queue.png</code>)
- Evidence: Registered node detail drill-in (all status groups, both actions) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWHHFPVR8Q8N95YC19ETZSHM/02-node-detail-drill-in.png</code>)
- Evidence: Admit dry-run preview panel (shared ActionPreview blockers/confirmation) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWHHFPVR8Q8N95YC19ETZSHM/03-admit-preview-panel.png</code>)
- Evidence: Candidate detail drill-in with evidence (reject-only) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWHHFPVR8Q8N95YC19ETZSHM/04-candidate-detail-evidence.png</code>)
- Evidence: Reject dry-run preview panel (required-reason validation) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWHHFPVR8Q8N95YC19ETZSHM/05-reject-preview-panel.png</code>)
- Evidence: Reject executed end-to-end + persisted (flash, Rejected badge, decision card) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWHHFPVR8Q8N95YC19ETZSHM/06-reject-executed-persisted.png</code>)
- Evidence: Responsive mobile layout (collapsed sidebar rail, updated queue counts) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWHHFPVR8Q8N95YC19ETZSHM/07-nodes-mobile-collapsed-sidebar.png</code>)
<details>
<summary>Evidence: Persisted rejection decision verified in Postgres</summary>

```text
admission_category | decision | reason | decided_at
rejected | rejected | Untrusted bootstrap source; endpoint failed trust attestation. | 2026-07-02 14:29:28.517339
(1 row)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/console/node_detail_live.ex:484` - Periodic auto-refresh silently discards execute-action error messages. When `execute_action` fails, `put_action_error/2` sets `action.error`, but the 5s refresh timer fires `handle_info(:refresh_node_detail) -&gt; load_detail -&gt; refresh_open_action -&gt; put_action(...)`, and `put_action/4` always rebuilds the action map with `error: nil` (node_detail_live.ex:504). So a failed admit/reject error banner vanishes within one refresh interval; if the failure produced no persistent blocker (e.g. the generic `&#34;Node admission action failed.&#34;` fallback), the submit button re-enables and the operator loses all signal that the prior attempt failed. Preserve `action.error` across `refresh_open_action`.
- ℹ️ `apps/orchard_controller/lib/orchard/console/nodes_live.ex:980` - Admission-source label helpers handle `:provisioned_node`, but the actual `AdmissionCandidate` source enum value is `:provisioned_placeholder` (admission_candidate.ex:15; `candidate_source_for_node/1` returns `:provisioned_placeholder`). Both `pending_source_tone(:provisioned_node)` and `pending_source_label(:provisioned_node)` are therefore dead clauses, and a real provisioned-placeholder candidate falls through to the fallback, rendering the verbose &#34;Provisioned placeholder&#34; badge instead of the intended &#34;provisioned&#34;. Change the atom (and string) clauses to `:provisioned_placeholder`.
- ℹ️ `apps/orchard_controller/lib/orchard/console/layouts/root.html.heex:2` - The root layout now forces `overflow-hidden` on `&lt;html&gt;`/`&lt;body&gt;`, and `app.css` makes `#console-app` `position: fixed; inset: 3px 0 0`. This converts the entire console into a fixed app-shell where document-level scrolling is disabled and all vertical scroll must go through `&lt;main class=&#34;...overflow-y-auto&#34;&gt;`. The `:browser` pipeline (and thus this root layout) is scoped to `/console`, so it affects every console page (playground, models, model-hub, settings, requests, tenants, etc.), not just Nodes. Any console page with content that overflows a nested non-scroll container could now be clipped. Worth confirming the change was browser-verified across all console routes, not only the Nodes workspace.

🔧 Fix: fix admission action error persistence and provisioned source label
1 info still open:
- ℹ️ `apps/orchard_controller/lib/orchard/console/node_detail_live.ex:761` - Several private helpers are duplicated near-verbatim across the three new/changed console modules: `format_status_value/1` and `status_value/3` are identical in node_detail_live.ex (761, 687) and nodes_live.ex (~1085, ~1099); `candidate_display_label/1`, `format_host_port/2`, and `present?/1` are duplicated between node_detail_live.ex (668, 783, 791) and nodes_page_data.ex; and `admission_category_tone/1` + `compatibility_tone/1` are duplicated between node_detail_live.ex and nodes_live.ex. Per the repo&#39;s ex_dna policy (extract a shared module for genuine duplication), these could move to a shared status/display helper module. Non-functional; safe to defer.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/console/node_detail_live_test.exs apps/orchard_controller/test/orchard/console/nodes_live_test.exs` — 65 passing</code>
- <code>Seeded dev DB (registered node awaiting admission, pending observed/provisioned candidates, rejected audit record, active inventory nodes) via `mix run --no-start` seed script</code>
- <code>Started `MIX_ENV=dev ORCHARD_SOURCE_DEV_ROLE=controller mix phx.server` and browsed `/console/nodes` — captured admission review queue</code>
- <code>Drilled into registered node `/console/nodes/&lt;id&gt;` and clicked Preview admit — captured shared ActionPreview admit panel (blockers trust_not_established/pool_required/policy_required, confirmation requires_yes_flag, transition Registered→Admitted)</code>
- <code>Drilled into candidate `/console/nodes/pending/&lt;id&gt;` — captured evidence blocks + reject-only action, then Preview reject panel (requires_reason validation, transition Pending observed→Rejected)</code>
- `Executed reject through the UI (filled reason, confirmed, submitted) — captured success flash + Rejected badge + Latest Admission Decision card`
- <code>Verified persistence: `psql orchard_dev` join of node_admission_candidates/node_admission_decisions shows admission_category=rejected with reason and decided_at</code>
- `Captured responsive layout at 390px viewport (collapsed sidebar rail, table-local horizontal scroll, updated queue counts)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
