### PR TITLE
feat(cli): add cluster init first-admin provisioning

### DIFF
--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -14,8 +14,11 @@ This README is orientation only. Normative CLI requirements live in
 - Read-only cluster status through `cluster status`, with a `--json` mode that
   emits the shared `ControlPlaneStatus` payload plus an Active/Standby-focused summary of
   deployment mode, controller role, and advisory-lock status.
+- First cluster-admin provisioning through `cluster init`, minting the bootstrap
+  admin API Client credential with required One-time Secret Output (`--output`),
+  `--json`, `--client-name`, and `--force-new-admin`/`--yes` recovery minting.
 - SPEC-required future command paths that return explicit deferred status until
-  their milestones land: `cluster init` and `node join`.
+  their milestones land: `node join`.
 - Node-admission-review commands (`nodes inspect`, `nodes pending`,
   `nodes admit`, `nodes reject`) with stable JSON and human output, `--dry-run`
   previews, and `--yes`/`--reason` execution gating.
@@ -40,10 +43,21 @@ This README is orientation only. Normative CLI requirements live in
 
 ## Current command status
 
-The deferred paths above are advertised by `orchardctl`, exit non-zero when
-run, and print command-specific usage, `SPEC.md` traceability, and the current
-supported source-dev or packaged workflow. `--help` for the same paths is
+The deferred path above is advertised by `orchardctl`, exits non-zero when
+run, and prints command-specific usage, `SPEC.md` traceability, and the current
+supported source-dev or packaged workflow. `--help` for the same path is
 side-effect free.
