### PR TITLE
docs: document external Postgres rehearsal setup

### DIFF
--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -32,6 +32,56 @@ Before starting the controller for the first time:
 3. Create `controller.env` with the required variables (see below).
 4. Run release migrations (see below).
 
+### Local two-Mac rehearsal PostgreSQL setup
+
+For the current packaged two-Mac rehearsal, prefer a Homebrew-managed PostgreSQL 16 server on the controller Mac, bound to loopback.
+This still counts as operator-managed external PostgreSQL because Orchard does not install, bootstrap, or supervise it.
+It avoids exposing Postgres to the worker Mac, and it matches the current packaged BEAM topology where only the controller Mac needs database access.
+
+Install and start PostgreSQL on the controller Mac:
+
+```bash
+brew install postgresql@16
+brew services start postgresql@16
+/opt/homebrew/opt/postgresql@16/bin/pg_isready -h 127.0.0.1 -p 5432
+```
+
+If Homebrew is installed somewhere other than `/opt/homebrew`, replace `/opt/homebrew` with `$(brew --prefix)`.
+Create an Orchard database user and database without placing the password in shell history:
+
+```bash
+$(brew --prefix)/opt/postgresql@16/bin/createuser --pwprompt orchard
+$(brew --prefix)/opt/postgresql@16/bin/createdb -O orchard orchard_controller
+$(brew --prefix)/opt/postgresql@16/bin/psql "postgresql://orchard@127.0.0.1:5432/orchard_controller" -c 'select 1'
+```
+
+Set the packaged controller DSN to loopback in `/Library/Application Support/Orchard/config/controller.env`.
+URL-encode any special characters in the password.
+For a local lab loopback database, omit TLS or set `ssl=false`; use TLS for a PostgreSQL host reached over a private LAN, VPN, or Tailscale network.
+
+```bash
+DATABASE_URL="ecto://orchard:URL_ENCODED_PASSWORD@127.0.0.1:5432/orchard_controller?ssl=false"
+```
+
+The worker Mac does not need direct PostgreSQL reachability in the packaged BEAM first cut.
+Do not point node-agent env files at Postgres.
+If a separate PostgreSQL host is required, restrict it to the controller Mac's private IP or VPN IP in PostgreSQL `listen_addresses`, `pg_hba.conf`, and host firewall rules rather than opening `0.0.0.0/0`.
+Use PostgreSQL 16 or newer, require password authentication, and prefer TLS for any non-loopback database connection.
+
+Operational notes:
+
+- `brew services start postgresql@16` is convenient for local rehearsal and restarts PostgreSQL when the owning user logs in.
+- It is not a substitute for Orchard Managed Database Mode, boot-before-login service management, backup automation, or production hardening.
+- Back up rehearsal state with `pg_dump` or `pg_dumpall` before deleting the Homebrew data directory.
+- Homebrew's default PostgreSQL 16 data directory on Apple Silicon is usually `/opt/homebrew/var/postgresql@16`.
+
+Fallback local container path:
+
+Use the container path only when an organization-approved local container runtime is already part of the operator environment.
+Run `postgres:16` or a PostgreSQL 16+ equivalent with a persistent named volume, `POSTGRES_USER=orchard`, `POSTGRES_DB=orchard_controller`, a generated password, and a loopback-only port binding such as `127.0.0.1:5432:5432`.
+The container must publish Postgres only on loopback for the two-Mac rehearsal.
+The chosen container runtime must be running before its restart policy can bring the database back after a reboot or logout.
+
 ## Packaged External-Sites Multi-Mac First Cut
 
 The first external-sites packaged cut supports one controller Mac and one or more node-agent Macs on a trusted private network or VPN.


### PR DESCRIPTION
## Summary

This docs-only PR adds a concrete external PostgreSQL setup path for the packaged two-Mac Orchard rehearsal.

Recommendation:

- Prefer Homebrew-managed PostgreSQL 16 on the controller Mac, bound to `127.0.0.1`.
- Use a loopback-only PostgreSQL 16+ container as the fallback only when an organization-approved local container runtime is already part of the operator environment.
- Do not require direct PostgreSQL reachability from the worker Mac in the current packaged BEAM first cut.

## Why

The existing packaging docs clearly said controller-bearing packaged installs require operator-managed external PostgreSQL, but they stopped at a `DATABASE_URL` placeholder.
That made the two-Mac rehearsal ambiguous after local Postgres worked on `localhost:5432` while the worker Mac could not reach the controller Mac's Postgres port.
Repo truth says only the controller Mac needs database access for this packaged BEAM path, so the simplest repeatable setup is loopback PostgreSQL on the controller Mac.

## What Changed

- Added a local two-Mac rehearsal PostgreSQL runbook to `packaging/pkg/README.md`.
- Documented Homebrew PostgreSQL 16 install, service start, DB/user creation, loopback `DATABASE_URL`, and backup notes.
- Documented the container fallback in runtime-neutral terms with loopback-only binding and persistent-volume requirements.
- Added security guidance for any separate PostgreSQL host: restrict `listen_addresses`, `pg_hba.conf`, and firewall scope to the controller Mac's private or VPN IP instead of opening the database broadly.

## Validation

- `git diff --check`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/najib/.codex/worktrees/cca3/orchard/mise.toml OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`

OpenSpec result: 4 passed, 0 failed.
The `MISE_TRUSTED_CONFIG_PATHS` override was used because this detached worktree's `mise.toml` had not been permanently trusted.

## Residual Risk

- Homebrew `brew services` is a local rehearsal convenience, not Orchard Managed Database Mode or production-grade boot-before-login service management.
- The loopback DSN uses `ssl=false`; non-loopback PostgreSQL should use TLS and tighter host authentication.
- The container fallback depends on the chosen organization-approved local container runtime being started before its restart policy can recover the database.
