### PR TITLE
docs: define F11 controller dispatch capacity authority

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -288,9 +288,21 @@ Each single-controller or Active/Standby Controller instance SHALL have a durabl
 * BEAM Authorization Root custody reference, never the root value
 * instance status
 * first-enrolled and last-seen timestamps
+* running Orchard version
+* supported dispatch-capacity contract version, indivisible all-consumers-ready declaration, and capability observation timestamp
 
 Controller-instance identity is durable cluster truth.
 Advisory-lock leadership is transient and SHALL NOT be conflated with Controller-instance identity.
+
+Every non-retired Controller instance SHALL atomically publish its running Orchard version, supported dispatch-capacity contract version, `dispatch_capacity_consumers_ready`, and capability observation timestamp at boot and on each Controller membership heartbeat.
+The supervised `Orchard.ControllerMembership` owner SHALL emit that heartbeat every `10000` ms and update `last_seen_at` plus the complete capability tuple in one write.
+Heartbeat failure SHALL be retried without reporting fresh capability evidence, and evidence older than the freshness threshold SHALL remain stale until a successful complete write.
+`dispatch_capacity_consumers_ready = true` SHALL declare that MultiNode, admitted SingleNode, Node queue-source refresh, QueueManager, and dispatch-time revalidation all use the shared evaluation as one indivisible contract-versioned capability.
+For F11, Controller capability is compatible only when `dispatch_capacity_contract_version` exactly equals the locked singleton row's `required_contract_version` and `dispatch_capacity_consumers_ready` is true.
+Supporting multiple contract versions in one Controller requires a future explicit supported-version-set contract and SHALL NOT be inferred from greater-than-or-equal comparison.
+Missing evidence, version `0`, a false readiness declaration, or evidence older than `controller_capability_freshness_threshold_ms` SHALL block enforcement cutover for any non-retired Controller instance.
+The default Controller capability freshness threshold SHALL be `30000` ms.
+An obsolete or permanently unavailable Controller SHALL be explicitly retired through `POST /ops/v1/controllers/:controller_id/retire` before it can be excluded from cutover preflight.
 
 Leader controller behavior:
 
@@ -629,6 +641,7 @@ A node record SHALL include:
 * lifecycle state
 * current health
 * last heartbeat timestamp
+* durable dispatch capacity policy after Node Admission
 
 A Node's canonical production BEAM node name SHALL be null until validated private IPv4 inventory is recorded.
 Node Admission SHALL NOT authorize a Peer Grant, and no production Runtime Endpoint target or `admitted -> active` BEAM authorization SHALL proceed, while that canonical name is absent or unvalidated.
@@ -691,7 +704,8 @@ decommissioning -> removed
 * `registered -> admitted`
 
   * trigger: Admin API action
-  * conditions: inventory captured, trust established, pool assigned, required policy inputs supplied
+  * conditions: inventory captured, trust established, pool assigned, and required policy inputs supplied
+  * effect: atomically persist an explicit Controller Dispatch Ceiling and approval provenance before the lifecycle transition; when the administrator omits the value, persist the explicit default `1`; before enforcement cutover the policy state is `approved_explicit`, and after enforcement cutover it is `enforcing`
 
 * `admitted -> active`
 
@@ -869,11 +883,13 @@ Compatibility and defaulting rules:
 * current `RuntimePrefixCacheStatus.status_code` vocabulary is: `ok`, `disabled`, `unavailable`, `error`, `invalid_status`
 * these status codes are observational only in this slice and SHALL NOT gate readiness, admission, or scheduling
 * aggregate `active_request_count` on a Runtime Endpoint Observation, and on the current gRPC compatibility `StatusResponse`, SHALL report active runtime requests across the endpoint node
-* `max_concurrency` on the current gRPC compatibility `StatusResponse` SHALL report the aggregate runtime request capacity enforced by the node agent; omitted or zero values SHALL be treated conservatively as endpoint node capacity `1` by schedulers
+* `max_concurrency` on the current gRPC compatibility `StatusResponse` SHALL report the Node-owned Runtime Concurrency Enforcement Limit
+* an omitted or zero compatibility-protocol `max_concurrency` MAY normalize to Runtime Concurrency Enforcement Limit `1` only for an explicitly unmanaged source-development or compatibility target
+* an omitted, zero, malformed, unavailable, or stale Runtime Concurrency Enforcement Limit for an admitted production Node SHALL yield Effective Dispatch Limit `0`
 * absent or empty Placement Capacity on a Runtime Endpoint Observation, including absent or empty `runtime_model_placements` on the current gRPC compatibility `StatusResponse`, SHALL mean no explicit per-placement capacity observation is available
 * absent or empty Placement Capacity SHALL NOT be treated as a status-probe error
-* Placement Capacity entries SHALL report controller-observed capacity for loaded Model Placements using model reference, active request count, and max concurrency; `max_concurrency <= 0`, malformed entries, duplicate matching entries, or non-matching entries SHALL be treated as unknown capacity
-* valid per-placement capacity SHALL NOT prove endpoint eligibility when known aggregate node-level `active_request_count >= max_concurrency`
+* Placement Capacity entries SHALL report Node-owned capacity for loaded Model Placements through Runtime Endpoint Observations using model reference, active request count, and max concurrency; `max_concurrency <= 0`, malformed entries, duplicate matching entries, or non-matching entries SHALL be treated as unknown capacity
+* valid per-placement capacity SHALL NOT prove endpoint eligibility when the shared authority decision has no positive available slots; under `f11_enforcing`, this means Dispatch Headroom is `0`
 * unknown Placement Capacity SHALL NOT prove scheduler eligibility for an already-active endpoint; `Orchard.Scheduler.MultiNode` MAY keep a matching loaded-model active candidate eligible only when exactly one valid matching Placement Capacity entry reports `active_request_count < max_concurrency`
 
 Effective readiness rules for future hosted routing:
@@ -882,9 +898,161 @@ Effective readiness rules for future hosted routing:
 * the registry tool `execution_mode` SHALL be `:server_hostable`
 * the node SHALL advertise matching static hosted-tool capability for the same `tool://<name>@<version>`
 * the node lifecycle state SHALL be `active`
-* node health SHALL be `healthy` or `degraded`
+* node health SHALL be `healthy`
 * the Runtime Endpoint Observation SHALL be fresh under Orchard's existing freshness thresholds
 * dynamic readiness for that tool SHALL exist and have `ready = true`
+
+### 4.6.2 Controller dispatch capacity authority
+
+Every admitted production Node SHALL have one durable Controller dispatch capacity policy.
+For this contract, the production cohort begins only when Node Admission commits; a registered but unadmitted Node is enrolled inventory but is not yet a dispatch-policy subject.
+The operational cohort ends only when lifecycle `removed`, trust revocation, and the removal audit commit durably.
+A removed Node's policy remains historical evidence but is excluded from capacity evaluation, operator-approval blockers, Controller compatibility cutover preflight, and zero-occupancy quiescence.
+Any later re-enrollment SHALL pass a new Node Admission and persist policy under the then-current phase.
+Except for the bounded pre-F11 cohort while its policy state is `shadow_legacy`, that policy SHALL contain a non-negative Controller Dispatch Ceiling and an explicit policy state.
+The bounded `shadow_legacy` record SHALL deliberately contain a null ceiling, SHALL be distinct from a missing policy record, and SHALL never authorize the new production capacity semantics.
+The Controller Dispatch Ceiling is Controller-owned policy and SHALL NOT be inferred, copied, or backfilled from runtime telemetry.
+New Node Admission SHALL persist a Controller Dispatch Ceiling in the same transaction as admission, using an explicit value supplied by the administrator or the explicit default `1`.
+The cluster SHALL persist one durable dispatch-capacity enforcement phase with values `pre_cutover` and `enforcing`.
+The admission transaction SHALL lock and read that phase rather than infer cutover from policy rows, Controller version, transport, or cluster occupancy.
+While the phase is `pre_cutover`, new admission SHALL write `approved_explicit`; while the phase is `enforcing`, new admission SHALL write `enforcing` directly because every semantic consumer is already enforcing the shared evaluation.
+An explicit Controller Dispatch Ceiling of `0` is valid policy and, while the authority decision is `f11_enforcing`, prevents new Controller allocations without changing Node Lifecycle State or forcibly cancelling accepted, running, or streaming work solely because of the policy value.
+While the phase is `pre_cutover`, an approved ceiling including `0` is not yet allocation authority, and admission or mutation previews SHALL expose `controller_dispatch_ceiling_not_yet_enforcing`.
+A missing policy record, or a missing ceiling outside the bounded `shadow_legacy` exception, is an integrity failure and SHALL yield Effective Dispatch Limit `0`.
+A permanent null value meaning runtime-managed capacity is prohibited.
+
+The Runtime Concurrency Enforcement Limit is the Node-owned dynamic aggregate limit that the Node Agent enforces locally.
+The Controller SHALL treat a Runtime Endpoint capacity observation as fresh only while both the trusted Node heartbeat and the capacity observation remain within the scheduler freshness threshold.
+For an admitted production Node, the Controller SHALL compute:
+
+```text
+effective_dispatch_limit =
+  if trusted_identity
+     and lifecycle_state == active
+     and node_health == healthy
+     and heartbeat_is_scheduler_fresh
+     and capacity_observation_is_scheduler_fresh
+     and dispatch_capacity_enforcement_phase == enforcing
+     and controller_dispatch_policy_state == enforcing
+     and controller_dispatch_ceiling_is_valid
+     and runtime_concurrency_enforcement_limit_is_valid
+  then min(runtime_concurrency_enforcement_limit, controller_dispatch_ceiling)
+  else 0
+
+dispatch_headroom =
+  max(effective_dispatch_limit - controller_accounted_allocation, 0)
+```
+
+Dispatch Headroom SHALL authorize only acquisition of a new allocation.
+Dispatch revalidation of a recognized pre-acceptance allocation SHALL NOT require positive Dispatch Headroom after counting that same allocation a second time.
+Instead, the shared evaluation SHALL serialize revalidation with allocation changes, exclude only the current recognized allocation from the allocation operand, and allow execution only when the resulting value is positive and every non-allocation gate still passes.
+An allocation held during connection or model loading is pre-acceptance work and is not grandfathered across a ceiling reduction.
+A request already accepted by the Node, running, or streaming SHALL NOT be forcibly cancelled solely because the Controller Dispatch Ceiling is lowered.
+
+The shared evaluation SHALL take the durable cluster enforcement phase as an explicit input.
+While the phase is `pre_cutover`, a `shadow_legacy` or `approved_explicit` policy SHALL return counterfactual Effective Dispatch Limit and Dispatch Headroom `0` plus an explicit `legacy_pre_cutover` decision that preserves the named legacy capacity behavior for every semantic consumer.
+The `legacy_pre_cutover` decision is temporary migration behavior, SHALL NOT be presented as Effective Dispatch Limit or Dispatch Headroom, and SHALL NOT create durable policy from telemetry.
+The shared evaluator SHALL calculate the temporary decision centrally as follows:
+
+```text
+legacy_pre_cutover_limit =
+  if fresh runtime max_concurrency is a positive integer
+  then max_concurrency
+  else 1
+
+legacy_pre_cutover_reported_allocation =
+  if fresh aggregate active_request_count is a non-negative integer
+  then active_request_count
+  else 0
+
+legacy_pre_cutover_claimed_allocation =
+  count(unique non-released Controller-local temporary legacy claims)
+
+legacy_pre_cutover_available_slots =
+  max(
+    legacy_pre_cutover_limit
+      - legacy_pre_cutover_reported_allocation
+      - legacy_pre_cutover_claimed_allocation,
+    0
+  )
+```
+
+The temporary decision SHALL authorize new work only when trusted identity, lifecycle `active`, health `healthy` or `degraded`, scheduler-fresh heartbeat and Runtime Endpoint Observation, pool, format, memory, placement, and breaker gates pass and `legacy_pre_cutover_available_slots` is positive.
+All five semantic consumers SHALL use the decision and its centrally calculated available slots without independently interpreting runtime concurrency.
+Acquisition of a temporary legacy claim SHALL serialize across every placement and queue lane for the Node so concurrent consumers cannot spend the same temporary slot.
+The claim SHALL begin before connection or model loading, remain attached to the logical request through accepted, running, and streaming work, and release exactly once on terminal completion, cancellation, pre-acceptance failure, or before retrying another Node.
+Pre-acceptance legacy revalidation SHALL exclude only the current recognized temporary claim from the claimed-allocation operand and SHALL retain the claim through Node acceptance.
+The reported allocation plus temporary-claim calculation is deliberately conservative when Runtime Endpoint telemetry also observes Controller work.
+Queue-source and lane contributions are scheduling hints only; every grant SHALL still acquire the serialized temporary legacy claim before dispatch.
+Controller-accounted Allocation MAY be tracked counterfactually before cutover but SHALL NOT replace reported allocation or the separate temporary-claim bound.
+The frozen missing or malformed aggregate-active-count normalization to `0` is limited to this temporary branch and is the explicit malformed aggregate active-count follow-up outside F11 enforcement scope.
+While the phase is `enforcing`, only an `enforcing` policy MAY produce a non-zero Effective Dispatch Limit.
+A `pre_cutover` phase with an `enforcing` policy, or an `enforcing` phase with `shadow_legacy` or `approved_explicit`, is an integrity mismatch and SHALL fail closed for new allocation and expose `dispatch_capacity_phase_policy_mismatch`.
+
+Controller-accounted Allocation SHALL count unique, non-released, Node-scoped logical allocations owned by the current Active Controller.
+Queued requests, unassigned queue grants, configured base lane capacity, Node-reported active request counts, and Placement Capacity telemetry SHALL NOT count as Controller-accounted Allocation.
+One request SHALL acquire at most one allocation on a Node before model loading or execution, retain it through dispatch and running work, and release it exactly once before retrying another Node or after cancellation, pre-acceptance failure, or terminal completion.
+Acquisition of the final unit of Dispatch Headroom SHALL be serialized so two concurrent requests cannot both claim it.
+This F11 accounting contract is Controller-local and SHALL NOT be represented as a durable dispatch permit, leader epoch, Node-verifiable token, crash-recoverable reservation ledger, or proof of actual Node occupancy.
+
+The Active Controller SHALL provide one Controller-local cluster transition barrier and one Controller-local acceptance gate per admitted production Node.
+Node policy mutation SHALL serialize through that Node's acceptance gate.
+Final dispatch revalidation SHALL acquire the same acceptance gate and hold it continuously from the final shared evaluation through either Node acceptance or pre-acceptance failure.
+If dispatch holds the gate first, Node acceptance linearizes before a later ceiling mutation and the accepted work may drain naturally.
+If policy mutation holds the gate first, later revalidation SHALL observe the new ceiling and phase before execution.
+Enforcement cutover SHALL use the cluster transition barrier and every Node acceptance gate in stable order so no temporary legacy claim or pre-acceptance handoff can cross the phase change.
+These gates define one live Active Controller's F11 linearization boundary and are not a substitute for M7 leadership fencing or durable dispatch permits.
+
+One shared transport-independent capacity evaluation SHALL produce the Runtime Concurrency Enforcement Limit, Controller Dispatch Ceiling, Effective Dispatch Limit, Controller-accounted Allocation, Dispatch Headroom, durable enforcement phase, policy state, normalized target management class, explicit legacy-pre-cutover or F11-enforcing decision, eligibility, and stable reason codes.
+`Orchard.Scheduler.MultiNode`, admitted `Orchard.Scheduler.SingleNode`, Node observation queue-source refresh, `Orchard.Inference.QueueManager`, and dispatch-time revalidation SHALL consume that evaluation without re-deriving the formulas or defaulting missing production policy to `1`.
+Transport selection SHALL NOT classify capacity authority.
+An admitted production Node remains governed by this contract over BEAM, gRPC compatibility, or a static target reference.
+Every normalized Runtime Endpoint target descriptor SHALL carry `capacity_management_class` with one of `production_managed`, `unmanaged_source_development`, or `unmanaged_compatibility`.
+The Controller SHALL resolve trusted admitted production inventory before applying configured classification, and an inventory match SHALL force `production_managed` regardless of a conflicting unmanaged declaration.
+`unmanaged_source_development` SHALL be accepted only from Controller-owned source-development configuration while the Controller runs in source-development mode.
+`unmanaged_compatibility` SHALL be accepted only from an explicitly enabled Controller-owned compatibility target configuration that does not resolve to admitted production inventory.
+The classification SHALL NOT come from Node telemetry, transport type, address shape, probe outcome, or adapter fallback.
+Absent, malformed, conflicting, or unresolved classification SHALL fail closed for production dispatch with no legacy normalization.
+Only a valid explicitly classified unmanaged source-development or compatibility target MAY retain legacy capacity behavior, and failure to resolve a production-managed target SHALL NOT downgrade it to that exception.
+
+Placement Capacity remains Node-owned and MAY further reduce capacity for one Model Placement.
+For each placement, allocatable capacity SHALL be bounded by both that Placement Capacity and the shared authority decision's available slots.
+While the decision is `f11_enforcing`, acquisition of new Controller-accounted Allocations across every placement and queue lane for one Node SHALL NOT cause the total to exceed its Effective Dispatch Limit.
+While the decision is `legacy_pre_cutover`, the temporary centrally calculated legacy slots plus serialized temporary claims remain the aggregate bound and Effective Dispatch Limit remains counterfactual `0`.
+A ceiling reduction MAY temporarily leave accepted, running, or streaming allocations above the new Effective Dispatch Limit while they drain naturally, but no new allocation may increase that total.
+Configured base queue capacity and source-scoped lane capacity govern queue flow only and SHALL NOT create production dispatch authority.
+
+While the authority decision is `f11_enforcing`, lowering a Controller Dispatch Ceiling SHALL affect new allocation and pre-acceptance revalidation immediately, SHALL NOT forcibly cancel accepted, running, or streaming work solely because of the reduction, and SHALL leave Dispatch Headroom at `0` while Controller-accounted Allocation is greater than or equal to the lowered Effective Dispatch Limit.
+Accepted, running, and streaming work SHALL finish naturally, and new allocation MAY resume only after Dispatch Headroom becomes positive.
+Pre-acceptance work that no longer passes serialized held-allocation revalidation SHALL release its allocation exactly once and requeue or fail under the existing contract.
+While the authority decision is `f11_enforcing`, raising a Controller Dispatch Ceiling SHALL create no allocation by itself, SHALL remain bounded by the current Runtime Concurrency Enforcement Limit and all other eligibility gates, and MAY wake queued work only after shared capacity re-evaluation.
+
+Existing Nodes SHALL migrate through policy states `shadow_legacy`, `approved_explicit`, and `enforcing` in that order.
+`shadow_legacy` SHALL apply only to non-removed production Nodes whose Node Admission committed before the F11 expand migration, identified by durable `admitted_at` or equivalent admission history, and SHALL be a temporary counterfactual observation state, not a steady-state authority mode.
+During `shadow_legacy`, the present policy record's intentionally absent ceiling computes counterfactual Effective Dispatch Limit `0` while named legacy behavior continues temporarily and mismatch diagnostics remain non-authoritative.
+Operator approval SHALL persist an explicit ceiling, actor, timestamp, and reason before advancing the policy to `approved_explicit`.
+No Node SHALL enter `enforcing` until every named capacity consumer uses the shared evaluation.
+Enforcement cutover SHALL run under the migration advisory lock and one Postgres transaction that locks the cluster-wide phase, verifies every non-removed admitted production Node has approved policy, verifies fresh compatible all-consumers-ready evidence for every non-retired Controller instance, advances approved policies, records cutover actor, time, reason, and required contract version, and changes the phase to `enforcing`.
+Before that transaction, cutover SHALL enter a visible `quiescing` operation under the Controller-local cluster transition barrier, refuse new temporary legacy claims, and allow existing temporary claims and accepted work to finish without forced cancellation.
+Cutover SHALL proceed only after every non-removed admitted production Node has zero live temporary legacy claims and a new scheduler-fresh aggregate Runtime Endpoint Observation reporting `active_request_count = 0`.
+Excluding a removed tombstone SHALL require durable lifecycle `removed`, revoked trust, and the existing successful removal audit; no other lifecycle state or unreachable Node gains an implicit exclusion.
+Cutover SHALL then acquire every Node acceptance gate in stable order, revalidate quiescence and every other precondition, and hold those gates through transaction commit and local phase publication.
+Cutover SHALL NOT adopt live legacy work into Controller-accounted Allocation or infer any durable policy from telemetry.
+If quiescence times out, evidence becomes stale, or any precondition fails, Orchard SHALL leave phase and policies unchanged, reopen legacy dispatch, and expose the blocker.
+If any precondition or write fails, neither the phase nor any policy transition SHALL commit.
+At enforcement cutover, every otherwise eligible non-removed admitted production Node SHALL have an operator-approved ceiling and advance atomically to `enforcing`, or fail closed with Effective Dispatch Limit `0`.
+After enforcement cutover, each new admission SHALL persist an `enforcing` explicit policy in the admission transaction and SHALL fail closed if that write or its audit record fails.
+Every Controller SHALL read the durable phase at boot, readiness, Active-role acquisition, admission mutation, and dispatch evaluation.
+A Controller that cannot enforce the marker's required contract version SHALL fail readiness and refuse admission and dispatch after cutover rather than treating the cluster as `pre_cutover`.
+The migration SHALL NOT assign existing Nodes a ceiling of `1`, infer a ceiling from telemetry, or treat a missing policy record as legacy state.
+
+Operator diagnostics SHALL expose durable enforcement phase, policy state, normalized target management class, authority decision, Runtime Concurrency Enforcement Limit, Controller Dispatch Ceiling, Effective Dispatch Limit, Controller-accounted Allocation, Dispatch Headroom, the relevant observation time, and stable reason codes.
+While the decision is `legacy_pre_cutover`, diagnostics SHALL additionally expose `legacy_pre_cutover_available_slots`, live temporary legacy claim count, and cutover quiescing state as temporary non-authoritative migration evidence and SHALL keep Effective Dispatch Limit and Dispatch Headroom at `0`.
+Stable capacity reason codes SHALL include `node_health_degraded`, `controller_dispatch_ceiling_missing`, `controller_dispatch_ceiling_invalid`, `controller_dispatch_ceiling_not_yet_enforcing`, `controller_dispatch_ceiling_zero`, `controller_dispatch_ceiling_exhausted`, `runtime_concurrency_limit_unknown`, `runtime_concurrency_limit_exhausted`, `dispatch_headroom_exhausted`, `placement_capacity_exhausted`, `dispatch_capacity_revalidation_failed`, `dispatch_capacity_pre_cutover_legacy`, `dispatch_capacity_phase_policy_mismatch`, `dispatch_capacity_cutover_quiescing`, `dispatch_capacity_cutover_occupancy_not_zero`, `runtime_endpoint_management_class_missing`, `runtime_endpoint_management_class_invalid`, `dispatch_ceiling_shadow_mismatch`, and `dispatch_ceiling_not_approved`.
+The term `Admitted Capacity` SHALL NOT be used for any of these concepts.
+
+Durable dispatch permits, leadership epochs and dispatch fencing, crash or handover reservation recovery, and compromised-node occupancy integrity are M7-aligned follow-ups outside F11.
+Malformed aggregate active-count handling, production probe-failure direct scheduling fallback, queue-source expiry and reservation provenance, and configured-base versus live-capacity provenance are separate follow-ups outside F11.
 
 ### 4.7 Pool model
 
