### PR TITLE
docs: reconcile scheduler explanation contract truth after PRs #44-#46

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1928,6 +1928,10 @@ POST   /ops/v1/nodes/:node_id/diagnostics
 POST   /ops/v1/support-bundles
 ```
 
+Operator API requests SHALL authenticate with a service-account-owned API Token whose owning API Client is enabled and holds a cluster-scoped `operator` or `admin` RoleBinding.
+Tenant-direct API Keys, tenant-scoped Access Levels, and public inference credentials SHALL NOT authorize Operator API access and SHALL fail closed.
+Missing or invalid credentials SHALL return `401 invalid_api_key`; authenticated non-operator principals SHALL return `403 operator_required`.
+
 Eligibility-changing or destructive Operator and Admin node actions SHALL provide an Action Preview before execution.
 Action Previews SHALL be side-effect-free and SHALL NOT create domain rows, audit events, or Node Admission Decisions unless a future preview-audit contract explicitly says otherwise.
 The preview response SHALL separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements`.
@@ -2041,6 +2045,13 @@ Skipped candidates SHALL be represented in `skipped_candidates` outside the reje
 The initial scheduler rejection vocabulary SHALL include `inventory_missing`, `node_not_admitted`, `node_not_active`, `node_not_registered`, `node_health_unreachable`, `node_health_unhealthy`, `node_observation_stale`, `transport_unreachable`, `runtime_not_ready`, `runtime_identity_mismatch`, `version_incompatible`, `pool_not_allowed`, `model_format_unsupported`, `model_not_available_on_node`, `insufficient_memory`, `node_concurrency_exhausted`, `placement_concurrency_exhausted`, `placement_suppressed`, `node_circuit_breaker_open`, `model_load_suppressed`, `policy_required`, `pool_required`, `queue_lane_capacity_unavailable`, `trust_not_established`, and `unknown_capacity`.
 The initial scheduler skip vocabulary SHALL include `lower_tier_not_considered`, `not_scored_after_selection`, `not_applicable_to_request`, and `candidate_limit_reached`.
 Queue-waitable capacity outcomes SHALL preserve whether the wait reason is live node capacity, requested model path capacity, placement capacity, or tenant active capacity.
+Scored candidates SHALL be listed in the scheduler's actual selection ranking order.
+The selected node SHALL correspond to the top-ranked eligible scored candidate.
+A scored candidate's `score` SHALL be consistent with its additive `components` breakdown.
+Component keys are stable machine-readable identifiers within a persisted explanation and MAY evolve as the ranking model changes, but score and components SHALL remain internally consistent for a given persisted decision.
+Scheduler explanation generation, validation, and persistence are observational.
+An invalid or unbuildable explanation SHALL NOT fail, block, or alter the user's inference request.
+Invalid explanation payloads SHALL NOT be persisted; the controller SHALL drop them with a logged error while still recording the underlying scheduler decision.
 
 ---
 
@@ -3741,6 +3752,9 @@ Node lifecycle CLI commands SHALL provide side-effect-free `--dry-run` Action Pr
 Lifecycle execution SHALL enforce the preview's confirmation requirements, including `--yes`, consequence acknowledgement for drain and decommission, and a typed node id for decommission.
 Node lifecycle CLI commands use the same local controller-runtime authority boundary as node-admission CLI commands and SHALL enforce the same leader-only write-path, mutation-time revalidation, cluster-scoped audit, and shared-presenter semantics.
 Manual `draining -> maintenance` execution SHALL remain blocked with a `drain_completion_unverified` blocker until drain completion can be verified.
+
+`orchardctl requests inspect` SHALL render a request's persisted scheduler explanation through the shared scheduler explanation reason-code contract in stable human and JSON forms.
+Broader request execution diagnostics beyond persisted scheduler explanations remain future work.
 
 `orchardctl support bundle create` SHALL be able to emit `orchard.support_bundle.v2` for cluster-management support bundles.
 Console-triggered support bundles and CLI-created support bundles SHALL use the same v2 archive format for the same scope.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -514,6 +514,14 @@ not add a parallel comfortable table variant. A future PR may add table density
 only after a browser walk demonstrates a concrete table-crush regression caused
 by other typography or layout changes.
 
