### PR TITLE
docs: propose product versioning and release governance

### DIFF
--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -709,6 +709,70 @@ _Avoid_: Blocker, permission grant
 
 ### Packaging, Trust, and Operations
 
+**Product Version**:
+The canonical semantic version that identifies an Orchard development line, release candidate, or final release.
+_Avoid_: build number, Git SHA, component package version
+
+**Build Provenance**:
+The evidence that distinguishes one Orchard build by its source, channel, build sequence, components, verification, and artifact identities.
+_Avoid_: Product Version, release notes
+
+**Release Line**:
+An explicitly approved Orchard compatibility family identified by a product-version major and minor pair.
+_Avoid_: Milestone, numerically inferred previous version
+
+**Previous Supported Release Line**:
+The one explicitly named earlier Release Line that the current Controller release must support for Node Agent compatibility.
+_Avoid_: automatic minor-version subtraction, every historical release
+
+**Release Candidate**:
+A pre-final Orchard Product Version whose ordered `rc` identifier names its maturity relative to the corresponding final version.
+_Avoid_: Candidate, development build, GitHub draft
+
+**Candidate**:
+One immutable signed version tag, source commit, and Release Channel that is eligible for governed Orchard artifact construction.
+_Avoid_: untagged build, mutable channel promotion, GitHub draft
+
+**Verified Candidate**:
+A Candidate whose final artifact identities and required evidence are sealed in an immutable Candidate Manifest.
+_Avoid_: published release, successful build attempt
+
+**Release Channel**:
+The complete contract for a release audience, eligible version form, required artifacts, verification level, publication surfaces, and completion condition.
+_Avoid_: build metadata only, deployment environment
+
+**Candidate Manifest**:
+The immutable machine-readable identity and verification record for one Verified Candidate.
+_Avoid_: mutable release status, checksum sidecar, State Attestation
+
+**State Attestation**:
+Append-only evidence of a release approval, attempt, surface observation, or state transition for one Candidate Manifest.
+_Avoid_: Candidate Manifest, mutable current-state field
+
+**Promotion**:
+The movement of exact Verified Candidate bytes to a required release surface without rebuilding, resigning, or repackaging them.
+_Avoid_: rebuild, artifact replacement
+
+**Partially Published Release**:
+A release for which at least one required publication surface is live while another required surface remains incomplete.
+_Avoid_: Published Release, Draft, failed build
+
+**Delivered Distribution**:
+A channel distribution that has reached every required restricted-delivery surface without representing a Published Release.
+_Avoid_: Published Release, partial delivery, build completion
+
+**Published Release**:
+A release whose exact approved bytes have reached every publication surface required by its Release Channel.
+_Avoid_: valid tag, Verified Candidate, one-surface publication
+
+**Solo-owner Custodianship**:
+The current operating model in which the Repository Owner holds all release, signing, publication, allocation, and trust-administration roles while preserving separate actions and evidence.
+_Avoid_: two-person control, unrestricted manual release
+
+**Single-owner Exception**:
+A Candidate-bound authorization that permits Solo-owner Custodianship for one exact trial, pilot, or release distribution under mandatory compensating controls.
+_Avoid_: permanent waiver, reusable approval, two-person control
+
 **Transport Mode**:
 The public API listener mode: reverse proxy, direct HTTPS, or degraded loopback HTTP.
 _Avoid_: Certificate Source, internal mTLS

