### PR TITLE
fix(orchard_worker_mlx): cap transformers below 5.13 to keep MLX worker importable

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -109,6 +109,16 @@ MLX extras remain opt-in because they pull the real inference stack:
 mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx
 ```
 
+The default `pytest` run above skips `tests/test_mlx_import_smoke.py` because the
+`mlx` extra is absent. When refreshing the `transformers`/`mlx-lm` pins (for
+example lifting the issue #57 `transformers<5.13` cap), exercise the import
+regression guard with the extra installed:
+
+```bash
+mise exec -- uv run --directory native/orchard_worker_mlx --extra mlx \
+  pytest tests/test_mlx_import_smoke.py
+```
+
 Package builds should run through the same toolchain:
 
 ```bash

--- a/native/orchard_worker_mlx/pyproject.toml
+++ b/native/orchard_worker_mlx/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
 mlx = [
   "mlx>=0.31.2",
   "mlx-lm>=0.31.3",
-  "transformers>=5.0.0",
+  # Issue #57: transformers 5.13 tightens _LazyAutoMapping.register, so mlx-lm
+  # 0.31.3's string NewlineTokenizer config key fails at import. Lift once mlx-lm fixes it.
+  "transformers>=5.0.0,<5.13",
   "protobuf>=6.33.5",
   "numpy>=1.26.0",
 ]

