### PR TITLE
test(orchard_cli): isolate temporary test directories across interrupted runs

### DIFF
--- a/apps/orchard_cli/mix.exs
+++ b/apps/orchard_cli/mix.exs
@@ -9,6 +9,7 @@ defmodule OrchardCLI.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
+      elixirc_paths: elixirc_paths(Mix.env()),
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       # M0 exception: this shell is intentionally shallow and the threshold will
@@ -25,6 +26,9 @@ defmodule OrchardCLI.MixProject do
       extra_applications: [:crypto, :logger, :public_key]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_env), do: ["lib"]
 
   defp deps do
     [

--- a/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/nodes_test.exs
@@ -104,6 +104,14 @@ defmodule OrchardCLI.Commands.NodesTest do
   alias Orchard.Repo
   alias OrchardCLI.Commands.Nodes, as: NodesCmd
   alias OrchardCLI.Commands.NodesTest.FailingAuditLog
+  alias OrchardCLI.TestTemp
+
+  setup_all do
+    test_run = TestTemp.create_run!(prefix: "orchard-cli-node-trust")
+    on_exit(fn -> TestTemp.cleanup!(test_run) end)
+
+    {:ok, node_trust_test_run: test_run}
+  end
 
   setup do
     previous_console = Application.get_env(:orchard_controller, :console, [])
@@ -631,8 +639,10 @@ defmodule OrchardCLI.Commands.NodesTest do
       assert Repo.get!(Node, node.id).state == :registered
     end
 
-    test "SPEC.md §4.7 yes execution admits a registered node and emits action result json" do
-      trust = establish_local_controller_identity!()
+    test "SPEC.md §4.7 yes execution admits a registered node and emits action result json", %{
+      node_trust_test_run: test_run
+    } do
+      trust = establish_local_controller_identity!(test_run)
       node = insert_node!(state: :registered, display_name: "admit-execute-node")
 
       assert {:ok, output} =
@@ -996,8 +1006,8 @@ defmodule OrchardCLI.Commands.NodesTest do
   end
 
   describe "action persistence failures" do
-    setup do
-      establish_local_controller_identity!()
+    setup %{node_trust_test_run: test_run} do
+      establish_local_controller_identity!(test_run)
       Application.put_env(:orchard_controller, :governance_audit_log_impl, FailingAuditLog)
       on_exit(fn -> Application.delete_env(:orchard_controller, :governance_audit_log_impl) end)
       :ok
@@ -1096,22 +1106,14 @@ defmodule OrchardCLI.Commands.NodesTest do
     end
   end
 
-  defp establish_local_controller_identity! do
+  defp establish_local_controller_identity!(test_run) do
     previous_trust = Application.get_env(:orchard_controller, :node_trust)
-
-    root =
-      Path.join(
-        System.tmp_dir!(),
-        "orchard-cli-node-trust-#{System.unique_integer([:positive, :monotonic])}"
-      )
-
-    File.mkdir!(root)
-    File.chmod!(root, 0o700)
-    trust_root = Path.join(root, "node-trust")
+    artifact = TestTemp.create_child!(test_run, prefix: "controller")
+    trust_root = TestTemp.path(artifact, "node-trust")
     Application.put_env(:orchard_controller, :node_trust, root: trust_root)
 
     on_exit(fn ->
-      File.rm_rf!(root)
+      TestTemp.cleanup!(artifact)
 
       if previous_trust do
         Application.put_env(:orchard_controller, :node_trust, previous_trust)

--- a/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
@@ -45,6 +45,28 @@ defmodule OrchardCLI.TestTempTest do
     end
   end
 
+  test "an abandoned held run bounds its wait and cleans up only its owned root", %{base: base} do
+    label = "abandoned-run"
+    ready = Path.join(base, "#{label}.ready")
+    release = Path.join(base, "#{label}.release")
+
+    task =
+      Task.async(fn ->
+        run_fresh_beam(["hold", base, label, ready, release], [
+          {"ORCHARD_TEST_TEMP_HOLD_TIMEOUT_MS", "100"}
+        ])
+      end)
+
+    root = await_ready!(task, ready, System.monotonic_time(:millisecond) + 5_000)
+    assert File.dir?(root)
+
+    {output, status} = Task.await(task, 5_000)
+
+    assert status == 0, "abandoned held run failed (status #{status}):\n#{output}"
+    refute File.exists?(release)
+    refute File.exists?(root)
+  end
+
   defp run_in_fresh_beam!(base, label, cleanup) do
     {output, status} = run_fresh_beam(["run", base, label, cleanup])
 
@@ -87,7 +109,7 @@ defmodule OrchardCLI.TestTempTest do
 
   defp release_and_await!(run) do
     if Process.alive?(run.task.pid) do
-      File.write!(run.release, "cleanup")
+      OrchardCLI.TestTemp.atomic_write!(run.release, "cleanup")
       {output, status} = Task.await(run.task, 5_000)
       assert status == 0, "fresh BEAM cleanup failed (status #{status}):\n#{output}"
     end
@@ -95,7 +117,7 @@ defmodule OrchardCLI.TestTempTest do
     :ok
   end
 
-  defp run_fresh_beam(args) do
+  defp run_fresh_beam(args, env \\ []) do
     elixir = System.find_executable("elixir") || flunk("elixir executable not found")
 
     System.cmd(
@@ -107,6 +129,7 @@ defmodule OrchardCLI.TestTempTest do
         "OrchardCLI.TestTempProcess.main(System.argv())",
         "--" | args
       ],
+      env: env,
       stderr_to_stdout: true
     )
   end

--- a/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
@@ -1,0 +1,113 @@
+defmodule OrchardCLI.TestTempTest do
+  use ExUnit.Case, async: true
+
+  @test_temp_support Path.expand("../support/test_temp.ex", __DIR__)
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "orchard-cli-test-temp-#{Ecto.UUID.generate()}")
+    File.mkdir!(base)
+    on_exit(fn -> File.rm_rf!(base) end)
+
+    {:ok, base: base}
+  end
+
+  test "a stale interrupted run cannot collide with or be cleaned by a later run", %{base: base} do
+    interrupted_root = run_in_fresh_beam!(base, "interrupted", "leave")
+    stale_marker = Path.join(interrupted_root, "owner-marker")
+    current_root = run_in_fresh_beam!(base, "current", "cleanup")
+
+    refute current_root == interrupted_root
+    assert File.dir?(interrupted_root)
+    refute File.exists?(current_root)
+    assert File.read!(stale_marker) == "interrupted"
+  end
+
+  test "concurrent runs cannot clean each other's owned artifacts", %{base: base} do
+    first = start_held_run!(base, "first-run")
+
+    try do
+      second = start_held_run!(base, "second-run")
+
+      try do
+        refute first.root == second.root
+        assert Task.yield(second.task, 0) == nil
+
+        release_and_await!(first)
+
+        refute File.exists?(first.root)
+        assert Task.yield(second.task, 0) == nil
+        assert File.read!(Path.join(second.root, "owner-marker")) == "second-run"
+      after
+        release_and_await!(second)
+      end
+    after
+      release_and_await!(first)
+    end
+  end
+
+  defp run_in_fresh_beam!(base, label, cleanup) do
+    {output, status} = run_fresh_beam(["run", base, label, cleanup])
+
+    assert status == 0, "fresh BEAM test-temp run failed (status #{status}):\n#{output}"
+    String.trim(output)
+  end
+
+  defp start_held_run!(base, label) do
+    ready = Path.join(base, "#{label}.ready")
+    release = Path.join(base, "#{label}.release")
+
+    task =
+      Task.async(fn ->
+        run_fresh_beam(["hold", base, label, ready, release])
+      end)
+
+    root = await_ready!(task, ready, System.monotonic_time(:millisecond) + 5_000)
+    %{release: release, root: root, task: task}
+  end
+
+  defp await_ready!(task, ready, deadline) do
+    cond do
+      File.regular?(ready) ->
+        File.read!(ready)
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("fresh BEAM did not publish its owned test-temp root")
+
+      true ->
+        case Task.yield(task, 0) do
+          {:ok, {output, status}} ->
+            flunk("fresh BEAM exited before publishing its root (status #{status}):\n#{output}")
+
+          nil ->
+            Process.sleep(10)
+            await_ready!(task, ready, deadline)
+        end
+    end
+  end
+
+  defp release_and_await!(run) do
+    if Process.alive?(run.task.pid) do
+      File.write!(run.release, "cleanup")
+      {output, status} = Task.await(run.task, 5_000)
+      assert status == 0, "fresh BEAM cleanup failed (status #{status}):\n#{output}"
+    end
+
+    :ok
+  end
+
+  defp run_fresh_beam(args) do
+    elixir = System.find_executable("elixir") || flunk("elixir executable not found")
+
+    System.cmd(
+      elixir,
+      [
+        "-r",
+        @test_temp_support,
+        "-e",
+        "OrchardCLI.TestTempProcess.main(System.argv())",
+        "--" | args
+      ],
+      stderr_to_stdout: true
+    )
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
@@ -48,17 +48,22 @@ defmodule OrchardCLI.TestTempTest do
   test "an abandoned held run bounds its wait and cleans up only its owned root", %{base: base} do
     label = "abandoned-run"
     ready = Path.join(base, "#{label}.ready")
