### PR TITLE
feat(console): add scheduler explanation panel to request detail view

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/request_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/request_live.ex
@@ -1,7 +1,8 @@
 defmodule OrchardConsole.RequestLive do
   @moduledoc """
   Console request detail page — shows request summary, usage, errors,
-  canonical request JSON, and event timeline for a single inference request.
+  canonical request JSON, the persisted scheduler explanation, and event
+  timeline for a single inference request.
   """
 
   use OrchardConsole, :live_view

--- a/apps/orchard_controller/lib/orchard/console/request_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/request_live.ex
@@ -6,6 +6,7 @@ defmodule OrchardConsole.RequestLive do
 
   use OrchardConsole, :live_view
 
+  alias Orchard.API.Ops.SchedulerExplanationPresenter
   alias Orchard.Governance
   alias Orchard.Governance.{ApiKey, Tenant}
   alias Orchard.Requests
@@ -13,6 +14,7 @@ defmodule OrchardConsole.RequestLive do
   alias OrchardConsole.TimeHelpers
 
   @default_refresh_interval_ms 5_000
+  @unsafe_scheduler_diagnostic_key_pattern ~r/(prompt|token|secret|credential|password|dsn|body|payload|request|response)/i
 
   # ===========================================================================
   # Lifecycle
@@ -105,6 +107,11 @@ defmodule OrchardConsole.RequestLive do
           <.request_usage request={@request} />
           <.request_timeline events={@events} />
           <.request_execution_metadata request={@request} />
+          <.request_scheduler_explanation
+            status={@scheduler_explanation_status}
+            explanation={@scheduler_explanation}
+            error_reason={@scheduler_explanation_error}
+          />
           <.request_errors request={@request} />
           <.request_provenance request={@request} />
           <.request_response_debug request={@request} />
@@ -240,6 +247,206 @@ defmodule OrchardConsole.RequestLive do
           </.detail_field>
         </.detail_grid>
       </.card>
+    </div>
+    """
+  end
+
+  attr(:status, :atom, required: true)
+  attr(:explanation, :map, default: nil)
+  attr(:error_reason, :any, default: nil)
+
+  defp request_scheduler_explanation(assigns) do
+    ~H"""
+    <div id="request-scheduler-explanation-card">
+      <.card variant={scheduler_explanation_card_variant(@status)}>
+        <:title>Scheduler Explanation</:title>
+        <:subtitle>
+          Shared selected, scored, skipped, and rejected candidate contract from SPEC.md §7.3.5.
+        </:subtitle>
+
+        <%= case @status do %>
+          <% :ok -> %>
+            <div class="space-y-5">
+              <.detail_grid class="grid-cols-1 sm:grid-cols-3">
+                <.detail_field id="scheduler-explanation-request-id" label="Request ID" mono break_all>
+                  {format_text(@explanation.request_id)}
+                </.detail_field>
+                <.detail_field id="scheduler-explanation-selected-node" label="Selected Node" mono break_all>
+                  {format_text(@explanation.selected_node_id)}
+                </.detail_field>
+                <.detail_field id="scheduler-explanation-selection-tier" label="Selection Tier" mono>
+                  {format_text(@explanation.selection_tier)}
+                </.detail_field>
+              </.detail_grid>
+
+              <.candidate_group
+                id="scheduler-selected-candidate"
+                title="Selected Candidate"
+                candidates={selected_candidates(@explanation)}
+                empty_text="No selected candidate was recorded."
+                tone={:success}
+              />
+              <.candidate_group
+                id="scheduler-scored-candidates"
+                title="Scored Candidates"
+                candidates={@explanation.scored_candidates}
+                empty_text="No scored candidates were recorded."
+                tone={:info}
+              />
+              <.candidate_group
+                id="scheduler-skipped-candidates"
+                title="Skipped Candidates"
+                candidates={@explanation.skipped_candidates}
+                empty_text="No skipped candidates were recorded."
+                tone={:warning}
+              />
+              <.candidate_group
+                id="scheduler-rejected-candidates"
+                title="Rejected Candidates"
+                candidates={@explanation.rejected_candidates}
+                empty_text="No rejected candidates were recorded."
+                tone={:error}
+              />
+            </div>
+
+          <% :not_found -> %>
+            <.state_message
+              id="scheduler-explanation-not-found"
+              kind={:empty}
+              layout={:compact}
+              title="No scheduler explanation recorded."
+              body="This request has no persisted scheduler explanation."
+            />
+
+          <% :invalid -> %>
+            <.state_message
+              id="scheduler-explanation-invalid"
+              kind={:error}
+              layout={:compact}
+              title="Scheduler explanation is invalid."
+              body={scheduler_explanation_error_body(@error_reason)}
+            />
+
+          <% _ -> %>
+            <.state_message
+              id="scheduler-explanation-loading"
+              kind={:loading}
+              layout={:compact}
+              title="Loading scheduler explanation."
+              body="The scheduler explanation will appear when the LiveView connects."
+            />
+        <% end %>
+      </.card>
+    </div>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:title, :string, required: true)
+  attr(:candidates, :list, default: [])
+  attr(:empty_text, :string, required: true)
+  attr(:tone, :atom, default: :neutral)
+
+  defp candidate_group(assigns) do
+    ~H"""
+    <section id={@id} class="space-y-3">
+      <div class="flex items-center gap-2">
+        <h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">{@title}</h4>
+        <.badge tone={@tone} class="font-mono">{length(@candidates)}</.badge>
+      </div>
+
+      <div :if={@candidates == []} class="rounded-lg border border-dashed border-slate-200 p-4 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+        {@empty_text}
+      </div>
+
+      <div :if={@candidates != []} class="grid gap-3 lg:grid-cols-2">
+        <.candidate_card :for={{candidate, index} <- Enum.with_index(@candidates, 1)} id_prefix={@id} candidate={candidate} index={index} />
+      </div>
+    </section>
+    """
+  end
+
+  attr(:id_prefix, :string, required: true)
+  attr(:candidate, :map, required: true)
+  attr(:index, :integer, required: true)
+
+  defp candidate_card(assigns) do
+    assigns =
+      assigns
+      |> assign(:components, scheduler_entries(assigns.candidate.components))
+      |> assign(
+        :diagnostics,
+        scheduler_entries(sanitized_scheduler_diagnostics(assigns.candidate.diagnostics))
+      )
+
+    ~H"""
+    <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Candidate {@index}
+          </p>
+          <p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
+            {format_text(@candidate.node_id)}
+          </p>
+        </div>
+        <.badge tone={candidate_eligibility_tone(@candidate.eligible)}>
+          {candidate_eligibility_label(@candidate.eligible)}
+        </.badge>
+      </div>
+
+      <.detail_grid class="mt-4 grid-cols-2" gap_class="gap-x-4 gap-y-3">
+        <.detail_field id={"#{@id_prefix}-candidate-#{@index}-target"} label="Target" mono break_all>
+          {format_text(@candidate.target_ref)}
+        </.detail_field>
+        <.detail_field id={"#{@id_prefix}-candidate-#{@index}-tier"} label="Tier" mono>
+          {format_text(@candidate.tier)}
+        </.detail_field>
+        <.detail_field id={"#{@id_prefix}-candidate-#{@index}-score"} label="Score" mono>
+          {format_scheduler_score(@candidate.score)}
+        </.detail_field>
+      </.detail_grid>
+
+      <div class="mt-4 space-y-3">
+        <.code_badges title="Reason Codes" values={@candidate.reason_codes} empty_text="No reason codes." />
+        <.key_value_list title="Score Components" entries={@components} empty_text="No score components." />
+        <.key_value_list title="Diagnostics" entries={@diagnostics} empty_text="No diagnostics." />
+      </div>
+    </article>
+    """
+  end
+
+  attr(:title, :string, required: true)
+  attr(:values, :list, default: [])
+  attr(:empty_text, :string, required: true)
+
+  defp code_badges(assigns) do
+    ~H"""
+    <div>
+      <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{@title}</p>
+      <div :if={@values != []} class="mt-2 flex flex-wrap gap-2">
+        <.badge :for={value <- @values} tone={:neutral} class="font-mono">{value}</.badge>
+      </div>
+      <p :if={@values == []} class="mt-1 text-sm text-slate-400 dark:text-slate-500">{@empty_text}</p>
+    </div>
+    """
+  end
+
+  attr(:title, :string, required: true)
+  attr(:entries, :list, default: [])
+  attr(:empty_text, :string, required: true)
+
+  defp key_value_list(assigns) do
+    ~H"""
+    <div>
+      <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{@title}</p>
+      <dl :if={@entries != []} class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div :for={{key, value} <- @entries} class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+          <dt class="font-mono text-xs text-slate-500 dark:text-slate-400">{key}</dt>
+          <dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">{format_scheduler_value(value)}</dd>
+        </div>
+      </dl>
+      <p :if={@entries == []} class="mt-1 text-sm text-slate-400 dark:text-slate-500">{@empty_text}</p>
     </div>
     """
   end
