### PR TITLE
fix(packaging): route packaged orchardctl node commands through controller RPC

### DIFF
--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -101,6 +101,12 @@ jobs:
       - name: Run Dialyzer
         run: mise exec -- mix dialyzer
 
+      - name: Test packaged orchardctl Controller runtime routing
+        run: scripts/test-packaged-orchardctl-controller-runtime.sh
+
+      - name: Test packaged orchardctl assembled Controller release RPC
+        run: scripts/test-packaged-orchardctl-controller-release.sh
+
       - name: Run tests
         run: mise exec -- mix test
 

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -101,17 +101,17 @@ jobs:
       - name: Run Dialyzer
         run: mise exec -- mix dialyzer
 
-      - name: Test packaged orchardctl Controller runtime routing
-        run: scripts/test-packaged-orchardctl-controller-runtime.sh
-
-      - name: Test packaged orchardctl assembled Controller release RPC
-        run: scripts/test-packaged-orchardctl-controller-release.sh
-
       - name: Run tests
         run: mise exec -- mix test
 
       - name: Run coverage
         run: mise exec -- mix test --cover
+
+      - name: Test packaged orchardctl Controller runtime routing
+        run: scripts/test-packaged-orchardctl-controller-runtime.sh
+
+      - name: Test packaged orchardctl assembled Controller release RPC
+        run: scripts/test-packaged-orchardctl-controller-release.sh
 
       - name: Validate OpenSpec
         env:

--- a/apps/orchard_cli/lib/orchard_cli/controller_rpc.ex
+++ b/apps/orchard_cli/lib/orchard_cli/controller_rpc.ex
@@ -1,0 +1,88 @@
+defmodule OrchardCLI.ControllerRPC do
+  @moduledoc false
+
+  alias OrchardCLI.Commands.Nodes
+
+  @protocol "ORCHARDCTL_RPC_V1"
+  @controller_commands ~w(
+    list
+    inspect
+    pending
+    admit
+    reject
+    cordon
+    uncordon
+    drain
+    cancel-drain
+    maintenance
+    resume
+    decommission
+  )
+
+  @doc "Executes an encoded packaged node command and writes one result envelope to the RPC caller."
+  @spec main_base64([String.t()]) :: :ok
+  def main_base64(encoded_args) do
+    caller_group_leader = Process.group_leader()
+    envelope = with_isolated_group_leader(fn -> run_base64(encoded_args) end)
+    IO.puts(caller_group_leader, envelope)
+  end
+
+  @doc "Decodes an encoded packaged node command and returns its versioned RPC result envelope."
+  @spec run_base64([String.t()]) :: String.t()
+  def run_base64(encoded_args) when is_list(encoded_args) do
+    with {:ok, args} <- decode_arguments(encoded_args),
+         {:ok, node_args} <- controller_node_args(args) do
+      node_args
+      |> Nodes.run()
+      |> encode_result()
+    else
+      {:error, :invalid_arguments} ->
+        encode_result({:error, "Error: invalid Controller runtime RPC arguments.", 1})
+
+      {:error, :command_not_allowed} ->
+        encode_result(
+          {:error, "Error: command is not available through Controller runtime RPC.", 1}
+        )
+    end
+  end
+
+  defp with_isolated_group_leader(fun) do
+    caller_group_leader = Process.group_leader()
+    {:ok, sink} = StringIO.open("")
+    true = Process.group_leader(self(), sink)
+
+    try do
+      fun.()
+    after
+      Logger.flush()
+      true = Process.group_leader(self(), caller_group_leader)
+      StringIO.close(sink)
+    end
+  end
+
+  defp decode_arguments(encoded_args) do
+    Enum.reduce_while(encoded_args, {:ok, []}, fn encoded, {:ok, decoded} ->
+      case Base.decode64(encoded) do
+        {:ok, argument} -> {:cont, {:ok, [argument | decoded]}}
+        :error -> {:halt, {:error, :invalid_arguments}}
+      end
+    end)
+    |> case do
+      {:ok, decoded} -> {:ok, Enum.reverse(decoded)}
+      error -> error
+    end
+  end
+
+  defp controller_node_args(["nodes", command | rest]) when command in @controller_commands,
+    do: {:ok, [command | rest]}
+
+  defp controller_node_args(_args), do: {:error, :command_not_allowed}
+
+  defp encode_result(:ok), do: envelope(0, "none", "")
+  defp encode_result({:ok, message}), do: envelope(0, "stdout", message)
+  defp encode_result({:error, message, status}), do: envelope(status, "stderr", message)
+
+  defp envelope(status, stream, message) do
+    Enum.join([@protocol, status, stream, Base.encode64(message)], ":")
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/start_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/start_test.exs
@@ -59,6 +59,12 @@ defmodule OrchardCLI.Commands.StartTest do
     )
   end
 
+  # Runtime without a :services key, so LifecycleSupport resolves its own
+  # production service list the way the packaged CLI does.
+  defp default_services_runtime(overrides) do
+    Map.delete(base_runtime(overrides), :services)
+  end
+
   # Simulate service not loaded (launchctl list returns non-zero)
   defp not_loaded_cmd(parent) do
     fn prog, args, _opts ->
@@ -363,8 +369,7 @@ defmodule OrchardCLI.Commands.StartTest do
     parent = self()
 
     runtime =
-      base_runtime(%{
-        services: nil,
+      default_services_runtime(%{
         file_regular?: fn path ->
           String.ends_with?(path, "com.orchard.postgres.plist") or
             String.ends_with?(path, "com.orchard.node-agent.plist") or
@@ -704,8 +709,7 @@ defmodule OrchardCLI.Commands.StartTest do
     parent = self()
 
     runtime =
-      base_runtime(%{
-        services: nil,
+      default_services_runtime(%{
         file_regular?: fn path ->
           String.ends_with?(path, "com.orchard.postgres.plist") or
             String.ends_with?(path, "com.orchard.node-agent.plist") or

--- a/apps/orchard_cli/test/orchard_cli/commands/start_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/start_test.exs
@@ -363,39 +363,15 @@ defmodule OrchardCLI.Commands.StartTest do
     parent = self()
 
     runtime =
-      %{
-        uid: fn -> 0 end,
+      base_runtime(%{
+        services: nil,
         file_regular?: fn path ->
           String.ends_with?(path, "com.orchard.postgres.plist") or
             String.ends_with?(path, "com.orchard.node-agent.plist") or
             String.ends_with?(path, "com.orchard.controller.plist")
         end,
-        cmd: not_loaded_cmd(parent),
-        monotonic_ms: fn -> 0 end,
-        sleep: fn _ms -> :ok end,
-        ready_timeout_ms: 100,
-        poll_interval_ms: 10,
-        status_runtime: %{
-          version: fn -> "0.1.0" end,
-          endpoint_candidates: fn -> [%{base_url: "http://localhost:4000", ca_certfile: nil}] end,
-          request: fn _url, _opts ->
-            {:ok,
-             %{
-               status: 200,
-               body: %{
-                 "status" => "ok",
-                 "runtime" => %{
-                   "status" => "ok",
-                   "node_id" => "n1",
-                   "worker_state" => "idle",
-                   "counts" => %{"loaded_models" => 0},
-                   "health" => "healthy"
-                 }
-               }
-             }}
-          end
-        }
-      }
+        cmd: not_loaded_cmd(parent)
+      })
 
     assert {:ok, _banner} = Start.run([], runtime)
 
@@ -728,8 +704,8 @@ defmodule OrchardCLI.Commands.StartTest do
     parent = self()
 
     runtime =
-      %{
-        uid: fn -> 0 end,
+      base_runtime(%{
+        services: nil,
         file_regular?: fn path ->
           String.ends_with?(path, "com.orchard.postgres.plist") or
             String.ends_with?(path, "com.orchard.node-agent.plist") or
@@ -753,16 +729,12 @@ defmodule OrchardCLI.Commands.StartTest do
               {"\n", 0}
           end
         end,
-        monotonic_ms: fn -> 0 end,
-        sleep: fn _ms -> :ok end,
-        ready_timeout_ms: 100,
-        poll_interval_ms: 10,
         status_runtime: %{
           version: fn -> "0.1.0" end,
           endpoint_candidates: fn -> [%{base_url: "http://localhost:4000", ca_certfile: nil}] end,
           request: fn _url, _opts -> {:error, :econnrefused} end
         }
-      }
+      })
 
     assert {:error, msg, 1} = Start.run([], runtime)
     assert msg =~ "Node Agent was loaded into launchd but not rolled back"

--- a/apps/orchard_cli/test/orchard_cli/commands/stop_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/stop_test.exs
@@ -233,15 +233,16 @@ defmodule OrchardCLI.Commands.StopTest do
       end
     end
 
-    runtime = %{
-      uid: fn -> 0 end,
-      file_regular?: fn path ->
-        String.ends_with?(path, "com.orchard.postgres.plist") or
-          String.ends_with?(path, "com.orchard.node-agent.plist") or
-          String.ends_with?(path, "com.orchard.controller.plist")
-      end,
-      cmd: cmd_fn
-    }
+    runtime =
+      base_runtime(%{
+        services: nil,
+        file_regular?: fn path ->
+          String.ends_with?(path, "com.orchard.postgres.plist") or
+            String.ends_with?(path, "com.orchard.node-agent.plist") or
+            String.ends_with?(path, "com.orchard.controller.plist")
+        end,
+        cmd: cmd_fn
+      })
 
     assert {:ok, msg} = Stop.run([], runtime)
     assert msg =~ "Stopped Orchard services."

--- a/apps/orchard_cli/test/orchard_cli/commands/stop_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/stop_test.exs
@@ -35,6 +35,12 @@ defmodule OrchardCLI.Commands.StopTest do
     )
   end
 
+  # Runtime without a :services key, so LifecycleSupport resolves its own
+  # production service list the way the packaged CLI does.
+  defp default_services_runtime(overrides) do
+    Map.delete(base_runtime(overrides), :services)
+  end
+
   # Services are loaded (launchctl list returns 0)
   defp loaded_cmd(parent) do
     fn prog, args, _opts ->
@@ -234,8 +240,7 @@ defmodule OrchardCLI.Commands.StopTest do
     end
 
     runtime =
-      base_runtime(%{
-        services: nil,
+      default_services_runtime(%{
         file_regular?: fn path ->
           String.ends_with?(path, "com.orchard.postgres.plist") or
             String.ends_with?(path, "com.orchard.node-agent.plist") or

--- a/apps/orchard_cli/test/orchard_cli/controller_rpc_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/controller_rpc_test.exs
@@ -1,0 +1,86 @@
+defmodule OrchardCLI.ControllerRPCTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias OrchardCLI.Commands.Nodes
+  alias OrchardCLI.ControllerRPC
+
+  test "SPEC 11.9 packages node admission results for Controller-runtime RPC" do
+    encoded_args = encode_args(["nodes", "admit", "--help"])
+    expected = Nodes.run(["admit", "--help"])
+
+    assert decode_envelope(ControllerRPC.run_base64(encoded_args)) ==
+             {:stdout, 0, elem(expected, 1)}
+  end
+
+  test "Controller RPC allowlist matches every packaged authoritative node command" do
+    for command <- ~w(
+          list
+          inspect
+          pending
+          admit
+          reject
+          cordon
+          uncordon
+          drain
+          cancel-drain
+          maintenance
+          resume
+          decommission
+        ) do
+      assert {:stdout, 0, _message} =
+               ["nodes", command, "--help"]
+               |> encode_args()
+               |> ControllerRPC.run_base64()
+               |> decode_envelope()
+    end
+  end
+
+  test "SPEC 11.9 preserves node command errors without halting the Controller" do
+    encoded_args = encode_args(["nodes", "admit"])
+    {:error, expected_message, expected_status} = Nodes.run(["admit"])
+
+    assert decode_envelope(ControllerRPC.run_base64(encoded_args)) ==
+             {:stderr, expected_status, expected_message}
+  end
+
+  test "SPEC 11.9 RPC entrypoint writes exactly one transport envelope" do
+    encoded_args = encode_args(["nodes", "pending", "--help"])
+
+    output = capture_io(fn -> assert :ok = ControllerRPC.main_base64(encoded_args) end)
+
+    assert [envelope] = String.split(output, "\n", trim: true)
+    assert {:stdout, 0, message} = decode_envelope(envelope)
+    assert message =~ "orchardctl nodes pending"
+  end
+
+  test "RPC bridge rejects commands outside the Controller-runtime authority set" do
+    for args <- [
+          ["status"],
+          ["nodes", "enrollment", "create"],
+          ["nodes", "trust", "init"],
+          ["nodes", "unknown"]
+        ] do
+      assert {:stderr, 1, "Error: command is not available through Controller runtime RPC."} =
+               args |> encode_args() |> ControllerRPC.run_base64() |> decode_envelope()
+    end
+  end
+
+  test "RPC bridge rejects malformed Base64 arguments" do
+    assert {:stderr, 1, "Error: invalid Controller runtime RPC arguments."} =
+             ["%%%"] |> ControllerRPC.run_base64() |> decode_envelope()
+  end
+
+  defp encode_args(args), do: Enum.map(args, &Base.encode64/1)
+
+  defp decode_envelope(envelope) do
+    assert ["ORCHARDCTL_RPC_V1", status, stream, encoded_message] =
+             String.split(envelope, ":", parts: 4)
+
+    assert {status, ""} = Integer.parse(status)
+    assert {:ok, message} = Base.decode64(encoded_message)
+
+    {String.to_existing_atom(stream), status, message}
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/packaging_script_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/packaging_script_test.exs
@@ -923,6 +923,74 @@ defmodule OrchardCLI.PackagingScriptTest do
     end)
   end
 
+  test "controller wrapper accepts a pre-existing loopback management EPMD listener" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+        ORCHARD_CONSOLE_ENABLED=false
+        """
+      )
+
+      assert {output, 0} =
+               run_controller_wrapper(script, ctx, [
+                 {"CONTROLLER_ENV_STAT_UID", "0"},
+                 {"CONTROLLER_ENV_STAT_MODE", "600"},
+                 {"CONTROLLER_EPMD_LISTENER_MODE", "loopback"}
+               ])
+
+      assert output =~ "fake orchard_controller start"
+      assert output =~ "fake release node=orchard_controller_management@127.0.0.1"
+    end)
+  end
+
+  test "controller wrapper starts when EPMD inspection emits only benign advisories" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+        ORCHARD_CONSOLE_ENABLED=false
+        """
+      )
+
+      assert {output, 0} =
+               run_controller_wrapper(script, ctx, [
+                 {"CONTROLLER_ENV_STAT_UID", "0"},
+                 {"CONTROLLER_ENV_STAT_MODE", "600"},
+                 {"CONTROLLER_EPMD_LISTENER_MODE", "none-with-advisory"}
+               ])
+
+      assert output =~ "fake orchard_controller start"
+      refute output =~ "could not inspect the Controller management EPMD listener"
+      refute output =~ "Output information may be incomplete"
+    end)
+  end
+
+  test "controller wrapper ignores a hostile TMPDIR while inspecting the EPMD listener" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+        ORCHARD_CONSOLE_ENABLED=false
+        TMPDIR="#{Path.join(ctx.root, "no-such-tmpdir")}"
+        """
+      )
+
+      assert {output, 0} =
+               run_controller_wrapper(script, ctx, [
+                 {"CONTROLLER_ENV_STAT_UID", "0"},
+                 {"CONTROLLER_ENV_STAT_MODE", "600"},
+                 {"TMPDIR", "/nonexistent/orchard-hostile-tmpdir"}
+               ])
+
+      assert output =~ "fake orchard_controller start"
+      refute output =~ "could not inspect the Controller management EPMD listener"
+    end)
+  end
+
   test "controller wrapper fails closed when management EPMD inspection errors" do
     with_temp_controller_wrapper(fn %{script: script} = ctx ->
       File.write!(
@@ -1840,13 +1908,28 @@ defmodule OrchardCLI.PackagingScriptTest do
   defp write_fake_controller_lsof!(ctx) do
     File.write!(Path.join(ctx.fake_bin, "lsof"), """
     #!/bin/sh
+    warn=true
+    for arg in "$@"; do
+      case "$arg" in
+        -w) warn=false ;;
+        -iTCP:*) port=${arg#-iTCP:} ;;
+      esac
+    done
+
     case "${CONTROLLER_EPMD_LISTENER_MODE:-none}" in
       none) exit 1 ;;
+      none-with-advisory)
+        if [ "$warn" = true ]; then
+          printf "lsof: WARNING: can't stat() smbfs file system /Volumes/share\\n" >&2
+          printf '      Output information may be incomplete.\\n' >&2
+        fi
+        exit 1
+        ;;
       loopback) listener="127.0.0.1" ;;
       wildcard) listener="*" ;;
       *) exit 2 ;;
     esac
-    port=${3#-iTCP:}
+
     printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\\n'
     printf 'epmd 123 root 0u IPv4 0 0t0 TCP %s:%s (LISTEN)\\n' "$listener" "$port"
     """)

--- a/apps/orchard_cli/test/orchard_cli/packaging_script_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/packaging_script_test.exs
@@ -841,7 +841,7 @@ defmodule OrchardCLI.PackagingScriptTest do
     end)
   end
 
-  test "controller wrapper demotes gRPC compatibility fallback to non-distributed release" do
+  test "controller wrapper keeps loopback management distribution in gRPC compatibility mode" do
     with_temp_controller_wrapper(fn %{script: script} = ctx ->
       File.write!(
         Path.join([ctx.root, "config", "controller.env"]),
@@ -858,14 +858,42 @@ defmodule OrchardCLI.PackagingScriptTest do
                ])
 
       assert output =~ "Runtime Endpoint transport grpc"
-      assert output =~ "compatibility fallback"
-      assert output =~ "fake release distribution=none"
-      assert output =~ "fake release node="
-      assert output =~ "fake release cookie=unset"
+      assert output =~ "loopback Controller management distribution enabled"
+      assert output =~ "fake release distribution=name"
+      assert output =~ "fake release node=orchard_controller_management@127.0.0.1"
+      assert output =~ "fake release cookie=set"
+      assert output =~ "fake epmd port=4369"
+      assert output =~ "fake epmd address=127.0.0.1"
+      assert output =~ "inet_dist_use_interface {127,0,0,1}"
+      assert output =~ "inet_dist_listen_min 52171"
     end)
   end
 
-  test "controller wrapper makes gRPC fallback authoritative over inherited release env" do
+  test "controller wrapper rejects a pre-existing wildcard management EPMD listener" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+        ORCHARD_CONSOLE_ENABLED=false
+        """
+      )
+
+      assert {output, 78} =
+               run_controller_wrapper(script, ctx, [
+                 {"CONTROLLER_ENV_STAT_UID", "0"},
+                 {"CONTROLLER_ENV_STAT_MODE", "600"},
+                 {"CONTROLLER_EPMD_LISTENER_MODE", "wildcard"}
+               ])
+
+      assert output =~
+               "existing Controller management EPMD listener must bind exclusively to loopback"
+
+      refute output =~ "fake orchard_controller start"
+    end)
+  end
+
+  test "controller wrapper makes gRPC management identity authoritative over inherited release env" do
     with_temp_controller_wrapper(fn %{script: script} = ctx ->
       File.write!(
         Path.join([ctx.root, "config", "controller.env"]),
@@ -886,13 +914,36 @@ defmodule OrchardCLI.PackagingScriptTest do
                  {"ERL_AFLAGS", "-name wrong@10.0.0.99 -setcookie inherited-cookie"}
                ])
 
-      assert output =~ "fake release distribution=none"
-      assert output =~ "fake release node="
-      assert output =~ "fake release cookie=unset"
-      assert output =~ "fake epmd port="
-      assert output =~ "fake erl aflags=\n"
+      assert output =~ "fake release distribution=name"
+      assert output =~ "fake release node=orchard_controller_management@127.0.0.1"
+      assert output =~ "fake release cookie=set"
+      assert output =~ "fake epmd port=4369"
+      assert output =~ "fake epmd address=127.0.0.1"
+      assert output =~ "inet_dist_use_interface {127,0,0,1}"
       refute output =~ "wrong@10.0.0.99"
       refute output =~ "inherited-cookie"
+    end)
+  end
+
+  test "controller wrapper rejects non-loopback gRPC management identity" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+        ORCHARD_CONTROLLER_MANAGEMENT_NODE_NAME=orchard_controller_management@10.0.0.10
+        ORCHARD_CONSOLE_ENABLED=false
+        """
+      )
+
+      assert {output, 78} =
+               run_controller_wrapper(script, ctx, [
+                 {"CONTROLLER_ENV_STAT_UID", "0"},
+                 {"CONTROLLER_ENV_STAT_MODE", "600"}
+               ])
+
+      assert output =~ "ORCHARD_CONTROLLER_MANAGEMENT_NODE_NAME must use a loopback IPv4 address"
+      refute output =~ "fake orchard_controller start"
     end)
   end
 
@@ -1650,12 +1701,14 @@ defmodule OrchardCLI.PackagingScriptTest do
         printf 'fake release cookie=unset\\n'
       fi
       printf 'fake epmd port=%s\\n' "${ERL_EPMD_PORT:-}"
+      printf 'fake epmd address=%s\\n' "${ERL_EPMD_ADDRESS:-}"
       printf 'fake erl aflags=%s\\n' "${ERL_AFLAGS:-}"
       exit 0
       """)
 
       File.chmod!(release, 0o755)
       write_fake_controller_stat!(ctx)
