### PR TITLE
fix(console): degrade license status safely on malformed licensing config

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -650,6 +650,7 @@ registered  -> decommissioning
 admitted    -> decommissioning
 active      -> decommissioning
 cordoned    -> decommissioning
+draining    -> decommissioning
 maintenance -> decommissioning
 decommissioning -> removed
 ```
@@ -690,7 +691,7 @@ decommissioning -> removed
   * trigger: operator/admin action
   * conditions: health is not `unreachable` or `unhealthy`
 
-* `* -> decommissioning`
+* `registered|admitted|active|cordoned|draining|maintenance -> decommissioning`
 
   * trigger: admin action
   * effect: cordon, revoke future scheduling, cancel or drain active work, revoke join trust
@@ -1930,6 +1931,7 @@ POST   /ops/v1/support-bundles
 Eligibility-changing or destructive Operator and Admin node actions SHALL provide an Action Preview before execution.
 Action Previews SHALL be side-effect-free and SHALL NOT create domain rows, audit events, or Node Admission Decisions unless a future preview-audit contract explicitly says otherwise.
 The preview response SHALL separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements`.
+Blocker, warning, consequence, and confirmation requirement codes SHALL be stable machine-readable identifiers shared by Admin API, Operator API, CLI, Console, support bundles, and tests.
 Blockers are non-bypassable safety, permission, leadership, write-path, lifecycle, or data-integrity constraints.
 Warnings are advisory and MAY require confirmation.
 Consequence codes describe expected effects accepted only through explicit parameters or confirmation requirements.
@@ -3718,6 +3720,12 @@ Required commands:
 * `orchardctl nodes pending`
 * `orchardctl nodes admit`
 * `orchardctl nodes reject`
+* `orchardctl nodes cordon`
+* `orchardctl nodes uncordon`
+* `orchardctl nodes drain`
+* `orchardctl nodes maintenance`
+* `orchardctl nodes resume`
+* `orchardctl nodes decommission`
 * `orchardctl api-clients bulk-provision`
 * `orchardctl models import`
 * `orchardctl requests inspect`
@@ -3728,6 +3736,11 @@ Node-admission CLI commands SHALL provide stable human and JSON output for list,
 `orchardctl nodes admit` and `orchardctl nodes reject` SHALL support side-effect-free `--dry-run` Action Preview output and explicit execution gates, including `--yes` for execution and `--reason` for rejection.
 For source-dev and packaged local use, node-admission CLI commands are local operator/admin commands that execute in the controller runtime context rather than proving Admin API bearer-token authorization.
 They SHALL still enforce the same leader-only write-path, admission, confirmation, cluster-scoped audit, and shared-presenter semantics as the Admin API.
+
+Node lifecycle CLI commands SHALL provide side-effect-free `--dry-run` Action Preview output in stable human and JSON forms.
+Lifecycle execution SHALL enforce the preview's confirmation requirements, including `--yes`, consequence acknowledgement for drain and decommission, and a typed node id for decommission.
+Node lifecycle CLI commands use the same local controller-runtime authority boundary as node-admission CLI commands and SHALL enforce the same leader-only write-path, mutation-time revalidation, cluster-scoped audit, and shared-presenter semantics.
+Manual `draining -> maintenance` execution SHALL remain blocked with a `drain_completion_unverified` blocker until drain completion can be verified.
 
 `orchardctl support bundle create` SHALL be able to emit `orchard.support_bundle.v2` for cluster-management support bundles.
 Console-triggered support bundles and CLI-created support bundles SHALL use the same v2 archive format for the same scope.

--- a/apps/orchard_controller/lib/orchard/console/license_status.ex
+++ b/apps/orchard_controller/lib/orchard/console/license_status.ex
@@ -113,8 +113,7 @@ defmodule OrchardConsole.LicenseStatus do
   defp safe_enforcement_mode do
     Licensing.enforcement_mode()
   rescue
-    ArgumentError -> :hard
-    RuntimeError -> :hard
+    _ -> :hard
   end
 
   defp activation_guidance(%Licensing{state: :valid}), do: nil

