### PR TITLE
feat(inference): auto-select MultiNode scheduler for any configured runtime target

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2071,7 +2071,7 @@ Response example:
 ```
 
 Scheduler explanations SHALL expose stable reason codes for selected, rejected, and skipped candidates.
-Scheduler explanations are produced whenever at least one runtime target is configured.
+Scheduler explanations are produced whenever at least one runtime target is configured and the scheduler evaluates lifecycle-managed candidates; the no-candidate fallback path emits no explanation.
 Reason codes SHALL be shared by Operator API, CLI, Console, support bundles, and tests.
 Human-readable explanation text MAY be included, but it SHALL be supplemental to machine-readable reason codes.
 Rejected candidates SHALL include at least one stable rejection reason code.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2071,6 +2071,7 @@ Response example:
 ```
 
 Scheduler explanations SHALL expose stable reason codes for selected, rejected, and skipped candidates.
+Scheduler explanations are produced whenever at least one runtime target is configured.
 Reason codes SHALL be shared by Operator API, CLI, Console, support bundles, and tests.
 Human-readable explanation text MAY be included, but it SHALL be supplemental to machine-readable reason codes.
 Rejected candidates SHALL include at least one stable rejection reason code.

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -283,7 +283,7 @@ defmodule Orchard.Inference do
       explicit_runtime_endpoint_targets?() ->
         Orchard.Scheduler.MultiNode
 
-      length(runtime_client_targets()) > 1 ->
+      runtime_client_targets() != [] ->
         Orchard.Scheduler.MultiNode
 
       true ->

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -394,6 +394,59 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseRuntimeCli
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient do
+  @moduledoc false
+
+  alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.Operation
+
+  def connect(target), do: {:ok, target}
+
+  def status(target, _opts) do
+    address = target.address
+    key = {Keyword.fetch!(address, :host), Keyword.fetch!(address, :port)}
+
+    case Process.get({__MODULE__, key}) do
+      nil -> {:error, :unavailable}
+      response -> {:ok, response}
+    end
+  end
+
+  def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{}, _opts),
+    do:
+      {:ok,
+       %Operation.EnsureModelLoadedResult{
+         already_loaded: false,
+         placement_state: :loaded,
+         worker_supports_prompt_token_ids: true
+       }}
+
+  def unload_model(_channel, %Operation.UnloadModelRequest{}, _opts),
+    do: {:ok, %Operation.Ack{ok: true}}
+
+  def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    stream_ref = make_ref()
+
+    send(
+      owner,
+      {:runtime_endpoint_event, stream_ref, request.request_id,
+       InferenceEvent.completed(:finish_reason_stop, %InferenceEvent.Usage{})}
+    )
+
+    send(owner, {:runtime_endpoint_done, stream_ref, :ok})
+
+    {:ok, stream_ref}
+  end
+
+  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts), do: :ok
+
+  def disconnect(_channel), do: :ok
+
+  def score_prefix_cache(_target, _request, _opts),
+    do: {:ok, %{status_code: "unavailable", score_tier: "unknown"}}
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.StubLiveCapacityScheduler do
   @behaviour Orchard.Scheduler.SingleNode
 
@@ -656,6 +709,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheUnavailableScheduler
+  alias Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient
 
   alias Orchard.API.Ops.SchedulerExplanationPresenter
   alias Orchard.ArtifactBundle
@@ -666,6 +720,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.InferenceEvent
   alias Orchard.Node
   alias Orchard.Node.ModelManager
+  alias Orchard.Nodes.Node, as: InventoryNode
   alias Orchard.Requests
   alias Orchard.Requests.Idempotency
   alias Orchard.Requests.RequestServer
@@ -839,6 +894,36 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert request.scheduler_decision["candidate_count"] == 2
     assert request.scheduler_decision["selected_tier"] == "loaded"
     assert request.scheduler_decision["node_id"] == scheduled_node_id()
