### PR TITLE
feat: default split-role source-dev runtime transport to BEAM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,11 +280,21 @@ and starts `iex -S mix phx.server`.
 
 For source-dev cluster roles, use `mise exec -- bin/dev-controller` for the
 Phoenix/controller host and `mise exec -- bin/dev-node-agent` for a
-node-agent-only worker host. The current validated two-Mac smoke pattern is:
-start `mise exec -- bin/dev-node-agent` on the worker host with
-`ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0`, then start
+node-agent-only worker host.
+The split-role scripts default to BEAM Runtime Endpoint transport when
+`ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` is unset.
+The current validated two-Mac smoke pattern starts `mise exec -- bin/dev-node-agent`
+on each worker host with `ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<ipv4>` and a
+shared owner-only `ORCHARD_BEAM_COOKIE_FILE`, then starts
 `mise exec -- bin/dev-controller` on the controller host with
-`ORCHARD_RUNTIME_CLIENT_TARGETS=<worker-ip>:50071`.
+`ORCHARD_BEAM_NODE_NAME=orchard_controller@<controller-ipv4>`, the same cookie
+file, and `ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@<worker-ipv4>`.
+Use `ORCHARD_BEAM_EPMD_PORT=43690` or another shared nonstandard port when a host
+already has EPMD on `4369`.
+Use `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`,
+`ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0`, and
+`ORCHARD_RUNTIME_CLIENT_TARGETS=<worker-ip>:50071` only for the gRPC compatibility
+opt-out path.
 
 When to bypass `bin/dev`:
 - `mise exec -- iex -S mix` — BEAM without HTTP server (one-off scripts, migrations)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Clients (SDKs / curl / apps)
    Runtime Endpoint Interface
         │
    Runtime Endpoint adapter(s)
-   ├── gRPC compatibility adapter (current default)
-   └── first-party BEAM adapter (default-off rollout)
+   ├── first-party BEAM adapter (split-role source-dev default)
+   └── gRPC compatibility adapter (explicit opt-out)
         │
    Node Agent Runtime Endpoint(s)
    ├── Model cache + verification
@@ -67,10 +67,11 @@ Clients (SDKs / curl / apps)
 - All durable state lives in Postgres.
 - Controller runtime execution uses the Runtime Endpoint Interface.
 - The current `NodeRuntimeService` gRPC path is a compatibility adapter, not the durable domain contract.
-- First-party BEAM communication is implemented behind explicit guardrails and must not become durable cluster truth.
-- Source-dev uses the gRPC compatibility adapter by default until BEAM Runtime Endpoint transport is explicitly promoted after accepted two-Mac smoke evidence.
-- Source-dev BEAM is available only through the explicit split-role `bin/dev-controller` and `bin/dev-node-agent` flow while all-in-one `bin/dev` remains the gRPC default.
-- Explicit Source-dev BEAM mode does not automatically retry a failed request through gRPC compatibility.
+- First-party BEAM communication is the split-role source-dev default behind explicit guardrails and must not become durable cluster truth.
+- Split-role source dev uses BEAM by default through `bin/dev-controller` and `bin/dev-node-agent`.
+- Set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` only when intentionally opting into the gRPC compatibility adapter.
+- All-in-one `bin/dev` remains the single-host gRPC default and rejects explicit BEAM mode.
+- Source-dev BEAM mode does not automatically retry a failed request through gRPC compatibility.
 - Workers are local to node agents and are never exposed on the network.
 - Token streams always pass through the controller for governance and accounting.
 - HA-lite only: exactly one active leader, active/standby via Postgres advisory locks, no active/active consensus.
@@ -82,7 +83,7 @@ Clients (SDKs / curl / apps)
 | Language | Elixir/OTP (umbrella app) |
 | Database | Postgres |
 | Inference | MLX-LM runtime adapter managed by the node agent |
-| Runtime endpoint transport | Runtime Endpoint Interface with current gRPC compatibility adapter, explicit split-role first-party BEAM mode, and recorded two-Mac smoke evidence awaiting separate default promotion |
+| Runtime endpoint transport | Runtime Endpoint Interface with first-party BEAM as the split-role source-dev default and gRPC as the explicit opt-out compatibility adapter |
 | APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
 | Packaging | DMG, PKG, launchd |
 | CLI | `orchardctl` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -45,10 +45,11 @@ Supported deployment modes:
 * Controller runtime execution SHALL use the Runtime Endpoint Interface.
 * Runtime Endpoint semantics are transport-independent.
 * The gRPC/protobuf `NodeRuntimeService` remains the compatibility transport and a candidate protocol for future non-BEAM adapters.
-* First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
-* Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until BEAM Runtime Endpoint transport is explicitly promoted in a separate change.
-* Accepted two-Mac smoke evidence SHALL exist before BEAM Runtime Endpoint transport is promoted as the source-dev default.
-* When BEAM Runtime Endpoint transport is explicitly selected, Orchard MUST NOT retry the same request through gRPC compatibility as an automatic fallback.
+* First-party Orchard Controller and Node Agent source-dev services SHALL use BEAM Distribution as the default live Controller-to-Node Agent Runtime Endpoint transport when the endpoint is an admitted first-party Orchard service.
+* Source-dev split-role `bin/dev-controller` and `bin/dev-node-agent` SHALL default to BEAM Runtime Endpoint transport when `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` is unset.
+* Source-dev gRPC compatibility remains available on port `50071` through explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` opt-out.
+* Accepted two-Mac smoke evidence SHALL remain recorded before and after BEAM Runtime Endpoint transport is promoted as the source-dev default.
+* When BEAM Runtime Endpoint transport is selected, Orchard MUST NOT retry the same request through gRPC compatibility as an automatic fallback.
 * Console live runtime diagnostics SHALL use the configured Runtime Endpoint target list; explicit BEAM Runtime Endpoint targets SHALL take precedence over legacy gRPC runtime client targets.
 * Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
 * BEAM Runtime Endpoint targets MUST carry a valid BEAM node-name address (`service@host`) as an atom or binary; a configured `node_id`, when present, MUST be a UUID and MUST match observed endpoint metadata before scheduler or dispatch may trust that candidate identity.
@@ -2208,11 +2209,12 @@ PATCH /admin/v1/observability
 Controller runtime execution SHALL use the Runtime Endpoint Interface.
 Runtime Endpoint semantics are transport-independent.
 The gRPC/protobuf `NodeRuntimeService` remains the gRPC Compatibility Adapter and a candidate protocol for future non-BEAM adapters.
