### PR TITLE
docs: shape operator first-run journey and node-enrollment OpenSpec package

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ for full build documentation.
 
 For operators:
 
+- [`docs/operator-journey.md`](docs/operator-journey.md) — current and target
+  operator journeys, friction baseline, recovery points, and ordered
+  improvement slices.
 - [`packaging/pkg/README.md`](packaging/pkg/README.md) — install, roles,
   transport, and TLS runbook.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -3540,9 +3540,11 @@ Certificate-backed node lifecycle RPC and current gRPC compatibility transports 
 
 * TLS 1.3
 * mutual TLS
-* controller CA generated at cluster init or imported by admin
+* controller CA generated through an explicit node-trust initialization operation or imported by admin
 * SAN validation against node id / controller id
 * certificate renewal before expiry
+
+The internal node-trust initialization operation SHALL remain separate from `orchardctl cluster init`, which is credential-only per §11.9.
 
 Node cert lifetime default:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ large spec sections.
 
 ### I want to package or install Orchard
 
+- [`operator-journey.md`](operator-journey.md) - current and target operator journeys, friction baseline, recovery points, and ordered improvement slices.
 - [`../packaging/pkg/README.md`](../packaging/pkg/README.md) — current PKG
   build/operator runbook.
 - [`../packaging/container/postgres/README.md`](../packaging/container/postgres/README.md)

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -626,6 +626,11 @@ _Avoid_: Public API transport, Trusted Proxy
 A time-limited or one-time Node join credential used before certificate trust is established.
 _Avoid_: API Key, Node Certificate
 
+**Node Enrollment Bundle**:
+A per-Node, versioned, short-lived bootstrap artifact containing Controller and cluster identity, a Controller trust pin, and one one-time Bootstrap Token.
+It is sensitive One-time Secret Output but is not durable Node identity, Node Admission, or runtime transport authority.
+_Avoid_: BEAM cookie bundle, admission bundle, worker credential bundle, Node Certificate, cluster-admin credential
+
 **Node Certificate**:
 A Node identity certificate used for internal RPC trust and renewal.
 _Avoid_: Bootstrap Token, API Key, Public HTTPS certificate
@@ -674,3 +679,11 @@ _Avoid_: LaunchDaemon, system service
 **Tray/Menu Bar App**:
 The local macOS app for status, onboarding, logs, and support-bundle entry.
 _Avoid_: Orchard Console, LaunchDaemon
+
+**Install Role**:
+The app or package lifecycle selection that determines whether one Mac installs and manages the `all`, `controller`, or `node-agent` service set.
+_Avoid_: RBAC Role, Access Level, Node Lifecycle State
+
+**Node Enrollment**:
+The identity bootstrap process that uses a Node Enrollment Bundle to move one provisioned Node to registered state through Controller validation and Node Certificate issuance.
+_Avoid_: Node Admission, Runtime Endpoint discovery, Worker Runtime enrollment

