### PR TITLE
feat(nodes): add node lifecycle previews and orchardctl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,14 @@ with the current supported path. `orchardctl nodes inspect`,
 `orchardctl nodes pending`, `orchardctl nodes admit`, and
 `orchardctl nodes reject` are implemented for the current node-admission-review
 slice, with stable JSON and human output, `--dry-run` previews, and
-`--yes`/`--reason` execution gating. `orchardctl support bundle create`
+`--yes`/`--reason` execution gating. `orchardctl nodes cordon`,
+`orchardctl nodes uncordon`, `orchardctl nodes drain`,
+`orchardctl nodes maintenance`, `orchardctl nodes resume`, and
+`orchardctl nodes decommission` add node lifecycle previews and execution on the
+shared Action Preview contract, gated by `--yes`, `--acknowledge`, and
+`--typed-node-id`; `orchardctl nodes maintenance` previews only, with its
+`draining -> maintenance` execution deferred until drain completion can be
+verified. `orchardctl support bundle create`
 creates a local diagnostic `.tar.gz` with bounded redacted logs, redacted
 config, service status, node snapshots, shared cluster-management node
 status, and request summaries.

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -16,6 +16,12 @@ This README is orientation only. Normative CLI requirements live in
 - Node-admission-review commands (`nodes inspect`, `nodes pending`,
   `nodes admit`, `nodes reject`) with stable JSON and human output, `--dry-run`
   previews, and `--yes`/`--reason` execution gating.
+- Node lifecycle commands (`nodes cordon`, `nodes uncordon`, `nodes drain`,
+  `nodes maintenance`, `nodes resume`, `nodes decommission`) on the shared
+  Action Preview contract, with `--dry-run`/`--json` previews and `--yes`,
+  `--acknowledge`, and `--typed-node-id` execution gating. `nodes maintenance`
+  previews only; its `draining -> maintenance` execution stays blocked until
+  drain completion can be verified.
 - Local diagnostic support bundle creation via `support bundle create`.
 - Bulk API Client provisioning through `api-clients bulk-provision`, including
   Dry Run, all-or-nothing Apply, output preflight, Key Rotation, and One-time

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -8,6 +8,7 @@ defmodule OrchardCLI.Commands.Nodes do
   alias Orchard.ControlPlane
   alias Orchard.Nodes
   alias Orchard.Nodes.AdmissionCandidate
+  alias Orchard.Nodes.Lifecycle
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(args) do
@@ -26,7 +27,13 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_command("pending", rest), do: run_pending(rest)
   defp run_command("admit", rest), do: run_admit(rest)
   defp run_command("reject", rest), do: run_reject(rest)
-  defp run_command(_command, _rest), do: {:error, group_usage(), 1}
+
+  defp run_command(command, rest) do
+    case lifecycle_command_action(command) do
+      {:ok, action} -> run_lifecycle(action, rest)
+      :error -> {:error, group_usage(), 1}
+    end
+  end
 
   defp run_inspect(["--help"]), do: {:ok, inspect_usage()}
   defp run_inspect(["help"]), do: {:ok, inspect_usage()}
@@ -124,6 +131,37 @@ defmodule OrchardCLI.Commands.Nodes do
     end
   end
 
+  defp run_lifecycle(action, ["--help"]), do: {:ok, lifecycle_usage(action)}
+  defp run_lifecycle(action, ["help"]), do: {:ok, lifecycle_usage(action)}
+
+  defp run_lifecycle(action, args) do
+    case parse_lifecycle_args(action, args) do
+      {:ok, %{dry_run?: true} = opts} ->
+        preview =
+          guarded_preview(
+            fn -> ActionPreviewBuilder.node_lifecycle(action, opts.id, opts.attrs) end,
+            action,
+            opts.id
+          )
+
+        {:ok, render_preview(preview, opts.json?)}
+
+      {:ok, opts} ->
+        preview = ActionPreviewBuilder.node_lifecycle(action, opts.id, opts.attrs)
+
+        case lifecycle_confirmation_error(preview, opts) do
+          nil -> execute_lifecycle(opts)
+          message -> confirmation_error(preview, opts, action, message)
+        end
+
+      {:help, usage} ->
+        {:ok, usage}
+
+      {:error, message, code} ->
+        {:error, message, code}
+    end
+  end
+
   defp execute_admit(opts) do
     with :ok <- ControlPlane.authorize_write_path(:node_admission),
          {:ok, result} <- Nodes.admit_node(opts.id, opts.attrs) do
@@ -138,6 +176,18 @@ defmodule OrchardCLI.Commands.Nodes do
     with :ok <- ControlPlane.authorize_write_path(:node_admission),
          {:ok, result} <- Nodes.reject_admission(opts.id, opts.attrs) do
       output = NodeAdmissionPresenter.reject_result(result)
+      {:ok, render_action_result(output, opts.json?)}
+    else
+      {:error, reason} -> action_error(reason, opts.json?)
+    end
+  end
+
+  defp execute_lifecycle(opts) do
+    with :ok <- ControlPlane.authorize_write_path(:node_lifecycle),
+         {:ok, result} <- Lifecycle.execute(opts.action, opts.id, opts.attrs) do
+      output =
+        NodeAdmissionPresenter.lifecycle_result(Lifecycle.audit_action(opts.action), result)
+
       {:ok, render_action_result(output, opts.json?)}
     else
       {:error, reason} -> action_error(reason, opts.json?)
@@ -261,6 +311,33 @@ defmodule OrchardCLI.Commands.Nodes do
     end
   end
 
+  defp parse_lifecycle_args(action, args) do
+    case OptionParser.parse(args, strict: lifecycle_switches()) do
+      {opts, [node_id], []} ->
+        if Keyword.get(opts, :help, false) do
+          {:help, lifecycle_usage(action)}
+        else
+          {:ok,
+           %{
+             action: action,
+             id: node_id,
+             json?: Keyword.get(opts, :json, false),
+             dry_run?: Keyword.get(opts, :dry_run, false),
+             yes?: Keyword.get(opts, :yes, false),
+             acknowledge?: Keyword.get(opts, :acknowledge, false),
+             typed_node_id: Keyword.get(opts, :typed_node_id),
+             attrs: lifecycle_attrs(opts)
+           }}
+        end
+
+      {_opts, _rest, [{flag, _value} | _unknown]} ->
+        unknown_option(flag)
+
+      _other ->
+        {:error, lifecycle_usage(action), 1}
+    end
+  end
+
   defp admit_switches do
     [
       dry_run: :boolean,
@@ -286,6 +363,18 @@ defmodule OrchardCLI.Commands.Nodes do
     ]
   end
 
+  defp lifecycle_switches do
+    [
+      acknowledge: :boolean,
+      dry_run: :boolean,
+      help: :boolean,
+      json: :boolean,
+      reason: :string,
+      typed_node_id: :string,
+      yes: :boolean
+    ]
+  end
+
   defp admission_attrs(opts) do
     %{}
     |> put_opt(opts, :trust_evidence_ref)
@@ -297,6 +386,8 @@ defmodule OrchardCLI.Commands.Nodes do
   end
 
   defp reject_attrs(opts), do: put_opt(%{}, opts, :reason)
+
+  defp lifecycle_attrs(opts), do: put_opt(%{}, opts, :reason)
 
   defp put_opt(attrs, opts, key) do
     case Keyword.get(opts, key) do
@@ -316,6 +407,14 @@ defmodule OrchardCLI.Commands.Nodes do
     {:error, message <> "\n\n" <> render_preview(preview, false), 2}
   end
 
+  defp confirmation_error(%ActionPreview{} = preview, %{json?: true}, _action, _message) do
+    {:error, render_preview(preview, true), 2}
+  end
+
+  defp confirmation_error(%ActionPreview{} = preview, _opts, _action, message) do
+    {:error, message <> "\n\n" <> render_preview(preview, false), 2}
+  end
+
   defp confirmation_message(preview, opts, action) do
     cond do
       preview_blocked?(preview) ->
@@ -329,8 +428,54 @@ defmodule OrchardCLI.Commands.Nodes do
     end
   end
 
+  defp lifecycle_confirmation_error(%ActionPreview{} = preview, opts) do
+    if preview_blocked?(preview) do
+      "Error: #{action_name(opts.action)} cannot execute because preview blockers are present."
+    else
+      Enum.find_value(preview.confirmation_requirements, &lifecycle_requirement_error(&1, opts))
+    end
+  end
+
+  defp lifecycle_requirement_error("requires_yes_flag", %{yes?: false} = opts) do
+    "Error: #{action_name(opts.action)} requires --yes before execution."
+  end
+
+  defp lifecycle_requirement_error("requires_typed_node_id", opts) do
+    if opts.typed_node_id == opts.id do
+      nil
+    else
+      "Error: #{action_name(opts.action)} requires --typed-node-id matching the target node id."
+    end
+  end
+
+  defp lifecycle_requirement_error(
+         "requires_drain_consequence_acknowledgement",
+         %{
+           acknowledge?: false
+         } = opts
+       ) do
+    "Error: #{action_name(opts.action)} requires --acknowledge before execution."
+  end
+
+  defp lifecycle_requirement_error(
+         "requires_decommission_consequence_acknowledgement",
+         %{
+           acknowledge?: false
+         } = opts
+       ) do
+    "Error: #{action_name(opts.action)} requires --acknowledge before execution."
+  end
+
+  defp lifecycle_requirement_error(_requirement, _opts), do: nil
+
   defp action_name(:admit), do: "node admission"
   defp action_name(:reject), do: "node admission rejection"
+  defp action_name(:cordon), do: "node cordon"
+  defp action_name(:uncordon), do: "node uncordon"
+  defp action_name(:drain), do: "node drain"
+  defp action_name(:maintenance), do: "node maintenance"
+  defp action_name(:resume), do: "node resume"
+  defp action_name(:decommission), do: "node decommission"
 
   defp action_error(reason, true) when is_atom(reason) do
     {:error, Jason.encode!(%{object: "error", code: Atom.to_string(reason)}, pretty: true), 1}
@@ -349,10 +494,21 @@ defmodule OrchardCLI.Commands.Nodes do
   defp human_reason(:admission_not_pending), do: "admission is not pending."
   defp human_reason(:admission_rejected), do: "admission rejection must be cleared first."
   defp human_reason(:controller_standby), do: "this controller is in standby mode."
+  defp human_reason(:decommission_already_running), do: "node decommission is already running."
+  defp human_reason(:drain_already_running), do: "node drain is already running."
   defp human_reason(:inventory_missing), do: "registered node inventory is missing."
+
+  defp human_reason(:lifecycle_transition_invalid),
+    do: "node lifecycle state does not allow this action."
+
+  defp human_reason(:maintenance_requires_drain), do: "node must be draining before maintenance."
   defp human_reason(:node_not_found), do: "node was not found."
