### PR TITLE
docs: reconcile cluster-management contracts after admission UX landed

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -721,10 +721,14 @@ Valid health values:
 Required controller thresholds:
 
 * heartbeat interval: **2000 ms**
-* stale threshold: **6000 ms**
-* unreachable threshold: **15000 ms**
+* heartbeat freshness threshold (`node_freshness_threshold_ms`): **30000 ms** default
+* heartbeat unreachable threshold (`node_unreachable_threshold_ms`): **15000 ms** default
 
-Cluster-management status freshness categories and scheduler eligibility SHALL derive from the same heartbeat freshness threshold source.
+Cluster-management status freshness categories and scheduler eligibility SHALL derive from the same configurable heartbeat freshness thresholds.
+The cluster-management freshness display is `fresh` through the smaller of the heartbeat freshness and unreachable thresholds, `stale` through the larger threshold, and `unreachable` after the larger threshold.
+With current defaults this means `fresh` at or under 15000 ms, `stale` from over 15000 ms through 30000 ms, and freshness `unreachable` over 30000 ms.
+Scheduler eligibility and the `node_observation_stale` reason code use `node_freshness_threshold_ms`, default 30000 ms, so a `stale` freshness display state can remain schedulable until that cutoff.
+The freshness category named `unreachable` is distinct from the Node Health `unreachable` value; Node Health `unreachable` uses the 15000 ms unreachable threshold.
 
 Health derivation:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -169,7 +169,7 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 | ----------------------- | ---------------------------- | ---------------------------------------------------------- |
 | Tray/menu bar app       | `.app` + LaunchAgent         | local status, onboarding, logs, support bundle entry point |
 | `orchardctl` CLI            | binary                       | admin/operator automation, bootstrap, diagnostics          |
-| Orchard Console         | controller LiveView          | local/operator UI for runtime status, requests, Organizations, API Tokens, and API Clients |
+| Orchard Console         | controller LiveView          | local/operator UI for runtime status, node inventory and admission review, action previews, requests, Organizations, API Tokens, and API Clients |
 | Managed Postgres helper | LaunchDaemon in managed mode | local DB lifecycle only                                    |
 
 ### 2.4 Repository structure
@@ -723,6 +723,8 @@ Required controller thresholds:
 * heartbeat interval: **2000 ms**
 * stale threshold: **6000 ms**
 * unreachable threshold: **15000 ms**
+
+Cluster-management status freshness categories and scheduler eligibility SHALL derive from the same heartbeat freshness threshold source.
 
 Health derivation:
 
@@ -2089,6 +2091,7 @@ Node Admission Candidate review endpoints SHALL expose sanitized observed identi
 Admin admission execution SHALL require a registered trusted Node with inventory, pool, and required policy inputs.
 Pending admission rejection SHALL persist a Node Admission Decision and audit event without deleting observed inventory.
 Clearing rejection SHALL require admin authority and SHALL persist an audit event.
+Admin admit and pending-admission reject endpoints SHALL support `dry_run` requests that return the shared Action Preview shape and follow the side-effect-free invariants in §7.3.1.
 
 #### 7.4.2 Tenant create example
 
@@ -3707,12 +3710,20 @@ Required commands:
 * `orchardctl cluster init`
 * `orchardctl node join`
 * `orchardctl nodes list`
+* `orchardctl nodes inspect`
+* `orchardctl nodes pending`
 * `orchardctl nodes admit`
+* `orchardctl nodes reject`
 * `orchardctl api-clients bulk-provision`
 * `orchardctl models import`
 * `orchardctl requests inspect`
 * `orchardctl support bundle create`
 * `orchardctl upgrade plan`
+
+Node-admission CLI commands SHALL provide stable human and JSON output for list, inspect, pending-review, admit, and reject workflows.
+`orchardctl nodes admit` and `orchardctl nodes reject` SHALL support side-effect-free `--dry-run` Action Preview output and explicit execution gates, including `--yes` for execution and `--reason` for rejection.
+For source-dev and packaged local use, node-admission CLI commands are local operator/admin commands that execute in the controller runtime context rather than proving Admin API bearer-token authorization.
+They SHALL still enforce the same leader-only write-path, admission, confirmation, cluster-scoped audit, and shared-presenter semantics as the Admin API.
 
 `orchardctl support bundle create` SHALL be able to emit `orchard.support_bundle.v2` for cluster-management support bundles.
 Console-triggered support bundles and CLI-created support bundles SHALL use the same v2 archive format for the same scope.