--- a/docs/operator-journey.md
+++ b/docs/operator-journey.md
@@ -1,0 +1,301 @@
+# Orchard Operator Journey
+
+This document describes how an operator moves from Orchard release media to a usable Controller, an available Node Agent, and a successful inference request.
+It deliberately separates current supported behavior from target product intent.
+Detailed commands remain in the packaging runbooks and are linked instead of repeated here.
+
+`SPEC.md` remains the normative build contract.
+This document is the durable journey and prioritization guide for closing the gap between that contract and the current build.
+
+## Journey Vocabulary
+
+The product-facing action may say "Add a worker", but the managed resource that enrolls is a **Node** running the **Node Agent**.
+The **Worker Runtime** is a local MLX process supervised by that Node Agent and does not enroll independently.
+
+A current Runtime Endpoint observation proves reachability only.
+It does not prove Node identity, registration, admission, or scheduling authority.
+
+The target journey keeps these states distinct:
+
+1. Orchard is installed for an Install Role.
+2. A Node proves its identity and becomes `registered`.
+3. An administrator admits the registered Node.
+4. A fresh healthy authenticated observation makes the Node `active`.
+5. A model is available and loaded on an eligible Runtime Endpoint.
+6. A real inference request succeeds.
+
+## Layer 1: Current Supported Journey
+
+### Current Status Boundary
+
+The current app-primary DMG provides a verified `Orchard.app` and an app-owned root-authorized service lifecycle.
+The app lifecycle supports `all`, `controller`, and `node-agent` Install Roles and preserves operator-owned state during update and default uninstall.
+It does not yet provide an app setup wizard.
+
+The packaged CLI provides `orchardctl init`, with `orchardctl first-run` as an alias, as a guided command sequencer for license validation, env-template generation, migration, local HTTPS, optional Console enablement, service start, and status.
+The sequencer stops at a failed step and prints a resume command.
+It does not collect an external Postgres DSN, edit BEAM identity or target values, create Node trust, distribute a shared cookie, import a model to remote Macs, or replace the separate `orchardctl cluster init` first-admin operation.
+
+The current packaged multi-Mac path is a first-cut private-network deployment and rehearsal path.
+It uses manually distributed shared BEAM cookie material and an explicit Controller target list.
+`orchardctl node join`, Bootstrap Token exchange, Node Certificate issuance, and certificate-backed registration remain unfinished.
+Admission review surfaces exist, but an observed unregistered endpoint cannot be admitted merely because it is reachable.
+
+The authoritative current command details are in:
+
+- [`packaging/dmg/README.md`](../packaging/dmg/README.md) for DMG verification and the app-owned lifecycle.
+- [`packaging/pkg/README.md`](../packaging/pkg/README.md) for packaged configuration, external Postgres, transport, licensing, Console, service start, and the current multi-Mac first cut.
+- [`docs/local-dev.md`](local-dev.md) for source-development topology and diagnostics.
+
+### Common Prerequisites
+
+Before a current packaged Controller can reach Console, the operator needs:
+
+- An Apple Silicon Mac and local administrator authorization for system service installation.
+- A valid Orchard license supplied outside the generic distribution artifact.
+- Operator-managed PostgreSQL 16 or newer because Managed Database Mode is not implemented.
+- A public transport plan using direct HTTPS, an operator-managed reverse proxy, or explicit local generated HTTPS for a lab.
+- A signed, notarized, stapled release-quality DMG and its checksum and signing sidecars.
+- Protected storage for one-time cluster-admin and inference credentials.
+
+A multi-Mac deployment also needs:
+
+- Stable private IPv4 addresses on a trusted LAN or VPN.
+- Private reachability for EPMD and the bounded BEAM distribution ports.
+- A secure out-of-band channel for the shared BEAM cookie.
+- A Model Bundle that can be staged at a path usable by the selected Node Agent host.
+
+### Release Acquisition And Installation
+
+1. Obtain the DMG distribution set and verify the checksum and mounted app trust evidence as described in the DMG runbook.
+2. Copy `Orchard.app` to `/Applications` on every participating Mac.
+3. Run the app-owned lifecycle helper with the required Install Role under explicit root authorization.
+4. Treat the resulting state as installed but not configured because install deliberately starts no services.
+
+The same generic DMG is used on Controller and worker Macs.
+The selected Install Role decides which LaunchDaemons are installed and managed.
+
+### Topology Differences
+
+| Path | Install Role | Console outcome | Inference outcome | Material current differences |
+|---|---|---|---|---|
+| All-in-one | `all` | Available after Controller configuration, first-admin initialization, Console enablement, and service start. | Possible on the same Mac after Organization/API Token creation and local model import. | No cross-Mac cookie transfer or remote model path is needed, but external Postgres is still required in the current build. |
+| Controller-only | `controller` | Available after the same Controller setup. | Not possible until at least one eligible Runtime Endpoint is configured and model-ready. | This path is useful for governance and Console setup but is not a complete first-inference topology. |
+| Controller plus workers | `controller` on the Controller and `node-agent` on each worker Mac. | Available after Controller setup. | Technically exercisable through the current private-network first cut after explicit targets and worker-reachable model staging, but it is not the finished certificate-backed join journey. | Every worker adds a root-owned env edit, shared-cookie delivery, private-network checks, an explicit Controller target entry, and model staging. |
+
+### Controller To First Console Access
+
+The operator currently performs these outcomes, using the packaged runbook for commands:
+
+1. Activate or verify the Orchard license without placing it in command arguments, logs, or the release artifact.
+2. Generate the Controller or all-role env template.
+3. Set and validate the external `DATABASE_URL` and retain the generated `SECRET_KEY_BASE` unless deliberately rotating it.
+4. Configure the Controller BEAM node name, cookie path, Runtime Endpoint targets when used, and public transport values.
+5. Run migrations.
+6. Run `orchardctl cluster init` with a protected output path to create the first cluster-admin API Client and one-time API Token.
+7. Configure public HTTPS or a supported reverse proxy.
+8. Enable Console through its interactive credential prompt when browser access is desired.
+9. Start the role-selected services and verify status and readiness.
+10. Open Console at the configured public host.
+
+`orchardctl cluster init` is credential-only.
+It does not provision public TLS, internal Node trust, a Bootstrap Token, or a BEAM cookie.
+
+### Worker Bring-Up In The Current Multi-Mac First Cut
+
+For each worker Mac, the operator currently:
+
+1. Installs the `node-agent` role from the same DMG.
+2. Generates the Node Agent env template.
+3. Edits the root-owned env file with a unique BEAM node name, display name, shared cookie path, and worker settings.
+4. Copies the same shared BEAM cookie to the protected path with owner-only permissions.
+5. Starts the Node Agent and verifies local service state.
+6. Adds the worker's BEAM node name to the Controller's explicit Runtime Endpoint target list and restarts or reconfigures the Controller as required.
+7. Verifies transport reachability and Runtime Endpoint diagnostics.
+
+This sequence does not execute the target `provisioned -> registered -> admitted -> active` trust flow.
+The shared cookie is current transport access material and must not be described as Node identity or Node Enrollment.
+
+### Organization, Model, And First Inference
+
+After Console is reachable, the operator currently:
+
+1. Creates an Organization.
+2. Creates a tenant-direct API Token for bootstrap or manual use, or provisions an API Client and API Token for a named non-interactive principal.
+3. Stores the one-time API Token output securely.
+4. Imports and activates a Model Bundle.
+5. Verifies that the model source is reachable by the Node Agent that will load it.
+6. Confirms `/v1/models` lists the active model.
+7. Runs a small request through Playground or the Public Inference API.
+
+The current local-file import path is not controller-hosted model distribution.
+For a remote worker, the operator must pre-stage the same model at a usable path or use another worker-reachable source supported by the lower-level acquisition path.
+Console and docs must not claim that one local import distributes the model across the cluster today.
+
+### Current Friction Baseline
+
+The counts below are structural estimates derived from the current one-Controller, one-worker runbooks.
+They are not measured usability timings and may vary with the chosen TLS and license paths.
+
+| Friction | All-in-one baseline | Controller plus one worker baseline | Scaling behavior |
+|---|---:|---:|---|
+| Root-owned env files requiring operator review or edits | 2 | 2 | Adds 1 per worker. |
+| Cross-Mac secret transfers | 0 | 1 shared-cookie transfer | Adds 1 destination per worker while the current shared-cookie path remains. |
+| Explicit Runtime Endpoint target entries | 1 local target when configured | 1 remote target | Adds 1 entry per worker and requires Controller configuration ownership. |
+| Macs requiring hands-on install/configuration | 1 | 2 | Adds 1 per worker. |
+| Distinct secret categories requiring custody | License material, `SECRET_KEY_BASE`, Console credential, cluster-admin output, and inference token | The all-in-one categories plus the shared BEAM cookie | Cookie distribution expands to every worker. |
+| External prerequisites | Postgres, license, public transport, model bundle | The all-in-one set plus private addressing, port reachability, secure file transfer, and remote model availability | Network and model preparation recur per site or worker. |
+
+The current repo has no accepted packaged benchmark for time-to-Console, time-to-first-worker-ready, or time-to-first-inference.
+Future implementation PRs should record sanitized timings against the measurement definitions below rather than placing machine-specific evidence in this document.
+
+### Current Recovery And Failure Points
+
+| Failure point | Current observable symptom | Current recovery boundary |
+|---|---|---|
+| Invalid or missing license | Guided first-run stops before useful work. | Activate through a non-argv source and rerun the guided command. |
+| Missing or invalid external Postgres configuration | Migration, DB-backed CLI, or Controller readiness fails. | Correct the root-owned Controller env, verify Postgres independently, run migrations, and resume. |
+| Partial TLS state | App lifecycle or Controller boot preflight fails closed. | Restore a complete set or deliberately regenerate the local lab set before retrying. |
+| App and PKG ownership conflict | App lifecycle reports the `com.orchard.pkg` receipt blocker. | Continue through the PKG-compatible lifecycle instead of allowing app takeover. |
+| BEAM cookie missing, mismatched, or too broadly readable | Node Agent or Controller transport validation fails. | Correct protected file ownership/mode and compare digests without exposing cookie contents. |
+| EPMD or distribution port conflict | Runtime Endpoint connection fails or returns unreachable. | Align the private-network port configuration on every participating Mac and verify reachability. |
+| Static target missing or wrong | Console diagnostics and scheduler cannot reach the intended Node Agent. | Correct the Controller target list and restart or reconfigure the Controller. |
+| Endpoint observed but not trusted | Admission execution remains blocked and the endpoint is not schedulable. | Complete the future certificate-backed registration flow when implemented; observation alone is insufficient. |
+| Lost first-admin credential | Admin API access is unavailable. | Use local `orchardctl cluster init --force-new-admin --yes` break-glass recovery and audit the new credential. |
+| Controller-local model source on a remote worker | Model acquisition fails with an unavailable path or artifact. | Pre-stage the verified bundle on the worker or provide a worker-reachable source. |
+| Worker or Controller upgrade interrupts readiness | Service status, heartbeat, or requests become unavailable. | Follow the packaging runbook's service-level backup, preflight, update, and health checks, and use cordon, drain, and resume only where lifecycle-managed Nodes exist. |
+
+## Layer 2: Target Operator Journey
+
+The target experience is product intent.
+It is not a claim about the current build.
+
+### Target Principles
+
+- One signed DMG installs every Orchard role.
+- Product setup composes the same domain operations used by CLI and APIs rather than creating UI-only mutations.
+- Installation, registration, Node Admission, activation, model readiness, and inference success remain visibly separate.
+- Enrollment authenticates the Controller before sending a Bootstrap Token and authenticates the Node through a locally generated key and controller-signed Node Certificate.
+- A Node Enrollment Bundle is one-use, short-lived, per-Node, inspectable, revocable, and auditable.
+- A Node Enrollment Bundle never contains a BEAM cookie, cluster-admin credential, CA private key, Node private key, long-lived Node Certificate, database credential, or static target list.
+- External Postgres remains an explicit prerequisite until Managed Database Mode is implemented.
+- Setup ends with a real inference result, not merely green service processes.
+- Every failure identifies the failed boundary and offers a safe resume path.
+
+### Target All-In-One Journey
+
+1. The operator verifies and installs `Orchard.app`.
+2. The operator chooses **Create Orchard on this Mac** and authorizes the `all` Install Role.
+3. Guided setup validates licensing, external Postgres, public transport, storage, and retained state.
+4. Orchard runs migrations and the distinct first-admin and internal Node trust initialization operations.
+5. Orchard enables Console and starts services.
+6. The local Node Agent registers through the same identity model used by remote Nodes, and guided setup performs the same explicit audited Node Admission operation with confirmation inside the setup flow.
+7. The operator creates or confirms an Organization and inference credential.
+8. The operator imports one Model Bundle.
+9. Orchard verifies, places, and loads the model on the local Node Agent.
+10. Playground runs a small inference and shows the selected Node and model version.
+
+### Target Controller-Only Journey
+
+The Controller setup is identical through first Console access, but setup labels the cluster **No inference capacity** until a Node becomes active and model-ready.
+Console offers **Add a worker** as the next action and does not imply that a healthy Controller alone can run inference.
+
+### Target Controller Plus Worker Journey
+
+1. The operator creates the Controller and reaches Console.
+2. Console or CLI creates one Node Enrollment Bundle per worker Mac.
+3. The bundle contains the Controller address, stable cluster and Node identifiers, a Controller trust pin, and one one-time Bootstrap Token with an expiry.
+4. On each worker Mac, the operator installs the same DMG and chooses **Join existing Orchard**.
+5. The worker previews the cluster identity and expiry, authorizes the `node-agent` Install Role, and imports the bundle.
+6. The worker generates its private key locally, validates the pinned Controller, submits its CSR and bounded inventory, and receives a Node Certificate.
+7. The worker reports **Registered, awaiting administrator approval**.
+8. Console shows the registered Node, trust evidence, inventory, compatibility, and any blockers.
+9. The operator previews and approves Node Admission.
+10. The Controller derives the Runtime Endpoint target from trusted Node inventory, and a fresh healthy authenticated observation advances the Node to `active`.
+11. The operator imports a model once.
+12. Orchard distributes the verified Artifact Bundle to selected admitted Nodes and shows transfer, verification, placement, and load progress.
+13. Playground runs inference and shows the chosen Node, placement, model version, timing, and remediation when scheduling fails.
+
+### Target Failure And Recovery Experience
+
+Target setup must distinguish at least these conditions:
+
+- Controller unreachable before any secret is sent.
+- Controller trust-pin mismatch.
+- Expired, consumed, revoked, wrong-cluster, or wrong-Node enrollment material.
+- Registration response lost after the one-time token is consumed.
+- Registration complete but admission still pending.
+- Admission rejected with preserved decision history.
+- Node Certificate issuance, storage, renewal, or revocation failure.
+- Registered Node transport unreachable or runtime unhealthy.
+- External Postgres unavailable or migrations behind.
+- Model source unavailable, transfer interrupted, checksum mismatch, insufficient disk, or load failure.
+- Public transport or Console authentication misconfiguration.
+- Upgrade preflight blocked, drain incomplete, or post-update health verification failed.
+
+Retry after a lost registration response must resume only when the enrollment identifier, locally held Node key, and CSR fingerprint match the consumed attempt.
+Different key material must fail closed.
+
+### Target Friction And Time Budgets
+
+The following are shaping budgets for future acceptance tests, not current performance claims:
+
+| Measure | Target outcome |
+|---|---|
+| Manual root-owned file edits for a normal all-in-one setup | 0 |
+| Manual root-owned file edits for adding a worker | 0 |
+| Shared cluster-secret transfers for adding a worker | 0 |
+| Human admission decisions per worker | 1 by default |
+| Machine-to-machine enrollment artifacts | 1 per worker, short-lived and one-use |
+| Controller target-list edits per worker | 0 |
+| Model imports per model version | 1 per cluster |
+| Setup restart after a recoverable failure | 0, because setup resumes at the failed boundary |
+
+Time measurements use these definitions:
+
+- **Time-to-Console** starts when a verified app first launches setup and ends when authenticated Console renders Controller readiness.
+- **Time-to-first-worker-ready** starts when a Node Enrollment Bundle is created and ends when the admitted Node has a fresh healthy authenticated Runtime Endpoint observation.
+- **Time-to-first-inference** starts when Console is first ready and ends when Playground receives a successful terminal response.
+- **Operator-active time** is the portion of each named elapsed metric during which setup awaits required operator input or the operator performs a required action.
+- Model-byte transfer time and administrator waiting time are recorded separately so large artifacts and human delay do not hide workflow friction.
+
+Initial acceptance targets should be no more than 15 minutes of operator-active time across the full time-to-Console boundary, no more than 10 minutes of operator-active time across the full time-to-first-worker-ready boundary, and no more than 10 minutes of operator-active time across the full time-to-first-inference boundary.
+Each result must also report the complete elapsed metric plus model transfer, automated processing, and administrator waiting components rather than substituting a shorter start or earlier end state.
+Implementation PRs should validate these budgets on supported release hardware and record sanitized evidence in the PR or issue.
+
+## Layer 3: Gap Map And Ordered Improvement Slices
+
+| Order | Slice | Operator value | Completion boundary |
+|---:|---|---|---|
+| 1 | Secure one-Controller, one-Node enrollment tracer | Replaces manual identity bootstrap with a real trusted `provisioned -> registered -> admitted -> active` path and gives existing admission UX a valid input. | One short-lived per-Node bundle, local key generation, pinned Controller connection, certificate-backed registration, explicit admission, dynamic target resolution, and authenticated healthy activation all work without a shared-cookie transfer or target-list edit. |
+| 2 | Enrollment hardening and production BEAM identity binding | Makes enrollment recoverable, revocable, renewable, multi-Node capable, and compatible with the selected first-party runtime transport. | Expiry cleanup, revocation, reissue, renewal, response-loss resume, Active/Standby behavior, and a node-bound revocable production BEAM credential design are accepted and tested. |
+| 3 | Controller-hosted model distribution | Removes per-worker model staging and makes cluster model readiness observable. | One verified Artifact Bundle import can be authorized, transferred, resumed, verified, placed, and loaded on selected admitted Nodes. |
+| 4 | First-inference Playground tracer | Turns infrastructure readiness into user-visible useful work. | Playground completes one request through an admitted active Node and exposes model, placement, selected Node, request state, and scheduler explanation. |
+| 5 | App-guided Controller and worker setup | Removes env editing and composes the stable CLI/domain operations into a coherent macOS experience. | App setup covers role authorization, prerequisite preflight, resumable progress, enrollment creation/import, admission status, model distribution progress, and first inference without UI-only mutation paths. |
+| 6 | Managed Database Mode | Removes the largest remaining Controller prerequisite for the all-in-one path. | Orchard provisions, starts, monitors, backs up, and upgrades its supported local Postgres mode according to `SPEC.md`. |
+| 7 | Coordinated upgrade and drain | Makes multi-Mac lifecycle maintenance safe and legible. | Preflight, cordon, drain, update, certificate/transport recovery, health verification, and resume are coordinated across the topology. |
+
+### First Recommended Implementation Slice
+
+The next product-code PR should implement the secure enrollment tracer in slice 1.
+It should remain CLI-first so the trust, persistence, retry, and lifecycle contracts stabilize before an app UI depends on them.
+
+The tracer uses one Controller and one Node Agent and ends only when the Node is `active` through an authenticated Runtime Endpoint observation.
+It does not include model transfer, Playground work, multi-Node bulk issuance, or broad setup UI.
+
+The first authenticated runtime proof may make the existing gRPC compatibility adapter certificate-backed according to `SPEC.md` §10.6 because the adapter is already a supported Runtime Endpoint path.
+The slice must add the missing mTLS listener, client credentials, CA validation, and Node-id/controller-id SAN validation rather than treating certificate backing as current behavior.
+This does not change the packaged BEAM-first direction.
+A later design must define node-bound, revocable production BEAM credentials before the enrolled product path uses BEAM without reintroducing a cluster-wide cookie as identity.
+
+### Contract Impact
+
+The target journey is already supported by `SPEC.md` node trust, Node lifecycle, model distribution, packaging, Console, and milestone direction.
+This shaping slice does not mirror the journey into `SPEC.md`.
+
+One narrow contradiction does require reconciliation now.
+`SPEC.md` §10.6 previously tied the internal Controller CA to `orchardctl cluster init`, while ADR 0011 and `SPEC.md` §11.9 define that command as credential-only.
+Internal Node trust initialization or CA import must therefore be a distinct explicit operation.
+
+No tactical `docs/DESIGN.md` update is needed until the app-guided setup slice defines reusable onboarding, progress, and recovery components.
+No new ADR is needed until Orchard chooses a durable production BEAM credential mechanism or another hard-to-reverse transport-specific trust decision.

