### PR TITLE
feat(orchard_cli): add requests inspect scheduler explanation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ An initial cluster-admin `/admin/v1` node-admission surface (candidate review, r
 The roadmap and target behavior are governed by `SPEC.md` §14.
 
 Some SPEC-required CLI paths are present before their milestone implementation:
-`orchardctl cluster init`, `orchardctl node join`, and
-`orchardctl requests inspect` return command-specific deferred-status errors
-with the current supported path. `orchardctl nodes inspect`,
+`orchardctl cluster init` and `orchardctl node join` return command-specific deferred-status errors with the current supported path.
+`orchardctl requests inspect <request-id>` is implemented for local controller request diagnostics with stable human and JSON scheduler-explanation output.
+`orchardctl nodes inspect`,
 `orchardctl nodes pending`, `orchardctl nodes admit`, and
 `orchardctl nodes reject` are implemented for the current node-admission-review
 slice, with stable JSON and human output, `--dry-run` previews, and

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -12,7 +12,7 @@ This README is orientation only. Normative CLI requirements live in
 - Operator commands for environment, transport, migrations, status, start/stop,
   upgrades, tenants, API keys, API Client bulk provisioning, nodes, and models.
 - SPEC-required future command paths that return explicit deferred status until
-  their milestones land: `cluster init`, `node join`, and `requests inspect`.
+  their milestones land: `cluster init` and `node join`.
 - Node-admission-review commands (`nodes inspect`, `nodes pending`,
   `nodes admit`, `nodes reject`) with stable JSON and human output, `--dry-run`
   previews, and `--yes`/`--reason` execution gating.
@@ -22,6 +22,9 @@ This README is orientation only. Normative CLI requirements live in
   `--acknowledge`, and `--typed-node-id` execution gating. `nodes maintenance`
   previews only; its `draining -> maintenance` execution stays blocked until
   drain completion can be verified.
+- Request diagnostics through `requests inspect <request-id>`, including stable
+  human and JSON scheduler-explanation output from the shared Operator API
+  presenter and scheduler explanation contract.
 - Local diagnostic support bundle creation via `support bundle create`.
 - Bulk API Client provisioning through `api-clients bulk-provision`, including
   Dry Run, all-or-nothing Apply, output preflight, Key Rotation, and One-time
@@ -35,6 +38,9 @@ The deferred paths above are advertised by `orchardctl`, exit non-zero when
 run, and print command-specific usage, `SPEC.md` traceability, and the current
 supported source-dev or packaged workflow. `--help` for the same paths is
 side-effect free.
+
+`orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for the request.
+Use `--json` for the same stable explanation map exposed by the Operator API presenter.
 
 `orchardctl support bundle create` writes a local `.tar.gz` with bounded
 redacted logs, redacted config, service status, node snapshots, and request

--- a/apps/orchard_cli/lib/orchard_cli/commands/requests.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/requests.ex
@@ -1,22 +1,164 @@
 defmodule OrchardCLI.Commands.Requests do
   @moduledoc false
 
-  alias OrchardCLI.Commands.Deferred
-
-  @commands [
-    %{
-      path: ["inspect"],
-      usage: "orchardctl requests inspect",
-      summary: "Inspect request execution details for operator diagnostics (SPEC.md 11.9).",
-      status:
-        "Defined by SPEC.md 11.9 for the diagnostics CLI; not implemented in the current build.",
-      guidance: [
-        "Use Orchard Console request views and controller logs for current request diagnostics.",
-        "Use health and readiness endpoints for current machine-checkable status."
-      ]
-    }
-  ]
+  alias Orchard.API.Ops.SchedulerExplanationPresenter
+  alias Orchard.Requests
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
-  def run(args), do: Deferred.run(args, %{name: "requests", commands: @commands})
+  def run(args) do
+    case args do
+      ["inspect", "--help"] -> {:ok, inspect_usage()}
+      ["inspect", "help"] -> {:ok, inspect_usage()}
+      ["help"] -> {:ok, group_usage()}
+      ["--help"] -> {:ok, group_usage()}
+      [] -> {:error, group_usage(), 1}
+      ["inspect" | rest] -> run_inspect(rest)
+      _other -> {:error, group_usage(), 1}
+    end
+  end
+
+  defp run_inspect(args) do
+    case parse_inspect_args(args) do
+      {:ok, opts} -> inspect_request(opts)
+      {:help, usage} -> {:ok, usage}
+      {:error, message, code} -> {:error, message, code}
+    end
+  end
+
+  defp inspect_request(%{request_id: request_id, json?: json?}) do
+    with {:ok, request} <- guarded_fetch_request(request_id),
+         {:ok, explanation} <- SchedulerExplanationPresenter.show(request) do
+      {:ok, render_explanation(explanation, json?)}
+    else
+      {:error, :scheduler_explanation_not_found} -> explanation_not_found(json?)
+      {:error, reason} -> invalid_explanation(reason, json?)
+    end
+  end
+
+  defp parse_inspect_args(args) do
+    case OptionParser.parse(args, strict: [json: :boolean, help: :boolean]) do
+      {opts, [request_id], []} ->
+        if Keyword.get(opts, :help, false) do
+          {:help, inspect_usage()}
+        else
+          {:ok, %{request_id: request_id, json?: Keyword.get(opts, :json, false)}}
+        end
+
+      {_opts, _rest, [{flag, _value} | _unknown]} ->
+        {:error, "Unknown option: #{flag}", 2}
+
+      _other ->
+        {:error, inspect_usage(), 1}
+    end
+  end
+
+  defp guarded_fetch_request(request_id) do
+    if repo_available?() do
+      case Requests.get_request_by_public_id(request_id) do
+        nil -> {:error, :scheduler_explanation_not_found}
+        request -> {:ok, request}
+      end
+    else
+      {:error, :scheduler_explanation_not_found}
+    end
+  rescue
+    _exception in [DBConnection.ConnectionError, DBConnection.OwnershipError, Postgrex.Error] ->
+      {:error, :scheduler_explanation_not_found}
+  end
+
+  defp repo_available? do
+    pid = Process.whereis(Orchard.Repo)
+    is_pid(pid) and Process.alive?(pid)
+  end
+
+  defp render_explanation(explanation, true), do: encode_json(explanation)
+
+  defp render_explanation(explanation, false) do
+    Enum.join(
+      [
+        "Request: #{explanation.request_id}",
+        "Selected node: #{explanation.selected_node_id || "-"}",
+        "Selection tier: #{explanation.selection_tier || "-"}",
+        "Scored candidates:",
+        render_candidates(explanation.scored_candidates),
+        "Rejected candidates:",
+        render_candidates(explanation.rejected_candidates),
+        "Skipped candidates:",
+        render_candidates(explanation.skipped_candidates)
+      ],
+      "\n"
+    )
+  end
+
+  defp render_candidates([]), do: "  none"
+
+  defp render_candidates(candidates) do
+    Enum.map_join(candidates, "\n", fn candidate ->
+      node_id = candidate.node_id || candidate.target_ref || "-"
+      tier = candidate.tier || "-"
+      score = if is_nil(candidate.score), do: "-", else: candidate.score
+      codes = format_reason_codes(candidate.reason_codes)
+
+      "  #{node_id} tier=#{tier} score=#{score} reason_codes=#{codes}"
+    end)
+  end
+
+  defp format_reason_codes([]), do: "none"
+  defp format_reason_codes(codes), do: Enum.join(codes, ",")
+
+  defp explanation_not_found(json?) do
+    message = "Scheduler explanation was not found."
+
+    if json? do
+      {:error,
+       encode_json(%{
+         object: "error",
+         code: "scheduler_explanation_not_found",
+         message: message
+       }), 1}
+    else
+      {:error, "Error: #{message}", 1}
+    end
+  end
+
+  defp invalid_explanation(reason, json?) do
+    message = "Persisted scheduler explanation is invalid."
+
+    if json? do
+      {:error,
+       encode_json(%{
+         object: "error",
+         code: "scheduler_explanation_invalid",
+         message: message,
+         details: inspect(reason)
+       }), 1}
+    else
+      {:error, "Error: #{message}\nDetails: #{inspect(reason)}", 1}
+    end
+  end
+
+  defp encode_json(payload), do: Jason.encode!(payload, pretty: true)
+
+  defp group_usage do
+    Enum.join(
+      [
+        "Usage: orchardctl requests <command>",
+        "",
+        "Commands:",
+        "  inspect  Inspect a request scheduler explanation"
+      ],
+      "\n"
+    )
+  end
+
+  defp inspect_usage do
+    Enum.join(
+      [
+        "Usage: orchardctl requests inspect <request-id> [--json]",
+        "",
+        "Shows the persisted scheduler explanation for a request using the shared scheduler explanation contract."
+      ],
+      "\n"
+    )
+  end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
@@ -1,0 +1,175 @@
+defmodule OrchardCLI.Commands.RequestsTest do
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.API.Ops.SchedulerExplanationPresenter
+  alias Orchard.Repo
+  alias Orchard.Requests
+  alias OrchardCLI.Commands.Requests, as: RequestsCmd
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  setup do
+    :ok = Sandbox.checkout(Repo)
+    Sandbox.mode(Repo, {:shared, self()})
+    :ok
+  end
+
+  describe "help and usage" do
+    test "group usage lists inspect" do
+      assert {:ok, message} = RequestsCmd.run(["--help"])
+      assert message =~ "Usage: orchardctl requests <command>"
+      assert message =~ "inspect"
+    end
+
+    test "inspect help documents json output" do
+      assert {:ok, message} = RequestsCmd.run(["inspect", "--help"])
+      assert message =~ "Usage: orchardctl requests inspect <request-id> [--json]"
+      assert message =~ "shared scheduler explanation contract"
+    end
+
+    test "unknown option reports the flag" do
+      assert {:error, message, 2} = RequestsCmd.run(["inspect", "resp_1", "--bogus"])
+      assert message == "Unknown option: --bogus"
+    end
+  end
+
+  describe "inspect" do
+    test "SPEC.md §7.3.5 and §11.9 json output derives scheduler explanation from Operator API presenter" do
+      request = persist_valid_explanation!("resp_cli_scheduler_explanation")
+      assert {:ok, expected} = SchedulerExplanationPresenter.show(request)
+
+      assert {:ok, output} = RequestsCmd.run(["inspect", request.public_id, "--json"])
+
+      assert Jason.decode!(output) == Jason.decode!(Jason.encode!(expected))
+    end
+
+    test "human output renders selected rejected and skipped scheduler explanation sections" do
+      request = persist_valid_explanation!("resp_cli_scheduler_explanation_human")
+
+      assert {:ok, output} = RequestsCmd.run(["inspect", request.public_id])
+
+      assert output =~ "Request: #{request.public_id}"
+      assert output =~ "Selected node: node-selected"
+      assert output =~ "Selection tier: loaded"
+      assert output =~ "Scored candidates:"
+      assert output =~ "node-selected tier=loaded score=842 reason_codes=none"
+      assert output =~ "Rejected candidates:"
+
+      assert output =~
+               "node-rejected tier=- score=- reason_codes=node_not_active,insufficient_memory"
+
+      assert output =~ "Skipped candidates:"
+      assert output =~ "node-skipped tier=- score=- reason_codes=lower_tier_not_considered"
+    end
+
+    test "SPEC.md §7.3.5 json output reports unknown request id as scheduler explanation not found" do
+      assert {:error, output, 1} =
+               RequestsCmd.run(["inspect", "resp_missing_cli_explanation", "--json"])
+
+      assert Jason.decode!(output) == %{
+               "object" => "error",
+               "code" => "scheduler_explanation_not_found",
+               "message" => "Scheduler explanation was not found."
+             }
+    end
+
+    test "documented legacy scheduler decisions without candidates render an empty explanation shape" do
+      request =
+        create_request!(%{
+          public_id: "resp_cli_legacy_scheduler_decision",
+          scheduler_decision: %{"strategy" => "single_node", "node_id" => nil}
+        })
+
+      assert {:ok, output} = RequestsCmd.run(["inspect", request.public_id, "--json"])
+
+      assert Jason.decode!(output) == %{
+               "request_id" => request.public_id,
+               "selected_node_id" => nil,
+               "selection_tier" => nil,
+               "scored_candidates" => [],
+               "rejected_candidates" => [],
+               "skipped_candidates" => []
+             }
+    end
+
+    test "SPEC.md §7.3.5 json output reports invalid persisted scheduler explanations" do
+      request =
+        create_request!(%{
+          public_id: "resp_cli_invalid_scheduler_explanation",
+          scheduler_decision: %{
+            "request_id" => "resp_cli_invalid_scheduler_explanation",
+            "rejected_candidates" => [
+              %{"node_id" => "node-rejected", "reason_codes" => ["not_a_scheduler_code"]}
+            ]
+          }
+        })
+
+      assert {:error, output, 1} = RequestsCmd.run(["inspect", request.public_id, "--json"])
+
+      assert %{
+               "object" => "error",
+               "code" => "scheduler_explanation_invalid",
+               "message" => "Persisted scheduler explanation is invalid.",
+               "details" => details
+             } = Jason.decode!(output)
+
+      assert details =~ "not_a_scheduler_code"
+    end
+
+    test "degrades to scheduler explanation not found when the controller repo is unavailable" do
+      request = persist_valid_explanation!("resp_cli_repo_unavailable_explanation")
+
+      with_repo_unavailable(fn ->
+        assert {:error, output, 1} = RequestsCmd.run(["inspect", request.public_id, "--json"])
+        assert Jason.decode!(output)["code"] == "scheduler_explanation_not_found"
+      end)
+    end
+  end
+
+  defp with_repo_unavailable(fun) do
+    repo_pid = Process.whereis(Repo)
+    Process.unregister(Repo)
+
+    try do
+      fun.()
+    after
+      Process.register(repo_pid, Repo)
+    end
+  end
+
+  defp persist_valid_explanation!(public_id) do
+    request = create_request!(%{public_id: public_id})
+
+    assert {:ok, request} =
+             Requests.record_schedule(request, %{
+               request_id: request.public_id,
+               selected_node_id: "node-selected",
+               selection_tier: :loaded,
+               scored_candidates: [
+                 %{
+                   node_id: "node-selected",
+                   eligible: true,
+                   tier: :loaded,
+                   score: 842,
+                   components: %{pool_bonus: 200},
+                   reason_codes: []
+                 }
+               ],
+               rejected_candidates: [
+                 %{
+                   node_id: "node-rejected",
+                   reason_codes: [:node_not_active, "insufficient_memory"]
+                 }
+               ],
+               skipped_candidates: [
+                 %{
+                   node_id: "node-skipped",
+                   reason_codes: [:lower_tier_not_considered]
+                 }
+               ]
+             })
+
+    request
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
@@ -1,6 +1,8 @@
 defmodule OrchardCLI.Commands.RequestsTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
+
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.API.Ops.SchedulerExplanationPresenter
   alias Orchard.Repo
@@ -31,6 +33,36 @@ defmodule OrchardCLI.Commands.RequestsTest do
     test "unknown option reports the flag" do
       assert {:error, message, 2} = RequestsCmd.run(["inspect", "resp_1", "--bogus"])
       assert message == "Unknown option: --bogus"
+    end
+  end
+
+  describe "public dispatcher" do
+    test "OrchardCLI.main/2 prints request scheduler explanation to stdout and exits zero" do
+      parent = self()
+      request = persist_valid_explanation!("resp_cli_main_scheduler_explanation")
+
+      stdout =
+        capture_io(fn ->
+          OrchardCLI.main(["requests", "inspect", request.public_id], halt_stub(parent))
+        end)
+
+      assert stdout =~ "Request: #{request.public_id}"
+      assert stdout =~ "Selected node: node-selected"
+      assert stdout =~ "Rejected candidates:"
+      assert stdout =~ "node_not_active,insufficient_memory"
+      refute_received {:halt_called, _code}
+    end
+
+    test "OrchardCLI.main/2 prints stable not-found error to stderr and exits non-zero" do
+      parent = self()
+
+      stderr =
+        capture_io(:stderr, fn ->
+          OrchardCLI.main(["requests", "inspect", "resp_cli_main_missing"], halt_stub(parent))
+        end)
+
+      assert stderr =~ "Error: Scheduler explanation was not found."
+      assert_received {:halt_called, 1}
     end
   end
 
@@ -125,6 +157,10 @@ defmodule OrchardCLI.Commands.RequestsTest do
         assert Jason.decode!(output)["code"] == "scheduler_explanation_not_found"
       end)
     end
+  end
+
+  defp halt_stub(parent) do
+    fn code -> send(parent, {:halt_called, code}) end
   end
 
   defp with_repo_unavailable(fun) do

--- a/apps/orchard_cli/test/orchard_cli_test.exs
+++ b/apps/orchard_cli/test/orchard_cli_test.exs
@@ -95,8 +95,7 @@ defmodule OrchardCLITest do
   test "advertised deferred commands report docs-backed status" do
     commands = [
       {Cluster, ["init"], "orchardctl cluster init"},
-      {Node, ["join"], "orchardctl node join"},
-      {Requests, ["inspect"], "orchardctl requests inspect"}
+      {Node, ["join"], "orchardctl node join"}
     ]
 
     for {module, args, usage} <- commands do
@@ -115,8 +114,7 @@ defmodule OrchardCLITest do
 
     commands = [
       ["cluster", "init"],
-      ["node", "join"],
-      ["requests", "inspect"]
+      ["node", "join"]
     ]
 
     for command <- commands do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,10 +16,9 @@ product/system/build contract.
   a target mode but is not available in current builds; the packaged
   `orchard-managed-postgres` helper is an operator-safe guard, not a runtime
   service.
-- **Current CLI limitation:** SPEC-required future paths such as
-  `orchardctl cluster init`, `orchardctl node join`, and
-  `orchardctl requests inspect` are routed by `orchardctl` but return
-  deferred-status errors with the current supported path.
+- **Current CLI limitation:** SPEC-required future paths such as `orchardctl cluster init` and `orchardctl node join` are routed by `orchardctl` but return deferred-status errors with the current supported path.
+  `orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for a request, with stable human and `--json` output from the shared Operator API presenter.
+  Broader request execution diagnostics beyond persisted scheduler explanations remain future work.
   `orchardctl nodes inspect`, `orchardctl nodes pending`,
   `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for
   the current node-admission-review slice, with stable JSON and human output,

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -991,8 +991,9 @@ sudo launchctl kickstart -k system/com.orchard.node-agent
 
 ## Smoke Test Troubleshooting
 
-`orchardctl requests inspect` is a SPEC-required diagnostics path that returns
-deferred status in this build. `orchardctl support bundle create` creates a
+`orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for a request, with stable human and `--json` output from the shared Operator API presenter.
+Broader request execution diagnostics beyond persisted scheduler explanations remain future work.
+`orchardctl support bundle create` creates a
 local diagnostic `.tar.gz` containing bounded redacted logs, redacted config,
 service status, node snapshots, shared cluster-management node status, and
 request summaries; use `--support-root` and

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -53,7 +53,9 @@
   Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, persisted lifecycle reason columns, decommission trust revocation, and Admin/Operator API lifecycle routes remain future work.
   Console lifecycle action preview panels are now implemented under task 5.3.
   Note: `SPEC.md` §11.9 now records the lifecycle commands and their preview and confirmation gates.
-- [ ] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
+- [x] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
+  Note: Implemented `orchardctl requests inspect <request-id>` because `SPEC.md` §11.9 names `requests inspect` as the required CLI path while `SPEC.md` §7.3.5 requires shared scheduler explanation reason codes across CLI and the Operator API.
+  Note: The command uses local controller-runtime authority, reads the same request row as the Operator API, and renders human plus JSON output through `SchedulerExplanationPresenter` and the shared scheduler explanation contract.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
 
 ## 5. Console Nodes UX

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -56,6 +56,7 @@
 - [x] 4.7 Implement `orchardctl scheduler explain <request-id>` or reconcile with the existing `requests inspect` command if that is the repo-preferred path.
   Note: Implemented `orchardctl requests inspect <request-id>` because `SPEC.md` §11.9 names `requests inspect` as the required CLI path while `SPEC.md` §7.3.5 requires shared scheduler explanation reason codes across CLI and the Operator API.
   Note: The command uses local controller-runtime authority, reads the same request row as the Operator API, and renders human plus JSON output through `SchedulerExplanationPresenter` and the shared scheduler explanation contract.
+  Note: Broader request execution diagnostics under `requests inspect` beyond persisted scheduler explanations remain future work, so the general command name is not fully delivered by this slice.
 - [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
 
 ## 5. Console Nodes UX

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1057,8 +1057,11 @@ this build. Role selection, env generation, service start, and
 This deferred bootstrap ensures services start with valid environment and TLS
 configuration rather than crash-looping with missing setup.
 
-`orchardctl requests inspect` is also a SPEC-required diagnostics path that
-returns deferred status. `orchardctl support bundle create` creates a local
+`orchardctl requests inspect <request-id>` reads the local controller Repo and
+renders the persisted scheduler explanation for a request, with stable human and
+`--json` output from the shared Operator API presenter; broader request
+execution diagnostics beyond persisted scheduler explanations remain future
+work. `orchardctl support bundle create` creates a local
 diagnostic `.tar.gz` with bounded redacted logs, redacted config, service
 status, node snapshots, and request summaries. It records
 `support_bundle.generated` when the controller Repo is available. Archives are


### PR DESCRIPTION
## Intent

The developer was working in an Orchard (Elixir/OTP LLM orchestration platform) worktree to add a "requests inspect" capability that surfaces persisted request scheduler explanations through the CLI. Their goal was to finish and validate a vertical slice: implement the request scheduler explanation inspect feature and back it with test coverage for the dispatcher. They wanted the CLI to print a request's scheduler explanation to stdout with a zero exit code on success, and print a stable "not found" error to stderr with a non-zero exit code on failure. They also asked to close out two follow-ups by adding those CLI tests and updating the OpenSpec change (cluster-management-ux-foundation) with a note scoping broader requests-inspect diagnostics beyond persisted scheduler explanations as future work. Finally, they required the standard Orchard quality gates to pass before handoff (mix format, credo --strict, targeted mix test, and strict OpenSpec validation) and a conventional-commit commit of the result.

## What Changed

- Implemented `orchardctl requests inspect <request-id>` in `apps/orchard_cli/lib/orchard_cli/commands/requests.ex`, reading persisted scheduler explanations from the controller Repo and rendering human-readable or `--json` output — printing to stdout with exit code 0 on success and a stable "Scheduler explanation was not found." error to stderr with a non-zero exit code when the request/explanation is absent or the Repo is unavailable.
- Added command and public-dispatcher test coverage in `requests_test.exs` and `orchard_cli_test.exs`, exercising the human, `--json`, and missing-id paths through `OrchardCLI.main/2` with exit-code assertions (Test stage: 50 passed for the targeted suite, 558 passed for the full app suite).
- Synced the docs and OpenSpec surface to the implemented behavior: README, CLI README, `docs/architecture.md`, `docs/local-dev.md`, `packaging/pkg/README.md`, and the `cluster-management-ux-foundation` tasks note (scoping broader requests-inspect diagnostics as future work).

## Risk Assessment

✅ Low: The change is well-bounded, comprehensively tested (happy path, JSON, not-found, invalid-explanation, legacy-shape, repo-unavailable), follows the existing repo-guard/presenter conventions, and the round-1 doc drift is now reconciled; the only note is a deliberate, tested error-masking tradeoff.

## Testing

Ran the change's targeted tests and the full orchard_cli suite (all green), then produced product-level evidence by driving the real orchardctl entry point against a live Postgres-backed Repo: the success path prints the scheduler explanation (human + JSON) to stdout with exit 0, and the not-found path prints a stable error to stderr with exit 1 (plain and JSON `scheduler_explanation_not_found`). The seeded request used a sandbox connection that rolled back, so no DB state persisted and the worktree stayed clean. This is a CLI feature with no rendered UI surface, so the reviewer-visible evidence is a captured CLI transcript rather than a screenshot. Everything passed and the user intent is demonstrated end-to-end.

<details>
<summary>Evidence: orchardctl requests inspect — CLI transcript (success stdout/exit 0, not-found stderr/exit 1)</summary>

<code>$ orchardctl requests inspect resp_operator_demo_scheduler_explanation&#10;Request: resp_operator_demo_scheduler_explanation&#10;Selected node: node-selected&#10;Selection tier: loaded&#10;Scored candidates:&#10;node-selected tier=loaded score=842 reason_codes=none&#10;Rejected candidates:&#10;node-rejected tier=- score=- reason_codes=node_not_active,insufficient_memory&#10;Skipped candidates:&#10;node-skipped tier=- score=- reason_codes=lower_tier_not_considered&#10;[stdout above] exit code: 0&#10;&#10;$ orchardctl requests inspect resp_operator_demo_scheduler_explanation --json&#10;{ ...request_id/selected_node_id/selection_tier + scored/rejected/skipped candidate arrays... }&#10;[stdout above] exit code: 0&#10;&#10;$ orchardctl requests inspect resp_does_not_exist&#10;[stderr] Error: Scheduler explanation was not found.&#10;[stderr above] exit code: 1&#10;&#10;$ orchardctl requests inspect resp_does_not_exist --json&#10;{&#10;&#34;code&#34;: &#34;scheduler_explanation_not_found&#34;,&#10;&#34;message&#34;: &#34;Scheduler explanation was not found.&#34;,&#10;&#34;object&#34;: &#34;error&#34;&#10;}&#10;[stderr above] exit code: 1</code>

```text

========================================================================
$ orchardctl requests inspect resp_operator_demo_scheduler_explanation
========================================================================
Request: resp_operator_demo_scheduler_explanation
Selected node: node-selected
Selection tier: loaded
Scored candidates:
  node-selected tier=loaded score=842 reason_codes=none
Rejected candidates:
  node-rejected tier=- score=- reason_codes=node_not_active,insufficient_memory
Skipped candidates:
  node-skipped tier=- score=- reason_codes=lower_tier_not_considered
[stdout above]  exit code: 0

========================================================================
$ orchardctl requests inspect resp_operator_demo_scheduler_explanation --json
========================================================================
{
  "request_id": "resp_operator_demo_scheduler_explanation",
  "selected_node_id": "node-selected",
  "selection_tier": "loaded",
  "scored_candidates": [
    {
      "components": {
        "pool_bonus": 200
      },
      "node_id": "node-selected",
      "diagnostics": {},
      "eligible": true,
      "tier": "loaded",
      "score": 842,
      "reason_codes": [],
      "target_ref": null
    }
  ],
  "rejected_candidates": [
    {
      "components": {},
      "node_id": "node-rejected",
      "diagnostics": {},
      "eligible": false,
      "tier": null,
      "score": null,
      "reason_codes": [
        "node_not_active",
        "insufficient_memory"
      ],
      "target_ref": null
    }
  ],
  "skipped_candidates": [
    {
      "components": {},
      "node_id": "node-skipped",
      "diagnostics": {},
      "eligible": false,
      "tier": null,
      "score": null,
      "reason_codes": [
        "lower_tier_not_considered"
      ],
      "target_ref": null
    }
  ]
}
[stdout above]  exit code: 0

========================================================================
$ orchardctl requests inspect resp_does_not_exist
========================================================================
[stderr] Error: Scheduler explanation was not found.
[stderr above]  exit code: 1

========================================================================
$ orchardctl requests inspect resp_does_not_exist --json
========================================================================
{
  "code": "scheduler_explanation_not_found",
  "message": "Scheduler explanation was not found.",
  "object": "error"
}
[stderr above]  exit code: 1

== demo complete (sandbox transaction rolls back; no DB rows persist) ==
```
</details>
<details>
<summary>Evidence: Evidence harness script (drives real OrchardCLI.main/2 over rolled-back sandbox)</summary>

```text
# Drives the real orchardctl entry point (OrchardCLI.main/2, the escript's
# main_module) against a live Postgres-backed Orchard.Repo. A sandbox
# connection in shared mode holds the seeded request and rolls back on exit,
# so no DB state persists. System.halt is stubbed only to observe the exit
# code the operator's shell would receive (identical mechanism to main/1).

Application.ensure_all_started(:ex_unit)
import ExUnit.CaptureIO

alias Ecto.Adapters.SQL.Sandbox
alias Orchard.Repo
alias Orchard.Requests

# Start the controller Repo (test config sets start_repo: false).
case Process.whereis(Repo) do
  nil -> {:ok, _} = Repo.start_link()
  _ -> :ok
end

Sandbox.mode(Repo, :manual)
:ok = Sandbox.checkout(Repo)
Sandbox.mode(Repo, {:shared, self()})

public_id = "resp_operator_demo_scheduler_explanation"

request_attrs = %{
  public_id: public_id,
  endpoint: :chat_completions,
  tenant_id: Ecto.UUID.generate(),
  requested_model: "mlx-community/phi-3-demo@main",
  state: :received,
  stream: true,
  payload_capture_mode: :metadata,
  sampling_params: %{"temperature" => 0.7},
  response_format: %{"type" => "text"},
  input_tokens: 0,
  output_tokens: 0,
  reserved_output_tokens: 128,
  timeout_at: ~U[2026-03-10 00:00:00.000000Z]
}

{:ok, request} = Requests.create_request(request_attrs)

{:ok, request} =
  Requests.record_schedule(request, %{
    request_id: request.public_id,
    selected_node_id: "node-selected",
    selection_tier: :loaded,
    scored_candidates: [
      %{
        node_id: "node-selected",
        eligible: true,
        tier: :loaded,
        score: 842,
        components: %{pool_bonus: 200},
        reason_codes: []
      }
    ],
    rejected_candidates: [
      %{node_id: "node-rejected", reason_codes: [:node_not_active, "insufficient_memory"]}
    ],
    skipped_candidates: [
      %{node_id: "node-skipped", reason_codes: [:lower_tier_not_considered]}
    ]
  })

# halt stub: records the code the operator's shell would receive as $?
{:ok, halt_agent} = Agent.start_link(fn -> nil end)
halt_fn = fn code -> Agent.update(halt_agent, fn _ -> code end) end
reset_halt = fn -> Agent.update(halt_agent, fn _ -> nil end) end
last_exit = fn -> Agent.get(halt_agent, & &1) end

banner = fn title ->
  IO.puts("\n========================================================================")
  IO.puts("$ #{title}")
  IO.puts("========================================================================")
end

# --- Success: human-readable scheduler explanation to stdout, exit 0 ---
reset_halt.()

stdout_human =
  capture_io(fn ->
    OrchardCLI.main(["requests", "inspect", request.public_id], halt_fn)
  end)

banner.("orchardctl requests inspect #{request.public_id}")
IO.write(stdout_human)
IO.puts("[stdout above]  exit code: #{inspect(last_exit.() || 0)}")

# --- Success: --json output to stdout, exit 0 ---
reset_halt.()

stdout_json =
  capture_io(fn ->
    OrchardCLI.main(["requests", "inspect", request.public_id, "--json"], halt_fn)
  end)

banner.("orchardctl requests inspect #{request.public_id} --json")
IO.write(stdout_json)
IO.puts("[stdout above]  exit code: #{inspect(last_exit.() || 0)}")

# --- Failure: stable not-found error to stderr, non-zero exit ---
reset_halt.()

stderr_missing =
  capture_io(:stderr, fn ->
    OrchardCLI.main(["requests", "inspect", "resp_does_not_exist"], halt_fn)
  end)

banner.("orchardctl requests inspect resp_does_not_exist")
IO.write("[stderr] ")
IO.write(stderr_missing)
IO.puts("[stderr above]  exit code: #{inspect(last_exit.())}")

# --- Failure: --json not-found error to stderr, non-zero exit ---
reset_halt.()

stderr_missing_json =
  capture_io(:stderr, fn ->
    OrchardCLI.main(["requests", "inspect", "resp_does_not_exist", "--json"], halt_fn)
  end)

banner.("orchardctl requests inspect resp_does_not_exist --json")
IO.write(stderr_missing_json)
IO.puts("[stderr above]  exit code: #{inspect(last_exit.())}")

IO.puts("\n== demo complete (sandbox transaction rolls back; no DB rows persist) ==")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `docs/architecture.md:21` - This behavior change (implementing `requests inspect`) leaves `docs/architecture.md` stale: it still lists `orchardctl requests inspect` among SPEC-required paths that &#34;are routed by `orchardctl` but return deferred-status errors.&#34; The command now returns real human/JSON scheduler-explanation output, so this contributor-facing doc now contradicts the implementation. The author updated README.md and apps/orchard_cli/README.md but missed this file.
- ⚠️ `docs/local-dev.md:994` - `docs/local-dev.md` still states `orchardctl requests inspect` &#34;is a SPEC-required diagnostics path that returns deferred status in this build.&#34; That is now false after this change; the command reads the controller Repo and renders scheduler explanations. Operator/smoke-test guidance here contradicts the implemented behavior.
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/requests.ex:69` - `repo_available?/0` (line 69) is byte-identical to `nodes.ex`, and `parse_inspect_args/1` (line 38) plus the `guarded_fetch_request` rescue-guard are near-identical to the `guarded_read`/`parse_inspect_args` pattern in `nodes.ex`. This is a second copy of the same Repo-availability guard; a shared CLI helper (e.g. a repo-guard module) would remove the duplication. Low priority since it follows the existing per-command convention.

🔧 Fix: document requests inspect scheduler explanation in architecture and local-dev docs
1 info still open:
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/requests.ex:55` - guarded_fetch_request/1 collapses three distinct conditions into the same {:error, :scheduler_explanation_not_found}: request truly absent, controller Repo process not running (repo_available? false), and live DB failures (DBConnection.ConnectionError/OwnershipError/Postgrex.Error rescued). For a diagnostics command this can mislead: an operator running `requests inspect resp_x` during a Postgres outage sees &#34;Error: Scheduler explanation was not found.&#34; and may conclude the request/explanation doesn&#39;t exist rather than that the controller couldn&#39;t reach its DB. This is a deliberate, explicitly tested degradation that mirrors the established nodes.ex guarded_read pattern, so it is an accepted tradeoff rather than a defect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd apps/orchard_cli &amp;&amp; PGDATABASE_TEST=orchard_test_nm_2b20bc518d75 MIX_ENV=test mise exec -- mix test test/orchard_cli/commands/requests_test.exs test/orchard_cli_test.exs` — 50 passed (includes the new &#39;public dispatcher&#39; cases that drive OrchardCLI.main/2 with capture_io + a halt stub for stdout/stderr and exit-code assertions)</code>
- <code>`PGDATABASE_TEST=orchard_test_nm_2b20bc518d75 MIX_ENV=test mise exec -- mix test` (full orchard_cli suite) — 558 passed, 10 excluded; no regressions</code>
- <code>Manual end-to-end CLI transcript: `mise exec -- mix run requests_inspect_cli_demo.exs` seeds a request via `Requests.record_schedule` in a rolled-back Ecto sandbox and invokes the real `OrchardCLI.main([&#39;requests&#39;,&#39;inspect&#39;, id], halt_fn)` for the human, `--json`, missing-id, and missing-id+`--json` paths, capturing stdout/stderr and the halt exit code</code>
- <code>Verified no rows persisted after the demo (`select count(*) ... where public_id like &#39;resp_operator_demo%&#39;` = 0) and the worktree stayed clean (`git status --porcelain` empty)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