+
+`orchardctl cluster init` mints the first cluster-admin API Client credential as
+a local, one-shot, audited controller-host operation behind the leader-only
+write gate. It requires a `--output` path for One-time Secret Output with
+preflight; the token is written only to that file (never stdout) and only its
+hash and prefix persist. It refuses with a stable `cluster_already_initialized`
+error once an enabled cluster-scoped admin exists, `--force-new-admin --yes`
+mints an additional recovery admin without mutating existing credentials, and
+`--client-name` overrides the default bootstrap client name. Successful output
+directs operators to provision named admin API Clients and then revoke the
+bootstrap credential; `--json` emits the same contract for automation.
 
 `orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for the request.
 Use `--json` for the same stable explanation map exposed by the Operator API presenter.

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -25,22 +25,28 @@ defmodule OrchardCLI.Commands.Cluster do
   defp run_init(["--help"]), do: {:ok, init_usage()}
 
   defp run_init(args) do
-    with {:ok, opts} <- parse_init_args(args),
-         {:ok, output_path} <- fetch_required_output(opts),
+    case parse_init_args(args) do
+      {:ok, opts} -> run_init_parsed(opts)
+      {:help, usage} -> {:ok, usage}
+      {:error, message, code} -> {:error, message, code}
+    end
+  end
+
+  defp run_init_parsed(opts) do
+    json? = Keyword.get(opts, :json, false)
+
+    with {:ok, output_path} <- fetch_required_output(opts),
          :ok <- preflight_output(output_path),
          :ok <- confirm_recovery(opts),
          {:ok, result} <- mint_admin(opts),
-         {:ok, message} <- write_output_and_render(result, output_path, opts) do
+         {:ok, message} <- write_output_and_render(result, output_path, json?) do
       {:ok, message}
     else
-      {:help, usage} ->
-        {:ok, usage}
-
-      {:error, message, code} ->
-        {:error, message, code}
+      {:error, code, message, exit_code} ->
+        render_init_error(code, message, exit_code, json?)
 
       {:error, reason} ->
-        init_error(reason, Keyword.get(parse_init_args_best_effort(args), :json, false))
+        init_error(reason, json?)
     end
   end
 
@@ -67,15 +73,9 @@ defmodule OrchardCLI.Commands.Cluster do
     end
   end
 
-  defp parse_init_args_best_effort(args) do
-    case OptionParser.parse(args, strict: [json: :boolean]) do
-      {opts, _rest, _invalid} -> opts
-    end
-  end
-
   defp fetch_required_output(opts) do
     case Keyword.get(opts, :output) do
-      nil -> {:error, "Error: missing required option: --output\n\n#{init_usage()}", 1}
+      nil -> {:error, :missing_output, "missing required option: --output", 1}
       path -> {:ok, Path.expand(path)}
     end
   end
@@ -85,10 +85,10 @@ defmodule OrchardCLI.Commands.Cluster do
 
     cond do
       File.exists?(path) or match?({:ok, _stat}, File.lstat(path)) ->
-        {:error, "Error: output path already exists: #{path}", 1}
+        {:error, :output_path_exists, "output path already exists: #{path}", 1}
 
       not File.dir?(parent) ->
-        {:error, "Error: output parent directory does not exist: #{parent}", 1}
+        {:error, :output_parent_missing, "output parent directory does not exist: #{parent}", 1}
 
       true ->
         preflight_output_parent(path, parent)
@@ -104,9 +104,8 @@ defmodule OrchardCLI.Commands.Cluster do
         verify_preflight_probe_closed(File.close(file), probe, parent)
 
       {:error, reason} ->
-        {:error,
-         "Error: output parent directory is not writable: #{parent}: #{format_file_error(reason)}",
-         1}
+        {:error, :output_parent_not_writable,
+         "output parent directory is not writable: #{parent}: #{format_file_error(reason)}", 1}
     end
   end
 
@@ -118,14 +117,15 @@ defmodule OrchardCLI.Commands.Cluster do
         :ok
 
       {:error, _reason} ->
-        {:error, "Error: output parent directory is not writable: #{parent}", 1}
+        {:error, :output_parent_not_writable,
+         "output parent directory is not writable: #{parent}", 1}
     end
   end
 
   defp confirm_recovery(opts) do
     if Keyword.get(opts, :force_new_admin, false) and not Keyword.get(opts, :yes, false) do
-      {:error,
-       "Error: --force-new-admin requires --yes before minting a recovery admin credential.", 2}
+      {:error, :recovery_confirmation_required,
+       "--force-new-admin requires --yes before minting a recovery admin credential.", 2}
     else
       :ok
     end
@@ -150,20 +150,27 @@ defmodule OrchardCLI.Commands.Cluster do
     end
   end
 
-  defp write_output_and_render(result, output_path, opts) do
+  defp write_output_and_render(result, output_path, json?) do
     case write_output(output_path, result) do
       :ok ->
-        {:ok, render_init_success(result, output_path, Keyword.get(opts, :json, false))}
+        {:ok, render_init_success(result, output_path, json?, [])}
 
-      {:error, message, code} ->
+      {:ok, {:tmp_cleanup_failed, tmp_path}} ->
+        {:ok, render_init_success(result, output_path, json?, [tmp_leftover_warning(tmp_path)])}
+
+      {:error, message} ->
         _ =
           ClusterBootstrap.mark_output_failed(result, %{
             "reason" => message,
             "api_token_prefix" => result.api_token_prefix
           })
 
-        {:error, message, code}
+        {:error, :one_time_secret_output_failed, message, 1}
     end
+  end
+
+  defp tmp_leftover_warning(tmp_path) do
+    "credential was written but the temporary secret file #{tmp_path} could not be removed; delete it manually."
   end
 
   defp write_output(path, result) do
@@ -183,16 +190,17 @@ defmodule OrchardCLI.Commands.Cluster do
       )
 
     with :ok <- write_exclusive_file(tmp_path, payload),
-         :ok <- File.ln(tmp_path, path),
-         :ok <- cleanup_tmp(tmp_path) do
-      :ok
+         :ok <- File.ln(tmp_path, path) do
+      case cleanup_tmp(tmp_path) do
+        :ok -> :ok
+        {:error, _reason} -> {:ok, {:tmp_cleanup_failed, tmp_path}}
+      end
     else
       {:error, reason} ->
         File.rm(tmp_path)
 
         {:error,
-         "Error: cluster init minted a credential but One-time Secret Output failed: #{format_file_error(reason)}",
-         1}
+         "cluster init minted a credential but One-time Secret Output failed: #{format_file_error(reason)}"}
     end
   end
 
@@ -220,39 +228,57 @@ defmodule OrchardCLI.Commands.Cluster do
     end
   end
 
-  defp render_init_success(result, output_path, true) do
-    Jason.encode!(
-      %{
-        object: @cluster_init_object,
-        contract_version: @cluster_init_contract_version,
-        api_client_id: result.api_client_id,
-        api_token_id: result.api_token_id,
-        api_token_prefix: result.api_token_prefix,
-        recovery: result.recovery?,
-        output_path: output_path,
-        next_steps: [
-          "Provision named admin API Clients for regular operators.",
-          "Revoke this bootstrap credential after named admin access is verified."
-        ]
-      },
-      pretty: true
-    )
+  defp render_init_success(result, output_path, true, warnings) do
+    base = %{
+      object: @cluster_init_object,
+      contract_version: @cluster_init_contract_version,
+      api_client_id: result.api_client_id,
+      api_token_id: result.api_token_id,
+      api_token_prefix: result.api_token_prefix,
+      recovery: result.recovery?,
+      output_path: output_path,
+      next_steps: [
+        "Provision named admin API Clients for regular operators.",
+        "Revoke this bootstrap credential after named admin access is verified."
+      ]
+    }
+
+    base
+    |> maybe_put_warnings(warnings)
+    |> Jason.encode!(pretty: true)
   end
 
-  defp render_init_success(result, output_path, false) do
-    Enum.join(
-      [
-        "Cluster admin credential minted.",
-        "One-time Secret Output: #{output_path}",
-        "API Client ID: #{result.api_client_id}",
-        "API Token ID: #{result.api_token_id}",
-        "API Token prefix: #{result.api_token_prefix}",
-        "Recovery credential: #{if(result.recovery?, do: "yes", else: "no")}",
-        "Next: provision named admin API Clients for regular operators, verify access, then revoke this bootstrap credential."
-      ],
-      "\n"
-    )
+  defp render_init_success(result, output_path, false, warnings) do
+    lines = [
+      "Cluster admin credential minted.",
+      "One-time Secret Output: #{output_path}",
+      "API Client ID: #{result.api_client_id}",
+      "API Token ID: #{result.api_token_id}",
+      "API Token prefix: #{result.api_token_prefix}",
+      "Recovery credential: #{if(result.recovery?, do: "yes", else: "no")}",
+      "Next: provision named admin API Clients for regular operators, verify access, then revoke this bootstrap credential."
+    ]
+
+    (lines ++ Enum.map(warnings, &"Warning: #{&1}"))
+    |> Enum.join("\n")
   end
+
+  defp maybe_put_warnings(base, []), do: base
+  defp maybe_put_warnings(base, warnings), do: Map.put(base, :warnings, warnings)
+
+  defp render_init_error(code, message, exit_code, true) do
+    {:error,
+     Jason.encode!(%{object: "error", code: Atom.to_string(code), message: message},
+       pretty: true
+     ), exit_code}
+  end
+
+  defp render_init_error(code, message, exit_code, false) do
+    {:error, append_usage(code, "Error: #{message}"), exit_code}
+  end
+
+  defp append_usage(:missing_output, text), do: text <> "\n\n" <> init_usage()
+  defp append_usage(_code, text), do: text
 
   defp init_error(%Ecto.Changeset{} = changeset, true) do
     {:error,

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -4,6 +4,7 @@ defmodule OrchardCLI.Commands.Cluster do
   alias Orchard.ClusterManagement.ControlPlaneStatus
   alias Orchard.ControlPlane
   alias Orchard.Governance.ClusterBootstrap
+  alias OrchardCLI.Commands.GovernanceHelpers
 
   @cluster_status_object "cluster_management.cluster_status"
   @cluster_status_contract_version "orchard.cluster_management.cluster_status.v1"
@@ -32,6 +33,9 @@ defmodule OrchardCLI.Commands.Cluster do
          {:ok, message} <- write_output_and_render(result, output_path, opts) do
       {:ok, message}
     else
+      {:help, usage} ->
+        {:ok, usage}
+
       {:error, message, code} ->
         {:error, message, code}
 
@@ -248,6 +252,23 @@ defmodule OrchardCLI.Commands.Cluster do
       ],
       "\n"
     )
+  end
+
+  defp init_error(%Ecto.Changeset{} = changeset, true) do
+    {:error,
+     Jason.encode!(
+       %{
+         object: "error",
+         code: "cluster_init_invalid",
+         errors: GovernanceHelpers.format_changeset_errors(changeset)
+       },
+       pretty: true
+     ), 1}
+  end
+
+  defp init_error(%Ecto.Changeset{} = changeset, false) do
+    detail = changeset |> GovernanceHelpers.format_changeset_errors() |> Enum.join("; ")
+    {:error, "Error: cluster_init_invalid: #{detail}", 1}
   end
 
   defp init_error(reason, true) when is_atom(reason) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -3,35 +3,267 @@ defmodule OrchardCLI.Commands.Cluster do
 
   alias Orchard.ClusterManagement.ControlPlaneStatus
   alias Orchard.ControlPlane
-  alias OrchardCLI.Commands.Deferred
+  alias Orchard.Governance.ClusterBootstrap
 
   @cluster_status_object "cluster_management.cluster_status"
   @cluster_status_contract_version "orchard.cluster_management.cluster_status.v1"
 
-  @commands [
-    %{
-      path: ["init"],
-      usage: "orchardctl cluster init",
-      summary: "Initialize controller-side cluster bootstrap state (SPEC.md 11.9).",
-      status:
-        "Defined by SPEC.md 11.9 for node lifecycle work; not implemented in the current build.",
-      guidance: [
-        "For packaged controller setup, follow packaging/pkg/README.md with env init, migrate, transport configuration, start, and status.",
-        "For source-dev split roles, use bin/dev-controller and bin/dev-node-agent."
-      ]
-    }
-  ]
-
+  @cluster_init_object "cluster_management.cluster_init"
+  @cluster_init_contract_version "orchard.cluster_management.cluster_init.v1"
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(["status" | rest]), do: run_status(rest)
   def run(["help"]), do: {:ok, group_usage()}
   def run(["--help"]), do: {:ok, group_usage()}
   def run([]), do: {:error, group_usage(), 1}
 
-  def run(["init" | _rest] = args),
-    do: Deferred.run(args, %{name: "cluster", commands: @commands})
+  def run(["init" | rest]), do: run_init(rest)
 
   def run(_args), do: {:error, group_usage(), 1}
+
+  defp run_init(["help"]), do: {:ok, init_usage()}
+  defp run_init(["--help"]), do: {:ok, init_usage()}
+
+  defp run_init(args) do
+    with {:ok, opts} <- parse_init_args(args),
+         {:ok, output_path} <- fetch_required_output(opts),
+         :ok <- preflight_output(output_path),
+         :ok <- confirm_recovery(opts),
+         {:ok, result} <- mint_admin(opts),
+         {:ok, message} <- write_output_and_render(result, output_path, opts) do
+      {:ok, message}
+    else
+      {:error, message, code} ->
+        {:error, message, code}
+
+      {:error, reason} ->
+        init_error(reason, Keyword.get(parse_init_args_best_effort(args), :json, false))
+    end
+  end
+
+  defp parse_init_args(args) do
+    switches = [
+      output: :string,
+      json: :boolean,
+      client_name: :string,
+      force_new_admin: :boolean,
+      yes: :boolean,
+      help: :boolean
+    ]
+
+    case OptionParser.parse(args, strict: switches) do
+      {opts, [], []} ->
+        if Keyword.get(opts, :help, false), do: {:help, init_usage()}, else: {:ok, opts}
+
+      {_opts, positional, []} ->
+        {:error,
+         "Error: unexpected argument(s): #{Enum.join(positional, ", ")}\n\n#{init_usage()}", 1}
+
+      {_opts, _positional, [{flag, _value} | _unknown]} ->
+        {:error, "Unknown option: #{format_unknown_flag(flag)}", 2}
+    end
+  end
+
+  defp parse_init_args_best_effort(args) do
+    case OptionParser.parse(args, strict: [json: :boolean]) do
+      {opts, _rest, _invalid} -> opts
+    end
+  end
+
+  defp fetch_required_output(opts) do
+    case Keyword.get(opts, :output) do
+      nil -> {:error, "Error: missing required option: --output\n\n#{init_usage()}", 1}
+      path -> {:ok, Path.expand(path)}
+    end
+  end
+
+  defp preflight_output(path) do
+    parent = Path.dirname(path)
+
+    cond do
+      File.exists?(path) or match?({:ok, _stat}, File.lstat(path)) ->
+        {:error, "Error: output path already exists: #{path}", 1}
+
+      not File.dir?(parent) ->
+        {:error, "Error: output parent directory does not exist: #{parent}", 1}
+
+      true ->
+        preflight_output_parent(path, parent)
+    end
+  end
+
+  defp preflight_output_parent(path, parent) do
+    probe =
+      Path.join(parent, ".#{Path.basename(path)}.preflight-#{System.unique_integer([:positive])}")
+
+    case File.open(probe, [:write, :exclusive, :binary]) do
+      {:ok, file} ->
+        verify_preflight_probe_closed(File.close(file), probe, parent)
+
+      {:error, reason} ->
+        {:error,
+         "Error: output parent directory is not writable: #{parent}: #{format_file_error(reason)}",
+         1}
+    end
+  end
+
+  defp verify_preflight_probe_closed(close_result, probe, parent) do
+    File.rm(probe)
+
+    case close_result do
+      :ok ->
+        :ok
+
+      {:error, _reason} ->
+        {:error, "Error: output parent directory is not writable: #{parent}", 1}
+    end
+  end
+
+  defp confirm_recovery(opts) do
+    if Keyword.get(opts, :force_new_admin, false) and not Keyword.get(opts, :yes, false) do
+      {:error,
+       "Error: --force-new-admin requires --yes before minting a recovery admin credential.", 2}
+    else
+      :ok
+    end
+  end
+
+  defp mint_admin(opts) do
+    mint_opts =
+      [actor_id: "local-orchardctl"]
+      |> maybe_put_client_name(opts)
+
+    if Keyword.get(opts, :force_new_admin, false) do
+      ClusterBootstrap.mint_recovery_admin(mint_opts)
+    else
+      ClusterBootstrap.mint_first_admin(mint_opts)
+    end
+  end
+
+  defp maybe_put_client_name(mint_opts, opts) do
+    case Keyword.fetch(opts, :client_name) do
+      {:ok, client_name} -> Keyword.put(mint_opts, :client_name, client_name)
+      :error -> mint_opts
+    end
+  end
+
+  defp write_output_and_render(result, output_path, opts) do
+    case write_output(output_path, result) do
+      :ok ->
+        {:ok, render_init_success(result, output_path, Keyword.get(opts, :json, false))}
+
+      {:error, message, code} ->
+        _ =
+          ClusterBootstrap.mark_output_failed(result, %{
+            "reason" => message,
+            "api_token_prefix" => result.api_token_prefix
+          })
+
+        {:error, message, code}
+    end
+  end
+
+  defp write_output(path, result) do
+    payload =
+      Jason.encode!(%{
+        object: "cluster_management.cluster_admin_credential",
+        api_client_id: result.api_client_id,
+        api_token_id: result.api_token_id,
+        api_token_prefix: result.api_token_prefix,
+        api_token: result.token
+      })
+
+    tmp_path =
+      Path.join(
+        Path.dirname(path),
+        ".#{Path.basename(path)}.tmp-#{System.unique_integer([:positive])}"
+      )
+
+    with :ok <- write_exclusive_file(tmp_path, payload),
+         :ok <- File.ln(tmp_path, path),
+         :ok <- cleanup_tmp(tmp_path) do
+      :ok
+    else
+      {:error, reason} ->
+        File.rm(tmp_path)
+
+        {:error,
+         "Error: cluster init minted a credential but One-time Secret Output failed: #{format_file_error(reason)}",
+         1}
+    end
+  end
+
+  defp write_exclusive_file(path, contents) do
+    case File.open(path, [:write, :exclusive, :binary]) do
+      {:ok, file} ->
+        result = with :ok <- File.chmod(path, 0o600), do: IO.binwrite(file, contents)
+        close_result = File.close(file)
+        write_file_result(result, close_result)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp write_file_result(:ok, :ok), do: :ok
+  defp write_file_result({:error, reason}, _close_result), do: {:error, reason}
+  defp write_file_result(:ok, {:error, reason}), do: {:error, reason}
+
+  defp cleanup_tmp(path) do
+    case File.rm(path) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp render_init_success(result, output_path, true) do
+    Jason.encode!(
+      %{
+        object: @cluster_init_object,
+        contract_version: @cluster_init_contract_version,
+        api_client_id: result.api_client_id,
+        api_token_id: result.api_token_id,
+        api_token_prefix: result.api_token_prefix,
+        recovery: result.recovery?,
+        output_path: output_path,
+        next_steps: [
+          "Provision named admin API Clients for regular operators.",
+          "Revoke this bootstrap credential after named admin access is verified."
+        ]
+      },
+      pretty: true
+    )
+  end
+
+  defp render_init_success(result, output_path, false) do
+    Enum.join(
+      [
+        "Cluster admin credential minted.",
+        "One-time Secret Output: #{output_path}",
+        "API Client ID: #{result.api_client_id}",
+        "API Token ID: #{result.api_token_id}",
+        "API Token prefix: #{result.api_token_prefix}",
+        "Recovery credential: #{if(result.recovery?, do: "yes", else: "no")}",
+        "Next: provision named admin API Clients for regular operators, verify access, then revoke this bootstrap credential."
+      ],
+      "\n"
+    )
+  end
+
+  defp init_error(reason, true) when is_atom(reason) do
+    {:error, Jason.encode!(%{object: "error", code: Atom.to_string(reason)}, pretty: true), 1}
+  end
+
+  defp init_error(reason, false) when is_atom(reason),
+    do: {:error, "Error: #{human_init_reason(reason)}", 1}
+
+  defp human_init_reason(:cluster_already_initialized), do: "cluster_already_initialized"
+  defp human_init_reason(:controller_standby), do: "this controller is in standby mode."
+
+  defp human_init_reason(:controller_leadership_unproven),
+    do: "this controller has not proven local leadership."
+
+  defp human_init_reason(reason), do: Atom.to_string(reason)
 
   defp run_status(["help"]), do: {:ok, status_usage()}
 
@@ -126,6 +358,9 @@ defmodule OrchardCLI.Commands.Cluster do
 
   defp format_unknown_flag(flag), do: to_string(flag)
 
+  defp format_file_error(reason) when is_atom(reason),
+    do: reason |> :file.format_error() |> to_string()
+
   defp group_usage do
     """
     Usage: orchardctl cluster <command>
@@ -133,6 +368,22 @@ defmodule OrchardCLI.Commands.Cluster do
     Commands:
       init     Initialize controller-side cluster bootstrap state (SPEC.md 11.9).
       status   Show read-only cluster and Active/Standby control-plane status.
+    """
+    |> String.trim()
+  end
+
+  defp init_usage do
+    """
+    Usage: orchardctl cluster init --output <path> [--json] [--client-name <name>] [--force-new-admin --yes]
+
+    Mint the first cluster-admin API Client credential as a local controller-host operation.
+
+    Options:
+      --output <path>      Required one-time secret output path.
+      --json               Emit stable JSON for automation.
+      --client-name <name> API Client name to create.
+      --force-new-admin    Mint an additional recovery admin credential.
+      --yes                Confirm recovery mint when --force-new-admin is set.
     """
     |> String.trim()
   end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -1,12 +1,25 @@
 defmodule OrchardCLI.Commands.ClusterTest do
   use ExUnit.Case, async: false
 
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.Governance.{ApiKey, AuditLog, RoleBinding, ServiceAccount}
+  alias Orchard.Repo
   alias OrchardCLI.Commands.Cluster, as: ClusterCmd
 
   setup do
+    :ok = Sandbox.checkout(Repo)
+    Sandbox.mode(Repo, {:shared, self()})
+
     previous = Application.get_env(:orchard_controller, :control_plane)
 
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "orchard-cluster-test-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp_dir)
+
     on_exit(fn ->
+      File.rm_rf(tmp_dir)
+
       if is_nil(previous) do
         Application.delete_env(:orchard_controller, :control_plane)
       else
@@ -14,7 +27,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
       end
     end)
 
-    :ok
+    %{tmp_dir: tmp_dir}
   end
 
   describe "help and usage" do
@@ -37,6 +50,103 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert {:error, message, 2} = ClusterCmd.run(["status", "--bogus"])
 
       assert message == "Unknown option: --bogus"
+    end
+  end
+
+  describe "init" do
+    test "SPEC.md §11.9 JSON success writes secret once to output and not stdout", %{
+      tmp_dir: tmp_dir
+    } do
+      output_path = Path.join(tmp_dir, "admin.json")
+
+      assert {:ok, message} =
+               ClusterCmd.run([
+                 "init",
+                 "--output",
+                 output_path,
+                 "--json",
+                 "--client-name",
+                 "json-admin"
+               ])
+
+      decoded = Jason.decode!(message)
+      credential = Jason.decode!(File.read!(output_path))
+      token = Map.fetch!(credential, "api_token")
+
+      assert decoded["object"] == "cluster_management.cluster_init"
+      assert decoded["contract_version"] == "orchard.cluster_management.cluster_init.v1"
+      assert decoded["api_client_id"] == credential["api_client_id"]
+      assert decoded["api_token_id"] == credential["api_token_id"]
+      assert decoded["api_token_prefix"] == credential["api_token_prefix"]
+      assert decoded["recovery"] == false
+      assert decoded["output_path"] == output_path
+      assert decoded["next_steps"] != []
+      assert token =~ "orch_"
+      refute message =~ token
+      assert token_occurrences(File.read!(output_path), token) == 1
+    end
+
+    test "SPEC.md §11.9 force-new-admin requires yes and then mints recovery additively", %{
+      tmp_dir: tmp_dir
+    } do
+      first_output = Path.join(tmp_dir, "first-admin.json")
+      blocked_output = Path.join(tmp_dir, "blocked-recovery.json")
+      recovery_output = Path.join(tmp_dir, "recovery-admin.json")
+
+      assert {:ok, _message} = ClusterCmd.run(["init", "--output", first_output])
+
+      assert {:error, blocked_message, 2} =
+               ClusterCmd.run(["init", "--output", blocked_output, "--force-new-admin"])
+
+      assert blocked_message =~ "--force-new-admin requires --yes"
+      refute File.exists?(blocked_output)
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 1
+
+      assert {:ok, recovery_message} =
+               ClusterCmd.run([
+                 "init",
+                 "--output",
+                 recovery_output,
+                 "--force-new-admin",
+                 "--yes"
+               ])
+
+      recovery = Jason.decode!(File.read!(recovery_output))
+      token = Map.fetch!(recovery, "api_token")
+
+      assert recovery_message =~ "Recovery credential: yes"
+      refute recovery_message =~ token
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 2
+      assert Repo.aggregate(ApiKey, :count, :id) == 2
+      assert Repo.aggregate(RoleBinding, :count, :id) == 2
+    end
+
+    test "SPEC.md §11.9 second init returns stable cluster_already_initialized error", %{
+      tmp_dir: tmp_dir
+    } do
+      first_output = Path.join(tmp_dir, "first-admin.json")
+      second_output = Path.join(tmp_dir, "second-admin.json")
+
+      assert {:ok, _message} = ClusterCmd.run(["init", "--output", first_output])
+      assert {:error, message, 1} = ClusterCmd.run(["init", "--output", second_output])
+
+      assert message == "Error: cluster_already_initialized"
+      refute File.exists?(second_output)
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 1
+      assert Repo.aggregate(ApiKey, :count, :id) == 1
+    end
+
+    test "SPEC.md §11.9 preflights output path before minting", %{tmp_dir: tmp_dir} do
+      output_path = Path.join(tmp_dir, "admin.json")
+      File.write!(output_path, "existing")
+
+      assert {:error, message, 1} = ClusterCmd.run(["init", "--output", output_path])
+
+      assert message =~ "output path already exists"
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 0
+      assert Repo.aggregate(ApiKey, :count, :id) == 0
+      assert Repo.aggregate(RoleBinding, :count, :id) == 0
+      assert Repo.aggregate(AuditLog, :count, :id) == 0
     end
   end
 
@@ -166,5 +276,12 @@ defmodule OrchardCLI.Commands.ClusterTest do
       refute output =~ "orchard_admin"
       refute output =~ "db.internal"
     end
+  end
+
+  defp token_occurrences(contents, token) do
+    contents
+    |> String.split(token)
+    |> length()
+    |> Kernel.-(1)
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -148,6 +148,71 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert Repo.aggregate(RoleBinding, :count, :id) == 0
       assert Repo.aggregate(AuditLog, :count, :id) == 0
     end
+
+    test "--help combined with other flags prints usage without minting", %{tmp_dir: tmp_dir} do
+      output_path = Path.join(tmp_dir, "admin.json")
+
+      assert {:ok, message} = ClusterCmd.run(["init", "--output", output_path, "--help"])
+
+      assert message =~ "orchardctl cluster init"
+      assert message =~ "--output"
+      refute File.exists?(output_path)
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 0
+    end
+
+    test "recovery mint with a duplicate --client-name renders a clean error", %{tmp_dir: tmp_dir} do
+      first_output = Path.join(tmp_dir, "first-admin.json")
+      recovery_output = Path.join(tmp_dir, "recovery-admin.json")
+
+      assert {:ok, _message} =
+               ClusterCmd.run(["init", "--output", first_output, "--client-name", "dup-admin"])
+
+      assert {:error, message, 1} =
+               ClusterCmd.run([
+                 "init",
+                 "--output",
+                 recovery_output,
+                 "--json",
+                 "--client-name",
+                 "dup-admin",
+                 "--force-new-admin",
+                 "--yes"
+               ])
+
+      decoded = Jason.decode!(message)
+
+      assert decoded["object"] == "error"
+      assert decoded["code"] == "cluster_init_invalid"
+      assert decoded["errors"] != []
+      refute File.exists?(recovery_output)
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 1
+      assert Repo.aggregate(ApiKey, :count, :id) == 1
+    end
+
+    test "first mint colliding with a disabled service account renders a clean error", %{
+      tmp_dir: tmp_dir
+    } do
+      {:ok, _disabled} =
+        %ServiceAccount{}
+        |> ServiceAccount.changeset(%{
+          tenant_id: Orchard.Governance.legacy_tenant_id(),
+          name: "orchard-bootstrap-admin",
+          owner_contact: "prior-admin",
+          purpose: "cluster_admin_bootstrap",
+          disabled_at: DateTime.truncate(DateTime.utc_now(), :microsecond)
+        })
+        |> Repo.insert()
+
+      output_path = Path.join(tmp_dir, "admin.json")
+
+      assert {:error, message, 1} = ClusterCmd.run(["init", "--output", output_path])
+
+      assert message =~ "cluster_init_invalid"
+      refute File.exists?(output_path)
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 1
+      assert Repo.aggregate(ApiKey, :count, :id) == 0
+      assert Repo.aggregate(RoleBinding, :count, :id) == 0
+    end
   end
 
   describe "status" do

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -149,6 +149,50 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert Repo.aggregate(AuditLog, :count, :id) == 0
     end
 
+    test "SPEC.md §11.9 --json missing --output emits a stable JSON error object" do
+      assert {:error, message, 1} = ClusterCmd.run(["init", "--json"])
+
+      decoded = Jason.decode!(message)
+
+      assert decoded["object"] == "error"
+      assert decoded["code"] == "missing_output"
+      assert decoded["message"] =~ "--output"
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 0
+    end
+
+    test "SPEC.md §11.9 --json existing output path emits a stable JSON error object", %{
+      tmp_dir: tmp_dir
+    } do
+      output_path = Path.join(tmp_dir, "admin.json")
+      File.write!(output_path, "existing")
+
+      assert {:error, message, 1} = ClusterCmd.run(["init", "--output", output_path, "--json"])
+
+      decoded = Jason.decode!(message)
+
+      assert decoded["object"] == "error"
+      assert decoded["code"] == "output_path_exists"
+      assert decoded["message"] =~ "already exists"
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 0
+    end
+
+    test "SPEC.md §11.9 --json force-new-admin without --yes emits a stable JSON error object", %{
+      tmp_dir: tmp_dir
+    } do
+      output_path = Path.join(tmp_dir, "recovery.json")
+
+      assert {:error, message, 2} =
+               ClusterCmd.run(["init", "--output", output_path, "--json", "--force-new-admin"])
+
+      decoded = Jason.decode!(message)
+
+      assert decoded["object"] == "error"
+      assert decoded["code"] == "recovery_confirmation_required"
+      assert decoded["message"] =~ "--yes"
+      refute File.exists?(output_path)
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 0
+    end
+
     test "--help combined with other flags prints usage without minting", %{tmp_dir: tmp_dir} do
       output_path = Path.join(tmp_dir, "admin.json")
 

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -95,12 +95,24 @@ defmodule OrchardCLI.Commands.ClusterTest do
 
       assert {:ok, _message} = ClusterCmd.run(["init", "--output", first_output])
 
+      existing_name = "orchard-bootstrap-admin-recovery-00000000-0000-0000-0000-000000000001"
+
+      assert {:ok, _existing} =
+               %ServiceAccount{}
+               |> ServiceAccount.changeset(%{
+                 tenant_id: Orchard.Governance.legacy_tenant_id(),
+                 name: existing_name,
+                 owner_contact: "existing-operator",
+                 purpose: "cluster_admin_bootstrap"
+               })
+               |> Repo.insert()
+
       assert {:error, blocked_message, 2} =
                ClusterCmd.run(["init", "--output", blocked_output, "--force-new-admin"])
 
       assert blocked_message =~ "--force-new-admin requires --yes"
       refute File.exists?(blocked_output)
-      assert Repo.aggregate(ServiceAccount, :count, :id) == 1
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 2
 
       assert {:ok, recovery_message} =
                ClusterCmd.run([
@@ -114,9 +126,16 @@ defmodule OrchardCLI.Commands.ClusterTest do
       recovery = Jason.decode!(File.read!(recovery_output))
       token = Map.fetch!(recovery, "api_token")
 
+      api_client = Repo.get!(ServiceAccount, Map.fetch!(recovery, "api_client_id"))
+
       assert recovery_message =~ "Recovery credential: yes"
       refute recovery_message =~ token
-      assert Repo.aggregate(ServiceAccount, :count, :id) == 2
+      assert api_client.name != existing_name
+      assert String.starts_with?(api_client.name, "orchard-bootstrap-admin-recovery-")
+
+      suffix = String.replace_prefix(api_client.name, "orchard-bootstrap-admin-recovery-", "")
+      assert {:ok, _uuid} = Ecto.UUID.cast(suffix)
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 3
       assert Repo.aggregate(ApiKey, :count, :id) == 2
       assert Repo.aggregate(RoleBinding, :count, :id) == 2
     end

--- a/apps/orchard_cli/test/orchard_cli_test.exs
+++ b/apps/orchard_cli/test/orchard_cli_test.exs
@@ -94,7 +94,6 @@ defmodule OrchardCLITest do
 
   test "advertised deferred commands report docs-backed status" do
     commands = [
-      {Cluster, ["init"], "orchardctl cluster init"},
       {Node, ["join"], "orchardctl node join"}
     ]
 
@@ -113,7 +112,6 @@ defmodule OrchardCLITest do
     parent = self()
 
     commands = [
-      ["cluster", "init"],
       ["node", "join"]
     ]
 

--- a/apps/orchard_controller/lib/orchard/governance/cluster_bootstrap.ex
+++ b/apps/orchard_controller/lib/orchard/governance/cluster_bootstrap.ex
@@ -188,7 +188,7 @@ defmodule Orchard.Governance.ClusterBootstrap do
   defp recovery_client_name(opts) do
     case Keyword.fetch(opts, :client_name) do
       {:ok, name} -> name
-      :error -> "#{@default_client_name}-recovery-#{System.unique_integer([:positive])}"
+      :error -> "#{@default_client_name}-recovery-#{Ecto.UUID.generate()}"
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/governance/cluster_bootstrap.ex
+++ b/apps/orchard_controller/lib/orchard/governance/cluster_bootstrap.ex
@@ -1,0 +1,217 @@
+defmodule Orchard.Governance.ClusterBootstrap do
+  @moduledoc """
+  Local controller-runtime bootstrap for the first cluster-admin API Client.
+  """
+
+  import Ecto.Query
+
+  alias Orchard.ControlPlane
+  alias Orchard.Governance
+  alias Orchard.Governance.{ApiKey, ApiKeySecret, AuditLog, RoleBinding, ServiceAccount}
+  alias Orchard.Repo
+
+  @default_client_name "orchard-bootstrap-admin"
+  @default_token_name "bootstrap"
+
+  @type mint_result :: %{
+          api_client_id: Ecto.UUID.t(),
+          api_token_id: Ecto.UUID.t(),
+          api_token_prefix: String.t(),
+          token: String.t(),
+          recovery?: boolean()
+        }
+
+  @spec mint_first_admin(keyword()) :: {:ok, mint_result()} | {:error, term()}
+  def mint_first_admin(opts \\ []) when is_list(opts) do
+    mint_admin(opts, false)
+  end
+
+  @spec mint_recovery_admin(keyword()) :: {:ok, mint_result()} | {:error, term()}
+  def mint_recovery_admin(opts \\ []) when is_list(opts) do
+    opts
+    |> Keyword.put(:client_name, recovery_client_name(opts))
+    |> mint_admin(true)
+  end
+
+  @spec mark_output_failed(mint_result(), map()) ::
+          {:ok, AuditLog.t()} | {:error, Ecto.Changeset.t()}
+  def mark_output_failed(result, error_summary) when is_map(result) and is_map(error_summary) do
+    %AuditLog{}
+    |> AuditLog.changeset(%{
+      scope: "cluster",
+      tenant_id: nil,
+      api_key_id: nil,
+      actor_type: "operator",
+      actor_id: "local-orchardctl",
+      action: "cluster_admin_bootstrap.output_failed",
+      target_type: "service_account",
+      target_id: Map.fetch!(result, :api_client_id),
+      occurred_at: utc_now(),
+      payload: %{
+        "api_client_id" => Map.fetch!(result, :api_client_id),
+        "api_token_id" => Map.fetch!(result, :api_token_id),
+        "api_token_prefix" => Map.fetch!(result, :api_token_prefix),
+        "error_summary" => sanitize_error_summary(error_summary)
+      }
+    })
+    |> Repo.insert()
+  end
+
+  defp mint_admin(opts, recovery?) do
+    with :ok <- ControlPlane.authorize_write_path(:cluster_init) do
+      mint_admin_transaction(opts, recovery?)
+    end
+  end
+
+  defp mint_admin_transaction(opts, recovery?) do
+    Repo.transaction(fn ->
+      with :ok <- lock_bootstrap_guard(),
+           :ok <- maybe_ensure_not_initialized(recovery?),
+           {:ok, api_client} <- insert_api_client(opts),
+           {:ok, api_key, token} <- insert_api_key(api_client),
+           {:ok, _role_binding} <- insert_admin_role_binding(api_client),
+           {:ok, _audit_log} <- insert_bootstrap_audit_log(api_client, api_key, opts, recovery?) do
+        {:ok, mint_result(api_client, api_key, token, recovery?)}
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
+  defp lock_bootstrap_guard do
+    Repo.query!("SELECT pg_advisory_xact_lock(hashtext('orchard.cluster_bootstrap.first_admin'))")
+    :ok
+  end
+
+  defp maybe_ensure_not_initialized(true), do: :ok
+
+  defp maybe_ensure_not_initialized(false) do
+    if initialized?(), do: {:error, :cluster_already_initialized}, else: :ok
+  end
+
+  defp initialized? do
+    RoleBinding
+    |> where([role_binding], role_binding.principal_type == :service_account)
+    |> where([role_binding], role_binding.role == :admin)
+    |> where([role_binding], is_nil(role_binding.tenant_scope_id))
+    |> join(:inner, [role_binding], service_account in ServiceAccount,
+      on:
+        service_account.id == role_binding.principal_id and
+          is_nil(service_account.disabled_at)
+    )
+    |> Repo.exists?()
+  end
+
+  defp insert_api_client(opts) do
+    %ServiceAccount{}
+    |> ServiceAccount.changeset(%{
+      tenant_id: Governance.legacy_tenant_id(),
+      name: client_name(opts),
+      owner_contact: actor_id(opts),
+      purpose: "cluster_admin_bootstrap"
+    })
+    |> Repo.insert()
+  end
+
+  defp insert_api_key(%ServiceAccount{} = api_client) do
+    generated = ApiKeySecret.generate()
+
+    %ApiKey{}
+    |> ApiKey.service_account_owned_changeset(%{
+      service_account_id: api_client.id,
+      name: @default_token_name,
+      token_prefix: generated.token_prefix,
+      secret_hash: generated.secret_hash
+    })
+    |> Repo.insert()
+    |> case do
+      {:ok, api_key} -> {:ok, api_key, generated.token}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  defp insert_admin_role_binding(%ServiceAccount{} = api_client) do
+    %RoleBinding{}
+    |> RoleBinding.changeset(%{
+      principal_type: :service_account,
+      principal_id: api_client.id,
+      role: :admin,
+      tenant_scope_id: nil
+    })
+    |> Repo.insert()
+  end
+
+  defp insert_bootstrap_audit_log(api_client, api_key, opts, recovery?) do
+    %AuditLog{}
+    |> AuditLog.changeset(%{
+      scope: "cluster",
+      tenant_id: nil,
+      api_key_id: nil,
+      actor_type: "operator",
+      actor_id: actor_id(opts),
+      action: "cluster_admin_bootstrap.minted",
+      target_type: "service_account",
+      target_id: api_client.id,
+      occurred_at: utc_now(),
+      payload: %{
+        "api_client_id" => api_client.id,
+        "api_token_id" => api_key.id,
+        "api_token_prefix" => api_key.token_prefix,
+        "recovery" => recovery?
+      }
+    })
+    |> Repo.insert()
+  end
+
+  defp mint_result(api_client, api_key, token, recovery?) do
+    %{
+      api_client_id: api_client.id,
+      api_token_id: api_key.id,
+      api_token_prefix: api_key.token_prefix,
+      token: token,
+      recovery?: recovery?
+    }
+  end
+
+  defp client_name(opts) do
+    opts
+    |> Keyword.get(:client_name, @default_client_name)
+    |> to_string()
+    |> String.trim()
+    |> case do
+      "" -> @default_client_name
+      name -> name
+    end
+  end
+
+  defp recovery_client_name(opts) do
+    case Keyword.fetch(opts, :client_name) do
+      {:ok, name} -> name
+      :error -> "#{@default_client_name}-recovery-#{System.unique_integer([:positive])}"
+    end
+  end
+
+  defp actor_id(opts) do
+    opts
+    |> Keyword.get(:actor_id, "local-orchardctl")
+    |> to_string()
+    |> String.trim()
+    |> case do
+      "" -> "local-orchardctl"
+      actor_id -> actor_id
+    end
+  end
+
+  defp sanitize_error_summary(summary) do
+    summary
+    |> Map.take(["reason", "api_token_prefix"])
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp unwrap_transaction_result({:ok, {:ok, result}}), do: {:ok, result}
+  defp unwrap_transaction_result({:error, reason}), do: {:error, reason}
+
+  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+end

--- a/apps/orchard_controller/test/orchard/governance/cluster_bootstrap_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/cluster_bootstrap_test.exs
@@ -58,6 +58,32 @@ defmodule Orchard.Governance.ClusterBootstrapTest do
       assert audit_log.actor_id == "break-glass"
       assert audit_log.payload["recovery"] == true
     end
+
+    test "default recovery name uses a durable unique UUID suffix" do
+      existing_name = "orchard-bootstrap-admin-recovery-00000000-0000-0000-0000-000000000001"
+
+      assert {:ok, _existing} =
+               %ServiceAccount{}
+               |> ServiceAccount.changeset(%{
+                 tenant_id: Orchard.Governance.legacy_tenant_id(),
+                 name: existing_name,
+                 owner_contact: "existing-operator",
+                 purpose: "cluster_admin_bootstrap"
+               })
+               |> Repo.insert()
+
+      assert {:ok, _first} = ClusterBootstrap.mint_first_admin(client_name: "bootstrap-primary")
+      assert {:ok, recovery} = ClusterBootstrap.mint_recovery_admin(actor_id: "break-glass")
+
+      api_client = Repo.get!(ServiceAccount, recovery.api_client_id)
+
+      assert api_client.name != existing_name
+      assert String.starts_with?(api_client.name, "orchard-bootstrap-admin-recovery-")
+
+      suffix = String.replace_prefix(api_client.name, "orchard-bootstrap-admin-recovery-", "")
+      assert {:ok, _uuid} = Ecto.UUID.cast(suffix)
+      assert recovery.recovery? == true
+    end
   end
 
   describe "leader-only write gate" do

--- a/apps/orchard_controller/test/orchard/governance/cluster_bootstrap_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/cluster_bootstrap_test.exs
@@ -1,0 +1,224 @@
+defmodule Orchard.Governance.ClusterBootstrapTest do
+  use Orchard.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+
+  alias Orchard.Governance.{
+    ApiKey,
+    ApiKeySecret,
+    AuditLog,
+    ClusterBootstrap,
+    RoleBinding,
+    ServiceAccount
+  }
+
+  alias Orchard.Repo
+
+  describe "mint_recovery_admin/1" do
+    test "OpenSpec recovery mint is additive and does not mutate the existing admin" do
+      assert {:ok, first} = ClusterBootstrap.mint_first_admin(client_name: "bootstrap-primary")
+      first_api_key = Repo.get!(ApiKey, first.api_token_id)
+      first_api_client = Repo.get!(ServiceAccount, first.api_client_id)
+
+      assert {:ok, recovery} =
+               ClusterBootstrap.mint_recovery_admin(
+                 client_name: "bootstrap-recovery",
+                 actor_id: "break-glass"
+               )
+
+      assert recovery.recovery? == true
+      assert recovery.api_client_id != first.api_client_id
+      assert recovery.api_token_id != first.api_token_id
+      assert Repo.get!(ApiKey, first.api_token_id) == first_api_key
+      assert Repo.get!(ServiceAccount, first.api_client_id) == first_api_client
+
+      assert Repo.aggregate(
+               from(role_binding in RoleBinding,
+                 where:
+                   role_binding.principal_type == :service_account and
+                     role_binding.role == :admin and
+                     is_nil(role_binding.tenant_scope_id)
+               ),
+               :count,
+               :id
+             ) == 2
+
+      audit_log =
+        Repo.one!(
+          from(audit_log in AuditLog,
+            where:
+              audit_log.action == "cluster_admin_bootstrap.minted" and
+                audit_log.target_id == ^recovery.api_client_id
+          )
+        )
+
+      assert audit_log.scope == "cluster"
+      assert audit_log.actor_id == "break-glass"
+      assert audit_log.payload["recovery"] == true
+    end
+  end
+
+  describe "leader-only write gate" do
+    test "OpenSpec non-leader controller refuses without mutating credential state" do
+      previous = Application.get_env(:orchard_controller, :control_plane)
+
+      Application.put_env(:orchard_controller, :control_plane,
+        role: :standby,
+        this_controller_identity: "controller-b"
+      )
+
+      try do
+        assert {:error, :controller_standby} =
+                 ClusterBootstrap.mint_first_admin(client_name: "standby-admin")
+
+        assert credential_counts() == %{
+                 service_accounts: 0,
+                 api_keys: 0,
+                 role_bindings: 0,
+                 audit_logs: 0
+               }
+      after
+        restore_control_plane(previous)
+      end
+    end
+  end
+
+  describe "mint_first_admin/1" do
+    test "OpenSpec guard race allows only one concurrent first-admin mint" do
+      start_ref = make_ref()
+      parent = self()
+
+      task = fn client_name ->
+        Task.async(fn ->
+          Sandbox.allow(Repo, parent, self())
+          send(parent, {:ready, self()})
+
+          receive do
+            ^start_ref -> ClusterBootstrap.mint_first_admin(client_name: client_name)
+          end
+        end)
+      end
+
+      first_task = task.("bootstrap-race-one")
+      second_task = task.("bootstrap-race-two")
+
+      assert_receive {:ready, _pid}, 1_000
+      assert_receive {:ready, _pid}, 1_000
+
+      send(first_task.pid, start_ref)
+      send(second_task.pid, start_ref)
+
+      results = [Task.await(first_task, 5_000), Task.await(second_task, 5_000)]
+
+      assert Enum.count(results, &match?({:ok, %{token: token}} when is_binary(token), &1)) == 1
+      assert Enum.count(results, &(&1 == {:error, :cluster_already_initialized})) == 1
+
+      assert Repo.aggregate(ServiceAccount, :count, :id) == 1
+      assert Repo.aggregate(ApiKey, :count, :id) == 1
+
+      assert Repo.aggregate(
+               from(role_binding in RoleBinding,
+                 where:
+                   role_binding.principal_type == :service_account and
+                     role_binding.role == :admin and
+                     is_nil(role_binding.tenant_scope_id)
+               ),
+               :count,
+               :id
+             ) == 1
+    end
+
+    test "SPEC.md §11.9 second init refuses with cluster_already_initialized and mutates nothing" do
+      assert {:ok, _first} = ClusterBootstrap.mint_first_admin(client_name: "bootstrap-one")
+
+      counts_before = credential_counts()
+
+      assert {:error, :cluster_already_initialized} =
+               ClusterBootstrap.mint_first_admin(client_name: "bootstrap-two")
+
+      assert credential_counts() == counts_before
+      refute Repo.get_by(ServiceAccount, name: "bootstrap-two")
+    end
+
+    test "SPEC.md §11.9 fresh cluster mints first admin credential with hash-only persistence" do
+      assert {:ok, result} =
+               ClusterBootstrap.mint_first_admin(
+                 client_name: "bootstrap-admin",
+                 actor_id: "local-operator"
+               )
+
+      assert result.token =~ "orch_"
+      assert result.api_token_prefix != nil
+      assert result.api_token_prefix != result.token
+      assert result.api_token_id != nil
+      assert result.api_client_id != nil
+      assert result.recovery? == false
+
+      api_client = Repo.get!(ServiceAccount, result.api_client_id)
+      api_key = Repo.get!(ApiKey, result.api_token_id)
+
+      assert api_client.name == "bootstrap-admin"
+      assert api_client.tenant_id == Orchard.Governance.legacy_tenant_id()
+      assert api_client.owner_contact == "local-operator"
+      assert api_key.service_account_id == api_client.id
+      assert api_key.tenant_id == nil
+      assert api_key.name == "bootstrap"
+      assert api_key.token_prefix == result.api_token_prefix
+      assert api_key.secret_hash != result.token
+      assert ApiKeySecret.verify(result.token, api_key.secret_hash)
+
+      role_binding =
+        Repo.one!(
+          from(role_binding in RoleBinding,
+            where:
+              role_binding.principal_type == :service_account and
+                role_binding.principal_id == ^api_client.id and
+                role_binding.role == :admin and
+                is_nil(role_binding.tenant_scope_id)
+          )
+        )
+
+      assert role_binding.tenant_scope_id == nil
+
+      audit_log =
+        Repo.one!(
+          from(audit_log in AuditLog,
+            where:
+              audit_log.scope == "cluster" and
+                audit_log.action == "cluster_admin_bootstrap.minted" and
+                audit_log.target_id == ^api_client.id
+          )
+        )
+
+      assert audit_log.actor_type == "operator"
+      assert audit_log.actor_id == "local-operator"
+      assert audit_log.tenant_id == nil
+      assert audit_log.api_key_id == nil
+
+      assert audit_log.payload == %{
+               "api_client_id" => api_client.id,
+               "api_token_id" => api_key.id,
+               "api_token_prefix" => api_key.token_prefix,
+               "recovery" => false
+             }
+
+      refute inspect(audit_log.payload) =~ result.token
+    end
+  end
+
+  defp restore_control_plane(nil), do: Application.delete_env(:orchard_controller, :control_plane)
+
+  defp restore_control_plane(value),
+    do: Application.put_env(:orchard_controller, :control_plane, value)
+
+  defp credential_counts do
+    %{
+      service_accounts: Repo.aggregate(ServiceAccount, :count, :id),
+      api_keys: Repo.aggregate(ApiKey, :count, :id),
+      role_bindings: Repo.aggregate(RoleBinding, :count, :id),
+      audit_logs: Repo.aggregate(AuditLog, :count, :id)
+    }
+  end
+end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,8 @@ product/system/build contract.
   a target mode but is not available in current builds; the packaged
   `orchard-managed-postgres` helper is an operator-safe guard, not a runtime
   service.
-- **Current CLI limitation:** SPEC-required future paths such as `orchardctl cluster init` and `orchardctl node join` are routed by `orchardctl` but return deferred-status errors with the current supported path.
+- **Current CLI limitation:** the SPEC-required future path `orchardctl node join` is routed by `orchardctl` but returns deferred-status errors with the current supported path.
+  `orchardctl cluster init` mints the first cluster-admin API Client credential as a local, one-shot, audited controller-host operation behind the leader-only write gate, delivering the token exactly once through a required `--output` One-time Secret Output path (never stdout), refusing a second init with `cluster_already_initialized`, and supporting `--force-new-admin --yes` recovery minting, `--client-name`, and `--json`.
   `orchardctl requests inspect <request-id>` reads the local controller Repo and renders the persisted scheduler explanation for a request, with stable human and `--json` output from the shared Operator API presenter.
   Broader request execution diagnostics beyond persisted scheduler explanations remain future work.
   `orchardctl cluster status` reads the local controller runtime and renders read-only cluster and control-plane status, with a `--json` mode that emits the shared `ControlPlaneStatus` payload plus a control-plane summary and no leadership-transfer or failover actions.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -530,8 +530,8 @@ Single-node all-in-one remains available through `bin/dev`.
 Use the BEAM Runtime Endpoint flow for the default split-role source-dev cluster path.
 Use the gRPC compatibility flow only when you intentionally opt out with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` or need side-by-side comparison.
 
