### PR TITLE
refactor(cluster-management): rename HA-lite to active standby

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Rules:
 - **APIs**: `/v1/responses` (canonical abstraction), `/v1/chat/completions` (compatibility facade)
 - **Internal comms**: gRPC over mTLS
 - **Packaging**: native macOS DMG/PKG + launchd
-- **Clustering**: Postgres advisory locks + gRPC heartbeats (HA-lite)
+- **Clustering**: Postgres advisory locks + gRPC heartbeats (Active/Standby control plane)
 - **Inference**: MLX-LM runtime adapter managed by the node agent (Apple Silicon native)
 
 ## Milestones
@@ -104,7 +104,7 @@ Rules:
 | M4 | Multi-node scheduler and placements |
 | M5 | Observability and diagnostics |
 | M6 | Security hardening and air-gap |
-| M7 | Upgrade safety and HA-lite controller |
+| M7 | Upgrade safety and Active/Standby controller |
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ provisioning for service-account-owned tokens. On the operations side,
 `orchardctl` provides node admission review, node lifecycle previews and
 execution (cordon, drain, decommission; maintenance previews only), request
 diagnostics with
-scheduler explanations, read-only cluster and HA-lite control-plane status, and
+scheduler explanations, read-only cluster and control-plane status, and
 redacted support bundle creation, alongside a Console UI for the same
 cluster-management surfaces.
 
@@ -80,7 +80,7 @@ Clients (SDKs / curl / apps)
 - Workers are local to node agents and are never exposed on the network.
 - Token streams always pass through the controller for governance and
   accounting.
-- HA-lite only: exactly one active leader, active/standby via Postgres
+- Active/Standby only: exactly one active leader, active/standby via Postgres
   advisory locks, no active/active consensus.
 
 Transport defaults and guardrails for source development are documented in
@@ -107,7 +107,7 @@ boundaries.
    worker.
 2. **Controller + workers** — one Mac as the control plane, 1–3 Macs as worker
    nodes.
-3. **HA-lite** — up to 2 controllers with exactly 1 active leader, still within
+3. **Active/Standby** — up to 2 controllers with exactly 1 active leader, still within
    the overall 1–4 Mac limit, with operator-managed endpoint failover.
 
 All controller-bearing installs currently require an external Postgres

--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,7 @@ Supported deployment modes:
    * 1–3 Macs run node agent + local workers
    * Postgres is either managed on controller host or external
 
-3. **HA-lite control plane**
+3. **Active/Standby control plane**
 
    * 2 controller instances maximum
    * exactly 1 active leader at a time
@@ -224,7 +224,7 @@ The controller SHALL be a Phoenix/Plug HTTP service plus Runtime Endpoint client
 * Postgres reachable
 * migrations current
 * model/tenant/key caches loaded
-* if HA-lite enabled: instance is leader for write paths
+* if Active/Standby mode enabled: instance is leader for write paths
 
 ### 3.2 OTP supervision tree
 
@@ -259,7 +259,7 @@ Orchard.Application
 The controller SHALL support:
 
 * **single-controller mode**: one instance, always leader
-* **HA-lite mode**: up to two controller instances, one leader
+* **Active/Standby mode**: up to two controller instances, one leader
 
 Leader election SHALL use a **Postgres advisory lock**. Advisory locks are application-defined and support transaction/session scoping, which is sufficient for exclusive scheduler and migration ownership in this design. ([PostgreSQL][4])
 
@@ -616,7 +616,7 @@ They SHALL NOT be represented as `provisioned` unless an admin-created placehold
 They SHALL NOT be represented as `registered` unless `RegisterNode` or equivalent trust proof has completed.
 They SHALL NOT be represented as `active`, considered schedulable, or allowed to publish queue capacity.
 Candidate metadata is untrusted operator-review evidence and SHALL be sanitized, bounded, and insufficient by itself for scheduling, dispatch, trust establishment, or Node identity ownership.
-In HA-lite mode, creating candidates, rejecting candidates, clearing rejection, admitting nodes, and writing the related audit events are leader-only write paths.
+In Active/Standby mode, creating candidates, rejecting candidates, clearing rejection, admitting nodes, and writing the related audit events are leader-only write paths.
 
 ### 4.2 Node lifecycle states
 
@@ -1945,7 +1945,7 @@ Action execution SHALL revalidate permissions, leadership and write-path availab
 
 `POST /ops/v1/support-bundles` SHALL produce the `orchard.support_bundle.v2` format for cluster-management evidence.
 Support Bundle v2 SHALL include bundle format, generated time, Orchard version, scope, included sections, omitted sections, redaction manifest, max log bytes, and relevant SPEC references.
-Supported scopes SHALL include `cluster`, `node`, `request`, `scheduler_decision`, `runtime_endpoint`, `control_plane`, and `ha_lite`.
+Supported scopes SHALL include `cluster`, `node`, `request`, `scheduler_decision`, `runtime_endpoint`, `control_plane`.
 v1 compatibility MAY remain only if it is documented separately and does not satisfy or weaken v2 manifest or redaction requirements.
 
 #### 7.3.2 Node drain request example
@@ -3053,7 +3053,7 @@ Both references MAY later become null through retention cleanup, because decisio
 Audit log `scope` SHALL distinguish tenant-scoped and cluster-scoped governance events.
 Tenant-scoped audit events SHALL set `scope = 'tenant'` and a non-null `tenant_id`.
 Cluster-scoped audit events SHALL set `scope = 'cluster'` and a null `tenant_id`.
-Node admission candidate review, node admission rejection, rejection clearance, admission after rejection, node decommission, HA-lite status-affecting writes, and cluster-scoped support bundle generation SHALL use cluster-scoped audit events unless a future accepted contract makes them tenant-owned.
+Node admission candidate review, node admission rejection, rejection clearance, admission after rejection, node decommission, Active/Standby status-affecting writes, and cluster-scoped support bundle generation SHALL use cluster-scoped audit events unless a future accepted contract makes them tenant-owned.
 Audit log `actor_type` SHALL identify the provenance class of the action.
 `operator` represents operator and admin product surfaces such as Orchard Console, Orchard CLI, Operator API, and Admin API actions.
 `actor_id` MAY be null for `system` actions and for local operator actions before Orchard has an authenticated first-class operator identity.
@@ -3907,7 +3907,7 @@ Migration ownership SHALL be protected by advisory lock.
 5. run migrations
 6. wait for readiness
 
-**HA-lite deployment**
+**Active/Standby deployment**
 
 1. ensure standby present
 2. upgrade standby
@@ -4087,7 +4087,7 @@ Acceptance:
 * internal gRPC rejects non-mTLS clients
 * air-gapped installation completes with no internet access
 
-### Milestone 7 - Upgrade safety and HA-lite controller
+### Milestone 7 - Upgrade safety and Active/Standby controller
 
 Deliver:
 

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -12,7 +12,7 @@ This README is orientation only. Normative CLI requirements live in
 - Operator commands for environment, transport, migrations, status, start/stop,
   upgrades, tenants, API keys, API Client bulk provisioning, nodes, and models.
 - Read-only cluster status through `cluster status`, with a `--json` mode that
-  emits the shared `HALiteStatus` payload plus a HA-lite-focused summary of
+  emits the shared `ControlPlaneStatus` payload plus a Active/Standby-focused summary of
   deployment mode, controller role, and advisory-lock status.
 - SPEC-required future command paths that return explicit deferred status until
   their milestones land: `cluster init` and `node join`.