@@ -3978,9 +3989,9 @@ Deliver:
 * node registration
 * heartbeats
 * pools
-* admission API
+* admission API and admission-review CLI commands
 * cordon/drain/maintenance/decommission
-* node status pages
+* Console node status and admission-review pages
 
 Acceptance:
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -497,7 +497,7 @@ Warnings and consequences may use compact badges plus short copy, but stable cod
 Confirmation requirements sit directly above the execution control they gate.
 Page-local preview panels are valid for node actions when they keep review context visible.
 
-Node detail drill-ins keep lifecycle, health, freshness, transport, runtime, compatibility, scheduling, and warnings in labeled groups instead of flattening them into a generic table.
+Node detail drill-ins keep lifecycle, admission, health, freshness, transport, runtime, compatibility, scheduling, and warnings in labeled groups instead of flattening them into a generic table.
 Use `<.detail_grid>`, `<.detail_field>`, and compact status badges for grouped facts.
 Source and compatibility badges should stay close to the identity or inventory field they qualify.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,7 +1,7 @@
 # DESIGN.md — Orchard Console Tactical UI Contract
 
 **Status:** Active (v2)
-**Last Updated:** 2026-06-28
+**Last Updated:** 2026-07-03
 **Audience:** AI coding agents and contributors generating or modifying Console UI.
 
 This document is the tactical, component-level design contract for the Orchard
@@ -487,7 +487,21 @@ columns or margins through `class`. The component must not bake in page-specific
 column counts. Use it only with children that render `<dt>` / `<dd>` pairs,
 normally `<.detail_field>`.
 
-### 6.4 Table Density Policy
+### 6.4 Operational Review Panels
+
+Console actions that use the shared Action Preview contract render the preview as one panel, not as scattered flash text.
+Use the existing card surface vocabulary for the panel and reserve semantic alert rows for blockers and warnings.
+Order preview content as blockers, warnings, consequence codes, confirmation requirements, then the execution control.
+Blocker rows must read as non-bypassable and must disable or omit the execute command for that action.
+Warnings and consequences may use compact badges plus short copy, but stable codes remain visible or inspectable when the code is part of the user-facing contract.
+Confirmation requirements sit directly above the execution control they gate.
+Page-local preview panels are valid for node actions when they keep review context visible.
+
+Node detail drill-ins keep lifecycle, health, freshness, transport, runtime, compatibility, scheduling, and warnings in labeled groups instead of flattening them into a generic table.
+Use `<.detail_grid>`, `<.detail_field>`, and compact status badges for grouped facts.
+Source and compatibility badges should stay close to the identity or inventory field they qualify.
+
+### 6.5 Table Density Policy
 
 `<.table>` remains the standard Console table density in v2. PR3 does **not**
 introduce a `density` attribute, does not bump table-cell typography, and does

--- a/docs/decisions/0006-local-orchardctl-node-admission-authority.md
+++ b/docs/decisions/0006-local-orchardctl-node-admission-authority.md
@@ -1,0 +1,17 @@
+# Local orchardctl node admission uses controller runtime authority
+
+Accepted.
+
+Node-admission CLI commands are local operator/admin commands for source-dev and packaged controller hosts.
+They execute inside the controller runtime context and do not require the caller to present an Admin API bearer token.
+They still call the same admission domain functions, leader-only write gate, shared Action Preview builder, presenters, and cluster-scoped audit paths used by Admin API admission execution.
+
+This is separate from ADR 0004.
+Admin API remains service-account-owned bearer-token auth for HTTP callers.
+The local CLI path exists because first-admin credential provisioning and remote Admin API transport are separate slices, while packaged and source-dev operators need a local controller-host recovery and review tool.
+
+The trade-off is a parallel trust boundary: local OS/package access to `orchardctl` is treated as operator context for these commands.
+That boundary must not silently expand to remote or tenant-scoped execution.
+If a future remote CLI transport delegates to Admin API, it must preserve the shared admission contract and use the ADR 0004 token boundary.
+
+SPEC.md impact: `SPEC.md` §11.9 records the local node-admission CLI authority boundary.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -368,6 +368,16 @@ _Avoid_: provisioned Node, registered Node, active Node, trusted Node
 The admin-controlled reconciliation step that accepts a trusted registered Node into cluster participation.
 _Avoid_: Request Admission, Runtime Endpoint Observation, automatic discovery
 
