### PR TITLE
docs: reframe README as a product-facing overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,7 +348,7 @@ See `packaging/pkg/README.md` for full PKG operator documentation and `packaging
 | SPEC.md | Normative build contract |
 | AGENTS.md | This file — agent operating guide |
 | CLAUDE.md | Claude Code import shim for AGENTS.md |
-| README.md | High-level product and roadmap overview |
+| README.md | High-level product overview |
 | CONTRIBUTING.md | Human collaborator workflow |
 | CONTEXT-MAP.md | Domain-modeling discovery map for glossary context |
 | Makefile | Thin convenience command index over `mise exec --` |

--- a/README.md
+++ b/README.md
@@ -7,32 +7,40 @@
 
 **Your LLMs. Your hardware. Your rules.**
 
-Orchard is a sovereign on-prem LLM orchestration platform for 1–4 Apple Silicon macOS machines. It runs inference on your own hardware, behind your own firewall, with no cloud dependency.
+Orchard is a sovereign on-prem LLM orchestration platform for 1–4 Apple Silicon
+macOS machines. It runs inference on your own hardware, behind your own
+firewall, with no cloud dependency.
 
-## Where to start
+## What Orchard does
 
-- [`SPEC.md`](SPEC.md) is the normative build contract.
-- [`docs/README.md`](docs/README.md) is the collaborator docs hub.
-- [`docs/architecture.md`](docs/architecture.md) maps the repo and runtime boundaries.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) covers human collaboration workflow.
-- [`docs/local-dev.md`](docs/local-dev.md) covers source-dev setup.
-- [`packaging/pkg/README.md`](packaging/pkg/README.md) covers the current PKG runbook.
+- Orchestrates LLM inference across 1–4 Mac nodes using
+  [MLX](https://github.com/ml-explore/mlx), Apple Silicon's native ML stack.
+- Exposes OpenAI-compatible APIs: `/v1/responses` as the canonical abstraction,
+  `/v1/chat/completions` as a compatibility facade, both with SSE streaming.
+- Governs access with multi-tenant RBAC, API Tokens, API Clients, quotas, and
+  audit logs.
+- Ships as a native macOS PKG with launchd services — no Kubernetes, no
+  containers required.
+- Uses Postgres as the sole persistence and coordination layer (external
+  Postgres today; a managed local mode is planned).
 
-## Target product capabilities
+## Status
 
-Defined by `SPEC.md`, Orchard is being built to:
+Pre-release. Orchard is built from a normative contract
+([`SPEC.md`](SPEC.md)); features land as spec-traced slices.
 
-- orchestrate LLM inference across 1–4 Mac nodes using [MLX](https://github.com/ml-explore/mlx);
-- expose OpenAI-compatible APIs with `/v1/responses` as the canonical abstraction and `/v1/chat/completions` as a compatibility facade;
-- support multi-tenant RBAC, API Token and API Client scoping, quotas, and audit logs;
-- ship as native macOS PKG/DMG media with launchd services and no Kubernetes requirement;
-- support managed Postgres in a future local-container mode while also supporting external Postgres.
+Working today: authenticated `/v1/models`, `/v1/chat/completions` with SSE, a
+bounded `/v1/responses` slice, tenant-direct API Tokens, and bulk API Client
+provisioning for service-account-owned tokens. On the operations side,
+`orchardctl` provides node admission review, node lifecycle previews and
+execution (cordon, drain, maintenance, decommission), request diagnostics with
+scheduler explanations, read-only cluster and HA-lite control-plane status, and
+redacted support bundle creation, alongside a Console UI for the same
+cluster-management surfaces.
 
-Current packaged controller-bearing installs require external Postgres. Managed
-Postgres is not available in current builds; the shipped
-`orchard-managed-postgres` helper is an operator-safe guard that prints external
-database setup guidance and exits non-zero for operational invocations. DMG
-media remains reserved for future work.
+Not yet operator-usable: multi-node cluster bootstrap and join, the multi-node
+scheduler, and managed Postgres (packaged controller installs require an
+external database).
 
 ## Architecture
 
@@ -51,8 +59,8 @@ Clients (SDKs / curl / apps)
    Runtime Endpoint Interface
         │
    Runtime Endpoint adapter(s)
-   ├── first-party BEAM adapter (split-role source-dev default)
-   └── gRPC compatibility adapter (explicit opt-out)
+   ├── first-party BEAM adapter
+   └── gRPC compatibility adapter
         │
    Node Agent Runtime Endpoint(s)
    ├── Model cache + verification
@@ -62,19 +70,22 @@ Clients (SDKs / curl / apps)
      Postgres (sole persistence + coordination layer)
 ```
 