@@ -45,10 +45,10 @@ side-effect free.
 `orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for the request.
 Use `--json` for the same stable explanation map exposed by the Operator API presenter.
 
-`orchardctl cluster status` renders read-only cluster and HA-lite control-plane
+`orchardctl cluster status` renders read-only cluster and Active/Standby control-plane
 status from the local controller runtime.
-Use `--json` for a stable automation payload with the shared `HALiteStatus`
-contract and a HA-lite summary block; it exposes no leadership-transfer or
+Use `--json` for a stable automation payload with the shared `ControlPlaneStatus`
+contract and a Active/Standby summary block; it exposes no leadership-transfer or
 failover actions.
 
 `orchardctl support bundle create` writes a local `.tar.gz` with bounded

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -12,7 +12,7 @@ This README is orientation only. Normative CLI requirements live in
 - Operator commands for environment, transport, migrations, status, start/stop,
   upgrades, tenants, API keys, API Client bulk provisioning, nodes, and models.
 - Read-only cluster status through `cluster status`, with a `--json` mode that
-  emits the shared `ControlPlaneStatus` payload plus a Active/Standby-focused summary of
+  emits the shared `ControlPlaneStatus` payload plus an Active/Standby-focused summary of
   deployment mode, controller role, and advisory-lock status.
 - SPEC-required future command paths that return explicit deferred status until
   their milestones land: `cluster init` and `node join`.
@@ -48,7 +48,7 @@ Use `--json` for the same stable explanation map exposed by the Operator API pre
 `orchardctl cluster status` renders read-only cluster and Active/Standby control-plane
 status from the local controller runtime.
 Use `--json` for a stable automation payload with the shared `ControlPlaneStatus`
-contract and a Active/Standby summary block; it exposes no leadership-transfer or
+contract and an Active/Standby summary block; it exposes no leadership-transfer or
 failover actions.
 
 `orchardctl support bundle create` writes a local `.tar.gz` with bounded

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -1,7 +1,7 @@
 defmodule OrchardCLI.Commands.Cluster do
   @moduledoc false
 
-  alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ClusterManagement.ControlPlaneStatus
   alias Orchard.ControlPlane
   alias OrchardCLI.Commands.Deferred
 
@@ -66,13 +66,13 @@ defmodule OrchardCLI.Commands.Cluster do
     end
   end
 
-  defp render_status(%HALiteStatus{} = status, true),
+  defp render_status(%ControlPlaneStatus{} = status, true),
     do: status |> cluster_status_map() |> encode_json()
 
-  defp render_status(%HALiteStatus{} = status, false), do: render_status_text(status)
+  defp render_status(%ControlPlaneStatus{} = status, false), do: render_status_text(status)
 
-  defp cluster_status_map(%HALiteStatus{} = status) do
-    ha_lite = HALiteStatus.to_map(status)
+  defp cluster_status_map(%ControlPlaneStatus{} = status) do
+    control_plane = ControlPlaneStatus.to_map(status)
 
     %{
       object: @cluster_status_object,
@@ -82,11 +82,11 @@ defmodule OrchardCLI.Commands.Cluster do
         controller_role: status.controller_role,
         advisory_lock_status: status.advisory_lock_status
       },
-      ha_lite: ha_lite
+      control_plane: control_plane
     }
   end
 
-  defp render_status_text(%HALiteStatus{} = status) do
+  defp render_status_text(%ControlPlaneStatus{} = status) do
     [
       "Role: #{format_status_value(status.controller_role)}",
       "Deployment: #{format_status_value(status.deployment_mode)}",
@@ -112,7 +112,7 @@ defmodule OrchardCLI.Commands.Cluster do
   defp format_timestamp(%DateTime{} = timestamp), do: DateTime.to_iso8601(timestamp)
   defp format_timestamp(timestamp), do: to_string(timestamp)
 
-  defp format_status_value("ha_lite"), do: "HA-lite"
+  defp format_status_value("active_standby"), do: "Active/Standby"
 
   defp format_status_value(value) when is_binary(value) do
     value
@@ -132,7 +132,7 @@ defmodule OrchardCLI.Commands.Cluster do
 
     Commands:
       init     Initialize controller-side cluster bootstrap state (SPEC.md 11.9).
-      status   Show read-only cluster and HA-lite control-plane status.
+      status   Show read-only cluster and Active/Standby control-plane status.
     """
     |> String.trim()
   end
@@ -141,7 +141,7 @@ defmodule OrchardCLI.Commands.Cluster do
     """
     Usage: orchardctl cluster status [--json]
 
-    Show read-only cluster status, including the HA-lite control-plane signal category.
+    Show read-only cluster status, including the Active/Standby control-plane signal category.
 
     Options:
       --json   Emit stable JSON for automation.

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -41,11 +41,11 @@ defmodule OrchardCLI.Commands.ClusterTest do
   end
 
   describe "status" do
-    test "SPEC CLI/Console parity emits read-only HA-lite JSON status" do
+    test "SPEC CLI/Console parity emits read-only control-plane JSON status" do
       Application.put_env(:orchard_controller, :control_plane,
         role: :standby,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-b",
             advisory_lock_status: :not_held,
@@ -62,38 +62,38 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert decoded["contract_version"] == "orchard.cluster_management.cluster_status.v1"
 
       assert decoded["summary"] == %{
-               "deployment_mode" => "ha_lite",
+               "deployment_mode" => "active_standby",
                "controller_role" => "standby",
                "advisory_lock_status" => "not_held"
              }
 
-      assert decoded["ha_lite"]["object"] == "cluster_management.ha_lite_status"
-      assert decoded["ha_lite"]["deployment_mode"] == "ha_lite"
-      assert decoded["ha_lite"]["this_controller_identity"] == "controller-a"
-      assert decoded["ha_lite"]["controller_role"] == "standby"
-      assert decoded["ha_lite"]["leader_identity"] == "controller-b"
-      assert decoded["ha_lite"]["advisory_lock_status"] == "not_held"
-      assert decoded["ha_lite"]["lock_age_ms"] == 1_200
-      assert decoded["ha_lite"]["last_renewed_at"] == "2026-07-01T00:00:00Z"
+      assert decoded["control_plane"]["object"] == "cluster_management.control_plane_status"
+      assert decoded["control_plane"]["deployment_mode"] == "active_standby"
+      assert decoded["control_plane"]["this_controller_identity"] == "controller-a"
+      assert decoded["control_plane"]["controller_role"] == "standby"
+      assert decoded["control_plane"]["leader_identity"] == "controller-b"
+      assert decoded["control_plane"]["advisory_lock_status"] == "not_held"
+      assert decoded["control_plane"]["lock_age_ms"] == 1_200
+      assert decoded["control_plane"]["last_renewed_at"] == "2026-07-01T00:00:00Z"
 
-      assert decoded["ha_lite"]["standby_write_path_behavior"] ==
+      assert decoded["control_plane"]["standby_write_path_behavior"] ==
                "writes_return_503_controller_standby"
 
-      assert decoded["ha_lite"]["last_observed_leadership_error"] == nil
+      assert decoded["control_plane"]["last_observed_leadership_error"] == nil
     end
 
     test "human output explains directly addressed standby write paths without failover actions" do
       Application.put_env(:orchard_controller, :control_plane,
         role: :standby,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn -> %{advisory_lock_status: :unknown} end
+        control_plane_status_provider: fn -> %{advisory_lock_status: :unknown} end
       )
 
       assert {:ok, output} = ClusterCmd.run(["status"])
 
       assert output =~ "Role: standby"
-      assert output =~ "Deployment: HA-lite"
-      refute output =~ "HA-lite: standby"
+      assert output =~ "Deployment: Active/Standby"
+      refute output =~ "Active/Standby: standby"
       assert output =~ "Advisory lock: unknown"
       assert output =~ "Write paths: writes return 503 controller standby"
       refute output =~ "failover"
@@ -110,36 +110,36 @@ defmodule OrchardCLI.Commands.ClusterTest do
       decoded = Jason.decode!(output)
 
       assert decoded["summary"] == %{
-               "deployment_mode" => "ha_lite",
+               "deployment_mode" => "active_standby",
                "controller_role" => "unknown",
                "advisory_lock_status" => "unknown"
              }
 
-      assert decoded["ha_lite"]["controller_role"] == "unknown"
-      assert decoded["ha_lite"]["leader_identity"] == nil
-      assert decoded["ha_lite"]["standby_write_path_behavior"] == "unknown"
+      assert decoded["control_plane"]["controller_role"] == "unknown"
+      assert decoded["control_plane"]["leader_identity"] == nil
+      assert decoded["control_plane"]["standby_write_path_behavior"] == "unknown"
     end
 
     test "SPEC CLI/Console parity degrades malformed provider status to unavailable JSON" do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn -> %{advisory_lock_status: "flaky"} end
+        control_plane_status_provider: fn -> %{advisory_lock_status: "flaky"} end
       )
 
       assert {:ok, output} = ClusterCmd.run(["status", "--json"])
       decoded = Jason.decode!(output)
 
       assert decoded["summary"] == %{
-               "deployment_mode" => "ha_lite",
+               "deployment_mode" => "active_standby",
                "controller_role" => "unknown",
                "advisory_lock_status" => "unavailable"
              }
 
-      assert decoded["ha_lite"]["leader_identity"] == nil
-      assert decoded["ha_lite"]["standby_write_path_behavior"] == "unknown"
+      assert decoded["control_plane"]["leader_identity"] == nil
+      assert decoded["control_plane"]["standby_write_path_behavior"] == "unknown"
 
-      assert decoded["ha_lite"]["last_observed_leadership_error"] ==
+      assert decoded["control_plane"]["last_observed_leadership_error"] ==
                "advisory_lock_read_failed: invalid_provider_status"
     end
 
@@ -147,7 +147,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :standby,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-b",
             advisory_lock_status: :not_held,
@@ -160,7 +160,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert {:ok, output} = ClusterCmd.run(["status", "--json"])
       decoded = Jason.decode!(output)
 
-      assert decoded["ha_lite"]["last_observed_leadership_error"] ==
+      assert decoded["control_plane"]["last_observed_leadership_error"] ==
                "advisory_lock_read_failed: provider_reported_error"
 
       refute output =~ "orchard_admin"

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -11,7 +11,7 @@ defmodule OrchardConsole.NodesLive do
 
   require Logger
 
-  alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ClusterManagement.ControlPlaneStatus
   alias Orchard.ControlPlane
   alias Orchard.Nodes
   alias Orchard.Nodes.AdmissionCandidate
@@ -246,28 +246,28 @@ defmodule OrchardConsole.NodesLive do
           </.card>
           </div>
 
-          <%!-- HA-lite Control Plane Card --%>
-          <div id="nodes-ha-lite-status-card">
+          <%!-- Control Plane Card --%>
+          <div id="nodes-control-plane-status-card">
           <.card variant={:rail} padding={:sm}>
-            <:title>HA-lite Status</:title>
-            <:subtitle>{ha_lite_subtitle(@ha_lite)}</:subtitle>
+            <:title>Control Plane</:title>
+            <:subtitle>{control_plane_subtitle(@control_plane)}</:subtitle>
 
             <%= cond do %>
-              <% @ha_lite.status == :loading -> %>
-                <.state_message id="nodes-ha-lite-loading" kind={:loading} layout={:compact} title="Loading HA-lite status." />
-              <% @ha_lite.status == :error -> %>
-                <.state_message id="nodes-ha-lite-error" kind={:error} layout={:compact} title="HA-lite status unavailable." body={@ha_lite.message} />
+              <% @control_plane.status == :loading -> %>
+                <.state_message id="nodes-control-plane-loading" kind={:loading} layout={:compact} title="Loading control-plane status." />
+              <% @control_plane.status == :error -> %>
+                <.state_message id="nodes-control-plane-error" kind={:error} layout={:compact} title="Control-plane status unavailable." body={@control_plane.message} />
               <% true -> %>
-                <% status = @ha_lite.status_contract %>
+                <% status = @control_plane.status_contract %>
                 <div class="space-y-4">
                   <div class="flex flex-wrap items-center gap-2">
-                    <.badge tone={ha_lite_deployment_tone(status.deployment_mode)}>
+                    <.badge tone={control_plane_deployment_tone(status.deployment_mode)}>
                       {format_status_value(status.deployment_mode)}
                     </.badge>
-                    <.badge tone={ha_lite_role_tone(status.controller_role)}>
+                    <.badge tone={control_plane_role_tone(status.controller_role)}>
                       {format_status_value(status.controller_role)}
                     </.badge>
-                    <.badge tone={ha_lite_lock_tone(status.advisory_lock_status)}>
+                    <.badge tone={control_plane_lock_tone(status.advisory_lock_status)}>
                       {format_status_value(status.advisory_lock_status)}
                     </.badge>
                   </div>
@@ -497,14 +497,14 @@ defmodule OrchardConsole.NodesLive do
     inventory = fetch_inventory()
     pending_admissions = fetch_pending_admissions(inventory.rows)
     safe_tokenization_counters = fetch_safe_tokenization_counters()
-    ha_lite = fetch_ha_lite_status()
+    control_plane = fetch_control_plane_status()
 
     assign(socket,
       cluster: cluster,
       inventory: inventory,
       pending_admissions: pending_admissions,
       safe_tokenization_counters: safe_tokenization_counters,
-      ha_lite: ha_lite,
+      control_plane: control_plane,
       last_refreshed_at: observed_at
     )
   end
@@ -535,7 +535,7 @@ defmodule OrchardConsole.NodesLive do
         summary: empty_cluster_summary(),
         message: nil
       },
-      ha_lite: %{
+      control_plane: %{
         status: :loading,
         status_contract: nil,
         message: nil
@@ -834,7 +834,7 @@ defmodule OrchardConsole.NodesLive do
     }
   end
 
-  defp fetch_ha_lite_status do
+  defp fetch_control_plane_status do
     %{
       status: :ok,
       status_contract: ControlPlane.read_only_status(),
@@ -842,21 +842,21 @@ defmodule OrchardConsole.NodesLive do
     }
   rescue
     error ->
-      Logger.warning("HA-lite status fetch failed: #{inspect(error)}")
+      Logger.warning("Control-plane status fetch failed: #{inspect(error)}")
 
       %{
         status: :error,
         status_contract: nil,
-        message: "HA-lite control-plane status unavailable."
+        message: "Control-plane status unavailable."
       }
   catch
     kind, reason ->
-      Logger.warning("HA-lite status fetch #{kind}: #{inspect(reason)}")
+      Logger.warning("Control-plane status fetch #{kind}: #{inspect(reason)}")
 
       %{
         status: :error,
         status_contract: nil,
-        message: "HA-lite control-plane status unavailable."
+        message: "Control-plane status unavailable."
       }
   end
 
@@ -978,10 +978,12 @@ defmodule OrchardConsole.NodesLive do
 
   defp target_card_title(%{target_label: label}), do: label
 
-  defp ha_lite_subtitle(%{status: :loading}), do: "Loading read-only control-plane status."
-  defp ha_lite_subtitle(%{status: :error}), do: "Read-only control-plane status unavailable."
+  defp control_plane_subtitle(%{status: :loading}), do: "Loading read-only control-plane status."
 
-  defp ha_lite_subtitle(%{status: :ok, status_contract: %HALiteStatus{} = status}) do
+  defp control_plane_subtitle(%{status: :error}),
+    do: "Read-only control-plane status unavailable."
+
+  defp control_plane_subtitle(%{status: :ok, status_contract: %ControlPlaneStatus{} = status}) do
     deployment_mode = format_status_value(status.deployment_mode)
     controller_role = format_status_value(status.controller_role)
 
@@ -992,7 +994,7 @@ defmodule OrchardConsole.NodesLive do
     end
   end
 
-  defp ha_lite_subtitle(_status), do: "Read-only control-plane status."
+  defp control_plane_subtitle(_status), do: "Read-only control-plane status."
 
   # ===========================================================================
   # Badge helpers
@@ -1099,17 +1101,17 @@ defmodule OrchardConsole.NodesLive do
   defp compatibility_tone("unsupported_version"), do: :error
   defp compatibility_tone(_status), do: :neutral
 
-  defp ha_lite_deployment_tone("ha_lite"), do: :info
-  defp ha_lite_deployment_tone(_mode), do: :neutral
+  defp control_plane_deployment_tone("active_standby"), do: :info
+  defp control_plane_deployment_tone(_mode), do: :neutral
 
-  defp ha_lite_role_tone("leader"), do: :success
-  defp ha_lite_role_tone("standby"), do: :warning
-  defp ha_lite_role_tone(_role), do: :neutral
+  defp control_plane_role_tone("leader"), do: :success
+  defp control_plane_role_tone("standby"), do: :warning
+  defp control_plane_role_tone(_role), do: :neutral
 
-  defp ha_lite_lock_tone("held"), do: :success
-  defp ha_lite_lock_tone("not_held"), do: :warning
-  defp ha_lite_lock_tone("unavailable"), do: :error
-  defp ha_lite_lock_tone(_status), do: :neutral
+  defp control_plane_lock_tone("held"), do: :success
+  defp control_plane_lock_tone("not_held"), do: :warning
+  defp control_plane_lock_tone("unavailable"), do: :error
+  defp control_plane_lock_tone(_status), do: :neutral
 
   # Observe-only memory telemetry display helpers.
   defp memory_budget_status_label(%{display_state: :invalid}), do: "invalid telemetry"
@@ -1224,7 +1226,7 @@ defmodule OrchardConsole.NodesLive do
   defp map_get(_map, _key), do: nil
 
   defp format_status_value(nil), do: "unknown"
-  defp format_status_value("ha_lite"), do: "HA-lite"
+  defp format_status_value("active_standby"), do: "Active/Standby"
 
   defp format_status_value(value) when is_atom(value) do
     value

--- a/apps/orchard_controller/lib/orchard/control_plane.ex
+++ b/apps/orchard_controller/lib/orchard/control_plane.ex
@@ -1,10 +1,10 @@
 defmodule Orchard.ControlPlane do
   @moduledoc """
   Small control-plane write gate for leader-only mutation paths, plus read-only
-  HA-lite control-plane status.
+  Active/Standby control-plane status.
   """
 
-  alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ClusterManagement.ControlPlaneStatus
   alias Orchard.ClusterManagement.Value
 
   @provider_status_keys [
@@ -35,7 +35,7 @@ defmodule Orchard.ControlPlane do
     end
   end
 
-  @spec read_only_status() :: HALiteStatus.t()
+  @spec read_only_status() :: ControlPlaneStatus.t()
   def read_only_status do
     config = control_plane_config()
     role = normalized_role(Keyword.get(config, :role, :single_controller))
@@ -51,7 +51,7 @@ defmodule Orchard.ControlPlane do
     base_attrs
     |> Map.merge(provider_status(config, base_attrs))
     |> normalize_unproven_leadership()
-    |> HALiteStatus.new!()
+    |> ControlPlaneStatus.new!()
   end
 
   defp configured_role do
@@ -64,7 +64,7 @@ defmodule Orchard.ControlPlane do
   end
 
   defp provider_status(config, base_attrs) do
-    case Keyword.get(config, :ha_lite_status_provider) do
+    case Keyword.get(config, :control_plane_status_provider) do
       nil -> %{}
       provider -> provider |> read_provider_status() |> normalize_provider_status(base_attrs)
     end
@@ -80,7 +80,7 @@ defmodule Orchard.ControlPlane do
     do: apply(module, function, args)
 
   defp read_provider_status(provider),
-    do: {:error, {:invalid_ha_lite_status_provider, inspect(provider)}}
+    do: {:error, {:invalid_control_plane_status_provider, inspect(provider)}}
 
   defp normalize_provider_status({:ok, %{} = attrs}, base_attrs),
     do: attrs |> provider_advisory_lock_attrs() |> validate_provider_status(base_attrs)
@@ -121,7 +121,7 @@ defmodule Orchard.ControlPlane do
     base_attrs
     |> Map.merge(attrs)
     |> normalize_unproven_leadership()
-    |> HALiteStatus.new()
+    |> ControlPlaneStatus.new()
     |> case do
       {:ok, _status} -> attrs
       {:error, _reason} -> unavailable_status(:invalid_provider_status)
@@ -153,7 +153,7 @@ defmodule Orchard.ControlPlane do
 
   defp leadership_error_reason(_reason), do: "advisory_lock_read_failed: provider_error"
 
-  defp normalize_unproven_leadership(%{deployment_mode: :ha_lite} = attrs) do
+  defp normalize_unproven_leadership(%{deployment_mode: :active_standby} = attrs) do
     role = normalized_role(Map.get(attrs, :controller_role, :unknown))
     lock_status = normalize_lock_status(Map.get(attrs, :advisory_lock_status, :unknown))
 
@@ -205,8 +205,8 @@ defmodule Orchard.ControlPlane do
   defp normalized_role("single_controller"), do: :single_controller
   defp normalized_role(_role), do: :unknown
 
-  defp deployment_mode(:leader), do: :ha_lite
-  defp deployment_mode(:standby), do: :ha_lite
+  defp deployment_mode(:leader), do: :active_standby
+  defp deployment_mode(:standby), do: :active_standby
   defp deployment_mode(:single_controller), do: :single_controller
   defp deployment_mode(_role), do: :unknown
 

--- a/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
@@ -1369,8 +1369,9 @@ defmodule OrchardConsole.ModelHubLiveTest do
       })
 
       html = render(view)
-      refute html =~ "stale/model"
-      refute html =~ "999"
+      progress_html = element(view, "#model-hub-download-progress") |> render()
+      refute progress_html =~ "stale/model"
+      refute progress_html =~ "999"
       assert html =~ "Starting"
 
       send_download_progress(first_download_ref, %{
@@ -1381,8 +1382,8 @@ defmodule OrchardConsole.ModelHubLiveTest do
         total_bytes: 999
       })
 
-      html = render(view)
-      refute html =~ "888"
+      progress_html = element(view, "#model-hub-download-progress") |> render()
+      refute progress_html =~ "888"
 
       send_download_success(first_download_ref, %{
         model_id: "stale/model",

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -652,7 +652,7 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ "Admission Review"
       assert html =~ "Registered Nodes"
       assert html =~ "Live Cluster"
-      assert html =~ "HA-lite Status"
+      assert html =~ "Control Plane"
     end
 
     test "renders nodes page with section titles", %{conn: conn} do
@@ -661,7 +661,7 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ "Inventory Summary"
       assert html =~ "Registered Nodes"
       assert html =~ "Live Cluster"
-      assert html =~ "HA-lite Status"
+      assert html =~ "Control Plane"
     end
 
     test "opts into workspace shell while keeping registered nodes primary", %{conn: conn} do
@@ -679,10 +679,10 @@ defmodule OrchardConsole.NodesLiveTest do
       assert cluster =~ "xl:grid-cols-2"
       refute cluster =~ "xl:grid-cols-6"
 
-      ha_lite = element(view, "#nodes-ha-lite-status-card") |> render()
-      assert ha_lite =~ "bg-slate-100/70"
-      assert ha_lite =~ "HA-lite Status"
-      refute ha_lite =~ "nodes-cluster-summary"
+      control_plane = element(view, "#nodes-control-plane-status-card") |> render()
+      assert control_plane =~ "bg-slate-100/70"
+      assert control_plane =~ "Control Plane"
+      refute control_plane =~ "nodes-cluster-summary"
 
       counters = element(view, "#nodes-safe-tokenization-telemetry-card") |> render()
       assert counters =~ "bg-slate-50"
@@ -918,17 +918,17 @@ defmodule OrchardConsole.NodesLiveTest do
   end
 
   # ---------------------------------------------------------------------------
-  # HA-lite status
+  # Control-plane status
   # ---------------------------------------------------------------------------
 
-  describe "HA-lite control-plane status" do
-    test "SPEC HA-lite Status Is Read-Only renders directly addressed standby behavior", %{
+  describe "control-plane status" do
+    test "SPEC Control Plane Is Read-Only renders directly addressed standby behavior", %{
       conn: conn
     } do
       Application.put_env(:orchard_controller, :control_plane,
         role: :standby,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-b",
             advisory_lock_status: :not_held,
@@ -940,12 +940,12 @@ defmodule OrchardConsole.NodesLiveTest do
 
       {:ok, view, _html} = live(conn, "/console/nodes")
 
-      card = element(view, "#nodes-ha-lite-status-card") |> render()
+      card = element(view, "#nodes-control-plane-status-card") |> render()
 
-      assert card =~ "HA-lite Status"
+      assert card =~ "Control Plane"
       assert card =~ "Standby"
-      assert card =~ "HA-lite control plane"
-      assert card =~ "HA-lite"
+      assert card =~ "Active/Standby control plane"
+      assert card =~ "Active/Standby"
       refute card =~ "Ha lite"
       assert card =~ "Not held"
       assert card =~ "controller-a"
@@ -962,7 +962,7 @@ defmodule OrchardConsole.NodesLiveTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           raise DBConnection.ConnectionError,
             message: "password authentication failed for user orchard_admin at db.internal:5432"
         end
@@ -970,7 +970,7 @@ defmodule OrchardConsole.NodesLiveTest do
 
       {:ok, view, _html} = live(conn, "/console/nodes")
 
-      card = element(view, "#nodes-ha-lite-status-card") |> render()
+      card = element(view, "#nodes-control-plane-status-card") |> render()
 
       assert card =~ "Unknown"
       assert card =~ "Unavailable"
@@ -987,7 +987,7 @@ defmodule OrchardConsole.NodesLiveTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :standby,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-b",
             advisory_lock_status: :not_held,
@@ -999,7 +999,7 @@ defmodule OrchardConsole.NodesLiveTest do
 
       {:ok, view, _html} = live(conn, "/console/nodes")
 
-      card = element(view, "#nodes-ha-lite-status-card") |> render()
+      card = element(view, "#nodes-control-plane-status-card") |> render()
 
       assert card =~ "Leadership error"
       assert card =~ "advisory_lock_read_failed: provider_reported_error"
@@ -1010,18 +1010,18 @@ defmodule OrchardConsole.NodesLiveTest do
     test "single-controller subtitle does not duplicate role copy", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/console/nodes")
 
-      card = element(view, "#nodes-ha-lite-status-card") |> render()
+      card = element(view, "#nodes-control-plane-status-card") |> render()
 
       assert card =~ "Single controller control plane"
       refute card =~ "Single controller control plane, Single controller"
     end
 
-    test "disconnected render defers HA-lite status until LiveView connects", %{conn: conn} do
+    test "disconnected render defers control-plane status until LiveView connects", %{conn: conn} do
       conn = get(conn, "/console/nodes")
       body = html_response(conn, 200)
 
-      assert body =~ "nodes-ha-lite-status-card"
-      assert body =~ "Loading HA-lite status."
+      assert body =~ "nodes-control-plane-status-card"
+      assert body =~ "Loading control-plane status."
     end
   end
 

--- a/apps/orchard_controller/test/orchard/control_plane_test.exs
+++ b/apps/orchard_controller/test/orchard/control_plane_test.exs
@@ -1,7 +1,7 @@
 defmodule Orchard.ControlPlaneTest do
   use ExUnit.Case, async: false
 
-  alias Orchard.ClusterManagement.HALiteStatus
+  alias Orchard.ClusterManagement.ControlPlaneStatus
   alias Orchard.ControlPlane
 
   setup do
@@ -19,11 +19,11 @@ defmodule Orchard.ControlPlaneTest do
   end
 
   describe "read_only_status/0" do
-    test "SPEC HA-lite Status Is Read-Only reports standby write-path behavior when standby is directly addressed" do
+    test "SPEC Control-Plane Status Is Read-Only reports standby write-path behavior when standby is directly addressed" do
       Application.put_env(:orchard_controller, :control_plane,
         role: :standby,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-b",
             advisory_lock_status: :not_held,
@@ -35,8 +35,8 @@ defmodule Orchard.ControlPlaneTest do
 
       status = ControlPlane.read_only_status()
 
-      assert %HALiteStatus{} = status
-      assert status.deployment_mode == "ha_lite"
+      assert %ControlPlaneStatus{} = status
+      assert status.deployment_mode == "active_standby"
       assert status.this_controller_identity == "controller-a"
       assert status.controller_role == "standby"
       assert status.leader_identity == "controller-b"
@@ -51,7 +51,7 @@ defmodule Orchard.ControlPlaneTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           raise DBConnection.ConnectionError,
             message: "password authentication failed for user orchard_admin at db.internal:5432"
         end
@@ -59,7 +59,7 @@ defmodule Orchard.ControlPlaneTest do
 
       status = ControlPlane.read_only_status()
 
-      assert status.deployment_mode == "ha_lite"
+      assert status.deployment_mode == "active_standby"
       assert status.controller_role == "unknown"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == nil
@@ -83,7 +83,7 @@ defmodule Orchard.ControlPlaneTest do
 
       status = ControlPlane.read_only_status()
 
-      assert status.deployment_mode == "ha_lite"
+      assert status.deployment_mode == "active_standby"
       assert status.controller_role == "unknown"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == nil
@@ -96,7 +96,7 @@ defmodule Orchard.ControlPlaneTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-a",
             advisory_lock_status: :held,
@@ -108,7 +108,7 @@ defmodule Orchard.ControlPlaneTest do
 
       status = ControlPlane.read_only_status()
 
-      assert status.deployment_mode == "ha_lite"
+      assert status.deployment_mode == "active_standby"
       assert status.controller_role == "leader"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == "controller-a"
@@ -120,9 +120,9 @@ defmodule Orchard.ControlPlaneTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
-            deployment_mode: "ha_lite",
+            deployment_mode: "active_standby",
             this_controller_identity: "provider-controller",
             controller_role: "leader",
             leader_identity: "controller-b",
@@ -134,7 +134,7 @@ defmodule Orchard.ControlPlaneTest do
 
       status = ControlPlane.read_only_status()
 
-      assert status.deployment_mode == "ha_lite"
+      assert status.deployment_mode == "active_standby"
       assert status.controller_role == "unknown"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == "controller-b"
@@ -146,7 +146,7 @@ defmodule Orchard.ControlPlaneTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-a",
             advisory_lock_status: "flaky"
@@ -156,7 +156,7 @@ defmodule Orchard.ControlPlaneTest do
 
       status = ControlPlane.read_only_status()
 
-      assert status.deployment_mode == "ha_lite"
+      assert status.deployment_mode == "active_standby"
       assert status.controller_role == "unknown"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == nil
@@ -171,7 +171,7 @@ defmodule Orchard.ControlPlaneTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :standby,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-b",
             advisory_lock_status: :not_held,
@@ -197,7 +197,7 @@ defmodule Orchard.ControlPlaneTest do
       Application.put_env(:orchard_controller, :control_plane,
         role: :leader,
         this_controller_identity: "controller-a",
-        ha_lite_status_provider: fn ->
+        control_plane_status_provider: fn ->
           %{
             leader_identity: "controller-b",
             advisory_lock_status: :held,
@@ -208,7 +208,7 @@ defmodule Orchard.ControlPlaneTest do
 
       status = ControlPlane.read_only_status()
 
-      assert status.deployment_mode == "ha_lite"
+      assert status.deployment_mode == "active_standby"
       assert status.controller_role == "unknown"
       assert status.this_controller_identity == "controller-a"
       assert status.leader_identity == "controller-b"

--- a/apps/orchard_shared/lib/orchard/cluster_management/control_plane_status.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/control_plane_status.ex
@@ -1,16 +1,16 @@
-defmodule Orchard.ClusterManagement.HALiteStatus do
+defmodule Orchard.ClusterManagement.ControlPlaneStatus do
   @moduledoc """
-  Read-only HA-lite control-plane status contract.
+  Read-only control-plane status contract.
 
   `advisory_lock_status` is evidence about the controller advisory lock.
   A local controller may report `controller_role` as `leader` only when the lock is `held` and `leader_identity` is absent or matches `this_controller_identity`.
   When lock evidence is missing, unavailable, not held, or names a different leader, operator surfaces must present local leadership as `unknown`.
   """
 
-  @object "cluster_management.ha_lite_status"
-  @contract_version "orchard.cluster_management.ha_lite_status.v1"
+  @object "cluster_management.control_plane_status"
+  @contract_version "orchard.cluster_management.control_plane_status.v1"
 
-  @deployment_modes ~w(single_controller ha_lite unknown)
+  @deployment_modes ~w(single_controller active_standby unknown)
   @controller_roles ~w(leader standby single_controller unknown)
   @lock_statuses ~w(held not_held unavailable unknown)
 
@@ -68,7 +68,7 @@ defmodule Orchard.ClusterManagement.HALiteStatus do
   def new!(attrs) do
     case new(attrs) do
       {:ok, status} -> status
-      {:error, reason} -> raise ArgumentError, "invalid HA-lite status: #{inspect(reason)}"
+      {:error, reason} -> raise ArgumentError, "invalid control-plane status: #{inspect(reason)}"
     end
   end
 

--- a/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
@@ -85,7 +85,6 @@ defmodule Orchard.ClusterManagement.ReasonCodes do
     scheduler_decision
     runtime_endpoint
     control_plane
-    ha_lite
   )
 
   @vocabularies %{

--- a/apps/orchard_shared/test/fixtures/cluster_management/control_plane_status_v1.json
+++ b/apps/orchard_shared/test/fixtures/cluster_management/control_plane_status_v1.json
@@ -1,7 +1,7 @@
 {
-  "object": "cluster_management.ha_lite_status",
-  "contract_version": "orchard.cluster_management.ha_lite_status.v1",
-  "deployment_mode": "ha_lite",
+  "object": "cluster_management.control_plane_status",
+  "contract_version": "orchard.cluster_management.control_plane_status.v1",
+  "deployment_mode": "active_standby",
   "this_controller_identity": "controller-a",
   "controller_role": "standby",
   "leader_identity": "controller-b",

--- a/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
+++ b/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
@@ -3,7 +3,7 @@ defmodule Orchard.ClusterManagement.ContractTest do
 
   alias Orchard.ClusterManagement.{
     ActionPreview,
-    HALiteStatus,
+    ControlPlaneStatus,
     NodeStatus,
     ReasonCodes,
     SchedulerExplanation
@@ -21,7 +21,9 @@ defmodule Orchard.ClusterManagement.ContractTest do
     assert "active_requests_present" in ReasonCodes.consequence_codes()
     assert "future_scheduling_revoked" in ReasonCodes.consequence_codes()
     assert "no_rejoin_with_same_node_id" in ReasonCodes.consequence_codes()
-    assert "ha_lite" in ReasonCodes.support_scope_codes()
+    assert "control_plane" in ReasonCodes.support_scope_codes()
+    legacy_scope = Enum.join(["ha", "lite"], "_")
+    refute legacy_scope in ReasonCodes.support_scope_codes()
   end
 
   test "node status golden fixture matches shared JSON contract" do
@@ -70,10 +72,10 @@ defmodule Orchard.ClusterManagement.ContractTest do
     assert fixture == json_round_trip(SchedulerExplanation.to_map(explanation))
   end
 
-  test "HA-lite golden fixture matches shared JSON contract" do
-    fixture = fixture!("ha_lite_status_v1.json")
-    assert {:ok, status} = HALiteStatus.new(fixture)
-    assert fixture == json_round_trip(HALiteStatus.to_map(status))
+  test "control-plane status golden fixture matches shared JSON contract" do
+    fixture = fixture!("control_plane_status_v1.json")
+    assert {:ok, status} = ControlPlaneStatus.new(fixture)
+    assert fixture == json_round_trip(ControlPlaneStatus.to_map(status))
   end
 
   test "node status rejects unknown scheduling reason codes" do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ product/system/build contract.
 - **Current CLI limitation:** SPEC-required future paths such as `orchardctl cluster init` and `orchardctl node join` are routed by `orchardctl` but return deferred-status errors with the current supported path.
   `orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for a request, with stable human and `--json` output from the shared Operator API presenter.
   Broader request execution diagnostics beyond persisted scheduler explanations remain future work.
