### PR TITLE
docs: specify orchardctl cluster init first-admin contract (ADR 0011)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3808,6 +3808,15 @@ Lifecycle execution SHALL enforce the preview's confirmation requirements, inclu
 Node lifecycle CLI commands use the same local controller-runtime authority boundary as node-admission CLI commands and SHALL enforce the same leader-only write-path, mutation-time revalidation, cluster-scoped audit, and shared-presenter semantics.
 Manual `draining -> maintenance` execution SHALL remain blocked with a `drain_completion_unverified` blocker until drain completion can be verified.
 
+`orchardctl cluster init` SHALL mint the first cluster-admin credential as a local, one-shot, audited controller-host operation.
+It SHALL create a service-account-owned API Client holding a cluster-scoped `admin` RoleBinding and an API Token whose secret is emitted exactly once through a required operator-chosen `--output` path with preflight, persisting only the token hash and prefix.
+It SHALL refuse with a stable `cluster_already_initialized` error when an enabled cluster-scoped `admin` RoleBinding already exists.
+An explicit `--force-new-admin` recovery flag SHALL mint an additional admin credential without resetting, deleting, or mutating existing credentials, and SHALL require confirmation and record a cluster-scoped audit event.
+`orchardctl cluster init` uses the same local controller-runtime authority boundary and leader-only write-path gate as node-admission CLI commands.
+First-admin provisioning is a local controller-host CLI operation, not an Admin API endpoint; Bootstrap Tokens remain scoped to node join only per §10.1.
+`orchardctl cluster init` is credential-only: TLS material remains provisioned separately per §11.4, and PKG `postinstall` SHALL NOT seed admin credentials.
+Successful initialization output SHOULD direct operators to provision named admin API Clients and then revoke the bootstrap credential.
+
 `orchardctl requests inspect` SHALL render a request's persisted scheduler explanation through the shared scheduler explanation reason-code contract in stable human and JSON forms.
 Broader request execution diagnostics beyond persisted scheduler explanations remain future work.
 

--- a/docs/decisions/0004-admin-api-cluster-admin-auth.md
+++ b/docs/decisions/0004-admin-api-cluster-admin-auth.md
@@ -13,3 +13,5 @@ It also makes API Client disablement the single kill switch for service-account-
 
 The first Admin API admission slice may seed admin credentials in tests and local setup code.
 The operator-facing first-admin and cluster bootstrap workflow remains a separate `orchardctl cluster init`, bootstrap-token, or provisioning slice.
+
+Amended 2026-07-06: the deferred first-admin workflow is now decided as local `orchardctl cluster init`, with the bootstrap-token and network-provisioning alternatives rejected; see ADR 0011.