@@ -1067,23 +1235,24 @@ Scheduler wake-up triggers:
 
 Queue lane capacity SHALL be the configured base lane capacity plus live capacity sources.
 Valid loaded-placement observations MAY add source-scoped capacity for the matching model/version lane.
-Eligible cold/no-placement node observations MAY add conservative source-scoped capacity for queued model/version lanes, bounded by aggregate node concurrency and by one unreserved cold slot per lane per node observation.
+Eligible cold/no-placement node observations MAY add conservative source-scoped capacity for queued model/version lanes, bounded by the shared authority decision's available slots and by one unreserved cold slot per lane per node observation.
 Live capacity source refreshes SHALL be allowed to wake queued requests without a new admission event.
 Stale, unavailable, non-loaded, invalid, exhausted, ineligible, or transport-failed node and placement observations SHALL NOT inflate queue admission capacity and SHALL clear any stale capacity source owned by that node or target.
 BEAM Runtime Endpoint observations MAY refresh queue capacity only when the target resolves back to the same persisted node identity; address-only or mismatched BEAM observations SHALL NOT publish queue capacity.
 Runtime Endpoint Admission Candidates SHALL NOT publish queue lane capacity.
 Queue lane capacity SHALL come only from trusted active Nodes or Runtime Endpoints resolved to trusted active Nodes.
+Configured base lane capacity and live capacity sources SHALL NOT authorize production dispatch unless the shared capacity authority decision is `legacy_pre_cutover` with positive centrally calculated legacy slots or `f11_enforcing` with positive Dispatch Headroom at allocation time.
 
 ### 5.5 Eligibility filter
 
 A node is eligible only if all conditions are true:
 
 * node state = `active`
-* node health in `{healthy, degraded}`
+* node health = `healthy`, or node health in `{healthy, degraded}` while the shared capacity authority decision is `legacy_pre_cutover`
 * pool is allowed by routing policy
 * model format is supported by node runtime
 * node has enough memory headroom
-* node concurrency not exceeded
+* the shared capacity authority decision is `legacy_pre_cutover` with positive centrally calculated legacy slots or `f11_enforcing` with positive Dispatch Headroom
 * model placement concurrency not exceeded
 * no placement/node circuit breaker suppresses dispatch
 
@@ -1108,13 +1277,13 @@ Eligibility condition:
 available_memory_bytes >= required_bytes
 ```
 
-Endpoint node concurrency is not exceeded only when the live Runtime Endpoint Observation reports aggregate `active_request_count < max_concurrency`.
-If aggregate `max_concurrency` is omitted or zero, schedulers SHALL interpret endpoint node capacity as `1`.
+Endpoint node concurrency is not exceeded only when the shared capacity evaluation returns `legacy_pre_cutover` with positive centrally calculated legacy slots or `f11_enforcing` with Dispatch Headroom greater than `0`.
+Under `f11_enforcing`, a degraded, unhealthy, unreachable, non-Active, untrusted, scheduler-stale, or policy-missing admitted production Node SHALL have Effective Dispatch Limit `0` and SHALL be ineligible for new work.
 Model placement concurrency is evaluated independently through valid matching Placement Capacity.
 Both endpoint-level aggregate capacity and requested-placement capacity must remain available for a loaded candidate to be eligible.
 Scheduler decisions MAY include `queue_lane_capacity` when live loaded-placement capacity or eligible cold Runtime Endpoint capacity leaves room for the requested lane.
-Loaded candidate contribution SHALL be constrained by both requested-placement capacity and aggregate endpoint capacity.
-Cold candidate contribution SHALL count only candidates with remaining aggregate endpoint capacity.
+Loaded candidate contribution SHALL be constrained by both requested-placement capacity and the shared authority decision's available slots.
+Cold candidate contribution SHALL count only candidates whose shared authority decision has positive available slots.
 Omitted `queue_lane_capacity` means the controller queue must use its conservative configured capacity.
 
 ### 5.6 Candidate tiers
@@ -1149,7 +1318,6 @@ score =
   + residency_bonus
   + mem_bonus
   + load_bonus
-  + health_bonus
   + warmth_bonus
   - swap_penalty
 ```
@@ -1177,11 +1345,6 @@ Where:
 
   * `100 - floor(100 * active_requests / node_max_concurrency)`
 
-* `health_bonus`
-
-  * 30 if `healthy`
-  * 0 if `degraded`
-
 * `warmth_bonus`
 
   * 20 if same model used on node in last 5 minutes
@@ -1199,22 +1362,21 @@ Tie-break order:
 
 The score/bonus model above is the broader M4 scheduling contract. The current bounded Phase 4C/4E implementation uses the late tie-break order below and does not introduce threshold-based memory admission or request rejection.
 
-Controller-side cache-affinity, safe-tokenization capable-worker preference, Phase 4D tie-only scoring, and memory-admission ranking for the bounded current implementation SHALL use the following late tie-break order among otherwise schedulable candidates in the same residency/load/health position:
+Controller-side cache-affinity, safe-tokenization capable-worker preference, Phase 4D tie-only scoring, and memory-admission ranking for the bounded current implementation SHALL use the following late tie-break order among otherwise schedulable candidates in the same residency/load position:
 
 1. loaded model already present
 2. lower active request count for the requested placement when valid matching Placement Capacity is available, otherwise lower endpoint aggregate `active_request_count`
-3. healthier node (`healthy` before `degraded`)
-4. live prefix-cache fingerprint match, only when both `cache_affinity.enabled=true` and `cache_affinity.live_fingerprint_match_enabled=true`
-5. historical cache-affinity match from recent completed placements, when cache affinity is enabled
-6. safe-tokenization capable-worker preference, only when `tokenizer_safe_mode_prefer_capable=true`, `tokenizer_safe_mode` is not `:off`, and the live status probe reports `supports_prompt_token_ids=true`
-7. explicit memory-headroom observation, only when `memory_admission.enabled=true` and the candidate's matching `RuntimeMemoryBudget` has `status_code = "ok"` and `headroom_available = true`
-8. lexicographically smaller `node_id`
+3. live prefix-cache fingerprint match, only when both `cache_affinity.enabled=true` and `cache_affinity.live_fingerprint_match_enabled=true`
+4. historical cache-affinity match from recent completed placements, when cache affinity is enabled
+5. safe-tokenization capable-worker preference, only when `tokenizer_safe_mode_prefer_capable=true`, `tokenizer_safe_mode` is not `:off`, and the live status probe reports `supports_prompt_token_ids=true`
+6. explicit memory-headroom observation, only when `memory_admission.enabled=true` and the candidate's matching `RuntimeMemoryBudget` has `status_code = "ok"` and `headroom_available = true`
+7. lexicographically smaller `node_id`
 
 Default Phase 4D runtime behavior remains observe-only (`prefix_cache_scoring.ranking_mode = :observe_only`) and rank-neutral.
 
-When `prefix_cache_scoring.enabled=true`, `cache_affinity.enabled=true`, `cache_affinity.live_fingerprint_match_enabled=true`, and `prefix_cache_scoring.ranking_mode = :tie_only`, the scheduler MAY apply one bounded conditional score step immediately before step 8, only for the leading rank-equivalence group where steps 1–7 are equal and only deterministic `node_id` differs. Candidate scoring in this conditional step is capped at 2 (incumbent + challenger). The challenger MAY be promoted only when challenger score normalizes to `status_code = "ok"` with `resident_fingerprint_match = true` and `score_tier = "resident_fingerprint"`, and the incumbent score is comparable `ok` non-resident (`status_code = "ok"`, `resident_fingerprint_match = false`, and `score_tier` is `"no_match"` or `"recent_fingerprint_only"`). Any non-`ok`, timeout, unsupported, unavailable, `model_not_loaded`, `invalid_request`, missing, malformed, contradictory, or transport-failure score outcome for either candidate SHALL preserve base order fail-open and deterministic `node_id` fallback.
+When `prefix_cache_scoring.enabled=true`, `cache_affinity.enabled=true`, `cache_affinity.live_fingerprint_match_enabled=true`, and `prefix_cache_scoring.ranking_mode = :tie_only`, the scheduler MAY apply one bounded conditional score step immediately before step 7, only for the leading rank-equivalence group where steps 1–6 are equal and only deterministic `node_id` differs. Candidate scoring in this conditional step is capped at 2 (incumbent + challenger). The challenger MAY be promoted only when challenger score normalizes to `status_code = "ok"` with `resident_fingerprint_match = true` and `score_tier = "resident_fingerprint"`, and the incumbent score is comparable `ok` non-resident (`status_code = "ok"`, `resident_fingerprint_match = false`, and `score_tier` is `"no_match"` or `"recent_fingerprint_only"`). Any non-`ok`, timeout, unsupported, unavailable, `model_not_loaded`, `invalid_request`, missing, malformed, contradictory, or transport-failure score outcome for either candidate SHALL preserve base order fail-open and deterministic `node_id` fallback.
 
-A live prefix-cache fingerprint match is a bounded, approximate warmth hint. It SHALL bias ranking only after health and before historical affinity. Safe-tokenization capable-worker preference is default-off and SHALL bias ranking only after live and historical cache-affinity signals and before memory-headroom admission. The memory-headroom observation is a bounded, positive-only hint. It SHALL bias ranking only after live cache-affinity, historical cache-affinity, and any enabled safe-tokenization capable-worker preference, and before deterministic `node_id`; candidates with absent, malformed, unavailable, or non-`ok` memory-budget telemetry remain schedulable and rank-neutral. Neither hint SHALL change node eligibility, request admission, queue ordering, public error contracts, or runtime concurrency.
+A live prefix-cache fingerprint match is a bounded, approximate warmth hint. It SHALL bias ranking only after eligibility and before historical affinity. Safe-tokenization capable-worker preference is default-off and SHALL bias ranking only after live and historical cache-affinity signals and before memory-headroom admission. The memory-headroom observation is a bounded, positive-only hint. It SHALL bias ranking only after live cache-affinity, historical cache-affinity, and any enabled safe-tokenization capable-worker preference, and before deterministic `node_id`; candidates with absent, malformed, unavailable, or non-`ok` memory-budget telemetry remain schedulable and rank-neutral. Neither hint SHALL change node eligibility, request admission, queue ordering, public error contracts, or runtime concurrency.
 
 ### 5.8 Scheduling algorithm
 
@@ -1245,11 +1407,13 @@ schedule(req):
 Dispatch sequence:
 
 1. reserve request in request FSM (`scheduled`)
-2. if placement not `loaded`, call `EnsureModelLoaded`
-3. re-check node freshness after load
-4. call `ExecuteInference`
-5. wait for `accepted`
-6. transition request to `running`
+2. resolve trusted production identity and consume the shared capacity authority decision; under `f11_enforcing`, atomically acquire or recognize exactly one Node-scoped Controller allocation under Dispatch Headroom, while under `legacy_pre_cutover`, acquire or recognize exactly one serialized Node-scoped temporary legacy claim under the centrally calculated slots
+3. if placement not `loaded`, call `EnsureModelLoaded` while retaining the allocation
+4. after load and immediately before execution, acquire the Node acceptance gate and re-run the same authority decision and Placement Capacity checks; `f11_enforcing` SHALL revalidate the recognized pre-acceptance allocation after excluding only that allocation from the allocation operand, while `legacy_pre_cutover` SHALL revalidate the recognized temporary claim after excluding only that claim from the claimed-allocation operand
+5. if revalidation fails, release the allocation exactly once and requeue or fail under the existing queue deadline and public error contract
+6. call `ExecuteInference`
+7. wait for `accepted` while retaining the Node acceptance gate, or treat failure before `accepted` as pre-acceptance failure
+8. after `accepted`, release the acceptance gate, retain the allocation or temporary legacy claim through terminal completion, and transition request to `running`
 
 Retry rule:
 
@@ -1975,6 +2139,11 @@ POST   /ops/v1/nodes/:node_id/uncordon
 POST   /ops/v1/nodes/:node_id/drain
 POST   /ops/v1/nodes/:node_id/maintenance
 POST   /ops/v1/nodes/:node_id/resume
+GET    /ops/v1/controllers
+POST   /ops/v1/controllers/:controller_id/retire
+GET    /ops/v1/nodes/:node_id/dispatch-capacity-policy
+PATCH  /ops/v1/nodes/:node_id/dispatch-capacity-policy
+POST   /ops/v1/dispatch-capacity/enforcement-cutover
 GET    /ops/v1/requests/:request_id
 POST   /ops/v1/requests/:request_id/cancel
 POST   /ops/v1/requests/:request_id/retry
@@ -1996,6 +2165,24 @@ Warnings are advisory and MAY require confirmation.
 Consequence codes describe expected effects accepted only through explicit parameters or confirmation requirements.
 Confirmation requirements are explicit acknowledgements or typed values and MUST NOT bypass blockers.
 Action execution SHALL revalidate permissions, leadership and write-path availability, lifecycle state, health, active request count when relevant, and blockers at mutation time.