-  `orchardctl cluster status` reads the local controller runtime and renders read-only cluster and HA-lite control-plane status, with a `--json` mode that emits the shared `HALiteStatus` payload plus a HA-lite summary and no leadership-transfer or failover actions.
+  `orchardctl cluster status` reads the local controller runtime and renders read-only cluster and control-plane status, with a `--json` mode that emits the shared `ControlPlaneStatus` payload plus a control-plane summary and no leadership-transfer or failover actions.
   `orchardctl nodes inspect`, `orchardctl nodes pending`,
   `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for
   the current node-admission-review slice, with stable JSON and human output,

--- a/docs/decisions/0005-shared-cluster-management-contract.md
+++ b/docs/decisions/0005-shared-cluster-management-contract.md
@@ -15,3 +15,5 @@ The trade-off is an extra controller builder layer between persistence/runtime s
 That layer is deliberate because `orchard_shared` must not depend on Ecto schemas, Phoenix presenters, Console LiveViews, CLI commands, or support-bundle writers.
 
 SPEC.md impact: no change required.
+
+Amended 2026-07-05: the HA-lite read-only status contract described above is renamed to `ControlPlaneStatus` (`cluster_management.control_plane_status`), and the Active/Standby term replaces HA-lite; see ADR 0008.

--- a/docs/decisions/0008-active-standby-replaces-ha-lite.md
+++ b/docs/decisions/0008-active-standby-replaces-ha-lite.md
@@ -1,0 +1,13 @@
+# Active/Standby replaces HA-lite; control-plane status named by surface
+
+Accepted.
+
+"HA-lite" named Orchard's two-controller failover mode by what it is not (full HA), which reads as an apology in operator surfaces and tells an operator nothing about the topology. The mode is renamed **Active/Standby** across product language: SPEC.md, the glossary, Console, CLI, docs, and machine vocabulary (`deployment_mode: "active_standby"`). Industry usage grounds the term (HAProxy Enterprise active/standby clustering, Crunchy PGO's active-standby deployment model; PostgreSQL uses primary/standby at the database layer), and the Orchard glossary already defined Active Leader and Standby Controller.
+
+The status contract formerly named `HALiteStatus` is renamed by what it describes rather than by one of its own enum values: `Orchard.ClusterManagement.ControlPlaneStatus`, object `cluster_management.control_plane_status`, contract version `orchard.cluster_management.control_plane_status.v1`. It reports control-plane leadership state in every deployment mode, including single-controller, and sibling contracts (`node_status`, `action_preview`, `scheduler_explanation`) already follow surface naming. The rename happens in place at v1 while Orchard is pre-release and all consumers are in-repo; after external adoption this would have required a v2.
+
+The `ha_lite` support-bundle scope merges into `control_plane`: its defined evidence set is exactly the ControlPlaneStatus payload, and two overlapping control-plane scopes invited drift. Support bundle v2 is unimplemented, so the merge is vocabulary-only.
+
+The design constraint keeps its force under the new name: at most two Controller instances, exactly one Active Leader, Postgres advisory-lock election, no active/active consensus. "HA-lite" remains only in historical records (archived change packages, investigation notes, milestone notes, and ADR 0005 as amended).
+
+SPEC.md impact: update required in the deployment-mode, controller-leadership, leader-only write, audit, and upgrade sections, plus the Milestone 7 title — same semantics, renamed mode.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -79,7 +79,7 @@ _Avoid_: Single binary install, External Database Mode
 A deployment topology where one Mac runs the Controller and one to three Macs run Node Agents and Worker Runtimes; database ownership may be managed on the controller host or external.
 _Avoid_: Database mode, cloud cluster, Kubernetes cluster
 
-**HA-lite Control Plane**:
+**Active/Standby Control Plane**:
 A control-plane mode with at most two Controller instances and exactly one Active Leader.
 _Avoid_: Active-active cluster, consensus cluster
 
@@ -96,7 +96,7 @@ A Postgres coordination lock used by Orchard for exclusive leadership and owners
 _Avoid_: Distributed lock service
 
 **Leader-only Write Path**:
-A mutating operation that may execute only on the Active Leader in HA-lite mode and must fail closed on a Standby Controller.
+A mutating operation that may execute only on the Active Leader in Active/Standby mode and must fail closed on a Standby Controller.
 Examples include node admission rejection, rejection clearance, admission, decommissioning, and the related cluster-scoped audit events.
 _Avoid_: best-effort write, local-controller write
 
@@ -391,7 +391,7 @@ The observed condition of a Node, independent of its operator-controlled lifecyc
 _Avoid_: Node Lifecycle State, operator action
 
 **Cluster Management Status**:
-A shared operator-facing status contract that separates lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and HA-lite read-only signals.
+A shared operator-facing status contract that separates lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and control-plane read-only signals.
 It is a cross-surface status vocabulary, not a replacement for the Node Lifecycle State machine.
 _Avoid_: Node Lifecycle State, Node Health, Console-only status label
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -532,7 +532,7 @@ Use the gRPC compatibility flow only when you intentionally opt out with `ORCHAR
 
 `orchardctl cluster init` and `orchardctl node join` are SPEC-required future node-lifecycle commands.
 In this build they return deferred status.