+      write_fake_controller_lsof!(ctx)
       write_test_controller_wrapper!(ctx)
       fun.(ctx)
     after
@@ -1671,6 +1724,7 @@ defmodule OrchardCLI.PackagingScriptTest do
         ~s(ORCHARD_ROOT="/Library/Application Support/Orchard"),
         ~s(ORCHARD_ROOT="#{ctx.root}")
       )
+      |> String.replace("/usr/sbin/lsof", Path.join(ctx.fake_bin, "lsof"))
 
     File.write!(ctx.script, content)
     File.chmod!(ctx.script, 0o755)
@@ -1705,6 +1759,23 @@ defmodule OrchardCLI.PackagingScriptTest do
     """)
 
     File.chmod!(Path.join(ctx.fake_bin, "stat"), 0o755)
+  end
+
+  defp write_fake_controller_lsof!(ctx) do
+    File.write!(Path.join(ctx.fake_bin, "lsof"), """
+    #!/bin/sh
+    case "${CONTROLLER_EPMD_LISTENER_MODE:-none}" in
+      none) exit 1 ;;
+      loopback) listener="127.0.0.1" ;;
+      wildcard) listener="*" ;;
+      *) exit 2 ;;
+    esac
+    port=${3#-iTCP:}
+    printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\\n'
+    printf 'epmd 123 root 0u IPv4 0 0t0 TCP %s:%s (LISTEN)\\n' "$listener" "$port"
+    """)
+
+    File.chmod!(Path.join(ctx.fake_bin, "lsof"), 0o755)
   end
 
   defp run_controller_wrapper(script, ctx, extra_env) do
@@ -1756,6 +1827,7 @@ defmodule OrchardCLI.PackagingScriptTest do
         printf 'fake release cookie=unset\\n'
       fi
       printf 'fake epmd port=%s\\n' "${ERL_EPMD_PORT:-}"
+      printf 'fake epmd address=%s\\n' "${ERL_EPMD_ADDRESS:-}"
       printf 'fake erl aflags=%s\\n' "${ERL_AFLAGS:-}"
       exit 0
       """)

--- a/apps/orchard_cli/test/orchard_cli/packaging_script_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/packaging_script_test.exs
@@ -815,6 +815,36 @@ defmodule OrchardCLI.PackagingScriptTest do
     end)
   end
 
+  test "controller wrapper clears inherited ERL_EPMD_ADDRESS for cluster distribution" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
+        ORCHARD_BEAM_NODE_NAME=orchard_controller@10.0.0.10
+        ORCHARD_BEAM_COOKIE_FILE="#{ctx.cookie_file}"
+        ORCHARD_CONSOLE_ENABLED=false
+        ERL_EPMD_ADDRESS=127.0.0.1
+        """
+      )
+
+      for inherited <- [[], [{"ERL_AFLAGS", "-kernel inet_dist_listen_min 52300"}]] do
+        assert {output, 0} =
+                 run_controller_wrapper(
+                   script,
+                   ctx,
+                   [
+                     {"CONTROLLER_ENV_STAT_UID", "0"},
+                     {"CONTROLLER_ENV_STAT_MODE", "600"}
+                   ] ++ inherited
+                 )
+
+        assert output =~ "fake epmd address=\n"
+        assert output =~ "inet_dist_use_interface {10,0,0,10}"
+      end
+    end)
+  end
+
   test "controller wrapper makes BEAM release identity authoritative over inherited env" do
     with_temp_controller_wrapper(fn %{script: script} = ctx ->
       File.write!(
@@ -889,6 +919,52 @@ defmodule OrchardCLI.PackagingScriptTest do
       assert output =~
                "existing Controller management EPMD listener must bind exclusively to loopback"
 
+      refute output =~ "fake orchard_controller start"
+    end)
+  end
+
+  test "controller wrapper fails closed when management EPMD inspection errors" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+        ORCHARD_CONSOLE_ENABLED=false
+        """
+      )
+
+      assert {output, 78} =
+               run_controller_wrapper(script, ctx, [
+                 {"CONTROLLER_ENV_STAT_UID", "0"},
+                 {"CONTROLLER_ENV_STAT_MODE", "600"},
+                 {"CONTROLLER_EPMD_LISTENER_MODE", "inspection-error"}
+               ])
+
+      assert output =~ "could not inspect the Controller management EPMD listener"
+      refute output =~ "fake orchard_controller start"
+    end)
+  end
+
+  test "controller wrapper fails closed when the management EPMD inspector is unavailable" do
+    with_temp_controller_wrapper(fn %{script: script} = ctx ->
+      File.write!(
+        Path.join([ctx.root, "config", "controller.env"]),
+        """
+        ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+        ORCHARD_CONSOLE_ENABLED=false
+        """
+      )
+
+      File.rm!(Path.join(ctx.fake_bin, "lsof"))
+
+      assert {output, 78} =
+               run_controller_wrapper(script, ctx, [
+                 {"CONTROLLER_ENV_STAT_UID", "0"},
+                 {"CONTROLLER_ENV_STAT_MODE", "600"}
+               ])
+
+      assert output =~ "could not inspect the Controller management EPMD listener"
+      assert output =~ "is not executable"
       refute output =~ "fake orchard_controller start"
     end)
   end

--- a/apps/orchard_controller/test/orchard/scheduler/single_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/single_node_test.exs
@@ -441,8 +441,7 @@ defmodule Orchard.Scheduler.SingleNodeTest do
   end
 
   defp stopped_authority do