+### 6.6 Read-only Evidence Panels
+
+Read-only evidence surfaces such as the scheduler explanation panel render persisted decision evidence, not gated actions.
+They must not carry an execute control, confirmation input, or blocker row; those belong only to Action Preview panels.
+Use the existing card surface vocabulary and keep grouped candidate or evidence sections in labeled blocks rather than a flattened table.
+Render stable machine-readable codes as compact mono badges that stay visible or inspectable.
+When raw decision debug JSON is shown, apply the same key-based unsafe-key deny-list used for diagnostics and components, and render only a safe error category rather than echoing an offending raw token.
+
 ---
 
 ## 7. Motion

--- a/docs/decisions/0007-operator-api-operator-or-admin-auth.md
+++ b/docs/decisions/0007-operator-api-operator-or-admin-auth.md
@@ -1,0 +1,17 @@
+# Operator API uses operator-or-admin cluster-scoped service-account tokens
+
+Accepted.
+
+Operator API requests are cluster runtime-operations calls and require a service-account-owned API Token whose owning API Client is enabled and holds a cluster-scoped `operator` or `admin` RoleBinding with `tenant_scope_id = nil`.
+Tenant-direct API Keys and tenant-scoped Access Levels such as `inference_client` and `tenant_admin` do not authorize Operator API access.
+Public inference credentials do not authorize Operator API access.
+Unauthenticated callers receive `401 invalid_api_key`; authenticated non-operator principals receive `403 operator_required`.
+
+This extends ADR 0004's service-account bearer boundary to the narrower operator surface that ADR 0004 deferred.
+Admin-role principals retain Operator API access because cluster admin is a superset of operator.
+The admin and operator request-context plugs share one parameterized bearer-auth base so the two surfaces cannot drift.
+
+The trade-off is a second cluster-scoped bearer boundary that must stay fail-closed against tenant and public credentials.
+API Client disablement remains the single kill switch for both Admin and Operator service-account tokens.
+
+SPEC.md impact: `SPEC.md` §7.3 records the Operator API authentication boundary and its 401/403 codes.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -493,12 +493,17 @@ _Avoid_: Node inventory, hardware host
 A scheduling group based on model residency, such as loaded, cached, or cold.
 _Avoid_: Node pool
 
+**Queue Wait Reason**:
+A stable machine-readable classification of why queued work is still waiting, as live node capacity, requested model path capacity, placement capacity, or tenant active capacity.
+It is distinct from a Scheduler Reason Code, which explains a rejected or skipped candidate.
+_Avoid_: Scheduler Reason Code, tenant-facing error message, free-text wait note
+
 **Scheduler Decision**:
 The selected Runtime Endpoint and sanitized ranking metadata persisted with a Request.
 _Avoid_: Quota, Routing Policy, Scheduler Explanation, tenant-facing error reason
 
 **Scheduler Explanation**:
-Operator-facing reasoning for selected and rejected scheduling candidates.
+Operator-facing reasoning for a request's scheduling decision across selected, scored, skipped, and rejected candidates.
 _Avoid_: persisted Scheduler Decision metadata, tenant-facing error contract
 
 **Scheduler Reason Code**:

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -4,12 +4,16 @@
   Note: Reconciled accepted admission, Admin API dry-run preview, CLI admission-review command, Console admission-review, and shared freshness behavior from PRs #30 through #37.
   Reconciled node lifecycle transitions, lifecycle CLI commands, and preview-code stability from PRs #40 and #41.
   PR #42 required no `SPEC.md` change.
+  Reconciled scheduler explanation ordering, observational persistence, Operator API authentication, and requests inspect behavior from PRs #44 through #46.
 - [x] 1.2 Update `docs/DESIGN.md` only if Console node-management UI patterns introduce reusable tactical components.
   Note: Documented reusable operational review panel guidance for Action Preview panels, grouped node detail drill-ins, and source or compatibility badges.
+  Documented read-only evidence panel guidance for the request-scoped scheduler explanation panel.
 - [x] 1.3 Update `docs/glossary/CONTEXT.md` if accepted terminology adds durable glossary entries such as pending admission, action preview, or scheduler reason code.
   Note: Added Pending Admission and Rejected Admission entries; existing entries already cover Runtime Endpoint Admission Candidate, Node Admission, Node Admission Decision, Action Preview, and reason-code terms.