-`orchardctl cluster status [--json]` is implemented for read-only cluster and HA-lite control-plane status, with the shared `HALiteStatus` payload and a HA-lite summary in `--json` mode.
+`orchardctl cluster status [--json]` is implemented for read-only cluster and control-plane status, with the shared `ControlPlaneStatus` payload and a control-plane summary in `--json` mode.
 `orchardctl nodes inspect`, `orchardctl nodes pending`, `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for the current node-admission-review slice, with stable JSON and human output, `--dry-run` previews, and `--yes`/`--reason` execution gating.
 `orchardctl nodes cordon`, `orchardctl nodes uncordon`, `orchardctl nodes drain`, `orchardctl nodes maintenance`, `orchardctl nodes resume`, and `orchardctl nodes decommission` add node lifecycle previews and execution on the shared Action Preview contract, gated by `--yes`, `--acknowledge`, and `--typed-node-id`; `orchardctl nodes maintenance` previews only, with its `draining -> maintenance` execution deferred until drain completion can be verified.
 Use the env-var split-role flows below for source-dev cluster testing.

--- a/openspec/changes/cluster-management-ux-foundation/design.md
+++ b/openspec/changes/cluster-management-ux-foundation/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-Orchard targets one to four Apple Silicon macOS nodes, with all durable state in Postgres and HA-lite coordination through a Postgres advisory lock.
+Orchard targets one to four Apple Silicon macOS nodes, with all durable state in Postgres and Active/Standby coordination through a Postgres advisory lock.
 `SPEC.md` §4 defines a managed node lifecycle from `provisioned` through `removed`, with explicit Admin API admission before a node can become `active`.
 `SPEC.md` §4.5 says health is orthogonal to lifecycle state.
 `SPEC.md` §5.5 says scheduler eligibility depends on lifecycle, health, pool policy, model/runtime support, memory, concurrency, placements, and circuit breakers.
@@ -20,13 +20,13 @@ The pre-implementation source tree had useful foundations but did not yet implem
 - Keep CLI, Console, Operator API, and Admin API behavior consistent enough that automation and human review speak the same language.
 - Make risky node actions reviewable before execution, especially drain, maintenance, resume, and decommission.
 - Let support and diagnostic workflows collect useful evidence without leaking secrets or collapsing local evidence logs into product truth.
-- Show HA-lite leadership and advisory-lock status as read-only status first.
+- Show Active/Standby leadership and advisory-lock status as read-only status first.
 
 ## Non-Goals
 
 - Do not include product code in this OpenSpec-only change package; implementation tasks below are future slices.
 - Do not define active/active controller behavior.
-- Do not add HA-lite failover, leadership transfer, or standby mutation actions.
+- Do not add Active/Standby failover, leadership transfer, or standby mutation actions.
 - Do not change scheduler ranking policy or dispatch behavior beyond explanation vocabulary.
 - Do not make local research outputs product truth.
 - Do not commit raw prompt exports, local context stores, tool identifiers, credentials, DSNs, or transient evidence logs.
@@ -48,7 +48,7 @@ These UX conclusions are subordinate to `SPEC.md`, `docs/brand-identity.md`, `do
 | Scheduler explanations use fixed reason codes shared by API, CLI, Console, support bundles, and tests. | `SPEC.md` §5.5, §7.3.5, §9.1 | Durable codes make automation and support analysis possible. |
 | Node actions expose preview, eligibility, blockers, and consequences before mutation. | `SPEC.md` §4.4, §4.8, §7.3, §7.4, §13.4 | Cordon, drain, maintenance, resume, and decommission can affect live work. |
 | Support bundle creation has shared CLI and Console semantics, including scope and redaction manifest. | `SPEC.md` §7.3, §9, §10.2, §11.9, current support bundle CLI | Operators need one evidence artifact, not separate Console-only and CLI-only formats. |
