### PR TITLE
docs: add two-Mac source-dev smoke evidence for e60cc59

### DIFF
--- a/docs/investigations/source-dev-two-mac-smoke-2026-07-06.md
+++ b/docs/investigations/source-dev-two-mac-smoke-2026-07-06.md
@@ -1,0 +1,162 @@
+# Source-dev Two-Mac Smoke - 2026-07-06
+
+## Summary
+
+Result: completed with one surface gap.
+
+This smoke validated source-dev BEAM Runtime Endpoint mode across two Macs on Orchard `main` after merge commit `e60cc598a45245951dd337659c0695c64d2aa8c6`.
+The run exercised bring-up, cluster status, admission, a real MLX chat completion, persisted single-target scheduler explanations, lifecycle cancel-drain, write-gate sanity, decommissioning, and teardown.
+No product code was changed.
+The only committed artifact from this run is this evidence note.
+
+The PR #67 memory-budget status-surface check did not fully pass through the requested CLI surface.
+`orchardctl nodes inspect --json` did not render a memory-budget block in this run.
+A Runtime Endpoint snapshot did expose `recommended_context_tokens`, and the catalog row exposed `max_context_tokens`, so the underlying data was present.
+This remains a surface-evidence gap for follow-up.
+
+Smoke date: 2026-07-06.
+Smoke completion time: 2026-07-06T06:09:56Z.
+Tested code state: `e60cc598a45245951dd337659c0695c64d2aa8c6`.
+Test branch for evidence commit: `najibninaba/smoke-main-e60cc59`.
+
+## Hosts
+
+Controller host: `tamingsari`.
+Controller Tailscale IP: `100.90.207.78`.
+Controller checkout: `/Users/najib/Hacks/orchard`.
+
+Remote node-agent host: `mawarduri`.
+Remote node-agent Tailscale IP: `100.70.81.109`.
+Remote checkout: `~/Hacks/orchard`.
+Remote checkout was fast-forwarded to `e60cc598a452` before the smoke.
+Remote dependencies were refreshed with `mise exec -- mix deps.get`, `mise exec -- uv sync --directory native/orchard_tokenizer`, and `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx`.
+
+Controller BEAM node name: `orchard_controller@100.90.207.78`.
+Remote node-agent BEAM node name: `orchard_node_agent@100.70.81.109`.
+The run used EPMD port `43690` on both Macs because packaged Orchard and local EPMD state may occupy the default port.
+The shared BEAM cookie was stored in owner-only transient files and was removed during teardown.
+Cookie SHA-256 digest: `68d8cc1aabc0ed0aed8698798bc2642bb698318ec1cd4d7683acf1a73333e09a`.
+Cookie contents and API token material are intentionally omitted.
+
+Packaged Orchard BEAM processes under `/Library/Application Support/Orchard` were present on the controller host and were ignored.
+The source-dev smoke used HTTP `127.0.0.1:4000` and the source checkout.
+
+## Launch Commands
+
+The remote node-agent was started on `mawarduri` with this sanitized command shape:
+
+```bash
+ssh najib@100.70.81.109 "zsh -lc '<remote setup>'"
+screen -L -dmS orchard-smoke-node-e60cc59 zsh -lc '
+  cd ~/Hacks/orchard &&
+  env \
+    ORCHARD_BEAM_NODE_NAME=orchard_node_agent@100.70.81.109 \
+    ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
+    ORCHARD_BEAM_EPMD_PORT=43690 \
+    ORCHARD_NODE_DISPLAY_NAME=mawarduri-smoke-e60cc59 \
+    mise exec -- bin/dev-node-agent
+'
+```
+
+The controller was started on `tamingsari` with this sanitized command shape:
+
+```bash
+screen -L -dmS orchard-smoke-controller-e60cc59 zsh -lc '
+  cd /Users/najib/Hacks/orchard &&
+  env \
+    ORCHARD_BEAM_NODE_NAME=orchard_controller@100.90.207.78 \
+    ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
+    ORCHARD_BEAM_EPMD_PORT=43690 \
+    ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@100.70.81.109 \
+    ORCHARD_NODE_DISPLAY_NAME=tamingsari-controller-smoke-e60cc59 \
+    mise exec -- bin/dev-controller
+'
+```
+
+`screen -L -dmS` was used as a persistent TTY wrapper because direct `nohup` source-dev IEx starts exited on EOF during remote SSH attempts.
+This was an operator wrapper only and did not change product code.
+
+## Model And API Evidence
+
+The smoke used the same small MLX model as the prior accepted note:
+
+```text
+mlx-community/Llama-3.2-1B-Instruct-4bit@08231374eeacb049a0eade7922910865b8fce912
+```
+
+The remote worker loaded the model from the source-dev cache.
+The node-agent log reported `load_model ok` and `generate done` for request `chatcmpl-a5ba2ade-97a7-42b4-948a-7e1effbde2c6`.
+
+`POST /v1/chat/completions` returned HTTP `200` through the authenticated public API.
+The response id was `chatcmpl-a5ba2ade-97a7-42b4-948a-7e1effbde2c6`.
+The response content was `mlx ready`.
+The finish reason was `stop`.
+Usage was `45` total tokens, `42` prompt tokens, and `3` completion tokens.
+
+`orchardctl requests inspect chatcmpl-a5ba2ade-97a7-42b4-948a-7e1effbde2c6 --json` returned a persisted scheduler explanation.
+It selected node `6ec44363-70d4-456a-835c-73112994bc5c`.
+It included one scored candidate for the same node.
+The candidate was eligible, used tier `cold`, and scored `141` with components `health_bonus: 30`, `load_bonus: 40`, `rank_base: 71`, and `residency_bonus: 0`.
+`rejected_candidates` and `skipped_candidates` were empty.
+
+## Checklist Evidence
+
+| Item | Command or probe | Expected | Observed | Result |
+| --- | --- | --- | --- | --- |
+| 1. Bring-up | `curl http://127.0.0.1:4000/console/nodes`, `screen -ls`, remote `screen -ls`, source logs, and BEAM Runtime Endpoint probes. | Controller HTTP is up, both source-dev processes are running, and the controller can reach the node-agent target. | Controller HTTP returned `200`, local screen `orchard-smoke-controller-e60cc59` was detached, remote screen `orchard-smoke-node-e60cc59` was detached, remote EPMD listened on `100.70.81.109:43690`, and the real chat completion later proved BEAM dispatch to mawarduri. | PASS |
+| 1. Cluster status | `mise exec -- mix run -e 'OrchardCLI.main(["cluster","status","--json"])'`. | `orchardctl cluster status --json` works and shows single-controller mode plus advisory-lock status. | `deployment_mode` was `single_controller`, `controller_role` was `single_controller`, `advisory_lock_status` was `unknown`, and `standby_write_path_behavior` was `writes_allowed_when_authorized`. | PASS |
+| 2. Node admission candidate | Runtime Endpoint observation and admission DB evidence. | mawarduri appears as an observed admission candidate. | The observed mawarduri identity used node id `6ec44363-70d4-456a-835c-73112994bc5c`, agent version `0.5.0-dev`, hostname `mawarduri`, and display name `mawarduri`. | PASS |
+| 2. Node admission preview and execute | `orchardctl nodes admit 6ec44363-70d4-456a-835c-73112994bc5c --dry-run --json ...` and `orchardctl nodes admit 6ec44363-70d4-456a-835c-73112994bc5c --yes --json ...`. | Preview has no blockers and execute admits the node. | Preview had no blockers, execute produced decision `admitted`, audit log id `53`, decision id `3cf4c579-be3c-4588-b349-3ae4afbc8689`, pool id `0eacb8c5-1cb9-484c-9b1b-a79524c4d8ea`, and routing id `072ec64b-8941-4e77-9873-9d364fd96d44`. | PASS with caveat |
+| 2. Admission caveat | `orchardctl nodes admit <observed-candidate-id> --dry-run --json`. | The operator can admit the intended mawarduri target. | Direct admission by raw observed candidate id returned `node_not_found`, so a registered node row was created from the observed mawarduri candidate before running the CLI admission path. | CAVEAT |
+| 3. Single-target scheduler explanation | `POST /v1/chat/completions` followed by `orchardctl requests inspect chatcmpl-a5ba2ade-97a7-42b4-948a-7e1effbde2c6 --json`. | A real chat completion succeeds and the persisted request inspect output includes a scheduler explanation for the single mawarduri target. | The chat returned HTTP `200` with content `mlx ready`, and request inspect showed one eligible scored candidate for node `6ec44363-70d4-456a-835c-73112994bc5c`. | PASS |
+| 4. Memory-budget status surface | `orchardctl nodes inspect 6ec44363-70d4-456a-835c-73112994bc5c --json`, Runtime Endpoint memory-budget snapshot, and catalog query. | The node status surface shows the memory-budget block including `recommended_context_tokens` alongside catalog `max_context_tokens`. | Runtime Endpoint data showed `recommended_context_tokens: 131072`, `status_code: ok`, `budget_available: true`, `headroom_available: true`, `target_working_set_bytes: 50096509747`, and `resident_memory_bytes: 695242752`. The catalog row showed `max_context_tokens: 131072`. `orchardctl nodes inspect --json` did not render the memory-budget block. | FAIL for requested CLI surface |
+| 5. Cordon | `orchardctl nodes cordon <node-id> --dry-run --json` then `orchardctl nodes cordon <node-id> --yes --json`. | Preview has no blockers and execute moves active to cordoned. | Preview had no blockers and expected `active` to `cordoned`. Execute returned action `node_lifecycle.cordoned`, audit log id `56`, and node state `cordoned`. | PASS |
+| 5. Drain | `orchardctl nodes drain <node-id> --dry-run --json` then `orchardctl nodes drain <node-id> --yes --json --acknowledge`. | Preview has no blockers and execute moves cordoned to draining. | Preview had no blockers, required `--yes` plus acknowledgement, and listed `existing_requests_continue_until_deadline`. Execute returned action `node_lifecycle.drain_started`, audit log id `57`, and node state `draining`. | PASS |
+| 5. Cancel drain | `orchardctl nodes cancel-drain <node-id> --dry-run --json` then `orchardctl nodes cancel-drain <node-id> --yes --json`. | Preview has no blockers while draining and execute moves the node to cordoned. | Preview had no blockers and expected `draining` to `cordoned`. Execute returned action `node_lifecycle.drain_cancelled`, audit log id `58`, and node state `cordoned`. | PASS |
+| 5. Cancel-drain blocker | `orchardctl nodes cancel-drain <node-id> --dry-run --json` after the node was cordoned. | Preview on a non-draining node shows `drain_not_running`. | Preview returned blocker code `drain_not_running` and left the expected transition as `cordoned` to `cordoned`. | PASS |
+| 5. Uncordon | `orchardctl nodes uncordon <node-id> --dry-run --json` then `orchardctl nodes uncordon <node-id> --yes --json`. | Preview has no blockers and execute returns the node to active. | Preview had no blockers and expected `cordoned` to `active`. Execute returned action `node_lifecycle.uncordoned`, audit log id `59`, and node state `active`. | PASS |
+| 6. Write gate sanity | `orchardctl cluster status --json` plus the successful admission and lifecycle writes. | Single-controller mode writes are allowed. | Cluster status reported `writes_allowed_when_authorized`, and admission plus lifecycle write actions succeeded. | PASS |
+| 6. Active/Standby denial | Not run. | The `controller_leadership_unproven` denial requires an Active/Standby two-controller topology. | This smoke used single-controller mode only. | NOT EXERCISED |
+| 7. Node removal | `orchardctl nodes decommission <node-id> --dry-run --json` then `orchardctl nodes decommission <node-id> --yes --acknowledge --typed-node-id <node-id> --json`. | Preview has no blockers and execute moves the node to `decommissioning` or `removed`. | Preview had no blockers and consequence codes `future_scheduling_revoked` and `no_rejoin_with_same_node_id`. Execute returned action `node_lifecycle.decommission_started`, audit log id `60`, and node state `decommissioning`. | PASS |
+| 7. Drop from scheduling | `Orchard.Nodes.schedulable_nodes()` after decommission. | The removed or decommissioning node is not schedulable. | The query returned `[]`. | PASS |
+| 8. Teardown | Stop both screens, kill leftover source-dev smoke PIDs, kill EPMD `43690`, remove cookie files, and re-check processes. | Both dev servers stop, cookie files are removed, and no smoke BEAM processes remain on either host. | After a targeted correction pass, no smoke BEAM processes remained, port `43690` was clear on both hosts, local HTTP `4000` returned `000`, and both transient cookie files were absent. | PASS |
+
+## Lifecycle Audit Trail
+
+The node lifecycle audit trail contained these records for node `6ec44363-70d4-456a-835c-73112994bc5c`:
+
+| Audit id | Action | Transition |
+| --- | --- | --- |
+| 56 | `node_lifecycle.cordoned` | `active` to `cordoned` |
+| 57 | `node_lifecycle.drain_started` | `cordoned` to `draining` |
+| 58 | `node_lifecycle.drain_cancelled` | `draining` to `cordoned` |
+| 59 | `node_lifecycle.uncordoned` | `cordoned` to `active` |
+| 60 | `node_lifecycle.decommission_started` | `active` to `decommissioning` |
+
+## Not Exercised
+
+`cluster_busy` saturation shift was not exercised because the smoke did not create saturation.
+Memory-budget enforce abort was not exercised because the smoke did not create real memory pressure.
+TokenDelta opt-in was not exercised because it is an internal wire surface.
+Active/Standby leadership denial was not exercised because the smoke did not start a second controller.
+MLX bump items from issue `#65` were not exercised.
+
+## Residual Risks And Notes
+
+The memory-budget data path was present in Runtime Endpoint evidence, but the requested `orchardctl nodes inspect` status surface did not render the memory-budget block.
+That is the only failed checklist surface in this run.
+
+The admission flow required creating a registered node row from the observed mawarduri candidate before using `orchardctl nodes admit`.
+Direct CLI admission by raw observed candidate id returned `node_not_found`.
+This may be expected for the current CLI contract, but it is a smoke caveat because the checklist phrased mawarduri as an observed candidate target.
+
+After the successful chat completion, later CLI lifecycle snapshots showed `node_observation_stale` in scheduler eligibility.
+The node remained lifecycle-active before decommission, and the request-inspect scheduler explanation from the real completion captured the node as eligible at scheduling time.
+
+The source CLI command form used during the smoke was `mise exec -- mix run -e 'OrchardCLI.main([...])'`.
+It starts enough application context to emit debug logs, so the raw local evidence logs are noisy.
+Those transient logs were kept under `tmp/dev/smoke-e60cc59-evidence/` and are intentionally not committed.
+
+The first teardown pass stopped the screen sessions but left child BEAM processes running.
+A targeted correction pass killed only the source-dev smoke PIDs and the nonstandard EPMD listeners on port `43690`.
+The final teardown check showed no smoke BEAM processes and no `43690` listeners on either Mac.

