### PR TITLE
docs: define production BEAM-first Runtime Endpoint contract with scoped BEAM peer grants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,9 +93,9 @@ Rules:
 - **Language**: Elixir/OTP (umbrella app)
 - **Database**: Postgres (sole persistence + coordination layer)
 - **APIs**: `/v1/responses` (canonical abstraction), `/v1/chat/completions` (compatibility facade)
-- **Internal comms**: gRPC over mTLS
+- **Internal comms**: BEAM-first Runtime Endpoints for admitted first-party services; certificate-authenticated gRPC control and compatibility paths
 - **Packaging**: native macOS DMG/PKG + launchd
-- **Clustering**: Postgres advisory locks + gRPC heartbeats (Active/Standby control plane)
+- **Clustering**: Postgres advisory locks + authenticated Runtime Endpoint observations (Active/Standby control plane)
 - **Inference**: MLX-LM runtime adapter managed by the node agent (Apple Silicon native)
 
 ## Milestones

--- a/SPEC.md
+++ b/SPEC.md
@@ -3021,7 +3021,7 @@ create table beam_peer_grants (
   revoked_at timestamptz,
   inserted_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  unique (controller_id, node_id, generation),
+  unique (cluster_id, controller_id, node_id, purpose, generation),
   check (expires_at > not_before_at),
   check (cutover_at is null or cutover_at >= not_before_at),
   check (cutover_at is null or cutover_at <= expires_at)
@@ -3444,7 +3444,7 @@ create index idx_controller_instances_status_seen
   on controller_instances(status, last_seen_at desc nulls last);
 
 create index idx_beam_peer_grants_controller_node_generation
-  on beam_peer_grants(controller_id, node_id, generation desc);
+  on beam_peer_grants(cluster_id, controller_id, node_id, purpose, generation desc);
 
 create index idx_beam_peer_grants_state_expiry
   on beam_peer_grants(state, expires_at);

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,7 +51,10 @@ Supported deployment modes:
 * Accepted two-Mac smoke evidence SHALL remain recorded before and after BEAM Runtime Endpoint transport is promoted as the source-dev default.
 * When BEAM Runtime Endpoint transport is selected, Orchard MUST NOT retry the same request through gRPC compatibility as an automatic fallback.
 * Console live runtime diagnostics SHALL use the configured Runtime Endpoint target list; explicit BEAM Runtime Endpoint targets SHALL take precedence over legacy gRPC runtime client targets.
-* Production BEAM Distribution MUST be explicitly enabled, identity-bound, network-restricted, and fail closed when required admission configuration is missing.
+* Production first-party BEAM Distribution MUST use OTP TLS distribution, exact Node and Controller Certificate validation, trusted inventory, and an active Controller-to-Node BEAM Peer Grant.
+* A Node Certificate is the durable Node identity anchor; a BEAM Peer Grant is bounded transport authorization and MUST NOT be treated as Node identity.
+* Production BEAM MUST NOT use one shared cluster cookie as identity or authorization.
+* Production BEAM MUST be explicitly enabled, network-restricted, limited to admitted first-party Orchard services, and fail closed when certificate, inventory, Peer Grant, or admission state is missing or invalid.
 * BEAM Runtime Endpoint targets MUST carry a valid BEAM node-name address (`service@host`) as an atom or binary; a configured `node_id`, when present, MUST be a UUID and MUST match observed endpoint metadata before scheduler or dispatch may trust that candidate identity.
 * External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 * All public API traffic SHALL terminate at the controller.
@@ -86,8 +89,8 @@ Supported deployment modes:
                                |           |
                      +---------v--+   +---v---------------------------+
                      | Postgres    |   | Runtime Endpoint Adapter(s) |
-                     | durable DB  |   | - current gRPC compatibility|
-                     +------------ +   | - default-off BEAM          |
+                     | durable DB  |   | - first-party BEAM          |
+                     +------------ +   | - gRPC compatibility        |
                                        | - future external/provider  |
                                        +---+-------------------------+
                                            |
@@ -276,6 +279,18 @@ Standby controller behavior:
 * MAY serve `GET /health/live`
 * SHALL return `503 controller_standby` for write paths if directly addressed
 * SHALL not schedule, dispatch, or mutate cluster runtime state
+
+Each single-controller or Active/Standby Controller instance SHALL have a durable Controller-instance record containing:
+
+* stable `controller_id` UUID
+* Controller Certificate URI SAN, certificate identifier, and fingerprint
+* canonical production Controller BEAM node name
+* BEAM Authorization Root custody reference, never the root value
+* instance status
+* first-enrolled and last-seen timestamps
+
+Controller-instance identity is durable cluster truth.
+Advisory-lock leadership is transient and SHALL NOT be conflated with Controller-instance identity.
 
 Leader controller behavior:
 
@@ -607,12 +622,16 @@ A node record SHALL include:
 * stable `node_id` UUID
 * hostname
 * advertise address
+* canonical production BEAM node name after validated private IPv4 inventory exists
 * pool membership
 * chip/memory/runtime capabilities
 * trust material reference
 * lifecycle state
 * current health
 * last heartbeat timestamp
+
+A Node's canonical production BEAM node name SHALL be null until validated private IPv4 inventory is recorded.
+Node Admission SHALL NOT authorize a Peer Grant, and no production Runtime Endpoint target or `admitted -> active` BEAM authorization SHALL proceed, while that canonical name is absent or unvalidated.
 
 Runtime Endpoint metadata MAY be observed before a trusted Node exists.
 An unreconciled first observation SHALL create or update a Runtime Endpoint Admission Candidate for admin review, not a Node row.
@@ -915,6 +934,8 @@ Node agent SHALL:
 * register with controller
 * renew node certificate
 * heartbeat every 2s
+* retrieve, protect, stage, rotate, and revoke scoped BEAM Peer Grants for admitted production connections
+* expose the first-party Runtime Endpoint through production TLS distribution after certificate and Peer Grant authorization succeeds
 * expose the current gRPC Runtime Endpoint compatibility service
 * download/verify model artifacts
 * manage worker subprocess lifecycle
@@ -1621,7 +1642,8 @@ The platform SHALL expose four API surfaces:
 4. **Runtime Endpoint and Worker Interfaces**
 
    * controller↔Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, and Placement Capacity
-   * current first implementation uses the gRPC Compatibility Adapter over mTLS
+   * admitted first-party production Controller and Node Agent services use the BEAM Runtime Endpoint adapter under the production identity and authorization contract in §7.5 and §10.6
+   * the certificate-backed gRPC Compatibility Adapter remains an explicit compatibility, diagnostics, recovery, external-adapter, and operator opt-out path
    * Worker Runtime Interface remains local to the Node Agent
 
 ---
@@ -2256,6 +2278,125 @@ External Runtime Endpoints MUST NOT join the first-party BEAM mesh.
 Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling history, request state, and operator-visible status.
 BEAM Distribution MUST NOT be treated as durable cluster truth.
 
+#### 7.5.0 Production first-party BEAM identity and authorization
+
+The Production BEAM Operating Model SHALL use OTP TLS distribution with explicit peer verification on both endpoints.
+The accepting endpoint SHALL require a peer certificate.
+The Controller SHALL validate the exact Node-ID URI SAN, certificate identifier, serial, fingerprint, and internal trust authority recorded for the Node.
+The Node Agent SHALL validate the exact Controller-ID URI SAN, certificate identifier, fingerprint, and enrolled internal trust authority recorded for the Controller instance.
+TLS certificate validation is necessary but SHALL NOT be treated as complete OTP distribution authorization.
+
+Each production distribution relationship SHALL also require one active BEAM Peer Grant scoped to:
+
+* contract version and purpose
+* cluster ID
+* Controller ID and canonical Controller BEAM name
+* Controller Certificate identifier and fingerprint
+* Node ID and canonical Node BEAM name
+* Node Certificate identifier and fingerprint
+* Controller BEAM Authorization Root ID
+* grant ID and generation
+* issue, not-before, cutover, and expiry times
+
+Each Controller instance SHALL own a distinct BEAM Authorization Root containing at least 256 bits of random key material.
+The root SHALL be separate from the node-signing CA, Controller Certificate private key, database credentials, and other cluster secrets.
+It SHALL be stored in macOS Keychain or an owner-only Controller path, SHALL never be stored in Postgres, and SHALL never be delivered to a Node.
+
+The Controller SHALL derive the encoded Peer Grant secret with HMAC-SHA-256 over a versioned, length-delimited canonical encoding of the complete immutable grant scope.
+Only Controller-approved active or staged grant records may cause the encoded value to be converted to the cookie atom required by OTP.
+Externally supplied or otherwise untrusted values MUST NOT create atoms.
+
+A BEAM Peer Grant record SHALL include:
+
+* stable `grant_id` UUID and monotonically increasing pair generation
+* cluster ID, Controller ID, canonical Controller BEAM name, Controller Certificate identifier and fingerprint, and BEAM Authorization Root ID
+* Node ID, canonical Node BEAM name, and Node Certificate identifier and fingerprint
+* contract version and purpose
+* issue, not-before, cutover, and expiry timestamps
+* lifecycle state
+* delivery, activation, supersession, failure, and revocation evidence
+* SHA-256 hash of the encoded secret
+
+The closed grant lifecycle states SHALL be `pending_delivery`, `staged`, `active`, `superseded`, `revoked`, `expired`, and `delivery_failed`.
+Only `active` authorizes ordinary new connections.
+`staged` authorizes only its scheduled cutover, and all other states SHALL fail closed for new connections.
+Postgres SHALL NOT store the plaintext Peer Grant or BEAM Authorization Root.
+
+The initial Peer Grant validity SHALL default to 30 days, with normal rotation beginning 7 days before expiry.
+Only one active generation and at most one staged successor generation may exist for an exact Controller-to-Node pair.
+A database uniqueness constraint SHALL enforce at most one `active` and at most one `staged` generation per exact `(cluster_id, controller_id, node_id, purpose)` scope.
+Normal generation creation SHALL be rate-limited to no more than once per hour per pair so legitimate rotation cannot cause unbounded OTP atom creation.
+
+The Node Admission state transition, its Node Admission Decision and audit event, and one initial `pending_delivery` Peer Grant record for each currently eligible Controller instance SHALL commit in one Postgres transaction.
+If any part cannot be persisted, admission SHALL fail closed with no partial admission and no orphaned grant metadata.
+A Controller instance enrolled after Node Admission SHALL obtain its initial grant metadata through a separate leader-authorized operation that is itself atomic.
+A registered but unadmitted Node SHALL receive no production Peer Grant.
+The Node SHALL retrieve the exact Controller's authorized grant through certificate-authenticated control traffic and store it atomically in its owner-only identity root.
+Lost delivery responses SHALL return the same authorized generation and derived secret after identity, certificate, admission, generation, and expiry are revalidated.
+
+Normal rotation SHALL stage the successor on both endpoints, cut over at an agreed time, deliberately disconnect the old distribution connection, and require the successor generation on reconnect.
+Revocation SHALL update Postgres authority immediately, replace the exact-name cookie mapping, exclude the Runtime Endpoint from scheduling and queue capacity, disconnect the peer, and append a sanitized cluster-scoped audit event.
+Revocation SHALL remain visibly incomplete until disconnection succeeds or the affected distribution process is restarted.
+`net_kernel:allow/1` SHALL NOT be treated as a revocation mechanism.
+
+Node or Controller Certificate renewal SHALL require a new Peer Grant generation bound to the renewed certificate identifier and fingerprint.
+Because certificate identity and fingerprint are part of the immutable grant scope, certificate-renewal cadence necessarily drives Peer Grant rotation and a staged reconnect.
+Re-admission SHALL require a new grant ID and generation after current trust and admission requirements succeed.
+Decommission SHALL revoke every Peer Grant involving the Node, revoke the Node Certificate, disconnect the Node from every reachable Controller, and prevent reuse of the same Node ID, canonical BEAM name, certificate, or grant.
+Loss or compromise of a BEAM Authorization Root SHALL stop new authorization under that root until the root is restored or replaced and every affected pair is reissued through certificate-authenticated control traffic.
+
+Each Active/Standby Controller instance SHALL have a distinct stable Controller ID, Controller Certificate URI SAN, canonical BEAM name, BEAM Authorization Root, and Peer Grant with each admitted Node.
+Active and Standby Controllers SHALL NOT share pair grants.
+Both Controllers MAY keep authenticated distribution connections for liveness, status, and explicitly read-only diagnostics.
+Only the Active Leader may initiate inference execution, model mutation, cancellation, or lifecycle writes, enforced by the Postgres advisory-lock write gate before the operation leaves the Controller.
+A Peer Grant proves Controller-instance membership, not advisory-lock leadership.
+The Node Agent cannot cryptographically prove that a connected Controller owns the Postgres advisory lock, and Orchard MUST NOT claim otherwise through a certificate, cookie, or Node-local leader flag.
+
+Canonical production Node Agent names SHALL use `orchard_node_agent_<node-id-without-hyphens>@<private-ipv4>`.
+Canonical Controller names SHALL use `orchard_controller_<controller-id-without-hyphens>@<private-ipv4>`.
+The complete UUID SHALL be used to avoid short-ID collisions.
+The enrolled product path SHALL derive those names and targets from trusted inventory and SHALL NOT require an operator-maintained static target list.
+An address or name match alone SHALL NOT establish identity, admission, or Peer Grant authority.
+Changing the advertised address changes the canonical BEAM name and SHALL require a certificate-authenticated inventory update, a new Peer Grant, and deliberate reconnect.
+Static target overrides MAY remain for documented source-development and explicit compatibility operation, but SHALL NOT establish product trust.
+
+Distributed Erlang membership is a high-trust code boundary, not a per-function capability sandbox.
+A scoped Peer Grant reduces credential blast radius and cross-Node impersonation, but it does not restrict an authenticated peer to individual Runtime Endpoint functions.
+Production BEAM SHALL therefore be limited to signed first-party Orchard releases on operator-controlled admitted Macs inside restricted private networks.
+External providers, third-party adapters, tenant-controlled compute, and partially trusted machines SHALL remain outside the BEAM mesh.
+
+The initial stable operator-facing production BEAM failure vocabulary SHALL include:
+
+* `beam_target_not_in_trusted_inventory`
+* `beam_target_not_admitted`
+* `beam_peer_certificate_invalid`
+* `beam_peer_identity_mismatch`
+* `beam_peer_name_not_authorized`
+* `beam_peer_grant_missing`
+* `beam_peer_grant_not_active`
+* `beam_peer_grant_expired`
+* `beam_peer_grant_revoked`
+* `beam_peer_grant_generation_mismatch`
+* `beam_peer_credential_mismatch`
+* `beam_peer_disconnect_incomplete`
+* `beam_peer_rotation_incomplete`
+* `beam_distribution_disabled`
+* `beam_distribution_unavailable`
+* `beam_target_invalid`
+* `beam_target_unknown`
+* `beam_node_unavailable`
+* `beam_node_timeout`
+* `beam_rpc_failed`
+
+These failures SHALL be visible through shared operator diagnostics without exposing certificates, grant values, hashes, local paths, or raw OTP exception terms.
+The current adapter outcomes `unknown_beam_node`, `node_unavailable`, `node_timeout`, and `beam_rpc_error` SHALL normalize to `beam_target_unknown`, `beam_node_unavailable`, `beam_node_timeout`, and `beam_rpc_failed` before reaching CLI, Console, support bundles, or tests.
+Transport and liveness failures SHALL remain distinguishable from Peer Grant and certificate failures.
+When BEAM is selected, none of these failures may cause the same Runtime Endpoint operation to retry through gRPC compatibility.
+Certificate and Peer Grant recovery through the explicitly selected gRPC/mTLS control path is not an inference fallback.
+
+The gRPC/mTLS path SHALL remain available for enrollment, Node and Controller Certificate lifecycle, Peer Grant delivery and recovery, diagnostics, explicit Runtime Endpoint compatibility, future external or non-BEAM adapters, and explicit operator opt-out.
+The Python/MLX Worker Runtime SHALL remain a Node Agent-local subprocess and SHALL NOT receive Node Certificates, BEAM Peer Grants, or BEAM membership.
+
 Definitions:
 
 * **Runtime Endpoint**: the scheduler-selected execution boundary that can receive model runtime work from the Controller.
@@ -2728,6 +2869,16 @@ create type node_admission_decision_kind as enum (
   'admitted'
 );
 
+create type beam_peer_grant_state as enum (
+  'pending_delivery',
+  'staged',
+  'active',
+  'superseded',
+  'revoked',
+  'expired',
+  'delivery_failed'
+);
+
 create type worker_state as enum (
   'starting',
   'idle',
@@ -2799,6 +2950,7 @@ create table nodes (
   hostname text not null,
   display_name text not null unique,
   advertise_addr text not null,
+  canonical_beam_name text,
   rpc_port integer not null default 9444,
   state node_state not null default 'provisioned',
   health node_health not null default 'unreachable',
@@ -2817,6 +2969,62 @@ create table nodes (
   decommission_reason text,
   inserted_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
+);
+
+create table controller_instances (
+  id uuid primary key,
+  certificate_uri_san text not null unique,
+  certificate_identifier text not null,
+  certificate_fingerprint_sha256 text not null,
+  canonical_beam_name text not null unique,
+  beam_authorization_root_id uuid not null unique,
+  authorization_root_custody_ref text not null,
+  status text not null check (
+    status in ('enrolled', 'operational', 'recovery_required', 'retired')
+  ),
+  first_enrolled_at timestamptz not null,
+  last_seen_at timestamptz,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table beam_peer_grants (
+  id uuid primary key default gen_random_uuid(),
+  generation bigint not null check (generation > 0),
+  cluster_id uuid not null,
+  controller_id uuid not null references controller_instances(id),
+  controller_beam_name text not null,
+  controller_certificate_identifier text not null,
+  controller_certificate_fingerprint_sha256 text not null,
+  beam_authorization_root_id uuid not null,
+  node_id uuid not null references nodes(id),
+  node_beam_name text not null,
+  node_certificate_identifier text not null,
+  node_certificate_fingerprint_sha256 text not null,
+  contract_version integer not null check (contract_version > 0),
+  purpose text not null,
+  state beam_peer_grant_state not null default 'pending_delivery',
+  secret_hash bytea not null check (octet_length(secret_hash) = 32),
+  issued_at timestamptz not null,
+  not_before_at timestamptz not null,
+  cutover_at timestamptz,
+  expires_at timestamptz not null,
+  delivery_evidence jsonb not null default '{}'::jsonb,
+  activation_evidence jsonb not null default '{}'::jsonb,
+  supersession_evidence jsonb not null default '{}'::jsonb,
+  failure_evidence jsonb not null default '{}'::jsonb,
+  revocation_evidence jsonb not null default '{}'::jsonb,
+  delivered_at timestamptz,
+  activated_at timestamptz,
+  superseded_at timestamptz,
+  failed_at timestamptz,
+  revoked_at timestamptz,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (controller_id, node_id, generation),
+  check (expires_at > not_before_at),
+  check (cutover_at is null or cutover_at >= not_before_at),
+  check (cutover_at is null or cutover_at <= expires_at)
 );
 
 create table node_heartbeats (
@@ -3095,6 +3303,13 @@ They MUST NOT contain plaintext secrets, credentials, DSNs, prompt bodies, respo
 `target_ref` and `endpoint_target` are operator-review references only and SHALL NOT prove Node identity ownership.
 No uniqueness or reconciliation decision SHALL depend on `target_ref` or `endpoint_target` alone.
 
+`controller_instances` SHALL store durable Controller membership identity and only an opaque local custody reference for the BEAM Authorization Root.
+The custody reference SHALL NOT contain the root value, a recoverable encoding of the root, credentials, or machine-specific path details exposed through operator surfaces.
+
+The immutable `beam_peer_grants` scope columns SHALL not change after insert.
+Lifecycle transitions SHALL update only state, bounded sanitized evidence, transition timestamps, and `updated_at`.
+Grant evidence SHALL NOT contain the plaintext secret, root material, certificate private keys, raw OTP exception terms, or local custody paths.
+
 `node_admission_decisions` SHALL store durable admission decisions for rejection, rejection clearance, and admission after rejection.
 A rejection SHALL write `decision = 'rejected'`, actor, decided timestamp, reason, observed identity or node reference, target reference when applicable, and `audit_log_id`.
 Clearing a rejection SHALL write `decision = 'rejection_cleared'` and a related audit event.
@@ -3221,6 +3436,27 @@ create index idx_node_admission_decisions_audit_log
   on node_admission_decisions(audit_log_id)
   where audit_log_id is not null;
 
+create unique index idx_nodes_canonical_beam_name
+  on nodes(canonical_beam_name)
+  where canonical_beam_name is not null;
+
+create index idx_controller_instances_status_seen
+  on controller_instances(status, last_seen_at desc nulls last);
+
+create index idx_beam_peer_grants_controller_node_generation
+  on beam_peer_grants(controller_id, node_id, generation desc);
+
+create index idx_beam_peer_grants_state_expiry
+  on beam_peer_grants(state, expires_at);
+
+create unique index idx_beam_peer_grants_one_active
+  on beam_peer_grants(cluster_id, controller_id, node_id, purpose)
+  where state = 'active';
+
+create unique index idx_beam_peer_grants_one_staged
+  on beam_peer_grants(cluster_id, controller_id, node_id, purpose)
+  where state = 'staged';
+
 create index idx_model_placements_node_state
   on model_placements(node_id, state);
 
@@ -3292,6 +3528,8 @@ create index idx_audit_logs_cluster_occurred_at
 * `node_heartbeats`: 7 days
 * `node_admission_candidates`: unresolved candidates until admin resolution; resolved candidate metadata 90 days minimum
 * `node_admission_decisions`: 365 days minimum
+* `controller_instances`: retained while enrolled or referenced by retained Peer Grant history
+* `beam_peer_grants`: pending, staged, and active records retained; terminal lifecycle history 365 days minimum
 * `request_events`: 30 days
 * `requests`: 90 days metadata minimum
 * `audit_logs`: 365 days minimum
@@ -3536,13 +3774,17 @@ Supported join modes:
 
 ### 10.6 Internal transport
 
-Certificate-backed node lifecycle RPC and current gRPC compatibility transports SHALL use:
+Certificate-backed node lifecycle RPC, production first-party BEAM Distribution, and current gRPC compatibility transports SHALL use:
 
 * TLS 1.3
 * mutual TLS
 * controller CA generated through an explicit node-trust initialization operation or imported by admin
 * SAN validation against node id / controller id
 * certificate renewal before expiry
+
+Production first-party BEAM Distribution SHALL additionally enforce the BEAM Peer Grant contract in §7.5.0.
+Certificate identity alone SHALL NOT authorize a production OTP distribution connection.
+Current source-development and packaged first-cut shared-cookie behavior SHALL remain visibly transitional until the enrolled Production BEAM Operating Model passes its required packaged acceptance.
 
 The internal node-trust initialization operation SHALL remain separate from `orchardctl cluster init`, which is credential-only per §11.9.
 
@@ -4172,7 +4414,8 @@ Deliver:
 Acceptance:
 
 * node join via bootstrap produces signed cert
-* internal gRPC rejects non-mTLS clients
+* internal gRPC compatibility rejects non-mTLS clients
+* production first-party BEAM rejects missing, expired, revoked, wrong-generation, wrong-name, wrong-certificate, and wrong-identity Peer Grant connections without automatic gRPC fallback
 * air-gapped installation completes with no internet access
 
 ### Milestone 7 - Upgrade safety and Active/Standby controller

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,8 +56,8 @@ Public clients
   -> Controller (Phoenix/Elixir public APIs, Console, admission, scheduling)
      -> Postgres for durable state and coordination
      -> Runtime Endpoint Interface
-        -> first-party BEAM adapter as the split-role source-dev and packaged external-sites default
-        -> gRPC compatibility adapter as the explicit opt-out path
+        -> first-party BEAM adapter as the split-role source-dev default and enrolled production target
+        -> gRPC compatibility adapter as the explicit control, recovery, diagnostics, external-adapter, and opt-out path
         -> future external/provider adapters
      -> Node Agent(s)
         -> Worker Runtime subprocesses for local MLX inference
@@ -70,16 +70,34 @@ Core design rules from `SPEC.md`:
 - token streams pass through the controller;
 - the Controller dispatches model runtime work through the Runtime Endpoint Interface;
 - the current `NodeRuntimeService` gRPC/protobuf path is a compatibility adapter, not the durable domain contract;
-- first-party BEAM communication is the split-role source-dev and packaged external-sites default behind explicit guardrails;
+- first-party BEAM communication is the split-role source-dev default and the enrolled production target behind explicit guardrails;
 - split-role source dev uses BEAM by default through `bin/dev-controller` and `bin/dev-node-agent` launches;
 - gRPC remains available as an explicit opt-out compatibility adapter with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`;
 - all-in-one `bin/dev` remains the single-host gRPC default and rejects explicit BEAM mode;
 - source-dev BEAM mode does not automatically fall back to gRPC compatibility for the same request;
 - Console live runtime diagnostics use the same configured Runtime Endpoint target list as scheduler and dispatch, with explicit BEAM targets taking precedence over legacy gRPC runtime client targets;
 - BEAM Runtime Endpoint targets validate BEAM node-name addresses and configured node UUIDs before scheduler or dispatch trusts endpoint identity;
+- production BEAM uses OTP TLS distribution plus one scoped BEAM Peer Grant for each exact Controller-to-Node pair;
+- Node Certificates remain durable identity anchors, while BEAM Peer Grants provide bounded transport authorization and never replace Node Admission;
+- each Active/Standby Controller has a distinct identity, BEAM name, authorization root, and Peer Grant with each admitted Node;
+- a Peer Grant proves Controller-instance membership, not advisory-lock leadership, so leader-only operations remain gated by Postgres before leaving the Controller;
+- distributed Erlang membership is a high-trust code boundary rather than a per-function capability sandbox;
 - node agents are the v1 first-party Runtime Endpoint boundary;
 - worker runtimes are local subprocesses, not public services;
 - Postgres remains durable truth for inventory, lifecycle state, Runtime Endpoint Observations, scheduling, and request state.
+
+The current packaged multi-Mac first cut remains transitional.
+It still uses one manually distributed shared cookie and explicit Controller target entries until the enrolled production Peer Grant path is implemented and passes packaged acceptance.
+The source-development shared-cookie model remains separately documented and does not establish production Node identity or authorization.
+
+In the enrolled production model, Postgres stores durable Controller-instance identity and one closed-state Peer Grant record per authorized Controller-to-Node pair.
+Node Admission, its decision and audit event, and the initial `pending_delivery` grant records commit atomically before asynchronous certificate-authenticated delivery begins.
+Each Controller derives only its own pair secrets from a protected Controller-local BEAM Authorization Root, while Postgres stores the grant scope, lifecycle, and a hash rather than the plaintext secret.
+The Node retrieves the grant over certificate-authenticated control traffic, stores it in protected local identity state, and uses it with exact certificate validation to form the TLS distribution connection.
+Rotation and revocation deliberately disconnect the old connection because OTP does not expire cookies or terminate established peers when certificate, allowlist, or grant state changes.
+
+BEAM connection failure remains visible and never retries the same Runtime Endpoint operation through gRPC.
+The gRPC/mTLS path remains available for enrollment, certificate lifecycle, Peer Grant delivery and recovery, diagnostics, explicit compatibility mode, future external adapters, and operator opt-out.
 
 ## Repository map
 

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -4,6 +4,7 @@
 
 Accepted.
 Source-dev split-role default promoted on 2026-07-05.
+Production identity and authorization are refined by [ADR 0012](0012-scoped-beam-peer-grants.md).
 
 ## Context
 
@@ -29,6 +30,7 @@ Use BEAM Distribution for guarded live first-party communication, monitoring, an
 Persist Runtime Endpoint Observations in Postgres for inventory, lifecycle, availability, scheduling, and operator-visible history.
 A connected BEAM node is not automatically schedulable.
 Production BEAM Distribution must be explicitly configured, identity-bound, network-restricted, and limited to admitted first-party Orchard services.
+For enrolled production services, identity-bound means exact certificate validation plus an exact Controller-to-Node BEAM Peer Grant under ADR 0012, not a shared cookie or certificate-only OTP authorization.
 External Runtime Endpoints must not join the BEAM mesh.
 
 Keep the Runtime Endpoint Interface independent of a transport protocol.

--- a/docs/decisions/0012-scoped-beam-peer-grants.md
+++ b/docs/decisions/0012-scoped-beam-peer-grants.md
@@ -1,0 +1,146 @@
+# ADR: Production BEAM uses scoped Peer Grants
+
+## Status
+
+Accepted on 2026-07-12.
+
+## Context
+
+ADR 0001 selects BEAM Distribution as Orchard's preferred live transport between admitted first-party Controller and Node Agent services.
+PR #87 established Node Certificates with exact Node-ID and Controller-ID URI SAN validation as Orchard's durable internal identity anchors.
+The packaged BEAM first cut still uses one manually distributed shared cookie and explicit target lists, which cannot provide per-Node authorization, rotation, or revocation.
+
+Erlang/OTP 29 TLS distribution can validate certificate chains and certificate properties, and `net_kernel` can restrict claimed node names.
+Those checks do not form one supported public hook that atomically correlates the peer certificate's Orchard identity, the claimed BEAM node name, and current Orchard admission state.
+OTP distribution also always requires cookie authentication, `net_kernel:allow/1` is append-only, and neither certificate nor allowlist changes terminate an established connection.
+The OTP cookie is therefore unavoidable transport authorization material, even though it must not become durable Node identity.
+
+## Decision
+
+Production first-party BEAM SHALL use OTP TLS distribution plus a scoped BEAM Peer Grant.
+The Node Certificate remains the sole durable Node identity credential.
+The BEAM Peer Grant authorizes one exact Controller instance and one exact admitted Node to form an OTP distribution connection for a bounded generation and time interval.
+Neither the certificate nor the Peer Grant authorizes the connection alone.
+
+The effective authorization decision is the conjunction of:
+
+- exact Node and Controller Certificate validation;
+- exact trusted-inventory BEAM names and addresses;
+- an exact per-name Peer Grant cookie on both endpoints;
+- current admitted grant state in Postgres;
+- restricted private-network policy;
+- explicit disconnection when authorization is revoked or replaced.
+
+A BEAM Peer Grant SHALL be scoped to a version, purpose, cluster ID, Controller ID and BEAM name, Node ID and BEAM name, both certificate identifiers and fingerprints, authorization-root ID, grant ID, generation, issue time, not-before time, cutover time, and expiry time.
+The initial grant validity SHALL default to 30 days with normal rotation beginning 7 days before expiry.
+Only one active generation and at most one staged successor generation may exist for an exact Controller-to-Node pair.
+Normal generation creation SHALL be rate-limited to protect the non-garbage-collected OTP atom table.
+
+Each Controller instance SHALL own an independent BEAM Authorization Root with at least 256 bits of random key material.
+The root SHALL remain separate from the node-signing CA, Controller Certificate private key, database credentials, and other cluster secrets.
+It SHALL live in macOS Keychain or an owner-only Controller path and SHALL never be stored in Postgres or delivered to a Node.
+
+The Controller SHALL derive the Peer Grant secret using HMAC-SHA-256 over a versioned, length-delimited canonical encoding of the complete immutable grant scope.
+The encoded result SHALL be converted to an OTP cookie atom only from Controller-approved grant metadata.
+Untrusted or externally supplied values SHALL never create atoms.
+Postgres SHALL store the complete non-secret scope, closed lifecycle state, timestamps, delivery and activation evidence, and a SHA-256 hash of the encoded secret, never the plaintext Peer Grant or authorization root.
+The lifecycle states are `pending_delivery`, `staged`, `active`, `superseded`, `revoked`, `expired`, and `delivery_failed`.
+Only `active` authorizes ordinary new connections, while `staged` authorizes only its scheduled cutover.
+
+The admission transition, decision, audit event, and one `pending_delivery` grant record per currently eligible Controller SHALL commit in one Postgres transaction or fail closed without partial state.
+A Controller enrolled after admission SHALL obtain its grant through a separate leader-authorized atomic operation.
+The Node SHALL retrieve each grant over certificate-authenticated control traffic only after explicit admission.
+The Node SHALL store the plaintext grant atomically in its owner-only identity root, separately for each exact Controller ID and BEAM name.
+Lost delivery responses SHALL be safely retryable because the same authorized generation derives the same secret.
+A registered but unadmitted Node SHALL receive no production BEAM Peer Grant.
+
+Rotation SHALL stage the successor on both endpoints, cut over at the agreed time, deliberately disconnect the existing distribution connection, and require the successor generation on reconnect.
+Revocation SHALL update Postgres authority immediately, replace the exact-name cookie mapping, disconnect the peer, exclude its Runtime Endpoint from scheduling and queue capacity, and append a sanitized cluster-scoped audit event.
+Revocation SHALL remain visibly incomplete until disconnection succeeds or the affected distribution process is restarted.
+`net_kernel:allow/1` SHALL NOT be treated as a revocation mechanism.
+
+Certificate renewal SHALL create a new Peer Grant generation bound to the renewed certificate identifiers and fingerprints.
+Certificate renewal therefore drives Peer Grant rotation and a staged reconnect.
+Re-admission SHALL create a new grant ID and generation after current trust and admission requirements succeed.
+Decommission SHALL revoke every Peer Grant involving the Node, revoke its Node Certificate, disconnect it from every reachable Controller, and prevent reuse of the same Node ID, BEAM name, certificate, or grant.
+Loss of a Controller's BEAM Authorization Root SHALL require explicit root recovery or creation of a new root followed by reissuance of every affected pair through certificate-authenticated control traffic.
+
+## Active/Standby Controllers
+
+Each Controller instance SHALL have a distinct stable Controller ID, Controller Certificate URI SAN, BEAM node name, BEAM Authorization Root, and Peer Grant with each admitted Node.
+Active and Standby Controllers SHALL never share a Controller-to-Node Peer Grant.
+Both Controllers may keep authenticated distribution connections for liveness, status, and explicitly read-only diagnostics.
+Only the Active Leader may initiate inference execution, model mutation, cancellation, or lifecycle writes, enforced by the existing Postgres advisory-lock write gate before the operation leaves the Controller.
+
+A Peer Grant proves Controller-instance membership, not current leadership.
+The Node Agent cannot cryptographically prove that a connected Controller holds the Postgres advisory lock.
+Orchard SHALL NOT invent a certificate field, cookie field, or Node-local leader flag that claims otherwise.
+Failover SHALL require the promoted Controller to prove leadership through the Controller write gate before runtime mutation, but it SHALL NOT require Node re-enrollment or a new Peer Grant.
+
+## Trusted Names And Targets
+
+The enrolled product path SHALL derive canonical BEAM names and targets from trusted Controller and Node inventory.
+Node Agent names SHALL use the complete Node ID without hyphens in the service component and the validated private IPv4 address in the host component.
+Controller names SHALL use the complete Controller ID without hyphens in the service component and the validated private IPv4 address in the host component.
+An address or BEAM name match alone SHALL never establish identity, admission, or Peer Grant authority.
+Changing an advertised address changes the canonical BEAM name and requires a certificate-authenticated inventory update, a new Peer Grant, and deliberate reconnect.
+
+Static target lists and shared cookies MAY remain in the documented Source-dev BEAM Operating Model and explicit compatibility paths.
+They SHALL NOT establish trust or authorization for the enrolled Production BEAM Operating Model.
+
+## High-trust boundary
+
+Distributed Erlang membership is a high-trust code boundary, not a per-function capability sandbox.
+A scoped Peer Grant reduces credential blast radius and cross-Node impersonation, but it does not restrict an authenticated peer to the `Orchard.Node.RuntimeEndpoint` facade.
+The current BEAM adapter uses `:rpc.call`, and a connected peer can exercise broader distributed Erlang primitives.
+
+Production BEAM is therefore limited to signed first-party Orchard releases on operator-controlled, admitted Macs inside restricted private networks.
+External providers, third-party adapters, tenant-controlled compute, and partially trusted machines SHALL remain outside the BEAM mesh and use gRPC/mTLS or another explicit protocol adapter.
+A compromised trusted Controller or admitted Node Agent remains inside this residual trust boundary.
+
+## Alternatives rejected
+
+### Enrollment PKI without a scoped Peer Grant
+
+TLS verification is necessary but does not atomically bind the certificate's Orchard Node ID to the claimed BEAM node name and current admission through one supported OTP authorization hook.
+OTP also still requires a cookie, so treating one shared cookie as a non-identity constant preserves excessive blast radius without closing the binding gap.
+
+### One shared cluster cookie
+
+A shared cookie grants cluster-wide symmetric authority, cannot be revoked per Node, and turns compromise of any copy into a cluster-wide credential event.
+It remains a transitional source-development and packaged first-cut mechanism only.
+
+### Random recoverable per-pair secrets
+
+Random per-pair credentials would require plaintext or recoverably encrypted secrets in Postgres, or would make Controller restart and disaster recovery depend on unrecoverable local state.
+Deterministic derivation preserves hash-only Postgres storage and lets each Controller rematerialize only its own authorized grants.
+
+### A separate BEAM PKI
+
+A second PKI would duplicate identity, renewal, revocation, and recovery surfaces while increasing drift from the enrollment identity established by PR #87.
+
+### A custom distribution carrier
+
+A custom carrier would add a large security-critical handshake and compatibility surface without turning distributed Erlang into a method-level authorization system.
+The selected model keeps stock OTP TLS distribution and makes Orchard's additional authorization explicit.
+
+## Consequences
+
+Production BEAM gains exact pair-scoped authorization, per-pair rotation, revocation, Active/Standby isolation, deterministic recovery, and visible failure without weakening Node Certificate identity.
+Credential rotation and revocation cause a deliberate brief disconnect because OTP supports only one effective cookie per remote node name.
+Orchard must supervise expiry, staging, cutover, disconnection, and recovery because OTP cookies have no native lifecycle.
+The gRPC/mTLS control path remains required for enrollment, certificate lifecycle, Peer Grant delivery and recovery, explicit Runtime Endpoint compatibility, diagnostics, external adapters, and operator opt-out.
+None of those roles permits automatic retry of a failed BEAM Runtime Endpoint operation through gRPC.
+The Python and MLX Worker Runtime remains a Node Agent-local subprocess and never receives a Node Certificate, Peer Grant, or BEAM membership.
+
+This decision does not close the packaged two-Mac smoke gap from PR #87.
+Root-owned CLI, launchd, separate release processes, restart and reconnection, and the real two-Mac grant journey still require explicit packaged acceptance evidence.
+
+## SPEC.md impact
+
+`SPEC.md` requires updates to define the two-layer production BEAM identity and authorization model, Active/Standby pair grants, trusted target derivation, lifecycle and failure semantics, the high-trust boundary, retained gRPC roles, and the no-fallback rule.
+The `operator-first-run-journey` OpenSpec package requires matching Section 3 tasks and acceptance scenarios before implementation begins.
+
+## External grounding
+
+This decision is grounded in the current Erlang/OTP 29 documentation for [TLS distribution](https://www.erlang.org/doc/apps/ssl/ssl_distribution.html), the [distribution handshake](https://www.erlang.org/docs/29/apps/erts/erl_dist_protocol.html), [`net_kernel`](https://www.erlang.org/doc/apps/kernel/net_kernel.html), [per-node cookies](https://www.erlang.org/doc/apps/erts/erlang.html), and [TLS hardening and revocation](https://www.erlang.org/docs/29/apps/ssl/ssl_hardening.html).

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -62,7 +62,7 @@ _Avoid_: Redis, Kafka, distributed Erlang state
 The live Orchard communication and monitoring layer between first-party Elixir services.
 The BEAM Runtime Endpoint adapter is the split-role source-dev default for first-party Controller-to-Node Agent communication.
 In split-role source-dev, it is the primary Runtime Endpoint transport, promoted on 2026-07-05 after accepted two-Mac smoke evidence.
-In packaged production, BEAM Distribution is limited to admitted first-party Orchard services.
+In packaged production, BEAM Distribution is limited to admitted first-party Orchard services and uses Node Certificates plus scoped BEAM Peer Grants.
 _Avoid_: Durable cluster truth, database replacement, public API, external provider integration
 
 **Source-dev BEAM Operating Model**:
@@ -70,6 +70,24 @@ The source-development distribution profile for first-party Controller-to-Node A
 It uses long BEAM node names with IPv4-literal hosts, explicit shared cookie material, bounded distribution networking, explicit BEAM target configuration, and no automatic gRPC fallback.
 The current implementation exposes this as the default through `bin/dev-controller` and `bin/dev-node-agent` source-dev launches while `bin/dev` remains the gRPC default.
 _Avoid_: Production BEAM security model, ambient `.erlang.cookie`, implicit fallback, durable cluster truth
+
+**Production BEAM Operating Model**:
+The enrolled first-party Controller-to-Node Agent distribution profile that combines Node Certificates, trusted inventory, and scoped BEAM Peer Grants.
+_Avoid_: Source-dev shared-cookie model, certificate-only BEAM authorization, static target list
+
+**BEAM Peer Grant**:
+A bounded transport authorization for one exact Controller instance and one admitted Node to form an OTP distribution connection.
+It is not Node identity and is invalid without the corresponding Node and Controller Certificates.
+_Avoid_: Node Certificate, Node Enrollment Bundle, shared cluster cookie, RBAC Role
+
+**BEAM Authorization Root**:
+A Controller-local secret from which that Controller derives its BEAM Peer Grant secrets.
+_Avoid_: Node-signing CA, shared cluster cookie, Node private key, database secret
+
+**High-trust BEAM Boundary**:
+The trust boundary entered when first-party Orchard services complete distributed Erlang authorization.
+It is not a per-function capability sandbox.
+_Avoid_: Runtime Endpoint Interface, protocol-isolated adapter, least-privilege RPC boundary
 
 **All-in-One Deployment**:
 A deployment topology where one Mac runs the Controller, Node Agent, Worker Runtime, and Managed Database Mode.
@@ -129,7 +147,7 @@ _Avoid_: Worker Runtime Interface, Node Lifecycle Interface, transport protocol
 
 **gRPC Compatibility Adapter**:
 The current adapter that maps Runtime Endpoint Interface semantics to `proto/cluster/v1` and `NodeRuntimeService`.
-It preserves today's gRPC/protobuf implementation while keeping the durable Controller domain contract transport-independent.
+It remains an explicit mTLS compatibility, diagnostics, external-provider, recovery, and operator opt-out path while keeping the durable Controller domain contract transport-independent.
 _Avoid_: Runtime Endpoint Interface, Worker Runtime Interface, first-party BEAM mesh
 
 **Worker Runtime Interface**:
@@ -632,8 +650,9 @@ It is sensitive One-time Secret Output but is not durable Node identity, Node Ad
 _Avoid_: BEAM cookie bundle, admission bundle, worker credential bundle, Node Certificate, cluster-admin credential
 
 **Node Certificate**:
-A Node identity certificate used for internal RPC trust and renewal.
-_Avoid_: Bootstrap Token, API Key, Public HTTPS certificate
+A Node's durable cryptographic identity anchor used for certificate-authenticated internal trust and renewal.
+It is necessary but not sufficient for production BEAM authorization.
+_Avoid_: Bootstrap Token, API Key, BEAM Peer Grant, Public HTTPS certificate
 
 **Trusted Proxy**:
 A configured reverse proxy source whose forwarded headers may be trusted in reverse-proxy transport mode.

--- a/docs/operator-journey.md
+++ b/docs/operator-journey.md
@@ -44,6 +44,8 @@ It does not print or export CA or Controller private key material.
 The current packaged multi-Mac path remains a first-cut private-network deployment and rehearsal path.
 The packaged BEAM-first end state still uses manually distributed shared BEAM cookie material and an explicit Controller target list.
 The secure enrollment tracer now provides owner-only Node Enrollment Bundles, pinned HTTPS Bootstrap Token redemption, protected local Node identity, Node Certificate issuance, certificate-backed registration, explicit audited admission, and authenticated gRPC compatibility activation.
+The PR #87 post-merge smoke passed focused and full validation, coverage, real ephemeral HTTPS, and certificate-backed mTLS gRPC paths.
+It did not exercise the root-owned packaged CLI, launchd, separate release processes, restart and reconnection, or a two-Mac enrollment journey, so that packaged acceptance gap remains open.
 For a remote gRPC compatibility Node, `ORCHARD_NODE_AGENT_ADVERTISE_HOST` must name the Controller-reachable private address because a wildcard listen address is never persisted as a target.
 Registration remains pending and non-schedulable until explicit admission, and admission remains non-schedulable until a fresh healthy identity-matched authenticated observation.
 
@@ -184,6 +186,10 @@ It is not a claim about the current build.
 - Enrollment authenticates the Controller before sending a Bootstrap Token and authenticates the Node through a locally generated key and controller-signed Node Certificate.
 - A Node Enrollment Bundle is one-use, short-lived, per-Node, inspectable, revocable, and auditable.
 - A Node Enrollment Bundle never contains a BEAM cookie, cluster-admin credential, CA private key, Node private key, long-lived Node Certificate, database credential, or static target list.
+- Production BEAM uses the enrolled Node and Controller Certificates plus one scoped BEAM Peer Grant for each exact Controller-to-Node pair.
+- A BEAM Peer Grant is issued only after explicit Node Admission and never becomes Node identity, Node Enrollment material, or advisory-lock leadership proof.
+- Production BEAM names and targets derive from trusted inventory rather than operator-maintained target lists.
+- A failed production BEAM operation remains visible and never retries the same operation through gRPC compatibility.
 - External Postgres remains an explicit prerequisite until Managed Database Mode is implemented.
 - Setup ends with a real inference result, not merely green service processes.
 - Every failure identifies the failed boundary and offers a safe resume path.
@@ -217,10 +223,13 @@ Console offers **Add a worker** as the next action and does not imply that a hea
 7. The worker reports **Registered, awaiting administrator approval**.
 8. Console shows the registered Node, trust evidence, inventory, compatibility, and any blockers.
 9. The operator previews and approves Node Admission.
-10. The Controller derives the Runtime Endpoint target from trusted Node inventory, and a fresh healthy authenticated observation advances the Node to `active`.
-11. The operator imports a model once.
-12. Orchard distributes the verified Artifact Bundle to selected admitted Nodes and shows transfer, verification, placement, and load progress.
-13. Playground runs inference and shows the chosen Node, placement, model version, timing, and remediation when scheduling fails.
+10. The Active Leader authorizes one BEAM Peer Grant for each eligible Controller-to-Node pair.
+11. The worker retrieves the grants over certificate-authenticated control traffic and stores them in protected local identity state.
+12. The Controller derives the canonical BEAM name and Runtime Endpoint target from trusted inventory.
+13. A TLS distribution status probe using the exact certificates and Peer Grant produces a fresh healthy authenticated observation and advances the Node to `active`.
+14. The operator imports a model once.
+15. Orchard distributes the verified Artifact Bundle to selected admitted Nodes and shows transfer, verification, placement, and load progress.
+16. Playground runs inference and shows the chosen Node, placement, model version, timing, and remediation when scheduling fails.
 
 ### Target Failure And Recovery Experience
 
@@ -233,6 +242,9 @@ Target setup must distinguish at least these conditions:
 - Registration complete but admission still pending.
 - Admission rejected with preserved decision history.
 - Node Certificate issuance, storage, renewal, or revocation failure.
+- BEAM Authorization Root missing or unrecoverable.
+- BEAM Peer Grant delivery, expiry, generation, rotation, or revocation failure.
+- Peer revocation recorded but distribution disconnection incomplete.
 - Registered Node transport unreachable or runtime unhealthy.
 - External Postgres unavailable or migrations behind.
 - Model source unavailable, transfer interrupted, checksum mismatch, insufficient disk, or load failure.
@@ -273,8 +285,8 @@ Implementation PRs should validate these budgets on supported release hardware a
 
 | Order | Slice | Operator value | Completion boundary |
 |---:|---|---|---|
-| 1 | Secure one-Controller, one-Node enrollment tracer | Replaces manual identity bootstrap with a real trusted `provisioned -> registered -> admitted -> active` path and gives existing admission UX a valid input. | One short-lived per-Node bundle, local key generation, pinned Controller connection, certificate-backed registration, explicit admission, dynamic target resolution, and authenticated healthy activation all work without a shared-cookie transfer or target-list edit. |
-| 2 | Enrollment hardening and production BEAM identity binding | Makes enrollment recoverable, revocable, renewable, multi-Node capable, and compatible with the selected first-party runtime transport. | Expiry cleanup, revocation, reissue, renewal, response-loss resume, Active/Standby behavior, and a node-bound revocable production BEAM credential design are accepted and tested. |
+| 1 | Secure one-Controller, one-Node enrollment tracer | Replaces manual identity bootstrap with a real trusted `provisioned -> registered -> admitted -> active` path and gives existing admission UX a valid input. | Delivered in PR #87 through certificate-backed gRPC compatibility activation; root-owned packaged, restart, separate-release, and two-Mac acceptance remains open. |
+| 2 | Enrollment hardening and production BEAM authorization | Makes enrollment recoverable, revocable, renewable, multi-Node capable, and compatible with the selected first-party runtime transport. | BEAM Peer Grant delivery, inventory-derived names and targets, TLS distribution activation, rotation, revocation, renewal, re-admission, decommission, Active/Standby behavior, and packaged acceptance are implemented and tested. |
 | 3 | Controller-hosted model distribution | Removes per-worker model staging and makes cluster model readiness observable. | One verified Artifact Bundle import can be authorized, transferred, resumed, verified, placed, and loaded on selected admitted Nodes. |
 | 4 | First-inference Playground tracer | Turns infrastructure readiness into user-visible useful work. | Playground completes one request through an admitted active Node and exposes model, placement, selected Node, request state, and scheduler explanation. |
 | 5 | App-guided Controller and worker setup | Removes env editing and composes the stable CLI/domain operations into a coherent macOS experience. | App setup covers role authorization, prerequisite preflight, resumable progress, enrollment creation/import, admission status, model distribution progress, and first inference without UI-only mutation paths. |
@@ -283,26 +295,21 @@ Implementation PRs should validate these budgets on supported release hardware a
 
 ### First Recommended Implementation Slice
 
-The next product-code PR should implement the secure enrollment tracer in slice 1.
-It should remain CLI-first so the trust, persistence, retry, and lifecycle contracts stabilize before an app UI depends on them.
+The next product-code PR should implement the first narrow Section 3 BEAM Peer Grant tracer.
+It should remain CLI-first and cover one Controller and one Node Agent with real separate BEAM nodes and real TLS distribution.
 
-The tracer uses one Controller and one Node Agent and ends only when the Node is `active` through an authenticated Runtime Endpoint observation.
-It does not include model transfer, Playground work, multi-Node bulk issuance, or broad setup UI.
+The tracer starts from the certificate-backed `registered` Node delivered by PR #87.
+It proves that no grant exists before admission, admission authorizes one exact pair grant, the Node retrieves it over gRPC/mTLS, the Runtime Endpoint target derives from trusted inventory without a static product target, and a BEAM status observation advances `admitted -> active`.
+It must also prove wrong certificate, wrong BEAM name, wrong pair secret, wrong generation, missing, expired, and revoked grant failures, active disconnection on revocation, deterministic delivery retry, visible transport state, and no automatic gRPC Runtime Endpoint fallback.
 
-The first authenticated runtime proof may make the existing gRPC compatibility adapter certificate-backed according to `SPEC.md` §10.6 because the adapter is already a supported Runtime Endpoint path.
-The slice must add the missing mTLS listener, client credentials, CA validation, and Node-id/controller-id SAN validation rather than treating certificate backing as current behavior.
-This does not change the packaged BEAM-first direction.
-A later design must define node-bound, revocable production BEAM credentials before the enrolled product path uses BEAM without reintroducing a cluster-wide cookie as identity.
+The tracer deliberately excludes Active/Standby failover, automated normal rotation, Controller Certificate and authorization-root rotation, multi-Node issuance, app UI, model distribution, dynamic address roaming, external Runtime Endpoints, and any claim of per-function BEAM sandboxing.
+The root-owned packaged, separate-release, restart and reconnection, and two-Mac journey remains a later acceptance gate rather than evidence supplied by this contract workstream.
 
 ### Contract Impact
 
-The target journey is already supported by `SPEC.md` node trust, Node lifecycle, model distribution, packaging, Console, and milestone direction.
-This shaping slice does not mirror the journey into `SPEC.md`.
-
-One narrow contradiction does require reconciliation now.
-`SPEC.md` §10.6 previously tied the internal Controller CA to `orchardctl cluster init`, while ADR 0011 and `SPEC.md` §11.9 define that command as credential-only.
-Internal Node trust initialization or CA import must therefore be a distinct explicit operation.
-The production local initialization entry point is `orchardctl nodes trust init`; it remains separate from public HTTPS configuration and the credential-only `orchardctl cluster init` operation.
+PR #87 completed the Section 2 secure enrollment implementation while preserving the packaged acceptance gap above.
+ADR 0012 selects the hard-to-reverse production BEAM identity and authorization mechanism required before Section 3 implementation.
+`SPEC.md` now defines Node Certificates as durable identity, BEAM Peer Grants as exact pair authorization, separate Active/Standby grants, trusted inventory targets, explicit rotation and revocation, the high-trust BEAM boundary, and the retained gRPC/mTLS roles.
+The active OpenSpec package carries the first implementation tracer and later Section 3 lifecycle acceptance without implementing them in this contract workstream.
 
 No tactical `docs/DESIGN.md` update is needed until the app-guided setup slice defines reusable onboarding, progress, and recovery components.
-No new ADR is needed until Orchard chooses a durable production BEAM credential mechanism or another hard-to-reverse transport-specific trust decision.

--- a/openspec/changes/operator-first-run-journey/design.md
+++ b/openspec/changes/operator-first-run-journey/design.md
@@ -12,6 +12,7 @@ Current app and packaging behavior includes:
 - A local, one-shot, audited `orchardctl cluster init` first-admin credential path.
 - Console and CLI node admission review, Action Preview, rejection history, and lifecycle actions.
 - A packaged multi-Mac BEAM first cut using a manually shared root-owned cookie and explicit Controller targets.
+- A secure enrollment tracer with Node Enrollment Bundles, pinned HTTPS redemption, Node Certificates, exact Node-ID and Controller-ID SAN validation, explicit admission, and authenticated gRPC compatibility activation.
 - Local model import and lower-level worker acquisition paths without a finished controller-hosted distribution experience.
 
 The selected target contract includes Bootstrap Tokens, locally generated Node keys, controller-signed Node Certificates, explicit Node Admission, authenticated Runtime Endpoint observations, controller-hosted artifacts, guided app onboarding, and Playground inference.
@@ -32,7 +33,8 @@ Those target pieces are not all implemented.
 - This change does not make Node Admission implicit.
 - This change does not make Runtime Endpoint observation a trust proof.
 - This change does not change the packaged BEAM-first direction.
-- This change does not select a final node-bound production BEAM credential design.
+- This change selects but does not implement the node-bound production BEAM identity and authorization design.
+- This change does not enter Section 3 product implementation.
 - This change does not promise model transfer time independent of artifact size or network throughput.
 
 ## Decision 1: Use One Three-Layer Journey Document
@@ -136,7 +138,7 @@ The target join exchange is:
 The Controller never reconciles Node identity from hostname, IP address, display name, BEAM node name, or target string alone.
 The Node Agent accepts later runtime mTLS only when the Controller client certificate chains to the enrolled internal trust authority and carries the exact stable Controller-id SAN established by the bundle and registration result.
 
-## Decision 6: First Implementation Slice Is Secure Enrollment
+## Decision 6: Secure Enrollment Was The First Implementation Slice
 
 Three sequences were considered.
 
@@ -158,6 +160,9 @@ It is selected.
 The first product-code tracer covers one configured Controller and one Node Agent.
 It starts after app or PKG role installation and ends when the Node is `active` through a fresh authenticated Runtime Endpoint observation.
 It excludes model transfer, Playground, multi-Node bulk issuance, Managed Database Mode, and app UI.
+PR #87 delivered that tracer through certificate-backed gRPC compatibility activation.
+The post-merge smoke passed focused and full validation, coverage, real ephemeral HTTPS, and certificate-backed mTLS gRPC paths.
+Root-owned packaged CLI, launchd, separate release processes, restart and reconnection, and a two-Mac enrollment journey remain an explicit acceptance gap.
 
 ## First Tracer Interfaces
 
@@ -185,15 +190,14 @@ Existing admission preview and execution then move it to `admitted`.
 Dynamic target resolution derives the Runtime Endpoint from trusted Node inventory.
 A fresh healthy authenticated observation moves the Node to `active`.
 
-## Runtime Transport For The First Tracer
+## Runtime Transport For The Secure Enrollment Tracer
 
-The first certificate-authenticated Runtime Endpoint proof may extend the existing gRPC compatibility adapter with the mTLS behavior required by `SPEC.md` §10.6.
-The current adapter is not certificate-backed, so the tracer must add the Node Agent TLS listener, Controller client credentials, CA validation, and exact Node-id/controller-id SAN validation against the identities persisted during enrollment.
+The first certificate-authenticated Runtime Endpoint proof extended the existing gRPC compatibility adapter with the mTLS behavior required by `SPEC.md` §10.6.
+PR #87 added the Node Agent TLS listener, Controller client credentials, CA validation, and exact Node-ID and Controller-ID SAN validation against the identities persisted during enrollment.
 The enrollment identity, certificate, admission, and dynamic target work remain transport-independent.
 
 This tracer does not change the packaged BEAM-first direction.
-Before the enrolled product path uses BEAM in production, Orchard must define a node-bound, revocable production credential model that does not treat one cluster-wide shared cookie as Node identity.
-That transport-specific choice may require a later ADR if it introduces a hard-to-reverse security boundary.
+ADR 0012 now defines the node-bound, revocable production authorization model before the enrolled product path uses BEAM without reintroducing a cluster-wide cookie as identity.
 
 ## Registration Retry And Concurrency
 
@@ -212,6 +216,70 @@ Standby or leadership-unproven Controllers reject issuance and registration muta
 An observation that arrives before registration remains a Runtime Endpoint Admission Candidate.
 Registration may reconcile earlier candidate evidence only through the certified Node identity.
 Target-string equality is never reconciliation authority.
+
+## Decision 7: Production BEAM Uses Scoped Peer Grants
+
+Production first-party BEAM uses OTP TLS distribution plus one BEAM Peer Grant for each exact Controller-to-Node pair.
+The Node Certificate remains the durable Node identity anchor.
+The Peer Grant is bounded transport authorization and is invalid without the corresponding Node and Controller Certificates.
+
+This choice resolves an OTP 29 limitation rather than replacing certificate trust.
+TLS certificate verification can inspect the peer certificate, and `net_kernel` can restrict claimed node names, but stock OTP exposes no supported public hook that atomically correlates the certificate's Orchard Node ID, the claimed BEAM node name, and current Orchard admission state.
+OTP also always requires a cookie for distribution.
+The complete Orchard authorization decision is therefore the conjunction of exact certificate validation, an inventory-derived BEAM name, an exact per-name Peer Grant cookie, current admitted grant state, private-network policy, and explicit disconnection on revocation.
+
+Each Controller instance owns a separate BEAM Authorization Root with at least 256 bits of random key material.
+The root is separate from the node-signing CA and Controller Certificate private key, lives in protected Controller-local storage, never enters Postgres, and is never delivered to a Node.
+The Controller derives each pair secret with HMAC-SHA-256 over a versioned, length-delimited encoding of the grant's immutable Controller, Node, certificate, name, generation, and time scope.
+Postgres stores durable Controller-instance identity plus each grant's non-secret scope, closed lifecycle state, lifecycle evidence, and encoded-secret hash rather than the plaintext secret or root.
+Grant state is `pending_delivery`, `staged`, `active`, `superseded`, `revoked`, `expired`, or `delivery_failed`; only `active` authorizes ordinary new connections and `staged` authorizes only its scheduled cutover.
+
+The admission transition, decision, audit event, and one `pending_delivery` grant record per currently eligible Controller commit in one Postgres transaction or fail closed without partial admission.
+A Controller enrolled after admission obtains its grant through a separate leader-authorized atomic operation.
+The Node retrieves the authorized generation through certificate-authenticated control traffic and stores it atomically in owner-only identity state.
+Deterministic derivation makes a lost delivery response safely retryable after the identities, certificates, admission, generation, and expiry are revalidated.
+A registered but unadmitted Node receives no production Peer Grant.
+
+The initial validity is 30 days, with normal rotation beginning 7 days before expiry.
+Only one active generation and at most one staged successor generation may exist for an exact pair.
+Rotation stages the successor on both endpoints, cuts over at an agreed time, deliberately disconnects the old connection, and requires the new generation on reconnect.
+Revocation updates Postgres authority immediately, excludes the Runtime Endpoint, replaces the exact-name cookie mapping, disconnects the peer, and remains visibly incomplete until disconnection succeeds or the distribution process is restarted.
+`net_kernel:allow/1` is not a revocation mechanism because its allowlist is append-only and it does not terminate established connections.
+
+Certificate renewal creates a new Peer Grant generation bound to the renewed certificate identifier and fingerprint.
+Re-admission creates a new grant ID and generation after current trust and admission succeed.
+Decommission revokes every grant involving the Node, revokes its Node Certificate, disconnects it from every reachable Controller, and prevents identity or grant reuse.
+Loss of a Controller's BEAM Authorization Root requires explicit restoration or a new root followed by reissuance of every affected pair through certificate-authenticated control traffic.
+
+Active and Standby Controllers have distinct stable Controller IDs, Certificate URI SANs, canonical BEAM names, BEAM Authorization Roots, and grants with every admitted Node.
+Both may keep authenticated connections for liveness, status, and explicitly read-only diagnostics.
+Only the Active Leader may send mutating runtime operations, enforced by the Postgres advisory-lock write gate before the operation leaves the Controller.
+A Peer Grant proves Controller-instance membership, not advisory-lock leadership.
+The Node Agent cannot cryptographically prove that a connected Controller owns the Postgres advisory lock, and the product must not claim otherwise.
+
+The enrolled product derives canonical Node Agent and Controller BEAM names from complete stable UUIDs plus validated private IPv4 inventory.
+It derives Runtime Endpoint targets only from current trusted inventory and active or staged-for-cutover grant state.
+An address or name match alone never establishes identity or authorization.
+Static target lists and shared cookies remain limited to documented source-development and compatibility operation.
+
+Distributed Erlang membership is a high-trust code boundary, not a per-function capability sandbox.
+The current BEAM adapter uses `:rpc.call`, so a Peer Grant limits who may enter the relationship but does not constrain the admitted peer to individual Runtime Endpoint functions.
+Production BEAM is limited to signed first-party Orchard services on operator-controlled admitted Macs inside restricted private networks.
+External providers, third-party adapters, tenant-controlled compute, and partially trusted machines stay outside the BEAM mesh.
+
+gRPC/mTLS remains for enrollment, certificate lifecycle, Peer Grant delivery and recovery, diagnostics, explicit Runtime Endpoint compatibility, external adapters, and operator opt-out.
+Recovery control traffic is not permission to retry a failed BEAM Runtime Endpoint operation through gRPC.
+The Python/MLX Worker Runtime remains a Node Agent-local subprocess and never receives a Node Certificate, Peer Grant, or BEAM membership.
+
+## First Section 3 Implementation Tracer
+
+The first Section 3 product-code tracer uses one Controller and one Node Agent with real separate BEAM nodes and real TLS distribution.
+It proves that no grant exists before admission, admission authorizes one exact pair grant, certificate-authenticated delivery is retryable, the BEAM target derives from trusted inventory without a static product target, and an authenticated BEAM status observation advances `admitted -> active`.
+
+The public-interface security matrix includes wrong Node Certificate SAN or fingerprint, wrong BEAM name, wrong or another Node's pair secret, missing grant, expired grant, revoked grant, wrong generation, unadmitted Node, static target without trusted inventory, revocation while connected, incomplete disconnection, lost delivery response, lost Controller root, and BEAM failure without gRPC fallback.
+
+The tracer excludes Active/Standby failover, automated normal rotation, Controller Certificate and authorization-root rotation, multi-Node issuance, dynamic address roaming, app UI, model distribution, external Runtime Endpoints, Worker Runtime changes, and any claim of per-function BEAM sandboxing.
+The separate packaged acceptance gap covers root-owned CLI, launchd, separate releases, restart and reconnection, and a two-Mac journey.
 
 ## Model Distribution And First Inference
 
@@ -256,7 +324,7 @@ It does not create UI-only mutation paths.
 | First admin | Protect one-time output and replace bootstrap use with named credentials. | Keep initialization local, one-shot, audited, leader-gated, and credential-only. |
 | Node Enrollment | Transfer one sensitive short-lived bundle per Node. | Pin Controller identity, consume once, issue Node identity, audit, expire, revoke, and resume safely. |
 | Node Admission | Review registered identity, inventory, compatibility, pool, and policy. | Keep admission explicit and preserve decision history. |
-| Runtime transport | Protect current compatibility material and private network. | Derive targets from trusted inventory and use node-bound revocable credentials. |
+| Runtime transport | Protect current shared-cookie compatibility material and private network. | Use TLS distribution, trusted inventory, exact certificates, and scoped revocable BEAM Peer Grants without automatic gRPC fallback. |
 | Model availability | Pre-stage remote artifacts in the current build. | Import once, authorize distribution, verify on each Node, and expose progress. |
 | API credentials | Protect one-time API Token output. | Store only hashes/prefixes and expose clear rotation and revocation. |
 | Retained state | Back up config, database, models, bundles, and support state. | Preserve documented operator-owned paths and coordinate safe upgrades. |
@@ -321,6 +389,21 @@ Each slice has explicit tasks in `tasks.md`.
 
 ## Alternatives Rejected
 
+### Use Enrollment PKI Without A Scoped Peer Grant
+
+Exact certificate validation remains mandatory, but stock OTP does not atomically correlate the certificate's Orchard Node ID, the claimed BEAM name, and current admission through one supported authorization hook.
+OTP also still requires a cookie, so leaving that cookie shared preserves excessive blast radius without closing the binding gap.
+
+### Store Random Recoverable Pair Secrets
+
+Random pair credentials would require plaintext or recoverably encrypted secrets in Postgres or would make Controller restart and recovery depend on unrecoverable local state.
+Deterministic derivation preserves hash-only Postgres storage and lets each Controller rematerialize only its own authorized grants.
+
+### Build A Custom Distribution Carrier
+
+A custom carrier would add a large security-critical handshake and compatibility surface without turning distributed Erlang into a method-level authorization system.
+The selected model keeps stock OTP TLS distribution and makes Orchard's additional authorization explicit.
+
 ### Put The Shared BEAM Cookie In An Expiring Bundle
 
 This reduces manual steps but does not reduce the extracted cookie's cluster-wide authority or blast radius.
@@ -348,9 +431,9 @@ Distribution waits for an admitted authenticated Node.
 ADR 0011 and `SPEC.md` §11.9 define `orchardctl cluster init` as credential-only.
 This change resolves the contradiction by requiring explicit separate node-trust initialization or admin import.
 
-No broader `SPEC.md` journey rewrite is needed.
+ADR 0012 and `SPEC.md` §7.5 and §10.6 now select the production BEAM Peer Grant model and close the previously deferred Section 3 identity and authorization decision.
+The OpenSpec requirements and tasks define the first narrow implementation tracer without entering Section 3 product code.
 No `docs/DESIGN.md` change is needed before app-guided setup defines reusable UI patterns.
-No ADR is needed until Orchard selects a transport-specific production BEAM credential model or another hard-to-reverse security decision.
 
 ## External Grounding
 
@@ -360,5 +443,6 @@ The design borrows interaction principles without copying deployment assumptions
 - K3s secure tokens pin cluster CA identity before sending join credentials and its bootstrap tokens are describable, expiring, listable, and revocable, but Orchard does not reuse an all-powerful server token.
 - Syncthing treats device identity as cryptographic and mutual rather than hostname-based, but Orchard centralizes admission instead of requiring bilateral manual configuration.
 - Nomad separates shared gossip encryption from mTLS-secured RPC and one-shot ACL bootstrap, reinforcing that a shared transport key is not Node identity.
+- Erlang/OTP 29 documents that TLS distribution still uses cookies, that certificate verification and `net_kernel` name authorization are separate surfaces, and that revocation requires application-managed certificate and connection lifecycle.
 
 The Orchard-specific result remains subordinate to `SPEC.md` and existing ADRs.

--- a/openspec/changes/operator-first-run-journey/proposal.md
+++ b/openspec/changes/operator-first-run-journey/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Orchard now has an app-primary DMG, a safe root-authorized service lifecycle, first-admin credential initialization, admission review, and a technically workable packaged multi-Mac path.
+Orchard now has an app-primary DMG, a safe root-authorized service lifecycle, first-admin credential initialization, admission review, and a secure enrollment tracer through certificate-backed gRPC compatibility activation.
 The operator still has to assemble those capabilities through external Postgres preparation, root-owned env edits, shared BEAM cookie distribution, explicit Runtime Endpoint targets, separate trust and Console steps, per-worker model staging, and manual inference verification.
 
 The current path and target `SPEC.md` path are spread across packaging, local-development, security, node-lifecycle, model, and Console documents.
@@ -13,8 +13,12 @@ Without one durable journey and ordered change package, current behavior can be 
 - Make sudo/root authorization, external Postgres, licensing, public transport, first-admin credentials, current BEAM transport, Node Admission, model availability, retained state, recovery, and upgrade responsibilities explicit.
 - Define structural friction counts and stable measurement boundaries for time-to-Console, time-to-first-worker-ready, and time-to-first-inference.
 - Define **Node Enrollment Bundle** as the canonical per-Node bootstrap artifact and prohibit shared BEAM cookies or long-lived credentials from that artifact.
-- Shape a CLI-first secure one-Controller, one-Node enrollment tracer as the first implementation slice.
-- Preserve enrollment hardening, production BEAM identity binding, controller-hosted model distribution, Playground verification, app-guided setup, Managed Database Mode, and coordinated upgrade work as explicit later tasks.
+- Preserve the CLI-first secure one-Controller, one-Node enrollment tracer as the completed Section 2 identity foundation.
+- Record that the secure enrollment tracer shipped in PR #87 while its root-owned packaged, restart, separate-release, and two-Mac acceptance remains open.
+- Select OTP TLS distribution plus an exact Controller-to-Node BEAM Peer Grant as the enrolled production identity and authorization model.
+- Define per-Controller authorization roots, hash-only Postgres state, certificate-authenticated grant delivery, inventory-derived names and targets, rotation, revocation, Active/Standby isolation, visible failures, and the high-trust BEAM boundary.
+- Shape a narrow one-Controller, one-Node BEAM Peer Grant tracer as the first Section 3 implementation slice without implementing it here.
+- Preserve enrollment lifecycle hardening, controller-hosted model distribution, Playground verification, app-guided setup, Managed Database Mode, and coordinated upgrade work as explicit later tasks.
 - Reconcile the narrow `SPEC.md` contradiction between credential-only `orchardctl cluster init` and internal Controller CA initialization.
 
 ## Capabilities
@@ -30,16 +34,17 @@ Without one durable journey and ordered change package, current behavior can be 
 ## Impact
 
 - Documentation impact: add `docs/operator-journey.md`, link it from the docs index, and add the Node Enrollment Bundle glossary term.
-- SPEC.md impact: narrow §10.6 so internal node trust is initialized or imported through an explicit operation separate from credential-only `orchardctl cluster init`.
+- SPEC.md impact: reconcile §3.3, §4.1, §7.5, §8, and §10.6 for durable Controller identity, production BEAM Peer Grants, their normative persistence model, and node trust initialized separately from credential-only `orchardctl cluster init`.
 - OpenSpec impact: add this shaping package without modifying or claiming completion of `cluster-management-ux-foundation`, `first-admin-cluster-init`, or `amore-dmg-service-lifecycle`.
-- Security impact: establish that Node Enrollment cannot package the cluster-wide BEAM cookie, admin credentials, CA private keys, Node private keys, or long-lived Node Certificates.
+- Security impact: establish that Node Enrollment cannot package the cluster-wide BEAM cookie, admin credentials, CA private keys, Node private keys, or long-lived Node Certificates, and that production BEAM requires exact certificate validation plus a scoped Peer Grant.
 - Implementation impact: none in this change.
-- Future implementation impact: the first product-code slice spans Node Enrollment persistence, one-time output, local key generation, certificate-backed registration, explicit Node Admission, dynamic target resolution, and authenticated activation.
+- Completed implementation: PR #87 delivered Node Enrollment persistence, one-time output, local key generation, certificate-backed registration, explicit Node Admission, dynamic target resolution, and certificate-backed gRPC authenticated activation; root-owned packaged, restart, separate-release, and two-Mac acceptance remains open.
+- Future implementation impact: the next product-code slice is the narrow Section 3 BEAM Peer Grant tracer.
 
 ## Non-Goals
 
 - Do not implement product code, new CLI commands, database migrations, app UI, Node Certificate issuance, model transfer, or upgrade orchestration in this change.
-- Do not claim `orchardctl node join`, certificate bootstrap, dynamic target discovery, controller-hosted model distribution, Managed Database Mode, or app-guided setup exists.
+- Do not claim dynamic multi-Node production target discovery, controller-hosted model distribution, Managed Database Mode, or app-guided setup exists.
 - Do not replace the current packaged BEAM first-cut runbook before the secure product path is implemented and validated.
-- Do not choose a durable production BEAM credential mechanism in this shaping change.
+- Do not implement Section 3 product code, persistence, CLI surfaces, TLS distribution configuration, Peer Grant delivery, rotation, revocation, or Active/Standby behavior in this contract change.
 - Do not mirror the complete operator journey into `SPEC.md`.

--- a/openspec/changes/operator-first-run-journey/specs/operator-first-run-journey/spec.md
+++ b/openspec/changes/operator-first-run-journey/specs/operator-first-run-journey/spec.md
@@ -140,14 +140,22 @@ This refines `SPEC.md` §4.2 through §4.6, §5.5, §7.4.1, and §11.9.
 
 The enrolled product path SHALL derive Runtime Endpoint targets from trusted Node inventory rather than requiring an operator to edit a static Controller target list for each Node.
 Target derivation SHALL validate that observed endpoint identity matches the persisted Node and Node Certificate identity.
+For production first-party BEAM, a derived Runtime Endpoint target SHALL additionally require an `admitted` or `active` Node with an exact `active` Peer Grant, or an exact `staged` Peer Grant only at its scheduled cutover.
+Registered-but-unadmitted inventory, address or BEAM-name equality, certificate identity, and source-development or compatibility overrides SHALL NOT by themselves authorize a production target.
 Source-development and explicit compatibility target overrides MAY remain separately documented and SHALL NOT establish Node trust.
-This refines `SPEC.md` §1.2, §4.1, §4.6.1, §5.4, §5.5, and §7.5.
+This refines `SPEC.md` §1.2, §4.1, §4.6.1, §5.4, §5.5, §7.5, §8, and §10.6.
 
 #### Scenario: Target address alone cannot reconcile identity
 
 - **WHEN** an observed Runtime Endpoint uses the same address or target string as a provisioned or registered Node but cannot prove the matching Node Certificate identity
 - **THEN** Orchard does not reconcile the observation to that Node
 - **AND** Orchard does not publish scheduling capacity from the observation
+
+#### Scenario: Certificate identity without an active grant cannot authorize a target
+
+- **WHEN** a registered or admitted Node has valid trusted inventory and matching Node Certificate identity but no exact `active` Peer Grant, or only a `staged` grant before its scheduled cutover
+- **THEN** Orchard does not authorize a production BEAM Runtime Endpoint target for that Node
+- **AND** Orchard publishes no schedulable capacity from that endpoint
 
 ### Requirement: Runtime Controller Identity Is Bound During Enrollment
 
@@ -167,6 +175,89 @@ This refines `SPEC.md` §4.1, §7.5, §10.5, and §10.6.
 - **WHEN** a Node runtime certificate chains to the internal CA but carries a different Node-id SAN from the trusted Node record
 - **THEN** the Controller refuses the Runtime Endpoint identity
 - **AND** Orchard does not activate the Node or publish its capacity
+
+### Requirement: Production BEAM Requires Certificate Identity And A Scoped Peer Grant
+
+Production first-party BEAM Distribution SHALL use TLS distribution with exact Node and Controller Certificate identity validation plus one active BEAM Peer Grant for the exact Controller-to-Node pair.
+The Peer Grant SHALL be scoped to immutable cluster, Controller, Node, certificate, canonical BEAM-name, generation, and validity identifiers.
+A registered but unadmitted Node SHALL receive no production Peer Grant.
+Postgres SHALL retain grant scope, state, lifecycle evidence, and a secret hash but SHALL NOT retain the plaintext pair secret or a BEAM Authorization Root.
+Each Controller instance SHALL own a distinct protected authorization root and SHALL derive only its own pair secrets.
+Postgres SHALL retain durable Controller-instance identity and a grant record whose closed lifecycle state is `pending_delivery`, `staged`, `active`, `superseded`, `revoked`, `expired`, or `delivery_failed`.
+Only `active` SHALL authorize ordinary new connections, and `staged` SHALL authorize only its scheduled cutover.
+A database uniqueness constraint SHALL permit at most one active and at most one staged generation for an exact cluster, Controller, Node, and purpose scope.
+This refines `SPEC.md` §3.3, §7.5, §8, §10.5, §10.6, and §10.8 and ADR 0012.
+
+#### Scenario: Admission authorizes one exact pair
+
+- **WHEN** an administrator admits a registered Node whose Node Certificate and trusted inventory remain valid
+- **THEN** Orchard commits the admission transition, decision, audit event, and one `pending_delivery` grant record per currently eligible Controller in one Postgres transaction
+- **AND** each grant uses the exact Controller identity, Node identity, certificate scope, canonical BEAM names, generation, and validity window
+- **AND** the Node retrieves that generation only through certificate-authenticated control traffic
+- **AND** a lost delivery response can be retried only after the complete immutable scope is revalidated
+
+#### Scenario: Admission cannot persist every initial grant
+
+- **WHEN** Orchard cannot persist the admission transition, decision, audit event, and every required initial grant record atomically
+- **THEN** admission fails closed
+- **AND** Orchard retains no partial admission and no orphaned grant metadata
+
+#### Scenario: Pair material is presented for another identity
+
+- **WHEN** a peer presents a valid Orchard certificate but claims the wrong BEAM name or presents another Controller-to-Node pair secret
+- **THEN** Orchard refuses production BEAM authorization
+- **AND** Orchard publishes no authenticated Runtime Endpoint observation
+
+### Requirement: BEAM Peer Grant Lifecycle Fails Closed
+
+The initial BEAM Peer Grant validity SHALL be 30 days and normal rotation SHALL begin 7 days before expiry.
+An exact pair SHALL have at most one active generation and one staged successor.
+Rotation SHALL stage the successor at both endpoints, cut over deliberately, disconnect the old connection, and require the successor generation on reconnect.
+Revocation SHALL remove Postgres authority and Runtime Endpoint eligibility immediately and SHALL remain visibly incomplete until the connected peer is disconnected or the distribution process is restarted.
+Certificate renewal, re-admission, decommission, and Controller authorization-root loss SHALL require the reissuance or revocation behavior defined by ADR 0012.
+This refines `SPEC.md` §4.2 through §4.6, §7.5, §10.6, and §12.7.
+
+#### Scenario: Revocation occurs while the peer remains connected
+
+- **WHEN** an operator revokes an active pair grant while its distributed Erlang connection remains established
+- **THEN** Orchard immediately excludes that Runtime Endpoint from new work
+- **AND** Orchard reports revocation as incomplete until deliberate disconnect or process restart succeeds
+- **AND** Orchard does not retry failed BEAM Runtime Endpoint work through gRPC
+
+#### Scenario: Controller loses its authorization root
+
+- **WHEN** a Controller cannot recover its BEAM Authorization Root
+- **THEN** Orchard cannot rematerialize that Controller's existing pair secrets from Postgres
+- **AND** Orchard requires explicit root restoration or a new root followed by certificate-authenticated reissuance for every affected pair
+
+### Requirement: Active And Standby Controllers Use Distinct BEAM Authorization
+
+Active and Standby Controller instances SHALL use distinct stable Controller IDs, Controller Certificates, canonical BEAM names, BEAM Authorization Roots, and pair grants with each admitted Node.
+Both instances MAY maintain authenticated connections for liveness, status, and explicitly read-only diagnostics.
+Only the Active Leader SHALL originate mutating runtime operations, enforced by the Postgres advisory-lock write gate before the operation leaves the Controller.
+A Node Agent SHALL NOT treat a valid pair grant as proof that the connected Controller currently owns the advisory lock.
+This refines `SPEC.md` §3.2, §3.3, §7.5, and §10.6.
+
+#### Scenario: Standby is authenticated but is not leader
+
+- **WHEN** a Standby Controller has a valid certificate and pair grant but does not own the Postgres advisory lock
+- **THEN** it may perform allowed liveness, status, or read-only diagnostic operations
+- **AND** its Controller-side write gate refuses mutating runtime operations before they leave the Controller
+
+### Requirement: Production BEAM Is A High-Trust First-Party Boundary
+
+Production distributed Erlang SHALL be limited to signed first-party Orchard services on admitted operator-controlled Macs inside restricted private networks.
+A BEAM Peer Grant SHALL authorize membership in that high-trust relationship and SHALL NOT be described as method-level or per-function authorization.
+gRPC/mTLS SHALL remain available for enrollment, certificate lifecycle, Peer Grant delivery and recovery, diagnostics, explicit Runtime Endpoint compatibility, external adapters, and operator opt-out.
+Orchard SHALL NOT automatically retry a failed BEAM inference or Runtime Endpoint operation through gRPC.
+The Python/MLX Worker Runtime SHALL remain a Node Agent-local subprocess and SHALL receive no Node Certificate, Peer Grant, or BEAM membership.
+This refines `SPEC.md` §1.2, §7.5, §10.1, §10.5, and §10.6.
+
+#### Scenario: BEAM transport fails after operation dispatch
+
+- **WHEN** a first-party Runtime Endpoint operation fails through BEAM after dispatch begins
+- **THEN** Orchard reports a stable BEAM transport or authorization failure
+- **AND** Orchard does not replay that operation through the gRPC compatibility adapter
 
 ### Requirement: Model Distribution Uses Admitted Node Identity
 

--- a/openspec/changes/operator-first-run-journey/tasks.md
+++ b/openspec/changes/operator-first-run-journey/tasks.md
@@ -16,16 +16,21 @@
 - [x] 2.7 Derive the first authenticated Runtime Endpoint target from trusted Node inventory and advance `admitted -> active` only after a fresh healthy identity-matched observation.
 - [x] 2.8 Make the gRPC compatibility adapter certificate-backed for the first authenticated Runtime Endpoint proof by adding a Node Agent mTLS listener, Controller client credentials, CA validation, exact Node-id/controller-id SAN validation against enrollment-persisted identities, and fail-closed identity errors without changing the packaged BEAM-first end state.
 - [x] 2.9 Add public-interface tests for happy path, wrong HTTPS trust pin, wrong internal CA, wrong Node-id SAN, wrong Controller-id SAN, expired bundle, consumed bundle, revoked bundle, wrong cluster, wrong Node, concurrent redemption, crash before token consumption, crash after consumption before certificate issuance, crash after issuance before response delivery, crash before local certificate persistence, response loss with matching key/CSR resume, response loss with different key rejection, non-leader refusal, pending-admission exclusion, and authenticated activation.
-- [x] 2.10 Run the full Elixir workflow, strict OpenSpec validation, one-Controller/one-Node packaged smoke, and security review before handoff.
+- [x] 2.10 Run the full Elixir workflow, strict OpenSpec validation, security review, real ephemeral HTTPS, and certificate-backed mTLS gRPC smoke before handoff.
+- [ ] 2.11 Close the remaining packaged acceptance gap with root-owned CLI, launchd, separate Controller and Node Agent releases, restart and reconnection, and preferably two physical Macs.
 
-## 3. Enrollment Hardening And Production BEAM Identity
+## 3. Enrollment Hardening And Production BEAM Authorization
 
-- [ ] 3.1 Add list, inspect, revoke, and reissue surfaces that never reveal the Bootstrap Token secret and preserve append-only audit history.
-- [ ] 3.2 Add bounded cleanup for expired and consumed enrollment records while retaining required audit and decision evidence.
-- [ ] 3.3 Add Node Certificate renewal, explicit revocation, decommission integration, and restart-safe local credential recovery.
-- [ ] 3.4 Define and accept a node-bound, revocable production BEAM credential and authorization model that does not use one cluster-wide cookie as Node identity.
-- [ ] 3.5 Replace static product target lists with targets derived from trusted registered/admitted Node inventory while preserving explicit source-development and compatibility overrides.
-- [ ] 3.6 Validate multi-Node issuance, Active/Standby retries, controller failover, certificate rotation, rejected admission, re-admission, and decommission failure paths.
+- [x] 3.1 Define and accept ADR 0012's Node Certificate plus scoped BEAM Peer Grant authorization model, including lifecycle, Active/Standby, trust-boundary, and no-fallback rules.
+- [ ] 3.2 Implement the first one-Controller/one-Node production tracer with real separate BEAM nodes and TLS distribution, no grant before admission, one exact-pair grant after admission, retryable certificate-authenticated delivery, an inventory-derived canonical target, and authenticated `admitted -> active` observation.
+- [ ] 3.3 Add the public-interface security matrix for wrong certificate identity, wrong BEAM name, wrong or cross-Node secret, missing, expired, revoked, or wrong-generation grant, unadmitted Node, untrusted static target, connected-peer revocation, incomplete disconnection, lost delivery response, lost Controller authorization root, and BEAM failure without gRPC fallback.
+- [ ] 3.4 Generalize BEAM Authorization Root custody, deterministic HMAC derivation, hash-only Postgres persistence, owner-only Node storage, one-active/one-staged rotation, and stable lifecycle evidence beyond the first tracer.
+- [ ] 3.5 Replace static product target lists with canonical names and Runtime Endpoint targets derived only from trusted admitted Node inventory plus exact active or cutover-staged Peer Grant state while preserving explicit source-development and compatibility overrides; a registered but unadmitted Node must not yield a trusted production target.
+- [ ] 3.6 Add list, inspect, revoke, and reissue surfaces that never reveal Bootstrap Token or BEAM Peer Grant secret material and preserve append-only audit history.
+- [ ] 3.7 Add bounded cleanup for expired and consumed enrollment records while retaining required audit and decision evidence.
+- [ ] 3.8 Add Node Certificate renewal, explicit revocation, re-admission, decommission integration, authorization-root loss recovery, and restart-safe local credential recovery.
+- [ ] 3.9 Validate multi-Node issuance, distinct Active and Standby grants, controller failover, deliberate disconnect and reconnect, normal rotation, certificate rotation, rejected admission, re-admission, and decommission failure paths.
+- [ ] 3.10 Close the packaged acceptance gap with root-owned CLI, launchd, separate Controller and Node Agent releases, restart and reconnection, and preferably a two-Mac journey before certifying production BEAM authorization.
 
 ## 4. Controller-Hosted Model Distribution
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -167,7 +167,7 @@ gRPC compatibility fallback:
 Explicit deferrals:
 
 - BEAM cookie provisioning is operator-managed in this phase and must produce a root-owned mode `0600` file.
-- Production BEAM credential hardening remains future work and the shared BEAM cookie must not be treated as Node identity.
+- The production BEAM credential model is now defined by `SPEC.md` §7.5 and ADR 0012 as Node Certificates plus scoped BEAM Peer Grants; its implementation and packaged acceptance remain future work, and the shared BEAM cookie in this first cut must not be treated as Node identity.
 - Managed Postgres is unavailable in this build.
 
 ## Install Role Selection


### PR DESCRIPTION
## Intent

Reconcile Orchard's production BEAM-first Runtime Endpoint contract before operator-first-run-journey Section 3. Define Node Certificate identity plus exact scoped per-Controller-to-Node BEAM Peer Grant authorization, lifecycle, persistence, Active/Standby limits, inventory-derived targets, high-trust boundary, gRPC and Python roles, stable no-fallback failures, and the first narrow implementation tracer. Update only SPEC, ADRs, architecture, glossary, operator journey, AGENTS guidance, and OpenSpec. Do not implement product code or enter Section 3 implementation. Preserve the explicit root-owned packaged CLI, launchd, separate-release, restart/reconnection, and two-Mac acceptance gap.

## What Changed

- Defined the production BEAM-first Runtime Endpoint authorization contract in `SPEC.md` (+255 lines): Node Certificates as sole durable identity plus scoped per-Controller-to-Node BEAM Peer Grants, including the normative `beam_peer_grants` / `controller_instances` DDL, lifecycle states (`pending_delivery`, `staged`, `active`, `superseded`, `revoked`, `expired`, `delivery_failed`), partial-unique constraints, HMAC-SHA-256 secret derivation, per-Controller Authorization Root, Active/Standby limits, inventory-derived targets, and stable no-fallback failure semantics.
- Added ADR `docs/decisions/0012-scoped-beam-peer-grants.md` and cross-referenced ADR 0001; scoped grant generation uniqueness by `(cluster_id, controller_id, node_id, purpose, generation)` so grants differing only by `purpose` no longer collide on a shared generation counter.
- Propagated the model into `docs/glossary/CONTEXT.md` (new Production BEAM Operating Model, BEAM Peer Grant, BEAM Authorization Root, High-trust BEAM Boundary terms), `docs/architecture.md`, `docs/operator-journey.md`, `AGENTS.md`, `packaging/pkg/README.md`, and the `operator-first-run-journey` OpenSpec change (proposal, design, spec delta, tasks) while preserving the explicit gRPC compatibility, root-owned packaged CLI/launchd, and two-Mac acceptance gaps ahead of Section 3 implementation.

## Risk Assessment

✅ Low: Documentation and contract-only change with no executable code; the normative DDL and prose are internally consistent and the prior-round generation/purpose scope concern is already resolved.

## Testing

Confirmed the diff is documentation/OpenSpec-only with no product code, then ran the two AGENTS-mandated OpenSpec strict validations (single-change and --all) which both pass. Because the substantive product artifact is the normative SQL schema and its uniqueness/lifecycle constraints, I loaded the verbatim SPEC.md DDL into a throwaway Postgres instance and drove six behavioral checks: the partial unique indexes correctly enforce "at most one active and at most one staged grant per (cluster_id, controller_id, node_id, purpose)" scope, two active grants differing only by purpose coexist (directly validating the b7d1fec review fix), and the time-window and 32-byte secret_hash check constraints reject malformed rows. All checks matched the SPEC prose; throwaway DB and temp SQL were removed and the worktree is clean. No screenshot applies — this is a spec/contract change with no rendered UI surface; the reviewer-visible artifact is the DB constraint transcript.

<details>
<summary>Evidence: beam_peer_grants constraint behavior (Postgres transcript vs. SPEC prose)</summary>

`TEST 1 second ACTIVE same scope -> REJECTED (idx_beam_peer_grants_one_active); TEST 2 one STAGED successor -> ACCEPTED; TEST 3 second STAGED -> REJECTED (idx_beam_peer_grants_one_staged); TEST 4 ACTIVE differing only by purpose=diagnostics -> ACCEPTED (proves b7d1fec purpose-scoping); TEST 5 expires<=not_before -> REJECTED; TEST 6 wrong-length secret_hash -> REJECTED. Final persisted: (gen1 inference active), (gen2 inference staged), (gen1 diagnostics active).`

```text
INSERT 0 1
INSERT 0 1
INSERT 0 1
--- TEST 1: second ACTIVE grant, same scope (should be REJECTED by idx_beam_peer_grants_one_active) ---
psql:/tmp/beam_grants_behavior.sql:41: ERROR:  duplicate key value violates unique constraint "idx_beam_peer_grants_one_active"
DETAIL:  Key (cluster_id, controller_id, node_id, purpose)=(cccccccc-cccc-cccc-cccc-cccccccccccc, 22222222-2222-2222-2222-222222222222, 11111111-1111-1111-1111-111111111111, inference) already exists.
--- TEST 2: one STAGED successor for the same scope (should be ACCEPTED) ---
INSERT 0 1
--- TEST 3: second STAGED for same scope (should be REJECTED by idx_beam_peer_grants_one_staged) ---
psql:/tmp/beam_grants_behavior.sql:69: ERROR:  duplicate key value violates unique constraint "idx_beam_peer_grants_one_staged"
DETAIL:  Key (cluster_id, controller_id, node_id, purpose)=(cccccccc-cccc-cccc-cccc-cccccccccccc, 22222222-2222-2222-2222-222222222222, 11111111-1111-1111-1111-111111111111, inference) already exists.
--- TEST 4: second ACTIVE grant differing ONLY by purpose=diagnostics (should be ACCEPTED -- proves the b7d1fec purpose-scoping fix) ---
INSERT 0 1
--- TEST 5: invalid time window expires_at <= not_before_at (should be REJECTED by check constraint) ---
psql:/tmp/beam_grants_behavior.sql:97: ERROR:  new row for relation "beam_peer_grants" violates check constraint "beam_peer_grants_check"
DETAIL:  Failing row contains (2d8be0dd-c803-4d36-9b07-95cc5b3ac764, 9, cccccccc-cccc-cccc-cccc-cccccccccccc, 22222222-2222-2222-2222-222222222222, orchard_controller_2222@10.0.0.1, cid-a, fp-a, 33333333-3333-3333-3333-333333333333, 11111111-1111-1111-1111-111111111111, orchard_node_agent_1111@10.0.0.2, ncid, nfp, 1, badtime, active, \xed13a1b6b310425c96d620072f9196a5102f6c48700561edb3f732e7fe72e5..., 2026-07-12 14:17:07.260727+08, 2026-07-17 14:17:07.260727+08, null, 2026-07-13 14:17:07.260727+08, {}, {}, {}, {}, {}, null, null, null, null, null, 2026-07-12 14:17:07.260727+08, 2026-07-12 14:17:07.260727+08).
--- TEST 6: wrong-length secret_hash (should be REJECTED by octet_length check) ---
psql:/tmp/beam_grants_behavior.sql:111: ERROR:  new row for relation "beam_peer_grants" violates check constraint "beam_peer_grants_secret_hash_check"
DETAIL:  Failing row contains (ae529933-00f0-42d3-82f2-75484fd1c8c4, 10, cccccccc-cccc-cccc-cccc-cccccccccccc, 22222222-2222-2222-2222-222222222222, orchard_controller_2222@10.0.0.1, cid-a, fp-a, 33333333-3333-3333-3333-333333333333, 11111111-1111-1111-1111-111111111111, orchard_node_agent_1111@10.0.0.2, ncid, nfp, 1, shorthash, active, \x00, 2026-07-12 14:17:07.261211+08, 2026-07-12 14:17:07.261211+08, null, 2026-08-11 14:17:07.261211+08, {}, {}, {}, {}, {}, null, null, null, null, null, 2026-07-12 14:17:07.261211+08, 2026-07-12 14:17:07.261211+08).

=== FINAL STATE: grants that were actually persisted ===
 generation |   purpose   | state  
------------+-------------+--------
          1 | diagnostics | active
          2 | inference   | staged
          1 | inference   | active
(3 rows)
```
</details>
<details>
<summary>Evidence: OpenSpec strict validation (--all)</summary>

```text
✓ change/operator-first-run-journey and 6 others — Totals: 7 passed, 0 failed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `SPEC.md:305` - In the normative `beam_peer_grants` DDL, the generation-uniqueness constraint is `unique (controller_id, node_id, generation)`, but the active/staged partial-unique indexes and the surrounding SPEC text scope a grant by `(cluster_id, controller_id, node_id, purpose)` — i.e. `purpose` is a scoping dimension. Because `purpose` is omitted from the generation constraint, two grants that differ only by `purpose` for the same pair would collide on generation, forcing a single shared generation counter across purposes. If a second `purpose` is ever introduced, this constraint contradicts the per-(pair,purpose) generation model implied elsewhere. Consider `unique (cluster_id, controller_id, node_id, purpose, generation)` (or documenting that generation is intentionally pair-global regardless of purpose).

🔧 Fix: scope beam_peer_grants generation uniqueness by cluster and purpose
1 info still open:
- ℹ️ `SPEC.md:3447` - The non-unique index idx_beam_peer_grants_controller_node_generation leads with the same columns (cluster_id, controller_id, node_id, purpose, generation) as the composite `unique (…, generation)` constraint&#39;s implicit index; only the `generation desc` ordering differs. Postgres can serve latest-generation lookups via a backward scan of the unique index, so this extra index is largely redundant write/storage overhead on a rotating table. Trivial DDL cleanup only, and this lives in a normative spec a migration will later realize.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-only cba0925..b7d1fec` — confirmed all 11 changed files are docs/OpenSpec markdown, no product code</code>
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate operator-first-run-journey --type change --strict --no-interactive` — change is valid</code>
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` — 7 passed, 0 failed</code>
- `Loaded the verbatim SPEC.md §9 DDL (beam_peer_grant_state enum, controller_instances, beam_peer_grants, all indexes) into a throwaway Postgres DB — DDL is valid SQL`
- <code>Exercised grant lifecycle constraints in Postgres: rejected a 2nd `active` and 2nd `staged` per (cluster,controller,node,purpose) scope, accepted one staged successor, accepted a 2nd active differing only by `purpose` (proving the b7d1fec purpose-scoping fix), and rejected invalid time-window and wrong-length secret_hash rows</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