-| HA-lite starts read-only in Console and CLI. | `SPEC.md` §3.3, §12.6, §13.3 | Leadership and lock state are high-risk control-plane facts and mutating actions need a separate design. |
+| Control-plane status starts read-only in Console and CLI. | `SPEC.md` §3.3, §12.6, §13.3 | Leadership and lock state are high-risk control-plane facts and mutating actions need a separate design. |
 
 ## UX Model
 
@@ -127,7 +127,7 @@ Scheduling values should be derived from fixed reason codes rather than a free-t
 Warnings answer operator attention needs that do not by themselves decide lifecycle or scheduling.
 Warnings include degraded health causes, swap pressure, thermal pressure, low disk, old metadata, and observe-only telemetry risks.
 
-HA-lite answers which controller is leader, whether this controller is leader or standby, lock age, last renew time, and write-path behavior.
+Control-plane status answers which controller is leader, whether this controller is leader or standby, lock age, last renew time, and write-path behavior.
 This status is read-only in this foundation.
 
 ## Reason-Code Vocabulary
@@ -208,7 +208,6 @@ Support bundle and diagnostics scope codes should include:
 - `scheduler_decision`
 - `runtime_endpoint`
 - `control_plane`
-- `ha_lite`
 
 These vocabularies are intentionally small enough for tests and docs to lock down.
 Future implementation may add codes, but it should not replace accepted codes without a SPEC reconciliation.