--- a/docs/decisions/0011-first-admin-cluster-init.md
+++ b/docs/decisions/0011-first-admin-cluster-init.md
@@ -1,0 +1,48 @@
+# ADR: First cluster-admin credential is minted by local `orchardctl cluster init`
+
+## Status
+
+Accepted. Implementation closes GitHub issue #75.
+
+## Context
+
+ADR 0004 defines the Admin API credential shape (a service-account-owned API Token whose enabled API Client holds a cluster-scoped `admin` RoleBinding) but explicitly deferred how the first such credential comes to exist.
+Until a provisioning path lands, a fresh deployment has no supported way to mint the first cluster-admin credential, so the Admin API cannot be presented as operator-usable.
+SPEC.md §11.9 already lists `orchardctl cluster init` as a required command, §11.7 places it immediately after PKG install in the offline flow, and the CLI carries a deferred stub for it.
+SPEC.md §10.1 scopes Bootstrap Tokens to initial node join only, and `POST /admin/v1/bootstrap-tokens` requires the very admin credential being minted, so bootstrap tokens are not a first-admin path.
+ADR 0006 already established the trust boundary a first credential needs: local `orchardctl` on the controller host executes with controller-runtime authority, without a bearer token, behind leader-only write gates and cluster-scoped audit.
+ADR 0002 and SPEC.md §7.4.4 established the one-time-secret CLI output pattern (required operator-chosen `--output` path with preflight, hash-only persistence).
+
+## Decision
+
+Mint the first cluster-admin credential with `orchardctl cluster init` as a local, one-shot, audited controller-host operation.
+
+Fixed contract points:
+
+* One-shot by default: refuse with a stable `cluster_already_initialized` error when an enabled cluster-scoped `admin` RoleBinding already exists.
+* Explicit break-glass: a `--force-new-admin` flag mints an additional admin credential, never resets, deletes, or mutates existing credentials, requires confirmation, and records a cluster-scoped audit event. This is the lost-all-tokens recovery path; local host access under ADR 0006 is the recovery authority.
+* One-time secret output: required operator-chosen `--output` path with preflight per the §7.4.4 pattern; only the token hash and prefix persist.
+* Leader-only write gate: same boundary as node-admission and lifecycle CLI commands, so the command is Active/Standby-safe from day one.
+* No default token expiry: rotation is encouraged through post-setup output guidance (provision named admin API Clients, then revoke the bootstrap credential) rather than a forced expiry that could brick the admin path on an appliance. This follows the ADR 0002 precedent of encouraging, not requiring, expiry.
+* Credential-only scope: TLS material remains provisioned separately (`orchardctl tls init` local-CA helper or operator-provided material per §11.4), and this slice ships CLI-only with the §11.3 bootstrap UI deferred.
+
+Alternatives rejected:
+
+* Unauthenticated one-shot bootstrap API endpoint (Nomad `acl bootstrap` shape) — Nomad needs a network bootstrap because its CLI is a pure API client; `orchardctl` already runs in the controller runtime, so a network mint surface adds an unauthenticated endpoint, a fresh-install race window, and a reset procedure that requires local disk authority anyway, while buying nothing for a 1-4 node on-prem product.
+* Installer/PKG-seeded credential — controller hosts require external Postgres configured after install, so `postinstall` generally has no database to mint into; §11.4 precedent says the installer never generates trust material; unattended MDM installs would scatter root-owned secret files with no operator-chosen destination; seeded default admins are the documented anti-pattern (Grafana `admin/admin`, MinIO `minioadmin`).
+* Environment-seeded admin at controller boot — long-lived plaintext secret in launchd env files against §10.2's discipline, with re-seeding ambiguity on every boot; only fits container-first products.
+
+Prior art: kubeadm mints local-file cluster-admin authority at `kubeadm init` and keeps bootstrap tokens strictly node-join material; k3s uses a server-local node token; Nomad's one-shot `acl bootstrap` demonstrates the one-shot guard plus guarded reset; Vault's `operator init` root token comes with use-for-setup-then-revoke hardening guidance, which this decision adopts as output guidance.
+
+## Consequences
+
+The Admin API becomes operator-usable on fresh installs through a documented local ritual, and the offline flow in §11.7 becomes fully executable.
+The implementation slice adds a governance bootstrap module (transactional guard, ADR 0004 binding shape, one-time secret emission, audit) and the real `cluster init` CLI command with stable human and JSON output, plus happy-path and failure-path tests including the one-shot guard race, non-leader refusal, and output preflight failure.
+The one-shot guard must be transactionally race-safe (unique constraint or serializable guard query), because two concurrent inits on a fresh database must not both succeed silently.
+Future Console or Admin API credential-management surfaces may graduate the break-glass path to a dedicated command; the `--force-new-admin` flag remains the minimal slice until then.
+
+## SPEC.md impact
+
+§11.9 gains the normative `orchardctl cluster init` first-admin contract (one-shot guard, recovery flag, one-time output, leader-only, audit, credential-only scope).
+§10.1's node-join-only scoping of Bootstrap Tokens is unchanged and is now explicitly load-bearing for this decision.
+The OpenSpec change `first-admin-cluster-init` carries the corresponding `api-client-provisioning` requirement delta.

--- a/openspec/changes/first-admin-cluster-init/design.md
+++ b/openspec/changes/first-admin-cluster-init/design.md
@@ -1,0 +1,24 @@
+## Design Notes
+
+### Trust boundary
+
+First-admin minting runs under the ADR 0006 local controller-runtime authority boundary: local OS access to `orchardctl` on the controller host is operator context, no bearer token exists yet, and the leader-only write gate plus cluster-scoped audit apply exactly as they do for node-admission commands.
+A network bootstrap endpoint was rejected (unauthenticated mint surface, fresh-install race window, reset procedure that needs local disk authority anyway); installer seeding was rejected (external Postgres is configured after install, §11.4 forbids installer-generated trust material, unattended MDM installs would scatter secrets); environment seeding was rejected (long-lived plaintext in launchd env files).
+Prior art: kubeadm local `admin.conf`, k3s server-local token, Nomad one-shot `acl bootstrap`, Vault init-then-revoke-root guidance.
+
+### One-shot guard race
+
+Two concurrent `cluster init` runs on a fresh database must not both succeed.
+The guard query (no enabled API Client with a cluster-scoped `admin` RoleBinding) runs inside the minting transaction; race safety comes from a uniqueness guarantee rather than the read alone — either a partial unique index on cluster-scoped admin role bindings or an equivalent serializable/advisory-locked check.
+The recovery path (`--force-new-admin`) skips the guard by design and is additive only.
+
+### Secret handling
+
+The token secret exists in memory once: generated, written to the preflighted `--output` destination, and returned to the operator.
+Postgres stores hash and prefix only (ADR 0002 / SPEC §10.2 discipline).
+Output preflight runs before any database mutation so a failed write cannot strand a minted-but-unsaved credential; if the output write fails after mint, follow the `mark_output_failed` precedent from `ApiClientProvisioning`.
+No default expiry: rotation is guidance, not enforcement, per ADR 0011.
+
+### Active/Standby
+
+The leader-only write gate makes the command safe under Active/Standby from day one: a standby controller refuses with the existing standby semantics, and an unproven leader refuses with `controller_leadership_unproven` per the PR #69 write-gate contract.

