### PR TITLE
feat(scheduler): add operator endpoint for scheduler explanations

### DIFF
--- a/apps/orchard_controller/lib/orchard/api/admin_request_context.ex
+++ b/apps/orchard_controller/lib/orchard/api/admin_request_context.ex
@@ -3,85 +3,8 @@ defmodule Orchard.API.AdminRequestContext do
   Plug that resolves and authorizes `/admin/v1/*` caller context.
   """
 
-  @behaviour Plug
-
-  alias Orchard.API.AdminErrorHelpers
-  alias Orchard.Governance
-
-  @invalid_api_key_message "Invalid API key provided."
-  @admin_required_message "Admin API requires a cluster-scoped admin API Client token."
-
-  @impl Plug
-  @spec init(Keyword.t()) :: Keyword.t()
-  def init(opts), do: opts
-
-  @impl Plug
-  @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
-  def call(conn, _opts) do
-    case bearer_token(conn) do
-      {:ok, token} ->
-        authenticate_request(conn, token)
-
-      {:error, reason} ->
-        conn
-        |> audit_auth_failure(nil, reason)
-        |> send_auth_error()
-    end
-  end
-
-  defp authenticate_request(conn, token) do
-    case Governance.authenticate_api_key(token) do
-      {:ok, auth_context} ->
-        Governance.touch_api_key_last_used(auth_context.api_key_id)
-        authorize_request(conn, auth_context)
-
-      {:error, reason} ->
-        conn
-        |> audit_auth_failure(token, reason)
-        |> send_auth_error()
-    end
-  end
-
-  defp authorize_request(conn, auth_context) do
-    case Governance.authorize_admin_api(auth_context) do
-      :ok ->
-        conn
-        |> Plug.Conn.assign(:tenant_id, auth_context.tenant_id)
-        |> Plug.Conn.assign(:principal_type, auth_context.principal_type)
-        |> Plug.Conn.assign(:principal_id, auth_context.principal_id)
-        |> Plug.Conn.assign(:service_account_id, auth_context.service_account_id)
-        |> Plug.Conn.assign(:api_key_id, auth_context.api_key_id)
-
-      {:error, :admin_required} ->
-        send_admin_required_error(conn)
-    end
-  end
-
-  defp bearer_token(conn) do
-    case Plug.Conn.get_req_header(conn, "authorization") do
-      [header] -> parse_bearer_header(header)
-      [] -> {:error, :missing_header}
-      _headers -> {:error, :malformed_header}
-    end
-  end
-
-  defp parse_bearer_header("Bearer " <> token) when token != "", do: {:ok, token}
-  defp parse_bearer_header(_header), do: {:error, :malformed_header}
-
-  defp audit_auth_failure(conn, token, reason) do
-    Governance.audit_api_key_auth_failure(token, reason)
-    conn
-  end
-
-  defp send_auth_error(conn) do
-    conn
-    |> AdminErrorHelpers.send_error(:unauthorized, "invalid_api_key", @invalid_api_key_message)
-    |> Plug.Conn.halt()
-  end
-
-  defp send_admin_required_error(conn) do
-    conn
-    |> AdminErrorHelpers.send_error(:forbidden, "admin_required", @admin_required_message)
-    |> Plug.Conn.halt()
-  end
+  use Orchard.API.ScopedRequestContext,
+    authorizer: &Orchard.Governance.authorize_admin_api/1,
+    required_code: "admin_required",
+    required_message: "Admin API requires a cluster-scoped admin API Client token."
 end

--- a/apps/orchard_controller/lib/orchard/api/operator_request_context.ex
+++ b/apps/orchard_controller/lib/orchard/api/operator_request_context.ex
@@ -3,85 +3,8 @@ defmodule Orchard.API.OperatorRequestContext do
   Plug that resolves and authorizes `/ops/v1/*` caller context.
   """
 
-  @behaviour Plug
-
-  alias Orchard.API.AdminErrorHelpers
-  alias Orchard.Governance
-
-  @invalid_api_key_message "Invalid API key provided."
-  @operator_required_message "Operator API requires a cluster-scoped operator or admin API Client token."
-
-  @impl Plug
-  @spec init(Keyword.t()) :: Keyword.t()
-  def init(opts), do: opts
-
-  @impl Plug
-  @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
-  def call(conn, _opts) do
-    case bearer_token(conn) do
-      {:ok, token} ->
-        authenticate_request(conn, token)
-
-      {:error, reason} ->
-        conn
-        |> audit_auth_failure(nil, reason)
-        |> send_auth_error()
-    end
-  end
-
-  defp authenticate_request(conn, token) do
-    case Governance.authenticate_api_key(token) do
-      {:ok, auth_context} ->
-        Governance.touch_api_key_last_used(auth_context.api_key_id)
-        authorize_request(conn, auth_context)
-
-      {:error, reason} ->
-        conn
-        |> audit_auth_failure(token, reason)
-        |> send_auth_error()
-    end
-  end
-
-  defp authorize_request(conn, auth_context) do
-    case Governance.authorize_operator_api(auth_context) do
-      :ok ->
-        conn
-        |> Plug.Conn.assign(:tenant_id, auth_context.tenant_id)
-        |> Plug.Conn.assign(:principal_type, auth_context.principal_type)
-        |> Plug.Conn.assign(:principal_id, auth_context.principal_id)
-        |> Plug.Conn.assign(:service_account_id, auth_context.service_account_id)
-        |> Plug.Conn.assign(:api_key_id, auth_context.api_key_id)
-
-      {:error, :operator_required} ->
-        send_operator_required_error(conn)
-    end
-  end
-
-  defp bearer_token(conn) do
-    case Plug.Conn.get_req_header(conn, "authorization") do
-      [header] -> parse_bearer_header(header)
-      [] -> {:error, :missing_header}
-      _headers -> {:error, :malformed_header}
-    end
-  end
-
-  defp parse_bearer_header("Bearer " <> token) when token != "", do: {:ok, token}
-  defp parse_bearer_header(_header), do: {:error, :malformed_header}
-
-  defp audit_auth_failure(conn, token, reason) do
-    Governance.audit_api_key_auth_failure(token, reason)
-    conn
-  end
-
-  defp send_auth_error(conn) do
-    conn
-    |> AdminErrorHelpers.send_error(:unauthorized, "invalid_api_key", @invalid_api_key_message)
-    |> Plug.Conn.halt()
-  end
-
-  defp send_operator_required_error(conn) do
-    conn
-    |> AdminErrorHelpers.send_error(:forbidden, "operator_required", @operator_required_message)
-    |> Plug.Conn.halt()
-  end
+  use Orchard.API.ScopedRequestContext,
+    authorizer: &Orchard.Governance.authorize_operator_api/1,
+    required_code: "operator_required",
+    required_message: "Operator API requires a cluster-scoped operator or admin API Client token."
 end

--- a/apps/orchard_controller/lib/orchard/api/operator_request_context.ex
+++ b/apps/orchard_controller/lib/orchard/api/operator_request_context.ex
@@ -1,0 +1,87 @@
+defmodule Orchard.API.OperatorRequestContext do
+  @moduledoc """
+  Plug that resolves and authorizes `/ops/v1/*` caller context.
+  """
+
+  @behaviour Plug
+
+  alias Orchard.API.AdminErrorHelpers
+  alias Orchard.Governance
+
+  @invalid_api_key_message "Invalid API key provided."
+  @operator_required_message "Operator API requires a cluster-scoped operator or admin API Client token."
+
+  @impl Plug
+  @spec init(Keyword.t()) :: Keyword.t()
+  def init(opts), do: opts
+
+  @impl Plug
+  @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    case bearer_token(conn) do
+      {:ok, token} ->
+        authenticate_request(conn, token)
+
+      {:error, reason} ->
+        conn
+        |> audit_auth_failure(nil, reason)
+        |> send_auth_error()
+    end
+  end
+
+  defp authenticate_request(conn, token) do
+    case Governance.authenticate_api_key(token) do
+      {:ok, auth_context} ->
+        Governance.touch_api_key_last_used(auth_context.api_key_id)
+        authorize_request(conn, auth_context)
+
+      {:error, reason} ->
+        conn
+        |> audit_auth_failure(token, reason)
+        |> send_auth_error()
+    end
+  end
+
+  defp authorize_request(conn, auth_context) do
+    case Governance.authorize_operator_api(auth_context) do
+      :ok ->
+        conn
+        |> Plug.Conn.assign(:tenant_id, auth_context.tenant_id)
+        |> Plug.Conn.assign(:principal_type, auth_context.principal_type)
+        |> Plug.Conn.assign(:principal_id, auth_context.principal_id)
+        |> Plug.Conn.assign(:service_account_id, auth_context.service_account_id)
+        |> Plug.Conn.assign(:api_key_id, auth_context.api_key_id)
+
+      {:error, :operator_required} ->
+        send_operator_required_error(conn)
+    end
+  end
+
+  defp bearer_token(conn) do
+    case Plug.Conn.get_req_header(conn, "authorization") do
+      [header] -> parse_bearer_header(header)
+      [] -> {:error, :missing_header}
+      _headers -> {:error, :malformed_header}
+    end
+  end
+
+  defp parse_bearer_header("Bearer " <> token) when token != "", do: {:ok, token}
+  defp parse_bearer_header(_header), do: {:error, :malformed_header}
+
+  defp audit_auth_failure(conn, token, reason) do
+    Governance.audit_api_key_auth_failure(token, reason)
+    conn
+  end
+
+  defp send_auth_error(conn) do
+    conn
+    |> AdminErrorHelpers.send_error(:unauthorized, "invalid_api_key", @invalid_api_key_message)
+    |> Plug.Conn.halt()
+  end
+
+  defp send_operator_required_error(conn) do
+    conn
+    |> AdminErrorHelpers.send_error(:forbidden, "operator_required", @operator_required_message)
+    |> Plug.Conn.halt()
+  end
+end

--- a/apps/orchard_controller/lib/orchard/api/ops/scheduler_explanation_presenter.ex
+++ b/apps/orchard_controller/lib/orchard/api/ops/scheduler_explanation_presenter.ex
@@ -1,0 +1,29 @@
+defmodule Orchard.API.Ops.SchedulerExplanationPresenter do
+  @moduledoc """
+  Operator API projection for persisted scheduler explanations.
+  """
+
+  alias Orchard.ClusterManagement.SchedulerExplanation
+  alias Orchard.Requests.Request
+
+  @spec show(Request.t()) :: {:ok, map()} | {:error, term()}
+  def show(%Request{public_id: public_id, scheduler_decision: decision}) when is_map(decision) do
+    decision
+    |> Map.put_new("request_id", public_id)
+    |> Map.put_new("selected_node_id", Map.get(decision, "node_id"))
+    |> Map.put_new("selection_tier", Map.get(decision, "selected_tier"))
+    |> SchedulerExplanation.new()
+    |> case do
+      {:ok, explanation} -> {:ok, api_map(explanation)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def show(%Request{}), do: {:error, :scheduler_explanation_not_found}
+
+  defp api_map(%SchedulerExplanation{} = explanation) do
+    explanation
+    |> SchedulerExplanation.to_map()
+    |> Map.drop([:object, :contract_version])
+  end
+end

--- a/apps/orchard_controller/lib/orchard/api/ops/scheduler_explanations_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/ops/scheduler_explanations_controller.ex
@@ -1,0 +1,53 @@
+defmodule Orchard.API.Ops.SchedulerExplanationsController do
+  @moduledoc false
+
+  use Phoenix.Controller
+
+  alias Orchard.API.AdminErrorHelpers
+  alias Orchard.API.Ops.SchedulerExplanationPresenter
+  alias Orchard.Requests
+
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show(conn, %{"request_id" => request_id}) do
+    case Requests.get_request_by_public_id(request_id) do
+      nil ->
+        send_error(
+          conn,
+          :not_found,
+          "scheduler_explanation_not_found",
+          "Scheduler explanation was not found."
+        )
+
+      request ->
+        render_explanation(conn, request)
+    end
+  end
+
+  defp render_explanation(conn, request) do
+    case SchedulerExplanationPresenter.show(request) do
+      {:ok, explanation} ->
+        json(conn, explanation)
+
+      {:error, :scheduler_explanation_not_found} ->
+        send_error(
+          conn,
+          :not_found,
+          "scheduler_explanation_not_found",
+          "Scheduler explanation was not found."
+        )
+
+      {:error, reason} ->
+        send_error(
+          conn,
+          :unprocessable_entity,
+          "scheduler_explanation_invalid",
+          "Persisted scheduler explanation is invalid.",
+          details: inspect(reason)
+        )
+    end
+  end
+
+  defp send_error(conn, status, code, message, opts \\ []) do
+    AdminErrorHelpers.send_error(conn, status, code, message, opts)
+  end
+end

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -20,6 +20,11 @@ defmodule Orchard.API.Router do
     plug(Orchard.API.AdminRequestContext)
   end
 
+  pipeline :operator_api do
+    plug(:accepts, ["json"])
+    plug(Orchard.API.OperatorRequestContext)
+  end
+
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)
@@ -49,6 +54,12 @@ defmodule Orchard.API.Router do
     get("/models", ModelsController, :index)
     post("/chat/completions", ChatCompletionsController, :create)
     post("/responses", ResponsesController, :create)
