### PR TITLE
fix: reconcile degraded health bonus

### DIFF
--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -365,7 +365,7 @@ defmodule Orchard.Scheduler.MultiNode do
   defp load_bonus(candidate), do: max(40 - active_request_rank(candidate) * 10, 0)
 
   defp health_bonus(%{node: %{health: :healthy}}), do: 30
-  defp health_bonus(%{node: %{health: :degraded}}), do: 10
+  defp health_bonus(%{node: %{health: :degraded}}), do: 0
   defp health_bonus(_candidate), do: 0
 
   defp maybe_put_score_component(components, _key, _value, false), do: components

--- a/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
@@ -169,9 +169,27 @@ defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
                ]
              }
     end
+
+    test "preserves a legacy persisted degraded health bonus" do
+      token = operator_token!("ops-scheduler-legacy-health-bonus")
+
+      request =
+        persist_valid_explanation!(
+          "resp_scheduler_legacy_health_bonus",
+          %{health_bonus: 10}
+        )
+
+      conn = get_explanation(token, request.public_id)
+
+      assert conn.status == 200
+
+      assert [
+               %{"components" => %{"health_bonus" => 10}}
+             ] = Jason.decode!(conn.resp_body)["scored_candidates"]
+    end
   end
 
-  defp persist_valid_explanation!(public_id) do
+  defp persist_valid_explanation!(public_id, components \\ %{pool_bonus: 200}) do
     request = create_request!(%{public_id: public_id})
 
     assert {:ok, request} =
@@ -185,7 +203,7 @@ defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
                    eligible: true,
                    tier: :loaded,
                    score: 842,
-                   components: %{pool_bonus: 200},
+                   components: components,
                    reason_codes: []
                  }
                ],

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -4167,6 +4167,9 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert schedule.strategy == :multi_node
       assert schedule.node_id == node_a.id
       assert schedule.candidate_count == 2
+
+      selected = Enum.find(schedule.scored_candidates, &(&1.node_id == node_a.id))
+      assert selected.components.health_bonus == 0
     end
 
     test "prefers loaded model even when all degraded" do


### PR DESCRIPTION
## Summary

- Align degraded scheduler explanation `health_bonus` with `SPEC.md` by reporting `0` instead of `10`.
- Preserve scheduler eligibility, ranking, candidate ordering, and dispatch behavior.
- Preserve read compatibility for persisted legacy explanations containing `health_bonus: 10`.

## TDD evidence

- Red: the public `MultiNode.schedule/2` regression returned degraded `health_bonus: 10`.
- Green: the same regression returns `0` after the one-line explanation-layer correction.
- Affected scheduler and operator API modules: 126 tests passed.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `ORCHARD_TEST_NODE_AGENT_PORT=50172 mise exec -- mix test`
- `ORCHARD_TEST_NODE_AGENT_PORT=50172 mise exec -- mix test --cover`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
- `git diff --check`

The full umbrella suite passed with 4,274 tests and 5 skips.
Controller coverage was 84.6%, and `Orchard.Scheduler.MultiNode` coverage was 88.2%.
Exact-head RepoPrompt Review and Oracle both returned `GO` with no P0, P1, or P2 findings.

Closes #94.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787452482&installation_model_id=428414&pr_number=107&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F107&signature=9f355af45157c08418713d39fba13a023846099f08dba70c18fbcfa5f63dc022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->