--- a/apps/orchard_controller/test/orchard/console/license_status_test.exs
+++ b/apps/orchard_controller/test/orchard/console/license_status_test.exs
@@ -1,0 +1,20 @@
+defmodule OrchardConsole.LicenseStatusTest do
+  use ExUnit.Case, async: false
+
+  alias OrchardConsole.LicenseStatus
+
+  describe "fetch/0" do
+    test "returns a safe hard-mode summary instead of raising when licensing config is malformed" do
+      previous = Application.get_env(:orchard_shared, :licensing, [])
+      on_exit(fn -> Application.put_env(:orchard_shared, :licensing, previous) end)
+
+      Application.put_env(:orchard_shared, :licensing, %{enforcement_mode: :off})
+
+      summary = LicenseStatus.fetch()
+
+      assert is_map(summary)
+      refute LicenseStatus.valid?(summary)
+      assert LicenseStatus.visible?(summary)
+    end
+  end
+end

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -497,6 +497,10 @@ Blocker rows must read as non-bypassable and must disable or omit the execute co
 Warnings and consequences may use compact badges plus short copy, but stable codes remain visible or inspectable when the code is part of the user-facing contract.
 Confirmation requirements sit directly above the execution control they gate.
 Page-local preview panels are valid for node actions when they keep review context visible.
+Typed-identifier confirmation inputs require the operator to retype the exact target identifier; do not prefill, autocomplete, or accept partial matches.
+Consequence acknowledgement controls default to unacknowledged and name the consequence they accept.
+The execute control stays disabled until every confirmation requirement is satisfied, and satisfying requirements never bypasses blockers.
+When one page offers several previewable actions, show one open preview panel at a time so review context stays unambiguous.
 
 Node detail drill-ins keep lifecycle, admission, health, freshness, transport, runtime, compatibility, scheduling, and warnings in labeled groups instead of flattening them into a generic table.
 Use `<.detail_grid>`, `<.detail_field>`, and compact status badges for grouped facts.

--- a/docs/decisions/0006-local-orchardctl-node-admission-authority.md
+++ b/docs/decisions/0006-local-orchardctl-node-admission-authority.md
@@ -5,6 +5,8 @@ Accepted.
 Node-admission CLI commands are local operator/admin commands for source-dev and packaged controller hosts.
 They execute inside the controller runtime context and do not require the caller to present an Admin API bearer token.
 They still call the same admission domain functions, leader-only write gate, shared Action Preview builder, presenters, and cluster-scoped audit paths used by Admin API admission execution.
+The same local controller-runtime authority boundary applies to node lifecycle commands: cordon, uncordon, drain, maintenance, resume, and decommission.
+Lifecycle execution enforces the same leader-only write-path, confirmation, revalidation, and cluster-scoped audit semantics as admission execution.
 
 This is separate from ADR 0004.
 Admin API remains service-account-owned bearer-token auth for HTTP callers.