@@ -250,9 +249,9 @@ Request and scheduler-decision scopes should include sanitized metadata only and
 Console-triggered bundles should produce the same v2 archive format as `orchardctl support bundle create`.
 Console may add a guided wizard, but it must not create a separate support artifact contract.
 
-## HA-Lite Read-Only Status
+## Control-Plane Read-Only Status
 
-The first HA-lite UX should show read-only control-plane state.
+The first control-plane UX should show read-only control-plane state.
 At minimum it should show deployment mode, this controller identity, leader identity when known, advisory-lock status, lock age, last renewal, standby write-path behavior, and last observed leadership error.
 
 Standby controllers must make write-path limits obvious.
@@ -271,7 +270,7 @@ Alternative: build Console first and let CLI follow.
 That risks mismatched vocabulary and makes automated operations weaker.
 The contract should define shared semantics first, then allow UI-specific presentation differences.
 
-Alternative: include HA-lite failover actions now.
+Alternative: include Active/Standby failover actions now.
 That increases risk before the read-only status model and permission/audit contract are stable.
 
 ## Migration Plan
@@ -281,7 +280,7 @@ That increases risk before the read-only status model and permission/audit contr
 3. Update the node persistence model so first-observed nodes do not become `active` without explicit admission.
 4. Add rejected-admission decision metadata and audit handling.
 5. Add CLI parity commands and JSON contracts for list, detail, admission, rejection, actions, explanations, and support bundles.
-6. Add Console pending admission, detail drill-in, action preview dialogs, diagnostics entry points, and HA-lite read-only status.
+6. Add Console pending admission, detail drill-in, action preview dialogs, diagnostics entry points, and control-plane read-only status.
 7. Add scheduler explanation persistence and rendering using fixed reason-code vocabularies.
 8. Add tests that cite the accepted SPEC sections and verify CLI/Console parity.
 9. Run the applicable Elixir quality workflow for implementation slices.

--- a/openspec/changes/cluster-management-ux-foundation/proposal.md
+++ b/openspec/changes/cluster-management-ux-foundation/proposal.md
@@ -1,7 +1,7 @@
 ## Why
 
 Orchard's cluster management surface is approaching the point where operators need one coherent answer across Console, CLI, Operator API, Admin API, scheduler explanations, diagnostics, and support bundles.
-`SPEC.md` already defines node lifecycle, health, scheduler eligibility, Runtime Endpoint observations, operator APIs, admin APIs, diagnostics, support bundles, and HA-lite leadership.
+`SPEC.md` already defines node lifecycle, health, scheduler eligibility, Runtime Endpoint observations, operator APIs, admin APIs, diagnostics, support bundles, and Active/Standby leadership.
 Before this change, implementation reality was not yet aligned with the full contract: `Orchard.Nodes` performed observational node discovery from successful Runtime Endpoint status reads and inserted new nodes as `active`, while `orchardctl nodes admit` and `orchardctl cluster init` were deferred.
 This change defines the operator-facing UX contract before implementation so the next code slices reconcile that gap deliberately instead of growing disconnected Console and CLI behavior.
 
@@ -12,17 +12,17 @@ This change defines the operator-facing UX contract before implementation so the
 - Define rejected pending admission as admission-decision metadata, not a `decommissioning` lifecycle transition.
 - Require Console, CLI, Operator API, and Admin API surfaces to keep lifecycle, health, freshness, transport reachability, runtime readiness, compatibility, scheduling, and warnings distinct.
 - Define fixed operator-facing reason-code vocabularies for scheduler explanations and node action previews.
-- Require CLI and Console parity for node list, node detail, admission review, action eligibility, scheduler explanation, diagnostics, support bundle creation, and HA-lite read-only status.
+- Require CLI and Console parity for node list, node detail, admission review, action eligibility, scheduler explanation, diagnostics, support bundle creation, and control-plane read-only status.
 - Define a safe action model for eligibility-changing and destructive node operations: cordon, uncordon, drain, maintenance, resume, admit, reject pending admission, and decommission.
 - Define support bundle and diagnostics expectations, including scope selection, redaction manifest, and shared CLI/Console behavior.
-- Keep HA-lite leadership and lock status read-only in this foundation change, with mutating failover or leadership actions deferred to a later accepted change.
+- Keep Active/Standby leadership and lock status read-only in this foundation change, with mutating failover or leadership actions deferred to a later accepted change.
 - Exclude product code implementation from this change package.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `cluster-management-ux`: Operator-facing cluster UX contract for node admission, lifecycle state presentation, reason-code taxonomy, CLI/Console parity, safe node actions, scheduler explanations, diagnostics, support bundles, and HA-lite status.
+- `cluster-management-ux`: Operator-facing cluster UX contract for node admission, lifecycle state presentation, reason-code taxonomy, CLI/Console parity, safe node actions, scheduler explanations, diagnostics, support bundles, and control-plane status.
 
 ### Modified Capabilities
 
@@ -34,9 +34,9 @@ This change defines the operator-facing UX contract before implementation so the
 - SPEC.md impact: this change refines `SPEC.md` §1.1, §1.2, §3.3, §4.1 through §4.9, §5.4 through §5.10, §7.3, §7.4, §7.5, §9, §10.2, §11.8, §11.9, §12.7, §13.4, §13.7, and Milestones 3 through 5.
 - Current implementation impact: `apps/orchard_controller/lib/orchard/nodes.ex` must stop treating first successful observation as automatically admitted and active when this behavior is implemented.
 - Current data-model impact: implementation slices need the `node_admission_candidates` and `node_admission_decisions` persistence contract from `SPEC.md` §8 to store observed candidates and rejected decisions without adding lifecycle enums absent from `SPEC.md`.
-- Current audit impact: implementation slices need cluster-scoped audit events for node admission, rejection, rejection clearance, decommission, HA-lite write-path decisions, and cluster-scoped support bundles.
+- Current audit impact: implementation slices need cluster-scoped audit events for node admission, rejection, rejection clearance, decommission, Active/Standby write-path decisions, and cluster-scoped support bundles.
 - Current CLI impact: `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex` currently supports `nodes list` and defers `nodes admit`; implementation slices must add the parity commands described here.
 - Current Console impact: `apps/orchard_controller/lib/orchard/console/nodes_live.ex` currently shows registered inventory and live runtime diagnostics; implementation slices must add admission review, action previews, reason-code detail, and diagnostics entry points without collapsing signal categories.
 - Current diagnostics impact: `apps/orchard_cli/lib/orchard_cli/commands/support.ex` already creates support bundles with redaction and manifests; implementation slices must align Console-triggered support bundles and node diagnostics with the same contract.
 - Security impact: support bundle and diagnostic surfaces must preserve `SPEC.md` §10.2 secret handling and must never include plaintext secrets, credentials, DSNs, prompt bodies, response bodies, or raw local evidence logs unless an accepted capture-mode contract explicitly permits them.
-- HA-lite impact: this change only defines read-only leadership and advisory-lock visibility; failover, leadership transfer, and standby write-path UX remain future work.
+- Active/Standby impact: this change only defines read-only leadership and advisory-lock visibility; failover, leadership transfer, and standby write-path UX remain future work.

--- a/openspec/changes/cluster-management-ux-foundation/specs/cluster-management-ux/spec.md
+++ b/openspec/changes/cluster-management-ux-foundation/specs/cluster-management-ux/spec.md
@@ -70,7 +70,7 @@ Admission decision history SHALL be append-only.
 Admission decision rows SHOULD reference a candidate or Node when created if that row exists.
 Admission decision rows MAY later have null candidate and Node references after retention cleanup, because bounded snapshot fields preserve the durable decision record.
 Candidate and decision metadata SHALL be sanitized and MUST NOT include plaintext secrets, credentials, DSNs, prompt bodies, response bodies, raw local evidence logs, local tool session identifiers, or machine-specific prompt exports.
-Node Admission candidate review, rejection, rejection clearance, admission after rejection, decommission, HA-lite write-path decisions, and cluster-scoped support bundle generation SHALL use cluster-scoped audit events with no tenant id.
+Node Admission candidate review, rejection, rejection clearance, admission after rejection, decommission, Active/Standby write-path decisions, and cluster-scoped support bundle generation SHALL use cluster-scoped audit events with no tenant id.
 Candidate review queries SHALL have indexes for admission category and recent observation time.
 Recent-observation indexes SHALL order candidates without an observation timestamp after candidates with observed timestamps.
 Decision review queries SHALL have indexes by candidate, node, and audit log reference.
@@ -113,7 +113,7 @@ This refines `SPEC.md` §8.1 through §8.5.
 
 ### Requirement: Cluster Status Separates Signal Categories
 Orchard Console, CLI, Operator API, and Admin API SHALL present node and cluster status as separate signal categories rather than a single combined status badge.