+  end
+
+  scope "/ops/v1", Orchard.API.Ops do
+    pipe_through(:operator_api)
+
+    get("/scheduler/explanations/:request_id", SchedulerExplanationsController, :show)
   end
 
   scope "/admin/v1", Orchard.API.Admin do

--- a/apps/orchard_controller/lib/orchard/api/scoped_request_context.ex
+++ b/apps/orchard_controller/lib/orchard/api/scoped_request_context.ex
@@ -1,0 +1,121 @@
+defmodule Orchard.API.ScopedRequestContext do
+  @moduledoc """
+  Shared bearer-token authentication and authorization plug for cluster-scoped
+  API surfaces (`/admin/v1/*`, `/ops/v1/*`).
+
+  Concrete plugs configure the authorization callback and the role-required
+  error via `use Orchard.API.ScopedRequestContext, ...`, keeping their own
+  public module names while sharing the authentication and error-response flow.
+  """
+
+  alias Orchard.API.AdminErrorHelpers
+  alias Orchard.Governance
+
+  @invalid_api_key_message "Invalid API key provided."
+
+  @type authorizer :: (Governance.api_key_auth_result() -> :ok | {:error, atom()})
+
+  @type config :: %{
+          authorizer: authorizer(),
+          required_code: String.t(),
+          required_message: String.t()
+        }
+
+  @doc false
+  defmacro __using__(opts) do
+    authorizer = Keyword.fetch!(opts, :authorizer)
+    required_code = Keyword.fetch!(opts, :required_code)
+    required_message = Keyword.fetch!(opts, :required_message)
+
+    quote do
+      @behaviour Plug
+
+      @impl Plug
+      @spec init(Keyword.t()) :: Keyword.t()
+      def init(opts), do: opts
+
+      @impl Plug
+      @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
+      def call(conn, _opts) do
+        unquote(__MODULE__).call(conn, %{
+          authorizer: unquote(authorizer),
+          required_code: unquote(required_code),
+          required_message: unquote(required_message)
+        })
+      end
+    end
+  end
+
+  @spec call(Plug.Conn.t(), config()) :: Plug.Conn.t()
+  def call(conn, config) do
+    case bearer_token(conn) do
+      {:ok, token} ->
+        authenticate_request(conn, token, config)
+
+      {:error, reason} ->
+        conn
+        |> audit_auth_failure(nil, reason)
+        |> send_auth_error()
+    end
+  end
+
+  defp authenticate_request(conn, token, config) do
+    case Governance.authenticate_api_key(token) do
+      {:ok, auth_context} ->
+        Governance.touch_api_key_last_used(auth_context.api_key_id)
+        authorize_request(conn, auth_context, config)
+
+      {:error, reason} ->
+        conn
+        |> audit_auth_failure(token, reason)
+        |> send_auth_error()
+    end
+  end
+
+  defp authorize_request(conn, auth_context, config) do
+    case config.authorizer.(auth_context) do
+      :ok ->
+        assign_auth_context(conn, auth_context)
+
+      {:error, _reason} ->
+        send_role_required_error(conn, config)
+    end
+  end
+
+  defp assign_auth_context(conn, auth_context) do
+    conn
+    |> Plug.Conn.assign(:tenant_id, auth_context.tenant_id)
+    |> Plug.Conn.assign(:principal_type, auth_context.principal_type)
+    |> Plug.Conn.assign(:principal_id, auth_context.principal_id)
+    |> Plug.Conn.assign(:service_account_id, auth_context.service_account_id)
+    |> Plug.Conn.assign(:api_key_id, auth_context.api_key_id)
+  end
+
+  defp bearer_token(conn) do
+    case Plug.Conn.get_req_header(conn, "authorization") do
+      [header] -> parse_bearer_header(header)
+      [] -> {:error, :missing_header}
+      _headers -> {:error, :malformed_header}
+    end
+  end
+
+  defp parse_bearer_header("Bearer " <> token) when token != "", do: {:ok, token}
+  defp parse_bearer_header(_header), do: {:error, :malformed_header}
+
+  defp audit_auth_failure(conn, token, reason) do
+    Governance.audit_api_key_auth_failure(token, reason)
+    conn
+  end
+
+  defp send_auth_error(conn) do
+    conn
+    |> AdminErrorHelpers.send_error(:unauthorized, "invalid_api_key", @invalid_api_key_message)
+    |> Plug.Conn.halt()
+  end
+
+  defp send_role_required_error(conn, config) do
+    conn
+    |> AdminErrorHelpers.send_error(:forbidden, config.required_code, config.required_message)
+    |> Plug.Conn.halt()
+  end
+end

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -336,14 +336,6 @@ defmodule Orchard.Governance do
     end
   end
 
-  @spec has_cluster_operator_access?(ServiceAccount.t() | Ecto.UUID.t()) :: boolean()
-  def has_cluster_operator_access?(service_account_or_id) do
-    case resolve_api_client(service_account_or_id) do
-      {:ok, api_client} -> cluster_operator_role_binding_exists?(api_client.id)
-      {:error, _reason} -> false
-    end
-  end
-
   @spec authorize_public_inference(api_key_auth_result()) :: :ok | {:error, authorization_error()}
   def authorize_public_inference(%{principal_type: :tenant}), do: :ok
 

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -336,6 +336,14 @@ defmodule Orchard.Governance do
     end
   end
 
+  @spec has_cluster_operator_access?(ServiceAccount.t() | Ecto.UUID.t()) :: boolean()
+  def has_cluster_operator_access?(service_account_or_id) do
+    case resolve_api_client(service_account_or_id) do
+      {:ok, api_client} -> cluster_operator_role_binding_exists?(api_client.id)
+      {:error, _reason} -> false
+    end
+  end
+
   @spec authorize_public_inference(api_key_auth_result()) :: :ok | {:error, authorization_error()}
   def authorize_public_inference(%{principal_type: :tenant}), do: :ok
 
@@ -370,6 +378,22 @@ defmodule Orchard.Governance do
   end
 
   def authorize_admin_api(_auth_context), do: {:error, :admin_required}
+
+  @spec authorize_operator_api(api_key_auth_result()) :: :ok | {:error, :operator_required}
+  def authorize_operator_api(%{
+        principal_type: :service_account,
+        principal_id: service_account_id
+      }) do
+    with {:ok, api_client} <- resolve_api_client(service_account_id),
+         false <- ServiceAccount.disabled?(api_client),
+         true <- cluster_operator_or_admin_role_binding_exists?(api_client.id) do
+      :ok
+    else
+      _ -> {:error, :operator_required}
+    end
+  end
+
+  def authorize_operator_api(_auth_context), do: {:error, :operator_required}
 
   @spec bulk_validate_api_clients([map()], keyword()) ::
           {:ok, ApiClientProvisioning.plan()}
@@ -973,11 +997,32 @@ defmodule Orchard.Governance do
     end
   end
 
+  defp cluster_operator_role_binding_exists?(service_account_id) do
+    case fetch_cluster_operator_role_binding(service_account_id) do
+      %RoleBinding{} -> true
+      nil -> false
+    end
+  end
+
+  defp cluster_operator_or_admin_role_binding_exists?(service_account_id) do
+    cluster_operator_role_binding_exists?(service_account_id) or
+      cluster_admin_role_binding_exists?(service_account_id)
+  end
+
   defp fetch_cluster_admin_role_binding(service_account_id) do
     RoleBinding
     |> where([role_binding], role_binding.principal_type == :service_account)
     |> where([role_binding], role_binding.principal_id == ^service_account_id)
     |> where([role_binding], role_binding.role == :admin)
+    |> where([role_binding], is_nil(role_binding.tenant_scope_id))
+    |> Repo.one()
+  end
+
+  defp fetch_cluster_operator_role_binding(service_account_id) do
+    RoleBinding
+    |> where([role_binding], role_binding.principal_type == :service_account)
+    |> where([role_binding], role_binding.principal_id == ^service_account_id)
+    |> where([role_binding], role_binding.role == :operator)
     |> where([role_binding], is_nil(role_binding.tenant_scope_id))
     |> Repo.one()
   end

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -182,10 +182,11 @@ defmodule Orchard.Inference.QueueManager do
   @spec requeue(Grant.t(), admission_request(), keyword()) :: requeue_result()
   def requeue(%Grant{} = grant, attrs, opts \\ []) do
     config = Keyword.get(opts, :config, Orchard.Inference.queue_admission_config())
+    queue_wait_reason = Keyword.get(opts, :queue_wait_reason)
 
     call_manager(
       grant.server,
-      {:requeue, grant, normalize_request(attrs), normalize_config(config)}
+      {:requeue, grant, normalize_request(attrs), normalize_config(config), queue_wait_reason}
     )
   end
 
@@ -463,9 +464,9 @@ defmodule Orchard.Inference.QueueManager do
     {:reply, :ok, release_grant(grant_id, state)}
   end
 
-  def handle_call({:requeue, %Grant{} = grant, request, config}, _from, state) do
+  def handle_call({:requeue, %Grant{} = grant, request, config, queue_wait_reason}, _from, state) do
     config = queue_config_for_request(config, request)
-    {result, state} = requeue_grant(grant, request, config, state)
+    {result, state} = requeue_grant(grant, request, config, queue_wait_reason, state)
     {:reply, result, state}
   end
 
@@ -2817,10 +2818,10 @@ defmodule Orchard.Inference.QueueManager do
     end
   end
 
-  defp requeue_grant(%Grant{} = grant, request, config, state) do
+  defp requeue_grant(%Grant{} = grant, request, config, queue_wait_reason, state) do
     case Map.fetch(state.grants, grant.grant_id) do
       {:ok, grant_state} ->
-        requeue_active_grant(grant, grant_state, request, config, state)
+        requeue_active_grant(grant, grant_state, request, config, queue_wait_reason, state)
 
       :error ->
         metadata = error_metadata(:invalid_requeue, request.queue_key)
@@ -2828,7 +2829,7 @@ defmodule Orchard.Inference.QueueManager do
     end
   end
 
-  defp requeue_active_grant(grant, grant_state, request, config, state) do
+  defp requeue_active_grant(grant, grant_state, request, config, queue_wait_reason, state) do
     cond do
       grant_state.queue_key != request.queue_key ->
         metadata = error_metadata(:invalid_requeue, request.queue_key)
@@ -2850,11 +2851,11 @@ defmodule Orchard.Inference.QueueManager do
         {{:error, :request_caller_disconnect, metadata}, maybe_grant_next_global(state)}
 
       true ->
-        requeue_live_grant(grant, grant_state, request, config, state)
+        requeue_live_grant(grant, grant_state, request, config, queue_wait_reason, state)
     end
   end
 
-  defp requeue_live_grant(grant, grant_state, request, config, state) do
+  defp requeue_live_grant(grant, grant_state, request, config, queue_wait_reason, state) do
     now_ms = monotonic_ms()
     remaining_ms = grant_state.queue_deadline_monotonic_ms - now_ms
     queued_at = grant_state.queued_at || now_iso8601()
@@ -2871,7 +2872,7 @@ defmodule Orchard.Inference.QueueManager do
     else
       {ticket, state} =
         request
-        |> requeue_entry(config, grant_state, queued_at, remaining_ms)
+        |> requeue_entry(config, grant_state, queued_at, remaining_ms, queue_wait_reason)
         |> put_requeued_entry(state)
 
       state =
@@ -2883,7 +2884,7 @@ defmodule Orchard.Inference.QueueManager do
     end
   end
 