-    pid = spawn(fn -> :ok end)
-    monitor = Process.monitor(pid)
+    {pid, monitor} = spawn_monitor(fn -> :ok end)
     assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}
     pid
   end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule Orchard.MixProject do
       orchard_controller: [
         applications: [
           orchard_shared: :permanent,
-          orchard_controller: :permanent
+          orchard_controller: :permanent,
+          orchard_cli: :load
         ]
       ],
       orchard_node_agent: [

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -162,6 +162,7 @@ gRPC compatibility fallback:
 - Configure controller `ORCHARD_RUNTIME_CLIENT_TARGETS` with comma-separated node-agent `host:port` values.
 - Enroll and admit the node so the controller schedules it from trusted Node inventory; the certificate-backed gRPC path requires the issued Node Certificate, so `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT="grpc"` selects mutual TLS automatically.
 - Set `ORCHARD_ALLOW_STATIC_RUNTIME_TARGET_FALLBACK="true"` only to schedule static `ORCHARD_RUNTIME_CLIENT_TARGETS` without an enrolled, admitted node; it is off by default.
+- The controller still enables a loopback-only management distribution endpoint so local `orchardctl` node commands keep executing in the running Controller; see "Env File Overrides" for its defaults, overrides, and startup gate.
 - Use this path only for compatibility or diagnostic fallback, not as the packaged happy path.
 
 Explicit deferrals:
@@ -452,6 +453,8 @@ not overwritten during package upgrades.
 | Readiness reports `migrations_current: false` (with DB reachable) | Migrations not run | Run `sudo orchardctl migrate` |
 | DB-backed CLI command fails with `database_unavailable` | Command run without `sudo`, `DATABASE_URL` unset, DB unreachable, or migrations pending | Re-run with `sudo`; verify `DATABASE_URL` in `controller.env` and `psql "$DATABASE_URL" -c 'select 1'`; run `sudo orchardctl migrate` if pending |
 | `WARNING: ignoring env file` in controller.log | File not root-owned or has group/world permission bits | `sudo chown root:wheel <file> && sudo chmod 600 <file>` |
+| `sudo orchardctl nodes ...` fails with `controller_runtime_unavailable` | Controller service not running, management identity/cookie mismatch, or the Controller RPC hit its 30-second watchdog or output limit | Check `orchardctl status` and `controller.log`, confirm the root-owned cookie and any `ORCHARD_CONTROLLER_MANAGEMENT_*` overrides, then inspect Controller and node state before retrying |
+| Controller exits `78` with `existing Controller management EPMD listener must bind exclusively to loopback` | With `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT="grpc"`, a pre-existing EPMD on the management port is bound to a wildcard or routable address | Stop the foreign `epmd`, or set `ORCHARD_CONTROLLER_MANAGEMENT_EPMD_PORT` to a free port so the Controller owns a loopback-only listener |
 
 ## Upgrade Preflight
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -266,10 +266,8 @@ with the desired role and reinstall the universal PKG.
 
 ## Env File Overrides
 
-Wrapper scripts (`bin/orchard-node-agent`, `bin/orchard-controller`) source
-optional env files before starting the BEAM release. `bin/orchardctl` also
-sources `controller.env` so DB-backed CLI commands, including upgrade preflight,
-use the same database configuration as the controller:
+Wrapper scripts (`bin/orchard-node-agent`, `bin/orchard-controller`) source optional env files before starting the BEAM release.
+`bin/orchardctl` also sources `controller.env` so DB-backed CLI commands, including upgrade preflight, use the same database configuration as the controller:
 
 | Service | Env File |
 |---------|----------|
@@ -278,13 +276,21 @@ use the same database configuration as the controller:
 
 Format: plain `KEY=value` lines. Comments (`#`) and blank lines are fine.
 
-DB-backed CLI commands (for example `orchardctl nodes`, `models`, `requests`,
-`cluster status`, `cluster init`, `tenants`, `api-keys`, and `api-clients`)
-start the controller Repo on demand, so they must run as root (`sudo`) to read
-`controller.env` and its `DATABASE_URL`. When the database is unreachable or
-`DATABASE_URL` is unset, these commands fail with a `database_unavailable`
-error and remediation guidance rather than returning empty or "not found"
-output.
+The SPEC §11.9 node-admission commands (`nodes list`, `inspect`, `pending`, `admit`, and `reject`) and node-lifecycle commands execute through the already-running Controller release.
+This gives them the Controller-owned Repo, leader gate, audit path, and dispatch-capacity acceptance authority without starting a second Controller authority.
+Under the packaged BEAM Runtime Endpoint transport, these commands use the Controller's configured BEAM identity, root-owned cookie, and EPMD port.
+Under the gRPC compatibility transport, the Controller keeps inference traffic on gRPC and enables a separate loopback-only distribution endpoint for local management commands.
+Its EPMD listener, Controller distribution listener, and temporary release RPC client distribution listener are all restricted to loopback interfaces.
+The management endpoint defaults to `orchard_controller_management@127.0.0.1`, the packaged root-owned cookie, EPMD TCP `4369`, and distribution TCP `52171`.
+A Controller RPC has a 30-second watchdog and approximately 1 MiB captured-output limit per stream.
+Timeout, excessive output, invalid envelopes, or other RPC failures terminate and reap the client, remove captured files, emit a sanitized error, and fail closed without a standalone mutation fallback.
+Inspect Controller and node state before retrying because transport loss can be ambiguous after dispatch.
+Offline node help, `nodes enrollment`, and `nodes trust` continue to use the standalone CLI release.
+Unknown future `nodes` subcommands are denied by the package wrapper until they are explicitly classified as offline or Controller-authoritative.
+Unrelated commands continue to use the standalone CLI release.
+
+Other DB-backed CLI commands (for example `models`, `requests`, `cluster status`, `cluster init`, `tenants`, `api-keys`, and `api-clients`) start the controller Repo on demand, so they must run as root (`sudo`) to read `controller.env` and its `DATABASE_URL`.
+When the database is unreachable or `DATABASE_URL` is unset, these commands fail with a `database_unavailable` error and remediation guidance rather than returning empty or "not found" output.
 
 Primary use case: operational rollback of the worker backend without editing
 launchd plists or global environment.
@@ -422,6 +428,10 @@ sudo chmod 600 '/Library/Application Support/Orchard/config/controller.env'
 | `ORCHARD_BEAM_COOKIE_FILE` | `/Library/Application Support/Orchard/config/beam.cookie` | Root-owned mode `0600` BEAM cookie file shared across controller and node-agent Macs. |
 | `ORCHARD_BEAM_EPMD_PORT` | `4369` | EPMD port. Set the same override on every Mac when needed. |
 | `ORCHARD_BEAM_DIST_PORT_MIN` / `ORCHARD_BEAM_DIST_PORT_MAX` | `52171` | Controller BEAM distribution port range. |
+| `ORCHARD_CONTROLLER_MANAGEMENT_NODE_NAME` | `orchard_controller_management@127.0.0.1` | Local Controller management identity used only when the inference Runtime Endpoint transport is `grpc`. The host must be loopback. |
+| `ORCHARD_CONTROLLER_MANAGEMENT_COOKIE_FILE` | `/Library/Application Support/Orchard/config/beam.cookie` | Root-owned mode `0600` cookie used by the loopback management endpoint and local packaged `orchardctl`. |
+| `ORCHARD_CONTROLLER_MANAGEMENT_EPMD_PORT` | `4369` | EPMD port for the loopback management endpoint in gRPC compatibility mode. |
+| `ORCHARD_CONTROLLER_MANAGEMENT_DIST_PORT` | `52171` | Fixed loopback distribution port for the management endpoint in gRPC compatibility mode. |
 | `ORCHARD_RUNTIME_CLIENT_TARGETS` | unset | gRPC compatibility fallback only. Comma-separated node-agent `host:port` values. |
 | `ORCHARD_ALLOW_STATIC_RUNTIME_TARGET_FALLBACK` | `false` | Compatibility escape hatch. When `true`, the controller schedules `ORCHARD_RUNTIME_CLIENT_TARGETS` while no enrolled Node is admitted; the packaged happy path leaves this `false` and derives targets from trusted Node inventory. |
 | `ORCHARD_NODE_TRUST_ROOT` | `/Library/Application Support/Orchard/config/node-trust` | Controller root for internal Node trust material initialized by `orchardctl nodes trust init`; rare override when the support-root layout is intentionally changed. |

--- a/packaging/pkg/bin/orchard-controller
+++ b/packaging/pkg/bin/orchard-controller
@@ -115,9 +115,29 @@ beam_validate_cookie_file() {
 
 beam_validate_management_epmd_listener() {
     _listener_port=$1
-    if ! _listeners=$(/usr/sbin/lsof -nP -iTCP:"$_listener_port" -sTCP:LISTEN 2>/dev/null); then
-        return 0
+    _listener_lsof=/usr/sbin/lsof
+
+    if [ ! -x "$_listener_lsof" ]; then
+        beam_fail "could not inspect the Controller management EPMD listener: $_listener_lsof is not executable"
     fi
+
+    _listener_err=$(mktemp "${TMPDIR:-/tmp}/orchard-epmd-listener.XXXXXX") || \
+        beam_fail "could not inspect the Controller management EPMD listener"
+
+    _listener_status=0
+    _listeners=$("$_listener_lsof" -nP -iTCP:"$_listener_port" -sTCP:LISTEN 2>"$_listener_err") ||
+        _listener_status=$?
+    _listener_diagnostics=$(cat "$_listener_err" 2>/dev/null) || _listener_diagnostics=""
+    rm -f "$_listener_err"
+
+    if [ "$_listener_status" -ne 0 ]; then
+        if [ "$_listener_status" -eq 1 ] && [ -z "$_listeners" ] &&
+           [ -z "$_listener_diagnostics" ]; then
+            return 0
+        fi
+        beam_fail "could not inspect the Controller management EPMD listener"
+    fi
+
     if ! printf '%s\n' "$_listeners" |
          grep -F -- "127.0.0.1:$_listener_port (LISTEN)" >/dev/null; then
         beam_fail "existing Controller management EPMD listener must bind exclusively to loopback"
@@ -220,11 +240,13 @@ beam_configure_release() {
     if [ "$_management_only" = true ]; then
         export ERL_AFLAGS="$_beam_kernel_flags"
         export ERL_EPMD_ADDRESS=127.0.0.1
-    elif [ -n "${ERL_AFLAGS:-}" ]; then
-        unset ERL_EPMD_ADDRESS
-        export ERL_AFLAGS="$ERL_AFLAGS $_beam_kernel_flags"
     else
-        export ERL_AFLAGS="$_beam_kernel_flags"
+        unset ERL_EPMD_ADDRESS
+        if [ -n "${ERL_AFLAGS:-}" ]; then
+            export ERL_AFLAGS="$ERL_AFLAGS $_beam_kernel_flags"
+        else
+            export ERL_AFLAGS="$_beam_kernel_flags"
+        fi
     fi
 
     printf 'orchard-controller: Runtime Endpoint transport %s\n' "$ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" >&2

--- a/packaging/pkg/bin/orchard-controller
+++ b/packaging/pkg/bin/orchard-controller
@@ -94,21 +94,37 @@ beam_validate_ipv4() {
 
 beam_validate_cookie_file() {
     _cookie_file=$1
+    _cookie_label=$2
     if [ ! -f "$_cookie_file" ]; then
-        beam_fail "ORCHARD_BEAM_COOKIE_FILE must point to an existing regular file"
+        beam_fail "$_cookie_label must point to an existing regular file"
     fi
     if [ ! -s "$_cookie_file" ]; then
-        beam_fail "ORCHARD_BEAM_COOKIE_FILE must not be empty"
+        beam_fail "$_cookie_label must not be empty"
     fi
     _cookie_meta=$(stat -f '%u:%Lp' "$_cookie_file" 2>/dev/null) || \
-        beam_fail "could not inspect ORCHARD_BEAM_COOKIE_FILE"
+        beam_fail "could not inspect $_cookie_label"
     _cookie_uid=${_cookie_meta%%:*}
     _cookie_mode=${_cookie_meta#*:}
     if [ "$_cookie_uid" != "0" ]; then
-        beam_fail "ORCHARD_BEAM_COOKIE_FILE must be root-owned"
+        beam_fail "$_cookie_label must be root-owned"
     fi
     if [ "${_cookie_mode#?}" != "00" ]; then
-        beam_fail "ORCHARD_BEAM_COOKIE_FILE must be owner-only"
+        beam_fail "$_cookie_label must be owner-only"
+    fi
+}
+
+beam_validate_management_epmd_listener() {
+    _listener_port=$1
+    if ! _listeners=$(/usr/sbin/lsof -nP -iTCP:"$_listener_port" -sTCP:LISTEN 2>/dev/null); then
+        return 0
+    fi
+    if ! printf '%s\n' "$_listeners" |
+         grep -F -- "127.0.0.1:$_listener_port (LISTEN)" >/dev/null; then
+        beam_fail "existing Controller management EPMD listener must bind exclusively to loopback"
+    fi
+    if printf '%s\n' "$_listeners" | sed '1d' |
+       grep -Ev -- "(127\\.0\\.0\\.1|\\[::1\\]):$_listener_port \\(LISTEN\\)" | grep -q .; then
+        beam_fail "existing Controller management EPMD listener must bind exclusively to loopback"
     fi
 }
 
@@ -117,31 +133,44 @@ beam_configure_release() {
     case "$_transport" in
         ''|beam)
             ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
-            export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT
+            _node_label=ORCHARD_BEAM_NODE_NAME
+            _node_name=${ORCHARD_BEAM_NODE_NAME:-orchard_controller@127.0.0.1}
+            _cookie_label=ORCHARD_BEAM_COOKIE_FILE
+            _cookie_file=${ORCHARD_BEAM_COOKIE_FILE:-"$ORCHARD_ROOT/config/beam.cookie"}
+            _epmd_label=ORCHARD_BEAM_EPMD_PORT
+            _epmd_port=${ORCHARD_BEAM_EPMD_PORT:-4369}
+            _dist_min_label=ORCHARD_BEAM_DIST_PORT_MIN
+            _dist_max_label=ORCHARD_BEAM_DIST_PORT_MAX
+            _dist_min=${ORCHARD_BEAM_DIST_PORT_MIN:-52171}
+            _dist_max=${ORCHARD_BEAM_DIST_PORT_MAX:-52171}
+            _management_only=false
             ;;
         grpc)
-            RELEASE_DISTRIBUTION=none
-            export RELEASE_DISTRIBUTION
-            unset RELEASE_NODE
-            unset RELEASE_COOKIE
-            unset ERL_EPMD_PORT
-            unset ERL_AFLAGS
-            printf 'orchard-controller: Runtime Endpoint transport grpc; BEAM distribution disabled for compatibility fallback\n' >&2
-            return 0
+            _node_label=ORCHARD_CONTROLLER_MANAGEMENT_NODE_NAME
+            _node_name=${ORCHARD_CONTROLLER_MANAGEMENT_NODE_NAME:-orchard_controller_management@127.0.0.1}
+            _cookie_label=ORCHARD_CONTROLLER_MANAGEMENT_COOKIE_FILE
+            _cookie_file=${ORCHARD_CONTROLLER_MANAGEMENT_COOKIE_FILE:-"$ORCHARD_ROOT/config/beam.cookie"}
+            _epmd_label=ORCHARD_CONTROLLER_MANAGEMENT_EPMD_PORT
+            _epmd_port=${ORCHARD_CONTROLLER_MANAGEMENT_EPMD_PORT:-4369}
+            _dist_min_label=ORCHARD_CONTROLLER_MANAGEMENT_DIST_PORT
+            _dist_max_label=ORCHARD_CONTROLLER_MANAGEMENT_DIST_PORT
+            _dist_min=${ORCHARD_CONTROLLER_MANAGEMENT_DIST_PORT:-52171}
+            _dist_max=$_dist_min
+            _management_only=true
             ;;
         *)
             beam_fail "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be beam or grpc"
             ;;
     esac
+    export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT
 
-    _node_name=${ORCHARD_BEAM_NODE_NAME:-orchard_controller@127.0.0.1}
     case "$_node_name" in
         *@*)
             _service=${_node_name%@*}
             _host=${_node_name#*@}
             ;;
         *)
-            beam_fail "ORCHARD_BEAM_NODE_NAME must be a long BEAM node name in service@ipv4 form"
+            beam_fail "$_node_label must be a long BEAM node name in service@ipv4 form"
             ;;
     esac
 
@@ -151,23 +180,26 @@ beam_configure_release() {
     esac
     case "$_service" in
         *[!A-Za-z0-9_.-]*|'')
-            beam_fail "ORCHARD_BEAM_NODE_NAME service contains invalid characters"
+            beam_fail "$_node_label service contains invalid characters"
             ;;
     esac
-    beam_validate_ipv4 "ORCHARD_BEAM_NODE_NAME" "$_host"
+    beam_validate_ipv4 "$_node_label" "$_host"
+    if [ "$_management_only" = true ]; then
+        case "$_host" in
+            127.*) ;;
+            *) beam_fail "$_node_label must use a loopback IPv4 address" ;;
+        esac
+    fi
 
-    _cookie_file=${ORCHARD_BEAM_COOKIE_FILE:-"$ORCHARD_ROOT/config/beam.cookie"}
-    beam_validate_cookie_file "$_cookie_file"
-
-    _epmd_port=${ORCHARD_BEAM_EPMD_PORT:-4369}
-    beam_validate_port "ORCHARD_BEAM_EPMD_PORT" "$_epmd_port"
-
-    _dist_min=${ORCHARD_BEAM_DIST_PORT_MIN:-52171}
-    _dist_max=${ORCHARD_BEAM_DIST_PORT_MAX:-52171}
-    beam_validate_port "ORCHARD_BEAM_DIST_PORT_MIN" "$_dist_min"
-    beam_validate_port "ORCHARD_BEAM_DIST_PORT_MAX" "$_dist_max"
+    beam_validate_cookie_file "$_cookie_file" "$_cookie_label"
+    beam_validate_port "$_epmd_label" "$_epmd_port"
+    if [ "$_management_only" = true ]; then
+        beam_validate_management_epmd_listener "$_epmd_port"
+    fi
+    beam_validate_port "$_dist_min_label" "$_dist_min"
+    beam_validate_port "$_dist_max_label" "$_dist_max"
     if [ "$_dist_min" -gt "$_dist_max" ]; then
-        beam_fail "ORCHARD_BEAM_DIST_PORT_MIN must be less than or equal to ORCHARD_BEAM_DIST_PORT_MAX"
+        beam_fail "$_dist_min_label must be less than or equal to $_dist_max_label"
     fi
 
     _a=${_host%%.*}
@@ -185,13 +217,20 @@ beam_configure_release() {
     RELEASE_COOKIE=$(cat "$_cookie_file")
     export RELEASE_COOKIE
     export ERL_EPMD_PORT="$_epmd_port"
-    if [ -n "${ERL_AFLAGS:-}" ]; then
+    if [ "$_management_only" = true ]; then
+        export ERL_AFLAGS="$_beam_kernel_flags"
+        export ERL_EPMD_ADDRESS=127.0.0.1
+    elif [ -n "${ERL_AFLAGS:-}" ]; then
+        unset ERL_EPMD_ADDRESS
         export ERL_AFLAGS="$ERL_AFLAGS $_beam_kernel_flags"
     else
         export ERL_AFLAGS="$_beam_kernel_flags"
     fi
 
-    printf 'orchard-controller: Runtime Endpoint transport beam\n' >&2
+    printf 'orchard-controller: Runtime Endpoint transport %s\n' "$ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" >&2
+    if [ "$_management_only" = true ]; then
+        printf 'orchard-controller: loopback Controller management distribution enabled\n' >&2
+    fi
     printf 'orchard-controller: BEAM node name %s\n' "$RELEASE_NODE" >&2
     printf 'orchard-controller: BEAM cookie file %s\n' "$_cookie_file" >&2
     printf 'orchard-controller: BEAM EPMD port %s\n' "$_epmd_port" >&2

--- a/packaging/pkg/bin/orchard-controller
+++ b/packaging/pkg/bin/orchard-controller
@@ -121,22 +121,25 @@ beam_validate_management_epmd_listener() {
         beam_fail "could not inspect the Controller management EPMD listener: $_listener_lsof is not executable"
     fi
 
-    _listener_err=$(mktemp "${TMPDIR:-/tmp}/orchard-epmd-listener.XXXXXX") || \
-        beam_fail "could not inspect the Controller management EPMD listener"
-
     _listener_status=0
-    _listeners=$("$_listener_lsof" -nP -iTCP:"$_listener_port" -sTCP:LISTEN 2>"$_listener_err") ||
+    _listeners=$("$_listener_lsof" -w -nP -iTCP:"$_listener_port" -sTCP:LISTEN 2>/dev/null) ||
         _listener_status=$?
-    _listener_diagnostics=$(cat "$_listener_err" 2>/dev/null) || _listener_diagnostics=""
-    rm -f "$_listener_err"
 
-    if [ "$_listener_status" -ne 0 ]; then
-        if [ "$_listener_status" -eq 1 ] && [ -z "$_listeners" ] &&
-           [ -z "$_listener_diagnostics" ]; then
-            return 0
-        fi
+    if [ "$_listener_status" -gt 1 ]; then
         beam_fail "could not inspect the Controller management EPMD listener"
     fi
+
+    if [ "$_listener_status" -eq 1 ]; then
+        if [ -n "$_listeners" ]; then
+            beam_fail "could not inspect the Controller management EPMD listener"
+        fi
+        return 0
+    fi
+
+    case "$_listeners" in
+        COMMAND*) ;;
+        *) beam_fail "could not inspect the Controller management EPMD listener" ;;
+    esac
 
     if ! printf '%s\n' "$_listeners" |
          grep -F -- "127.0.0.1:$_listener_port (LISTEN)" >/dev/null; then

--- a/packaging/pkg/bin/orchardctl
+++ b/packaging/pkg/bin/orchardctl
@@ -1,18 +1,27 @@
 #!/bin/sh
 set -eu
 # Orchard CLI wrapper.
-# Dispatches shell arguments through release `eval` into OrchardCLI.main/1.
-# This is necessary because the release binary only understands OTP commands
-# (start, stop, eval, etc.), not application-level CLI commands (tls, models, etc.).
+# Controller-authority node commands execute through the running Controller VM.
+# Other commands use the standalone CLI release.
 
 ORCHARD_ROOT="/Library/Application Support/Orchard"
 ENV_FILE="$ORCHARD_ROOT/config/controller.env"
 ORCHARD_CLI="$ORCHARD_ROOT/releases/orchard_cli/bin/orchard_cli"
+ORCHARD_CONTROLLER="$ORCHARD_ROOT/releases/orchard_controller/bin/orchard_controller"
+RPC_PROTOCOL="ORCHARDCTL_RPC_V1"
+RPC_TMP_PARENT="/private/tmp"
+RPC_TIMEOUT_SECONDS=30
+RPC_TERM_GRACE_SECONDS=2
+RPC_OUTPUT_LIMIT_BLOCKS=2048
+SAFE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+PATH=$SAFE_PATH
+export PATH
+umask 077
 
-# Source controller env for DB-backed CLI commands such as upgrade preflight.
+# Source controller env for DB-backed CLI commands and Controller RPC discovery.
 # Env files must be root-owned with no group/world permissions (e.g. 0600).
 if [ -f "$ENV_FILE" ]; then
-    _env_meta=$(stat -f '%u:%Lp' "$ENV_FILE" 2>/dev/null) || _env_meta=""
+    _env_meta=$(/usr/bin/stat -f '%u:%Lp' "$ENV_FILE" 2>/dev/null) || _env_meta=""
     _env_uid=${_env_meta%%:*}
     _env_mode=${_env_meta#*:}
     if [ -z "$_env_meta" ]; then
@@ -30,7 +39,436 @@ if [ -f "$ENV_FILE" ]; then
     fi
 fi
 
-# Build an Elixir string-list literal from shell argv.
+# A trusted env file may set PATH for the release, but this privileged wrapper
+# only resolves system utilities from the macOS system path.
+PATH=$SAFE_PATH
+export PATH
+
+controller_runtime_command() {
+    [ "${1:-}" = "nodes" ] || return 1
+
+    case "${2:-}" in
+        ''|help|--help)
+            return 1
+            ;;
+        enrollment)
+            case "${3:-}" in
+                ''|help|--help|create) return 1 ;;
+                *) return 2 ;;
+            esac
+            ;;
+        trust)
+            case "${3:-}" in
+                ''|help|--help) return 1 ;;
+                init)
+                    [ "$#" -le 4 ] || return 2
+                    case "${4:-}" in
+                        ''|help|--help) return 1 ;;
+                        *) return 2 ;;
+                    esac
+                    ;;
+                *) return 2 ;;
+            esac
+            ;;
+        list|inspect|pending|admit|reject|cordon|uncordon|drain|cancel-drain|maintenance|resume|decommission)
+            ;;
+        *)
+            return 2
+            ;;
+    esac
+
+    [ "${3:-}" = "help" ] && return 1
+
+    for _arg in "$@"; do
+        [ "$_arg" = "--help" ] && return 1
+    done
+
+    return 0
+}
+
+unknown_nodes_command_error() {
+    _json=false
+
+    for _arg in "$@"; do
+        [ "$_arg" = "--json" ] && _json=true
+    done
+
+    if [ "$_json" = true ]; then
+        printf '%s\n' '{"object":"error","code":"unknown_packaged_nodes_command","message":"Unknown packaged nodes command. This command is denied until its Controller-runtime authority classification is explicit."}' >&2
+    else
+        printf '%s\n' 'Error: unknown packaged nodes command. Authority classification is required before execution.' >&2
+    fi
+}
+
+controller_runtime_error() {
+    _json=false
+
+    for _arg in "$@"; do
+        [ "$_arg" = "--json" ] && _json=true
+    done
+
+    if [ "$_json" = true ]; then
+        printf '%s\n' '{"object":"error","code":"controller_runtime_unavailable","message":"The running Controller could not execute this command. Verify Controller status and inspect node state before retrying."}' >&2
+    else
+        printf '%s\n' 'Error: controller runtime unavailable. Verify Controller status and inspect node state before retrying.' >&2
+    fi
+}
+
+validate_port() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+
+    [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
+
+validate_loopback_listener() {
+    _listener_port=$1
+    _listeners=$(/usr/sbin/lsof -nP -iTCP:"$_listener_port" -sTCP:LISTEN 2>/dev/null) || return 1
+    printf '%s\n' "$_listeners" | grep -F -- "127.0.0.1:$_listener_port (LISTEN)" >/dev/null || return 1
+    if printf '%s\n' "$_listeners" | sed '1d' |
+       grep -Ev -- "(127\\.0\\.0\\.1|\\[::1\\]):$_listener_port \\(LISTEN\\)" | grep -q .; then
+        return 1
+    fi
+}
+
+validate_ipv4() {
+    _host=$1
+    _old_ifs=$IFS
+    IFS=.
+    set -- $_host
+    IFS=$_old_ifs
+
+    [ "$#" -eq 4 ] || return 1
+    _nonzero=false
+
+    for _octet in "$@"; do
+        case "$_octet" in
+            ''|*[!0-9]*) return 1 ;;
+        esac
+        [ "$_octet" -le 255 ] || return 1
+        [ "$_octet" -eq 0 ] || _nonzero=true
+    done
+
+    [ "$_nonzero" = true ]
+}
+
+configure_controller_rpc() {
+    _transport=${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT:-beam}
+    case "$_transport" in
+        ''|beam)
+            _node_name=${ORCHARD_BEAM_NODE_NAME:-orchard_controller@127.0.0.1}
+            _cookie_file=${ORCHARD_BEAM_COOKIE_FILE:-"$ORCHARD_ROOT/config/beam.cookie"}
+            _epmd_port=${ORCHARD_BEAM_EPMD_PORT:-4369}
+            _management_only=false
+            ;;
+        grpc)
+            _node_name=${ORCHARD_CONTROLLER_MANAGEMENT_NODE_NAME:-orchard_controller_management@127.0.0.1}
+            _cookie_file=${ORCHARD_CONTROLLER_MANAGEMENT_COOKIE_FILE:-"$ORCHARD_ROOT/config/beam.cookie"}
+            _epmd_port=${ORCHARD_CONTROLLER_MANAGEMENT_EPMD_PORT:-4369}
+            _dist_port=${ORCHARD_CONTROLLER_MANAGEMENT_DIST_PORT:-52171}
+            _management_only=true
+            ;;
+        *) return 1 ;;
+    esac
+    case "$_node_name" in
+        *@*)
+            _service=${_node_name%@*}
+            _host=${_node_name#*@}
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    case "$_service" in
+        orchard_controller*) ;;
+        *) return 1 ;;
+    esac
+    case "$_service" in
+        *[!A-Za-z0-9_.-]*|'') return 1 ;;
+    esac
+    validate_ipv4 "$_host" || return 1
+    if [ "$_management_only" = true ]; then
+        case "$_host" in
+            127.*) ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    [ -f "$_cookie_file" ] || return 1
+    [ -s "$_cookie_file" ] || return 1
+    [ -r "$_cookie_file" ] || return 1
+
+    _cookie_meta=$(/usr/bin/stat -f '%u:%Lp' "$_cookie_file" 2>/dev/null) || return 1
+    _cookie_uid=${_cookie_meta%%:*}
+    _cookie_mode=${_cookie_meta#*:}
+    [ "$_cookie_uid" = "0" ] || return 1
+    [ "${_cookie_mode#?}" = "00" ] || return 1
+
+    validate_port "$_epmd_port" || return 1
+    if [ "$_management_only" = true ]; then
+        validate_port "$_dist_port" || return 1
+        validate_loopback_listener "$_epmd_port" || return 1
+        validate_loopback_listener "$_dist_port" || return 1
+    fi
+
+    _a=${_host%%.*}
+    _rest=${_host#*.}
+    _b=${_rest%%.*}
+    _rest=${_rest#*.}
+    _c=${_rest%%.*}
+    _d=${_rest#*.}
+
+    RELEASE_DISTRIBUTION=name
+    RELEASE_NODE=$_node_name
+    RELEASE_COOKIE=$(cat "$_cookie_file")
+    ERL_EPMD_PORT=$_epmd_port
+    ERL_AFLAGS="-kernel inet_dist_use_interface {$_a,$_b,$_c,$_d}"
+    export RELEASE_DISTRIBUTION RELEASE_NODE RELEASE_COOKIE ERL_EPMD_PORT ERL_AFLAGS
+    if [ "$_management_only" = true ]; then
+        ERL_EPMD_ADDRESS=127.0.0.1
+        export ERL_EPMD_ADDRESS
+    else
+        unset ERL_EPMD_ADDRESS
+    fi
+}
+
+rpc_terminate_and_reap() {
+    if [ -z "${_rpc_pid:-}" ]; then
+        return 0
+    fi
+
+    if kill -0 "$_rpc_pid" 2>/dev/null; then
+        kill -TERM "$_rpc_pid" 2>/dev/null || true
+        _rpc_grace_elapsed=0
+        while kill -0 "$_rpc_pid" 2>/dev/null &&
+              [ "$_rpc_grace_elapsed" -lt "$RPC_TERM_GRACE_SECONDS" ]; do
+            _rpc_state=$(/bin/ps -o stat= -p "$_rpc_pid" 2>/dev/null) || _rpc_state=""
+            case "$_rpc_state" in
+                *Z*) break ;;
+            esac
+            /bin/sleep 1
+            _rpc_grace_elapsed=$((_rpc_grace_elapsed + 1))
+        done
+        _rpc_state=$(/bin/ps -o stat= -p "$_rpc_pid" 2>/dev/null) || _rpc_state=""
+        case "$_rpc_state" in
+            *Z*|'') ;;
+            *) kill -KILL "$_rpc_pid" 2>/dev/null || true ;;
+        esac
+    fi
+
+    wait "$_rpc_pid" 2>/dev/null || true
+    _rpc_pid=""
+}
+
+rpc_cleanup() {
+    rpc_terminate_and_reap
+    if [ -n "${_rpc_tmp:-}" ]; then
+        rm -rf "$_rpc_tmp"
+        _rpc_tmp=""
+    fi
+}
+
+rpc_abort() {
+    rpc_cleanup
+    printf '%s\n' 'Error: controller runtime unavailable. The RPC client was interrupted; inspect node state before retrying.' >&2
+    exit 1
+}
+
+run_in_controller() {
+    configure_controller_rpc || {
+        controller_runtime_error "$@"
+        return 1
+    }
+
+    _encoded_args=""
+    for _arg in "$@"; do
+        _encoded=$(printf '%s' "$_arg" | /usr/bin/base64 | tr -d '\r\n')
+        if [ -n "$_encoded_args" ]; then
+            _encoded_args="$_encoded_args, \"$_encoded\""
+        else
+            _encoded_args="\"$_encoded\""
+        fi
+    done
+
+    _expression="OrchardCLI.ControllerRPC.main_base64([$_encoded_args])"
+    _rpc_tmp=$(mktemp -d "$RPC_TMP_PARENT/orchardctl-rpc.XXXXXX") || {
+        controller_runtime_error "$@"
+        return 1
+    }
+    chmod 0700 "$_rpc_tmp"
+    _rpc_stdout="$_rpc_tmp/stdout"
+    _rpc_stderr="$_rpc_tmp/stderr"
+    _decoded="$_rpc_tmp/decoded"
+    : >"$_rpc_stdout"
+    : >"$_rpc_stderr"
+    : >"$_decoded"
+    chmod 0600 "$_rpc_stdout" "$_rpc_stderr" "$_decoded"
+    _rpc_pid=""
+    trap rpc_cleanup EXIT
+    trap rpc_abort HUP INT TERM
+
+    (
+        ulimit -f "$RPC_OUTPUT_LIMIT_BLOCKS"
+        exec "$ORCHARD_CONTROLLER" rpc "$_expression"
+    ) >"$_rpc_stdout" 2>"$_rpc_stderr" &
+    _rpc_pid=$!
+    _rpc_started_at=$(/bin/date +%s)
+    _rpc_output_limit_bytes=$((RPC_OUTPUT_LIMIT_BLOCKS * 512))
+    _rpc_bounded_failure=false
+    _rpc_status=""
+
+    while :; do
+        _rpc_stdout_size=$(/usr/bin/stat -f '%z' "$_rpc_stdout" 2>/dev/null) || _rpc_stdout_size=$_rpc_output_limit_bytes
+        _rpc_stderr_size=$(/usr/bin/stat -f '%z' "$_rpc_stderr" 2>/dev/null) || _rpc_stderr_size=$_rpc_output_limit_bytes
+        _rpc_now=$(/bin/date +%s)
+        _rpc_elapsed=$((_rpc_now - _rpc_started_at))
+
+        if [ "$_rpc_stdout_size" -ge "$_rpc_output_limit_bytes" ] ||
+           [ "$_rpc_stderr_size" -ge "$_rpc_output_limit_bytes" ] ||
+           [ "$_rpc_elapsed" -ge "$RPC_TIMEOUT_SECONDS" ]; then
+            _rpc_bounded_failure=true
+            break
+        fi
+
+        _rpc_state=$(/bin/ps -o stat= -p "$_rpc_pid" 2>/dev/null) || _rpc_state=""
+        if ! kill -0 "$_rpc_pid" 2>/dev/null ||
+           { case "$_rpc_state" in *Z*) true ;; *) false ;; esac; }; then
+            set +e
+            wait "$_rpc_pid"
+            _rpc_status=$?
+            set -e
+            _rpc_pid=""
+            break
+        fi
+
+        /bin/sleep 0.1
+    done
+
+    if [ "$_rpc_bounded_failure" = true ]; then
+        rpc_terminate_and_reap
+        controller_runtime_error "$@"
+        return 1
+    fi
+
+    [ -n "$_rpc_status" ] || {
+        controller_runtime_error "$@"
+        return 1
+    }
+
+    _rpc_stdout_size=$(/usr/bin/stat -f '%z' "$_rpc_stdout" 2>/dev/null) || _rpc_stdout_size=$_rpc_output_limit_bytes
+    _rpc_stderr_size=$(/usr/bin/stat -f '%z' "$_rpc_stderr" 2>/dev/null) || _rpc_stderr_size=$_rpc_output_limit_bytes
+    if [ "$_rpc_stdout_size" -ge "$_rpc_output_limit_bytes" ] ||
+       [ "$_rpc_stderr_size" -ge "$_rpc_output_limit_bytes" ] ||
+       [ "$_rpc_status" -ne 0 ]; then
+        controller_runtime_error "$@"
+        return 1
+    fi
+
+    _rpc_output=""
+    exec 3<"$_rpc_stdout"
+    if ! IFS= read -r _rpc_output <&3; then
+        exec 3<&-
+        controller_runtime_error "$@"
+        return 1
+    fi
+    _rpc_extra=""
+    if IFS= read -r _rpc_extra <&3 || [ -n "$_rpc_extra" ]; then
+        exec 3<&-
+        controller_runtime_error "$@"
+        return 1
+    fi
+    exec 3<&-
+
+    case "$_rpc_output" in
+        "$RPC_PROTOCOL":*)
+            ;;
+        *)
+            controller_runtime_error "$@"
+            return 1
+            ;;
+    esac
+
+    _remainder=${_rpc_output#"$RPC_PROTOCOL":}
+    _status=${_remainder%%:*}
+    [ "$_status" != "$_remainder" ] || {
+        controller_runtime_error "$@"
+        return 1
+    }
+    _remainder=${_remainder#*:}
+    _stream=${_remainder%%:*}
+    [ "$_stream" != "$_remainder" ] || {
+        controller_runtime_error "$@"
+        return 1
+    }
+    _payload=${_remainder#*:}
+
+    case "$_status" in
+        ''|*[!0-9]*)
+            controller_runtime_error "$@"
+            return 1
+            ;;
+    esac
+    [ "$_status" -le 255 ] || {
+        controller_runtime_error "$@"
+        return 1
+    }
+    case "$_payload" in
+        *[!A-Za-z0-9+/=]*)
+            controller_runtime_error "$@"
+            return 1
+            ;;
+    esac
+
+    if ! printf '%s' "$_payload" | /usr/bin/base64 -D >"$_decoded" 2>/dev/null; then
+        controller_runtime_error "$@"
+        return 1
+    fi
+
+    case "$_stream:$_status" in
+        none:0)
+            [ ! -s "$_decoded" ] || {
+                controller_runtime_error "$@"
+                return 1
+            }
+            ;;
+        stdout:0)
+            cat "$_decoded"
+            printf '\n'
+            ;;
+        stderr:0)
+            controller_runtime_error "$@"
+            return 1
+            ;;
+        stderr:*)
+            [ "$_status" -gt 0 ] || {
+                controller_runtime_error "$@"
+                return 1
+            }
+            cat "$_decoded" >&2
+            printf '\n' >&2
+            return "$_status"
+            ;;
+        *)
+            controller_runtime_error "$@"
+            return 1
+            ;;
+    esac
+}
+
+if controller_runtime_command "$@"; then
+    run_in_controller "$@"
+    exit $?
+else
+    _node_route_status=$?
+    if [ "$_node_route_status" -eq 2 ]; then
+        unknown_nodes_command_error "$@"
+        exit 1
+    fi
+fi
+
+# Build an Elixir string-list literal from shell argv for the standalone CLI.
 # Escapes backslashes, double quotes, hash (prevents #{} interpolation), and tabs.
 args=""
 for arg in "$@"; do