@@ -579,6 +786,9 @@ defmodule OrchardConsole.RequestLive do
       request_status: :loading,
       request: nil,
       events: [],
+      scheduler_explanation_status: :loading,
+      scheduler_explanation: nil,
+      scheduler_explanation_error: nil,
       load_error: nil,
       last_checked_at: nil,
       refresh_mode: :static
@@ -595,6 +805,9 @@ defmodule OrchardConsole.RequestLive do
           request_status: :not_found,
           request: nil,
           events: [],
+          scheduler_explanation_status: :not_found,
+          scheduler_explanation: nil,
+          scheduler_explanation_error: nil,
           load_error: nil,
           last_checked_at: now,
           refresh_mode: :static
@@ -606,7 +819,8 @@ defmodule OrchardConsole.RequestLive do
         mode =
           if should_poll?(%{request_status: :ok, request: request}), do: :polling, else: :static
 
-        assign(socket,
+        socket
+        |> assign(
           request_status: :ok,
           request: request,
           events: events,
@@ -614,6 +828,7 @@ defmodule OrchardConsole.RequestLive do
           last_checked_at: now,
           refresh_mode: mode
         )
+        |> assign_scheduler_explanation(request)
     end
   rescue
     e ->
@@ -621,10 +836,38 @@ defmodule OrchardConsole.RequestLive do
         request_status: :error,
         request: nil,
         events: [],
+        scheduler_explanation_status: :error,
+        scheduler_explanation: nil,
+        scheduler_explanation_error: nil,
         load_error: "Request details unavailable: #{Exception.message(e)}",
         last_checked_at: DateTime.utc_now() |> DateTime.truncate(:second),
         refresh_mode: :static
       )
+  end
+
+  defp assign_scheduler_explanation(socket, request) do
+    case SchedulerExplanationPresenter.show(request) do
+      {:ok, explanation} ->
+        assign(socket,
+          scheduler_explanation_status: :ok,
+          scheduler_explanation: explanation,
+          scheduler_explanation_error: nil
+        )
+
+      {:error, :scheduler_explanation_not_found} ->
+        assign(socket,
+          scheduler_explanation_status: :not_found,
+          scheduler_explanation: nil,
+          scheduler_explanation_error: nil
+        )
+
+      {:error, reason} ->
+        assign(socket,
+          scheduler_explanation_status: :invalid,
+          scheduler_explanation: nil,
+          scheduler_explanation_error: reason
+        )
+    end
   end
 
   # ===========================================================================
@@ -720,6 +963,59 @@ defmodule OrchardConsole.RequestLive do
   # ===========================================================================
   # Formatting
   # ===========================================================================
+
+  defp scheduler_explanation_card_variant(:ok), do: :primary
+  defp scheduler_explanation_card_variant(_status), do: :default
+
+  defp scheduler_explanation_error_body(nil),
+    do: "Persisted scheduler explanation is invalid."
+
+  defp scheduler_explanation_error_body(reason),
+    do: "Persisted scheduler explanation is invalid: #{inspect(reason)}"
+
+  defp selected_candidates(%{selected_node_id: selected_node_id, scored_candidates: candidates})
+       when is_binary(selected_node_id) and is_list(candidates) do
+    Enum.filter(candidates, &(&1.node_id == selected_node_id))
+  end
+
+  defp selected_candidates(_explanation), do: []
+
+  defp candidate_eligibility_tone(true), do: :success
+  defp candidate_eligibility_tone(false), do: :neutral
+
+  defp candidate_eligibility_label(true), do: "Eligible"
+  defp candidate_eligibility_label(false), do: "Not eligible"
+
+  defp format_scheduler_score(score) when is_integer(score), do: to_string(score)
+  defp format_scheduler_score(_score), do: "Not recorded"
+
+  defp format_scheduler_value(value) when is_integer(value), do: to_string(value)
+
+  defp format_scheduler_value(value) when is_float(value),
+    do: :erlang.float_to_binary(value, decimals: 2)
+
+  defp format_scheduler_value(value) when is_boolean(value), do: to_string(value)
+  defp format_scheduler_value(value) when is_binary(value), do: value
+  defp format_scheduler_value(nil), do: "Not recorded"
+  defp format_scheduler_value(value), do: inspect(value)
+
+  defp scheduler_entries(map) when is_map(map) do
+    map
+    |> Enum.map(fn {key, value} -> {to_string(key), value} end)
+    |> Enum.sort_by(fn {key, _value} -> key end)
+  end
+
+  defp scheduler_entries(_value), do: []
+
+  defp sanitized_scheduler_diagnostics(map) when is_map(map) do
+    Map.reject(map, fn {key, _value} ->
+      key
+      |> to_string()
+      |> String.match?(@unsafe_scheduler_diagnostic_key_pattern)
+    end)
+  end
+
+  defp sanitized_scheduler_diagnostics(_value), do: %{}
 
   defp state_tone(:completed), do: :success
   defp state_tone(:failed), do: :error