-  defp requeue_entry(request, config, grant_state, queued_at, remaining_ms) do
+  defp requeue_entry(request, config, grant_state, queued_at, remaining_ms, queue_wait_reason) do
     ticket_ref = make_ref()
     monitor_ref = Process.monitor(request.caller_pid)
     timeout_ref = Process.send_after(self(), {:queue_timeout, ticket_ref}, remaining_ms)
@@ -2895,7 +2896,9 @@ defmodule Orchard.Inference.QueueManager do
       queued_at: queued_at,
       enqueued_monotonic_ms: grant_state.enqueued_monotonic_ms,
       max_wait_ms: config.max_wait_ms,
-      queue_wait_reason: Map.get(grant_state, :queue_wait_reason, :requested_model_path_capacity)
+      queue_wait_reason:
+        queue_wait_reason ||
+          Map.get(grant_state, :queue_wait_reason, :requested_model_path_capacity)
     }
 
     entry = %{

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -3437,11 +3437,11 @@ defmodule Orchard.Inference.QueueManager do
     }
   end
 
-  defp queue_wait_reason(state, lane, request, config) do
-    cond do
-      not tenant_active_capacity?(state, request, config) -> :tenant_active_capacity
-      not active_capacity?(lane, config.capacity) -> :requested_model_path_capacity
-      true -> :requested_model_path_capacity
+  defp queue_wait_reason(state, _lane, request, config) do
+    if tenant_active_capacity?(state, request, config) do
+      :requested_model_path_capacity
+    else
+      :tenant_active_capacity
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -46,7 +46,8 @@ defmodule Orchard.Inference.QueueManager do
       :queue_result,
       :queued_at,
       :queue_granted_at,
-      :queue_wait_ms
+      :queue_wait_ms,
+      :queue_wait_reason
     ]
 
     @type t :: %__MODULE__{
@@ -56,7 +57,8 @@ defmodule Orchard.Inference.QueueManager do
             queue_result: :immediate | :queued,
             queued_at: String.t() | nil,
             queue_granted_at: String.t(),
-            queue_wait_ms: non_neg_integer()
+            queue_wait_ms: non_neg_integer(),
+            queue_wait_reason: atom() | nil
           }
   end
 
@@ -69,7 +71,8 @@ defmodule Orchard.Inference.QueueManager do
       :queue_key,
       :queued_at,
       :enqueued_monotonic_ms,
-      :max_wait_ms
+      :max_wait_ms,
+      :queue_wait_reason
     ]
     defstruct [
       :server,
@@ -77,7 +80,8 @@ defmodule Orchard.Inference.QueueManager do
       :queue_key,
       :queued_at,
       :enqueued_monotonic_ms,
-      :max_wait_ms
+      :max_wait_ms,
+      :queue_wait_reason
     ]
 
     @type t :: %__MODULE__{
@@ -86,7 +90,8 @@ defmodule Orchard.Inference.QueueManager do
             queue_key: String.t(),
             queued_at: String.t(),
             enqueued_monotonic_ms: integer(),
-            max_wait_ms: non_neg_integer()
+            max_wait_ms: non_neg_integer(),
+            queue_wait_reason: atom()
           }
   end
 
@@ -363,7 +368,8 @@ defmodule Orchard.Inference.QueueManager do
       queue_wait_ms: grant.queue_wait_ms,
       queued_at: grant.queued_at,
       queue_granted_at: grant.queue_granted_at,
-      queue_grant_id: grant.grant_id
+      queue_grant_id: grant.grant_id,
+      queue_wait_reason: grant.queue_wait_reason
     }
     |> reject_nil_values()
   end
@@ -373,6 +379,7 @@ defmodule Orchard.Inference.QueueManager do
     :queued
     |> error_metadata(ticket.queue_key, elapsed_ms(ticket.enqueued_monotonic_ms))
     |> Map.put(:queued_at, ticket.queued_at)
+    |> Map.put(:queue_wait_reason, ticket.queue_wait_reason)
   end
 
   @spec error_metadata(atom(), String.t(), non_neg_integer()) :: map()
@@ -429,7 +436,9 @@ defmodule Orchard.Inference.QueueManager do
         {:reply, {:error, :queue_full, metadata}, state}
 
       tenant_has_queued_entries?(state, request.tenant_id) ->
-        {ticket, state} = enqueue_request(request, config, state)
+        {ticket, state} =
+          enqueue_request(request, config, state, queue_wait_reason(state, lane, request, config))
+
         {:reply, {:queued, ticket}, state}
 
       active_capacity?(lane, config.capacity) and
@@ -443,7 +452,9 @@ defmodule Orchard.Inference.QueueManager do
         {:reply, {:error, :queue_full, metadata}, state}
 
       true ->
-        {ticket, state} = enqueue_request(request, config, state)
+        {ticket, state} =
+          enqueue_request(request, config, state, queue_wait_reason(state, lane, request, config))
+
         {:reply, {:queued, ticket}, state}
     end
   end
@@ -2530,7 +2541,7 @@ defmodule Orchard.Inference.QueueManager do
      put_immediate_grant(grant, request, config, started_monotonic_ms, admission_sequence, state)}
   end
 
-  defp enqueue_request(request, config, state) do
+  defp enqueue_request(request, config, state, queue_wait_reason) do
     {admission_sequence, state} = take_admission_sequence(state)
     ticket_ref = make_ref()
     enqueued_monotonic_ms = monotonic_ms()
@@ -2546,7 +2557,8 @@ defmodule Orchard.Inference.QueueManager do
       queue_key: request.queue_key,
       queued_at: queued_at,
       enqueued_monotonic_ms: enqueued_monotonic_ms,
-      max_wait_ms: config.max_wait_ms
+      max_wait_ms: config.max_wait_ms,
+      queue_wait_reason: queue_wait_reason
     }
 
     entry = %{
@@ -2571,7 +2583,8 @@ defmodule Orchard.Inference.QueueManager do
       terminal_result: nil,
       terminal_retry_ref: nil,
       terminal_retry_after_ms: config.poll_interval_ms,
-      max_active_per_tenant: config.max_active_per_tenant
+      max_active_per_tenant: config.max_active_per_tenant,
+      queue_wait_reason: queue_wait_reason
     }
 
     {ticket, put_entry(entry, state)}
@@ -2881,7 +2894,8 @@ defmodule Orchard.Inference.QueueManager do
       queue_key: request.queue_key,
       queued_at: queued_at,
       enqueued_monotonic_ms: grant_state.enqueued_monotonic_ms,
-      max_wait_ms: config.max_wait_ms
+      max_wait_ms: config.max_wait_ms,
+      queue_wait_reason: Map.get(grant_state, :queue_wait_reason, :requested_model_path_capacity)
     }
 
     entry = %{
@@ -2906,7 +2920,8 @@ defmodule Orchard.Inference.QueueManager do
       terminal_result: nil,
       terminal_retry_ref: nil,
       terminal_retry_after_ms: config.poll_interval_ms,
-      max_active_per_tenant: config.max_active_per_tenant
+      max_active_per_tenant: config.max_active_per_tenant,
+      queue_wait_reason: ticket.queue_wait_reason
     }
 
     {ticket, entry}
@@ -3033,7 +3048,14 @@ defmodule Orchard.Inference.QueueManager do
     capacity_source_kind = capacity_source_kind_for_grant(entry.queue_key, capacity_source, state)
 
     grant =
-      build_grant(state, entry.queue_key, :queued, entry.queued_at, entry.enqueued_monotonic_ms)
+      build_grant(
+        state,
+        entry.queue_key,
+        :queued,
+        entry.queued_at,
+        entry.enqueued_monotonic_ms,
+        entry.queue_wait_reason
+      )
 
     state = promote_entry_to_grant(entry, grant, capacity_source, capacity_source_kind, state)
     reply_awaiter(entry, {:ok, grant})
@@ -3085,7 +3107,8 @@ defmodule Orchard.Inference.QueueManager do
         server: state.server,
         capacity_source: capacity_source,
         capacity_source_kind: capacity_source_kind,
-        capacity_source_observed?: false
+        capacity_source_observed?: false,
+        queue_wait_reason: entry.queue_wait_reason
       })
 
     %{
@@ -3391,22 +3414,55 @@ defmodule Orchard.Inference.QueueManager do
     }
   end
 
+  defp build_grant(
+         state,
+         queue_key,
+         queue_result,
+         queued_at,
+         started_monotonic_ms,
+         queue_wait_reason
+       ) do
+    %Grant{
+      server: state.server,
+      grant_id: Ecto.UUID.generate(),
+      queue_key: queue_key,
+      queue_result: queue_result,
+      queued_at: queued_at,
+      queue_granted_at: now_iso8601(),
+      queue_wait_ms: elapsed_ms(started_monotonic_ms),
+      queue_wait_reason: queue_wait_reason
+    }
+  end
+
+  defp queue_wait_reason(state, lane, request, config) do
+    cond do
+      not tenant_active_capacity?(state, request, config) -> :tenant_active_capacity
+      not active_capacity?(lane, config.capacity) -> :requested_model_path_capacity
+      true -> :requested_model_path_capacity
+    end
+  end
+
   defp timeout_metadata(%Ticket{} = ticket) do
     :queue_timeout
     |> error_metadata(ticket.queue_key, elapsed_ms(ticket.enqueued_monotonic_ms))
     |> Map.put(:queued_at, ticket.queued_at)
+    |> Map.put(:queue_wait_reason, ticket.queue_wait_reason)
   end
 
   defp timeout_metadata(entry) do
     :queue_timeout
     |> error_metadata(entry.queue_key, elapsed_ms(entry))
     |> Map.put(:queued_at, entry.queued_at)
+    |> Map.put(:queue_wait_reason, Map.get(entry, :queue_wait_reason))
+    |> reject_nil_values()
   end
 
   defp timeout_metadata(grant_state, queued_at) do
     :queue_timeout
     |> error_metadata(grant_state.queue_key, elapsed_ms(grant_state.enqueued_monotonic_ms))
     |> Map.put(:queued_at, queued_at)
+    |> Map.put(:queue_wait_reason, Map.get(grant_state, :queue_wait_reason))
+    |> reject_nil_values()
   end
 
   defp terminalize_requeued_timeout(request, grant_state, queued_at, config, metadata) do

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -425,7 +425,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp dispatch_with_queue_grant(db_request, canonical, model, grant, execution_opts) do
     case do_dispatch_with_queue_grant(db_request, canonical, model, grant, execution_opts) do
       {:error, reason} when reason in [:cluster_busy, :model_busy] ->
-        requeue_after_schedule_busy(db_request, canonical, model, grant, execution_opts)
+        requeue_after_schedule_busy(db_request, canonical, model, grant, execution_opts, reason)
 
       result ->
         result
@@ -434,10 +434,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
     Inference.queue_manager().release(grant)
   end
 
-  defp requeue_after_schedule_busy(db_request, canonical, model, grant, execution_opts) do
+  defp requeue_after_schedule_busy(db_request, canonical, model, grant, execution_opts, reason) do
     request = queue_admission_request(db_request, canonical, execution_opts.caller)
 
-    case Inference.queue_manager().requeue(grant, request) do
+    case Inference.queue_manager().requeue(grant, request,
+           queue_wait_reason: busy_queue_wait_reason(reason)
+         ) do
       {:queued, %QueueManager.Ticket{} = ticket} ->
         with {:ok, next_grant} <- await_queued_grant(db_request, ticket) do
           dispatch_if_queue_request_live(db_request, canonical, model, next_grant, execution_opts)
@@ -457,6 +459,9 @@ defmodule Orchard.Inference.RequestOrchestrator do
         handle_queue_await_error(db_request, metadata, reason, false)
     end
   end
+
+  defp busy_queue_wait_reason(:cluster_busy), do: :live_node_capacity
+  defp busy_queue_wait_reason(:model_busy), do: :requested_model_path_capacity
 
   defp do_dispatch_with_queue_grant(db_request, canonical, model, grant, execution_opts) do
     metadata = QueueManager.grant_metadata(grant)

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -255,7 +255,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
        ) do
     with {:ok, schedule} <- schedule_request(canonical),
          {:ok, _} <-
-           Requests.record_schedule(db_request, scheduler_persistence_metadata(schedule)),
+           record_scheduler_decision(db_request, scheduler_persistence_metadata(schedule)),
          :ok <- put_request_scheduled_context(schedule),
          :ok <- advance_fsm(db_request.id, :scheduled),
          :ok <- advance_fsm(db_request.id, :dispatching) do
@@ -476,7 +476,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
            ),
          {:ok, schedule} <- schedule_request(canonical),
          {:ok, _} <-