+**Pending Admission**:
+A derived review category for a Runtime Endpoint Admission Candidate, provisioned placeholder, or registered Node that has not been explicitly admitted.
+It is not a Node Lifecycle State and never makes the target schedulable.
+_Avoid_: pending lifecycle state, active Node, automatic join
+
+**Rejected Admission**:
+A Node Admission outcome that keeps a candidate or lifecycle-managed Node out of scheduling while preserving review evidence and decision history.
+It is not Decommission and does not delete observed inventory.
+_Avoid_: Decommission, removed Node, failed heartbeat
+
 **Node Admission Decision**:
 Durable metadata recording a Node Admission outcome such as rejection or rejection clearance, with actor, timestamp, reason, observed identity or node reference, target reference when applicable, and audit event reference.
 _Avoid_: Node Lifecycle State, Decommission, debug note

--- a/docs/investigations/cluster-admission-admin-api-slice-plan.md
+++ b/docs/investigations/cluster-admission-admin-api-slice-plan.md
@@ -2,6 +2,8 @@
 
 ## Status
 
+> Superseded: this historical slice plan is superseded by landed PRs #30-#37; the current contract lives in `SPEC.md` and the OpenSpec task list.
+
 Accepted implementation plan for the initial cluster-management Admin API node-admission slice.
 The implemented slice covers OpenSpec task `2.8` and preserves the explicit out-of-scope boundaries below for later CLI, Console, bootstrap, and diagnostics work.
 

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -1,9 +1,13 @@
 ## 1. Contract Reconciliation
 
-- [ ] 1.1 Reconcile accepted cluster-management UX behavior back into `SPEC.md` without mirroring this OpenSpec package.
-- [ ] 1.2 Update `docs/DESIGN.md` only if Console node-management UI patterns introduce reusable tactical components.
-- [ ] 1.3 Update `docs/glossary/CONTEXT.md` if accepted terminology adds durable glossary entries such as pending admission, action preview, or scheduler reason code.
-- [ ] 1.4 Add or update an ADR only if implementation chooses a durable architectural boundary not already fixed by `SPEC.md`.
+- [x] 1.1 Reconcile accepted cluster-management UX behavior back into `SPEC.md` without mirroring this OpenSpec package.
+  Note: Reconciled accepted admission, Admin API dry-run preview, CLI admission-review command, Console admission-review, and shared freshness behavior from PRs #30 through #37.
+- [x] 1.2 Update `docs/DESIGN.md` only if Console node-management UI patterns introduce reusable tactical components.
+  Note: Documented reusable operational review panel guidance for Action Preview panels, grouped node detail drill-ins, and source or compatibility badges.
+- [x] 1.3 Update `docs/glossary/CONTEXT.md` if accepted terminology adds durable glossary entries such as pending admission, action preview, or scheduler reason code.
+  Note: Added Pending Admission and Rejected Admission entries; existing entries already cover Runtime Endpoint Admission Candidate, Node Admission, Node Admission Decision, Action Preview, and reason-code terms.
+- [x] 1.4 Add or update an ADR only if implementation chooses a durable architectural boundary not already fixed by `SPEC.md`.
+  Note: Existing ADRs 0003, 0004, and 0005 cover observed candidates, Admin API cluster-admin auth, and shared cluster-management contracts; ADR 0006 records the local `orchardctl` node-admission authority boundary.
 
 ## 2. Node Lifecycle And Admission
 
@@ -26,7 +30,8 @@
 - [ ] 3.3 Ensure reason codes are used by Operator API, Admin API, CLI, Console, support bundles, and tests.
   Note: CLI/Admin admission previews now use shared `ActionPreview` blocker and confirmation codes.
   Console pending admission queue, detail drill-in, and admit/reject preview panels now render shared status, scheduler, blocker, warning, consequence, and confirmation codes for this slice.