--- a/openspec/changes/operator-first-run-journey/.openspec.yaml
+++ b/openspec/changes/operator-first-run-journey/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/operator-first-run-journey/design.md
+++ b/openspec/changes/operator-first-run-journey/design.md
@@ -1,0 +1,364 @@
+## Context
+
+Orchard targets one to four Apple Silicon Macs and supports all-in-one, Controller-plus-worker, and Active/Standby topologies.
+The current build has several pieces of a first-run experience, but no single durable journey explains their order or status.
+
+Current app and packaging behavior includes:
+
+- A verified app-primary DMG and app-owned root-authorized `install`, `update`, `uninstall`, and `status` lifecycle.
+- Universal `all`, `controller`, and `node-agent` Install Roles.
+- A guided packaged CLI sequencer through `orchardctl init` and its `orchardctl first-run` alias.
+- External Postgres as a current Controller prerequisite.
+- A local, one-shot, audited `orchardctl cluster init` first-admin credential path.
+- Console and CLI node admission review, Action Preview, rejection history, and lifecycle actions.
+- A packaged multi-Mac BEAM first cut using a manually shared root-owned cookie and explicit Controller targets.
+- Local model import and lower-level worker acquisition paths without a finished controller-hosted distribution experience.
+
+The selected target contract includes Bootstrap Tokens, locally generated Node keys, controller-signed Node Certificates, explicit Node Admission, authenticated Runtime Endpoint observations, controller-hosted artifacts, guided app onboarding, and Playground inference.
+Those target pieces are not all implemented.
+
+## Goals
+
+- Give operators and contributors one durable path from release media to first inference.
+- Prevent current compatibility and rehearsal behavior from being presented as finished enrollment or model distribution.
+- Make trust boundaries and retained state explicit at every stage.
+- Define observable target outcomes without forcing UI details before domain operations exist.
+- Order implementation slices so each one is a coherent end-to-end improvement.
+- Make the first recommended product-code slice specific enough to implement and review independently.
+
+## Non-Goals
+
+- No product implementation belongs in this change.
+- This change does not make Node Admission implicit.
+- This change does not make Runtime Endpoint observation a trust proof.
+- This change does not change the packaged BEAM-first direction.
+- This change does not select a final node-bound production BEAM credential design.
+- This change does not promise model transfer time independent of artifact size or network throughput.
+
+## Decision 1: Use One Three-Layer Journey Document
+
+The durable document has three explicit layers:
+
+1. Current supported journey, written in present tense and linked to runbooks.
+2. Target operator journey, written as product intent and observable outcomes.
+3. Gap map and ordered improvement slices, including recovery and measurement boundaries.
+
+Topology differences appear in one shared document rather than separate runbooks.
+This keeps common prerequisites, trust boundaries, and terminology consistent while allowing all-in-one, Controller-only, and Controller-plus-worker paths to diverge where necessary.
+
+Detailed commands stay in existing packaging and local-development runbooks.
+The journey document summarizes outcomes and links to those commands.
+
+## Decision 2: Enroll A Node, Not A Worker Runtime
+
+The product may use the action label **Add a worker**, but the durable domain resource is a Node running the Node Agent.
+The Worker Runtime remains a local subprocess supervised by the Node Agent.
+It does not receive enrollment material or join the cluster independently.
+
+The canonical term is **Node Enrollment Bundle**.
+It is distinct from a Bootstrap Token, Node Certificate, Node Admission, API Token, and BEAM cookie.
+
+## Decision 3: Keep Enrollment, Admission, Activation, And Readiness Separate
+
+The target state progression is:
+
+```text
+installed
+  -> provisioned
+  -> registered
+  -> admitted
+  -> active
+  -> model-ready
+  -> inference-verified
+```
+
+`installed`, `model-ready`, and `inference-verified` are journey milestones rather than new Node Lifecycle State values.
+The existing Node Lifecycle State machine continues to own `provisioned`, `registered`, `admitted`, and `active`.
+
+A successful transport connection or Runtime Endpoint observation never skips registration or Node Admission.
+A registered Node remains visibly pending until an administrator admits it.
+An admitted Node becomes active only after a fresh healthy authenticated observation.
+
+## Decision 4: Node Enrollment Bundle Is A Narrow One-Time Trust Artifact
+
+One bundle enrolls exactly one Node.
+The target bundle is versioned, one-use, short-lived, inspectable, revocable, and auditable.
+
+It contains:
+
+- Bundle format and enrollment identifier.
+- Stable cluster identifier and optional human-readable cluster name.
+- Stable Controller identifier that will be required in the later runtime mTLS client certificate SAN.
+- Allocated stable Node identifier.
+- Controller HTTPS address.
+- Controller trust pin or public trust-anchor material.
+- One one-time Bootstrap Token.
+- Issued and expiry timestamps.
+- Optional intended display name, pool, or bounded policy hints.
+
+It never contains:
+
+- A BEAM cookie.
+- A cluster-admin, operator, tenant, or inference credential.
+- A Controller or node-signing CA private key.
+- A Node private key.
+- A long-lived Node Certificate.
+- A database credential or DSN.
+- A static Runtime Endpoint target list.
+
+The Controller stores the Bootstrap Token secret only as a hash and prefix.
+It also persists the enrollment identifier, allocated Node reference, creator, lifecycle timestamps and state, expected Controller identity, CSR fingerprint after redemption begins, certificate issuance outcome, and sanitized audit context required for safe resume and review.
+The Node private key is generated and retained only on the Node Agent host.
+
+The default expiry is one hour and the maximum accepted expiry is 24 hours.
+The implementation may later tighten those values based on supported deployment evidence without weakening one-use behavior.
+
+## Decision 5: Authenticate The Controller Before Sending The Bootstrap Token
+
+The joining Node Agent validates the pinned Controller trust material before transmitting the Bootstrap Token.
+There is no short-token mode that silently trusts the first Controller response.
+
+The target join exchange is:
+
+1. Parse and validate the bundle locally.
+2. Reject unsupported format, wrong cluster, wrong Node, or local expiry before network access.
+3. Generate the Node keypair locally and persist it atomically in protected Node Agent state before any redemption request.
+4. Create a CSR bound to the allocated Node identifier and the persisted local key.
+5. Connect to the bundle's Controller address.
+6. Validate the Controller trust pin and presented chain.
+7. Submit the Bootstrap Token, CSR, bounded inventory, and advertised endpoint metadata.
+8. Atomically consume the Bootstrap Token.
+9. Issue a Node Certificate bound to the Node identifier and return the internal runtime trust chain plus the expected stable Controller identifier.
+10. Persist the Node Certificate, internal trust chain, and expected Controller identifier atomically beside the local private key.
+11. Transition `provisioned -> registered`.
+12. Report that administrator admission remains required.
+
+The Controller never reconciles Node identity from hostname, IP address, display name, BEAM node name, or target string alone.
+The Node Agent accepts later runtime mTLS only when the Controller client certificate chains to the enrolled internal trust authority and carries the exact stable Controller-id SAN established by the bundle and registration result.
+
+## Decision 6: First Implementation Slice Is Secure Enrollment
+
+Three sequences were considered.
+
+### Guided Setup First
+
+This sequence would immediately reduce Controller setup friction.
+It was not selected first because the UI or sequencer would still stop at manual worker cookie distribution and static targets or would encode those temporary mechanics into the product flow.
+
+### Controller-Hosted Model Distribution First
+
+This sequence would remove a major first-inference blocker.
+It was not selected first because secure distribution needs an authenticated admitted Node identity and channel, while current pre-staging remains an explicit workaround.
+
+### Secure Node Enrollment First
+
+This sequence gives existing admission review a trusted registered Node, removes the largest security ambiguity, and creates the authenticated identity needed by later model distribution.
+It is selected.
+
+The first product-code tracer covers one configured Controller and one Node Agent.
+It starts after app or PKG role installation and ends when the Node is `active` through a fresh authenticated Runtime Endpoint observation.
+It excludes model transfer, Playground, multi-Node bulk issuance, Managed Database Mode, and app UI.
+
+## First Tracer Interfaces
+
+The exact command spelling remains implementation-reviewable, but the shaped command family is:
+
+```text
+orchardctl nodes enrollment create --output PATH [--expires-in DURATION] [--node-name LABEL] [--pool-id ID]
+orchardctl node join --enrollment-bundle PATH
+```
+
+Controller-side issuance:
+
+1. Preflights exclusive owner-only output creation before mutation.
+2. Uses the local Controller runtime authority boundary and leader-only write gate.
+3. Requires stable cluster identity, Controller HTTPS identity, and an initialized or imported internal node-signing authority.
+4. Creates a `provisioned` Node placeholder with a stable Node identifier.
+5. Creates one Bootstrap Token scoped to that Node and cluster.
+6. Stores only the secret hash and prefix.
+7. Writes the bundle once to the chosen path.
+8. Records a cluster-scoped audit event without secret material.
+9. Records a safe output-failure state if committed issuance cannot be delivered.
+
+Node-side join follows Decision 5 and leaves the Node `registered`.
+Existing admission preview and execution then move it to `admitted`.
+Dynamic target resolution derives the Runtime Endpoint from trusted Node inventory.
+A fresh healthy authenticated observation moves the Node to `active`.
+
+## Runtime Transport For The First Tracer
+
+The first certificate-authenticated Runtime Endpoint proof may extend the existing gRPC compatibility adapter with the mTLS behavior required by `SPEC.md` §10.6.
+The current adapter is not certificate-backed, so the tracer must add the Node Agent TLS listener, Controller client credentials, CA validation, and exact Node-id/controller-id SAN validation against the identities persisted during enrollment.
+The enrollment identity, certificate, admission, and dynamic target work remain transport-independent.
+
+This tracer does not change the packaged BEAM-first direction.
+Before the enrolled product path uses BEAM in production, Orchard must define a node-bound, revocable production credential model that does not treat one cluster-wide shared cookie as Node identity.
+That transport-specific choice may require a later ADR if it introduces a hard-to-reverse security boundary.
+
+## Registration Retry And Concurrency
+
+Bootstrap Token consumption is atomic.
+Concurrent first use permits at most one successful Node identity.
+
+If the Controller consumes the token and the response is lost, the join may resume only with the same enrollment identifier, durably held Node key, and persisted CSR fingerprint.
+A retry with different key material fails closed.
+
+The enrollment record persists certificate issuance state so a crash before issuance, after issuance, or before response delivery can be distinguished without minting a second identity.
+The Node Agent persists its key before redemption and persists the returned certificate and runtime trust binding atomically before reporting registration complete.
+
+Expired, consumed, revoked, wrong-cluster, or wrong-Node bundles do not create additional Node rows or Node Certificates.
+Standby or leadership-unproven Controllers reject issuance and registration mutations through the existing write-path semantics.
+
+An observation that arrives before registration remains a Runtime Endpoint Admission Candidate.
+Registration may reconcile earlier candidate evidence only through the certified Node identity.
+Target-string equality is never reconciliation authority.
+
+## Model Distribution And First Inference
+
+Controller-hosted model distribution follows secure enrollment and production transport hardening.
+The Controller stores one verified Artifact Bundle and authorizes selected admitted Nodes to fetch it over an authenticated internal channel.
+Node Agents verify hashes and optional signatures before changing Placement State.
+
+Console shows distribution, verification, placement, and load progress separately from Node activation.
+A Node can be active while no requested model is available.
+
+The first-inference tracer follows model distribution.
+It completes one Playground request and exposes the chosen Node, model version, placement, request state, and scheduler explanation.
+
+## Guided App Setup
+
+App-guided setup is implemented after the domain and CLI operations stabilize.
+It composes:
+
+- Install Role authorization through the app-owned lifecycle.
+- License status and activation guidance.
+- External Postgres validation until Managed Database Mode exists.
+- Public transport configuration.
+- Migrations.
+- First-admin credential initialization.
+- Separate internal Node trust initialization or import.
+- Node Enrollment Bundle creation and import.
+- Node Admission status.
+- Model import and distribution progress.
+- Playground verification.
+
+The app delegates privileged service mutations to `orchard-service` and uses the same domain operations as CLI and APIs.
+It does not create UI-only mutation paths.
+
+## Trust Boundaries And Responsibilities
+
+| Boundary | Operator responsibility now | Target Orchard responsibility |
+|---|---|---|
+| System-root mutation | Authorize app or PKG lifecycle and protect root-owned configuration. | Present explicit role and mutation scope, preserve state, and resume safely after failure. |
+| External Postgres | Provision, secure, back up, and keep PostgreSQL reachable. | Validate configuration clearly until Managed Database Mode owns the lifecycle. |
+| Licensing | Supply activation material out of band and protect it. | Validate before useful work without embedding customer material in the release. |
+| Public transport | Choose direct HTTPS, reverse proxy, or explicit lab-local TLS. | Validate mode and certificate state without mutating trust stores implicitly. |
+| First admin | Protect one-time output and replace bootstrap use with named credentials. | Keep initialization local, one-shot, audited, leader-gated, and credential-only. |
+| Node Enrollment | Transfer one sensitive short-lived bundle per Node. | Pin Controller identity, consume once, issue Node identity, audit, expire, revoke, and resume safely. |
+| Node Admission | Review registered identity, inventory, compatibility, pool, and policy. | Keep admission explicit and preserve decision history. |
+| Runtime transport | Protect current compatibility material and private network. | Derive targets from trusted inventory and use node-bound revocable credentials. |
+| Model availability | Pre-stage remote artifacts in the current build. | Import once, authorize distribution, verify on each Node, and expose progress. |
+| API credentials | Protect one-time API Token output. | Store only hashes/prefixes and expose clear rotation and revocation. |
+| Retained state | Back up config, database, models, bundles, and support state. | Preserve documented operator-owned paths and coordinate safe upgrades. |
+
+## Friction Measurement
+
+Durable docs record structural friction, measurement definitions, and acceptance budgets.
+Machine-specific timings belong in implementation PR or issue evidence.
+
+Structural measures include:
+
+- Manual root-owned file edits.
+- Root-authorized workflows.
+- Cross-Mac secret transfers.
+- Static target-list entries.
+- Macs requiring hands-on steps.
+- External prerequisites.
+- Secret custody events.
+- Model imports and per-worker staging operations.
+
+Time boundaries are:
+
+- Time-to-Console from verified app setup launch to authenticated Console readiness.
+- Time-to-first-worker-ready from bundle creation to a fresh healthy authenticated observation on an admitted Node.
+- Time-to-first-inference from first Console readiness to a successful Playground terminal response.
+- Operator-active time as the intervals inside each named boundary when setup awaits required operator input or the operator performs a required action.
+
+Complete elapsed time, operator-active time, model-byte transfer, automated processing, and administrator waiting are reported as separate components without changing the named metric boundaries.
+
+## Failure And Recovery Model
+
+Every setup stage reports the failed boundary, preserves prior completed work, and provides a safe resume action.
+
+Required failure classes include:
+
+- License invalid or missing.
+- External Postgres unavailable or migrations behind.
+- Partial TLS state or public transport mismatch.
+- App/PKG ownership conflict.
+- Enrollment bundle malformed, expired, consumed, revoked, wrong-cluster, or wrong-Node.
+- Controller trust-pin mismatch before credential submission.
+- Registration response lost after token consumption.
+- Registration complete but admission pending or rejected.
+- Node Certificate issuance, persistence, renewal, or revocation failure.
+- Runtime transport unreachable or identity mismatch.
+- Model source unavailable, transfer interrupted, checksum mismatch, disk exhaustion, or load failure.
+- Upgrade preflight, drain, update, health verification, or resume failure.
+
+Secrets, private keys, DSNs, raw local evidence, and machine-specific paths never enter audit logs, support bundles, or durable docs.
+
+## Ordered Slices
+
+1. Secure one-Controller, one-Node enrollment tracer.
+2. Enrollment hardening and production BEAM identity binding.
+3. Controller-hosted model distribution.
+4. First-inference Playground tracer.
+5. App-guided Controller and worker setup.
+6. Managed Database Mode.
+7. Coordinated upgrade and drain.
+
+Each slice has explicit tasks in `tasks.md`.
+
+## Alternatives Rejected
+
+### Put The Shared BEAM Cookie In An Expiring Bundle
+
+This reduces manual steps but does not reduce the extracted cookie's cluster-wide authority or blast radius.
+It conflates enrollment authorization, durable Node identity, and runtime transport access.
+The current shared-cookie path remains documented as compatibility and rehearsal behavior, not Node Enrollment.
+
+### Make Admission Automatic
+
+This would collapse registration and administrator trust review and contradict the current Node Lifecycle contract.
+Explicit admission remains the default.
+
+### Build App UI Before CLI And Domain Operations
+
+This would create UI-only orchestration or encode current manual mechanics.
+The app follows stable domain operations.
+
+### Distribute Models To Observed Endpoints
+
+Observation is not trust.
+Distribution waits for an admitted authenticated Node.
+
+## Contract Reconciliation
+
+`SPEC.md` §10.6 previously said the internal Controller CA was generated by `cluster init` or imported by an administrator.
+ADR 0011 and `SPEC.md` §11.9 define `orchardctl cluster init` as credential-only.
+This change resolves the contradiction by requiring explicit separate node-trust initialization or admin import.
+
+No broader `SPEC.md` journey rewrite is needed.
+No `docs/DESIGN.md` change is needed before app-guided setup defines reusable UI patterns.
+No ADR is needed until Orchard selects a transport-specific production BEAM credential model or another hard-to-reverse security decision.
+
+## External Grounding
+
+The design borrows interaction principles without copying deployment assumptions:
+
+- Tailscale separates device registration, optional approval, key expiry, and revocation, but Orchard must remain sovereign and on-prem.
+- K3s secure tokens pin cluster CA identity before sending join credentials and its bootstrap tokens are describable, expiring, listable, and revocable, but Orchard does not reuse an all-powerful server token.
+- Syncthing treats device identity as cryptographic and mutual rather than hostname-based, but Orchard centralizes admission instead of requiring bilateral manual configuration.
+- Nomad separates shared gossip encryption from mTLS-secured RPC and one-shot ACL bootstrap, reinforcing that a shared transport key is not Node identity.
+
+The Orchard-specific result remains subordinate to `SPEC.md` and existing ADRs.