--- a/openspec/changes/product-versioning-release-governance/.openspec.yaml
+++ b/openspec/changes/product-versioning-release-governance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/product-versioning-release-governance/design.md
+++ b/openspec/changes/product-versioning-release-governance/design.md
@@ -1,0 +1,326 @@
+## Context
+
+Orchard currently reports product version `0.5.0-dev` from first-party OTP application metadata and records Git SHA, build date, and build channel separately through `Orchard.BuildInfo`.
+The same product-version literal is repeated in the umbrella and four first-party Mix projects, while the PKG builder reads only the umbrella value.
+The app builder receives independent marketing and build values, and no current gate proves that those values agree with the staged payload or PKG identity.
+The two bundled Python helpers each use an independent `0.1.0` package version, which is component provenance rather than Orchard product identity.
+
+The live repository state was reverified on 2026-07-23 from commit `b564f90e858820ccfbfaffbe432feb601ae24d67`.
+The only live tag is the annotated but unsigned `v0.4.0`, and GitHub has no Release objects.
+The private repository's current required CI runs on pull requests and pushes to `main`, validates Elixir and OpenSpec, and has read-only repository permissions.
+It does not run on tags, build a governed release set, or manage GitHub Release state.
+
+`SPEC.md` §13.1 requires controller version `N` to support node-agent versions `N` and `N-1`, but it does not define how those symbols map to product SemVer.
+The current upgrade implementation treats `N` as a SemVer major and minor line and calculates `N-1` by minor-version subtraction while ignoring patch and prerelease components.
+That behavior is executable evidence, but it is not authoritative until the meaning is accepted in `SPEC.md`.
+
+`SPEC.md` §11 requires the DMG distribution set to include release notes, a DMG checksum, and before and after app-signing manifests.
+It also assigns final DMG assembly, notarization, stapling, hosting, and publication integration to Amore while retaining nested signing and verification under Orchard control.
+The accepted `app-distribution-lifecycle` and `packaging-deployment` capabilities continue to own artifact-specific assembly, verification, and lifecycle behavior.
+This change adds product-wide governance without duplicating those contracts.
+
+Primary-source research constrains the proposal without replacing Orchard policy.
+SemVer permits prerelease identifiers and treats build metadata as non-precedence provenance.
+Apple requires a three-integer `CFBundleShortVersionString` and a numeric `CFBundleVersion` with one to three integer components.
+GitHub recommends completing a draft's asset set before publishing an immutable Release and recommends least-privilege workflow permissions.
+GitHub protected-environment approvals, immutable Releases, and artifact attestations remain capability gates because availability for this private repository has not been proved.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish one canonical Orchard product-version authority for every first-party release surface.
+- Define a pre-1.0 release-transition policy that does not use product-version bumps as per-commit build identity.
+- Bind a governed release to an exact version, signed tag, clean commit, channel, compatibility declaration, and immutable manifest.
+- Fail closed when runtime, PKG, staged payload, app, DMG, filenames, manifests, sidecars, or publication surfaces disagree about release identity.
+- Define deterministic Apple marketing-version and globally monotonic build-version constraints for the Orchard app bundle identifier.
+- Preserve independent helper package versions while recording exact provenance and a candidate-level SPDX SBOM.
+- Separate read-only normal validation from narrowly permissioned candidate, signing, drafting, approval, and publication workflows.
+- Make credential, capability, and owner-assignment gates explicit in the release handoff.
+- Define `N` and `N-1` as explicit Current and Previous Supported Release Lines before implementation changes compatibility behavior.
+
+**Non-Goals:**
+
+- Bump the current Orchard product version.
+- Create or rewrite tags, GitHub Releases, packages, apps, DMGs, checksums, manifests, SBOMs, or release notes.
+- Implement build scripts, CI workflows, signing, notarization, or publication.
+- Change app lifecycle, PKG lifecycle, generic artifact secrecy, or existing signing-order requirements.
+- Force internal Python package versions to match the Orchard product version.
+- Backfill a GitHub Release for `v0.4.0` or rewrite historical release evidence.
+- Store credentials, keychain names, DSNs, local paths, or workflow session identifiers in release metadata.
+- Assume that a private-repository GitHub feature or an Amore capability exists before a live implementation check proves it.
+
+## Decisions
+
+### Decision: A Root VERSION File Is Canonical Storage
+
+Orchard will store its product version in a root `VERSION` file containing exactly one ASCII SemVer line and one terminal newline.
+The file will contain no comments, surrounding whitespace, or SemVer build metadata.
+Root and child Mix projects, runtime reporting, shell packaging, Swift app assembly, PKG metadata, filenames, and tag validation will derive from that file or fail exact validation against it.
+Independent Python helper versions remain separate.
+
+The `VERSION` file is canonical storage, while semantic authority remains `SPEC.md`, accepted release policy, and authorized transition evidence.
+The alternative of retaining root Mix metadata as the cross-language authority is rejected because shell and Swift consumers should not require Mix evaluation or five synchronized literals.
+
+### Decision: Product Version And Build Provenance Remain Separate
+
+The Product Version identifies an Orchard development version, Release Candidate, or final release.
+Build Provenance identifies a particular build through the full source commit, build date, Release Channel, Apple build number, toolchain, signing evidence, artifact digests, and helper provenance.
+Ordinary commits and merges do not change Product Version.
+SemVer build metadata is forbidden in `VERSION` because Orchard records build identity through governed provenance instead.
+
+The alternative of bumping Product Version for every merge is rejected because Git and build evidence already provide immutable per-build identity.
+
+### Decision: Pre-1.0 Transitions Use A Restricted Grammar
+
+Development versions use `0.Y.Z-dev`, Release Candidates use `0.Y.Z-rc.K`, and final releases use `0.Y.Z`.
+The candidate counter `K` starts at `1`, increases consecutively for the same base version, and has no leading zeroes.
+At least one Verified Candidate is required before a final release.
+A patch follows the complete `0.Y.(Z+1)-dev`, `0.Y.(Z+1)-rc.1`, and `0.Y.(Z+1)` sequence.
+After a final release, a separate authorized transition selects the next patch or minor development line.
+Skipped minor lines require explicit transition intent.
+A transition to `1.0.0-dev` requires a separate apex compatibility decision.
+Versions and tags never move backward and are never reused.
+
+Additional commits after an RC transition retain that RC product version until an authorized transition selects the next candidate.
+Only a signed tag identifies a governed candidate.
+The first recommended governed transition is `0.5.0-dev` to `0.5.0-rc.1`, but this proposal does not perform that transition.
+
+### Decision: Transition Authorization Is Bound To Reviewed Evidence
+
+Every Product Version change will occur in a dedicated transition pull request that adds one append-only JSON record under `release/version-transitions/<target-version>.json`.
+The record will identify its schema version, from and to versions, transition kind, authorization pull request, reason, Current Release Line, Previous Supported Release Line, fixed Release Channel, and Apple build-number allocation reference when an app is included.
+Validation will require exact agreement between the record and version diff, an allowed transition, an unused target version, one fixed channel, and the required compatibility declaration.
+
+A submitter-authored `approved_by` string is not authorization.
+The preferred authorization proof is approval after the latest push from an approved Release Owner identity or group, verified read-only against the exact reviewed head revision.
+If private-repository review protection is unavailable, a canonical detached approval envelope must bind the transition-record digest, exact head commit, target version, signer key identifier, issued time, expiry, nonce, and single-use purpose.
+The fallback envelope must use deterministic canonical serialization, a detached signature verified against a versioned repository key registry, and revocation data checked at validation time.
+The signed envelope must reside in a proved append-only evidence store outside the approved head commit, and the chosen store remains an implementation capability gate.
+Validation must resolve the signer against a key-registry revision already trusted before the transition pull request began.
+A transition pull request cannot change the trust roots used to authorize itself, and key additions, removals, or revocations require a separate protected trust-administration change approved under the previously trusted registry.
+Publication remains disabled until one of those mechanisms is configured and proved.
+
+### Decision: Signed Immutable Tags Start Candidate Construction
+
+Governed tags are annotated and cryptographically signed by an authorized release actor.
+RC tags use `v0.Y.Z-rc.K`, and final tags use `v0.Y.Z`.
+Development tags, unsigned tags, invalid counters, moved tags, deleted tags, and reused tag names are rejected.
+The tag is created only after the transition pull request merges and required validation passes for the exact committed version.
+The tag starts candidate construction but does not prove that artifacts, a draft, or a Published Release exist.
+Candidate identity is the exact signed tag, full source commit, and one Release Channel declared by the transition record.
+One tag produces at most one Candidate Manifest for that fixed channel, and advancing from trial to pilot or from pilot to release requires a new Product Version and tag.
+
+Infrastructure failures before manifest sealing may rebuild from the same exact tag and must record abandoned attempts.
+After sealing, retries may only reuse preserved exact bytes.
+Any digest change after sealing makes the candidate invalid and requires a new Product Version and tag.
+A valid unpublished RC may be superseded by `rc.K+1`.
+A Published Release is never superseded, but it may be withdrawn and followed by a patch or later release.
+
+### Decision: Candidate And Distribution States Are Separate
+
+Candidate states are `tagged`, `verified`, `invalid`, and `superseded`.
+Distribution states are recorded independently per Release Channel as `not_started`, `staged`, `approved`, `partially_delivered`, `delivered`, `partially_published`, `published`, and `withdrawn`.
+Draft is a GitHub-specific or Amore-specific surface state and is not a candidate state.
+Failed is an attempt outcome and is not a durable candidate state.
+
+GitHub surface states are `absent`, `draft`, `non_draft`, and `withdrawn`.
+Amore surface states are `absent`, `staged`, `restricted_live`, `general_live`, and `withdrawn`.
+Internal recipient-delivery states are `absent`, `staged`, `delivered`, and `withdrawn`.
+Internal allows only recipient delivery through `absent -> staged -> delivered -> withdrawn`.
+Trial allows GitHub `absent -> draft -> withdrawn` and Amore `absent -> staged -> restricted_live -> withdrawn`, and it prohibits a trial GitHub draft from becoming non-draft.
+Pilot allows GitHub `absent -> draft -> non_draft -> withdrawn` and Amore `absent -> staged -> restricted_live -> withdrawn`.
+Release allows GitHub `absent -> draft -> non_draft -> withdrawn` and Amore `absent -> staged -> general_live -> withdrawn`.
+Failed attempts and unavailable observations produce signed attestations without advancing surface state.
+Each transition requires the actor authorized for that surface and an atomic compare-and-swap append against the unique current attestation-chain head, so stale or concurrent forks fail closed.
+Transitions to internal `delivered`, Amore `restricted_live` or `general_live`, and GitHub `non_draft` require a Verified Candidate or sealed Internal Build Manifest plus every digest-bound approval required by the channel.
+GitHub `draft` and Amore `staged` may exist before approval, but they remain staging evidence and cannot yield successful or partial delivery or publication state until the required verification and approval are valid.
+An externally observed live target state without those prerequisites records a fail-closed observation and does not advance the governed surface or distribution state.
+
+Distribution state uses one ordered total reduction over every reachable combination.
+Any required withdrawn surface or explicit channel withdrawal reduces first to `withdrawn`.
+An invalid or superseded Candidate reduces to `withdrawn` when any required surface advanced beyond `absent` and otherwise reduces to `not_started`.
+Before any complete or partial delivery or publication reduction, the Candidate must be `verified` or the Internal Build Manifest must be sealed and every channel-required approval must remain valid.
+If those prerequisites are absent, pre-live `draft` or `staged` surfaces reduce only to `staged`, while any observed live target state fails closed without changing the governed state.
+Internal reduces to `delivered` when its recipient surface is `delivered`.
+Trial reduces to `delivered` only for GitHub `draft` plus Amore `restricted_live`.
+Pilot reduces to `published` only for GitHub `non_draft` plus Amore `restricted_live`.
+Release reduces to `published` only for GitHub `non_draft` plus Amore `general_live`.
+Trial reduces to `partially_delivered` when exactly one required surface has reached its channel target, while pilot and release reduce to `partially_published` under the same target-state rule.
+Any remaining verified combination with valid digest-bound approval reduces to `approved`.
+Any remaining verified combination with at least one required surface in `draft` or `staged` reduces to `staged`.
+All remaining combinations in which required surfaces are `absent` reduce to `not_started`.
+Any combination outside the channel-specific transition graph or this ordered reduction fails closed without changing state.
+Matching partial uploads are retryable, while mismatched bytes invalidate the candidate.
+Operational rollback may restore an older verified release as the recommended download without moving tags, overwriting Release objects, or erasing publication evidence.
+
+### Decision: Release Channels Are Complete Distribution Contracts
+
+A Release Channel defines its eligible version form, audience, required artifacts, signing and verification level, publication surfaces, and completion condition.
+Every Candidate has exactly one fixed Release Channel, and its compiled build-channel value must exactly match that channel.
+Exact-byte Promotion occurs only within that channel, while a channel change requires a new Product Version and tag.
+
+| Channel | Audience | Eligible version | Required distribution | Required surfaces and completion |
+| --- | --- | --- | --- | --- |
+| `internal` | Orchard collaborators | Development, RC, or final | Selected installable artifact, checksum, build manifest, validation summary, and component inventory, plus all apex-required sidecars for any DMG | No GitHub Release or Amore publication is required, and completion is Delivered when exact intended recipients can retrieve the recorded bytes. |
+| `trial` | One named time-bounded evaluator engagement | RC | Signed and notarized DMG, release notes, DMG checksum, before and after signing manifests, Candidate Manifest, compatibility report, SPDX SBOM, and state evidence | A private GitHub draft record and an access-restricted Amore delivery surface must contain the same candidate, and successful completion is Delivered rather than Published. |
+| `pilot` | Named design partners or a controlled production-like rollout | RC | The same required set as `trial` | A non-draft private GitHub Release and access-restricted Amore delivery must contain the exact approved bytes. |
+| `release` | Generally available Orchard customers | Final | Signed and notarized DMG, release notes, DMG checksum, before and after signing manifests, Candidate Manifest, compatibility report, SPDX SBOM, and state evidence | General Amore delivery must be live and the private GitHub Release must be non-draft for the same approved candidate. |
+
+PKG remains optional for every channel unless a later accepted offline-distribution contract makes it required.
+Any included PKG must be signed, notarized, checksummed, and bound to the same Candidate Manifest.
+Because this repository is private, GitHub Releases act as the internal release registry while Amore remains the customer-facing distribution surface assigned by `SPEC.md`.
+The release workflow publishes through Amore first, verifies its live state and digest, and publishes the GitHub Release last.
+
+Trial, pilot, and release publication remain disabled until Amore proves the required audience restriction, idempotency, digest inspection, and promotion behavior.
+If Amore cannot distinguish restricted and general audiences, the affected channels remain disabled until an alternative surface is approved.
+
+An untagged development build in the internal channel is an Internal Build rather than a Candidate.
+It uses a commit-bound Internal Build Manifest with Product Version, full source commit, channel, artifact identities, validation summary, component inventory, and any Apple build-number allocation, and it does not enter Candidate or Candidate Manifest state.
+Internal Build delivery produces signed, hash-chained Internal Build Attestations that reference the Internal Build Manifest digest and use the same proved append-only evidence store and signer-verification rules as Candidate State Attestations.
+Signed RC or final internal builds use the Candidate path and one fixed internal channel.
+
+### Decision: Final Verified Bytes Are Promoted Without Rebuild
+
+Signing, notarization, stapling, mounted verification, final checksums, and required compatibility verification occur before an artifact becomes promotable.
+The immutable Candidate Manifest records the identity of each final promotable artifact.
+Drafting, uploading, approving, and publishing reuse those exact bytes and do not rebuild, resign, repackage, or inject metadata into them.
+Any digest change creates a new candidate and repeats required verification.
+
+### Decision: One Candidate Manifest Governs Cross-Artifact Agreement
+
+Each Verified Candidate produces one immutable, versioned, canonically serialized Candidate Manifest after final artifact verification.
+The manifest records Product Version, signed tag, full 40-character commit, Release Channel, transition-record digest, Current and Previous Supported Release Lines, Apple versions, required artifact matrix, signing and notarization results, helper provenance, SBOM digest, validation-result digests, and identity evidence for every governed artifact.
+The manifest excludes itself from its artifact collection and receives its own SHA-256 after serialization.
+
+Final distributable files record a path-independent logical name, byte size, media or artifact type, and SHA-256 over exact bytes.
+Directory trees record a canonical JSON tree sorted by bytewise relative path with entry type, normalized permission mode, regular-file size and digest, and exact symlink target.
+Tree identity excludes timestamps, user IDs, group IDs, and machine-local paths.
+The Orchard app tree includes every file, including resources, `Info.plist`, signatures, and `CodeResources`.
+Signing manifests remain required evidence but do not replace complete tree identity.
+
+Later approval, attempt, upload, surface-observation, withdrawal, and publication events produce authenticated append-only State Attestations that reference the Candidate Manifest digest.
+Each attestation uses deterministic canonical serialization, identifies the actor and signer key, records transition type, timestamp, channel, stable surface identifiers, and previous-attestation digest, and carries a detached signature verified against the versioned release key registry.
+The chain is mandatory after the first attestation and resides in a proved append-only evidence store that rejects overwrite and deletion.
+They never contain credentials, secrets, keychain names, local paths, or workflow session identifiers.
+A replaceable current-state projection may be generated for convenience but is not audit evidence.
+
+GitHub artifact attestations may supplement this evidence only after availability is proved.
+The Candidate Manifest, SBOM, digests, and State Attestations remain sufficient when the GitHub feature is unavailable.
+
+### Decision: Apple Metadata Uses A Numeric Base And Global Sequence
+
+`CFBundleShortVersionString` uses the numeric `X.Y.Z` base of Product Version.
+Prerelease identity remains in Product Version, tag, Release Channel, and Candidate Manifest.
+`CFBundleVersion` uses one positive decimal integer in the safe range `1..9999` allocated by the protected Apple Build Number Allocator in an append-only allocation record.
+The number increases globally for bundle identifier `com.orchard.app` across every channel, marketing version, hotfix, major-version transition, and distributed Internal Build.
+A retry of the same exact Candidate or Internal Build reuses its allocated number, while a new tagged candidate or distributed app build consumes a new number.
+Git SHA, date, workflow identity, and rerun count are not Apple build numbers.
+
+Before initializing the sequence, implementation must inspect any historically distributed `com.orchard.app` build and seed above the highest observed value.
+Allocation uses merge-time serialization and uniqueness checks, and app publication stops before `9999` is exhausted until an accepted migration defines and validates a replacement Apple-safe mapping.
+Publication remains disabled until the historical maximum and live Amore and Apple validation paths are proved.
+
+### Decision: Internal Helpers Keep Independent Versions And Exact Provenance
+
+The tokenizer and MLX worker retain independent package versions.
+For each helper, the Candidate Manifest records package name, package version, source commit, source-tree digest, `pyproject.toml` digest, `uv.lock` digest, selected extras, target platform and architecture, installed distribution inventory, and packaged tree or deterministic archive digest.
+Numeric equality with Product Version neither establishes nor is required for compatibility.
+
+Every tagged Candidate, including the internal channel, includes one SPDX 2.3 JSON SBOM covering first-party components, resolved Elixir dependencies, packaged Python dependencies, Swift package dependencies, and discoverable packaged native libraries and runtimes.
+The Candidate Manifest references the SBOM by SHA-256.
+The SBOM supplements and does not replace exact artifact and tree identities.
+
+### Decision: Normal And Release CI Are Separate Trust Boundaries
+
+Normal pull-request and `main` CI validates Product Version authority, transition rules, first-party BEAM agreement, packaging mappings, glossary and OpenSpec consistency, and affected tests with read-only repository permissions.
+Candidate validation reads source and validation evidence but has no release credentials.
+Candidate construction may write only ephemeral workflow artifacts.
+Apple build-number allocation, Apple signing and notarization, GitHub drafting, Amore staging, publication approval, Amore publication, and GitHub publication use separate jobs and narrowly scoped credentials.
+Signing, Amore publication, and GitHub publication credentials do not coexist in one job.
+
+Distribution approval binds the Candidate Manifest or Internal Build Manifest digest, channel, Product Version, tag when applicable, required artifact set, approving identity, timestamp, expiry, and single-use intent.
+Any changed digest, channel, artifact requirement, or compatibility declaration revokes approval automatically.
+The GitHub Release becomes non-draft only after Amore live verification succeeds for the exact approved candidate.
+
+Implementation must prove private-repository support for environment reviewers, self-review prevention, tag or ruleset restrictions, immutable Releases, environment-scoped secrets, and artifact attestations before claiming those controls.
+If protected reviewer support is unavailable, the signed approval fallback and a separately controlled runner or secret store are required.
+Trial delivery and pilot or release publication must not silently degrade to an unrestricted manual workflow.
+
+### Decision: N And N-1 Use Explicit Release Lines
+
+The Current Release Line is the candidate controller's Orchard `major.minor` line.
+The Previous Supported Release Line is one explicitly enumerated earlier line and is not calculated by subtracting one from the minor version.
+Patch and prerelease components do not create new Release Lines.
+The terminology replaces ambiguous arithmetic while fulfilling the existing `SPEC.md` `N` and `N-1` guarantee.
+
+The first governed `0.5` release selects `0.4` as its Previous Supported Release Line because `v0.4.0` is the only historical release tag.
+Historical tagging does not prove compatibility, so every candidate must pass Current and Previous Supported Release Line suites.
+A future `0.7` release may select `0.5` if `0.6` was never approved, and a future `1.0` release may select an explicitly approved `0.x` line.
+The bundled worker must match the Node Agent Product Version required by `SPEC.md`, while its Python package version remains independent provenance.
+Any candidate that cannot satisfy both required lines remains blocked unless an accepted change amends `SPEC.md` before release.
+
+Current numeric minor arithmetic in `Orchard.Upgrade` remains unchanged until `SPEC.md` adopts this mapping and the implementation is reconciled in the same change.
+
+## Risks / Trade-offs
+
+- A root `VERSION` file can become another manually edited value if consumers do not derive from it, so derivation is required where practical and exact validation remains mandatory everywhere else.
+- A tag-triggered build can fail after a signed immutable tag exists, so failed attempts remain evidence and replacement candidates receive new versions and tags.
+- Separating candidate, distribution, and surface states is more explicit than one state machine, but it prevents a GitHub draft or split publication from being misreported as candidate failure.
+- Apple prerelease candidates share one marketing version, so the global build sequence, tag, and Candidate Manifest distinguish them.
+- A global Apple sequence needs protected allocation and historical seeding, so app publication stays disabled until both are proved.
+- Current dirty-build support can be mistaken for release eligibility, so dirty or ambiguous provenance remains ineligible for governed promotion.
+- Cross-artifact checks can duplicate artifact-specific verification, so this capability governs shared identity and references existing app and packaging contracts.
+- Release automation can expose credentials too broadly, so credential capabilities remain isolated and publication requires digest-bound approval.
+- Private-repository GitHub features may be unavailable, so the contract specifies required guarantees and fail-closed fallbacks rather than assuming a plan entitlement.
+- Amore may not expose all required audience and digest semantics, so trial, pilot, and release publication remain disabled until live capability checks pass.
+- An explicit Previous Supported Release Line adds a registry decision, but it handles skipped minor lines without inventing compatibility through arithmetic.
+- A Candidate Manifest can become incomplete as channels evolve, so its schema is versioned and unsupported mandatory fields fail closed.
+- SPDX generation increases release evidence, but it provides a portable candidate-level inventory without coupling policy to optional GitHub attestations.
+
+## Migration Plan
+
+1. Amend `SPEC.md` with accepted Product Version, Release Channel, publication, and Release Line semantics without changing the current version.
+2. Add root `VERSION`, transition-record and compatibility-registry schemas, and exact first-party BEAM validation.
+3. Derive or validate PKG, staged payload, app, Apple metadata, runtime reporting, and filenames against the governed identity.
+4. Define Candidate Manifest, canonical tree, State Attestation, component-provenance, and SPDX SBOM schemas without enabling publication.
+5. Add normal CI governance checks with read-only permissions.
+6. Add a non-publishing signed-tag candidate workflow and exercise it in an isolated repository or dry-run mode.
+7. Probe private-repository GitHub controls, live Amore behavior, historical Apple build numbers, signing identities, and credential custody.
+8. Add isolated credential-gated signing, notarization, stapling, final verification, and manifest sealing in that order.
+9. Add private GitHub draft creation and Amore staging only after candidate evidence passes.
+10. Enable digest-bound approval and exact-byte promotion only after the required capability and role-assignment gates pass.
+11. Publish through Amore first and make the matching private GitHub Release non-draft last.
+12. Reconcile `SPEC.md` compatibility language and `Orchard.Upgrade` behavior in the same implementation branch.
+13. Leave `v0.4.0` and historical state unchanged unless a separate accepted migration requests a backfill.
+
+Rollback before publication disables candidate or publication workflows while leaving normal validation intact.
+A Published Release is never rewritten or replaced in place, so remediation withdraws it and uses a new version, tag, and release.
+
+### Decision: The Current Operating Model Uses Solo-Owner Custodianship
+
+The solo Repository Owner currently holds the Release Owner, Tag Signer, publication approver, Apple Build Number Allocator, Apple-signing custodian, Amore-publication custodian, GitHub-publication custodian, and release-trust administrator roles.
+No collaborator or backup currently has enough established experience and trust to assume those authorities.
+This is a deliberate current operating constraint rather than an implied two-person control claim.
+
+Each trial, pilot, or release Candidate must carry a signed single-owner exception bound to the exact Candidate Manifest digest and channel.
+The exception is a mandatory `single_owner_exception` State Attestation with deterministic canonical serialization.
+Its payload records schema version, Candidate Manifest digest, Release Channel, consolidated roles, signer identity and key identifier, single-Candidate purpose, issue time, expiry, unique nonce, and acknowledgement of every mandatory compensating control.
+Validation verifies its signature against the pre-existing release key registry and current revocation data, rejects malformed, future-issued, or expired validity windows, and stores it in the Candidate's append-only attestation chain.
+Every exception-dependent transition revalidates issue time and expiry against the trusted transition time before accessing delivery or publication capability.
+Revocation before terminal use requires a later signed revocation attestation and blocks delivery or publication.
+The authorized delivered, published, withdrawn, invalidated, or superseded transition atomically consumes the exception through the attestation-chain compare-and-swap update, after which it cannot authorize another transition or Candidate.
+Approval, signing, staging, and publication remain separate actions and jobs even when the same Repository Owner performs them.
+Hardware-backed signing credentials, least-privilege capability isolation, pre-existing trust roots, exact-byte verification, and immutable evidence remain mandatory compensating controls.
+The absence of an experienced backup is recorded as a resilience risk in every release handoff but does not independently block release under a valid candidate-bound exception.
+
+Two-person control remains the preferred future operating model after at least one collaborator has demonstrated sufficient release experience and has been explicitly entrusted with a named role.
+Delegation is not automatic, and any new custodian or backup requires a separately protected trust-administration change before receiving authority.
+
+## Remaining Gates
+
+- Verify private-repository GitHub plan support for each proposed protected control before trial delivery or pilot and release publication.
+- Verify Amore audience restriction, idempotency, digest inspection, and exact-byte promotion behavior before trial delivery or pilot and release publication.
+- Inspect the highest historically distributed `CFBundleVersion` for `com.orchard.app` before allocating the first governed number.
+- Identify actual signing identities, credential stores, and release hosts without recording secret or machine-local values in durable policy.
+- Select and prove the append-only evidence store used for approvals and attestations.