-First-party Orchard Controller and Node Agent services MAY use default-off BEAM Distribution for live communication and monitoring when the endpoint is an admitted first-party Orchard service.
-Source-dev SHALL keep the gRPC compatibility path as the default Controller-to-Node Agent runtime transport on port `50071` until BEAM Runtime Endpoint transport is explicitly promoted in a separate change.
-Accepted two-Mac smoke evidence SHALL exist before BEAM Runtime Endpoint transport is promoted as the source-dev default.
+First-party Orchard Controller and Node Agent source-dev services SHALL use BEAM Distribution as the default live Controller-to-Node Agent Runtime Endpoint transport when the endpoint is an admitted first-party Orchard service.
+Source-dev split-role `bin/dev-controller` and `bin/dev-node-agent` SHALL default to BEAM Runtime Endpoint transport when `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` is unset.
+Source-dev gRPC compatibility remains available on port `50071` through explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` opt-out.
+Accepted two-Mac smoke evidence SHALL remain recorded before and after BEAM Runtime Endpoint transport is promoted as the source-dev default.
 The accepted smoke requires Console Nodes to show local and remote Node Agents reachable, `GET /v1/models` to return `200`, and `POST /v1/chat/completions` to complete through the Console Playground or an equivalent API request.
-When BEAM Runtime Endpoint transport is explicitly selected, Orchard MUST NOT retry the same request through gRPC compatibility as an automatic fallback.
+When BEAM Runtime Endpoint transport is selected, Orchard MUST NOT retry the same request through gRPC compatibility as an automatic fallback.
 Console live runtime diagnostics SHALL use the configured Runtime Endpoint target list.
 Explicit BEAM Runtime Endpoint targets SHALL take precedence over legacy gRPC runtime client targets for Console probes.
 Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.

--- a/apps/orchard_controller/README.md
+++ b/apps/orchard_controller/README.md
@@ -17,8 +17,7 @@ This README is orientation only. Normative behavior lives in
 - Governance persistence and lifecycle APIs for Organizations, tenant-direct API Tokens, API Clients, service-account-owned API Tokens, role bindings, and provisioning batches.
 - Request canonicalization, tokenization orchestration, admission, scheduling,
   dispatch, lifecycle persistence, and public response serialization.
-- Runtime Endpoint client adapters, including the gRPC compatibility adapter and
-  default-off first-party BEAM adapter.
+- Runtime Endpoint client adapters, including the split-role source-dev default first-party BEAM adapter and explicit opt-out gRPC compatibility adapter.
 
 ## Does not own
 

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -208,9 +208,12 @@ defmodule Orchard.Inference do
   def runtime_client_targets do
     case config()[:runtime_client_targets] do
       targets when is_list(targets) and targets != [] -> dedup_targets(targets)
-      _ -> [runtime_client_target()]
+      _ -> runtime_client_target_fallback(runtime_client_target())
     end
   end
+
+  defp runtime_client_target_fallback(nil), do: []
+  defp runtime_client_target_fallback(target), do: [target]
 
   @doc """
   Returns the configured Runtime Endpoint client adapter.

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -295,6 +295,9 @@ defmodule Orchard.InferenceTest do
                Orchard.RuntimeEndpoint.BeamClient
 
       assert Keyword.fetch!(inference, :runtime_client_targets) == []
+
+      Application.put_env(:orchard_controller, :inference, inference)
+      assert Inference.runtime_client_targets() == []
     end
 
     test "dev.exs rejects invalid runtime endpoint transport values" do

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -282,6 +282,21 @@ defmodule Orchard.InferenceTest do
              ]
     end
 
+    test "dev.exs beam controller mode without explicit legacy targets configures no gRPC targets" do
+      inference =
+        read_dev_controller_inference!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@127.0.0.1",
+          "ORCHARD_RUNTIME_CLIENT_TARGETS" => nil
+        })
+
+      assert Keyword.fetch!(inference, :runtime_endpoint_client_impl) ==
+               Orchard.RuntimeEndpoint.BeamClient
+
+      assert Keyword.fetch!(inference, :runtime_client_targets) == []
+    end
+
     test "dev.exs rejects invalid runtime endpoint transport values" do
       assert_raise RuntimeError, ~r/ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc\|beam/, fn ->
         read_dev_controller_inference!(%{"ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "http"})

--- a/apps/orchard_node_agent/README.md
+++ b/apps/orchard_node_agent/README.md
@@ -1,7 +1,7 @@
 # orchard_node_agent
 
 Node-agent release for Orchard's worker-node boundary.
-It exposes the current gRPC Runtime Endpoint compatibility service and default-off BEAM Runtime Endpoint facade, reports node/runtime status, manages model acquisition and cache state, and supervises local worker subprocesses.
+It exposes the split-role source-dev default BEAM Runtime Endpoint facade and explicit opt-out gRPC Runtime Endpoint compatibility service, reports node/runtime status, manages model acquisition and cache state, and supervises local worker subprocesses.
 
 This README is orientation only. Normative behavior lives in
 [`../../SPEC.md`](../../SPEC.md); repo/runtime boundaries are mapped in
@@ -26,7 +26,7 @@ This README is orientation only. Normative behavior lives in
 ## Local work
 
 Use `mise exec -- bin/dev-node-agent` for source-dev worker hosts.
-For gRPC split-role testing, configure `ORCHARD_NODE_AGENT_LISTEN_HOST` and the controller's `ORCHARD_RUNTIME_CLIENT_TARGETS`.
-For BEAM split-role testing, configure `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`, `ORCHARD_BEAM_NODE_NAME`, and the shared cookie surface documented in local-dev.
+For default BEAM split-role testing, configure `ORCHARD_BEAM_NODE_NAME` when overriding the role default and use the shared cookie surface documented in local-dev.
+For gRPC split-role compatibility testing, set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`, configure `ORCHARD_NODE_AGENT_LISTEN_HOST`, and configure the controller's `ORCHARD_RUNTIME_CLIENT_TARGETS`.
 For setup and validation commands, see [`../../docs/local-dev.md`](../../docs/local-dev.md)
 and [`../../docs/tooling.md`](../../docs/tooling.md).

--- a/bin/dev-controller
+++ b/bin/dev-controller
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # bin/dev-controller — Source-dev controller role startup for Orchard.
-# Creates/migrates the dev DB, sets the dev gRPC target port, starts Phoenix.
-# Use ORCHARD_RUNTIME_CLIENT_TARGETS for gRPC compatibility targets.
-# Use ORCHARD_RUNTIME_ENDPOINT_TARGETS with ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
-# for split-role BEAM Runtime Endpoint targets.
+# Creates/migrates the dev DB, sets the dev runtime port, starts Phoenix.
+# Defaults to split-role BEAM Runtime Endpoint transport.
+# Use ORCHARD_RUNTIME_ENDPOINT_TARGETS for BEAM Runtime Endpoint targets.
+# Use ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc with ORCHARD_RUNTIME_CLIENT_TARGETS
+# for gRPC compatibility targets.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/bin/dev-controller
+++ b/bin/dev-controller
@@ -38,10 +38,13 @@ fi
 
 export ORCHARD_NODE_AGENT_LISTEN_PORT="$resolved_port"
 export ORCHARD_RUNTIME_CLIENT_PORT="$resolved_port"
-export ORCHARD_RUNTIME_CLIENT_TARGETS="${ORCHARD_RUNTIME_CLIENT_TARGETS:-127.0.0.1:${resolved_port}}"
 
 source "$REPO_ROOT/bin/lib/source-dev-beam.sh"
 orchard_source_dev_beam_bootstrap controller "$REPO_ROOT"
+
+if [[ "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT}" != "beam" ]]; then
+  export ORCHARD_RUNTIME_CLIENT_TARGETS="${ORCHARD_RUNTIME_CLIENT_TARGETS:-127.0.0.1:${resolved_port}}"
+fi
 
 # Bootstrap dev database. The controller owns the schema.
 echo "==> Ensuring dev database..."
@@ -51,7 +54,9 @@ mix ecto.migrate --quiet
 # Start the source-dev controller.
 echo "==> Starting Orchard dev controller (role: controller)"
 echo "==> HTTP endpoint: 127.0.0.1:${PORT:-4000}"
-echo "==> Runtime client targets: ${ORCHARD_RUNTIME_CLIENT_TARGETS}"
+if [[ -n "${ORCHARD_RUNTIME_CLIENT_TARGETS:-}" ]]; then
+  echo "==> Runtime client targets: ${ORCHARD_RUNTIME_CLIENT_TARGETS}"
+fi
 cd "$REPO_ROOT/apps/orchard_controller"
 if [[ "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT}" == "beam" ]]; then
   exec iex "${ORCHARD_BEAM_IEX_ARGS[@]}" -S mix phx.server

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -3,10 +3,10 @@ set -euo pipefail
 
 # bin/dev-node-agent — Source-dev node-agent role startup for Orchard.
 # Starts only the node-agent app from source; no DB create/migrate, no Phoenix.
-# For gRPC compatibility testing, set ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0
-# on LAN/Tailscale worker hosts.
-# For BEAM Runtime Endpoint testing, set ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
-# and an ORCHARD_BEAM_NODE_NAME with the host's IPv4 address.
+# Defaults to split-role BEAM Runtime Endpoint transport.
+# For BEAM Runtime Endpoint testing, set ORCHARD_BEAM_NODE_NAME with the host's IPv4 address.
+# For gRPC compatibility testing, set ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc and
+# ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0 on LAN/Tailscale worker hosts.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/bin/lib/source-dev-beam.sh
+++ b/bin/lib/source-dev-beam.sh
@@ -10,13 +10,13 @@ orchard_source_dev_beam_bootstrap() {
   local transport
   transport="$(orchard_source_dev_beam_trim "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-}")"
   case "$transport" in
-    ""|grpc)
+    ""|beam)
+      export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT="beam"
+      ;;
+    grpc)
       export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT="grpc"
       export ORCHARD_SOURCE_DEV_ROLE="$role"
       return 0