+
+Dispatch-capacity policy reads SHALL require a cluster-scoped `operator` or `admin` RoleBinding.
+Dispatch-capacity policy mutation and enforcement cutover SHALL require a cluster-scoped `admin` RoleBinding and SHALL be leader-only writes.
+Controller-instance reads SHALL require cluster `operator` or `admin`.
+`POST /ops/v1/controllers/:controller_id/retire` SHALL require cluster `admin`, Active leadership, a non-empty reason, `expected_updated_at`, side-effect-free Action Preview, and typed Controller ID confirmation.
+Retirement SHALL be blocked for the current Active Controller, a Controller that still holds the leadership lock, or the last non-retired Controller instance.
+Execution SHALL revalidate identity, status, optimistic concurrency, and leadership, set status `retired`, and persist a cluster-scoped audit event atomically.
+Only this explicit audited retirement state SHALL exclude a Controller instance from dispatch-capacity cutover capability preflight.
+`PATCH /ops/v1/nodes/:node_id/dispatch-capacity-policy` SHALL accept a non-negative `controller_dispatch_ceiling`, a non-empty `reason`, an optimistic concurrency value such as `expected_updated_at`, `dry_run`, and any confirmation required by its Action Preview.
+Before cutover, that mutation SHALL approve a `shadow_legacy` policy as `approved_explicit` or update an existing `approved_explicit` ceiling; after cutover, it SHALL update an `enforcing` ceiling without changing the policy state.
+The mutation SHALL revalidate authorization, Active leadership, the durable enforcement phase, Node Admission evidence, current policy version, and the non-negative ceiling inside the write transaction.
+Its Action Preview SHALL expose prior and proposed ceilings, policy state, current Controller-accounted Allocation, projected Effective Dispatch Limit and Dispatch Headroom when evidence is available, blockers, warnings, consequence codes, and confirmation requirements.
+Before cutover, the preview SHALL warn `controller_dispatch_ceiling_not_yet_enforcing` and SHALL NOT claim that the approved ceiling, including `0`, changes temporary legacy allocation.
+Under `f11_enforcing`, a reduction below Controller-accounted Allocation SHALL require an explicit `capacity_reduction_drain` confirmation and SHALL state that accepted, running, and streaming work drains naturally while new and pre-acceptance work is blocked or revalidated.
+`POST /ops/v1/dispatch-capacity/enforcement-cutover` SHALL accept a non-empty reason, `dry_run`, the expected durable phase, `expected_required_contract_version`, and typed cutover confirmation.
+The submitted expected version SHALL equal the locked singleton row's required contract version and SHALL NOT change it during cutover.
+Its Action Preview SHALL list every missing or unapproved admitted production Node, every non-retired Controller with missing, stale, incompatible, or all-consumers-not-ready capability evidence, and the exact policies that would advance.
+Successful approval, ceiling change, and enforcement cutover SHALL persist a cluster-scoped audit event in the same transaction as the authoritative mutation.
 
 `POST /ops/v1/support-bundles` SHALL produce the `orchard.support_bundle.v2` format for cluster-management evidence.
 Support Bundle v2 SHALL include bundle format, generated time, Orchard version, scope, included sections, omitted sections, redaction manifest, max log bytes, and relevant SPEC references.
@@ -2064,13 +2251,12 @@ Response example:
       "node_id": "node-2",
       "eligible": true,
       "tier": "loaded",
-      "score": 842,
+      "score": 812,
       "components": {
         "pool_bonus": 200,
         "residency_bonus": 500,
         "mem_bonus": 72,
         "load_bonus": 40,
-        "health_bonus": 30,
         "warmth_bonus": 20,
         "swap_penalty": 20
       },
@@ -2098,7 +2284,7 @@ Reason codes SHALL be shared by Operator API, CLI, Console, support bundles, and
 Human-readable explanation text MAY be included, but it SHALL be supplemental to machine-readable reason codes.
 Rejected candidates SHALL include at least one stable rejection reason code.
 Skipped candidates SHALL be represented in `skipped_candidates` outside the rejected-candidate list and SHALL include at least one stable skip reason code.
-The initial scheduler rejection vocabulary SHALL include `inventory_missing`, `node_not_admitted`, `node_not_active`, `node_not_registered`, `node_health_unreachable`, `node_health_unhealthy`, `node_observation_stale`, `transport_unreachable`, `runtime_not_ready`, `runtime_identity_mismatch`, `version_incompatible`, `pool_not_allowed`, `model_format_unsupported`, `model_not_available_on_node`, `insufficient_memory`, `node_concurrency_exhausted`, `placement_concurrency_exhausted`, `placement_suppressed`, `node_circuit_breaker_open`, `model_load_suppressed`, `policy_required`, `pool_required`, `queue_lane_capacity_unavailable`, `trust_not_established`, and `unknown_capacity`.
+The initial scheduler rejection vocabulary SHALL include `inventory_missing`, `node_not_admitted`, `node_not_active`, `node_not_registered`, `node_health_degraded`, `node_health_unreachable`, `node_health_unhealthy`, `node_observation_stale`, `transport_unreachable`, `runtime_not_ready`, `runtime_identity_mismatch`, `version_incompatible`, `pool_not_allowed`, `model_format_unsupported`, `model_not_available_on_node`, `insufficient_memory`, `node_concurrency_exhausted`, `placement_concurrency_exhausted`, `placement_suppressed`, `node_circuit_breaker_open`, `model_load_suppressed`, `policy_required`, `pool_required`, `queue_lane_capacity_unavailable`, `trust_not_established`, `unknown_capacity`, `controller_dispatch_ceiling_missing`, `controller_dispatch_ceiling_invalid`, `controller_dispatch_ceiling_zero`, `controller_dispatch_ceiling_exhausted`, `runtime_concurrency_limit_unknown`, `runtime_concurrency_limit_exhausted`, `dispatch_headroom_exhausted`, `placement_capacity_exhausted`, `dispatch_capacity_revalidation_failed`, `dispatch_capacity_phase_policy_mismatch`, `runtime_endpoint_management_class_missing`, `runtime_endpoint_management_class_invalid`, `dispatch_ceiling_shadow_mismatch`, and `dispatch_ceiling_not_approved`.
 The initial scheduler skip vocabulary SHALL include `lower_tier_not_considered`, `not_scored_after_selection`, `not_applicable_to_request`, and `candidate_limit_reached`.
 Queue-waitable capacity outcomes SHALL preserve whether the wait reason is live node capacity, requested model path capacity, placement capacity, or tenant active capacity.
 Scored candidates SHALL be listed in the scheduler's actual selection ranking order.
@@ -2162,6 +2348,8 @@ POST   /admin/v1/bootstrap-tokens
 
 Node Admission Candidate review endpoints SHALL expose sanitized observed identity, target reference, inventory, compatibility evidence, last observation timestamp when present, admission category, decision metadata when present, and audit event reference when present.
 Admin admission execution SHALL require a registered trusted Node with inventory, pool, and required policy inputs.
+`POST /admin/v1/nodes/:node_id/admit` SHALL accept optional non-negative `controller_dispatch_ceiling`, a required non-empty `capacity_policy_reason`, `dry_run`, and any confirmation required by its Action Preview; it SHALL default the ceiling explicitly to `1` only when omitted and include the resolved value and phase-derived policy state in its Action Preview.
+Admission execution SHALL lock and read the durable enforcement phase, persist the explicit ceiling, approval actor, timestamp, and reason with the admission decision, and fail the entire transaction on policy or audit failure.
 Pending admission rejection SHALL persist a Node Admission Decision and audit event without deleting observed inventory.
 Clearing rejection SHALL require admin authority and SHALL persist an audit event.
 Admin admit and pending-admission reject endpoints SHALL support `dry_run` requests that return the shared Action Preview shape and follow the side-effect-free invariants in §7.3.1.
@@ -2585,8 +2773,8 @@ message StatusResponse {
   repeated RuntimePrefixCacheStatus runtime_prefix_cache_statuses = 9;
   bool supports_prompt_token_ids = 10;
   repeated RuntimeModelPlacement runtime_model_placements = 11;
-  // Aggregate runtime request capacity for the node.
-  // Controllers must treat absent or zero values as node capacity 1.
+  // Node-owned Runtime Concurrency Enforcement Limit.
+  // Only explicit unmanaged compatibility may normalize absent or zero to 1.
   uint32 max_concurrency = 12;
 }
 
@@ -2786,18 +2974,18 @@ Runtime capacity and Placement Capacity observation semantics:
 * `WorkerStatusResponse.active_request_count` SHALL report active `Generate` calls in that worker process
 * `WorkerStatusResponse.max_concurrency` SHALL report the worker's effective overlapping `Generate` capacity; omitted or zero values SHALL be treated as worker capacity `1` by the node agent
 * `StatusResponse.active_request_count` SHALL report aggregate active runtime requests across all loaded models on the node
-* `StatusResponse.max_concurrency` SHALL report the aggregate runtime request capacity that the node agent will enforce across loaded models
-* omitted or zero `StatusResponse.max_concurrency` SHALL mean aggregate capacity is unknown or legacy; schedulers SHALL treat it conservatively as node capacity `1`
+* `StatusResponse.max_concurrency` SHALL report the Runtime Concurrency Enforcement Limit that the node agent will enforce across loaded models
+* omitted or zero `StatusResponse.max_concurrency` SHALL mean the Runtime Concurrency Enforcement Limit is unknown or legacy; an explicitly unmanaged source-development or compatibility adapter MAY normalize it to `1`, while an admitted production Node SHALL receive Effective Dispatch Limit `0`
 * Runtime Endpoint Observations SHALL report active request count and max concurrency for each loaded runtime/model path as Placement Capacity
 * the current gRPC Compatibility Adapter maps Placement Capacity to and from `StatusResponse.runtime_model_placements` through the existing `GetStatus` probe
 * omitted or empty Placement Capacity SHALL mean no explicit per-placement capacity observation is available
 * omitted or empty Placement Capacity SHALL NOT be treated as an endpoint status error, readiness failure, admission failure, model-admission failure, or scheduler-eligibility failure for otherwise idle candidates
 * a matching placement capacity observation is valid only when exactly one entry matches the requested `model_ref`, `active_request_count >= 0`, and `max_concurrency > 0`
 * duplicate matching entries, malformed matching entries, non-matching entries, or `max_concurrency <= 0` SHALL make placement capacity unknown for that request
-* a valid matching placement observation SHALL NOT override exhausted node-level aggregate capacity
+* a valid matching placement observation SHALL NOT override a shared authority decision with no positive available slots; under `f11_enforcing`, this includes exhausted Dispatch Headroom
 * unknown placement capacity SHALL NOT prove eligibility for an already-active loaded-model candidate; an already-active loaded-model candidate MAY remain eligible only when exactly one valid matching entry reports `active_request_count < max_concurrency`
-* when multiple eligible candidates remain, the scheduler SHALL rank by the requested placement's active request count before health when a valid matching placement observation is available; otherwise it SHALL use the endpoint aggregate `active_request_count`
-* controller queue capacity MAY be refreshed from Runtime Endpoint Observations; loaded placement observations contribute only to their matching model/version lane, while cold/no-placement endpoint observations contribute conservative source-scoped capacity for queued lanes without exceeding aggregate endpoint capacity
+* when multiple eligible candidates remain, the scheduler SHALL rank by the requested placement's active request count before live cache-affinity and the remaining tie-breaks when a valid matching Placement Capacity observation is available; otherwise it SHALL use the endpoint aggregate `active_request_count`
+* controller queue capacity MAY be refreshed from Runtime Endpoint Observations; loaded placement observations contribute only to their matching model/version lane, while cold/no-placement endpoint observations contribute conservative source-scoped capacity for queued lanes without exceeding the shared authority decision's available slots
 * stale, unavailable, non-loaded, invalid, exhausted, ineligible, or transport-failed observations SHALL clear their endpoint-owned queue capacity sources instead of preserving stale admission capacity
 * BEAM Runtime Endpoint observations MAY refresh queue capacity only when the target resolves back to the same persisted node identity; address-only or mismatched BEAM observations SHALL NOT publish queue capacity
 * node-agent request admission SHALL reject a new runtime request when aggregate active request count has reached the effective aggregate worker request limit, even if the requested model placement has remaining per-placement capacity