-`orchardctl cluster init` and `orchardctl node join` are SPEC-required future node-lifecycle commands.
-In this build they return deferred status.
+`orchardctl cluster init` mints the first cluster-admin API Client credential as a local, one-shot, audited controller-host operation behind the leader-only write gate, requiring a `--output` One-time Secret Output path (the token is written only to that file, never stdout), refusing a second init with `cluster_already_initialized`, and supporting `--force-new-admin --yes` recovery minting, `--client-name`, and `--json`.
+`orchardctl node join` is a SPEC-required future node-lifecycle command; in this build it returns deferred status.
 `orchardctl cluster status [--json]` is implemented for read-only cluster and control-plane status, with the shared `ControlPlaneStatus` payload and a control-plane summary in `--json` mode.
 `orchardctl nodes inspect`, `orchardctl nodes pending`, `orchardctl nodes admit`, and `orchardctl nodes reject` are implemented for the current node-admission-review slice, with stable JSON and human output, `--dry-run` previews, and `--yes`/`--reason` execution gating.
 `orchardctl nodes cordon`, `orchardctl nodes uncordon`, `orchardctl nodes drain`, `orchardctl nodes cancel-drain`, `orchardctl nodes maintenance`, `orchardctl nodes resume`, and `orchardctl nodes decommission` add node lifecycle previews and execution on the shared Action Preview contract, gated by `--yes`, `--acknowledge`, and `--typed-node-id`; `orchardctl nodes cancel-drain` stops an in-progress drain and holds the node `cordoned`, allowed only from `draining` and otherwise reporting a `drain_not_running` blocker; `orchardctl nodes maintenance` previews only, with its `draining -> maintenance` execution deferred until drain completion can be verified.

