### PR TITLE
docs: accept ADRs 0009/0010 and sync cancel-drain lifecycle contract

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -644,6 +644,7 @@ cordoned    -> active
 
 active      -> draining
 cordoned    -> draining
+draining    -> cordoned
 draining    -> maintenance
 maintenance -> active
 
@@ -681,6 +682,11 @@ decommissioning -> removed
 
   * trigger: operator/admin action
   * effect: no new requests, wait until `active_request_count == 0`
+
+* `draining -> cordoned`
+
+  * trigger: operator/admin action (cancel drain)
+  * effect: stop waiting for active-request quiescence; node remains unschedulable as `cordoned`; work already completed, cancelled, or quiesced during the drain is not restored; no drain completion is certified
 
 * `draining -> maintenance`
 

--- a/docs/decisions/0009-draining-recovery-edge.md
+++ b/docs/decisions/0009-draining-recovery-edge.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed. Resolves GitHub issue #48 once accepted.
+Accepted. Implementation of the edge closes GitHub issue #48.
 
 ## Context
 
@@ -17,6 +17,14 @@ SPEC.md §4.8 already treats `cordoned` as drain's resting state: on quiescence 
 
 Add a `draining -> cordoned` edge ("cancel drain") to SPEC.md §4.3 and to the lifecycle action table, triggered by operator/admin action. Effect: the node stops waiting for quiescence and holds as `cordoned` (still unschedulable); no drain-completion verification is required because nothing is being certified as drained. Recovery to scheduling then uses the existing `cordoned -> active` edge, so the operator regains a full path (`draining -> cordoned -> active`) without weakening the `drain_completion_unverified` gate on `maintenance`.
 
+Semantics fixed at acceptance:
+
+* Cancel drain is a distinct action (`cancel_drain`), not a reuse of `uncordon`: `uncordon` is bound to `cordoned -> active` in code and operator language, and cancel drain must not reopen scheduling.
+* Cancel drain does not restore, replay, or migrate back work that already completed, was cancelled, or quiesced while the drain ran; it only stops further waiting.
+* Cancel drain is allowed only from `draining`. Attempts from any other state produce a lifecycle blocker (`drain_not_running`), mirroring the existing `drain_already_running` blocker rather than introducing an idempotent no-op, which the lifecycle state machine has no precedent for. Mutation-time revalidation inside the lifecycle transaction already guarantees the state is re-checked at execution, so a drain that completed between preview and execution is rejected cleanly.
+
+Prior art supports this shape: Nomad exposes an explicit `node drain -disable` cancel primitive whose `-keep-ineligible` flag leaves the node unschedulable (exactly this edge), and Kubernetes models drain as cordon plus evictions where `uncordon` restores schedulability without undoing evictions.
+
 Alternatives rejected:
 
 * `draining -> active` directly — reopens scheduling in one step, skipping the explicit `uncordon` consent and its health considerations, and adds a second recovery edge to maintain for no extra capability.
@@ -24,7 +32,7 @@ Alternatives rejected:
 
 ## Consequences
 
-Drains become reversible. The lifecycle module gains one action (allowed from `[:draining]`, target `cordoned`) with the usual dry-run preview, confirmation, blocker, and audit vocabulary, plus tests for the new edge. §4.3 becomes consistent with §4.8's completion semantics. Drain-deadline orchestration and automatic `draining -> maintenance` remain untouched future work.
+Drains become reversible. The lifecycle module gains one action (allowed from `[:draining]`, target `cordoned`) with the usual dry-run preview, confirmation, blocker, and audit vocabulary, plus tests for the new edge. §4.3 becomes consistent with §4.8's completion semantics. Drain-deadline orchestration and automatic `draining -> maintenance` remain untouched future work; when drain-deadline orchestration lands it must honor an executed cancel drain by stopping its own countdown rather than acting on a node that is no longer `draining`.
 
 ## SPEC.md impact
 

--- a/docs/decisions/0010-single-target-scheduler-explanations.md
+++ b/docs/decisions/0010-single-target-scheduler-explanations.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed. Resolves GitHub issue #49 once accepted.
+Accepted. Implementation of the predicate change closes GitHub issue #49.
 
 ## Context
 