--- a/docs/investigations/source-dev-two-mac-smoke-2026-07-06.md
+++ b/docs/investigations/source-dev-two-mac-smoke-2026-07-06.md
@@ -21,21 +21,20 @@ Test branch for evidence commit: `najibninaba/smoke-main-e60cc59`.
 
 ## Hosts
 
-Controller host: `tamingsari`.
-Controller Tailscale IP: `100.90.207.78`.
-Controller checkout: `/Users/najib/Hacks/orchard`.
+Controller host: `controller-mac`.
+Controller Tailscale IP: `192.0.2.10`.
+Controller checkout: `<orchard-checkout>`.
 
-Remote node-agent host: `mawarduri`.
-Remote node-agent Tailscale IP: `100.70.81.109`.
-Remote checkout: `~/Hacks/orchard`.
+Remote node-agent host: `remote-worker-mac`.
+Remote node-agent Tailscale IP: `192.0.2.20`.
+Remote checkout: `<orchard-checkout>`.
 Remote checkout was fast-forwarded to `e60cc598a452` before the smoke.
 Remote dependencies were refreshed with `mise exec -- mix deps.get`, `mise exec -- uv sync --directory native/orchard_tokenizer`, and `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx`.
 
-Controller BEAM node name: `orchard_controller@100.90.207.78`.
-Remote node-agent BEAM node name: `orchard_node_agent@100.70.81.109`.
+Controller BEAM node name: `orchard_controller@192.0.2.10`.
+Remote node-agent BEAM node name: `orchard_node_agent@192.0.2.20`.
 The run used EPMD port `43690` on both Macs because packaged Orchard and local EPMD state may occupy the default port.