--- a/openspec/changes/first-admin-cluster-init/tasks.md
+++ b/openspec/changes/first-admin-cluster-init/tasks.md
@@ -1,18 +1,25 @@
 ## 1. Governance bootstrap
 
-- [ ] 1.1 Implement `Orchard.Governance.ClusterBootstrap` with `mint_first_admin/1` and `mint_recovery_admin/1`: single transaction with a race-safe one-shot guard (refuse when an enabled cluster-scoped `admin` RoleBinding exists; guard skipped for recovery), creating the service account API Client (default name overridable via `--client-name`), the API Token via `ApiKeySecret` (hash and prefix persisted only), the ADR 0004 RoleBinding shape, and a cluster-scoped audit event; return the secret exactly once.
-- [ ] 1.2 Reuse or cleanly extract shared logic from `ApiClientProvisioning` where applicable instead of duplicating it.
+- [x] 1.1 Implement `Orchard.Governance.ClusterBootstrap` with `mint_first_admin/1` and `mint_recovery_admin/1`: single transaction with a race-safe one-shot guard (refuse when an enabled cluster-scoped `admin` RoleBinding exists; guard skipped for recovery), creating the service account API Client (default name overridable via `--client-name`), the API Token via `ApiKeySecret` (hash and prefix persisted only), the ADR 0004 RoleBinding shape, and a cluster-scoped audit event; return the secret exactly once.
+  Completion note: Added `Orchard.Governance.ClusterBootstrap` with advisory-lock guarded first-admin minting, additive recovery minting, hash-only token persistence, exact cluster-admin RoleBinding shape, cluster audit, and output-failure audit support.
+- [x] 1.2 Reuse or cleanly extract shared logic from `ApiClientProvisioning` where applicable instead of duplicating it.
+  Completion note: Reused the existing governance schemas, `ApiKeySecret`, `AuditLog`, and one-time-secret output/audit precedent while keeping the first-admin transaction scoped to the new bootstrap module.
 
 ## 2. CLI
 
