### PR TITLE
fix(console): hide inactive license UI when enforcement is off

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/layouts/app.html.heex
+++ b/apps/orchard_controller/lib/orchard/console/layouts/app.html.heex
@@ -29,6 +29,7 @@
     <%!-- Sidebar footer: license + version + collapse toggle --%>
     <div class="p-3 border-t border-slate-200 dark:border-slate-700 flex-shrink-0">
       <div
+        :if={OrchardConsole.LicenseStatus.visible?(@license_status)}
         id="console-license-badge"
         class="mb-3 rounded-lg border border-slate-200 bg-slate-50 p-2 text-center dark:border-slate-700 dark:bg-slate-900/60"
         role="status"

--- a/apps/orchard_controller/lib/orchard/console/license_status.ex
+++ b/apps/orchard_controller/lib/orchard/console/license_status.ex
@@ -15,25 +15,40 @@ defmodule OrchardConsole.LicenseStatus do
           required(:licensee) => String.t() | nil,
           required(:max_machines) => pos_integer() | nil,
           required(:tracking) => Licensing.tracking_metadata() | nil,
-          required(:activation_guidance) => String.t() | nil
+          required(:activation_guidance) => String.t() | nil,
+          required(:visible?) => boolean()
         }
 
   @spec fetch() :: summary()
   def fetch do
-    licensing_impl().inspect_local()
-    |> summarize()
+    status = licensing_impl().inspect_local()
+
+    summarize(status, safe_enforcement_mode())
   rescue
     _ ->
-      summarize(%Licensing{
-        state: :malformed_bundle,
-        message: "License inspection failed.",
-        bundle_path: ""
-      })
+      summarize(
+        %Licensing{
+          state: :malformed_bundle,
+          message: "License inspection failed.",
+          bundle_path: ""
+        },
+        safe_enforcement_mode()
+      )
   end
 
   @spec valid?(summary()) :: boolean()
   def valid?(%{state: :valid}), do: true
   def valid?(_summary), do: false
+
+  @doc """
+  Returns whether Console license surfaces should render.
+
+  Valid license status stays visible in every enforcement mode.
+  Non-valid states stay quiet in `:off` and render in `:warn` or `:hard` for operator remediation.
+  """
+  @spec visible?(summary()) :: boolean()
+  def visible?(%{visible?: visible?}) when is_boolean(visible?), do: visible?
+  def visible?(_summary), do: true
 
   @spec badge_label(summary()) :: String.t()
   def badge_label(%{state: :valid, licensee: licensee}) do
@@ -69,7 +84,7 @@ defmodule OrchardConsole.LicenseStatus do
 
   def tracking_label(_summary), do: nil
 
-  defp summarize(%Licensing{} = status) do
+  defp summarize(%Licensing{} = status, enforcement_mode) do
     health = Licensing.health_summary(status)
     activation_guidance = activation_guidance(status)
 
@@ -84,8 +99,22 @@ defmodule OrchardConsole.LicenseStatus do
       licensee: Map.get(health, :licensee),
       max_machines: Map.get(health, :max_machines),
       tracking: Map.get(health, :tracking),
-      activation_guidance: activation_guidance
+      activation_guidance: activation_guidance,
+      visible?: visible_status?(status, enforcement_mode)
     }
+  end
+
+  defp visible_status?(%Licensing{state: :valid}, _enforcement_mode), do: true
+  defp visible_status?(%Licensing{}, :off), do: false
+
+  defp visible_status?(%Licensing{}, enforcement_mode) when enforcement_mode in [:warn, :hard],
+    do: true
+
+  defp safe_enforcement_mode do
+    Licensing.enforcement_mode()
+  rescue
+    ArgumentError -> :hard
+    RuntimeError -> :hard
   end
 
   defp activation_guidance(%Licensing{state: :valid}), do: nil

--- a/apps/orchard_controller/lib/orchard/console/overview_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/overview_live.ex
@@ -12,6 +12,7 @@ defmodule OrchardConsole.OverviewLive do
   alias Orchard.Models.Model
   alias Orchard.Requests
   alias Orchard.Requests.Request