--- a/packaging/pkg/bin/orchardctl
+++ b/packaging/pkg/bin/orchardctl
@@ -16,7 +16,6 @@ RPC_OUTPUT_LIMIT_BLOCKS=2048
 SAFE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 PATH=$SAFE_PATH
 export PATH
-umask 077
 
 # Source controller env for DB-backed CLI commands and Controller RPC discovery.
 # Env files must be root-owned with no group/world permissions (e.g. 0600).
@@ -277,6 +276,8 @@ rpc_abort() {
 }
 
 run_in_controller() {
+    umask 077
+
     configure_controller_rpc || {
         controller_runtime_error "$@"
         return 1

--- a/scripts/test-packaged-orchardctl-controller-release.sh
+++ b/scripts/test-packaged-orchardctl-controller-release.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Integration coverage for packaged orchardctl against an assembled Controller release.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+STAGED_ROOT="$TMP_ROOT/staged/Library/Application Support/Orchard"
+RUNTIME_ROOT="$TMP_ROOT/runtime-root"
+TOOLS="$TMP_ROOT/tools"
+CONTROLLER_LAUNCHER="$TMP_ROOT/orchard-controller"
+ORCHARDCTL_LAUNCHER="$TMP_ROOT/orchardctl"
+CONTROLLER_LOG="$TMP_ROOT/controller.log"
+CONTROLLER_PID=""
+HELD_RPC_PID=""
+DATABASE_CREATED=false
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-postgres}"
+PGPASSWORD="${PGPASSWORD:-postgres}"
+DATABASE_NAME="orchard_release_rpc_test_$$"
+HTTP_PORT=$((40000 + $$ % 1000))
+EPMD_PORT=$((44000 + $$ % 1000))
+DIST_PORT=$((52000 + $$ % 1000))
+MANAGEMENT_NODE="orchard_controller_management_$$@127.0.0.1"
+COOKIE_VALUE="release-rpc-cookie-$$"
+RELEASE_SOURCE="$REPO_ROOT/_build/prod/rel/orchard_controller"
+RELEASE_BIN="$STAGED_ROOT/releases/orchard_controller/bin/orchard_controller"
+PRODUCT_VERSION=$(cat "$REPO_ROOT/VERSION")
+
+fail() {
+  printf 'release RPC integration failure: %s\n' "$1" >&2
+  if [[ -f "$CONTROLLER_LOG" ]]; then
+    printf '%s\n' '--- controller log ---' >&2
+    tail -100 "$CONTROLLER_LOG" >&2 || true
+  fi
+  exit 1
+}
+
+assert_empty() {
+  local path="$1"
+  [[ ! -s "$path" ]] || fail "expected $path to be empty"
+}
+
+assert_contains() {
+  local expected="$1"
+  local path="$2"
+  grep -F -- "$expected" "$path" >/dev/null || fail "expected $path to contain $expected"
+}
+
+assert_matches() {
+  local expected="$1"
+  local path="$2"
+  grep -E -- "$expected" "$path" >/dev/null || fail "expected $path to match $expected"
+}
+
+assert_loopback_listener() {
+  local port="$1"
+  local label="$2"
+  local listeners
+  listeners=$(/usr/sbin/lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null) ||
+    fail "$label did not expose its expected listener"
+  printf '%s\n' "$listeners" | grep -F -- "127.0.0.1:$port" >/dev/null ||
+    fail "$label listener was not bound to IPv4 loopback"
+  if printf '%s\n' "$listeners" | grep -E -- "(\\*|0\\.0\\.0\\.0|\\[::\\]):$port" >/dev/null; then
+    fail "$label exposed a wildcard listener"
+  fi
+}
+
+stop_controller() {
+  if [[ -n "$CONTROLLER_PID" ]] && kill -0 "$CONTROLLER_PID" 2>/dev/null; then
+    kill -TERM "$CONTROLLER_PID" 2>/dev/null || true
+    for _ in $(seq 1 40); do
+      kill -0 "$CONTROLLER_PID" 2>/dev/null || break
+      /bin/sleep 0.25
+    done
+    if kill -0 "$CONTROLLER_PID" 2>/dev/null; then
+      kill -KILL "$CONTROLLER_PID" 2>/dev/null || true
+    fi
+    wait "$CONTROLLER_PID" 2>/dev/null || true
+  fi
+  CONTROLLER_PID=""
+}
+
+cleanup() {
+  if [[ -n "$HELD_RPC_PID" ]] && kill -0 "$HELD_RPC_PID" 2>/dev/null; then
+    kill -KILL "$HELD_RPC_PID" 2>/dev/null || true
+    wait "$HELD_RPC_PID" 2>/dev/null || true
+  fi
+  HELD_RPC_PID=""
+  stop_controller
+  ERL_EPMD_PORT="$EPMD_PORT" mise exec -- epmd -kill >/dev/null 2>&1 || true
+  if [[ "$DATABASE_CREATED" == true ]]; then
+    PGDATABASE_TEST="$DATABASE_NAME" MIX_ENV=test mise exec -- mix ecto.drop >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+release_rpc() {
+  env \
+    RELEASE_DISTRIBUTION=name \
+    RELEASE_NODE="$MANAGEMENT_NODE" \
+    RELEASE_COOKIE="$COOKIE_VALUE" \
+    ERL_EPMD_PORT="$EPMD_PORT" \
+    ERL_EPMD_ADDRESS=127.0.0.1 \
+    ERL_AFLAGS='-kernel inet_dist_use_interface {127,0,0,1}' \
+    "$RELEASE_BIN" rpc "$1"
+}
+
+cd "$REPO_ROOT"
+MIX_ENV=prod mise exec -- mix release orchard_controller --overwrite >/dev/null
+
+mkdir -p "$STAGED_ROOT/share/bin" "$STAGED_ROOT/releases" "$STAGED_ROOT/config" "$RUNTIME_ROOT" "$TOOLS"
+cp "$REPO_ROOT/packaging/pkg/bin/orchardctl" "$STAGED_ROOT/share/bin/orchardctl"
+cp "$REPO_ROOT/packaging/pkg/bin/orchard-controller" "$STAGED_ROOT/share/bin/orchard-controller"
+cp -R "$RELEASE_SOURCE" "$STAGED_ROOT/releases/orchard_controller"
+chmod 0755 "$STAGED_ROOT/share/bin/orchardctl" "$STAGED_ROOT/share/bin/orchard-controller"
+
+cmp -s "$REPO_ROOT/packaging/pkg/bin/orchardctl" "$STAGED_ROOT/share/bin/orchardctl" ||
+  fail "staged orchardctl does not match the changed source wrapper"
+CONTROLLER_RPC_BEAM=$(find "$STAGED_ROOT/releases/orchard_controller/lib" -path '*/ebin/Elixir.OrchardCLI.ControllerRPC.beam' -print -quit)
+[[ -n "$CONTROLLER_RPC_BEAM" ]] || fail "assembled Controller release is missing ControllerRPC"
+REL_FILE="$STAGED_ROOT/releases/orchard_controller/releases/$PRODUCT_VERSION/orchard_controller.rel"
+assert_contains "{orchard_cli,\"$PRODUCT_VERSION\",load}" "$REL_FILE"
+
+cat > "$TOOLS/stat" <<'SH'
+#!/bin/sh
+case "${2:-}" in
+  '%u:%Lp') printf '0:600\n' ;;
+  '%z') /usr/bin/stat -f '%z' "$3" ;;
+  *) exit 1 ;;
+esac
+SH
+chmod 0755 "$TOOLS/stat"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  "$STAGED_ROOT/share/bin/orchard-controller" > "$CONTROLLER_LAUNCHER"
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^RPC_TMP_PARENT=.*$|RPC_TMP_PARENT=\"$TMP_ROOT\"|" \
+  -e 's|^RPC_TIMEOUT_SECONDS=.*$|RPC_TIMEOUT_SECONDS=5|' \
+  -e "s|/usr/bin/stat|$TOOLS/stat|g" \
+  "$STAGED_ROOT/share/bin/orchardctl" > "$ORCHARDCTL_LAUNCHER"
+chmod 0755 "$CONTROLLER_LAUNCHER" "$ORCHARDCTL_LAUNCHER"
+
+printf '%s\n' "$COOKIE_VALUE" > "$STAGED_ROOT/config/beam.cookie"
+chmod 0600 "$STAGED_ROOT/config/beam.cookie"
+
+DATABASE_URL="ecto://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${DATABASE_NAME}"
+cat > "$STAGED_ROOT/config/controller.env" <<ENV
+DATABASE_URL="$DATABASE_URL"
+SECRET_KEY_BASE="$(printf 'release-rpc-secret-%.0s' {1..8})"
+ORCHARD_SUPPORT_ROOT="$RUNTIME_ROOT"
+ORCHARD_NODE_TRUST_ROOT="$RUNTIME_ROOT/node-trust"
+ORCHARD_LICENSE_ENFORCEMENT=off
+ORCHARD_TRANSPORT_MODE=plain_http_localhost
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+ORCHARD_RUNTIME_CLIENT_TARGETS="127.0.0.1:59999"
+ORCHARD_CONTROLLER_MANAGEMENT_NODE_NAME="$MANAGEMENT_NODE"
+ORCHARD_CONTROLLER_MANAGEMENT_COOKIE_FILE="$STAGED_ROOT/config/beam.cookie"
+ORCHARD_CONTROLLER_MANAGEMENT_EPMD_PORT=$EPMD_PORT
+ORCHARD_CONTROLLER_MANAGEMENT_DIST_PORT=$DIST_PORT
+ORCHARD_CONSOLE_ENABLED=false
+PORT=$HTTP_PORT
+POOL_SIZE=4
+ENV
+chmod 0600 "$STAGED_ROOT/config/controller.env"
+
+PGDATABASE_TEST="$DATABASE_NAME" MIX_ENV=test mise exec -- mix ecto.create >/dev/null
+DATABASE_CREATED=true
+PGDATABASE_TEST="$DATABASE_NAME" MIX_ENV=test mise exec -- mix ecto.migrate >/dev/null
+
+PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" "$CONTROLLER_LAUNCHER" start >"$CONTROLLER_LOG" 2>&1 &
+CONTROLLER_PID=$!
+
+for _ in $(seq 1 40); do
+  if ERL_EPMD_PORT="$EPMD_PORT" mise exec -- epmd -names 2>/dev/null | grep -F -- "name ${MANAGEMENT_NODE%@*}" >/dev/null; then
+    break
+  fi
+  kill -0 "$CONTROLLER_PID" 2>/dev/null || fail "assembled Controller exited before EPMD registration"
+  /bin/sleep 0.25
+done
+
+DIRECT_READY_STDOUT="$TMP_ROOT/direct-ready.stdout"
+DIRECT_READY_STDERR="$TMP_ROOT/direct-ready.stderr"
+release_rpc 'IO.puts(Process.group_leader(), "release-rpc-ready")' >"$DIRECT_READY_STDOUT" 2>"$DIRECT_READY_STDERR" &
+DIRECT_READY_PID=$!
+direct_ready=false
+for _ in $(seq 1 40); do
+  if ! kill -0 "$DIRECT_READY_PID" 2>/dev/null; then
+    set +e
+    wait "$DIRECT_READY_PID"
+    DIRECT_READY_STATUS=$?
+    set -e
+    if [[ "$DIRECT_READY_STATUS" -eq 0 ]] && grep -Fx -- 'release-rpc-ready' "$DIRECT_READY_STDOUT" >/dev/null; then
+      direct_ready=true
+    fi
+    break
+  fi
+  /bin/sleep 0.25
+done
+if [[ "$direct_ready" != true ]]; then
+  kill -TERM "$DIRECT_READY_PID" 2>/dev/null || true
+  wait "$DIRECT_READY_PID" 2>/dev/null || true
+  {
+    printf '%s\n' '--- direct release RPC stdout ---'
+    cat "$DIRECT_READY_STDOUT" 2>/dev/null || true
+    printf '%s\n' '--- direct release RPC stderr ---'
+    cat "$DIRECT_READY_STDERR" 2>/dev/null || true
+  } >> "$CONTROLLER_LOG"
+  fail "assembled release could not target the running Controller"
+fi
+
+assert_loopback_listener "$EPMD_PORT" "management EPMD"
+assert_loopback_listener "$DIST_PORT" "Controller management distribution"
+
+release_rpc 'Process.sleep(10_000)' >/dev/null 2>&1 &
+HELD_RPC_PID=$!
+RPC_CLIENT_PORT=""
+for _ in $(seq 1 40); do
+  RPC_CLIENT_PORT=$(ERL_EPMD_PORT="$EPMD_PORT" mise exec -- epmd -names 2>/dev/null |
+    awk '/name rpc-/ {print $NF; exit}')
+  [[ "$RPC_CLIENT_PORT" =~ ^[0-9]+$ ]] && break
+  kill -0 "$HELD_RPC_PID" 2>/dev/null || fail "temporary release RPC exited before listener inspection"
+  /bin/sleep 0.1
+done
+[[ "$RPC_CLIENT_PORT" =~ ^[0-9]+$ ]] || fail "temporary release RPC did not register with management EPMD"
+assert_loopback_listener "$RPC_CLIENT_PORT" "temporary release RPC distribution"
+kill -TERM "$HELD_RPC_PID" 2>/dev/null || true
+wait "$HELD_RPC_PID" 2>/dev/null || true
+HELD_RPC_PID=""
+
+READY_STDOUT="$TMP_ROOT/ready.stdout"
+READY_STDERR="$TMP_ROOT/ready.stderr"
+ready=false
+for _ in $(seq 1 40); do
+  if PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
+       "$ORCHARDCTL_LAUNCHER" nodes list --json >"$READY_STDOUT" 2>"$READY_STDERR"; then
+    ready=true
+    break
+  fi
+  kill -0 "$CONTROLLER_PID" 2>/dev/null || fail "assembled Controller exited during startup"
+  /bin/sleep 0.25
+done
+if [[ "$ready" != true ]]; then
+  {
+    printf '%s\n' '--- EPMD names ---'
+    ERL_EPMD_PORT="$EPMD_PORT" mise exec -- epmd -names 2>&1 || true
+    printf '%s\n' '--- management listeners ---'
+    /usr/sbin/lsof -nP -iTCP:"$EPMD_PORT" -sTCP:LISTEN 2>&1 || true
+    /usr/sbin/lsof -nP -iTCP:"$DIST_PORT" -sTCP:LISTEN 2>&1 || true
+    printf '%s\n' '--- orchardctl stderr ---'
+    cat "$READY_STDERR" 2>/dev/null || true
+  } >> "$CONTROLLER_LOG"
+  fail "assembled Controller did not become RPC-ready"
+fi
+assert_empty "$READY_STDERR"
+assert_contains 'cluster_management.node_status_list' "$READY_STDOUT"
+
+MODULE_OUTPUT=$(release_rpc 'IO.puts(Process.group_leader(), if(:code.which(OrchardCLI.ControllerRPC) == :non_existing, do: "missing", else: "loaded"))')
+[[ "$MODULE_OUTPUT" == "loaded" ]] || fail "ControllerRPC module was not loaded in the running release"
+
+DIRECT_ENVELOPE=$(release_rpc 'OrchardCLI.ControllerRPC.main_base64(["bm9kZXM=", "bGlzdA==", "LS1qc29u"])')
+if [[ $(printf '%s\n' "$DIRECT_ENVELOPE" | awk 'END {print NR}') -ne 1 ]]; then
+  printf '%s\n' '--- direct envelope output ---' "$DIRECT_ENVELOPE" >> "$CONTROLLER_LOG"
+  fail "real release RPC emitted more than one envelope line"
+fi
+[[ "$DIRECT_ENVELOPE" == ORCHARDCTL_RPC_V1:0:stdout:* ]] || fail "real release RPC did not emit the stdout envelope"
+
+ERROR_ENVELOPE=$(release_rpc 'OrchardCLI.ControllerRPC.main_base64(["bm9kZXM=", "ZW5yb2xsbWVudA=="])')
+[[ $(printf '%s\n' "$ERROR_ENVELOPE" | awk 'END {print NR}') -eq 1 ]] || fail "real release RPC error emitted more than one envelope line"
+[[ "$ERROR_ENVELOPE" == ORCHARDCTL_RPC_V1:1:stderr:* ]] || fail "real release RPC did not emit the stderr envelope"
+
+AUTHORITY_BEFORE=$(release_rpc 'pid = Process.whereis(Orchard.DispatchCapacity.AllocationAuthority); supervised = Enum.any?(Supervisor.which_children(Orchard.Inference), fn {id, child, _, _} -> id == Orchard.DispatchCapacity.AllocationAuthority and child == pid end); IO.puts(Process.group_leader(), "#{inspect(pid)}:#{supervised}:#{Process.alive?(pid)}")')
+[[ "$AUTHORITY_BEFORE" == '#PID<'*':true:true' ]] || fail "AllocationAuthority is not the supervised Controller authority"
+
+NODE_ID=$(release_rpc 'root = System.fetch_env!("ORCHARD_NODE_TRUST_ROOT"); {:ok, _trust} = Orchard.NodeTrust.initialize(root: root); node_id = Ecto.UUID.generate(); attrs = %{id: node_id, hostname: "release-rpc-node.local", display_name: "release-rpc-node", advertise_addr: "127.0.0.2", rpc_port: 50071, state: :registered, health: :healthy, capabilities: %{}, agent_version: "0.5.0", last_heartbeat_at: DateTime.utc_now()}; %Orchard.Nodes.Node{} |> Orchard.Nodes.Node.changeset(attrs) |> Orchard.Repo.insert!(); IO.puts(Process.group_leader(), node_id)' | grep -E '^[0-9a-f-]{36}$' | tail -1)
+[[ "$NODE_ID" =~ ^[0-9a-f-]{36}$ ]] || fail "release RPC did not seed a registered node"
+
+POOL_ID="11111111-1111-4111-8111-111111111111"
+ROUTING_POLICY_ID="22222222-2222-4222-8222-222222222222"
+ADMIT_STDOUT="$TMP_ROOT/admit.stdout"
+ADMIT_STDERR="$TMP_ROOT/admit.stderr"
+set +e
+PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
+  "$ORCHARDCTL_LAUNCHER" nodes admit "$NODE_ID" --yes --json \
+  --trust-evidence-ref registration-audit:release-rpc \
+  --pool-id "$POOL_ID" \
+  --routing-policy-id "$ROUTING_POLICY_ID" \
+  --capacity-policy-reason "assembled release RPC integration" \
+  >"$ADMIT_STDOUT" 2>"$ADMIT_STDERR"
+ADMIT_STATUS=$?
+set -e
+[[ "$ADMIT_STATUS" -eq 0 ]] || fail "authoritative admission failed through packaged wrapper"
+assert_empty "$ADMIT_STDERR"
+assert_matches '"action"[[:space:]]*:[[:space:]]*"node_admission.admitted"' "$ADMIT_STDOUT"
+assert_matches '"controller_dispatch_ceiling"[[:space:]]*:[[:space:]]*1' "$ADMIT_STDOUT"
+
+AUTHORITY_AFTER=$(release_rpc 'pid = Process.whereis(Orchard.DispatchCapacity.AllocationAuthority); supervised = Enum.any?(Supervisor.which_children(Orchard.Inference), fn {id, child, _, _} -> id == Orchard.DispatchCapacity.AllocationAuthority and child == pid end); IO.puts(Process.group_leader(), "#{inspect(pid)}:#{supervised}:#{Process.alive?(pid)}")')
+[[ "$AUTHORITY_AFTER" == "$AUTHORITY_BEFORE" ]] || fail "authoritative operation did not preserve the supervised AllocationAuthority"
+
+ERROR_STDOUT="$TMP_ROOT/error.stdout"
+ERROR_STDERR="$TMP_ROOT/error.stderr"
+set +e
+PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
+  "$ORCHARDCTL_LAUNCHER" nodes inspect 00000000-0000-4000-a000-000000000000 --json \
+  >"$ERROR_STDOUT" 2>"$ERROR_STDERR"
+ERROR_STATUS=$?
+set -e
+[[ "$ERROR_STATUS" -eq 1 ]] || fail "packaged wrapper did not preserve Controller command error status"
+assert_empty "$ERROR_STDOUT"
+[[ -s "$ERROR_STDERR" ]] || fail "packaged wrapper did not preserve Controller command stderr"
+
+kill -0 "$CONTROLLER_PID" 2>/dev/null || fail "Controller did not survive release RPC commands"
+SURVIVAL=$(release_rpc 'IO.puts(Process.group_leader(), "controller-alive=#{Process.alive?(Process.whereis(Orchard.Supervisor))}")')
+[[ "$SURVIVAL" == "controller-alive=true" ]] || fail "Controller supervision tree did not survive RPC commands"
+
+printf 'assembled Controller release RPC integration tests passed\n'