@@ -14,13 +14,17 @@ Code reading shows MultiNode with one candidate is neither expensive nor diverge
 
 SPEC.md §7.3.5 defines no single-node exemption and states: "Scheduler explanation generation, validation, and persistence are observational. An invalid or unbuildable explanation SHALL NOT fail, block, or alter the user's inference request."
 
+External prior art supports uniform scheduler diagnostics rather than gating them on cluster size. Kubernetes evaluates candidates through the same scheduling-framework phases and emits `FailedScheduling` events even when only one node is available. Nomad's `alloc status -verbose` exposes evaluated-node counts, rejections, and placement metrics, including single-evaluated-node cases. Operators expect the scheduler to explain its decision whenever a real runtime target exists.
+
 ## Decision
 
 Make explanation coverage uniform: select MultiNode whenever any runtime target exists (predicate becomes non-empty `runtime_client_targets()`), keeping SingleNode as the no-target fallback and MultiNode's degradation path. Empty explanation panels in the smallest real deployment read as a defect; since the single-candidate placement outcome is equivalent and the cost negligible, uniform observability wins over documenting the threshold, which would enshrine a transport inconsistency the BEAM path already contradicts.
 
 ## Consequences
 
-Single-target gRPC deployments gain persisted explanations and runtime observations at a small per-request DB cost. Saturation on that path reports `cluster_busy` rather than `model_busy`; a target whose node is not yet admitted still yields no explanation via fallback, which is correct — there are no lifecycle-managed candidates to explain. Scheduler-selection tests need updating for the new predicate.
+Single-target gRPC deployments gain persisted explanations and runtime observations at a small per-request DB cost. Saturation on that path reports `cluster_busy` rather than `model_busy`; a target whose node is not yet admitted still yields no explanation via fallback, which is correct — there are no lifecycle-managed candidates to explain. Scheduler-selection tests need updating for the new predicate, and must cover both a single configured legacy gRPC target and duplicate legacy targets that deduplicate to one, because the predicate is "any normalized runtime client target exists", not "more than one distinct target exists".
+
+The glossary entry for Model Busy currently reads "runtime or single-node scheduler outcome"; when the implementation lands, that entry must be sharpened to reflect that Model Busy remains reachable only via the no-target fallback path, while configured-target saturation reports Cluster Busy uniformly.
 
 ## SPEC.md impact
 

--- a/openspec/changes/cluster-management-ux-foundation/design.md
+++ b/openspec/changes/cluster-management-ux-foundation/design.md
@@ -173,6 +173,7 @@ Action preview blocker codes should include these initial stable values:
 - `node_unhealthy`
 - `inventory_missing`
 - `drain_already_running`
+- `drain_not_running`
 - `decommission_already_running`
 - `maintenance_requires_drain`
 - `drain_completion_unverified`

--- a/openspec/changes/cluster-management-ux-foundation/proposal.md
+++ b/openspec/changes/cluster-management-ux-foundation/proposal.md
@@ -13,7 +13,7 @@ This change defines the operator-facing UX contract before implementation so the
 - Require Console, CLI, Operator API, and Admin API surfaces to keep lifecycle, health, freshness, transport reachability, runtime readiness, compatibility, scheduling, and warnings distinct.
 - Define fixed operator-facing reason-code vocabularies for scheduler explanations and node action previews.
 - Require CLI and Console parity for node list, node detail, admission review, action eligibility, scheduler explanation, diagnostics, support bundle creation, and control-plane read-only status.
-- Define a safe action model for eligibility-changing and destructive node operations: cordon, uncordon, drain, maintenance, resume, admit, reject pending admission, and decommission.
+- Define a safe action model for eligibility-changing and destructive node operations: cordon, uncordon, drain, cancel drain, maintenance, resume, admit, reject pending admission, and decommission.
 - Define support bundle and diagnostics expectations, including scope selection, redaction manifest, and shared CLI/Console behavior.
 - Keep Active/Standby leadership and lock status read-only in this foundation change, with mutating failover or leadership actions deferred to a later accepted change.
 - Exclude product code implementation from this change package.