-**Key design rules:**
+**Design rules:**
 
-- All durable state lives in Postgres.
-- Controller runtime execution uses the Runtime Endpoint Interface.
-- The current `NodeRuntimeService` gRPC path is a compatibility adapter, not the durable domain contract.
-- First-party BEAM communication is the split-role source-dev default behind explicit guardrails and must not become durable cluster truth.
-- Split-role source dev uses BEAM by default through `bin/dev-controller` and `bin/dev-node-agent`.
-- Set `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` only when intentionally opting into the gRPC compatibility adapter.
-- All-in-one `bin/dev` remains the single-host gRPC default and rejects explicit BEAM mode.
-- Source-dev BEAM mode does not automatically retry a failed request through gRPC compatibility.
+- All durable state lives in Postgres — no separate message broker or cache to
+  operate.
+- Controller-to-node communication goes through the Runtime Endpoint
+  Interface, with a first-party BEAM adapter and a gRPC compatibility adapter.
 - Workers are local to node agents and are never exposed on the network.
-- Token streams always pass through the controller for governance and accounting.
-- HA-lite only: exactly one active leader, active/standby via Postgres advisory locks, no active/active consensus.
+- Token streams always pass through the controller for governance and
+  accounting.
+- HA-lite only: exactly one active leader, active/standby via Postgres
+  advisory locks, no active/active consensus.
+
+Transport defaults and guardrails for source development are documented in
+[`docs/local-dev.md`](docs/local-dev.md);
+[`docs/architecture.md`](docs/architecture.md) maps the repo and runtime
+boundaries.
 
 ## Tech stack
 
@@ -83,141 +94,72 @@ Clients (SDKs / curl / apps)
 | Language | Elixir/OTP (umbrella app) |
 | Database | Postgres |
 | Inference | MLX-LM runtime adapter managed by the node agent |
-| Runtime endpoint transport | Runtime Endpoint Interface with first-party BEAM as the split-role source-dev default and gRPC as the explicit opt-out compatibility adapter |
-| APIs | Phoenix/Plug (loopback HTTP in source dev; HTTPS + SSE in packaged installs) |
-| Packaging | DMG, PKG, launchd |
+| Runtime endpoint transport | Runtime Endpoint Interface (first-party BEAM adapter; gRPC compatibility adapter) |
+| APIs | Phoenix/Plug with SSE streaming |
+| Packaging | PKG + launchd (DMG reserved for future work) |
 | CLI | `orchardctl` |
 | Toolchain | mise-pinned Erlang/OTP, Elixir, Python, uv, Node.js, npm, and OpenSpec |
 
-### Current transport behavior
+## Deployment modes
 
-- **Source dev:** controller runs on loopback HTTP (`127.0.0.1:4000`); CORS
-  disabled unless explicitly configured
-- **Packaged installs:** controller defaults to degraded loopback HTTP
-  (`ORCHARD_TRANSPORT_MODE=plain_http_localhost`) until an operator selects
-  `direct_https` or `reverse_proxy`; legacy `ORCHARD_TLS_*` variables are
-  one-release compatibility shims
-- **Provider-neutral TLS:** the PKG installer does not generate or procure
-  production certificates by default. Operators can use reverse-proxy TLS
-  termination, direct HTTPS with operator cert/key paths, proprietary/paid CAs,
-  internal PKI or air-gapped HTTPS, or explicit local-CA helper output from
-  `orchardctl tls init` for dev-lab bootstrap.
-- **Forwarded headers:** reverse-proxy mode trusts `x-forwarded-*` only from
-  loopback by default; non-loopback proxy binds require `ORCHARD_TRUSTED_PROXIES`.
-- **CORS:** explicit origin allowlist via `ORCHARD_CORS_ORIGINS` (empty =
-  disabled)
+1. **All-in-one** — a single Mac runs everything: controller, node agent, and
+   worker.
+2. **Controller + workers** — one Mac as the control plane, 1–3 Macs as worker
+   nodes.
+3. **HA-lite** — up to 2 controllers with exactly 1 active leader, still within
+   the overall 1–4 Mac limit, with operator-managed endpoint failover.
 