--- a/scripts/test-packaged-orchardctl-controller-runtime.sh
+++ b/scripts/test-packaged-orchardctl-controller-runtime.sh
@@ -126,6 +126,7 @@ chmod +x "$TOOLS/lsof"
 cat > "$PACKAGE_ROOT/releases/orchard_cli/bin/orchard_cli" <<'SH'
 #!/bin/sh
 printf 'standalone:%s\n' "$*" >> "$FAKE_INVOCATIONS"
+printf 'standalone_umask=%s\n' "$(umask)" >> "$FAKE_INVOCATIONS"
 printf 'standalone cli\n'
 SH
 chmod +x "$PACKAGE_ROOT/releases/orchard_cli/bin/orchard_cli"
@@ -138,6 +139,7 @@ printf 'release_cookie=%s\n' "${RELEASE_COOKIE:-missing}" >> "$FAKE_INVOCATIONS"
 printf 'epmd_port=%s\n' "${ERL_EPMD_PORT:-missing}" >> "$FAKE_INVOCATIONS"
 printf 'epmd_address=%s\n' "${ERL_EPMD_ADDRESS:-missing}" >> "$FAKE_INVOCATIONS"
 printf 'erl_aflags=%s\n' "${ERL_AFLAGS:-missing}" >> "$FAKE_INVOCATIONS"