-The categories SHALL include lifecycle, admission, health, heartbeat freshness, transport reachability, runtime readiness, compatibility, scheduling eligibility, warnings, and HA-lite control-plane status when available.
+The categories SHALL include lifecycle, admission, health, heartbeat freshness, transport reachability, runtime readiness, compatibility, scheduling eligibility, warnings, and control-plane status when available.
 Health SHALL remain orthogonal to lifecycle state.
 Runtime readiness SHALL remain distinct from transport reachability.
 Compatibility warnings SHALL remain distinct from scheduler eligibility.
@@ -159,7 +159,7 @@ This refines `SPEC.md` §5.5, §5.7, §5.8, §5.10, and §7.3.5.
 - **AND** skipped candidates are not reported as rejected candidates
 
 ### Requirement: CLI And Console Expose Equivalent Cluster Management Semantics
-Orchard CLI and Orchard Console SHALL expose equivalent cluster-management semantics for node list, node detail, pending admission review, admission, lifecycle action previews, scheduler explanations, diagnostics, support bundle creation, and HA-lite read-only status.
+Orchard CLI and Orchard Console SHALL expose equivalent cluster-management semantics for node list, node detail, pending admission review, admission, lifecycle action previews, scheduler explanations, diagnostics, support bundle creation, and control-plane read-only status.
 CLI output MAY differ visually from Console, but JSON output SHALL preserve the same status categories and reason-code arrays.
 Console copy SHALL not invent meanings that are absent from the shared domain contract.
 This refines `SPEC.md` §7.3, §7.4, §11.8, and §11.9.
@@ -216,7 +216,7 @@ This change SHALL define `orchard.support_bundle.v2` for shared Console and CLI 
 The fields required by this change SHALL be mandatory for the v2 contract.
 Any v1 compatibility behavior SHALL be documented separately and SHALL NOT weaken the v2 manifest or redaction requirements.
 The support bundle manifest SHALL include bundle format, generated time, Orchard version, scope, included sections, omitted sections, redaction manifest, max log bytes, and relevant SPEC references.
-Supported scopes SHALL include `cluster`, `node`, `request`, `scheduler_decision`, `runtime_endpoint`, `control_plane`, and `ha_lite`.
+Supported scopes SHALL include `cluster`, `node`, `request`, `scheduler_decision`, `runtime_endpoint`, `control_plane`.
 Scoped bundles SHALL include only evidence relevant to the selected scope and SHALL record omitted sections.
 Request and scheduler-decision scopes SHALL include sanitized metadata only.
 Support bundles MUST NOT include plaintext secrets, credentials, DSNs, prompt bodies, response bodies, raw token sequences, raw local evidence logs, local tool session identifiers, or machine-specific prompt exports.
@@ -233,19 +233,19 @@ This refines `SPEC.md` §7.3, §9, §10.2, §11.8, and §11.9.
 - **THEN** the redaction manifest may include redaction classes and counts
 - **AND** the redaction manifest does not include the secret values that were redacted
 
-### Requirement: HA-Lite Status Is Read-Only In The First Cluster UX
-Orchard SHALL expose HA-lite control-plane status as read-only cluster status before any mutating HA-lite control action is introduced.
+### Requirement: Control-Plane Status Is Read-Only In The First Cluster UX
+Orchard SHALL expose control-plane status as read-only cluster status before any mutating Active/Standby control action is introduced.
 The read-only status SHALL include deployment mode, this controller identity when known, leader identity when known, advisory-lock status, lock age, last renewal timestamp, standby write-path behavior, and last observed leadership error when available.
 Console and CLI SHALL NOT expose leadership transfer, failover, or standby mutation actions under this foundation change.
 This refines `SPEC.md` §3.3, §12.6, and §13.3.
 
 #### Scenario: Standby controller is directly addressed
-- **WHEN** an operator views HA-lite status from a standby controller
+- **WHEN** an operator views Active/Standby control-plane status from a standby controller
 - **THEN** Orchard shows that the controller is standby when known
 - **AND** Orchard explains that write paths return `503 controller_standby` when directly addressed
 - **AND** Orchard does not offer a failover action in this foundation change
 
 #### Scenario: Leadership status is unavailable
 - **WHEN** advisory-lock status cannot be read
-- **THEN** Orchard shows HA-lite status as unknown or unavailable
+- **THEN** Orchard shows control-plane status as unknown or unavailable
 - **AND** Orchard does not infer leadership from local process state alone

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -85,8 +85,8 @@
   Note: Public LiveView tests cover the full candidate groups, not found, legacy empty shape, invalid persisted explanation, and disconnected deferred render.
   Note: The diagnostics and components deny-list is key-based and does not inspect values, accepted because the data domain is internal scheduler metadata.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
-- [x] 5.6 Add read-only control-plane status control-plane status.
-  Note: Console Nodes now includes a separate read-only control-plane status Status rail card that renders deployment mode, this-controller identity, leader identity, advisory-lock status, lock age, last renewal, write-path behavior, and sanitized leadership errors without failover or transfer controls.
+- [x] 5.6 Add read-only control-plane status.
+  Note: Console Nodes now includes a separate read-only Control Plane status rail card that renders deployment mode, this-controller identity, leader identity, advisory-lock status, lock age, last renewal, write-path behavior, and sanitized leadership errors without failover or transfer controls.
 - [x] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
   Note: This task 5.6 slice browser-verified the Control Plane card after review fixes on desktop light, desktop dark, and mobile light screenshots under `tmp/screenshots/control-plane-card-review-fix-*.png`.
   Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile.
@@ -100,7 +100,7 @@
 - [ ] 6.2 Upgrade `orchardctl support bundle create` to emit `orchard.support_bundle.v2` for cluster-management support bundles.
 - [ ] 6.3 Make Console-triggered bundles use the same v2 archive format.
 - [ ] 6.4 Document any v1 compatibility behavior separately; v2 fields required by this change are mandatory for the new contract.
-- [ ] 6.5 Add scope selection for cluster, node, request, scheduler decision, runtime endpoint, control plane, and control-plane evidence.
+- [ ] 6.5 Add scope selection for cluster, node, request, scheduler decision, runtime endpoint, and control plane evidence.
 - [ ] 6.6 Add a redaction manifest with redaction classes and counts.
 - [ ] 6.7 Ensure support bundles exclude plaintext secrets, credentials, DSNs, prompt bodies, response bodies, raw token sequences, raw local evidence logs, and tool session identifiers.
 - [ ] 6.8 Add tests for support bundle manifest contents and redaction behavior.

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -31,7 +31,7 @@
 
 ## 3. Shared Status And Reason Codes
 
-- [x] 3.1 Add shared domain structures for lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and HA-lite read-only status.
+- [x] 3.1 Add shared domain structures for lifecycle, admission, freshness, transport, runtime readiness, compatibility, scheduling, warnings, and control-plane read-only status.
 - [x] 3.2 Add fixed scheduler explanation rejection codes and action preview blocker codes.
 - [ ] 3.3 Ensure reason codes are used by Operator API, Admin API, CLI, Console, support bundles, and tests.
   Note: CLI/Admin admission previews now use shared `ActionPreview` blocker and confirmation codes.
@@ -41,7 +41,7 @@
   The Operator API scheduler explanations endpoint and the multi-node scheduler explanation producer now consume the shared reason-code contract.
   Support bundles remain the outstanding consumer for a future slice.
 - [x] 3.4 Add tests that reject unknown or free-text-only scheduler explanation reasons where fixed codes are required.