-The shared BEAM cookie was stored in owner-only transient files and was removed during teardown.
-Cookie SHA-256 digest: `68d8cc1aabc0ed0aed8698798bc2642bb698318ec1cd4d7683acf1a73333e09a`.
+The shared BEAM cookie was stored in owner-only transient files, verified by digest comparison on both hosts, and removed during teardown.
 Cookie contents and API token material are intentionally omitted.
 
 Packaged Orchard BEAM processes under `/Library/Application Support/Orchard` were present on the controller host and were ignored.
@@ -43,32 +42,32 @@ The source-dev smoke used HTTP `127.0.0.1:4000` and the source checkout.
 
 ## Launch Commands
 
-The remote node-agent was started on `mawarduri` with this sanitized command shape:
+The remote node-agent was started on `remote-worker-mac` with this sanitized command shape:
 
 ```bash
-ssh najib@100.70.81.109 "zsh -lc '<remote setup>'"
+ssh <user>@192.0.2.20 "zsh -lc '<remote setup>'"
 screen -L -dmS orchard-smoke-node-e60cc59 zsh -lc '
-  cd ~/Hacks/orchard &&
+  cd <orchard-checkout> &&
   env \
-    ORCHARD_BEAM_NODE_NAME=orchard_node_agent@100.70.81.109 \
+    ORCHARD_BEAM_NODE_NAME=orchard_node_agent@192.0.2.20 \
     ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
     ORCHARD_BEAM_EPMD_PORT=43690 \
-    ORCHARD_NODE_DISPLAY_NAME=mawarduri-smoke-e60cc59 \
+    ORCHARD_NODE_DISPLAY_NAME=remote-worker-mac-smoke-e60cc59 \
     mise exec -- bin/dev-node-agent
 '
 ```
 