--- a/openspec/changes/operator-first-run-journey/proposal.md
+++ b/openspec/changes/operator-first-run-journey/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Orchard now has an app-primary DMG, a safe root-authorized service lifecycle, first-admin credential initialization, admission review, and a technically workable packaged multi-Mac path.
+The operator still has to assemble those capabilities through external Postgres preparation, root-owned env edits, shared BEAM cookie distribution, explicit Runtime Endpoint targets, separate trust and Console steps, per-worker model staging, and manual inference verification.
+
+The current path and target `SPEC.md` path are spread across packaging, local-development, security, node-lifecycle, model, and Console documents.
+Without one durable journey and ordered change package, current behavior can be mistaken for finished Node Enrollment or model distribution, and future setup work can encode temporary transport mechanics into the product experience.
+
+## What Changes
+
+- Add a durable operator-journey document that separates current supported behavior, target product intent, and the ordered gap map.
+- Define controller-only, all-in-one, and Controller-plus-worker differences from release acquisition through Console and first inference.
+- Make sudo/root authorization, external Postgres, licensing, public transport, first-admin credentials, current BEAM transport, Node Admission, model availability, retained state, recovery, and upgrade responsibilities explicit.
+- Define structural friction counts and stable measurement boundaries for time-to-Console, time-to-first-worker-ready, and time-to-first-inference.
+- Define **Node Enrollment Bundle** as the canonical per-Node bootstrap artifact and prohibit shared BEAM cookies or long-lived credentials from that artifact.
+- Shape a CLI-first secure one-Controller, one-Node enrollment tracer as the first implementation slice.
+- Preserve enrollment hardening, production BEAM identity binding, controller-hosted model distribution, Playground verification, app-guided setup, Managed Database Mode, and coordinated upgrade work as explicit later tasks.
+- Reconcile the narrow `SPEC.md` contradiction between credential-only `orchardctl cluster init` and internal Controller CA initialization.
+
+## Capabilities
+
+### New Capabilities
+
+- `operator-first-run-journey`: Defines current-versus-target operator journey disclosure, secure Node Enrollment, measurable setup outcomes, recovery semantics, first-inference completion, and phased implementation acceptance.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Documentation impact: add `docs/operator-journey.md`, link it from the docs index, and add the Node Enrollment Bundle glossary term.
+- SPEC.md impact: narrow §10.6 so internal node trust is initialized or imported through an explicit operation separate from credential-only `orchardctl cluster init`.
+- OpenSpec impact: add this shaping package without modifying or claiming completion of `cluster-management-ux-foundation`, `first-admin-cluster-init`, or `amore-dmg-service-lifecycle`.
+- Security impact: establish that Node Enrollment cannot package the cluster-wide BEAM cookie, admin credentials, CA private keys, Node private keys, or long-lived Node Certificates.
+- Implementation impact: none in this change.
+- Future implementation impact: the first product-code slice spans Node Enrollment persistence, one-time output, local key generation, certificate-backed registration, explicit Node Admission, dynamic target resolution, and authenticated activation.
+
+## Non-Goals
+
+- Do not implement product code, new CLI commands, database migrations, app UI, Node Certificate issuance, model transfer, or upgrade orchestration in this change.
+- Do not claim `orchardctl node join`, certificate bootstrap, dynamic target discovery, controller-hosted model distribution, Managed Database Mode, or app-guided setup exists.
+- Do not replace the current packaged BEAM first-cut runbook before the secure product path is implemented and validated.
+- Do not choose a durable production BEAM credential mechanism in this shaping change.
+- Do not mirror the complete operator journey into `SPEC.md`.