-- [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and HA-lite status.
+- [x] 3.5 Add shared JSON schema or golden fixtures for node status categories, action previews, scheduler explanations, and control-plane status.
 - [x] 3.6 Ensure action preview schema fixtures include separate `blockers`, `warnings`, `consequence_codes`, and `confirmation_requirements` fields.
 - [x] 3.7 Add parity tests proving CLI JSON and Console data assigns derive from the same domain structures.
 
@@ -62,8 +62,8 @@
   Note: Implemented `orchardctl requests inspect <request-id>` because `SPEC.md` §11.9 names `requests inspect` as the required CLI path while `SPEC.md` §7.3.5 requires shared scheduler explanation reason codes across CLI and the Operator API.
   Note: The command uses local controller-runtime authority, reads the same request row as the Operator API, and renders human plus JSON output through `SchedulerExplanationPresenter` and the shared scheduler explanation contract.
   Note: Broader request execution diagnostics under `requests inspect` beyond persisted scheduler explanations remain future work, so the general command name is not fully delivered by this slice.
-- [x] 4.8 Implement `orchardctl cluster status --json` for read-only HA-lite and cluster summary status.
-  Note: This slice adds `orchardctl cluster status --json` with a shared `HALiteStatus` payload and a HA-lite-focused `summary` block for deployment mode, controller role, and advisory-lock status.
+- [x] 4.8 Implement `orchardctl cluster status --json` for read-only control-plane status and cluster summary status.
+  Note: This slice adds `orchardctl cluster status --json` with a shared `ControlPlaneStatus` payload and a control-plane-focused `summary` block for deployment mode, controller role, and advisory-lock status.
   Node inventory and runtime reachability counts intentionally remain on the existing node and Live Cluster surfaces rather than being duplicated into this command.
 
 ## 5. Console Nodes UX
@@ -85,10 +85,10 @@
   Note: Public LiveView tests cover the full candidate groups, not found, legacy empty shape, invalid persisted explanation, and disconnected deferred render.
   Note: The diagnostics and components deny-list is key-based and does not inspect values, accepted because the data domain is internal scheduler metadata.
 - [ ] 5.5 Add diagnostics and support bundle entry points that use the shared support bundle contract.
-- [x] 5.6 Add read-only HA-lite control-plane status.
-  Note: Console Nodes now includes a separate read-only HA-lite Status rail card that renders deployment mode, this-controller identity, leader identity, advisory-lock status, lock age, last renewal, write-path behavior, and sanitized leadership errors without failover or transfer controls.
+- [x] 5.6 Add read-only control-plane status control-plane status.
+  Note: Console Nodes now includes a separate read-only control-plane status Status rail card that renders deployment mode, this-controller identity, leader identity, advisory-lock status, lock age, last renewal, write-path behavior, and sanitized leadership errors without failover or transfer controls.
 - [x] 5.7 Verify Console UI against `docs/DESIGN.md` and `docs/brand-identity.md` with browser screenshots during implementation.
-  Note: This task 5.6 slice browser-verified the HA-lite Status card after review fixes on desktop light, desktop dark, and mobile light screenshots under `tmp/screenshots/ha-lite-status-card-review-fix-*.png`.
+  Note: This task 5.6 slice browser-verified the Control Plane card after review fixes on desktop light, desktop dark, and mobile light screenshots under `tmp/screenshots/control-plane-card-review-fix-*.png`.
   Note: PR #37 browser-verified the admission-review slice against `docs/DESIGN.md` and brand identity on desktop and mobile.
   PR #41 browser-verified the Console lifecycle preview slice against `docs/DESIGN.md`.
   Note: This task 5.4 slice browser-verified the request-scoped scheduler explanation panel on desktop and mobile.
@@ -100,7 +100,7 @@
 - [ ] 6.2 Upgrade `orchardctl support bundle create` to emit `orchard.support_bundle.v2` for cluster-management support bundles.
 - [ ] 6.3 Make Console-triggered bundles use the same v2 archive format.
 - [ ] 6.4 Document any v1 compatibility behavior separately; v2 fields required by this change are mandatory for the new contract.
-- [ ] 6.5 Add scope selection for cluster, node, request, scheduler decision, runtime endpoint, control plane, and HA-lite evidence.
+- [ ] 6.5 Add scope selection for cluster, node, request, scheduler decision, runtime endpoint, control plane, and control-plane evidence.
 - [ ] 6.6 Add a redaction manifest with redaction classes and counts.
 - [ ] 6.7 Ensure support bundles exclude plaintext secrets, credentials, DSNs, prompt bodies, response bodies, raw token sequences, raw local evidence logs, and tool session identifiers.
 - [ ] 6.8 Add tests for support bundle manifest contents and redaction behavior.


### PR DESCRIPTION
## Intent

Retire the "HA-lite" product term in favor of **Active/Standby**, recorded in ADR 0008. "HA-lite" named the two-controller failover mode by what it is not, which reads apologetically in operator surfaces and tells an operator nothing about the topology; Active/Standby is standard industry vocabulary for it, and the glossary already defined Active Leader and Standby Controller.

Two modeling decisions ride with the term swap. First, the status contract is renamed by what it describes rather than by one of its own enum values: `HALiteStatus` becomes `Orchard.ClusterManagement.ControlPlaneStatus` (object `cluster_management.control_plane_status`), since it reports control-plane leadership state in every deployment mode including single-controller — matching the surface-naming convention of the sibling contracts. "Active/Standby" survives only as the `deployment_mode` value (`active_standby`). The contract version renames in place at v1 while Orchard is pre-release and all consumers are in-repo. Second, the `ha_lite` support-bundle scope merges into the existing `control_plane` scope: its defined evidence set is exactly the ControlPlaneStatus payload, and support bundle v2 is unimplemented, so the merge is vocabulary-only.

The rename sweeps SPEC.md (including the Milestone 7 title), the glossary (HA-lite moves to the Avoid list), Console (card becomes "Control Plane" with renamed DOM ids and copy), CLI output, README, architecture/local-dev docs, and the active cluster-management-ux-foundation change package. Historical records (archives, investigations, milestone notes, ADR 0005's original body) are deliberately untouched; ADR 0005 gains a dated amendment. No behavior change anywhere. One rider: an unrelated flaky ModelHub test assertion (stale download ref) is hardened so the full suite passes deterministically.

## What Changed

- Renamed the clustering control-plane status contract from `ha_lite_status` to `control_plane_status` (module, embedded schema JSON, and reason codes), updating the CLI `cluster status`/`--json` output and the controller `control_plane.ex` plus `nodes_live.ex` console status card to the "active standby" terminology, with contract/CLI/controller tests updated to match.
- Swept "HA-lite" → "active standby" across product docs (`SPEC.md`, `README.md`, `AGENTS.md`, architecture, glossary, local-dev, and OpenSpec cluster-management materials) and added decision record `0008-active-standby-replaces-ha-lite.md` documenting the rename.
- Scoped the stale-download-ref assertions in `model_hub_live_test.exs` to harden a flaky ModelHub test alongside the rename.

## Risk Assessment

✅ Low: Well-bounded mechanical terminology rename with fully consistent call sites, tests, and fixtures, and the only substantive concern (an in-place v1 contract identifier change) is explicitly justified in ADR 0008 for a pre-release with in-repo-only consumers.

## Testing

Ran the smallest relevant Elixir test slices covering every renamed surface (shared status contract, CLI cluster command, controller ControlPlane/NodesLive, and the ModelHub stale-download-ref regression) — all pass. Beyond green tests, I exercised the real CLI `cluster status` command, which now emits `Deployment: Active/Standby` and a top-level `control_plane` JSON object with `deployment_mode: "active_standby"` and contract `cluster_management.control_plane_status.v1` (no `ha_lite` keys), and I rendered and screenshotted the console Control Plane card in both light and dark themes showing the renamed "Control Plane" title and "Active/Standby" badge. Visual evidence was produced by dumping the card's live-rendered HTML and re-rendering it with the project's Tailwind v4 theme/dark-variant, since node_modules was absent for a full running-server capture.

- Evidence: Control Plane console card — light &amp; dark themes (renamed from HA-lite Status) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWS19EQQF8P1DQT1KE931BQA/control-plane-card-light-dark.png</code>)
<details>
<summary>Evidence: orchardctl cluster status (text + JSON) showing Active/Standby and control_plane key</summary>

<code>$ orchardctl cluster status&#10;Role: standby&#10;Deployment: Active/Standby&#10;This controller: controller-a&#10;Leader: controller-b&#10;Advisory lock: not held&#10;Lock age: 1200 ms&#10;Last renewed: 2026-07-01T00:00:00Z&#10;Write paths: writes return 503 controller standby&#10;&#10;$ orchardctl cluster status --json&#10;{&#10;&#34;summary&#34;: { &#34;deployment_mode&#34;: &#34;active_standby&#34;, &#34;controller_role&#34;: &#34;standby&#34;, &#34;advisory_lock_status&#34;: &#34;not_held&#34; },&#10;&#34;object&#34;: &#34;cluster_management.cluster_status&#34;,&#10;&#34;control_plane&#34;: {&#10;&#34;object&#34;: &#34;cluster_management.control_plane_status&#34;,&#10;&#34;contract_version&#34;: &#34;orchard.cluster_management.control_plane_status.v1&#34;,&#10;&#34;deployment_mode&#34;: &#34;active_standby&#34;, ...&#10;}&#10;}</code>

```text
$ orchardctl cluster status
Role: standby
Deployment: Active/Standby
This controller: controller-a
Leader: controller-b
Advisory lock: not held
Lock age: 1200 ms
Last renewed: 2026-07-01T00:00:00Z
Write paths: writes return 503 controller standby

$ orchardctl cluster status --json
{
  "summary": {
    "deployment_mode": "active_standby",
    "controller_role": "standby",
    "advisory_lock_status": "not_held"
  },
  "object": "cluster_management.cluster_status",
  "contract_version": "orchard.cluster_management.cluster_status.v1",
  "control_plane": {
    "object": "cluster_management.control_plane_status",
    "contract_version": "orchard.cluster_management.control_plane_status.v1",
    "deployment_mode": "active_standby",
    "this_controller_identity": "controller-a",
    "controller_role": "standby",
    "leader_identity": "controller-b",
    "advisory_lock_status": "not_held",
    "lock_age_ms": 1200,
    "last_renewed_at": "2026-07-01T00:00:00Z",
    "standby_write_path_behavior": "writes_return_503_controller_standby",
    "last_observed_leadership_error": null
  }
}
```
</details>
<details>
<summary>Evidence: Live-rendered Control Plane card HTML fragment (source for screenshot)</summary>

```text
<div id="nodes-control-plane-status-card"><div class="rounded-lg border border-slate-200 bg-slate-100/70 dark:border-slate-700 dark:bg-slate-900/50 "><div class="border-b border-slate-200 dark:border-slate-700 px-4 py-3 "><div class="flex items-center justify-between gap-4"><div><h3 class="text-sm font-semibold text-slate-900 dark:text-slate-100">
          Control Plane
        </h3><p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
          Active/Standby control plane, Standby
        </p></div></div></div><div class="px-4 py-3"><div class="space-y-4"><div class="flex flex-wrap items-center gap-2"><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-sky-50 text-sky-700 ring-sky-600/10 dark:bg-sky-900/30 dark:text-sky-300 dark:ring-sky-500/20 ">
  
                  Active/Standby
                
</span><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-amber-50 text-amber-700 ring-amber-600/10 dark:bg-amber-900/30 dark:text-amber-300 dark:ring-amber-500/20 ">
  
                  Standby
                
</span><span class="inline-flex items-center rounded-full font-medium ring-1 ring-inset px-2 py-0.5 text-xs bg-amber-50 text-amber-700 ring-amber-600/10 dark:bg-amber-900/30 dark:text-amber-300 dark:ring-amber-500/20 ">
  
                  Not held
                
</span></div><dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm"><dt class="text-slate-500 dark:text-slate-400">This controller</dt><dd class="font-mono text-slate-900 dark:text-slate-100">controller-a</dd><dt class="text-slate-500 dark:text-slate-400">Leader identity</dt><dd class="font-mono text-slate-900 dark:text-slate-100">controller-b</dd><dt class="text-slate-500 dark:text-slate-400">Lock age</dt><dd class="font-mono text-slate-900 dark:text-slate-100">1200 ms</dd><dt class="text-slate-500 dark:text-slate-400">Last renewed</dt><dd class="font-mono text-slate-900 dark:text-slate-100"><time id="lt-35" class="" datetime="2026-07-01T00:00:00Z" title="2026-07-01T00:00:00Z" phx-hook="LocalTime" data-local-time-format="datetime_second">2026-07-01 00:00:00 UTC</time></dd><dt class="text-slate-500 dark:text-slate-400">Write paths</dt><dd class="font-mono text-slate-900 dark:text-slate-100">writes return 503 controller standby</dd></dl></div></div></div></div>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mix test apps/orchard_shared/test/orchard/cluster_management/contract_test.exs apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs` (control-plane status contract + CLI cluster status pass)</code>
- <code>`mix test apps/orchard_controller/test/orchard/console/nodes_live_test.exs apps/orchard_controller/test/orchard/control_plane_test.exs apps/orchard_controller/test/orchard/console/model_hub_live_test.exs` (controller surface + scoped stale-download-ref regression, 134 tests pass)</code>
- <code>Drove `OrchardCLI.Commands.Cluster.run([&#34;status&#34;])` and `run([&#34;status&#34;, &#34;--json&#34;])` with an active-standby control-plane config to capture the actual operator-facing CLI output</code>
- <code>Rendered the live `#nodes-control-plane-status-card` HTML for the SPEC standby scenario and screenshotted it in light + dark themes via agent-browser</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