-           Requests.record_schedule(
+           record_scheduler_decision(
              db_request,
              scheduler_persistence_metadata(Map.merge(schedule, metadata))
            ),
@@ -705,6 +705,32 @@ defmodule Orchard.Inference.RequestOrchestrator do
     _kind, _reason ->
       log_warn("scheduler threw")
       {:error, orchestration_crash(:scheduler, :throw)}
+  end
+
+  defp record_scheduler_decision(db_request, metadata) do
+    case Requests.record_schedule(db_request, metadata) do
+      {:error, {:invalid_scheduler_explanation, reason}} ->
+        log_error(
+          "invalid scheduler explanation for request #{db_request.public_id}: " <>
+            "#{inspect(reason)}; persisting scheduler decision without explanation candidates"
+        )
+
+        Requests.record_schedule(db_request, drop_scheduler_explanation(metadata))
+
+      result ->
+        result
+    end
+  end
+
+  defp drop_scheduler_explanation(metadata) do
+    Map.drop(metadata, [
+      :scored_candidates,
+      "scored_candidates",
+      :rejected_candidates,
+      "rejected_candidates",
+      :skipped_candidates,
+      "skipped_candidates"
+    ])
   end
 
   defp scheduler_persistence_metadata(schedule) do
@@ -1777,5 +1803,10 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp log_warn(message) do
     require Logger
     Logger.warning("[RequestOrchestrator] #{message}")
+  end
+
+  defp log_error(message) do
+    require Logger
+    Logger.error("[RequestOrchestrator] #{message}")
   end
 end

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -316,26 +316,25 @@ defmodule Orchard.Requests do
 
   def record_schedule(request_id, schedule) do
     Repo.transaction(fn ->
-      case lock_request(request_id) do
-        {:ok, request} ->
-          with {:ok, normalized_schedule} <- normalize_schedule(schedule) do
-            attrs = %{
-              scheduler_decision: normalized_schedule,
-              node_id: Map.get(schedule, :node_id)
-            }
-
-            request
-            |> Request.schedule_changeset(attrs)
-            |> Repo.update()
-          else
-            {:error, reason} -> Repo.rollback(reason)
-          end
-
-        {:error, :request_not_found} ->
-          Repo.rollback(:request_not_found)
+      with {:ok, request} <- lock_request(request_id),
+           {:ok, normalized_schedule} <- normalize_schedule(schedule) do
+        persist_schedule(request, schedule, normalized_schedule)
+      else
+        {:error, reason} -> Repo.rollback(reason)
       end
     end)
     |> unwrap_transaction_result()
+  end
+
+  defp persist_schedule(request, schedule, normalized_schedule) do
+    attrs = %{
+      scheduler_decision: normalized_schedule,
+      node_id: Map.get(schedule, :node_id)
+    }
+
+    request
+    |> Request.schedule_changeset(attrs)
+    |> Repo.update()
   end
 
   @doc """

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -305,7 +305,12 @@ defmodule Orchard.Requests do
   sets `node_id` when the schedule contains a non-nil UUID.
   """
   @spec record_schedule(struct() | Ecto.UUID.t(), map()) ::
-          {:ok, struct()} | {:error, Ecto.Changeset.t() | :request_not_found}
+          {:ok, struct()}
+          | {:error,
+             Ecto.Changeset.t()
+             | :request_not_found
+             | :already_terminal
+             | {:invalid_scheduler_explanation, term()}}
   def record_schedule(%Request{id: request_id}, schedule),
     do: record_schedule(request_id, schedule)
 

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -303,6 +303,12 @@ defmodule Orchard.Requests do
 
   Sets `scheduler_decision` (normalized to JSON-safe map) and optionally
   sets `node_id` when the schedule contains a non-nil UUID.
+
+  When the schedule carries scheduler-explanation candidate keys
+  (`scored_candidates`, `rejected_candidates`, or `skipped_candidates`), they
+  are validated against the shared `SchedulerExplanation` contract before
+  persistence; an invalid explanation returns
+  `{:error, {:invalid_scheduler_explanation, reason}}` and persists nothing.
   """
   @spec record_schedule(struct() | Ecto.UUID.t(), map()) ::
           {:ok, struct()}

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -5,6 +5,7 @@ defmodule Orchard.Requests do
 
   import Ecto.Query
 
+  alias Orchard.ClusterManagement.SchedulerExplanation
   alias Orchard.Repo
   alias Orchard.Requests.{Request, RequestEvent, RequestStepEvent}
 
@@ -312,14 +313,18 @@ defmodule Orchard.Requests do
     Repo.transaction(fn ->
       case lock_request(request_id) do
         {:ok, request} ->
-          attrs = %{
-            scheduler_decision: normalize_schedule(schedule),
-            node_id: Map.get(schedule, :node_id)
-          }
+          with {:ok, normalized_schedule} <- normalize_schedule(schedule) do
+            attrs = %{
+              scheduler_decision: normalized_schedule,
+              node_id: Map.get(schedule, :node_id)
+            }
 
-          request
-          |> Request.schedule_changeset(attrs)
-          |> Repo.update()
+            request
+            |> Request.schedule_changeset(attrs)
+            |> Repo.update()
+          else
+            {:error, reason} -> Repo.rollback(reason)
+          end
 
         {:error, :request_not_found} ->
           Repo.rollback(:request_not_found)
@@ -363,7 +368,27 @@ defmodule Orchard.Requests do
   defp bounded_positive_integer(_value, default), do: default
 
   defp normalize_schedule(schedule) when is_map(schedule) do
-    normalize_schedule_value(schedule)
+    normalized = normalize_schedule_value(schedule)
+
+    case validate_scheduler_explanation(normalized) do
+      :ok -> {:ok, normalized}
+      {:error, reason} -> {:error, {:invalid_scheduler_explanation, reason}}
+    end
+  end
+
+  defp validate_scheduler_explanation(schedule) do
+    if scheduler_explanation?(schedule) do
+      SchedulerExplanation.validate_map(schedule)
+    else
+      :ok
+    end
+  end
+
+  defp scheduler_explanation?(schedule) do
+    Enum.any?(
+      ~w(scored_candidates rejected_candidates skipped_candidates),
+      &Map.has_key?(schedule, &1)
+    )
   end
 
   defp normalize_schedule_value(value) when is_map(value) do
@@ -588,6 +613,9 @@ defmodule Orchard.Requests do
   defp unwrap_transaction_result({:ok, {:error, changeset}}), do: {:error, changeset}
   defp unwrap_transaction_result({:error, :request_not_found}), do: {:error, :request_not_found}
   defp unwrap_transaction_result({:error, :already_terminal}), do: {:error, :already_terminal}
+
+  defp unwrap_transaction_result({:error, {:invalid_scheduler_explanation, reason}}),
+    do: {:error, {:invalid_scheduler_explanation, reason}}
 
   defp unwrap_transaction_result({:error, {:request_event_changeset, changeset}}),
     do: {:error, changeset}

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -260,7 +260,7 @@ defmodule Orchard.Scheduler.MultiNode do
     %{
       selected_node_id: selected.node_id,
       selection_tier: selected_tier,
-      scored_candidates: Enum.map(scored, &scored_candidate(&1, ranking_opts)),
+      scored_candidates: scored_candidate_explanations(scored, ranking_opts),
       rejected_candidates: rejected_candidates(candidates, skipped_node_ids),
       skipped_candidates: skipped_candidates(ranked -- scored, selected_tier),
       request_id: request.public_id
@@ -273,8 +273,28 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp scored_candidates(ranked, _selected_tier), do: ranked
 
-  defp scored_candidate(candidate, ranking_opts) do
-    components = scheduler_score_components(candidate, ranking_opts)
+  defp scored_candidate_explanations(scored, ranking_opts) do
+    total = length(scored)
+    qualitative = Enum.map(scored, &qualitative_score_components(&1, ranking_opts))
+    rank_step = rank_score_step(qualitative)
+
+    [scored, qualitative]
+    |> Enum.zip()
+    |> Enum.with_index()
+    |> Enum.map(fn {{candidate, components}, rank} ->
+      scored_candidate(candidate, components, (total - rank) * rank_step)
+    end)
+  end
+
+  defp rank_score_step(qualitative) do
+    qualitative
+    |> Enum.map(&scheduler_score/1)
+    |> Enum.max(fn -> 0 end)
+    |> Kernel.+(1)
+  end
+
+  defp scored_candidate(candidate, qualitative_components, rank_base) do
+    components = Map.put(qualitative_components, :rank_base, rank_base)
 
     %{
       node_id: candidate.node_id,
@@ -292,7 +312,7 @@ defmodule Orchard.Scheduler.MultiNode do
     |> Enum.sum()
   end
 
-  defp scheduler_score_components(candidate, ranking_opts) do
+  defp qualitative_score_components(candidate, ranking_opts) do
     %{
       residency_bonus: residency_bonus(candidate),
       load_bonus: load_bonus(candidate),

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -194,6 +194,8 @@ defmodule Orchard.Scheduler.MultiNode do
             ranking_opts
           )
 
+        selected_tier = if(selected.loaded_model?, do: "loaded", else: "cold")
+
         schedule =
           %{
             strategy: :multi_node,
@@ -204,7 +206,7 @@ defmodule Orchard.Scheduler.MultiNode do
             node_id: selected.node_id,
             candidate_count: length(ranked),
             queue_lane_capacity: queue_lane_capacity(available_candidates),
-            selected_tier: if(selected.loaded_model?, do: "loaded", else: "cold")
+            selected_tier: selected_tier
           }
           |> maybe_put_runtime_client_target(selected.target)
           |> maybe_put_prefix_cache_status(Map.get(selected, :prefix_cache_status))
@@ -214,6 +216,9 @@ defmodule Orchard.Scheduler.MultiNode do
           )
           |> maybe_put_prefix_cache_score(selected_score)
           |> maybe_put_memory_admission(selected, memory_admission_enabled?)
+          |> Map.merge(
+            scheduler_explanation(request, selected, selected_tier, ranked, candidates)
+          )
 
         {:ok,
          Map.merge(schedule, CacheAffinity.scheduler_metadata(affinity_context, ranked, selected))}
@@ -240,6 +245,72 @@ defmodule Orchard.Scheduler.MultiNode do
          _beam_identity_rejected?
        ),
        do: :select_candidate
+
+  defp scheduler_explanation(request, selected, selected_tier, ranked, candidates) do
+    scored = scored_candidates(ranked, selected_tier)
+    skipped_node_ids = MapSet.new(Enum.map(ranked -- scored, & &1.node_id))
+
+    %{
+      selected_node_id: selected.node_id,
+      selection_tier: selected_tier,
+      scored_candidates: Enum.map(scored, &scored_candidate/1),
+      rejected_candidates: rejected_candidates(candidates, skipped_node_ids),
+      skipped_candidates: skipped_candidates(ranked -- scored, selected_tier),
+      request_id: request.public_id
+    }
+  end
+
+  defp scored_candidates(ranked, "loaded") do
+    Enum.filter(ranked, & &1.loaded_model?)
+  end
+
+  defp scored_candidates(ranked, _selected_tier), do: ranked
+
+  defp scored_candidate(candidate) do
+    %{
+      node_id: candidate.node_id,
+      eligible: true,
+      tier: candidate_tier(candidate),
+      reason_codes: []
+    }
+  end
+
+  defp rejected_candidates(candidates, skipped_node_ids) do
+    candidates
+    |> Enum.reject(&MapSet.member?(skipped_node_ids, &1.node_id))
+    |> Enum.reject(&(rejection_reason_codes(&1) == []))
+    |> Enum.map(fn candidate ->
+      %{node_id: candidate.node_id, reason_codes: rejection_reason_codes(candidate)}
+    end)
+  end
+
+  defp skipped_candidates(candidates, "loaded") do
+    Enum.map(candidates, fn candidate ->
+      %{
+        node_id: candidate.node_id,
+        reason_codes: ["lower_tier_not_considered"]
+      }
+    end)
+  end
+
+  defp skipped_candidates(_candidates, _selected_tier), do: []
+
+  defp rejection_reason_codes(candidate) do
+    [
+      rejection_reason(candidate, &runtime_endpoint_unavailable?/1, "runtime_not_ready"),
+      rejection_reason(candidate, &node_concurrency_full?/1, "node_concurrency_exhausted"),
+      rejection_reason(candidate, &placement_capacity_full?/1, "placement_concurrency_exhausted"),
+      rejection_reason(candidate, &active_without_known_capacity?/1, "unknown_capacity")
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp rejection_reason(candidate, predicate, code) do
+    if predicate.(candidate), do: code
+  end
+
+  defp candidate_tier(%{loaded_model?: true}), do: "loaded"
+  defp candidate_tier(_candidate), do: "cold"
 
   defp probe_target(target, client, timeout, observed_at, request) do
     case client.connect(target) do

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -217,7 +217,14 @@ defmodule Orchard.Scheduler.MultiNode do
           |> maybe_put_prefix_cache_score(selected_score)
           |> maybe_put_memory_admission(selected, memory_admission_enabled?)
           |> Map.merge(
-            scheduler_explanation(request, selected, selected_tier, ranked, candidates)
+            scheduler_explanation(
+              request,
+              selected,
+              selected_tier,
+              ranked,
+              candidates,
+              ranking_opts
+            )
           )
 
         {:ok,
@@ -246,14 +253,14 @@ defmodule Orchard.Scheduler.MultiNode do
        ),
        do: :select_candidate
 
-  defp scheduler_explanation(request, selected, selected_tier, ranked, candidates) do
+  defp scheduler_explanation(request, selected, selected_tier, ranked, candidates, ranking_opts) do
     scored = scored_candidates(ranked, selected_tier)
     skipped_node_ids = MapSet.new(Enum.map(ranked -- scored, & &1.node_id))
 
     %{
       selected_node_id: selected.node_id,
       selection_tier: selected_tier,
-      scored_candidates: Enum.map(scored, &scored_candidate/1),
+      scored_candidates: Enum.map(scored, &scored_candidate(&1, ranking_opts)),
       rejected_candidates: rejected_candidates(candidates, skipped_node_ids),
       skipped_candidates: skipped_candidates(ranked -- scored, selected_tier),
       request_id: request.public_id
@@ -266,14 +273,69 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp scored_candidates(ranked, _selected_tier), do: ranked
 
-  defp scored_candidate(candidate) do
+  defp scored_candidate(candidate, ranking_opts) do
+    components = scheduler_score_components(candidate, ranking_opts)
+
     %{
       node_id: candidate.node_id,
       eligible: true,
       tier: candidate_tier(candidate),
+      score: scheduler_score(components),
+      components: components,
       reason_codes: []
     }
   end
+
+  defp scheduler_score(components) do
+    components
+    |> Map.values()
+    |> Enum.sum()
+  end
+
+  defp scheduler_score_components(candidate, ranking_opts) do
+    %{
+      residency_bonus: residency_bonus(candidate),
+      load_bonus: load_bonus(candidate),
+      health_bonus: health_bonus(candidate)
+    }
+    |> maybe_put_score_component(
+      :cache_affinity_bonus,
+      200,
+      Map.get(candidate, :cache_affinity_match?, false)
+    )
+    |> maybe_put_score_component(
+      :live_fingerprint_bonus,
+      100,
+      Keyword.get(ranking_opts, :live_fingerprint_match?, false) and
+        Map.get(candidate, :prefix_cache_fingerprint_match?, false)
+    )
+    |> maybe_put_score_component(
+      :capable_worker_bonus,
+      25,
+      Keyword.get(ranking_opts, :prefer_capable_workers?, false) and
+        Map.get(candidate, :capable_worker_preferred?, false)
+    )
+    |> maybe_put_score_component(
+      :memory_headroom_bonus,
+      72,
+      Keyword.get(ranking_opts, :memory_admission?, false) and
+        Map.get(candidate, :memory_headroom_ok?, false)
+    )
+  end
+
+  defp residency_bonus(%{loaded_model?: true}), do: 500
+  defp residency_bonus(_candidate), do: 0
+
+  defp load_bonus(candidate), do: max(40 - active_request_rank(candidate) * 10, 0)
+
+  defp health_bonus(%{node: %{health: :healthy}}), do: 30
+  defp health_bonus(%{node: %{health: :degraded}}), do: 10
+  defp health_bonus(_candidate), do: 0
+
+  defp maybe_put_score_component(components, _key, _value, false), do: components
+
+  defp maybe_put_score_component(components, key, value, true),
+    do: Map.put(components, key, value)
 
   defp rejected_candidates(candidates, skipped_node_ids) do
     candidates

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -359,12 +359,12 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp rejected_candidates(candidates, skipped_node_ids) do
     candidates
-    |> Enum.reject(fn candidate ->
-      MapSet.member?(skipped_node_ids, candidate.node_id) or
-        rejection_reason_codes(candidate) == []
+    |> Enum.map(fn candidate -> {candidate, rejection_reason_codes(candidate)} end)
+    |> Enum.reject(fn {candidate, reason_codes} ->
+      MapSet.member?(skipped_node_ids, candidate.node_id) or reason_codes == []
     end)
-    |> Enum.map(fn candidate ->
-      %{node_id: candidate.node_id, reason_codes: rejection_reason_codes(candidate)}
+    |> Enum.map(fn {candidate, reason_codes} ->
+      %{node_id: candidate.node_id, reason_codes: reason_codes}
     end)
   end
 

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -277,8 +277,10 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp rejected_candidates(candidates, skipped_node_ids) do
     candidates
-    |> Enum.reject(&MapSet.member?(skipped_node_ids, &1.node_id))
-    |> Enum.reject(&(rejection_reason_codes(&1) == []))
+    |> Enum.reject(fn candidate ->
+      MapSet.member?(skipped_node_ids, candidate.node_id) or
+        rejection_reason_codes(candidate) == []
+    end)
     |> Enum.map(fn candidate ->
       %{node_id: candidate.node_id, reason_codes: rejection_reason_codes(candidate)}
     end)

--- a/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
@@ -1,0 +1,124 @@
+defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
+  use Orchard.ConnCase, async: false
+
+  alias Orchard.API.Router
+  alias Orchard.Governance
+  alias Orchard.Governance.RoleBinding
+  alias Orchard.Repo
+  alias Orchard.Requests
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  describe "GET /ops/v1/scheduler/explanations/:request_id" do
+    @describetag :db
+
+    test "SPEC.md §7.3.5 returns stable selected rejected and skipped candidate reason-code arrays",
+         _context do
+      token = operator_token!("ops-scheduler-explanations")
+      request = create_request!(%{public_id: "resp_scheduler_explanation"})
+
+      assert {:ok, _request} =
+               Requests.record_schedule(request, %{
+                 request_id: request.public_id,
+                 selected_node_id: "node-selected",
+                 selection_tier: :loaded,
+                 scored_candidates: [
+                   %{
+                     node_id: "node-selected",
+                     eligible: true,
+                     tier: :loaded,
+                     score: 842,
+                     components: %{pool_bonus: 200},
+                     reason_codes: []
+                   }
+                 ],
+                 rejected_candidates: [
+                   %{
+                     node_id: "node-rejected",
+                     reason_codes: [:node_not_active, "insufficient_memory"]
+                   }
+                 ],
+                 skipped_candidates: [
+                   %{
+                     node_id: "node-skipped",
+                     reason_codes: [:lower_tier_not_considered]
+                   }
+                 ]
+               })
+
+      conn =
+        build_conn(:get, "/ops/v1/scheduler/explanations/#{request.public_id}")
+        |> put_req_header("accept", "application/json")
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> Router.call(Router.init([]))
+
+      assert conn.status == 200
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "request_id" => request.public_id,
+               "selected_node_id" => "node-selected",
+               "selection_tier" => "loaded",
+               "scored_candidates" => [
+                 %{
+                   "node_id" => "node-selected",
+                   "target_ref" => nil,
+                   "eligible" => true,
+                   "tier" => "loaded",
+                   "score" => 842,
+                   "components" => %{"pool_bonus" => 200},
+                   "diagnostics" => %{},
+                   "reason_codes" => []
+                 }
+               ],
+               "rejected_candidates" => [
+                 %{
+                   "node_id" => "node-rejected",
+                   "target_ref" => nil,
+                   "eligible" => false,
+                   "tier" => nil,
+                   "score" => nil,
+                   "components" => %{},
+                   "diagnostics" => %{},
+                   "reason_codes" => ["node_not_active", "insufficient_memory"]
+                 }
+               ],
+               "skipped_candidates" => [
+                 %{
+                   "node_id" => "node-skipped",
+                   "target_ref" => nil,
+                   "eligible" => false,
+                   "tier" => nil,
+                   "score" => nil,
+                   "components" => %{},
+                   "diagnostics" => %{},
+                   "reason_codes" => ["lower_tier_not_considered"]
+                 }
+               ]
+             }
+    end
+  end
+
+  defp operator_token!(slug) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+
+    {:ok, api_client} =
+      Governance.upsert_api_client(tenant, %{
+        name: "#{slug}-client",
+        owner_contact: "owner@example.com"
+      })
+
+    %RoleBinding{}
+    |> RoleBinding.changeset(%{
+      principal_type: :service_account,
+      principal_id: api_client.id,
+      role: :operator,
+      tenant_scope_id: nil
+    })
+    |> Repo.insert!()
+
+    {:ok, %{token: token}} =
+      Governance.create_api_client_api_token(api_client, %{name: "Operator"})
+
+    token
+  end
+end

--- a/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
@@ -12,45 +12,118 @@ defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
   describe "GET /ops/v1/scheduler/explanations/:request_id" do
     @describetag :db
 
+    test "SPEC.md §7.3 rejects missing and malformed bearer tokens with 401" do
+      assert_operator_auth_error(build_conn(:get, explanation_path("missing-token")), 401)
+
+      conn =
+        build_conn(:get, explanation_path("malformed-token"))
+        |> put_req_header("authorization", "Token nope")
+
+      assert_operator_auth_error(conn, 401)
+    end
+
+    test "SPEC.md §7.3 rejects public tenant API tokens with 403" do
+      %{token: token} = create_tenant_token!("ops-scheduler-public-token")
+
+      token
+      |> authorized_conn("public-token")
+      |> assert_operator_required()
+    end
+
+    test "SPEC.md §7.3 rejects tenant-scoped service-account tokens with 403" do
+      %{token: token} =
+        create_api_client_token!("ops-scheduler-tenant-token", role: :inference_client)
+
+      token
+      |> authorized_conn("tenant-token")
+      |> assert_operator_required()
+    end
+
+    test "SPEC.md §7.3 rejects tenant-scoped operator role bindings with 403" do
+      %{token: token} =
+        create_api_client_token!("ops-scheduler-tenant-operator", role: :tenant_operator)
+
+      token
+      |> authorized_conn("tenant-operator")
+      |> assert_operator_required()
+    end
+
+    test "SPEC.md §7.3 rejects disabled service-account tokens with 403" do
+      %{token: token} =
+        create_api_client_token!("ops-scheduler-disabled-operator",
+          role: :operator,
+          disabled?: true
+        )
+
+      token
+      |> authorized_conn("disabled-operator")
+      |> assert_operator_required()
+    end
+
+    test "SPEC.md §7.3 allows cluster-scoped admin service-account tokens" do
+      %{token: token} = create_api_client_token!("ops-scheduler-admin-token", role: :admin)
+      request = persist_valid_explanation!("resp_scheduler_explanation_admin")
+
+      conn = get_explanation(token, request.public_id)
+
+      assert conn.status == 200
+      assert Jason.decode!(conn.resp_body)["request_id"] == request.public_id
+    end
+
+    test "SPEC.md §7.3.5 returns 404 when the request id has no scheduler explanation" do
+      token = operator_token!("ops-scheduler-explanation-missing")
+
+      conn = get_explanation(token, "resp_unknown_scheduler_explanation")
+
+      assert conn.status == 404
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "error" => %{
+                 "code" => "scheduler_explanation_not_found",
+                 "message" => "Scheduler explanation was not found."
+               }
+             }
+    end
+
+    test "SPEC.md §7.3.5 returns 422 when a persisted scheduler explanation is invalid" do
+      token = operator_token!("ops-scheduler-explanation-invalid")
+
+      request =
+        create_request!(%{
+          public_id: "resp_scheduler_explanation_invalid",
+          scheduler_decision: %{
+            "request_id" => "resp_scheduler_explanation_invalid",
+            "selected_node_id" => "node-selected",
+            "selection_tier" => "loaded",
+            "scored_candidates" => [],
+            "rejected_candidates" => [
+              %{"node_id" => "node-rejected", "reason_codes" => ["not_a_scheduler_code"]}
+            ],
+            "skipped_candidates" => []
+          }
+        })
+
+      conn = get_explanation(token, request.public_id)
+
+      assert conn.status == 422
+
+      assert %{
+               "error" => %{
+                 "code" => "scheduler_explanation_invalid",
+                 "message" => "Persisted scheduler explanation is invalid.",
+                 "details" => details
+               }
+             } = Jason.decode!(conn.resp_body)
+
+      assert details =~ "not_a_scheduler_code"
+    end
+
     test "SPEC.md §7.3.5 returns stable selected rejected and skipped candidate reason-code arrays",
          _context do
       token = operator_token!("ops-scheduler-explanations")
-      request = create_request!(%{public_id: "resp_scheduler_explanation"})
+      request = persist_valid_explanation!("resp_scheduler_explanation")
 
-      assert {:ok, _request} =
-               Requests.record_schedule(request, %{
-                 request_id: request.public_id,
-                 selected_node_id: "node-selected",
-                 selection_tier: :loaded,
-                 scored_candidates: [
-                   %{
-                     node_id: "node-selected",
-                     eligible: true,
-                     tier: :loaded,
-                     score: 842,
-                     components: %{pool_bonus: 200},
-                     reason_codes: []
-                   }
-                 ],
-                 rejected_candidates: [
-                   %{
-                     node_id: "node-rejected",
-                     reason_codes: [:node_not_active, "insufficient_memory"]
-                   }
-                 ],
-                 skipped_candidates: [
-                   %{
-                     node_id: "node-skipped",
-                     reason_codes: [:lower_tier_not_considered]
-                   }
-                 ]
-               })
-
-      conn =
-        build_conn(:get, "/ops/v1/scheduler/explanations/#{request.public_id}")
-        |> put_req_header("accept", "application/json")
-        |> put_req_header("authorization", "Bearer #{token}")
-        |> Router.call(Router.init([]))
+      conn = get_explanation(token, request.public_id)
 
       assert conn.status == 200
 
@@ -98,7 +171,99 @@ defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
     end
   end
 
+  defp persist_valid_explanation!(public_id) do
+    request = create_request!(%{public_id: public_id})
+
+    assert {:ok, request} =
+             Requests.record_schedule(request, %{
+               request_id: request.public_id,
+               selected_node_id: "node-selected",
+               selection_tier: :loaded,
+               scored_candidates: [
+                 %{
+                   node_id: "node-selected",
+                   eligible: true,
+                   tier: :loaded,
+                   score: 842,
+                   components: %{pool_bonus: 200},
+                   reason_codes: []
+                 }
+               ],
+               rejected_candidates: [
+                 %{
+                   node_id: "node-rejected",
+                   reason_codes: [:node_not_active, "insufficient_memory"]
+                 }
+               ],
+               skipped_candidates: [
+                 %{
+                   node_id: "node-skipped",
+                   reason_codes: [:lower_tier_not_considered]
+                 }
+               ]
+             })
+
+    request
+  end
+
+  defp get_explanation(token, request_id) do
+    token
+    |> authorized_conn(request_id)
+    |> Router.call(Router.init([]))
+  end
+
+  defp authorized_conn(token, request_id) do
+    build_conn(:get, explanation_path(request_id))
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("authorization", "Bearer #{token}")
+  end
+
+  defp explanation_path(request_id), do: "/ops/v1/scheduler/explanations/#{request_id}"
+
+  defp assert_operator_auth_error(conn, status) do
+    conn = Router.call(conn, Router.init([]))
+
+    assert conn.halted
+    assert conn.status == status
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "error" => %{
+               "code" => "invalid_api_key",
+               "message" => "Invalid API key provided."
+             }
+           }
+  end
+
+  defp assert_operator_required(conn) do
+    conn = Router.call(conn, Router.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "error" => %{
+               "code" => "operator_required",
+               "message" =>
+                 "Operator API requires a cluster-scoped operator or admin API Client token."
+             }
+           }
+  end
+
+  defp create_tenant_token!(slug) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+
+    {:ok, %{api_key: api_key, token: token}} =
+      Governance.create_api_key(tenant, %{name: "Primary"})
+
+    %{tenant: tenant, api_key: api_key, token: token}
+  end
+
   defp operator_token!(slug) do
+    %{token: token} = create_api_client_token!(slug, role: :operator)
+    token
+  end
+
+  defp create_api_client_token!(slug, opts) do
     {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
 
     {:ok, api_client} =
@@ -107,18 +272,42 @@ defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
         owner_contact: "owner@example.com"
       })
 
+    grant_role!(api_client, tenant, Keyword.fetch!(opts, :role))
+
+    {:ok, %{api_key: api_key, token: token}} =
+      Governance.create_api_client_api_token(api_client, %{name: "Primary"})
+
+    if Keyword.get(opts, :disabled?, false) do
+      {:ok, _disabled} = Governance.disable_api_client(tenant, api_client)
+    end
+
+    %{tenant: tenant, api_client: api_client, api_key: api_key, token: token}
+  end
+
+  defp grant_role!(api_client, _tenant, :admin) do
+    {:ok, _role_binding} = Governance.ensure_cluster_admin_access(api_client)
+  end
+
+  defp grant_role!(api_client, tenant, :inference_client) do
+    {:ok, _role_binding} = Governance.ensure_inference_client_access(api_client, tenant)
+  end
+
+  defp grant_role!(api_client, _tenant, :operator) do
+    insert_role_binding!(api_client, :operator, nil)
+  end
+
+  defp grant_role!(api_client, tenant, :tenant_operator) do
+    insert_role_binding!(api_client, :operator, tenant.id)
+  end
+
+  defp insert_role_binding!(api_client, role, tenant_scope_id) do
     %RoleBinding{}
     |> RoleBinding.changeset(%{
       principal_type: :service_account,
       principal_id: api_client.id,
-      role: :operator,
-      tenant_scope_id: nil
+      role: role,
+      tenant_scope_id: tenant_scope_id
     })
     |> Repo.insert!()
-
-    {:ok, %{token: token}} =
-      Governance.create_api_client_api_token(api_client, %{name: "Operator"})
-
-    token
   end
 end

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -996,6 +996,8 @@ defmodule Orchard.Inference.QueueManagerTest do
                config: config
              )
 
+    assert QueueManager.queued_metadata(ticket).queue_wait_reason == :tenant_active_capacity
+
     awaiter = Task.async(fn -> QueueManager.await(ticket) end)
     refute Task.yield(awaiter, 50)
 

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -1478,6 +1478,26 @@ defmodule Orchard.Inference.QueueManagerTest do
     end)
   end
 
+  test "SPEC.md §7.3.5 requeue preserves explicit placement capacity wait reason" do
+    config = queue_config(max_wait_ms: 500, poll_interval_ms: 200)
+
+    with_queue_admission_config(config, fn ->
+      request = admission_request("req-requeue-placement-capacity")
+
+      assert {:ok, grant} = QueueManager.acquire(request)
+
+      assert {:queued, ticket} =
+               QueueManager.requeue(grant, request,
+                 config: config,
+                 queue_wait_reason: :placement_capacity
+               )
+
+      assert QueueManager.queued_metadata(ticket).queue_wait_reason == :placement_capacity
+
+      assert :ok = QueueManager.abandon(ticket)
+    end)
+  end
+
   test "SPEC.md §5.5 cluster_busy requeue retires source before other lane promotion" do
     assert_busy_requeue_retires_source(:cluster_busy)
   end

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -23,6 +23,28 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler do
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.StubMalformedExplanationScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
+
+  def schedule(%CanonicalRequest{} = request) do
+    with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
+      {:ok,
+       Map.merge(schedule, %{
+         selected_node_id: StubMultiNodeScheduler.scheduled_node_id(),
+         selection_tier: :loaded,
+         scored_candidates: [],
+         rejected_candidates: [
+           %{node_id: "00000000-0000-4000-a000-0000000000bb", reason_codes: [:made_up_reason]}
+         ],
+         skipped_candidates: []
+       })}
+    end
+  end
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointTargetScheduler do
   @behaviour Orchard.Scheduler.SingleNode
 
@@ -627,6 +649,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
   alias Orchard.Inference.RequestOrchestratorTest.StubCacheAffinityScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubLiveCapacityScheduler
+  alias Orchard.Inference.RequestOrchestratorTest.StubMalformedExplanationScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryTierOnlyScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryUnavailableScheduler
@@ -634,6 +657,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheUnavailableScheduler
 
+  alias Orchard.API.Ops.SchedulerExplanationPresenter
   alias Orchard.ArtifactBundle
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.CacheAffinity
@@ -815,6 +839,29 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert request.scheduler_decision["candidate_count"] == 2
     assert request.scheduler_decision["selected_tier"] == "loaded"
     assert request.scheduler_decision["node_id"] == scheduled_node_id()
+  end
+
+  test "SPEC.md §7.3.5 execute/3 fails open and completes dispatch when the scheduler explanation is invalid",
+       %{bundle: bundle} do
+    put_malformed_explanation_scheduler_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-bad-explanation")
+    canonical = canonical_request("request-orchestrator-bad-explanation", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    decision = request.scheduler_decision
+
+    assert decision["strategy"] == "multi_node"
+    assert decision["node_id"] == scheduled_node_id()
+    refute Map.has_key?(decision, "scored_candidates")
+    refute Map.has_key?(decision, "rejected_candidates")
+    refute Map.has_key?(decision, "skipped_candidates")
+
+    assert {:ok, %{scored_candidates: [], rejected_candidates: [], skipped_candidates: []}} =
+             SchedulerExplanationPresenter.show(request)
   end
 
   test "execute/3 strips dispatch-only runtime endpoint target metadata", %{bundle: bundle} do
@@ -2905,6 +2952,16 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
         ],
         scheduler_impl: Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
       )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+  end
+
+  defp put_malformed_explanation_scheduler_config do
+    put_multi_node_scheduler_config()
+
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.put(:scheduler_impl, StubMalformedExplanationScheduler)
 
     Application.put_env(:orchard_controller, :inference, inference)
   end

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -481,7 +481,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest.PreAwaitTerminalQueueManager
        queue_key: queue_key,
        queued_at: queued_at,
        enqueued_monotonic_ms: System.monotonic_time(:millisecond),
-       max_wait_ms: 1
+       max_wait_ms: 1,
+       queue_wait_reason: :requested_model_path_capacity
      }}
   end
 
@@ -1639,6 +1640,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     queued_request = Requests.get_request_by_public_id(canonical.public_id)
     assert_queue_metadata(queued_request, "queued", queued?: true)
+    assert queued_request.scheduler_decision["queue_wait_reason"] == "live_node_capacity"
     refute Map.has_key?(queued_request.scheduler_decision || %{}, "queue_grant_id")
 
     assert {:live_capacity_schedule_attempt, retry_scheduler_pid, ^public_id} =
@@ -1686,6 +1688,10 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     queued_request = Requests.get_request_by_public_id(canonical.public_id)
     assert_queue_metadata(queued_request, "queued", queued?: true)
+
+    assert queued_request.scheduler_decision["queue_wait_reason"] ==
+             "requested_model_path_capacity"
+
     refute Map.has_key?(queued_request.scheduler_decision || %{}, "queue_grant_id")
 
     assert {:live_capacity_schedule_attempt, retry_scheduler_pid, ^public_id} =

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -905,6 +905,28 @@ defmodule Orchard.RequestsTest do
              }
     end
 
+    test "rejects scheduler explanations with reason codes outside the accepted vocabulary" do
+      request = create_request!(%{public_id: "req_schedule_invalid_reason"})
+
+      schedule = %{
+        request_id: request.public_id,
+        selected_node_id: "node-a",
+        selection_tier: :loaded,
+        scored_candidates: [],
+        rejected_candidates: [
+          %{node_id: "node-b", reason_codes: [:made_up_reason]}
+        ],
+        skipped_candidates: []
+      }
+
+      assert {:error,
+              {:invalid_scheduler_explanation,
+               {:unknown_code, :scheduler_rejection, "made_up_reason"}}} =
+               Requests.record_schedule(request, schedule)
+
+      assert Repo.get!(Orchard.Requests.Request, request.id).scheduler_decision == nil
+    end
+
     test "preserves nil node_id when schedule has no node" do
       request = create_request!(%{public_id: "req_schedule_3"})
 

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -868,6 +868,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
                  status_client: StubClient
                )
 
+      assert :ok = Orchard.ClusterManagement.SchedulerExplanation.validate_map(schedule)
       assert schedule.node_id == node_b.id
 
       assert schedule.scored_candidates == [

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -827,6 +827,73 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.candidate_count == 2
     end
 
+    test "SPEC.md §7.3.5 scheduler explanation separates selected rejected and skipped candidates" do
+      node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})
+      node_c = insert_node!(%{advertise_addr: "10.0.0.3", rpc_port: 50_063})
+
+      put_inference(
+        runtime_client_targets: [
+          [host: "10.0.0.1", port: 50_061],
+          [host: "10.0.0.2", port: 50_062],
+          [host: "10.0.0.3", port: 50_063]
+        ]
+      )
+
+      stub_probe("10.0.0.1", 50_061, make_status(node_a.id, host: "10.0.0.1", port: 50_061))
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(node_b.id,
+          host: "10.0.0.2",
+          port: 50_062,
+          loaded_models: [%{model_id: "test-model", version: "v1"}]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.3",
+        50_063,
+        make_status(node_c.id,
+          host: "10.0.0.3",
+          port: 50_063,
+          active_request_count: 1,
+          max_concurrency: 1
+        )
+      )
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request("test-model", "v1"),
+                 status_client: StubClient
+               )
+
+      assert schedule.node_id == node_b.id
+
+      assert schedule.scored_candidates == [
+               %{
+                 node_id: node_b.id,
+                 eligible: true,
+                 tier: "loaded",
+                 reason_codes: []
+               }
+             ]
+
+      assert schedule.rejected_candidates == [
+               %{
+                 node_id: node_c.id,
+                 reason_codes: ["node_concurrency_exhausted"]
+               }
+             ]
+
+      assert schedule.skipped_candidates == [
+               %{
+                 node_id: node_a.id,
+                 reason_codes: ["lower_tier_not_considered"]
+               }
+             ]
+    end
+
     test "keeps probe candidates when disconnect cleanup raises" do
       node_a = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
       node_b = insert_node!(%{advertise_addr: "10.0.0.2", rpc_port: 50_062})

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -7,6 +7,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
   alias Orchard.CanonicalRequest
   alias Orchard.CanonicalRequest.ModelRef
   alias Orchard.Cluster.V1.ScorePrefixCacheResponse
+  alias Orchard.ClusterManagement.SchedulerExplanation
   alias Orchard.Inference.CacheAffinity
   alias Orchard.Inference.QueueManager
   alias Orchard.Nodes.Node
@@ -868,7 +869,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
                  status_client: StubClient
                )
 
-      assert :ok = Orchard.ClusterManagement.SchedulerExplanation.validate_map(schedule)
+      assert :ok = SchedulerExplanation.validate_map(schedule)
       assert schedule.node_id == node_b.id
 
       assert schedule.scored_candidates == [

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -877,8 +877,9 @@ defmodule Orchard.Scheduler.MultiNodeTest do
                  node_id: node_b.id,
                  eligible: true,
                  tier: "loaded",
-                 score: 570,
+                 score: 1141,
                  components: %{
+                   rank_base: 571,
                    residency_bonus: 500,
                    load_bonus: 40,
                    health_bonus: 30
@@ -900,6 +901,53 @@ defmodule Orchard.Scheduler.MultiNodeTest do
                  reason_codes: ["lower_tier_not_considered"]
                }
              ]
+    end
+
+    test "SPEC.md §7.3.5 (OpenSpec task 7.4) scored candidate scores stay ordered with actual ranking" do
+      {id_a, id_b} = insert_ordered_nodes!()
+      set_node_health!(id_a, :degraded)
+      set_node_health!(id_b, :healthy)
+
+      stub_probe(
+        "10.0.0.1",
+        50_061,
+        make_status(id_a,
+          host: "10.0.0.1",
+          port: 50_061,
+          health: %{ready: true, health_code: "warn", health_message: "degraded"},
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          runtime_model_placements: [model_placement("test-model", "v1", 0, 4)]
+        )
+      )
+
+      stub_probe(
+        "10.0.0.2",
+        50_062,
+        make_status(id_b,
+          host: "10.0.0.2",
+          port: 50_062,
+          loaded_models: [%{model_id: "test-model", version: "v1"}],
+          runtime_model_placements: [model_placement("test-model", "v1", 1, 4)]
+        )
+      )
+
+      request = canonical_request("test-model", "v1")
+
+      assert {:ok, schedule} = MultiNode.schedule(request, status_client: StubClient)
+      assert :ok = SchedulerExplanation.validate_map(schedule)
+
+      assert schedule.node_id == id_a
+      assert [first, second] = schedule.scored_candidates
+      assert first.node_id == id_a
+      assert second.node_id == id_b
+
+      assert first.score > second.score
+      assert first.score == Enum.sum(Map.values(first.components))
+      assert second.score == Enum.sum(Map.values(second.components))
+
+      first_bonuses = Map.delete(first.components, :rank_base)
+      second_bonuses = Map.delete(second.components, :rank_base)
+      assert Enum.sum(Map.values(first_bonuses)) < Enum.sum(Map.values(second_bonuses))
     end
 
     test "keeps probe candidates when disconnect cleanup raises" do

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -877,6 +877,12 @@ defmodule Orchard.Scheduler.MultiNodeTest do
                  node_id: node_b.id,
                  eligible: true,
                  tier: "loaded",
+                 score: 570,
+                 components: %{
+                   residency_bonus: 500,
+                   load_bonus: 40,
+                   health_bonus: 30
+                 },
                  reason_codes: []
                }
              ]

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -89,12 +89,18 @@
 
 ## 7. Scheduler Explanations
 
-- [ ] 7.1 Persist scheduler explanations using stable reason-code arrays.
-- [ ] 7.2 Expose `GET /ops/v1/scheduler/explanations/:request_id` with the accepted reason-code vocabulary.
-- [ ] 7.3 Ensure queue-waitable outcomes preserve whether the reason was live node capacity, requested model path capacity, placement capacity, or tenant active capacity.
-- [ ] 7.4 Add tests that explanations match actual scheduler decisions.
-- [ ] 7.5 Add `skipped_candidates` explanation output with stable skip codes and keep skipped candidates outside the rejected-candidate list.
-- [ ] 7.6 Add tests for selected, rejected, and skipped candidate explanation shapes.
+- [x] 7.1 Persist scheduler explanations using stable reason-code arrays.
+  Note: `Requests.record_schedule/2` now validates scheduler explanation maps against the shared fixed reason-code contract before persisting them.
+- [x] 7.2 Expose `GET /ops/v1/scheduler/explanations/:request_id` with the accepted reason-code vocabulary.
+  Note: The Operator API route now returns persisted scheduler explanations through the shared `SchedulerExplanation` presenter and cluster operator or admin service-account authorization.
+- [x] 7.3 Ensure queue-waitable outcomes preserve whether the reason was live node capacity, requested model path capacity, placement capacity, or tenant active capacity.
+  Note: Queue admission and post-grant requeue metadata now preserve stable `queue_wait_reason` values for tenant active capacity, requested model path capacity, live node capacity, and explicit placement capacity.
+- [x] 7.4 Add tests that explanations match actual scheduler decisions.
+  Note: `MultiNode.schedule/2` tests now assert the generated explanation validates against the shared contract and matches selected, rejected, and skipped scheduler decisions.
+- [x] 7.5 Add `skipped_candidates` explanation output with stable skip codes and keep skipped candidates outside the rejected-candidate list.
+  Note: Multi-node scheduling now emits lower-tier candidates in `skipped_candidates` with `lower_tier_not_considered` instead of reporting them as rejected.
+- [x] 7.6 Add tests for selected, rejected, and skipped candidate explanation shapes.
+  Note: Scheduler tests now cover selected scored candidates, capacity rejected candidates, and skipped lower-tier candidates through the public `MultiNode.schedule/2` API.
 
 ## 8. Validation
 

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -93,8 +93,10 @@
   Note: `Requests.record_schedule/2` now validates scheduler explanation maps against the shared fixed reason-code contract before persisting them.
 - [x] 7.2 Expose `GET /ops/v1/scheduler/explanations/:request_id` with the accepted reason-code vocabulary.
   Note: The Operator API route now returns persisted scheduler explanations through the shared `SchedulerExplanation` presenter and cluster operator or admin service-account authorization.
+  Future slice note: `SPEC.md §7.3.5` defines the not-found code for absent requests but is silent on legacy scheduler decisions without candidate keys, so the endpoint currently keeps returning an empty explanation shape for those rows.
 - [x] 7.3 Ensure queue-waitable outcomes preserve whether the reason was live node capacity, requested model path capacity, placement capacity, or tenant active capacity.
   Note: Queue admission and post-grant requeue metadata now preserve stable `queue_wait_reason` values for tenant active capacity, requested model path capacity, live node capacity, and explicit placement capacity.
+  Future slice note: Placement-capacity queue-wait emission remains incomplete end to end until the orchestrator busy return can carry a placement-specific scheduler reason.
 - [x] 7.4 Add tests that explanations match actual scheduler decisions.
   Note: `MultiNode.schedule/2` tests now assert the generated explanation validates against the shared contract and matches selected, rejected, and skipped scheduler decisions.
 - [x] 7.5 Add `skipped_candidates` explanation output with stable skip codes and keep skipped candidates outside the rejected-candidate list.


### PR DESCRIPTION
## What Changed

- Add a `GET /ops/v1/scheduler/explanations/:request_id` operator endpoint (new `operator_api` router pipeline, `SchedulerExplanationsController`, and `SchedulerExplanationPresenter`) that projects a request's persisted scheduler decision — selected node, tier, and scored/rejected/skipped candidates with reason codes — through the shared `SchedulerExplanation` contract, returning 401/403/404/422 as appropriate. Access is gated by a new `Governance.authorize_operator_api/1` (cluster operator or admin role binding), and the admin/operator bearer-auth flow is deduplicated into a shared `ScopedRequestContext` plug.
- Generate the explanation in `MultiNode.schedule/2` (order-faithful additive scores plus rejection/skip reason codes) and validate candidate payloads in `Requests.record_schedule/2`; the orchestrator's `record_scheduler_decision` fails open — persisting the decision without candidates and logging an error when an explanation is invalid — so an observability defect can't fail live inference.
- Thread a `queue_wait_reason` through the queue manager's enqueue, requeue, and timeout paths so queued requests carry a machine-readable wait reason (e.g. `live_node_capacity`, `requested_model_path_capacity`, tenant concurrency).

## Risk Assessment

✅ Low: A well-bounded follow-up that correctly and provably implements the prior round's instructions (order-faithful scores, decoupled fail-open explanation, deduped auth plug), each backed by targeted regression tests; only a minor, non-functional dedup opportunity remains.

## Testing

Set up the Elixir umbrella (deps, test-env compile, DB create/migrate) then ran every suite touched by the change: the operator-endpoint controller test (9 passed, exercising the real HTTP surface incl. auth/404/422/200), the scheduler/requests/queue-manager tests (242 passed, covering explanation shapes, order-faithful scoring, reason-code validation, and queue_wait_reason preservation), and the orchestrator tests (73 passed from the umbrella root; the earlier in-app-dir failure was purely a run-location issue since the test references a node-agent module). For reviewer-visible product evidence I wrote a throwaway test that drives the real multi-node scheduler through persistence and the Phoenix router with genuine service-account tokens, capturing the actual operator JSON for the 200 explanation (selected node score 1141 with component breakdown, one rejected node_concurrency_exhausted, one skipped lower_tier_not_considered) and the 404/422/401/403 error bodies. All tests pass; the temp test was deleted and the working tree is clean.

<details>
<summary>Evidence: Operator endpoint evidence transcript (all status paths)</summary>

```text
# Operator scheduler-explanations endpoint — evidence transcript

`GET /ops/v1/scheduler/explanations/:request_id`

Captured by driving the real multi-node scheduler, persisting through
`Requests.record_schedule/2`, and calling the endpoint over the Phoenix
router with real service-account tokens.

- Selected (loaded) node explanation persisted for `resp_evidence_scheduler_ok` and returned with HTTP 200.
- Unknown request returns HTTP 404 `scheduler_explanation_not_found`.
- Invalid persisted explanation (`resp_evidence_invalid`) returns HTTP 422 `scheduler_explanation_invalid`.
- Missing bearer token returns HTTP 401 `invalid_api_key`.
- Non-operator tenant token returns HTTP 403 `operator_required`.

### 01_scheduler_decision_raw.json

`` `json
{
  "request_id": "pub_102",
  "node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
  "selected_node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
  "selection_tier": "loaded",
  "scored_candidates": [
    {
      "components": {
        "health_bonus": 30,
        "load_bonus": 40,
        "residency_bonus": 500,
        "rank_base": 571
      },
      "node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
      "eligible": true,
      "reason_codes": [],
      "score": 1141,
      "tier": "loaded"
    }
  ],
  "rejected_candidates": [
    {
      "node_id": "df79b39b-52ac-4d21-b646-0b785003a1f7",
      "reason_codes": [
        "node_concurrency_exhausted"
      ]
    }
  ],
  "skipped_candidates": [
    {
      "node_id": "90cdaf66-487f-440a-94c1-62608e0a4e04",
      "reason_codes": [
        "lower_tier_not_considered"
      ]
    }
  ]
}
`` `

### 02_operator_api_200_success.json

`` `json
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_scheduler_ok",
  "http_status": 200,
  "response_body": {
    "rejected_candidates": [
      {
        "components": {},
        "diagnostics": {},
        "eligible": false,
        "node_id": "df79b39b-52ac-4d21-b646-0b785003a1f7",
        "reason_codes": [
          "node_concurrency_exhausted"
        ],
        "score": null,
        "target_ref": null,
        "tier": null
      }
    ],
    "request_id": "pub_102",
    "scored_candidates": [
      {
        "components": {
          "health_bonus": 30,
          "load_bonus": 40,
          "rank_base": 571,
          "residency_bonus": 500
        },
        "diagnostics": {},
        "eligible": true,
        "node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
        "reason_codes": [],
        "score": 1141,
        "target_ref": null,
        "tier": "loaded"
      }
    ],
    "selected_node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
    "selection_tier": "loaded",
    "skipped_candidates": [
      {
        "components": {},
        "diagnostics": {},
        "eligible": false,
        "node_id": "90cdaf66-487f-440a-94c1-62608e0a4e04",
        "reason_codes": [
          "lower_tier_not_considered"
        ],
        "score": null,
        "target_ref": null,
        "tier": null
      }
    ]
  }
}
`` `

### 03_operator_api_404_not_found.json

`` `json
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_unknown",
  "http_status": 404,
  "response_body": {
    "error": {
      "code": "scheduler_explanation_not_found",
      "message": "Scheduler explanation was not found."
    }
  }
}
`` `

### 04_operator_api_422_invalid.json

`` `json
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_invalid",
  "http_status": 422,
  "response_body": {
    "error": {
      "code": "scheduler_explanation_invalid",
      "details": "{:unknown_code, :scheduler_rejection, \"not_a_scheduler_code\"}",
      "message": "Persisted scheduler explanation is invalid."
    }
  }
}
`` `

### 05_operator_api_401_unauthorized.json

`` `json
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_scheduler_ok",
  "http_status": 401,
  "response_body": {
    "error": {
      "code": "invalid_api_key",
      "message": "Invalid API key provided."
    }
  }
}
`` `

### 06_operator_api_403_forbidden.json

`` `json
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_scheduler_ok",
  "http_status": 403,
  "response_body": {
    "error": {
      "code": "operator_required",
      "message": "Operator API requires a cluster-scoped operator or admin API Client token."
    }
  }
}
`` `
```
</details>
<details>
<summary>Evidence: Real MultiNode.schedule/2 explanation output (selected/rejected/skipped)</summary>

```text
{
  "request_id": "pub_102",
  "node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
  "selected_node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
  "selection_tier": "loaded",
  "scored_candidates": [
    {
      "components": {
        "health_bonus": 30,
        "load_bonus": 40,
        "residency_bonus": 500,
        "rank_base": 571
      },
      "node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
      "eligible": true,
      "reason_codes": [],
      "score": 1141,
      "tier": "loaded"
    }
  ],
  "rejected_candidates": [
    {
      "node_id": "df79b39b-52ac-4d21-b646-0b785003a1f7",
      "reason_codes": [
        "node_concurrency_exhausted"
      ]
    }
  ],
  "skipped_candidates": [
    {
      "node_id": "90cdaf66-487f-440a-94c1-62608e0a4e04",
      "reason_codes": [
        "lower_tier_not_considered"
      ]
    }
  ]
}
```
</details>
<details>
<summary>Evidence: GET /ops/v1/scheduler/explanations/:id — 200 operator response</summary>

`HTTP 200 → selected_node score 1141 {rank_base:571,residency:500,load:40,health:30}, tier loaded; rejected: node_concurrency_exhausted; skipped: lower_tier_not_considered`

```text
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_scheduler_ok",
  "http_status": 200,
  "response_body": {
    "rejected_candidates": [
      {
        "components": {},
        "diagnostics": {},
        "eligible": false,
        "node_id": "df79b39b-52ac-4d21-b646-0b785003a1f7",
        "reason_codes": [
          "node_concurrency_exhausted"
        ],
        "score": null,
        "target_ref": null,
        "tier": null
      }
    ],
    "request_id": "pub_102",
    "scored_candidates": [
      {
        "components": {
          "health_bonus": 30,
          "load_bonus": 40,
          "rank_base": 571,
          "residency_bonus": 500
        },
        "diagnostics": {},
        "eligible": true,
        "node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
        "reason_codes": [],
        "score": 1141,
        "target_ref": null,
        "tier": "loaded"
      }
    ],
    "selected_node_id": "32834b3f-265b-4c7a-8b87-8775347cf0f8",
    "selection_tier": "loaded",
    "skipped_candidates": [
      {
        "components": {},
        "diagnostics": {},
        "eligible": false,
        "node_id": "90cdaf66-487f-440a-94c1-62608e0a4e04",
        "reason_codes": [
          "lower_tier_not_considered"
        ],
        "score": null,
        "target_ref": null,
        "tier": null
      }
    ]
  }
}
```
</details>
<details>
<summary>Evidence: GET explanations — 404 scheduler_explanation_not_found</summary>

```text
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_unknown",
  "http_status": 404,
  "response_body": {
    "error": {
      "code": "scheduler_explanation_not_found",
      "message": "Scheduler explanation was not found."
    }
  }
}
```
</details>
<details>
<summary>Evidence: GET explanations — 422 scheduler_explanation_invalid (bad reason code)</summary>

```text
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_invalid",
  "http_status": 422,
  "response_body": {
    "error": {
      "code": "scheduler_explanation_invalid",
      "details": "{:unknown_code, :scheduler_rejection, \"not_a_scheduler_code\"}",
      "message": "Persisted scheduler explanation is invalid."
    }
  }
}
```
</details>
<details>
<summary>Evidence: GET explanations — 401 invalid_api_key (missing bearer)</summary>

```text
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_scheduler_ok",
  "http_status": 401,
  "response_body": {
    "error": {
      "code": "invalid_api_key",
      "message": "Invalid API key provided."
    }
  }
}
```
</details>
<details>
<summary>Evidence: GET explanations — 403 operator_required (tenant token)</summary>

```text
{
  "request": "GET /ops/v1/scheduler/explanations/resp_evidence_scheduler_ok",
  "http_status": 403,
  "response_body": {
    "error": {
      "code": "operator_required",
      "message": "Operator API requires a cluster-scoped operator or admin API Client token."
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:289` - The operator-facing `score` on scored_candidates is an additive reconstruction (residency 500 / load `max(40 - rank*10,0)` / health 30|10 / optional bonuses) computed independently of the actual lexicographic tuple ranking (`base_rank` = [not loaded?, active_request_rank, health_rank, ...]). Because the tuple weights active_request_rank above health while the additive model weights a healthy/degraded gap (20) more than one rank step (10), the two can invert. Concretely, two loaded candidates — P: rank 0, degraded → tuple [false,0,1], score 500+40+10=550; Q: rank 1, healthy → tuple [false,1,0], score 500+30+30=560 — result in P being selected/ranked first yet displayed with a *lower* score (550) than the non-selected Q (560). Candidates are listed in true ranking order, so the score column can decrease-then-increase, contradicting task 7.4&#39;s goal that explanations match the actual decision. Node selection, tiers, and reason codes are correct; only the numeric score can mislead operators.
- ℹ️ `apps/orchard_controller/lib/orchard/api/ops/scheduler_explanation_presenter.ex:109` - SchedulerExplanationPresenter.show/1 treats any non-nil `scheduler_decision` map as a valid explanation: single-node schedules and queued-but-unscheduled rows (which carry `queue_wait_reason` but no candidate keys, and possibly no node_id) return HTTP 200 with empty scored/rejected/skipped arrays and a possibly-null `selected_node_id`, rather than 404. Only requests with `scheduler_decision == nil` get 404. This is documented as an intentional future-slice tradeoff in the change&#39;s tasks.md (task 7.2 note), so no action is required now — noting it so reviewers are aware the not-found path is narrow.

🔧 Fix: make scheduler explanation scores order-faithful to ranking
3 issues (2 warnings, 1 info) still open:
- ⚠️ `apps/orchard_controller/lib/orchard/requests.ex:320` - record_schedule now short-circuits on {:error, {:invalid_scheduler_explanation, reason}} from normalize_schedule (validate at requests.ex:385). In the primary scheduling path (request_orchestrator.ex:256-261) this error breaks the dispatch `with`, flows to handle_dispatch_pipeline_result({:error, reason}, ...) -&gt; fail_and_return_error, and terminalizes the actual inference request as FAILED. That couples a purely observational payload to the critical dispatch path: a bug in the internally-generated explanation (bad reason code, non-map candidate, etc.) no longer just degrades observability — it fails the user&#39;s request. Consider fail-open: persist the schedule without the invalid explanation and log, so an explanation defect can&#39;t take down live inference. This gate was added deliberately (&#34;harden scheduler explanation slice&#34;), so confirm the intended tradeoff.
- ⚠️ `apps/orchard_controller/lib/orchard/api/operator_request_context.ex:1` - OperatorRequestContext is a near-byte-identical clone of AdminRequestContext: call/2, authenticate_request/2, authorize_request/2, bearer_token/1, parse_bearer_header/1, audit_auth_failure/3, send_auth_error/1 are identical, differing only in the Governance.authorize_* callee, message module attributes, and the operator/admin error code/atom. This is exactly the near-miss structural clone the project&#39;s ex_dna gate (min_mass 80) is configured to catch, and AGENTS.md mandates zero findings plus &#34;extract a shared module&#34; for genuine duplication. Extract a shared base plug parameterized by the authorize function and messages.
- ℹ️ `apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:360` - rejected_candidates/2 evaluates rejection_reason_codes(candidate) twice for each surviving candidate — once in Enum.reject and again in Enum.map — recomputing all four rejection predicates redundantly. Map to {candidate, rejection_reason_codes(candidate)} once, then reject on empty codes and build the result map from the memoized value.

🔧 Fix: decouple explanation validation from dispatch, dedupe auth plugs
1 info still open:
- ℹ️ `apps/orchard_controller/lib/orchard/inference/queue_manager.ex:3408` - `build_grant/5` (line 3408) and `build_grant/6` (line 3420) are near-identical struct builders differing only in the `queue_wait_reason` field, which the `%Grant{}` struct already defaults to nil. `build_grant/5` has a single caller (the immediate-grant path) and can delegate to `build_grant/6` with `queue_wait_reason: nil` (identical output), removing the duplicated 7-field struct literal. This is the kind of near-miss structural clone the project&#39;s ex_dna gate targets.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mix test apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs` — 9 passed (real operator endpoint via Phoenix router: 401 missing/malformed token, 403 public/tenant/tenant-operator/disabled tokens, 200 admin+operator, 404 unknown, 422 invalid persisted explanation)</code>
- <code>`mix test apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs test/orchard/requests_test.exs test/orchard/inference/queue_manager_test.exs` — 242 passed (real MultiNode.schedule/2 explanation shape &amp; order-faithful scores, record_schedule reason-code validation, queue_wait_reason preservation across enqueue/requeue/timeout)</code>
- <code>`mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs` (from umbrella root) — 73 passed; log confirms an invalid explanation is logged as error and the decision persists without candidates instead of failing dispatch</code>
- `Temporary evidence test drove real MultiNode.schedule/2 → Requests.record_schedule/2 → operator API over the Phoenix router with real service-account tokens, writing the actual JSON responses for 200/404/422/401/403 to the evidence dir (test removed afterward; working tree clean)`
- <code>Baseline: `mix deps.get`, `MIX_ENV=test mix compile`, `mix ecto.create`, `mix ecto.migrate` — all succeeded</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