--- a/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
+++ b/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
@@ -1,0 +1,34 @@
+"""Import smoke tests for optional MLX runtime dependencies."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_mlx_lm_imports_with_autotokenizer_path(tmp_path: Path) -> None:
+    """Issue #57: mlx_lm import must not fail during tokenizer registration."""
+    pytest.importorskip("mlx", reason="MLX optional extra is not installed")
+    pytest.importorskip("mlx_lm", reason="mlx-lm optional extra is not installed")
+    transformers = pytest.importorskip(
+        "transformers",
+        reason="transformers optional dependency is not installed",
+    )
+    tokenizers = pytest.importorskip("tokenizers", reason="tokenizers dependency is not installed")
+
+    tokenizer_dir = tmp_path / "tokenizer"
+    tokenizer_dir.mkdir()
+    tokenizer = tokenizers.Tokenizer(tokenizers.models.WordLevel({"[UNK]": 0}, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = tokenizers.pre_tokenizers.Whitespace()
+    tokenizer.save(str(tokenizer_dir / "tokenizer.json"))
+    (tokenizer_dir / "config.json").write_text(json.dumps({"model_type": "bert"}))
+    (tokenizer_dir / "special_tokens_map.json").write_text(json.dumps({"unk_token": "[UNK]"}))
+    (tokenizer_dir / "tokenizer_config.json").write_text(
+        json.dumps({"model_max_length": 2048, "unk_token": "[UNK]"})
+    )
+
+    loaded = transformers.AutoTokenizer.from_pretrained(tokenizer_dir, local_files_only=True)
+
+    assert loaded.unk_token == "[UNK]"

--- a/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
+++ b/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
@@ -1,22 +1,39 @@
-"""Import smoke tests for optional MLX runtime dependencies."""
+"""Import smoke tests for optional MLX runtime dependencies.
+
+The issue #57 regression guard is only exercised when the optional ``mlx`` extra
+is installed. Run it with::
+
+    mise exec -- uv run --directory native/orchard_worker_mlx --extra mlx \\
+        pytest tests/test_mlx_import_smoke.py
+
+Dependency-refresh validation MUST run this way; the default dev-only environment
+lacks the extra and the test skips.
+"""
 
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import json
 from pathlib import Path
 
 import pytest
 
+_MLX_STACK = ("mlx", "mlx_lm", "transformers", "tokenizers")
+_missing = [name for name in _MLX_STACK if importlib.util.find_spec(name) is None]
+
+pytestmark = pytest.mark.skipif(
+    bool(_missing),
+    reason=f"MLX optional extra is not installed (missing: {', '.join(_missing)})",
+)
+
 
 def test_mlx_lm_imports_with_autotokenizer_path(tmp_path: Path) -> None:
     """Issue #57: mlx_lm import must not fail during tokenizer registration."""
-    pytest.importorskip("mlx", reason="MLX optional extra is not installed")
-    pytest.importorskip("mlx_lm", reason="mlx-lm optional extra is not installed")
-    transformers = pytest.importorskip(
-        "transformers",
-        reason="transformers optional dependency is not installed",
-    )
-    tokenizers = pytest.importorskip("tokenizers", reason="tokenizers dependency is not installed")
+    importlib.import_module("mlx")
+    importlib.import_module("mlx_lm")
+    transformers = importlib.import_module("transformers")
+    tokenizers = importlib.import_module("tokenizers")
 
     tokenizer_dir = tmp_path / "tokenizer"
     tokenizer_dir.mkdir()

--- a/native/orchard_worker_mlx/uv.lock
+++ b/native/orchard_worker_mlx/uv.lock
@@ -663,7 +663,7 @@ requires-dist = [
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.31.3" },
     { name = "numpy", marker = "extra == 'mlx'", specifier = ">=1.26.0" },
     { name = "protobuf", marker = "extra == 'mlx'", specifier = ">=6.33.5" },
-    { name = "transformers", marker = "extra == 'mlx'", specifier = ">=5.0.0" },
+    { name = "transformers", marker = "extra == 'mlx'", specifier = ">=5.0.0,<5.13" },
 ]
 provides-extras = ["mlx"]
 


### PR DESCRIPTION
## Intent

Closes #57.

Defuse a dormant supply-chain hazard in the MLX worker before it becomes a breakage. Nothing fails today — `uv.lock` resolves transformers 5.3.0 — but transformers 5.13.0 tightened `_LazyAutoMapping.register`, which breaks `mlx-lm` 0.31.3 at import time (it registers `NewlineTokenizer` with a string config key, raising `AttributeError`), so any future lock refresh resolving 5.13+ would kill the worker at `import mlx_lm`. oMLX and vLLM-Metal hit this independently and both capped.

The change caps `transformers>=5.0.0,<5.13` with a comment recording the mechanism and the lift condition (mlx-lm fixing its tokenizer registration path), keeps the lock update constraint-metadata-only with zero version churn, and adds an import-smoke regression test so a poisonous bump fails in pytest rather than at worker runtime. The test skips only on a package-presence check when the optional mlx extra is absent; when the stack is installed it hard-imports, so any import-time exception — including the non-ImportError `AttributeError` this issue is about — fails the test instead of skipping.

## What Changed

- Pinned the `mlx` extra's `transformers` dependency to `>=5.0.0,<5.13` in `native/orchard_worker_mlx/pyproject.toml` (with a comment tracking issue #57) and regenerated `uv.lock` so it resolves to transformers 5.3.0 — avoiding the `_LazyAutoMapping.register` tightening that broke mlx-lm 0.31.3's `NewlineTokenizer` import at MLX worker startup.
- Added `tests/test_mlx_import_smoke.py`, a regression guard that imports `transformers` and `mlx_lm` (hard import once the extra is present) so a future transformers bump that reintroduces the breakage fails CI instead of silently skipping.
- Documented in `docs/tooling.md` that the MLX import smoke test must run with the `mlx` extra installed when refreshing transformers.

## Risk Assessment

✅ Low: The change is a narrow dependency cap plus a matching lockfile update and a regression smoke test restructured exactly per the round-1 fix; it is well-bounded, internally consistent, and introduces no new risks.

## Testing

Exercised the fix end-to-end at the level a node-agent operator hits it: confirmed the capped mlx extra resolves transformers 5.3.0 and that `import mlx_lm` (the path that broke at worker startup) now succeeds, ran the new import smoke test with the extra actually installed so it executes rather than skips, and reproduced the original issue #57 crash by importing mlx_lm 0.31.3 against transformers 5.13.0 to prove the cap is load-bearing. The full changed-package suite (576 passed, 2 skipped) and `uv lock --check` both pass. No UI surface is involved; evidence is a CLI transcript capturing the before/after imports. All test-created artifacts (.venv, caches, .coverage) are gitignored and the tracked tree remains clean.

<details>
<summary>Evidence: Issue #57 transformers-cap end-to-end verification transcript</summary>

<code>Counterfactual (transformers 5.13.0): mlx_lm import FAILED: AttributeError &#39;str&#39; object has no attribute &#39;__module__&#39;&#10;Fixed (transformers 5.3.0): mlx_lm 0.31.3 import OK -&gt; issue #57 tokenizer registration path does not break&#10;Guard: tests/test_mlx_import_smoke.py::test_mlx_lm_imports_with_autotokenizer_path PASSED&#10;Suite: 576 passed, 2 skipped, 84% coverage</code>

```text
Issue #57 — MLX worker startup breakage from transformers 5.13 — end-to-end verification
=========================================================================================

FIX: native/orchard_worker_mlx/pyproject.toml pins  transformers>=5.0.0,<5.13
     uv.lock resolves transformers -> 5.3.0

1) COUNTERFACTUAL — reproduce the breakage the cap prevents (transformers >=5.13):
   $ uv run --isolated --no-project --with mlx-lm==0.31.3 --with 'transformers>=5.13' --with mlx \
       python -c "import mlx_lm"
   transformers 5.13.0
   mlx_lm import FAILED: AttributeError 'str' object has no attribute '__module__'
   (mlx-lm 0.31.3's string NewlineTokenizer key vs tightened _LazyAutoMapping.register)

2) FIX VERIFIED — capped extra imports cleanly:
   $ uv run --directory native/orchard_worker_mlx --extra mlx \
       python -c "import transformers, mlx_lm; print(...)"
   transformers 5.3.0
   mlx_lm 0.31.3
   mlx_lm import OK -> issue #57 tokenizer registration path does not break

3) REGRESSION GUARD (tests/test_mlx_import_smoke.py) actually executes with the extra:
   $ uv run --directory native/orchard_worker_mlx --extra mlx pytest tests/test_mlx_import_smoke.py -v
   tests/test_mlx_import_smoke.py::test_mlx_lm_imports_with_autotokenizer_path PASSED
   1 passed in 0.96s

4) LOCK CONSISTENCY:
   $ uv lock --directory native/orchard_worker_mlx --check
   Resolved 46 packages in 18ms   (no drift)

5) FULL CHANGED-PACKAGE SUITE:
   $ uv run --directory native/orchard_worker_mlx --extra mlx pytest --cov
   576 passed, 2 skipped, 2 warnings   TOTAL coverage 84%
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `native/orchard_worker_mlx/tests/test_mlx_import_smoke.py:12` - The new smoke test in native/orchard_worker_mlx/tests/test_mlx_import_smoke.py is intended as the issue #57 regression guard, but `mlx`/`mlx-lm`/`transformers` live only in the optional `mlx` extra (pyproject.toml:16-24), not in the `dev` group. The standard native validation workflow (`uv run --directory native/orchard_worker_mlx pytest`) installs only dev deps, so all three `pytest.importorskip(...)` calls skip and the test asserts nothing — CI stays green regardless of the regression. Compounding this, `pytest.importorskip(&#34;mlx_lm&#34;)` guards the very import whose failure is issue #57: if the breakage surfaces as an ImportError it is swallowed and the test skips instead of failing. To make this a real guard, the mlx extra must be installed in the run that exercises this test, and the mlx_lm import should be a hard `import` (not importorskip) once the extra is guaranteed present.

🔧 Fix: harden mlx import smoke test against silent skip
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- uv lock --directory native/orchard_worker_mlx --check` (lock matches pyproject, no drift; transformers resolves to 5.3.0)</code>
- <code>`mise exec -- uv run --directory native/orchard_worker_mlx --extra mlx pytest tests/test_mlx_import_smoke.py -v` (guard executes and passes with mlx extra installed)</code>
- <code>`mise exec -- uv run --directory native/orchard_worker_mlx --extra mlx python -c &#39;import transformers, mlx_lm&#39;` (transformers 5.3.0 + mlx_lm 0.31.3 import OK)</code>
- <code>Counterfactual: `uv run --isolated --no-project --with mlx-lm==0.31.3 --with &#39;transformers&gt;=5.13&#39; --with mlx python -c &#39;import mlx_lm&#39;` reproduces issue #57 (`AttributeError: &#39;str&#39; object has no attribute &#39;__module__&#39;`)</code>
- <code>`mise exec -- uv run --directory native/orchard_worker_mlx --extra mlx pytest --cov` (576 passed, 2 skipped, 84% coverage)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