--- a/openspec/changes/operator-first-run-journey/specs/operator-first-run-journey/spec.md
+++ b/openspec/changes/operator-first-run-journey/specs/operator-first-run-journey/spec.md
@@ -1,0 +1,233 @@
+## ADDED Requirements
+
+### Requirement: Operator Journey Separates Current And Target Behavior
+
+Orchard documentation and setup surfaces SHALL distinguish current supported behavior from target product intent.
+Current behavior SHALL NOT claim that app-guided setup, Bootstrap Token exchange, Node Certificate issuance, dynamic Runtime Endpoint discovery, controller-hosted model distribution, or Managed Database Mode exists before each capability is implemented and validated.
+The durable journey SHALL cover all-in-one, Controller-only, and Controller-plus-worker paths and SHALL link to current runbooks for detailed commands.
+This refines `SPEC.md` §1.1, §2.3, §4, §6, §10, §11, and §14.
+
+#### Scenario: Current multi-Mac path is described accurately
+
+- **WHEN** an operator reads the current Controller-plus-worker journey
+- **THEN** Orchard describes manual shared-cookie provisioning and explicit Runtime Endpoint targets as current compatibility or first-cut behavior
+- **AND** Orchard does not describe that behavior as Node Enrollment, Node registration, Node Admission, or certificate bootstrap
+
+#### Scenario: Target journey is visibly aspirational
+
+- **WHEN** documentation describes importing a model once and distributing it to admitted Nodes
+- **THEN** the documentation labels that flow as target product intent until controller-hosted distribution is implemented
+- **AND** the current local-file and pre-staging limitations remain visible
+
+### Requirement: Node Enrollment Bundle Is Per-Node And Short-Lived
+
+Orchard SHALL define a Node Enrollment Bundle as a versioned, per-Node, one-use, short-lived bootstrap artifact.
+The bundle SHALL include stable cluster, Controller, and Node identifiers, a Controller address, a Controller trust pin or public trust-anchor material, one Bootstrap Token, and issued and expiry timestamps.
+The default expiry SHALL be one hour and the accepted maximum expiry SHALL be 24 hours.
+The Controller SHALL persist the Bootstrap Token secret only as a hash and prefix.
+The Controller SHALL also persist the enrollment id, allocated Node reference, creator, lifecycle state and timestamps, expected Controller identity, CSR fingerprint after redemption begins, certificate issuance outcome, resume metadata, and sanitized audit context.
+The bundle SHALL be treated as sensitive One-time Secret Output.
+This refines `SPEC.md` §4.1, §10.1, §10.5, §10.6, §11.7, and §11.9.
+
+#### Scenario: Controller creates one bundle for one Node
+
+- **WHEN** an authorized local Controller operator creates a Node Enrollment Bundle with a preflighted output path
+- **THEN** Orchard allocates one stable Node id and one `provisioned` Node placeholder
+- **AND** Orchard writes one bundle for that Node through exclusive owner-only output creation
+- **AND** Orchard persists no plaintext Bootstrap Token
+- **AND** Orchard records a cluster-scoped audit event without secret material
+
+#### Scenario: Local clock shows that the bundle expired
+
+- **WHEN** a Node Agent imports a bundle whose expiry has passed according to the local clock
+- **THEN** Orchard refuses registration
+- **AND** Orchard does not transmit the Bootstrap Token
+- **AND** Orchard creates no additional Node identity or Node Certificate
+
+#### Scenario: Controller rejects an expired bundle at redemption
+
+- **WHEN** local clock skew allows a Node Agent to submit a bundle that is expired under Controller-authoritative time
+- **THEN** the Controller refuses redemption
+- **AND** the Controller does not consume the token as a successful registration
+- **AND** Orchard creates no additional Node identity or Node Certificate
+
+### Requirement: Enrollment Bundle Excludes Durable And Shared Secrets
+
+A Node Enrollment Bundle SHALL NOT contain a BEAM cookie, cluster-admin credential, operator credential, tenant credential, inference credential, database credential, DSN, CA private key, Node private key, long-lived Node Certificate, or static Runtime Endpoint target list.
+Node Enrollment SHALL NOT treat a shared transport secret as durable Node identity.
+This refines `SPEC.md` §1.2, §4.1, §10.1, §10.2, §10.5, §10.6, and §11.4.
+
+#### Scenario: Current BEAM cookie is not enrollment material
+
+- **WHEN** Orchard creates a Node Enrollment Bundle for a packaged Node Agent
+- **THEN** the bundle contains no current shared BEAM cookie material
+- **AND** extracting or redeeming the bundle does not grant cluster-wide BEAM mesh authority
+
+### Requirement: Node Validates Controller Before Sending Join Credential
+
+The Node Agent SHALL validate the bundle's pinned Controller identity and presented certificate chain before transmitting the Bootstrap Token.
+Orchard SHALL NOT provide a join mode that sends the Bootstrap Token after implicitly trusting the first Controller response.
+This refines `SPEC.md` §10.5 and §10.6.
+
+#### Scenario: Controller trust pin does not match
+
+- **WHEN** the Node Agent connects to a Controller whose trust material does not match the bundle
+- **THEN** Orchard refuses before transmitting the Bootstrap Token, CSR, or private inventory
+- **AND** the bundle remains unconsumed unless separately expired or revoked
+
+### Requirement: Node Private Key Is Generated Locally
+
+The Node Agent SHALL generate its Node private key locally and persist it atomically in protected Node Agent state before transmitting the Bootstrap Token.
+The Node private key SHALL NOT be generated by the Controller, embedded in the Node Enrollment Bundle, persisted in Postgres, or returned through audit, logs, or support bundles.
+The Node Agent SHALL submit a CSR bound to the allocated Node id and persisted local key.
+The Node Agent SHALL persist the issued Node Certificate, internal runtime trust chain, and expected stable Controller identity atomically beside the local private key before reporting registration complete.
+This refines `SPEC.md` §4.1, §10.5, §10.6, and §10.8.
+
+#### Scenario: Successful registration establishes Node identity
+
+- **WHEN** a Node Agent validates the Controller, redeems a valid bundle, and submits a CSR matching the allocated Node id
+- **THEN** Orchard atomically consumes the Bootstrap Token
+- **AND** Orchard issues a Node Certificate bound to that Node id
+- **AND** Orchard transitions the Node from `provisioned` to `registered`
+- **AND** Orchard reports that Node Admission remains required
+
+### Requirement: Registration Retry Is Identity-Bound
+
+Bootstrap Token consumption SHALL be atomic under concurrent registration attempts.
+If a successful token consumption response is lost, Orchard SHALL allow a bounded resume only when the enrollment id, durably held Node key, and persisted CSR fingerprint match the consumed attempt.
+A retry using different key material after consumption SHALL fail closed.
+The Controller SHALL persist enough certificate issuance state to distinguish a crash before issuance, after issuance, and before response delivery without minting a second Node identity.
+This refines `SPEC.md` §3.7, §4.4, §10.5, and §12.7.
+
+#### Scenario: Concurrent redemption has one winner
+
+- **WHEN** two registration attempts concurrently redeem the same Node Enrollment Bundle
+- **THEN** at most one attempt establishes the Node identity
+- **AND** the other attempt cannot create another Node row or Node Certificate
+
+#### Scenario: Lost response resumes with the same identity
+
+- **WHEN** the Controller consumes the Bootstrap Token and issues a Node Certificate but the response is lost
+- **AND** the Node Agent retries with the same enrollment id, local key, and CSR fingerprint
+- **THEN** Orchard resumes or returns the same established identity without creating a duplicate
+
+#### Scenario: Lost response retry changes key material
+
+- **WHEN** a consumed enrollment is retried with a different Node key or CSR fingerprint
+- **THEN** Orchard refuses the retry
+- **AND** Orchard does not replace or add Node Certificate state
+
+### Requirement: Registration Does Not Imply Admission
+
+Successful Node registration SHALL leave the Node non-schedulable in `registered` state until explicit administrator Node Admission succeeds.
+Admission SHALL reuse the shared Action Preview, leader-only write gate, inventory, trust, pool, policy, confirmation, and cluster-scoped audit contracts.
+A fresh healthy authenticated Runtime Endpoint observation SHALL advance `admitted -> active` only after admission.
+This refines `SPEC.md` §4.2 through §4.6, §5.5, §7.4.1, and §11.9.
+
+#### Scenario: Registered Node waits for approval
+
+- **WHEN** a Node completes certificate-backed registration
+- **THEN** Console and CLI show the Node as registered and pending admission
+- **AND** the scheduler and queue consume no capacity from that Node
+
+#### Scenario: Admission activates only after authenticated health
+
+- **WHEN** an administrator admits a registered trusted Node
+- **THEN** Orchard transitions it to `admitted`
+- **AND** Orchard does not make it schedulable until a fresh healthy authenticated observation advances it to `active`
+
+### Requirement: Product Runtime Targets Derive From Trusted Node Inventory
+
+The enrolled product path SHALL derive Runtime Endpoint targets from trusted Node inventory rather than requiring an operator to edit a static Controller target list for each Node.
+Target derivation SHALL validate that observed endpoint identity matches the persisted Node and Node Certificate identity.
+Source-development and explicit compatibility target overrides MAY remain separately documented and SHALL NOT establish Node trust.
+This refines `SPEC.md` §1.2, §4.1, §4.6.1, §5.4, §5.5, and §7.5.
+
+#### Scenario: Target address alone cannot reconcile identity
+
+- **WHEN** an observed Runtime Endpoint uses the same address or target string as a provisioned or registered Node but cannot prove the matching Node Certificate identity
+- **THEN** Orchard does not reconcile the observation to that Node
+- **AND** Orchard does not publish scheduling capacity from the observation
+
+### Requirement: Runtime Controller Identity Is Bound During Enrollment
+
+Node Enrollment SHALL establish the exact stable Controller identity and internal trust authority expected by the Node Agent for later runtime mTLS.
+The Node Agent SHALL accept a runtime Controller client certificate only when it chains to the enrolled internal trust authority and carries the exact Controller-id SAN established by the bundle and registration result.
+The Controller SHALL accept a Node runtime certificate only when it chains to the internal trust authority and carries the exact persisted Node-id SAN.
+This refines `SPEC.md` §4.1, §7.5, §10.5, and §10.6.
+
+#### Scenario: Runtime Controller certificate has the wrong identity
+
+- **WHEN** a runtime Controller client certificate chains to the enrolled internal CA but carries a different Controller-id SAN
+- **THEN** the Node Agent refuses the runtime connection
+- **AND** Orchard does not publish an authenticated healthy observation
+
+#### Scenario: Runtime Node certificate has the wrong identity
+
+- **WHEN** a Node runtime certificate chains to the internal CA but carries a different Node-id SAN from the trusted Node record
+- **THEN** the Controller refuses the Runtime Endpoint identity
+- **AND** Orchard does not activate the Node or publish its capacity
+
+### Requirement: Model Distribution Uses Admitted Node Identity
+
+Controller-hosted model distribution SHALL authorize only admitted Nodes through authenticated Node identity.
+One verified Artifact Bundle import SHALL be distributable to selected admitted Nodes without per-worker manual source staging.
+The Node Agent SHALL verify artifact hashes and optional signatures before changing Placement State.
+Distribution progress and failure SHALL remain distinct from Node lifecycle and health.
+This refines `SPEC.md` §6.5 through §6.8, §7.5, §10.5, and §10.6.
+
+#### Scenario: Observed endpoint cannot download a model
+
+- **WHEN** a Runtime Endpoint Admission Candidate is reachable but is not an admitted authenticated Node
+- **THEN** Orchard refuses controller-hosted Artifact Bundle distribution to that endpoint
+- **AND** Orchard does not treat reachability as model-placement authority
+
+#### Scenario: Active Node has no model yet
+
+- **WHEN** a Node is active but the requested Artifact Bundle is not verified and ready on its Runtime Endpoint
+- **THEN** Orchard shows the Node as active
+- **AND** Orchard separately shows the model as unavailable, transferring, verifying, or failed
+
+### Requirement: Setup Completes With Verified Inference
+
+The target first-run journey SHALL end with a real inference request through Playground or the Public Inference API.
+Completion SHALL require an active Node, an active model, a ready Model Placement, a valid inference credential, and a successful terminal response.
+The completion result SHALL identify the selected Node and model version and SHALL provide stable remediation when scheduling fails.
+This refines `SPEC.md` §5, §6, §7.2, §11.8, and Milestones 1, 3, and 4.
+
+#### Scenario: Green services are not first-run completion
+
+- **WHEN** the Controller and Node Agent processes are running but no model-ready active Node can serve the request
+- **THEN** Orchard does not report first-run inference as complete
+- **AND** Orchard identifies the missing activation, model, placement, credential, or scheduling boundary
+
+### Requirement: Setup Is Resumable At The Failed Boundary
+
+Guided setup SHALL preserve completed work and resume at the failed boundary after recoverable license, database, transport, enrollment, admission, model, or service errors.
+Setup SHALL NOT require the operator to restart the entire journey after a recoverable failure.
+Failure output SHALL distinguish blockers, operator responsibilities, safe remediation, and retained state.
+This refines `SPEC.md` §11, §12, and §13.
+
+#### Scenario: External Postgres fails during Controller setup
+
+- **WHEN** guided setup cannot reach the configured external Postgres server
+- **THEN** Orchard preserves prior install and configuration work
+- **AND** Orchard reports the database boundary and safe validation steps
+- **AND** rerunning setup resumes at database validation or the next incomplete step
+
+### Requirement: Operator Friction Is Measured Consistently
+
+Orchard SHALL track manual root-owned file edits, root-authorized workflows, cross-Mac secret transfers, static target edits, machines touched, external prerequisites, model staging operations, and secret custody events for each supported topology.
+Time-to-Console SHALL run from verified app setup launch to authenticated Console readiness.
+Time-to-first-worker-ready SHALL run from Node Enrollment Bundle creation to a fresh healthy authenticated observation on an admitted Node.
+Time-to-first-inference SHALL run from first Console readiness to a successful Playground terminal response.
+Operator-active time SHALL be the intervals inside each named boundary when setup awaits required operator input or the operator performs a required action.
+Complete elapsed time, operator-active time, model-byte transfer, automated processing, and administrator waiting SHALL be reported separately without changing the named boundaries.
+Machine-specific evidence SHALL live in implementation PRs or issues rather than durable journey docs.
+This refines `SPEC.md` §11, §12, §13, and §14.
+
+#### Scenario: Model transfer does not hide setup friction
+
+- **WHEN** Orchard measures time-to-first-inference for a large Model Bundle
+- **THEN** the result reports operator-active setup time separately from model-byte transfer time
+- **AND** the durable repo document retains the measurement definition without machine-specific logs or paths