+  alias OrchardConsole.LicenseStatus
   alias Phoenix.LiveView.JS
 
   @readiness_check_order [
@@ -351,14 +352,14 @@ defmodule OrchardConsole.OverviewLive do
         </div>
       </.card>
 
-      <.card>
+      <.card :if={LicenseStatus.visible?(@license_status)}>
         <:title>License</:title>
         <:subtitle>Orchard product license state for operator recovery.</:subtitle>
 
         <div id="overview-license-card" class="space-y-4">
           <div class="flex flex-wrap items-center gap-2">
-            <.badge tone={OrchardConsole.LicenseStatus.badge_tone(@license_status)}>
-              {OrchardConsole.LicenseStatus.state_label(@license_status)}
+            <.badge tone={LicenseStatus.badge_tone(@license_status)}>
+              {LicenseStatus.state_label(@license_status)}
             </.badge>
             <span
               :if={@license_status.licensee}
@@ -375,7 +376,7 @@ defmodule OrchardConsole.OverviewLive do
                 State
               </dt>
               <dd class="mt-1 text-sm font-mono text-slate-900 dark:text-slate-100">
-                {OrchardConsole.LicenseStatus.state_label(@license_status)}
+                {LicenseStatus.state_label(@license_status)}
               </dd>
             </div>
             <div :if={@license_status.expires_at}>
@@ -394,18 +395,18 @@ defmodule OrchardConsole.OverviewLive do
                 {@license_status.licensee}
               </dd>
             </div>
-            <div :if={OrchardConsole.LicenseStatus.tracking_label(@license_status)}>
+            <div :if={LicenseStatus.tracking_label(@license_status)}>
               <dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Tracking
               </dt>
               <dd id="overview-license-tracking" class="mt-1 text-sm font-mono text-slate-900 dark:text-slate-100">
-                {OrchardConsole.LicenseStatus.tracking_label(@license_status)}
+                {LicenseStatus.tracking_label(@license_status)}
               </dd>
             </div>
           </dl>
 
           <div
-            :if={!OrchardConsole.LicenseStatus.valid?(@license_status)}
+            :if={!LicenseStatus.valid?(@license_status)}
             id="overview-license-activation"
             class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800/60 dark:bg-amber-950/30 dark:text-amber-200"
           >
@@ -583,7 +584,7 @@ defmodule OrchardConsole.OverviewLive do
     request_summary = fetch_request_summary()
     request_performance = fetch_request_performance()
     has_active_api_keys = fetch_active_api_keys()
-    license_status = OrchardConsole.LicenseStatus.fetch()
+    license_status = LicenseStatus.fetch()
     client_state = quickstart_client_state(socket)
 
     assign(socket,

--- a/apps/orchard_controller/lib/orchard/console/settings_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/settings_live.ex
@@ -574,7 +574,7 @@ defmodule OrchardConsole.SettingsLive do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
-      <section id="settings-license-card">
+      <section :if={LicenseStatus.visible?(@license_status)} id="settings-license-card">
         <.card>
           <:title>License</:title>
           <:subtitle>Local license state and operator recovery guidance.</:subtitle>

--- a/apps/orchard_controller/test/orchard/console/overview_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/overview_live_test.exs
@@ -368,6 +368,8 @@ defmodule OrchardConsole.OverviewLiveTest do
     end
 
     test "renders valid license badge in the shared shell", %{conn: conn} do
+      set_license_enforcement(:off)
+
       {:ok, view, _html} = live(conn, "/console")
 
       badge = view |> element("#console-license-badge") |> render()
@@ -375,7 +377,19 @@ defmodule OrchardConsole.OverviewLiveTest do
       refute badge =~ "orchardctl license activate"
     end
 
+    test "hides source-dev missing license noise in the shared shell", %{conn: conn} do
+      set_license_enforcement(:off)
+      put_console_config(licensing_impl: OrchardConsole.OverviewLiveTest.LicensingMissingStub)
+
+      {:ok, view, html} = live(conn, "/console")
+
+      refute has_element?(view, "#console-license-badge")
+      refute has_element?(view, "#overview-license-card")
+      refute html =~ "orchardctl license activate"
+    end
+
     test "renders activation badge in the shared shell for invalid licenses", %{conn: conn} do
+      set_license_enforcement(:warn)
       put_console_config(licensing_impl: OrchardConsole.OverviewLiveTest.LicensingMissingStub)
 
       {:ok, view, _html} = live(conn, "/console")
@@ -397,6 +411,8 @@ defmodule OrchardConsole.OverviewLiveTest do
 
   describe "license visibility" do
     test "overview license card renders valid license identity and expiry", %{conn: conn} do
+      set_license_enforcement(:off)
+
       {:ok, view, _html} = live(conn, "/console")
 
       card = view |> element("#overview-license-card") |> render()
@@ -418,9 +434,23 @@ defmodule OrchardConsole.OverviewLiveTest do
       refute card =~ "program="
     end
 
+    test "overview hides expired license noise when enforcement is off", %{conn: conn} do
+      set_license_enforcement(:off)
+      put_console_config(licensing_impl: OrchardConsole.OverviewLiveTest.LicensingExpiredStub)
+
+      {:ok, view, html} = live(conn, "/console")
+
+      refute has_element?(view, "#console-license-badge")
+      refute has_element?(view, "#overview-license-card")
+      refute html =~ "Expired Orchard Lab"
+      refute html =~ "orchardctl license activate"
+    end
+
     test "overview license card omits unsafe identity and tracking for invalid signature", %{
       conn: conn
     } do
+      set_license_enforcement(:warn)
+
       put_console_config(
         licensing_impl: OrchardConsole.OverviewLiveTest.LicensingInvalidSignatureRawFieldsStub
       )
@@ -434,6 +464,7 @@ defmodule OrchardConsole.OverviewLiveTest do
     end
 
     test "overview license card renders activation guidance for a missing license", %{conn: conn} do
+      set_license_enforcement(:warn)
       put_console_config(licensing_impl: OrchardConsole.OverviewLiveTest.LicensingMissingStub)
 
       {:ok, view, _html} = live(conn, "/console")
@@ -444,6 +475,7 @@ defmodule OrchardConsole.OverviewLiveTest do
     end
 
     test "overview license card renders activation guidance for an expired license", %{conn: conn} do
+      set_license_enforcement(:hard)
       put_console_config(licensing_impl: OrchardConsole.OverviewLiveTest.LicensingExpiredStub)
 
       {:ok, view, _html} = live(conn, "/console")

--- a/apps/orchard_controller/test/orchard/console/settings_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/settings_live_test.exs
@@ -2,7 +2,9 @@ defmodule OrchardConsole.SettingsLiveTest do
   use Orchard.ConnCase, async: false
 
   import Phoenix.LiveViewTest
-  import Orchard.TestSupport.LicenseGateHelpers, only: [activation_guidance: 0]
+
+  import Orchard.TestSupport.LicenseGateHelpers,
+    only: [activation_guidance: 0, set_license_enforcement: 1]
 
   alias Orchard.ConsoleSettings
 
@@ -72,7 +74,22 @@ defmodule OrchardConsole.SettingsLiveTest do
   end
 
   describe "License Status" do
+    test "hides missing license activation noise when enforcement is off", %{conn: conn} do
+      set_license_enforcement(:off)
+      put_console_config(licensing_impl: __MODULE__.LicensingMissingStub)
+
+      {:ok, view, html} = live(conn, "/console/settings")
+
+      refute has_element?(view, "#settings-license-card")
+      refute html =~ activation_guidance()
+      assert has_element?(view, "#settings-appearance-card")
+      assert has_element?(view, "#settings-inference-defaults-card")
+      assert has_element?(view, "#settings-advanced-card")
+    end
+
     test "renders display-safe license fields as read-only status", %{conn: conn} do
+      set_license_enforcement(:off)
+
       {:ok, view, _html} = live(conn, "/console/settings")
 
       card_html = view |> element("#settings-license-card") |> render()
@@ -90,7 +107,10 @@ defmodule OrchardConsole.SettingsLiveTest do
       refute card_html =~ "phx-click"
     end
 
-    test "renders fetched activation guidance when the license is not activated", %{conn: conn} do
+    test "renders fetched activation guidance in warn mode when the license is not activated", %{
+      conn: conn
+    } do
+      set_license_enforcement(:warn)
       put_console_config(licensing_impl: __MODULE__.LicensingMissingStub)
 
       {:ok, view, _html} = live(conn, "/console/settings")
@@ -105,6 +125,7 @@ defmodule OrchardConsole.SettingsLiveTest do
     end
 
     test "degrades safely when license inspection fails", %{conn: conn} do
+      set_license_enforcement(:hard)
       put_console_config(licensing_impl: __MODULE__.LicensingProbeFailureStub)
 
       {:ok, view, _html} = live(conn, "/console/settings")

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -622,8 +622,9 @@ For each pair of `{light, dark} × {sidebar-expanded, sidebar-collapsed}`:
 - [ ] Disabled nav item is visibly inactive.
 - [ ] Collapse animation and toggle icon rotation still work; reduced
   motion is respected.
-- [ ] License badge and version label still render correctly when expanded;
-  they collapse cleanly when collapsed.
+- [ ] Version label still renders correctly when expanded; it collapses
+  cleanly when collapsed. The license badge does the same when present (valid
+  license, or `:warn`/`:hard` enforcement); it is absent otherwise.
 
 **Form input wells (Model Hub search)**
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -273,10 +273,11 @@ Notes:
 - The `border-r border-slate-200 dark:border-slate-700` divider remains the
   single source of the rail/canvas boundary. Do not add a second
   `shadow-*` or `ring-*` divider in v2.
-- Footer chrome inside the rail (license badge, version, collapse button)
+- Footer chrome inside the rail (visible license badge, version, collapse button)
   keeps its existing classes, including the badge wrapper's `bg-slate-50
   dark:bg-slate-900/60`. The badge now reads as a tinted chip *inside* the
   recessed rail; this is intended.
+- The license badge is visible when the local license is valid or shared license enforcement is `:warn` or `:hard`.
   In the collapsed rail the badge hides cleanly; see section 5.3.
 
 ### 5.2 Sidebar Nav Items (`sidebar_nav/1`)
@@ -333,7 +334,7 @@ implementation. Do not add hover styling to the disabled span.
   rules in `app.css` (`#console-sidebar { width / min-width }`,
   `.sidebar-collapsed` overrides, reduced-motion media query) are unchanged
   from v2.
-- `#console-license-badge` collapses out of view in `.sidebar-collapsed` mode via an `app.css` rule (`max-height` / `opacity` / `margin` / `border` / `padding` reset) that mirrors `console-sidebar-version`, so the full license chip does not crowd the 4.5rem collapsed rail.
+- When rendered, `#console-license-badge` collapses out of view in `.sidebar-collapsed` mode via an `app.css` rule (`max-height` / `opacity` / `margin` / `border` / `padding` reset) that mirrors `console-sidebar-version`, so the full license chip does not crowd the 4.5rem collapsed rail.
 - The icon column at `h-5 w-5 flex-shrink-0` is kept on every nav item so
   collapsed-state alignment continues to work.
 - Active `aria-current="page"` is set by `sidebar_nav/1` and must remain.


### PR DESCRIPTION
## Intent

Remove or hide Orchard Console's noisy license activation UI when shared licensing enforcement is off for source-dev/test style operation, while preserving packaged warn/hard remediation surfaces and valid-license identity display. This slice is intentionally limited to Console visibility and a small display helper: it must not weaken API/CLI license gates, health license payloads, node-agent startup handling, Sentry license context, or packaged licensing behavior. LiveView tests cover missing/expired licenses hidden in :off, valid licenses visible in :off, and warn/hard activation guidance still visible. Docs are updated only to make the sidebar badge guidance conditional. Local validation already passed before this No Mistakes rerun: format, compile warnings-as-errors, focused Console LiveView tests, credo strict, dialyzer, browser verification, and coverage except for an unrelated stale local artifact test that passed against a fresh artifacts root.

## What Changed

- Added a `visible?` field to `OrchardConsole.LicenseStatus` summaries plus a `visible?/1` helper, computed from license state and the resolved enforcement mode: valid licenses stay visible in every mode, while non-valid states are hidden under `:off` and shown under `:warn`/`:hard` for operator remediation. `fetch/0` now resolves enforcement through a `safe_enforcement_mode/0` that degrades to `:hard` on failure.
- Gated the sidebar license badge, the Overview license card, and the Settings license card on `LicenseStatus.visible?/1`, so source-dev/test runs with enforcement `:off` no longer surface missing/expired activation noise; also collapsed the Overview module onto the `LicenseStatus` alias.
- Added LiveView tests covering hidden missing/expired licenses in `:off`, visible valid licenses in `:off`, and still-visible warn/hard activation guidance; updated `docs/DESIGN.md` to describe the license badge as conditionally rendered.

## Risk Assessment

✅ Low: The change is a small, well-tested, presentation-only visibility gate that preserves valid-license display and warn/hard remediation surfaces, leaves API/CLI/health/startup licensing untouched, and packaged builds default to :hard (unaffected).

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/console/license_status.ex:35` - fetch/0&#39;s rescue branch re-invokes safe_enforcement_mode(), which only rescues ArgumentError/RuntimeError. If enforcement-mode resolution ever raises a type outside that set (e.g. a FunctionClauseError from a malformed non-keyword :licensing config), the rescue branch re-raises instead of degrading to a safe summary — partially undermining the &#39;degrades safely when license inspection fails&#39; guarantee. In practice the realistic misconfig (invalid mode string/atom) raises RuntimeError and is covered, so impact is low. Consider computing the mode once (e.g. `mode = safe_enforcement_mode()` before the try body and reusing it), or widening safe_enforcement_mode&#39;s rescue so it is total.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
