### PR TITLE
ci: cache Dialyzer PLTs in required validation

### DIFF
--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -87,13 +87,13 @@ jobs:
         run: mise exec -- mix credo --strict
 
       - name: Cache Dialyzer PLTs
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.mix/dialyxir_erlang-*.plt
             _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt
             _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt.hash
-          key: orchard-dialyzer-plt-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mix.lock', 'mix.exs', 'apps/*/mix.exs') }}
+          key: orchard-dialyzer-plt-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mix.lock', 'mix.exs', 'apps/*/mix.exs') }}
 
       - name: Run Dialyzer
         run: mise exec -- mix dialyzer

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -86,6 +86,15 @@ jobs:
       - name: Run Credo
         run: mise exec -- mix credo --strict
 
+      - name: Cache Dialyzer PLTs
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            ~/.mix/dialyxir_erlang-*.plt
+            _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt
+            _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt.hash
+          key: orchard-dialyzer-plt-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mix.lock', 'mix.exs', 'apps/*/mix.exs') }}
+
       - name: Run Dialyzer
         run: mise exec -- mix dialyzer
 


### PR DESCRIPTION
## Intent

Test whether Blacksmith's colocated GitHub Actions cache materially speeds Orchard CI without weakening the fresh-machine build invariant.

## What changed

- Added one SHA-pinned `actions/cache@v5.0.5` step immediately before Dialyzer.
- Cached only Dialyxir's reproducible core PLTs, dependency PLT, and dependency hash sidecar.
- Keyed the cache exactly by runner OS, architecture, `mise.toml`, `mix.lock`, the root `mix.exs`, and every child `mix.exs`.
- Added no restore prefixes and no cache-dependent conditions.

The stable `Required Orchard validation` check and every Postgres, dependency-install, native bootstrap, worker-probe, validation, product, `SPEC.md`, and OpenSpec path remain unchanged.

## Exact-head benchmark

Commit: `4db6a9aa26b82741cd9c67ffebae10ac7bfa8870`

Run: https://github.com/kapitan-ai/orchard/actions/runs/29885115377

| Attempt | Cache result | Dialyzer | Whole job | Result |
| --- | --- | ---: | ---: | --- |
| 1 | Exact `v2` miss, then saved | 2m14s | 10m56s | Passed |
| 3 | Exact `v2` hit, 8.55 MB restored | 15s | 9m05s | Passed |

The warm run saved 1m59s in Dialyzer and 1m51s across the whole job, a 16.9% total reduction.
Both attempts reconstructed the native environments from lockfiles and ran the MLX worker probe before restoring the PLTs.

Attempt 2 hit an intermittent existing `QueueManagerTest` database-connection failure after cache restoration and Dialyzer had passed.
The unchanged attempt 3 passed all required gates, so no product code or product test was changed in this PR.

## Validation

- Workflow YAML parsed successfully.
- Local full `mix dialyzer` completed with zero errors and materialized every configured cache path.
- `git diff --check` passed.
- No Mistakes returned `checks-passed` on the exact head.
- Final RepoPrompt Review returned GO with no P0/P1/P2 findings.
- Final Oracle review returned GO with no P0/P1 correctness, scope, cache-staleness, poisoning, fresh-machine-masking, action-runtime, or branch-protection findings.
- Exact-head cold and warm `Required Orchard validation` runs passed on Blacksmith.

## Scope

Changed file: `.github/workflows/required-validation.yml`

`SPEC.md`, OpenSpec artifacts, product behavior, product tests, cutover, runtime state, `.venv`, `deps`, `_build` as a directory, `node_modules`, and Postgres data are unchanged and uncached.