--- a/openspec/changes/operator-first-run-journey/tasks.md
+++ b/openspec/changes/operator-first-run-journey/tasks.md
@@ -1,0 +1,72 @@
+## 1. Documentation And Contract Shaping
+
+- [x] 1.1 Add one durable operator-journey document with current behavior, target intent, topology differences, trust boundaries, recovery points, friction measures, and ordered slices.
+- [x] 1.2 Add the canonical Node Enrollment Bundle glossary term and distinguish it from Bootstrap Token, Node Certificate, Node Admission, API Token, and BEAM cookie.
+- [x] 1.3 Reconcile `SPEC.md` §10.6 so internal node-trust initialization is explicit and separate from credential-only `orchardctl cluster init`.
+- [x] 1.4 Add this OpenSpec proposal, design, phased tasks, and normative requirement delta without implementing product code.
+
+## 2. Secure Enrollment Tracer
+
+- [ ] 2.1 Define versioned Node Enrollment persistence with one Bootstrap Token hash/prefix, enrollment id, issued/expiry/consumed/revoked/output-failed state, allocated Node reference, creator, expected Controller identity, CSR fingerprint, certificate issuance outcome, resume metadata, and sanitized audit metadata.
+- [ ] 2.2 Add explicit internal node-trust initialization or admin import that is separate from first-admin credential initialization and exposes only public trust material to enrollment issuance.
+- [ ] 2.3 Add a local Controller-host issuance command that depends on initialized or imported node trust and uses required exclusive owner-only output preflight, one-hour default expiry, 24-hour maximum expiry, leader-only write gating, one Node per bundle, hash-only persistence, cluster-scoped audit, and safe output-failure handling.
+- [ ] 2.4 Implement `orchardctl node join --enrollment-bundle PATH` with local format/expiry checks, Controller trust-pin validation before credential transmission, local Node key generation and atomic protected persistence before redemption, CSR submission, atomic token consumption, Node Certificate issuance, and atomic certificate/runtime-trust persistence.
+- [ ] 2.5 Reconcile `provisioned -> registered` only through allocated Node id, Bootstrap Token record, CSR, and issued certificate, never through hostname, IP address, BEAM node name, or target-string equality.
+- [ ] 2.6 Integrate existing pending-admission preview and execution so the registered Node remains non-schedulable until explicit audited admission.
+- [ ] 2.7 Derive the first authenticated Runtime Endpoint target from trusted Node inventory and advance `admitted -> active` only after a fresh healthy identity-matched observation.
+- [ ] 2.8 Make the gRPC compatibility adapter certificate-backed for the first authenticated Runtime Endpoint proof by adding a Node Agent mTLS listener, Controller client credentials, CA validation, exact Node-id/controller-id SAN validation against enrollment-persisted identities, and fail-closed identity errors without changing the packaged BEAM-first end state.
+- [ ] 2.9 Add public-interface tests for happy path, wrong HTTPS trust pin, wrong internal CA, wrong Node-id SAN, wrong Controller-id SAN, expired bundle, consumed bundle, revoked bundle, wrong cluster, wrong Node, concurrent redemption, crash before token consumption, crash after consumption before certificate issuance, crash after issuance before response delivery, crash before local certificate persistence, response loss with matching key/CSR resume, response loss with different key rejection, non-leader refusal, pending-admission exclusion, and authenticated activation.
+- [ ] 2.10 Run the full Elixir workflow, strict OpenSpec validation, one-Controller/one-Node packaged smoke, and security review before handoff.
+
+## 3. Enrollment Hardening And Production BEAM Identity
+
+- [ ] 3.1 Add list, inspect, revoke, and reissue surfaces that never reveal the Bootstrap Token secret and preserve append-only audit history.
+- [ ] 3.2 Add bounded cleanup for expired and consumed enrollment records while retaining required audit and decision evidence.
+- [ ] 3.3 Add Node Certificate renewal, explicit revocation, decommission integration, and restart-safe local credential recovery.
+- [ ] 3.4 Define and accept a node-bound, revocable production BEAM credential and authorization model that does not use one cluster-wide cookie as Node identity.
+- [ ] 3.5 Replace static product target lists with targets derived from trusted registered/admitted Node inventory while preserving explicit source-development and compatibility overrides.
+- [ ] 3.6 Validate multi-Node issuance, Active/Standby retries, controller failover, certificate rotation, rejected admission, re-admission, and decommission failure paths.
+
+## 4. Controller-Hosted Model Distribution
+
+- [ ] 4.1 Add an authenticated Controller artifact endpoint or Runtime Endpoint operation that authorizes admitted Nodes by Node Certificate and never serves artifacts to observations or admission candidates.
+- [ ] 4.2 Import one verified Artifact Bundle into the Controller artifact root and expose cluster-level distribution eligibility separately from Catalog State.
+- [ ] 4.3 Add resumable Node Agent transfer, checksum and optional signature verification, atomic cache placement, bounded retry, and disk-pressure failure handling.
+- [ ] 4.4 Expose distribution, verification, Placement State, load progress, and stable failure codes through shared CLI, API, and Console semantics.
+- [ ] 4.5 Test interrupted transfer, wrong hash, revoked Node Certificate, insufficient disk, duplicate request idempotency, partial cleanup, and air-gapped operation.
+
+## 5. First-Inference Playground Tracer
+
+- [ ] 5.1 Add a setup completion check that requires at least one active Node, an active model, a ready Model Placement, and a valid inference credential.
+- [ ] 5.2 Run one small Playground request through the admitted authenticated Runtime Endpoint and display selected Node, model version, placement, request state, latency, and scheduler explanation.
+- [ ] 5.3 Preserve failure separation for no active Node, model unavailable, transfer incomplete, load failure, scheduler exclusion, invalid credential, and public transport failure.
+- [ ] 5.4 Record sanitized time-to-first-inference evidence with model-byte transfer and administrator waiting time reported separately.
+
+## 6. App-Guided Setup
+
+- [ ] 6.1 Update `docs/DESIGN.md` before implementation with reusable setup progress, blocker, resume, secret-output, and recovery patterns that follow existing Console and brand contracts.
+- [ ] 6.2 Add **Create Orchard on this Mac** for `all` and `controller` roles, composing lifecycle authorization, license validation, external Postgres preflight, public transport, migrations, first-admin initialization, internal node trust initialization, Console enablement, start, and readiness.
+- [ ] 6.3 Add **Join existing Orchard** for the `node-agent` role, composing bundle preview/import, trust validation, local key generation, registration, pending-admission status, rejection, and activation without UI-only mutations.
+- [ ] 6.4 Add resumable setup checkpoints that preserve completed work and return to the exact failed boundary after app restart.
+- [ ] 6.5 Add all-in-one, Controller-only, and Controller-plus-worker browser/app integration tests with accessibility and failure-state coverage.
+- [ ] 6.6 Validate zero manual root-owned env edits and zero static Controller target-list edits for the normal target paths.
+
+## 7. Managed Database Mode
+
+- [ ] 7.1 Implement the `SPEC.md` Managed Database Mode contract behind the same Controller setup preflight and retained-state model.
+- [ ] 7.2 Add backup, restore, health, startup ordering, upgrade, and recovery guidance before making Managed Database Mode the default all-in-one path.
+- [ ] 7.3 Keep External Database Mode available and explicit for Controller-plus-worker and advanced deployments.
+
+## 8. Coordinated Upgrade And Drain
+
+- [ ] 8.1 Compose upgrade preflight, cordon, drain, app-owned update or PKG update, certificate and transport recovery, health verification, and resume into one observable workflow.
+- [ ] 8.2 Preserve the `draining -> cordoned` cancel-drain recovery edge and never certify drain completion from a cancelled drain.
+- [ ] 8.3 Add Controller, Node Agent, model-transfer, certificate-renewal, and Active/Standby failure recovery tests.
+
+## 9. Acceptance Measurement
+
+- [ ] 9.1 Record manual file edits, root-authorized workflows, cross-Mac secret transfers, static target edits, machines touched, external prerequisites, and model staging operations for each topology.
+- [ ] 9.2 Measure complete elapsed and operator-active time-to-Console from verified app setup launch to authenticated Console readiness, with automated processing reported separately.
+- [ ] 9.3 Measure complete elapsed and operator-active time-to-first-worker-ready from bundle creation to a fresh healthy authenticated observation on an admitted Node, with administrator waiting and automated processing reported separately.
+- [ ] 9.4 Measure complete elapsed and operator-active time-to-first-inference from first Console readiness to successful Playground completion, with model-byte transfer, administrator waiting, and automated processing reported separately.
+- [ ] 9.5 Store sanitized measurement evidence in the implementation PR or issue rather than committing machine-specific logs or evidence documents.