-      ;;
-    beam)
-      export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT="beam"
       ;;
     *)
       echo "error: ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc|beam, got: $transport" >&2

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -370,12 +370,19 @@ config :orchard_controller, Orchard.Repo,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 
+dev_runtime_client_target =
+  if runtime_endpoint_transport == :beam do
+    nil
+  else
+    [host: dev_runtime_client_host, port: dev_runtime_port]
+  end
+
 config :orchard_controller,
   inference:
     Keyword.merge(
       Keyword.merge(
         controller_inference_defaults,
-        runtime_client_target: [host: dev_runtime_client_host, port: dev_runtime_port],
+        runtime_client_target: dev_runtime_client_target,
         runtime_client_targets: dev_runtime_targets,
         tokenizer_executable:
           System.get_env("ORCHARD_TOKENIZER_EXECUTABLE") ||

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,8 @@ Public clients
   -> Controller (Phoenix/Elixir public APIs, Console, admission, scheduling)
      -> Postgres for durable state and coordination
      -> Runtime Endpoint Interface
-        -> current gRPC compatibility adapter
-        -> explicit split-role first-party BEAM adapter, eligible for promotion after accepted source-dev smoke evidence
+        -> first-party BEAM adapter as the split-role source-dev default
+        -> gRPC compatibility adapter as the explicit opt-out path
         -> future external/provider adapters
      -> Node Agent(s)
         -> Worker Runtime subprocesses for local MLX inference
@@ -61,10 +61,11 @@ Core design rules from `SPEC.md`:
 - token streams pass through the controller;
 - the Controller dispatches model runtime work through the Runtime Endpoint Interface;
 - the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
-- first-party BEAM communication is implemented behind explicit guardrails and remains default-off until explicit promotion;
-- source-dev uses the gRPC compatibility adapter by default until BEAM Runtime Endpoint transport is explicitly promoted after accepted two-Mac smoke evidence;
-- explicit source-dev BEAM mode runs only through split-role `bin/dev-controller` and `bin/dev-node-agent` launches, not all-in-one `bin/dev`;
-- explicit source-dev BEAM mode does not automatically fall back to gRPC compatibility for the same request;
+- first-party BEAM communication is the split-role source-dev default behind explicit guardrails;
+- split-role source dev uses BEAM by default through `bin/dev-controller` and `bin/dev-node-agent` launches;
+- gRPC remains available as an explicit opt-out compatibility adapter with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`;
+- all-in-one `bin/dev` remains the single-host gRPC default and rejects explicit BEAM mode;
+- source-dev BEAM mode does not automatically fall back to gRPC compatibility for the same request;
 - Console live runtime diagnostics use the same configured Runtime Endpoint target list as scheduler and dispatch, with explicit BEAM targets taking precedence over legacy gRPC runtime client targets;
 - BEAM Runtime Endpoint targets validate BEAM node-name addresses and configured node UUIDs before scheduler or dispatch trusts endpoint identity;
 - node agents are the v1 first-party Runtime Endpoint boundary;
@@ -124,7 +125,7 @@ Runtime Endpoint and worker runtime contracts are separate:
 
 - `proto/cluster/v1/` describes the current controller ↔ node-agent gRPC compatibility transport.
 - Runtime Endpoint domain structs describe the Controller-facing scheduler and dispatch contract.
-- `Orchard.RuntimeEndpoint.BeamClient` and `Orchard.Node.RuntimeEndpoint` provide the default-off first-party BEAM adapter and Node Agent facade.
+- `Orchard.RuntimeEndpoint.BeamClient` and `Orchard.Node.RuntimeEndpoint` provide the split-role source-dev default first-party BEAM adapter and Node Agent facade.
 - `native/orchard_worker_mlx/proto/` describes node-agent ↔ worker messages/services.
 
 ### Persistence and coordination

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted
+Accepted.
+Source-dev split-role default promoted on 2026-07-05.
 
 ## Context
 
@@ -37,11 +38,13 @@ Existing `proto/cluster/v1` work should be demoted from the default first-party 
 Placement Capacity is a first-class Runtime Endpoint observation and must be exposed by the interface independently of transport.
 Unknown, malformed, duplicate, or nonmatching Placement Capacity must not prove eligibility for an active loaded placement.
 
-The BEAM Runtime Endpoint adapter is eligible to become the primary source-dev Controller-to-Node Agent path after accepted two-Mac smoke evidence and explicit promotion.
+The BEAM Runtime Endpoint adapter is the primary source-dev Controller-to-Node Agent path for split-role `bin/dev-controller` and `bin/dev-node-agent` launches after accepted two-Mac smoke evidence and explicit promotion.
 The accepted smoke evidence is recorded in `docs/investigations/source-dev-beam-smoke-2026-06-27.md`.
-Until a separate promotion change is accepted, current source-dev continues to use the gRPC Compatibility Adapter on port `50071` as the explicitly selected compatibility path.
+The 2026-07-05 refresh on `main` 3454423 revalidated BEAM transport, observation, admission, lifecycle actions, and multi-node scheduler explanations against a real remote node-agent.
+The 2026-07-05 promotion makes split-role source dev behave as if `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` when the variable is unset.
+Current split-role source dev continues to expose the gRPC Compatibility Adapter on port `50071` only through explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` opt-out.
 The Source-dev BEAM Operating Model uses long BEAM node names with IPv4-literal hosts, explicit shared cookie material, bounded distribution networking, and BEAM-specific Runtime Endpoint target variables rather than legacy gRPC runtime client variables.
-The current implementation exposes that model through explicit split-role `bin/dev-controller` and `bin/dev-node-agent` launches while all-in-one `bin/dev` remains the gRPC default and rejects explicit BEAM mode.
+All-in-one `bin/dev` remains the gRPC default and rejects explicit BEAM mode.
 Same-host source dev may generate a repo-local `tmp/dev/beam.cookie` file, while two-Mac source dev must provision the same cookie material on both Macs.
 Packaged or release runtime configuration must not inherit the repo-local cookie model; it should use runtime secret injection such as release cookie configuration.
 Cookie files must be `0600` or stricter and must not be printed in logs or templates.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -60,15 +60,15 @@ _Avoid_: Redis, Kafka, distributed Erlang state
 
 **BEAM Distribution**:
 The live Orchard communication and monitoring layer between first-party Elixir services.
-The default-off BEAM Runtime Endpoint adapter exists for first-party Controller-to-Node Agent communication.
-In source-dev, it becomes the primary Runtime Endpoint transport only after accepted two-Mac smoke evidence and explicit promotion.
+The BEAM Runtime Endpoint adapter is the split-role source-dev default for first-party Controller-to-Node Agent communication.
+In split-role source-dev, it is the primary Runtime Endpoint transport, promoted on 2026-07-05 after accepted two-Mac smoke evidence.
 In packaged production, BEAM Distribution is limited to admitted first-party Orchard services.
 _Avoid_: Durable cluster truth, database replacement, public API, external provider integration
 
 **Source-dev BEAM Operating Model**:
 The source-development distribution profile for first-party Controller-to-Node Agent BEAM Runtime Endpoint communication.
-It uses long BEAM node names with IPv4-literal hosts, explicit shared cookie material, bounded distribution networking, explicit BEAM target configuration, no automatic gRPC fallback, and split-role promotion before all-in-one source dev.
-The current implementation exposes this through explicit `bin/dev-controller` and `bin/dev-node-agent` source-dev launches while `bin/dev` remains the gRPC default.
+It uses long BEAM node names with IPv4-literal hosts, explicit shared cookie material, bounded distribution networking, explicit BEAM target configuration, and no automatic gRPC fallback.
+The current implementation exposes this as the default through `bin/dev-controller` and `bin/dev-node-agent` source-dev launches while `bin/dev` remains the gRPC default.
 _Avoid_: Production BEAM security model, ambient `.erlang.cookie`, implicit fallback, durable cluster truth
 
 **All-in-One Deployment**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -231,8 +231,8 @@ the fake runtime through `config/test.exs`, not a dev env override.
 Batch generation mode can admit multiple same-model requests up to the worker-reported limit.
 The node agent also enforces aggregate active request capacity across loaded models using the resolved worker limits, conservatively falling back to single-request capacity when worker status omits `max_concurrency`.
 The node-agent reports aggregate and placement capacity through Runtime Endpoint status.
-The default source-dev path maps the current gRPC compatibility status response into Runtime Endpoint Observations before multi-node scheduler candidate filtering and queue wakeups from loaded-placement or cold/no-placement capacity.
-When the BEAM adapter is explicitly configured, the Node Agent facade maps the same status semantics into BEAM Runtime Endpoint Observations.
+The default split-role source-dev path maps BEAM Runtime Endpoint Observations before multi-node scheduler candidate filtering and queue wakeups from loaded-placement or cold/no-placement capacity.
+When the gRPC compatibility adapter is explicitly selected, the Node Agent facade maps the current gRPC status response into Runtime Endpoint Observations.
 Transport failures and ineligible Runtime Endpoint Observations clear endpoint-owned queue capacity sources so queued work is not promoted against stale loaded-placement or cold/no-placement slots.
 BEAM observations publish queue capacity only when the target resolves back to the same persisted node identity.
 Stream mode reports max concurrency as `1` at both node and placement levels.
@@ -245,21 +245,20 @@ Stream mode reports max concurrency as `1` at both node and placement levels.
 | `ORCHARD_RUNTIME_CLIENT_TARGETS` | _(empty)_ | Comma-separated `host:port` list for multi-node scheduling. When set with >1 target, the scheduler auto-selects `MultiNode`. |
 
 These env vars configure only the gRPC compatibility target path.
-Source-dev BEAM Runtime Endpoint mode uses a separate Runtime Endpoint env surface, not `ORCHARD_RUNTIME_CLIENT_TARGETS`.
-The accepted source-dev surface is `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` plus `ORCHARD_RUNTIME_ENDPOINT_TARGETS`, with BEAM node and distribution settings under `ORCHARD_BEAM_*` variables.
+Split-role source-dev defaults to BEAM Runtime Endpoint mode and uses a separate Runtime Endpoint env surface, not `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+The accepted source-dev BEAM surface is `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` plus `ORCHARD_RUNTIME_ENDPOINT_TARGETS`, with BEAM node and distribution settings under `ORCHARD_BEAM_*` variables.
 Console Nodes live runtime diagnostics follow the active Runtime Endpoint target source.
-When explicit BEAM Runtime Endpoint targets are configured, Console probes those BEAM targets through the configured Runtime Endpoint client.
+When BEAM Runtime Endpoint targets are configured, Console probes those BEAM targets through the configured Runtime Endpoint client.
 Keep `ORCHARD_RUNTIME_CLIENT_TARGETS` alongside BEAM targets only when deliberately comparing the gRPC compatibility path.
 Do not rely on automatic gRPC fallback when BEAM mode is selected.
 
 #### Source-dev BEAM Runtime Endpoint Split-role Mode
 
-Source dev now supports an explicit BEAM Runtime Endpoint mode for split-role launches.
-The default source-dev path is still gRPC compatibility on port `50071`.
-Accepted two-Mac smoke evidence is recorded in `docs/investigations/source-dev-beam-smoke-2026-06-27.md`, but default promotion remains a separate change.
-Unset `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` or set it to `grpc` to keep the existing gRPC path.
-Set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` only with `bin/dev-controller` and `bin/dev-node-agent`.
-All-in-one `bin/dev` intentionally rejects explicit BEAM mode and remains the gRPC default.
+Source dev defaults to BEAM Runtime Endpoint mode for split-role launches through `bin/dev-controller` and `bin/dev-node-agent`.
+Accepted two-Mac smoke evidence is recorded in `docs/investigations/source-dev-beam-smoke-2026-06-27.md`, and the BEAM default was promoted on 2026-07-05.
+Leave `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` unset or set it to `beam` for the default split-role BEAM path.
+Set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` only when intentionally opting into the gRPC compatibility path on port `50071`.
+All-in-one `bin/dev` intentionally rejects explicit BEAM mode and remains the single-host gRPC default.
 
 The BEAM source-dev env surface is separate from the legacy gRPC compatibility target surface.
 `ORCHARD_RUNTIME_CLIENT_TARGETS` remains gRPC compatibility-only and accepts only `host:port` targets.
@@ -273,7 +272,7 @@ CLI scaffolding for these variables is deferred to a separate change.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` | `grpc` | Runtime Endpoint transport selector. Use `beam` for split-role BEAM source dev. |
+| `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` | `beam` for split-role scripts | Runtime Endpoint transport selector. Leave unset for split-role BEAM source dev, or set `grpc` for compatibility opt-out. |
 | `ORCHARD_RUNTIME_ENDPOINT_TARGETS` | _(empty)_ | Controller-only comma-separated BEAM target list. Each target must be `orchard_node_agent@<ipv4-literal>`. |
 | `ORCHARD_BEAM_NODE_NAME` | `orchard_controller@127.0.0.1` or `orchard_node_agent@127.0.0.1` | Long BEAM node name for the current split-role VM. The host part must be an IPv4 literal. |
 | `ORCHARD_BEAM_COOKIE_FILE` | `tmp/dev/beam.cookie` | Cookie file path. Same-host source dev generates it when absent. Two-Mac source dev must provision the same cookie material on each Mac. |
@@ -294,7 +293,6 @@ Same-host BEAM split-role smoke can run from two terminals in the same checkout.
 Start the node-agent first:
 
 ```bash
-ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
 ORCHARD_WORKER_BACKEND=stub \
 mise exec -- bin/dev-node-agent
 ```
@@ -302,7 +300,6 @@ mise exec -- bin/dev-node-agent
 Then start the controller:
 
 ```bash
-ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
 ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@127.0.0.1 \
 mise exec -- bin/dev-controller
 ```
@@ -528,9 +525,9 @@ operator workflow, permission expectations, and external certificate setup.
 
 ## Two-Node Source-Dev Cluster Testing
 
-Single-node remains the default.
-Use the gRPC compatibility flow when you want the stable default source-dev path.
-Use the BEAM Runtime Endpoint flow when you are validating the explicit split-role BEAM operating model.
+Single-node all-in-one remains available through `bin/dev`.
+Use the BEAM Runtime Endpoint flow for the default split-role source-dev cluster path.
+Use the gRPC compatibility flow only when you intentionally opt out with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` or need side-by-side comparison.
 
 `orchardctl cluster init` and `orchardctl node join` are SPEC-required future node-lifecycle commands.
 In this build they return deferred status.
@@ -543,6 +540,7 @@ Use the env-var split-role flows below for source-dev cluster testing.
 The gRPC compatibility flow keeps all-in-one `bin/dev` on the controller Mac and starts one remote node-agent.
 It uses `ORCHARD_RUNTIME_CLIENT_TARGETS` as a comma-separated `host:port` list.
 This variable is gRPC-only and is not used by BEAM Runtime Endpoint mode.
+For split-role compatibility testing, set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` on `bin/dev-controller` and `bin/dev-node-agent`.
 
 #### Controller host
 
@@ -561,7 +559,8 @@ IPv6 addresses are not supported in the gRPC compatibility target list.
 #### Remote node-agent host
 
 ```bash
-ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0 \
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc \
+  ORCHARD_NODE_AGENT_LISTEN_HOST=0.0.0.0 \
   ORCHARD_NODE_AGENT_LISTEN_PORT=50071 \
   ORCHARD_WORKER_BACKEND=stub \
   ORCHARD_NODE_DISPLAY_NAME=<worker-label> \
@@ -590,7 +589,6 @@ Do not commit cookie material, raw local evidence logs, or machine-specific path
 #### Controller Mac local node-agent terminal
 
 ```bash
-ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
 ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<controller-ipv4> \
 ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
 ORCHARD_WORKER_BACKEND=stub \
@@ -601,7 +599,6 @@ mise exec -- bin/dev-node-agent
 #### Remote node-agent Mac terminal
 
 ```bash
-ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
 ORCHARD_BEAM_NODE_NAME=orchard_node_agent@<worker-ipv4> \
 ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
 ORCHARD_WORKER_BACKEND=stub \
@@ -612,7 +609,6 @@ mise exec -- bin/dev-node-agent
 #### Controller Mac controller terminal
 
 ```bash
-ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam \
 ORCHARD_RUNTIME_ENDPOINT_TARGETS="orchard_node_agent@<controller-ipv4>,orchard_node_agent@<worker-ipv4>" \
 ORCHARD_BEAM_NODE_NAME=orchard_controller@<controller-ipv4> \
 ORCHARD_BEAM_COOKIE_FILE="$PWD/tmp/dev/beam.cookie" \
@@ -624,6 +620,8 @@ The default controller distribution port is TCP `52171`.
 The default node-agent distribution port is TCP `52172`.
 The default EPMD port is TCP `4369`.
 Those ports must be reachable between the participating private IPs.
+If another EPMD already owns `4369`, set the same nonstandard `ORCHARD_BEAM_EPMD_PORT` on every participating terminal.
+The validated two-Mac smokes used `ORCHARD_BEAM_EPMD_PORT=43690` on hosts with EPMD conflicts.
 If you override the EPMD or distribution port variables, use the same values in your firewall rules and smoke notes.
 
 For a remote Runtime Endpoint RPC check from the controller IEx session:
@@ -653,7 +651,7 @@ It should not fall back to gRPC.
 Do not create `docs/investigations/source-dev-beam-smoke-<date>.md` unless a real two-Mac BEAM smoke has actually been run.
 When that evidence is added, sanitize host labels, commands, node names, pass/fail status, and Runtime Endpoint RPC evidence.
 The evidence must not include cookie material, credentials, raw logs, prompt exports, local tool session identifiers, DSNs, or machine-specific filesystem paths.
-Default promotion remains deferred to a future OpenSpec change even after the smoke evidence gate passes.
+BEAM split-role default promotion was accepted on 2026-07-05 after the smoke evidence gate passed.
 
 ### Troubleshooting
 
@@ -1087,7 +1085,7 @@ mise exec -- iex -S mix phx.server
   Tenant-direct API Tokens remain supported, and service-account-owned API Tokens require an enabled API Client with tenant-scoped `inference_client` access.
   Full quota policy remains incomplete
 - Multi-node is supported for source-dev testing only (production/packaged multi-node — M4)
-- Explicit split-role BEAM Runtime Endpoint mode is implemented for `bin/dev-controller` and `bin/dev-node-agent`; default source dev still uses the gRPC compatibility adapter
+- Split-role BEAM Runtime Endpoint mode is the default for `bin/dev-controller` and `bin/dev-node-agent`
 - All-in-one `bin/dev` rejects explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
-- BEAM Runtime Endpoint transport becomes the primary source-dev path only through a separate promotion after accepted two-Mac smoke evidence
+- gRPC compatibility remains available for split-role source dev only through `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`
 - Model import from local filesystem only (no remote download)

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -269,6 +269,7 @@ When BEAM mode is selected, BEAM configuration, guardrail, connection, identity,
 The controller does not automatically retry the same request through gRPC.
 `orchardctl env init` does not render this BEAM env surface yet.
 CLI scaffolding for these variables is deferred to a separate change.
+For a default BEAM controller launch, `ORCHARD_RUNTIME_ENDPOINT_TARGETS` is effectively required, and startup fails early naming the variable when it is absent.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/openspec/changes/promote-beam-runtime-default/.openspec.yaml
+++ b/openspec/changes/promote-beam-runtime-default/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/promote-beam-runtime-default/design.md
+++ b/openspec/changes/promote-beam-runtime-default/design.md
@@ -1,0 +1,59 @@
+# Design: promote-beam-runtime-default
+
+## Context
+
+ADR 0001 accepted BEAM Distribution as the preferred first-party Controller-to-Node Agent transport with the adapter default-off behind a promotion gate.
+The gate's evidence exists twice: the accepted 2026-06-27 two-Mac run in `docs/investigations/source-dev-beam-smoke-2026-06-27.md`, and the 2026-07-05 refresh on `main` 3454423 that proved BEAM transport, observation, admission, lifecycle actions, and multi-node scheduler explanations against a real remote node-agent.
+The refresh also produced the one open finding: `bin/dev-controller` in BEAM mode still sets the implicit legacy `Runtime client targets: 127.0.0.1:50071`.
+Two fully implemented change packages (`beam-first-runtime-endpoints`, `source-dev-beam-operating-model`) await archive; their `runtime-endpoints` deltas are not yet synced into main specs.
+Constraints: BEAM mode fails visibly by design with no automatic gRPC fallback; production BEAM distribution guardrails from ADR 0001 (identity-bound, network-restricted, first-party only) are unchanged by this promotion.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make BEAM the default split-role source-dev transport with gRPC as explicit opt-out.
+- Fully quiesce the implicit legacy gRPC client target in BEAM mode.
+- Bring contributor docs, SPEC internal-comms language, and decision records in line with the promoted default.
+- Archive both completed BEAM packages, syncing their deltas to main specs.
+
+**Non-Goals:**
+- Packaged runtime transport changes (packaged builds keep their current path; promotion there is a later decision).
+- Removing the gRPC compatibility adapter or `ORCHARD_RUNTIME_CLIENT_TARGETS` (explicit comparison use stays supported).
+- BEAM support in all-in-one `bin/dev` (single-VM topology has no cross-host transport need).
+- Production BEAM guardrail changes, epmd port policy changes, or cookie management tooling (`orchardctl env init` scaffolding stays deferred).
+
+## Decisions
+
+- **Default flip location: the dev scripts, not config defaults.**
+  `bin/dev-controller` and `bin/dev-node-agent` resolve `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` and default it to `beam` when unset, keeping the config layer's explicit-selection semantics intact.
+  Alternative considered: flipping the default inside `config/dev.exs`; rejected because the scripts already own the split-role env surface (BEAM node names, EPMD port, cookie paths) and all-in-one `bin/dev` must keep a different default.
+- **Quiescing: suppress the implicit gRPC target when transport resolves to BEAM.**
+  The controller script and runtime config stop injecting `127.0.0.1:50071` as a default runtime client target in BEAM mode; an explicitly set `ORCHARD_RUNTIME_CLIENT_TARGETS` still configures the comparison surface.
+  Alternative considered: hard-rejecting `ORCHARD_RUNTIME_CLIENT_TARGETS` in BEAM mode; rejected because `docs/local-dev.md` deliberately documents side-by-side comparison.
+- **All-in-one `bin/dev` keeps gRPC loopback and keeps rejecting explicit BEAM mode.**
+  A single VM hosting controller and node-agent gains nothing from distribution; the rejection preserves the fail-visible contract.
+- **Decision record: amend ADR 0001 status rather than a successor ADR.**
+  The promotion is the completion of ADR 0001's own gate, not a new boundary; a dated promotion note in ADR 0001 (and its SPEC-impact line) keeps one durable home.
+  Alternative considered: ADR 0008; rejected as duplication of an existing decision's lifecycle.
+- **Archive both BEAM packages inside this change's acceptance flow.**
+  Their deltas describe behavior that is already implemented and now becomes default-relevant; archiving them alongside this change's own delta keeps main specs consistent in one sync.
+
+## Risks / Trade-offs
+
+- [Contributors with muscle-memory split-role gRPC workflows break on update] → BREAKING note in docs and PR body; `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` restores the old behavior in one variable.
+- [BEAM default requires EPMD/cookie setup that gRPC did not] → `docs/local-dev.md` already documents cookie provisioning and `ORCHARD_BEAM_EPMD_PORT`; same-host source dev auto-generates the cookie; two-Mac setup instructions are carried into the AGENTS.md pattern.
+- [Hosts with packaged Orchard EPMD on 4369 conflict with the BEAM default] → documented alternate `ORCHARD_BEAM_EPMD_PORT` guidance (the 2026-06-27 and 2026-07-05 smokes both used 43690); startup failure remains visible with the exact remedy in the error.
+- [Quiescing regression silently re-enables gRPC default] → regression test asserting no runtime client target is configured in BEAM mode without explicit `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+- [Archive sync of three delta sets (two packages plus this change) produces conflicting main specs] → run strict validation after each archive step and review the generated main spec for placeholder prose per AGENTS.md.
+
+## Migration Plan
+
+1. Land the script/config changes with regression tests.
+2. Update docs (`AGENTS.md`, `docs/local-dev.md`) and SPEC internal-comms language in the same PR.
+3. Amend ADR 0001 with the dated promotion note.
+4. After merge, archive `beam-first-runtime-endpoints` and `source-dev-beam-operating-model`, then this change, running strict validation after each sync.
+Rollback: revert the PR; the BEAM adapter remains available behind the explicit env var exactly as today.
+
+## Open Questions
+
+- None blocking; packaged-runtime transport promotion is explicitly deferred to a future decision.

--- a/openspec/changes/promote-beam-runtime-default/proposal.md
+++ b/openspec/changes/promote-beam-runtime-default/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: promote-beam-runtime-default
+
+## Why
+
+ADR 0001 accepted BEAM Distribution as the preferred first-party Controller-to-Node Agent transport but kept the BEAM adapter default-off, gated on accepted two-Mac smoke evidence and an explicit promotion decision.
+That evidence now exists twice: the accepted 2026-06-27 run recorded in `docs/investigations/source-dev-beam-smoke-2026-06-27.md`, and a 2026-07-05 refresh on current `main` that proved transport, observation, admission, lifecycle, and multi-node scheduler explanations over real two-Mac BEAM distribution.
+Source dev still defaults to the gRPC compatibility path, and BEAM mode currently leaves the legacy gRPC client surface configured, so the shipped defaults no longer match the accepted architecture direction.
+
+## What Changes
+
+- **BREAKING (source-dev workflow)**: `bin/dev-controller` and `bin/dev-node-agent` default to `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`; the gRPC compatibility path requires explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` opt-out.
+- BEAM mode fully quiesces the legacy gRPC client surface: no default `Runtime client targets: 127.0.0.1:50071` is set when BEAM transport is selected (fixes the 2026-07-05 promotion-gate finding).
+- `ORCHARD_RUNTIME_CLIENT_TARGETS` is demoted to a comparison-only compatibility surface in operator and contributor docs.
+- `AGENTS.md`'s two-Mac source-dev pattern and `docs/local-dev.md` describe the BEAM surface as the primary path and the gRPC surface as compatibility opt-out.
+- `SPEC.md` internal-communications language records BEAM Distribution as the default first-party source-dev Controller-to-Node Agent path with gRPC as a compatibility adapter, per ADR 0001.
+- The promotion decision is recorded durably as a decision record update (ADR 0001 addendum or successor ADR).
+- The fully implemented change packages `beam-first-runtime-endpoints` and `source-dev-beam-operating-model` are archived as part of acceptance, syncing their `runtime-endpoints` deltas into main specs.
+- All-in-one `bin/dev` transport stance is decided in design: it currently rejects explicit BEAM mode and stays single-host gRPC loopback unless design concludes otherwise.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `runtime-endpoints`: default source-dev transport selection changes from gRPC compatibility to BEAM, and BEAM mode gains a legacy-surface quiescing requirement.
+
+## Impact
+
+- `bin/dev-controller`, `bin/dev-node-agent`, and the runtime endpoint transport resolution they configure.
+- Contributor and operator docs: `AGENTS.md`, `docs/local-dev.md`, `docs/tooling.md` if command forms change.
+- `SPEC.md` internal-comms/transport language.
+- `docs/decisions/0001-runtime-endpoints-beam-first.md` (or a successor record).
+- OpenSpec archive state for `beam-first-runtime-endpoints` and `source-dev-beam-operating-model`.
+- SPEC.md impact: yes; the internal transport default language changes as described above.

--- a/openspec/changes/promote-beam-runtime-default/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/promote-beam-runtime-default/specs/runtime-endpoints/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Source-dev Split-role BEAM Transport Default
+Source-dev split-role launches SHALL default to the BEAM Runtime Endpoint transport.
+`bin/dev-controller` and `bin/dev-node-agent` SHALL behave as if `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` when the variable is unset.
+The gRPC compatibility transport SHALL remain available only through explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` opt-out.
+This changes the source-dev default transport language currently described alongside `SPEC.md` section 7.5 internal communications and the split-role guidance in `docs/local-dev.md`.
+
+#### Scenario: Default split-role launch uses BEAM
+- **WHEN** `bin/dev-controller` or `bin/dev-node-agent` starts without `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` set
+- **THEN** the process configures the BEAM Runtime Endpoint transport and BEAM distribution settings
+
+#### Scenario: Explicit gRPC opt-out preserved
+- **WHEN** `bin/dev-controller` or `bin/dev-node-agent` starts with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`
+- **THEN** the process configures the gRPC compatibility transport exactly as before this change
+
+### Requirement: BEAM Mode Quiesces the Legacy gRPC Client Surface
+When the BEAM Runtime Endpoint transport is selected, the controller SHALL NOT configure a default legacy gRPC runtime client target.
+The implicit `127.0.0.1:50071` runtime client target SHALL be absent in BEAM mode unless `ORCHARD_RUNTIME_CLIENT_TARGETS` is explicitly set for deliberate gRPC comparison.
+Explicitly set `ORCHARD_RUNTIME_CLIENT_TARGETS` values SHALL continue to configure only the gRPC compatibility surface.
+
+#### Scenario: BEAM mode without explicit gRPC targets
+- **WHEN** the controller starts in BEAM mode without `ORCHARD_RUNTIME_CLIENT_TARGETS` set
+- **THEN** no legacy gRPC runtime client target is configured or logged as active
+
+#### Scenario: Deliberate comparison targets remain possible
+- **WHEN** the controller starts in BEAM mode with `ORCHARD_RUNTIME_CLIENT_TARGETS` explicitly set
+- **THEN** the explicit gRPC targets are configured for comparison while BEAM remains the active Runtime Endpoint transport
+
+### Requirement: All-in-one Source Dev Remains Single-host gRPC Loopback
+All-in-one `bin/dev` SHALL keep its single-host gRPC loopback default and SHALL reject explicit BEAM mode with a clear error.
+Split-role scripts SHALL remain the only supported source-dev BEAM entry points.
+
+#### Scenario: All-in-one rejects explicit BEAM mode
+- **WHEN** `bin/dev` starts with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
+- **THEN** startup fails with a clear error directing the operator to the split-role scripts

--- a/openspec/changes/promote-beam-runtime-default/tasks.md
+++ b/openspec/changes/promote-beam-runtime-default/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: promote-beam-runtime-default
+
+## 1. Transport Default Flip
+
+- [ ] 1.1 Default `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` to `beam` in `bin/dev-controller` when unset, preserving explicit `grpc` opt-out behavior.
+- [ ] 1.2 Default `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` to `beam` in `bin/dev-node-agent` when unset, preserving explicit `grpc` opt-out behavior.
+- [ ] 1.3 Keep all-in-one `bin/dev` on the single-host gRPC loopback default and verify it still rejects explicit BEAM mode with a clear error.
+- [ ] 1.4 Add or update tests covering default-BEAM resolution and explicit-gRPC opt-out for the split-role env surface.
+
+## 2. Legacy Surface Quiescing
+
+- [ ] 2.1 Stop configuring the implicit `127.0.0.1:50071` legacy runtime client target when the resolved transport is BEAM.
+- [ ] 2.2 Preserve explicitly set `ORCHARD_RUNTIME_CLIENT_TARGETS` as a gRPC comparison surface in BEAM mode.
+- [ ] 2.3 Add a regression test asserting no legacy gRPC runtime client target is configured in BEAM mode without explicit `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+
+## 3. Docs And Contract Truth
+
+- [ ] 3.1 Update `docs/local-dev.md`: BEAM split-role mode becomes the documented default, gRPC becomes the explicit opt-out compatibility path, and `ORCHARD_RUNTIME_CLIENT_TARGETS` is described as comparison-only.
+- [ ] 3.2 Update `AGENTS.md`'s two-Mac source-dev pattern to the BEAM surface (node names, cookie provisioning, `ORCHARD_BEAM_EPMD_PORT` guidance) with the gRPC pattern as opt-out.
+- [ ] 3.3 Update `SPEC.md` internal-communications language: BEAM Distribution is the default first-party source-dev Controller-to-Node Agent path and gRPC is the compatibility adapter, per ADR 0001.
+- [ ] 3.4 Amend `docs/decisions/0001-runtime-endpoints-beam-first.md` with a dated promotion note recording the executed gate and its evidence.
+
+## 4. Validation And Acceptance
+
+- [ ] 4.1 Run the full Elixir quality workflow from the umbrella root (format, compile --warnings-as-errors, credo --strict, dialyzer, test, cover).
+- [ ] 4.2 Run strict OpenSpec validation for this change.
+- [ ] 4.3 Verify split-role BEAM default end-to-end on a single host (controller plus node-agent, default env) before PR handoff.
+- [ ] 4.4 After merge: archive `beam-first-runtime-endpoints`, `source-dev-beam-operating-model`, and then this change, running strict validation after each sync and reviewing generated main specs for placeholder prose.

--- a/openspec/changes/promote-beam-runtime-default/tasks.md
+++ b/openspec/changes/promote-beam-runtime-default/tasks.md
@@ -2,23 +2,37 @@
 
 ## 1. Transport Default Flip
 
-- [ ] 1.1 Default `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` to `beam` in `bin/dev-controller` when unset, preserving explicit `grpc` opt-out behavior.
-- [ ] 1.2 Default `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` to `beam` in `bin/dev-node-agent` when unset, preserving explicit `grpc` opt-out behavior.
-- [ ] 1.3 Keep all-in-one `bin/dev` on the single-host gRPC loopback default and verify it still rejects explicit BEAM mode with a clear error.
-- [ ] 1.4 Add or update tests covering default-BEAM resolution and explicit-gRPC opt-out for the split-role env surface.
+- [x] 1.1 Default `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` to `beam` in `bin/dev-controller` when unset, preserving explicit `grpc` opt-out behavior.
+  - Implemented in `bin/lib/source-dev-beam.sh` and exercised through `bin/dev-controller` in `scripts/test-source-dev-beam-bootstrap.sh` scenario I.
+- [x] 1.2 Default `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` to `beam` in `bin/dev-node-agent` when unset, preserving explicit `grpc` opt-out behavior.
+  - Implemented in `bin/lib/source-dev-beam.sh` and exercised through `bin/dev-node-agent` in `scripts/test-source-dev-beam-bootstrap.sh` scenario I.
+- [x] 1.3 Keep all-in-one `bin/dev` on the single-host gRPC loopback default and verify it still rejects explicit BEAM mode with a clear error.
+  - Verified by `scripts/test-source-dev-beam-bootstrap.sh` scenario H.
+- [x] 1.4 Add or update tests covering default-BEAM resolution and explicit-gRPC opt-out for the split-role env surface.
+  - Added default-BEAM helper assertions in `scripts/test-source-dev-beam-bootstrap.sh` scenario A.
+  - Updated entrypoint default-BEAM assertions in scenario I and explicit-gRPC opt-out assertions in scenario J.
 
 ## 2. Legacy Surface Quiescing
 
-- [ ] 2.1 Stop configuring the implicit `127.0.0.1:50071` legacy runtime client target when the resolved transport is BEAM.
-- [ ] 2.2 Preserve explicitly set `ORCHARD_RUNTIME_CLIENT_TARGETS` as a gRPC comparison surface in BEAM mode.
-- [ ] 2.3 Add a regression test asserting no legacy gRPC runtime client target is configured in BEAM mode without explicit `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+- [x] 2.1 Stop configuring the implicit `127.0.0.1:50071` legacy runtime client target when the resolved transport is BEAM.
+  - Implemented in `bin/dev-controller` by injecting the implicit target only after transport resolves to non-BEAM.
+- [x] 2.2 Preserve explicitly set `ORCHARD_RUNTIME_CLIENT_TARGETS` as a gRPC comparison surface in BEAM mode.
+  - Preserved by leaving explicit `ORCHARD_RUNTIME_CLIENT_TARGETS` untouched when BEAM is selected.
+  - Verified by `dev.exs beam controller mode configures BEAM client and endpoint targets`.
+- [x] 2.3 Add a regression test asserting no legacy gRPC runtime client target is configured in BEAM mode without explicit `ORCHARD_RUNTIME_CLIENT_TARGETS`.
+  - Added `dev.exs beam controller mode without explicit legacy targets configures no gRPC targets`.
+  - Added a shell assertion that default BEAM controller startup does not log `Runtime client targets: 127.0.0.1:50071`.
 
 ## 3. Docs And Contract Truth
 
-- [ ] 3.1 Update `docs/local-dev.md`: BEAM split-role mode becomes the documented default, gRPC becomes the explicit opt-out compatibility path, and `ORCHARD_RUNTIME_CLIENT_TARGETS` is described as comparison-only.
-- [ ] 3.2 Update `AGENTS.md`'s two-Mac source-dev pattern to the BEAM surface (node names, cookie provisioning, `ORCHARD_BEAM_EPMD_PORT` guidance) with the gRPC pattern as opt-out.
-- [ ] 3.3 Update `SPEC.md` internal-communications language: BEAM Distribution is the default first-party source-dev Controller-to-Node Agent path and gRPC is the compatibility adapter, per ADR 0001.
-- [ ] 3.4 Amend `docs/decisions/0001-runtime-endpoints-beam-first.md` with a dated promotion note recording the executed gate and its evidence.
+- [x] 3.1 Update `docs/local-dev.md`: BEAM split-role mode becomes the documented default, gRPC becomes the explicit opt-out compatibility path, and `ORCHARD_RUNTIME_CLIENT_TARGETS` is described as comparison-only.
+  - Updated the split-role sections, command examples, EPMD guidance, troubleshooting, and source-dev limitations.
+- [x] 3.2 Update `AGENTS.md`'s two-Mac source-dev pattern to the BEAM surface (node names, cookie provisioning, `ORCHARD_BEAM_EPMD_PORT` guidance) with the gRPC pattern as opt-out.
+  - Updated the Dev Environment two-Mac pattern with BEAM node names, shared cookie file, nonstandard EPMD guidance, and gRPC opt-out variables.
+- [x] 3.3 Update `SPEC.md` internal-communications language: BEAM Distribution is the default first-party source-dev Controller-to-Node Agent path and gRPC is the compatibility adapter, per ADR 0001.
+  - Updated the architecture summary and section 7.5 Runtime Endpoint and Internal Worker Interfaces language.
+- [x] 3.4 Amend `docs/decisions/0001-runtime-endpoints-beam-first.md` with a dated promotion note recording the executed gate and its evidence.
+  - Added the 2026-07-05 promotion status and evidence note citing the 2026-06-27 investigation plus the 2026-07-05 refresh.
 
 ## 4. Validation And Acceptance
 

--- a/openspec/changes/promote-beam-runtime-default/tasks.md
+++ b/openspec/changes/promote-beam-runtime-default/tasks.md
@@ -36,7 +36,21 @@
 
 ## 4. Validation And Acceptance
 
-- [ ] 4.1 Run the full Elixir quality workflow from the umbrella root (format, compile --warnings-as-errors, credo --strict, dialyzer, test, cover).
-- [ ] 4.2 Run strict OpenSpec validation for this change.
-- [ ] 4.3 Verify split-role BEAM default end-to-end on a single host (controller plus node-agent, default env) before PR handoff.
+- [x] 4.1 Run the full Elixir quality workflow from the umbrella root (format, compile --warnings-as-errors, credo --strict, dialyzer, test, cover).
+  - Passed `mise exec -- mix format`.
+  - Passed `mise exec -- mix compile --warnings-as-errors`.
+  - Passed `mise exec -- mix credo --strict` with zero issues.
+  - Passed `mise exec -- mix dialyzer`.
+  - `ORCHARD_TEST_NODE_AGENT_PORT=50081 mise exec -- mix test` initially failed once because the worker venv entrypoint was missing before the suite materialized it.
+  - The rerun of `ORCHARD_TEST_NODE_AGENT_PORT=50081 mise exec -- mix test` passed.
+  - Passed `ORCHARD_TEST_NODE_AGENT_PORT=50081 mise exec -- mix test --cover`.
+- [x] 4.2 Run strict OpenSpec validation for this change.
+  - Passed `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate promote-beam-runtime-default --type change --strict --no-interactive`.
+- [x] 4.3 Verify split-role BEAM default end-to-end on a single host (controller plus node-agent, default env) before PR handoff.
+  - Verified source-dev split-role launch with no `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` set on either process.
+  - Used `ORCHARD_BEAM_EPMD_PORT=43690` because default EPMD port `4369` failed local listener verification on this host before Mix started.
+  - Verified node-agent and controller logs both reported `Runtime endpoint transport: beam`.
+  - Verified the controller log did not report the implicit `Runtime client targets: 127.0.0.1:50071` line.
+  - Verified an RPC probe through `Orchard.RuntimeEndpoint.BeamClient.status/1` returned a BEAM observation for `orchard_node_agent@127.0.0.1` with `health.ready == true`.
+  - Verified cleanup left HTTP `4000`, gRPC `50071`, and nonstandard EPMD `43690` without source-dev listeners, and removed the generated same-host cookie.
 - [ ] 4.4 After merge: archive `beam-first-runtime-endpoints`, `source-dev-beam-operating-model`, and then this change, running strict validation after each sync and reviewing generated main specs for placeholder prose.

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -150,11 +150,15 @@ SH
 
 chmod +x "$DEFAULT_TOOLS/epmd" "$DEFAULT_TOOLS/lsof"
 
-# A: unset or grpc mode is a no-op for IEx distribution args.
-assert_succeeds "$TMP_ROOT/a0.out" run_helper controller "$TMP_ROOT/repo-a0"
-assert_grep 'transport=grpc' "$TMP_ROOT/a0.out"
-assert_grep 'node=unset' "$TMP_ROOT/a0.out"
-assert_grep 'args=' "$TMP_ROOT/a0.out"
+# A: unset split-role transport defaults to BEAM; explicit grpc is the no-BEAM opt-out.
+assert_succeeds "$TMP_ROOT/a0-controller.out" run_helper controller "$TMP_ROOT/repo-a0-controller"
+assert_grep 'transport=beam' "$TMP_ROOT/a0-controller.out"
+assert_grep 'node=orchard_controller@127.0.0.1' "$TMP_ROOT/a0-controller.out"
+assert_grep '--name orchard_controller@127.0.0.1' "$TMP_ROOT/a0-controller.out"
+assert_succeeds "$TMP_ROOT/a0-node.out" run_helper node_agent "$TMP_ROOT/repo-a0-node"
+assert_grep 'transport=beam' "$TMP_ROOT/a0-node.out"
+assert_grep 'node=orchard_node_agent@127.0.0.1' "$TMP_ROOT/a0-node.out"
+assert_grep '--name orchard_node_agent@127.0.0.1' "$TMP_ROOT/a0-node.out"
 assert_succeeds "$TMP_ROOT/a.out" run_helper controller "$TMP_ROOT/repo-a" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
 assert_grep 'transport=grpc' "$TMP_ROOT/a.out"
 assert_grep 'node=unset' "$TMP_ROOT/a.out"
@@ -376,45 +380,33 @@ CONTROLLER_REPO="$TMP_ROOT/controller-entrypoint"
 mkdir -p "$CONTROLLER_REPO"
 : > "$TMP_ROOT/i-controller-mix.log"
 assert_succeeds "$TMP_ROOT/i-controller.out" \
-  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-controller-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@127.0.0.1 "$ENTRYPOINT_REPO/bin/dev-controller"
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-controller-iex.log" ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@127.0.0.1 "$ENTRYPOINT_REPO/bin/dev-controller"
 assert_grep 'mix called: ecto.create --quiet' "$TMP_ROOT/i-controller-mix.log"
 assert_grep 'mix called: ecto.migrate --quiet' "$TMP_ROOT/i-controller-mix.log"
 assert_grep 'ERL_EPMD_ADDRESS=127.0.0.1' "$TMP_ROOT/i-controller-iex.log"
 assert_grep '--name orchard_controller@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52171 inet_dist_listen_max 52171 -S mix phx.server' "$TMP_ROOT/i-controller-iex.log"
 assert_grep 'BEAM cookie file:' "$TMP_ROOT/i-controller.out"
+assert_no_grep 'Runtime client targets: 127.0.0.1:50071' "$TMP_ROOT/i-controller.out"
 
 : > "$TMP_ROOT/i-node-mix.log"
 assert_succeeds "$TMP_ROOT/i-node.out" \
-  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-node-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam "$ENTRYPOINT_REPO/bin/dev-node-agent"
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-node-iex.log" "$ENTRYPOINT_REPO/bin/dev-node-agent"
 assert_grep 'ERL_EPMD_ADDRESS=127.0.0.1' "$TMP_ROOT/i-node-iex.log"
 assert_grep '--name orchard_node_agent@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52172 inet_dist_listen_max 52172 -S mix run --no-halt' "$TMP_ROOT/i-node-iex.log"
 
-# J: split-role gRPC entrypoints do not require BEAM IEx args.
-GRPC_ENTRYPOINT_REPO="$TMP_ROOT/grpc-entrypoint-repo"
-mkdir -p "$GRPC_ENTRYPOINT_REPO/bin/lib" "$GRPC_ENTRYPOINT_REPO/apps/orchard_controller" "$GRPC_ENTRYPOINT_REPO/apps/orchard_node_agent"
-cp "$REPO_ROOT/bin/dev-controller" "$GRPC_ENTRYPOINT_REPO/bin/dev-controller"
-cp "$REPO_ROOT/bin/dev-node-agent" "$GRPC_ENTRYPOINT_REPO/bin/dev-node-agent"
-chmod +x "$GRPC_ENTRYPOINT_REPO/bin/dev-controller" "$GRPC_ENTRYPOINT_REPO/bin/dev-node-agent"
-: > "$GRPC_ENTRYPOINT_REPO/mix.exs"
-cat > "$GRPC_ENTRYPOINT_REPO/bin/lib/source-dev-beam.sh" <<'SH'
-#!/usr/bin/env bash
-orchard_source_dev_beam_bootstrap() {
-  export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
-  export ORCHARD_SOURCE_DEV_ROLE="$1"
-}
-SH
-
+# J: explicit split-role gRPC opt-out entrypoints do not require BEAM IEx args.
 : > "$TMP_ROOT/j-controller-mix.log"
 assert_succeeds "$TMP_ROOT/j-controller.out" \
-  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/j-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/j-controller-iex.log" "$GRPC_ENTRYPOINT_REPO/bin/dev-controller"
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/j-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/j-controller-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc "$ENTRYPOINT_REPO/bin/dev-controller"
 assert_grep 'mix called: ecto.create --quiet' "$TMP_ROOT/j-controller-mix.log"
 assert_grep '-S mix phx.server' "$TMP_ROOT/j-controller-iex.log"
 assert_no_grep '--name' "$TMP_ROOT/j-controller-iex.log"
 assert_no_grep '--erl' "$TMP_ROOT/j-controller-iex.log"
+assert_grep 'Runtime client targets: 127.0.0.1:50071' "$TMP_ROOT/j-controller.out"
 
 : > "$TMP_ROOT/j-node-mix.log"
 assert_succeeds "$TMP_ROOT/j-node.out" \
-  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/j-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/j-node-iex.log" "$GRPC_ENTRYPOINT_REPO/bin/dev-node-agent"
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/j-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/j-node-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc "$ENTRYPOINT_REPO/bin/dev-node-agent"
 assert_grep '-S mix run --no-halt' "$TMP_ROOT/j-node-iex.log"
 assert_no_grep '--name' "$TMP_ROOT/j-node-iex.log"
 assert_no_grep '--erl' "$TMP_ROOT/j-node-iex.log"

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -388,6 +388,13 @@ assert_grep '--name orchard_controller@127.0.0.1 --erl -kernel inet_dist_use_int
 assert_grep 'BEAM cookie file:' "$TMP_ROOT/i-controller.out"
 assert_no_grep 'Runtime client targets: 127.0.0.1:50071' "$TMP_ROOT/i-controller.out"
 
+: > "$TMP_ROOT/i2-controller-mix.log"
+assert_succeeds "$TMP_ROOT/i2-controller.out" \
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i2-controller-mix.log" IEX_ARG_LOG="$TMP_ROOT/i2-controller-iex.log" ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@127.0.0.1 ORCHARD_RUNTIME_CLIENT_TARGETS=10.0.0.1:50071 "$ENTRYPOINT_REPO/bin/dev-controller"
+assert_grep 'Runtime endpoint transport: beam' "$TMP_ROOT/i2-controller.out"
+assert_grep 'Runtime client targets: 10.0.0.1:50071' "$TMP_ROOT/i2-controller.out"
+assert_grep '--name orchard_controller@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52171 inet_dist_listen_max 52171 -S mix phx.server' "$TMP_ROOT/i2-controller-iex.log"
+
 : > "$TMP_ROOT/i-node-mix.log"
 assert_succeeds "$TMP_ROOT/i-node.out" \
   env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/i-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/i-node-iex.log" "$ENTRYPOINT_REPO/bin/dev-node-agent"


### PR DESCRIPTION
## Intent

Execute the explicit promotion that ADR 0001 gated on two-Mac smoke evidence: make the BEAM Runtime Endpoint transport the default for split-role source dev, demoting gRPC to an explicit opt-out compatibility adapter. Evidence: the accepted 2026-06-27 investigation plus a 2026-07-05 two-Mac refresh on current main that proved transport, observation, admission, lifecycle, and multi-node scheduler explanations over real BEAM distribution. The change is BREAKING for source-dev workflows relying on the implicit gRPC default; `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` restores prior behavior in one variable (the opt-out branch is byte-equivalent to the old path). It also fixes the smoke finding that BEAM mode left the implicit `127.0.0.1:50071` legacy runtime client target configured — quiescing now holds at both the script layer and the config accessor (`Orchard.Inference.runtime_client_targets/0` returns `[]` instead of resurrecting the fallback), while explicitly set `ORCHARD_RUNTIME_CLIENT_TARGETS` remains a deliberate gRPC comparison surface. All-in-one `bin/dev` deliberately stays single-host gRPC loopback and continues rejecting explicit BEAM mode. Contract truth is updated everywhere the default was stated (SPEC.md internal comms, AGENTS.md two-Mac pattern, docs/local-dev.md, README.md, docs/architecture.md, both app READMEs, glossary) and ADR 0001 carries a dated promotion amendment. The OpenSpec change package (openspec/changes/promote-beam-runtime-default) was owner-approved before implementation; its task 4.4 — archiving beam-first-runtime-endpoints, source-dev-beam-operating-model, and then this change — is the deliberate post-merge acceptance cascade. Packaged-runtime transport promotion is an explicit non-goal.

## What Changed

- Flipped the split-role source-dev default: `bin/dev-controller`, `bin/dev-node-agent`, and `bin/lib/source-dev-beam.sh` now treat an unset `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` as BEAM Runtime Endpoint transport, making `grpc` an explicit opt-out; the controller now only exports and echoes legacy gRPC `ORCHARD_RUNTIME_CLIENT_TARGETS` when transport is not `beam`.
- Closed the legacy-target resurrection path: `config/dev.exs` leaves `runtime_client_target` `nil` under BEAM, and `Orchard.Inference.runtime_client_targets/0` now returns `[]` instead of `[nil]` when no targets are configured, with a new regression test covering BEAM controller mode.
- Synced the contract and docs (`SPEC.md`, decision `0001`, `README.md`, `AGENTS.md`, `docs/architecture.md`, `docs/local-dev.md`, glossary, app READMEs) to describe BEAM as the default, added the OpenSpec `promote-beam-runtime-default` change package, and extended `scripts/test-source-dev-beam-bootstrap.sh` with a default-BEAM scenario.

## Risk Assessment

✅ Low: The change is a well-bounded, spec-traceable default flip (gRPC→BEAM) confined to source-dev shell scripts and dev config, with the one intentional behavior change (bare bin/dev-controller now requiring targets) explicitly documented in SPEC.md, the decision record, and local-dev docs, and directly covered by new unit and bootstrap tests.

## Testing

Ran the repo's two relevant regression suites — the `scripts/test-source-dev-beam-bootstrap.sh` shell contract and the `orchard_controller` inference config test (63 passed, including the new BEAM empty-targets regression at L#285) after `mise trust` + `mix deps.get` — both green. To show the actual end-user experience rather than pass/fail counts, I drove the real `bin/dev-controller`/`bin/dev-node-agent` entrypoints with stubbed mix/iex/epmd/lsof and captured a CLI transcript: with the transport env unset both scripts now default to BEAM and launch with `--name orchard_*@127.0.0.1` distribution flags, the controller emits no legacy gRPC client-target line (confirming the target-resurrection path is closed), and only the explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` opt-out restores the `Runtime client targets: 127.0.0.1:50071` compatibility path. This is a CLI/dev-tooling change with no rendered UI surface, so the appropriate reviewer-visible artifact is the CLI transcript rather than a screenshot. Worktree left clean (deps/_build are gitignored).

<details>
<summary>Evidence: Default-BEAM split-role entrypoint CLI transcript</summary>

<code>### 1. bin/dev-node-agent [no transport env] =&gt; BEAM named node&#10;==&gt; Runtime endpoint transport: beam&#10;==&gt; BEAM node name: orchard_node_agent@127.0.0.1&#10;iex launch flags -&gt; --name orchard_node_agent@127.0.0.1 --erl ... -S mix run --no-halt&#10;&#10;### 2. bin/dev-controller [no transport env] =&gt; BEAM; NO legacy gRPC client-target line&#10;==&gt; Runtime endpoint transport: beam&#10;==&gt; BEAM node name: orchard_controller@127.0.0.1&#10;iex launch flags -&gt; --name orchard_controller@127.0.0.1 --erl ... -S mix phx.server&#10;&#10;### 3. bin/dev-controller ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc =&gt; explicit gRPC opt-out&#10;==&gt; Runtime client targets: 127.0.0.1:50071&#10;iex launch flags -&gt; -S mix phx.server</code>

```text
Orchard promote-beam-runtime-default — split-role source-dev entrypoints
Behavior under test: with ORCHARD_RUNTIME_ENDPOINT_TRANSPORT UNSET the split-role
scripts now default to BEAM Runtime Endpoint transport; gRPC is an explicit opt-out.
(mix/iex/epmd/lsof stubbed; iex line shows the exact launch flags handed to the VM.)
===========================================================================================

### 1. bin/dev-node-agent   [no transport env]  => BEAM named node (orchard_node_agent@127.0.0.1)
    ==> Runtime endpoint transport: beam
    ==> BEAM node name: orchard_node_agent@127.0.0.1
    ==> BEAM cookie file: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.z8LwxZch4X/repo/tmp/dev/beam.cookie
    ==> BEAM EPMD port: 4369
    ==> BEAM distribution port range: 52172..52172
    ==> Starting Orchard dev node-agent (role: node-agent)
    ==> gRPC endpoint: 127.0.0.1:50071
    ==> Worker executable: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.z8LwxZch4X/repo/native/orchard_worker_mlx/bin/orchard-worker-mlx
        iex launch flags -> --name orchard_node_agent@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52172 inet_dist_listen_max 52172 -S mix run --no-halt

### 2. bin/dev-controller   [no transport env, BEAM target given]  => BEAM; NO legacy gRPC client-target line
    ==> Runtime endpoint transport: beam
    ==> BEAM node name: orchard_controller@127.0.0.1
    ==> BEAM cookie file: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.z8LwxZch4X/repo/tmp/dev/beam.cookie
    ==> BEAM EPMD port: 4369
    ==> BEAM distribution port range: 52171..52171
    ==> Ensuring dev database...
    ==> Starting Orchard dev controller (role: controller)
    ==> HTTP endpoint: 127.0.0.1:4000
        iex launch flags -> --name orchard_controller@127.0.0.1 --erl -kernel inet_dist_use_interface {127,0,0,1} inet_dist_listen_min 52171 inet_dist_listen_max 52171 -S mix phx.server

### 3. bin/dev-controller   ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc  => explicit gRPC opt-out compatibility path
    ==> Ensuring dev database...
    ==> Starting Orchard dev controller (role: controller)
    ==> HTTP endpoint: 127.0.0.1:4000
    ==> Runtime client targets: 127.0.0.1:50071
        iex launch flags -> -S mix phx.server
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash scripts/test-source-dev-beam-bootstrap.sh` — source-dev BEAM bootstrap shell contract (unset transport defaults to BEAM named node; explicit grpc is the no-BEAM opt-out; controller emits no legacy gRPC client-target line under BEAM)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference_test.exs` — full inference config suite (63 passed)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference_test.exs:285 --trace` — new regression: dev.exs BEAM controller mode without explicit legacy targets configures `runtime_client_targets == []`</code>
- <code>Manual: ran the real `bin/dev-node-agent` and `bin/dev-controller` with stubbed mix/iex/epmd/lsof to capture the default-BEAM vs. explicit-gRPC startup transcript</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