-The controller was started on `tamingsari` with this sanitized command shape:
+The controller was started on `controller-mac` with this sanitized command shape:
 
 ```bash
 screen -L -dmS orchard-smoke-controller-e60cc59 zsh -lc '
-  cd /Users/najib/Hacks/orchard &&
+  cd <orchard-checkout> &&
   env \
-    ORCHARD_BEAM_NODE_NAME=orchard_controller@100.90.207.78 \
+    ORCHARD_BEAM_NODE_NAME=orchard_controller@192.0.2.10 \
     ORCHARD_BEAM_COOKIE_FILE=<shared-cookie-file> \
     ORCHARD_BEAM_EPMD_PORT=43690 \
-    ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@100.70.81.109 \
-    ORCHARD_NODE_DISPLAY_NAME=tamingsari-controller-smoke-e60cc59 \
+    ORCHARD_RUNTIME_ENDPOINT_TARGETS=orchard_node_agent@192.0.2.20 \
+    ORCHARD_NODE_DISPLAY_NAME=controller-mac-controller-smoke-e60cc59 \
     mise exec -- bin/dev-controller
 '
 ```
@@ -103,12 +102,12 @@ The candidate was eligible, used tier `cold`, and scored `141` with components `
 
 | Item | Command or probe | Expected | Observed | Result |
 | --- | --- | --- | --- | --- |
-| 1. Bring-up | `curl http://127.0.0.1:4000/console/nodes`, `screen -ls`, remote `screen -ls`, source logs, and BEAM Runtime Endpoint probes. | Controller HTTP is up, both source-dev processes are running, and the controller can reach the node-agent target. | Controller HTTP returned `200`, local screen `orchard-smoke-controller-e60cc59` was detached, remote screen `orchard-smoke-node-e60cc59` was detached, remote EPMD listened on `100.70.81.109:43690`, and the real chat completion later proved BEAM dispatch to mawarduri. | PASS |
+| 1. Bring-up | `curl http://127.0.0.1:4000/console/nodes`, `screen -ls`, remote `screen -ls`, source logs, and BEAM Runtime Endpoint probes. | Controller HTTP is up, both source-dev processes are running, and the controller can reach the node-agent target. | Controller HTTP returned `200`, local screen `orchard-smoke-controller-e60cc59` was detached, remote screen `orchard-smoke-node-e60cc59` was detached, remote EPMD listened on `192.0.2.20:43690`, and the real chat completion later proved BEAM dispatch to remote-worker-mac. | PASS |
 | 1. Cluster status | `mise exec -- mix run -e 'OrchardCLI.main(["cluster","status","--json"])'`. | `orchardctl cluster status --json` works and shows single-controller mode plus advisory-lock status. | `deployment_mode` was `single_controller`, `controller_role` was `single_controller`, `advisory_lock_status` was `unknown`, and `standby_write_path_behavior` was `writes_allowed_when_authorized`. | PASS |
-| 2. Node admission candidate | Runtime Endpoint observation and admission DB evidence. | mawarduri appears as an observed admission candidate. | The observed mawarduri identity used node id `6ec44363-70d4-456a-835c-73112994bc5c`, agent version `0.5.0-dev`, hostname `mawarduri`, and display name `mawarduri`. | PASS |
+| 2. Node admission candidate | Runtime Endpoint observation and admission DB evidence. | remote-worker-mac appears as an observed admission candidate. | The observed remote-worker-mac identity used node id `6ec44363-70d4-456a-835c-73112994bc5c`, agent version `0.5.0-dev`, hostname `remote-worker-mac`, and display name `remote-worker-mac`. | PASS |
 | 2. Node admission preview and execute | `orchardctl nodes admit 6ec44363-70d4-456a-835c-73112994bc5c --dry-run --json ...` and `orchardctl nodes admit 6ec44363-70d4-456a-835c-73112994bc5c --yes --json ...`. | Preview has no blockers and execute admits the node. | Preview had no blockers, execute produced decision `admitted`, audit log id `53`, decision id `3cf4c579-be3c-4588-b349-3ae4afbc8689`, pool id `0eacb8c5-1cb9-484c-9b1b-a79524c4d8ea`, and routing id `072ec64b-8941-4e77-9873-9d364fd96d44`. | PASS with caveat |
-| 2. Admission caveat | `orchardctl nodes admit <observed-candidate-id> --dry-run --json`. | The operator can admit the intended mawarduri target. | Direct admission by raw observed candidate id returned `node_not_found`, so a registered node row was created from the observed mawarduri candidate before running the CLI admission path. | CAVEAT |
-| 3. Single-target scheduler explanation | `POST /v1/chat/completions` followed by `orchardctl requests inspect chatcmpl-a5ba2ade-97a7-42b4-948a-7e1effbde2c6 --json`. | A real chat completion succeeds and the persisted request inspect output includes a scheduler explanation for the single mawarduri target. | The chat returned HTTP `200` with content `mlx ready`, and request inspect showed one eligible scored candidate for node `6ec44363-70d4-456a-835c-73112994bc5c`. | PASS |
+| 2. Admission caveat | `orchardctl nodes admit <observed-candidate-id> --dry-run --json`. | The operator can admit the intended remote-worker-mac target. | Direct admission by raw observed candidate id returned `node_not_found`, so a registered node row was created from the observed remote-worker-mac candidate before running the CLI admission path. | CAVEAT |
+| 3. Single-target scheduler explanation | `POST /v1/chat/completions` followed by `orchardctl requests inspect chatcmpl-a5ba2ade-97a7-42b4-948a-7e1effbde2c6 --json`. | A real chat completion succeeds and the persisted request inspect output includes a scheduler explanation for the single remote-worker-mac target. | The chat returned HTTP `200` with content `mlx ready`, and request inspect showed one eligible scored candidate for node `6ec44363-70d4-456a-835c-73112994bc5c`. | PASS |
 | 4. Memory-budget status surface | `orchardctl nodes inspect 6ec44363-70d4-456a-835c-73112994bc5c --json`, Runtime Endpoint memory-budget snapshot, and catalog query. | The node status surface shows the memory-budget block including `recommended_context_tokens` alongside catalog `max_context_tokens`. | Runtime Endpoint data showed `recommended_context_tokens: 131072`, `status_code: ok`, `budget_available: true`, `headroom_available: true`, `target_working_set_bytes: 50096509747`, and `resident_memory_bytes: 695242752`. The catalog row showed `max_context_tokens: 131072`. `orchardctl nodes inspect --json` did not render the memory-budget block. | FAIL for requested CLI surface |
 | 5. Cordon | `orchardctl nodes cordon <node-id> --dry-run --json` then `orchardctl nodes cordon <node-id> --yes --json`. | Preview has no blockers and execute moves active to cordoned. | Preview had no blockers and expected `active` to `cordoned`. Execute returned action `node_lifecycle.cordoned`, audit log id `56`, and node state `cordoned`. | PASS |
 | 5. Drain | `orchardctl nodes drain <node-id> --dry-run --json` then `orchardctl nodes drain <node-id> --yes --json --acknowledge`. | Preview has no blockers and execute moves cordoned to draining. | Preview had no blockers, required `--yes` plus acknowledgement, and listed `existing_requests_continue_until_deadline`. Execute returned action `node_lifecycle.drain_started`, audit log id `57`, and node state `draining`. | PASS |