@@ -2881,6 +3069,17 @@ create type node_admission_decision_kind as enum (
   'rejected',
   'rejection_cleared',
   'admitted'
+);
+
+create type node_dispatch_capacity_policy_state as enum (
+  'shadow_legacy',
+  'approved_explicit',
+  'enforcing'
+);
+
+create type dispatch_capacity_enforcement_phase as enum (
+  'pre_cutover',
+  'enforcing'
 );
 
 create type beam_peer_grant_state as enum (
@@ -2985,6 +3184,59 @@ create table nodes (
   updated_at timestamptz not null default now()
 );
 
+create table node_dispatch_capacity_policies (
+  node_id uuid primary key references nodes(id) on delete cascade,
+  policy_state node_dispatch_capacity_policy_state not null,
+  controller_dispatch_ceiling integer,
+  approved_by_actor_type actor_type,
+  approved_by_actor_id text,
+  approved_at timestamptz,
+  approval_reason text,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (
+    (policy_state = 'shadow_legacy'
+      and controller_dispatch_ceiling is null
+      and approved_by_actor_type is null
+      and approved_by_actor_id is null
+      and approved_at is null
+      and approval_reason is null)
+    or
+    (policy_state in ('approved_explicit', 'enforcing')
+      and controller_dispatch_ceiling is not null
+      and controller_dispatch_ceiling >= 0
+      and approved_by_actor_type is not null
+      and approved_by_actor_id is not null
+      and approved_at is not null
+      and approval_reason is not null)
+  )
+);
+
+create table dispatch_capacity_authority (
+  singleton boolean primary key default true check (singleton),
+  enforcement_phase dispatch_capacity_enforcement_phase not null default 'pre_cutover',
+  required_contract_version integer not null default 1 check (required_contract_version > 0),
+  cutover_by_actor_type actor_type,
+  cutover_by_actor_id text,
+  cutover_at timestamptz,
+  cutover_reason text,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (
+    (enforcement_phase = 'pre_cutover'
+      and cutover_by_actor_type is null
+      and cutover_by_actor_id is null
+      and cutover_at is null
+      and cutover_reason is null)
+    or
+    (enforcement_phase = 'enforcing'
+      and cutover_by_actor_type is not null
+      and cutover_by_actor_id is not null
+      and cutover_at is not null
+      and cutover_reason is not null)
+  )
+);
+
 create table controller_instances (
   id uuid primary key,
   certificate_uri_san text not null unique,
@@ -2996,6 +3248,11 @@ create table controller_instances (
   status text not null check (
     status in ('enrolled', 'operational', 'recovery_required', 'retired')
   ),
+  software_version text,
+  dispatch_capacity_contract_version integer not null default 0
+    check (dispatch_capacity_contract_version >= 0),
+  dispatch_capacity_consumers_ready boolean not null default false,
+  dispatch_capacity_capability_observed_at timestamptz,
   first_enrolled_at timestamptz not null,
   last_seen_at timestamptz,
   inserted_at timestamptz not null default now(),
@@ -3335,7 +3592,7 @@ Both references MAY later become null through retention cleanup, because decisio
 Audit log `scope` SHALL distinguish tenant-scoped and cluster-scoped governance events.
 Tenant-scoped audit events SHALL set `scope = 'tenant'` and a non-null `tenant_id`.
 Cluster-scoped audit events SHALL set `scope = 'cluster'` and a null `tenant_id`.
-Node admission candidate review, node admission rejection, rejection clearance, admission after rejection, node decommission, Active/Standby status-affecting writes, and cluster-scoped support bundle generation SHALL use cluster-scoped audit events unless a future accepted contract makes them tenant-owned.
+Node admission candidate review, node admission rejection, rejection clearance, admission after rejection, Controller Dispatch Ceiling approval or change, dispatch-capacity enforcement cutover, Controller-instance retirement, node decommission, Active/Standby status-affecting writes, and cluster-scoped support bundle generation SHALL use cluster-scoped audit events unless a future accepted contract makes them tenant-owned.
 Audit log `actor_type` SHALL identify the provenance class of the action.
 `operator` represents operator and admin product surfaces such as Orchard Console, Orchard CLI, Operator API, and Admin API actions.
 `actor_id` MAY be null for `system` actions and for local operator actions before Orchard has an authenticated first-class operator identity.
@@ -3453,6 +3710,9 @@ create index idx_node_admission_decisions_audit_log
 create unique index idx_nodes_canonical_beam_name
   on nodes(canonical_beam_name)
   where canonical_beam_name is not null;
+
+create index idx_node_dispatch_capacity_policies_state
+  on node_dispatch_capacity_policies(policy_state, updated_at desc);
 
 create index idx_controller_instances_status_seen
   on controller_instances(status, last_seen_at desc nulls last);
@@ -3870,6 +4130,7 @@ Audit logs SHALL capture:
 * Node Admission rejection clearance
 * node admission after rejection
 * registration or trust event used to permit re-admission
+* Controller Dispatch Ceiling creation, approval, raising, lowering, and enforcement-state change
 * operator drain/cancel/retry actions
 * support bundle generation
 * upgrade actions
@@ -4080,6 +4341,9 @@ Required commands:
 
 Node-admission CLI commands SHALL provide stable human and JSON output for list, inspect, pending-review, admit, and reject workflows.
 `orchardctl nodes admit` and `orchardctl nodes reject` SHALL support side-effect-free `--dry-run` Action Preview output and explicit execution gates, including `--yes` for execution and `--reason` for rejection.
+`orchardctl nodes admit` SHALL accept optional `--controller-dispatch-ceiling <non-negative-integer>` and required `--capacity-policy-reason <non-empty-text>`.
+When the ceiling flag is omitted, the CLI SHALL preview and persist the explicit new-admission default `1`; its human and JSON previews SHALL include the resolved ceiling, durable enforcement phase, phase-derived policy state, blockers, warnings, consequences, and confirmation requirements.
+CLI admission execution SHALL record actor type `operator` with bounded local Controller-runtime principal provenance and SHALL use the same leader-only atomic Node Admission, policy, admission-decision, and cluster-audit transaction as the Admin API.
 For source-dev and packaged local use, node-admission CLI commands are local operator/admin commands that execute in the controller runtime context rather than proving Admin API bearer-token authorization.
 They SHALL still enforce the same leader-only write-path, admission, confirmation, cluster-scoped audit, and shared-presenter semantics as the Admin API.
 
@@ -4235,6 +4499,16 @@ Rules:
 * new code reads both old and new where needed
 * background backfill if required
 * destructive drops only after all nodes/controllers run compatible version
+
+The expand migration SHALL create the singleton durable dispatch-capacity authority row in phase `pre_cutover` with required contract version `1`.
+The F11 dispatch-capacity migration SHALL create `shadow_legacy` policy rows only for non-removed production Nodes whose Node Admission committed before the expand migration, using durable `admitted_at` or equivalent admission history, and SHALL leave their Controller Dispatch Ceiling null during that temporary state.
+Durably removed Nodes with revoked trust and successful removal audit SHALL retain historical policy evidence but SHALL NOT block approval or cutover.
+Before enforcement cutover, new admissions SHALL write `approved_explicit` policy with an explicit ceiling before admission commits.
+The migrate phase SHALL require operator approval without telemetry backfill and verify that all capacity consumers use the shared evaluation.
+Cutover SHALL lock the singleton phase and migration advisory lock, quiesce every non-removed admitted production Node to zero live temporary claims and new fresh zero-active aggregate evidence under the Controller-local gates, validate the expected `pre_cutover` phase and fresh compatible all-consumers-ready evidence for every non-retired Controller instance, atomically advance approved policies to `enforcing`, record cutover provenance, and set the durable phase to `enforcing` in one transaction.
+After enforcement cutover, new admissions SHALL write `enforcing` policy with an explicit ceiling before admission commits.
+Admission SHALL select the singleton phase for update inside its transaction, including on an otherwise empty cluster, and SHALL fail closed if the phase is missing, malformed, or unsupported by that Controller.
+The contract phase SHALL reject any otherwise eligible admitted production Node without an enforcing explicit policy and MAY strengthen persistence constraints after the bounded legacy cohort is removed.
 
 Migration ownership SHALL be protected by advisory lock.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -898,7 +898,7 @@ Effective readiness rules for future hosted routing:
 * the registry tool `execution_mode` SHALL be `:server_hostable`
 * the node SHALL advertise matching static hosted-tool capability for the same `tool://<name>@<version>`
 * the node lifecycle state SHALL be `active`
-* node health SHALL be `healthy`
+* node health SHALL be `healthy` or `degraded`
 * the Runtime Endpoint Observation SHALL be fresh under Orchard's existing freshness thresholds
 * dynamic readiness for that tool SHALL exist and have `ready = true`
 
@@ -1318,6 +1318,7 @@ score =
   + residency_bonus
   + mem_bonus
   + load_bonus
+  + health_bonus
   + warmth_bonus
   - swap_penalty
 ```
@@ -1345,6 +1346,11 @@ Where:
 
   * `100 - floor(100 * active_requests / node_max_concurrency)`
 
+* `health_bonus`
+
+  * 30 if `healthy`
+  * 0 if `degraded`
+
 * `warmth_bonus`
 
   * 20 if same model used on node in last 5 minutes
@@ -1362,21 +1368,22 @@ Tie-break order:
 
 The score/bonus model above is the broader M4 scheduling contract. The current bounded Phase 4C/4E implementation uses the late tie-break order below and does not introduce threshold-based memory admission or request rejection.
 
-Controller-side cache-affinity, safe-tokenization capable-worker preference, Phase 4D tie-only scoring, and memory-admission ranking for the bounded current implementation SHALL use the following late tie-break order among otherwise schedulable candidates in the same residency/load position:
+Controller-side cache-affinity, safe-tokenization capable-worker preference, Phase 4D tie-only scoring, and memory-admission ranking for the bounded current implementation SHALL use the following late tie-break order among otherwise schedulable candidates in the same residency/load/health position:
 
 1. loaded model already present
 2. lower active request count for the requested placement when valid matching Placement Capacity is available, otherwise lower endpoint aggregate `active_request_count`
-3. live prefix-cache fingerprint match, only when both `cache_affinity.enabled=true` and `cache_affinity.live_fingerprint_match_enabled=true`
-4. historical cache-affinity match from recent completed placements, when cache affinity is enabled
-5. safe-tokenization capable-worker preference, only when `tokenizer_safe_mode_prefer_capable=true`, `tokenizer_safe_mode` is not `:off`, and the live status probe reports `supports_prompt_token_ids=true`
-6. explicit memory-headroom observation, only when `memory_admission.enabled=true` and the candidate's matching `RuntimeMemoryBudget` has `status_code = "ok"` and `headroom_available = true`
-7. lexicographically smaller `node_id`
+3. healthier node (`healthy` before `degraded`)
+4. live prefix-cache fingerprint match, only when both `cache_affinity.enabled=true` and `cache_affinity.live_fingerprint_match_enabled=true`
+5. historical cache-affinity match from recent completed placements, when cache affinity is enabled
+6. safe-tokenization capable-worker preference, only when `tokenizer_safe_mode_prefer_capable=true`, `tokenizer_safe_mode` is not `:off`, and the live status probe reports `supports_prompt_token_ids=true`
+7. explicit memory-headroom observation, only when `memory_admission.enabled=true` and the candidate's matching `RuntimeMemoryBudget` has `status_code = "ok"` and `headroom_available = true`
+8. lexicographically smaller `node_id`
 
 Default Phase 4D runtime behavior remains observe-only (`prefix_cache_scoring.ranking_mode = :observe_only`) and rank-neutral.
 
-When `prefix_cache_scoring.enabled=true`, `cache_affinity.enabled=true`, `cache_affinity.live_fingerprint_match_enabled=true`, and `prefix_cache_scoring.ranking_mode = :tie_only`, the scheduler MAY apply one bounded conditional score step immediately before step 7, only for the leading rank-equivalence group where steps 1–6 are equal and only deterministic `node_id` differs. Candidate scoring in this conditional step is capped at 2 (incumbent + challenger). The challenger MAY be promoted only when challenger score normalizes to `status_code = "ok"` with `resident_fingerprint_match = true` and `score_tier = "resident_fingerprint"`, and the incumbent score is comparable `ok` non-resident (`status_code = "ok"`, `resident_fingerprint_match = false`, and `score_tier` is `"no_match"` or `"recent_fingerprint_only"`). Any non-`ok`, timeout, unsupported, unavailable, `model_not_loaded`, `invalid_request`, missing, malformed, contradictory, or transport-failure score outcome for either candidate SHALL preserve base order fail-open and deterministic `node_id` fallback.
+When `prefix_cache_scoring.enabled=true`, `cache_affinity.enabled=true`, `cache_affinity.live_fingerprint_match_enabled=true`, and `prefix_cache_scoring.ranking_mode = :tie_only`, the scheduler MAY apply one bounded conditional score step immediately before step 8, only for the leading rank-equivalence group where steps 1–7 are equal and only deterministic `node_id` differs. Candidate scoring in this conditional step is capped at 2 (incumbent + challenger). The challenger MAY be promoted only when challenger score normalizes to `status_code = "ok"` with `resident_fingerprint_match = true` and `score_tier = "resident_fingerprint"`, and the incumbent score is comparable `ok` non-resident (`status_code = "ok"`, `resident_fingerprint_match = false`, and `score_tier` is `"no_match"` or `"recent_fingerprint_only"`). Any non-`ok`, timeout, unsupported, unavailable, `model_not_loaded`, `invalid_request`, missing, malformed, contradictory, or transport-failure score outcome for either candidate SHALL preserve base order fail-open and deterministic `node_id` fallback.
 
-A live prefix-cache fingerprint match is a bounded, approximate warmth hint. It SHALL bias ranking only after eligibility and before historical affinity. Safe-tokenization capable-worker preference is default-off and SHALL bias ranking only after live and historical cache-affinity signals and before memory-headroom admission. The memory-headroom observation is a bounded, positive-only hint. It SHALL bias ranking only after live cache-affinity, historical cache-affinity, and any enabled safe-tokenization capable-worker preference, and before deterministic `node_id`; candidates with absent, malformed, unavailable, or non-`ok` memory-budget telemetry remain schedulable and rank-neutral. Neither hint SHALL change node eligibility, request admission, queue ordering, public error contracts, or runtime concurrency.
+A live prefix-cache fingerprint match is a bounded, approximate warmth hint. It SHALL bias ranking only after health and before historical affinity. Safe-tokenization capable-worker preference is default-off and SHALL bias ranking only after live and historical cache-affinity signals and before memory-headroom admission. The memory-headroom observation is a bounded, positive-only hint. It SHALL bias ranking only after live cache-affinity, historical cache-affinity, and any enabled safe-tokenization capable-worker preference, and before deterministic `node_id`; candidates with absent, malformed, unavailable, or non-`ok` memory-budget telemetry remain schedulable and rank-neutral. Neither hint SHALL change node eligibility, request admission, queue ordering, public error contracts, or runtime concurrency.
 
 ### 5.8 Scheduling algorithm
 
@@ -2251,12 +2258,13 @@ Response example:
       "node_id": "node-2",
       "eligible": true,
       "tier": "loaded",
-      "score": 812,
+      "score": 842,
       "components": {
         "pool_bonus": 200,
         "residency_bonus": 500,
         "mem_bonus": 72,
         "load_bonus": 40,
+        "health_bonus": 30,
         "warmth_bonus": 20,
         "swap_penalty": 20
       },

--- a/docs/decisions/0013-controller-dispatch-capacity-authority.md
+++ b/docs/decisions/0013-controller-dispatch-capacity-authority.md
@@ -1,0 +1,95 @@
+# Controller dispatch is bounded by a mandatory per-Node ceiling
+
+## Status
+
+Accepted.
+
+## Context
+
+Orchard currently lets Node-reported aggregate concurrency telemetry act as the Controller's dispatch authority.
+That conflates the Node Agent's local enforcement responsibility with the Controller's responsibility to govern how much work it allocates to an admitted production Node.
+The distinction becomes critical when runtime limits change, telemetry is absent, a Node becomes unhealthy or stale, or an operator needs to reduce new work without cancelling running requests.
+
+The decision is hard to reverse because it fixes the authority boundary across Node Admission, scheduling, queue capacity, dispatch, diagnostics, and later Active/Standby hardening.
+It is surprising because both the Node and the Controller own different limits that apply simultaneously.
+It resolves a real trade-off between runtime-managed capacity, Controller-only policy, and an explicit composition of both authorities.
+
+## Decision
+
+Every admitted production Node has one mandatory durable Controller Dispatch Ceiling in steady-state operation.
+The operational cohort begins at committed Node Admission and ends only at durable lifecycle `removed` with trust revoked and removal audited.
+A removed tombstone retains its historical policy but does not block approval, quiescence, or cutover, and later re-enrollment requires a new admission policy.
+The only temporary exception is the bounded pre-F11 `shadow_legacy` cohort, whose durable policy record deliberately has no ceiling, authorizes none of the new semantics, and remains distinct from a missing policy record.
+New Node Admission persists an explicit ceiling atomically with admission and uses the explicit default `1` when the administrator omits the value.
+An explicit ceiling of `0` is valid policy for stopping new Controller allocations under `f11_enforcing` without changing Node Lifecycle State.
+Before cutover, every approved ceiling is recorded policy but is not yet allocation authority, and previews must warn that even `0` does not change temporary legacy allocation.
+
+The Node owns its dynamic Runtime Concurrency Enforcement Limit and enforces that limit locally.
+For a trusted, Active, healthy production Node with scheduler-fresh heartbeat and capacity observations, valid runtime and ceiling values, durable cluster phase `enforcing`, and policy state `enforcing`, the Effective Dispatch Limit is the smaller of the Runtime Concurrency Enforcement Limit and the Controller Dispatch Ceiling.
+Before cutover, new admissions enter non-enforcing `approved_explicit`; after cutover, new admissions enter `enforcing` directly.
+Under `f11_enforcing`, the Effective Dispatch Limit is `0` for an untrusted, non-Active, degraded, unhealthy, stale, policy-missing, or runtime-limit-missing production Node.
+Dispatch Headroom is the non-negative difference between the Effective Dispatch Limit and Controller-accounted Allocation.
+
+Controller-accounted Allocation counts unique, non-released, Node-scoped logical allocations owned by the current Active Controller.
+It does not derive from Node-reported active request telemetry or Placement Capacity.
+The current Active Controller serializes allocation of the final unit of headroom, retains one allocation through model loading and execution, and releases it exactly once before retry or after failure, cancellation, or completion.
+Pre-acceptance revalidation excludes only the request's recognized allocation from the allocation operand so the claim is not counted twice.
+
+Placement Capacity remains Node-owned and may further restrict a requested Model Placement.
+Placement and queue-lane capacity never increase aggregate authority beyond the shared authority decision's available slots, and under `f11_enforcing` no new allocation across all placements on a Node may cause the total to exceed its Effective Dispatch Limit.
+A lower ceiling may temporarily leave accepted, running, or streaming allocations above the new limit while they drain naturally.
+
+Under `f11_enforcing`, lowering a Controller Dispatch Ceiling blocks new allocation above the new limit, revalidates pre-acceptance held allocations, and lets accepted, running, or streaming work drain naturally without forced cancellation solely because of the reduction.
+Under `f11_enforcing`, raising a ceiling creates no allocation by itself and remains bounded by current runtime enforcement and every other eligibility gate.
+
+Existing Nodes migrate through `shadow_legacy`, `approved_explicit`, and `enforcing`.
+The legacy cohort is explicit and temporary, receives no silent default of `1`, and receives no telemetry-derived durable ceiling.
+Operator approval persists the ceiling and provenance before enforcement.
+After cutover, a missing policy fails closed with Effective Dispatch Limit `0`.
+
+One durable cluster-wide enforcement phase distinguishes `pre_cutover` from `enforcing` and records the required contract version plus cutover provenance.
+Admission locks and reads that marker in its transaction instead of inferring cutover from policy rows, Controller version, or cluster occupancy.
+In `pre_cutover`, every named consumer uses one shared legacy decision while F11 Effective Dispatch Limit and Dispatch Headroom remain counterfactual zero for `shadow_legacy` and `approved_explicit`.
+That decision centrally freezes the pre-F11 calculation as positive fresh runtime maximum or fallback `1`, minus non-negative fresh reported aggregate active count or fallback `0`, floored at zero, under the pre-F11 trusted, Active, healthy-or-degraded, fresh, placement, and routing gates.
+Every legacy dispatch also acquires one serialized Controller-local temporary claim across all placements and lanes, and the shared temporary available-slot calculation subtracts both reported allocation and live temporary claims.
+The claim remains through Node acceptance and terminal completion so concurrent lanes cannot spend the same temporary slot.
+Cutover requires fresh evidence from every non-retired Controller whose published contract version exactly equals the locked required version and whose all-consumers-ready declaration is true, atomically advances approved policies and the marker, and makes a Controller that cannot enforce the recorded contract version fail closed after cutover.
+Cutover quiesces new legacy claims, waits for all temporary claims to release and for new fresh aggregate observations to report zero active requests on every non-removed admitted production Node, then holds every applicable per-Node acceptance gate while it revalidates and commits.
+It never adopts live legacy work across the phase boundary and never derives durable policy from the zero-occupancy observation.
+The supervised Controller membership owner refreshes the complete capability tuple every `10000` ms, and the leader-only admin retirement surface supplies the audited recovery path for a stale non-Active, non-last Controller.
+
+One shared transport-independent evaluation supplies the capacity semantics to MultiNode, admitted SingleNode, Node queue-source refresh, QueueManager, and dispatch-time revalidation.
+Transport selection does not create an exemption for an admitted production Node.
+Every normalized target carries Controller-owned `capacity_management_class`, admitted inventory always forces `production_managed`, and absent, invalid, or inferred classification fails closed.
+Only a valid explicitly classified unmanaged source-development or compatibility target may retain legacy capacity behavior.
+
+The normative management surfaces are Operator API policy reads for cluster `operator` or `admin`, leader-only and admin-only Operator API policy mutations and enforcement cutover, and matching Admin API and local `orchardctl nodes admit` inputs for the initial ceiling and reason.
+API mutations require cluster `admin`, while local CLI admission uses the established Controller-runtime authority boundary; both require Action Preview, explicit confirmation when consequences require it, mutation-time revalidation, and atomic cluster-scoped audit persistence.
+Per-Node policy mutation and final dispatch revalidation share one Controller-local acceptance gate that remains held through Node acceptance or pre-acceptance failure.
+This makes either acceptance or the policy change happen first without an authority gap, while leaving distributed leadership fencing to M7.
+
+## Rejected alternatives
+
+Runtime telemetry alone is rejected because it gives the Controller no durable dispatch policy.
+Controller policy alone is rejected because the Node must retain local authority to reduce its dynamic runtime limit and reject excess work.
+A permanent null ceiling meaning runtime-managed is rejected because it makes missing policy indistinguishable from deliberate policy and migration state.
+Silently assigning existing Nodes a ceiling of `1` is rejected because it can unexpectedly reduce working capacity.
+Inferring a durable ceiling from telemetry is rejected because observations are not operator-approved policy.
+Independent per-placement ceilings without an aggregate bound are rejected because multiple lanes could exceed Node-level authority.
+Persisting only the Effective Dispatch Limit is rejected because it erases the two independent authority inputs.
+The term `Admitted Capacity` is rejected because it conflates Node Admission, Request Admission, policy, runtime enforcement, and remaining headroom.
+
+## Consequences
+
+Node Admission and operator policy changes become auditable capacity-authority writes.
+Diagnostics must show the separate runtime limit, Controller ceiling, effective limit, Controller allocation, headroom, policy state, and reason codes.
+Production capacity becomes fail-closed when policy, trust, health, freshness, or runtime evidence is missing.
+Source-development and compatibility exceptions require explicit unmanaged classification and cannot be inferred from transport.
+
+F11 provides durable Controller policy and a serialized Controller-local bound on new allocations by one live Active Controller.
+It does not provide a durable distributed dispatch permit, leader epoch, Node-verifiable token, crash-recoverable reservation ledger, or proof of actual Node occupancy.
+Durable dispatch permits, leadership fencing, reservation recovery, and compromised-node occupancy integrity remain M7-aligned follow-ups.
+
+## SPEC.md impact
+
+Update required in `SPEC.md` §4.1, §4.4, §4.6.1, new §4.6.2, §5.4, §5.5, §5.9, §7.3.5, §7.5.3, §8, §10.9, and §13.2.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -466,8 +466,9 @@ A per-Runtime Endpoint model state describing whether a model is unavailable, ca
 _Avoid_: Catalog State, tenant-visible model activation
 
 **Placement Capacity**:
-A first-class Runtime Endpoint Observation describing current active request count and maximum concurrency for a Model Placement.
-_Avoid_: Quota, durable capacity guarantee, transport field name
+The Node-owned active request count and concurrency bound for one Model Placement, reported through Runtime Endpoint Observations.
+It may reduce placement eligibility but never increases aggregate authority beyond the Effective Dispatch Limit.
+_Avoid_: Controller Dispatch Ceiling, aggregate Node capacity, Dispatch Headroom, durable capacity guarantee, queue lane capacity
 
 **Model Bundle**:
 An offline-importable model artifact directory or archive supplied to Orchard with a Model Manifest.
@@ -510,6 +511,27 @@ _Avoid_: Healthy node, every Runtime Endpoint
 **Schedulable Runtime Endpoint**:
 A Runtime Endpoint eligible for new work because policy, capability, health, capacity, and breaker conditions allow it.
 _Avoid_: Node inventory, hardware host
+
+**Runtime Concurrency Enforcement Limit**:
+The Node-owned dynamic upper bound on concurrent runtime work that the Node will accept and enforce at a given time.
+_Avoid_: advertised capacity, Controller concurrency limit, durable Node capacity, Controller Dispatch Ceiling, Placement Capacity
+
+**Controller Dispatch Ceiling**:
+The mandatory steady-state durable, operator-approved upper bound on concurrent work the Controller may allocate to an admitted production Node.
+The bounded pre-F11 `shadow_legacy` policy has no ceiling, authorizes none of the new semantics, and is not a missing policy record.
+_Avoid_: Admitted Capacity, runtime-managed capacity, nullable ceiling, inferred telemetry limit, Placement Capacity
+
+**Effective Dispatch Limit**:
+The aggregate limit the Controller may use after combining current Node runtime enforcement, durable Controller policy, and production eligibility.
+_Avoid_: Admitted Capacity, runtime max concurrency, Controller Dispatch Ceiling, Dispatch Headroom, Placement Capacity, queue lane capacity
+
+**Controller-accounted Allocation**:
+The count of work the current Active Controller treats as occupying a Node's aggregate dispatch allocation.
+_Avoid_: runtime active request count, worker occupancy, durable dispatch permit, queue grant, Placement Capacity
+
+**Dispatch Headroom**:
+The count of additional allocations the Controller may make within the Effective Dispatch Limit.
+_Avoid_: Admitted Capacity, spare runtime slots, queue capacity, Placement Capacity, dispatch permit balance
 
 **Candidate Tier**:
 A scheduling group based on model residency, such as loaded, cached, or cold.
@@ -584,14 +606,9 @@ Queue admission also uses valid loaded-placement observations to wake queued sam
 _Avoid_: Catalog State, durable placement record, model manifest metadata
 
 **Runtime Node Capacity**:
-Runtime Endpoint Observation data for aggregate runtime capacity on one endpoint-backed node.
-The current gRPC Compatibility Adapter maps this from `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`.
-The BEAM Node Agent facade maps the same node-agent status semantics into BEAM Runtime Endpoint Observations.
-The scheduler uses it to exclude endpoint-backed nodes that have exhausted aggregate request slots before considering per-placement capacity.
-Queue admission uses eligible endpoint observations to bound cold/no-placement wakeups and to keep active source reservations from being double-counted across queued lanes.
-Transport-failed or newly ineligible endpoints clear endpoint-owned aggregate, cold, and placement sources instead of retaining stale capacity.
-BEAM observations publish queue capacity only when the target resolves back to the same persisted node identity.
-_Avoid_: Tenant quota, durable Node inventory capacity, model-specific capacity
+Node-owned Runtime Endpoint Observation data describing aggregate runtime occupancy and enforcement limits for one endpoint-backed Node.
+It is an input to Controller capacity evaluation, not durable Controller policy or Controller allocation accounting.
+_Avoid_: Tenant quota, Controller Dispatch Ceiling, Effective Dispatch Limit, Controller-accounted Allocation, model-specific capacity
 
 **Prefix-cache Score**:
 A bounded, fail-open score RPC result used only as explicitly configured scheduler tie-break telemetry.

--- a/openspec/changes/controller-dispatch-capacity-authority/design.md
+++ b/openspec/changes/controller-dispatch-capacity-authority/design.md
@@ -1,0 +1,249 @@
+# Design: Controller dispatch capacity authority
+
+## Context
+
+The Node Agent already owns local worker admission and reports aggregate runtime concurrency through Runtime Endpoint Observations.
+MultiNode, SingleNode, Node observation refresh, QueueManager, and dispatch currently interpret those values independently.
+This design introduces durable Controller policy and a shared semantic evaluation without moving local enforcement out of the Node.
+
+## Authority model
+
+The Node owns the Runtime Concurrency Enforcement Limit and local enforcement.
+The Controller owns the durable Controller Dispatch Ceiling and its own allocation accounting.
+Placement Capacity remains Node-owned model-specific evidence.
+
+For an admitted production Node:
+
+```text
+effective_dispatch_limit =
+  min(runtime_concurrency_enforcement_limit, controller_dispatch_ceiling)
+```
+
+The formula produces a non-zero value only when the durable cluster phase is `enforcing`, trusted identity, lifecycle state `active`, health `healthy`, scheduler-fresh heartbeat, scheduler-fresh capacity observation, an `enforcing` explicit policy with a valid non-negative ceiling, and a valid runtime limit are all present.
+Otherwise the Effective Dispatch Limit is `0`.
+
+```text
+dispatch_headroom =
+  max(effective_dispatch_limit - controller_accounted_allocation, 0)
+```
+
+## Durable policy model
+
+Use a one-to-one `node_dispatch_capacity_policies` record for each admitted production Node.
+The record owns policy state, the Controller Dispatch Ceiling, approval actor, approval time, and approval reason.
+This keeps missing policy distinct from an explicit ceiling of `0` and from temporary migration state.
+
+The allowed policy states are:
+
+```text
+shadow_legacy -> approved_explicit -> enforcing
+enforcing -> enforcing
+```
+
+Initial policy state is `approved_explicit` for admission before enforcement cutover and `enforcing` for admission after cutover.
+
+`shadow_legacy` is created only for non-removed production Nodes whose Node Admission committed before the expand migration, identified from durable admission evidence.
+Durably removed Nodes whose trust is revoked and removal is audited retain historical policy evidence but are outside the operational capacity cohort and do not block approval, quiescence, or cutover.
+Later re-enrollment passes a new Node Admission under the then-current phase.
+It carries no ceiling and is a temporary counterfactual observation state.
+Legacy behavior may continue during the bounded shadow window, but the counterfactual Effective Dispatch Limit is `0` until an explicit ceiling exists.
+
+`approved_explicit` contains an operator-approved ceiling and provenance but remains non-enforcing until every semantic consumer is wired.
+`enforcing` means every named consumer applies the shared evaluation.
+An audited ceiling update keeps an enforcing policy in the enforcing state.
+
+Before enforcement cutover, new Node Admission atomically writes `approved_explicit` policy before the lifecycle transition commits.
+After enforcement cutover, new Node Admission writes `enforcing` directly because every semantic consumer already applies the shared evaluation.
+The administrator may provide any non-negative integer, including `0`.
+When omitted, the Controller persists the explicit default `1`.
+Policy write or audit failure rolls back admission.
+
+Missing policy is never interpreted as legacy state.
+Runtime telemetry is never copied into the durable ceiling.
+Cutover preflight requires every otherwise eligible legacy Node to have an explicit approved ceiling and requires every named consumer to use the shared evaluation.
+Cutover advances those policies to `enforcing` atomically, and post-cutover admission fails closed unless its `enforcing` policy and audit record commit with the lifecycle transition.
+
+## Durable enforcement phase
+
+Persist one cluster-wide dispatch-capacity authority row with phase `pre_cutover` or `enforcing`, a positive required contract version, and cutover provenance.
+The row exists even for an empty cluster.
+Admission locks and reads it inside the admission transaction, so the initial policy state is never inferred from existing Node policies, Controller version, transport, or cluster occupancy.
+
+The shared evaluator takes the durable phase as an explicit input.
+In `pre_cutover`, `shadow_legacy` and `approved_explicit` return counterfactual F11 values of zero plus one explicit legacy decision consumed by all named consumers.
+That decision centrally calculates temporary available slots as positive fresh runtime `max_concurrency` or fallback `1`, minus non-negative fresh aggregate `active_request_count` or fallback `0`, floored at `0`.
+It then subtracts unique non-released Controller-local temporary legacy claims, acquired serially across all placements and lanes and retained through terminal completion.
+Legacy revalidation excludes only the current recognized temporary claim, and every queue grant must acquire that claim even when queue-source capacity advertised the same slots to multiple lanes.
+It preserves the pre-F11 trusted, Active, healthy-or-degraded, fresh, placement, pool, format, memory, and breaker gates.
+Queue contribution, scheduler eligibility, QueueManager, admitted SingleNode, and dispatch revalidation consume those temporary slots directly instead of requiring positive Dispatch Headroom or re-deriving legacy concurrency.
+The missing or malformed active-count fallback is a named temporary legacy finding and never enters F11 enforcement or durable policy.
+In `enforcing`, only an `enforcing` policy can authorize positive F11 capacity.
+Either phase-policy mismatch fails closed.
+
+Cutover runs under the migration advisory lock and one Postgres transaction.
+It locks the phase row, proves every non-removed admitted production Node has approved policy, proves every non-retired Controller has fresh capability evidence whose contract version exactly equals the locked required version and whose indivisible all-consumers-ready declaration is true, advances approved policies, records provenance, and changes the phase to `enforcing` atomically.
+Before the transaction, a visible Controller-local transition barrier blocks new temporary legacy claims while existing claims and accepted work drain.
+Cutover requires zero live temporary claims plus a new fresh aggregate observation reporting zero active requests for every non-removed admitted production Node.
+Only durable lifecycle `removed` with revoked trust and an existing successful removal audit qualifies for exclusion; other lifecycle states and unreachable Nodes remain blockers.
+It then acquires every per-Node acceptance gate in stable order, revalidates quiescence, and holds the gates through commit and local phase publication.
+Timeout or stale or nonzero evidence aborts quiescence without changing phase or policies and reopens legacy dispatch.
+No live legacy work is adopted across cutover, and the zero-occupancy evidence never becomes durable policy.
+The cutover request carries only `expected_required_contract_version` for optimistic comparison and cannot change the durable required version.
+Any failure rolls back the entire transition.
+A Controller that cannot support the recorded contract version fails readiness and refuses admission and dispatch after cutover.
+The supervised Controller membership owner refreshes `last_seen_at` and the complete capability tuple atomically every `10000` ms.
+The Operator API provides leader-only admin-authorized audited retirement for a non-Active, non-last Controller so stale evidence has an explicit recovery path before cutover.
+
+## Management surface
+
+Node Admission accepts an optional non-negative initial ceiling, defaults it explicitly to `1` only when omitted, and requires a capacity-policy reason.
+The Operator API exposes policy reads to cluster `operator` or `admin`; policy approval or ceiling updates and enforcement cutover require cluster `admin` and Active leadership.
+Every mutation supports a side-effect-free Action Preview, mutation-time authorization and phase revalidation, optimistic concurrency where policy is updated, explicit consequence confirmation, and atomic cluster-scoped audit persistence.
+Under `f11_enforcing`, lowering below current Controller-accounted Allocation previews natural drain and pre-acceptance revalidation consequences.
+Before cutover, admission and mutation previews warn `controller_dispatch_ceiling_not_yet_enforcing`, including for ceiling `0`, and do not claim the approved ceiling changes temporary legacy allocation.
+The local `orchardctl nodes admit` surface accepts the same optional ceiling and required reason, previews the same resolved values, and uses the same atomic Controller-runtime transaction and audit contract.
+
+## Controller-accounted Allocation
+
+Controller-accounted Allocation is the number of unique, non-released, Node-scoped logical allocations owned by the current Active Controller.
+An allocation begins when Node selection and the capacity claim are atomically committed.
+It is retained through connection, model loading, scheduled, dispatching, accepted, running, and streaming work.
+It is released exactly once on terminal completion, cancellation, pre-acceptance failure, or before a retry claims another Node.
+
+Queued requests, unassigned queue grants, configured lane capacity, Runtime Endpoint active-request telemetry, and Placement Capacity do not count as Controller-accounted Allocation.
+The final unit of headroom must be serialized so concurrent requests cannot both acquire it.
+Dispatch Headroom authorizes acquisition of a new allocation only.
+For revalidation before Node acceptance, the same shared evaluation serializes with allocation changes, excludes only the request's recognized allocation from the allocation operand, and requires the resulting value to be positive without counting that claim twice.
+If the held allocation no longer fits, dispatch releases it exactly once and requeues or fails under the existing contract.
+A request already accepted by the Node, running, or streaming is not forcibly cancelled solely because a ceiling is lowered.
+
+One Controller-local acceptance gate exists per admitted production Node.
+Final dispatch revalidation holds it continuously through Node acceptance or pre-acceptance failure, and ceiling mutation holds the same gate through commit and local publication.
+Whichever operation acquires the gate first defines whether the work is accepted under the old policy and drains, or must revalidate under the new policy.
+A cluster transition barrier coordinates those gates for cutover.
+This is Controller-local F11 serialization, not cross-Controller leadership fencing or a durable permit.
+
+This is a live Controller-local accounting contract.
+It does not promise persistence across a Controller crash or leadership change.
+M7 remains responsible for durable permits, leader fencing, reservation recovery, and compromised-node occupancy integrity.
+
+## Shared evaluation
+
+One pure transport-independent evaluation returns:
+
+- Runtime Concurrency Enforcement Limit.
+- Controller Dispatch Ceiling.
+- Effective Dispatch Limit.
+- Controller-accounted Allocation.
+- Dispatch Headroom.
+- Durable enforcement phase.
+- Policy state.
+- Normalized target `capacity_management_class`.
+- Authority decision, `legacy_pre_cutover`, `f11_enforcing`, or fail-closed.
+- Decision-specific available slots, including temporary `legacy_pre_cutover_available_slots` when applicable.
+- Eligibility.
+- Stable reason codes.
+
+The following consumers must use that same result:
+
+1. MultiNode candidate eligibility and queue-lane contribution.
+2. SingleNode whenever the target resolves to an admitted or otherwise production-managed Node.
+3. Node observation queue-source refresh and source clearing.
+4. QueueManager aggregate Node claims across all lanes.
+5. Dispatch-time revalidation after model loading and immediately before `ExecuteInference`.
+
+No consumer may re-derive the formulas, default missing production policy to `1`, or treat configured queue capacity as dispatch authority.
+
+## Placement aggregate bound
+
+Placement Capacity can only reduce capacity for the requested Model Placement.
+The effective capacity of one placement is bounded by its Node-owned Placement Capacity and the shared authority decision's available slots.
+Every queue lane and placement on a Node shares the same aggregate allocation authority.
+Under `f11_enforcing`, no new allocation across all placements and lanes may cause the total to exceed the Node's Effective Dispatch Limit.
+Under `legacy_pre_cutover`, the centrally calculated temporary available slots and serialized temporary claims provide the aggregate bound while Effective Dispatch Limit remains counterfactual `0`.
+A ceiling reduction may temporarily leave accepted, running, or streaming allocations above the new limit while they drain naturally.
+
+Cold model loading retains its Node allocation while the model loads.
+Dispatch revalidates the recognized pre-acceptance allocation without double-counting it and revalidates Placement Capacity before execution.
+
+## Raising and lowering
+
+Under `f11_enforcing`, lowering a ceiling applies to new allocations and pre-acceptance held-allocation revalidation immediately.
+Accepted, running, and streaming work is not forcibly cancelled solely because the ceiling changed, and the Node does not enter lifecycle state `draining` merely because the ceiling changed.
+Dispatch Headroom remains `0` while allocation is greater than or equal to the lowered Effective Dispatch Limit and becomes positive only as work finishes.
+
+Under `f11_enforcing`, raising a ceiling does not create an allocation.
+It remains bounded by the fresh Runtime Concurrency Enforcement Limit and every trust, lifecycle, health, freshness, placement, and breaker gate.
+Queue wake-up follows shared re-evaluation.
+
+## Source-development and compatibility boundary
+
+Transport is not an authority classification.
+An admitted production Node remains governed over BEAM, gRPC compatibility, or a static target reference.
+Production inventory resolution happens before any source-development or compatibility exception is considered.
+Failure to resolve or probe a production-managed target cannot downgrade it to unmanaged legacy behavior.
+
+Each normalized target has Controller-owned `capacity_management_class` of `production_managed`, `unmanaged_source_development`, or `unmanaged_compatibility`.
+An admitted inventory match always forces `production_managed`.
+Unmanaged source development is valid only in source-development mode, and unmanaged compatibility is valid only for explicitly enabled compatibility configuration that does not match admitted inventory.
+Missing, malformed, conflicting, telemetry-derived, transport-derived, or probe-derived classification fails closed.
+Only a valid explicitly classified unmanaged source-development or static compatibility target may retain legacy capacity behavior.
+Compatibility normalization of missing or zero runtime maximum to `1` populates only the ephemeral Runtime Concurrency Enforcement Limit.
+It never creates or backfills a Controller Dispatch Ceiling.
+
+## Diagnostics
+
+Operator status exposes durable enforcement phase, policy state, normalized target management class, authority decision, all five aggregate capacity values, Placement Capacity, observation time, and stable reason codes.
+Pre-cutover status also exposes temporary `legacy_pre_cutover_available_slots`, live temporary legacy claim count, and cutover quiescing state while the canonical F11 Effective Dispatch Limit and Dispatch Headroom remain `0`.
+At minimum, the fixed vocabulary includes:
+
+- `node_health_degraded`.
+- `controller_dispatch_ceiling_missing`.
+- `controller_dispatch_ceiling_invalid`.
+- `controller_dispatch_ceiling_zero`.
+- `controller_dispatch_ceiling_exhausted`.
+- `runtime_concurrency_limit_unknown`.
+- `runtime_concurrency_limit_exhausted`.
+- `dispatch_headroom_exhausted`.
+- `placement_capacity_exhausted`.
+- `dispatch_capacity_revalidation_failed`.
+- `dispatch_capacity_pre_cutover_legacy`.
+- `dispatch_capacity_phase_policy_mismatch`.
+- `dispatch_capacity_cutover_quiescing`.
+- `dispatch_capacity_cutover_occupancy_not_zero`.
+- `runtime_endpoint_management_class_missing`.
+- `runtime_endpoint_management_class_invalid`.
+- `dispatch_ceiling_shadow_mismatch`.
+- `dispatch_ceiling_not_approved`.
+
+Public request outcomes remain the existing sanitized `cluster_busy`, `queue_timeout`, and dispatch error contracts.
+The term `Admitted Capacity` is prohibited because it conflates unrelated admission and capacity concepts.
+
+## First implementation tracer
+
+The first tracer is intentionally non-enforcing.
+It adds the policy table and constraints, creates `shadow_legacy` rows for the existing cohort, adds the pure evaluator and truth-table tests, atomically persists admission default `1`, and exposes policy diagnostics.
+It does not advance any policy to `enforcing` and does not claim production enforcement.
+
+The next implementation slice is the first enforcing vertical tracer.
+It must wire all five consumers, serialize temporary legacy and F11 allocation claims, add the transition barrier and per-Node acceptance gates, preserve each claim through model loading and Node acceptance, revalidate before execution, release once on every terminal path, and quiesce legacy occupancy before cutover.
+Partial enforcing wiring is rejected because an unwired consumer could bypass the ceiling.
+
+## Rejected alternatives
+
+Runtime telemetry alone is rejected because it is not durable Controller policy.
+Controller ceiling alone is rejected because the Node must retain local dynamic enforcement.
+Permanent null meaning runtime-managed is rejected because it makes missing policy ambiguous.
+Silent existing-row default `1` is rejected because it can collapse working capacity.
+Telemetry backfill is rejected because observation is not operator approval.
+Independent placement limits without an aggregate bound are rejected because multiple lanes can exceed Node authority.
+Persisting only Effective Dispatch Limit is rejected because it erases the two authority inputs.
+`Admitted Capacity` is rejected as ambiguous language.
+
+## Follow-up boundaries
+
+F11 defines durable policy and a serialized bound for one live Active Controller.
+It does not add a durable dispatch permit, leader epoch, Node-verifiable capacity token, crash-recoverable reservation ledger, or proof of actual Node occupancy.
+Those are M7-aligned follow-ups.
+
+Malformed aggregate active-count handling, production probe-failure direct scheduling fallback, queue-source expiry and reservation provenance, and configured-base versus live-capacity provenance remain separate implementation findings.

--- a/openspec/changes/controller-dispatch-capacity-authority/proposal.md
+++ b/openspec/changes/controller-dispatch-capacity-authority/proposal.md
@@ -1,0 +1,43 @@
+# Controller dispatch capacity authority
+
+## Why
+
+Orchard currently derives Controller scheduling and queue capacity directly from Node-reported aggregate concurrency telemetry.
+There is no durable per-Node Controller authority that limits how much new work the Controller may allocate.
+Missing and legacy runtime telemetry can also fall back to capacity `1`, which cannot safely stand in for missing production policy.
+
+This change separates the Node-owned dynamic enforcement limit from the Controller-owned durable ceiling and defines one shared fail-closed production contract.
+
+## What changes
+
+- Add a mandatory durable Controller Dispatch Ceiling for every admitted production Node, with a bounded null-ceiling `shadow_legacy` exception only for Nodes admitted before the F11 migration.
+- Persist an explicit ceiling at Node Admission, defaulting new admissions to `1`.
+- Define Runtime Concurrency Enforcement Limit, Effective Dispatch Limit, Controller-accounted Allocation, Dispatch Headroom, and their relationship to Placement Capacity.
+- Require strict trusted, Active, healthy, and scheduler-fresh production eligibility.
+- Add explicit `shadow_legacy -> approved_explicit -> enforcing` migration states with operator approval and no telemetry backfill.
+- Add a durable cluster-wide `pre_cutover -> enforcing` phase that serializes admission with atomic enforcement cutover and Controller compatibility checks.
+- Serialize temporary legacy claims across all lanes, quiesce them before cutover, and share one per-Node boundary between policy mutation and the final dispatch-to-acceptance handoff.
+- Add fresh durable Controller capability evidence for the required contract version and indivisible all-five-consumers readiness.
+- Add the Controller membership heartbeat and audited retirement recovery path needed to keep that evidence actionable at cutover.
+- Bound placement and queue-lane contributions by one aggregate per-Node authority.
+- Require MultiNode, admitted SingleNode, Node queue-source refresh, QueueManager, and dispatch-time revalidation to consume one shared evaluation.
+- Define matching Admin API and `orchardctl nodes admit` inputs plus Operator API policy and cutover management surfaces with Action Preview, confirmation, and audit behavior.
+- Define a normalized Controller-owned target capacity management class so unmanaged compatibility can never be inferred from transport or failure.
+- Define raising, lowering, source-development exceptions, diagnostics, and stable reason vocabulary.
+
+## SPEC.md impact
+
+This change updates `SPEC.md` §4.1, §4.4, §4.6.1, new §4.6.2, §5.4, §5.5, §5.9, §7.3.5, §7.5.3, §8, §10.9, and §13.2.
+`SPEC.md` remains the apex contract, and these OpenSpec deltas define the implementation and acceptance intent beneath it.
+
+## Out of scope
+
+- Durable dispatch permits.
+- Leadership epochs and dispatch fencing.
+- Crash or handover reservation recovery.
+- Compromised-node occupancy integrity.
+- Malformed aggregate active-count hardening.
+- Production probe-failure direct scheduling fallback cleanup.
+- Queue-source expiry and reservation provenance.
+- Configured-base versus live-capacity provenance.
+- Product-code implementation in this contract PR.

--- a/openspec/changes/controller-dispatch-capacity-authority/specs/dispatch-capacity/spec.md
+++ b/openspec/changes/controller-dispatch-capacity-authority/specs/dispatch-capacity/spec.md
@@ -1,0 +1,443 @@
+## ADDED Requirements
+
+### Requirement: Mandatory Durable Controller Dispatch Ceiling
+Every admitted production Node SHALL have one durable Controller dispatch capacity policy.
+Registered but unadmitted production inventory SHALL NOT enter the migration cohort or require dispatch policy until Node Admission commits.
+The operational cohort SHALL end only when lifecycle `removed`, trust revocation, and the removal audit commit durably.
+A removed tombstone SHALL retain historical policy evidence but SHALL NOT block approval, compatibility preflight, zero-occupancy quiescence, or cutover.
+Later re-enrollment SHALL pass a new Node Admission and persist policy under the then-current phase.
+Except for the bounded pre-F11 cohort while its policy state is `shadow_legacy`, that policy SHALL have an explicit non-negative Controller Dispatch Ceiling.
+The `shadow_legacy` record SHALL deliberately have no ceiling, SHALL authorize none of the new production capacity semantics, and SHALL remain distinct from a missing policy record.
+Node Admission SHALL persist the policy atomically before the Node enters `admitted`, using an administrator-supplied value or the explicit default `1`.
+Before enforcement cutover, admission SHALL persist `approved_explicit`; after enforcement cutover, admission SHALL persist `enforcing` directly.
+An explicit ceiling of `0` SHALL be valid policy and SHALL remain distinct from missing policy.
+It SHALL stop new allocation only under `f11_enforcing`; before cutover, it SHALL be approved but not yet authoritative.
+A missing policy or missing ceiling for an admitted production Node SHALL yield Effective Dispatch Limit `0`.
+A permanent null ceiling meaning runtime-managed capacity SHALL be prohibited.
+The durable ceiling SHALL NOT be inferred or backfilled from Runtime Endpoint telemetry.
+This refines `SPEC.md` §4.1, §4.4, §4.6.2, §8, §10.9, and §13.2.
+
+#### Scenario: New admission uses explicit default
+- **WHEN** an administrator admits a registered production Node without supplying a ceiling
+- **THEN** Orchard persists Controller Dispatch Ceiling `1` in the admission transaction
+- **AND** Orchard records approval provenance
+- **AND** Orchard persists `approved_explicit` before cutover or `enforcing` after cutover
+- **AND** admission rolls back if policy or audit persistence fails
+
+#### Scenario: Administrator supplies a ceiling
+- **WHEN** an administrator admits a registered production Node with an explicit non-negative ceiling
+- **THEN** Orchard persists exactly that ceiling
+- **AND** Orchard does not replace it with runtime telemetry
+
+#### Scenario: Explicit zero pauses new allocation
+- **WHEN** under `f11_enforcing` an admitted production Node has Controller Dispatch Ceiling `0`
+- **THEN** its Effective Dispatch Limit is `0`
+- **AND** Orchard distinguishes the explicit policy from missing policy
+- **AND** Orchard does not forcibly cancel accepted, running, or streaming work solely because of the policy value or change Node Lifecycle State
+
+#### Scenario: Pre-cutover zero is not yet authority
+- **WHEN** an administrator approves Controller Dispatch Ceiling `0` during `pre_cutover`
+- **THEN** the Action Preview exposes `controller_dispatch_ceiling_not_yet_enforcing`
+- **AND** the `legacy_pre_cutover` decision remains authoritative until cutover
+- **AND** Orchard does not claim the approved zero has paused temporary legacy allocation
+
+#### Scenario: Production policy is missing
+- **WHEN** an admitted production Node has no durable policy record or no in-force explicit ceiling
+- **THEN** its Effective Dispatch Limit is `0`
+- **AND** Orchard does not infer ceiling `1` or copy a runtime limit into policy
+
+#### Scenario: Enforcing policy ceiling is malformed
+- **WHEN** an admitted production Node resolves an `enforcing` policy whose ceiling input is unavailable, malformed, or negative
+- **THEN** its Effective Dispatch Limit is `0`
+- **AND** Orchard exposes `controller_dispatch_ceiling_invalid`
+- **AND** Orchard does not pass the invalid value to the minimum formula
+
+### Requirement: Node-Owned Runtime Concurrency Enforcement Limit
+The Node SHALL own and locally enforce the dynamic Runtime Concurrency Enforcement Limit.
+The Controller SHALL treat that limit as one input to Effective Dispatch Limit and SHALL NOT replace the Node's local enforcement.
+Missing, malformed, unavailable, or scheduler-stale runtime-limit evidence for an admitted production Node SHALL NOT prove positive capacity.
+This refines `SPEC.md` §4.6.1, §4.6.2, and §7.5.3.
+
+#### Scenario: Runtime limit binds below the ceiling
+- **WHEN** a production Node reports a valid Runtime Concurrency Enforcement Limit of `2`
+- **AND** its Controller Dispatch Ceiling is `4`
+- **AND** every production eligibility gate passes
+- **THEN** its Effective Dispatch Limit is `2`
+
+#### Scenario: Controller ceiling binds below runtime
+- **WHEN** a production Node reports a valid Runtime Concurrency Enforcement Limit of `8`
+- **AND** its Controller Dispatch Ceiling is `3`
+- **AND** every production eligibility gate passes
+- **THEN** its Effective Dispatch Limit is `3`
+
+#### Scenario: Runtime evidence is missing in production
+- **WHEN** an admitted production Node lacks valid scheduler-fresh Runtime Concurrency Enforcement Limit evidence
+- **THEN** its Effective Dispatch Limit is `0`
+- **AND** its Controller Dispatch Ceiling alone does not prove positive capacity
+
+### Requirement: Effective Dispatch Limit Derivation
+For a trusted, Active, healthy admitted production Node with scheduler-fresh heartbeat and capacity observations, durable cluster phase `enforcing`, in-force explicit policy, and valid runtime evidence, Orchard SHALL compute Effective Dispatch Limit as the smaller of Runtime Concurrency Enforcement Limit and Controller Dispatch Ceiling.
+Orchard SHALL compute Effective Dispatch Limit `0` when any required gate fails.
+Under `f11_enforcing`, health SHALL mean exactly `healthy`; `degraded` SHALL NOT authorize new production allocation.
+Freshness SHALL require both the Node heartbeat and the capacity observation to remain within the scheduler freshness threshold.
+Under `legacy_pre_cutover`, the shared evaluator SHALL calculate one temporary available-slot result as positive fresh runtime `max_concurrency` or fallback `1`, minus non-negative fresh aggregate `active_request_count` or fallback `0`, minus unique non-released Controller-local temporary legacy claims, floored at `0`.
+That temporary branch SHALL require trusted identity, lifecycle `active`, health `healthy` or `degraded`, fresh heartbeat and observation, and existing pool, format, memory, placement, and breaker gates.
+Every named consumer SHALL use that central result, and no legacy value SHALL be presented as Effective Dispatch Limit or Dispatch Headroom or persisted as policy.
+Temporary legacy claim acquisition SHALL serialize across every placement and lane, retain the claim through Node acceptance and terminal completion, and release it exactly once.
+This refines `SPEC.md` §4.5, §4.6.2, and §5.5.
+
+#### Scenario: All production gates pass
+- **WHEN** a Node identity is trusted
+- **AND** lifecycle is `active`
+- **AND** health is `healthy`
+- **AND** heartbeat and capacity observation are scheduler-fresh
+- **AND** the ceiling and runtime limit are valid
+- **AND** the durable cluster phase and policy state are both `enforcing`
+- **THEN** Orchard derives the Effective Dispatch Limit with the minimum formula
+
+#### Scenario: Pre-cutover policies use one legacy decision
+- **WHEN** the durable cluster phase is `pre_cutover`
+- **AND** an admitted production Node policy is `shadow_legacy` or `approved_explicit`
+- **THEN** the shared evaluation reports counterfactual Effective Dispatch Limit and Dispatch Headroom `0`
+- **AND** every named consumer receives the same explicit `legacy_pre_cutover` decision for named temporary legacy behavior
+- **AND** the decision carries the centrally calculated temporary available slots
+- **AND** Orchard does not present legacy values as either canonical F11 value
+
+#### Scenario: Frozen legacy fallback remains temporary
+- **WHEN** a fresh pre-cutover observation omits or zeroes runtime `max_concurrency`
+- **AND** aggregate `active_request_count` is missing or malformed
+- **THEN** the central legacy calculation uses limit `1` and reported allocation `0`
+- **AND** Orchard still subtracts serialized live temporary legacy claims
+- **AND** Orchard records `dispatch_capacity_pre_cutover_legacy`
+- **AND** Orchard does not persist either fallback as Controller policy
+
+#### Scenario: Phase and policy mismatch fails closed
+- **WHEN** the cluster observes either `pre_cutover` with an `enforcing` policy or `enforcing` with a `shadow_legacy` or `approved_explicit` policy
+- **THEN** Orchard permits no new allocation
+- **AND** Orchard exposes `dispatch_capacity_phase_policy_mismatch`
+
+#### Scenario: Identity is not trusted
+- **WHEN** a target is unresolved, rejected, identity-mismatched, or otherwise untrusted
+- **THEN** its Effective Dispatch Limit is `0`
+
+#### Scenario: Lifecycle is not Active
+- **WHEN** a trusted Node is `admitted`, `cordoned`, `draining`, `maintenance`, `decommissioning`, or `removed`
+- **THEN** its Effective Dispatch Limit is `0`
+
+#### Scenario: Health is degraded or unhealthy
+- **WHEN** the decision is `f11_enforcing` and a trusted Active Node is `degraded`, `unhealthy`, or `unreachable`
+- **THEN** its Effective Dispatch Limit is `0`
+- **AND** a degraded Node exposes `node_health_degraded`
+- **AND** existing work may finish under its existing lifecycle and failure contracts
+
+#### Scenario: Capacity evidence is stale
+- **WHEN** either the trusted Node heartbeat or Runtime Endpoint capacity observation exceeds the scheduler freshness threshold
+- **THEN** its Effective Dispatch Limit is `0`
+- **AND** Orchard clears Node-owned queue capacity sources
+
+### Requirement: Dispatch Headroom From Controller-accounted Allocation
+Orchard SHALL compute Dispatch Headroom as the non-negative difference between Effective Dispatch Limit and Controller-accounted Allocation.
+Controller-accounted Allocation SHALL count unique, non-released, Node-scoped logical allocations owned by the current Active Controller.
+It SHALL exclude queued requests, unassigned grants, configured queue capacity, Node-reported active request counts, and Placement Capacity telemetry.
+Allocation of the final unit of headroom SHALL be serialized.
+Each request SHALL acquire at most one Node allocation, retain it through model loading and execution, and release it exactly once before retry or after failure, cancellation, or completion.
+Dispatch Headroom SHALL authorize only acquisition of a new allocation.
+Pre-acceptance revalidation SHALL serialize with allocation changes, exclude only the request's recognized allocation from the allocation operand, and require the resulting value to be positive without counting that claim twice.
+Final revalidation SHALL share a per-Node acceptance gate with policy mutation and SHALL hold that gate continuously through Node acceptance or pre-acceptance failure.
+This refines `SPEC.md` §4.6.2, §5.4, §5.5, and §5.9.
+
+#### Scenario: Allocation leaves headroom
+- **WHEN** Effective Dispatch Limit is `4`
+- **AND** Controller-accounted Allocation is `1`
+- **THEN** Dispatch Headroom is `3`
+
+#### Scenario: Allocation equals or exceeds the limit
+- **WHEN** Controller-accounted Allocation is greater than or equal to Effective Dispatch Limit
+- **THEN** Dispatch Headroom is `0`
+- **AND** Orchard allocates no new work to that Node
+
+#### Scenario: Two requests race for one unit
+- **WHEN** two concurrent requests attempt to acquire the final unit of Dispatch Headroom on one Node
+- **THEN** exactly one request acquires the allocation
+- **AND** the other request waits, retries, or fails under the existing queue contract
+
+#### Scenario: Node occupancy telemetry is malformed
+- **WHEN** Node-reported aggregate active-request telemetry is missing or malformed
+- **THEN** Orchard does not use that value to increase Dispatch Headroom
+- **AND** hardening the malformed telemetry path remains a separate follow-up
+
+### Requirement: Capacity Policy Migration And Operator Approval
+Existing production Nodes SHALL migrate through `shadow_legacy`, `approved_explicit`, and `enforcing` in that order.
+`shadow_legacy` SHALL apply only to non-removed production Nodes whose Node Admission committed before the F11 expand migration, selected from durable admission evidence, and SHALL be temporary and counterfactual.
+Operator approval SHALL persist a ceiling, actor, timestamp, and reason before policy becomes `approved_explicit`.
+No policy SHALL become `enforcing` until every named consumer uses the shared evaluation.
+After cutover, every otherwise eligible non-removed admitted production Node SHALL have enforcing explicit policy or fail closed.
+This refines `SPEC.md` §4.6.2 and §13.2.
+
+#### Scenario: Existing Node enters shadow without backfill
+- **WHEN** the expand migration encounters a production Node with durable evidence that Node Admission committed before F11
+- **THEN** Orchard creates `shadow_legacy` policy without a ceiling
+- **AND** Orchard does not assign `1`
+- **AND** Orchard does not infer a value from telemetry
+
+#### Scenario: Shadow diagnostics are counterfactual
+- **WHEN** a legacy Node lacks an explicit ceiling during the bounded shadow window
+- **THEN** its counterfactual Effective Dispatch Limit is `0`
+- **AND** any temporary legacy behavior is named and non-authoritative
+- **AND** Orchard distinguishes the present `shadow_legacy` policy from a missing policy record
+- **AND** Orchard exposes a shadow mismatch reason when legacy behavior differs
+
+#### Scenario: Operator approves explicit policy
+- **WHEN** an authorized operator approves a ceiling for a shadow Node
+- **THEN** Orchard persists the value and provenance
+- **AND** the policy becomes `approved_explicit`
+- **AND** telemetry does not supply the value
+
+#### Scenario: Enforcement cutover finds missing policy
+- **WHEN** cutover evaluates an otherwise eligible admitted production Node without approved policy
+- **THEN** Orchard excludes the Node with Effective Dispatch Limit `0`
+- **AND** Orchard does not treat the missing record as legacy mode
+
+#### Scenario: Cutover advances approved policy
+- **WHEN** cutover verifies that every named semantic consumer uses the shared evaluation
+- **AND** a legacy Node has an `approved_explicit` ceiling with approval provenance
+- **THEN** Orchard advances that policy to `enforcing` as part of cutover
+- **AND** the Node can have a non-zero Effective Dispatch Limit only after that advancement
+
+#### Scenario: Post-cutover admission is immediately enforcing
+- **WHEN** an administrator admits a new production Node after enforcement cutover
+- **THEN** Orchard persists an `enforcing` explicit policy in the admission transaction
+- **AND** Orchard does not strand the Node in `approved_explicit`
+- **AND** admission fails if policy or audit persistence fails
+
+### Requirement: Durable Enforcement Cutover Phase
+Orchard SHALL persist one cluster-wide dispatch-capacity enforcement phase with values `pre_cutover` and `enforcing`, a positive required contract version, and cutover provenance.
+The phase row SHALL exist for an empty cluster and SHALL NOT be inferred from Node policy rows, Controller version, transport, or cluster occupancy.
+Admission SHALL lock and read the phase inside its transaction.
+Every non-retired Controller SHALL atomically publish running software version, supported dispatch-capacity contract version, an indivisible all-five-consumers-ready declaration, and capability observation time at boot and on each Controller membership heartbeat.
+For F11, compatibility SHALL require exact equality between the published contract version and the locked durable required contract version plus an all-five-consumers-ready declaration of true.
+Greater-than-or-equal comparison SHALL NOT prove compatibility.
+The supervised Controller membership owner SHALL emit heartbeats every `10000` ms and atomically update `last_seen_at` with the complete capability tuple.
+Missing, version-zero, false, or stale capability evidence SHALL block cutover until the Controller refreshes evidence or is explicitly retired through `POST /ops/v1/controllers/:controller_id/retire`.
+Cutover SHALL use the migration advisory lock and one transaction to validate the expected phase and fresh compatible all-consumers-ready evidence for every non-retired Controller, advance approved policies, record provenance, and change the phase atomically.
+Before that transaction, cutover SHALL enter a visible Controller-local quiescing barrier, refuse new temporary legacy claims, wait for zero live temporary claims and a new fresh aggregate observation reporting zero active requests for every non-removed admitted production Node, then acquire every applicable per-Node acceptance gate in stable order and revalidate the zero-occupancy boundary.
+Cutover SHALL exclude a removed tombstone only when durable lifecycle `removed`, revoked trust, and the existing successful removal audit all prove the exclusion; every other lifecycle state and unreachable Node SHALL remain a blocker.
+Cutover SHALL hold those gates through commit and local phase publication, SHALL NOT adopt live legacy work into Controller-accounted Allocation, and SHALL reopen legacy dispatch without phase or policy changes when quiescence or revalidation fails.
+A Controller that cannot enforce the recorded contract version SHALL fail readiness and refuse admission and dispatch after cutover.
+This refines `SPEC.md` §4.6.2, §8.3, and §13.2.
+
+#### Scenario: Empty cluster admission reads durable phase
+- **WHEN** no Node policy rows exist and a Node Admission begins
+- **THEN** the admission transaction locks and reads the cluster-wide phase row
+- **AND** Orchard does not infer `pre_cutover` from the empty policy set
+
+#### Scenario: Cutover commits atomically
+- **WHEN** cutover proves every non-removed admitted production Node has approved policy and every non-retired Controller has fresh capability evidence at the required version with all five consumers ready
+- **AND** quiescing has reached zero live temporary claims and new fresh zero-active aggregate observations under the per-Node acceptance gates
+- **THEN** Orchard advances approved policies and the phase to `enforcing` in one transaction
+- **AND** Orchard records cutover actor, time, reason, and required contract version
+- **AND** any failed precondition or write rolls back both policy and phase changes
+
+#### Scenario: Admission races with cutover
+- **WHEN** Node Admission and enforcement cutover execute concurrently
+- **THEN** both operations serialize through the locked phase row
+- **AND** the admitted policy state matches the phase observed in its transaction
+
+#### Scenario: Cutover cannot reach zero occupancy
+- **WHEN** a temporary legacy claim remains live or a fresh aggregate observation remains nonzero, stale, missing, or malformed until the quiescing deadline
+- **THEN** Orchard leaves every policy and the durable phase unchanged
+- **AND** Orchard reopens legacy dispatch and exposes `dispatch_capacity_cutover_occupancy_not_zero`
+
+#### Scenario: Removed tombstone does not block cutover
+- **WHEN** a former production Node has durable lifecycle `removed`, revoked trust, and a successful removal audit
+- **THEN** cutover retains its historical policy but excludes it from approval and zero-occupancy blockers
+- **AND** an unreachable, decommissioning, or otherwise non-removed Node receives no implicit exclusion
+- **AND** later re-enrollment persists a new admission policy under the current phase
+
+#### Scenario: Cutover excludes new legacy handoffs
+- **WHEN** cutover enters its Controller-local quiescing barrier
+- **THEN** Orchard refuses new temporary legacy claims with `dispatch_capacity_cutover_quiescing`
+- **AND** existing accepted work drains without forced cancellation
+- **AND** no pre-acceptance handoff crosses the phase commit
+
+#### Scenario: Incompatible Controller observes enforcing phase
+- **WHEN** a Controller cannot enforce the durable required contract version
+- **AND** the cluster-wide phase is `enforcing`
+- **THEN** that Controller fails readiness
+- **AND** it refuses admission and dispatch rather than treating the cluster as `pre_cutover`
+
+#### Scenario: Stale Controller capability blocks cutover
+- **WHEN** any non-retired Controller has missing, stale, version-zero, incompatible, or all-consumers-not-ready evidence
+- **THEN** cutover Action Preview lists that Controller as a blocker
+- **AND** Orchard does not advance any policy or the durable phase
+
+#### Scenario: Cutover expected version mismatches durable authority
+- **WHEN** a cutover request's `expected_required_contract_version` differs from the locked singleton row
+- **THEN** Orchard rejects cutover as an optimistic concurrency conflict
+- **AND** Orchard does not change the durable required version, policy states, or enforcement phase
+
+#### Scenario: Membership heartbeat refreshes capability atomically
+- **WHEN** the supervised Controller membership owner emits its `10000` ms heartbeat
+- **THEN** Orchard updates `last_seen_at` and the complete capability tuple in one write
+- **AND** a failed or partial write does not make stale evidence fresh
+
+### Requirement: Capacity Policy Management Surface
+`POST /admin/v1/nodes/:node_id/admit` SHALL accept optional non-negative `controller_dispatch_ceiling`, required non-empty `capacity_policy_reason`, `dry_run`, and required confirmation, and SHALL expose the resolved ceiling and phase-derived policy state in its Action Preview.
+`orchardctl nodes admit` SHALL accept optional `--controller-dispatch-ceiling`, required `--capacity-policy-reason`, `--dry-run`, and execution confirmation, and SHALL expose the same resolved ceiling, phase-derived state, and preview semantics in human and JSON output.
+`GET /ops/v1/nodes/:node_id/dispatch-capacity-policy` SHALL require cluster `operator` or `admin` authority.
+`GET /ops/v1/controllers` SHALL require cluster `operator` or `admin` authority.
+`POST /ops/v1/controllers/:controller_id/retire` SHALL require cluster `admin`, Active leadership, reason, optimistic concurrency, side-effect-free Action Preview, and typed Controller ID confirmation.
+Retirement SHALL be blocked for the current Active Controller, a Controller holding the leadership lock, or the last non-retired Controller, and successful retirement SHALL atomically persist status plus cluster-scoped audit evidence.
+`PATCH /ops/v1/nodes/:node_id/dispatch-capacity-policy` and `POST /ops/v1/dispatch-capacity/enforcement-cutover` SHALL be leader-only, require cluster `admin`, support side-effect-free Action Preview, and revalidate authorization, leadership, durable phase, compatibility, and mutation blockers inside the transaction.
+Cutover SHALL accept `expected_required_contract_version`, require it to equal the locked singleton row, and SHALL NOT change the durable required version.
+Policy updates SHALL require a non-negative ceiling, non-empty reason, optimistic concurrency value, and any consequence confirmation.
+Policy updates SHALL hold the target Node's acceptance gate through commit and local policy publication.
+Before cutover, admission and policy-mutation previews SHALL expose `controller_dispatch_ceiling_not_yet_enforcing` and SHALL NOT claim any approved ceiling changes temporary legacy allocation.
+Under `f11_enforcing`, lowering below Controller-accounted Allocation SHALL require `capacity_reduction_drain` confirmation.
+Successful admission policy writes, approvals, ceiling changes, and cutover SHALL persist cluster-scoped audit evidence atomically with the authoritative mutation.
+Local CLI admission SHALL use actor type `operator` with bounded Controller-runtime principal provenance and the same leader-only atomic admission, policy, decision, and audit transaction as the Admin API.
+This refines `SPEC.md` §7.3.1, §7.4.1, §10.9, and §13.2.
+
+#### Scenario: Admission preview resolves default
+- **WHEN** an administrator previews Node Admission without supplying a ceiling
+- **THEN** the Action Preview shows explicit Controller Dispatch Ceiling `1`
+- **AND** it shows `approved_explicit` for `pre_cutover` or `enforcing` for the enforcing phase
+- **AND** it warns `controller_dispatch_ceiling_not_yet_enforcing` when the phase is `pre_cutover`
+- **AND** the preview creates no policy or audit row
+
+#### Scenario: CLI admission uses the shared policy contract
+- **WHEN** a local administrator previews `orchardctl nodes admit --capacity-policy-reason planned-capacity` without a ceiling flag
+- **THEN** human and JSON output show explicit ceiling `1` and the phase-derived policy state
+- **AND** execution with required confirmation persists the same policy, admission decision, local operator provenance, and cluster audit atomically
+
+#### Scenario: Operator approves or changes a ceiling
+- **WHEN** a cluster administrator submits a policy mutation with a non-negative ceiling, reason, current optimistic concurrency value, and required confirmation
+- **THEN** the Active Controller revalidates the phase and policy version inside the transaction
+- **AND** Orchard persists actor, reason, prior value, new value, timestamp, and cluster-scoped audit evidence atomically
+
+#### Scenario: Lowering preview shows drain consequence
+- **WHEN** under `f11_enforcing` a proposed ceiling is below Controller-accounted Allocation
+- **THEN** the Action Preview requires `capacity_reduction_drain` confirmation
+- **AND** it explains natural drain for accepted, running, or streaming work and revalidation for pre-acceptance work
+
+#### Scenario: Standby or unauthorized mutation fails closed
+- **WHEN** a non-Active Controller or a principal without cluster `admin` attempts policy mutation or cutover
+- **THEN** Orchard performs no authoritative write
+- **AND** Orchard returns the existing leadership or authorization blocker contract
+
+#### Scenario: Administrator retires a stale Controller
+- **WHEN** a cluster administrator previews retirement of a non-Active non-last Controller with stale capability evidence
+- **AND** supplies reason, current optimistic concurrency value, and typed Controller ID confirmation
+- **THEN** the Active Controller revalidates membership and leadership blockers
+- **AND** Orchard atomically marks the instance `retired` and persists cluster-scoped audit evidence
+- **AND** only then may cutover preflight exclude that instance
+
+### Requirement: Raising And Lowering Semantics
+Under `f11_enforcing`, lowering a Controller Dispatch Ceiling SHALL apply to new allocations and pre-acceptance held-allocation revalidation immediately.
+It SHALL NOT forcibly cancel accepted, running, or streaming work solely because of the reduction.
+Dispatch Headroom SHALL remain `0` while Controller-accounted Allocation is greater than or equal to the lowered Effective Dispatch Limit.
+Under `f11_enforcing`, raising a ceiling SHALL create no allocation and SHALL remain bounded by runtime enforcement and all other eligibility gates.
+Queue wake-up after a raise SHALL require shared capacity re-evaluation.
+Policy mutation and final dispatch revalidation SHALL serialize through the same per-Node acceptance gate, held by dispatch through Node acceptance or pre-acceptance failure.
+This refines `SPEC.md` §4.6.2 and §5.4.
+
+#### Scenario: Ceiling is lowered below current allocation
+- **WHEN** the ceiling falls from `4` to `2`
+- **AND** Controller-accounted Allocation is `3`
+- **THEN** Orchard does not forcibly cancel accepted, running, or streaming work solely because of the ceiling change
+- **AND** Dispatch Headroom is `0`
+- **AND** no new allocation occurs until allocation falls below the Effective Dispatch Limit
+
+#### Scenario: Ceiling is raised
+- **WHEN** an operator raises a ceiling and the fresh runtime limit permits more work
+- **THEN** Orchard re-evaluates capacity
+- **AND** queued work may wake when Dispatch Headroom becomes positive
+- **AND** the raise does not bypass trust, lifecycle, health, freshness, placement, or breaker gates
+
+#### Scenario: Ceiling mutation races Node acceptance
+- **WHEN** a ceiling mutation races a dispatch after final revalidation but before Node acceptance
+- **THEN** the shared per-Node gate linearizes the operations
+- **AND** either Node acceptance completes before the mutation and the work drains naturally, or the mutation completes first and dispatch revalidates under the new policy
+- **AND** pre-acceptance work never executes under an obsolete authority decision
+
+### Requirement: Single Shared Capacity Consumer Contract
+Orchard SHALL produce one transport-independent capacity evaluation and SHALL require MultiNode, admitted SingleNode, Node queue-source refresh, QueueManager, and dispatch-time revalidation to consume it.
+The evaluation result SHALL include all five canonical aggregate values, durable phase, policy state, normalized target management class, explicit authority decision, decision-specific available slots, eligibility, and stable reason codes.
+No named consumer SHALL re-derive the formulas, default missing production policy to `1`, or use configured queue capacity as dispatch authority.
+Every consumer SHALL accept either `legacy_pre_cutover` with positive centrally calculated temporary slots and successful serialized temporary-claim acquisition or `f11_enforcing` with positive Dispatch Headroom.
+Dispatch SHALL re-run the same decision after model loading and immediately before `ExecuteInference`, using held-claim revalidation under both decisions and retaining the per-Node acceptance gate through Node acceptance.
+This refines `SPEC.md` §4.6.2, §5.4, §5.5, and §5.9.
+
+#### Scenario: All consumers evaluate the same Node fixture
+- **WHEN** the same trusted Node, policy, observation, allocation, and placement fixture is evaluated through every named consumer
+- **THEN** every consumer returns the same authority decision, available slots, canonical capacity values, and reason codes
+
+#### Scenario: Ceiling changes during model loading
+- **WHEN** under `f11_enforcing` a request holds a Node allocation while `EnsureModelLoaded` runs
+- **AND** the ceiling is lowered so dispatch revalidation fails
+- **THEN** Orchard does not call `ExecuteInference`
+- **AND** Orchard excludes only that request's recognized allocation from the serialized allocation operand during revalidation
+- **AND** Orchard releases the allocation exactly once
+- **AND** Orchard requeues or fails under the existing deadline and public error contract
+
+### Requirement: Diagnostics And Status Vocabulary
+Operator diagnostics SHALL expose durable enforcement phase, policy state, normalized target management class, authority decision, Runtime Concurrency Enforcement Limit, Controller Dispatch Ceiling, Effective Dispatch Limit, Controller-accounted Allocation, Dispatch Headroom, Placement Capacity, observation time, and stable reason codes.
+Under `legacy_pre_cutover`, diagnostics SHALL expose temporary `legacy_pre_cutover_available_slots`, live temporary legacy claim count, and cutover quiescing state while keeping the canonical F11 Effective Dispatch Limit and Dispatch Headroom at `0`.
+The stable reason vocabulary SHALL distinguish degraded health, missing policy, invalid policy, explicit zero, ceiling exhaustion, runtime-limit uncertainty or exhaustion, headroom exhaustion, placement exhaustion, revalidation failure, pre-cutover legacy mode, phase-policy mismatch, missing or invalid target management class, shadow mismatch, and unapproved policy.
+Public inference errors SHALL retain existing sanitized `cluster_busy`, `queue_timeout`, and dispatch error contracts.
+The term `Admitted Capacity` SHALL NOT be used.
+This refines `SPEC.md` §7.3.5 and the shared cluster-management contract.
+
+#### Scenario: Missing policy is visible
+- **WHEN** an admitted production Node has no in-force ceiling
+- **THEN** diagnostics expose `controller_dispatch_ceiling_missing`
+- **AND** diagnostics show Effective Dispatch Limit and Dispatch Headroom as `0`
+
+#### Scenario: Ceiling is the binding authority
+- **WHEN** the Controller Dispatch Ceiling is lower than the Runtime Concurrency Enforcement Limit and allocation exhausts the ceiling
+- **THEN** diagnostics distinguish ceiling exhaustion from runtime-limit exhaustion
+
+### Requirement: Source-development And Compatibility Boundary
+Transport selection SHALL NOT determine whether the capacity-authority contract applies.
+An admitted production Node SHALL remain governed over BEAM, gRPC compatibility, or a static target reference.
+Production inventory resolution SHALL happen before any unmanaged exception is considered.
+Every normalized Runtime Endpoint target SHALL carry Controller-owned `capacity_management_class` of `production_managed`, `unmanaged_source_development`, or `unmanaged_compatibility`.
+Resolution to admitted production inventory SHALL force `production_managed` regardless of conflicting configuration.
+`unmanaged_source_development` SHALL be valid only in Controller source-development mode, and `unmanaged_compatibility` SHALL be valid only for explicitly enabled compatibility configuration that does not match admitted inventory.
+Missing, malformed, conflicting, Node-reported, transport-inferred, or probe-inferred classification SHALL fail closed.
+Only a valid explicitly classified unmanaged source-development or compatibility target MAY retain legacy capacity behavior.
+Failure to resolve or probe a production-managed target SHALL NOT downgrade it to unmanaged behavior.
+This refines `SPEC.md` §4.6.2, §5.9, and §7.5.
+
+#### Scenario: Production Node uses gRPC compatibility
+- **WHEN** a gRPC compatibility target resolves to admitted production inventory
+- **THEN** Orchard requires an in-force Controller Dispatch Ceiling and shared capacity evaluation
+
+#### Scenario: Static target matches production inventory
+- **WHEN** a static target reference resolves to an admitted production Node
+- **THEN** Orchard applies production capacity authority before dispatch
+- **AND** static configuration does not create an unmanaged exemption
+
+#### Scenario: Explicit unmanaged source development
+- **WHEN** Controller-owned source-development configuration sets `capacity_management_class = unmanaged_source_development`
+- **AND** the Controller is in source-development mode and the target does not resolve to admitted production inventory
+- **THEN** Orchard may retain documented legacy capacity behavior
+- **AND** any missing-runtime normalization to `1` remains ephemeral runtime interpretation
+- **AND** Orchard creates no durable Controller Dispatch Ceiling from that interpretation
+
+#### Scenario: Admitted inventory overrides unmanaged declaration
+- **WHEN** a target resolves to admitted production inventory
+- **AND** configuration declares an unmanaged capacity management class
+- **THEN** Orchard classifies the target as `production_managed`
+- **AND** Orchard applies the enforcing production contract
+
+#### Scenario: Management class is missing or invalid
+- **WHEN** a target does not resolve to admitted inventory and its capacity management class is absent, malformed, conflicting, or invalid for the Controller mode
+- **THEN** Orchard fails closed for new dispatch
+- **AND** Orchard exposes `runtime_endpoint_management_class_missing` or `runtime_endpoint_management_class_invalid`
+- **AND** Orchard does not infer classification from transport, address, telemetry, or probe outcome
+
+#### Scenario: Production probe fails
+- **WHEN** a production-managed target cannot provide fresh trusted capacity evidence before dispatch
+- **THEN** Orchard does not allocate or execute new work through a compatibility fallback
+- **AND** broader probe-failure fallback cleanup remains a separate implementation finding

--- a/openspec/changes/controller-dispatch-capacity-authority/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/controller-dispatch-capacity-authority/specs/runtime-endpoints/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Placement Capacity Observation
+Placement Capacity SHALL be a first-class Runtime Endpoint Observation for Model Placements.
+Placement Capacity SHALL include the model reference, active request count, and maximum concurrency for the placement.
+Unknown, malformed, duplicate, or nonmatching Placement Capacity MUST NOT prove scheduler eligibility for an active loaded placement.
+Placement Capacity SHALL remain Node-owned and MAY reduce capacity for one requested Model Placement.
+The effective capacity of one placement SHALL be bounded by both its Placement Capacity and the shared authority decision's available slots.
+Under `f11_enforcing`, no new Controller-accounted Allocation across all placements and queue lanes on one Node SHALL cause the total to exceed that Node's Effective Dispatch Limit.
+Under `legacy_pre_cutover`, the central temporary legacy available slots SHALL subtract both reported allocation and serialized live temporary legacy claims across all placements and lanes while Effective Dispatch Limit remains counterfactual `0`.
+A lower ceiling MAY temporarily leave accepted, running, or streaming allocations above the new limit while they drain naturally.
+Placement Capacity SHALL NOT create aggregate Controller authority or increase Dispatch Headroom.
+This refines `SPEC.md` §4.6.1, §4.6.2, §5.4, §5.5, and §7.5.3.
+
+#### Scenario: Active loaded placement has spare capacity
+- **WHEN** exactly one matching Placement Capacity observation reports `active_request_count < max_concurrency`
+- **AND** the shared authority decision has positive available slots
+- **THEN** the Scheduler may keep that active loaded placement eligible for the requested work
+
+#### Scenario: Active loaded placement has unknown capacity
+- **WHEN** Placement Capacity is absent, malformed, duplicate, or nonmatching for an active loaded placement
+- **THEN** the Scheduler does not treat that placement as eligible based on capacity
+
+#### Scenario: Active loaded placement is full
+- **WHEN** matching Placement Capacity reports `active_request_count >= max_concurrency`
+- **THEN** the Scheduler treats that placement as currently unavailable for new work
+
+#### Scenario: Placement reports more than aggregate authority
+- **WHEN** a Placement Capacity reports maximum concurrency above the shared authority decision's available slots
+- **THEN** Orchard bounds allocatable placement capacity by those available slots
+- **AND** the placement report does not increase aggregate authority
+
+#### Scenario: Multiple placement lanes share one Node bound
+- **WHEN** multiple placement lanes on one Node each report spare capacity
+- **THEN** every dispatch grant serializes acquisition of one aggregate Node claim
+- **AND** no new allocation causes their combined allocation to exceed the shared authority decision's available slots
+
+#### Scenario: Placement is tighter than aggregate authority
+- **WHEN** the shared authority decision has positive available slots but the requested Placement Capacity is exhausted
+- **THEN** Orchard does not allocate the request to that placement

--- a/openspec/changes/controller-dispatch-capacity-authority/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/controller-dispatch-capacity-authority/specs/runtime-endpoints/spec.md
@@ -33,7 +33,8 @@ This refines `SPEC.md` §4.6.1, §4.6.2, §5.4, §5.5, and §7.5.3.
 #### Scenario: Multiple placement lanes share one Node bound
 - **WHEN** multiple placement lanes on one Node each report spare capacity
 - **THEN** every dispatch grant serializes acquisition of one aggregate Node claim
-- **AND** no new allocation causes their combined allocation to exceed the shared authority decision's available slots
+- **AND** under `f11_enforcing` no new allocation causes combined Controller-accounted Allocation to exceed Effective Dispatch Limit
+- **AND** under `legacy_pre_cutover` every grant requires freshly recomputed positive temporary available slots and serialized temporary-claim acquisition
 
 #### Scenario: Placement is tighter than aggregate authority
 - **WHEN** the shared authority decision has positive available slots but the requested Placement Capacity is exhausted

--- a/openspec/changes/controller-dispatch-capacity-authority/tasks.md
+++ b/openspec/changes/controller-dispatch-capacity-authority/tasks.md
@@ -1,0 +1,72 @@
+# Tasks
+
+## 1. Contract and architecture
+
+- [x] 1.1 Update `SPEC.md` with the accepted authority split, formulas, policy persistence, migration, consumer, placement-bound, diagnostics, and scope contract.
+- [x] 1.2 Add ADR 0013 for Controller dispatch capacity authority and rejected alternatives.
+- [x] 1.3 Add the canonical glossary terms and `_Avoid_` aliases, including the rejected `Admitted Capacity` alias.
+- [x] 1.4 Add focused `dispatch-capacity` and `runtime-endpoints` OpenSpec deltas with acceptance scenarios.
+- [x] 1.5 Run strict validation for this exact OpenSpec change.
+- [ ] 1.6 Review generated main specs for placeholder prose after archive or sync.
+
+## 2. Non-enforcing foundation tracer
+
+- [ ] 2.1 Add `node_dispatch_capacity_policies` plus the singleton dispatch-capacity authority row in `pre_cutover`, with policy states, approval and cutover provenance, positive required contract version, non-negative explicit ceilings, and constraints that allow a null ceiling only in temporary `shadow_legacy`.
+- [ ] 2.2 Create `shadow_legacy` rows only for non-removed production Nodes whose Node Admission committed before the expand migration, selected from durable `admitted_at` or equivalent admission history, without assigning `1` and without reading telemetry into policy; retain historical policy for durably removed, trust-revoked, audited tombstones without making them cutover blockers.
+- [ ] 2.3 Add one pure shared capacity evaluator that takes durable phase and normalized target management class, calculates the frozen pre-cutover runtime-max-or-1 minus reported-active-or-0 and live temporary legacy claims centrally, and returns the five canonical aggregate values, durable phase, policy state, normalized management class, explicit authority decision, decision-specific available slots, eligibility, and reason codes.
+- [ ] 2.4 Add truth-table tests for phase-policy combinations, trust, lifecycle, healthy-only eligibility, heartbeat and capacity freshness, policy presence, runtime evidence, target management class, explicit zero, and min/headroom arithmetic.
+- [ ] 2.5 Make Node Admission lock and read the durable phase, atomically persist `approved_explicit` before cutover with an administrator-supplied value or the explicit default `1`, and roll back admission if phase, policy, or audit persistence fails.
+- [ ] 2.6 Expose policy and counterfactual capacity diagnostics without advancing any policy to `enforcing` or claiming production enforcement.
+- [ ] 2.7 Add the supervised Controller membership owner and its `10000` ms heartbeat, atomically publishing `last_seen_at`, software version, supported dispatch-capacity contract version, all-five-consumers-ready declaration, and capability observation time at boot and on each heartbeat.
+
+## 3. Operator approval and migration cutover
+
+- [ ] 3.1 Add the specified Operator API policy and Controller-instance reads, leader-only admin-authorized approval/update, cutover, and Controller retirement endpoints, Admin admission ceiling and reason fields, and matching `orchardctl nodes admit` flags with shared Action Previews, confirmations, actor provenance, and cluster-scoped audit writes.
+- [ ] 3.2 Add optimistic concurrency, mutation-time authorization, leadership, durable-phase and policy revalidation, and explicit support for an audited ceiling of `0`.
+- [ ] 3.3 Add cutover preview and preflight proving every non-removed admitted legacy Node has an approved ceiling and every non-retired Controller has fresh capability evidence at the required contract version with all five consumers ready; exclude only durably removed Nodes with revoked trust and successful removal audit.
+- [ ] 3.4 Under the migration advisory lock and Controller-local transition barrier, quiesce new legacy claims, wait for zero live temporary claims and new fresh zero-active aggregate observations, acquire every per-Node acceptance gate in stable order, revalidate, then atomically advance approved policies and the durable phase or reopen legacy dispatch unchanged on failure.
+- [ ] 3.5 After enforcement cutover, make Node Admission lock the phase and atomically persist `enforcing` policy and its audit record before the lifecycle transition commits.
+- [ ] 3.6 Contract away the bounded legacy migration state after every non-removed admitted production Node has explicit policy, while retaining removed tombstones as historical evidence.
+- [ ] 3.7 Implement Controller retirement blockers for the current Active, leadership-lock holder, and last non-retired instance, with optimistic concurrency and atomic cluster audit.
+
+## 4. First enforcing vertical tracer
+
+- [ ] 4.1 Wire MultiNode eligibility and lane contribution to the shared evaluation.
+- [ ] 4.2 Wire admitted and production-managed SingleNode paths to the same evaluation while preserving only explicitly unmanaged source-development compatibility behavior.
+- [ ] 4.3 Wire Node queue-source refresh to publish bounded effective capacity and clear sources on trust, lifecycle, health, freshness, policy, or runtime-limit loss.
+- [ ] 4.4 Wire QueueManager so all placements and lanes on one Node share one aggregate allocation bound.
+- [ ] 4.5 Serialize Controller-local acquisition of both temporary legacy claims and the final Dispatch Headroom unit across all placements and lanes, retain the applicable claim through model loading, acceptance, and terminal completion, and release it exactly once on failure, cancellation, retry, or completion.
+- [ ] 4.6 Add the per-Node acceptance gate shared by policy mutation and dispatch, then revalidate after model loading and immediately before `ExecuteInference`, excluding only the request's recognized claim from the applicable operand and holding the gate through Node acceptance or pre-acceptance failure.
+- [ ] 4.7 Prove with one shared fixture that MultiNode, admitted SingleNode, Node refresh, QueueManager, and dispatch revalidation return the same capacity values and reasons.
+- [ ] 4.8 Publish `dispatch_capacity_consumers_ready = true` only when the running Controller version has all five consumers wired and the shared fixture passes; otherwise publish false.
+- [ ] 4.9 Prove all five consumers authorize `legacy_pre_cutover` from the same central temporary slots and serialized claims without requiring positive Dispatch Headroom, then quiesce to zero live claims and fresh zero observed occupancy before switching atomically to F11 authority at cutover.
+
+## 5. Acceptance and diagnostics
+
+- [ ] 5.1 Cover trusted and untrusted, Active and non-Active, healthy, degraded, unhealthy, fresh and stale, policy present, missing, and malformed, explicit zero, runtime-bound, ceiling-bound, and equal-bound scenarios.
+- [ ] 5.2 Cover raising and lowering, pre-acceptance held-allocation revalidation without double-counting, accepted/running/streaming natural drain without forced cancellation solely because of a reduction, and queue wake-up after re-evaluation.
+- [ ] 5.3 Cover two concurrent requests racing for one final allocation and prove exactly one succeeds.
+- [ ] 5.3a Cover two legacy queue lanes racing for one temporary slot and prove exactly one acquires a temporary claim.
+- [ ] 5.4 Cover Placement Capacity above the Effective Dispatch Limit, Placement Capacity below it, and aggregate exhaustion with per-placement room.
+- [ ] 5.5 Cover migration without telemetry backfill or existing-row default `1` and fail-closed cutover for missing policy.
+- [ ] 5.6 Cover `approved_explicit` to `enforcing` cutover and post-cutover admission entering `enforcing` directly.
+- [ ] 5.7 Cover an empty cluster, admission racing with cutover, rollback of partial cutover, exact Controller-to-required-version equality, expected-version mismatch, and incompatible Controller fail-closed behavior against the durable phase.
+- [ ] 5.7a Cover cutover quiescing, new-claim refusal, natural legacy drain, stale or nonzero occupancy timeout with unchanged phase, and successful zero-occupancy revalidation under every acceptance gate.
+- [ ] 5.7b Cover ceiling mutation racing the final dispatch-to-acceptance handoff and prove the shared gate linearizes either acceptance before mutation or revalidation under the new policy.
+- [ ] 5.7c Cover removed tombstone exclusion, rejection of implicit exclusion for unreachable or other lifecycle states, and re-enrollment under the current phase.
+- [ ] 5.8 Cover fresh, stale, missing, incompatible, and all-consumers-not-ready Controller capability evidence plus audited retirement before exclusion from cutover.
+- [ ] 5.9 Cover Admin and CLI admission preview, pre-cutover not-yet-enforcing warnings including zero, Operator API read and update authorization, optimistic concurrency, enforcing drain confirmation, standby rejection, local actor provenance, and atomic audit persistence.
+- [ ] 5.10 Cover explicit unmanaged source development and compatibility, invalid or missing management class, inventory override, admitted production over gRPC compatibility, and static targets matching admitted production inventory.
+- [ ] 5.11 Add fixed reason codes and expose the complete shared evaluation result, including phase, policy state, management class, authority decision, decision-specific available slots, eligibility, and canonical capacity values, consistently across operator status surfaces.
+
+## 6. Validation
+
+- [x] 6.1 Run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate controller-dispatch-capacity-authority --type change --strict --no-interactive`.
+  Validation passed for this contract PR.
+- [ ] 6.2 For implementation slices, run `mise exec -- mix format`.
+- [ ] 6.3 For implementation slices, run `mise exec -- mix compile --warnings-as-errors`.
+- [ ] 6.4 For implementation slices, run `mise exec -- mix credo --strict`.
+- [ ] 6.5 For implementation slices, run `mise exec -- mix dialyzer`.
+- [ ] 6.6 For implementation slices, run `mise exec -- mix test`.
+- [ ] 6.7 For implementation slices, run `mise exec -- mix test --cover`.
+- [ ] 6.8 After archive or sync, run `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` and remove placeholder prose such as `Purpose TBD`.


### PR DESCRIPTION
## Summary

- define the contract-first F11 capacity-authority split between the Node-owned Runtime Concurrency Enforcement Limit and Controller-owned durable Controller Dispatch Ceiling
- add ADR 0013, canonical glossary terms, and the `controller-dispatch-capacity-authority` OpenSpec proposal, design, tasks, and focused spec deltas
- define fail-closed evaluation, legacy migration and quiesced cutover, operator approval, shared consumer semantics, placement bounds, diagnostics, and a narrow non-enforcing foundation tracer
- keep durable permits, leadership fencing, reservation recovery, compromised-node occupancy integrity, and the named adjacent findings outside F11 implementation scope

No product code is implemented in this PR.

## Validation

- `git diff --check origin/main...HEAD`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate controller-dispatch-capacity-authority --type change --strict --no-interactive`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
- RP design review: CLEAN
- RP Oracle review: CLEAN
- No Mistakes: reviewed the behavior-sensitive diff, restored two incidental SPEC changes outside the OpenSpec intent, and surfaced one pre-existing net-unchanged degraded health-bonus discrepancy for separate follow-up

## First implementation tracer

Add the durable policy and phase tables, create only bounded `shadow_legacy` rows without telemetry backfill or silent default `1`, add the pure shared evaluator and truth-table tests, persist admission default `1` atomically, publish Controller capability evidence, and expose counterfactual diagnostics without advancing any policy to `enforcing`.