--- a/openspec/changes/cluster-management-ux-foundation/specs/cluster-management-ux/spec.md
+++ b/openspec/changes/cluster-management-ux-foundation/specs/cluster-management-ux/spec.md
@@ -210,6 +210,32 @@ This refines `SPEC.md` §4.4, §4.8, §7.3, §7.4, §12.7, §13.4, and §13.7.
 - **THEN** Orchard revalidates the action at execution time
 - **AND** Orchard does not execute the stale preview as if the node still had no active requests
 
+### Requirement: Cancel Drain Provides A Draining Recovery Path
+Orchard SHALL provide a `cancel_drain` node action that transitions a node from `draining` to `cordoned`.
+Cancel drain SHALL stop further waiting for active-request quiescence and SHALL leave the node unschedulable as `cordoned`.
+Cancel drain SHALL NOT certify drain completion and SHALL NOT weaken the `drain_completion_unverified` blocker on manual `draining -> maintenance` execution.
+Cancel drain SHALL NOT restore, replay, or migrate back work that completed, was cancelled, or quiesced while the drain ran.
+Cancel drain SHALL be allowed only from `draining`; execution from any other lifecycle state SHALL produce a `drain_not_running` blocker.
+Cancel drain SHALL use the shared action preview, confirmation, blocker, audit, and mutation-time revalidation vocabulary defined for other lifecycle actions.
+This refines `SPEC.md` §4.3, §4.4, and §4.8 per ADR 0009.
+
+#### Scenario: Operator cancels a drain that no longer needs to run
+- **WHEN** an operator executes `cancel_drain` on a node in `draining`
+- **THEN** Orchard transitions the node to `cordoned`
+- **AND** the node remains excluded from scheduling until a separate `uncordon` action
+- **AND** Orchard records a cluster-scoped audit event for the cancellation
+
+#### Scenario: Cancel drain on a node that is not draining
+- **WHEN** an operator previews or executes `cancel_drain` on a node that is not in `draining`
+- **THEN** Orchard reports a `drain_not_running` blocker
+- **AND** Orchard does not mutate the node
+
+#### Scenario: Drain completes between preview and execution
+- **WHEN** an operator previews `cancel_drain` for a draining node
+- **AND** the node leaves `draining` before the operator confirms execution
+- **THEN** Orchard revalidates at execution time and reports `drain_not_running`
+- **AND** Orchard does not execute the stale preview
+
 ### Requirement: Diagnostics And Support Bundles Share One Artifact Contract
 Console-triggered support bundles and `orchardctl support bundle create` SHALL use one shared support bundle artifact contract.
 This change SHALL define `orchard.support_bundle.v2` for shared Console and CLI cluster-management support bundles.

--- a/openspec/changes/cluster-management-ux-foundation/tasks.md
+++ b/openspec/changes/cluster-management-ux-foundation/tasks.md
@@ -65,6 +65,8 @@
 - [x] 4.8 Implement `orchardctl cluster status --json` for read-only control-plane status and cluster summary status.
   Note: This slice adds `orchardctl cluster status --json` with a shared `ControlPlaneStatus` payload and a control-plane-focused `summary` block for deployment mode, controller role, and advisory-lock status.
   Node inventory and runtime reachability counts intentionally remain on the existing node and Live Cluster surfaces rather than being duplicated into this command.
+- [ ] 4.9 Implement the `cancel_drain` lifecycle action per ADR 0009 and `SPEC.md` §4.3/§4.4: allowed only from `draining`, target `cordoned`, with dry-run preview, confirmation, `drain_not_running` blocker for non-draining states, audit, CLI command, and Console action panel pickup.
+  Note: cancel drain stops waiting for active-request quiescence and leaves the node unschedulable as `cordoned`; it certifies no drain completion and does not weaken the `drain_completion_unverified` gate on `maintenance`.
 
 ## 5. Console Nodes UX
 


### PR DESCRIPTION
## Intent