--- a/openspec/changes/product-versioning-release-governance/proposal.md
+++ b/openspec/changes/product-versioning-release-governance/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Orchard has traceable build metadata and strong packaging verification, but it has no single enforced product-version authority or governed release identity spanning source, tags, runtime reporting, macOS artifacts, and publication state.
+Active development now needs release-boundary SemVer and immutable build provenance to become one fail-closed, collaborator-reviewable contract before the next release is prepared.
+
+## What Changes
+
+- Define one machine-readable Orchard product-version authority and require every first-party BEAM application to derive from it or pass an exact consistency check.
+- Define pre-1.0 development, release-candidate, final, patch, and next-development transitions while preserving the rule that ordinary commits and merges do not bump the product version.
+- Keep product version separate from Git commit, build date, build channel, Apple build number, signing evidence, and independently versioned internal components.
+- Bind each governed release to an exact product version, signed immutable tag, clean tagged commit, release channel, compatibility declaration, immutable candidate manifest, and append-only state attestations.
+- Define separate candidate, distribution, and publication-surface states plus GitHub Release draft and publication gates without granting release permissions to normal pull-request or `main` validation.
+- Require verified artifacts from the exact tagged commit to be promoted without rebuilding or changing their recorded bytes.
+- Require cross-artifact agreement across runtime reporting, PKG metadata and filename, staged payload, `Orchard.app`, DMG contents, release filenames, manifests, and sidecars.
+- Define an Apple-safe mapping from Orchard release identity to `CFBundleShortVersionString` and a globally monotonic numeric `CFBundleVersion` for the Orchard app bundle identifier.
+- Preserve independent Python helper package versions and record exact helper provenance plus a candidate-level SPDX SBOM without treating helper versions as Orchard product-version mismatches.
+- Add separate normal-validation and tag-triggered release gates, including exact-commit evidence, credential boundaries, owner approval boundaries, and fail-closed publication behavior.
+- Replace the undefined use of controller and node version `N` and `N-1` with an explicitly enumerated Current Release Line and Previous Supported Release Line rather than allowing current implementation arithmetic to become policy silently.
+- Keep the current product version unchanged and create no tags, releases, or distribution artifacts in this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `product-release-governance`: Defines Orchard product-version authority, release transitions, release identity and state, tag and commit agreement, compatibility declarations, immutable artifact promotion, cross-artifact consistency, Apple bundle mapping, internal component provenance and SBOM evidence, CI gates, and release handoff evidence.
+
+### Modified Capabilities
+
+- None.
+  Existing `app-distribution-lifecycle` and `packaging-deployment` requirements remain the owners of artifact-specific assembly, verification, lifecycle, and generic distribution behavior.
+
+## Impact
+
+- SPEC.md impact: this proposal would refine §13.1 to define Orchard product-release identity, version transitions, and the meaning of controller and node compatibility versions, and would add narrow §11 release-governance requirements for immutable promotion, cross-artifact agreement, Apple bundle mapping, release state, and handoff evidence.
+- Build metadata impact: the umbrella and first-party Mix applications, runtime version reporting, `Orchard.BuildInfo`, and upgrade compatibility checks would consume or validate one governed product-release identity.
+- Packaging impact: PKG, staged payload, app, DMG, manifests, filenames, and sidecars would gain cross-artifact identity checks without duplicating their existing artifact-specific contracts.
+- CI impact: normal validation would gain non-publishing governance checks, while a separately permissioned tag-triggered lane would own candidate construction, credential-gated verification, draft creation, and approved publication.
+- Release operations impact: tags and GitHub Release state would become distinct, verified states tied to the same clean commit and immutable artifact digests.
+- Compatibility impact: the proposal maps `N` to the Current Release Line and maps `N-1` to one explicitly enumerated Previous Supported Release Line, so the current numeric subtraction behavior must remain unchanged until the corresponding `SPEC.md` amendment and implementation land together.
+- Approved design direction: the owner accepted the RP plus primary-source recommendations for canonical storage, pre-1.0 transitions, transition authorization, signed tag sequencing, channel completion, Apple mapping, helper provenance, SBOM evidence, compatibility representation, and least-privilege release boundaries.
+- Current ownership: the solo Repository Owner holds every release, signing, publication, allocation, and trust-administration role under a candidate-bound single-owner exception with logical action separation and immutable evidence.
+- Remaining gates: private-repository GitHub feature availability, Amore audience and promotion capabilities, historical Apple build-number maximum, concrete credential custody, release hosts, and the append-only evidence store must be verified before trial delivery or pilot and release publication is enabled.