+  defp human_reason(:node_not_active), do: "node is not active."
+  defp human_reason(:node_not_admitted), do: "node is not admitted."
   defp human_reason(:node_not_pending_admission), do: "node is not pending admission."
   defp human_reason(:node_not_registered), do: "node is not registered."
+  defp human_reason(:node_unhealthy), do: "node health is unhealthy."
+  defp human_reason(:node_unreachable), do: "node is unreachable."
   defp human_reason(:policy_required), do: "required policy inputs are missing."
   defp human_reason(:pool_required), do: "node pool assignment is required."
   defp human_reason(:reason_required), do: "a nonblank rejection reason is required."
@@ -439,6 +595,17 @@ defmodule OrchardCLI.Commands.Nodes do
     "Rejected admission candidate #{candidate.id}."
   end
 
+  defp render_action_result(
+         %{
+           object: "node_lifecycle_action_result",
+           action: action,
+           node: node
+         },
+         false
+       ) do
+    "#{lifecycle_result_label(action)} node #{node.id}. State: #{node.state}."
+  end
+
   defp encode_json(payload), do: Jason.encode!(payload, pretty: true)
 
   defp format_scheduling(nil), do: "unknown"
@@ -457,6 +624,25 @@ defmodule OrchardCLI.Commands.Nodes do
 
   defp format_codes([]), do: "none"
   defp format_codes(values), do: Enum.join(values, ", ")
+
+  defp lifecycle_result_label("node_lifecycle.cordoned"), do: "Cordoned"
+  defp lifecycle_result_label("node_lifecycle.uncordoned"), do: "Uncordoned"
+  defp lifecycle_result_label("node_lifecycle.drain_started"), do: "Started drain for"
+  defp lifecycle_result_label("node_lifecycle.maintenance_entered"), do: "Moved to maintenance"
+  defp lifecycle_result_label("node_lifecycle.resumed"), do: "Resumed"
+
+  defp lifecycle_result_label("node_lifecycle.decommission_started"),
+    do: "Started decommission for"
+
+  defp lifecycle_result_label(_action), do: "Updated"
+
+  defp lifecycle_command_action("cordon"), do: {:ok, :cordon}
+  defp lifecycle_command_action("uncordon"), do: {:ok, :uncordon}
+  defp lifecycle_command_action("drain"), do: {:ok, :drain}
+  defp lifecycle_command_action("maintenance"), do: {:ok, :maintenance}
+  defp lifecycle_command_action("resume"), do: {:ok, :resume}
+  defp lifecycle_command_action("decommission"), do: {:ok, :decommission}
+  defp lifecycle_command_action(_command), do: :error
 
   # NOTE: list_nodes/0 and summary/0 gracefully degrade to []/zero when the
   # repo is unavailable. The CLI cannot distinguish "no nodes" from "DB down".
@@ -564,7 +750,13 @@ defmodule OrchardCLI.Commands.Nodes do
         "  inspect  Inspect one node",
         "  pending  Review pending or rejected node admission candidates",
         "  admit    Admit a registered pending node into the cluster",
-        "  reject   Reject pending node admission"
+        "  reject   Reject pending node admission",
+        "  cordon   Stop scheduling new work to an active node",
+        "  uncordon Allow scheduling to a cordoned node",
+        "  drain    Start draining an active or cordoned node",
+        "  maintenance Move a draining node into maintenance",
+        "  resume   Resume a maintenance node",
+        "  decommission Start decommissioning a node"
       ],
       "\n"
     )
@@ -622,6 +814,54 @@ defmodule OrchardCLI.Commands.Nodes do
         "",
         "Previews or rejects pending node admission.",
         "Execution requires --yes, --reason, and a preview with no blockers."
+      ],
+      "\n"
+    )
+  end
+
+  defp lifecycle_usage(:cordon) do
+    lifecycle_usage("cordon", "Previews or cordons an active node.")
+  end
+
+  defp lifecycle_usage(:uncordon) do
+    lifecycle_usage("uncordon", "Previews or uncordons a cordoned node.")
+  end
+
+  defp lifecycle_usage(:drain) do
+    lifecycle_usage(
+      "drain",
+      "Previews or starts draining an active or cordoned node.",
+      "Execution requires --yes, --acknowledge, and a preview with no blockers."
+    )
+  end
+
+  defp lifecycle_usage(:maintenance) do
+    lifecycle_usage("maintenance", "Previews or moves a draining node into maintenance.")
+  end
+
+  defp lifecycle_usage(:resume) do
+    lifecycle_usage("resume", "Previews or resumes a maintenance node.")
+  end
+
+  defp lifecycle_usage(:decommission) do
+    lifecycle_usage(
+      "decommission",
+      "Previews or starts decommissioning a node.",
+      "Execution requires --yes, --acknowledge, --typed-node-id, and a preview with no blockers."
+    )
+  end
+
+  defp lifecycle_usage(
+         command,
+         summary,
+         execution_line \\ "Execution requires --yes and a preview with no blockers."
+       ) do
+    Enum.join(
+      [
+        "Usage: orchardctl nodes #{command} <node-id> [--dry-run] [--json] [--yes] [--reason REASON] [--acknowledge] [--typed-node-id NODE_ID]",
+        "",
+        summary,
+        execution_line
       ],
       "\n"
     )

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -448,21 +448,11 @@ defmodule OrchardCLI.Commands.Nodes do
     end
   end
 
-  defp lifecycle_requirement_error(
-         "requires_drain_consequence_acknowledgement",
-         %{
-           acknowledge?: false
-         } = opts
-       ) do
-    "Error: #{action_name(opts.action)} requires --acknowledge before execution."
-  end
-
-  defp lifecycle_requirement_error(
-         "requires_decommission_consequence_acknowledgement",
-         %{
-           acknowledge?: false
-         } = opts
-       ) do
+  defp lifecycle_requirement_error(requirement, %{acknowledge?: false} = opts)
+       when requirement in [
+              "requires_drain_consequence_acknowledgement",
+              "requires_decommission_consequence_acknowledgement"
+            ] do
     "Error: #{action_name(opts.action)} requires --acknowledge before execution."
   end
 
@@ -502,6 +492,10 @@ defmodule OrchardCLI.Commands.Nodes do
     do: "node lifecycle state does not allow this action."
 
   defp human_reason(:maintenance_requires_drain), do: "node must be draining before maintenance."
+
+  defp human_reason(:drain_completion_unverified),
+    do: "manual maintenance is unavailable until node drain completion can be verified."
+
   defp human_reason(:node_not_found), do: "node was not found."
   defp human_reason(:node_not_active), do: "node is not active."
   defp human_reason(:node_not_admitted), do: "node is not admitted."
@@ -836,7 +830,11 @@ defmodule OrchardCLI.Commands.Nodes do
   end
 
   defp lifecycle_usage(:maintenance) do
-    lifecycle_usage("maintenance", "Previews or moves a draining node into maintenance.")
+    lifecycle_usage(
+      "maintenance",
+      "Previews the draining node maintenance transition.",
+      "Execution is deferred until node drain completion can be verified."
+    )
   end
 
   defp lifecycle_usage(:resume) do

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -18,6 +18,7 @@ defmodule OrchardCLI.Commands.NodesTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.ClusterManagement.StatusBuilder
+  alias Orchard.Governance.AuditLog
   alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
   alias Orchard.Repo
   alias OrchardCLI.Commands.Nodes, as: NodesCmd
@@ -42,6 +43,12 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert msg =~ "pending"
       assert msg =~ "admit"
       assert msg =~ "reject"
+      assert msg =~ "cordon"
+      assert msg =~ "uncordon"
+      assert msg =~ "drain"
+      assert msg =~ "maintenance"
+      assert msg =~ "resume"
+      assert msg =~ "decommission"
     end
 
     test "--help returns group usage" do
@@ -84,6 +91,13 @@ defmodule OrchardCLI.Commands.NodesTest do
     test "reject --help with a target id prints usage to stdout with success" do
       assert {:ok, msg} = NodesCmd.run(["reject", Ecto.UUID.generate(), "--help"])
       assert msg =~ "orchardctl nodes reject"
+    end
+
+    test "lifecycle --help with a node id prints usage to stdout with success" do
+      for command <- ~w(cordon uncordon drain maintenance resume decommission) do
+        assert {:ok, msg} = NodesCmd.run([command, Ecto.UUID.generate(), "--help"])
+        assert msg =~ "orchardctl nodes #{command}"
+      end
     end
   end
 
@@ -451,6 +465,139 @@ defmodule OrchardCLI.Commands.NodesTest do
     end
   end
 
