### PR TITLE
test: wait for QueueManager restart readiness

### DIFF
--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -3489,9 +3489,16 @@ defmodule Orchard.Inference.QueueManagerTest do
 
   defp manager_restarted?(manager, previous_pid) do
     case GenServer.whereis(manager) do
-      pid when is_pid(pid) and pid != previous_pid -> true
+      pid when is_pid(pid) and pid != previous_pid -> manager_ready?(pid)
       _other -> false
     end
+  end
+
+  defp manager_ready?(pid) do
+    :sys.get_state(pid, 100)
+    true
+  catch
+    :exit, _reason -> false
   end
 
   defp resume_manager(manager) do


### PR DESCRIPTION
## Context

The required Orchard validation on PR #105 exposed a timing race in the QueueManager restart tests.
The shared helper treated registration of a replacement PID as proof that the replacement had completed initialization.
QueueManager performs startup reconciliation synchronously inside `init/1`, so the test could inspect the persisted request before reconciliation finished.

## Change

- Wait for the replacement QueueManager to answer `:sys.get_state/2` before asserting reconciliation results.
- Treat timeout or process exit as not ready and let the existing bounded wait retry.
- Keep the change limited to test synchronization with no production behavior changes.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `ORCHARD_TEST_NODE_AGENT_PORT=50172 mise exec -- mix test`
- `ORCHARD_TEST_NODE_AGENT_PORT=50172 mise exec -- mix test --cover`
- Focused restart test passed 100 consecutive repetitions.
- Full QueueManager test module passed.
- `git diff --check`
- RepoPrompt review found no blockers.

The first full-suite attempt in the fresh worktree identified a missing native helper environment.
After running the repository-pinned `mise exec -- uv sync --directory native/orchard_worker_mlx`, the full test and coverage suites passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787441366&installation_model_id=428414&pr_number=106&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F106&signature=ca1993120797211fb3893534dce62b5c7a6639c8b5f3450105b3cb67d3941f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->