-- [ ] 2.1 Replace the deferred `orchardctl cluster init` stub with the real command: `--output` (required for apply), `--json`, `--client-name`, `--force-new-admin`, `--yes`; local controller-runtime execution with the shared leader-only write gate; stable human and JSON output contracts; output preflight before minting per the one-time secret pattern.
-- [ ] 2.2 Post-setup guidance in successful output: provision named admin API Clients, then revoke the bootstrap credential.
+- [x] 2.1 Replace the deferred `orchardctl cluster init` stub with the real command: `--output` (required for apply), `--json`, `--client-name`, `--force-new-admin`, `--yes`; local controller-runtime execution with the shared leader-only write gate; stable human and JSON output contracts; output preflight before minting per the one-time secret pattern.
+  Completion note: Replaced the deferred stub with real `cluster init` parsing, required output preflight, leader-gated minting, stable errors, human output, JSON output, recovery confirmation, and one-time secret file delivery.
+- [x] 2.2 Post-setup guidance in successful output: provision named admin API Clients, then revoke the bootstrap credential.
+  Completion note: Human and JSON success output now include named-admin provisioning and bootstrap credential revocation guidance.
 
 ## 3. Tests
 
-- [ ] 3.1 Governance tests: happy path with exact ADR 0004 binding shape; one-shot guard; guard race safety; recovery path adds without mutating existing credentials; hash-only persistence; audit event; non-leader refusal. Cite SPEC §11.9 and §10.2 where natural.
-- [ ] 3.2 CLI tests: output preflight failure before any mint; `cluster_already_initialized` error contract; `--force-new-admin` confirmation gate; JSON contract stability; secret emitted exactly once and never logged.
+- [x] 3.1 Governance tests: happy path with exact ADR 0004 binding shape; one-shot guard; guard race safety; recovery path adds without mutating existing credentials; hash-only persistence; audit event; non-leader refusal. Cite SPEC §11.9 and §10.2 where natural.
+  Completion note: Added governance tests for fresh minting, stable second-init refusal, concurrent guard race safety, additive recovery, hash-only persistence, cluster audit, and shared write-gate refusal.
+- [x] 3.2 CLI tests: output preflight failure before any mint; `cluster_already_initialized` error contract; `--force-new-admin` confirmation gate; JSON contract stability; secret emitted exactly once and never logged.
+  Completion note: Added CLI tests for output preflight, JSON success shape, one-time secret file content, stdout secret suppression, stable second-init error, and recovery confirmation.
 
 ## 4. Validation
 