+    armed = Path.join(base, "#{label}.armed")
     release = Path.join(base, "#{label}.release")
 
     task =
       Task.async(fn ->
-        run_fresh_beam(["hold", base, label, ready, release], [
+        run_fresh_beam(["hold", base, label, ready, armed, release], [
           {"ORCHARD_TEST_TEMP_HOLD_TIMEOUT_MS", "100"}
         ])
       end)
 
     root = await_ready!(task, ready, System.monotonic_time(:millisecond) + 5_000)
     assert File.dir?(root)
+
+    Process.sleep(150)
+    assert File.dir?(root)
+    OrchardCLI.TestTemp.atomic_write!(armed, "armed")
 
     {output, status} = Task.await(task, 5_000)
 
@@ -76,14 +81,17 @@ defmodule OrchardCLI.TestTempTest do
 
   defp start_held_run!(base, label) do
     ready = Path.join(base, "#{label}.ready")
+    armed = Path.join(base, "#{label}.armed")
     release = Path.join(base, "#{label}.release")
 
     task =
       Task.async(fn ->
-        run_fresh_beam(["hold", base, label, ready, release])
+        run_fresh_beam(["hold", base, label, ready, armed, release])
       end)
 
     root = await_ready!(task, ready, System.monotonic_time(:millisecond) + 5_000)
+    assert File.dir?(root)
+    OrchardCLI.TestTemp.atomic_write!(armed, "armed")
     %{release: release, root: root, task: task}
   end
 

--- a/apps/orchard_cli/test/support/test_temp.ex
+++ b/apps/orchard_cli/test/support/test_temp.ex
@@ -87,6 +87,7 @@ defmodule OrchardCLI.TestTempProcess do
 
   alias OrchardCLI.TestTemp
 
+  @arm_timeout_ms 60_000
   @hold_timeout_ms 60_000
 
   @spec main([String.t()]) :: :ok
@@ -101,12 +102,19 @@ defmodule OrchardCLI.TestTempProcess do
     IO.write(root)
   end
 
-  def main(["hold", base, label, ready, release]) do
+  def main(["hold", base, label, ready, armed, release]) do
     owner = create_marked_run!(base, label)
-    TestTemp.atomic_write!(ready, TestTemp.root(owner))
 
-    await_cleanup!(release, System.monotonic_time(:millisecond) + hold_timeout_ms())
-    TestTemp.cleanup!(owner)
+    try do
+      TestTemp.atomic_write!(ready, TestTemp.root(owner))
+
+      case await_signal!(armed, "armed", deadline(@arm_timeout_ms)) do
+        :ok -> await_signal!(release, "cleanup", deadline(hold_timeout_ms()))
+        :timeout -> :ok
+      end
+    after
+      TestTemp.cleanup!(owner)
+    end
   end
 
   defp hold_timeout_ms do
@@ -123,24 +131,26 @@ defmodule OrchardCLI.TestTempProcess do
     owner
   end
 
-  defp await_cleanup!(release, deadline) do
-    case File.read(release) do
-      {:ok, "cleanup"} ->
+  defp deadline(timeout_ms), do: System.monotonic_time(:millisecond) + timeout_ms
+
+  defp await_signal!(path, expected, deadline) do
+    case File.read(path) do
+      {:ok, ^expected} ->
         :ok
 
       {:error, :enoent} ->
         if System.monotonic_time(:millisecond) >= deadline do
-          :ok
+          :timeout
         else
           Process.sleep(10)
-          await_cleanup!(release, deadline)
+          await_signal!(path, expected, deadline)
         end
 
       {:ok, command} ->
-        raise "unexpected test-temp process command: #{inspect(command)}"
+        raise "unexpected test-temp process command in #{path}: #{inspect(command)}"
 
       {:error, reason} ->
-        raise File.Error, reason: reason, action: "read test-temp process command", path: release
+        raise File.Error, reason: reason, action: "read test-temp process command", path: path
     end
   end
 end

--- a/apps/orchard_cli/test/support/test_temp.ex
+++ b/apps/orchard_cli/test/support/test_temp.ex
@@ -1,0 +1,125 @@
+defmodule OrchardCLI.TestTemp do
+  @moduledoc false
+
+  @create_attempts 10
+
+  @enforce_keys [:root]
+  defstruct [:root]
+
+  @opaque t :: %__MODULE__{root: String.t()}
+
+  @spec create_run!(keyword()) :: t()
+  def create_run!(opts \\ []) do
+    base = Keyword.get(opts, :base, System.tmp_dir!())
+    prefix = Keyword.fetch!(opts, :prefix)
+
+    create_owned_root!(base, prefix, @create_attempts)
+  end
+
+  @spec create_child!(t(), keyword()) :: t()
+  def create_child!(%__MODULE__{root: root}, opts) do
+    prefix = Keyword.fetch!(opts, :prefix)
+    create_owned_root!(root, prefix, @create_attempts)
+  end
+
+  @spec root(t()) :: String.t()
+  def root(%__MODULE__{root: root}), do: root
+
+  @spec path(t(), String.t()) :: String.t()
+  def path(%__MODULE__{root: root}, name), do: Path.join(root, name)
+
+  @spec cleanup!(t()) :: :ok
+  def cleanup!(%__MODULE__{root: root}) do
+    File.rm_rf!(root)
+    :ok
+  end
+
+  defp create_owned_root!(_base, _prefix, 0) do
+    raise File.Error,
+      reason: :eexist,
+      action: "create uniquely owned test run directory",
+      path: ""
+  end
+
+  defp create_owned_root!(base, prefix, attempts_left) do
+    root = Path.join(base, "#{prefix}-#{random_suffix()}")
+
+    case File.mkdir(root) do
+      :ok ->
+        make_private_owner!(root)
+
+      {:error, :eexist} ->
+        create_owned_root!(base, prefix, attempts_left - 1)
+
+      {:error, reason} ->
+        raise File.Error, reason: reason, action: "create test run directory", path: root
+    end
+  end
+
+  defp make_private_owner!(root) do
+    case File.chmod(root, 0o700) do
+      :ok ->
+        %__MODULE__{root: root}
+
+      {:error, reason} ->
+        File.rmdir(root)
+        raise File.Error, reason: reason, action: "make test run directory private", path: root
+    end
+  end
+
+  defp random_suffix do
+    16
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16(case: :lower)
+  end
+end
+
+defmodule OrchardCLI.TestTempProcess do
+  @moduledoc false
+
+  alias OrchardCLI.TestTemp
+
+  @spec main([String.t()]) :: :ok
+  def main(["run", base, label, cleanup]) do
+    owner = create_marked_run!(base, label)
+    root = TestTemp.root(owner)
+
+    if cleanup == "cleanup" do
+      TestTemp.cleanup!(owner)
+    end
+
+    IO.write(root)
+  end
+
+  def main(["hold", base, label, ready, release]) do
+    owner = create_marked_run!(base, label)
+    File.write!(ready, TestTemp.root(owner))
+
+    await_cleanup!(release)
+    TestTemp.cleanup!(owner)
+  end
+
+  defp create_marked_run!(base, label) do
+    {:ok, _apps} = Application.ensure_all_started(:crypto)
+    owner = TestTemp.create_run!(base: base, prefix: "run")
+    File.write!(TestTemp.path(owner, "owner-marker"), label)
+    owner
+  end
+
+  defp await_cleanup!(release) do
+    case File.read(release) do
+      {:ok, "cleanup"} ->
+        :ok
+
+      {:error, :enoent} ->
+        Process.sleep(10)
+        await_cleanup!(release)
+
+      {:ok, command} ->
+        raise "unexpected test-temp process command: #{inspect(command)}"
+
+      {:error, reason} ->
+        raise File.Error, reason: reason, action: "read test-temp process command", path: release
+    end
+  end
+end

--- a/apps/orchard_cli/test/support/test_temp.ex
+++ b/apps/orchard_cli/test/support/test_temp.ex
@@ -34,6 +34,14 @@ defmodule OrchardCLI.TestTemp do
     :ok
   end
 
+  @spec atomic_write!(String.t(), iodata()) :: :ok
+  def atomic_write!(path, contents) do
+    tmp = "#{path}.tmp-#{random_suffix()}"
+    File.write!(tmp, contents)
+    File.rename!(tmp, path)
+    :ok
+  end
+
   defp create_owned_root!(_base, _prefix, 0) do
     raise File.Error,
       reason: :eexist,
@@ -79,6 +87,8 @@ defmodule OrchardCLI.TestTempProcess do
 
   alias OrchardCLI.TestTemp
 
+  @hold_timeout_ms 60_000
+
   @spec main([String.t()]) :: :ok
   def main(["run", base, label, cleanup]) do
     owner = create_marked_run!(base, label)
@@ -93,10 +103,17 @@ defmodule OrchardCLI.TestTempProcess do
 
   def main(["hold", base, label, ready, release]) do
     owner = create_marked_run!(base, label)
-    File.write!(ready, TestTemp.root(owner))
+    TestTemp.atomic_write!(ready, TestTemp.root(owner))
 
-    await_cleanup!(release)
+    await_cleanup!(release, System.monotonic_time(:millisecond) + hold_timeout_ms())
     TestTemp.cleanup!(owner)
+  end
+
+  defp hold_timeout_ms do
+    case System.get_env("ORCHARD_TEST_TEMP_HOLD_TIMEOUT_MS") do
+      nil -> @hold_timeout_ms
+      value -> String.to_integer(value)
+    end
   end
 
   defp create_marked_run!(base, label) do
@@ -106,14 +123,18 @@ defmodule OrchardCLI.TestTempProcess do
     owner
   end
 
-  defp await_cleanup!(release) do
+  defp await_cleanup!(release, deadline) do
     case File.read(release) do
       {:ok, "cleanup"} ->
         :ok
 
       {:error, :enoent} ->
-        Process.sleep(10)
-        await_cleanup!(release)
+        if System.monotonic_time(:millisecond) >= deadline do
+          :ok
+        else
+          Process.sleep(10)
+          await_cleanup!(release, deadline)
+        end
 
       {:ok, command} ->
         raise "unexpected test-temp process command: #{inspect(command)}"


### PR DESCRIPTION
## Intent

Fix Orchard GitHub issue #95, Isolate temporary test directories across interrupted runs, as a focused test-infrastructure reliability change. Give each BEAM test run a uniquely scoped, explicitly owned temporary root so stale artifacts from an interrupted run cannot collide with a later run. Cleanup must remove only the current run's exact owned artifacts and must not delete or mutate another active run's artifacts. Regression coverage must use independent BEAM OS processes for stale interrupted artifacts and concurrent live runs. The held-child harness must publish coordination atomically, bound abandoned waits, and use an explicit arming handshake so its short cleanup timeout begins only after the parent has observed the owned root. Prefer cryptographically random atomically claimed roots over broad cleanup or time-based deletion. Keep the separate pre-existing orchard_controller System.unique_integer helper out of scope because issue #95 specifically targets orchard-cli-node-trust-* and changing one of many unrelated helpers would be arbitrary expansion. Do not change product behavior, production runtime code, APIs, migrations, packaging, release automation, SPEC.md, OpenSpec, or unrelated tests.

## What Changed

- Added a test-only `OrchardCLI.TestTemp` support module that claims uniquely-scoped, owner-private (`0o700`), cryptographically-random temp roots via atomic `File.mkdir` retries, cleans up only the current run's exact owned root, and writes coordination files atomically (temp-then-rename); a companion `OrchardCLI.TestTempProcess` drives `run`/`hold` harness modes with a bounded arm/hold handshake and an explicit arming signal. Wired `test/support` into `elixirc_paths(:test)` in `mix.exs` so it compiles only under the test env.
- Refactored the `orchard-cli-node-trust` tests in `nodes_test.exs` to own their temp root through `TestTemp` (replacing the ad-hoc `System.tmp_dir!` + `System.unique_integer` construction and manual `File.rm_rf!` cleanup), threading a `setup_all`-owned run into the identity helper and action-persistence-failure setup.
- Added `test_temp_test.exs` regression coverage that spawns independent BEAM OS processes to verify a stale interrupted run cannot collide with or be cleaned by a later run, concurrent runs cannot clean each other's owned artifacts, and an abandoned held run bounds its wait while cleaning up only its own root.

## Risk Assessment

✅ Low: Well-bounded, test-infrastructure-only change that satisfies every stated intent criterion (uniquely owned crypto-random roots, own-artifact-only cleanup, independent-BEAM regression coverage, atomic coordination, bounded waits, arming handshake) with no product, runtime, or API impact.

## Testing

All tests pass and isolation demonstrated end-to-end.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/orchard_cli/test/orchard_cli/test_temp_test.exs:79` - The `run` harness mode returns its owned test-temp root via stdout, which is merged with stderr (`stderr_to_stdout: true` at line 141), and `run_in_fresh_beam!` derives the root purely from `String.trim(output)` (line 79). Any incidental stderr from the fresh BEAM (e.g. an OTP/SASL warning) would be prepended to the parsed path, silently corrupting it - a flaky-failure vector in the interrupted-run assertions and a potentially misleading pass in the cleanup case where `refute File.exists?(corrupted_path)` trivially holds. The `hold` mode already avoids this by publishing its root atomically to a dedicated `ready` file; `run` mode could do the same instead of trusting merged stdout. Low-probability today since the support module compiles cleanly, but it is the one spot in an otherwise reliability-hardened change that relies on stdout parsing for a critical value.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `ran test_temp_test.exs`
- `ran nodes_test.exs`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

Closes #95