--- a/apps/orchard_controller/lib/orchard/console/request_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/request_live.ex
@@ -592,7 +592,7 @@ defmodule OrchardConsole.RequestLive do
             Scheduler Decision
           </h4>
           <.json_block
-            data={@request.scheduler_decision}
+            data={sanitized_scheduler_decision(@request.scheduler_decision)}
             content_id="request-scheduler-decision"
             fallback_id="request-scheduler-decision-fallback"
             fallback_text="Not recorded for this request."
@@ -1008,14 +1008,32 @@ defmodule OrchardConsole.RequestLive do
   defp scheduler_entries(_value), do: []
 
   defp sanitized_scheduler_diagnostics(map) when is_map(map) do
-    Map.reject(map, fn {key, _value} ->
-      key
-      |> to_string()
-      |> String.match?(@unsafe_scheduler_diagnostic_key_pattern)
-    end)
+    Map.reject(map, fn {key, _value} -> unsafe_scheduler_key?(key) end)
   end
 
   defp sanitized_scheduler_diagnostics(_value), do: %{}
+
+  defp sanitized_scheduler_decision(map) when is_map(map) do
+    map
+    |> Map.reject(fn {key, _value} -> unsafe_scheduler_key?(key) end)
+    |> Map.new(fn {key, value} -> {key, sanitized_scheduler_decision_value(value)} end)
+  end
+
+  defp sanitized_scheduler_decision(_value), do: nil
+
+  defp sanitized_scheduler_decision_value(value) when is_map(value),
+    do: sanitized_scheduler_decision(value)
+
+  defp sanitized_scheduler_decision_value(values) when is_list(values),
+    do: Enum.map(values, &sanitized_scheduler_decision_value/1)
+
+  defp sanitized_scheduler_decision_value(value), do: value
+
+  defp unsafe_scheduler_key?(key) do
+    key
+    |> to_string()
+    |> String.match?(@unsafe_scheduler_diagnostic_key_pattern)
+  end
 
   defp state_tone(:completed), do: :success
   defp state_tone(:failed), do: :error

--- a/apps/orchard_controller/lib/orchard/console/request_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/request_live.ex
@@ -1033,8 +1033,6 @@ defmodule OrchardConsole.RequestLive do
     |> Enum.sort_by(fn {key, _value} -> key end)
   end
 
-  defp scheduler_entries(_value), do: []
-
   defp sanitized_scheduler_metadata(map) when is_map(map) do
     Map.reject(map, fn {key, _value} -> unsafe_scheduler_key?(key) end)
   end

--- a/apps/orchard_controller/lib/orchard/console/request_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/request_live.ex
@@ -329,11 +329,11 @@ defmodule OrchardConsole.RequestLive do
 
           <% _ -> %>
             <.state_message
-              id="scheduler-explanation-loading"
-              kind={:loading}
+              id="scheduler-explanation-unavailable"
+              kind={:error}
               layout={:compact}
-              title="Loading scheduler explanation."
-              body="The scheduler explanation will appear when the LiveView connects."
+              title="Scheduler explanation unavailable."
+              body="The scheduler explanation state is unavailable."
             />
         <% end %>
       </.card>
@@ -373,10 +373,13 @@ defmodule OrchardConsole.RequestLive do
   defp candidate_card(assigns) do
     assigns =
       assigns
