### PR TITLE
feat(console): add node lifecycle action previews to node detail

### DIFF
--- a/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
+++ b/apps/orchard_controller/lib/orchard/cluster_management/action_preview_builder.ex
@@ -16,7 +16,7 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
       {:ok, %Node{} = node} ->
         blockers =
           []
-          |> add_write_path_blocker()
+          |> add_write_path_blocker(:node_admission)
           |> add_blockers(Nodes.admission_blocker_codes(node, attrs))
 
         action_preview(%{
@@ -71,7 +71,7 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
       {:ok, %Node{} = node} ->
         blockers =
           []
-          |> add_write_path_blocker()
+          |> add_write_path_blocker(:node_lifecycle)
           |> add_blockers(Lifecycle.blocker_codes(action, node))
 
         action_preview(%{
@@ -129,7 +129,7 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
   defp reject_candidate_preview(%AdmissionCandidate{} = candidate, attrs) do
     blockers =
       []
-      |> add_write_path_blocker()
+      |> add_write_path_blocker(:node_admission)
       |> add_blockers(candidate_rejection_blockers(candidate))
 
     action_preview(%{
@@ -148,7 +148,7 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
   defp reject_node_preview(%Node{} = node, attrs) do
     blockers =
       []
-      |> add_write_path_blocker()
+      |> add_write_path_blocker(:node_admission)
       |> add_blockers(node_rejection_blockers(node))
 
     action_preview(%{
@@ -218,8 +218,8 @@ defmodule Orchard.ClusterManagement.ActionPreviewBuilder do
     |> then(& &1.scheduling)
   end
 
-  defp add_write_path_blocker(blockers) do
-    case ControlPlane.authorize_write_path(:node_admission) do
+  defp add_write_path_blocker(blockers, write_path) do
+    case ControlPlane.authorize_write_path(write_path) do
       :ok -> blockers
       {:error, :controller_standby} -> blockers ++ [:ha_standby_write_blocked]
     end

--- a/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
@@ -10,10 +10,11 @@ defmodule OrchardConsole.NodeDetailLive do
   alias Orchard.ClusterManagement.{ActionPreview, ActionPreviewBuilder, StatusBuilder}
   alias Orchard.ControlPlane
   alias Orchard.Nodes
-  alias Orchard.Nodes.{AdmissionCandidate, Node}
+  alias Orchard.Nodes.{AdmissionCandidate, Lifecycle, Node}
 
   @default_refresh_interval_ms 5_000
   @pending_admission_categories ~w(pending_observed pending_provisioned pending_registered)
+  @lifecycle_actions Lifecycle.actions()
 
   # ===========================================================================
   # Lifecycle
@@ -80,8 +81,27 @@ defmodule OrchardConsole.NodeDetailLive do
     end
   end
 
+  def handle_event(
+        "open_lifecycle",
+        %{"action" => action},
+        %{assigns: %{record: %Node{}}} = socket
+      ) do
+    with {:ok, action} <- lifecycle_action(action),
+         :node <- socket.assigns.target_kind do
+      {:noreply, put_action(socket, action, default_action_inputs(action), false)}
+    else
+      _error -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("open_lifecycle", _params, socket), do: {:noreply, socket}
+
   def handle_event("cancel_action", _params, socket) do
     {:noreply, assign(socket, action: nil)}
+  end
+
+  def handle_event("action_change", %{"action" => _params}, %{assigns: %{action: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("action_change", %{"action" => params}, socket) do
@@ -90,6 +110,10 @@ defmodule OrchardConsole.NodeDetailLive do
     confirmed? = truthy?(Map.get(params, "confirmed"))
 
     {:noreply, put_action(socket, action.kind, inputs, confirmed?)}
+  end
+
+  def handle_event("execute_action", %{"action" => _params}, %{assigns: %{action: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("execute_action", %{"action" => params}, socket) do
@@ -135,28 +159,41 @@ defmodule OrchardConsole.NodeDetailLive do
               <.card>
                 <:title>{detail_title(@target_kind, @record)}</:title>
                 <:subtitle>{detail_subtitle(@target_kind, @record)}</:subtitle>
-                <:actions>
-                  <div class="flex flex-wrap justify-end gap-2">
-                    <.button
-                      :if={can_open_admit?(@target_kind, @record, @status)}
-                      id="node-detail-open-admit"
-                      variant={:primary}
-                      size={:sm}
-                      phx-click="open_admit"
-                    >
-                      Preview admit
-                    </.button>
-                    <.button
-                      :if={can_open_reject?(@target_kind, @record, @status)}
-                      id="node-detail-open-reject"
-                      variant={:danger}
-                      size={:sm}
-                      phx-click="open_reject"
-                    >
-                      Preview reject
-                    </.button>
-                  </div>
-                </:actions>
+
+                <div
+                  :if={detail_action_buttons?(@target_kind, @record, @status)}
+                  id="node-detail-actions"
+                  class="mb-4 flex flex-wrap gap-2"
+                >
+                  <.button
+                    :if={can_open_admit?(@target_kind, @record, @status)}
+                    id="node-detail-open-admit"
+                    variant={:primary}
+                    size={:sm}
+                    phx-click="open_admit"
+                  >
+                    Preview admit
+                  </.button>
+                  <.button
+                    :if={can_open_reject?(@target_kind, @record, @status)}
+                    id="node-detail-open-reject"
+                    variant={:danger}
+                    size={:sm}
+                    phx-click="open_reject"
+                  >
+                    Preview reject
+                  </.button>
+                  <.button
+                    :for={lifecycle_action <- lifecycle_action_buttons(@target_kind, @record)}
+                    id={"node-detail-open-lifecycle-#{lifecycle_action}"}
+                    variant={lifecycle_action_variant(lifecycle_action)}
+                    size={:sm}
+                    phx-click="open_lifecycle"
+                    phx-value-action={lifecycle_action}
+                  >
+                    {lifecycle_action_button_label(lifecycle_action)}
+                  </.button>
+                </div>
 
                 <div class="flex flex-wrap items-center gap-2">
                   <.badge tone={admission_category_tone(status_value(@status, :admission, :category))}>
@@ -535,6 +572,15 @@ defmodule OrchardConsole.NodeDetailLive do
     ActionPreviewBuilder.reject_admission(id, inputs)
   end
 
+  defp build_action_preview(
+         %{assigns: %{target_kind: :node, record: %Node{id: id}}},
+         kind,
+         inputs
+       )
+       when kind in @lifecycle_actions do
+    ActionPreviewBuilder.node_lifecycle(kind, id, inputs)
+  end
+
   defp execute_action(socket, %{kind: :admit, inputs: inputs}) do
     with :ok <- ControlPlane.authorize_write_path(:node_admission),
          {:ok, _result} <- Nodes.admit_node(socket.assigns.record.id, inputs, audit_opts()) do
@@ -578,6 +624,20 @@ defmodule OrchardConsole.NodeDetailLive do
     end
   end
 
+  defp execute_action(%{assigns: %{target_kind: :node}} = socket, %{kind: kind, inputs: inputs})
+       when kind in @lifecycle_actions do
+    with :ok <- ControlPlane.authorize_write_path(:node_lifecycle),
+         {:ok, _result} <- Lifecycle.execute(kind, socket.assigns.record.id, inputs, audit_opts()) do
+      {:noreply,
+       socket
+       |> put_flash(:info, lifecycle_success_message(kind))
+       |> assign(action: nil)
+       |> load_detail()}
+    else
+      {:error, reason} -> {:noreply, put_action_error(socket, error_message(reason))}
+    end
+  end
+
   defp put_action_error(%{assigns: %{action: action}} = socket, message) do
     assign(socket, action: Map.put(action, :error, message))
   end
@@ -589,6 +649,16 @@ defmodule OrchardConsole.NodeDetailLive do
   end
 
   defp default_action_inputs(:reject), do: %{"reason" => ""}
+
+  defp default_action_inputs(:decommission) do
+    %{"reason" => "", "node_id_confirmation" => "", "acknowledged" => "false"}
+  end
+
+  defp default_action_inputs(:drain), do: %{"reason" => "", "acknowledged" => "false"}
+
+  defp default_action_inputs(action) when action in @lifecycle_actions do
+    %{"reason" => ""}
+  end
 
   defp normalize_action_inputs(:admit, params) do
     %{
@@ -602,6 +672,25 @@ defmodule OrchardConsole.NodeDetailLive do
     %{"reason" => Map.get(params, "reason", "")}
   end
 
+  defp normalize_action_inputs(:decommission, params) do
+    %{
+      "reason" => Map.get(params, "reason", ""),
+      "node_id_confirmation" => Map.get(params, "node_id_confirmation", ""),
+      "acknowledged" => Map.get(params, "acknowledged", "false")
+    }
+  end
+
+  defp normalize_action_inputs(:drain, params) do
+    %{
+      "reason" => Map.get(params, "reason", ""),
+      "acknowledged" => Map.get(params, "acknowledged", "false")
+    }
+  end
+
+  defp normalize_action_inputs(action, params) when action in @lifecycle_actions do
+    %{"reason" => Map.get(params, "reason", "")}
+  end
+
   defp action_executable?(%{confirmed: true, preview: preview, kind: kind, inputs: inputs}) do
     preview_entries(preview, :blockers) == [] and
       not missing_required_input?(kind, preview, inputs)
@@ -612,6 +701,13 @@ defmodule OrchardConsole.NodeDetailLive do
   defp missing_required_input?(:reject, preview, inputs) do
     "requires_reason" in preview_codes(preview, :confirmation_requirements) and
       blank?(Map.get(inputs, "reason"))
+  end
+
+  defp missing_required_input?(kind, preview, inputs) when kind in @lifecycle_actions do
+    requirements = preview_codes(preview, :confirmation_requirements)
+
+    missing_typed_node_id?(requirements, inputs, preview) or
+      missing_consequence_acknowledgement?(requirements, inputs)
   end
 
   defp missing_required_input?(_kind, _preview, _inputs), do: false
@@ -628,6 +724,25 @@ defmodule OrchardConsole.NodeDetailLive do
   end
 
   defp can_open_reject?(_target_kind, _record, _status), do: false
+
+  defp detail_action_buttons?(target_kind, record, status) do
+    can_open_admit?(target_kind, record, status) or
+      can_open_reject?(target_kind, record, status) or
+      lifecycle_action_buttons(target_kind, record) != []
+  end
+
+  defp lifecycle_action_buttons(:node, %Node{}), do: @lifecycle_actions
+  defp lifecycle_action_buttons(_target_kind, _record), do: []
+
+  defp lifecycle_action_kind?(kind), do: kind in @lifecycle_actions
+
+  defp lifecycle_action(action) when is_binary(action) do
+    action = String.to_existing_atom(action)
+
+    if action in @lifecycle_actions, do: {:ok, action}, else: :error
+  rescue
+    ArgumentError -> :error
+  end
 
   # ===========================================================================
   # Display helpers
@@ -842,14 +957,26 @@ defmodule OrchardConsole.NodeDetailLive do
 
   defp action_title(:admit), do: "Admit Node Preview"
   defp action_title(:reject), do: "Reject Admission Preview"
+  defp action_title(:cordon), do: "Cordon Node Preview"
+  defp action_title(:uncordon), do: "Uncordon Node Preview"
+  defp action_title(:drain), do: "Drain Node Preview"
+  defp action_title(:maintenance), do: "Maintenance Node Preview"
+  defp action_title(:resume), do: "Resume Node Preview"
+  defp action_title(:decommission), do: "Decommission Node Preview"
 
   defp action_submit_label(:admit), do: "Admit node"
   defp action_submit_label(:reject), do: "Reject admission"
+  defp action_submit_label(:cordon), do: "Cordon node"
+  defp action_submit_label(:uncordon), do: "Uncordon node"
+  defp action_submit_label(:drain), do: "Start drain"
+  defp action_submit_label(:maintenance), do: "Enter maintenance"
+  defp action_submit_label(:resume), do: "Resume node"
+  defp action_submit_label(:decommission), do: "Start decommission"
 
-  defp action_variant(:reject), do: :danger
+  defp action_variant(kind) when kind in [:reject, :decommission], do: :danger
   defp action_variant(_kind), do: :primary
 
-  defp action_panel_class(:reject),
+  defp action_panel_class(kind) when kind in [:reject, :decommission],
     do: "border-red-200 bg-red-50/40 dark:border-red-900/50 dark:bg-red-950/20"
 
   defp action_panel_class(_kind), do: ""
@@ -862,6 +989,38 @@ defmodule OrchardConsole.NodeDetailLive do
     "Rejection records an admission decision and keeps the candidate visible for audit review."
   end
 
+  defp action_explanation(kind) when kind in @lifecycle_actions do
+    "Execution revalidates lifecycle blockers before mutating node state."
+  end
+
+  defp action_form_id(kind) when kind in [:admit, :reject], do: "admission-action-form"
+  defp action_form_id(kind) when kind in @lifecycle_actions, do: "node-action-form"
+
+  defp confirmation_label(kind) when kind in [:admit, :reject] do
+    "I reviewed the preview and understand this admission action."
+  end
+
+  defp confirmation_label(kind) when kind in @lifecycle_actions do
+    "I reviewed the preview and understand this lifecycle action."
+  end
+
+  defp lifecycle_action_button_label(:cordon), do: "Preview cordon"
+  defp lifecycle_action_button_label(:uncordon), do: "Preview uncordon"
+  defp lifecycle_action_button_label(:drain), do: "Preview drain"
+  defp lifecycle_action_button_label(:maintenance), do: "Preview maintenance"
+  defp lifecycle_action_button_label(:resume), do: "Preview resume"
+  defp lifecycle_action_button_label(:decommission), do: "Preview decommission"
+
+  defp lifecycle_action_variant(:decommission), do: :danger
+  defp lifecycle_action_variant(_action), do: :secondary
+
+  defp lifecycle_success_message(:cordon), do: "Node cordoned."
+  defp lifecycle_success_message(:uncordon), do: "Node uncordoned."
+  defp lifecycle_success_message(:drain), do: "Node drain started."
+  defp lifecycle_success_message(:maintenance), do: "Node moved to maintenance."
+  defp lifecycle_success_message(:resume), do: "Node resumed."
+  defp lifecycle_success_message(:decommission), do: "Node decommission started."
+
   defp error_message(:controller_standby), do: "This controller is in standby mode."
   defp error_message(:candidate_not_found), do: "Node admission candidate was not found."
   defp error_message(:node_not_found), do: "Node was not found."
@@ -871,11 +1030,44 @@ defmodule OrchardConsole.NodeDetailLive do
   defp error_message(:admission_rejected), do: "Admission rejection must be cleared first."
   defp error_message(:node_not_registered), do: "Node is not registered."
   defp error_message(:node_not_pending_admission), do: "Node is not pending admission."
+  defp error_message(:node_not_active), do: "Node is not active."
+  defp error_message(:node_unhealthy), do: "Node health is unhealthy."
+  defp error_message(:node_unreachable), do: "Node is unreachable."
+  defp error_message(:drain_already_running), do: "Node drain is already running."
+  defp error_message(:decommission_already_running), do: "Node decommission is already running."
+  defp error_message(:maintenance_requires_drain), do: "Node must be draining before maintenance."
+
+  defp error_message(:drain_completion_unverified),
+    do: "Manual maintenance is unavailable until node drain completion can be verified."
+
+  defp error_message(:lifecycle_transition_invalid),
+    do: "Node lifecycle state does not allow this action."
+
   defp error_message(:inventory_missing), do: "Registered node inventory is missing."
   defp error_message(:trust_not_established), do: "Node trust evidence is required."
   defp error_message(:pool_required), do: "Node pool assignment is required."
   defp error_message(:policy_required), do: "Required policy inputs are missing."
-  defp error_message(_reason), do: "Node admission action failed."
+  defp error_message(_reason), do: "Node action failed."
+
+  defp missing_typed_node_id?(requirements, inputs, preview) do
+    "requires_typed_node_id" in requirements and
+      Map.get(inputs, "node_id_confirmation") != nested_preview_value(preview, :target, :id)
+  end
+
+  defp missing_consequence_acknowledgement?(requirements, inputs) do
+    consequence_acknowledgement_required?(requirements) and
+      not truthy?(Map.get(inputs, "acknowledged"))
+  end
+
+  defp consequence_acknowledgement_required?(requirements) do
+    Enum.any?(
+      requirements,
+      &(&1 in [
+          "requires_drain_consequence_acknowledgement",
+          "requires_decommission_consequence_acknowledgement"
+        ])
+    )
+  end
 
   # ===========================================================================
   # Refresh / config
@@ -1015,12 +1207,12 @@ defmodule OrchardConsole.NodeDetailLive do
 
   defp action_preview_panel(assigns) do
     ~H"""
-    <div id="node-admission-action-preview">
+    <div id="node-action-preview">
       <.card class={action_panel_class(@action.kind)}>
         <:title>{action_title(@action.kind)}</:title>
         <:subtitle>{action_explanation(@action.kind)}</:subtitle>
 
-        <form id="admission-action-form" phx-change="action_change" phx-submit="execute_action" class="space-y-5">
+        <form id={action_form_id(@action.kind)} phx-change="action_change" phx-submit="execute_action" class="space-y-5">
           <div id="action-preview-summary" class="grid gap-4 lg:grid-cols-3">
             <.detail_grid id="action-preview-current" class="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-950">
               <.detail_field id="action-preview-current-state" label="Current" mono>
@@ -1142,13 +1334,42 @@ defmodule OrchardConsole.NodeDetailLive do
             />
           </div>
 
+          <div :if={lifecycle_action_kind?(@action.kind)} id="action-lifecycle-inputs" class="space-y-4">
+            <.input
+              id="action-lifecycle-reason"
+              name="action[reason]"
+              type="textarea"
+              rows="2"
+              value={@action.inputs["reason"]}
+              label="Reason"
+              placeholder="Optional operator note."
+            />
+            <.input
+              :if={"requires_typed_node_id" in preview_codes(@action.preview, :confirmation_requirements)}
+              id="action-node-id-confirmation"
+              name="action[node_id_confirmation]"
+              value={@action.inputs["node_id_confirmation"]}
+              label="Type Node ID"
+              placeholder={nested_preview_value(@action.preview, :target, :id)}
+              errors={typed_node_id_errors(@action)}
+            />
+            <.input
+              :if={consequence_acknowledgement_required?(preview_codes(@action.preview, :confirmation_requirements))}
+              id="action-acknowledged"
+              name="action[acknowledged]"
+              type="checkbox"
+              checked={truthy?(@action.inputs["acknowledged"])}
+              label="I acknowledge the disclosed lifecycle consequences."
+            />
+          </div>
+
           <div class="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/50">
             <.input
               id="action-confirmed"
               name="action[confirmed]"
               type="checkbox"
               checked={@action.confirmed}
-              label="I reviewed the preview and understand this admission action."
+              label={confirmation_label(@action.kind)}
             />
           </div>
 
@@ -1182,6 +1403,16 @@ defmodule OrchardConsole.NodeDetailLive do
   end
 
   defp reject_reason_errors(_action), do: []
+
+  defp typed_node_id_errors(%{kind: :decommission, preview: preview, inputs: inputs}) do
+    requirements = preview_codes(preview, :confirmation_requirements)
+
+    if missing_typed_node_id?(requirements, inputs, preview),
+      do: ["Type the node ID exactly to confirm decommission."],
+      else: []
+  end
+
+  defp typed_node_id_errors(_action), do: []
 
   defp code_chip_class(:error),
     do:

--- a/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
@@ -202,6 +202,213 @@ defmodule OrchardConsole.NodeDetailLiveTest do
     end
   end
 
+  describe "lifecycle action previews" do
+    test "renders lifecycle preview affordances for node rows only", %{conn: conn} do
+      node = insert_node!(state: :active, display_name: "lifecycle-affordance-node")
+      candidate = insert_candidate!(target_ref: "10.4.0.88:50071")
+
+      {:ok, _view, node_html} = live(conn, "/console/nodes/#{node.id}")
+
+      assert node_html =~ "Preview cordon"
+      assert node_html =~ "Preview uncordon"
+      assert node_html =~ "Preview drain"
+      assert node_html =~ "Preview maintenance"
+      assert node_html =~ "Preview resume"
+      assert node_html =~ "Preview decommission"
+
+      {:ok, _view, candidate_html} = live(conn, "/console/nodes/pending/#{candidate.id}")
+
+      refute candidate_html =~ "Preview cordon"
+      refute candidate_html =~ "Preview uncordon"
+      refute candidate_html =~ "Preview drain"
+      refute candidate_html =~ "Preview maintenance"
+      refute candidate_html =~ "Preview resume"
+      refute candidate_html =~ "Preview decommission"
+    end
+
+    test "previews and executes node cordon through the shared action preview", %{conn: conn} do
+      node =
+        insert_node!(%{
+          display_name: "cordon-detail-node",
+          state: :active,
+          health: :healthy
+        })
+
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+
+      view
+      |> element("#node-detail-open-lifecycle-cordon")
+      |> render_click()
+
+      html = render(view)
+      assert html =~ "Cordon Node Preview"
+      assert html =~ "node_lifecycle.cordon"
+      assert html =~ "requires_yes_flag"
+      assert html =~ "Active"
+      assert html =~ "Cordoned"
+
+      view
+      |> form("#node-action-form", %{"action" => %{"confirmed" => "true"}})
+      |> render_change()
+
+      view
+      |> form("#node-action-form", %{"action" => %{"confirmed" => "true"}})
+      |> render_submit()
+
+      assert Repo.get!(Node, node.id).state == :cordoned
+      assert render(view) =~ "Cordoned"
+    end
+
+    test "gates decommission execution on typed node id and consequence acknowledgement", %{
+      conn: conn
+    } do
+      node =
+        insert_node!(%{
+          display_name: "decommission-detail-node",
+          state: :active,
+          health: :healthy
+        })
+
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+
+      view
+      |> element("#node-detail-open-lifecycle-decommission")
+      |> render_click()
+
+      html = render(view)
+      assert html =~ "Decommission Node Preview"
+      assert html =~ "requires_typed_node_id"
+      assert html =~ "requires_decommission_consequence_acknowledgement"
+      assert html =~ "future_scheduling_revoked"
+      assert html =~ "no_rejoin_with_same_node_id"
+      assert has_element?(view, "#action-submit[disabled]")
+
+      decommission_attrs = %{
+        "action" => %{
+          "node_id_confirmation" => node.id,
+          "acknowledged" => "true",
+          "confirmed" => "true"
+        }
+      }
+
+      view
+      |> form("#node-action-form", decommission_attrs)
+      |> render_change()
+
+      view
+      |> form("#node-action-form", decommission_attrs)
+      |> render_submit()
+
+      assert Repo.get!(Node, node.id).state == :decommissioning
+      assert render(view) =~ "Decommissioning"
+    end
+
+    test "gates drain execution on consequence acknowledgement", %{conn: conn} do
+      node =
+        insert_node!(%{
+          display_name: "drain-detail-node",
+          state: :active,
+          health: :healthy
+        })
+
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+
+      view
+      |> element("#node-detail-open-lifecycle-drain")
+      |> render_click()
+
+      html = render(view)
+      assert html =~ "Drain Node Preview"
+      assert html =~ "node_lifecycle.drain"
+      assert html =~ "existing_requests_continue_until_deadline"
+      assert html =~ "requires_drain_consequence_acknowledgement"
+      assert has_element?(view, "#action-submit[disabled]")
+
+      view
+      |> form("#node-action-form", %{"action" => %{"confirmed" => "true"}})
+      |> render_change()
+
+      assert has_element?(view, "#action-submit[disabled]")
+
+      drain_attrs = %{
+        "action" => %{
+          "acknowledged" => "true",
+          "confirmed" => "true"
+        }
+      }
+
+      view
+      |> form("#node-action-form", drain_attrs)
+      |> render_change()
+
+      view
+      |> form("#node-action-form", drain_attrs)
+      |> render_submit()
+
+      assert Repo.get!(Node, node.id).state == :draining
+      assert render(view) =~ "Draining"
+    end
+
+    test "shows invalid-state lifecycle blockers without allowing execution", %{conn: conn} do
+      node =
+        insert_node!(%{
+          display_name: "blocked-cordon-detail-node",
+          state: :registered,
+          health: :healthy
+        })
+
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+
+      view
+      |> element("#node-detail-open-lifecycle-cordon")
+      |> render_click()
+
+      html = render(view)
+      assert html =~ "Cordon Node Preview"
+      assert html =~ "node_not_admitted"
+      assert has_element?(view, "#action-submit[disabled]")
+
+      view
+      |> form("#node-action-form", %{"action" => %{"confirmed" => "true"}})
+      |> render_submit()
+
+      assert Repo.get!(Node, node.id).state == :registered
+      assert render(view) =~ "Resolve blockers and confirm the preview before executing."
+    end
+
+    test "previews maintenance but keeps execution blocked until drain completion is verified", %{
+      conn: conn
+    } do
+      node =
+        insert_node!(%{
+          display_name: "maintenance-detail-node",
+          state: :draining,
+          health: :healthy
+        })
+
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+
+      view
+      |> element("#node-detail-open-lifecycle-maintenance")
+      |> render_click()
+
+      html = render(view)
+      assert html =~ "Maintenance Node Preview"
+      assert html =~ "node_lifecycle.maintenance"
+      assert html =~ "drain_completion_unverified"
+      assert html =~ "Draining"
+      assert html =~ "Maintenance"
+      assert has_element?(view, "#action-submit[disabled]")
+
+      view
+      |> form("#node-action-form", %{"action" => %{"confirmed" => "true"}})
+      |> render_submit()
+
+      assert Repo.get!(Node, node.id).state == :draining
+      assert render(view) =~ "Resolve blockers and confirm the preview before executing."
+    end
+  end
+
   defp insert_node!(attrs) do
     unique = System.unique_integer([:positive])
 

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -47,7 +47,8 @@
 - [x] 4.6 Implement safe lifecycle commands for cordon, uncordon, drain, maintenance, resume, and decommission with dry-run, confirmation requirements, and JSON output.
   Note: this slice implements local `orchardctl nodes` lifecycle commands on the shared `ActionPreview` contract with transactional lifecycle state mutation, mutation-time revalidation, and cluster-scoped audit.
   Manual `draining -> maintenance` execution remains deferred: the `maintenance` command still exposes its dry-run preview but execution is blocked with a `drain_completion_unverified` blocker until drain completion (active-work quiescence) can be verified.
-  Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, persisted lifecycle reason columns, decommission trust revocation, Admin/Operator API lifecycle routes, and Console lifecycle panels remain future work.
+  Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, persisted lifecycle reason columns, decommission trust revocation, and Admin/Operator API lifecycle routes remain future work.
+  Console lifecycle action preview panels are now implemented under task 5.3.
   Note: `SPEC.md` §11.9 currently enumerates only the node-admission CLI commands as a required-command floor; promoting these lifecycle commands into that normative list remains an owner/OpenSpec-acceptance decision to be reconciled when this change is accepted.
 - [ ] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -56,10 +56,13 @@
 
 - [x] 5.1 Add a pending admission queue to the Console Nodes workspace.
 - [x] 5.2 Add node detail drill-in that preserves separate lifecycle, health, freshness, transport, runtime, compatibility, scheduling, and warning groups.
-- [ ] 5.3 Add action preview dialogs or page-local panels for admit, reject pending admission, cordon, uncordon, drain, maintenance, resume, and decommission.
+- [x] 5.3 Add action preview dialogs or page-local panels for admit, reject pending admission, cordon, uncordon, drain, maintenance, resume, and decommission.
   Note: this slice implements Console admit and reject pending admission preview panels using the shared `ActionPreview` contract.
   Reusable Console review-panel guidance is now documented in `docs/DESIGN.md`.
-  Full lifecycle action previews and any reusable dialog primitive remain future work.
+  Console node detail now exposes lifecycle action preview panels for cordon, uncordon, drain, maintenance, resume, and decommission using the shared `ActionPreview` contract.
+  Existing backend execution is wired for cordon, uncordon, drain, resume, and decommission with confirmation gates and mutation-time lifecycle revalidation.
+  Maintenance remains preview-visible but execution-blocked by `drain_completion_unverified` until drain completion and active-work quiescence can be verified.
+  Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, known active request counts, and any reusable dialog primitive remain future slices.
 - [ ] 5.4 Add scheduler explanation views with selected candidate, skipped candidates, fixed reason codes, and sanitized diagnostics.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
 - [ ] 5.6 Add read-only HA-lite control-plane status.


### PR DESCRIPTION
## Intent

Implement the tight Orchard Console slice for lifecycle action previews on node detail. The change should reuse the shared ActionPreview and existing lifecycle dry-run/domain behavior from the cluster-management UX foundation, expose preview panels for cordon, uncordon, drain, maintenance, resume, and decommission, keep previews side-effect-free, gate execution with confirmation requirements where the backend supports execution, keep maintenance preview-visible but execution-blocked by drain_completion_unverified, avoid scheduler explanations/support bundles/HA-lite/broad Operator API scope, and record future-slice notes in OpenSpec for unsupported drain active-work and maintenance automation semantics.

## What Changed

- Node detail LiveView (`node_detail_live.ex`) now renders preview buttons and side-effect-free panels for the six lifecycle actions (cordon, uncordon, drain, maintenance, resume, decommission) built on the shared `ActionPreview`/`ActionPreviewBuilder` contract, wiring execution for cordon/uncordon/drain/resume/decommission behind confirmation gates (typed-node-ID for decommission, consequence acknowledgement for drain/decommission) with mutation-time lifecycle revalidation; maintenance stays preview-visible but execution-blocked by `drain_completion_unverified`.
- `ActionPreviewBuilder.add_write_path_blocker/2` now takes an explicit write-path argument so lifecycle previews authorize against `:node_lifecycle` while admission/rejection previews continue to use `:node_admission`.
- Added 6 lifecycle-preview LiveView tests and updated the `cluster-management-ux-foundation` OpenSpec `tasks.md` to mark task 5.3 complete and record future-slice notes for unsupported drain active-work cancellation and maintenance automation semantics.

## Risk Assessment

✅ Low: The change is additive and well-bounded, reuses established side-effect-free preview contracts with mutation-time blocker revalidation, and ships six new tests covering happy-path execution and blocked/gated paths; the only observation is a deliberate UX affordance choice.

## Testing

Ran the change's LiveView test file (all 12 pass) as the baseline, then produced reviewer-visible visual evidence by booting the actual Orchard Console dev server against a seeded Postgres and driving it with a headless browser. Screenshots capture every intent element: all six preview affordances on node rows, each preview panel's blockers/consequences/confirmation requirements, the confirmation-gated (disabled→enabled) execute button, a real cordon execution that changed persisted node state (confirmed via UI reload and direct psql), the maintenance-preview-visible-but-blocked-by-`drain_completion_unverified` case, and a lifecycle blocker (`node_not_admitted`) preventing execution. Overall result: the feature works end-to-end exactly as intended; no failures or defects found. Cleaned up: stopped the server, removed the seeded dev-DB nodes, and confirmed the git working tree is clean (build outputs are gitignored).

- Evidence: Active node detail — all six lifecycle preview buttons (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/01-active-node-all-lifecycle-buttons.png</code>)
- Evidence: Cordon preview panel — side-effect-free from→to + audit action (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/02-cordon-preview-panel.png</code>)
- Evidence: Cordon requirements (requires_yes_flag) with execute disabled (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/03-cordon-requirements-gated-execute.png</code>)
- Evidence: Decommission preview — typed Node ID + consequence acknowledgement gates (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/04-decommission-preview-gates.png</code>)
- Evidence: Maintenance preview visible but execution-blocked by drain_completion_unverified (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/05-maintenance-blocked-drain-unverified.png</code>)
- Evidence: Drain preview — existing_requests_continue_until_deadline + drain acknowledgement gate (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/06-drain-preview-consequence-gate.png</code>)
- Evidence: Cordon confirmed — execute button enabled (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/07-cordon-confirmed-execute-enabled.png</code>)
- Evidence: Cordon executed — &#39;Node cordoned.&#39; flash + scheduling now node_not_active (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/08-cordon-executed-state-cordoned.png</code>)
- Evidence: Reloaded node — Lifecycle badge and STATE now Cordoned (persisted) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/09-node-now-cordoned-header.png</code>)
- Evidence: Registered node — cordon preview shown but node_not_admitted blocks execution (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWK6DWQ7BW36WGD661D8Z9HZ/10-registered-node-cordon-blocked.png</code>)
<details>
<summary>Evidence: Persisted DB state after UI cordon (psql)</summary>

```text
$ psql -d orchard_dev -tAc "select display_name, state from nodes where id in (...)"
evidence-active-node|cordoned # active → cordoned via console execution
evidence-draining-node|draining # unchanged: maintenance was execution-blocked
evidence-registered-node|registered
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/console/node_detail_live.ex:734` - Lifecycle preview buttons render unconditionally for every node state (lifecycle_action_buttons(:node, %Node{}) returns all six actions), whereas the admit/reject buttons are state-gated via can_open_admit?/can_open_reject?. As a result a healthy active node shows &#39;Preview uncordon&#39;, &#39;Preview maintenance&#39;, &#39;Preview resume&#39;, etc. — buttons that only ever open an all-blocker panel from the current state. This is defensible (previews are side-effect-free and educational, and the intent lists all six as exposed), but the asymmetry with the gated admit/reject affordances is worth confirming as the intended UX rather than filtering buttons to valid transitions.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`ORCHARD_TEST_NODE_AGENT_PORT=50099 mise exec -- mix test apps/orchard_controller/test/orchard/console/node_detail_live_test.exs` — all 12 tests pass (6 new lifecycle-preview tests + 6 pre-existing)</code>
- <code>Booted the real dev console (`mix phx.server` on :4009, dev DB, compiled Tailwind/esbuild assets) and seeded active/draining/registered nodes</code>
- `Browser: navigated to node detail for the active node and confirmed all six lifecycle preview buttons render (Preview cordon/uncordon/drain/maintenance/resume, Preview decommission as danger)`
- <code>Browser: opened the cordon preview — verified side-effect-free from→to transition, audit action `node_lifecycle.cordoned`, `requires_yes_flag`, and disabled &#39;Cordon node&#39; execute button</code>
- <code>Browser: opened decommission preview — verified `requires_typed_node_id` + `requires_decommission_consequence_acknowledgement` gates, `future_scheduling_revoked`/`no_rejoin_with_same_node_id` consequences, typed-Node-ID input with inline validation, disabled execute</code>
- <code>Browser: opened maintenance preview on a draining node — verified it stays previewable but is execution-blocked by `drain_completion_unverified` (execute disabled, state unchanged)</code>
- <code>Browser: opened drain preview — verified `existing_requests_continue_until_deadline` consequence and `requires_drain_consequence_acknowledgement` gate</code>
- `Browser end-to-end: checked the confirmation box (execute enabled), clicked 'Cordon node', observed 'Node cordoned.' flash and Lifecycle badge/STATE change to Cordoned`
- <code>Verified persisted state via `psql -d orchard_dev` — active node → cordoned, draining node unchanged (maintenance blocked), registered node unchanged</code>
- <code>Browser: opened cordon preview on a registered node — verified `node_not_admitted` blocker shown with execute disabled (preview visible, execution blocked)</code>
- `Reviewed OpenSpec tasks.md delta recording future-slice notes for unsupported drain active-work and maintenance automation semantics`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
