### PR TITLE
feat(cluster): expose HA-lite status in CLI and Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The roadmap and target behavior are governed by `SPEC.md` §14.
 Some SPEC-required CLI paths are present before their milestone implementation:
 `orchardctl cluster init` and `orchardctl node join` return command-specific deferred-status errors with the current supported path.
 `orchardctl requests inspect <request-id>` is implemented for local controller request diagnostics with stable human and JSON scheduler-explanation output.
+`orchardctl cluster status [--json]` is implemented for read-only cluster and HA-lite control-plane status, emitting the shared `HALiteStatus` payload and a HA-lite summary in `--json` mode with no leadership-transfer or failover actions.
 `orchardctl nodes inspect`,
 `orchardctl nodes pending`, `orchardctl nodes admit`, and
 `orchardctl nodes reject` are implemented for the current node-admission-review

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -11,6 +11,9 @@ This README is orientation only. Normative CLI requirements live in
 
 - Operator commands for environment, transport, migrations, status, start/stop,
   upgrades, tenants, API keys, API Client bulk provisioning, nodes, and models.
+- Read-only cluster status through `cluster status`, with a `--json` mode that
+  emits the shared `HALiteStatus` payload plus a HA-lite-focused summary of
+  deployment mode, controller role, and advisory-lock status.
 - SPEC-required future command paths that return explicit deferred status until
   their milestones land: `cluster init` and `node join`.
 - Node-admission-review commands (`nodes inspect`, `nodes pending`,
@@ -41,6 +44,12 @@ side-effect free.
 
 `orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for the request.
 Use `--json` for the same stable explanation map exposed by the Operator API presenter.
+
+`orchardctl cluster status` renders read-only cluster and HA-lite control-plane
+status from the local controller runtime.
+Use `--json` for a stable automation payload with the shared `HALiteStatus`
+contract and a HA-lite summary block; it exposes no leadership-transfer or
+failover actions.
 
 `orchardctl support bundle create` writes a local `.tar.gz` with bounded
 redacted logs, redacted config, service status, node snapshots, and request

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -129,8 +129,8 @@ defmodule OrchardCLI.Commands.Cluster do
     Usage: orchardctl cluster <command>
 
     Commands:
-      cluster init     Initialize controller-side cluster bootstrap state (SPEC.md 11.9).
-      cluster status   Show read-only cluster and HA-lite control-plane status.
+      init     Initialize controller-side cluster bootstrap state (SPEC.md 11.9).
+      status   Show read-only cluster and HA-lite control-plane status.
     """
     |> String.trim()
   end

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -112,6 +112,8 @@ defmodule OrchardCLI.Commands.Cluster do
   defp format_timestamp(%DateTime{} = timestamp), do: DateTime.to_iso8601(timestamp)
   defp format_timestamp(timestamp), do: to_string(timestamp)
 
+  defp format_status_value("ha_lite"), do: "HA-lite"
+
   defp format_status_value(value) when is_binary(value) do
     value
     |> String.replace("_", " ")

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -122,7 +122,6 @@ defmodule OrchardCLI.Commands.Cluster do
 
   defp encode_json(payload), do: Jason.encode!(payload, pretty: true)
 
-  defp format_unknown_flag(flag) when is_atom(flag), do: "--#{Atom.to_string(flag)}"
   defp format_unknown_flag(flag), do: to_string(flag)
 
   defp group_usage do

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -1,7 +1,12 @@
 defmodule OrchardCLI.Commands.Cluster do
   @moduledoc false
 
+  alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ControlPlane
   alias OrchardCLI.Commands.Deferred
+
+  @cluster_status_object "cluster_management.cluster_status"
+  @cluster_status_contract_version "orchard.cluster_management.cluster_status.v1"
 
   @commands [
     %{
@@ -18,5 +23,128 @@ defmodule OrchardCLI.Commands.Cluster do
   ]
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
-  def run(args), do: Deferred.run(args, %{name: "cluster", commands: @commands})
+  def run(["status" | rest]), do: run_status(rest)
+  def run(["help"]), do: {:ok, group_usage()}
+  def run(["--help"]), do: {:ok, group_usage()}
+  def run([]), do: {:error, group_usage(), 1}
+
+  def run(["init" | _rest] = args),
+    do: Deferred.run(args, %{name: "cluster", commands: @commands})
+
+  def run(_args), do: {:error, group_usage(), 1}
+
+  defp run_status(["help"]), do: {:ok, status_usage()}
+
+  defp run_status(args) do
+    case parse_status_args(args) do
+      {:ok, %{json?: json?}} ->
+        status = ControlPlane.read_only_status()
+        {:ok, render_status(status, json?)}
+
+      {:help, usage} ->
+        {:ok, usage}
+
+      {:error, message, code} ->
+        {:error, message, code}
+    end
+  end
+
+  defp parse_status_args(args) do
+    case OptionParser.parse(args, strict: [json: :boolean, help: :boolean]) do
+      {opts, [], []} ->
+        if Keyword.get(opts, :help, false) do
+          {:help, status_usage()}
+        else
+          {:ok, %{json?: Keyword.get(opts, :json, false)}}
+        end
+
+      {_opts, _rest, [{flag, _value} | _unknown]} ->
+        {:error, "Unknown option: #{format_unknown_flag(flag)}", 2}
+
+      _other ->
+        {:error, status_usage(), 1}
+    end
+  end
+
+  defp render_status(%HALiteStatus{} = status, true),
+    do: status |> cluster_status_map() |> encode_json()
+
+  defp render_status(%HALiteStatus{} = status, false), do: render_status_text(status)
+
+  defp cluster_status_map(%HALiteStatus{} = status) do
+    ha_lite = HALiteStatus.to_map(status)
+
+    %{
+      object: @cluster_status_object,
+      contract_version: @cluster_status_contract_version,
+      summary: %{
+        deployment_mode: status.deployment_mode,
+        controller_role: status.controller_role,
+        advisory_lock_status: status.advisory_lock_status
+      },
+      ha_lite: ha_lite
+    }
+  end
+
+  defp render_status_text(%HALiteStatus{} = status) do
+    [
+      "HA-lite: #{format_status_value(status.controller_role)}",
+      "Deployment: #{format_status_value(status.deployment_mode)}",
+      "This controller: #{status.this_controller_identity || "unknown"}",
+      "Leader: #{status.leader_identity || "unknown"}",
+      "Advisory lock: #{format_status_value(status.advisory_lock_status)}",
+      "Lock age: #{format_lock_age(status.lock_age_ms)}",
+      "Last renewed: #{format_timestamp(status.last_renewed_at)}",
+      "Write paths: #{format_status_value(status.standby_write_path_behavior)}",
+      leadership_error_line(status.last_observed_leadership_error)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp leadership_error_line(nil), do: nil
+  defp leadership_error_line(message), do: "Leadership error: #{message}"
+
+  defp format_lock_age(nil), do: "unknown"
+  defp format_lock_age(milliseconds), do: "#{milliseconds} ms"
+
+  defp format_timestamp(nil), do: "unknown"
+  defp format_timestamp(%DateTime{} = timestamp), do: DateTime.to_iso8601(timestamp)
+  defp format_timestamp(timestamp), do: to_string(timestamp)
+
+  defp format_status_value(value) when is_binary(value) do
+    value
+    |> String.replace("_", " ")
+    |> String.downcase()
+  end
+
+  defp format_status_value(value), do: value |> to_string() |> format_status_value()
+
+  defp encode_json(payload), do: Jason.encode!(payload, pretty: true)
+
+  defp format_unknown_flag(flag) when is_atom(flag), do: "--#{Atom.to_string(flag)}"
+  defp format_unknown_flag(flag), do: to_string(flag)
+
+  defp group_usage do
+    """
+    Usage: orchardctl cluster <command>
+
+    Commands:
+      cluster init     Initialize controller-side cluster bootstrap state (SPEC.md 11.9).
+      cluster status   Show read-only cluster and HA-lite control-plane status.
+    """
+    |> String.trim()
+  end
+
+  defp status_usage do
+    """
+    Usage: orchardctl cluster status [--json]
+
+    Show read-only cluster status, including the HA-lite control-plane signal category.
+
+    Options:
+      --json   Emit stable JSON for automation.
+    """
+    |> String.trim()
+  end
 end

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -88,7 +88,7 @@ defmodule OrchardCLI.Commands.Cluster do
 
   defp render_status_text(%HALiteStatus{} = status) do
     [
-      "HA-lite: #{format_status_value(status.controller_role)}",
+      "Role: #{format_status_value(status.controller_role)}",
       "Deployment: #{format_status_value(status.deployment_mode)}",
       "This controller: #{status.this_controller_identity || "unknown"}",
       "Leader: #{status.leader_identity || "unknown"}",

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -1,0 +1,102 @@
+defmodule OrchardCLI.Commands.ClusterTest do
+  use ExUnit.Case, async: false
+
+  alias OrchardCLI.Commands.Cluster, as: ClusterCmd
+
+  setup do
+    previous = Application.get_env(:orchard_controller, :control_plane)
+
+    on_exit(fn ->
+      if is_nil(previous) do
+        Application.delete_env(:orchard_controller, :control_plane)
+      else
+        Application.put_env(:orchard_controller, :control_plane, previous)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "help and usage" do
+    test "group usage includes init and status" do
+      assert {:error, message, 1} = ClusterCmd.run([])
+
+      assert message =~ "orchardctl cluster"
+      assert message =~ "cluster init"
+      assert message =~ "cluster status"
+    end
+
+    test "status --help returns status usage" do
+      assert {:ok, message} = ClusterCmd.run(["status", "--help"])
+
+      assert message =~ "orchardctl cluster status"
+      assert message =~ "--json"
+    end
+
+    test "unknown status option returns exit code 2" do
+      assert {:error, message, 2} = ClusterCmd.run(["status", "--bogus"])
+
+      assert message == "Unknown option: --bogus"
+    end
+  end
+
+  describe "status" do
+    test "SPEC CLI/Console parity emits read-only HA-lite JSON status" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-b",
+            advisory_lock_status: :not_held,
+            lock_age_ms: 1_200,
+            last_renewed_at: ~U[2026-07-01 00:00:00Z]
+          }
+        end
+      )
+
+      assert {:ok, output} = ClusterCmd.run(["status", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["object"] == "cluster_management.cluster_status"
+      assert decoded["contract_version"] == "orchard.cluster_management.cluster_status.v1"
+
+      assert decoded["summary"] == %{
+               "deployment_mode" => "ha_lite",
+               "controller_role" => "standby",
+               "advisory_lock_status" => "not_held"
+             }
+
+      assert decoded["ha_lite"]["object"] == "cluster_management.ha_lite_status"
+      assert decoded["ha_lite"]["deployment_mode"] == "ha_lite"
+      assert decoded["ha_lite"]["this_controller_identity"] == "controller-a"
+      assert decoded["ha_lite"]["controller_role"] == "standby"
+      assert decoded["ha_lite"]["leader_identity"] == "controller-b"
+      assert decoded["ha_lite"]["advisory_lock_status"] == "not_held"
+      assert decoded["ha_lite"]["lock_age_ms"] == 1_200
+      assert decoded["ha_lite"]["last_renewed_at"] == "2026-07-01T00:00:00Z"
+
+      assert decoded["ha_lite"]["standby_write_path_behavior"] ==
+               "writes_return_503_controller_standby"
+
+      assert decoded["ha_lite"]["last_observed_leadership_error"] == nil
+    end
+
+    test "human output explains directly addressed standby write paths without failover actions" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn -> %{advisory_lock_status: :unknown} end
+      )
+
+      assert {:ok, output} = ClusterCmd.run(["status"])
+
+      assert output =~ "HA-lite: standby"
+      assert output =~ "Deployment: ha lite"
+      assert output =~ "Advisory lock: unknown"
+      assert output =~ "Write paths: writes return 503 controller standby"
+      refute output =~ "failover"
+      refute output =~ "transfer"
+    end
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -22,8 +22,8 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert {:error, message, 1} = ClusterCmd.run([])
 
       assert message =~ "orchardctl cluster"
-      assert message =~ "cluster init"
-      assert message =~ "cluster status"
+      assert message =~ "init"
+      assert message =~ "status"
     end
 
     test "status --help returns status usage" do

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -118,5 +118,26 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert decoded["ha_lite"]["leader_identity"] == nil
       assert decoded["ha_lite"]["standby_write_path_behavior"] == "unknown"
     end
+
+    test "SPEC CLI/Console parity degrades malformed provider status to unavailable JSON" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn -> %{advisory_lock_status: "flaky"} end
+      )
+
+      assert {:ok, output} = ClusterCmd.run(["status", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["summary"] == %{
+               "deployment_mode" => "ha_lite",
+               "controller_role" => "unknown",
+               "advisory_lock_status" => "unavailable"
+             }
+
+      assert decoded["ha_lite"]["leader_identity"] == nil
+      assert decoded["ha_lite"]["standby_write_path_behavior"] == "unknown"
+      assert is_binary(decoded["ha_lite"]["last_observed_leadership_error"])
+    end
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -92,7 +92,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert {:ok, output} = ClusterCmd.run(["status"])
 
       assert output =~ "Role: standby"
-      assert output =~ "Deployment: ha lite"
+      assert output =~ "Deployment: HA-lite"
       refute output =~ "HA-lite: standby"
       assert output =~ "Advisory lock: unknown"
       assert output =~ "Write paths: writes return 503 controller standby"

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -137,7 +137,9 @@ defmodule OrchardCLI.Commands.ClusterTest do
 
       assert decoded["ha_lite"]["leader_identity"] == nil
       assert decoded["ha_lite"]["standby_write_path_behavior"] == "unknown"
-      assert is_binary(decoded["ha_lite"]["last_observed_leadership_error"])
+
+      assert decoded["ha_lite"]["last_observed_leadership_error"] ==
+               "advisory_lock_read_failed: invalid_provider_status"
     end
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -142,5 +142,29 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert decoded["ha_lite"]["last_observed_leadership_error"] ==
                "advisory_lock_read_failed: invalid_provider_status"
     end
+
+    test "SPEC CLI/Console parity sanitizes provider-returned leadership error in JSON" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-b",
+            advisory_lock_status: :not_held,
+            last_observed_leadership_error:
+              "password authentication failed for user orchard_admin at db.internal:5432"
+          }
+        end
+      )
+
+      assert {:ok, output} = ClusterCmd.run(["status", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["ha_lite"]["last_observed_leadership_error"] ==
+               "advisory_lock_read_failed: provider_reported_error"
+
+      refute output =~ "orchard_admin"
+      refute output =~ "db.internal"
+    end
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -98,5 +98,25 @@ defmodule OrchardCLI.Commands.ClusterTest do
       refute output =~ "failover"
       refute output =~ "transfer"
     end
+
+    test "SPEC Leadership status is unknown in JSON when advisory-lock status is unreadable" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a"
+      )
+
+      assert {:ok, output} = ClusterCmd.run(["status", "--json"])
+      decoded = Jason.decode!(output)
+
+      assert decoded["summary"] == %{
+               "deployment_mode" => "ha_lite",
+               "controller_role" => "unknown",
+               "advisory_lock_status" => "unknown"
+             }
+
+      assert decoded["ha_lite"]["controller_role"] == "unknown"
+      assert decoded["ha_lite"]["leader_identity"] == nil
+      assert decoded["ha_lite"]["standby_write_path_behavior"] == "unknown"
+    end
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -91,8 +91,9 @@ defmodule OrchardCLI.Commands.ClusterTest do
 
       assert {:ok, output} = ClusterCmd.run(["status"])
 
-      assert output =~ "HA-lite: standby"
+      assert output =~ "Role: standby"
       assert output =~ "Deployment: ha lite"
+      refute output =~ "HA-lite: standby"
       assert output =~ "Advisory lock: unknown"
       assert output =~ "Write paths: writes return 503 controller standby"
       refute output =~ "failover"

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -11,6 +11,8 @@ defmodule OrchardConsole.NodesLive do
 
   require Logger
 
+  alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ControlPlane
   alias Orchard.Nodes
   alias Orchard.Nodes.AdmissionCandidate
   alias Orchard.RuntimeEndpoint.Target
@@ -244,6 +246,54 @@ defmodule OrchardConsole.NodesLive do
           </.card>
           </div>
 
+          <%!-- HA-lite Control Plane Card --%>
+          <div id="nodes-ha-lite-status-card">
+          <.card variant={:rail} padding={:sm}>
+            <:title>HA-lite Status</:title>
+            <:subtitle>{ha_lite_subtitle(@ha_lite)}</:subtitle>
+
+            <%= cond do %>
+              <% @ha_lite.status == :loading -> %>
+                <.state_message id="nodes-ha-lite-loading" kind={:loading} layout={:compact} title="Loading HA-lite status." />
+              <% @ha_lite.status == :error -> %>
+                <.state_message id="nodes-ha-lite-error" kind={:error} layout={:compact} title="HA-lite status unavailable." body={@ha_lite.message} />
+              <% true -> %>
+                <% status = @ha_lite.status_contract %>
+                <div class="space-y-4">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <.badge tone={ha_lite_deployment_tone(status.deployment_mode)}>
+                      {format_status_value(status.deployment_mode)}
+                    </.badge>
+                    <.badge tone={ha_lite_role_tone(status.controller_role)}>
+                      {format_status_value(status.controller_role)}
+                    </.badge>
+                    <.badge tone={ha_lite_lock_tone(status.advisory_lock_status)}>
+                      {format_status_value(status.advisory_lock_status)}
+                    </.badge>
+                  </div>
+
+                  <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+                    <dt class="text-slate-500 dark:text-slate-400">This controller</dt>
+                    <dd class="font-mono text-slate-900 dark:text-slate-100">{status.this_controller_identity || "unknown"}</dd>
+                    <dt class="text-slate-500 dark:text-slate-400">Leader identity</dt>
+                    <dd class="font-mono text-slate-900 dark:text-slate-100">{status.leader_identity || "unknown"}</dd>
+                    <dt class="text-slate-500 dark:text-slate-400">Lock age</dt>
+                    <dd class="font-mono text-slate-900 dark:text-slate-100">{format_lock_age(status.lock_age_ms)}</dd>
+                    <dt class="text-slate-500 dark:text-slate-400">Last renewed</dt>
+                    <dd class="font-mono text-slate-900 dark:text-slate-100">
+                      <.local_time :if={status.last_renewed_at} value={status.last_renewed_at} format={:datetime_second} />
+                      <span :if={!status.last_renewed_at}>unknown</span>
+                    </dd>
+                    <dt class="text-slate-500 dark:text-slate-400">Write paths</dt>
+                    <dd class="font-mono text-slate-900 dark:text-slate-100">{format_write_path_behavior(status.standby_write_path_behavior)}</dd>
+                    <dt :if={status.last_observed_leadership_error} class="text-slate-500 dark:text-slate-400">Leadership error</dt>
+                    <dd :if={status.last_observed_leadership_error} class="text-slate-900 dark:text-slate-100">{status.last_observed_leadership_error}</dd>
+                  </dl>
+                </div>
+            <% end %>
+          </.card>
+          </div>
+
           <%!-- Per-Target Runtime Cards --%>
           <div id="nodes-runtime-targets" class="space-y-4">
             <div :for={t <- @cluster.targets} id={"nodes-runtime-card-#{t.target_dom_id}"}>
@@ -447,12 +497,14 @@ defmodule OrchardConsole.NodesLive do
     inventory = fetch_inventory()
     pending_admissions = fetch_pending_admissions(inventory.rows)
     safe_tokenization_counters = fetch_safe_tokenization_counters()
+    ha_lite = fetch_ha_lite_status()
 
     assign(socket,
       cluster: cluster,
       inventory: inventory,
       pending_admissions: pending_admissions,
       safe_tokenization_counters: safe_tokenization_counters,
+      ha_lite: ha_lite,
       last_refreshed_at: observed_at
     )
   end
@@ -481,6 +533,11 @@ defmodule OrchardConsole.NodesLive do
         status: :loading,
         targets: [],
         summary: empty_cluster_summary(),
+        message: nil
+      },
+      ha_lite: %{
+        status: :loading,
+        status_contract: nil,
         message: nil
       },
       safe_tokenization_counters: fetch_safe_tokenization_counters(),
@@ -777,6 +834,32 @@ defmodule OrchardConsole.NodesLive do
     }
   end
 
+  defp fetch_ha_lite_status do
+    %{
+      status: :ok,
+      status_contract: ControlPlane.read_only_status(),
+      message: nil
+    }
+  rescue
+    error ->
+      Logger.warning("HA-lite status fetch failed: #{inspect(error)}")
+
+      %{
+        status: :error,
+        status_contract: nil,
+        message: "HA-lite control-plane status unavailable."
+      }
+  catch
+    kind, reason ->
+      Logger.warning("HA-lite status fetch #{kind}: #{inspect(reason)}")
+
+      %{
+        status: :error,
+        status_contract: nil,
+        message: "HA-lite control-plane status unavailable."
+      }
+  end
+
   defp fetch_safe_tokenization_counters do
     telemetry_counters_impl().snapshot()
     |> normalize_safe_tokenization_counters()
@@ -895,6 +978,15 @@ defmodule OrchardConsole.NodesLive do
 
   defp target_card_title(%{target_label: label}), do: label
 
+  defp ha_lite_subtitle(%{status: :loading}), do: "Loading read-only control-plane status."
+  defp ha_lite_subtitle(%{status: :error}), do: "Read-only control-plane status unavailable."
+
+  defp ha_lite_subtitle(%{status: :ok, status_contract: %HALiteStatus{} = status}) do
+    "#{format_status_value(status.deployment_mode)} control plane, #{format_status_value(status.controller_role)}"
+  end
+
+  defp ha_lite_subtitle(_status), do: "Read-only control-plane status."
+
   # ===========================================================================
   # Badge helpers
   # ===========================================================================
@@ -999,6 +1091,18 @@ defmodule OrchardConsole.NodesLive do
   defp compatibility_tone("version_skew"), do: :warning
   defp compatibility_tone("unsupported_version"), do: :error
   defp compatibility_tone(_status), do: :neutral
+
+  defp ha_lite_deployment_tone("ha_lite"), do: :info
+  defp ha_lite_deployment_tone(_mode), do: :neutral
+
+  defp ha_lite_role_tone("leader"), do: :success
+  defp ha_lite_role_tone("standby"), do: :warning
+  defp ha_lite_role_tone(_role), do: :neutral
+
+  defp ha_lite_lock_tone("held"), do: :success
+  defp ha_lite_lock_tone("not_held"), do: :warning
+  defp ha_lite_lock_tone("unavailable"), do: :error
+  defp ha_lite_lock_tone(_status), do: :neutral
 
   # Observe-only memory telemetry display helpers.
   defp memory_budget_status_label(%{display_state: :invalid}), do: "invalid telemetry"
@@ -1127,6 +1231,20 @@ defmodule OrchardConsole.NodesLive do
   end
 
   defp format_status_value(value), do: to_string(value)
+
+  defp format_lock_age(nil), do: "unknown"
+  defp format_lock_age(milliseconds) when is_integer(milliseconds), do: "#{milliseconds} ms"
+  defp format_lock_age(_milliseconds), do: "unknown"
+
+  defp format_write_path_behavior("writes_return_503_controller_standby") do
+    "writes return 503 controller standby"
+  end
+
+  defp format_write_path_behavior("writes_allowed_when_authorized") do
+    "writes allowed when authorized"
+  end
+
+  defp format_write_path_behavior(value), do: format_status_value(value)
 
   defp format_pending_target(%{target_ref: target}) when is_binary(target) and target != "",
     do: target

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -982,7 +982,14 @@ defmodule OrchardConsole.NodesLive do
   defp ha_lite_subtitle(%{status: :error}), do: "Read-only control-plane status unavailable."
 
   defp ha_lite_subtitle(%{status: :ok, status_contract: %HALiteStatus{} = status}) do
-    "#{format_status_value(status.deployment_mode)} control plane, #{format_status_value(status.controller_role)}"
+    deployment_mode = format_status_value(status.deployment_mode)
+    controller_role = format_status_value(status.controller_role)
+
+    if deployment_mode == controller_role do
+      "#{deployment_mode} control plane"
+    else
+      "#{deployment_mode} control plane, #{controller_role}"
+    end
   end
 
   defp ha_lite_subtitle(_status), do: "Read-only control-plane status."
@@ -1217,6 +1224,7 @@ defmodule OrchardConsole.NodesLive do
   defp map_get(_map, _key), do: nil
 
   defp format_status_value(nil), do: "unknown"
+  defp format_status_value("ha_lite"), do: "HA-lite"
 
   defp format_status_value(value) when is_atom(value) do
     value

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -5,6 +5,7 @@ defmodule Orchard.ControlPlane do
   """
 
   alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ClusterManagement.Value
 
   @provider_status_keys [
     :leader_identity,
@@ -12,6 +13,14 @@ defmodule Orchard.ControlPlane do
     :lock_age_ms,
     :last_renewed_at,
     :last_observed_leadership_error
+  ]
+
+  @stable_leadership_errors [
+    "advisory_lock_read_failed: db_connection_error",
+    "advisory_lock_read_failed: invalid_provider_status",
+    "advisory_lock_read_failed: unexpected_provider_result",
+    "advisory_lock_read_failed: provider_error",
+    "advisory_lock_read_failed: provider_reported_error"
   ]
 
   @type write_path :: atom()
@@ -88,6 +97,24 @@ defmodule Orchard.ControlPlane do
   defp provider_advisory_lock_attrs(attrs) do
     Map.new(@provider_status_keys, fn key -> {key, provider_attr(attrs, key)} end)
     |> Map.reject(fn {_key, value} -> is_nil(value) end)
+    |> sanitize_leadership_error()
+  end
+
+  defp sanitize_leadership_error(%{last_observed_leadership_error: error} = attrs) do
+    case stable_leadership_error(error) do
+      nil -> Map.delete(attrs, :last_observed_leadership_error)
+      reason -> Map.put(attrs, :last_observed_leadership_error, reason)
+    end
+  end
+
+  defp sanitize_leadership_error(attrs), do: attrs
+
+  defp stable_leadership_error(error) do
+    case Value.normalize_string(error) do
+      nil -> nil
+      normalized when normalized in @stable_leadership_errors -> normalized
+      _raw -> "advisory_lock_read_failed: provider_reported_error"
+    end
   end
 
   defp validate_provider_status(attrs, base_attrs) do

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -31,6 +31,7 @@ defmodule Orchard.ControlPlane do
       standby_write_path_behavior: standby_write_path_behavior(role)
     }
     |> Map.merge(provider_status(config))
+    |> normalize_unproven_leadership()
     |> HALiteStatus.new!()
   end
 
@@ -78,6 +79,29 @@ defmodule Orchard.ControlPlane do
       last_observed_leadership_error: message
     }
   end
+
+  defp normalize_unproven_leadership(%{deployment_mode: :ha_lite} = attrs) do
+    role = normalized_role(Map.get(attrs, :controller_role, :unknown))
+    lock_status = normalize_lock_status(Map.get(attrs, :advisory_lock_status, :unknown))
+
+    if role == :leader and lock_status != :held do
+      attrs
+      |> Map.put(:controller_role, :unknown)
+      |> Map.put(:standby_write_path_behavior, "unknown")
+    else
+      attrs
+    end
+  end
+
+  defp normalize_unproven_leadership(attrs), do: attrs
+
+  defp normalize_lock_status(:held), do: :held
+  defp normalize_lock_status("held"), do: :held
+  defp normalize_lock_status(:not_held), do: :not_held
+  defp normalize_lock_status("not_held"), do: :not_held
+  defp normalize_lock_status(:unavailable), do: :unavailable
+  defp normalize_lock_status("unavailable"), do: :unavailable
+  defp normalize_lock_status(_status), do: :unknown
 
   defp normalized_role(:leader), do: :leader
   defp normalized_role("leader"), do: :leader

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -60,9 +60,9 @@ defmodule Orchard.ControlPlane do
       provider -> provider |> read_provider_status() |> normalize_provider_status(base_attrs)
     end
   rescue
-    exception -> unavailable_status(Exception.message(exception))
+    exception -> unavailable_status(exception)
   catch
-    kind, reason -> unavailable_status("#{kind}: #{inspect(reason)}")
+    _kind, _reason -> unavailable_status(:provider_error)
   end
 
   defp read_provider_status(provider) when is_function(provider, 0), do: provider.()
@@ -79,11 +79,11 @@ defmodule Orchard.ControlPlane do
   defp normalize_provider_status(%{} = attrs, base_attrs),
     do: attrs |> provider_advisory_lock_attrs() |> validate_provider_status(base_attrs)
 
-  defp normalize_provider_status({:error, reason}, _base_attrs),
-    do: unavailable_status(inspect(reason))
+  defp normalize_provider_status({:error, _reason}, _base_attrs),
+    do: unavailable_status(:provider_error)
 
-  defp normalize_provider_status(other, _base_attrs),
-    do: unavailable_status("unexpected provider result: #{inspect(other)}")
+  defp normalize_provider_status(_other, _base_attrs),
+    do: unavailable_status(:unexpected_provider_result)
 
   defp provider_advisory_lock_attrs(attrs) do
     Map.new(@provider_status_keys, fn key -> {key, provider_attr(attrs, key)} end)
@@ -97,7 +97,7 @@ defmodule Orchard.ControlPlane do
     |> HALiteStatus.new()
     |> case do
       {:ok, _status} -> attrs
-      {:error, reason} -> unavailable_status(inspect(reason))
+      {:error, _reason} -> unavailable_status(:invalid_provider_status)
     end
   end
 
@@ -105,15 +105,26 @@ defmodule Orchard.ControlPlane do
     Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
   end
 
-  defp unavailable_status(message) do
+  defp unavailable_status(reason) do
     %{
       advisory_lock_status: :unavailable,
       leader_identity: nil,
       lock_age_ms: nil,
       last_renewed_at: nil,
-      last_observed_leadership_error: message
+      last_observed_leadership_error: leadership_error_reason(reason)
     }
   end
+
+  defp leadership_error_reason(%DBConnection.ConnectionError{}),
+    do: "advisory_lock_read_failed: db_connection_error"
+
+  defp leadership_error_reason(:invalid_provider_status),
+    do: "advisory_lock_read_failed: invalid_provider_status"
+
+  defp leadership_error_reason(:unexpected_provider_result),
+    do: "advisory_lock_read_failed: unexpected_provider_result"
+
+  defp leadership_error_reason(_reason), do: "advisory_lock_read_failed: provider_error"
 
   defp normalize_unproven_leadership(%{deployment_mode: :ha_lite} = attrs) do
     role = normalized_role(Map.get(attrs, :controller_role, :unknown))

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -31,14 +31,16 @@ defmodule Orchard.ControlPlane do
     config = control_plane_config()
     role = normalized_role(Keyword.get(config, :role, :single_controller))
 
-    %{
+    base_attrs = %{
       deployment_mode: deployment_mode(role),
       this_controller_identity: Keyword.get(config, :this_controller_identity),
       controller_role: role,
       advisory_lock_status: :unknown,
       standby_write_path_behavior: standby_write_path_behavior(role)
     }
-    |> Map.merge(provider_status(config))
+
+    base_attrs
+    |> Map.merge(provider_status(config, base_attrs))
     |> normalize_unproven_leadership()
     |> HALiteStatus.new!()
   end
@@ -52,10 +54,10 @@ defmodule Orchard.ControlPlane do
     Application.get_env(:orchard_controller, :control_plane, [])
   end
 
-  defp provider_status(config) do
+  defp provider_status(config, base_attrs) do
     case Keyword.get(config, :ha_lite_status_provider) do
       nil -> %{}
-      provider -> provider |> read_provider_status() |> normalize_provider_status()
+      provider -> provider |> read_provider_status() |> normalize_provider_status(base_attrs)
     end
   rescue
     exception -> unavailable_status(Exception.message(exception))
@@ -71,16 +73,32 @@ defmodule Orchard.ControlPlane do
   defp read_provider_status(provider),
     do: {:error, {:invalid_ha_lite_status_provider, inspect(provider)}}
 
-  defp normalize_provider_status({:ok, %{} = attrs}), do: provider_advisory_lock_attrs(attrs)
-  defp normalize_provider_status(%{} = attrs), do: provider_advisory_lock_attrs(attrs)
-  defp normalize_provider_status({:error, reason}), do: unavailable_status(inspect(reason))
+  defp normalize_provider_status({:ok, %{} = attrs}, base_attrs),
+    do: attrs |> provider_advisory_lock_attrs() |> validate_provider_status(base_attrs)
 
-  defp normalize_provider_status(other),
+  defp normalize_provider_status(%{} = attrs, base_attrs),
+    do: attrs |> provider_advisory_lock_attrs() |> validate_provider_status(base_attrs)
+
+  defp normalize_provider_status({:error, reason}, _base_attrs),
+    do: unavailable_status(inspect(reason))
+
+  defp normalize_provider_status(other, _base_attrs),
     do: unavailable_status("unexpected provider result: #{inspect(other)}")
 
   defp provider_advisory_lock_attrs(attrs) do
     Map.new(@provider_status_keys, fn key -> {key, provider_attr(attrs, key)} end)
     |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp validate_provider_status(attrs, base_attrs) do
+    base_attrs
+    |> Map.merge(attrs)
+    |> normalize_unproven_leadership()
+    |> HALiteStatus.new()
+    |> case do
+      {:ok, _status} -> attrs
+      {:error, reason} -> unavailable_status(inspect(reason))
+    end
   end
 
   defp provider_attr(attrs, key) do

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -20,20 +20,63 @@ defmodule Orchard.ControlPlane do
 
   @spec read_only_status() :: HALiteStatus.t()
   def read_only_status do
-    role = normalized_role(configured_role())
+    config = control_plane_config()
+    role = normalized_role(Keyword.get(config, :role, :single_controller))
 
-    HALiteStatus.new!(%{
+    %{
       deployment_mode: deployment_mode(role),
+      this_controller_identity: Keyword.get(config, :this_controller_identity),
       controller_role: role,
       advisory_lock_status: :unknown,
       standby_write_path_behavior: standby_write_path_behavior(role)
-    })
+    }
+    |> Map.merge(provider_status(config))
+    |> HALiteStatus.new!()
   end
 
   defp configured_role do
-    :orchard_controller
-    |> Application.get_env(:control_plane, [])
+    control_plane_config()
     |> Keyword.get(:role, :single_controller)
+  end
+
+  defp control_plane_config do
+    Application.get_env(:orchard_controller, :control_plane, [])
+  end
+
+  defp provider_status(config) do
+    case Keyword.get(config, :ha_lite_status_provider) do
+      nil -> %{}
+      provider -> provider |> read_provider_status() |> normalize_provider_status()
+    end
+  rescue
+    exception -> unavailable_status(Exception.message(exception))
+  catch
+    kind, reason -> unavailable_status("#{kind}: #{inspect(reason)}")
+  end
+
+  defp read_provider_status(provider) when is_function(provider, 0), do: provider.()
+
+  defp read_provider_status({module, function, args}) when is_list(args),
+    do: apply(module, function, args)
+
+  defp read_provider_status(provider),
+    do: {:error, {:invalid_ha_lite_status_provider, inspect(provider)}}
+
+  defp normalize_provider_status({:ok, %{} = attrs}), do: attrs
+  defp normalize_provider_status(%{} = attrs), do: attrs
+  defp normalize_provider_status({:error, reason}), do: unavailable_status(inspect(reason))
+
+  defp normalize_provider_status(other),
+    do: unavailable_status("unexpected provider result: #{inspect(other)}")
+
+  defp unavailable_status(message) do
+    %{
+      advisory_lock_status: :unavailable,
+      leader_identity: nil,
+      lock_age_ms: nil,
+      last_renewed_at: nil,
+      last_observed_leadership_error: message
+    }
   end
 
   defp normalized_role(:leader), do: :leader

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -6,6 +6,14 @@ defmodule Orchard.ControlPlane do
 
   alias Orchard.ClusterManagement.HALiteStatus
 
+  @provider_status_keys [
+    :leader_identity,
+    :advisory_lock_status,
+    :lock_age_ms,
+    :last_renewed_at,
+    :last_observed_leadership_error
+  ]
+
   @type write_path :: atom()
   @type write_error :: :controller_standby
 
@@ -63,12 +71,21 @@ defmodule Orchard.ControlPlane do
   defp read_provider_status(provider),
     do: {:error, {:invalid_ha_lite_status_provider, inspect(provider)}}
 
-  defp normalize_provider_status({:ok, %{} = attrs}), do: attrs
-  defp normalize_provider_status(%{} = attrs), do: attrs
+  defp normalize_provider_status({:ok, %{} = attrs}), do: provider_advisory_lock_attrs(attrs)
+  defp normalize_provider_status(%{} = attrs), do: provider_advisory_lock_attrs(attrs)
   defp normalize_provider_status({:error, reason}), do: unavailable_status(inspect(reason))
 
   defp normalize_provider_status(other),
     do: unavailable_status("unexpected provider result: #{inspect(other)}")
+
+  defp provider_advisory_lock_attrs(attrs) do
+    Map.new(@provider_status_keys, fn key -> {key, provider_attr(attrs, key)} end)
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp provider_attr(attrs, key) do
+    Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  end
 
   defp unavailable_status(message) do
     %{

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -119,7 +119,7 @@ defmodule Orchard.ControlPlane do
     role = normalized_role(Map.get(attrs, :controller_role, :unknown))
     lock_status = normalize_lock_status(Map.get(attrs, :advisory_lock_status, :unknown))
 
-    if role == :leader and lock_status != :held do
+    if role == :leader and not local_leadership_proven?(attrs, lock_status) do
       attrs
       |> Map.put(:controller_role, :unknown)
       |> Map.put(:standby_write_path_behavior, "unknown")
@@ -129,6 +129,27 @@ defmodule Orchard.ControlPlane do
   end
 
   defp normalize_unproven_leadership(attrs), do: attrs
+
+  defp local_leadership_proven?(attrs, :held) do
+    leader_identity = status_identity(Map.get(attrs, :leader_identity))
+    this_controller_identity = status_identity(Map.get(attrs, :this_controller_identity))
+
+    is_nil(leader_identity) or leader_identity == this_controller_identity
+  end
+
+  defp local_leadership_proven?(_attrs, _lock_status), do: false
+
+  defp status_identity(nil), do: nil
+
+  defp status_identity(value) do
+    value
+    |> to_string()
+    |> String.trim()
+    |> case do
+      "" -> nil
+      identity -> identity
+    end
+  end
 
   defp normalize_lock_status(:held), do: :held
   defp normalize_lock_status("held"), do: :held

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -944,7 +944,9 @@ defmodule OrchardConsole.NodesLiveTest do
 
       assert card =~ "HA-lite Status"
       assert card =~ "Standby"
-      assert card =~ "Ha lite"
+      assert card =~ "HA-lite control plane"
+      assert card =~ "HA-lite"
+      refute card =~ "Ha lite"
       assert card =~ "Not held"
       assert card =~ "controller-a"
       assert card =~ "controller-b"
@@ -979,6 +981,15 @@ defmodule OrchardConsole.NodesLiveTest do
       refute card =~ "db.internal"
       refute card =~ "Held"
       refute card =~ "writes allowed when authorized"
+    end
+
+    test "single-controller subtitle does not duplicate role copy", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/console/nodes")
+
+      card = element(view, "#nodes-ha-lite-status-card") |> render()
+
+      assert card =~ "Single controller control plane"
+      refute card =~ "Single controller control plane, Single controller"
     end
 
     test "disconnected render defers HA-lite status until LiveView connects", %{conn: conn} do

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -960,7 +960,10 @@ defmodule OrchardConsole.NodesLiveTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn -> raise DBConnection.ConnectionError, message: "db down" end
+        ha_lite_status_provider: fn ->
+          raise DBConnection.ConnectionError,
+            message: "password authentication failed for user orchard_admin at db.internal:5432"
+        end
       )
 
       {:ok, view, _html} = live(conn, "/console/nodes")
@@ -969,10 +972,11 @@ defmodule OrchardConsole.NodesLiveTest do
 
       assert card =~ "Unknown"
       assert card =~ "Unavailable"
-      assert card =~ "Leader identity"
-      assert card =~ "unknown"
+      assert card =~ ~r/<dt[^>]*>Leader identity<\/dt>\s*<dd[^>]*>\s*unknown\s*<\/dd>/
       assert card =~ "Leadership error"
-      assert card =~ "db down"
+      assert card =~ "advisory_lock_read_failed: db_connection_error"
+      refute card =~ "orchard_admin"
+      refute card =~ "db.internal"
       refute card =~ "Held"
       refute card =~ "writes allowed when authorized"
     end

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -610,6 +610,7 @@ defmodule OrchardConsole.NodesLiveTest do
 
   setup do
     previous = Application.get_env(:orchard_controller, :console, [])
+    previous_control_plane = Application.get_env(:orchard_controller, :control_plane)
 
     Application.put_env(
       :orchard_controller,
@@ -621,7 +622,17 @@ defmodule OrchardConsole.NodesLiveTest do
       )
     )
 
-    on_exit(fn -> Application.put_env(:orchard_controller, :console, previous) end)
+    Application.put_env(:orchard_controller, :control_plane, role: :single_controller)
+
+    on_exit(fn ->
+      Application.put_env(:orchard_controller, :console, previous)
+
+      if is_nil(previous_control_plane) do
+        Application.delete_env(:orchard_controller, :control_plane)
+      else
+        Application.put_env(:orchard_controller, :control_plane, previous_control_plane)
+      end
+    end)
 
     Sandbox.mode(Repo, {:shared, self()})
     :ok
@@ -641,6 +652,7 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ "Admission Review"
       assert html =~ "Registered Nodes"
       assert html =~ "Live Cluster"
+      assert html =~ "HA-lite Status"
     end
 
     test "renders nodes page with section titles", %{conn: conn} do
@@ -649,6 +661,7 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ "Inventory Summary"
       assert html =~ "Registered Nodes"
       assert html =~ "Live Cluster"
+      assert html =~ "HA-lite Status"
     end
 
     test "opts into workspace shell while keeping registered nodes primary", %{conn: conn} do
@@ -665,6 +678,11 @@ defmodule OrchardConsole.NodesLiveTest do
       assert cluster =~ ~s(id="nodes-cluster-summary")
       assert cluster =~ "xl:grid-cols-2"
       refute cluster =~ "xl:grid-cols-6"
+
+      ha_lite = element(view, "#nodes-ha-lite-status-card") |> render()
+      assert ha_lite =~ "bg-slate-100/70"
+      assert ha_lite =~ "HA-lite Status"
+      refute ha_lite =~ "nodes-cluster-summary"
 
       counters = element(view, "#nodes-safe-tokenization-telemetry-card") |> render()
       assert counters =~ "bg-slate-50"
@@ -896,6 +914,74 @@ defmodule OrchardConsole.NodesLiveTest do
 
       assert html =~ "No nodes registered yet."
       assert html =~ "nodes-empty-state"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # HA-lite status
+  # ---------------------------------------------------------------------------
+
+  describe "HA-lite control-plane status" do
+    test "SPEC HA-lite Status Is Read-Only renders directly addressed standby behavior", %{
+      conn: conn
+    } do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-b",
+            advisory_lock_status: :not_held,
+            lock_age_ms: 1_200,
+            last_renewed_at: ~U[2026-07-01 00:00:00Z]
+          }
+        end
+      )
+
+      {:ok, view, _html} = live(conn, "/console/nodes")
+
+      card = element(view, "#nodes-ha-lite-status-card") |> render()
+
+      assert card =~ "HA-lite Status"
+      assert card =~ "Standby"
+      assert card =~ "Ha lite"
+      assert card =~ "Not held"
+      assert card =~ "controller-a"
+      assert card =~ "controller-b"
+      assert card =~ "1200 ms"
+      assert card =~ "writes return 503 controller standby"
+      refute card =~ "Failover"
+      refute card =~ "Transfer"
+    end
+
+    test "SPEC Leadership status is unavailable does not infer leadership from local role", %{
+      conn: conn
+    } do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn -> raise DBConnection.ConnectionError, message: "db down" end
+      )
+
+      {:ok, view, _html} = live(conn, "/console/nodes")
+
+      card = element(view, "#nodes-ha-lite-status-card") |> render()
+
+      assert card =~ "Leader"
+      assert card =~ "Unavailable"
+      assert card =~ "Leader identity"
+      assert card =~ "unknown"
+      assert card =~ "Leadership error"
+      assert card =~ "db down"
+      refute card =~ "Held"
+    end
+
+    test "disconnected render defers HA-lite status until LiveView connects", %{conn: conn} do
+      conn = get(conn, "/console/nodes")
+      body = html_response(conn, 200)
+
+      assert body =~ "nodes-ha-lite-status-card"
+      assert body =~ "Loading HA-lite status."
     end
   end
 

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -983,6 +983,30 @@ defmodule OrchardConsole.NodesLiveTest do
       refute card =~ "writes allowed when authorized"
     end
 
+    test "SPEC Leadership status sanitizes provider-returned leadership error", %{conn: conn} do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-b",
+            advisory_lock_status: :not_held,
+            last_observed_leadership_error:
+              "password authentication failed for user orchard_admin at db.internal:5432"
+          }
+        end
+      )
+
+      {:ok, view, _html} = live(conn, "/console/nodes")
+
+      card = element(view, "#nodes-ha-lite-status-card") |> render()
+
+      assert card =~ "Leadership error"
+      assert card =~ "advisory_lock_read_failed: provider_reported_error"
+      refute card =~ "orchard_admin"
+      refute card =~ "db.internal"
+    end
+
     test "single-controller subtitle does not duplicate role copy", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/console/nodes")
 

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -967,13 +967,14 @@ defmodule OrchardConsole.NodesLiveTest do
 
       card = element(view, "#nodes-ha-lite-status-card") |> render()
 
-      assert card =~ "Leader"
+      assert card =~ "Unknown"
       assert card =~ "Unavailable"
       assert card =~ "Leader identity"
       assert card =~ "unknown"
       assert card =~ "Leadership error"
       assert card =~ "db down"
       refute card =~ "Held"
+      refute card =~ "writes allowed when authorized"
     end
 
     test "disconnected render defers HA-lite status until LiveView connects", %{conn: conn} do

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -133,5 +133,28 @@ defmodule Orchard.ControlPlaneTest do
       assert status.advisory_lock_status == "not_held"
       assert status.standby_write_path_behavior == "unknown"
     end
+
+    test "SPEC Leadership status is unavailable when provider emits out-of-vocabulary lock status" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-a",
+            advisory_lock_status: "flaky"
+          }
+        end
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert status.deployment_mode == "ha_lite"
+      assert status.controller_role == "unknown"
+      assert status.this_controller_identity == "controller-a"
+      assert status.leader_identity == nil
+      assert status.advisory_lock_status == "unavailable"
+      assert status.standby_write_path_behavior == "unknown"
+      assert is_binary(status.last_observed_leadership_error)
+    end
   end
 end

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -167,6 +167,32 @@ defmodule Orchard.ControlPlaneTest do
                "advisory_lock_read_failed: invalid_provider_status"
     end
 
+    test "SPEC Leadership status sanitizes provider-returned leadership error into a stable reason" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-b",
+            advisory_lock_status: :not_held,
+            last_observed_leadership_error:
+              "password authentication failed for user orchard_admin at db.internal:5432"
+          }
+        end
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert status.advisory_lock_status == "not_held"
+      assert status.leader_identity == "controller-b"
+
+      assert status.last_observed_leadership_error ==
+               "advisory_lock_read_failed: provider_reported_error"
+
+      refute status.last_observed_leadership_error =~ "orchard_admin"
+      refute status.last_observed_leadership_error =~ "db.internal"
+    end
+
     test "SPEC Leadership status demotes held-lock evidence owned by another controller" do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -107,5 +107,31 @@ defmodule Orchard.ControlPlaneTest do
       assert status.advisory_lock_status == "held"
       assert status.standby_write_path_behavior == "writes_allowed_when_authorized"
     end
+
+    test "SPEC Leadership status ignores provider attempts to override local role metadata" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            deployment_mode: "ha_lite",
+            this_controller_identity: "provider-controller",
+            controller_role: "leader",
+            leader_identity: "controller-b",
+            advisory_lock_status: "not_held",
+            standby_write_path_behavior: "writes_allowed_when_authorized"
+          }
+        end
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert status.deployment_mode == "ha_lite"
+      assert status.controller_role == "unknown"
+      assert status.this_controller_identity == "controller-a"
+      assert status.leader_identity == "controller-b"
+      assert status.advisory_lock_status == "not_held"
+      assert status.standby_write_path_behavior == "unknown"
+    end
   end
 end

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -156,5 +156,28 @@ defmodule Orchard.ControlPlaneTest do
       assert status.standby_write_path_behavior == "unknown"
       assert is_binary(status.last_observed_leadership_error)
     end
+
+    test "SPEC Leadership status demotes held-lock evidence owned by another controller" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-b",
+            advisory_lock_status: :held,
+            lock_age_ms: 400
+          }
+        end
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert status.deployment_mode == "ha_lite"
+      assert status.controller_role == "unknown"
+      assert status.this_controller_identity == "controller-a"
+      assert status.leader_identity == "controller-b"
+      assert status.advisory_lock_status == "held"
+      assert status.standby_write_path_behavior == "unknown"
+    end
   end
 end

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -51,7 +51,10 @@ defmodule Orchard.ControlPlaneTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn -> raise DBConnection.ConnectionError, message: "db down" end
+        ha_lite_status_provider: fn ->
+          raise DBConnection.ConnectionError,
+            message: "password authentication failed for user orchard_admin at db.internal:5432"
+        end
       )
 
       status = ControlPlane.read_only_status()
@@ -64,7 +67,12 @@ defmodule Orchard.ControlPlaneTest do
       assert status.lock_age_ms == nil
       assert status.last_renewed_at == nil
       assert status.standby_write_path_behavior == "unknown"
-      assert status.last_observed_leadership_error =~ "db down"
+
+      assert status.last_observed_leadership_error ==
+               "advisory_lock_read_failed: db_connection_error"
+
+      refute status.last_observed_leadership_error =~ "orchard_admin"
+      refute status.last_observed_leadership_error =~ "db.internal"
     end
 
     test "SPEC Leadership status is unknown when no advisory-lock reader is configured" do
@@ -154,7 +162,9 @@ defmodule Orchard.ControlPlaneTest do
       assert status.leader_identity == nil
       assert status.advisory_lock_status == "unavailable"
       assert status.standby_write_path_behavior == "unknown"
-      assert is_binary(status.last_observed_leadership_error)
+
+      assert status.last_observed_leadership_error ==
+               "advisory_lock_read_failed: invalid_provider_status"
     end
 
     test "SPEC Leadership status demotes held-lock evidence owned by another controller" do

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -57,13 +57,13 @@ defmodule Orchard.ControlPlaneTest do
       status = ControlPlane.read_only_status()
 
       assert status.deployment_mode == "ha_lite"
-      assert status.controller_role == "leader"
+      assert status.controller_role == "unknown"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == nil
       assert status.advisory_lock_status == "unavailable"
       assert status.lock_age_ms == nil
       assert status.last_renewed_at == nil
-      assert status.standby_write_path_behavior == "writes_allowed_when_authorized"
+      assert status.standby_write_path_behavior == "unknown"
       assert status.last_observed_leadership_error =~ "db down"
     end
 
@@ -76,11 +76,36 @@ defmodule Orchard.ControlPlaneTest do
       status = ControlPlane.read_only_status()
 
       assert status.deployment_mode == "ha_lite"
-      assert status.controller_role == "leader"
+      assert status.controller_role == "unknown"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == nil
       assert status.advisory_lock_status == "unknown"
+      assert status.standby_write_path_behavior == "unknown"
       assert status.last_observed_leadership_error == nil
+    end
+
+    test "SPEC Leadership status reports leader only when advisory lock is held" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-a",
+            advisory_lock_status: :held,
+            lock_age_ms: 400,
+            last_renewed_at: ~U[2026-07-01 00:00:00Z]
+          }
+        end
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert status.deployment_mode == "ha_lite"
+      assert status.controller_role == "leader"
+      assert status.this_controller_identity == "controller-a"
+      assert status.leader_identity == "controller-a"
+      assert status.advisory_lock_status == "held"
+      assert status.standby_write_path_behavior == "writes_allowed_when_authorized"
     end
   end
 end

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -1,0 +1,86 @@
+defmodule Orchard.ControlPlaneTest do
+  use ExUnit.Case, async: false
+
+  alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ControlPlane
+
+  setup do
+    previous = Application.get_env(:orchard_controller, :control_plane)
+
+    on_exit(fn ->
+      if is_nil(previous) do
+        Application.delete_env(:orchard_controller, :control_plane)
+      else
+        Application.put_env(:orchard_controller, :control_plane, previous)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "read_only_status/0" do
+    test "SPEC HA-lite Status Is Read-Only reports standby write-path behavior when standby is directly addressed" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn ->
+          %{
+            leader_identity: "controller-b",
+            advisory_lock_status: :not_held,
+            lock_age_ms: 1_200,
+            last_renewed_at: ~U[2026-07-01 00:00:00Z]
+          }
+        end
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert %HALiteStatus{} = status
+      assert status.deployment_mode == "ha_lite"
+      assert status.this_controller_identity == "controller-a"
+      assert status.controller_role == "standby"
+      assert status.leader_identity == "controller-b"
+      assert status.advisory_lock_status == "not_held"
+      assert status.lock_age_ms == 1_200
+      assert status.last_renewed_at == ~U[2026-07-01 00:00:00Z]
+      assert status.standby_write_path_behavior == "writes_return_503_controller_standby"
+      assert status.last_observed_leadership_error == nil
+    end
+
+    test "SPEC Leadership status is unavailable when advisory-lock status cannot be read" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a",
+        ha_lite_status_provider: fn -> raise DBConnection.ConnectionError, message: "db down" end
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert status.deployment_mode == "ha_lite"
+      assert status.controller_role == "leader"
+      assert status.this_controller_identity == "controller-a"
+      assert status.leader_identity == nil
+      assert status.advisory_lock_status == "unavailable"
+      assert status.lock_age_ms == nil
+      assert status.last_renewed_at == nil
+      assert status.standby_write_path_behavior == "writes_allowed_when_authorized"
+      assert status.last_observed_leadership_error =~ "db down"
+    end
+
+    test "SPEC Leadership status is unknown when no advisory-lock reader is configured" do
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :leader,
+        this_controller_identity: "controller-a"
+      )
+
+      status = ControlPlane.read_only_status()
+
+      assert status.deployment_mode == "ha_lite"
+      assert status.controller_role == "leader"
+      assert status.this_controller_identity == "controller-a"
+      assert status.leader_identity == nil
+      assert status.advisory_lock_status == "unknown"
+      assert status.last_observed_leadership_error == nil
+    end
+  end
+end

--- a/apps/orchard_shared/lib/orchard/cluster_management/ha_lite_status.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/ha_lite_status.ex
@@ -1,6 +1,10 @@
 defmodule Orchard.ClusterManagement.HALiteStatus do
   @moduledoc """
   Read-only HA-lite control-plane status contract.
+
+  `advisory_lock_status` is evidence about the controller advisory lock.
+  A local controller may report `controller_role` as `leader` only when the lock is `held` and `leader_identity` is absent or matches `this_controller_identity`.
+  When lock evidence is missing, unavailable, not held, or names a different leader, operator surfaces must present local leadership as `unknown`.
   """
 
   @object "cluster_management.ha_lite_status"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ product/system/build contract.
 - **Current CLI limitation:** SPEC-required future paths such as `orchardctl cluster init` and `orchardctl node join` are routed by `orchardctl` but return deferred-status errors with the current supported path.
   `orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for a request, with stable human and `--json` output from the shared Operator API presenter.
   Broader request execution diagnostics beyond persisted scheduler explanations remain future work.
+  `orchardctl cluster status` reads the local controller runtime and renders read-only cluster and HA-lite control-plane status, with a `--json` mode that emits the shared `HALiteStatus` payload plus a HA-lite summary and no leadership-transfer or failover actions.
   `orchardctl nodes inspect`, `orchardctl nodes pending`,
   `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for
   the current node-admission-review slice, with stable JSON and human output,

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -532,6 +532,7 @@ Use the gRPC compatibility flow only when you intentionally opt out with `ORCHAR
 
 `orchardctl cluster init` and `orchardctl node join` are SPEC-required future node-lifecycle commands.
 In this build they return deferred status.
+`orchardctl cluster status [--json]` is implemented for read-only cluster and HA-lite control-plane status, with the shared `HALiteStatus` payload and a HA-lite summary in `--json` mode.
 `orchardctl nodes inspect`, `orchardctl nodes pending`, `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for the current node-admission-review slice, with stable JSON and human output, `--dry-run` previews, and `--yes`/`--reason` execution gating.
 `orchardctl nodes cordon`, `orchardctl nodes uncordon`, `orchardctl nodes drain`, `orchardctl nodes maintenance`, `orchardctl nodes resume`, and `orchardctl nodes decommission` add node lifecycle previews and execution on the shared Action Preview contract, gated by `--yes`, `--acknowledge`, and `--typed-node-id`; `orchardctl nodes maintenance` previews only, with its `draining -> maintenance` execution deferred until drain completion can be verified.
 Use the env-var split-role flows below for source-dev cluster testing.

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -62,7 +62,9 @@
   Note: Implemented `orchardctl requests inspect <request-id>` because `SPEC.md` §11.9 names `requests inspect` as the required CLI path while `SPEC.md` §7.3.5 requires shared scheduler explanation reason codes across CLI and the Operator API.
   Note: The command uses local controller-runtime authority, reads the same request row as the Operator API, and renders human plus JSON output through `SchedulerExplanationPresenter` and the shared scheduler explanation contract.
   Note: Broader request execution diagnostics under `requests inspect` beyond persisted scheduler explanations remain future work, so the general command name is not fully delivered by this slice.
-- [ ] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
+- [x] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
+  Note: This slice adds `orchardctl cluster status --json` with a shared `HALiteStatus` payload and a HA-lite-focused `summary` block for deployment mode, controller role, and advisory-lock status.
+  Node inventory and runtime reachability counts intentionally remain on the existing node and Live Cluster surfaces rather than being duplicated into this command.
 
 ## 5. Console Nodes UX
 
@@ -83,8 +85,10 @@
   Note: Public LiveView tests cover the full candidate groups, not found, legacy empty shape, invalid persisted explanation, and disconnected deferred render.
   Note: The diagnostics and components deny-list is key-based and does not inspect values, accepted because the data domain is internal scheduler metadata.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
-- [ ] 5.6 Add read-only HA-lite control-plane status.
-- [ ] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
+- [x] 5.6 Add read-only HA-lite control-plane status.
+  Note: Console Nodes now includes a separate read-only HA-lite Status rail card that renders deployment mode, this-controller identity, leader identity, advisory-lock status, lock age, last renewal, write-path behavior, and sanitized leadership errors without failover or transfer controls.
+- [x] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
+  Note: This task 5.6 slice browser-verified the HA-lite Status card after review fixes on desktop light, desktop dark, and mobile light screenshots under `tmp/screenshots/ha-lite-status-card-review-fix-*.png`.
   Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile.
   PR #41 browser-verified the Console lifecycle preview slice against `docs/DESIGN.md`.
   Note: This task 5.4 slice browser-verified the request-scoped scheduler explanation panel on desktop and mobile.


### PR DESCRIPTION
## Intent

Implement the HA-lite read-only status slice of the `cluster-management-ux-foundation` OpenSpec change (tasks 4.8, 5.6, 5.7): give operators visibility into control-plane leadership state before any mutating HA-lite action exists. Adds `orchardctl cluster status [--json]` for read-only HA-lite and cluster summary status, a read-only HA-lite Status card in the Console Nodes view as a separate signal category, and browser verification per `docs/DESIGN.md`.

Safety semantics follow the spec requirement "HA-Lite Status Is Read-Only In The First Cluster UX": leadership is never inferred from local config or process state alone. `Orchard.ControlPlane.read_only_status/0` gains a provider seam for advisory-lock facts, whitelisted to those facts only; a held lock proves local leadership only when the leader identity is absent or matches this controller; malformed or out-of-vocabulary provider values degrade to `unavailable` identically in CLI and Console; and operator-facing leadership errors are stable reason strings, never raw exception text. No failover, transfer, or standby mutation actions are introduced.

Deliberate deferrals: `authorize_write_path/1` still checks configured role only (lock-checked write enforcement is M7 controller work, tracked as a follow-up); the real advisory-lock reader that feeds the provider seam is likewise M7 scope, so unwired deployments honestly report `unknown`; the `cluster_status` JSON envelope stays CLI-local until a second consumer appears; SPEC.md §11.9 sync happens at the change's reconciliation/archive pass per established practice.

## What Changed

- Added `orchardctl cluster status` output and a read-only HA-lite card in the Console nodes view that surface controller role, advisory-lock state, and write-path authorization, backed by a new `read_only_status` path in `control_plane.ex` and the `HALiteStatus` value type.
- Hardened the provider seam: whitelist advisory-lock status facts, degrade malformed provider status to `unavailable` instead of crashing, require local leader-identity proof before reporting leadership, and sanitize provider-returned/raised leadership errors into stable reason strings so raw exception text never reaches operator surfaces.
- Polished status copy for consistent `HA-lite` branding and role labels, and updated CLI/architecture/local-dev docs plus the `cluster-management-ux-foundation` OpenSpec tasks; added CLI, control-plane, and Console LiveView test coverage.

## Risk Assessment

✅ Low: The change is a well-bounded, read-only status slice with robust error/degradation handling and no crash paths; the only open item is a confirm-intent question about an as-yet-unwired provider seam, which is safe to merge and address as follow-up.

## Testing

Ran the three targeted test files (80 tests, all passing) after a clean compile, then produced product-level evidence beyond unit passes: a real CLI transcript showing `orchardctl cluster status` human ("Role: standby", "Deployment: HA-lite") and `--json` output across standby/leader-unavailable/proven-leader/usage cases, and two browser screenshots of the actual Console Nodes page rendering the new HA-lite Status card — one standby state (HA-lite/Standby/Not held badges, "writes return 503 controller standby") and one leader-with-unreadable-lock state proving leadership is not inferred (Unknown/Unavailable) and the provider error is sanitized with no credential/DSN leakage. The dev server used auth :none and a runtime-injected control_plane provider; the worktree was left clean (dev data dir is gitignored) and temp scripts removed. Overall result: all tests pass and the user intent is demonstrated end-to-end on both the CLI and Console surfaces.

- Evidence: Console Nodes page — HA-lite Status card (standby, directly addressed) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWRQ4Q68Q9ZWFJ3PTFYR7F6Z/console-nodes-standby-full.png</code>)
- Evidence: Console Nodes page — HA-lite Status card (leader with unreadable advisory lock; leadership not inferred, error sanitized) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWRQ4Q68Q9ZWFJ3PTFYR7F6Z/console-nodes-leader-unavailable-full.png</code>)
<details>
<summary>Evidence: CLI transcript — orchardctl cluster status (human + --json) across scenarios</summary>

```text
===== Standby controller (directly addressed) =====
$ orchardctl cluster status
Role: standby
Deployment: HA-lite
This controller: controller-a
Leader: controller-b
Advisory lock: not held
Lock age: 1200 ms
Last renewed: 2026-07-01T00:00:00Z
Write paths: writes return 503 controller standby
$ orchardctl cluster status --json
{
  "summary": {
    "advisory_lock_status": "not_held",
    "deployment_mode": "ha_lite",
    "controller_role": "standby"
  },
  "contract_version": "orchard.cluster_management.cluster_status.v1",
  "ha_lite": {
    "this_controller_identity": "controller-a",
    "leader_identity": "controller-b",
    "advisory_lock_status": "not_held",
    "lock_age_ms": 1200,
    "last_renewed_at": "2026-07-01T00:00:00Z",
    "deployment_mode": "ha_lite",
    "controller_role": "standby",
    "contract_version": "orchard.cluster_management.ha_lite_status.v1",
    "object": "cluster_management.ha_lite_status",
    "standby_write_path_behavior": "writes_return_503_controller_standby",
  },
  "object": "cluster_management.cluster_status"
}
$ orchardctl cluster status
Role: unknown
Deployment: HA-lite
This controller: controller-a
Leader: unknown
Advisory lock: unavailable
Lock age: unknown
Last renewed: unknown
Write paths: unknown
$ orchardctl cluster status --json
{
  "summary": {
    "advisory_lock_status": "unavailable",
    "deployment_mode": "ha_lite",
    "controller_role": "unknown"
  },
  "contract_version": "orchard.cluster_management.cluster_status.v1",
  "ha_lite": {
    "this_controller_identity": "controller-a",
    "leader_identity": null,
    "advisory_lock_status": "unavailable",
    "lock_age_ms": null,
    "last_renewed_at": null,
    "deployment_mode": "ha_lite",
    "controller_role": "unknown",
    "contract_version": "orchard.cluster_management.ha_lite_status.v1",
    "object": "cluster_management.ha_lite_status",
    "standby_write_path_behavior": "unknown",
  },
  "object": "cluster_management.cluster_status"
}
===== Proven leader (lock held, identity matches) =====
$ orchardctl cluster status
Role: leader
Deployment: HA-lite
This controller: controller-a
Leader: controller-a
Advisory lock: held
Lock age: 400 ms
Last renewed: 2026-07-01T00:00:00Z
Write paths: writes allowed when authorized
$ orchardctl cluster status --json
{
  "summary": {
    "advisory_lock_status": "held",
    "deployment_mode": "ha_lite",
    "controller_role": "leader"
  },
  "contract_version": "orchard.cluster_management.cluster_status.v1",
  "ha_lite": {
    "this_controller_identity": "controller-a",
    "leader_identity": "controller-a",
    "advisory_lock_status": "held",
    "lock_age_ms": 400,
    "last_renewed_at": "2026-07-01T00:00:00Z",
    "deployment_mode": "ha_lite",
    "controller_role": "leader",
    "contract_version": "orchard.cluster_management.ha_lite_status.v1",
    "object": "cluster_management.ha_lite_status",
    "standby_write_path_behavior": "writes_allowed_when_authorized",
  },
  "object": "cluster_management.cluster_status"
}
===== Group usage (no args) =====
Usage: orchardctl cluster <command>
Commands:
  init     Initialize controller-side cluster bootstrap state (SPEC.md 11.9).
  status   Show read-only cluster and HA-lite control-plane status.
```
</details>
<details>
<summary>Evidence: CLI human output — standby scenario (excerpt)</summary>

```text
$ orchardctl cluster status
Role: standby
Deployment: HA-lite
This controller: controller-a
Leader: controller-b
Advisory lock: not held
Lock age: 1200 ms
Last renewed: 2026-07-01T00:00:00Z
Write paths: writes return 503 controller standby
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/control_plane.ex:14` - Provider-supplied `last_observed_leadership_error` and `leader_identity` are whitelisted (@provider_status_keys) and pass through `HALiteStatus.new/1` unsanitized when the provider *returns* a status map. The branch&#39;s error-sanitization only applies when the provider *raises* (rescue -&gt; stable reason string). The real provider is the advisory-lock reader that encounters DB errors, so a reader returning `{:ok, %{..., last_observed_leadership_error: &#34;&lt;raw DB exception&gt;&#34;}}` would leak raw exception text (credentials, hostnames) to operator CLI/Console surfaces, defeating the stated sanitization goal.
- ℹ️ `apps/orchard_controller/lib/orchard/control_plane.ex:21` - `authorize_write_path/1` keys off the raw configured role, so an unproven leader (advisory lock not held) is still authorized to write, while `read_only_status/0` reports controller_role `unknown` and write paths `unknown`. The write gate is unchanged by this branch and the status is explicitly read-only, but the new status surface can visibly disagree with the actual write-authorization behavior.

🔧 Fix: sanitize provider-returned ha-lite leadership errors
1 info still open:
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/cluster.ex:115` - The CLI human status output renders the deployment mode via `format_status_value/1`, which downcases and space-splits, so `ha_lite` prints as `Deployment: ha lite`. The Console special-cases this to `HA-lite` (nodes_live.ex) and the CLI&#39;s own usage/help strings use `HA-lite`, so the same feature shows the brand term two different ways. A CLI test explicitly locks `&#34;Deployment: ha lite&#34;`, so this appears deliberate rather than accidental, but it conflicts with the branch&#39;s stated copy-polish goal of consistent `HA-lite` capitalization. Consider a special-case (mirroring the Console) if the intent was brand consistency.

🔧 Fix: fix: render HA-lite deployment brand term in CLI status
1 info still open:
- ℹ️ `apps/orchard_controller/lib/orchard/control_plane.ex:66` - The ha_lite_status_provider seam is optional and is not wired in any product config (no :control_plane / ha_lite_status_provider found under config/ or apps/*/config, and no advisory-lock leadership reader exists in product code — only tests inject a provider). Net effect on a real HA-lite deployment: with no provider, advisory_lock_status stays :unknown, so normalize_unproven_leadership/1 demotes a configured leader to controller_role=unknown and write_paths=unknown. So an actual leader always renders as &#39;unknown&#39; in both `orchardctl cluster status` and the Console card until a provider is wired, while authorize_write_path/1 (keyed on the raw config role) still permits its writes. This appears to be intentional slice scaffolding (status contract + rendering now, live advisory-lock reader later), but confirm operators won&#39;t be misled by leaders reporting role=unknown in the interim.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mix test apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs` — 8 passed (CLI status text/JSON, usage, unknown-option exit code)</code>
- <code>`mix test apps/orchard_controller/test/orchard/control_plane_test.exs` — 8 passed (provider whitelist, degrade-to-unavailable, leadership proof gating, error sanitization)</code>
- <code>`mix test apps/orchard_controller/test/orchard/console/nodes_live_test.exs` — 64 passed (HA-lite card render, sanitized error, deferred mount, single-controller subtitle)</code>
- <code>`mix compile` — clean</code>
- <code>Manual CLI transcript via `OrchardCLI.Commands.Cluster.run/1` across standby, leader-unreadable (sanitized error), proven-leader, and group-usage scenarios → cli-cluster-status-transcript.txt</code>
- <code>Drove the real Console dev server (`mix phx.server`, auth :none) in a browser at /console/nodes with an injected HA-lite standby provider → console-nodes-standby-full.png</code>
- `Drove the Console with a leader + unreadable-advisory-lock provider (raising a DBConnection error containing credentials) → console-nodes-leader-unavailable-full.png, confirming role shows 'Unknown', lock 'Unavailable', and error sanitized to 'advisory_lock_read_failed: db_connection_error'`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `SPEC.md:3729` - SPEC.md §11.9 &#39;Required commands&#39; list (line 3729) omits the newly-shipped `orchardctl cluster status`, and the Console surface description (~line 173) does not mention the read-only HA-lite status card. These are the apex normative contract; adding a command/surface there is normally handled by promoting the `cluster-management-ux-foundation` OpenSpec change on archival rather than a unilateral SPEC edit, so it needs a human decision on timing/wording. The OpenSpec spec delta already carries the requirement.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