-      |> assign(:components, scheduler_entries(assigns.candidate.components))
+      |> assign(
+        :components,
+        scheduler_entries(sanitized_scheduler_metadata(assigns.candidate.components))
+      )
       |> assign(
         :diagnostics,
-        scheduler_entries(sanitized_scheduler_diagnostics(assigns.candidate.diagnostics))
+        scheduler_entries(sanitized_scheduler_metadata(assigns.candidate.diagnostics))
       )
 
     ~H"""
@@ -971,14 +974,38 @@ defmodule OrchardConsole.RequestLive do
     do: "Persisted scheduler explanation is invalid."
 
   defp scheduler_explanation_error_body(reason),
-    do: "Persisted scheduler explanation is invalid: #{inspect(reason)}"
+    do:
+      "Persisted scheduler explanation is invalid: #{scheduler_explanation_error_category(reason)}"
 
-  defp selected_candidates(%{selected_node_id: selected_node_id, scored_candidates: candidates})
-       when is_binary(selected_node_id) and is_list(candidates) do
-    Enum.filter(candidates, &(&1.node_id == selected_node_id))
+  defp scheduler_explanation_error_category({category, _field, _value}) when is_atom(category),
+    do: to_string(category)
+
+  defp scheduler_explanation_error_category({category, _value}) when is_atom(category),
+    do: to_string(category)
+
+  defp scheduler_explanation_error_category(category) when is_atom(category),
+    do: to_string(category)
+
+  defp scheduler_explanation_error_category(_reason), do: "unknown"
+
+  defp selected_candidates(%{selected_node_id: selected_node_id} = explanation)
+       when is_binary(selected_node_id) do
+    explanation
+    |> scheduler_candidate_lists()
+    |> Enum.filter(&(&1.node_id == selected_node_id))
   end
 
   defp selected_candidates(_explanation), do: []
+
+  defp scheduler_candidate_lists(explanation) do
+    [
+      Map.get(explanation, :scored_candidates),
+      Map.get(explanation, :skipped_candidates),
+      Map.get(explanation, :rejected_candidates)
+    ]
+    |> Enum.filter(&is_list/1)
+    |> List.flatten()
+  end
 
   defp candidate_eligibility_tone(true), do: :success
   defp candidate_eligibility_tone(false), do: :neutral
@@ -1007,11 +1034,11 @@ defmodule OrchardConsole.RequestLive do
 
   defp scheduler_entries(_value), do: []
 
-  defp sanitized_scheduler_diagnostics(map) when is_map(map) do
+  defp sanitized_scheduler_metadata(map) when is_map(map) do
     Map.reject(map, fn {key, _value} -> unsafe_scheduler_key?(key) end)
   end
 
-  defp sanitized_scheduler_diagnostics(_value), do: %{}
+  defp sanitized_scheduler_metadata(_value), do: %{}
 
   defp sanitized_scheduler_decision(map) when is_map(map) do
     map

--- a/apps/orchard_controller/test/orchard/console/request_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/request_live_test.exs
@@ -385,6 +385,8 @@ defmodule OrchardConsole.RequestLiveTest do
       assert explanation_html =~ "loaded"
       assert explanation_html =~ "842"
       assert explanation_html =~ "pool_bonus"
+      refute explanation_html =~ "prompt_fragment"
+      refute explanation_html =~ "component prompt leak"
       assert explanation_html =~ "Selected Candidate"
       assert explanation_html =~ "Scored Candidates"
       assert explanation_html =~ "Skipped Candidates"
@@ -468,7 +470,8 @@ defmodule OrchardConsole.RequestLiveTest do
       assert explanation_html =~ "scheduler-explanation-invalid"
       assert explanation_html =~ "Scheduler explanation is invalid."
       assert explanation_html =~ "Persisted scheduler explanation is invalid"
-      assert explanation_html =~ "not_a_scheduler_code"
+      assert explanation_html =~ "unknown_code"
+      refute explanation_html =~ "not_a_scheduler_code"
       refute explanation_html =~ "Selected Candidate"
     end
 
@@ -1306,7 +1309,11 @@ defmodule OrchardConsole.RequestLiveTest do
                    eligible: true,
                    tier: :loaded,
                    score: 842,
-                   components: %{pool_bonus: 200, health_bonus: 30},
+                   components: %{
+                     pool_bonus: 200,
+                     health_bonus: 30,
+                     prompt_fragment: "component prompt leak"
+                   },
                    diagnostics: %{capacity_window: "warm", internal_prompt: "must not render"},
                    reason_codes: []
                  }

--- a/apps/orchard_controller/test/orchard/console/request_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/request_live_test.exs
@@ -372,7 +372,10 @@ defmodule OrchardConsole.RequestLiveTest do
     } do
       request = persist_valid_scheduler_explanation!("resp_console_scheduler_explanation_full")
 
-      {:ok, view, _html} = live(conn, "/console/requests/#{request.public_id}")
+      {:ok, view, html} = live(conn, "/console/requests/#{request.public_id}")
+
+      refute html =~ "internal_prompt"
+      refute html =~ "must not render"
 
       explanation_html = element(view, "#request-scheduler-explanation-card") |> render()
 
@@ -390,10 +393,96 @@ defmodule OrchardConsole.RequestLiveTest do
       assert explanation_html =~ "node_not_active"
       assert explanation_html =~ "insufficient_memory"
       assert explanation_html =~ "capacity_window"
+      refute explanation_html =~ "internal_prompt"
+      refute explanation_html =~ "must not render"
 
       skipped_pos = :binary.match(explanation_html, "Skipped Candidates") |> elem(0)
       rejected_pos = :binary.match(explanation_html, "Rejected Candidates") |> elem(0)
       assert skipped_pos < rejected_pos
+    end
+
+    test "SPEC.md §7.3.5 renders legacy candidate-less scheduler decisions as empty explanation shape",
+         %{conn: conn} do
+      request =
+        create_request!(%{
+          state: :completed,
+          public_id: "resp_console_scheduler_explanation_legacy",
+          scheduler_decision: %{"strategy" => "single_node"}
+        })
+
+      {:ok, view, _html} = live(conn, "/console/requests/#{request.public_id}")
+
+      explanation_html = element(view, "#request-scheduler-explanation-card") |> render()
+
+      assert explanation_html =~ "Scheduler Explanation"
+      assert explanation_html =~ request.public_id
+      assert explanation_html =~ "No selected candidate was recorded."
+      assert explanation_html =~ "No scored candidates were recorded."
+      assert explanation_html =~ "No skipped candidates were recorded."
+      assert explanation_html =~ "No rejected candidates were recorded."
+      refute explanation_html =~ "scheduler-explanation-invalid"
+      refute explanation_html =~ "scheduler-explanation-not-found"
+    end
+
+    test "SPEC.md §7.3.5 renders not-found state when a request has no scheduler explanation",
+         %{conn: conn} do
+      request =
+        create_request!(%{
+          state: :completed,
+          public_id: "resp_console_scheduler_explanation_missing",
+          scheduler_decision: nil
+        })
+
+      {:ok, view, _html} = live(conn, "/console/requests/#{request.public_id}")
+
+      explanation_html = element(view, "#request-scheduler-explanation-card") |> render()
+
+      assert explanation_html =~ "scheduler-explanation-not-found"
+      assert explanation_html =~ "No scheduler explanation recorded."
+      assert explanation_html =~ "This request has no persisted scheduler explanation."
+      refute explanation_html =~ "scheduler-explanation-invalid"
+    end
+
+    test "SPEC.md §7.3.5 renders invalid persisted scheduler explanations as safe error state",
+         %{conn: conn} do
+      request =
+        create_request!(%{
+          state: :completed,
+          public_id: "resp_console_scheduler_explanation_invalid",
+          scheduler_decision: %{
+            "request_id" => "resp_console_scheduler_explanation_invalid",
+            "selected_node_id" => "node-selected",
+            "selection_tier" => "loaded",
+            "scored_candidates" => [],
+            "rejected_candidates" => [
+              %{"node_id" => "node-rejected", "reason_codes" => ["not_a_scheduler_code"]}
+            ],
+            "skipped_candidates" => []
+          }
+        })
+
+      {:ok, view, _html} = live(conn, "/console/requests/#{request.public_id}")
+
+      explanation_html = element(view, "#request-scheduler-explanation-card") |> render()
+
+      assert explanation_html =~ "scheduler-explanation-invalid"
+      assert explanation_html =~ "Scheduler explanation is invalid."
+      assert explanation_html =~ "Persisted scheduler explanation is invalid"
+      assert explanation_html =~ "not_a_scheduler_code"
+      refute explanation_html =~ "Selected Candidate"
+    end
+
+    test "disconnected render defers scheduler explanation loading behind request loading state",
+         %{conn: conn} do
+      request = persist_valid_scheduler_explanation!("resp_console_scheduler_explanation_static")
+
+      conn = get(conn, "/console/requests/#{request.public_id}")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "request-loading-card"
+      assert conn.resp_body =~ "Request details will appear when the LiveView connects."
+      refute conn.resp_body =~ "request-scheduler-explanation-card"
+      refute conn.resp_body =~ "node-selected"
     end
   end
 

--- a/apps/orchard_controller/test/orchard/console/request_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/request_live_test.exs
@@ -363,6 +363,41 @@ defmodule OrchardConsole.RequestLiveTest do
   end
 
   # ===========================================================================
+  # Scheduler explanation
+  # ===========================================================================
+
+  describe "scheduler explanation" do
+    test "SPEC.md §7.3.5 renders selected scored skipped and rejected candidates separately", %{
+      conn: conn
+    } do
+      request = persist_valid_scheduler_explanation!("resp_console_scheduler_explanation_full")
+
+      {:ok, view, _html} = live(conn, "/console/requests/#{request.public_id}")
+
+      explanation_html = element(view, "#request-scheduler-explanation-card") |> render()
+
+      assert explanation_html =~ "Scheduler Explanation"
+      assert explanation_html =~ request.public_id
+      assert explanation_html =~ "node-selected"
+      assert explanation_html =~ "loaded"
+      assert explanation_html =~ "842"
+      assert explanation_html =~ "pool_bonus"
+      assert explanation_html =~ "Selected Candidate"
+      assert explanation_html =~ "Scored Candidates"
+      assert explanation_html =~ "Skipped Candidates"
+      assert explanation_html =~ "Rejected Candidates"
+      assert explanation_html =~ "lower_tier_not_considered"
+      assert explanation_html =~ "node_not_active"
+      assert explanation_html =~ "insufficient_memory"
+      assert explanation_html =~ "capacity_window"
+
+      skipped_pos = :binary.match(explanation_html, "Skipped Candidates") |> elem(0)
+      rejected_pos = :binary.match(explanation_html, "Rejected Candidates") |> elem(0)
+      assert skipped_pos < rejected_pos
+    end
+  end
+
+  # ===========================================================================
   # Canonical request
   # ===========================================================================
 
@@ -1166,5 +1201,43 @@ defmodule OrchardConsole.RequestLiveTest do
   defp append_event!(request, attrs) do
     {:ok, event} = Requests.append_request_event(request, attrs)
     event
+  end
+
+  defp persist_valid_scheduler_explanation!(public_id) do
+    request = create_request!(%{public_id: public_id})
+
+    assert {:ok, request} =
+             Requests.record_schedule(request, %{
+               request_id: request.public_id,
+               selected_node_id: "node-selected",
+               selection_tier: :loaded,
+               scored_candidates: [
+                 %{
+                   node_id: "node-selected",
+                   eligible: true,
+                   tier: :loaded,
+                   score: 842,
+                   components: %{pool_bonus: 200, health_bonus: 30},
+                   diagnostics: %{capacity_window: "warm", internal_prompt: "must not render"},
+                   reason_codes: []
+                 }
+               ],
+               rejected_candidates: [
+                 %{
+                   node_id: "node-rejected",
+                   diagnostics: %{capacity_window: "full"},
+                   reason_codes: [:node_not_active, "insufficient_memory"]
+                 }
+               ],
+               skipped_candidates: [
+                 %{
+                   node_id: "node-skipped",
+                   diagnostics: %{capacity_window: "not_considered"},
+                   reason_codes: [:lower_tier_not_considered]
+                 }
+               ]
+             })
+
+    request
   end
 end

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -70,12 +70,18 @@
   Existing backend execution is wired for cordon, uncordon, drain, resume, and decommission with confirmation gates and mutation-time lifecycle revalidation.
   Maintenance remains preview-visible but execution-blocked by `drain_completion_unverified` until drain completion and active-work quiescence can be verified.
   Drain deadline orchestration, active-work cancellation, automatic `draining -> maintenance`, known active request counts, and any reusable dialog primitive remain future slices.
-- [ ] 5.4 Add scheduler explanation views with selected candidate, skipped candidates, fixed reason codes, and sanitized diagnostics.
+- [x] 5.4 Add scheduler explanation views with selected candidate, skipped candidates, fixed reason codes, and sanitized diagnostics.
+  Note: Console request detail now renders the shared `SchedulerExplanationPresenter` contract in a request-scoped panel after Execution Metadata.
+  Note: The placement follows the existing request detail IA because scheduler explanations are request-scoped execution evidence and the page already owns execution metadata and request provenance.
+  Note: The panel keeps selected, scored, skipped, and rejected candidates in separate grouped sections and renders stable reason codes as compact badges.
+  Note: Scheduler decision debug JSON and candidate diagnostics now filter unsafe prompt, token, secret, credential, DSN, body, payload, request, and response keys before rendering.
+  Note: Public LiveView tests cover the full candidate groups, not found, legacy empty shape, invalid persisted explanation, and disconnected deferred render.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
 - [ ] 5.6 Add read-only HA-lite control-plane status.
 - [ ] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
   Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile.
   PR #41 browser-verified the Console lifecycle preview slice against `docs/DESIGN.md`.
+  Note: This task 5.4 slice browser-verified the request-scoped scheduler explanation panel on desktop and mobile with screenshots at `tmp/browser-verification/scheduler-explanation-desktop.png` and `tmp/browser-verification/scheduler-explanation-mobile.png`.
   Keep this unchecked as a recurring gate for future Console slices.
 
 ## 6. Diagnostics And Support Bundles

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -74,8 +74,9 @@
   Note: Console request detail now renders the shared `SchedulerExplanationPresenter` contract in a request-scoped panel after Execution Metadata.
   Note: The placement follows the existing request detail IA because scheduler explanations are request-scoped execution evidence and the page already owns execution metadata and request provenance.
   Note: The panel keeps selected, scored, skipped, and rejected candidates in separate grouped sections and renders stable reason codes as compact badges.
-  Note: Scheduler decision debug JSON and candidate diagnostics now filter unsafe prompt, token, secret, credential, DSN, body, payload, request, and response keys before rendering.
+  Note: Scheduler decision debug JSON plus candidate diagnostics and score components now filter unsafe prompt, token, secret, credential, DSN, body, payload, request, and response keys before rendering.
   Note: Public LiveView tests cover the full candidate groups, not found, legacy empty shape, invalid persisted explanation, and disconnected deferred render.
+  Note: The diagnostics and components deny-list is key-based and does not inspect values, accepted because the data domain is internal scheduler metadata.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
 - [ ] 5.6 Add read-only HA-lite control-plane status.
 - [ ] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.


### PR DESCRIPTION
## Intent

The developer was working on the Orchard console's scheduler explanation panel feature (tracing to SPEC.md section 7.3.5 and the cluster-management-ux-foundation OpenSpec change) and asked the agent to address code review findings by hardening how persisted scheduler explanations render in the LiveView console. Their goal was to fix several security and correctness issues: closing a sanitization asymmetry so components apply the same unsafe-key deny-list filter as diagnostics, ensuring invalid explanation error bodies render only a safe category (like unknown_code) rather than echoing the raw offending token, replacing unreachable loading copy with a defensive unavailable fallback, and making the selected-candidate lookup consider scored, skipped, and rejected candidate lists. They required regression test coverage citing the relevant SPEC section and expected the full Elixir quality workflow (format, credo strict, tests) plus OpenSpec validation to pass, while recording the accepted residual risk that the deny-list is key-based and does not inspect values. The developer did not want the branch pushed.

## What Changed

- Added a scheduler-explanation panel to `RequestLive` that renders the persisted scheduler decision for a request — surfacing the selected candidate and scored/skipped/rejected candidate lists, with valid, invalid, and not-found states handled distinctly.
- Hardened the rendering path so components apply the same key-based unsafe-diagnostic deny-list as diagnostics, invalid explanations render only a safe error category (e.g. `unknown_code`) instead of echoing the raw offending token, and an unavailable/loading fallback replaces unreachable copy; also fixed an unreachable Dialyzer clause in the scored-entries handling.
- Added regression tests covering the valid, invalid, and not-found scheduler-explanation states (citing SPEC.md §7.3.5) and marked the corresponding `cluster-management-ux-foundation` task complete.

## Risk Assessment

✅ Low: A well-bounded, comprehensively tested LiveView rendering/hardening change whose security-relevant claims (symmetric deny-list, safe error-category rendering, no missing assigns) were verified against the presenter, shared contract, and tests, leaving only minor cosmetic/tradeoff notes.

## Testing

<code>Fetched missing deps and trusted the mise config, then ran the targeted SPEC.md §7.3.5 scheduler-explanation tests (5 pass) and the full request_live_test.exs file (60 real tests pass, no regressions). To show the actual end-user surface, I drove the LiveView to render the scheduler-explanation card for the valid, invalid, and not-found states, captured the rendered HTML, and produced a full-page screenshot (scheduler_explanation_states.png). The screenshot and grep checks confirm all four hardening goals: components/diagnostics deny-list symmetry (injected prompt keys and values are absent), safe error category `unknown_code` instead of the raw token, the &#34;unavailable&#34; fallback copy, and separate selected/scored/skipped/rejected candidate sections. The one remaining hardening detail — the `_ -&gt;` &#34;unavailable&#34; fallback branch — is a defensive unreachable state in the current status flow, so it has no user-drivable path and is verified only by code inspection rather than a screenshot.</code>

- Evidence: Rendered scheduler-explanation card — valid/invalid/not-found states (full-page screenshot) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWPV26ZZF0566ZHBFBKHH3MZ/scheduler_explanation_states.png</code>)
<details>
<summary>Evidence: Combined evidence HTML (three rendered card states)</summary>

```text
<!doctype html><html><head><meta charset=utf-8>
<style>
body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;background:#0f1115;color:#e6e6e6;margin:0;padding:24px;line-height:1.5}
h1{font-size:20px} h2{font-size:14px;color:#9fd3a8;border-bottom:1px solid #2a2f3a;padding-bottom:6px;margin-top:32px}
.card{background:#171a21;border:1px solid #2a2f3a;border-radius:10px;padding:16px;margin-top:10px;overflow:auto}
.card *{max-width:100%} dl{margin:4px 0} dt{color:#8aa0b8;font-size:12px} dd{margin:0 0 8px 0;font-family:ui-monospace,monospace}
h3,h4{color:#cbd5e1} table{border-collapse:collapse} td,th{border:1px solid #2a2f3a;padding:4px 8px;font-size:12px}
</style></head><body>
<h1>Orchard Console — Scheduler Explanation rendering (SPEC.md §7.3.5) — hardened states</h1>
<p style="color:#8aa0b8;font-size:12px">Rendered LiveView card fragments captured from OrchardConsole.RequestLiveTest. Utility classes unstyled; content/copy is the end-user-visible surface.</p>
<section><h2>1 — Valid explanation (sanitization symmetry): deny-listed component `prompt_fragment` and diagnostic `internal_prompt` are stripped; safe keys like pool_bonus / capacity_window remain</h2><div class="card"><div id="request-scheduler-explanation-card"><div class="rounded-lg border border-slate-200 bg-white shadow-sm ring-1 ring-navy/10 dark:border-slate-700 dark:bg-slate-800 dark:ring-sky-400/20 "><div class="border-b border-slate-200 dark:border-slate-700 px-6 py-4 "><div class="flex items-center justify-between gap-4"><div><h3 class="text-base font-semibold text-navy dark:text-sky-400">
          Scheduler Explanation
        </h3><p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
          
      Shared selected, scored, skipped, and rejected candidate contract from SPEC.md §7.3.5.
    
        </p></div></div></div><div class="px-6 py-4"><div class="space-y-5"><dl class="grid gap-x-6 gap-y-4 grid-cols-1 sm:grid-cols-3"><div id="scheduler-explanation-request-id" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Request ID
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
              resp_evidence_full
            
  </dd></div><div id="scheduler-explanation-selected-node" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Selected Node
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
              node-selected
            
  </dd></div><div id="scheduler-explanation-selection-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Selection Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
              loaded
            
  </dd></div></dl><section id="scheduler-selected-candidate" class="space-y-3"><div class="flex items-center gap-2"><h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Selected Candidate</h4><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-forest-50 text-forest-700 ring-forest/10 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-400/30 font-mono">
  1
</span></div><div class="grid gap-3 lg:grid-cols-2"><article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"><div class="flex flex-wrap items-start justify-between gap-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
        Candidate 1
      </p><p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
        node-selected
      </p></div><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-forest-50 text-forest-700 ring-forest/10 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-400/30 ">
  
      Eligible
    
</span></div><dl class="grid gap-x-4 gap-y-3 mt-4 grid-cols-2"><div id="scheduler-selected-candidate-candidate-1-target" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Target
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
      —
    
  </dd></div><div id="scheduler-selected-candidate-candidate-1-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      loaded
    
  </dd></div><div id="scheduler-selected-candidate-candidate-1-score" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Score
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      842
    
  </dd></div></dl><div class="mt-4 space-y-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason Codes</p><p class="mt-1 text-sm text-slate-400 dark:text-slate-500">No reason codes.</p></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Score Components</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">health_bonus</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">30</dd></div><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">pool_bonus</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">200</dd></div></dl></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostics</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">capacity_window</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">warm</dd></div></dl></div></div></article></div></section><section id="scheduler-scored-candidates" class="space-y-3"><div class="flex items-center gap-2"><h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Scored Candidates</h4><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-sky-50 text-sky-700 ring-sky-600/10 dark:bg-sky-900/30 dark:text-sky-300 dark:ring-sky-500/20 font-mono">
  1
</span></div><div class="grid gap-3 lg:grid-cols-2"><article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"><div class="flex flex-wrap items-start justify-between gap-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
        Candidate 1
      </p><p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
        node-selected
      </p></div><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-forest-50 text-forest-700 ring-forest/10 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-400/30 ">
  
      Eligible
    
</span></div><dl class="grid gap-x-4 gap-y-3 mt-4 grid-cols-2"><div id="scheduler-scored-candidates-candidate-1-target" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Target
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
      —
    
  </dd></div><div id="scheduler-scored-candidates-candidate-1-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      loaded
    
  </dd></div><div id="scheduler-scored-candidates-candidate-1-score" class=""><dt class="text-

... [3625 bytes truncated] ...

ext-slate-100 font-mono">
    
      Not recorded
    
  </dd></div></dl><div class="mt-4 space-y-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason Codes</p><div class="mt-2 flex flex-wrap gap-2"><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 font-mono">
  lower_tier_not_considered
</span></div></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Score Components</p><p class="mt-1 text-sm text-slate-400 dark:text-slate-500">No score components.</p></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostics</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">capacity_window</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">not_considered</dd></div></dl></div></div></article></div></section><section id="scheduler-rejected-candidates" class="space-y-3"><div class="flex items-center gap-2"><h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Rejected Candidates</h4><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-red-50 text-red-700 ring-red-600/10 dark:bg-red-900/30 dark:text-red-300 dark:ring-red-600/20 font-mono">
  1
</span></div><div class="grid gap-3 lg:grid-cols-2"><article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"><div class="flex flex-wrap items-start justify-between gap-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
        Candidate 1
      </p><p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
        node-rejected
      </p></div><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 ">
  
      Not eligible
    
</span></div><dl class="grid gap-x-4 gap-y-3 mt-4 grid-cols-2"><div id="scheduler-rejected-candidates-candidate-1-target" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Target
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
      —
    
  </dd></div><div id="scheduler-rejected-candidates-candidate-1-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      —
    
  </dd></div><div id="scheduler-rejected-candidates-candidate-1-score" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Score
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      Not recorded
    
  </dd></div></dl><div class="mt-4 space-y-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason Codes</p><div class="mt-2 flex flex-wrap gap-2"><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 font-mono">
  node_not_active
</span><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 font-mono">
  insufficient_memory
</span></div></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Score Components</p><p class="mt-1 text-sm text-slate-400 dark:text-slate-500">No score components.</p></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostics</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">capacity_window</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">full</dd></div></dl></div></div></article></div></section></div></div></div></div></div></section><section><h2>2 — Invalid persisted explanation: renders safe category `unknown_code`, never the raw offending token `not_a_scheduler_code`</h2><div class="card"><div id="request-scheduler-explanation-card"><div class="rounded-lg border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 "><div class="border-b border-slate-200 dark:border-slate-700 px-6 py-4 "><div class="flex items-center justify-between gap-4"><div><h3 class="text-base font-semibold text-slate-900 dark:text-slate-100">
          Scheduler Explanation
        </h3><p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
          
      Shared selected, scored, skipped, and rejected candidate contract from SPEC.md §7.3.5.
    
        </p></div></div></div><div class="px-6 py-4"><div id="scheduler-explanation-invalid" class="mx-auto max-w-sm rounded-lg border p-3 border-red-200 bg-red-50/50 dark:border-red-800 dark:bg-red-900/20"><div class="flex items-start gap-2.5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="h-5 w-5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"></path></svg><div class="min-w-0 flex-1"><p class="text-sm text-red-700 dark:text-red-300">
        Scheduler explanation is invalid.
      </p><p class="text-xs mt-0.5 text-slate-500 dark:text-slate-400">
        Persisted scheduler explanation is invalid: unknown_code
      </p></div></div></div></div></div></div></div></section><section><h2>3 — Not-found: no persisted scheduler explanation recorded</h2><div class="card"><div id="request-scheduler-explanation-card"><div class="rounded-lg border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800 "><div class="border-b border-slate-200 dark:border-slate-700 px-6 py-4 "><div class="flex items-center justify-between gap-4"><div><h3 class="text-base font-semibold text-slate-900 dark:text-slate-100">
          Scheduler Explanation
        </h3><p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
          
      Shared selected, scored, skipped, and rejected candidate contract from SPEC.md §7.3.5.
    
        </p></div></div></div><div class="px-6 py-4"><div id="scheduler-explanation-not-found" class="mx-auto max-w-sm rounded-lg border p-3 border-slate-200 bg-slate-50/50 dark:border-slate-700 dark:bg-slate-800/30"><div class="flex items-start gap-2.5"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="h-5 w-5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"></path></svg><div class="min-w-0 flex-1"><p class="text-sm text-slate-600 dark:text-slate-400">
        No scheduler explanation recorded.
      </p><p class="text-xs mt-0.5 text-slate-500 dark:text-slate-400">
        This request has no persisted scheduler explanation.
      </p></div></div></div></div></div></div></div></section>
</body></html>
```
</details>
<details>
<summary>Evidence: Valid card fragment (deny-listed component/diagnostic keys stripped)</summary>

```text
<div id="request-scheduler-explanation-card"><div class="rounded-lg border border-slate-200 bg-white shadow-sm ring-1 ring-navy/10 dark:border-slate-700 dark:bg-slate-800 dark:ring-sky-400/20 "><div class="border-b border-slate-200 dark:border-slate-700 px-6 py-4 "><div class="flex items-center justify-between gap-4"><div><h3 class="text-base font-semibold text-navy dark:text-sky-400">
          Scheduler Explanation
        </h3><p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
          
      Shared selected, scored, skipped, and rejected candidate contract from SPEC.md §7.3.5.
    
        </p></div></div></div><div class="px-6 py-4"><div class="space-y-5"><dl class="grid gap-x-6 gap-y-4 grid-cols-1 sm:grid-cols-3"><div id="scheduler-explanation-request-id" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Request ID
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
              resp_evidence_full
            
  </dd></div><div id="scheduler-explanation-selected-node" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Selected Node
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
              node-selected
            
  </dd></div><div id="scheduler-explanation-selection-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Selection Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
              loaded
            
  </dd></div></dl><section id="scheduler-selected-candidate" class="space-y-3"><div class="flex items-center gap-2"><h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Selected Candidate</h4><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-forest-50 text-forest-700 ring-forest/10 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-400/30 font-mono">
  1
</span></div><div class="grid gap-3 lg:grid-cols-2"><article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"><div class="flex flex-wrap items-start justify-between gap-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
        Candidate 1
      </p><p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
        node-selected
      </p></div><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-forest-50 text-forest-700 ring-forest/10 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-400/30 ">
  
      Eligible
    
</span></div><dl class="grid gap-x-4 gap-y-3 mt-4 grid-cols-2"><div id="scheduler-selected-candidate-candidate-1-target" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Target
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
      —
    
  </dd></div><div id="scheduler-selected-candidate-candidate-1-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      loaded
    
  </dd></div><div id="scheduler-selected-candidate-candidate-1-score" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Score
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      842
    
  </dd></div></dl><div class="mt-4 space-y-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason Codes</p><p class="mt-1 text-sm text-slate-400 dark:text-slate-500">No reason codes.</p></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Score Components</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">health_bonus</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">30</dd></div><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">pool_bonus</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">200</dd></div></dl></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostics</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">capacity_window</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">warm</dd></div></dl></div></div></article></div></section><section id="scheduler-scored-candidates" class="space-y-3"><div class="flex items-center gap-2"><h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Scored Candidates</h4><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-sky-50 text-sky-700 ring-sky-600/10 dark:bg-sky-900/30 dark:text-sky-300 dark:ring-sky-500/20 font-mono">
  1
</span></div><div class="grid gap-3 lg:grid-cols-2"><article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"><div class="flex flex-wrap items-start justify-between gap-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
        Candidate 1
      </p><p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
        node-selected
      </p></div><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-forest-50 text-forest-700 ring-forest/10 dark:bg-emerald-900/30 dark:text-emerald-400 dark:ring-emerald-400/30 ">
  
      Eligible
    
</span></div><dl class="grid gap-x-4 gap-y-3 mt-4 grid-cols-2"><div id="scheduler-scored-candidates-candidate-1-target" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Target
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
      —
    
  </dd></div><div id="scheduler-scored-candidates-candidate-1-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      loaded
    
  </dd></div><div id="scheduler-scored-candidates-candidate-1-score" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Score
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      842
    
  </dd></div></dl><div class="mt-4 space-y-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason Codes</p><p class="mt-1 text-sm text-slate-400 dark:text-slate-500">No reason codes.</p></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Score Components</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">health_bonus</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">30</dd></div><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">pool_bonus</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">200</dd></div></dl></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostics</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">capacity_window</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">warm</dd></div></dl></div></div></article></div></section><section id="scheduler-skipped-candidates" class="space-y-3"><div class="flex items-center gap-2"><h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Skipped Candidates</h4><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-amber-50 text-amber-700 ring-amber-600/10 dark:bg-amber-900/30 dark:text-amber-300 dark:ring-amber-500/20 font-mono">
  1
</span></div><div class="grid gap-3 lg:grid-cols-2"><article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"><div class="flex flex-wrap items-start justify-between gap-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
        Candidate 1
      </p><p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
        node-skipped
      </p></div><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 ">
  
      Not eligible
    
</span></div><dl class="grid gap-x-4 gap-y-3 mt-4 grid-cols-2"><div id="scheduler-skipped-candidates-candidate-1-target" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Target
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
      —
    
  </dd></div><div id="scheduler-skipped-candidates-candidate-1-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      —
    
  </dd></div><div id="scheduler-skipped-candidates-candidate-1-score" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Score
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      Not recorded
    
  </dd></div></dl><div class="mt-4 space-y-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason Codes</p><div class="mt-2 flex flex-wrap gap-2"><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 font-mono">
  lower_tier_not_considered
</span></div></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Score Components</p><p class="mt-1 text-sm text-slate-400 dark:text-slate-500">No score components.</p></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostics</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">capacity_window</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">not_considered</dd></div></dl></div></div></article></div></section><section id="scheduler-rejected-candidates" class="space-y-3"><div class="flex items-center gap-2"><h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Rejected Candidates</h4><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-red-50 text-red-700 ring-red-600/10 dark:bg-red-900/30 dark:text-red-300 dark:ring-red-600/20 font-mono">
  1
</span></div><div class="grid gap-3 lg:grid-cols-2"><article class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"><div class="flex flex-wrap items-start justify-between gap-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
        Candidate 1
      </p><p class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">
        node-rejected
      </p></div><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 ">
  
      Not eligible
    
</span></div><dl class="grid gap-x-4 gap-y-3 mt-4 grid-cols-2"><div id="scheduler-rejected-candidates-candidate-1-target" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Target
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">
    
      —
    
  </dd></div><div id="scheduler-rejected-candidates-candidate-1-tier" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Tier
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      —
    
  </dd></div><div id="scheduler-rejected-candidates-candidate-1-score" class=""><dt class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
    Score
  </dt><dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono">
    
      Not recorded
    
  </dd></div></dl><div class="mt-4 space-y-3"><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason Codes</p><div class="mt-2 flex flex-wrap gap-2"><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 font-mono">
  node_not_active
</span><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-slate-50 text-slate-600 ring-slate-500/10 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-500/20 font-mono">
  insufficient_memory
</span></div></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Score Components</p><p class="mt-1 text-sm text-slate-400 dark:text-slate-500">No score components.</p></div><div><p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostics</p><dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2"><div class="rounded-md bg-white px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"><dt class="font-mono text-xs text-slate-500 dark:text-slate-400">capacity_window</dt><dd class="mt-1 break-all font-mono text-sm text-slate-900 dark:text-slate-100">full</dd></div></dl></div></div></article></div></section></div></div></div></div>
```
</details>
- Evidence: Invalid card fragment (safe category unknown_code, no raw token) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWPV26ZZF0566ZHBFBKHH3MZ/card_invalid.html</code>)
<details>
<summary>Evidence: Invalid-state error copy (grep of captured HTML)</summary>

```text
1 Persisted scheduler explanation is invalid: unknown_code
(0 matches for not_a_scheduler_code)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/console/request_live.ex:1016` - format_scheduler_score/1 (line 1016-1017) only matches integers, so a candidate whose persisted score is a JSON float renders as &#34;Not recorded&#34; — hiding a real value. This is inconsistent with format_scheduler_value/1 (line 1019-1027), which handles floats via :erlang.float_to_binary/2. If scores are always integers this is harmless, but the two formatters diverge for the same value type; extend format_scheduler_score to handle floats for consistency.
- ℹ️ `apps/orchard_controller/lib/orchard/console/request_live.ex:17` - The key-based deny-list @unsafe_scheduler_diagnostic_key_pattern (line 17) matches substrings like &#34;token&#34;/&#34;prompt&#34;/&#34;request&#34;, so non-sensitive scoring signals (e.g. a &#34;token_budget&#34; component or a &#34;request_id&#34; key in the raw scheduler_decision debug block) are silently dropped from the operator view. This is the documented, author-accepted residual risk of mirroring the diagnostics filter; noting only so reviewers are aware the filter can hide legitimate scheduler data, not just secrets.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mix test test/orchard/console/request_live_test.exs:369` — the 5 SPEC.md §7.3.5 scheduler-explanation regression tests, all pass</code>
- <code>`mix test test/orchard/console/request_live_test.exs` — full file, 60 real tests pass (the only failure was my temporary evidence-capture test, since removed)</code>
- `Temporary evidence test drove the LiveView to render the scheduler-explanation card for the valid, invalid, and not-found states plus the disconnected page, writing the rendered HTML to the evidence dir`
- <code>grep verification of captured HTML: valid card contains pool_bonus/capacity_window but not prompt_fragment/component-prompt-leak/internal_prompt/must-not-render; invalid card shows `Persisted scheduler explanation is invalid: unknown_code` and not `not_a_scheduler_code`</code>
- `Rendered the three card states into a combined HTML page and captured a full-page screenshot via agent-browser`
- <code>Fixed environment setup: ran `mise trust` and `mix deps.get` (deps were unfetched in this worktree); used PGDATABASE_TEST=orchard_test_nm_2b20bc518d75 to isolate the worktree DB</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