-  Operator API and support bundles remain future slices.
+  Admin API, CLI, Console, and tests consume the shared contract for landed admission-review behavior.
+  Operator API, support bundles, and full scheduler-explanation producer wiring remain future slices.
 - [x] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
 - [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
 - [x] 3.6 Ensure action preview schema fixtures include separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements` fields.
@@ -47,13 +52,15 @@
 
 - [x] 5.1 Add a pending admission queue to the Console Nodes workspace.
 - [x] 5.2 Add node detail drill-in that preserves separate lifecycle, health, freshness, transport, runtime, compatibility, scheduling, and warning groups.
-- [ ] 5.3 Add action preview dialogs for admit, reject pending admission, cordon, uncordon, drain, maintenance, resume, and decommission.
+- [ ] 5.3 Add action preview dialogs or page-local panels for admit, reject pending admission, cordon, uncordon, drain, maintenance, resume, and decommission.
   Note: this slice implements Console admit and reject pending admission preview panels using the shared `ActionPreview` contract.
+  Reusable Console review-panel guidance is now documented in `docs/DESIGN.md`.
   Full lifecycle action previews and any reusable dialog primitive remain future work.
 - [ ] 5.4 Add scheduler explanation views with selected candidate, skipped candidates, fixed reason codes, and sanitized diagnostics.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
 - [ ] 5.6 Add read-only HA-lite control-plane status.
 - [ ] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
+  Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile; keep this unchecked as a recurring gate for future Console slices.
 
 ## 6. Diagnostics And Support Bundles
 
@@ -78,10 +85,12 @@
 
 ## 8. Validation
 
-- [ ] 8.1 Run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate cluster-management-ux-foundation --type change --strict --no-interactive`.
+- [x] 8.1 Run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate cluster-management-ux-foundation --type change --strict --no-interactive`.
+  Note: Re-run for this docs reconciliation slice; future implementation slices and archive handoff must rerun this gate.
 - [ ] 8.2 For implementation slices, run `mise exec -- mix format`.
 - [ ] 8.3 For implementation slices, run `mise exec -- mix compile --warnings-as-errors`.
 - [ ] 8.4 For implementation slices, run `mise exec -- mix credo --strict`.
 - [ ] 8.5 For implementation slices, run `mise exec -- mix dialyzer`.
 - [ ] 8.6 For implementation slices, run `mise exec -- mix test`.
 - [ ] 8.7 For implementation slices, run `mise exec -- mix test --cover`.
+  Note: These implementation gates remain unchecked for future product-code slices; this reconciliation changes docs and the normative contract only.


### PR DESCRIPTION
## Intent

Reconcile Orchard SPEC/OpenSpec durable truth after PRs #30 through #37 for the cluster-management UX/admission work that already landed. Keep this as a docs and contract slice only: no lifecycle command implementation, no scheduler explanation implementation, no support bundle v2 implementation, and no product code. Update SPEC.md for accepted admission, Admin API dry-run preview, CLI admission-review command, Console admission-review, and shared freshness behavior; add only durable glossary terms; update docs/DESIGN.md only for reusable Console review-panel guidance; update OpenSpec tasks for completed, partial, and future-slice work; and record the local orchardctl node-admission trust boundary in an ADR because it sits beside the Admin API auth decision.

## What Changed

- Reconciled `SPEC.md` with cluster-management/admission behavior shipped in PRs #30–#37: rewrote §4.5 heartbeat thresholds so freshness categories and scheduler eligibility derive from configurable `node_freshness_threshold_ms` (30000 ms) and `node_unreachable_threshold_ms` (15000 ms) and clarified `fresh`/`stale`/`unreachable` boundaries; added Admin API `dry_run` Action Preview endpoints (§7.4.1); added `orchardctl nodes inspect/pending/reject` with `--dry-run`/`--yes`/`--reason` gates plus the local controller-runtime authority note (§11.9); and extended the Console surface and M3 deliverables to cover node inventory and admission review.
- Added ADR 0006 recording the local `orchardctl` node-admission trust boundary (controller-runtime authority, distinct from the ADR 0004 Admin API bearer-token path), added `Pending Admission` and `Rejected Admission` glossary terms, and added `docs/DESIGN.md` §6.4 "Operational Review Panels" guidance with the table-density policy renumbered to §6.5.
- Marked completed, partial, and future-slice items in `cluster-management-ux-foundation/tasks.md` and flagged the historical Admin API slice plan as superseded by the landed PRs.

## Risk Assessment

✅ Low: Well-bounded documentation/contract-only reconciliation with no product code; every introduced cross-reference (SPEC sections, ADR links, glossary terms, Admin API endpoints, DESIGN.md components and renumbering) was verified to resolve correctly and remain internally consistent.

## Testing

Because this is a docs-and-contract slice with no product code, the end-user surface is the reconciled normative documentation plus the OpenSpec contract-integrity gate the change itself relies on. I installed the pinned OpenSpec toolchain and ran both strict validations — the change-scoped gate (task 8.1) reports valid and the `--all` gate passes 4/4 — then manually verified referential integrity: SPEC §11.9 records the local-CLI authority the ADR points to, the Admin API dry-run text resolves to the real §7.3.1 side-effect-free invariant, DESIGN §6.4 is new with Table Density cleanly renumbered to §6.5, the two new glossary terms follow sibling formatting and cite existing terms, and ADR 0006 references existing ADRs 0003–0005 with no placeholder prose. All five SPEC intent areas trace to concrete reconciled text. There is no LiveView/rendered-UI change here — DESIGN.md only gains reusable guidance prose, not template output — so instead of a running-app screenshot I rendered the reconciled contract content and intent→evidence trace to HTML and captured a full-page screenshot as reviewer-visible evidence. No findings; the change does exactly what the intent describes and the contract gate is green.

- Evidence: Reconciliation evidence (rendered contract content + intent→evidence trace + validation gate) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWJJ0AAGYD79WGKGPH25C938/reconciliation-evidence.png</code>)
<details>
<summary>Evidence: Rendered HTML source of the evidence page</summary>

```text
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>Cluster-Management Contract Reconciliation — Evidence</title>
<style>
  :root{--bg:#0f1512;--panel:#161d19;--panel2:#1c2621;--edge:#2b3a32;--ink:#e8efe9;--mut:#9db0a4;--acc:#63d29a;--warn:#e0b657;--blk:#e07a6b;--code:#12211a;}
  *{box-sizing:border-box}
  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;padding:32px 20px}
  main{max-width:960px;margin:0 auto}
  h1{font-size:24px;margin:0 0 4px}
  .sub{color:var(--mut);margin:0 0 22px;font-size:13.5px}
  .gate{display:flex;align-items:center;gap:12px;background:var(--panel);border:1px solid var(--edge);border-left:4px solid var(--acc);border-radius:10px;padding:14px 18px;margin-bottom:14px}
  .gate .dot{width:10px;height:10px;border-radius:50%;background:var(--acc);box-shadow:0 0 10px var(--acc)}
  .gate b{font-size:15px}
  .gate span{color:var(--mut);font-size:13px}
  pre{background:var(--code);border:1px solid var(--edge);border-radius:8px;padding:12px 14px;overflow:auto;font:12.5px/1.5 "SF Mono",ui-monospace,Menlo,monospace;color:#cfe6d8;margin:0 0 24px}
  pre .ok{color:var(--acc)}
  h2{font-size:15px;letter-spacing:.04em;text-transform:uppercase;color:var(--mut);margin:30px 0 12px;border-bottom:1px solid var(--edge);padding-bottom:6px}
  table{width:100%;border-collapse:collapse;margin-bottom:24px;font-size:13.5px}
  th,td{text-align:left;padding:9px 11px;border-bottom:1px solid var(--edge);vertical-align:top}
  th{color:var(--mut);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.03em}
  td.area{color:var(--ink);font-weight:600;width:31%}
  td.loc{color:var(--acc);font-family:"SF Mono",ui-monospace,monospace;font-size:12px;white-space:nowrap}
  .card{background:var(--panel);border:1px solid var(--edge);border-radius:10px;padding:16px 18px;margin-bottom:14px}
  .card h3{margin:0 0 4px;font-size:14px}
  .card .where{color:var(--acc);font-family:"SF Mono",ui-monospace,monospace;font-size:11.5px;margin:0 0 10px}
  .card p{margin:0 0 8px}
  .card p:last-child{margin-bottom:0}
  code{background:var(--panel2);padding:1px 5px;border-radius:4px;font:12.5px "SF Mono",ui-monospace,monospace;color:#bfe6ce}
  .new{background:linear-gradient(90deg,rgba(99,210,154,.16),transparent);border-left:3px solid var(--acc);padding-left:11px;margin-left:-14px}
  ul.cmd{margin:6px 0 0;padding-left:18px}
  ul.cmd li{margin:2px 0;font-family:"SF Mono",ui-monospace,monospace;font-size:12.5px;color:#cfe6d8}
  ul.cmd li.added{color:var(--acc)}
  ul.cmd li.added::after{content:" ← new";color:var(--mut);font-family:sans-serif;font-size:11px}
  .foot{color:var(--mut);font-size:12px;margin-top:26px;border-top:1px solid var(--edge);padding-top:12px}
  .pill{display:inline-block;background:var(--panel2);border:1px solid var(--edge);border-radius:20px;padding:2px 10px;font-size:11.5px;color:var(--mut);margin-right:6px}
</style>
</head>
<body>
<main>
  <h1>Cluster-Management Contract Reconciliation</h1>
  <p class="sub">Docs &amp; contract slice · base <code>23663b7</code> → <code>8e30cbc</code> · reconciling accepted admission / admission-review UX from PRs #30–#37 · <b>no product code changed</b></p>

  <div class="gate"><span class="dot"></span><b>OpenSpec strict validation — PASS</b><span>change-scoped (task 8.1) + <code>--all</code> gate</span></div>
<pre>$ openspec validate cluster-management-ux-foundation --type change --strict --no-interactive
<span class="ok">Change 'cluster-management-ux-foundation' is valid</span>

$ openspec validate --all --strict --no-interactive
<span class="ok">✓</span> change/beam-first-runtime-endpoints
<span class="ok">✓</span> change/bulk-api-client-provisioning
<span class="ok">✓</span> change/cluster-management-ux-foundation
<span class="ok">✓</span> change/source-dev-beam-operating-model
Totals: <span class="ok">4 passed, 0 failed</span> (4 items)</pre>

  <h2>Intent → Evidence trace</h2>
  <table>
    <tr><th>Intent item</th><th>Reconciled where</th><th>Verified</th></tr>
    <tr><td class="area">Accepted admission behavior into SPEC</td><td class="loc">SPEC §7.4.1, §11.9, §2.3, M3</td><td>✓</td></tr>
    <tr><td class="area">Admin API dry-run preview</td><td class="loc">SPEC §7.4.1 (line 2094)</td><td>✓ refs §7.3.1 side-effect-free</td></tr>
    <tr><td class="area">CLI admission-review command</td><td class="loc">SPEC §11.9 CLI</td><td>✓ inspect/pending/reject + <code>--dry-run</code></td></tr>
    <tr><td class="area">Console admission-review</td><td class="loc">SPEC §2.3 surface + M3 pages</td><td>✓</td></tr>
    <tr><td class="area">Shared freshness behavior</td><td class="loc">SPEC §10 heartbeat thresholds</td><td>✓ single threshold source</td></tr>
    <tr><td class="area">Durable glossary terms only</td><td class="loc">docs/glossary/CONTEXT.md</td><td>✓ Pending / Rejected Admission</td></tr>
    <tr><td class="area">Reusable Console review-panel guidance</td><td class="loc">docs/DESIGN.md §6.4</td><td>✓ (Table Density → §6.5)</td></tr>
    <tr><td class="area">OpenSpec tasks: done/partial/future</td><td class="loc">tasks.md §1,§3,§5,§8</td><td>✓</td></tr>
    <tr><td class="area">Local orchardctl trust boundary ADR</td><td class="loc">ADR 0006</td><td>✓ beside ADR 0004</td></tr>
  </table>

  <h2>Reconciled contract content</h2>

  <div class="card">
    <h3>SPEC §11.9 — CLI admission-review commands</h3>
    <p class="where">SPEC.md · Required commands</p>
    <ul class="cmd">
      <li>orchardctl nodes list</li>
      <li class="added">orchardctl nodes inspect</li>
      <li class="added">orchardctl nodes pending</li>
      <li>orchardctl nodes admit</li>
      <li class="added">orchardctl nodes reject</li>
    </ul>
    <p style="margin-top:10px" class="new"><code>admit</code>/<code>reject</code> SHALL support side-effect-free <code>--dry-run</code> Action Preview output and explicit execution gates (<code>--yes</code> execute, <code>--reason</code> reject). Local operator/admin commands execute in the controller runtime context rather than proving Admin API bearer-token auth — but still enforce the same leader-only write-path, admission, confirmation, cluster-scoped audit, and shared-presenter semantics.</p>
  </div>

  <div class="card">
    <h3>SPEC §7.4.1 — Admin API dry-run preview</h3>
    <p class="where">SPEC.md · Admin admission execution</p>
    <p class="new">Admin admit and pending-admission reject endpoints SHALL support <code>dry_run</code> requests that return the shared <b>Action Preview</b> shape and follow the side-effect-free invariants in <b>§7.3.1</b>.</p>
  </div>

  <div class="card">
    <h3>SPEC §10 — Shared freshness behavior</h3>
    <p class="where">SPEC.md · heartbeat thresholds (fresh 2000 / stale 6000 / unreachable 15000 ms)</p>
    <p class="new">Cluster-management status freshness categories and scheduler eligibility SHALL derive from the <b>same heartbeat freshness threshold source</b>.</p>
  </div>

  <div class="card">
    <h3>SPEC §2.3 &amp; Milestone M3 — Console admission-review surface</h3>
    <p class="where">SPEC.md · client surfaces + M3 deliverables/acceptance</p>
    <p>Console described as UI for <b>node inventory and admission review, action previews</b>, requests, Organizations, API Tokens, and API Clients.</p>
    <p>M3 now delivers <b>admission API and admission-review CLI commands</b> and <b>Console node status and admission-review pages</b>.</p>
  </div>

  <div class="card">
    <h3>docs/DESIGN.md §6.4 — Operational Review Panels (new, reusable)</h3>
    <p class="where">docs/DESIGN.md · Table Density Policy correctly renumbered to §6.5</p>
    <p class="new">Action Preview renders as one panel, not scattered flash text. Order: <b>blockers → warnings → consequence codes → confirmation requirements → execution control</b>. Blocker rows read non-bypassable and disable/omit execute. Node detail drill-ins keep lifecycle, health, freshness, transport, runtime, compatibility, scheduling, and warnings in labeled groups via <code>&lt;.detail_grid&gt;</code> / <code>&lt;.detail_field&gt;</code>.</p>
  </div>

  <div class="card">
    <h3>docs/glossary/CONTEXT.md — durable terms</h3>
    <p class="where">docs/glossary/CONTEXT.md · sibling formatting (bold term + <code>_Avoid_</code>)</p>
    <p class="new"><b>Pending Admission</b> — derived review category for a candidate / provisioned placeholder / registered Node not yet admitted. Not a Node Lifecycle State; never makes the target schedulable.</p>
    <p class="new"><b>Rejected Admission</b> — outcome keeping a candidate/managed Node out of scheduling while preserving review evidence. Not Decommission; does not delete observed inventory.</p>
  </div>

  <div class="card">
    <h3>ADR 0006 — Local orchardctl node-admission authority</h3>
    <p class="where">docs/decisions/0006-local-orchardctl-node-admission-authority.md · Accepted</p>
    <p class="new">Node-admission CLI commands run inside the controller runtime context and do <b>not</b> require an Admin API bearer token, yet call the same admission domain functions, leader-only write gate, shared Action Preview builder, presenters, and cluster-scoped audit paths. Separate from ADR 0004 (Admin API bearer-token boundary); the parallel local-OS trust boundary must not silently expand to remote/tenant-scoped execution. Records SPEC §11.9 impact.</p>
  </div>

  <p class="foot">
    <span class="pill">5 files changed</span>
    <span class="pill">0 product-code files</span>
    <span class="pill">refs verified: §7.3.1 · §11.9 · ADR 0003–0005 · Action Preview term</span>
    <span class="pill">no TBD/placeholder prose</span>
  </p>
</main>
</body>
</html>
```
</details>
<details>
<summary>Evidence: OpenSpec strict validation transcript (change-scoped + --all)</summary>

<code>$ openspec validate cluster-management-ux-foundation --type change --strict --no-interactive&#10;Change &#39;cluster-management-ux-foundation&#39; is valid&#10;&#10;$ openspec validate --all --strict --no-interactive&#10;✓ change/beam-first-runtime-endpoints&#10;✓ change/bulk-api-client-provisioning&#10;✓ change/cluster-management-ux-foundation&#10;✓ change/source-dev-beam-operating-model&#10;Totals: 4 passed, 0 failed (4 items)</code>

```text
$ openspec validate cluster-management-ux-foundation --type change --strict --no-interactive
Change 'cluster-management-ux-foundation' is valid

$ openspec validate --all --strict --no-interactive
✓ change/beam-first-runtime-endpoints
✓ change/bulk-api-client-provisioning
✓ change/cluster-management-ux-foundation
✓ change/source-dev-beam-operating-model
Totals: 4 passed, 0 failed (4 items)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-only base..target` → confirmed docs/contract-only: SPEC.md, docs/DESIGN.md, ADR 0006, glossary CONTEXT.md, tasks.md — no `.ex/.exs/.py/.eex/.heex` product code changed</code>
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate cluster-management-ux-foundation --type change --strict --no-interactive` → &#39;Change is valid&#39; (the gate task 8.1 asserts)</code>
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` → 4 passed, 0 failed</code>
- <code>Verified SPEC §11.9 CLI section records the local node-admission authority boundary that ADR 0006 claims (`SPEC.md §11.9 impact`)</code>
- <code>Verified new Admin API `dry_run` line references §7.3.1, which exists (line 1907) and states the side-effect-free Action-Preview invariant (line 1927)</code>
- `Verified DESIGN.md added §6.4 Operational Review Panels and Table Density Policy correctly renumbered to §6.5 with no dangling 6.4/6.5 cross-references`
- <code>Verified new glossary terms (Pending Admission, Rejected Admission) match sibling `**term**` + `_Avoid_` formatting and reference terms that exist (Runtime Endpoint Admission Candidate, Node Admission, Decommission, Node Lifecycle State); &#39;Action Preview&#39; term already present (line 580)</code>
- `Verified ADR 0006 references ADRs 0003/0004/0005 which all exist on disk; scanned added lines for TBD/TODO/placeholder prose — none`
- `Rendered the reconciled contract content + intent→evidence trace to a self-contained HTML page and captured a full-page screenshot via agent-browser`
- <code>Cleaned up transient `node_modules` (gitignored) and a stray `--full-page` file; `git status` clean</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `SPEC.md:727` - SPEC §4.5 documents the node-health thresholds as stale=6000 ms and unreachable=15000 ms, and the reconciliation added the sentence at line 727 asserting that cluster-management status freshness categories and scheduler eligibility derive from the same heartbeat freshness threshold source. But the shared freshness category in code (status_builder.ex) uses node_freshness_threshold_ms=30000 ms and node_unreachable_threshold_ms=15000 ms, yielding fresh &lt;=15s / stale &lt;=30s / unreachable &gt;30s — so the freshness-category boundaries differ from the §4.5 health numbers, and scheduler eligibility (30s cutoff) lets stale-categorized nodes stay schedulable. This is a conflicting-docs / ambiguous-intent case: either the code thresholds are a bug relative to the §4.5 values, or the SPEC should document the freshness-category boundaries separately from the health model. Cannot be safely reconciled in a docs-only pass without risking encoding a bug into the contract.
- ℹ️ `docs/investigations/cluster-admission-admin-api-slice-plan.md:246` - This accepted slice-plan&#39;s Out Of Scope section still says &#39;Do not implement orchardctl nodes admit&#39;, &#39;Do not implement Console pending admission UX&#39;, and &#39;Do not implement action previews&#39;, but all three have since landed in PRs #36–#37 (verified in the CLI, Admin API, and Console code). The doc&#39;s Status frames these as deferred &#39;for later CLI, Console... work&#39;, so it reads as a point-in-time snapshot rather than a false current claim. Whether to annotate this historical planning artifact as superseded or leave it frozen is an editorial judgment call the reconciliation deliberately left untouched, so I did not edit it.

🔧 Fix: sync SPEC §4.5 freshness thresholds, mark slice plan superseded
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