+printf 'rpc_umask=%s\n' "$(umask)" >> "$FAKE_INVOCATIONS"
 
 case "$FAKE_RPC_MODE" in
   success)
@@ -374,5 +376,11 @@ run_case configured success nodes pending
 assert_invocation "release_node=orchard_controller@127.0.0.1"
 assert_invocation "release_cookie=controller-cookie"
 assert_invocation "epmd_port=4369"
+assert_invocation "rpc_umask=0077"
+
+caller_umask="$(umask)"
+run_case umask-standalone success status
+[[ "$RUN_STATUS" -eq 0 ]] || fail "expected standalone invocation to succeed"
+assert_invocation "standalone_umask=$caller_umask"
 
 printf 'packaged orchardctl Controller-runtime routing tests passed\n'

--- a/scripts/test-packaged-orchardctl-controller-runtime.sh
+++ b/scripts/test-packaged-orchardctl-controller-runtime.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Regression coverage for packaged orchardctl Controller-runtime routing.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE_WRAPPER="$REPO_ROOT/packaging/pkg/bin/orchardctl"
+TMP_ROOT="$(mktemp -d)"
+PACKAGE_ROOT="$TMP_ROOT/Library/Application Support/Orchard"
+TOOLS="$TMP_ROOT/tools"
+WRAPPER="$TMP_ROOT/orchardctl"
+INVOCATIONS="$TMP_ROOT/invocations.log"
+UNTRUSTED_TOOL_CALLS="$TMP_ROOT/untrusted-tool-calls.log"
+PRIVATE_TMP="$TMP_ROOT/private-tmp"
+UNTRUSTED_TMP="$TMP_ROOT/untrusted-tmp"
+RPC_PROCESS_EVENTS="$TMP_ROOT/rpc-process-events.log"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local expected="$1"
+  local path="$2"
+
+  grep -F -- "$expected" "$path" >/dev/null || {
+    echo "expected $path to contain: $expected" >&2
+    cat "$path" >&2
+    exit 1
+  }
+}
+
+assert_file_empty() {
+  local path="$1"
+
+  if [[ -s "$path" ]]; then
+    echo "expected $path to be empty" >&2
+    cat "$path" >&2
+    exit 1
+  fi
+}
+
+assert_invocation() {
+  local expected="$1"
+
+  assert_file_contains "$expected" "$INVOCATIONS"
+}
+
+assert_no_invocation() {
+  local unexpected="$1"
+
+  if grep -F -- "$unexpected" "$INVOCATIONS" >/dev/null; then
+    echo "unexpected invocation: $unexpected" >&2
+    cat "$INVOCATIONS" >&2
+    exit 1
+  fi
+}
+
+run_case() {
+  local label="$1"
+  local mode="$2"
+  shift 2
+
+  : > "$INVOCATIONS"
+  RUN_STDOUT="$TMP_ROOT/$label.stdout"
+  RUN_STDERR="$TMP_ROOT/$label.stderr"
+
+  set +e
+  FAKE_RPC_MODE="$mode" FAKE_INVOCATIONS="$INVOCATIONS" \
+    FAKE_RPC_PROCESS_EVENTS="$RPC_PROCESS_EVENTS" \
+    UNTRUSTED_TOOL_CALLS="$UNTRUSTED_TOOL_CALLS" \
+    TMPDIR="$UNTRUSTED_TMP" PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
+    "$WRAPPER" "$@" >"$RUN_STDOUT" 2>"$RUN_STDERR"
+  RUN_STATUS=$?
+  set -e
+}
+
+mkdir -p "$PACKAGE_ROOT/releases/orchard_cli/bin"
+mkdir -p "$PACKAGE_ROOT/releases/orchard_controller/bin"
+mkdir -p "$PACKAGE_ROOT/config"
+mkdir -p "$TOOLS"
+mkdir -p "$PRIVATE_TMP"
+mkdir -p "$UNTRUSTED_TMP"
+printf 'controller-cookie\n' > "$PACKAGE_ROOT/config/beam.cookie"
+chmod 0600 "$PACKAGE_ROOT/config/beam.cookie"
+
+cat > "$TOOLS/stat" <<'SH'
+#!/bin/sh
+case "${2:-}" in
+  '%u:%Lp') printf '0:600\n' ;;
+  '%z') /usr/bin/stat -f '%z' "$3" ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$TOOLS/stat"
+
+cat > "$TOOLS/mktemp" <<'SH'
+#!/bin/sh
+printf 'mktemp:%s\n' "$*" >> "$UNTRUSTED_TOOL_CALLS"
+exec /usr/bin/mktemp "$@"
+SH
+chmod +x "$TOOLS/mktemp"
+
+cat > "$TOOLS/lsof" <<'SH'
+#!/bin/sh
+case "$*" in
+  *-iTCP:4369*) port=4369 ;;
+  *-iTCP:52171*) port=52171 ;;
+  *) exit 1 ;;
+esac
+printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
+if [ "${FAKE_LSOF_MODE:-loopback}" = wildcard ]; then
+  printf 'beam 123 root 0u IPv4 0 0t0 TCP *:%s (LISTEN)\n' "$port"
+else
+  printf 'beam 123 root 0u IPv4 0 0t0 TCP 127.0.0.1:%s (LISTEN)\n' "$port"
+fi
+SH
+chmod +x "$TOOLS/lsof"
+
+cat > "$PACKAGE_ROOT/releases/orchard_cli/bin/orchard_cli" <<'SH'
+#!/bin/sh
+printf 'standalone:%s\n' "$*" >> "$FAKE_INVOCATIONS"
+printf 'standalone cli\n'
+SH
+chmod +x "$PACKAGE_ROOT/releases/orchard_cli/bin/orchard_cli"
+
+cat > "$PACKAGE_ROOT/releases/orchard_controller/bin/orchard_controller" <<'SH'
+#!/bin/sh
+printf 'controller:%s\n' "$*" >> "$FAKE_INVOCATIONS"
+printf 'release_node=%s\n' "${RELEASE_NODE:-missing}" >> "$FAKE_INVOCATIONS"
+printf 'release_cookie=%s\n' "${RELEASE_COOKIE:-missing}" >> "$FAKE_INVOCATIONS"
+printf 'epmd_port=%s\n' "${ERL_EPMD_PORT:-missing}" >> "$FAKE_INVOCATIONS"
+printf 'epmd_address=%s\n' "${ERL_EPMD_ADDRESS:-missing}" >> "$FAKE_INVOCATIONS"
+printf 'erl_aflags=%s\n' "${ERL_AFLAGS:-missing}" >> "$FAKE_INVOCATIONS"
+
+case "$FAKE_RPC_MODE" in
+  success)
+    printf 'ORCHARDCTL_RPC_V1:0:stdout:Y29udHJvbGxlciBzdWNjZXNz\n'
+    ;;
+  error)
+    printf 'ORCHARDCTL_RPC_V1:7:stderr:RXJyb3I6IGNvbnRyb2xsZXIgcmVqZWN0ZWQ=\n'
+    ;;
+  none)
+    printf 'ORCHARDCTL_RPC_V1:0:none:\n'
+    ;;
+  malformed)
+    printf 'not-an-orchard-envelope\n'
+    ;;
+  extra-blank-line)
+    printf 'ORCHARDCTL_RPC_V1:0:stdout:Y29udHJvbGxlciBzdWNjZXNz\n\n'
+    ;;
+  nonresponsive)
+    trap 'printf "terminated\n" >> "$FAKE_RPC_PROCESS_EVENTS"; exit 143' TERM
+    while :; do /bin/sleep 1; done
+    ;;
+  term-resistant)
+    printf 'term-resistant:%s\n' "$$" >> "$FAKE_RPC_PROCESS_EVENTS"
+    trap '' TERM
+    while :; do /bin/sleep 1; done
+    ;;
+  oversized)
+    set -e
+    /usr/bin/yes X
+    printf 'oversized-complete\n' >> "$FAKE_RPC_PROCESS_EVENTS"
+    ;;
+  failure)
+    printf 'simulated rpc failure\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected fake mode: %s\n' "$FAKE_RPC_MODE" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$PACKAGE_ROOT/releases/orchard_controller/bin/orchard_controller"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$PACKAGE_ROOT\"|" \
+  -e "s|^RPC_TMP_PARENT=.*$|RPC_TMP_PARENT=\"$PRIVATE_TMP\"|" \
+  -e 's|^RPC_TIMEOUT_SECONDS=.*$|RPC_TIMEOUT_SECONDS=2|' \
+  -e 's|^RPC_TERM_GRACE_SECONDS=.*$|RPC_TERM_GRACE_SECONDS=1|' \
+  -e 's|^RPC_OUTPUT_LIMIT_BLOCKS=.*$|RPC_OUTPUT_LIMIT_BLOCKS=8|' \
+  -e "s|/usr/bin/stat|$TOOLS/stat|g" \
+  -e "s|/usr/sbin/lsof|$TOOLS/lsof|g" \
+  "$SOURCE_WRAPPER" > "$WRAPPER"
+chmod +x "$WRAPPER"
+
+node_commands=(
+  list inspect pending admit reject cordon uncordon drain cancel-drain maintenance resume decommission
+)
+
+for command in "${node_commands[@]}"; do
+  run_case "route-$command" success nodes "$command" node-id --yes
+  if [[ "$RUN_STATUS" -ne 0 ]]; then
+    cat "$RUN_STDOUT" "$RUN_STDERR" >&2
+    fail "expected nodes $command to succeed through Controller RPC"
+  fi
+  assert_invocation "controller:rpc "
+  assert_no_invocation "standalone:"
+  assert_file_contains "controller success" "$RUN_STDOUT"
+  assert_file_empty "$RUN_STDERR"
+done
+
+standalone_cases=(
+  "status"
+  "nodes --help"
+  "nodes admit --help"
+  "nodes enrollment create"
+  "nodes trust init"
+  "nodes"
+)
+
+for invocation in "${standalone_cases[@]}"; do
+  # shellcheck disable=SC2086 # Each fixture deliberately describes argv words.
+  run_case "standalone-${invocation// /-}" success $invocation
+  [[ "$RUN_STATUS" -eq 0 ]] || fail "expected standalone invocation to succeed: $invocation"
+  assert_invocation "standalone:eval "
+  assert_no_invocation "controller:"
+  assert_file_contains "standalone cli" "$RUN_STDOUT"
+done
+
+run_case error error nodes admit node-id --yes
+[[ "$RUN_STATUS" -eq 7 ]] || fail "expected Controller command error exit 7, got $RUN_STATUS"
+assert_file_empty "$RUN_STDOUT"
+assert_file_contains "Error: controller rejected" "$RUN_STDERR"
+assert_no_invocation "standalone:"
+
+run_case none none nodes list
+[[ "$RUN_STATUS" -eq 0 ]] || fail "expected no-output Controller result to succeed"
+assert_file_empty "$RUN_STDOUT"
+assert_file_empty "$RUN_STDERR"
+
+hostile_reason='capacity "quoted" #{System.halt(9)}
+second line'
+run_case hostile success nodes admit node-id --capacity-policy-reason "$hostile_reason" --yes
+[[ "$RUN_STATUS" -eq 0 ]] || fail "expected hostile argument fixture to remain data"
+assert_no_invocation "$hostile_reason"
+assert_invocation "OrchardCLI.ControllerRPC.main_base64("
+
+run_case rpc-failure failure nodes admit node-id --yes
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected RPC failure exit 1, got $RUN_STATUS"
+assert_no_invocation "standalone:"
+assert_file_contains "controller runtime" "$RUN_STDERR"
+
+run_case rpc-json-failure failure nodes admit node-id --yes --json
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected JSON RPC failure exit 1, got $RUN_STATUS"
+assert_file_empty "$RUN_STDOUT"
+assert_file_contains '"code":"controller_runtime_unavailable"' "$RUN_STDERR"
+if grep -F -- "simulated rpc failure" "$RUN_STDERR" >/dev/null; then
+  fail "expected JSON RPC failure to omit release diagnostics"
+fi
+assert_no_invocation "standalone:"
+
+: > "$INVOCATIONS"
+set +e
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc FAKE_RPC_MODE=success FAKE_INVOCATIONS="$INVOCATIONS" \
+  FAKE_RPC_PROCESS_EVENTS="$RPC_PROCESS_EVENTS" \
+  PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
+  "$WRAPPER" nodes admit node-id --yes >"$TMP_ROOT/grpc.stdout" 2>"$TMP_ROOT/grpc.stderr"
+grpc_status=$?
+set -e
+[[ "$grpc_status" -eq 0 ]] || fail "expected gRPC compatibility mode to retain Controller RPC"
+assert_file_contains "controller success" "$TMP_ROOT/grpc.stdout"
+assert_file_empty "$TMP_ROOT/grpc.stderr"
+assert_invocation "release_node=orchard_controller_management@127.0.0.1"
+assert_invocation "epmd_address=127.0.0.1"
+assert_invocation "erl_aflags=-kernel inet_dist_use_interface {127,0,0,1}"
+assert_no_invocation "standalone:"
+
+: > "$INVOCATIONS"
+set +e
+ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc FAKE_LSOF_MODE=wildcard FAKE_RPC_MODE=success \
+  FAKE_INVOCATIONS="$INVOCATIONS" FAKE_RPC_PROCESS_EVENTS="$RPC_PROCESS_EVENTS" \
+  PATH="$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin" \
+  "$WRAPPER" nodes pending >"$TMP_ROOT/wildcard.stdout" 2>"$TMP_ROOT/wildcard.stderr"
+wildcard_status=$?
+set -e
+[[ "$wildcard_status" -eq 1 ]] || fail "expected wildcard management listener to fail closed"
+assert_file_contains "controller runtime" "$TMP_ROOT/wildcard.stderr"
+assert_no_invocation "standalone:"
+assert_no_invocation "controller:"
+
+for invocation in "nodes enrollment future-mutation" "nodes trust future-mutation"; do
+  # shellcheck disable=SC2086 # Each fixture deliberately describes argv words.
+  run_case "unknown-${invocation// /-}" success $invocation
+  [[ "$RUN_STATUS" -eq 1 ]] || fail "expected unknown offline namespace command to be denied: $invocation"
+  assert_file_contains "unknown packaged nodes command" "$RUN_STDERR"
+  assert_no_invocation "standalone:"
+  assert_no_invocation "controller:"
+done
+
+run_case unknown-node success nodes future-mutation --yes
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected unknown nodes command to be denied"
+assert_file_empty "$RUN_STDOUT"
+assert_file_contains "unknown packaged nodes command" "$RUN_STDERR"
+assert_no_invocation "standalone:"
+assert_no_invocation "controller:"
+
+run_case unknown-node-json success nodes future-mutation --yes --json
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected unknown JSON nodes command to be denied"
+assert_file_empty "$RUN_STDOUT"
+assert_file_contains '"code":"unknown_packaged_nodes_command"' "$RUN_STDERR"
+assert_no_invocation "standalone:"
+assert_no_invocation "controller:"
+
+run_case malformed malformed nodes admit node-id --yes
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected malformed RPC response exit 1, got $RUN_STATUS"
+assert_no_invocation "standalone:"
+assert_file_contains "controller runtime" "$RUN_STDERR"
+
+run_case extra-blank-line extra-blank-line nodes admit node-id --yes
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected an extra RPC output line to fail closed"
+assert_no_invocation "standalone:"
+assert_file_contains "controller runtime" "$RUN_STDERR"
+
+: > "$UNTRUSTED_TOOL_CALLS"
+run_case untrusted-environment success nodes pending
+[[ "$RUN_STATUS" -eq 0 ]] || fail "expected a hostile inherited environment to be ignored"
+assert_file_empty "$UNTRUSTED_TOOL_CALLS"
+if find "$UNTRUSTED_TMP" -mindepth 1 -print -quit | grep -q .; then
+  fail "expected inherited TMPDIR to remain unused"
+fi
+
+: > "$RPC_PROCESS_EVENTS"
+timeout_started=$(/bin/date +%s)
+run_case nonresponsive nonresponsive nodes pending
+timeout_elapsed=$(( $(/bin/date +%s) - timeout_started ))
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected nonresponsive Controller RPC to fail closed"
+[[ "$timeout_elapsed" -le 5 ]] || fail "expected Controller RPC watchdog to bound execution"
+assert_file_contains "terminated" "$RPC_PROCESS_EVENTS"
+assert_file_contains "controller runtime" "$RUN_STDERR"
+assert_no_invocation "standalone:"
+if find "$PRIVATE_TMP" -mindepth 1 -print -quit | grep -q .; then
+  fail "expected watchdog cleanup to remove private RPC state"
+fi
+
+: > "$RPC_PROCESS_EVENTS"
+resistant_started=$(/bin/date +%s)
+run_case term-resistant term-resistant nodes pending
+resistant_elapsed=$(( $(/bin/date +%s) - resistant_started ))
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected TERM-resistant Controller RPC to fail closed"
+[[ "$resistant_elapsed" -le 7 ]] || fail "expected TERM-resistant RPC to be killed within the watchdog bound"
+resistant_pid=$(sed -n 's/^term-resistant://p' "$RPC_PROCESS_EVENTS" | tail -1)
+[[ "$resistant_pid" =~ ^[0-9]+$ ]] || fail "expected TERM-resistant fixture PID evidence"
+if kill -0 "$resistant_pid" 2>/dev/null; then
+  fail "expected TERM-resistant RPC process to be killed and reaped"
+fi
+assert_file_contains "controller runtime" "$RUN_STDERR"
+assert_no_invocation "standalone:"
+if find "$PRIVATE_TMP" -mindepth 1 -print -quit | grep -q .; then
+  fail "expected TERM-resistant watchdog cleanup to remove private RPC state"
+fi
+
+: > "$RPC_PROCESS_EVENTS"
+run_case oversized oversized nodes pending
+[[ "$RUN_STATUS" -eq 1 ]] || fail "expected oversized Controller RPC output to fail closed"
+assert_file_contains "controller runtime" "$RUN_STDERR"
+assert_no_invocation "standalone:"
+if grep -F -- "oversized-complete" "$RPC_PROCESS_EVENTS" >/dev/null; then
+  fail "expected output limit to terminate the RPC producer"
+fi
+if find "$PRIVATE_TMP" -mindepth 1 -print -quit | grep -q .; then
+  fail "expected oversized-output cleanup to remove private RPC state"
+fi
+
+run_case configured success nodes pending
+assert_invocation "release_node=orchard_controller@127.0.0.1"
+assert_invocation "release_cookie=controller-cookie"
+assert_invocation "epmd_port=4369"
+
+printf 'packaged orchardctl Controller-runtime routing tests passed\n'