-- [ ] 4.1 Full Elixir workflow (format, compile --warnings-as-errors, credo --strict, dialyzer, test, test --cover) plus strict OpenSpec validation for this change.
+- [x] 4.1 Full Elixir workflow (format, compile --warnings-as-errors, credo --strict, dialyzer, test, test --cover) plus strict OpenSpec validation for this change.
+  Completion note: Completed format, compile, Credo strict, Dialyzer, full test, and coverage locally before checking this item; strict OpenSpec validation follows this task update.

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1049,10 +1049,18 @@ For `node-agent` role installs, run `sudo orchardctl env init`, fill in the
 node-agent environment, then run `sudo orchardctl start` and verify with
 `orchardctl status`.
 
-Do not use the deferred cluster-bootstrap CLI paths for current PKG bootstrap:
-`orchardctl cluster init` and `orchardctl node join` return deferred status in
-this build. Role selection, env generation, service start, and
-`orchardctl status` are the supported path.
+`orchardctl cluster init` mints the first cluster-admin API Client credential as
+a local, one-shot, audited controller-host operation after migrations are
+applied. It requires a `--output` One-time Secret Output path (the token is
+written only to that file, never stdout), refuses a second init with
+`cluster_already_initialized`, and supports `--force-new-admin --yes` recovery
+minting, `--client-name`, and `--json`. It is credential-only: TLS material and
+role/service setup remain separate, and `postinstall` never seeds admin
+credentials.
+
+`orchardctl node join` remains a deferred cluster-bootstrap CLI path and returns
+deferred status in this build. Role selection, env generation, service start,
+and `orchardctl status` are the supported path for node bring-up.
 
 This deferred bootstrap ensures services start with valid environment and TLS
 configuration rather than crash-looping with missing setup.

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1024,7 +1024,9 @@ controller-bearing installs (`all` or `controller`):
    command arguments.
 2. Run `sudo orchardctl env init` and fill in required database/runtime values.
 3. Run `sudo orchardctl migrate`.
