### PR TITLE
feat(worker): enforce admission memory pressure gate

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1490,10 +1490,10 @@ The worker-side `memory_budget_mode` (`ORCHARD_WORKER_MEMORY_BUDGET_MODE`) is
   `memory_pressure_abort` terminal so operators can distinguish enforcement from
   other failures. Enforcement applies cooldown hysteresis between abort sweeps,
   and every enforcement gate is fail-open: an unavailable, missing, or failed
-  memory sample SHALL NOT fail a generation on its own. Pressure is sampled per
-  backend decode event only; prefill is not interruptible, so a request already
-  in prefill is not aborted mid-prefill. Admission-time memory gating is deferred
-  follow-up work (issue #68).
+  memory sample SHALL NOT fail a generation on its own. Pressure is sampled at
+  admission before backend prefill starts and per backend decode event. Prefill
+  is not interruptible, so a request already in prefill is not aborted
+  mid-prefill.
 
 ### 6.5 Model import
 

--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/service.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/service.py
@@ -453,10 +453,11 @@ class WorkerRuntimeServicer(worker_runtime_pb2_grpc.WorkerRuntimeServiceServicer
       ``mx.get_active_memory`` by default) compared against the loaded session's
       ``target_working_set_bytes`` from the backend memory-budget status. A
       breach means the sampled active memory exceeds the target.
-    - Checks run inside the ``Generate`` event-consuming loop only — pressure
-      only matters while generations are active, and every active generation
-      (stream or batch) flows through a ``Generate`` loop — rate-limited to one
-      check per ``memory_pressure_check_interval_s`` across all requests. No
+    - Checks run after ``start_generation`` before backend prefill and inside
+      the ``Generate`` event-consuming loop. Pressure only matters while
+      generations are active, and every active generation (stream or batch)
+      flows through a ``Generate`` loop. Checks are rate-limited to one check
+      per ``memory_pressure_check_interval_s`` across all requests. No
       background thread is used.
     - On breach the servicer sets every active-phase cancel event (reusing the
       client-cancel machinery), so all active generations abort. The model
@@ -727,6 +728,13 @@ class WorkerRuntimeServicer(worker_runtime_pb2_grpc.WorkerRuntimeServiceServicer
                     self._backend.record_fingerprint(fingerprint)
                 except Exception:
                     pass
+
+            self._maybe_enforce_memory_pressure()
+            if cancel_event.is_set():
+                proto_event = build_failed_event("cancelled", "request cancelled", False)
+                yield self._replace_memory_abort_terminal(proto_event, entry)
+                terminal_emitted = True
+                return
 
             backend_iterator = self._backend.generate(request, cancel_event)
             try:

--- a/native/orchard_worker_mlx/tests/test_service.py
+++ b/native/orchard_worker_mlx/tests/test_service.py
@@ -2064,6 +2064,7 @@ class MemoryBudgetBackend(HappyBackend):
         self.target_working_set_bytes = target_working_set_bytes
         self.max_deltas = max_deltas
         self.unload_calls = 0
+        self.generate_calls = 0
 
     def unload_model(self) -> None:
         self.unload_calls += 1
@@ -2084,6 +2085,7 @@ class MemoryBudgetBackend(HappyBackend):
 
     def generate(self, request: Any, cancel_event: threading.Event) -> Iterator[dict[str, Any]]:
         del request
+        self.generate_calls += 1
         for index in range(self.max_deltas):
             if cancel_event.is_set():
                 yield {
@@ -2118,11 +2120,25 @@ def _make_memory_pressure_servicer(
     )
 
 
+def test_enforce_preflight_breach_aborts_before_backend_prefill() -> None:
+    backend = MemoryBudgetBackend()
+    servicer = _make_memory_pressure_servicer(backend, memory_sampler=lambda: 2_000)
+
+    events = list(servicer.Generate(_make_request("req-preflight"), MagicMock()))
+
+    assert [event.WhichOneof("event") for event in events] == ["failed"]
+    assert events[0].failed.code == "memory_pressure_abort"
+    assert events[0].failed.retryable is True
+    assert backend.generate_calls == 0
+    assert backend._active is False
+
+
 def test_enforce_breach_aborts_all_active_generations_with_distinct_terminal(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     backend = MemoryBudgetBackend()
-    servicer = _make_memory_pressure_servicer(backend, memory_sampler=lambda: 2_000)
+    samples = iter([100, 2_000])
+    servicer = _make_memory_pressure_servicer(backend, memory_sampler=lambda: next(samples))
     other_entry = CancelEntry(
         event=threading.Event(),
         phase="active",
@@ -2163,6 +2179,23 @@ def test_observe_mode_never_aborts_under_identical_pressure() -> None:
     servicer = _make_memory_pressure_servicer(backend, memory_sampler=sampler)
 
     events = list(servicer.Generate(_make_request("req-observe"), MagicMock()))
+
+    kinds = [event.WhichOneof("event") for event in events]
+    assert kinds == ["output_text_delta"] * 3 + ["completed"]
+    assert sampler_calls == []
+
+
+def test_disabled_mode_never_aborts_under_identical_pressure() -> None:
+    backend = MemoryBudgetBackend(mode="disabled")
+    sampler_calls: list[int] = []
+
+    def sampler() -> int:
+        sampler_calls.append(1)
+        return 2_000
+
+    servicer = _make_memory_pressure_servicer(backend, memory_sampler=sampler)
+
+    events = list(servicer.Generate(_make_request("req-disabled"), MagicMock()))
 
     kinds = [event.WhichOneof("event") for event in events]
     assert kinds == ["output_text_delta"] * 3 + ["completed"]


### PR DESCRIPTION
## Intent

Closes #68.

The developer was working on Orchard issue #68, asking the coding agent to enforce an admission-time memory pressure gate in the MLX worker's Generate() path. They wanted the memory pressure check to run at admission (after start_generation() but before backend.generate()/prefill), reusing the existing fail-open enforcement, cooldown, target/sampler validation, and retryable memory_pressure_abort terminal, while ensuring the preflight abort still runs finish_generation() cleanup via the existing finally block. Requirements included following a TDD (red-green-refactor) workflow, adding tests for preflight abort before prefill, cleanup after abort, and disabled-mode no-abort behavior, and updating SPEC.md to reflect that admission gating now exists while mid-prefill interruption remains out of scope. They also expected the native Python quality workflow (ruff format, ruff check, pytest, pytest --cov) to pass before committing with a conventional commit message.

## What Changed

- Added an admission-time memory pressure check in the MLX worker's `Generate` path: `_maybe_enforce_memory_pressure()` now runs after `start_generation` but before `backend.generate()`/prefill, and an already-set cancel event yields a `memory_pressure_abort` terminal (via `_replace_memory_abort_terminal`) instead of starting prefill. The preflight abort still flows through the existing `finally` block so `finish_generation` cleanup runs.
- The gate reuses the existing fail-open enforcement, cooldown hysteresis, and per-interval rate limiting; mid-prefill interruption remains out of scope since prefill is not interruptible.
- Updated `SPEC.md` to state that pressure is now sampled at admission before prefill as well as per decode event, removing the deferred-follow-up note for issue #68, and expanded `test_service.py` with coverage for preflight abort before prefill, cleanup after abort, and disabled-mode no-abort behavior.

## Risk Assessment

✅ Low: A small, well-bounded change that reuses existing, tested fail-open enforcement machinery; cleanup, terminal-distinction, cooldown, and rate-limit invariants all hold, and the change is directly covered by new and updated tests plus a matching SPEC.md update.

## Testing

Ran the baseline native pytest slice for the memory-pressure surface (all passing, including the new preflight-abort, cleanup-after-abort, and disabled-mode tests plus the retooled mid-decode enforce test), then drove the servicer end-to-end to produce a client-facing transcript. The transcript is the load-bearing evidence: in enforce mode a breach at admission yields a single `memory_pressure_abort` (retryable=True) terminal, `backend.generate()` is called 0 times (proving the abort lands before prefill), `finish_generation()` cleanup ran once, and the backend session was released; in disabled mode the same 2000-byte pressure never aborts, the sampler is never consulted, and generation streams to completion. Removed the transient evidence driver; working tree is clean (`.venv` is gitignored). No screenshot applies — this is a gRPC worker service path with no rendered UI; the CLI transcript of the event stream is the end-user-equivalent surface.

<details>
<summary>Evidence: Admission-gate end-to-end event-stream transcript (enforce breach + disabled)</summary>

<code>memory budget enforcement aborted 1 active generation(s): sampled_active_memory_bytes=2000 target_working_set_bytes=1000 request_ids=[&#39;req-preflight&#39;]&#10;&#10;=== ENFORCE: breach at admission (before prefill) ===&#10;[0] failed: code=&#39;memory_pressure_abort&#39; retryable=True&#10;backend.generate() called: 0 time(s) (0 =&gt; aborted BEFORE prefill)&#10;backend.finish_generation() cleanup calls: 1 (&gt;=1 =&gt; finally cleanup ran)&#10;backend still active after abort: False (False =&gt; session released)&#10;&#10;=== DISABLED: identical pressure never aborts ===&#10;[0] output_text_delta: &#39;chunk-0&#39;&#10;[1] output_text_delta: &#39;chunk-1&#39;&#10;[2] output_text_delta: &#39;chunk-2&#39;&#10;[3] completed&#10;memory sampler consulted: 0 time(s) (0 =&gt; gate short-circuits when disabled)&#10;backend.generate() called: 1 time(s) (streamed normally to completion)&#10;&#10;Done.</code>

```text
memory budget enforcement aborted 1 active generation(s): sampled_active_memory_bytes=2000 target_working_set_bytes=1000 request_ids=['req-preflight']

=== ENFORCE: breach at admission (before prefill) ===
  [0] failed: code='memory_pressure_abort' retryable=True
  backend.generate() called: 0 time(s)  (0 => aborted BEFORE prefill)
  backend.finish_generation() cleanup calls: 1  (>=1 => finally cleanup ran)
  backend still active after abort: False  (False => session released)

=== DISABLED: identical pressure never aborts ===
  [0] output_text_delta: 'chunk-0'
  [1] output_text_delta: 'chunk-1'
  [2] output_text_delta: 'chunk-2'
  [3] completed
  memory sampler consulted: 0 time(s)  (0 => gate short-circuits when disabled)
  backend.generate() called: 1 time(s)  (streamed normally to completion)

Done.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- uv run --directory native/orchard_worker_mlx pytest tests/test_service.py -k &#34;memory_pressure or preflight or disabled_mode or enforce or observe_mode&#34;` — 19 passed</code>
- <code>`pytest -k &#34;preflight or disabled_mode or enforce_breach or observe_mode or fails_open&#34;` — 14 passed (covers preflight abort, cleanup-after-abort, disabled no-abort, mid-decode-loop abort, fail-open)</code>
- <code>Ran an end-to-end evidence driver invoking `WorkerRuntimeServicer.Generate` against the test fake backend to capture the client-visible event stream and backend accounting (generate/finish_generation calls, active flag)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

