### PR TITLE
ci: add required Orchard validation workflow

### DIFF
--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -16,7 +16,11 @@ concurrency:
 jobs:
   required-validation:
     name: Required Orchard validation
-    runs-on: ubuntu-24.04
+    # Orchard is an Apple Silicon macOS-native product: the suite exercises
+    # macOS system binaries (BSD `date -j -f`, `/usr/bin/lockf`, launchctl) and
+    # BEAM TLS Distribution behavior that only pass on macOS. Run the required
+    # check on a GitHub-hosted Apple Silicon runner.
+    runs-on: macos-15
     timeout-minutes: 60
     env:
       ORCHARD_TEST_NODE_AGENT_PORT: "50171"
@@ -25,26 +29,32 @@ jobs:
       PGUSER: postgres
       PGPASSWORD: postgres
       PGDATABASE_TEST: orchard_test
-    services:
-      postgres:
-        image: postgres:16.14-bookworm@sha256:92620daddcd947f8d5ab5ba66e848702fe443d87fed30c4cea8e389fd78dfc55
-        env:
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+      PGDATA: ${{ runner.temp }}/pgdata
 
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Provision deterministic Postgres
+        run: |
+          # macOS runners have no Docker service containers. Provision a fresh,
+          # reproducible Postgres 16 cluster with trust auth on a fixed port.
+          brew install postgresql@16
+          echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
+
+      - name: Start Postgres
+        run: |
+          rm -rf "$PGDATA"
+          initdb --username="$PGUSER" --auth=trust --encoding=UTF8 --pgdata="$PGDATA"
+          pg_ctl --pgdata="$PGDATA" --log="$RUNNER_TEMP/postgres.log" \
+            --options="-p $PGPORT -k $RUNNER_TEMP" --wait start
+          for _ in $(seq 1 30); do
+            pg_isready --host="$PGHOST" --port="$PGPORT" --username="$PGUSER" && break
+            sleep 1
+          done
+          pg_isready --host="$PGHOST" --port="$PGPORT" --username="$PGUSER"
 
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -19,8 +19,8 @@ jobs:
     # Orchard is an Apple Silicon macOS-native product: the suite exercises
     # macOS system binaries (BSD `date -j -f`, `/usr/bin/lockf`, launchctl) and
     # BEAM TLS Distribution behavior that only pass on macOS. Run the required
-    # check on a GitHub-hosted Apple Silicon runner.
-    runs-on: macos-15
+    # check on a pinned Apple Silicon runner.
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 60
     env:
       ORCHARD_TEST_NODE_AGENT_PORT: "50171"

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -1,0 +1,92 @@
+name: Orchard CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: orchard-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  required-validation:
+    name: Required Orchard validation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      ORCHARD_TEST_NODE_AGENT_PORT: "50171"
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE_TEST: orchard_test
+    services:
+      postgres:
+        image: postgres:16.14-bookworm@sha256:92620daddcd947f8d5ab5ba66e848702fe443d87fed30c4cea8e389fd78dfc55
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned toolchain
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+
+      - name: Install Elixir dependencies
+        run: make setup-elixir
+
+      - name: Bootstrap native environments from lockfiles
+        run: |
+          mise exec -- uv sync --locked --directory native/orchard_tokenizer
+          mise exec -- uv sync --locked --directory native/orchard_worker_mlx
+          mise exec -- native/orchard_worker_mlx/bin/orchard-worker-mlx --help >/dev/null
+
+      - name: Install OpenSpec dependencies
+        run: make setup-openspec
+
+      - name: Prepare test database
+        run: |
+          MIX_ENV=test mise exec -- mix ecto.create
+          MIX_ENV=test mise exec -- mix ecto.migrate
+
+      - name: Check formatting
+        run: mise exec -- mix format --check-formatted
+
+      - name: Compile without warnings
+        run: mise exec -- mix compile --warnings-as-errors
+
+      - name: Run Credo
+        run: mise exec -- mix credo --strict
+
+      - name: Run Dialyzer
+        run: mise exec -- mix dialyzer
+
+      - name: Run tests
+        run: mise exec -- mix test
+
+      - name: Run coverage
+        run: mise exec -- mix test --cover
+
+      - name: Validate OpenSpec
+        env:
+          OPENSPEC_TELEMETRY: "0"
+        run: mise exec -- npm run openspec -- validate --all --strict --no-interactive

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -29,7 +29,6 @@ jobs:
       PGUSER: postgres
       PGPASSWORD: postgres
       PGDATABASE_TEST: orchard_test