+  end
+
+  test "SPEC.md §7.3.5 execute/3 persists scheduler explanation for one legacy target",
+       %{bundle: bundle} do
+    target = [host: "10.0.0.1", port: 50_061]
+    node = insert_runtime_node!(target)
+
+    put_auto_runtime_endpoint_scheduler_config([target])
+    stub_runtime_status(target, runtime_status(node.id, target))
+
+    model = create_active_model!(bundle, "request-orchestrator-single-target-explanation")
+
+    canonical =
+      canonical_request("request-orchestrator-single-target-explanation", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    decision = request.scheduler_decision
+
+    assert decision["strategy"] == "multi_node"
+    assert decision["candidate_count"] == 1
+    assert decision["selected_tier"] == "cold"
+    assert decision["node_id"] == node.id
+
+    assert {:ok, explanation} = SchedulerExplanationPresenter.show(request)
+    assert explanation.selected_node_id == node.id
+    assert [%{node_id: node_id}] = explanation.scored_candidates
+    assert node_id == node.id
   end
 
   test "SPEC.md §7.3.5 execute/3 fails open and completes dispatch when the scheduler explanation is invalid",
@@ -2978,6 +3063,66 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     Application.put_env(:orchard_controller, :inference, inference)
   end
 
+  defp put_auto_runtime_endpoint_scheduler_config(targets) do
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.merge(
+        runtime_client_targets: targets,
+        runtime_endpoint_targets: [],
+        runtime_endpoint_client_impl: StubRuntimeEndpointClient,
+        scheduler_impl: nil
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+  end
+
+  defp insert_runtime_node!(target) do
+    unique = System.unique_integer([:positive])
+
+    attrs = %{
+      id: Ecto.UUID.generate(),
+      hostname: "single-target-#{unique}.local",
+      display_name: "single-target-#{unique}",
+      advertise_addr: Keyword.fetch!(target, :host),
+      rpc_port: Keyword.fetch!(target, :port),
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      last_heartbeat_at: DateTime.utc_now()
+    }
+
+    %InventoryNode{}
+    |> InventoryNode.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  defp stub_runtime_status(target, response) do
+    key = {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
+    Process.put({StubRuntimeEndpointClient, key}, response)
+  end
+
+  defp runtime_status(node_id, target) do
+    %{
+      node_metadata: %{
+        node_id: node_id,
+        display_name: "single-target-node",
+        hostname: "single-target-node.local",
+        agent_version: "0.1.0",
+        listen_host: Keyword.fetch!(target, :host),
+        listen_port: Keyword.fetch!(target, :port),
+        worker_backend: "mlx"
+      },
+      runtime_health: %{ready: true, health_code: "ok", health_message: "ready"},
+      loaded_models: [],
+      active_request_count: 0,
+      max_concurrency: 4,
+      runtime_memory_budgets: [],
+      runtime_prefix_cache_statuses: [],
+      runtime_model_placements: [],
+      supports_prompt_token_ids: false
+    }
+  end
+
   defp runtime_client_target_map do
     runtime_target = Orchard.Inference.runtime_client_target()
 
@@ -3012,7 +3157,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       Application.fetch_env!(:orchard_controller, :inference)
       |> Keyword.merge(
         runtime_endpoint_client_impl:
-          Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseRuntimeClient
+          Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseRuntimeClient,
+        scheduler_impl: Orchard.Scheduler.SingleNode
       )
 
     Application.put_env(:orchard_controller, :inference, inference)

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -70,7 +70,7 @@ defmodule Orchard.InferenceTest do
 
     assert Inference.request_supervisor() == Orchard.Requests.Supervisor
     assert Inference.tokenizer_client() == Orchard.Tokenizer.Client
-    assert Inference.scheduler() == Orchard.Scheduler.SingleNode
+    assert Inference.scheduler() == Orchard.Scheduler.MultiNode
   end
 
   @tag :db
@@ -795,8 +795,8 @@ defmodule Orchard.InferenceTest do
   end
 
   describe "scheduler auto-selection" do
-    test "defaults to SingleNode when plural targets are absent" do
-      put_inference(runtime_client_targets: [])
+    test "defaults to SingleNode when legacy plural targets and singular target are absent" do
+      put_inference(runtime_client_targets: [], runtime_client_target: nil)
       assert Inference.scheduler() == SingleNode
     end
 
@@ -812,7 +812,7 @@ defmodule Orchard.InferenceTest do
       assert Inference.scheduler() == MultiNode
     end
 
-    test "deduplicated plural targets that collapse to one still use SingleNode" do
+    test "SPEC.md §7.3.5 deduplicated legacy targets that collapse to one use MultiNode" do
       put_inference(
         runtime_client_targets: [
           [host: "10.0.0.1", port: 50_061],
@@ -821,7 +821,7 @@ defmodule Orchard.InferenceTest do
         scheduler_impl: nil
       )
 
-      assert Inference.scheduler() == SingleNode
+      assert Inference.scheduler() == MultiNode
     end
 
     test "SPEC.md §7.5 explicit Runtime Endpoint targets use endpoint-aware scheduling when singular" do

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -538,7 +538,8 @@ With queue admission enabled, this can return the request to the same Queue dead
 _Avoid_: Transport failure, model not found, queue full
 
 **Model Busy**:
-A runtime or single-node scheduler outcome meaning the requested model path cannot accept the request because live node or placement request capacity is exhausted.
+A no-target fallback scheduling outcome meaning the requested model path cannot accept the request because live node or placement request capacity is exhausted.
+Configured-target saturation reports Cluster Busy uniformly.
 It maps to a tenant-facing `503` capacity failure and is separate from tenant quota or queue-full admission failures.
 _Avoid_: Cluster Busy, quota exceeded, model not found
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -242,7 +242,7 @@ Stream mode reports max concurrency as `1` at both node and placement levels.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ORCHARD_RUNTIME_CLIENT_HOST` | `127.0.0.1` | Controller’s local gRPC target host |
-| `ORCHARD_RUNTIME_CLIENT_TARGETS` | _(empty)_ | Comma-separated `host:port` list for multi-node scheduling. When set with >1 target, the scheduler auto-selects `MultiNode`. |
+| `ORCHARD_RUNTIME_CLIENT_TARGETS` | _(empty)_ | Comma-separated `host:port` list for multi-node scheduling. When set with at least one target, the scheduler auto-selects `MultiNode`. |
 
 These env vars configure only the gRPC compatibility target path.
 Split-role source-dev defaults to BEAM Runtime Endpoint mode and uses a separate Runtime Endpoint env surface, not `ORCHARD_RUNTIME_CLIENT_TARGETS`.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -554,7 +554,7 @@ ORCHARD_RUNTIME_CLIENT_TARGETS="127.0.0.1:50071,<remote-tailscale-ip>:50071" \
 
 The local node-agent still binds to `127.0.0.1:50071`.
 The controller targets both local and remote gRPC nodes.
-The scheduler auto-selects `MultiNode` when it sees more than one target.
+The scheduler auto-selects `MultiNode` whenever at least one target is configured.
 Use a Tailscale IPv4 address such as `100.x.y.z` in the target list.
 IPv6 addresses are not supported in the gRPC compatibility target list.
 


### PR DESCRIPTION
## Intent

Closes #49.

Working from a dedicated worktree on Orchard issue #49, the developer wanted the scheduler's automatic selection logic to choose the MultiNode scheduler (instead of SingleNode) whenever any runtime client target is configured, including the single legacy gRPC target case, so that single-target scheduling produces a proper SPEC 7.3.5 scheduler explanation. They required a TDD approach (reproduce the wrong behavior first, then fix), a regression test proving a single legacy gRPC target persists a scheduler explanation, plus updated auto-selection tests for duplicate/deduped targets, zero-target fallback to SingleNode, and explicit Runtime Endpoint targets. They also wanted the SPEC 7.3.5 clarifying sentence added and the glossary 'Model Busy' definition sharpened, with the change committed as a conventional commit that closes issue #49. Per project constraints, the full Elixir quality workflow (format, compile with warnings-as-errors, credo --strict, dialyzer, test, and coverage) had to pass before handoff.

## What Changed

- Changed the scheduler auto-selection in `Orchard.Inference` to pick `MultiNode` whenever any runtime client target is configured (`runtime_client_targets() != []`) instead of requiring more than one, so a single legacy gRPC target now produces a proper SPEC 7.3.5 scheduler explanation and reserves the no-target path for the `SingleNode` fallback.
- Added and updated tests covering single legacy target explanation persistence, duplicate/deduped targets, zero-target `SingleNode` fallback, and explicit Runtime Endpoint targets across `request_orchestrator_test.exs` and `inference_test.exs`.
- Synced supporting docs: added the SPEC 7.3.5 clarifying sentence on when explanations are produced, sharpened the glossary "Model Busy" definition as a no-target fallback outcome, and updated the local-dev env-var table to reflect the any-target auto-select condition.

## Risk Assessment

✅ Low: A single-line, well-bounded auto-selection condition change backed by a targeted regression test, updated auto-selection tests, and consistent SPEC/glossary/doc edits that match the actual reason-code emission and fallback semantics.

## Testing

Baseline setup (mise trust, mix deps.get, mix compile) succeeded, then I ran the two affected test files (137 tests total, all passing) plus the four named SPEC 7.3.5 / issue-#49 tests in isolation. For product-level evidence I drove the public `Inference.scheduler()` seam under five distinct runtime-target configurations, confirming the fix: no targets → SingleNode (fallback), while a single legacy gRPC target, duplicate-deduped-to-one targets, two distinct targets, and a single Runtime Endpoint target all → MultiNode, which is what emits the SPEC 7.3.5 explanation. The single-legacy-target explanation-persistence test additionally exercises the full `RequestOrchestrator.execute/3` path and asserts the persisted scheduler_decision (strategy=multi_node, candidate_count=1) and the presenter's explanation. This is a scheduler/logic change with no UI surface, so no screenshot applies; the reviewer-visible artifact is the CLI transcript of the auto-selection decision table. Worktree left clean.

<details>
<summary>Evidence: Scheduler auto-selection decision by runtime target configuration</summary>

<code>SPEC 7.3.5 scheduler auto-selection by runtime target configuration&#10;======&#10;no targets configured (fallback) -&gt; Orchard.Scheduler.SingleNode&#10;single legacy gRPC target (issue #49 fix) -&gt; Orchard.Scheduler.MultiNode&#10;duplicate legacy targets dedupe to one (issue #49 fix) -&gt; Orchard.Scheduler.MultiNode&#10;two distinct legacy targets -&gt; Orchard.Scheduler.MultiNode&#10;explicit Runtime Endpoint target (single) -&gt; Orchard.Scheduler.MultiNode</code>

```text
SPEC 7.3.5 scheduler auto-selection by runtime target configuration
==========================================================================================
no targets configured (fallback)                           -> Orchard.Scheduler.SingleNode
single legacy gRPC target (issue #49 fix)                  -> Orchard.Scheduler.MultiNode
duplicate legacy targets dedupe to one (issue #49 fix)     -> Orchard.Scheduler.MultiNode
two distinct legacy targets                                -> Orchard.Scheduler.MultiNode
explicit Runtime Endpoint target (single)                  -> Orchard.Scheduler.MultiNode
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference_test.exs` (63 passed, incl. scheduler auto-selection describe block)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs` (74 passed)</code>
- <code>`mise exec -- mix test &lt;request_orchestrator_test.exs:899&gt; &lt;inference_test.exs:798,815,827&gt;` — the four named SPEC 7.3.5 / issue-#49 behaviors (4 passed)</code>
- <code>`MIX_ENV=test mix run` driving `Inference.scheduler()` across no-target, single legacy target, duplicate-deduped, two-distinct, and single Runtime Endpoint target configs to capture the actual auto-selection decision</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

