### PR TITLE
build(orchard_worker_mlx): update setuptools to 83.0.0

### DIFF
--- a/native/orchard_worker_mlx/uv.lock
+++ b/native/orchard_worker_mlx/uv.lock
@@ -1024,11 +1024,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Intent

Resolve Orchard Dependabot alert #8 for transitive setuptools below 83 in native/orchard_worker_mlx/uv.lock using the smallest deterministic pinned mise and uv lock change. Raise setuptools from 82.0.1 to at least 83.0.0 while preserving unrelated dependency versions and the existing grpcio-tools development dependency path. Do not perform issues #98 or #65 upgrades, and do not change product behavior, SPEC.md, OpenSpec, product versioning, packaging architecture, or release governance. Validate native formatting, lint, tests, coverage, fresh locked bootstrap, focused worker RPC behavior, the full Elixir quality workflow, strict OpenSpec, exact one-file scope, the existing review-ready PR, and terminal GitHub Actions.

## What Changed

- Bumped the transitive `setuptools` pin in `native/orchard_worker_mlx/uv.lock` from `82.0.1` to `83.0.0`, resolving Dependabot alert #8, while leaving all other resolved dependencies (including the `grpcio-tools` dev path) unchanged.
- Change is scoped to a single lockfile edit (3 insertions, 3 deletions) with no source, product-behavior, SPEC, or packaging changes.
- Verified consistent with `pyproject.toml` via `uv lock --check`, a fresh `uv sync --locked` bootstrap installing `setuptools==83.0.0`, and the full native worker suite (629 passed, 2 skipped).

## Risk Assessment

✅ Low: A single-line transitive setuptools bump (82.0.1→83.0.0) in one uv.lock file whose sdist and wheel hashes verify exactly against PyPI, with no unrelated dependencies or product behavior changed.

## Testing

Verified the setuptools 82.0.1→83.0.0 lock bump end-to-end: confirmed single-file scope, ran a fresh `uv sync --locked` bootstrap that installs setuptools==83.0.0 through the preserved grpcio-tools dev path, checked lock consistency with `uv lock --check` (no unrelated version drift), and ran the native worker test suite under `--frozen` (629 passed, 2 skipped) plus the focused RPC/service tests (102 passed). No visual artifact applies since this is a dependency-lock change with no UI surface. Transient venv/caches were removed and the worktree is clean.

<details>
<summary>Evidence: setuptools 83 bump evidence (scope, locked resolution, RPC/service tests)</summary>

<code>Exact scope: 1 file changed, 3 insertions(+), 3 deletions(-)&#10;Locked env: setuptools = 83.0.0 | grpcio-tools = 1.78.0&#10;uv lock --check: Resolved 46 packages (no drift)&#10;Native worker suite (frozen): 629 passed, 2 skipped&#10;Focused worker RPC/service: 102 passed</code>

```text
=== Dependabot alert #8: setuptools transitive pin >= 83 ===

--- Exact scope of change (base..target) ---
 native/orchard_worker_mlx/uv.lock | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

--- Locked env resolves setuptools to 83.0.0 (via grpcio-tools dev path) ---
setuptools   = 83.0.0
grpcio-tools = 1.78.0

--- uv lock --check (lock consistent with pyproject, no drift) ---
Resolved 46 packages in 35ms

--- Native worker test suite (locked/frozen) ---
629 passed, 2 skipped, 2 warnings in 8.08s

--- Focused worker RPC/service behavior ---
102 passed in 0.10s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 4d48cc5..c6f9c32` — confirmed exact one-file scope (uv.lock only)</code>
- <code>`mise exec -- uv lock --check` — lock consistent with pyproject, 46 packages resolved, no drift</code>
- <code>`mise exec -- uv sync --locked --all-extras` — fresh locked bootstrap installs setuptools==83.0.0</code>
- <code>`uv run --frozen python -c &#39;importlib.metadata.version(...)&#39;` — setuptools=83.0.0, grpcio-tools=1.78.0</code>
- <code>`mise exec -- uv run --frozen pytest` — full native worker suite: 629 passed, 2 skipped</code>
- <code>`mise exec -- uv run --frozen pytest tests/test_service.py` — focused worker RPC/service behavior: 102 passed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