@@ -14,4 +16,4 @@ The trade-off is a parallel trust boundary: local OS/package access to `orchardc
 That boundary must not silently expand to remote or tenant-scoped execution.
 If a future remote CLI transport delegates to Admin API, it must preserve the shared admission contract and use the ADR 0004 token boundary.
 
-SPEC.md impact: `SPEC.md` §11.9 records the local node-admission CLI authority boundary.
+SPEC.md impact: `SPEC.md` §11.9 records the local node-admission and node-lifecycle CLI authority boundary.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -641,6 +641,10 @@ The required diagnostic bundle format for cluster-management evidence, including
 v1 compatibility must not weaken v2 contents or redaction rules.
 _Avoid_: Support Bundle v1, raw local evidence, prompt export
 
+**License Enforcement Mode**:
+The resolved licensing mode, `off`, `warn`, or `hard`, that controls licensing checks at startup and packaged useful-work admission and whether non-valid license state is surfaced for operator remediation.
+_Avoid_: license validity, Console-only visibility flag, Payload Capture Mode
+
 **DMG Installer**:
 The interactive macOS distribution container for Orchard installer materials.
 _Avoid_: PKG Installer, launchd service

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -2,6 +2,8 @@
 
 - [x] 1.1 Reconcile accepted cluster-management UX behavior back into `SPEC.md` without mirroring this OpenSpec package.
   Note: Reconciled accepted admission, Admin API dry-run preview, CLI admission-review command, Console admission-review, and shared freshness behavior from PRs #30 through #37.
+  Reconciled node lifecycle transitions, lifecycle CLI commands, and preview-code stability from PRs #40 and #41.
+  PR #42 required no `SPEC.md` change.
 - [x] 1.2 Update `docs/DESIGN.md` only if Console node-management UI patterns introduce reusable tactical components.
   Note: Documented reusable operational review panel guidance for Action Preview panels, grouped node detail drill-ins, and source or compatibility badges.
 - [x] 1.3 Update `docs/glossary/CONTEXT.md` if accepted terminology adds durable glossary entries such as pending admission, action preview, or scheduler reason code.
@@ -31,6 +33,7 @@
   Note: CLI/Admin admission previews now use shared `ActionPreview` blocker and confirmation codes.
   Console pending admission queue, detail drill-in, and admit/reject preview panels now render shared status, scheduler, blocker, warning, consequence, and confirmation codes for this slice.
   Admin API, CLI, Console, and tests consume the shared contract for landed admission-review behavior.
+  Node lifecycle previews for cordon, uncordon, drain, maintenance, resume, and decommission now consume the shared blocker, consequence, and confirmation vocabulary across CLI and Console.
   Operator API, support bundles, and full scheduler-explanation producer wiring remain future slices.
 - [x] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
 - [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
@@ -49,7 +52,7 @@
   Manual `draining -> maintenance` execution remains deferred: the `maintenance` command still exposes its dry-run preview but execution is blocked with a `drain_completion_unverified` blocker until drain completion (active-work quiescence) can be verified.
   Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, persisted lifecycle reason columns, decommission trust revocation, and Admin/Operator API lifecycle routes remain future work.
   Console lifecycle action preview panels are now implemented under task 5.3.
-  Note: `SPEC.md` §11.9 currently enumerates only the node-admission CLI commands as a required-command floor; promoting these lifecycle commands into that normative list remains an owner/OpenSpec-acceptance decision to be reconciled when this change is accepted.
+  Note: `SPEC.md` §11.9 now records the lifecycle commands and their preview and confirmation gates.
 - [ ] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
 
@@ -68,7 +71,9 @@
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
 - [ ] 5.6 Add read-only HA-lite control-plane status.
 - [ ] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
-  Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile; keep this unchecked as a recurring gate for future Console slices.
+  Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile.
+  PR #41 browser-verified the Console lifecycle preview slice against `docs/DESIGN.md`.
+  Keep this unchecked as a recurring gate for future Console slices.
 
 ## 6. Diagnostics And Support Bundles
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1049,10 +1049,10 @@ For `node-agent` role installs, run `sudo orchardctl env init`, fill in the
 node-agent environment, then run `sudo orchardctl start` and verify with
 `orchardctl status`.
 
-Do not use the future node-lifecycle CLI paths for current PKG bootstrap:
-`orchardctl cluster init`, `orchardctl node join`, and
-`orchardctl nodes admit` return deferred status in this build. Role selection,
-env generation, service start, and `orchardctl status` are the supported path.
+Do not use the deferred cluster-bootstrap CLI paths for current PKG bootstrap:
+`orchardctl cluster init` and `orchardctl node join` return deferred status in
+this build. Role selection, env generation, service start, and
+`orchardctl status` are the supported path.
 
 This deferred bootstrap ensures services start with valid environment and TLS
 configuration rather than crash-looping with missing setup.


### PR DESCRIPTION
## What Changed

- Console `LicenseStatus.safe_enforcement_mode/0` now rescues any exception (not just `ArgumentError`/`RuntimeError`) and falls back to `:hard`, so a malformed `:licensing` config yields a safe non-valid, operator-visible status instead of raising in the Console; adds a regression test asserting the summary is returned, is not valid, and stays visible.
- `SPEC.md` reconciles the node lifecycle contract after PRs #40–#42: adds the `draining -> decommissioning` transition, enumerates the explicit decommission source states, requires blocker/warning/consequence/confirmation codes to be stable machine-readable identifiers shared across Admin/Operator APIs, CLI, Console, bundles, and tests, and promotes the node lifecycle CLI commands (cordon/uncordon/drain/maintenance/resume/decommission) into the required-command floor with their `--dry-run` preview, confirmation gates, and `drain_completion_unverified` blocker.
- Aligns supporting docs with the reconciled contract: DESIGN.md preview-confirmation UI rules (typed-identifier inputs, consequence acknowledgement defaults, single open preview panel), ADR 0006 lifecycle authority boundary, a new License Enforcement Mode glossary entry, OpenSpec task reconciliation notes, and a PKG README correction that stops listing `orchardctl nodes admit` as deferred.

## Risk Assessment

✅ Low: The only executable change is a well-scoped, correctly-reasoned fail-safe fix (broadening a Console-only rescue to catch FunctionClauseError from malformed licensing config) backed by a targeted regression test; the rest is internally-consistent documentation reconciliation.

## Testing

test

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `one item`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