### PR DESCRIPTION
## Intent

Create durable repo-owned Orchard operator-journey documentation and an OpenSpec shaping package that distinguish the current supported release-to-Console-and-inference journey from the target operator experience, quantify structural friction and measurement boundaries, make trust and recovery responsibilities explicit across all-in-one, controller-only, and controller-plus-worker topologies, and order coherent future slices without implementing product code. Preserve the current app-primary DMG lifecycle, external Postgres requirement, guided CLI sequencer, manual packaged BEAM cookie/target first cut, first-admin path, admission review, and model-staging limitations as current truth. Define a secure per-Node short-lived Node Enrollment Bundle that never carries a BEAM cookie or long-lived credential, recommend a CLI-first one-controller/one-node certificate-backed enrollment-to-active tracer before model distribution and app UI, reconcile SPEC section 10.6 so internal node trust initialization is separate from credential-only cluster init, and keep unfinished join, certificate bootstrap, dynamic targets, model distribution, Managed Database Mode, and app setup clearly labeled as target behavior.

## What Changed

- Added `docs/operator-journey.md` documenting the current supported release-to-Console-and-inference journey versus the target operator experience, with a structural friction baseline, measurement boundaries, and recovery responsibilities across all-in-one, controller-only, and controller-plus-worker topologies; linked it from the root `README.md` and `docs/README.md` operator indexes.
- Added the `operator-first-run-journey` OpenSpec shaping package (`proposal.md`, `design.md`, `tasks.md`, spec delta) defining a per-Node, short-lived Node Enrollment Bundle that never carries a BEAM cookie or long-lived credential, and ordering a CLI-first one-controller/one-node certificate-backed enrollment-to-active tracer ahead of model distribution and app UI, without changing product code.
- Reconciled `SPEC.md` §10.6 so internal node-trust initialization is an explicit operation separate from the credential-only `orchardctl cluster init` (§11.9), and added `Node Enrollment Bundle`, `Node Enrollment`, and `Install Role` glossary entries in `docs/glossary/CONTEXT.md`.

All OpenSpec strict validation passed (`operator-first-run-journey` change plus `--all`, 7 passed/0 failed) and the diff touches only docs, SPEC, and OpenSpec materials — no product code changed.

## Risk Assessment

✅ Low: Documentation-and-shaping-only change with no product code; the single normative SPEC edit reconciles §10.6 to already-existing credential-only cluster-init behavior, and all spot-checked CLI, file, and cross-reference claims are accurate and internally consistent.

## Testing

Because this is a docs/OpenSpec shaping change with no runtime surface, the meaningful gate is OpenSpec strict validation plus internal-consistency of the documentation and SPEC reconciliation. Strict validation passed for both the new change package and the full suite (7/7), the SPEC §10.6→§11.9 credential-only reconciliation is internally consistent, all doc cross-references resolve, and the diff is confined to SPEC.md/docs/openspec. I rendered docs/operator-journey.md to HTML and captured a full-page screenshot so a reviewer can see the actual three-layer journey documentation (current supported, target, and ordered gap-map slices) with all tables rendering correctly. Worktree left clean; transient temp files removed.