--- a/openspec/changes/product-versioning-release-governance/specs/product-release-governance/spec.md
+++ b/openspec/changes/product-versioning-release-governance/specs/product-release-governance/spec.md
@@ -1,0 +1,337 @@
+## ADDED Requirements
+
+### Requirement: Orchard Has One Product-Version Authority
+
+Orchard SHALL store Product Version in a root `VERSION` file containing exactly one ASCII SemVer line and one terminal newline, with no comments, surrounding whitespace, or build metadata.
+Every first-party Mix project, runtime report, shell packaging input, Swift app input, PKG identity, release filename, and tag validator SHALL derive from that file or fail exact validation against it.
+Independent internal component package versions SHALL NOT be treated as Orchard Product Version values.
+This requirement refines `SPEC.md` §13.1 without changing the current Product Version.
+
+#### Scenario: First-party version surface drifts
+
+- **WHEN** a first-party Mix application, runtime report, or packaging input exposes a Product Version different from root `VERSION`
+- **THEN** normal and release validation fail before a governed artifact is promoted or published
+
+#### Scenario: Canonical version syntax is invalid
+
+- **WHEN** root `VERSION` contains comments, extra whitespace, build metadata, more than one line, or a nonconforming Product Version
+- **THEN** repository validation rejects the value without rewriting it
+
+### Requirement: Product Version Changes Only At Release Boundaries
+
+Before Orchard 1.0, active development versions SHALL use `0.Y.Z-dev`, ordered Release Candidates SHALL use `0.Y.Z-rc.K`, and final releases SHALL use `0.Y.Z`.
+Release Candidate counter `K` SHALL start at `1`, increase consecutively for the same base version, and contain no leading zeroes.
+At least one Verified Candidate SHALL precede a final release, and a patch SHALL follow the full `-dev`, `-rc.1`, and final sequence.
+Ordinary commits and merges SHALL retain the current Product Version.
+After a final release, a separate authorized transition SHALL select the next patch or minor development line, and skipped minor lines SHALL require explicit transition intent.
+A transition to `1.0.0-dev` SHALL require a separately accepted apex compatibility decision.
+This requirement refines `SPEC.md` §13.1.
+
+#### Scenario: Ordinary feature merge lands
+
+- **WHEN** a feature, fix, documentation, or review commit lands without approved release-transition intent
+- **THEN** Orchard retains the current Product Version and uses Build Provenance to distinguish the commit
+
+#### Scenario: Patch release is prepared
+
+- **WHEN** Orchard prepares `0.Y.(Z+1)` after a final `0.Y.Z` release
+- **THEN** the patch follows `0.Y.(Z+1)-dev`, at least one ordered release candidate, and `0.Y.(Z+1)` final without reusing an earlier version or tag
+
+### Requirement: Version Transitions Require Reviewed Machine-Readable Evidence
+
+Each Product Version change SHALL occur in a dedicated transition pull request that adds exactly one append-only machine-readable transition record for the target version.
+The record SHALL identify schema version, from and to versions, transition kind, authorization pull request, reason, Current Release Line, Previous Supported Release Line, one fixed Release Channel, and an Apple build-number allocation reference when an app is included.
+Validation SHALL require exact agreement with the version diff, an allowed transition, unused target version, one fixed Release Channel, and required compatibility declaration.
+Authorization SHALL bind to the exact reviewed head revision through approved repository review protection or a cryptographically signed approval record whose signer is trusted by repository policy.
+A submitter-authored approval string in the transition record SHALL NOT establish authorization.
+Any signed-approval fallback SHALL use a canonical detached envelope that binds transition-record digest, exact head commit, target version, signer key identifier, issue time, expiry, nonce, and single-use purpose.
+The fallback SHALL use deterministic serialization, a detached signature, a versioned repository key registry, revocation checks, and a proved append-only evidence store outside the approved head commit.
+Approval validation SHALL resolve the signer against a key-registry revision trusted before the transition pull request began.
+A transition pull request SHALL NOT change the trust roots used to authorize itself, and key additions, removals, or revocations SHALL require a separate protected trust-administration change approved under the previously trusted registry.
+
+#### Scenario: Version changes without bound approval
+
+- **WHEN** a pull request changes `VERSION` without one matching transition record and approval bound to the exact reviewed revision
+- **THEN** normal validation rejects the transition
+
+#### Scenario: Private-repository review protection is unavailable
+
+- **WHEN** the configured GitHub plan cannot enforce the required protected review for the private repository
+- **THEN** publication remains disabled until the signed-approval fallback is configured and verified
+
+### Requirement: Product Version And Build Provenance Are Distinct
+
+Orchard SHALL represent Product Version separately from full source commit, build date, Release Channel, Apple build number, toolchain, signing state, artifact digests, and internal component versions.
+Two builds with the same Product Version SHALL remain distinguishable through immutable Build Provenance without requiring a Product Version bump.
+Governed provenance SHALL use the full source commit rather than only an abbreviated Git SHA.
+This requirement refines `SPEC.md` §11.8 and §13.1.
+
+#### Scenario: Two development builds share a version
+
+- **WHEN** two clean commits are built under the same development Product Version
+- **THEN** their full source commits and other Build Provenance distinguish them while their Product Version remains equal
+
+### Requirement: Signed Release Tags Match Clean Committed Versions
+
+A governed Orchard release tag SHALL be annotated, cryptographically signed by an authorized release actor, immutable, and bound to one clean committed revision whose root `VERSION` exactly matches the tag.
+Before Orchard 1.0, RC tags SHALL use `v0.Y.Z-rc.K`, final tags SHALL use `v0.Y.Z`, and development, unsigned, invalid-counter, moved, deleted, or reused tags SHALL be rejected.
+The tag SHALL be created only after the transition pull request merges and required validation passes for the exact commit.
+Creating the tag SHALL start candidate construction but SHALL NOT prove that artifacts, a draft, or a Published Release exists.
+Candidate identity SHALL consist of the signed tag, full source commit, and one Release Channel declared by the transition record.
+One tag SHALL produce at most one Candidate Manifest for that channel, and a channel change SHALL require a new Product Version and tag.
+
+#### Scenario: Tag and committed version disagree
+
+- **WHEN** a governed tag encodes a Product Version different from root `VERSION` at its target commit
+- **THEN** the candidate lane stops before artifact construction, credential access, drafting, or publication
+
+#### Scenario: Candidate source is dirty or ambiguous
+
+- **WHEN** provenance cannot prove an isolated checkout of the exact tagged commit without tracked changes, index drift, or untracked build inputs
+- **THEN** the candidate is ineligible for governed construction or promotion
+
+### Requirement: Candidate And Distribution States Are Separate
+
+Orchard SHALL record candidate state independently as `tagged`, `verified`, `invalid`, or `superseded`.
+Orchard SHALL record distribution state independently for each Release Channel as `not_started`, `staged`, `approved`, `partially_delivered`, `delivered`, `partially_published`, `published`, or `withdrawn`.
+Draft SHALL be a publication-surface state rather than a candidate state, and failed SHALL be an attempt outcome rather than a candidate state.
+A valid unpublished RC MAY be superseded by a later RC, while a Published Release SHALL only be withdrawn or followed by a new release and SHALL NOT be superseded in place.
+
+GitHub surface state SHALL be `absent`, `draft`, `non_draft`, or `withdrawn`.
+Amore surface state SHALL be `absent`, `staged`, `restricted_live`, `general_live`, or `withdrawn`.
+Internal recipient-delivery state SHALL be `absent`, `staged`, `delivered`, or `withdrawn` and SHALL follow `absent -> staged -> delivered -> withdrawn`.
+The `trial` channel SHALL allow GitHub only through `absent -> draft -> withdrawn` and Amore only through `absent -> staged -> restricted_live -> withdrawn`, and a trial GitHub draft SHALL NOT become non-draft.
+The `pilot` channel SHALL allow GitHub only through `absent -> draft -> non_draft -> withdrawn` and Amore only through `absent -> staged -> restricted_live -> withdrawn`.
+The `release` channel SHALL allow GitHub only through `absent -> draft -> non_draft -> withdrawn` and Amore only through `absent -> staged -> general_live -> withdrawn`.
+Failed attempts and unavailable observations SHALL produce authenticated attestations without advancing surface state.
+Every surface transition SHALL require the actor authorized for that surface and an atomic compare-and-swap append against the unique current attestation-chain head, and stale or concurrent forks SHALL fail closed.
+Transitions to internal `delivered`, Amore `restricted_live` or `general_live`, and GitHub `non_draft` SHALL require a Verified Candidate or sealed Internal Build Manifest plus every digest-bound approval required by the channel.
+GitHub `draft` and Amore `staged` MAY exist before approval, but they SHALL remain staging evidence and SHALL NOT yield successful or partial delivery or publication state until required verification and approval are valid.
+An externally observed live target state without those prerequisites SHALL record a fail-closed observation and SHALL NOT advance governed surface or distribution state.
+
+Distribution state SHALL use an ordered total reduction over every reachable channel combination.
+Any required withdrawn surface or explicit channel withdrawal SHALL reduce first to `withdrawn`.
+An invalid or superseded Candidate SHALL reduce to `withdrawn` when any required surface advanced beyond `absent` and otherwise SHALL reduce to `not_started`.
+Before any complete or partial delivery or publication reduction, the Candidate SHALL be `verified` or the Internal Build Manifest SHALL be sealed and every channel-required approval SHALL remain valid.
+When those prerequisites are absent, pre-live `draft` or `staged` surfaces SHALL reduce only to `staged`, while any observed live target state SHALL fail closed without changing governed state.
+Internal SHALL reduce to `delivered` when its recipient-delivery surface is `delivered`.
+Trial SHALL reduce to `delivered` only when GitHub is `draft` and Amore is `restricted_live`.
+Pilot SHALL reduce to `published` only when GitHub is `non_draft` and Amore is `restricted_live`.
+Release SHALL reduce to `published` only when GitHub is `non_draft` and Amore is `general_live`.
+Trial SHALL reduce to `partially_delivered` when exactly one required surface has reached its channel target, while pilot and release SHALL reduce to `partially_published` under the same target-state rule.
+Any remaining verified combination with valid digest-bound approval SHALL reduce to `approved`.
+Any remaining verified combination with at least one required surface in `draft` or `staged` SHALL reduce to `staged`.
+All remaining combinations in which required surfaces are `absent` SHALL reduce to `not_started`.
+Any combination outside the channel-specific transition graph or ordered reduction SHALL fail closed without changing state.
+
+#### Scenario: One required trial surface is live
+
+- **WHEN** one restricted surface required by the `trial` channel is live while another remains incomplete
+- **THEN** the distribution state is `partially_delivered` and Orchard does not report a Delivered Distribution
+
+#### Scenario: One required publication surface is live
+
+- **WHEN** one surface required by `pilot` or `release` is live while another remains incomplete
+- **THEN** the distribution state is `partially_published` and Orchard does not report a Published Release
+
+#### Scenario: Candidate construction fails before sealing
+
+- **WHEN** an infrastructure failure occurs before the Candidate Manifest is sealed without invalidating source identity
+- **THEN** Orchard records the failed attempt and may retry construction from the same exact tag
+
+### Requirement: Release Channels Define Complete Distribution Contracts
+
+Each Release Channel SHALL define its eligible Product Version form, intended audience, required artifact set, signing and verification level, publication surfaces, and completion condition.
+Each Candidate SHALL have exactly one fixed Release Channel, and the governed build-channel value embedded in every artifact SHALL exactly match it.
+Exact-byte Promotion SHALL occur only within that channel, and a channel change SHALL require a new Product Version and tag.
+
+The `internal` channel SHALL accept development, RC, or final versions and SHALL require the selected installable artifact, checksum, build manifest, validation summary, and component inventory, plus all `SPEC.md`-required sidecars when a DMG is included.
+The `internal` channel SHALL require no GitHub Release or Amore publication and SHALL become Delivered when exact intended recipients can retrieve the recorded bytes.
+An untagged development build in the `internal` channel SHALL be an Internal Build rather than a Candidate and SHALL use a commit-bound Internal Build Manifest containing Product Version, full source commit, channel, artifact identities, validation summary, component inventory, and any Apple build-number allocation.
+An untagged Internal Build SHALL NOT enter Candidate or Candidate Manifest state, while signed RC or final internal builds SHALL use the Candidate path.
+Internal Build delivery SHALL produce signed, hash-chained Internal Build Attestations that reference the Internal Build Manifest digest and use the same append-only evidence-store and signer-verification guarantees as Candidate State Attestations.
+
+The `trial` channel SHALL accept RC versions for one named time-bounded evaluator engagement and SHALL require a signed and notarized DMG, release notes, DMG checksum, before and after signing manifests, Candidate Manifest, compatibility report, SPDX SBOM, and State Attestation evidence.
+The `trial` channel SHALL require a private GitHub draft record and an access-restricted Amore delivery of the same candidate and SHALL become Delivered rather than Published when both are complete.
+
+The `pilot` channel SHALL accept RC versions for named design partners or controlled production-like rollout and SHALL require the same distribution set as `trial`.
+The `pilot` channel SHALL become Published only when a non-draft private GitHub Release and access-restricted Amore delivery contain or reference the exact approved candidate.
+
+The `release` channel SHALL accept final versions for generally available Orchard customer distribution and SHALL require the same distribution set as `trial`.
+The `release` channel SHALL become Published only when general Amore delivery is live and the private GitHub Release is non-draft for the exact approved candidate.
+The workflow SHALL publish through Amore first, verify its live state and digest, and publish the matching GitHub Release last.
+
+PKG SHALL remain optional unless a later accepted channel contract requires it.
+Any included PKG SHALL be signed, notarized, checksummed, and bound to the same Candidate Manifest.
+Trial, pilot, and release publication SHALL remain disabled until live capability checks prove the required Amore audience, idempotency, digest-inspection, and exact-byte promotion behavior.
+
+#### Scenario: Required channel artifact is absent
+
+- **WHEN** a Release Channel requires an artifact or evidence item that is absent
+- **THEN** the distribution remains incomplete and unpublishable
+
+#### Scenario: Amore cannot enforce a restricted audience
+
+- **WHEN** live capability checks cannot prove the audience restriction required by `trial` or `pilot`
+- **THEN** the affected publication lane remains disabled until an alternative surface is accepted
+
+### Requirement: Governed Artifacts Are Promoted Without Mutation
+
+Orchard SHALL promote only final verified artifact bytes whose identities are sealed after applicable signing, notarization, stapling, mounted verification, checksum generation, and compatibility verification.
+Drafting, uploading, approving, and publishing SHALL reuse those exact bytes and SHALL NOT rebuild, resign, repackage, or otherwise replace them.
+Failures before manifest sealing MAY retry construction from the exact tag, while failures after sealing MAY retry only with the preserved exact bytes.
+Any post-seal digest change SHALL make the candidate invalid and require a new Product Version and tag.
+This requirement adds immutable-promotion behavior beneath `SPEC.md` §11.3.
+
+#### Scenario: Artifact changes after sealing
+
+- **WHEN** an artifact digest differs between Candidate Manifest sealing and upload or publication
+- **THEN** promotion fails and Orchard requires a new candidate rather than silently replacing the artifact
+
+### Requirement: Candidate Manifest Governs Cross-Artifact Identity
+
+Each Verified Candidate SHALL produce one immutable, versioned, canonically serialized Candidate Manifest after final artifact verification.
+The Candidate Manifest SHALL record Product Version, signed tag, full source commit, Release Channel, transition-record digest, Current and Previous Supported Release Lines, Apple versions, required artifact matrix, signing and notarization results, helper provenance, SBOM digest, validation-result digests, and identity evidence for every governed artifact.
+The Candidate Manifest SHALL exclude itself from its artifact collection and SHALL receive its own SHA-256 after serialization.
+
+Every distributable file SHALL record a path-independent logical name, byte size, media or artifact type, and SHA-256 over exact bytes.
+Every governed directory tree SHALL record a canonical JSON tree sorted by bytewise relative path with entry type, normalized permission mode, regular-file size and digest, and exact symlink target.
+Canonical tree identity SHALL exclude timestamps, user IDs, group IDs, and machine-local paths.
+Orchard app identity SHALL cover every bundled file, while signing manifests SHALL remain required evidence without replacing complete tree identity.
+Every included runtime, PKG, staged payload, app, DMG, filename, manifest, sidecar, and SBOM SHALL agree with the candidate identity.
+
+Later approval, attempt, upload, surface-observation, withdrawal, and publication events SHALL produce authenticated append-only State Attestations that reference the Candidate Manifest digest.
+Each State Attestation SHALL use deterministic canonical serialization, identify the actor and signer key, record transition type, timestamp, Release Channel, stable surface identifiers, and previous-attestation digest, and carry a detached signature verified against the versioned release key registry.
+The chain SHALL be mandatory after the first attestation and SHALL reside in a proved append-only evidence store that rejects overwrite and deletion.
+Every append SHALL atomically compare the referenced previous-attestation digest with the unique current chain head and SHALL fail on a stale or conflicting head.
+Candidate Manifests and State Attestations SHALL NOT contain credentials, secrets, DSNs, keychain names, machine-local paths, or workflow session identifiers.
+An optional mutable current-state projection SHALL NOT count as audit evidence.
+
+#### Scenario: Directory artifact lacks canonical identity
+
+- **WHEN** a staged payload, OTP release, or app bundle lacks the required canonical tree identity
+- **THEN** the candidate remains unverifiable and cannot become a Verified Candidate
+
+#### Scenario: Candidate Manifest identity is calculated
+
+- **WHEN** final artifact identity and verification evidence is complete
+- **THEN** Orchard serializes the Candidate Manifest without a self-entry, calculates its digest, and uses that digest in every later State Attestation
+
+### Requirement: Apple Bundle Versions Follow A Deterministic Global Mapping
+
+`CFBundleShortVersionString` SHALL use the numeric `X.Y.Z` base of Product Version.
+`CFBundleVersion` SHALL use one positive decimal integer in the safe range `1..9999` allocated by the protected Apple Build Number Allocator in an append-only allocation record.
+The number SHALL increase globally for bundle identifier `com.orchard.app` across all Release Channels, marketing versions, hotfixes, major-version transitions, and distributed Internal Builds.
+A retry of the same exact Candidate or Internal Build SHALL reuse its allocated number, and a new Candidate or distributed app build SHALL consume a new number.
+Git SHA, date, workflow identity, and rerun count SHALL remain separate Build Provenance and SHALL NOT be used as `CFBundleVersion`.
+Before allocating the first governed number, implementation SHALL inspect any historically distributed app and seed above the highest observed value.
+Allocation SHALL use merge-time serialization and uniqueness checks, and app distribution SHALL stop before `9999` is exhausted until an accepted migration defines and validates a replacement Apple-safe mapping.
+This requirement adds Apple release identity beneath `SPEC.md` §11.3.
+
+#### Scenario: Prerelease app is assembled
+
+- **WHEN** Orchard assembles an app for `0.Y.Z-rc.K`
+- **THEN** its marketing version is `0.Y.Z`, its globally allocated build number is recorded, and prerelease identity remains in the tag, channel, manifest, and provenance
+
+#### Scenario: Historical Apple build maximum is unknown
+
+- **WHEN** implementation cannot prove that the next allocated number exceeds every historically distributed `com.orchard.app` build
+- **THEN** app publication remains disabled
+
+### Requirement: Internal Helpers Retain Independent Provenance And Candidate SBOM Evidence
+
+Internal Python helper package versions SHALL remain independent from Product Version and SHALL NOT imply compatibility through numeric equality.
+The Candidate Manifest SHALL record each helper's package name, package version, source commit, source-tree digest, `pyproject.toml` digest, `uv.lock` digest, selected extras, target platform and architecture, installed distribution inventory, and packaged tree or deterministic archive digest.
+Every tagged Candidate, including the `internal` channel, SHALL include one SPDX 2.3 JSON SBOM covering first-party components, resolved Elixir dependencies, packaged Python dependencies, Swift package dependencies, and discoverable packaged native libraries and runtimes.
+The Candidate Manifest SHALL reference the SBOM by SHA-256, and the SBOM SHALL NOT replace exact artifact or tree identities.
+This requirement refines component evidence beneath `SPEC.md` §11.8 and §13.1.
+
+#### Scenario: Helper version differs from Orchard
+
+- **WHEN** a release bundles a helper whose package version differs from Product Version
+- **THEN** validation records independent helper provenance and does not report a Product Version mismatch
+
+### Requirement: Normal Validation Enforces Governance Without Publication Authority
+
+Pull-request and ordinary `main` validation SHALL verify root `VERSION`, transition rules, first-party BEAM agreement, packaging mappings, compatibility declarations, glossary and OpenSpec consistency, and affected tests while retaining read-only release permissions.
+Normal validation SHALL NOT access release credentials or mutate tags, assets, GitHub Release state, or Amore state.
+This requirement adds CI governance beneath `SPEC.md` §11 and §13.1.
+
+#### Scenario: Pull request changes a governed version surface
+
+- **WHEN** a pull request changes Product Version storage, a consumer, transition evidence, packaging metadata, compatibility policy, or a release workflow
+- **THEN** CI validates affected invariants without obtaining publication authority
+
+### Requirement: Release Workflows Use Separate Least-Privilege Boundaries
+
+Candidate validation, Candidate or Internal Build construction, Apple build-number allocation, Apple signing and notarization, GitHub drafting, Amore staging, distribution approval, Amore delivery or publication, and GitHub publication SHALL use separate capability boundaries with only the credentials and permissions required for each operation.
+Signing, Amore publication, and GitHub publication credentials SHALL NOT coexist in one job.
+Distribution approval SHALL bind the Candidate Manifest or Internal Build Manifest digest, Release Channel, Product Version, tag when applicable, required artifact set, approving identity, timestamp, expiry, and single-use intent.
+Any changed digest, channel, artifact requirement, or compatibility declaration SHALL revoke approval automatically.
+The GitHub Release SHALL become non-draft only after Amore live verification succeeds for the same approved candidate.
+
+Implementation SHALL prove private-repository availability of every proposed GitHub protection before claiming it.
+If protected reviewers are unavailable, Orchard SHALL require the signed-approval fallback and separately controlled credential custody.
+Unavailable immutable Releases or artifact attestations SHALL NOT block a correctly configured fallback, but Orchard SHALL NOT claim platform-enforced immutability or attestation when the feature is unavailable.
+Applicable named role assignment, capability checks, digest-bound approval, and credential protection SHALL complete before trial delivery or pilot and release publication.
+Trial delivery and pilot or release publication SHALL NOT degrade to an unrestricted manual workflow.
+
+During Orchard's solo-owner operating phase, the Repository Owner MAY hold the Release Owner, Tag Signer, publication approver, Apple Build Number Allocator, Apple-signing custodian, Amore-publication custodian, GitHub-publication custodian, and release-trust administrator roles.
+Each trial, pilot, or release Candidate in that phase SHALL include a signed single-owner exception bound to the exact Candidate Manifest digest and Release Channel.
+The exception SHALL be a mandatory `single_owner_exception` State Attestation with deterministic canonical serialization.
+Its payload SHALL record schema version, Candidate Manifest digest, Release Channel, consolidated roles, signer identity and key identifier, single-Candidate purpose, issue time, expiry, unique nonce, and acknowledgement of every mandatory compensating control.
+Validation SHALL verify the signature against the pre-existing release key registry and current revocation data, SHALL reject malformed, future-issued, or expired validity windows, and SHALL store the exception in the Candidate's append-only attestation chain.
+Every exception-dependent transition SHALL revalidate issue time and expiry against the trusted transition time before accessing delivery or publication capability.
+Revocation before terminal use SHALL require a later signed revocation attestation and SHALL block delivery or publication.
+The authorized delivered, published, withdrawn, invalidated, or superseded transition SHALL atomically consume the exception through the attestation-chain compare-and-swap update, after which it SHALL NOT authorize another transition or Candidate.
+Approval, signing, staging, and publication SHALL remain separate actions and capability boundaries even when one Repository Owner performs them.
+Hardware-backed signing credentials, pre-existing authorization trust roots, exact-byte verification, least-privilege credential isolation, and immutable evidence SHALL remain mandatory compensating controls.
+The absence of an experienced backup SHALL be recorded as a resilience risk in every handoff and SHALL NOT independently block release under a valid candidate-bound exception.
+A future custodian or backup SHALL receive authority only through a separately protected trust-administration change.
+
+#### Scenario: Distribution approval is absent or stale
+
+- **WHEN** approval is absent, expired, bound to a different manifest, or revoked by a governed change
+- **THEN** delivery and publication credentials remain inaccessible and the distribution remains undelivered or unpublished
+
+#### Scenario: GitHub protection is unavailable
+
+- **WHEN** a required private-repository GitHub protection cannot be configured
+- **THEN** trial delivery and pilot or release publication remain disabled until the accepted fail-closed fallback is configured and verified
+
+### Requirement: Release Handoff Retains Exact Evidence And Gates
+
+A release handoff SHALL identify Product Version, full source commit, Release Channel, distribution state, required artifact set, final artifact identities, validation results, capability checks, credential gates, role assignments, and residual risks.
+For a tagged Candidate, the handoff SHALL additionally identify signed tag, transition-record digest, Current and Previous Supported Release Lines, Candidate Manifest digest, Candidate State Attestations, signing and notarization outcomes, mounted verification results, SBOM digest, and per-surface state required by its channel.
+For an untagged Internal Build, the handoff SHALL instead identify the Internal Build Manifest digest and Internal Build Attestations and SHALL mark Candidate-only fields as not applicable.
+The handoff SHALL distinguish an Internal Build, tagged Candidate, Verified Candidate, staged distribution, Partially Delivered Distribution, Delivered Distribution, Partially Published Release, Published Release, and withdrawn release.
+The handoff SHALL NOT report release readiness when a required capability, role assignment, approval, or evidence item remains unresolved.
+This requirement adds operator evidence beneath `SPEC.md` §11 and §13.1.
+
+#### Scenario: Candidate handoff is incomplete
+
+- **WHEN** the handoff cannot identify the exact commit, required artifacts, compatibility evidence, surface states, or remaining gates
+- **THEN** Orchard does not treat the candidate as release-ready or Published
+
+### Requirement: Explicit Release Lines Define N And N-1 Compatibility
+
+For `SPEC.md` §13.1, Current Release Line SHALL mean the candidate controller's Orchard `major.minor` line.
+Previous Supported Release Line SHALL mean one explicitly enumerated earlier Release Line and SHALL NOT be calculated by subtracting one from the minor version.
+Patch and prerelease components SHALL NOT create a new Release Line.
+The Current and Previous Supported Release Lines SHALL fulfill the existing symbolic `N` and `N-1` guarantee.
+
+The first governed `0.5` release SHALL select `0.4` as its Previous Supported Release Line but SHALL still pass exact compatibility tests because historical tagging alone does not prove support.
+Each candidate SHALL attest Current and Previous Supported Release Line support only after the required controller and Node Agent compatibility suites pass.
+The bundled worker SHALL match the Node Agent Product Version required by `SPEC.md`, while its Python package version remains independent provenance.
+Release validation SHALL fail when the declaration is absent, contradictory, narrower than the apex guarantee, or unsupported by tests.
+Current numeric minor arithmetic in `Orchard.Upgrade` SHALL remain unchanged until the corresponding `SPEC.md` amendment and implementation reconciliation land together.
+
+#### Scenario: A minor line was skipped
+
+- **WHEN** a `0.7` candidate follows an approved `0.5` line without an approved `0.6` line
+- **THEN** its Previous Supported Release Line may explicitly name `0.5` rather than inferring `0.6`
+
+#### Scenario: Candidate cannot support the previous line
+
+- **WHEN** a controller candidate cannot pass the required Previous Supported Release Line suite
+- **THEN** the release remains blocked unless an accepted change amends `SPEC.md` before that release