+  Added the Queue Wait Reason entry and refreshed the Scheduler Explanation entry to cover selected, scored, skipped, and rejected candidates.
 - [x] 1.4 Add or update an ADR only if implementation chooses a durable architectural boundary not already fixed by `SPEC.md`.
   Note: Existing ADRs 0003, 0004, and 0005 cover observed candidates, Admin API cluster-admin auth, and shared cluster-management contracts; ADR 0006 records the local `orchardctl` node-admission authority boundary.
+  ADR 0007 records the Operator API operator-or-admin service-account authentication boundary.
 
 ## 2. Node Lifecycle And Admission
 
@@ -34,7 +38,8 @@
   Console pending admission queue, detail drill-in, and admit/reject preview panels now render shared status, scheduler, blocker, warning, consequence, and confirmation codes for this slice.
   Admin API, CLI, Console, and tests consume the shared contract for landed admission-review behavior.
   Node lifecycle previews for cordon, uncordon, drain, maintenance, resume, and decommission now consume the shared blocker, consequence, and confirmation vocabulary across CLI and Console.
-  Operator API, support bundles, and full scheduler-explanation producer wiring remain future slices.
+  The Operator API scheduler explanations endpoint and the multi-node scheduler explanation producer now consume the shared reason-code contract.
+  Support bundles remain the outstanding consumer for a future slice.
 - [x] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
 - [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
 - [x] 3.6 Ensure action preview schema fixtures include separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements` fields.
@@ -82,7 +87,7 @@
 - [ ] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
   Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile.
   PR #41 browser-verified the Console lifecycle preview slice against `docs/DESIGN.md`.
-  Note: This task 5.4 slice browser-verified the request-scoped scheduler explanation panel on desktop and mobile with screenshots at `tmp/browser-verification/scheduler-explanation-desktop.png` and `tmp/browser-verification/scheduler-explanation-mobile.png`.
+  Note: This task 5.4 slice browser-verified the request-scoped scheduler explanation panel on desktop and mobile.
   Keep this unchecked as a recurring gate for future Console slices.
 
 ## 6. Diagnostics And Support Bundles


### PR DESCRIPTION
## Intent

Reconcile durable repo truth after the merged scheduler-explanations wave (PRs #44, #45, #46), per the standing contract-reconciliation cadence; the No Mistakes gate is required because SPEC.md changed. This slice records already-landed behavior only and changes no product behavior: add SPEC §7.3.5 normative text for order-faithful scored candidates (scores internally consistent with their additive components, component keys deliberately not frozen) and for observational explanation persistence (invalid explanations are dropped with a logged error, never persisted, and never fail the user's inference request); record the Operator API operator-or-admin service-account auth boundary in SPEC §7.3 and new ADR 0007, the narrower operator surface that ADR 0004 explicitly deferred to a future decision; describe `orchardctl requests inspect` scheduler-explanation rendering in SPEC §11.9 with its broader-diagnostics-remain-future-work caveat; add the Queue Wait Reason glossary entry and refresh Scheduler Explanation to cover selected, scored, skipped, and rejected candidates; document the read-only evidence panel pattern in DESIGN.md §6.6; and correct OpenSpec task notes (extend the 1.x reconciliation entries, refresh the stale 3.3 note, remove machine-local screenshot paths from the 5.7 note).

## What Changed

- Added `SPEC.md` normative clauses for the scheduler-explanations wave: Operator API operator-or-admin authentication with 401/403 codes, scored-candidate ranking/score-component consistency, observational (non-blocking) explanation persistence, and the `orchardctl requests inspect` reason-code contract.
- Recorded the durable decisions and vocabulary: new ADR 0007 for the Operator API service-account auth boundary, a `docs/DESIGN.md` read-only evidence panel pattern, and a new `Queue Wait Reason` glossary term plus a refreshed `Scheduler Explanation` definition covering selected/scored/skipped/rejected candidates.
- Updated the `cluster-management-ux-foundation` OpenSpec task notes to reflect the reconciled PRs #44-#46 scope and mark scheduler-explanation Operator API and producer wiring as landed, leaving support bundles as the outstanding consumer.

## Risk Assessment

✅ Low: Docs-only reconciliation slice whose contract statements I verified against the merged implementation (operator auth codes, shared plug base, ADR section reference, scheduler ordering, glossary/DESIGN numbering) — all accurate and internally consistent, with a correct removal of machine-local screenshot paths.

## Testing

test

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `a`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