- Evidence: Rendered operator-journey documentation (full-page screenshot) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KX5G2YAZQGQVX4F5KTYDBR05/operator-journey-full.png</code>)
<details>
<summary>Evidence: Rendered operator-journey documentation (standalone HTML)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>Orchard Operator Journey</title>
<style>body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;max-width:900px;margin:2rem auto;padding:0 1.5rem;line-height:1.55;color:#1a1a1a}
table{border-collapse:collapse;width:100%;margin:1rem 0;font-size:.9rem}th,td{border:1px solid #ccc;padding:.4rem .6rem;text-align:left;vertical-align:top}
th{background:#f4f4f4}h1,h2,h3{line-height:1.2}h1{border-bottom:2px solid #2b7a3d}code{background:#f0f0f0;padding:.1rem .3rem;border-radius:3px}</style></head><body>
<h1>Orchard Operator Journey</h1>
<p>This document describes how an operator moves from Orchard release media to a usable Controller, an available Node Agent, and a successful inference request.
It deliberately separates current supported behavior from target product intent.
Detailed commands remain in the packaging runbooks and are linked instead of repeated here.</p>
<p><code>SPEC.md</code> remains the normative build contract.
This document is the durable journey and prioritization guide for closing the gap between that contract and the current build.</p>
<h2>Journey Vocabulary</h2>
<p>The product-facing action may say &quot;Add a worker&quot;, but the managed resource that enrolls is a <strong>Node</strong> running the <strong>Node Agent</strong>.
The <strong>Worker Runtime</strong> is a local MLX process supervised by that Node Agent and does not enroll independently.</p>
<p>A current Runtime Endpoint observation proves reachability only.
It does not prove Node identity, registration, admission, or scheduling authority.</p>
<p>The target journey keeps these states distinct:</p>
<ol>
<li>Orchard is installed for an Install Role.</li>
<li>A Node proves its identity and becomes <code>registered</code>.</li>
<li>An administrator admits the registered Node.</li>
<li>A fresh healthy authenticated observation makes the Node <code>active</code>.</li>
<li>A model is available and loaded on an eligible Runtime Endpoint.</li>
<li>A real inference request succeeds.</li>
</ol>
<h2>Layer 1: Current Supported Journey</h2>
<h3>Current Status Boundary</h3>
<p>The current app-primary DMG provides a verified <code>Orchard.app</code> and an app-owned root-authorized service lifecycle.
The app lifecycle supports <code>all</code>, <code>controller</code>, and <code>node-agent</code> Install Roles and preserves operator-owned state during update and default uninstall.
It does not yet provide an app setup wizard.</p>
<p>The packaged CLI provides <code>orchardctl init</code>, with <code>orchardctl first-run</code> as an alias, as a guided command sequencer for license validation, env-template generation, migration, local HTTPS, optional Console enablement, service start, and status.
The sequencer stops at a failed step and prints a resume command.
It does not collect an external Postgres DSN, edit BEAM identity or target values, create Node trust, distribute a shared cookie, import a model to remote Macs, or replace the separate <code>orchardctl cluster init</code> first-admin operation.</p>
<p>The current packaged multi-Mac path is a first-cut private-network deployment and rehearsal path.
It uses manually distributed shared BEAM cookie material and an explicit Controller target list.
<code>orchardctl node join</code>, Bootstrap Token exchange, Node Certificate issuance, and certificate-backed registration remain unfinished.
Admission review surfaces exist, but an observed unregistered endpoint cannot be admitted merely because it is reachable.</p>
<p>The authoritative current command details are in:</p>
<ul>
<li><a href="../packaging/dmg/README.md"><code>packaging/dmg/README.md</code></a> for DMG verification and the app-owned lifecycle.</li>
<li><a href="../packaging/pkg/README.md"><code>packaging/pkg/README.md</code></a> for packaged configuration, external Postgres, transport, licensing, Console, service start, and the current multi-Mac first cut.</li>
<li><a href="local-dev.md"><code>docs/local-dev.md</code></a> for source-development topology and diagnostics.</li>
</ul>
<h3>Common Prerequisites</h3>
<p>Before a current packaged Controller can reach Console, the operator needs:</p>
<ul>
<li>An Apple Silicon Mac and local administrator authorization for system service installation.</li>
<li>A valid Orchard license supplied outside the generic distribution artifact.</li>
<li>Operator-managed PostgreSQL 16 or newer because Managed Database Mode is not implemented.</li>
<li>A public transport plan using direct HTTPS, an operator-managed reverse proxy, or explicit local generated HTTPS for a lab.</li>
<li>A signed, notarized, stapled release-quality DMG and its checksum and signing sidecars.</li>
<li>Protected storage for one-time cluster-admin and inference credentials.</li>
</ul>
<p>A multi-Mac deployment also needs:</p>
<ul>
<li>Stable private IPv4 addresses on a trusted LAN or VPN.</li>
<li>Private reachability for EPMD and the bounded BEAM distribution ports.</li>
<li>A secure out-of-band channel for the shared BEAM cookie.</li>
<li>A Model Bundle that can be staged at a path usable by the selected Node Agent host.</li>
</ul>
<h3>Release Acquisition And Installation</h3>
<ol>
<li>Obtain the DMG distribution set and verify the checksum and mounted app trust evidence as described in the DMG runbook.</li>
<li>Copy <code>Orchard.app</code> to <code>/Applications</code> on every participating Mac.</li>
<li>Run the app-owned lifecycle helper with the required Install Role under explicit root authorization.</li>
<li>Treat the resulting state as installed but not configured because install deliberately starts no services.</li>
</ol>
<p>The same generic DMG is used on Controller and worker Macs.
The selected Install Role decides which LaunchDaemons are installed and managed.</p>
<h3>Topology Differences</h3>
<table>
<thead>
<tr>
<th>Path</th>
<th>Install Role</th>
<th>Console outcome</th>
<th>Inference outcome</th>
<th>Material current differences</th>
</tr>
</thead>
<tbody><tr>
<td>All-in-one</td>
<td><code>all</code></td>
<td>Available after Controller configuration, first-admin initialization, Console enablement, and service start.</td>
<td>Possible on the same Mac after Organization/API Token creation and local model import.</td>
<td>No cross-Mac cookie transfer or remote model path is needed, but external Postgres is still required in the current build.</td>
</tr>
<tr>
<td>Controller-only</td>
<td><code>controller</code></td>
<td>Available after the same Controller setup.</td>
<td>Not possible until at least one eligible Runtime Endpoint is configured and model-ready.</td>
<td>This path is useful for governance and Console setup but is not a complete first-inference topology.</td>
</tr>
<tr>
<td>Controller plus workers</td>
<td><code>controller</code> on the Controller and <code>node-agent</code> on each worker Mac.</td>
<td>Available after Controller setup.</td>
<td>Technically exercisable through the current private-network first cut after explicit targets and worker-reachable model staging, but it is not the finished certificate-backed join journey.</td>
<td>Every worker adds a root-owned env edit, shared-cookie delivery, private-network checks, an explicit Controller target entry, and model staging.</td>
</tr>
</tbody></table>
<h3>Controller To First Console Access</h3>
<p>The operator currently performs these outcomes, using the packaged runbook for commands:</p>
<ol>
<li>Activate or verify the Orchard license without placing it in command arguments, logs, or the release artifact.</li>
<li>Generate the Controller or all-role env template.</li>
<li>Set and validate the external <code>DATABASE_URL</code> and retain the generated <code>SECRET_KEY_BASE</code> unless deliberately rotating it.</li>
<li>Configure the Controller BEAM node name, cookie path, Runtime Endpoint targets when used, and public transport values.</li>
<li>Run migrations.</li>
<li>Run <code>orchardctl cluster init</code> with a protected output path to create the first cluster-admin API Client and one-time API Token.</li>
<li>Configure public HTTPS or a supported reverse proxy.</li>
<li>Enable Console through its interactive credential 

... [11844 bytes truncated] ...

with preserved decision history.</li>
<li>Node Certificate issuance, storage, renewal, or revocation failure.</li>
<li>Registered Node transport unreachable or runtime unhealthy.</li>
<li>External Postgres unavailable or migrations behind.</li>
<li>Model source unavailable, transfer interrupted, checksum mismatch, insufficient disk, or load failure.</li>
<li>Public transport or Console authentication misconfiguration.</li>
<li>Upgrade preflight blocked, drain incomplete, or post-update health verification failed.</li>
</ul>
<p>Retry after a lost registration response must resume only when the enrollment identifier, locally held Node key, and CSR fingerprint match the consumed attempt.
Different key material must fail closed.</p>
<h3>Target Friction And Time Budgets</h3>
<p>The following are shaping budgets for future acceptance tests, not current performance claims:</p>
<table>
<thead>
<tr>
<th>Measure</th>
<th>Target outcome</th>
</tr>
</thead>
<tbody><tr>
<td>Manual root-owned file edits for a normal all-in-one setup</td>
<td>0</td>
</tr>
<tr>
<td>Manual root-owned file edits for adding a worker</td>
<td>0</td>
</tr>
<tr>
<td>Shared cluster-secret transfers for adding a worker</td>
<td>0</td>
</tr>
<tr>
<td>Human admission decisions per worker</td>
<td>1 by default</td>
</tr>
<tr>
<td>Machine-to-machine enrollment artifacts</td>
<td>1 per worker, short-lived and one-use</td>
</tr>
<tr>
<td>Controller target-list edits per worker</td>
<td>0</td>
</tr>
<tr>
<td>Model imports per model version</td>
<td>1 per cluster</td>
</tr>
<tr>
<td>Setup restart after a recoverable failure</td>
<td>0, because setup resumes at the failed boundary</td>
</tr>
</tbody></table>
<p>Time measurements use these definitions:</p>
<ul>
<li><strong>Time-to-Console</strong> starts when a verified app first launches setup and ends when authenticated Console renders Controller readiness.</li>
<li><strong>Time-to-first-worker-ready</strong> starts when a Node Enrollment Bundle is created and ends when the admitted Node has a fresh healthy authenticated Runtime Endpoint observation.</li>
<li><strong>Time-to-first-inference</strong> starts when Console is first ready and ends when Playground receives a successful terminal response.</li>
<li><strong>Operator-active time</strong> is the portion of each named elapsed metric during which setup awaits required operator input or the operator performs a required action.</li>
<li>Model-byte transfer time and administrator waiting time are recorded separately so large artifacts and human delay do not hide workflow friction.</li>
</ul>
<p>Initial acceptance targets should be no more than 15 minutes of operator-active time across the full time-to-Console boundary, no more than 10 minutes of operator-active time across the full time-to-first-worker-ready boundary, and no more than 10 minutes of operator-active time across the full time-to-first-inference boundary.
Each result must also report the complete elapsed metric plus model transfer, automated processing, and administrator waiting components rather than substituting a shorter start or earlier end state.
Implementation PRs should validate these budgets on supported release hardware and record sanitized evidence in the PR or issue.</p>
<h2>Layer 3: Gap Map And Ordered Improvement Slices</h2>
<table>
<thead>
<tr>
<th align="right">Order</th>
<th>Slice</th>
<th>Operator value</th>
<th>Completion boundary</th>
</tr>
</thead>
<tbody><tr>
<td align="right">1</td>
<td>Secure one-Controller, one-Node enrollment tracer</td>
<td>Replaces manual identity bootstrap with a real trusted <code>provisioned -&gt; registered -&gt; admitted -&gt; active</code> path and gives existing admission UX a valid input.</td>
<td>One short-lived per-Node bundle, local key generation, pinned Controller connection, certificate-backed registration, explicit admission, dynamic target resolution, and authenticated healthy activation all work without a shared-cookie transfer or target-list edit.</td>
</tr>
<tr>
<td align="right">2</td>
<td>Enrollment hardening and production BEAM identity binding</td>
<td>Makes enrollment recoverable, revocable, renewable, multi-Node capable, and compatible with the selected first-party runtime transport.</td>
<td>Expiry cleanup, revocation, reissue, renewal, response-loss resume, Active/Standby behavior, and a node-bound revocable production BEAM credential design are accepted and tested.</td>
</tr>
<tr>
<td align="right">3</td>
<td>Controller-hosted model distribution</td>
<td>Removes per-worker model staging and makes cluster model readiness observable.</td>
<td>One verified Artifact Bundle import can be authorized, transferred, resumed, verified, placed, and loaded on selected admitted Nodes.</td>
</tr>
<tr>
<td align="right">4</td>
<td>First-inference Playground tracer</td>
<td>Turns infrastructure readiness into user-visible useful work.</td>
<td>Playground completes one request through an admitted active Node and exposes model, placement, selected Node, request state, and scheduler explanation.</td>
</tr>
<tr>
<td align="right">5</td>
<td>App-guided Controller and worker setup</td>
<td>Removes env editing and composes the stable CLI/domain operations into a coherent macOS experience.</td>
<td>App setup covers role authorization, prerequisite preflight, resumable progress, enrollment creation/import, admission status, model distribution progress, and first inference without UI-only mutation paths.</td>
</tr>
<tr>
<td align="right">6</td>
<td>Managed Database Mode</td>
<td>Removes the largest remaining Controller prerequisite for the all-in-one path.</td>
<td>Orchard provisions, starts, monitors, backs up, and upgrades its supported local Postgres mode according to <code>SPEC.md</code>.</td>
</tr>
<tr>
<td align="right">7</td>
<td>Coordinated upgrade and drain</td>
<td>Makes multi-Mac lifecycle maintenance safe and legible.</td>
<td>Preflight, cordon, drain, update, certificate/transport recovery, health verification, and resume are coordinated across the topology.</td>
</tr>
</tbody></table>
<h3>First Recommended Implementation Slice</h3>
<p>The next product-code PR should implement the secure enrollment tracer in slice 1.
It should remain CLI-first so the trust, persistence, retry, and lifecycle contracts stabilize before an app UI depends on them.</p>
<p>The tracer uses one Controller and one Node Agent and ends only when the Node is <code>active</code> through an authenticated Runtime Endpoint observation.
It does not include model transfer, Playground work, multi-Node bulk issuance, or broad setup UI.</p>
<p>The first authenticated runtime proof may make the existing gRPC compatibility adapter certificate-backed according to <code>SPEC.md</code> §10.6 because the adapter is already a supported Runtime Endpoint path.
The slice must add the missing mTLS listener, client credentials, CA validation, and Node-id/controller-id SAN validation rather than treating certificate backing as current behavior.
This does not change the packaged BEAM-first direction.
A later design must define node-bound, revocable production BEAM credentials before the enrolled product path uses BEAM without reintroducing a cluster-wide cookie as identity.</p>
<h3>Contract Impact</h3>
<p>The target journey is already supported by <code>SPEC.md</code> node trust, Node lifecycle, model distribution, packaging, Console, and milestone direction.
This shaping slice does not mirror the journey into <code>SPEC.md</code>.</p>
<p>One narrow contradiction does require reconciliation now.
<code>SPEC.md</code> §10.6 previously tied the internal Controller CA to <code>orchardctl cluster init</code>, while ADR 0011 and <code>SPEC.md</code> §11.9 define that command as credential-only.
Internal Node trust initialization or CA import must therefore be a distinct explicit operation.</p>
<p>No tactical <code>docs/DESIGN.md</code> update is needed until the app-guided setup slice defines reusable onboarding, progress, and recovery components.
No new ADR is needed until Orchard chooses a durable production BEAM credential mechanism or another hard-to-reverse transport-specific trust decision.</p>

</body></html>
```
</details>
<details>
<summary>Evidence: OpenSpec strict validation output</summary>

```text
✓ change/operator-first-run-journey
Totals: 7 passed, 0 failed (7 items)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate operator-first-run-journey --type change --strict --no-interactive` — passed (Change &#39;operator-first-run-journey&#39; is valid)</code>
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` — 7 passed, 0 failed</code>
- <code>Verified SPEC §10.6 node-trust reconciliation references §11.9&#39;s credential-only `orchardctl cluster init` (SPEC.md:3547 ↔ SPEC.md:3841) — internally consistent</code>
- `Confirmed all doc cross-links resolve: packaging/dmg/README.md, packaging/pkg/README.md, docs/local-dev.md, docs/operator-journey.md`
- `Confirmed diff touches only SPEC.md, docs/, and openspec/ — no product code changed`
- `Rendered docs/operator-journey.md to standalone HTML and captured a full-page screenshot of the documentation surface`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