--- a/openspec/changes/product-versioning-release-governance/tasks.md
+++ b/openspec/changes/product-versioning-release-governance/tasks.md
@@ -1,0 +1,69 @@
+## 1. Owner Decisions And Contract Approval
+
+- [x] 1.1 Approve root `VERSION` as canonical storage, with every first-party Mix project and cross-language consumer deriving from it or failing exact validation.
+- [x] 1.2 Approve the restricted pre-1.0 `-dev`, `-rc.K`, final, patch, and next-development grammar plus dedicated transition pull requests and digest-bound authorization evidence.
+- [x] 1.3 Approve signed immutable tag grammar, one fixed channel per candidate, tag-before-build sequencing, separated candidate, delivery, distribution, and surface states, and exact-byte retry and withdrawal semantics.
+- [x] 1.4 Approve the `internal`, `trial`, `pilot`, and `release` channel contracts, optional PKG treatment, and conjunctive GitHub plus Amore completion for pilot and release.
+- [x] 1.5 Approve numeric-base `CFBundleShortVersionString` and one globally increasing `CFBundleVersion` allocation sequence in the safe range `1..9999` for `com.orchard.app`.
+- [x] 1.6 Approve exact helper package, source, lockfile, installed-distribution, and packaged-tree provenance plus an SPDX 2.3 JSON SBOM for every tagged Candidate.
+- [x] 1.7 Approve Current Release Line and explicitly enumerated Previous Supported Release Line as the meaning of `N` and `N-1`, with complete candidate compatibility suites.
+- [x] 1.8 Approve separate least-privilege candidate, signing, drafting, staging, approval, and publication boundaries plus fail-closed fallbacks for unavailable private-repository GitHub features.
+- [x] 1.9 Record the solo Repository Owner as the current holder of every release, signing, allocation, publication, and trust-administration role, with no experienced backup, and require a signed candidate-bound single-owner exception plus logical action separation for each trial, pilot, or release Candidate.
+- [ ] 1.10 Verify private-repository GitHub protections, Amore audience and promotion behavior, historical `CFBundleVersion` maximum, signing identities, credential stores, and release hosts before trial delivery or pilot and release publication.
+
+## 2. Apex Contract And Durable Documentation
+
+- [ ] 2.1 Update `SPEC.md` §13.1 with the accepted product-version authority, transition grammar, tag identity, and product-release compatibility mapping without changing the current version.
+- [ ] 2.2 Add narrow `SPEC.md` §11 requirements for governed release identity, immutable promotion, cross-artifact agreement, Apple mapping, publication state, and handoff evidence without duplicating artifact-specific contracts.
+- [ ] 2.3 Add or update a decision record only if the accepted authority, compatibility, or publication design meets Orchard's durable ADR criteria.
+- [ ] 2.4 Update `docs/process.md`, `docs/tooling.md`, contributor guidance, and relevant packaging documentation with the accepted release workflow and exact validation commands.
+- [ ] 2.5 Reconcile any accepted spec change with `app-distribution-lifecycle` and `packaging-deployment` references without adding adjacent deltas unless their existing requirements actually change.
+
+## 3. Product-Version Authority And Normal Validation
+
+- [ ] 3.1 Introduce root `VERSION` with the current Product Version and the exact file grammar without changing its value.
+- [ ] 3.2 Derive or validate the umbrella and all first-party Mix application versions against the canonical authority.
+- [ ] 3.3 Derive or validate runtime version reporting, controller membership evidence, node-agent advertisement, and CLI fallback reporting against the canonical authority.
+- [ ] 3.4 Add a repository command that validates Product Version grammar, dedicated transition evidence, canonical detached approvals, one-channel signed-tag rules, first-party agreement, compatibility declarations, Apple allocation, and packaging mappings without mutating files.
+- [ ] 3.5 Add public-interface regression tests that fail on root, child Mix, runtime, PKG, or app product-version drift.
+- [ ] 3.6 Add the non-publishing governance command to pull-request and `main` CI while retaining read-only release permissions.
+
+## 4. Release Manifest And Cross-Artifact Consistency
+
+- [ ] 4.1 Define and test the immutable Candidate Manifest, Internal Build Manifest, canonical detached approval, deterministic `single_owner_exception` and revocation attestations with atomic terminal consumption, mandatory signed Candidate and Internal Build Attestation chains with atomic compare-and-swap heads, pre-existing-trust key-registry rules, surface transition and reduction rules, separate candidate and delivery or publication states, required artifacts, signing and notarization evidence, compatibility declaration, component provenance, SPDX SBOM reference, and explicit exclusion of manifest self-digests.
+- [ ] 4.2 Record exact Python helper package, source, source-tree, `pyproject.toml`, `uv.lock`, extras, target, installed-distribution, and packaged-tree provenance without changing helper package versions to match Orchard.
+- [ ] 4.3 Make PKG metadata, staged payload metadata, runtime release contents, filenames, Git commit, build date, and build channel derive from or validate against the governed identity.
+- [ ] 4.4 Make app assembly derive or validate numeric-base `CFBundleShortVersionString`, the globally allocated `1..9999` numeric `CFBundleVersion`, Product Version, full source commit, fixed channel, and staged payload identity.
+- [ ] 4.5 Define exact file identity and canonical JSON tree identity, then inspect mounted DMG contents, PKG metadata, staged payloads, OTP releases, complete app bundles, manifests, SBOMs, and sidecars against the Candidate Manifest.
+- [ ] 4.6 Add immutable-promotion checks that reject dirty provenance, missing final verification, or any digest change after signing, notarization, stapling, mounted verification, and checksum generation.
+- [ ] 4.7 Add test fixtures for intentionally absent optional artifacts and missing required channel artifacts without requiring app and PKG to ship together unless the approved channel policy says so.
+
+## 5. Tag Candidate And Publication Workflows
+
+- [ ] 5.1 Add an untagged commit-bound Internal Build workflow that constructs the approved artifact set, allocates an Apple build number when an app is distributed, seals an Internal Build Manifest, records signed chained delivery attestations, and reduces recipient-delivery state without entering Candidate state.
+- [ ] 5.2 Add a non-publishing tag-triggered candidate lane that validates signed annotated tag grammar, exact committed-version agreement, isolated clean source, one fixed channel, compatibility declaration, and required validation results.
+- [ ] 5.3 Construct each approved unsigned or staged candidate input once from the exact tagged commit without finalizing the Candidate Manifest.
+- [ ] 5.4 Isolate and run signing, notarization, stapling, and credential access behind protected environments with least-privilege permissions and explicit failure reporting.
+- [ ] 5.5 Perform final artifact and mounted verification, generate final checksums, and then generate the immutable Candidate Manifest from the final promotable bytes and canonical tree identities.
+- [ ] 5.6 Create or update a private draft GitHub Release only after candidate identity, final artifact, Candidate Manifest, SBOM, and credential-gated verification succeed, and record the surface transition in an append-only State Attestation.
+- [ ] 5.7 Require digest-bound Release Owner approval, a valid candidate-bound single-owner exception or future approved role separation, proved capabilities, and complete handoff evidence before trial delivery or promotion of exact staged bytes through Amore and before making a GitHub Release non-draft.
+- [ ] 5.8 Verify every staged, uploaded, delivered, and published asset against the sealed identity, preserve matching partial uploads, record split trial delivery as `partially_delivered`, record split pilot or release surfaces as `partially_published`, publish through Amore first and GitHub last, and require a new version and tag for channel or sealed-byte changes.
+- [ ] 5.9 Add failure-path tests for tag mismatch, unsigned or moved tags, dirty provenance, channel changes, missing artifacts, invalid or exhausted Apple versions, digest drift, unavailable credentials, forged, stale, revoked, malformed, future-issued, expired, replayed, concurrently consumed, or denied approval, Single-owner Exceptions, and attestations, unauthorized observed live surfaces, pre-approval staging, partial delivery or publication, invalid candidates, supersession, withdrawal, concurrent attestation forks, and unavailable platform capabilities.
+
+## 6. Controller And Node Compatibility
+
+- [ ] 6.1 Add Current Release Line and explicitly enumerated Previous Supported Release Line to the Candidate Manifest and reject declarations that are absent, contradictory, narrower than the apex guarantee, or unsupported.
+- [ ] 6.2 Update `Orchard.Upgrade` and its public-interface tests in the same branch as the corresponding `SPEC.md` amendment so compatibility follows explicit Release Lines rather than minor-version subtraction.
+- [ ] 6.3 Add controller and Node Agent compatibility tests across current-line patch and prerelease versions, the explicitly named Previous Supported Release Line, skipped minors, undeclared lines, and older lines.
+- [ ] 6.4 Verify that the bundled worker matches the required Orchard node-agent release identity while its Python package version remains independent provenance.
+
+## 7. Validation And Handoff
+
+- [ ] 7.1 Run focused unit and integration tests for version authority, runtime reporting, packaging mappings, candidate-manifest and state-attestation validation, tag gates, and compatibility behavior.
+- [ ] 7.2 Run the full Elixir workflow from `AGENTS.md`, including formatting, warnings-as-errors compilation, Credo, Dialyzer, tests, and coverage.
+- [ ] 7.3 Run both native package Ruff, test, and coverage workflows, verify exact helper provenance and SPDX SBOM generation, and leave independent package versions unchanged unless separately justified.
+- [ ] 7.4 Run the Swift, app lifecycle, app assembly, signing-contract, DMG, PKG, and relevant credential-free release workflow tests from `AGENTS.md`.
+- [ ] 7.5 Run `git diff --check` and strictly validate `product-versioning-release-governance` with telemetry disabled.
+- [ ] 7.6 Run RP Review and No Mistakes against the accepted contract, implementation diff, tests, release failure paths, and exact validation evidence until blocker and important findings are resolved.
+- [ ] 7.7 Record a conditional release-governance handoff with common Product Version, full commit, Release Channel, distribution and surface state, artifact identities, validation results, capability gates, role assignments, and residual risks; include signed tag, transition record, Release Lines, Candidate Manifest, Candidate State Attestations, and SBOM for a tagged Candidate, or Internal Build Manifest and Internal Build Attestations with Candidate-only fields marked not applicable for an untagged Internal Build.
+- [ ] 7.8 After archive or sync, validate all OpenSpec materials strictly and review generated main specs for incomplete prose such as `Purpose TBD`.