+  describe "lifecycle commands" do
+    test "dry-run json returns shared preview and does not mutate" do
+      node = insert_node!(state: :active, display_name: "cordon-preview-node")
+
+      assert {:ok, output} = NodesCmd.run(["cordon", node.id, "--dry-run", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["object"] == "cluster_management.action_preview"
+      assert decoded["action"] == "node_lifecycle.cordon"
+      assert decoded["target"] == %{"type" => "node", "id" => node.id}
+      assert decoded["confirmation_requirements"] == ["requires_yes_flag"]
+      assert decoded["expected_transition"] == %{"from" => "active", "to" => "cordoned"}
+      assert Repo.get!(Node, node.id).state == :active
+    end
+
+    test "json execution without yes returns preview instead of mutating" do
+      node = insert_node!(state: :active, display_name: "cordon-needs-yes-node")
+
+      assert {:error, output, 2} = NodesCmd.run(["cordon", node.id, "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["action"] == "node_lifecycle.cordon"
+      assert decoded["blockers"] == []
+      assert decoded["confirmation_requirements"] == ["requires_yes_flag"]
+      assert Repo.get!(Node, node.id).state == :active
+    end
+
+    test "drain and decommission enforce consequence acknowledgement gates" do
+      drain_node = insert_node!(state: :active, display_name: "drain-needs-ack")
+      decommission_node = insert_node!(state: :active, display_name: "decommission-needs-ack")
+
+      assert {:error, drain_output, 2} =
+               NodesCmd.run(["drain", drain_node.id, "--yes"])
+
+      assert drain_output =~ "requires --acknowledge"
+      assert drain_output =~ "requires_drain_consequence_acknowledgement"
+      assert Repo.get!(Node, drain_node.id).state == :active
+
+      assert {:error, decommission_output, 2} =
+               NodesCmd.run([
+                 "decommission",
+                 decommission_node.id,
+                 "--yes",
+                 "--typed-node-id",
+                 decommission_node.id
+               ])
+
+      assert decommission_output =~ "requires --acknowledge"
+      assert decommission_output =~ "requires_decommission_consequence_acknowledgement"
+      assert Repo.get!(Node, decommission_node.id).state == :active
+    end
+
+    test "decommission requires typed node id before execution" do
+      node = insert_node!(state: :active, display_name: "decommission-needs-typed-id")
+
+      assert {:error, output, 2} =
+               NodesCmd.run(["decommission", node.id, "--yes", "--acknowledge"])
+
+      assert output =~ "requires --typed-node-id"
+      assert output =~ "requires_typed_node_id"
+      assert Repo.get!(Node, node.id).state == :active
+    end
+
+    test "yes execution mutates lifecycle state and emits action result json" do
+      cases = [
+        {"cordon", :active, "node_lifecycle.cordoned", "cordoned", []},
+        {"uncordon", :cordoned, "node_lifecycle.uncordoned", "active", []},
+        {"drain", :cordoned, "node_lifecycle.drain_started", "draining", ["--acknowledge"]},
+        {"maintenance", :draining, "node_lifecycle.maintenance_entered", "maintenance", []},
+        {"resume", :maintenance, "node_lifecycle.resumed", "active", []},
+        {"decommission", :active, "node_lifecycle.decommission_started", "decommissioning",
+         :typed}
+      ]
+
+      for {command, from_state, action, to_state, extra_args} <- cases do
+        node = insert_node!(state: from_state, display_name: "execute-#{command}")
+
+        extra_args =
+          if extra_args == :typed,
+            do: ["--acknowledge", "--typed-node-id", node.id],
+            else: extra_args
+
+        assert {:ok, output} =
+                 NodesCmd.run([
+                   command,
+                   node.id,
+                   "--yes",
+                   "--json",
+                   "--reason",
+                   "operator requested"
+                   | extra_args
+                 ])
+
+        decoded = Jason.decode!(output)
+        assert decoded["object"] == "node_lifecycle_action_result"
+        assert decoded["action"] == action
+        assert decoded["node"]["id"] == node.id
+        assert decoded["node"]["state"] == to_state
+        assert decoded["audit_log"]["scope"] == "cluster"
+        assert Repo.get!(Node, node.id).state == String.to_existing_atom(to_state)
+
+        audit_log = Repo.get!(AuditLog, decoded["audit_log"]["id"])
+        assert audit_log.payload["reason"] == "operator requested"
+      end
+    end
+
+    test "blocked lifecycle execution returns preview and preserves node" do
+      node = insert_node!(state: :registered, display_name: "cordon-blocked-node")
+
+      assert {:error, output, 2} =
+               NodesCmd.run(["cordon", node.id, "--yes", "--json"])
+
+      decoded = Jason.decode!(output)
+      assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_admitted"]
+      assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "dry-run degrades to a not-found preview when the controller repo is unavailable" do
+      node = insert_node!(state: :active, display_name: "cordon-dry-run-repo-off")
+
+      with_repo_unavailable(fn ->
+        assert {:ok, output} = NodesCmd.run(["cordon", node.id, "--dry-run", "--json"])
+        decoded = Jason.decode!(output)
+
+        assert decoded["action"] == "node_lifecycle.cordon"
+        assert decoded["target"] == %{"type" => "node", "id" => node.id}
+        assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_found"]
+      end)
+
+      assert Repo.get!(Node, node.id).state == :active
+    end
+  end
+
   describe "action persistence failures" do
     setup do
       Application.put_env(:orchard_controller, :governance_audit_log_impl, FailingAuditLog)
@@ -489,6 +636,18 @@ defmodule OrchardCLI.Commands.NodesTest do
 
       assert output =~ "the admission action could not be completed."
       assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
+    end
+
+    test "lifecycle json surfaces a clean error when audit persistence fails" do
+      node = insert_node!(state: :active, display_name: "cordon-audit-fail-node")
+
+      assert {:error, output, 1} =
+               NodesCmd.run(["cordon", node.id, "--yes", "--json"])
+
+      decoded = Jason.decode!(output)
+      assert decoded["object"] == "error"
+      assert decoded["code"] == "action_failed"
+      assert Repo.get!(Node, node.id).state == :active
     end
   end
 

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -533,7 +533,6 @@ defmodule OrchardCLI.Commands.NodesTest do
         {"cordon", :active, "node_lifecycle.cordoned", "cordoned", []},
         {"uncordon", :cordoned, "node_lifecycle.uncordoned", "active", []},
         {"drain", :cordoned, "node_lifecycle.drain_started", "draining", ["--acknowledge"]},
-        {"maintenance", :draining, "node_lifecycle.maintenance_entered", "maintenance", []},
         {"resume", :maintenance, "node_lifecycle.resumed", "active", []},
         {"decommission", :active, "node_lifecycle.decommission_started", "decommissioning",
          :typed}
@@ -580,6 +579,30 @@ defmodule OrchardCLI.Commands.NodesTest do
       decoded = Jason.decode!(output)
       assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_admitted"]
       assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "SPEC.md §4.4 maintenance execution stays blocked while drain completion is unverified" do
+      node = insert_node!(state: :draining, display_name: "maintenance-blocked-node")
+
+      assert {:error, output, 2} =
+               NodesCmd.run(["maintenance", node.id, "--yes", "--json"])
+
+      decoded = Jason.decode!(output)
+      assert Enum.map(decoded["blockers"], & &1["code"]) == ["drain_completion_unverified"]
+      assert Repo.get!(Node, node.id).state == :draining
+    end
+
+    test "SPEC.md §4.4 maintenance dry-run still previews the blocked transition" do
+      node = insert_node!(state: :draining, display_name: "maintenance-dry-run-node")
+
+      assert {:ok, output} = NodesCmd.run(["maintenance", node.id, "--dry-run", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["object"] == "cluster_management.action_preview"
+      assert decoded["action"] == "node_lifecycle.maintenance"
+      assert Enum.map(decoded["blockers"], & &1["code"]) == ["drain_completion_unverified"]
+      assert decoded["expected_transition"] == %{"from" => "draining", "to" => "maintenance"}
+      assert Repo.get!(Node, node.id).state == :draining
     end
 
     test "dry-run degrades to a not-found preview when the controller repo is unavailable" do

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -535,11 +535,13 @@ defmodule OrchardCLI.Commands.NodesTest do
         {"drain", :cordoned, "node_lifecycle.drain_started", "draining", ["--acknowledge"]},
         {"resume", :maintenance, "node_lifecycle.resumed", "active", []},
         {"decommission", :active, "node_lifecycle.decommission_started", "decommissioning",
+         :typed},
+        {"decommission", :draining, "node_lifecycle.decommission_started", "decommissioning",
          :typed}
       ]
 
       for {command, from_state, action, to_state, extra_args} <- cases do
-        node = insert_node!(state: from_state, display_name: "execute-#{command}")
+        node = insert_node!(state: from_state, display_name: "execute-#{command}-#{from_state}")
 
         extra_args =
           if extra_args == :typed,

--- a/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin/node_admission_presenter.ex
@@ -73,6 +73,16 @@ defmodule Orchard.API.Admin.NodeAdmissionPresenter do
     }
   end
 
+  @spec lifecycle_result(String.t(), %{node: Node.t(), audit_log: AuditLog.t()}) :: map()
+  def lifecycle_result(action, %{node: %Node{} = node, audit_log: audit_log}) do
+    %{
+      object: "node_lifecycle_action_result",
+      action: action,
+      node: present_node(node),
+      audit_log: audit_log(audit_log)
+    }
+  end
+
   defp candidate_action_result(action, %{
          candidate: %AdmissionCandidate{} = candidate,
          decision: decision,

--- a/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
@@ -6,7 +6,7 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
   alias Orchard.ClusterManagement.{ActionPreview, StatusBuilder}
   alias Orchard.ControlPlane
   alias Orchard.Nodes
-  alias Orchard.Nodes.{AdmissionCandidate, Node}
+  alias Orchard.Nodes.{AdmissionCandidate, Lifecycle, Node}
 
   @spec admit_node(Ecto.UUID.t(), map() | keyword()) :: ActionPreview.t()
   def admit_node(node_id, attrs \\ %{}) do
@@ -57,13 +57,75 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
     end
   end
 
-  @spec not_found_preview(:admit | :reject, Ecto.UUID.t()) :: ActionPreview.t()
+  @spec node_lifecycle(Lifecycle.action(), Ecto.UUID.t(), map() | keyword()) :: ActionPreview.t()
+  def node_lifecycle(action, node_id, attrs \\ %{})
+      when action in [
+             :cordon,
+             :uncordon,
+             :drain,
+             :maintenance,
+             :resume,
+             :decommission
+           ] do
+    _attrs = Map.new(attrs)
+
+    case Nodes.fetch_node(node_id) do
+      {:ok, %Node{} = node} ->
+        blockers =
+          []
+          |> add_write_path_blocker()
+          |> add_blockers(Lifecycle.blocker_codes(action, node))
+
+        action_preview(%{
+          action: Lifecycle.preview_action(action),
+          target: %{type: "node", id: node.id},
+          current: StatusBuilder.node_status_map(node),
+          active_request_count: nil,
+          scheduler_eligibility: scheduler_eligibility(node),
+          blockers: blockers,
+          warnings: [],
+          consequence_codes: Lifecycle.consequence_codes(action),
+          confirmation_requirements: Lifecycle.confirmation_requirements(action),
+          expected_transition: %{from: node.state, to: Lifecycle.target_state(action)},
+          audit_action: Lifecycle.audit_action(action),
+          confirmation_required: true
+        })
+
+      {:error, :node_not_found} ->
+        missing_target_preview(
+          Lifecycle.preview_action(action),
+          "node",
+          node_id,
+          Lifecycle.audit_action(action)
+        )
+    end
+  end
+
+  @spec not_found_preview(:admit | :reject | Lifecycle.action(), Ecto.UUID.t()) ::
+          ActionPreview.t()
   def not_found_preview(:admit, node_id) do
     missing_target_preview("node_admission.admit", "node", node_id, "node_admission.admitted")
   end
 
   def not_found_preview(:reject, target_id) do
     missing_target_preview("node_admission.reject", "node", target_id, "node_admission.rejected")
+  end
+
+  def not_found_preview(action, node_id)
+      when action in [
+             :cordon,
+             :uncordon,
+             :drain,
+             :maintenance,
+             :resume,
+             :decommission
+           ] do
+    missing_target_preview(
+      Lifecycle.preview_action(action),
+      "node",
+      node_id,
+      Lifecycle.audit_action(action)
+    )
   end
 
   defp reject_candidate_preview(%AdmissionCandidate{} = candidate, attrs) do
@@ -181,9 +243,22 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
 
   defp blocker_message(:ha_standby_write_blocked), do: "This controller is in standby mode."
   defp blocker_message(:inventory_missing), do: "Registered node inventory is missing."
+  defp blocker_message(:decommission_already_running), do: "Node decommission is already running."
+  defp blocker_message(:drain_already_running), do: "Node drain is already running."
+
+  defp blocker_message(:lifecycle_transition_invalid),
+    do: "Node lifecycle state does not allow this action."
+
+  defp blocker_message(:maintenance_requires_drain),
+    do: "Node must be draining before maintenance."
+
   defp blocker_message(:node_not_found), do: "Node was not found."
+  defp blocker_message(:node_not_active), do: "Node is not active."
+  defp blocker_message(:node_not_admitted), do: "Node is not admitted."
   defp blocker_message(:node_not_pending_admission), do: "Node is not pending admission."
   defp blocker_message(:node_not_registered), do: "Node is not registered."
+  defp blocker_message(:node_unhealthy), do: "Node health is unhealthy."
+  defp blocker_message(:node_unreachable), do: "Node is unreachable."
   defp blocker_message(:policy_required), do: "Required policy inputs are missing."
   defp blocker_message(:pool_required), do: "Node pool assignment is required."
   defp blocker_message(:trust_not_established), do: "Node trust evidence is required."

--- a/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
@@ -58,7 +58,7 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
   end
 
   @spec node_lifecycle(Lifecycle.action(), Ecto.UUID.t(), map() | keyword()) :: ActionPreview.t()
-  def node_lifecycle(action, node_id, attrs \\ %{})
+  def node_lifecycle(action, node_id, _attrs \\ %{})
       when action in [
              :cordon,
              :uncordon,
@@ -67,8 +67,6 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
              :resume,
              :decommission
            ] do
-    _attrs = Map.new(attrs)
-
     case Nodes.fetch_node(node_id) do
       {:ok, %Node{} = node} ->
         blockers =
@@ -251,6 +249,9 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
 
   defp blocker_message(:maintenance_requires_drain),
     do: "Node must be draining before maintenance."
+
+  defp blocker_message(:drain_completion_unverified),
+    do: "Manual maintenance is unavailable until node drain completion can be verified."
 
   defp blocker_message(:node_not_found), do: "Node was not found."
   defp blocker_message(:node_not_active), do: "Node is not active."

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -1483,7 +1483,9 @@ defmodule Orchard.Nodes do
     |> Repo.one()
   end
 
-  defp lock_node(node_id) do
+  @doc false
+  @spec lock_node(Ecto.UUID.t()) :: {:ok, Node.t()} | {:error, :node_not_found}
+  def lock_node(node_id) do
     with {:ok, node_id} <- normalize_uuid(node_id, :node_not_found) do
       Node
       |> where([node], node.id == ^node_id)

--- a/apps/orchard_controller/lib/orchard/nodes/lifecycle.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/lifecycle.ex
@@ -129,6 +129,7 @@ defmodule Orchard.Nodes.Lifecycle do
     []
     |> add_wrong_state_blocker(action, node.state, spec.allowed_states)
     |> add_resume_health_blockers(action, node.health)
+    |> add_maintenance_drain_verification_blocker(action, node.state)
     |> Enum.uniq()
   end
 
@@ -176,6 +177,11 @@ defmodule Orchard.Nodes.Lifecycle do
     do: blockers ++ [:node_unhealthy]
 
   defp add_resume_health_blockers(blockers, _action, _health), do: blockers
+
+  defp add_maintenance_drain_verification_blocker(blockers, :maintenance, :draining),
+    do: blockers ++ [:drain_completion_unverified]
+
+  defp add_maintenance_drain_verification_blocker(blockers, _action, _state), do: blockers
 
   defp update_node_state(%Node{} = node, state) do
     node

--- a/apps/orchard_controller/lib/orchard/nodes/lifecycle.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/lifecycle.ex
@@ -60,7 +60,7 @@ defmodule Orchard.Nodes.Lifecycle do
       consequence_codes: []
     },
     decommission: %{
-      allowed_states: [:registered, :admitted, :active, :cordoned, :maintenance],
+      allowed_states: [:registered, :admitted, :active, :cordoned, :draining, :maintenance],
       target_state: :decommissioning,
       preview_action: "node_lifecycle.decommission",
       audit_action: "node_lifecycle.decommission_started",

--- a/apps/orchard_controller/lib/orchard/nodes/lifecycle.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/lifecycle.ex
@@ -1,0 +1,222 @@
+defmodule Orchard.Nodes.Lifecycle do
+  @moduledoc """
+  Node lifecycle action transitions and audit persistence.
+  """
+
+  alias Orchard.Governance
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Nodes
+  alias Orchard.Nodes.Node
+  alias Orchard.Repo
+  alias Orchard.SchemaSupport
+
+  @typedoc "Supported operator lifecycle actions for admitted node inventory."
+  @type action :: :cordon | :uncordon | :drain | :maintenance | :resume | :decommission
+
+  @actions [:cordon, :uncordon, :drain, :maintenance, :resume, :decommission]
+
+  @action_specs %{
+    cordon: %{
+      allowed_states: [:active],
+      target_state: :cordoned,
+      preview_action: "node_lifecycle.cordon",
+      audit_action: "node_lifecycle.cordoned",
+      confirmation_requirements: [:requires_yes_flag],
+      consequence_codes: []
+    },
+    uncordon: %{
+      allowed_states: [:cordoned],
+      target_state: :active,
+      preview_action: "node_lifecycle.uncordon",
+      audit_action: "node_lifecycle.uncordoned",
+      confirmation_requirements: [:requires_yes_flag],
+      consequence_codes: []
+    },
+    drain: %{
+      allowed_states: [:active, :cordoned],
+      target_state: :draining,
+      preview_action: "node_lifecycle.drain",
+      audit_action: "node_lifecycle.drain_started",
+      confirmation_requirements: [
+        :requires_yes_flag,
+        :requires_drain_consequence_acknowledgement
+      ],
+      consequence_codes: [:existing_requests_continue_until_deadline]
+    },
+    maintenance: %{
+      allowed_states: [:draining],
+      target_state: :maintenance,
+      preview_action: "node_lifecycle.maintenance",
+      audit_action: "node_lifecycle.maintenance_entered",
+      confirmation_requirements: [:requires_yes_flag],
+      consequence_codes: []
+    },
+    resume: %{
+      allowed_states: [:maintenance],
+      target_state: :active,
+      preview_action: "node_lifecycle.resume",
+      audit_action: "node_lifecycle.resumed",
+      confirmation_requirements: [:requires_yes_flag],
+      consequence_codes: []
+    },
+    decommission: %{
+      allowed_states: [:registered, :admitted, :active, :cordoned, :maintenance],
+      target_state: :decommissioning,
+      preview_action: "node_lifecycle.decommission",
+      audit_action: "node_lifecycle.decommission_started",
+      confirmation_requirements: [
+        :requires_yes_flag,
+        :requires_typed_node_id,
+        :requires_decommission_consequence_acknowledgement
+      ],
+      consequence_codes: [:future_scheduling_revoked, :no_rejoin_with_same_node_id]
+    }
+  }
+
+  @spec actions() :: [action()]
+  def actions, do: @actions
+
+  @spec action?(term()) :: boolean()
+  def action?(action), do: action in @actions
+
+  @spec preview_action(action()) :: String.t()
+  def preview_action(action), do: fetch_spec!(action).preview_action
+
+  @spec audit_action(action()) :: String.t()
+  def audit_action(action), do: fetch_spec!(action).audit_action
+
+  @spec target_state(action()) :: atom()
+  def target_state(action), do: fetch_spec!(action).target_state
+
+  @spec confirmation_requirements(action()) :: [atom()]
+  def confirmation_requirements(action), do: fetch_spec!(action).confirmation_requirements
+
+  @spec consequence_codes(action()) :: [atom()]
+  def consequence_codes(action), do: fetch_spec!(action).consequence_codes
+
+  @spec blocker_codes(action(), Node.t()) :: [atom()]
+  def blocker_codes(action, %Node{} = node) do
+    action
+    |> fetch_spec!()
+    |> do_blocker_codes(action, node)
+  end
+
+  @spec execute(action(), Ecto.UUID.t(), map() | keyword(), keyword()) ::
+          {:ok, %{node: Node.t(), audit_log: AuditLog.t()}} | {:error, term()}
+  def execute(action, node_id, attrs \\ %{}, opts \\ [])
+
+  def execute(action, node_id, attrs, opts) when action in @actions do
+    attrs = SchemaSupport.normalize_attrs(attrs)
+
+    Repo.transaction(fn ->
+      with {:ok, node} <- Nodes.lock_node(node_id),
+           [] <- blocker_codes(action, node),
+           {:ok, updated_node} <- update_node_state(node, target_state(action)),
+           {:ok, audit_log} <-
+             insert_lifecycle_audit_log(action, node, updated_node, attrs, opts) do
+        {:ok, %{node: updated_node, audit_log: audit_log}}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+        [reason | _rest] -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  def execute(_action, _node_id, _attrs, _opts), do: {:error, :lifecycle_action_unknown}
+
+  defp do_blocker_codes(spec, action, %Node{} = node) do
+    []
+    |> add_wrong_state_blocker(action, node.state, spec.allowed_states)
+    |> add_resume_health_blockers(action, node.health)
+    |> Enum.uniq()
+  end
+
+  defp add_wrong_state_blocker(blockers, action, state, allowed_states) do
+    if state in allowed_states do
+      blockers
+    else
+      add_disallowed_state_blocker(blockers, action, state)
+    end
+  end
+
+  defp add_disallowed_state_blocker(blockers, :cordon, state)
+       when state in [:provisioned, :registered],
+       do: blockers ++ [:node_not_admitted]
+
+  defp add_disallowed_state_blocker(blockers, :cordon, _state),
+    do: blockers ++ [:node_not_active]
+
+  defp add_disallowed_state_blocker(blockers, :drain, :draining),
+    do: blockers ++ [:drain_already_running]
+
+  defp add_disallowed_state_blocker(blockers, :drain, state)
+       when state in [:provisioned, :registered, :admitted],
+       do: blockers ++ [:node_not_active]
+
+  defp add_disallowed_state_blocker(blockers, :drain, _state),
+    do: blockers ++ [:lifecycle_transition_invalid]
+
+  defp add_disallowed_state_blocker(blockers, :maintenance, _state),
+    do: blockers ++ [:maintenance_requires_drain]
+
+  defp add_disallowed_state_blocker(blockers, :decommission, :decommissioning),
+    do: blockers ++ [:decommission_already_running]
+
+  defp add_disallowed_state_blocker(blockers, :decommission, :provisioned),
+    do: blockers ++ [:node_not_registered]
+
+  defp add_disallowed_state_blocker(blockers, _action, _state),
+    do: blockers ++ [:lifecycle_transition_invalid]
+
+  defp add_resume_health_blockers(blockers, :resume, :unreachable),
+    do: blockers ++ [:node_unreachable]
+
+  defp add_resume_health_blockers(blockers, :resume, :unhealthy),
+    do: blockers ++ [:node_unhealthy]
+
+  defp add_resume_health_blockers(blockers, _action, _health), do: blockers
+
+  defp update_node_state(%Node{} = node, state) do
+    node
+    |> Ecto.Changeset.change(state: state)
+    |> Repo.update()
+  end
+
+  defp insert_lifecycle_audit_log(action, %Node{} = original, %Node{} = updated, attrs, opts) do
+    Governance.insert_cluster_audit_log(%{
+      actor_type: opts |> Keyword.get(:actor_type, "operator") |> to_string(),
+      actor_id: Keyword.get(opts, :actor_id),
+      action: audit_action(action),
+      target_type: "node",
+      target_id: updated.id,
+      occurred_at: SchemaSupport.utc_now(),
+      payload: lifecycle_audit_payload(original, updated, attrs)
+    })
+  end
+
+  defp lifecycle_audit_payload(%Node{} = original, %Node{} = updated, attrs) do
+    %{
+      "node_id" => updated.id,
+      "display_name" => updated.display_name,
+      "from_state" => Atom.to_string(original.state),
+      "to_state" => Atom.to_string(updated.state)
+    }
+    |> maybe_put_reason(Map.get(attrs, "reason"))
+  end
+
+  defp maybe_put_reason(payload, reason) when is_binary(reason) do
+    case String.trim(reason) do
+      "" -> payload
+      trimmed -> Map.put(payload, "reason", String.slice(trimmed, 0, 512))
+    end
+  end
+
+  defp maybe_put_reason(payload, _reason), do: payload
+
+  defp fetch_spec!(action), do: Map.fetch!(@action_specs, action)
+
+  defp unwrap_transaction_result({:ok, {:ok, value}}), do: {:ok, value}
+  defp unwrap_transaction_result({:ok, value}), do: value
+  defp unwrap_transaction_result({:error, reason}), do: {:error, reason}
+end

--- a/apps/orchard_controller/test/orchard/cluster_management/action_preview_builder_test.exs
+++ b/apps/orchard_controller/test/orchard/cluster_management/action_preview_builder_test.exs
@@ -1,0 +1,110 @@
+defmodule Orchard.ClusterManagement.ActionPreviewBuilderTest do
+  use ExUnit.Case, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.ClusterManagement.{ActionPreview, ActionPreviewBuilder}
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Nodes.Node
+  alias Orchard.Repo
+
+  setup do
+    :ok = Sandbox.checkout(Repo)
+    Sandbox.mode(Repo, {:shared, self()})
+
+    on_exit(fn -> Application.delete_env(:orchard_controller, :control_plane) end)
+
+    :ok
+  end
+
+  test "SPEC.md §7.3 lifecycle previews are side-effect-free and use shared ActionPreview" do
+    node = insert_node!(state: :active)
+
+    preview = ActionPreviewBuilder.node_lifecycle(:drain, node.id)
+    map = ActionPreview.to_map(preview)
+
+    assert map.object == "cluster_management.action_preview"
+    assert map.action == "node_lifecycle.drain"
+    assert map.target == %{type: "node", id: node.id}
+    assert map.active_request_count == nil
+    assert map.consequence_codes == ["existing_requests_continue_until_deadline"]
+
+    assert map.confirmation_requirements == [
+             "requires_yes_flag",
+             "requires_drain_consequence_acknowledgement"
+           ]
+
+    assert map.expected_transition == %{from: "active", to: "draining"}
+    assert Repo.get!(Node, node.id).state == :active
+
+    assert 0 =
+             AuditLog
+             |> where([audit_log], audit_log.target_id == ^node.id)
+             |> Repo.aggregate(:count)
+  end
+
+  test "decommission preview includes destructive confirmation requirements and consequences" do
+    node = insert_node!(state: :active)
+
+    preview = ActionPreviewBuilder.node_lifecycle(:decommission, node.id)
+    map = ActionPreview.to_map(preview)
+
+    assert map.action == "node_lifecycle.decommission"
+
+    assert map.consequence_codes == [
+             "future_scheduling_revoked",
+             "no_rejoin_with_same_node_id"
+           ]
+
+    assert map.confirmation_requirements == [
+             "requires_yes_flag",
+             "requires_typed_node_id",
+             "requires_decommission_consequence_acknowledgement"
+           ]
+
+    assert map.expected_transition == %{from: "active", to: "decommissioning"}
+  end
+
+  test "missing lifecycle target returns a node_not_found preview" do
+    node_id = Ecto.UUID.generate()
+
+    preview = ActionPreviewBuilder.node_lifecycle(:cordon, node_id)
+    map = ActionPreview.to_map(preview)
+
+    assert map.action == "node_lifecycle.cordon"
+    assert map.target == %{type: "node", id: node_id}
+    assert Enum.map(map.blockers, & &1.code) == ["node_not_found"]
+  end
+
+  test "standby control plane adds a write-path blocker" do
+    Application.put_env(:orchard_controller, :control_plane, role: :standby)
+    node = insert_node!(state: :active)
+
+    preview = ActionPreviewBuilder.node_lifecycle(:cordon, node.id)
+
+    assert "ha_standby_write_blocked" in Enum.map(preview.blockers, & &1.code)
+    assert Repo.get!(Node, node.id).state == :active
+  end
+
+  defp insert_node!(attrs) do
+    unique = System.unique_integer([:positive])
+
+    defaults = %{
+      id: Ecto.UUID.generate(),
+      hostname: "host-#{unique}.local",
+      display_name: "node-#{unique}",
+      advertise_addr: "127.0.0.#{rem(unique, 255)}",
+      rpc_port: 50_000 + rem(unique, 15_000),
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      agent_version: "0.1.0",
+      last_heartbeat_at: DateTime.utc_now()
+    }
+
+    %Node{}
+    |> Node.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> Repo.insert!()
+  end
+end

--- a/apps/orchard_controller/test/orchard/cluster_management/action_preview_builder_test.exs
+++ b/apps/orchard_controller/test/orchard/cluster_management/action_preview_builder_test.exs
@@ -66,6 +66,18 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilderTest do
     assert map.expected_transition == %{from: "active", to: "decommissioning"}
   end
 
+  test "SPEC.md §4.4 maintenance preview blocks draining nodes until drain completion is verified" do
+    node = insert_node!(state: :draining)
+
+    preview = ActionPreviewBuilder.node_lifecycle(:maintenance, node.id)
+    map = ActionPreview.to_map(preview)
+
+    assert map.action == "node_lifecycle.maintenance"
+    assert Enum.map(map.blockers, & &1.code) == ["drain_completion_unverified"]
+    assert map.expected_transition == %{from: "draining", to: "maintenance"}
+    assert Repo.get!(Node, node.id).state == :draining
+  end
+
   test "missing lifecycle target returns a node_not_found preview" do
     node_id = Ecto.UUID.generate()
 

--- a/apps/orchard_controller/test/orchard/nodes/lifecycle_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes/lifecycle_test.exs
@@ -35,7 +35,6 @@ defmodule Orchard.Nodes.LifecycleTest do
       {:cordon, :active, :cordoned, "node_lifecycle.cordoned"},
       {:uncordon, :cordoned, :active, "node_lifecycle.uncordoned"},
       {:drain, :cordoned, :draining, "node_lifecycle.drain_started"},
-      {:maintenance, :draining, :maintenance, "node_lifecycle.maintenance_entered"},
       {:resume, :maintenance, :active, "node_lifecycle.resumed"},
       {:decommission, :admitted, :decommissioning, "node_lifecycle.decommission_started"}
     ]
@@ -74,11 +73,12 @@ defmodule Orchard.Nodes.LifecycleTest do
       {:cordon, :registered, :node_not_admitted},
       {:drain, :draining, :drain_already_running},
       {:maintenance, :active, :maintenance_requires_drain},
+      {:maintenance, :draining, :drain_completion_unverified},
       {:decommission, :draining, :lifecycle_transition_invalid}
     ]
 
     for {action, state, reason} <- cases do
-      node = insert_node!(state: state, display_name: "blocked-#{action}")
+      node = insert_node!(state: state, display_name: "blocked-#{action}-from-#{state}")
 
       assert {:error, ^reason} = Lifecycle.execute(action, node.id)
       assert Repo.get!(Node, node.id).state == state

--- a/apps/orchard_controller/test/orchard/nodes/lifecycle_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes/lifecycle_test.exs
@@ -1,0 +1,138 @@
+defmodule Orchard.Nodes.LifecycleTest.FailingAuditLog do
+  @moduledoc false
+
+  import Ecto.Changeset
+
+  alias Orchard.Governance.AuditLog
+
+  @spec changeset(AuditLog.t(), map()) :: Ecto.Changeset.t()
+  def changeset(%AuditLog{} = audit_log, _attrs) do
+    audit_log
+    |> change()
+    |> add_error(:action, "forced lifecycle audit failure")
+  end
+end
+
+defmodule Orchard.Nodes.LifecycleTest do
+  use ExUnit.Case, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Nodes.Lifecycle
+  alias Orchard.Nodes.Node
+  alias Orchard.Repo
+
+  setup do
+    :ok = Sandbox.checkout(Repo)
+    Sandbox.mode(Repo, {:shared, self()})
+    :ok
+  end
+
+  test "SPEC.md §4.3 lifecycle actions transition nodes and write cluster audit" do
+    cases = [
+      {:cordon, :active, :cordoned, "node_lifecycle.cordoned"},
+      {:uncordon, :cordoned, :active, "node_lifecycle.uncordoned"},
+      {:drain, :cordoned, :draining, "node_lifecycle.drain_started"},
+      {:maintenance, :draining, :maintenance, "node_lifecycle.maintenance_entered"},
+      {:resume, :maintenance, :active, "node_lifecycle.resumed"},
+      {:decommission, :admitted, :decommissioning, "node_lifecycle.decommission_started"}
+    ]
+
+    for {action, from_state, to_state, audit_action} <- cases do
+      node = insert_node!(state: from_state, display_name: "lifecycle-#{action}")
+
+      assert {:ok, %{node: updated, audit_log: audit_log}} =
+               Lifecycle.execute(action, node.id, %{reason: "operator requested"})
+
+      assert updated.state == to_state
+      assert Repo.get!(Node, node.id).state == to_state
+      assert audit_log.scope == "cluster"
+      assert audit_log.action == audit_action
+      assert audit_log.target_type == "node"
+      assert audit_log.target_id == node.id
+      assert audit_log.payload["from_state"] == Atom.to_string(from_state)
+      assert audit_log.payload["to_state"] == Atom.to_string(to_state)
+      assert audit_log.payload["reason"] == "operator requested"
+    end
+  end
+
+  test "SPEC.md §7.3 execution revalidates lifecycle state at mutation time" do
+    node = insert_node!(state: :active)
+
+    node
+    |> Ecto.Changeset.change(state: :cordoned)
+    |> Repo.update!()
+
+    assert {:error, :node_not_active} = Lifecycle.execute(:cordon, node.id)
+    assert Repo.get!(Node, node.id).state == :cordoned
+  end
+
+  test "SPEC.md §4.3 disallowed lifecycle transitions do not mutate" do
+    cases = [
+      {:cordon, :registered, :node_not_admitted},
+      {:drain, :draining, :drain_already_running},
+      {:maintenance, :active, :maintenance_requires_drain},
+      {:decommission, :draining, :lifecycle_transition_invalid}
+    ]
+
+    for {action, state, reason} <- cases do
+      node = insert_node!(state: state, display_name: "blocked-#{action}")
+
+      assert {:error, ^reason} = Lifecycle.execute(action, node.id)
+      assert Repo.get!(Node, node.id).state == state
+    end
+  end
+
+  test "SPEC.md §4.4 resume blocks unhealthy and unreachable nodes" do
+    unreachable = insert_node!(state: :maintenance, health: :unreachable)
+    unhealthy = insert_node!(state: :maintenance, health: :unhealthy)
+
+    assert {:error, :node_unreachable} = Lifecycle.execute(:resume, unreachable.id)
+    assert {:error, :node_unhealthy} = Lifecycle.execute(:resume, unhealthy.id)
+    assert Repo.get!(Node, unreachable.id).state == :maintenance
+    assert Repo.get!(Node, unhealthy.id).state == :maintenance
+  end
+
+  test "audit persistence failure rolls back lifecycle state" do
+    node = insert_node!(state: :active)
+
+    Application.put_env(
+      :orchard_controller,
+      :governance_audit_log_impl,
+      Orchard.Nodes.LifecycleTest.FailingAuditLog
+    )
+
+    on_exit(fn -> Application.delete_env(:orchard_controller, :governance_audit_log_impl) end)
+
+    assert {:error, %Ecto.Changeset{}} = Lifecycle.execute(:cordon, node.id)
+    assert Repo.get!(Node, node.id).state == :active
+
+    assert 0 =
+             AuditLog
+             |> where([audit_log], audit_log.target_id == ^node.id)
+             |> Repo.aggregate(:count)
+  end
+
+  defp insert_node!(attrs) do
+    unique = System.unique_integer([:positive])
+
+    defaults = %{
+      id: Ecto.UUID.generate(),
+      hostname: "host-#{unique}.local",
+      display_name: "node-#{unique}",
+      advertise_addr: "127.0.0.#{rem(unique, 255)}",
+      rpc_port: 50_000 + rem(unique, 15_000),
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      agent_version: "0.1.0",
+      last_heartbeat_at: DateTime.utc_now()
+    }
+
+    %Node{}
+    |> Node.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> Repo.insert!()
+  end
+end

--- a/apps/orchard_controller/test/orchard/nodes/lifecycle_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes/lifecycle_test.exs
@@ -36,11 +36,12 @@ defmodule Orchard.Nodes.LifecycleTest do
       {:uncordon, :cordoned, :active, "node_lifecycle.uncordoned"},
       {:drain, :cordoned, :draining, "node_lifecycle.drain_started"},
       {:resume, :maintenance, :active, "node_lifecycle.resumed"},
-      {:decommission, :admitted, :decommissioning, "node_lifecycle.decommission_started"}
+      {:decommission, :admitted, :decommissioning, "node_lifecycle.decommission_started"},
+      {:decommission, :draining, :decommissioning, "node_lifecycle.decommission_started"}
     ]
 
     for {action, from_state, to_state, audit_action} <- cases do
-      node = insert_node!(state: from_state, display_name: "lifecycle-#{action}")
+      node = insert_node!(state: from_state, display_name: "lifecycle-#{action}-#{from_state}")
 
       assert {:ok, %{node: updated, audit_log: audit_log}} =
                Lifecycle.execute(action, node.id, %{reason: "operator requested"})
@@ -73,8 +74,7 @@ defmodule Orchard.Nodes.LifecycleTest do
       {:cordon, :registered, :node_not_admitted},
       {:drain, :draining, :drain_already_running},
       {:maintenance, :active, :maintenance_requires_drain},
-      {:maintenance, :draining, :drain_completion_unverified},
-      {:decommission, :draining, :lifecycle_transition_invalid}
+      {:maintenance, :draining, :drain_completion_unverified}
     ]
 
     for {action, state, reason} <- cases do

--- a/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
@@ -47,10 +47,12 @@ defmodule Orchard.ClusterManagement.ReasonCodes do
     node_not_active
     node_not_registered
     node_unreachable
+    node_unhealthy
     inventory_missing
     drain_already_running
     decommission_already_running
     maintenance_requires_drain
+    lifecycle_transition_invalid
     ha_standby_write_blocked
     cluster_lock_unavailable
     version_incompatible
@@ -71,6 +73,8 @@ defmodule Orchard.ClusterManagement.ReasonCodes do
     active_requests_present
     would_cancel_active_requests
     existing_requests_continue_until_deadline
+    future_scheduling_revoked
+    no_rejoin_with_same_node_id
   )
 
   @support_scope_codes ~w(

--- a/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
@@ -52,6 +52,7 @@ defmodule Orchard.ClusterManagement.ReasonCodes do
     drain_already_running
     decommission_already_running
     maintenance_requires_drain
+    drain_completion_unverified
     lifecycle_transition_invalid
     ha_standby_write_blocked
     cluster_lock_unavailable

--- a/apps/orchard_shared/test/fixtures/cluster_management/action_preview_lifecycle_v1.json
+++ b/apps/orchard_shared/test/fixtures/cluster_management/action_preview_lifecycle_v1.json
@@ -1,0 +1,42 @@
+{
+  "object": "cluster_management.action_preview",
+  "contract_version": "orchard.cluster_management.action_preview.v1",
+  "action": "node_lifecycle.decommission",
+  "target": {
+    "type": "node",
+    "id": "550e8400-e29b-41d4-a716-446655440000"
+  },
+  "current": {
+    "lifecycle": {
+      "state": "active"
+    },
+    "health": {
+      "status": "healthy"
+    },
+    "freshness": {
+      "status": "fresh"
+    }
+  },
+  "active_request_count": null,
+  "scheduler_eligibility": {
+    "eligible": true,
+    "reason_codes": []
+  },
+  "blockers": [],
+  "warnings": [],
+  "consequence_codes": [
+    "future_scheduling_revoked",
+    "no_rejoin_with_same_node_id"
+  ],
+  "confirmation_requirements": [
+    "requires_yes_flag",
+    "requires_typed_node_id",
+    "requires_decommission_consequence_acknowledgement"
+  ],
+  "expected_transition": {
+    "from": "active",
+    "to": "decommissioning"
+  },
+  "audit_action": "node_lifecycle.decommission_started",
+  "confirmation_required": true
+}

--- a/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
+++ b/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
@@ -15,8 +15,12 @@ defmodule Orchard.ClusterManagement.ContractTest do
     assert "node_not_active" in ReasonCodes.scheduler_rejection_codes()
     assert "lower_tier_not_considered" in ReasonCodes.scheduler_skip_codes()
     assert "node_not_pending_admission" in ReasonCodes.action_blocker_codes()
+    assert "lifecycle_transition_invalid" in ReasonCodes.action_blocker_codes()
+    assert "node_unhealthy" in ReasonCodes.action_blocker_codes()
     assert "requires_reason" in ReasonCodes.confirmation_requirement_codes()
     assert "active_requests_present" in ReasonCodes.consequence_codes()
+    assert "future_scheduling_revoked" in ReasonCodes.consequence_codes()
+    assert "no_rejoin_with_same_node_id" in ReasonCodes.consequence_codes()
     assert "ha_lite" in ReasonCodes.support_scope_codes()
   end
 
@@ -37,6 +41,27 @@ defmodule Orchard.ClusterManagement.ContractTest do
     assert [%{"code" => "legacy_metadata"}] = rendered["warnings"]
     assert rendered["consequence_codes"] == ["existing_requests_continue_until_deadline"]
     assert rendered["confirmation_requirements"] == ["requires_reason"]
+  end
+
+  test "lifecycle action preview golden fixture matches shared JSON contract" do
+    fixture = fixture!("action_preview_lifecycle_v1.json")
+    assert {:ok, preview} = ActionPreview.new(fixture)
+
+    rendered = json_round_trip(ActionPreview.to_map(preview))
+
+    assert fixture == rendered
+    assert rendered["action"] == "node_lifecycle.decommission"
+
+    assert rendered["consequence_codes"] == [
+             "future_scheduling_revoked",
+             "no_rejoin_with_same_node_id"
+           ]
+
+    assert rendered["confirmation_requirements"] == [
+             "requires_yes_flag",
+             "requires_typed_node_id",
+             "requires_decommission_consequence_acknowledgement"
+           ]
   end
 
   test "scheduler explanation golden fixture validates fixed rejected and skipped codes" do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,13 @@ product/system/build contract.
   `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for
   the current node-admission-review slice, with stable JSON and human output,
   `--dry-run` previews, and `--yes`/`--reason` execution gating.
+  `orchardctl nodes cordon`, `orchardctl nodes uncordon`,
+  `orchardctl nodes drain`, `orchardctl nodes maintenance`,
+  `orchardctl nodes resume`, and `orchardctl nodes decommission` add node
+  lifecycle previews and execution on the shared Action Preview contract, gated
+  by `--yes`, `--acknowledge`, and `--typed-node-id`; `orchardctl nodes
+  maintenance` previews only, with its `draining -> maintenance` execution
+  deferred until drain completion can be verified.
   `orchardctl support bundle create` creates a local diagnostic archive
   with bounded redacted logs, redacted config, service status, node snapshots,
   shared cluster-management node status, and request summaries.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -535,6 +535,7 @@ Use the BEAM Runtime Endpoint flow when you are validating the explicit split-ro
 `orchardctl cluster init` and `orchardctl node join` are SPEC-required future node-lifecycle commands.
 In this build they return deferred status.
 `orchardctl nodes inspect`, `orchardctl nodes pending`, `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for the current node-admission-review slice, with stable JSON and human output, `--dry-run` previews, and `--yes`/`--reason` execution gating.
+`orchardctl nodes cordon`, `orchardctl nodes uncordon`, `orchardctl nodes drain`, `orchardctl nodes maintenance`, `orchardctl nodes resume`, and `orchardctl nodes decommission` add node lifecycle previews and execution on the shared Action Preview contract, gated by `--yes`, `--acknowledge`, and `--typed-node-id`; `orchardctl nodes maintenance` previews only, with its `draining -> maintenance` execution deferred until drain completion can be verified.
 Use the env-var split-role flows below for source-dev cluster testing.
 
 ### gRPC compatibility flow

--- a/openspec/changes/cluster-management-ux-foundation/design.md
+++ b/openspec/changes/cluster-management-ux-foundation/design.md
@@ -170,10 +170,13 @@ Action preview blocker codes should include these initial stable values:
 - `node_not_active`
 - `node_not_registered`
 - `node_unreachable`
+- `node_unhealthy`
 - `inventory_missing`
 - `drain_already_running`
 - `decommission_already_running`
 - `maintenance_requires_drain`
+- `drain_completion_unverified`
+- `lifecycle_transition_invalid`
 - `ha_standby_write_blocked`
 - `cluster_lock_unavailable`
 - `version_incompatible`
@@ -194,6 +197,8 @@ Action preview consequence codes should include these initial stable values:
 - `active_requests_present`
 - `would_cancel_active_requests`
 - `existing_requests_continue_until_deadline`
+- `future_scheduling_revoked`
+- `no_rejoin_with_same_node_id`
 
 Support bundle and diagnostics scope codes should include:
 

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -46,6 +46,7 @@
 - [x] 4.5 Implement `orchardctl nodes reject <node-id|candidate-id>` with dry-run, JSON preview support, `--reason`, and required confirmation semantics aligned with Console and Admin API.
 - [x] 4.6 Implement safe lifecycle commands for cordon, uncordon, drain, maintenance, resume, and decommission with dry-run, confirmation requirements, and JSON output.
   Note: this slice implements local `orchardctl nodes` lifecycle commands on the shared `ActionPreview` contract with transactional lifecycle state mutation, mutation-time revalidation, and cluster-scoped audit.
+  Manual `draining -> maintenance` execution remains deferred: the `maintenance` command still exposes its dry-run preview but execution is blocked with a `drain_completion_unverified` blocker until drain completion (active-work quiescence) can be verified.
   Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, persisted lifecycle reason columns, decommission trust revocation, Admin/Operator API lifecycle routes, and Console lifecycle panels remain future work.
 - [ ] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -48,6 +48,7 @@
   Note: this slice implements local `orchardctl nodes` lifecycle commands on the shared `ActionPreview` contract with transactional lifecycle state mutation, mutation-time revalidation, and cluster-scoped audit.
   Manual `draining -> maintenance` execution remains deferred: the `maintenance` command still exposes its dry-run preview but execution is blocked with a `drain_completion_unverified` blocker until drain completion (active-work quiescence) can be verified.
   Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, persisted lifecycle reason columns, decommission trust revocation, Admin/Operator API lifecycle routes, and Console lifecycle panels remain future work.
+  Note: `SPEC.md` §11.9 currently enumerates only the node-admission CLI commands as a required-command floor; promoting these lifecycle commands into that normative list remains an owner/OpenSpec-acceptance decision to be reconciled when this change is accepted.
 - [ ] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
 

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -44,7 +44,9 @@
 - [x] 4.3 Implement `orchardctl nodes pending` or an equivalent admission-review command.
 - [x] 4.4 Implement `orchardctl nodes admit <node-id>` with dry-run and JSON preview support.
 - [x] 4.5 Implement `orchardctl nodes reject <node-id|candidate-id>` with dry-run, JSON preview support, `--reason`, and required confirmation semantics aligned with Console and Admin API.
-- [ ] 4.6 Implement safe lifecycle commands for cordon, uncordon, drain, maintenance, resume, and decommission with dry-run, confirmation requirements, and JSON output.
+- [x] 4.6 Implement safe lifecycle commands for cordon, uncordon, drain, maintenance, resume, and decommission with dry-run, confirmation requirements, and JSON output.
+  Note: this slice implements local `orchardctl nodes` lifecycle commands on the shared `ActionPreview` contract with transactional lifecycle state mutation, mutation-time revalidation, and cluster-scoped audit.
+  Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, persisted lifecycle reason columns, decommission trust revocation, Admin/Operator API lifecycle routes, and Console lifecycle panels remain future work.
 - [ ] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
 


### PR DESCRIPTION
## Intent

Retry validation for the updated Orchard lifecycle action previews and CLI commands PR at head e26848b after the No Mistakes test agent completed passing validation but failed its own schema submission. Validate that the PR remains domain plus CLI plus documentation, preserves maintenance execution blocking until drain completion can be verified, and allows decommission from draining nodes to align with SPEC §4.4. Scope defers Console lifecycle panels, scheduler explanations, support bundle v2, HA-lite read-only status, broad Operator API, drain deadline orchestration, active-work cancellation, automatic draining-to-maintenance orchestration, persisted lifecycle reason columns, and decommission trust revocation.

## What Changed

- Added `Orchard.Nodes.Lifecycle` with action specs, state-transition blocker codes, and audit persistence for six operator actions (cordon, uncordon, drain, maintenance, resume, decommission), plus `ActionPreviewBuilder.node_lifecycle/3` and a presenter result shape that expose them on the shared Action Preview contract; new reason codes (`node_unhealthy`, `drain_completion_unverified`, `lifecycle_transition_invalid`, `future_scheduling_revoked`, `no_rejoin_with_same_node_id`) and a lifecycle contract fixture back the wiring.
- Wired `orchardctl nodes cordon/uncordon/drain/maintenance/resume/decommission` with `--dry-run`/`--json` previews and `--yes`/`--acknowledge`/`--typed-node-id` execution gating; `maintenance` stays preview-only, blocking its `draining -> maintenance` execution with `drain_completion_unverified` until drain completion can be verified, while `decommission` is now permitted from `draining` nodes.
- Documented the new commands and reason codes across README, `docs/architecture.md`, `docs/local-dev.md`, the CLI README, and the OpenSpec cluster-management change package, and added controller/CLI/contract test coverage.

## Risk Assessment

✅ Low: Well-bounded domain+CLI+docs change following established admit/reject patterns, with comprehensive happy- and failure-path tests, complete reason-code vocabulary, correct transactional rollback, and no substantiated correctness, security, or regression risks.

## Testing

Ran the smallest relevant test slices across the controller domain, CLI, and shared-contract suites (baseline `mix deps.get` + `ecto.create/migrate` first) — all pass — then produced product-level evidence by driving the actual `orchardctl nodes` lifecycle commands through the real CLI entry point against a live dev database, capturing an operator transcript with rendered human output, JSON previews, exit codes, and a persisted cluster audit-log row. The transcript directly shows maintenance execution remaining blocked until drain completion can be verified and decommission succeeding from a draining node (SPEC §4.4), satisfying the stated user intent. This is a CLI + domain + docs change with no rendered UI surface (Console lifecycle panels are explicitly deferred in scope), so a CLI transcript plus persisted DB state is the appropriate end-user evidence rather than a screenshot. Transient dev-DB node rows and the local driver script were cleaned up, leaving the working tree clean.

<details>
<summary>Evidence: orchardctl nodes lifecycle — operator CLI transcript (real dispatch, live dev DB)</summary>

```text
==============================================================================
orchardctl nodes LIFECYCLE — operator transcript (real CLI dispatch)
==============================================================================


########## 1. Group usage now lists the six lifecycle commands ##########

$ orchardctl nodes help    [exit 0]
Usage: orchardctl nodes <command>

Commands:
  list     List registered nodes
  inspect  Inspect one node
  pending  Review pending or rejected node admission candidates
  admit    Admit a registered pending node into the cluster
  reject   Reject pending node admission
  cordon   Stop scheduling new work to an active node
  uncordon Allow scheduling to a cordoned node
  drain    Start draining an active or cordoned node
  maintenance Move a draining node into maintenance
  resume   Resume a maintenance node
  decommission Start decommissioning a node


########## 2. CORDON: dry-run preview -> gated execution -> mutation ##########
>> seeded node dd7c4787-5ef4-45e1-9c1c-d52d574e7239 in state=active

$ orchardctl nodes cordon dd7c4787-5ef4-45e1-9c1c-d52d574e7239 --dry-run    [exit 0]
Action: node_lifecycle.cordon
Target: node:dd7c4787-5ef4-45e1-9c1c-d52d574e7239
Blockers: none
Confirmation requirements: requires_yes_flag
Expected transition: active -> cordoned

$ orchardctl nodes cordon dd7c4787-5ef4-45e1-9c1c-d52d574e7239 --dry-run --json    [exit 0]
{
  "action": "node_lifecycle.cordon",
  "target": {
    "id": "dd7c4787-5ef4-45e1-9c1c-d52d574e7239",
    "type": "node"
  },
  "warnings": [],
  "active_request_count": null,
  "current": {
    "runtime": {
      "status": "unknown",
      "health_code": null,
      "health_message": null
    },
    "resource": {
      "id": "dd7c4787-5ef4-45e1-9c1c-d52d574e7239",
      "type": "node"
    },
    "warnings": [],
    "transport": {
      "status": "unknown"
    },
    "health": {
      "status": "healthy"
    },
    "object": "cluster_management.node_status",
    "contract_version": "orchard.cluster_management.status.v1",
    "admission": {
      "category": "admitted",
      "source": "registered_node",
      "latest_decision": null
    },
    "scheduling": {
      "eligible": true,
      "reason_codes": []
    },
    "compatibility": {
      "status": "unknown"
    },
    "freshness": {
      "status": "fresh",
      "source": "heartbeat",
      "observed_at": "2026-07-03T03:01:44.484277Z"
    },
    "lifecycle": {
      "state": "active"
    }
  },
  "object": "cluster_management.action_preview",
  "audit_action": "node_lifecycle.cordoned",
  "confirmation_requirements": [
    "requires_yes_flag"
  ],
  "contract_version": "orchard.cluster_management.action_preview.v1",
  "blockers": [],
  "expected_transition": {
    "to": "cordoned",
    "from": "active"
  },
  "confirmation_required": true,
  "scheduler_eligibility": {
    "eligible": true,
    "reason_codes": []
  },
  "consequence_codes": []
}

>> attempt execution WITHOUT --yes (should be refused, node stays active):

$ orchardctl nodes cordon dd7c4787-5ef4-45e1-9c1c-d52d574e7239    [exit 2]
Error: node cordon requires --yes before execution.

Action: node_lifecycle.cordon
Target: node:dd7c4787-5ef4-45e1-9c1c-d52d574e7239
Blockers: none
Confirmation requirements: requires_yes_flag
Expected transition: active -> cordoned
>> state after refused execution: active

>> execute WITH --yes:

$ orchardctl nodes cordon dd7c4787-5ef4-45e1-9c1c-d52d574e7239 --yes --reason planned maintenance window    [exit 0]
Cordoned node dd7c4787-5ef4-45e1-9c1c-d52d574e7239. State: cordoned.
>> state after execution: cordoned


########## 3. DRAIN: requires --yes AND --acknowledge ##########
>> seeded node afe853d6-0472-4630-8876-27bf20b03e3e in state=active

$ orchardctl nodes drain afe853d6-0472-4630-8876-27bf20b03e3e --dry-run    [exit 0]
Action: node_lifecycle.drain
Target: node:afe853d6-0472-4630-8876-27bf20b03e3e
Blockers: none
Confirmation requirements: requires_yes_flag, requires_drain_consequence_acknowledgement
Expected transition: active -> draining

>> --yes only (missing --acknowledge, should be refused):

$ orchardctl nodes drain afe853d6-0472-4630-8876-27bf20b03e3e --yes    [exit 2]
Error: node drain requires --acknowledge before execution.

Action: node_lifecycle.drain
Target: node:afe853d6-0472-4630-8876-27bf20b03e3e
Blockers: none
Confirmation requirements: requires_yes_flag, requires_drain_consequence_acknowledgement
Expected transition: active -> draining
>> state after refused drain: active

>> execute WITH --yes --acknowledge:

$ orchardctl nodes drain afe853d6-0472-4630-8876-27bf20b03e3e --yes --acknowledge --reason evacuate before reboot    [exit 0]
Started drain for node afe853d6-0472-4630-8876-27bf20b03e3e. State: draining.
>> state after execution: draining

>> persisted cluster audit_logs row written by the drain execution:
{
  "id": 22,
  "scope": "cluster",
  "action": "node_lifecycle.drain_started",
  "payload": {
    "display_name": "web-node-b-7554",
    "from_state": "active",
    "node_id": "afe853d6-0472-4630-8876-27bf20b03e3e",
    "reason": "evacuate before reboot",
    "to_state": "draining"
  },
  "target_id": "afe853d6-0472-4630-8876-27bf20b03e3e",
  "actor_type": "operator",
  "target_type": "node"
}


########## 4. MAINTENANCE: execution stays BLOCKED until drain completion verified (SPEC 4.4) ##########
>> seeded node 53bc69b9-3e7f-4202-81a7-40fb4180cbb4 in state=draining
>> dry-run preview shows the draining->maintenance transition with blocker:

$ orchardctl nodes maintenance 53bc69b9-3e7f-4202-81a7-40fb4180cbb4 --dry-run --json    [exit 0]
{
  "action": "node_lifecycle.maintenance",
  "target": {
    "id": "53bc69b9-3e7f-4202-81a7-40fb4180cbb4",
    "type": "node"
  },
  "warnings": [],
  "active_request_count": null,
  "current": {
    "runtime": {
      "status": "unknown",
      "health_code": null,
      "health_message": null
    },
    "resource": {
      "id": "53bc69b9-3e7f-4202-81a7-40fb4180cbb4",
      "type": "node"
    },
    "warnings": [],
    "transport": {
      "status": "unknown"
    },
    "health": {
      "status": "healthy"
    },
    "object": "cluster_management.node_status",
    "contract_version": "orchard.cluster_management.status.v1",
    "admission": {
      "category": "admitted",
      "source": "registered_node",
      "latest_decision": null
    },
    "scheduling": {
      "eligible": false,
      "reason_codes": [
        "node_not_active"
      ]
    },
    "compatibility": {
      "status": "unknown"
    },
    "freshness": {
      "status": "fresh",
      "source": "heartbeat",
      "observed_at": "2026-07-03T03:01:44.556516Z"
    },
    "lifecycle": {
      "state": "draining"
    }
  },
  "object": "cluster_management.action_preview",
  "audit_action": "node_lifecycle.maintenance_entered",
  "confirmation_requirements": [
    "requires_yes_flag"
  ],
  "contract_version": "orchard.cluster_management.action_preview.v1",
  "blockers": [
    {
      "code": "drain_completion_unverified",
      "message": "Manual maintenance is unavailable until node drain completion can be verified.",
      "metadata": {}
    }
  ],
  "expected_transition": {
    "to": "maintenance",
    "from": "draining"
  },
  "confirmation_required": true,
  "scheduler_eligibility": {
    "eligible": false,
    "reason_codes": [
      "node_not_active"
    ]
  },
  "consequence_codes": []
}

>> attempt real execution with --yes (must remain blocked):

$ orchardctl nodes maintenance 53bc69b9-3e7f-4202-81a7-40fb4180cbb4 --yes    [exit 2]
Error: node maintenance cannot execute because preview blockers are present.

Action: node_lifecycle.maintenance
Target: node:53bc69b9-3e7f-4202-81a7-40fb4180cbb4
Blockers: drain_completion_unverified
Confirmation requirements: requires_yes_flag
Expected transition: draining -> maintenance
>> state after blocked maintenance (must stay draining): draining


########## 5. DECOMMISSION: allowed from a DRAINING node (SPEC 4.4 fix) ##########
>> seeded node ae9d3b9d-05a0-4b9e-b642-7ad57d954307 in state=draining
>> dry-run preview from draining node:

$ orchardctl nodes decommission ae9d3b9d-05a0-4b9e-b642-7ad57d954307 --dry-run    [exit 0]
Action: node_lifecycle.decommission
Target: node:ae9d3b9d-05a0-4b9e-b642-7ad57d954307
Blockers: none
Confirmation requirements: requires_yes_flag, requires_typed_node_id, requires_decommission_consequence_acknowledgement
Expected transition: draining -> decommissioning

>> missing --typed-node-id (should be refused):

$ orchardctl nodes decommission ae9d3b9d-05a0-4b9e-b642-7ad57d954307 --yes --acknowledge    [exit 2]
Error: node decommission requires --typed-node-id matching the target node id.

Action: node_lifecycle.decommission
Target: node:ae9d3b9d-05a0-4b9e-b642-7ad57d954307
Blockers: none
Confirmation requirements: requires_yes_flag, requires_typed_node_id, requires_decommission_consequence_acknowledgement
Expected transition: draining -> decommissioning

>> execute WITH --yes --acknowledge --typed-node-id (from draining):

$ orchardctl nodes decommission ae9d3b9d-05a0-4b9e-b642-7ad57d954307 --yes --acknowledge --typed-node-id ae9d3b9d-05a0-4b9e-b642-7ad57d954307 --reason hardware retirement    [exit 0]
Started decommission for node ae9d3b9d-05a0-4b9e-b642-7ad57d954307. State: decommissioning.
>> state after execution (draining -> decommissioning): decommissioning


########## 6. Blocked lifecycle on wrong state returns the preview with a blocker ##########
>> seeded node 9619e595-ebaf-493f-ae8e-d92acf5aa99d in state=registered
>> cordon on a registered (not-admitted) node is blocked:

$ orchardctl nodes cordon 9619e595-ebaf-493f-ae8e-d92acf5aa99d --yes --json    [exit 2]
{
  "action": "node_lifecycle.cordon",
  "target": {
    "id": "9619e595-ebaf-493f-ae8e-d92acf5aa99d",
    "type": "node"
  },
  "warnings": [],
  "active_request_count": null,
  "current": {
    "runtime": {
      "status": "unknown",
      "health_code": null,
      "health_message": null
    },
    "resource": {
      "id": "9619e595-ebaf-493f-ae8e-d92acf5aa99d",
      "type": "node"
    },
    "warnings": [],
    "transport": {
      "status": "unknown"
    },
    "health": {
      "status": "healthy"
    },
    "object": "cluster_management.node_status",
    "contract_version": "orchard.cluster_management.status.v1",
    "admission": {
      "category": "pending_registered",
      "source": "registered_node",
      "latest_decision": null
    },
    "scheduling": {
      "eligible": false,
      "reason_codes": [
        "node_not_admitted"
      ]
    },
    "compatibility": {
      "status": "unknown"
    },
    "freshness": {
      "status": "fresh",
      "source": "heartbeat",
      "observed_at": "2026-07-03T03:01:44.571701Z"
    },
    "lifecycle": {
      "state": "registered"
    }
  },
  "object": "cluster_management.action_preview",
  "audit_action": "node_lifecycle.cordoned",
  "confirmation_requirements": [
    "requires_yes_flag"
  ],
  "contract_version": "orchard.cluster_management.action_preview.v1",
  "blockers": [
    {
      "code": "node_not_admitted",
      "message": "Node is not admitted.",
      "metadata": {}
    }
  ],
  "expected_transition": {
    "to": "cordoned",
    "from": "registered"
  },
  "confirmation_required": true,
  "scheduler_eligibility": {
    "eligible": false,
    "reason_codes": [
      "node_not_admitted"
    ]
  },
  "consequence_codes": []
}
>> state after blocked cordon: registered

==============================================================================
END OF TRANSCRIPT
==============================================================================

(cleanup: removed 5 evidence-seeded node rows)
```
</details>
<details>
<summary>Evidence: Maintenance execution stays blocked until drain completion verified (SPEC §4.4)</summary>

```text
$ orchardctl nodes maintenance <id> --yes [exit 2]
Error: node maintenance cannot execute because preview blockers are present.

Action: node_lifecycle.maintenance
Target: node:<id>
Blockers: drain_completion_unverified
Expected transition: draining -> maintenance
>> state after blocked maintenance (must stay draining): draining
```
</details>
<details>
<summary>Evidence: Decommission allowed from a draining node (SPEC §4.4 fix)</summary>

```text
$ orchardctl nodes decommission <id> --dry-run [exit 0]
Expected transition: draining -> decommissioning

$ orchardctl nodes decommission <id> --yes --acknowledge --typed-node-id <id> --reason hardware retirement [exit 0]
Started decommission for node <id>. State: decommissioning.
>> state after execution (draining -> decommissioning): decommissioning
```
</details>
<details>
<summary>Evidence: Persisted cluster audit_logs row written by drain execution</summary>

```text
{
"scope": "cluster",
"action": "node_lifecycle.drain_started",
"actor_type": "operator",
"target_type": "node",
"payload": {
"from_state": "active",
"to_state": "draining",
"reason": "evacuate before reboot"
}
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex:62` - The 6-element lifecycle action guard list is duplicated verbatim between node_lifecycle/3 (line 62) and not_found_preview/2 (line 113), and also re-enumerated in Lifecycle.@actions, the CLI&#39;s lifecycle_command_action/1, and action_name/1. Lifecycle already exposes actions/0 and action?/1. Extracting the builder&#39;s two guard lists into a shared module attribute (e.g. @lifecycle_actions) would remove the in-module duplication and keep the vocabulary in one place. Non-functional cleanup.
- ℹ️ `apps/orchard_controller/lib/orchard/nodes/lifecycle.ex:181` - In this slice, a node in :draining state has no executable transition except decommission: maintenance is permanently blocked by :drain_completion_unverified (its only allowed state is :draining), and there is no cancel-drain path back to :active or :cordoned. So draining is effectively irreversible until the deferred drain-verification/maintenance orchestration lands. This is consistent with the explicitly deferred scope (draining-&gt;maintenance orchestration, active-work cancellation), but worth confirming the operator UX gap is intended for the interim.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `controller lifecycle + preview builder tests`
- `CLI nodes lifecycle tests`
- `shared cluster-management contract test`
- `end-to-end orchardctl CLI transcript`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