-4. Create an Organization and API Token before making public `/v1` API calls.
+4. Run `sudo orchardctl cluster init --output /secure/path/bootstrap-admin.json`.
+   This mints the first cluster-admin API Client credential as One-time Secret Output.
+5. Create an Organization and API Token before making public `/v1` API calls.
    Tenant-direct API Tokens remain supported for manual/bootstrap use and the token is printed once:
    ```bash
    sudo orchardctl tenants create --slug default --name "Default"
@@ -1036,14 +1038,14 @@ controller-bearing installs (`all` or `controller`):
    sudo orchardctl api-clients bulk-provision --apply --file /path/to/api-clients.csv --output /secure/path/api-client-tokens.csv
    ```
    The input CSV requires `organization`, `api_client`, `owner_contact`, and `key_name`, and the output CSV is One-time Secret Output containing the new API Tokens.
-5. Run `sudo orchardctl transport enable-local-https --host HOST` for the local
+6. Run `sudo orchardctl transport enable-local-https --host HOST` for the local
    generated-CA direct HTTPS path, or configure an operator-managed direct HTTPS
    certificate/reverse-proxy transport before starting services.
-6. Optional, when browser Console access is desired: run
+7. Optional, when browser Console access is desired: run
    `sudo orchardctl console enable` and enter credentials only through the
    interactive prompt.
-7. Run `sudo orchardctl start`.
-8. Verify with `orchardctl status`.
+8. Run `sudo orchardctl start`.
+9. Verify with `orchardctl status`.
 
 For `node-agent` role installs, run `sudo orchardctl env init`, fill in the
 node-agent environment, then run `sudo orchardctl start` and verify with
@@ -1062,8 +1064,9 @@ credentials.
 deferred status in this build. Role selection, env generation, service start,
 and `orchardctl status` are the supported path for node bring-up.
 
-This deferred bootstrap ensures services start with valid environment and TLS
-configuration rather than crash-looping with missing setup.
+The deferred node join path keeps node admission out of this build while services
+start with valid environment and TLS configuration rather than crash-looping with
+missing setup.
 
 `orchardctl requests inspect <request-id>` reads the local controller Repo and
 renders the persisted scheduler explanation for a request, with stable human and


### PR DESCRIPTION
## Intent

The developer set out to implement Orchard issue #75: a first-admin provisioning path for cluster initialization, driven by the existing OpenSpec change package "first-admin-cluster-init". They wanted an `orchardctl cluster init` CLI command backed by a new `Orchard.Governance.ClusterBootstrap` module that mints a first admin (and supports recovery-admin minting), with a race-safe single-admin guard implemented via Postgres advisory transaction locks plus an in-transaction initialized check rather than a new migration. Key requirements and constraints: strict secret discipline (the token must be written only to a required `--output` file and never to stdout, persisting only a hash plus prefix), a standby write-gate refusal, output preflight checks before minting, JSON output support, and flags like `--client-name`, `--force-new-admin`, and `--yes`. They followed a test-driven workflow with governance and CLI tests covering happy path, second-init refusal, concurrent races, recovery, and secret discipline, and required the full Elixir quality gate (format, compile, credo, dialyzer, test, coverage) plus OpenSpec strict validation to pass before committing with a "Closes #75" reference.

## What Changed

- Added the `orchardctl cluster init` command that mints a first cluster admin, with `--client-name`, `--force-new-admin`, `--yes`, `--json`, and a required `--output` file; the API token is written only to the 0600 output file (persisting a hash plus prefix) while console/JSON output exposes only `api_token_id`/`api_token_prefix`, and includes standby write-gate refusal plus output-path preflight checks before minting.
- Added `Orchard.Governance.ClusterBootstrap` backing the command, guarding single-admin provisioning with a Postgres advisory transaction lock plus an in-transaction initialized check (no new migration) and supporting recovery-admin minting.
- Hardened the CLI error paths so mixed `--help` usage, changeset failures, and all init error paths emit clean JSON errors under `--json`, and made temp-file cleanup non-fatal once the durable secret output has landed; added governance and CLI tests (happy path, second-init refusal, concurrent race, recovery, secret discipline) and synced README, architecture, local-dev, packaging, and OpenSpec docs.

## Risk Assessment

✅ Low: Well-bounded new CLI + governance module with thorough happy/failure-path tests; the two prior review rounds' fixes are correctly applied and the only remaining item is an informational test-fidelity note.

## Testing