-See [docs/tooling.md](docs/tooling.md) for required local toolchain setup,
-[docs/local-dev.md](docs/local-dev.md) for dev setup, and
-[packaging/pkg/README.md](packaging/pkg/README.md) for operator transport
-configuration, including nginx/Caddy/Traefik snippets.
+All controller-bearing installs currently require an external Postgres
+database. The macOS PKG uses a universal payload with role selection
+(`all`, `controller`, or `node-agent`) at install time; see
+[`packaging/pkg/README.md`](packaging/pkg/README.md) for the operator runbook.
 
-### Building releases
+### Transport and TLS
 
-For distribution or testing the packaged installer:
+Packaged installs start on degraded loopback HTTP until an operator selects
+direct HTTPS or reverse-proxy mode. TLS is provider-neutral: bring
+reverse-proxy termination, operator-supplied certificates, internal PKI, or
+the local-CA helper (`orchardctl tls init`) for dev-lab bootstrap. CORS is an
+explicit origin allowlist, disabled by default. Full transport configuration,
+including nginx/Caddy/Traefik snippets, is in
+[`packaging/pkg/README.md`](packaging/pkg/README.md).
+
+### Building the installer
 
 ```bash
 mise exec -- ./scripts/build-pkg.sh
 ```
 
-This creates a native macOS PKG installer following the naming convention
-`Orchard-<version>-<date>-<git-sha>.pkg`. Use `--clean` for reproducible
-builds from scratch, or `--allow-dirty` for development builds.
+This produces `Orchard-<version>-<date>-<git-sha>.pkg`. Run `make setup`
+first; see [`packaging/pkg/README.md`](packaging/pkg/README.md#building-the-pkg)
+for full build documentation.
 
-**Prerequisites:** run `make setup` from the repo root, or run
-`mise trust && mise install` plus the setup commands in
-[`docs/local-dev.md`](docs/local-dev.md), before building. You also need the
-macOS packaging tools. The script validates dependencies and provides helpful
-errors if anything is missing.
+## Documentation
 
-See [packaging/pkg/README.md](packaging/pkg/README.md#building-the-pkg) for
-full build documentation.
+For operators:
 
-## Deployment modes
+- [`packaging/pkg/README.md`](packaging/pkg/README.md) — install, roles,
+  transport, and TLS runbook.
 
-These are the target product topologies defined by `SPEC.md`:
+For contributors:
 
-1. **All-in-one** — single Mac runs everything (controller + node agent + worker + managed Postgres)
-2. **Controller + workers** — 1 Mac as control plane, 1–3 Macs as worker nodes; Postgres is either managed on the controller host or operator-managed externally
-3. **HA-lite** — up to 2 controllers with exactly 1 active leader, still within the overall 1–4 Mac deployment limit, with operator-managed endpoint failover
-
-Current packaged controller-bearing installs require External Database Mode
-until Managed Database Mode is implemented and enabled; the managed Postgres
-helper is a guard only.
-
-The macOS PKG uses a universal payload with role selection at install time. Seed `/Library/Application Support/Orchard/support/.install-role.request` with `all`, `controller`, or `node-agent` before running `installer`; the installed marker is `/Library/Application Support/Orchard/support/.install-role`. Source development has matching split-role scripts: `bin/dev-controller` for the controller host and `bin/dev-node-agent` for worker hosts.
-
-## Roadmap
-
-| Milestone | Scope |
-|-----------|-------|
-| M0 | Skeleton and packaging foundation (umbrella, Postgres, launchd, `/health/live`, `/health/ready`) |
-| M1 | Single-node inference MVP (`GET /v1/models`, `POST /v1/chat/completions`, SSE streaming, MLX worker; compatibility-first while the internal canonical abstraction remains Responses-based) |
-| M2 | Responses API and governance core (public `POST /v1/responses`, tenants, API Tokens, API Clients, quotas, audit, idempotency) |
-| M3 | Node lifecycle and cluster join (bootstrap/cert join, heartbeats, pools, cordon/drain/maintenance) |
-| M4 | Multi-node scheduler and placements (tiered scoring, queueing, `EnsureModelLoaded`, pre-first-token retry) |
-| M5 | Observability and diagnostics (Prometheus, OTel tracing, structured logs, support bundles) |
-| M6 | Security hardening and air-gap (mTLS, cert renewal, retention modes, offline import/install) |
-| M7 | Upgrade safety and HA-lite controller (leadership locks, migration ownership, rolling upgrades, `orchardctl upgrade plan`) |
-
-## Status
-
-Pre-release.
-Building from spec.
-The current source tree includes authenticated
-`/v1/models`, `/v1/chat/completions`, a bounded `/v1/responses` slice, tenant-direct API Tokens, and bulk API Client provisioning for service-account-owned API Tokens.
-Full M2 quota behavior remains in progress.
-An initial cluster-admin `/admin/v1` node-admission surface (candidate review, rejection, rejection clearance, and admission) is present ahead of its M3 milestone, but is not yet operator-usable because cluster bootstrap and first-admin credential provisioning are not yet implemented.
-The roadmap and target behavior are governed by `SPEC.md` §14.
-
-Some SPEC-required CLI paths are present before their milestone implementation:
-`orchardctl cluster init` and `orchardctl node join` return command-specific deferred-status errors with the current supported path.
-`orchardctl requests inspect <request-id>` is implemented for local controller request diagnostics with stable human and JSON scheduler-explanation output.
-`orchardctl cluster status [--json]` is implemented for read-only cluster and HA-lite control-plane status, emitting the shared `HALiteStatus` payload and a HA-lite summary in `--json` mode with no leadership-transfer or failover actions.
-`orchardctl nodes inspect`,
-`orchardctl nodes pending`, `orchardctl nodes admit`, and
-`orchardctl nodes reject` are implemented for the current node-admission-review
-slice, with stable JSON and human output, `--dry-run` previews, and
-`--yes`/`--reason` execution gating. `orchardctl nodes cordon`,
-`orchardctl nodes uncordon`, `orchardctl nodes drain`,
-`orchardctl nodes maintenance`, `orchardctl nodes resume`, and
-`orchardctl nodes decommission` add node lifecycle previews and execution on the
-shared Action Preview contract, gated by `--yes`, `--acknowledge`, and
-`--typed-node-id`; `orchardctl nodes maintenance` previews only, with its
-`draining -> maintenance` execution deferred until drain completion can be
-verified. `orchardctl support bundle create`
-creates a local diagnostic `.tar.gz` with bounded redacted logs, redacted
-config, service status, node snapshots, shared cluster-management node
-status, and request summaries.
-
-## Spec
-
-[`SPEC.md`](SPEC.md) is the normative build contract — every implementation decision traces back to it.
-
-## Contributing And Workflow
-
-This repository is the collaborator-facing source of truth for Orchard.
-Historical coordination/workbench notes may inform work, but active guidance
-must be rewritten into this repo before it counts as Orchard truth.
-
-- [`SPEC.md`](SPEC.md) is the top-level normative build contract.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) explains human collaboration workflow.
-- [`AGENTS.md`](AGENTS.md) is the canonical automation and agent workflow guide; [`CLAUDE.md`](CLAUDE.md) imports it for Claude Code.
-- [`docs/glossary/CONTEXT.md`](docs/glossary/CONTEXT.md) defines Orchard's shared product language.
-- [`docs/README.md`](docs/README.md) is the collaborator docs hub.
-- [`docs/architecture.md`](docs/architecture.md) explains repo and runtime boundaries.
-- [`docs/tooling.md`](docs/tooling.md) explains the required mise toolchain and local accelerator tools.
-- [`docs/local-dev.md`](docs/local-dev.md) explains source development setup and smoke checks.
-- [`docs/process.md`](docs/process.md) explains artifact lifecycle and review gates.
-- [`openspec/README.md`](openspec/README.md) explains the initialized OpenSpec
-  change workflow subordinate to `SPEC.md`.
-
-Active local `goals/<slug>/` packages are transient execution scaffolding and
-are ignored by default.
+- [`SPEC.md`](SPEC.md) — the normative build contract; every implementation
+  decision traces back to it, and it governs the roadmap and target behavior.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — human collaboration workflow.
+- [`AGENTS.md`](AGENTS.md) — the canonical automation and agent workflow guide
+  ([`CLAUDE.md`](CLAUDE.md) imports it for Claude Code).
+- [`docs/README.md`](docs/README.md) — the collaborator docs hub, including
+  architecture, tooling, local development, process, and the product glossary.
+- [`openspec/README.md`](openspec/README.md) — the OpenSpec change workflow
+  subordinate to `SPEC.md`.
 
 ## Background
 
-Orchard is a ground-up rewrite of [Kapitan Orchard](https://github.com/najibninaba/kapitan-orchard) (v1: Rust + Kafka + Redis + Tauri). The rewrite replaces the distributed streaming architecture with Elixir/OTP + Postgres for simpler operations, better fault tolerance, and native macOS integration.
+Orchard is a ground-up rewrite of
+[Kapitan Orchard](https://github.com/najibninaba/kapitan-orchard)
+(v1: Rust + Kafka + Redis + Tauri). The rewrite replaces the distributed
+streaming architecture with Elixir/OTP + Postgres for simpler operations,
+better fault tolerance, and native macOS integration.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Working today: authenticated `/v1/models`, `/v1/chat/completions` with SSE, a
 bounded `/v1/responses` slice, tenant-direct API Tokens, and bulk API Client
 provisioning for service-account-owned tokens. On the operations side,
 `orchardctl` provides node admission review, node lifecycle previews and
-execution (cordon, drain, maintenance, decommission), request diagnostics with
+execution (cordon, drain, decommission; maintenance previews only), request
+diagnostics with
 scheduler explanations, read-only cluster and HA-lite control-plane status, and
 redacted support bundle creation, alongside a Console UI for the same
 cluster-management surfaces.


### PR DESCRIPTION
## Intent

The developer asked to revise README.md so it reads as a product-facing overview aimed at users and operators rather than an internal project document. Their specific requirement was to remove the roadmap section that enumerated all the milestones (M0–M7), on the grounds that a surface-level milestone/roadmap listing is not relevant or useful to the README's audience. The intent was to make the README more product-worthy and audience-appropriate while keeping the milestone detail out of that top-level document.

## What Changed

- Rewrote `README.md` to lead with what Orchard does, the shipped-vs-not status, deployment modes, and transport/TLS, replacing the internal doc-hub framing and per-milestone M0–M7 roadmap table.
- Condensed the "Status" section to name working surfaces (authenticated `/v1/models`, `/v1/chat/completions` SSE, bounded `/v1/responses`, API Tokens/Clients, `orchardctl` node/diagnostics/support-bundle commands) and clarified that `orchardctl nodes maintenance` is previews-only while multi-node bootstrap, the scheduler, and managed Postgres remain not operator-usable.
- Updated the `README.md` descriptor in the `AGENTS.md` key-files table from "product and roadmap overview" to "product overview" to match.

## Risk Assessment

✅ Low: Documentation-only README rewrite with accurate capability claims, valid internal links, and the prior-round maintenance overstatement already corrected.

## Testing

This is a documentation-only change to README.md with no automated test surface, so I validated the end-user artifact directly: confirmed the M0–M7 roadmap section is fully removed, verified all internal links still resolve, then rendered the new README to GitHub-styled HTML and captured a full-page screenshot showing it now reads as a product-facing overview. No worktree residue was left (a stray screenshot file from a flag typo was removed). Everything checks out; no issues found.

- Evidence: Rendered new README (product-facing, no roadmap) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWRXPP53BNFEF1M6C2N5X1GT/README-rendered-full.png</code>)
<details>
<summary>Evidence: Rendered README HTML source</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc 3.10" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>Orchard README (product-facing)</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: 1.5em;}
    div.column{flex: auto;}
    @media screen {
    div.columns{gap: min(4vw, 1.5em);}
    div.column{overflow-x: auto;}
    }
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
    /* CSS for syntax highlighting */
    html { -webkit-text-size-adjust: 100%; }
    pre > code.sourceCode { white-space: pre; position: relative; }
    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
    pre > code.sourceCode > span:empty { height: 1.2em; }
    .sourceCode { overflow: visible; }
    code.sourceCode > span { color: inherit; text-decoration: inherit; }
    div.sourceCode { margin: 1em 0; }
    pre.sourceCode { margin: 0; }
    @media screen {
    div.sourceCode { overflow: auto; }
    }
    @media print {
    pre > code.sourceCode { white-space: pre-wrap; }
    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
    }
    pre.numberSource code
      { counter-reset: source-line 0; }
    pre.numberSource code > span
      { position: relative; left: -4em; counter-increment: source-line; }
    pre.numberSource code > span > a:first-child::before
      { content: counter(source-line);
        position: relative; left: -1em; text-align: right; vertical-align: baseline;
        border: none; display: inline-block;
        -webkit-touch-callout: none; -webkit-user-select: none;
        -khtml-user-select: none; -moz-user-select: none;
        -ms-user-select: none; user-select: none;
        padding: 0 4px; width: 4em;
        color: #aaaaaa;
      }
    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
    div.sourceCode
      {   }
    @media screen {
    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
    }
    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
    code span.at { color: #7d9029; } /* Attribute */
    code span.bn { color: #40a070; } /* BaseN */
    code span.bu { color: #008000; } /* BuiltIn */
    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
    code span.ch { color: #4070a0; } /* Char */
    code span.cn { color: #880000; } /* Constant */
    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
    code span.dt { color: #902000; } /* DataType */
    code span.dv { color: #40a070; } /* DecVal */
    code span.er { color: #ff0000; font-weight: bold; } /* Error */
    code span.ex { } /* Extension */
    code span.fl { color: #40a070; } /* Float */
    code span.fu { color: #06287e; } /* Function */
    code span.im { color: #008000; font-weight: bold; } /* Import */
    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
    code span.op { color: #666666; } /* Operator */
    code span.ot { color: #007020; } /* Other */
    code span.pp { color: #bc7a00; } /* Preprocessor */
    code span.sc { color: #4070a0; } /* SpecialChar */
    code span.ss { color: #bb6688; } /* SpecialString */
    code span.st { color: #4070a0; } /* String */
    code span.va { color: #19177c; } /* Variable */
    code span.vs { color: #4070a0; } /* VerbatimString */
    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
  </style>
  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown-light.min.css" />
</head>
<body class="markdown-body" style="max-width:980px;margin:0 auto;padding:45px;">
<header id="title-block-header">
<h1 class="title">Orchard README (product-facing)</h1>
</header>
<h1 id="orchard">Orchard</h1>
<p><a href="docs/tooling.md"><img
src="https://img.shields.io/badge/Elixir-1.20.0--otp--29-4B275F"
alt="Elixir 1.20.0-otp-29" /></a> <a href="docs/tooling.md"><img
src="https://img.shields.io/badge/Erlang%2FOTP-29.0.2-A90533"
alt="Erlang/OTP 29.0.2" /></a> <a href="mise.toml"><img
src="https://img.shields.io/badge/toolchain-mise--pinned-0F766E"
alt="mise pinned" /></a> <a href="openspec/README.md"><img
src="https://img.shields.io/badge/OpenSpec-strict%20validation-2563EB"
alt="OpenSpec strict validation" /></a></p>
<p><strong>Your LLMs. Your hardware. Your rules.</strong></p>
<p>Orchard is a sovereign on-prem LLM orchestration platform for 1–4
Apple Silicon macOS machines. It runs inference on your own hardware,
behind your own firewall, with no cloud dependency.</p>
<h2 id="what-orchard-does">What Orchard does</h2>
<ul>
<li>Orchestrates LLM inference across 1–4 Mac nodes using <a
href="https://github.com/ml-explore/mlx">MLX</a>, Apple Silicon's native
ML stack.</li>
<li>Exposes OpenAI-compatible APIs: <code>/v1/responses</code> as the
canonical abstraction, <code>/v1/chat/completions</code> as a
compatibility facade, both with SSE streaming.</li>
<li>Governs access with multi-tenant RBAC, API Tokens, API Clients,
quotas, and audit logs.</li>
<li>Ships as a native macOS PKG with launchd services — no Kubernetes,
no containers required.</li>
<li>Uses Postgres as the sole persistence and coordination layer
(external Postgres today; a managed local mode is planned).</li>
</ul>
<h2 id="status">Status</h2>
<p>Pre-release. Orchard is built from a normative contract (<a
href="SPEC.md"><code>SPEC.md</code></a>); features land as spec-traced
slices.</p>
<p>Working today: authenticated <code>/v1/models</code>,
<code>/v1/chat/completions</code> with SSE, a bounded
<code>/v1/responses</code> slice, tenant-direct API Tokens, and bulk API
Client provisioning for service-account-owned tokens. On the operations
side, <code>orchardctl</code> provides node admission review, node
lifecycle previews and execution (cordon, drain, decommission;
maintenance previews only), request diagnostics with scheduler
explanations, read-only cluster and HA-lite control-plane status, and
redacted support bundle creation, alongside a Console UI for the same
cluster-management surfaces.</p>
<p>Not yet operator-usable: multi-node cluster bootstrap and join, the
multi-node scheduler, and managed Postgres (packaged controller installs
require an external database).</p>
<h2 id="architecture">Architecture</h2>
<pre><code>Clients (SDKs / curl / apps)
        │
   HTTPS / SSE
        │
   Controller (Elixir/OTP)
   ├── Inference API    ── `/v1/responses` canonical, `/v1/chat/completions` facade
   ├── Auth / RBAC      ── API Tokens, API Clients + tenant quotas
   ├── Scheduler        ── Runtime Endpoint selection, queueing, fairness
   ├── Dispatch         ── Runtime Endpoint operations + stream relay
   └── Observability    ── Prometheus, OTel, structured logs
        │
   Runtime Endpoint Interface
        │
   Runtime Endpoint adapter(s)
   ├── first-party BEAM adapter
   └── gRPC compatibility adapter
        │
   Node Agent Runtime Endpoint(s)
   ├── Model cache + verification
   ├── Worker supervisor
   └── MLX runtime (Apple Silicon native)
        │
     Postgres (sole persistence + coordination layer)</code></pre>
<p><strong>Design rules:</strong></p>
<ul>
<li>All durable state lives in Postgres — no separate message broker or
cache to operate.</li>
<li>Controller-to-node communication goes through the Runtime Endpoint
Interface, with a first-party BEAM adapter and a gRPC compatibility
adapter.</li>
<li>Workers are local to node agents and are never exposed on the
network.</li>
<li>Token streams always pass through the controller for governance and
accounting.</li>
<li>HA-lite only: exactly one active leader, active/standby via Postgres
advisory locks, no active/active consensus.</li>
</ul>
<p>Transport defaults and guardrails for source development are
documented in <a
href="docs/local-dev.md"><code>docs/local-dev.md</code></a>; <a
href="docs/architecture.md"><code>docs/architecture.md</code></a> maps
the repo and runtime boundaries.</p>
<h2 id="tech-stack">Tech stack</h2>
<table>
<thead>
<tr>
<th>Layer</th>
<th>Choice</th>
</tr>
</thead>
<tbody>
<tr>
<td>Language</td>
<td>Elixir/OTP (umbrella app)</td>
</tr>
<tr>
<td>Database</td>
<td>Postgres</td>
</tr>
<tr>
<td>Inference</td>
<td>MLX-LM runtime adapter managed by the node agent</td>
</tr>
<tr>
<td>Runtime endpoint transport</td>
<td>Runtime Endpoint Interface (first-party BEAM adapter; gRPC
compatibility adapter)</td>
</tr>
<tr>
<td>APIs</td>
<td>Phoenix/Plug with SSE streaming</td>
</tr>
<tr>
<td>Packaging</td>
<td>PKG + launchd (DMG reserved for future work)</td>
</tr>
<tr>
<td>CLI</td>
<td><code>orchardctl</code></td>
</tr>
<tr>
<td>Toolchain</td>
<td>mise-pinned Erlang/OTP, Elixir, Python, uv, Node.js, npm, and
OpenSpec</td>
</tr>
</tbody>
</table>
<h2 id="deployment-modes">Deployment modes</h2>
<ol type="1">
<li><strong>All-in-one</strong> — a single Mac runs everything:
controller, node agent, and worker.</li>
<li><strong>Controller + workers</strong> — one Mac as the control
plane, 1–3 Macs as worker nodes.</li>
<li><strong>HA-lite</strong> — up to 2 controllers with exactly 1 active
leader, still within the overall 1–4 Mac limit, with operator-managed
endpoint failover.</li>
</ol>
<p>All controller-bearing installs currently require an external
Postgres database. The macOS PKG uses a universal payload with role
selection (<code>all</code>, <code>controller</code>, or
<code>node-agent</code>) at install time; see <a
href="packaging/pkg/README.md"><code>packaging/pkg/README.md</code></a>
for the operator runbook.</p>
<h3 id="transport-and-tls">Transport and TLS</h3>
<p>Packaged installs start on degraded loopback HTTP until an operator
selects direct HTTPS or reverse-proxy mode. TLS is provider-neutral:
bring reverse-proxy termination, operator-supplied certificates,
internal PKI, or the local-CA helper (<code>orchardctl tls init</code>)
for dev-lab bootstrap. CORS is an explicit origin allowlist, disabled by
default. Full transport configuration, including nginx/Caddy/Traefik
snippets, is in <a
href="packaging/pkg/README.md"><code>packaging/pkg/README.md</code></a>.</p>
<h3 id="building-the-installer">Building the installer</h3>
<div class="sourceCode" id="cb2"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">mise</span> exec <span class="at">--</span> ./scripts/build-pkg.sh</span></code></pre></div>
<p>This produces
<code>Orchard-&lt;version&gt;-&lt;date&gt;-&lt;git-sha&gt;.pkg</code>.
Run <code>make setup</code> first; see <a
href="packaging/pkg/README.md#building-the-pkg"><code>packaging/pkg/README.md</code></a>
for full build documentation.</p>
<h2 id="documentation">Documentation</h2>
<p>For operators:</p>
<ul>
<li><a
href="packaging/pkg/README.md"><code>packaging/pkg/README.md</code></a>
— install, roles, transport, and TLS runbook.</li>
</ul>
<p>For contributors:</p>
<ul>
<li><a href="SPEC.md"><code>SPEC.md</code></a> — the normative build
contract; every implementation decision traces back to it, and it
governs the roadmap and target behavior.</li>
<li><a href="CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> — human
collaboration workflow.</li>
<li><a href="AGENTS.md"><code>AGENTS.md</code></a> — the canonical
automation and agent workflow guide (<a
href="CLAUDE.md"><code>CLAUDE.md</code></a> imports it for Claude
Code).</li>
<li><a href="docs/README.md"><code>docs/README.md</code></a> — the
collaborator docs hub, including architecture, tooling, local
development, process, and the product glossary.</li>
<li><a href="openspec/README.md"><code>openspec/README.md</code></a> —
the OpenSpec change workflow subordinate to <code>SPEC.md</code>.</li>
</ul>
<h2 id="background">Background</h2>
<p>Orchard is a ground-up rewrite of <a
href="https://github.com/najibninaba/kapitan-orchard">Kapitan
Orchard</a> (v1: Rust + Kafka + Redis + Tauri). The rewrite replaces the
distributed streaming architecture with Elixir/OTP + Postgres for
simpler operations, better fault tolerance, and native macOS
integration.</p>
<h2 id="license">License</h2>
<p>Proprietary. All rights reserved.</p>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Roadmap/milestone removal check</summary>

```text
$ grep -nE '\bM[0-7]\b|## Roadmap|Milestone \|' README.md
NONE FOUND (roadmap/milestones removed)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `README.md:33` - The &#39;Working today&#39; status paragraph lists node lifecycle &#39;previews and execution (cordon, drain, maintenance, decommission)&#39;. The removed detailed status text stated that `orchardctl nodes maintenance` is previews-only, with its `draining -&gt; maintenance` execution deferred until drain completion can be verified. Grouping maintenance with the executable verbs slightly overstates the shipped capability for a product-facing README.

🔧 Fix: clarify maintenance is previews-only in README status
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`grep -nE &#39;\bM[0-7]\b|## Roadmap|Milestone \|&#39; README.md` → confirmed no roadmap/milestone content remains</code>
- `Internal-link integrity: extracted all non-http README links and checked each path exists → all 11 (SPEC.md, docs/*, packaging/pkg/README.md, AGENTS.md, CLAUDE.md, CONTRIBUTING.md, openspec/README.md, mise.toml) resolve`
- <code>`pandoc README.md -f gfm -t html` → rendered new README with GitHub CSS</code>
- <code>`agent-browser open` + `screenshot --full` → captured full-page visual render of the product-facing README</code>
- `Visually reviewed the rendered screenshot: product-facing sections present, no roadmap/milestone table`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