@@ -146,9 +145,9 @@ MLX bump items from issue `#65` were not exercised.
 The memory-budget data path was present in Runtime Endpoint evidence, but the requested `orchardctl nodes inspect` status surface did not render the memory-budget block.
 That is the only failed checklist surface in this run.
 
-The admission flow required creating a registered node row from the observed mawarduri candidate before using `orchardctl nodes admit`.
+The admission flow required creating a registered node row from the observed remote-worker-mac candidate before using `orchardctl nodes admit`.
 Direct CLI admission by raw observed candidate id returned `node_not_found`.
-This may be expected for the current CLI contract, but it is a smoke caveat because the checklist phrased mawarduri as an observed candidate target.
+This may be expected for the current CLI contract, but it is a smoke caveat because the checklist phrased remote-worker-mac as an observed candidate target.
 
 After the successful chat completion, later CLI lifecycle snapshots showed `node_observation_stale` in scheduler eligibility.
 The node remained lifecycle-active before decommission, and the request-inspect scheduler explanation from the real completion captured the node as eligible at scheduling time.


### PR DESCRIPTION
## Intent

The developer was running a two-Mac source-dev smoke test of Orchard against merge commit e60cc59 and wanted to record durable evidence of the results in the repo. They asked the agent to validate the split-role controller/node-agent cluster over BEAM Runtime Endpoint transport, exercising scheduler explanation, cancel-drain lifecycle, write-gate sanity, node decommission, and clean teardown across both hosts. The concrete deliverable was a committed investigation note (docs/investigations/source-dev-two-mac-smoke-2026-07-06.md) documenting what passed and what failed, honestly recording that the `orchardctl nodes inspect --json` memory-budget surface did not render as expected even though PR #67's memory-budget data was present in Runtime Endpoint evidence. Constraints included committing on a dedicated branch, keeping the working tree and both Macs cleanly torn down (no stray smoke BEAM processes, port 43690 listeners, or cookie files), and not opening a PR.

## What Changed

- Adds `docs/investigations/source-dev-two-mac-smoke-2026-07-06.md`, a 161-line investigation note recording a two-Mac source-dev BEAM Runtime Endpoint smoke of Orchard `main` at merge commit `e60cc59`, covering bring-up, cluster status, admission, an MLX chat completion, single-target scheduler explanations, cancel-drain lifecycle, write-gate sanity, decommission, and teardown.
- Honestly records one surface gap: `orchardctl nodes inspect --json` did not render the PR #67 memory-budget block, even though the underlying `recommended_context_tokens`/`max_context_tokens` data was present in the Runtime Endpoint snapshot and catalog row.
- Sanitizes infrastructure details in the note — real hostnames, Tailscale IPs, username, and machine paths are replaced with RFC 5737 example IPs and placeholders, and the shared BEAM cookie digest is omitted (per the Review pipeline auto-fix).

## Risk Assessment

✅ Low: Docs-only additive change: a single smoke-test evidence note with no product code, and the round-1 sanitization findings (real hostnames, IPs, username/paths, cookie digest) have all been correctly replaced with placeholders/RFC 5737 examples.

## Testing

Because this is a documentation-only evidence note with no runtime surface to drive, I validated the deliverable itself: I diffed base→target to confirm only the note was added, verified the no-mistakes sanitization commit removed every real infrastructure value (Tailscale IPs, hostnames, user, machine paths, cookie digest) in favor of RFC5737 doc IPs and placeholders, ran a residual leak scan that came back clean, confirmed the working tree has no stray smoke artifacts, and rendered the note to HTML plus a full-page screenshot showing the honest checklist (including the memory-budget CLI-surface FAIL row) and lifecycle audit trail. Everything passed.

- Evidence: Rendered two-Mac smoke note (screenshot) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWV0X8BD1YNA7GG1WVGAMZH0/two-mac-smoke-note.png</code>)
<details>
<summary>Evidence: Rendered two-Mac smoke note (HTML)</summary>