### PR DESCRIPTION
## Reproduction

On an assembled M3 package, orchardctl nodes admit, cordon, drain, and related authoritative commands could not safely execute against the already-running Controller. The packaged wrapper's standalone CLI path either lacked Controller runtime state or risked creating a second mutation authority.

The release regression assembles the real Controller release, starts it in packaged gRPC inference mode, and confirms that packaged orchardctl admits a registered node through the existing Controller process.

## Root cause

The packaged CLI had no bounded bridge into the running Controller VM. Its command routing also lacked an explicit distinction between:

- Controller-authoritative node commands
- Offline commands such as help, enrollment, and trust bootstrap
- Unknown commands that must be denied until classified

## Fix and security boundary

- Add a versioned OrchardCLI.ControllerRPC envelope executed inside the running Controller release.
- Route authoritative node commands through loopback-only management distribution.
- Preserve gRPC inference mode while enabling a separate loopback management endpoint.
- Keep a single Controller authority with no standalone mutation fallback.
- Apply exact offline allowlists and deny unknown packaged node commands.
- Bound calls with a 30-second watchdog and capped output capture.
- Scope umask 077 only to the RPC capture path so standalone CLI semantics remain unchanged.
- Fail Controller startup closed for missing or failed lsof, malformed listener output, or wildcard/non-loopback management listeners.
- Use macOS lsof -w, treat exit 1 plus empty listener output as no listener, and avoid inherited TMPDIR in the boot-critical inspection path.
- Clear inherited ERL_EPMD_ADDRESS at the cluster-mode launcher boundary.
- Fix the existing scheduler test race using atomic spawn_monitor/1 without changing product behavior.

## Regression coverage

- RPC envelope, allowlist, denial, timeout, and output-bound unit coverage.
- Package-wrapper coverage for wildcard EPMD, missing or failing lsof, benign exit-1 diagnostics, hostile TMPDIR, inherited EPMD settings, and RPC-only umask scope.
- Runtime routing regression for authoritative, offline, and denied commands.
- Real assembled Controller release integration with Postgres and packaged gRPC mode.
- Required CI orders the expensive runtime and release regressions after mix test and mix test --cover, while keeping both mandatory.

## Validation

- No-mistakes independent review: passed after all findings were resolved.
- Focused package, bridge, scheduler, runtime, and assembled-release tests: passed.
- Format, warnings-as-errors compile, strict Credo, Dialyzer, full tests, and coverage: passed.
- Strict OpenSpec validation: passed.
- Required GitHub CI: passed.
- Final RepoPrompt independent review: GO.
- Diff remains exactly 13 files against origin/main at 5782f74.
- No final PKG was built and no live host was mutated.