--- a/openspec/changes/first-admin-cluster-init/proposal.md
+++ b/openspec/changes/first-admin-cluster-init/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+A fresh Orchard deployment has no supported way to mint the first cluster-admin credential (issue #75).
+ADR 0004 defined the credential shape and deferred provisioning; SPEC.md §11.9 requires `orchardctl cluster init` and §11.7 places it in the offline install flow, but the CLI stub is deferred and no minting path exists.
+Until this lands, the Admin API cannot be presented as operator-usable on a fresh install.
+
+## What Changes
+
+- Define `orchardctl cluster init` as the local, one-shot, audited first-admin credential mint per ADR 0011: service-account-owned API Client with a cluster-scoped `admin` RoleBinding and a hash-only API Token, one-time secret output through the §7.4.4 pattern, `cluster_already_initialized` guard, `--force-new-admin` additive break-glass with confirmation and audit, leader-only write gate.
+- Keep first-admin provisioning off the network: no Admin API endpoint, no installer seeding, no repurposing of node-join Bootstrap Tokens.
+- Keep the slice credential-only: TLS provisioning and the §11.3 bootstrap UI remain separate work.
+- Implement the governance bootstrap module, the real CLI command, and happy-path plus failure-path tests.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `api-client-provisioning`: gains the first cluster-admin credential provisioning requirement (`orchardctl cluster init` contract).

--- a/openspec/changes/first-admin-cluster-init/specs/api-client-provisioning/spec.md
+++ b/openspec/changes/first-admin-cluster-init/specs/api-client-provisioning/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: First Cluster-Admin Credential Provisioning
+Orchard SHALL provision the first cluster-admin credential through `orchardctl cluster init` as a local, one-shot, audited controller-host operation.
+`orchardctl cluster init` SHALL create a service-account-owned API Client holding a cluster-scoped `admin` RoleBinding and an API Token persisted as hash and prefix only.
+The token secret SHALL be emitted exactly once through a required operator-chosen output path with preflight, following the One-time Secret Output requirements.
+Initialization SHALL refuse with a stable `cluster_already_initialized` error when an enabled cluster-scoped `admin` RoleBinding already exists, and the one-shot guard SHALL be race-safe under concurrent initialization attempts.
+An explicit recovery flag SHALL mint an additional admin credential without resetting, deleting, or mutating existing credentials, SHALL require confirmation, and SHALL record a cluster-scoped audit event.
+Initialization SHALL execute under the local controller-runtime authority boundary with the leader-only write-path gate.
+First-admin provisioning SHALL NOT be exposed as an Admin API endpoint, SHALL NOT be seeded by installer packaging, and SHALL NOT repurpose node-join Bootstrap Tokens.
+This refines `SPEC.md` §10.1, §10.2, §11.4, and §11.9 per ADR 0011.
+
+#### Scenario: Fresh cluster mints the first admin credential
+- **WHEN** an operator runs `orchardctl cluster init` with a writable output path on a cluster with no enabled cluster-scoped `admin` RoleBinding
+- **THEN** Orchard creates the service-account-owned API Client, cluster-scoped `admin` RoleBinding, and API Token in one transaction
+- **AND** Orchard emits the token secret exactly once to the operator-chosen output path
+- **AND** Orchard persists only the token hash and prefix
+- **AND** Orchard records a cluster-scoped audit event
+
+#### Scenario: Second initialization refuses
+- **WHEN** an operator runs `orchardctl cluster init` on a cluster that already has an enabled cluster-scoped `admin` RoleBinding
+- **THEN** Orchard refuses with the stable `cluster_already_initialized` error
+- **AND** Orchard mutates no credential state
+
+#### Scenario: Recovery mint is additive
+- **WHEN** an operator runs `orchardctl cluster init` with the recovery flag and confirms
+- **THEN** Orchard mints an additional admin credential
+- **AND** Orchard does not reset, delete, or mutate existing credentials
+- **AND** Orchard records a cluster-scoped audit event for the recovery mint
+
+#### Scenario: Non-leader controller refuses
+- **WHEN** an operator runs `orchardctl cluster init` on a standby controller or a configured leader without proven advisory-lock leadership
+- **THEN** Orchard refuses through the shared leader-only write-path gate semantics
+- **AND** Orchard mutates no credential state

--- a/openspec/changes/first-admin-cluster-init/tasks.md
+++ b/openspec/changes/first-admin-cluster-init/tasks.md
@@ -1,0 +1,18 @@
+## 1. Governance bootstrap
+
+- [ ] 1.1 Implement `Orchard.Governance.ClusterBootstrap` with `mint_first_admin/1` and `mint_recovery_admin/1`: single transaction with a race-safe one-shot guard (refuse when an enabled cluster-scoped `admin` RoleBinding exists; guard skipped for recovery), creating the service account API Client (default name overridable via `--client-name`), the API Token via `ApiKeySecret` (hash and prefix persisted only), the ADR 0004 RoleBinding shape, and a cluster-scoped audit event; return the secret exactly once.
+- [ ] 1.2 Reuse or cleanly extract shared logic from `ApiClientProvisioning` where applicable instead of duplicating it.
+
+## 2. CLI
+
+- [ ] 2.1 Replace the deferred `orchardctl cluster init` stub with the real command: `--output` (required for apply), `--json`, `--client-name`, `--force-new-admin`, `--yes`; local controller-runtime execution with the shared leader-only write gate; stable human and JSON output contracts; output preflight before minting per the one-time secret pattern.
+- [ ] 2.2 Post-setup guidance in successful output: provision named admin API Clients, then revoke the bootstrap credential.
+
+## 3. Tests
+
+- [ ] 3.1 Governance tests: happy path with exact ADR 0004 binding shape; one-shot guard; guard race safety; recovery path adds without mutating existing credentials; hash-only persistence; audit event; non-leader refusal. Cite SPEC §11.9 and §10.2 where natural.
+- [ ] 3.2 CLI tests: output preflight failure before any mint; `cluster_already_initialized` error contract; `--force-new-admin` confirmation gate; JSON contract stability; secret emitted exactly once and never logged.
+
+## 4. Validation
+
+- [ ] 4.1 Full Elixir workflow (format, compile --warnings-as-errors, credo --strict, dialyzer, test, test --cover) plus strict OpenSpec validation for this change.


### PR DESCRIPTION
## Intent

Accept ADR 0011 and specify the `orchardctl cluster init` first-admin credential contract, closing the decision phase of issue #75. The implementation slice follows separately and is what closes the issue — deliberately no auto-close here.

The decision, grounded in repo constraints and orchestrator prior art (kubeadm local `admin.conf`, k3s server-local token, Nomad one-shot `acl bootstrap`, Vault init-then-revoke-root): mint the first cluster-admin credential via `orchardctl cluster init` as a local, one-shot, audited controller-host operation under the ADR 0006 authority boundary. Rejected shapes with rationale in the ADR: an unauthenticated network bootstrap endpoint, installer/PKG-seeded credentials (external Postgres arrives after install; §11.4 forbids installer trust material; seeded default admins are the documented anti-pattern), and env-seeded admins.

Fixed contract points: one-shot `cluster_already_initialized` guard (race-safe), additive `--force-new-admin` break-glass with confirmation and audit, one-time secret via the §7.4.4 `--output` preflight pattern with hash-only persistence, leader-only write gate (Active/Standby-safe), no default token expiry (rotation is post-setup output guidance), credential-only scope (TLS stays in its own flow), CLI-only with the §11.3 bootstrap UI deferred.

The OpenSpec change `first-admin-cluster-init` is deliberately active (not archived): its ADDED requirement specifies future behavior and its implementation tasks are unchecked; the main `api-client-provisioning` spec is intentionally untouched in this branch.

## What Changed

- Accepted ADR 0011 defining `orchardctl cluster init` as the local, one-shot, audited path for minting the first cluster-admin credential (service-account-owned API Client with a cluster-scoped `admin` RoleBinding and a hash-only API Token), and amended ADR 0004 to point its deferred first-admin workflow at that decision.
- Added the normative `orchardctl cluster init` contract to SPEC.md §11.9: `cluster_already_initialized` one-shot guard, additive `--force-new-admin` break-glass with confirmation and audit, one-time `--output` secret emission per §7.4.4, leader-only write gate, no default token expiry, and credential-only scope (TLS and the §11.3 bootstrap UI stay separate, installer must not seed admin credentials).
- Added the `first-admin-cluster-init` OpenSpec change package (proposal, design, tasks, and an `api-client-provisioning` spec delta with happy-path and failure-path scenarios); OpenSpec strict validation passed in the pipeline.

## Risk Assessment

✅ Low: Docs-only change (SPEC normative text, a new accepted ADR, and an OpenSpec change package) whose cross-references all resolve and whose contract points are internally consistent, with no code or behavior changes.

## Testing

Docs/spec/OpenSpec-only change; ran OpenSpec strict validation on the change and full corpus (both pass) and verified cross-document consistency. No visual artifact since only Markdown docs changed.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `openspec validate first-admin-cluster-init --type change --strict`
- `openspec validate --all --strict`
- `git status --porcelain`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