### PR DESCRIPTION
## Summary

- Adds the focused `product-versioning-release-governance` OpenSpec change.
- Defines root `VERSION` as the proposed canonical Product Version authority while keeping ordinary commits and merges version-neutral.
- Defines pre-1.0 development, release-candidate, final, patch, and next-development transitions.
- Separates Product Version from Git commit, build date, Release Channel, Apple build number, artifact identity, and independently versioned helpers.
- Defines signed immutable tags, exact-byte Promotion, Candidate and Internal Build manifests, authenticated append-only attestations, and channel-specific delivery and publication states.
- Defines Apple-safe bundle version mapping, helper provenance, SPDX SBOM evidence, normal and release CI trust boundaries, and explicit Current and Previous Supported Release Lines.
- Records the current Solo-owner Custodianship model with Candidate-bound Single-owner Exceptions and mandatory compensating controls.
- Adds the corresponding Orchard glossary vocabulary.

## Current state verified

- Product Version remains `0.5.0-dev` across the umbrella and four first-party Mix projects.
- PKG versioning derives from root Mix metadata, while `Orchard.app` receives separate marketing and build values.
- Git SHA, build date, and build channel remain separate build identity.
- Internal Python helpers remain independently versioned at `0.1.0`.
- `v0.4.0` is the only live tag and is annotated but unsigned.
- GitHub currently has no Release objects.
- Required CI is read-only and has no tag-triggered release lane.

## SPEC.md impact

This proposal would refine §13.1 with Product Version authority, transition semantics, tag identity, and explicit Current and Previous Supported Release Lines.
It would add narrow §11 release-governance requirements for immutable Promotion, cross-artifact agreement, Apple mapping, delivery and publication state, and handoff evidence.
`SPEC.md` is not changed in this proposal slice, and the current `Orchard.Upgrade` behavior remains untouched until the apex amendment and implementation land together.

## Guardrails

- Does not bump Product Version.
- Does not create or rewrite tags or GitHub Releases.
- Does not build or publish artifacts.
- Does not modify generated files or `CHANGELOG.md`.
- Keeps helper package versions independent.
- Keeps external GitHub, Amore, Apple-history, credential, release-host, and append-only-store capabilities as fail-closed implementation gates.

## Validation

- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate product-versioning-release-governance --type change --strict --no-interactive`
- `git diff --check`
- Explicit whitespace checks for the new OpenSpec files.
- No-em-dash check across the changed Markdown.
- Iterative RepoPrompt review through a terminal result with no blocker or important findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787360552&installation_model_id=428414&pr_number=105&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F105&signature=f9c482eb8ccb3b9b2a7404e1bc7a3681652c3e70a5a4012e7cf10d84e6814259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->