-      PGDATA: ${{ runner.temp }}/pgdata
 
     steps:
       - name: Check out repository
@@ -46,9 +45,9 @@ jobs:
 
       - name: Start Postgres
         run: |
-          rm -rf "$PGDATA"
-          initdb --username="$PGUSER" --auth=trust --encoding=UTF8 --pgdata="$PGDATA"
-          pg_ctl --pgdata="$PGDATA" --log="$RUNNER_TEMP/postgres.log" \
+          pgdata="$RUNNER_TEMP/pgdata"
+          initdb --username="$PGUSER" --auth=trust --encoding=UTF8 --pgdata="$pgdata"
+          pg_ctl --pgdata="$pgdata" --log="$RUNNER_TEMP/postgres.log" \
             --options="-p $PGPORT -k $RUNNER_TEMP" --wait start
           for _ in $(seq 1 30); do
             pg_isready --host="$PGHOST" --port="$PGPORT" --username="$PGUSER" && break

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,9 @@ and outcomes in the PR. For bug fixes, include a regression test when practical.
 
 Pull requests and `main` are gated by the required Orchard CI check
 (`.github/workflows/required-validation.yml`), which runs the same pinned
-validation sequence on a fresh checkout. Local validation must still pass before
-handoff; CI is a backstop, not a substitute.
+validation sequence on a fresh checkout. Because Orchard is an Apple Silicon
+macOS-native product, the check runs on a macOS Apple Silicon runner. Local
+validation must still pass before handoff; CI is a backstop, not a substitute.
 
 For OpenSpec-backed work, also run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,6 @@ subordinate to `SPEC.md`.
 Run the relevant validation workflow from `AGENTS.md` and report exact commands
 and outcomes in the PR. For bug fixes, include a regression test when practical.
 
-Pull requests and `main` are gated by the required Orchard CI check
-(`.github/workflows/required-validation.yml`), which runs the same pinned
-validation sequence on a fresh checkout. Because Orchard is an Apple Silicon
-macOS-native product, the check runs on a macOS Apple Silicon runner. Local
-validation must still pass before handoff; CI is a backstop, not a substitute.
-
 For OpenSpec-backed work, also run:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ subordinate to `SPEC.md`.
 Run the relevant validation workflow from `AGENTS.md` and report exact commands
 and outcomes in the PR. For bug fixes, include a regression test when practical.
 
+Pull requests and `main` are gated by the required Orchard CI check
+(`.github/workflows/required-validation.yml`), which runs the same pinned
+validation sequence on a fresh checkout. Local validation must still pass before
+handoff; CI is a backstop, not a substitute.
+
 For OpenSpec-backed work, also run:
 
 ```sh


### PR DESCRIPTION
## Intent

Add Orchard's smallest reliable required CI gate, including deterministic fresh-checkout native worker bootstrap, on a pinned Apple Silicon runner.

`SPEC.md`, OpenSpec artifacts, product behavior, product tests, and cutover remain unchanged.

## What changed

- Add one workflow with the stable check name `Required Orchard validation` for pull requests and pushes to `main`.
- Run on the pinned Blacksmith Apple Silicon label `blacksmith-6vcpu-macos-15`.
- Provision a fresh Postgres 16 cluster for every job.
- Install the mise-pinned toolchain and documented dependencies.
- Rebuild both native environments from lockfiles and probe `orchard-worker-mlx` before real-worker tests.
- Run formatting, warnings-as-errors compilation, strict Credo, Dialyzer, tests, coverage, and strict all-OpenSpec validation in order.
- Keep permissions read-only, actions SHA-pinned, the node-agent test port isolated, and caches disabled.

## Validation

Local validation passed for the complete required sequence, workflow YAML parsing, and `git diff --check`.

The exact head `6eae942a078415ddffb89a4899dca67f099957d8` completed three independent cold Blacksmith runs successfully:

- 10m30s: https://github.com/kapitan-ai/orchard/actions/runs/29878391166/job/88793756456
- 10m37s: https://github.com/kapitan-ai/orchard/actions/runs/29878391166/job/88795466199
- 10m30s: https://github.com/kapitan-ai/orchard/actions/runs/29878391166/job/88797192157

Median: 10m30s, compared with 16m46s on GitHub-hosted `macos-15` at the preceding head.

All three runs independently completed checkout, Postgres provisioning, pinned toolchain installation, locked native bootstrap, the real-worker probe, and every required validation gate without cache-backed working state.

## Operational note

After merge, configure `Required Orchard validation` as the required branch-protection check when the organization plan supports required checks for private repositories.
