### PR TITLE
fix(orchard_cli): start controller repo for packaged orchardctl db commands

### DIFF
--- a/apps/orchard_cli/lib/orchard_cli/commands/api_clients.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/api_clients.ex
@@ -5,6 +5,7 @@ defmodule OrchardCLI.Commands.ApiClients do
 
   alias Orchard.Governance
   alias Orchard.Governance.ApiClientProvisioning
+  alias OrchardCLI.RepoRuntime
 
   @output_headers ~w(
     organization
@@ -249,13 +250,25 @@ defmodule OrchardCLI.Commands.ApiClients do
   end
 
   defp execute_bulk(:dry_run, rows, csv, _output_path, opts) do
+    RepoRuntime.run(fn -> do_execute_bulk(:dry_run, rows, csv, nil, opts) end,
+      json: Keyword.get(opts, :json, false)
+    )
+  end
+
+  defp execute_bulk(:apply, rows, csv, output_path, opts) do
+    RepoRuntime.run(fn -> do_execute_bulk(:apply, rows, csv, output_path, opts) end,
+      json: Keyword.get(opts, :json, false)
+    )
+  end
+
+  defp do_execute_bulk(:dry_run, rows, csv, _output_path, opts) do
     case governance().bulk_validate_api_clients(rows, provisioning_opts(csv, opts)) do
       {:ok, plan} -> {:ok, render_dry_run(plan, Keyword.get(opts, :json, false))}
       {:error, errors} -> {:error, format_validation_errors(errors), 1}
     end
   end
 
-  defp execute_bulk(:apply, rows, csv, output_path, opts) do
+  defp do_execute_bulk(:apply, rows, csv, output_path, opts) do
     case governance().bulk_apply_api_clients(rows, provisioning_opts(csv, opts)) do
       {:ok, result} ->
         case write_output(output_path, result.output_rows) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/api_keys.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/api_keys.ex
@@ -6,6 +6,7 @@ defmodule OrchardCLI.Commands.ApiKeys do
   alias Ecto.Changeset
   alias Orchard.Governance
   alias OrchardCLI.Commands.GovernanceHelpers
+  alias OrchardCLI.RepoRuntime
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(args) do
@@ -108,6 +109,10 @@ defmodule OrchardCLI.Commands.ApiKeys do
   end
 
   defp create_api_key(tenant_id, name) do
+    RepoRuntime.run(fn -> do_create_api_key(tenant_id, name) end)
+  end
+
+  defp do_create_api_key(tenant_id, name) do
     case Governance.create_api_key(tenant_id, %{name: name}) do
       {:ok, %{api_key: api_key, token: token}} ->
         {:ok,
@@ -134,6 +139,10 @@ defmodule OrchardCLI.Commands.ApiKeys do
   end
 
   defp revoke_api_key(api_key_id) do
+    RepoRuntime.run(fn -> do_revoke_api_key(api_key_id) end)
+  end
+
+  defp do_revoke_api_key(api_key_id) do
     case Governance.revoke_api_key(api_key_id) do
       {:ok, api_key} ->
         {:ok,

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -5,6 +5,7 @@ defmodule OrchardCLI.Commands.Cluster do
   alias Orchard.ControlPlane
   alias Orchard.Governance.ClusterBootstrap
   alias OrchardCLI.Commands.GovernanceHelpers
+  alias OrchardCLI.RepoRuntime
 
   @cluster_status_object "cluster_management.cluster_status"
   @cluster_status_contract_version "orchard.cluster_management.cluster_status.v1"
@@ -136,12 +137,20 @@ defmodule OrchardCLI.Commands.Cluster do
       [actor_id: "local-orchardctl"]
       |> maybe_put_client_name(opts)
 
+    RepoRuntime.with_repo(fn -> do_mint_admin(opts, mint_opts) end)
+    |> unwrap_mint_admin()
+  end
+
+  defp do_mint_admin(opts, mint_opts) do
     if Keyword.get(opts, :force_new_admin, false) do
       ClusterBootstrap.mint_recovery_admin(mint_opts)
     else
       ClusterBootstrap.mint_first_admin(mint_opts)
     end
   end
+
+  defp unwrap_mint_admin({:ok, result}), do: result
+  defp unwrap_mint_admin({:error, reason}), do: {:error, reason}
 
   defp maybe_put_client_name(mint_opts, opts) do
     case Keyword.fetch(opts, :client_name) do
@@ -159,15 +168,40 @@ defmodule OrchardCLI.Commands.Cluster do
         {:ok, render_init_success(result, output_path, json?, [tmp_leftover_warning(tmp_path)])}
 
       {:error, message} ->
-        _ =
-          ClusterBootstrap.mark_output_failed(result, %{
-            "reason" => message,
-            "api_token_prefix" => result.api_token_prefix
-          })
+        message =
+          [message, output_failed_persistence_warning(mark_output_failed(result, message))]
+          |> Enum.reject(&is_nil/1)
+          |> Enum.join("\n")
 
         {:error, :one_time_secret_output_failed, message, 1}
     end
   end
+
+  defp mark_output_failed(result, message) do
+    RepoRuntime.with_repo(fn ->
+      ClusterBootstrap.mark_output_failed(result, %{
+        "reason" => message,
+        "api_token_prefix" => result.api_token_prefix
+      })
+    end)
+  end
+
+  defp output_failed_persistence_warning({:ok, {:ok, _result}}), do: nil
+
+  defp output_failed_persistence_warning({:ok, {:error, reason}}) do
+    "Failed to record output_failed status/audit: #{format_persistence_error(reason)}"
+  end
+
+  defp output_failed_persistence_warning({:error, {:database_unavailable, message}}) do
+    "Failed to record output_failed status/audit: #{message}"
+  end
+
+  defp format_persistence_error(%Ecto.Changeset{} = changeset) do
+    changeset.errors |> inspect()
+  end
+
+  defp format_persistence_error(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_persistence_error(reason), do: inspect(reason)
 
   defp tmp_leftover_warning(tmp_path) do
     "credential was written but the temporary secret file #{tmp_path} could not be removed; delete it manually."
@@ -297,6 +331,10 @@ defmodule OrchardCLI.Commands.Cluster do
     {:error, "Error: cluster_init_invalid: #{detail}", 1}
   end
 
+  defp init_error({:database_unavailable, _message} = reason, json?) do
+    RepoRuntime.command_error(reason, json?)
+  end
+
   defp init_error(reason, true) when is_atom(reason) do
     {:error, Jason.encode!(%{object: "error", code: Atom.to_string(reason)}, pretty: true), 1}
   end
@@ -317,8 +355,13 @@ defmodule OrchardCLI.Commands.Cluster do
   defp run_status(args) do
     case parse_status_args(args) do
       {:ok, %{json?: json?}} ->
-        status = ControlPlane.read_only_status()
-        {:ok, render_status(status, json?)}
+        RepoRuntime.run(
+          fn ->
+            status = ControlPlane.read_only_status()
+            {:ok, render_status(status, json?)}
+          end,
+          json: json?
+        )
 
       {:help, usage} ->
         {:ok, usage}

--- a/apps/orchard_cli/lib/orchard_cli/commands/models.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/models.ex
@@ -10,6 +10,7 @@ defmodule OrchardCLI.Commands.Models do
 
   alias Orchard.Models
   alias Orchard.Models.Importer
+  alias OrchardCLI.RepoRuntime
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(["import" | rest]) do
@@ -28,18 +29,7 @@ defmodule OrchardCLI.Commands.Models do
   end
 
   def run(["list"]) do
-    models = Models.list_active_models()
-
-    if models == [] do
-      {:ok, "No active models."}
-    else
-      lines =
-        Enum.map_join(models, "\n", fn model ->
-          "#{model.model_id}@#{model.version}  state=#{model.state}  format=#{model.format}"
-        end)
-
-      {:ok, lines}
-    end
+    RepoRuntime.run(fn -> list_active_models() end)
   end
 
   def run(["delete" | rest]), do: run_delete(rest)
@@ -49,6 +39,26 @@ defmodule OrchardCLI.Commands.Models do
   end
 
   defp run_import(source_path, opts) do
+    RepoRuntime.run(fn -> do_run_import(source_path, opts) end)
+  end
+
+  defp list_active_models do
+    Models.list_active_models()
+    |> render_active_models()
+  end
+
+  defp render_active_models([]), do: {:ok, "No active models."}
+
+  defp render_active_models(models) do
+    lines =
+      Enum.map_join(models, "\n", fn model ->
+        "#{model.model_id}@#{model.version}  state=#{model.state}  format=#{model.format}"
+      end)
+
+    {:ok, lines}
+  end
+
+  defp do_run_import(source_path, opts) do
     artifacts_root = Importer.default_artifacts_root()
 
     import_opts = [
@@ -90,13 +100,7 @@ defmodule OrchardCLI.Commands.Models do
   defp run_delete([identity]) do
     case parse_model_identity(identity) do
       {:ok, %{model_id: model_id, version: version}} ->
-        case Models.get_model_by_identity(model_id, version) do
-          nil ->
-            {:error, "Error: model not found: #{identity}", 1}
-
-          model ->
-            handle_delete_result(Models.delete_model(model.id), identity)
-        end
+        RepoRuntime.run(fn -> do_run_delete(model_id, version, identity) end)
 
       :error ->
         {:error,
@@ -106,6 +110,16 @@ defmodule OrchardCLI.Commands.Models do
 
   defp run_delete(_args) do
     {:error, "Error: expected exactly one model identity\n#{delete_usage()}", 1}
+  end
+
+  defp do_run_delete(model_id, version, identity) do
+    case Models.get_model_by_identity(model_id, version) do
+      nil ->
+        {:error, "Error: model not found: #{identity}", 1}
+
+      model ->
+        handle_delete_result(Models.delete_model(model.id), identity)
+    end
   end
 
   defp handle_delete_result({:ok, model}, _identity) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/nodes.ex
@@ -17,12 +17,13 @@ defmodule OrchardCLI.Commands.Nodes do
   alias Orchard.Nodes
   alias Orchard.Nodes.AdmissionCandidate
   alias Orchard.Nodes.Lifecycle
+  alias OrchardCLI.RepoRuntime
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(args) do
     case args do
-      ["list"] -> run_list()
-      ["list", "--json"] -> run_list_json()
+      ["list"] -> RepoRuntime.run(fn -> run_list() end)
+      ["list", "--json"] -> RepoRuntime.run(fn -> run_list_json() end, json: true)
       ["list", "--help"] -> {:ok, list_usage()}
       ["help"] -> {:ok, group_usage()}
       ["--help"] -> {:ok, group_usage()}
@@ -47,14 +48,15 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_inspect(["help"]), do: {:ok, inspect_usage()}
 
   defp run_inspect(args) do
-    with {:ok, %{id: node_id, json?: json?}} <- parse_inspect_args(args),
-         {:ok, node} <- guarded_fetch_node(node_id) do
-      output = node |> NodeAdmissionPresenter.node() |> with_memory_budget()
-      {:ok, render_node(output, json?)}
-    else
-      {:error, :node_not_found} -> {:error, "Error: node not found.", 1}
-      {:help, usage} -> {:ok, usage}
-      {:error, message, code} -> {:error, message, code}
+    case parse_inspect_args(args) do
+      {:ok, %{id: node_id, json?: json?}} ->
+        RepoRuntime.run(fn -> inspect_node(node_id, json?) end, json: json?)
+
+      {:help, usage} ->
+        {:ok, usage}
+
+      {:error, message, code} ->
+        {:error, message, code}
     end
   end
 
@@ -64,8 +66,13 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_pending(args) do
     case parse_pending_args(args) do
       {:ok, %{json?: json?}} ->
-        output = NodeAdmissionPresenter.list_candidates(guarded_pending_candidates())
-        {:ok, render_pending(output, json?)}
+        RepoRuntime.run(
+          fn ->
+            output = NodeAdmissionPresenter.list_candidates(pending_candidates())
+            {:ok, render_pending(output, json?)}
+          end,
+          json: json?
+        )
 
       {:help, usage} ->
         {:ok, usage}
@@ -81,23 +88,16 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_admit(args) do
     case parse_admit_args(args) do
       {:ok, %{dry_run?: true} = opts} ->
-        preview =
-          guarded_preview(
-            fn -> ActionPreviewBuilder.admit_node(opts.id, opts.attrs) end,
-            :admit,
-            opts.id
-          )
-
-        {:ok, render_preview(preview, opts.json?)}
+        RepoRuntime.run(
+          fn ->
+            preview = ActionPreviewBuilder.admit_node(opts.id, opts.attrs)
+            {:ok, render_preview(preview, opts.json?)}
+          end,
+          json: opts.json?
+        )
 
       {:ok, opts} ->
-        preview = ActionPreviewBuilder.admit_node(opts.id, opts.attrs)
-
-        if preview_blocked?(preview) or not opts.yes? do
-          confirmation_error(preview, opts, :admit)
-        else
-          execute_admit(opts)
-        end
+        RepoRuntime.run(fn -> preview_and_execute_admit(opts) end, json: opts.json?)
 
       {:help, usage} ->
         {:ok, usage}
@@ -113,23 +113,16 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_reject(args) do
     case parse_reject_args(args) do
       {:ok, %{dry_run?: true} = opts} ->
-        preview =
-          guarded_preview(
-            fn -> ActionPreviewBuilder.reject_admission(opts.id, opts.attrs) end,
-            :reject,
-            opts.id
-          )
-
-        {:ok, render_preview(preview, opts.json?)}
+        RepoRuntime.run(
+          fn ->
+            preview = ActionPreviewBuilder.reject_admission(opts.id, opts.attrs)
+            {:ok, render_preview(preview, opts.json?)}
+          end,
+          json: opts.json?
+        )
 
       {:ok, opts} ->
-        preview = ActionPreviewBuilder.reject_admission(opts.id, opts.attrs)
-
-        if preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) do
-          confirmation_error(preview, opts, :reject)
-        else
-          execute_reject(opts)
-        end
+        RepoRuntime.run(fn -> preview_and_execute_reject(opts) end, json: opts.json?)
 
       {:help, usage} ->
         {:ok, usage}
@@ -145,22 +138,16 @@ defmodule OrchardCLI.Commands.Nodes do
   defp run_lifecycle(action, args) do
     case parse_lifecycle_args(action, args) do
       {:ok, %{dry_run?: true} = opts} ->
-        preview =
-          guarded_preview(
-            fn -> ActionPreviewBuilder.node_lifecycle(action, opts.id, opts.attrs) end,
-            action,
-            opts.id
-          )
-
-        {:ok, render_preview(preview, opts.json?)}
+        RepoRuntime.run(
+          fn ->
+            preview = ActionPreviewBuilder.node_lifecycle(action, opts.id, opts.attrs)
+            {:ok, render_preview(preview, opts.json?)}
+          end,
+          json: opts.json?
+        )
 
       {:ok, opts} ->
-        preview = ActionPreviewBuilder.node_lifecycle(action, opts.id, opts.attrs)
-
-        case lifecycle_confirmation_error(preview, opts) do
-          nil -> execute_lifecycle(opts)
-          message -> confirmation_error(preview, opts, action, message)
-        end
+        RepoRuntime.run(fn -> preview_and_execute_lifecycle(action, opts) end, json: opts.json?)
 
       {:help, usage} ->
         {:ok, usage}
@@ -202,39 +189,50 @@ defmodule OrchardCLI.Commands.Nodes do
     end
   end
 
-  defp guarded_fetch_node(node_id) do
-    guarded_read(fn -> Nodes.fetch_node(node_id) end, {:error, :node_not_found})
-  end
+  defp inspect_node(node_id, json?) do
+    case fetch_node(node_id) do
+      {:ok, node} ->
+        output = node |> NodeAdmissionPresenter.node() |> with_memory_budget()
+        {:ok, render_node(output, json?)}
 
-  defp guarded_pending_candidates do
-    guarded_read(
-      fn ->
-        Nodes.list_admission_candidates(
-          admission_category: AdmissionCandidate.review_categories()
-        )
-      end,
-      []
-    )
-  end
-
-  defp guarded_preview(build_fun, action, target_id) do
-    guarded_read(build_fun, ActionPreviewBuilder.not_found_preview(action, target_id))
-  end
-
-  defp guarded_read(fun, fallback) do
-    if repo_available?() do
-      fun.()
-    else
-      fallback
+      {:error, :node_not_found} ->
+        {:error, "Error: node not found.", 1}
     end
-  rescue
-    _exception in [DBConnection.ConnectionError, DBConnection.OwnershipError, Postgrex.Error] ->
-      fallback
   end
 
-  defp repo_available? do
-    pid = Process.whereis(Orchard.Repo)
-    is_pid(pid) and Process.alive?(pid)
+  defp preview_and_execute_admit(opts) do
+    preview = ActionPreviewBuilder.admit_node(opts.id, opts.attrs)
+
+    if preview_blocked?(preview) or not opts.yes? do
+      confirmation_error(preview, opts, :admit)
+    else
+      execute_admit(opts)
+    end
+  end
+
+  defp preview_and_execute_reject(opts) do
+    preview = ActionPreviewBuilder.reject_admission(opts.id, opts.attrs)
+
+    if preview_blocked?(preview) or not opts.yes? or reason_missing?(opts.attrs) do
+      confirmation_error(preview, opts, :reject)
+    else
+      execute_reject(opts)
+    end
+  end
+
+  defp preview_and_execute_lifecycle(action, opts) do
+    preview = ActionPreviewBuilder.node_lifecycle(action, opts.id, opts.attrs)
+
+    case lifecycle_confirmation_error(preview, opts) do
+      nil -> execute_lifecycle(opts)
+      message -> confirmation_error(preview, opts, action, message)
+    end
+  end
+
+  defp fetch_node(node_id), do: Nodes.fetch_node(node_id)
+
+  defp pending_candidates do
+    Nodes.list_admission_candidates(admission_category: AdmissionCandidate.review_categories())
   end
 
   defp parse_inspect_args(args) do
@@ -713,9 +711,6 @@ defmodule OrchardCLI.Commands.Nodes do
   defp lifecycle_command_action("decommission"), do: {:ok, :decommission}
   defp lifecycle_command_action(_command), do: :error
 
-  # NOTE: list_nodes/0 and summary/0 gracefully degrade to []/zero when the
-  # repo is unavailable. The CLI cannot distinguish "no nodes" from "DB down".
-  # This is consistent with the console and health endpoint behavior.
   defp run_list do
     nodes = Nodes.list_nodes()
     summary = Nodes.summary()

--- a/apps/orchard_cli/lib/orchard_cli/commands/requests.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/requests.ex
@@ -3,6 +3,7 @@ defmodule OrchardCLI.Commands.Requests do
 
   alias Orchard.API.Ops.SchedulerExplanationPresenter
   alias Orchard.Requests
+  alias OrchardCLI.RepoRuntime
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(args) do
@@ -26,13 +27,18 @@ defmodule OrchardCLI.Commands.Requests do
   end
 
   defp inspect_request(%{request_id: request_id, json?: json?}) do
-    with {:ok, request} <- guarded_fetch_request(request_id),
-         {:ok, explanation} <- SchedulerExplanationPresenter.show(request) do
-      {:ok, render_explanation(explanation, json?)}
-    else
-      {:error, :scheduler_explanation_not_found} -> explanation_not_found(json?)
-      {:error, reason} -> invalid_explanation(reason, json?)
-    end
+    RepoRuntime.run(
+      fn ->
+        with {:ok, request} <- fetch_request(request_id),
+             {:ok, explanation} <- SchedulerExplanationPresenter.show(request) do
+          {:ok, render_explanation(explanation, json?)}
+        else
+          {:error, :scheduler_explanation_not_found} -> explanation_not_found(json?)
+          {:error, reason} -> invalid_explanation(reason, json?)
+        end
+      end,
+      json: json?
+    )
   end
 
   defp parse_inspect_args(args) do
@@ -52,23 +58,11 @@ defmodule OrchardCLI.Commands.Requests do
     end
   end
 
-  defp guarded_fetch_request(request_id) do
-    if repo_available?() do
-      case Requests.get_request_by_public_id(request_id) do
-        nil -> {:error, :scheduler_explanation_not_found}
-        request -> {:ok, request}
-      end
-    else
-      {:error, :scheduler_explanation_not_found}
+  defp fetch_request(request_id) do
+    case Requests.get_request_by_public_id(request_id) do
+      nil -> {:error, :scheduler_explanation_not_found}
+      request -> {:ok, request}
     end
-  rescue
-    _exception in [DBConnection.ConnectionError, DBConnection.OwnershipError, Postgrex.Error] ->
-      {:error, :scheduler_explanation_not_found}
-  end
-
-  defp repo_available? do
-    pid = Process.whereis(Orchard.Repo)
-    is_pid(pid) and Process.alive?(pid)
   end
 
   defp render_explanation(explanation, true), do: encode_json(explanation)

--- a/apps/orchard_cli/lib/orchard_cli/commands/tenants.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/tenants.ex
@@ -6,6 +6,7 @@ defmodule OrchardCLI.Commands.Tenants do
   alias Ecto.Changeset
   alias Orchard.Governance
   alias OrchardCLI.Commands.GovernanceHelpers
+  alias OrchardCLI.RepoRuntime
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
   def run(args) do
@@ -55,6 +56,10 @@ defmodule OrchardCLI.Commands.Tenants do
   end
 
   defp create_tenant(slug, name) do
+    RepoRuntime.run(fn -> do_create_tenant(slug, name) end)
+  end
+
+  defp do_create_tenant(slug, name) do
     case Governance.create_tenant(%{slug: slug, name: name}) do
       {:ok, tenant} ->
         {:ok,

--- a/apps/orchard_cli/lib/orchard_cli/repo_runtime.ex
+++ b/apps/orchard_cli/lib/orchard_cli/repo_runtime.ex
@@ -1,0 +1,140 @@
+defmodule OrchardCLI.RepoRuntime do
+  @moduledoc false
+
+  alias Ecto.Adapters.SQL
+
+  @controller_app :orchard_controller
+  @controller_env_path "/Library/Application Support/Orchard/config/controller.env"
+  @reachable_query "SELECT 1"
+
+  @type error :: {:database_unavailable, String.t()}
+
+  @spec run((-> OrchardCLI.command_result()), keyword()) :: OrchardCLI.command_result()
+  def run(fun, opts \\ []) when is_function(fun, 0) do
+    json? = Keyword.get(opts, :json, false)
+
+    case with_repo(fun) do
+      {:ok, result} -> result
+      {:error, reason} -> command_error(reason, json?)
+    end
+  end
+
+  @spec with_repo((-> result)) :: {:ok, result} | {:error, error()} when result: term()
+  def with_repo(fun) when is_function(fun, 0) do
+    Application.load(@controller_app)
+
+    case repo_configuration_error() do
+      nil -> run_with_repo(fun)
+      message -> {:error, {:database_unavailable, message}}
+    end
+  rescue
+    error in [
+      DBConnection.ConnectionError,
+      DBConnection.OwnershipError,
+      Postgrex.Error
+    ] ->
+      {:error, {:database_unavailable, unavailable_message(Exception.message(error))}}
+  end
+
+  @spec command_error(error(), boolean()) :: OrchardCLI.command_result()
+  def command_error({:database_unavailable, message}, true) do
+    {:error,
+     Jason.encode!(
+       %{
+         object: "error",
+         code: "database_unavailable",
+         message: message
+       },
+       pretty: true
+     ), 1}
+  end
+
+  def command_error({:database_unavailable, message}, false) do
+    {:error, "Error: #{message}", 1}
+  end
+
+  defp run_with_repo(fun) do
+    case Ecto.Migrator.with_repo(Orchard.Repo, fn repo -> run_after_reachable(repo, fun) end) do
+      {:ok, {:repo_runtime_result, result}, _apps} ->
+        {:ok, result}
+
+      {:ok, {:repo_runtime_error, message}, _apps} ->
+        {:error, {:database_unavailable, message}}
+
+      {:ok, {:repo_runtime_exception, error, stacktrace}, _apps} ->
+        reraise error, stacktrace
+
+      {:error, reason} ->
+        {:error, {:database_unavailable, unavailable_message(format_reason(reason))}}
+    end
+  rescue
+    error in [
+      DBConnection.ConnectionError,
+      DBConnection.OwnershipError,
+      Postgrex.Error
+    ] ->
+      {:error, {:database_unavailable, unavailable_message(Exception.message(error))}}
+  end
+
+  defp run_after_reachable(repo, fun) do
+    case SQL.query(repo, @reachable_query, []) do
+      {:ok, _result} -> run_callback(fun)
+      {:error, reason} -> {:repo_runtime_error, unavailable_message(format_reason(reason))}
+    end
+  end
+
+  defp run_callback(fun) do
+    {:repo_runtime_result, fun.()}
+  rescue
+    error in [
+      DBConnection.ConnectionError,
+      DBConnection.OwnershipError,
+      Postgrex.Error
+    ] ->
+      {:repo_runtime_error, unavailable_message(Exception.message(error))}
+
+    error ->
+      {:repo_runtime_exception, error, __STACKTRACE__}
+  end
+
+  defp repo_started? do
+    pid = Process.whereis(Orchard.Repo)
+    is_pid(pid) and Process.alive?(pid)
+  end
+
+  defp repo_configuration_error do
+    cond do
+      repo_started?() ->
+        nil
+
+      not repo_has_connection_config?() ->
+        missing_database_url_message()
+
+      not Application.get_env(@controller_app, :start_repo, true) ->
+        disabled_repo_message()
+
+      true ->
+        nil
+    end
+  end
+
+  defp repo_has_connection_config? do
+    repo_config = Application.get_env(@controller_app, Orchard.Repo, [])
+    Keyword.has_key?(repo_config, :url) or Keyword.has_key?(repo_config, :database)
+  end
+
+  defp missing_database_url_message do
+    "database is unavailable: DATABASE_URL is not configured. For packaged installs, run DB-backed orchardctl commands with sudo so the wrapper can read #{@controller_env_path}, then verify DATABASE_URL is set."
+  end
+
+  defp disabled_repo_message do
+    "database is unavailable: the controller Repo is configured not to start in this runtime. For packaged installs, run DB-backed orchardctl commands with sudo so the wrapper can read #{@controller_env_path}, then verify DATABASE_URL is set."
+  end
+
+  defp unavailable_message(reason) do
+    "database is unavailable: #{reason}. Verify DATABASE_URL in #{@controller_env_path}, confirm PostgreSQL is reachable, and run sudo orchardctl migrate if migrations are pending."
+  end
+
+  defp format_reason(reason) when is_binary(reason), do: reason
+  defp format_reason(reason), do: inspect(reason)
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -448,12 +448,15 @@ defmodule OrchardCLI.Commands.NodesTest do
       refute message =~ "----"
     end
 
-    test "degrades to not found when the controller repo is unavailable" do
+    test "reports database unavailable when the controller repo is unavailable" do
       node = insert_node!(display_name: "inspect-repo-off-node")
 
       with_repo_unavailable(fn ->
         assert {:error, message, 1} = NodesCmd.run(["inspect", node.id, "--json"])
-        assert message =~ "node not found"
+        decoded = Jason.decode!(message)
+
+        assert decoded["code"] == "database_unavailable"
+        assert decoded["message"] =~ "database is unavailable"
       end)
     end
   end
@@ -508,15 +511,15 @@ defmodule OrchardCLI.Commands.NodesTest do
       refute output =~ "admitted"
     end
 
-    test "degrades to empty review when the controller repo is unavailable" do
+    test "reports database unavailable when the controller repo is unavailable" do
       insert_candidate!()
 
       with_repo_unavailable(fn ->
-        assert {:ok, output} = NodesCmd.run(["pending"])
-        assert output =~ "No admission candidates pending review."
+        assert {:error, output, 1} = NodesCmd.run(["pending"])
+        assert output =~ "database is unavailable"
 
-        assert {:ok, json} = NodesCmd.run(["pending", "--json"])
-        assert Jason.decode!(json)["data"] == []
+        assert {:error, json, 1} = NodesCmd.run(["pending", "--json"])
+        assert Jason.decode!(json)["code"] == "database_unavailable"
       end)
     end
   end
@@ -636,16 +639,15 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert Repo.get!(Node, node.id).state == :registered
     end
 
-    test "dry-run degrades to a not-found preview when the controller repo is unavailable" do
+    test "dry-run reports database unavailable when the controller repo is unavailable" do
       node = insert_node!(state: :registered, display_name: "admit-dry-run-repo-off")
 
       with_repo_unavailable(fn ->
-        assert {:ok, output} = NodesCmd.run(["admit", node.id, "--dry-run", "--json"])
+        assert {:error, output, 1} = NodesCmd.run(["admit", node.id, "--dry-run", "--json"])
         decoded = Jason.decode!(output)
 
-        assert decoded["action"] == "node_admission.admit"
-        assert decoded["target"] == %{"type" => "node", "id" => node.id}
-        assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_found"]
+        assert decoded["code"] == "database_unavailable"
+        assert decoded["message"] =~ "database is unavailable"
       end)
 
       assert Repo.get!(Node, node.id).state == :registered
@@ -714,16 +716,15 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
     end
 
-    test "dry-run degrades to a not-found preview when the controller repo is unavailable" do
+    test "dry-run reports database unavailable when the controller repo is unavailable" do
       candidate = insert_candidate!()
 
       with_repo_unavailable(fn ->
-        assert {:ok, output} = NodesCmd.run(["reject", candidate.id, "--dry-run", "--json"])
+        assert {:error, output, 1} = NodesCmd.run(["reject", candidate.id, "--dry-run", "--json"])
         decoded = Jason.decode!(output)
 
-        assert decoded["action"] == "node_admission.reject"
-        assert decoded["target"] == %{"type" => "node", "id" => candidate.id}
-        assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_found"]
+        assert decoded["code"] == "database_unavailable"
+        assert decoded["message"] =~ "database is unavailable"
       end)
 
       assert Repo.get!(AdmissionCandidate, candidate.id).admission_category == :pending_observed
@@ -899,16 +900,15 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert Repo.get!(Node, node.id).state == :draining
     end
 
-    test "dry-run degrades to a not-found preview when the controller repo is unavailable" do
+    test "dry-run reports database unavailable when the controller repo is unavailable" do
       node = insert_node!(state: :active, display_name: "cordon-dry-run-repo-off")
 
       with_repo_unavailable(fn ->
-        assert {:ok, output} = NodesCmd.run(["cordon", node.id, "--dry-run", "--json"])
+        assert {:error, output, 1} = NodesCmd.run(["cordon", node.id, "--dry-run", "--json"])
         decoded = Jason.decode!(output)
 
-        assert decoded["action"] == "node_lifecycle.cordon"
-        assert decoded["target"] == %{"type" => "node", "id" => node.id}
-        assert Enum.map(decoded["blockers"], & &1["code"]) == ["node_not_found"]
+        assert decoded["code"] == "database_unavailable"
+        assert decoded["message"] =~ "database is unavailable"
       end)
 
       assert Repo.get!(Node, node.id).state == :active

--- a/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
@@ -149,12 +149,15 @@ defmodule OrchardCLI.Commands.RequestsTest do
       assert details =~ "not_a_scheduler_code"
     end
 
-    test "degrades to scheduler explanation not found when the controller repo is unavailable" do
+    test "reports database unavailable when the controller repo is unavailable" do
       request = persist_valid_explanation!("resp_cli_repo_unavailable_explanation")
 
       with_repo_unavailable(fn ->
         assert {:error, output, 1} = RequestsCmd.run(["inspect", request.public_id, "--json"])
-        assert Jason.decode!(output)["code"] == "scheduler_explanation_not_found"
+        decoded = Jason.decode!(output)
+
+        assert decoded["code"] == "database_unavailable"
+        assert decoded["message"] =~ "database is unavailable"
       end)
     end
   end

--- a/apps/orchard_cli/test/orchard_cli/release_eval_repo_runtime_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/release_eval_repo_runtime_test.exs
@@ -1,0 +1,372 @@
+defmodule OrchardCLI.ReleaseEvalRepoRuntimeTest do
+  use ExUnit.Case, async: false
+
+  defp repo_root do
+    Path.expand("../../../..", __DIR__)
+  end
+
+  defp shell_quote(value) do
+    "'" <> String.replace(value, "'", "'\\''") <> "'"
+  end
+
+  defp release_eval_script(output_path) do
+    """
+    Application.ensure_all_started(:logger)
+    Application.ensure_all_started(:telemetry)
+    Application.ensure_all_started(:postgrex)
+    Application.ensure_all_started(:ecto_sql)
+    Logger.configure(level: :warning)
+
+    test_repo_config = Application.fetch_env!(:orchard_controller, Orchard.Repo)
+
+    encode = fn value -> value |> to_string() |> URI.encode_www_form() end
+    username = encode.(Keyword.fetch!(test_repo_config, :username))
+    password = encode.(Keyword.get(test_repo_config, :password, ""))
+    hostname = Keyword.get(test_repo_config, :hostname, "localhost")
+    database = encode.(Keyword.fetch!(test_repo_config, :database))
+
+    port =
+      case Keyword.get(test_repo_config, :port) do
+        nil -> ""
+        value -> ":\#{value}"
+      end
+
+    System.put_env("RELEASE_NAME", "orchard_cli")
+    System.delete_env("MIX_RELEASE_NAME")
+    System.put_env("DATABASE_URL", "ecto://\#{username}:\#{password}@\#{hostname}\#{port}/\#{database}")
+    System.put_env("POOL_SIZE", "2")
+
+    runtime_config = Config.Reader.read!("config/runtime.exs", env: :prod)
+    controller_config = Keyword.fetch!(runtime_config, :orchard_controller)
+
+    Enum.each(controller_config, fn
+      {Orchard.Repo, value} -> Application.put_env(:orchard_controller, Orchard.Repo, value)
+      {key, value} -> Application.put_env(:orchard_controller, key, value)
+    end)
+
+    cleanup = fn ->
+      Ecto.Migrator.with_repo(Orchard.Repo, fn repo ->
+        repo.query!("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")
+
+        try do
+          repo.delete_all(Orchard.Governance.AuditLog)
+          repo.delete_all(Orchard.Governance.RoleBinding)
+          repo.delete_all(Orchard.Governance.ApiKey)
+          repo.delete_all(Orchard.Governance.ServiceAccount)
+        after
+          repo.query!("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
+        end
+      end)
+    end
+
+    cleanup.()
+
+    if Process.whereis(Orchard.Repo) do
+      raise "release eval test precondition failed: Orchard.Repo is already started"
+    end
+
+    try do
+      OrchardCLI.main([
+        "cluster",
+        "init",
+        "--output",
+        #{inspect(output_path)}
+      ])
+    after
+      cleanup.()
+    end
+    """
+  end
+
+  defp model_release_eval_script(bundle_path, artifacts_root) do
+    """
+    Application.ensure_all_started(:logger)
+    Application.ensure_all_started(:telemetry)
+    Application.ensure_all_started(:postgrex)
+    Application.ensure_all_started(:ecto_sql)
+    Logger.configure(level: :warning)
+
+    test_repo_config = Application.fetch_env!(:orchard_controller, Orchard.Repo)
+
+    encode = fn value -> value |> to_string() |> URI.encode_www_form() end
+    username = encode.(Keyword.fetch!(test_repo_config, :username))
+    password = encode.(Keyword.get(test_repo_config, :password, ""))
+    hostname = Keyword.get(test_repo_config, :hostname, "localhost")
+    database = encode.(Keyword.fetch!(test_repo_config, :database))
+
+    port =
+      case Keyword.get(test_repo_config, :port) do
+        nil -> ""
+        value -> ":\#{value}"
+      end
+
+    System.put_env("RELEASE_NAME", "orchard_cli")
+    System.delete_env("MIX_RELEASE_NAME")
+    System.put_env("DATABASE_URL", "ecto://\#{username}:\#{password}@\#{hostname}\#{port}/\#{database}")
+    System.put_env("ORCHARD_ARTIFACTS_ROOT", #{inspect(artifacts_root)})
+    System.put_env("POOL_SIZE", "2")
+
+    runtime_config = Config.Reader.read!("config/runtime.exs", env: :prod)
+    controller_config = Keyword.fetch!(runtime_config, :orchard_controller)
+
+    Enum.each(controller_config, fn
+      {Orchard.Repo, value} -> Application.put_env(:orchard_controller, Orchard.Repo, value)
+      {key, value} -> Application.put_env(:orchard_controller, key, value)
+    end)
+
+    cleanup_model = fn ->
+      Ecto.Migrator.with_repo(Orchard.Repo, fn repo ->
+        import Ecto.Query
+
+        repo.delete_all(
+          from model in Orchard.Models.Model,
+            where: model.model_id == "test-org/tiny-llm" and model.version == "mlx-q4-v1"
+        )
+      end)
+    end
+
+    assert_cli_runtime_only = fn ->
+      started_apps = Application.started_applications() |> Enum.map(&elem(&1, 0))
+
+      if :orchard_controller in started_apps do
+        raise "release eval started :orchard_controller"
+      end
+
+      if Process.whereis(Orchard.Supervisor) do
+        raise "release eval started Orchard.Supervisor"
+      end
+
+      if Process.whereis(Orchard.API.Endpoint) do
+        raise "release eval started Orchard.API.Endpoint"
+      end
+
+      if Process.whereis(Orchard.Repo) do
+        raise "release eval left Orchard.Repo running"
+      end
+    end
+
+    retire_model = fn ->
+      Ecto.Migrator.with_repo(Orchard.Repo, fn repo ->
+        import Ecto.Query
+
+        {1, _rows} =
+          repo.update_all(
+            from(model in Orchard.Models.Model,
+              where: model.model_id == "test-org/tiny-llm" and model.version == "mlx-q4-v1"
+            ),
+            set: [state: :retired]
+          )
+      end)
+    end
+
+    cleanup_model.()
+
+    if Process.whereis(Orchard.Repo) do
+      raise "release eval test precondition failed: Orchard.Repo is already started"
+    end
+
+    OrchardCLI.main(["models", "import", #{inspect(bundle_path)}, "--activate"])
+    assert_cli_runtime_only.()
+
+    OrchardCLI.main(["models", "list"])
+    assert_cli_runtime_only.()
+
+    retire_model.()
+    assert_cli_runtime_only.()
+
+    OrchardCLI.main(["models", "delete", "test-org/tiny-llm@mlx-q4-v1"])
+    assert_cli_runtime_only.()
+
+    cleanup_model.()
+    """
+  end
+
+  defp missing_database_url_script do
+    """
+    Application.ensure_all_started(:logger)
+    Logger.configure(level: :warning)
+
+    System.put_env("RELEASE_NAME", "orchard_cli")
+    System.delete_env("MIX_RELEASE_NAME")
+    System.delete_env("DATABASE_URL")
+    Application.delete_env(:orchard_controller, Orchard.Repo)
+
+    runtime_config = Config.Reader.read!("config/runtime.exs", env: :prod)
+    controller_config = Keyword.fetch!(runtime_config, :orchard_controller)
+
+    Enum.each(controller_config, fn
+      {Orchard.Repo, value} -> Application.put_env(:orchard_controller, Orchard.Repo, value)
+      {key, value} -> Application.put_env(:orchard_controller, key, value)
+    end)
+
+    OrchardCLI.main(["models", "list"])
+    """
+  end
+
+  defp unreachable_database_script(args \\ ["models", "list"]) do
+    """
+    Application.ensure_all_started(:logger)
+    Application.ensure_all_started(:telemetry)
+    Application.ensure_all_started(:postgrex)
+    Application.ensure_all_started(:ecto_sql)
+    Logger.configure(level: :warning)
+
+    System.put_env("RELEASE_NAME", "orchard_cli")
+    System.delete_env("MIX_RELEASE_NAME")
+    System.put_env("DATABASE_URL", "ecto://postgres:postgres@127.0.0.1:1/orchard_unreachable?ssl=false")
+    System.put_env("POOL_SIZE", "1")
+
+    runtime_config = Config.Reader.read!("config/runtime.exs", env: :prod)
+    controller_config = Keyword.fetch!(runtime_config, :orchard_controller)
+
+    Enum.each(controller_config, fn
+      {Orchard.Repo, value} -> Application.put_env(:orchard_controller, Orchard.Repo, value)
+      {key, value} -> Application.put_env(:orchard_controller, key, value)
+    end)
+
+    OrchardCLI.main(#{inspect(args)})
+    """
+  end
+
+  defp run_release_eval_script(script, tmp_dir, basename) do
+    script_path = Path.join(tmp_dir, "#{basename}.exs")
+    stdout_path = Path.join(tmp_dir, "#{basename}.stdout.txt")
+    stderr_path = Path.join(tmp_dir, "#{basename}.stderr.txt")
+
+    File.write!(script_path, script)
+
+    command =
+      "MIX_ENV=test mix run --no-compile --no-deps-check --no-start #{shell_quote(script_path)} " <>
+        "> #{shell_quote(stdout_path)} 2> #{shell_quote(stderr_path)}"
+
+    {_shell_output, exit_status} = System.cmd("sh", ["-c", command], cd: repo_root())
+
+    %{
+      exit_status: exit_status,
+      stdout: File.read!(stdout_path),
+      stderr: File.read!(stderr_path)
+    }
+  end
+
+  test "packaged release eval starts only the repo runtime for DB-backed cluster init" do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-cli-release-eval-repo-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    output_path = Path.join(tmp_dir, "bootstrap-admin.json")
+    script_path = Path.join(tmp_dir, "release_eval_cluster_init.exs")
+    stdout_path = Path.join(tmp_dir, "stdout.txt")
+    stderr_path = Path.join(tmp_dir, "stderr.txt")
+
+    File.write!(script_path, release_eval_script(output_path))
+
+    command =
+      "MIX_ENV=test mix run --no-compile --no-deps-check --no-start #{shell_quote(script_path)} " <>
+        "> #{shell_quote(stdout_path)} 2> #{shell_quote(stderr_path)}"
+
+    {_shell_output, exit_status} = System.cmd("sh", ["-c", command], cd: repo_root())
+
+    stdout = File.read!(stdout_path)
+    stderr = File.read!(stderr_path)
+
+    assert exit_status == 0, stderr
+    assert stdout =~ "Cluster admin credential minted."
+    assert stdout =~ "One-time Secret Output: #{output_path}"
+    assert File.regular?(output_path)
+
+    decoded = output_path |> File.read!() |> Jason.decode!()
+    assert decoded["api_token"] =~ "orch_"
+  end
+
+  test "packaged release eval runs model import list and delete without starting listeners" do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-cli-release-eval-models-#{System.unique_integer([:positive])}"
+      )
+
+    artifacts_root = Path.join(tmp_dir, "artifacts")
+
+    bundle_path =
+      Path.expand("../../../orchard_controller/test/fixtures/bundles/test-model-bundle", __DIR__)
+
+    File.mkdir_p!(artifacts_root)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    result =
+      model_release_eval_script(bundle_path, artifacts_root)
+      |> run_release_eval_script(tmp_dir, "release_eval_models")
+
+    assert result.exit_status == 0, result.stderr
+    assert result.stdout =~ "Imported test-org/tiny-llm@mlx-q4-v1 (state: active)"
+    assert result.stdout =~ "test-org/tiny-llm@mlx-q4-v1  state=active  format=mlx"
+    assert result.stdout =~ "Deleted test-org/tiny-llm@mlx-q4-v1"
+  end
+
+  test "packaged release eval reports missing DATABASE_URL with sudo env guidance" do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-cli-release-eval-missing-db-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    result =
+      run_release_eval_script(missing_database_url_script(), tmp_dir, "missing_database_url")
+
+    assert result.exit_status == 1
+    assert result.stdout == ""
+    assert result.stderr =~ "DATABASE_URL is not configured"
+    assert result.stderr =~ "sudo"
+    assert result.stderr =~ "/Library/Application Support/Orchard/config/controller.env"
+  end
+
+  test "packaged release eval reports unreachable database without falling back to empty data" do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-cli-release-eval-unreachable-db-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    result =
+      run_release_eval_script(unreachable_database_script(), tmp_dir, "unreachable_database")
+
+    assert result.exit_status == 1
+    assert result.stderr =~ "database is unavailable"
+    assert result.stderr =~ "PostgreSQL is reachable"
+    refute result.stdout =~ "No active models."
+    refute result.stderr =~ "No active models."
+  end
+
+  test "packaged release eval nodes list reports unreachable database without empty fallback" do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-cli-release-eval-unreachable-nodes-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf(tmp_dir) end)
+
+    result =
+      ["nodes", "list"]
+      |> unreachable_database_script()
+      |> run_release_eval_script(tmp_dir, "unreachable_nodes_database")
+
+    assert result.exit_status == 1
+    assert result.stderr =~ "database is unavailable"
+    assert result.stderr =~ "PostgreSQL is reachable"
+    refute result.stdout =~ "No nodes registered."
+    refute result.stderr =~ "No nodes registered."
+  end
+end

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -272,6 +272,14 @@ use the same database configuration as the controller:
 
 Format: plain `KEY=value` lines. Comments (`#`) and blank lines are fine.
 
+DB-backed CLI commands (for example `orchardctl nodes`, `models`, `requests`,
+`cluster status`, `cluster init`, `tenants`, `api-keys`, and `api-clients`)
+start the controller Repo on demand, so they must run as root (`sudo`) to read
+`controller.env` and its `DATABASE_URL`. When the database is unreachable or
+`DATABASE_URL` is unset, these commands fail with a `database_unavailable`
+error and remediation guidance rather than returning empty or "not found"
+output.
+
 Primary use case: operational rollback of the worker backend without editing
 launchd plists or global environment.
 
@@ -423,6 +431,7 @@ not overwritten during package upgrades.
 | Controller crash-loops with `DATABASE_URL is missing` | `controller.env` absent or ignored | Create the file with correct ownership/permissions |
 | Readiness reports `postgres_reachable: false` | Wrong DB URL, DB not running, or DB does not exist | Verify with `psql "$DATABASE_URL" -c 'select 1'` |
 | Readiness reports `migrations_current: false` (with DB reachable) | Migrations not run | Run `sudo orchardctl migrate` |
+| DB-backed CLI command fails with `database_unavailable` | Command run without `sudo`, `DATABASE_URL` unset, DB unreachable, or migrations pending | Re-run with `sudo`; verify `DATABASE_URL` in `controller.env` and `psql "$DATABASE_URL" -c 'select 1'`; run `sudo orchardctl migrate` if pending |
 | `WARNING: ignoring env file` in controller.log | File not root-owned or has group/world permission bits | `sudo chown root:wheel <file> && sudo chmod 600 <file>` |
 
 ## Upgrade Preflight


### PR DESCRIPTION
## What Changed

- Added `OrchardCLI.RepoRuntime`, which loads the `:orchard_controller` app, starts the controller Repo on demand for DB-backed CLI commands, and tears it down after the command — surfacing a `database_unavailable` error (exit 1, with JSON/plain variants and remediation guidance) when `DATABASE_URL` is unset or Postgres is unreachable.
- Routed the DB-backed commands (`nodes` list/pending/inspect and admit/reject/lifecycle dry-runs, `models`, `requests`, `cluster`, `tenants`, `api-keys`, `api-clients`) through `RepoRuntime.run/2`, removing the old "guarded" fallbacks that degraded to empty/not-found output with exit 0 when the repo was down.
- Added `release_eval_repo_runtime_test.exs` simulating the packaged `--no-start` release-eval environment plus updates to `nodes_test`/`requests_test`, and documented the `sudo`/`database_unavailable` behavior in `packaging/pkg/README.md`.

## Risk Assessment

✅ Low: Well-bounded, well-tested refactor that centralizes on-demand repo startup and error handling; the only notable item is an intentional, test-backed change from silent degradation to explicit database_unavailable errors, with no correctness bugs found.

## Testing

Baseline compile plus the targeted release-eval integration test (5 passed) already exercise the packaged --no-start CLI flow; I additionally captured real CLI transcripts driving the release-eval path directly, showing `orchardctl nodes list` now succeeds against a reachable DB with the repo runtime started transiently (and not left running, controller app not started), while an unreachable DB yields a clear "database is unavailable" error and exit 1 instead of a misleading empty result. This is a CLI/behavioral change with no visual surface, so CLI transcripts are the appropriate reviewer-visible evidence.

<details>
<summary>Evidence: orchardctl nodes list (packaged --no-start, reachable DB) — succeeds via transient repo runtime</summary>

<code>[precheck] Orchard.Repo running before command? false&#10;[precheck] :orchard_controller started? false&#10;--- running: orchardctl nodes list ---&#10;[postcheck] Orchard.Repo left running? false&#10;(stdout) Summary: total=0 healthy=0 degraded=0 unhealthy=0 unreachable=0&#10;(stdout) No nodes registered.</code>

```text
[precheck] Orchard.Repo running before command? false
[precheck] :orchard_controller started? false
--- running: orchardctl nodes list ---
[postcheck] Orchard.Repo left running? false
```
</details>
<details>
<summary>Evidence: orchardctl models list (unreachable DB) — actionable error, exit 1, no empty fallback</summary>

<code>exit=1&#10;Error: database is unavailable: %DBConnection.ConnectionError{... connection not available ...}. Verify DATABASE_URL in /Library/Application Support/Orchard/config/controller.env, confirm PostgreSQL is reachable, and run sudo orchardctl migrate if migrations are pending.</code>

```text
--- running: orchardctl models list  (DB pointed at unreachable 127.0.0.1:1) ---
Error: database is unavailable: %DBConnection.ConnectionError{message: "[Elixir.Orchard.Repo] connection not available and request was dropped from queue after 5995ms. This means requests are coming in and your connection pool cannot serve them fast enough. You can address this by:\n\n  1. Ensuring your database is available and that you can connect to it\n  2. Tracking down slow queries and making sure they are running fast enough\n  3. Increasing the pool_size (although this increases resource consumption)\n  4. Allowing requests to wait longer by increasing :queue_target and :queue_interval\n\nSee DBConnection.start_link/2 for more information\n", severity: :error, reason: :queue_timeout}. Verify DATABASE_URL in /Library/Application Support/Orchard/config/controller.env, confirm PostgreSQL is reachable, and run sudo orchardctl migrate if migrations are pending.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/orchard_cli/lib/orchard_cli/commands/nodes.ex:25` - Behavior change: DB-backed CLI commands (nodes list/pending/inspect, admit/reject/lifecycle dry-runs, requests inspect, models list) previously degraded to empty/not-found output with exit 0 when the controller repo was unavailable; they now return a `database_unavailable` error with exit 1. This is the deliberate, tested intent of the PR (and is an improvement — no more silently showing &#39;No nodes&#39; when the DB is down), but any automation/scripts that relied on the old exit-0 empty-result contract will break. Confirm no downstream consumers depend on the previous degrade-to-empty behavior.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`MIX_ENV=test mix test apps/orchard_cli/test/orchard_cli/release_eval_repo_runtime_test.exs` (5 passed) — simulates the packaged --no-start release-eval env running real CLI commands: cluster init, models import/list/delete, missing DATABASE_URL, and unreachable DB</code>
- <code>Manual release-eval transcript: `mix run --no-start` driving `OrchardCLI.main([&#34;nodes&#34;,&#34;list&#34;])` against a reachable migrated test DB — confirmed Repo not running and :orchard_controller not started before the command, command succeeds (`Summary: total=0 ...` / `No nodes registered.`), and Repo left not running afterward</code>
- <code>Manual release-eval transcript: `mix run --no-start` driving `OrchardCLI.main([&#34;models&#34;,&#34;list&#34;])` with DATABASE_URL pointed at an unreachable host (127.0.0.1:1) — confirmed exit 1 with `Error: database is unavailable: ...` guidance referencing controller.env and PostgreSQL reachability, and no `No active models.` empty fallback</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