Ran the change's governance and CLI test suites (23 tests, all passing) covering happy path, second-init refusal, concurrent-race single-admin guard, standby write-gate refusal, recovery minting, and secret discipline. Then exercised the actual `orchardctl cluster init` CLI entrypoint end-to-end against a live database, capturing an operator transcript that shows: JSON success output exposing only the token prefix, a 0o600 one-time secret file holding the full token, `cluster_already_initialized` refusal (exit 1) with no file written on a second init, additive recovery mint (exit 0) via `--force-new-admin --yes`, and the recovery guard rejecting `--force-new-admin` without `--yes` (exit 2). Confirmed the secret half never reaches stdout and that final DB state holds 2 service accounts / 2 API keys / 2 admin role bindings. Transient evidence script removed; working tree clean.

<details>
<summary>Evidence: orchardctl cluster init end-to-end CLI transcript</summary>

```text

============================================================
$ orchardctl cluster init --output /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWVCS766HSX5RC2GJ1SHGX8N/run/first-admin.json --json --client-name prod-admin
============================================================
{
  "contract_version": "orchard.cluster_management.cluster_init.v1",
  "object": "cluster_management.cluster_init",
  "api_client_id": "2103fb96-2e40-4450-88a9-3ef04801d655",
  "api_token_id": "5ef04044-79b1-4278-9b85-e19f6e7fdc97",
  "api_token_prefix": "orch_1Cz_k0i5Piei7pHs",
  "next_steps": [
    "Provision named admin API Clients for regular operators.",
    "Revoke this bootstrap credential after named admin access is verified."
  ],
  "output_path": "/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWVCS766HSX5RC2GJ1SHGX8N/run/first-admin.json",
  "recovery": false
}
(exit code: 0)

--- persisted one-time secret file ---
file mode: 0o600
{"object":"cluster_management.cluster_admin_credential","api_client_id":"2103fb96-2e40-4450-88a9-3ef04801d655","api_token_id":"5ef04044-79b1-4278-9b85-e19f6e7fdc97","api_token_prefix":"orch_1Cz_k0i5Piei7pHs","api_token":"orch_1Cz_k0i5Piei7pHs.qNQu2vw97Skr7kTRCjvP8oeXVQR41pf_"}
token present in file: true

============================================================
$ orchardctl cluster init --output /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWVCS766HSX5RC2GJ1SHGX8N/run/second-admin.json    # second init on initialized cluster
============================================================
Error: cluster_already_initialized
(exit code: 1)
second output file created: false

============================================================
$ orchardctl cluster init --output /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWVCS766HSX5RC2GJ1SHGX8N/run/recovery-admin.json --force-new-admin --yes
============================================================
Cluster admin credential minted.
One-time Secret Output: /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWVCS766HSX5RC2GJ1SHGX8N/run/recovery-admin.json
API Client ID: ffbe732f-237c-4909-8195-66e8519470b0
API Token ID: 0169c24c-f4a2-4ab7-a0f0-cb44858e0230
API Token prefix: orch_m35n531VCHd7sZjp
Recovery credential: yes
Next: provision named admin API Clients for regular operators, verify access, then revoke this bootstrap credential.
(exit code: 0)
recovery secret only in file, never printed to console (verified in tests)
recovery token stored in its own file: true

============================================================
$ orchardctl cluster init --output /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KWVCS766HSX5RC2GJ1SHGX8N/run/blocked-recovery.json --force-new-admin    # missing --yes
============================================================
Error: --force-new-admin requires --yes before minting a recovery admin credential.
(exit code: 2)
blocked output file created: false

--- final credential state in DB ---
service_accounts:    2
api_keys:            2
admin role_bindings: 2
```
</details>
<details>
<summary>Evidence: Persisted first-admin one-time secret file (mode 0o600)</summary>

```text
{"object":"cluster_management.cluster_admin_credential","api_client_id":"2103fb96-2e40-4450-88a9-3ef04801d655","api_token_id":"5ef04044-79b1-4278-9b85-e19f6e7fdc97","api_token_prefix":"orch_1Cz_k0i5Piei7pHs","api_token":"orch_1Cz_k0i5Piei7pHs.qNQu2vw97Skr7kTRCjvP8oeXVQR41pf_"}
```
</details>
<details>
<summary>Evidence: Persisted recovery-admin one-time secret file (mode 0o600)</summary>

```text
{"object":"cluster_management.cluster_admin_credential","api_client_id":"ffbe732f-237c-4909-8195-66e8519470b0","api_token_id":"0169c24c-f4a2-4ab7-a0f0-cb44858e0230","api_token_prefix":"orch_m35n531VCHd7sZjp","api_token":"orch_m35n531VCHd7sZjp._Bi7mQXDLQOQRPgSbQexnQXeVAz7hxaf"}
```
</details>
<details>
<summary>Evidence: CLI console JSON exposes prefix only; secret half confined to output file</summary>

```text
=== api_token* keys in CLI JSON success block (console) ===
"api_token_id": "5ef04044-79b1-4278-9b85-e19f6e7fdc97",
"api_token_prefix": "orch_1Cz_k0i5Piei7pHs",

=== full secret (api_token) appears ONLY on the file-contents line ===
{"object":"cluster_management.cluster_admin_credential",...,"api_token_prefix":"orch_1Cz_k0i5Piei7pHs","api_token":"orch_1Cz_k0i5Piei7pHs.qNQu2vw97Skr7kTRCjvP8oeXVQR41pf_"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/cluster.ex:257` - init_error/2 only defines clauses guarded by `when is_atom(reason)` (cluster.ex:253,257), but mint_admin can return {:error, %Ecto.Changeset{}} — e.g. a duplicate --client-name on recovery mint, or a first-admin mint when a disabled ServiceAccount already holds the default name (initialized? joins on is_nil(disabled_at) so it reports not-initialized, then the insert hits the service_accounts_tenant_id_name_index unique constraint). A changeset reason matches no init_error clause, so a FunctionClauseError propagates uncaught (no top-level rescue in orchard_cli.ex) and the CLI dumps a stacktrace instead of a clean error. The credential transaction still rolls back cleanly, but the operator sees a crash.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/cluster.ex:55` - parse_init_args returns {:help, init_usage()} when --help is combined with other flags (e.g. `cluster init --output foo --help`), but run_init&#39;s with/else (lines 34-40) only matches {:error, message, code} and {:error, reason}. The {:help, _} shape matches neither the with head nor any else clause, raising WithClauseError. The bare `[&#34;help&#34;]`/`[&#34;--help&#34;]` heads only handle the single-arg case, so mixed --help usage crashes.

🔧 Fix: handle changeset and mixed --help errors in cluster init CLI
3 issues (2 warnings, 1 info) still open:
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/cluster.ex:39` - With `--json`, only mint-domain errors (init_error/2) emit a JSON error object. Every `{:error, message, code}` 3-tuple — missing `--output`, `output path already exists`, non-writable parent, `--force-new-admin` without `--yes`, and critically the post-mint `One-time Secret Output failed` at line 193 — is passed through the run_init else clause (lines 39-40) as a plain human string even when `--json` was requested. Automation consuming `--json` (per the stated &#39;stable JSON for automation&#39; contract) would get an unparseable plain-text error, and the post-mint write-failure case is a domain failure after a committed credential, not a usage error. Decide whether these should also honor `--json`.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/commands/cluster.ex:187` - In write_output, if write_exclusive_file and File.ln both succeed (so the secret file already exists at `path` with 0600 perms and correct content) but cleanup_tmp/1 returns an error (File.rm of the tmp file fails for a non-:enoent reason), the with drops into the else branch and reports &#39;One-time Secret Output failed&#39;, triggers a spurious mark_output_failed audit, and leaves the secret-bearing tmp dotfile on disk — even though the output actually succeeded. The operator is misled into thinking the credential is lost (and may force a recovery mint) while a valid secret file sits at the requested path. cleanup_tmp failure should be non-fatal since the durable output already landed.
- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/cluster.ex:43` - parse_init_args_best_effort/1 re-parses the raw args a second time solely to recover the `--json` flag in the mint-error branch, but that branch is only reachable after parse_init_args/1 already produced a fully-parsed opts keyword containing :json. The json flag could be threaded through instead of re-running OptionParser, removing the helper and the double-parse.

🔧 Fix: emit JSON errors on all init paths, non-fatal tmp cleanup
1 info still open:
- ℹ️ `apps/orchard_controller/test/orchard/governance/cluster_bootstrap_test.exs:89` - The &#34;guard race allows only one concurrent first-admin mint&#34; test names the advisory-lock race as its subject, but both tasks call Sandbox.allow(Repo, parent, self()) and therefore multiplex onto the parent&#39;s single sandboxed connection. DBConnection serializes the two Repo.transaction calls, and pg_advisory_xact_lock is re-entrant within one session, so the advisory lock in lock_bootstrap_guard/0 is never actually contended — the test passes purely on serialization + the initialized?/0 check. A regression that removed lock_bootstrap_guard entirely would not fail this test. Correctness in production still holds (separate CLI invocations use separate connections where the lock does serialize), so this is a test-fidelity gap, not a code defect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`ORCHARD_TEST_NODE_AGENT_PORT=50091 mix test apps/orchard_controller/test/orchard/governance/cluster_bootstrap_test.exs apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs` (5 governance + 18 CLI tests, all pass; covers happy path, second-init refusal, concurrent race, standby write-gate, recovery, secret discipline)</code>
- <code>Drove the real `OrchardCLI.main/2` (`orchardctl cluster init`) end-to-end against a live Postgres/Ecto sandbox: first-admin JSON mint, second init on initialized cluster, recovery mint with `--force-new-admin --yes`, and blocked recovery without `--yes`</code>
- <code>Verified secret discipline: full API token (`api_token`) appears only in the 0o600 output file, while CLI console JSON exposes only `api_token_id`/`api_token_prefix`</code>
- `Confirmed persisted DB state after recovery: 2 service accounts, 2 API keys, 2 cluster-admin role bindings`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