Accept ADRs 0009 and 0010 (committed as Proposed by the triage sweep, PR #67) and land the contract updates acceptance implies. Both decisions were verified against current main and grounded in orchestrator prior art (Kubernetes and Nomad drain-cancellation and scheduler-diagnostics behavior) before acceptance.

- ADR 0009 (issue #48): add a `draining -> cordoned` cancel-drain recovery edge. Acceptance fixes the semantics: a distinct `cancel_drain` action rather than `uncordon` reuse, a `drain_not_running` blocker instead of an idempotent no-op (the lifecycle state machine has no no-op precedent), no restoration of work that completed or was cancelled while the drain ran, and no weakening of the `drain_completion_unverified` gate on maintenance.
- ADR 0010 (issue #49): select the MultiNode scheduler whenever any runtime target exists so explanation coverage is uniform. Records the accepted `cluster_busy` shift for single-target saturation, the dedupe-to-one test requirement, and the Model Busy glossary sharpening owed by the implementation slice.
- SPEC.md §4.3/§4.4 gain the new edge and its transition rule; OpenSpec `cluster-management-ux-foundation` gains the Cancel Drain requirement (three scenarios) and unchecked task 4.9. Contract-first: implementation follows in separate slices.

Issues #48 and #49 stay open deliberately — they close with the implementation slices, not this acceptance branch.

## What Changed

- Accepted ADRs 0009 (draining→cordoned cancel-drain edge, issue #48) and 0010 (uniform MultiNode scheduler explanations for any single runtime target, issue #49), flipping both to `Accepted` and adding grounded amendments citing Nomad/Kubernetes prior art plus explicit `cancel_drain` semantics, blocker behavior, and test coverage requirements.
- Synced `SPEC.md` §4.3/§4.4 with the new `draining -> cordoned` transition and its cancel-drain action row (stops quiescence waiting, holds the node unschedulable as `cordoned`, certifies no drain completion).
- Updated the `cluster-management-ux-foundation` OpenSpec change to add the `cancel_drain` action to the safe-action model, a `drain_not_running` blocker code, a new "Cancel Drain Provides A Draining Recovery Path" requirement with three scenarios, and an implementation task (4.9). OpenSpec strict validation passes (3 passed, 0 failed).

## Risk Assessment

✅ Low: Documentation-only change accepting two ADRs and syncing the SPEC/OpenSpec contracts; all factual claims about the codebase were verified accurate, the SPEC edits are internally consistent, and the corresponding implementation is intentionally deferred to an unchecked task per the established spec-ahead-of-code workflow.

## Testing

`Ran the mandated OpenSpec strict validation on the edited change package and the full workspace (both pass, 3/3 items), manually confirmed the SPEC.md lifecycle state machine is internally consistent after adding the draining->cordoned cancel-drain edge (present in both the transition diagram and rules table, with both endpoint states defined), and verified the ADR 0010 amendment's cited glossary wording is real and grounded in the current repo. No screenshot/visual artifact applies: this change touches only Markdown spec/decision docs with no rendered UI or runtime surface — the cancel_drain feature is documented intent, not yet implemented (task 4.9 unchecked). No source files were modified and no transient build artifacts were created; overall result is a clean pass.`

<details>
<summary>Evidence: OpenSpec strict validation (all items)</summary>

```text
✓ spec/api-client-provisioning
✓ change/cluster-management-ux-foundation
✓ spec/runtime-endpoints
Totals: 3 passed, 0 failed (3 items)
```
</details>
<details>
<summary>Evidence: SPEC.md §4.3 lifecycle diagram + §4.4 rule (new cancel-drain edge)</summary>

```text
active -> draining
cordoned -> draining
draining -> cordoned <-- new edge
draining -> maintenance
maintenance -> active

* `draining -> cordoned`
* trigger: operator/admin action (cancel drain)
* effect: stop waiting for active-request quiescence; node remains unschedulable as `cordoned`; work already completed, cancelled, or quiesced during the drain is not restored; no drain completion is certified
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate cluster-management-ux-foundation --type change --strict --no-interactive` — the edited change package validates</code>
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` — 3 passed, 0 failed across the workspace</code>
- <code>Manual consistency check of SPEC.md §4.3 diagram and §4.4 rules table: `draining -&gt; cordoned` edge present in both, endpoint states defined</code>
- <code>`grep -rn &#34;runtime or single-node scheduler outcome&#34; docs/glossary/` — verified ADR 0010&#39;s grounded glossary reference exists at CONTEXT.md:541</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