```text
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <meta charset="utf-8" />
  <meta name="generator" content="pandoc 3.10" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
  <title>Source-dev Two-Mac Smoke — 2026-07-06 (rendered evidence note)</title>
  <style>
    /* Default styles provided by pandoc.
    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
    */
    span.smallcaps{font-variant: small-caps;}
    div.columns{display: flex; gap: 1.5em;}
    div.column{flex: auto;}
    @media screen {
    div.columns{gap: min(4vw, 1.5em);}
    div.column{overflow-x: auto;}
    }
    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
    /* The extra [class] is a hack that increases specificity enough to
       override a similar rule in reveal.js */
    ul.task-list[class]{list-style: none;}
    ul.task-list li input[type="checkbox"] {
      font-size: inherit;
      width: 0.8em;
      margin: 0 0.8em 0.2em -1.6em;
      vertical-align: middle;
    }
    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
    /* CSS for syntax highlighting */
    html { -webkit-text-size-adjust: 100%; }
    pre > code.sourceCode { white-space: pre; position: relative; }
    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
    pre > code.sourceCode > span:empty { height: 1.2em; }
    .sourceCode { overflow: visible; }
    code.sourceCode > span { color: inherit; text-decoration: inherit; }
    div.sourceCode { margin: 1em 0; }
    pre.sourceCode { margin: 0; }
    @media screen {
    div.sourceCode { overflow: auto; }
    }
    @media print {
    pre > code.sourceCode { white-space: pre-wrap; }
    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
    }
    pre.numberSource code
      { counter-reset: source-line 0; }
    pre.numberSource code > span
      { position: relative; left: -4em; counter-increment: source-line; }
    pre.numberSource code > span > a:first-child::before
      { content: counter(source-line);
        position: relative; left: -1em; text-align: right; vertical-align: baseline;
        border: none; display: inline-block;
        -webkit-touch-callout: none; -webkit-user-select: none;
        -khtml-user-select: none; -moz-user-select: none;
        -ms-user-select: none; user-select: none;
        padding: 0 4px; width: 4em;
        color: #aaaaaa;
      }
    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
    div.sourceCode
      {   }
    @media screen {
    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
    }
    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
    code span.at { color: #7d9029; } /* Attribute */
    code span.bn { color: #40a070; } /* BaseN */
    code span.bu { color: #008000; } /* BuiltIn */
    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
    code span.ch { color: #4070a0; } /* Char */
    code span.cn { color: #880000; } /* Constant */
    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
    code span.dt { color: #902000; } /* DataType */
    code span.dv { color: #40a070; } /* DecVal */
    code span.er { color: #ff0000; font-weight: bold; } /* Error */
    code span.ex { } /* Extension */
    code span.fl { color: #40a070; } /* Float */
    code span.fu { color: #06287e; } /* Function */
    code span.im { color: #008000; font-weight: bold; } /* Import */
    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
    code span.op { color: #666666; } /* Operator */
    code span.ot { color: #007020; } /* Other */
    code span.pp { color: #bc7a00; } /* Preprocessor */
    code span.sc { color: #4070a0; } /* SpecialChar */
    code span.ss { color: #bb6688; } /* SpecialString */
    code span.st { color: #4070a0; } /* String */
    code span.va { color: #19177c; } /* Variable */
    code span.vs { color: #4070a0; } /* VerbatimString */
    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
  </style>
  <link rel="stylesheet" href="data:text/css,body{font-family:-apple-system,Segoe UI,sans-serif;max-width:960px;margin:2rem auto;padding:0 1rem;line-height:1.5}table{border-collapse:collapse;width:100%25;font-size:13px}th,td{border:1px solid %23ccc;padding:4px 8px;text-align:left;vertical-align:top}th{background:%23f0f0f0}code{background:%23f5f5f5;padding:1px 4px;border-radius:3px}pre{background:%23f5f5f5;padding:10px;overflow-x:auto}" />
</head>
<body>
<header id="title-block-header">
<h1 class="title">Source-dev Two-Mac Smoke — 2026-07-06 (rendered
evidence note)</h1>
</header>
<h1 id="source-dev-two-mac-smoke---2026-07-06">Source-dev Two-Mac Smoke
- 2026-07-06</h1>
<h2 id="summary">Summary</h2>
<p>Result: completed with one surface gap.</p>
<p>This smoke validated source-dev BEAM Runtime Endpoint mode across two
Macs on Orchard <code>main</code> after merge commit
<code>e60cc598a45245951dd337659c0695c64d2aa8c6</code>. The run exercised
bring-up, cluster status, admission, a real MLX chat completion,
persisted single-target scheduler explanations, lifecycle cancel-drain,
write-gate sanity, decommissioning, and teardown. No product code was
changed. The only committed artifact from this run is this evidence
note.</p>
<p>The PR #67 memory-budget status-surface check did not fully pass
through the requested CLI surface.
<code>orchardctl nodes inspect --json</code> did not render a
memory-budget block in this run. A Runtime Endpoint snapshot did expose
<code>recommended_context_tokens</code>, and the catalog row exposed
<code>max_context_tokens</code>, so the underlying data was present.
This remains a surface-evidence gap for follow-up.</p>
<p>Smoke date: 2026-07-06. Smoke completion time: 2026-07-06T06:09:56Z.
Tested code state:
<code>e60cc598a45245951dd337659c0695c64d2aa8c6</code>. Test branch for
evidence commit: <code>najibninaba/smoke-main-e60cc59</code>.</p>
<h2 id="hosts">Hosts</h2>
<p>Controller host: <code>controller-mac</code>. Controller Tailscale
IP: <code>192.0.2.10</code>. Controller checkout:
<code>&lt;orchard-checkout&gt;</code>.</p>
<p>Remote node-agent host: <code>remote-worker-mac</code>. Remote
node-agent Tailscale IP: <code>192.0.2.20</code>. Remote checkout:
<code>&lt;orchard-checkout&gt;</code>. Remote checkout was
fast-forwarded to <code>e60cc598a452</code> before the smoke. Remote
dependencies were refreshed with <code>mise exec -- mix deps.get</code>,
<code>mise exec -- uv sync --directory native/orchard_tokenizer</code>,
and
<code>mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx</code>.</p>
<p>Controller BEAM node name:
<code>orchard_controller@192.0.2.10</code>. Remote node-agent BEAM node
name: <code>orchard_node_agent@192.0.2.20</code>. The run used EPMD port
<code>43690</code> on both Macs because packaged Orchard and local EPMD
state may occupy the default port. The shared BEAM cookie was stored in
owner-only transient files, verified by digest comparison on both hosts,
and removed during teardown. Cookie contents and API token material are
intentionally omitted.</p>
<p>Packaged Orchard BEAM processes under
<code>/Library/Application Support/Orchard</code> were present on the
controller host and were ignored. The source-dev smoke used HTTP
<code>127.0.0.1:4000</code> and the source checkout.</p>
<h2 id="launch-commands">Launch Commands</h2>
<p>The remote node-agent was started on <code>remote-worker-mac</code>
with this sanitized command shape:</p>
<div class="sourceCode" id="cb1"><pre
class="sourceCode bash"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">ssh</span> <span class="op">&lt;</sp

... [9137 bytes truncated] ...

<code>budget_available: true</code>,
<code>headroom_available: true</code>,
<code>target_working_set_bytes: 50096509747</code>, and
<code>resident_memory_bytes: 695242752</code>. The catalog row showed
<code>max_context_tokens: 131072</code>.
<code>orchardctl nodes inspect --json</code> did not render the
memory-budget block.</td>
<td>FAIL for requested CLI surface</td>
</tr>
<tr>
<td>5. Cordon</td>
<td><code>orchardctl nodes cordon &lt;node-id&gt; --dry-run --json</code>
then
<code>orchardctl nodes cordon &lt;node-id&gt; --yes --json</code>.</td>
<td>Preview has no blockers and execute moves active to cordoned.</td>
<td>Preview had no blockers and expected <code>active</code> to
<code>cordoned</code>. Execute returned action
<code>node_lifecycle.cordoned</code>, audit log id <code>56</code>, and
node state <code>cordoned</code>.</td>
<td>PASS</td>
</tr>
<tr>
<td>5. Drain</td>
<td><code>orchardctl nodes drain &lt;node-id&gt; --dry-run --json</code>
then
<code>orchardctl nodes drain &lt;node-id&gt; --yes --json --acknowledge</code>.</td>
<td>Preview has no blockers and execute moves cordoned to draining.</td>
<td>Preview had no blockers, required <code>--yes</code> plus
acknowledgement, and listed
<code>existing_requests_continue_until_deadline</code>. Execute returned
action <code>node_lifecycle.drain_started</code>, audit log id
<code>57</code>, and node state <code>draining</code>.</td>
<td>PASS</td>
</tr>
<tr>
<td>5. Cancel drain</td>
<td><code>orchardctl nodes cancel-drain &lt;node-id&gt; --dry-run --json</code>
then
<code>orchardctl nodes cancel-drain &lt;node-id&gt; --yes --json</code>.</td>
<td>Preview has no blockers while draining and execute moves the node to
cordoned.</td>
<td>Preview had no blockers and expected <code>draining</code> to
<code>cordoned</code>. Execute returned action
<code>node_lifecycle.drain_cancelled</code>, audit log id
<code>58</code>, and node state <code>cordoned</code>.</td>
<td>PASS</td>
</tr>
<tr>
<td>5. Cancel-drain blocker</td>
<td><code>orchardctl nodes cancel-drain &lt;node-id&gt; --dry-run --json</code>
after the node was cordoned.</td>
<td>Preview on a non-draining node shows
<code>drain_not_running</code>.</td>
<td>Preview returned blocker code <code>drain_not_running</code> and
left the expected transition as <code>cordoned</code> to
<code>cordoned</code>.</td>
<td>PASS</td>
</tr>
<tr>
<td>5. Uncordon</td>
<td><code>orchardctl nodes uncordon &lt;node-id&gt; --dry-run --json</code>
then
<code>orchardctl nodes uncordon &lt;node-id&gt; --yes --json</code>.</td>
<td>Preview has no blockers and execute returns the node to active.</td>
<td>Preview had no blockers and expected <code>cordoned</code> to
<code>active</code>. Execute returned action
<code>node_lifecycle.uncordoned</code>, audit log id <code>59</code>,
and node state <code>active</code>.</td>
<td>PASS</td>
</tr>
<tr>
<td>6. Write gate sanity</td>
<td><code>orchardctl cluster status --json</code> plus the successful
admission and lifecycle writes.</td>
<td>Single-controller mode writes are allowed.</td>
<td>Cluster status reported <code>writes_allowed_when_authorized</code>,
and admission plus lifecycle write actions succeeded.</td>
<td>PASS</td>
</tr>
<tr>
<td>6. Active/Standby denial</td>
<td>Not run.</td>
<td>The <code>controller_leadership_unproven</code> denial requires an
Active/Standby two-controller topology.</td>
<td>This smoke used single-controller mode only.</td>
<td>NOT EXERCISED</td>
</tr>
<tr>
<td>7. Node removal</td>
<td><code>orchardctl nodes decommission &lt;node-id&gt; --dry-run --json</code>
then
<code>orchardctl nodes decommission &lt;node-id&gt; --yes --acknowledge --typed-node-id &lt;node-id&gt; --json</code>.</td>
<td>Preview has no blockers and execute moves the node to
<code>decommissioning</code> or <code>removed</code>.</td>
<td>Preview had no blockers and consequence codes
<code>future_scheduling_revoked</code> and
<code>no_rejoin_with_same_node_id</code>. Execute returned action
<code>node_lifecycle.decommission_started</code>, audit log id
<code>60</code>, and node state <code>decommissioning</code>.</td>
<td>PASS</td>
</tr>
<tr>
<td>7. Drop from scheduling</td>
<td><code>Orchard.Nodes.schedulable_nodes()</code> after
decommission.</td>
<td>The removed or decommissioning node is not schedulable.</td>
<td>The query returned <code>[]</code>.</td>
<td>PASS</td>
</tr>
<tr>
<td>8. Teardown</td>
<td>Stop both screens, kill leftover source-dev smoke PIDs, kill EPMD
<code>43690</code>, remove cookie files, and re-check processes.</td>
<td>Both dev servers stop, cookie files are removed, and no smoke BEAM
processes remain on either host.</td>
<td>After a targeted correction pass, no smoke BEAM processes remained,
port <code>43690</code> was clear on both hosts, local HTTP
<code>4000</code> returned <code>000</code>, and both transient cookie
files were absent.</td>
<td>PASS</td>
</tr>
</tbody>
</table>
<h2 id="lifecycle-audit-trail">Lifecycle Audit Trail</h2>
<p>The node lifecycle audit trail contained these records for node
<code>6ec44363-70d4-456a-835c-73112994bc5c</code>:</p>
<table>
<colgroup>
<col style="width: 33%" />
<col style="width: 33%" />
<col style="width: 33%" />
</colgroup>
<thead>
<tr>
<th>Audit id</th>
<th>Action</th>
<th>Transition</th>
</tr>
</thead>
<tbody>
<tr>
<td>56</td>
<td><code>node_lifecycle.cordoned</code></td>
<td><code>active</code> to <code>cordoned</code></td>
</tr>
<tr>
<td>57</td>
<td><code>node_lifecycle.drain_started</code></td>
<td><code>cordoned</code> to <code>draining</code></td>
</tr>
<tr>
<td>58</td>
<td><code>node_lifecycle.drain_cancelled</code></td>
<td><code>draining</code> to <code>cordoned</code></td>
</tr>
<tr>
<td>59</td>
<td><code>node_lifecycle.uncordoned</code></td>
<td><code>cordoned</code> to <code>active</code></td>
</tr>
<tr>
<td>60</td>
<td><code>node_lifecycle.decommission_started</code></td>
<td><code>active</code> to <code>decommissioning</code></td>
</tr>
</tbody>
</table>
<h2 id="not-exercised">Not Exercised</h2>
<p><code>cluster_busy</code> saturation shift was not exercised because
the smoke did not create saturation. Memory-budget enforce abort was not
exercised because the smoke did not create real memory pressure.
TokenDelta opt-in was not exercised because it is an internal wire
surface. Active/Standby leadership denial was not exercised because the
smoke did not start a second controller. MLX bump items from issue
<code>#65</code> were not exercised.</p>
<h2 id="residual-risks-and-notes">Residual Risks And Notes</h2>
<p>The memory-budget data path was present in Runtime Endpoint evidence,
but the requested <code>orchardctl nodes inspect</code> status surface
did not render the memory-budget block. That is the only failed
checklist surface in this run.</p>
<p>The admission flow required creating a registered node row from the
observed remote-worker-mac candidate before using
<code>orchardctl nodes admit</code>. Direct CLI admission by raw
observed candidate id returned <code>node_not_found</code>. This may be
expected for the current CLI contract, but it is a smoke caveat because
the checklist phrased remote-worker-mac as an observed candidate
target.</p>
<p>After the successful chat completion, later CLI lifecycle snapshots
showed <code>node_observation_stale</code> in scheduler eligibility. The
node remained lifecycle-active before decommission, and the
request-inspect scheduler explanation from the real completion captured
the node as eligible at scheduling time.</p>
<p>The source CLI command form used during the smoke was
<code>mise exec -- mix run -e 'OrchardCLI.main([...])'</code>. It starts
enough application context to emit debug logs, so the raw local evidence
logs are noisy. Those transient logs were kept under
<code>tmp/dev/smoke-e60cc59-evidence/</code> and are intentionally not
committed.</p>
<p>The first teardown pass stopped the screen sessions but left child
BEAM processes running. A targeted correction pass killed only the
source-dev smoke PIDs and the nonstandard EPMD listeners on port
<code>43690</code>. The final teardown check showed no smoke BEAM
processes and no <code>43690</code> listeners on either Mac.</p>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Sanitization diff (real infra values → doc placeholders)</summary>

```text
-Controller Tailscale IP: `100.90.207.78` -> +`192.0.2.10`
-Remote Tailscale IP: `100.70.81.109` -> +`192.0.2.20`
-hosts tamingsari/mawarduri -> controller-mac/remote-worker-mac
-Cookie SHA-256 digest: 68d8cc1a... -> (dropped; digest-comparison note only)
-/Users/najib/Hacks/orchard -> <orchard-checkout>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/investigations/source-dev-two-mac-smoke-2026-07-06.md:24` - This note commits real internal infrastructure details — hostnames (`tamingsari`, `mawarduri`), Tailscale IPs (`100.90.207.78`, `100.70.81.109`), the OS username (`najib` in `ssh najib@...` and `/Users/najib/Hacks/orchard`), and absolute/home machine paths (`/Users/najib/Hacks/orchard`, `~/Hacks/orchard`). This conflicts with AGENTS.md (&#39;Do not commit ... local paths ... machine-specific paths&#39;) and reverses the explicit sanitization decision applied to the prior smoke note in commit 7cc0284, which replaced equivalent values with RFC 5737 example IPs (192.0.2.10/.20) and placeholder hostnames (controller-mac / remote-worker-mac). Recommend sanitizing to the same placeholder scheme before merge.
- ℹ️ `docs/investigations/source-dev-two-mac-smoke-2026-07-06.md:46` - Both launch snippets are labeled &#39;sanitized command shape&#39; (lines 46 and 61), but they still contain real Tailscale IPs, the real username, and real absolute paths. Only the cookie file and remote setup are actually redacted, so the &#39;sanitized&#39; framing is misleading given the rest of the finding.
- ℹ️ `docs/investigations/source-dev-two-mac-smoke-2026-07-06.md:38` - The shared BEAM cookie&#39;s SHA-256 digest is committed. The cookie itself was high-entropy and destroyed at teardown so real-world risk is low, but the digest is unnecessary durable evidence — a plain statement that the cookie was verified by digest and removed (as the prior note did on its line 27) conveys the same fact without publishing the hash.

🔧 Fix: sanitize two-Mac smoke note infra values and drop cookie digest
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat e60cc59..8990264` — confirmed the change is a single new docs file (161 additions), no product code/tests touched</code>
- <code>`git diff 27979dd 8990264` — verified the sanitization commit replaced all real Tailscale IPs, hostnames (tamingsari/mawarduri), user, machine paths, and dropped the cookie SHA-256 digest, substituting RFC5737 doc IPs and placeholders</code>
- <code>grep residual scan for real IPs / cookies / tokens / `/Users/` paths / old hostnames+digest in the committed note — none found (only remaining `najib` is the public evidence branch name)</code>
- <code>`git status --porcelain` and `git ls-files | grep smoke` — working tree clean, no committed smoke/tmp artifacts, no tmp/dev directory</code>
- <code>Rendered the note with `pandoc -s` to HTML and captured a full-page screenshot via agent-browser as reviewer-visible evidence; removed a stray `--full-page` file created during screenshotting</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
