### PR TITLE
test(orchard_controller): prove CP1 missing-terminal detector against durable controls

### DIFF
--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -1353,7 +1353,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   defp terminal_inference_turn_step(events, terminal_attrs, step_context) do
     %{
-      event_type: terminal_step_event_type(terminal_attrs.state),
+      event_type: RequestStepEvent.terminal_step_event_type!(terminal_attrs.state),
       step_id: step_context.step_id,
       step_type: "inference_turn",
       turn_index: step_context.turn_index,
@@ -1411,12 +1411,6 @@ defmodule Orchard.Inference.RequestOrchestrator do
       model_version: canonical.model_ref.version
     }
   end
-
-  defp terminal_step_event_type(:completed), do: "request_step.completed"
-  defp terminal_step_event_type(:failed), do: "request_step.failed"
-  defp terminal_step_event_type(:cancelled), do: "request_step.cancelled"
-  defp terminal_step_event_type(:timed_out), do: "request_step.timed_out"
-  defp terminal_step_event_type(:interrupted), do: "request_step.interrupted"
 
   defp terminal_step_result(events, terminal_attrs) do
     %{}

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -60,6 +60,142 @@ defmodule Orchard.Requests do
     |> Enum.map(&RequestStepEvent.from_request_event!/1)
   end
 
+  @doc """
+  Classifies the persisted missing-finish-reason fingerprint for one inference turn.
+
+  Missing, malformed, ambiguous, or state-inconsistent evidence is inconclusive.
+  """
+  @spec classify_missing_terminal_candidate(Request.t() | Ecto.UUID.t(), keyword()) ::
+          {:ok, :missing_finish_reason_candidate | :not_candidate}
+          | {:error, {:inconclusive, atom()}}
+  def classify_missing_terminal_candidate(request_or_id, opts \\ [])
+
+  def classify_missing_terminal_candidate(request_or_id, opts) when is_list(opts) do
+    with {:ok, selector} <- missing_terminal_selector(opts),
+         {:ok, request} <- fetch_detector_request(request_or_id),
+         :ok <- require_terminal_request(request),
+         {:ok, terminal_step} <- fetch_terminal_inference_turn(request.id, selector),
+         :ok <- validate_terminal_step_state(request.state, terminal_step.event_type) do
+      classify_terminal_step(terminal_step)
+    end
+  end
+
+  def classify_missing_terminal_candidate(_request_or_id, _opts),
+    do: inconclusive(:invalid_selector)
+
+  defp missing_terminal_selector(opts) do
+    if Keyword.keyword?(opts) do
+      build_missing_terminal_selector(opts)
+    else
+      inconclusive(:invalid_selector)
+    end
+  end
+
+  defp build_missing_terminal_selector(opts) do
+    turn_index = Keyword.get(opts, :turn_index, 1)
+    attempt = Keyword.get(opts, :attempt, 1)
+
+    if Keyword.keys(opts) -- [:turn_index, :attempt] == [] and
+         is_integer(turn_index) and turn_index > 0 and
+         is_integer(attempt) and attempt > 0 do
+      {:ok, %{step_id: RequestStepEvent.inference_turn_step_id(turn_index, attempt)}}
+    else
+      inconclusive(:invalid_selector)
+    end
+  end
+
+  defp fetch_detector_request(%Request{id: request_id}), do: fetch_detector_request(request_id)
+
+  defp fetch_detector_request(request_id) do
+    case Ecto.UUID.cast(request_id) do
+      {:ok, request_uuid} ->
+        case Repo.get(Request, request_uuid) do
+          %Request{} = request -> {:ok, request}
+          nil -> inconclusive(:request_not_found)
+        end
+
+      :error ->
+        inconclusive(:request_not_found)
+    end
+  end
+
+  defp require_terminal_request(%Request{state: state}) do
+    if state in Request.terminal_states() do
+      :ok
+    else
+      inconclusive(:request_not_terminal)
+    end
+  end
+
+  defp fetch_terminal_inference_turn(request_id, %{step_id: step_id}) do
+    request_id
+    |> list_request_events()
+    |> Enum.filter(&target_terminal_inference_turn?(&1, step_id))
+    |> classify_terminal_rows()
+  end
+
+  defp target_terminal_inference_turn?(%RequestEvent{} = event, step_id) do
+    event.event_type in terminal_inference_turn_event_types() and
+      is_map(event.payload) and
+      Map.get(event.payload, "step_type") == "inference_turn" and
+      Map.get(event.payload, "step_id") == step_id
+  end
+
+  defp classify_terminal_rows([]), do: inconclusive(:terminal_step_not_found)
+
+  defp classify_terminal_rows([event]) do
+    case RequestStepEvent.from_request_event(event) do
+      {:ok, step_event} -> {:ok, step_event}
+      {:error, _reason} -> inconclusive(:invalid_terminal_step)
+    end
+  end
+
+  defp classify_terminal_rows(_events), do: inconclusive(:ambiguous_terminal_steps)
+
+  defp validate_terminal_step_state(request_state, event_type) do
+    expected_event_type =
+      case request_state do
+        :completed -> "request_step.completed"
+        :failed -> "request_step.failed"
+        :cancelled -> "request_step.cancelled"
+        :timed_out -> "request_step.timed_out"
+        :interrupted -> "request_step.interrupted"
+      end
+
+    if event_type == expected_event_type do
+      :ok
+    else
+      inconclusive(:terminal_state_mismatch)
+    end
+  end
+
+  defp classify_terminal_step(%RequestStepEvent{event_type: "request_step.completed"} = step) do
+    case Map.fetch(step.result, "finish_reason") do
+      :error ->
+        {:ok, :missing_finish_reason_candidate}
+
+      {:ok, finish_reason} when finish_reason in ["stop", "length", "tool_calls"] ->
+        {:ok, :not_candidate}
+
+      {:ok, _invalid} ->
+        inconclusive(:invalid_finish_reason)
+    end
+  end
+
+  defp classify_terminal_step(%RequestStepEvent{}), do: {:ok, :not_candidate}
+
+  defp terminal_inference_turn_event_types do
+    [
+      "request_step.completed",
+      "request_step.failed",
+      "request_step.cancelled",
+      "request_step.timed_out",
+      "request_step.interrupted"
+    ]
+  end
+
+  defp inconclusive(reason), do: {:error, {:inconclusive, reason}}
+
   @spec append_request_event(struct() | Ecto.UUID.t(), map()) ::
           {:ok, struct()} | {:error, Ecto.Changeset.t() | :request_not_found}
   def append_request_event(%Request{id: request_id}, attrs),

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -163,6 +163,7 @@ defmodule Orchard.Requests do
         :cancelled -> "request_step.cancelled"
         :timed_out -> "request_step.timed_out"
         :interrupted -> "request_step.interrupted"
+        _unsupported_terminal_state -> nil
       end
 
     if event_type == expected_event_type do

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -63,6 +63,9 @@ defmodule Orchard.Requests do
   @doc """
   Classifies the persisted missing-finish-reason fingerprint for one inference turn.
 
+  This candidate signal is bounded to the current dispatcher and orchestrator
+  persistence invariants and to the retention lifetime of `request_events`.
+  It is not general conformance evidence for `SPEC.md` section 7.5.5.
   Missing, malformed, ambiguous, or state-inconsistent evidence is inconclusive.
   """
   @spec classify_missing_terminal_candidate(Request.t() | Ecto.UUID.t(), keyword()) ::

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -9,6 +9,14 @@ defmodule Orchard.Requests do
   alias Orchard.Repo
   alias Orchard.Requests.{Request, RequestEvent, RequestStepEvent}
 
+  @audit_option_keys [:since, :until, :limit, :turn_index, :attempt]
+  @audit_default_limit 1000
+
+  @typedoc "Outcome of the bounded CP1 missing-`finish_reason` candidate detector."
+  @type classification ::
+          {:ok, :missing_finish_reason_candidate | :not_candidate}
+          | {:error, {:inconclusive, atom()}}
+
   @spec create_request(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_request(attrs) do
     %Request{}
@@ -66,25 +74,111 @@ defmodule Orchard.Requests do
   This candidate signal is bounded to the current dispatcher and orchestrator
   persistence invariants and to the retention lifetime of `request_events`.
   It is not general conformance evidence for `SPEC.md` section 7.5.5.
-  Missing, malformed, ambiguous, or state-inconsistent evidence is inconclusive.
+  Missing, malformed, duplicated, or state-inconsistent evidence is inconclusive.
   """
   @spec classify_missing_terminal_candidate(Request.t() | Ecto.UUID.t(), keyword()) ::
-          {:ok, :missing_finish_reason_candidate | :not_candidate}
-          | {:error, {:inconclusive, atom()}}
+          classification()
   def classify_missing_terminal_candidate(request_or_id, opts \\ [])
 
   def classify_missing_terminal_candidate(request_or_id, opts) when is_list(opts) do
     with {:ok, selector} <- missing_terminal_selector(opts),
          {:ok, request} <- fetch_detector_request(request_or_id),
          :ok <- require_terminal_request(request),
-         {:ok, terminal_step} <- fetch_terminal_inference_turn(request.id, selector),
-         :ok <- validate_terminal_step_state(request.state, terminal_step.event_type) do
-      classify_terminal_step(terminal_step)
+         {:ok, selected} <- fetch_terminal_inference_turn(request.id, selector),
+         :ok <- validate_terminal_step_state(request.state, selected) do
+      classify_terminal_step(selected.step)
     end
   end
 
   def classify_missing_terminal_candidate(_request_or_id, _opts),
     do: inconclusive(:invalid_selector)
+
+  @doc """
+  Sweeps terminal requests created inside an audit window and returns every
+  request whose inference turn is not a clean `not_candidate` control.
+
+  Candidate matches and inconclusive evidence are both returned, because both
+  require manual adjudication before a window's stability denominator is final.
+  """
+  @spec audit_missing_terminal_candidates(keyword()) ::
+          {:ok, [%{request_id: Ecto.UUID.t(), public_id: String.t(), result: classification()}]}
+          | {:error, {:inconclusive, atom()}}
+  def audit_missing_terminal_candidates(opts \\ [])
+
+  def audit_missing_terminal_candidates(opts) when is_list(opts) do
+    with {:ok, audit} <- build_audit_options(opts) do
+      matches =
+        audit
+        |> terminal_requests_for_audit()
+        |> Enum.map(&audit_request_match(&1, audit.selector_opts))
+        |> Enum.reject(&(&1.result == {:ok, :not_candidate}))
+
+      {:ok, matches}
+    end
+  end
+
+  def audit_missing_terminal_candidates(_opts), do: inconclusive(:invalid_audit_options)
+
+  defp audit_request_match(%Request{} = request, selector_opts) do
+    %{
+      request_id: request.id,
+      public_id: request.public_id,
+      result: classify_missing_terminal_candidate(request, selector_opts)
+    }
+  end
+
+  defp build_audit_options(opts) do
+    if Keyword.keyword?(opts) and Keyword.keys(opts) -- @audit_option_keys == [] do
+      validate_audit_options(opts)
+    else
+      inconclusive(:invalid_audit_options)
+    end
+  end
+
+  defp validate_audit_options(opts) do
+    limit = Keyword.get(opts, :limit, @audit_default_limit)
+    selector_opts = Keyword.take(opts, [:turn_index, :attempt])
+
+    with :ok <- validate_audit_bound(Keyword.get(opts, :since)),
+         :ok <- validate_audit_bound(Keyword.get(opts, :until)),
+         :ok <- validate_audit_limit(limit),
+         {:ok, _selector} <- missing_terminal_selector(selector_opts) do
+      {:ok,
+       %{
+         since: Keyword.get(opts, :since),
+         until: Keyword.get(opts, :until),
+         limit: limit,
+         selector_opts: selector_opts
+       }}
+    end
+  end
+
+  defp validate_audit_bound(nil), do: :ok
+  defp validate_audit_bound(%DateTime{}), do: :ok
+  defp validate_audit_bound(_bound), do: inconclusive(:invalid_audit_options)
+
+  defp validate_audit_limit(limit) when is_integer(limit) and limit > 0, do: :ok
+  defp validate_audit_limit(_limit), do: inconclusive(:invalid_audit_options)
+
+  defp terminal_requests_for_audit(audit) do
+    Request
+    |> where([request], request.state in ^Request.terminal_states())
+    |> audit_lower_bound(audit.since)
+    |> audit_upper_bound(audit.until)
+    |> order_by([request], asc: request.inserted_at, asc: request.id)
+    |> limit(^audit.limit)
+    |> Repo.all()
+  end
+
+  defp audit_lower_bound(query, nil), do: query
+
+  defp audit_lower_bound(query, %DateTime{} = since),
+    do: where(query, [request], request.inserted_at >= ^since)
+
+  defp audit_upper_bound(query, nil), do: query
+
+  defp audit_upper_bound(query, %DateTime{} = until),
+    do: where(query, [request], request.inserted_at <= ^until)
 
   defp missing_terminal_selector(opts) do
     if Keyword.keyword?(opts) do
@@ -132,46 +226,60 @@ defmodule Orchard.Requests do
 
   defp fetch_terminal_inference_turn(request_id, %{step_id: step_id}) do
     request_id
-    |> list_request_events()
-    |> Enum.filter(&target_terminal_inference_turn?(&1, step_id))
-    |> classify_terminal_rows()
+    |> terminal_inference_turn_events()
+    |> select_terminal_inference_turn(step_id)
   end
 
-  defp target_terminal_inference_turn?(%RequestEvent{} = event, step_id) do
-    event.event_type in terminal_inference_turn_event_types() and
-      is_map(event.payload) and
-      Map.get(event.payload, "step_type") == "inference_turn" and
-      Map.get(event.payload, "step_id") == step_id
+  defp terminal_inference_turn_events(request_id) do
+    event_types = RequestStepEvent.terminal_step_event_types()
+
+    RequestEvent
+    |> where(
+      [event],
+      event.request_id == ^request_id and event.event_type in ^event_types and
+        fragment("?->>? = ?", event.payload, "step_type", "inference_turn")
+    )
+    |> order_by([event], asc: event.seq)
+    |> Repo.all()
   end
 
-  defp classify_terminal_rows([]), do: inconclusive(:terminal_step_not_found)
+  defp select_terminal_inference_turn(events, step_id) do
+    case Enum.filter(events, &(step_event_payload(&1)["step_id"] == step_id)) do
+      [] -> inconclusive(:terminal_step_not_found)
+      [event] -> build_selected_terminal_step(event, List.last(events))
+      _duplicates -> inconclusive(:duplicate_terminal_steps)
+    end
+  end
 
-  defp classify_terminal_rows([event]) do
+  defp step_event_payload(%RequestEvent{payload: payload}) when is_map(payload), do: payload
+  defp step_event_payload(%RequestEvent{}), do: %{}
+
+  defp build_selected_terminal_step(%RequestEvent{} = event, %RequestEvent{} = last_event) do
     case RequestStepEvent.from_request_event(event) do
-      {:ok, step_event} -> {:ok, step_event}
-      {:error, _reason} -> inconclusive(:invalid_terminal_step)
+      {:ok, step_event} ->
+        {:ok, %{step: step_event, final?: event.seq == last_event.seq}}
+
+      {:error, _reason} ->
+        inconclusive(:invalid_terminal_step)
     end
   end
 
-  defp classify_terminal_rows(_events), do: inconclusive(:ambiguous_terminal_steps)
+  defp validate_terminal_step_state(_request_state, %{final?: false}), do: :ok
 
-  defp validate_terminal_step_state(request_state, event_type) do
-    expected_event_type =
-      case request_state do
-        :completed -> "request_step.completed"
-        :failed -> "request_step.failed"
-        :cancelled -> "request_step.cancelled"
-        :timed_out -> "request_step.timed_out"
-        :interrupted -> "request_step.interrupted"
-        _unsupported_terminal_state -> nil
-      end
+  defp validate_terminal_step_state(request_state, %{step: step}) do
+    case RequestStepEvent.fetch_terminal_step_event_type(request_state) do
+      {:ok, expected_event_type} ->
+        compare_terminal_step_event_type(step.event_type, expected_event_type)
 
-    if event_type == expected_event_type do
-      :ok
-    else
-      inconclusive(:terminal_state_mismatch)
+      :error ->
+        inconclusive(:unmapped_terminal_state)
     end
   end
+
+  defp compare_terminal_step_event_type(event_type, event_type), do: :ok
+
+  defp compare_terminal_step_event_type(_event_type, _expected),
+    do: inconclusive(:terminal_state_mismatch)
 
   defp classify_terminal_step(%RequestStepEvent{event_type: "request_step.completed"} = step) do
     case Map.fetch(step.result, "finish_reason") do
@@ -187,16 +295,6 @@ defmodule Orchard.Requests do
   end
 
   defp classify_terminal_step(%RequestStepEvent{}), do: {:ok, :not_candidate}
-
-  defp terminal_inference_turn_event_types do
-    [
-      "request_step.completed",
-      "request_step.failed",
-      "request_step.cancelled",
-      "request_step.timed_out",
-      "request_step.interrupted"
-    ]
-  end
 
   defp inconclusive(reason), do: {:error, {:inconclusive, reason}}
 

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -9,14 +9,6 @@ defmodule Orchard.Requests do
   alias Orchard.Repo
   alias Orchard.Requests.{Request, RequestEvent, RequestStepEvent}
 
-  @audit_option_keys [:since, :until, :limit, :turn_index, :attempt]
-  @audit_default_limit 1000
-
-  @typedoc "Outcome of the bounded CP1 missing-`finish_reason` candidate detector."
-  @type classification ::
-          {:ok, :missing_finish_reason_candidate | :not_candidate}
-          | {:error, {:inconclusive, atom()}}
-
   @spec create_request(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_request(attrs) do
     %Request{}
@@ -74,111 +66,25 @@ defmodule Orchard.Requests do
   This candidate signal is bounded to the current dispatcher and orchestrator
   persistence invariants and to the retention lifetime of `request_events`.
   It is not general conformance evidence for `SPEC.md` section 7.5.5.
-  Missing, malformed, duplicated, or state-inconsistent evidence is inconclusive.
+  Missing, malformed, ambiguous, or state-inconsistent evidence is inconclusive.
   """
   @spec classify_missing_terminal_candidate(Request.t() | Ecto.UUID.t(), keyword()) ::
-          classification()
+          {:ok, :missing_finish_reason_candidate | :not_candidate}
+          | {:error, {:inconclusive, atom()}}
   def classify_missing_terminal_candidate(request_or_id, opts \\ [])
 
   def classify_missing_terminal_candidate(request_or_id, opts) when is_list(opts) do
     with {:ok, selector} <- missing_terminal_selector(opts),
          {:ok, request} <- fetch_detector_request(request_or_id),
          :ok <- require_terminal_request(request),
-         {:ok, selected} <- fetch_terminal_inference_turn(request.id, selector),
-         :ok <- validate_terminal_step_state(request.state, selected) do
-      classify_terminal_step(selected.step)
+         {:ok, terminal_step} <- fetch_terminal_inference_turn(request.id, selector),
+         :ok <- validate_terminal_step_state(request.state, terminal_step.event_type) do
+      classify_terminal_step(terminal_step)
     end
   end
 
   def classify_missing_terminal_candidate(_request_or_id, _opts),
     do: inconclusive(:invalid_selector)
-
-  @doc """
-  Sweeps terminal requests created inside an audit window and returns every
-  request whose inference turn is not a clean `not_candidate` control.
-
-  Candidate matches and inconclusive evidence are both returned, because both
-  require manual adjudication before a window's stability denominator is final.
-  """
-  @spec audit_missing_terminal_candidates(keyword()) ::
-          {:ok, [%{request_id: Ecto.UUID.t(), public_id: String.t(), result: classification()}]}
-          | {:error, {:inconclusive, atom()}}
-  def audit_missing_terminal_candidates(opts \\ [])
-
-  def audit_missing_terminal_candidates(opts) when is_list(opts) do
-    with {:ok, audit} <- build_audit_options(opts) do
-      matches =
-        audit
-        |> terminal_requests_for_audit()
-        |> Enum.map(&audit_request_match(&1, audit.selector_opts))
-        |> Enum.reject(&(&1.result == {:ok, :not_candidate}))
-
-      {:ok, matches}
-    end
-  end
-
-  def audit_missing_terminal_candidates(_opts), do: inconclusive(:invalid_audit_options)
-
-  defp audit_request_match(%Request{} = request, selector_opts) do
-    %{
-      request_id: request.id,
-      public_id: request.public_id,
-      result: classify_missing_terminal_candidate(request, selector_opts)
-    }
-  end
-
-  defp build_audit_options(opts) do
-    if Keyword.keyword?(opts) and Keyword.keys(opts) -- @audit_option_keys == [] do
-      validate_audit_options(opts)
-    else
-      inconclusive(:invalid_audit_options)
-    end
-  end
-
-  defp validate_audit_options(opts) do
-    limit = Keyword.get(opts, :limit, @audit_default_limit)
-    selector_opts = Keyword.take(opts, [:turn_index, :attempt])
-
-    with :ok <- validate_audit_bound(Keyword.get(opts, :since)),
-         :ok <- validate_audit_bound(Keyword.get(opts, :until)),
-         :ok <- validate_audit_limit(limit),
-         {:ok, _selector} <- missing_terminal_selector(selector_opts) do
-      {:ok,
-       %{
-         since: Keyword.get(opts, :since),
-         until: Keyword.get(opts, :until),
-         limit: limit,
-         selector_opts: selector_opts
-       }}
-    end
-  end
-
-  defp validate_audit_bound(nil), do: :ok
-  defp validate_audit_bound(%DateTime{}), do: :ok
-  defp validate_audit_bound(_bound), do: inconclusive(:invalid_audit_options)
-
-  defp validate_audit_limit(limit) when is_integer(limit) and limit > 0, do: :ok
-  defp validate_audit_limit(_limit), do: inconclusive(:invalid_audit_options)
-
-  defp terminal_requests_for_audit(audit) do
-    Request
-    |> where([request], request.state in ^Request.terminal_states())
-    |> audit_lower_bound(audit.since)
-    |> audit_upper_bound(audit.until)
-    |> order_by([request], asc: request.inserted_at, asc: request.id)
-    |> limit(^audit.limit)
-    |> Repo.all()
-  end
-
-  defp audit_lower_bound(query, nil), do: query
-
-  defp audit_lower_bound(query, %DateTime{} = since),
-    do: where(query, [request], request.inserted_at >= ^since)
-
-  defp audit_upper_bound(query, nil), do: query
-
-  defp audit_upper_bound(query, %DateTime{} = until),
-    do: where(query, [request], request.inserted_at <= ^until)
 
   defp missing_terminal_selector(opts) do
     if Keyword.keyword?(opts) do
@@ -227,7 +133,8 @@ defmodule Orchard.Requests do
   defp fetch_terminal_inference_turn(request_id, %{step_id: step_id}) do
     request_id
     |> terminal_inference_turn_events()
-    |> select_terminal_inference_turn(step_id)
+    |> Enum.filter(&(step_event_payload(&1)["step_id"] == step_id))
+    |> classify_terminal_rows()
   end
 
   defp terminal_inference_turn_events(request_id) do
@@ -243,36 +150,27 @@ defmodule Orchard.Requests do
     |> Repo.all()
   end
 
-  defp select_terminal_inference_turn(events, step_id) do
-    case Enum.filter(events, &(step_event_payload(&1)["step_id"] == step_id)) do
-      [] -> inconclusive(:terminal_step_not_found)
-      [event] -> build_selected_terminal_step(event, List.last(events))
-      _duplicates -> inconclusive(:duplicate_terminal_steps)
-    end
-  end
-
   defp step_event_payload(%RequestEvent{payload: payload}) when is_map(payload), do: payload
   defp step_event_payload(%RequestEvent{}), do: %{}
 
-  defp build_selected_terminal_step(%RequestEvent{} = event, %RequestEvent{} = last_event) do
-    case RequestStepEvent.from_request_event(event) do
-      {:ok, step_event} ->
-        {:ok, %{step: step_event, final?: event.seq == last_event.seq}}
+  defp classify_terminal_rows([]), do: inconclusive(:terminal_step_not_found)
 
-      {:error, _reason} ->
-        inconclusive(:invalid_terminal_step)
+  defp classify_terminal_rows([event]) do
+    case RequestStepEvent.from_request_event(event) do
+      {:ok, step_event} -> {:ok, step_event}
+      {:error, _reason} -> inconclusive(:invalid_terminal_step)
     end
   end
 
-  defp validate_terminal_step_state(_request_state, %{final?: false}), do: :ok
+  defp classify_terminal_rows(_events), do: inconclusive(:ambiguous_terminal_steps)
 
-  defp validate_terminal_step_state(request_state, %{step: step}) do
+  defp validate_terminal_step_state(request_state, event_type) do
     case RequestStepEvent.fetch_terminal_step_event_type(request_state) do
       {:ok, expected_event_type} ->
-        compare_terminal_step_event_type(step.event_type, expected_event_type)
+        compare_terminal_step_event_type(event_type, expected_event_type)
 
       :error ->
-        inconclusive(:unmapped_terminal_state)
+        inconclusive(:terminal_state_mismatch)
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/requests/request_step_event.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request_step_event.ex
@@ -4,6 +4,7 @@ defmodule Orchard.Requests.RequestStepEvent do
   """
 
   alias Orchard.Inference.ToolExecutionOutcome
+  alias Orchard.Requests.Request
   alias Orchard.Requests.RequestEvent
 
   @step_event_types [
@@ -18,6 +19,22 @@ defmodule Orchard.Requests.RequestStepEvent do
   ]
   @step_types ["inference_turn", "tool_call", "tool_execution"]
   @boundaries ["pre_side_effect", "post_observation"]
+  @terminal_step_event_types [
+    completed: "request_step.completed",
+    failed: "request_step.failed",
+    cancelled: "request_step.cancelled",
+    timed_out: "request_step.timed_out",
+    interrupted: "request_step.interrupted"
+  ]
+
+  unmapped_terminal_states =
+    Request.terminal_states() -- Keyword.keys(@terminal_step_event_types)
+
+  if unmapped_terminal_states != [] do
+    raise "terminal request states without a request_step.* event type: " <>
+            inspect(unmapped_terminal_states)
+  end
+
   @top_level_fields [
     :request_id,
     :seq,
@@ -89,6 +106,36 @@ defmodule Orchard.Requests.RequestStepEvent do
 
   @spec boundaries() :: [boundary()]
   def boundaries, do: @boundaries
+
+  @doc """
+  Returns the `request_step.*` event types that close an inference turn.
+  """
+  @spec terminal_step_event_types() :: [event_type()]
+  def terminal_step_event_types, do: Keyword.values(@terminal_step_event_types)
+
+  @doc """
+  Returns the `request_step.*` event type a terminal `Request` state must persist.
+  """
+  @spec fetch_terminal_step_event_type(atom()) :: {:ok, event_type()} | :error
+  def fetch_terminal_step_event_type(request_state) when is_atom(request_state),
+    do: Keyword.fetch(@terminal_step_event_types, request_state)
+
+  def fetch_terminal_step_event_type(_request_state), do: :error
+
+  @doc """
+  Same as `fetch_terminal_step_event_type/1` but raises on an unmapped state.
+  """
+  @spec terminal_step_event_type!(atom()) :: event_type()
+  def terminal_step_event_type!(request_state) do
+    case fetch_terminal_step_event_type(request_state) do
+      {:ok, event_type} ->
+        event_type
+
+      :error ->
+        raise ArgumentError,
+              "no request_step.* event type for terminal state #{inspect(request_state)}"
+    end
+  end
 
   @spec request_step_event_type?(String.t()) :: boolean()
   def request_step_event_type?(event_type) when is_binary(event_type),

--- a/apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs
@@ -46,8 +46,6 @@ defmodule Orchard.Inference.CP1TerminalDetectorProofTest do
     assert Enum.frequencies(Enum.map(controls, & &1.source_cardinality)) ==
              %{exactly_one: @control_count}
 
-    assert {:ok, []} = Requests.audit_missing_terminal_candidates()
-
     assert TerminalCardinality.classify([InferenceEvent.accepted(0)]) == :zero
 
     assert TerminalCardinality.classify([

--- a/apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs
@@ -1,0 +1,118 @@
+defmodule Orchard.Inference.CP1TerminalDetectorProofTest do
+  use Orchard.DataCase, async: false
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  alias Orchard.InferenceEvent
+  alias Orchard.Requests
+  alias Orchard.Requests.RequestStepEvent
+  alias Orchard.TestSupport.TerminalCardinality
+
+  @control_categories [
+    {:stop, :completed, "request_step.completed", "stop"},
+    {:length, :completed, "request_step.completed", "length"},
+    {:tool_calls, :completed, "request_step.completed", "tool_calls"},
+    {:failure, :failed, "request_step.failed", nil},
+    {:cancellation, :cancelled, "request_step.cancelled", nil},
+    {:timeout, :timed_out, "request_step.timed_out", nil},
+    {:interruption, :interrupted, "request_step.interrupted", nil}
+  ]
+
+  test "issue #120 candidate detector has zero false positives across 105 durable controls" do
+    controls =
+      for category <- @control_categories,
+          sample <- 1..15 do
+        persist_terminal_control(category, sample)
+      end
+
+    classifications = Enum.map(controls, & &1.classification)
+    cardinalities = Enum.map(controls, & &1.cardinality)
+    category_counts = Enum.frequencies_by(controls, & &1.category)
+
+    assert length(controls) == 105
+    assert Map.values(category_counts) |> Enum.uniq() == [15]
+    assert Map.keys(category_counts) |> Enum.sort() == expected_categories()
+    assert Enum.frequencies(classifications) == %{{:ok, :not_candidate} => 105}
+    assert Enum.frequencies(cardinalities) == %{exactly_one: 105}
+
+    assert TerminalCardinality.classify([InferenceEvent.accepted(0)]) == :zero
+
+    assert TerminalCardinality.classify([
+             InferenceEvent.completed(:finish_reason_stop, nil),
+             InferenceEvent.failed("runtime_failed", "failed", false)
+           ]) == :multiple
+  end
+
+  defp persist_terminal_control(
+         {category, request_state, event_type, finish_reason},
+         sample
+       ) do
+    {:ok, request} =
+      Requests.create_request(
+        request_attrs(%{
+          public_id: "cp1-terminal-#{category}-#{sample}",
+          state: :running
+        })
+      )
+
+    source_events = [
+      InferenceEvent.accepted(0),
+      terminal_event(category)
+    ]
+
+    step_result =
+      if finish_reason do
+        %{"finish_reason" => finish_reason}
+      else
+        %{"error_code" => terminal_error_code(category)}
+      end
+
+    terminal_step = %{
+      event_type: event_type,
+      step_id: RequestStepEvent.inference_turn_step_id(1, 1),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: 1,
+      parent_step_id: nil,
+      boundary: "post_observation",
+      result: step_result
+    }
+
+    assert {:ok, _request} =
+             Requests.mark_terminal_with_step_events(
+               request,
+               %{state: request_state},
+               [terminal_step]
+             )
+
+    %{
+      cardinality: TerminalCardinality.classify(source_events),
+      category: category,
+      classification: Requests.classify_missing_terminal_candidate(request)
+    }
+  end
+
+  defp terminal_event(:stop),
+    do: InferenceEvent.completed(:finish_reason_stop, nil)
+
+  defp terminal_event(:length),
+    do: InferenceEvent.completed(:finish_reason_length, nil)
+
+  defp terminal_event(:tool_calls),
+    do: InferenceEvent.completed(:finish_reason_tool_calls, nil)
+
+  defp terminal_event(category) do
+    InferenceEvent.failed(terminal_error_code(category), "#{category} control", false)
+  end
+
+  defp terminal_error_code(:failure), do: "runtime_failed"
+  defp terminal_error_code(:cancellation), do: "request_cancelled"
+  defp terminal_error_code(:timeout), do: "deadline_exceeded"
+  defp terminal_error_code(:interruption), do: "request_client_disconnect"
+
+  defp expected_categories do
+    @control_categories
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.sort()
+  end
+end

--- a/apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs
@@ -17,23 +17,36 @@ defmodule Orchard.Inference.CP1TerminalDetectorProofTest do
     {:timeout, :timed_out, "request_step.timed_out", nil},
     {:interruption, :interrupted, "request_step.interrupted", nil}
   ]
+  @samples_per_category 15
+  @control_count length(@control_categories) * @samples_per_category
 
   test "issue #120 candidate detector has zero false positives across 105 durable controls" do
     controls =
       for category <- @control_categories,
-          sample <- 1..15 do
+          sample <- 1..@samples_per_category do
         persist_terminal_control(category, sample)
       end
 
-    classifications = Enum.map(controls, & &1.classification)
-    cardinalities = Enum.map(controls, & &1.cardinality)
     category_counts = Enum.frequencies_by(controls, & &1.category)
 
-    assert length(controls) == 105
-    assert Map.values(category_counts) |> Enum.uniq() == [15]
-    assert Map.keys(category_counts) |> Enum.sort() == expected_categories()
-    assert Enum.frequencies(classifications) == %{{:ok, :not_candidate} => 105}
-    assert Enum.frequencies(cardinalities) == %{exactly_one: 105}
+    assert @control_count == 105
+    assert length(controls) == @control_count
+    assert category_counts |> Map.values() |> Enum.uniq() == [@samples_per_category]
+    assert category_counts |> Map.keys() |> Enum.sort() == expected_categories()
+
+    assert controls |> Enum.map(& &1.durable_result) |> Enum.uniq() |> length() ==
+             @control_count
+
+    assert Enum.frequencies(Enum.map(controls, & &1.classification)) ==
+             %{{:ok, :not_candidate} => @control_count}
+
+    assert Enum.frequencies(Enum.map(controls, & &1.durable_terminal_steps)) ==
+             %{1 => @control_count}
+
+    assert Enum.frequencies(Enum.map(controls, & &1.source_cardinality)) ==
+             %{exactly_one: @control_count}
+
+    assert {:ok, []} = Requests.audit_missing_terminal_candidates()
 
     assert TerminalCardinality.classify([InferenceEvent.accepted(0)]) == :zero
 
@@ -60,12 +73,7 @@ defmodule Orchard.Inference.CP1TerminalDetectorProofTest do
       terminal_event(category)
     ]
 
-    step_result =
-      if finish_reason do
-        %{"finish_reason" => finish_reason}
-      else
-        %{"error_code" => terminal_error_code(category)}
-      end
+    step_result = terminal_step_result(category, finish_reason, sample)
 
     terminal_step = %{
       event_type: event_type,
@@ -86,10 +94,43 @@ defmodule Orchard.Inference.CP1TerminalDetectorProofTest do
              )
 
     %{
-      cardinality: TerminalCardinality.classify(source_events),
       category: category,
-      classification: Requests.classify_missing_terminal_candidate(request)
+      classification: Requests.classify_missing_terminal_candidate(request),
+      durable_result: durable_terminal_result(request),
+      durable_terminal_steps: durable_terminal_step_count(request),
+      source_cardinality: TerminalCardinality.classify(source_events)
     }
+  end
+
+  defp terminal_step_result(category, nil, sample) do
+    %{
+      "error_code" => terminal_error_code(category),
+      "error_message" => "#{category} control #{sample}",
+      "http_status" => 400 + sample
+    }
+  end
+
+  defp terminal_step_result(_category, finish_reason, sample) do
+    %{
+      "finish_reason" => finish_reason,
+      "http_status" => 200,
+      "input_tokens" => sample,
+      "output_tokens" => sample * 2
+    }
+  end
+
+  defp durable_terminal_steps(request) do
+    terminal_event_types = RequestStepEvent.terminal_step_event_types()
+
+    request
+    |> Requests.list_request_step_events()
+    |> Enum.filter(&(&1.step_type == "inference_turn" and &1.event_type in terminal_event_types))
+  end
+
+  defp durable_terminal_step_count(request), do: request |> durable_terminal_steps() |> length()
+
+  defp durable_terminal_result(request) do
+    request |> durable_terminal_steps() |> Enum.map(& &1.result)
   end
 
   defp terminal_event(:stop),

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -2155,7 +2155,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical = canonical_request("request-orchestrator-length-control", stream?: false)
 
     assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
-    assert Enum.count(events, &InferenceEvent.terminal?/1) == 1
+    assert TerminalCardinality.classify(events) == :exactly_one
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     terminal_step = Requests.list_request_step_events(request) |> List.last()
@@ -2248,6 +2248,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
                  step_event_appender: step_event_appender
                )
 
+      assert TerminalCardinality.classify(events) == :exactly_one
       assert match?(%{event: %InferenceEvent.Failed{code: ^code}}, List.last(events))
       refute_receive {:unexpected_terminal_step_appender_call, _step_events}
 
@@ -2304,7 +2305,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical = canonical_request("request-orchestrator-tool-proposals", stream?: false)
 
     assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
-    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+    assert TerminalCardinality.classify(events) == :exactly_one
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     step_events = Requests.list_request_step_events(request)

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -479,16 +479,20 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient do
     owner = Keyword.fetch!(opts, :owner)
     stream_ref = make_ref()
 
+    events =
+      Process.get(
+        {__MODULE__, :execute_events},
+        [InferenceEvent.completed(:finish_reason_stop, %InferenceEvent.Usage{})]
+      )
+
     send(
       owner,
       {:runtime_endpoint_event, stream_ref, request.request_id, InferenceEvent.accepted(0)}
     )
 
-    send(
-      owner,
-      {:runtime_endpoint_event, stream_ref, request.request_id,
-       InferenceEvent.completed(:finish_reason_stop, %InferenceEvent.Usage{})}
-    )
+    Enum.each(events, fn event ->
+      send(owner, {:runtime_endpoint_event, stream_ref, request.request_id, event})
+    end)
 
     send(owner, {:runtime_endpoint_done, stream_ref, :ok})
 
@@ -783,6 +787,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.Requests
   alias Orchard.Requests.Idempotency
   alias Orchard.Requests.RequestServer
+  alias Orchard.TestSupport.TerminalCardinality
 
   setup :setup_sentry_context
 
@@ -2110,7 +2115,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
                step_event_appender: step_event_appender
              )
 
-    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+    assert TerminalCardinality.classify(events) == :exactly_one
     refute_receive {:unexpected_terminal_step_appender_call, _step_events}
 
     request = Requests.get_request_by_public_id(canonical.public_id)
@@ -2132,6 +2137,66 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
                "output_tokens" => 0
              }
            ]
+
+    assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
+  end
+
+  test "execute/3 persists a length terminal as a non-candidate control", %{bundle: bundle} do
+    put_capturing_runtime_adapter_config()
+
+    put_runtime_events([
+      InferenceEvent.completed(
+        :finish_reason_length,
+        %InferenceEvent.Usage{input_tokens: 1, output_tokens: 1, total_tokens: 2}
+      )
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-length-control")
+    canonical = canonical_request("request-orchestrator-length-control", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert Enum.count(events, &InferenceEvent.terminal?/1) == 1
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    terminal_step = Requests.list_request_step_events(request) |> List.last()
+
+    assert terminal_step.result["finish_reason"] == "length"
+    assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
+  end
+
+  test "execute/3 leaves a durable missing-terminal detector candidate after the request process exits",
+       %{bundle: bundle} do
+    target = [host: "10.0.0.1", port: 50_061]
+    node = insert_runtime_node!(target)
+
+    put_auto_runtime_endpoint_scheduler_config([target])
+    stub_runtime_status(target, runtime_status(node.id, target))
+    stub_runtime_events([])
+
+    model = create_active_model!(bundle, "request-orchestrator-missing-terminal-detector")
+
+    canonical =
+      canonical_request("request-orchestrator-missing-terminal-detector", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted]
+    assert TerminalCardinality.classify(events) == :zero
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :completed
+    assert request.http_status == 200
+
+    assert [started_step, terminal_step] = Requests.list_request_step_events(request)
+    assert started_step.event_type == "request_step.started"
+    assert terminal_step.event_type == "request_step.completed"
+    refute Map.has_key?(terminal_step.result, "finish_reason")
+
+    assert wait_until(fn ->
+             RequestServer.get_state(request.id) == {:error, :not_found}
+           end)
+
+    assert {:ok, :missing_finish_reason_candidate} =
+             Requests.classify_missing_terminal_candidate(request)
   end
 
   test "execute/3 aborts before dispatch side effects when request_step.started persistence fails",
@@ -2188,6 +2253,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
       request = Requests.get_request_by_public_id(canonical.public_id)
       assert request.state == expected_state
+      assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
 
       step_events = Requests.list_request_step_events(request)
 
@@ -2242,6 +2308,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     step_events = Requests.list_request_step_events(request)
+    assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
 
     assert Enum.map(step_events, &{&1.event_type, &1.step_type, &1.step_id}) == [
              {"request_step.started", "inference_turn", "inference_turn:t1:a1"},
@@ -3213,6 +3280,10 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   defp stub_runtime_status(target, response) do
     key = {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
     Process.put({StubRuntimeEndpointClient, key}, response)
+  end
+
+  defp stub_runtime_events(events) do
+    Process.put({StubRuntimeEndpointClient, :execute_events}, events)
   end
 
   defp runtime_status(node_id, target) do

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -259,6 +259,157 @@ defmodule Orchard.RequestsTest do
            ]
   end
 
+  describe "classify_missing_terminal_candidate/2" do
+    test "identifies a terminal completed inference turn whose persisted result omits finish_reason" do
+      request = create_request!(%{public_id: "req_missing_terminal_candidate", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 request,
+                 %{state: :completed},
+                 [inference_turn_completed_step_attrs(%{result: %{"http_status" => 200}})]
+               )
+
+      assert {:ok, :missing_finish_reason_candidate} =
+               Requests.classify_missing_terminal_candidate(request)
+    end
+
+    test "rejects terminal-bearing completed and failure-shaped persisted controls" do
+      completed =
+        create_request!(%{public_id: "req_terminal_completed_control", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 completed,
+                 %{state: :completed},
+                 [inference_turn_completed_step_attrs()]
+               )
+
+      failed = create_request!(%{public_id: "req_terminal_failed_control", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 failed,
+                 %{state: :failed},
+                 [inference_turn_failed_step_attrs()]
+               )
+
+      assert {:ok, :not_candidate} =
+               Requests.classify_missing_terminal_candidate(completed)
+
+      assert {:ok, :not_candidate} =
+               Requests.classify_missing_terminal_candidate(failed)
+    end
+
+    test "treats absent, ambiguous, inconsistent, and malformed durable evidence as inconclusive" do
+      missing_request_id = Ecto.UUID.generate()
+
+      assert {:error, {:inconclusive, :request_not_found}} =
+               Requests.classify_missing_terminal_candidate(missing_request_id)
+
+      non_terminal = create_request!(%{public_id: "req_detector_non_terminal", state: :running})
+
+      assert {:error, {:inconclusive, :request_not_terminal}} =
+               Requests.classify_missing_terminal_candidate(non_terminal)
+
+      missing_step = create_request!(%{public_id: "req_detector_missing_step", state: :running})
+      assert {:ok, _request} = Requests.mark_terminal(missing_step, %{state: :completed})
+
+      assert {:error, {:inconclusive, :terminal_step_not_found}} =
+               Requests.classify_missing_terminal_candidate(missing_step)
+
+      invalid_reason =
+        create_request!(%{public_id: "req_detector_invalid_reason", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 invalid_reason,
+                 %{state: :completed},
+                 [inference_turn_completed_step_attrs(%{result: %{"finish_reason" => nil}})]
+               )
+
+      assert {:error, {:inconclusive, :invalid_finish_reason}} =
+               Requests.classify_missing_terminal_candidate(invalid_reason)
+
+      ambiguous = create_request!(%{public_id: "req_detector_ambiguous", state: :running})
+
+      assert {:ok, _steps} =
+               Requests.append_request_step_events(ambiguous, [
+                 inference_turn_completed_step_attrs(),
+                 inference_turn_completed_step_attrs()
+               ])
+
+      assert {:ok, _request} = Requests.mark_terminal(ambiguous, %{state: :completed})
+
+      assert {:error, {:inconclusive, :ambiguous_terminal_steps}} =
+               Requests.classify_missing_terminal_candidate(ambiguous)
+
+      inconsistent =
+        create_request!(%{public_id: "req_detector_inconsistent", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 inconsistent,
+                 %{state: :failed},
+                 [inference_turn_completed_step_attrs()]
+               )
+
+      assert {:error, {:inconclusive, :terminal_state_mismatch}} =
+               Requests.classify_missing_terminal_candidate(inconsistent)
+
+      malformed = create_request!(%{public_id: "req_detector_malformed", state: :running})
+
+      assert {:ok, _event} =
+               Requests.append_request_event(malformed, %{
+                 event_type: "request_step.completed",
+                 payload: %{
+                   "step_id" => RequestStepEvent.inference_turn_step_id(1, 1),
+                   "step_type" => "inference_turn",
+                   "turn_index" => 1,
+                   "attempt" => 1,
+                   "parent_step_id" => nil,
+                   "boundary" => "post_observation",
+                   "result" => "invalid"
+                 }
+               })
+
+      assert {:ok, _request} = Requests.mark_terminal(malformed, %{state: :completed})
+
+      assert {:error, {:inconclusive, :invalid_terminal_step}} =
+               Requests.classify_missing_terminal_candidate(malformed)
+    end
+
+    test "selects an exact inference turn and validates selectors" do
+      request = create_request!(%{public_id: "req_detector_selector", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 request,
+                 %{state: :completed},
+                 [
+                   inference_turn_completed_step_attrs(%{
+                     step_id: RequestStepEvent.inference_turn_step_id(2, 3),
+                     turn_index: 2,
+                     attempt: 3,
+                     result: %{}
+                   })
+                 ]
+               )
+
+      assert {:ok, :missing_finish_reason_candidate} =
+               Requests.classify_missing_terminal_candidate(request,
+                 turn_index: 2,
+                 attempt: 3
+               )
+
+      assert {:error, {:inconclusive, :terminal_step_not_found}} =
+               Requests.classify_missing_terminal_candidate(request)
+
+      assert {:error, {:inconclusive, :invalid_selector}} =
+               Requests.classify_missing_terminal_candidate(request, turn_index: 0)
+    end
+  end
+
   describe "mark_terminal_with_step_events/3" do
     test "atomically commits success-shaped terminal step rows with the terminal request update" do
       request = create_request!(%{public_id: "req_terminal_steps_success", state: :running})

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -331,18 +331,18 @@ defmodule Orchard.RequestsTest do
       assert {:error, {:inconclusive, :invalid_finish_reason}} =
                Requests.classify_missing_terminal_candidate(invalid_reason)
 
-      ambiguous = create_request!(%{public_id: "req_detector_ambiguous", state: :running})
+      duplicate = create_request!(%{public_id: "req_detector_duplicate", state: :running})
 
       assert {:ok, _steps} =
-               Requests.append_request_step_events(ambiguous, [
+               Requests.append_request_step_events(duplicate, [
                  inference_turn_completed_step_attrs(),
                  inference_turn_completed_step_attrs()
                ])
 
-      assert {:ok, _request} = Requests.mark_terminal(ambiguous, %{state: :completed})
+      assert {:ok, _request} = Requests.mark_terminal(duplicate, %{state: :completed})
 
-      assert {:error, {:inconclusive, :ambiguous_terminal_steps}} =
-               Requests.classify_missing_terminal_candidate(ambiguous)
+      assert {:error, {:inconclusive, :duplicate_terminal_steps}} =
+               Requests.classify_missing_terminal_candidate(duplicate)
 
       inconsistent =
         create_request!(%{public_id: "req_detector_inconsistent", state: :running})
@@ -407,6 +407,100 @@ defmodule Orchard.RequestsTest do
 
       assert {:error, {:inconclusive, :invalid_selector}} =
                Requests.classify_missing_terminal_candidate(request, turn_index: 0)
+    end
+
+    test "classifies a superseded earlier attempt without requiring whole-request state agreement" do
+      request = create_request!(%{public_id: "req_detector_earlier_attempt", state: :running})
+
+      assert {:ok, _steps} =
+               Requests.append_request_step_events(request, [
+                 inference_turn_completed_step_attrs(%{
+                   step_id: RequestStepEvent.inference_turn_step_id(1, 1),
+                   result: %{"http_status" => 200}
+                 })
+               ])
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 request,
+                 %{state: :failed},
+                 [
+                   inference_turn_failed_step_attrs(%{
+                     step_id: RequestStepEvent.inference_turn_step_id(1, 2),
+                     attempt: 2
+                   })
+                 ]
+               )
+
+      assert {:ok, :missing_finish_reason_candidate} =
+               Requests.classify_missing_terminal_candidate(request, attempt: 1)
+
+      assert {:ok, :not_candidate} =
+               Requests.classify_missing_terminal_candidate(request, attempt: 2)
+    end
+  end
+
+  describe "audit_missing_terminal_candidates/1" do
+    test "returns only candidate and inconclusive matches inside the audit window" do
+      control = create_request!(%{public_id: "req_audit_control", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 control,
+                 %{state: :completed},
+                 [inference_turn_completed_step_attrs()]
+               )
+
+      candidate = create_request!(%{public_id: "req_audit_candidate", state: :running})
+
+      assert {:ok, _request} =
+               Requests.mark_terminal_with_step_events(
+                 candidate,
+                 %{state: :completed},
+                 [inference_turn_completed_step_attrs(%{result: %{"http_status" => 200}})]
+               )
+
+      inconclusive = create_request!(%{public_id: "req_audit_inconclusive", state: :running})
+      assert {:ok, _request} = Requests.mark_terminal(inconclusive, %{state: :completed})
+
+      active = create_request!(%{public_id: "req_audit_active", state: :running})
+
+      assert {:ok, matches} = Requests.audit_missing_terminal_candidates()
+
+      assert matches |> Enum.map(&{&1.public_id, &1.result}) |> Enum.sort() == [
+               {"req_audit_candidate", {:ok, :missing_finish_reason_candidate}},
+               {"req_audit_inconclusive", {:error, {:inconclusive, :terminal_step_not_found}}}
+             ]
+
+      refute Enum.any?(matches, &(&1.public_id in ["req_audit_control", active.public_id]))
+      assert Enum.all?(matches, &(&1.request_id in [candidate.id, inconclusive.id]))
+
+      assert {:ok, []} =
+               Requests.audit_missing_terminal_candidates(
+                 since: DateTime.add(DateTime.utc_now(), 60, :second)
+               )
+
+      assert {:ok, []} =
+               Requests.audit_missing_terminal_candidates(
+                 until: DateTime.add(DateTime.utc_now(), -60, :second)
+               )
+    end
+
+    test "rejects malformed audit options" do
+      assert {:error, {:inconclusive, :invalid_audit_options}} =
+               Requests.audit_missing_terminal_candidates(limit: 0)
+
+      assert {:error, {:inconclusive, :invalid_audit_options}} =
+               Requests.audit_missing_terminal_candidates(since: "2026-07-31")
+
+      assert {:error, {:inconclusive, :invalid_audit_options}} =
+               Requests.audit_missing_terminal_candidates(unknown: true)
+
+      assert {:error, {:inconclusive, :invalid_audit_options}} =
+               Requests.audit_missing_terminal_candidates(%{limit: 5})
+
+      assert {:error, {:inconclusive, :invalid_selector}} =
+               Requests.audit_missing_terminal_candidates(attempt: 0)
     end
   end
 

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -331,18 +331,18 @@ defmodule Orchard.RequestsTest do
       assert {:error, {:inconclusive, :invalid_finish_reason}} =
                Requests.classify_missing_terminal_candidate(invalid_reason)
 
-      duplicate = create_request!(%{public_id: "req_detector_duplicate", state: :running})
+      ambiguous = create_request!(%{public_id: "req_detector_ambiguous", state: :running})
 
       assert {:ok, _steps} =
-               Requests.append_request_step_events(duplicate, [
+               Requests.append_request_step_events(ambiguous, [
                  inference_turn_completed_step_attrs(),
                  inference_turn_completed_step_attrs()
                ])
 
-      assert {:ok, _request} = Requests.mark_terminal(duplicate, %{state: :completed})
+      assert {:ok, _request} = Requests.mark_terminal(ambiguous, %{state: :completed})
 
-      assert {:error, {:inconclusive, :duplicate_terminal_steps}} =
-               Requests.classify_missing_terminal_candidate(duplicate)
+      assert {:error, {:inconclusive, :ambiguous_terminal_steps}} =
+               Requests.classify_missing_terminal_candidate(ambiguous)
 
       inconsistent =
         create_request!(%{public_id: "req_detector_inconsistent", state: :running})
@@ -407,100 +407,6 @@ defmodule Orchard.RequestsTest do
 
       assert {:error, {:inconclusive, :invalid_selector}} =
                Requests.classify_missing_terminal_candidate(request, turn_index: 0)
-    end
-
-    test "classifies a superseded earlier attempt without requiring whole-request state agreement" do
-      request = create_request!(%{public_id: "req_detector_earlier_attempt", state: :running})
-
-      assert {:ok, _steps} =
-               Requests.append_request_step_events(request, [
-                 inference_turn_completed_step_attrs(%{
-                   step_id: RequestStepEvent.inference_turn_step_id(1, 1),
-                   result: %{"http_status" => 200}
-                 })
-               ])
-
-      assert {:ok, _request} =
-               Requests.mark_terminal_with_step_events(
-                 request,
-                 %{state: :failed},
-                 [
-                   inference_turn_failed_step_attrs(%{
-                     step_id: RequestStepEvent.inference_turn_step_id(1, 2),
-                     attempt: 2
-                   })
-                 ]
-               )
-
-      assert {:ok, :missing_finish_reason_candidate} =
-               Requests.classify_missing_terminal_candidate(request, attempt: 1)
-
-      assert {:ok, :not_candidate} =
-               Requests.classify_missing_terminal_candidate(request, attempt: 2)
-    end
-  end
-
-  describe "audit_missing_terminal_candidates/1" do
-    test "returns only candidate and inconclusive matches inside the audit window" do
-      control = create_request!(%{public_id: "req_audit_control", state: :running})
-
-      assert {:ok, _request} =
-               Requests.mark_terminal_with_step_events(
-                 control,
-                 %{state: :completed},
-                 [inference_turn_completed_step_attrs()]
-               )
-
-      candidate = create_request!(%{public_id: "req_audit_candidate", state: :running})
-
-      assert {:ok, _request} =
-               Requests.mark_terminal_with_step_events(
-                 candidate,
-                 %{state: :completed},
-                 [inference_turn_completed_step_attrs(%{result: %{"http_status" => 200}})]
-               )
-
-      inconclusive = create_request!(%{public_id: "req_audit_inconclusive", state: :running})
-      assert {:ok, _request} = Requests.mark_terminal(inconclusive, %{state: :completed})
-
-      active = create_request!(%{public_id: "req_audit_active", state: :running})
-
-      assert {:ok, matches} = Requests.audit_missing_terminal_candidates()
-
-      assert matches |> Enum.map(&{&1.public_id, &1.result}) |> Enum.sort() == [
-               {"req_audit_candidate", {:ok, :missing_finish_reason_candidate}},
-               {"req_audit_inconclusive", {:error, {:inconclusive, :terminal_step_not_found}}}
-             ]
-
-      refute Enum.any?(matches, &(&1.public_id in ["req_audit_control", active.public_id]))
-      assert Enum.all?(matches, &(&1.request_id in [candidate.id, inconclusive.id]))
-
-      assert {:ok, []} =
-               Requests.audit_missing_terminal_candidates(
-                 since: DateTime.add(DateTime.utc_now(), 60, :second)
-               )
-
-      assert {:ok, []} =
-               Requests.audit_missing_terminal_candidates(
-                 until: DateTime.add(DateTime.utc_now(), -60, :second)
-               )
-    end
-
-    test "rejects malformed audit options" do
-      assert {:error, {:inconclusive, :invalid_audit_options}} =
-               Requests.audit_missing_terminal_candidates(limit: 0)
-
-      assert {:error, {:inconclusive, :invalid_audit_options}} =
-               Requests.audit_missing_terminal_candidates(since: "2026-07-31")
-
-      assert {:error, {:inconclusive, :invalid_audit_options}} =
-               Requests.audit_missing_terminal_candidates(unknown: true)
-
-      assert {:error, {:inconclusive, :invalid_audit_options}} =
-               Requests.audit_missing_terminal_candidates(%{limit: 5})
-
-      assert {:error, {:inconclusive, :invalid_selector}} =
-               Requests.audit_missing_terminal_candidates(attempt: 0)
     end
   end
 

--- a/apps/orchard_controller/test/support/terminal_cardinality.ex
+++ b/apps/orchard_controller/test/support/terminal_cardinality.ex
@@ -1,0 +1,14 @@
+defmodule Orchard.TestSupport.TerminalCardinality do
+  @moduledoc false
+
+  alias Orchard.InferenceEvent
+
+  @spec classify([InferenceEvent.t()]) :: :zero | :exactly_one | :multiple
+  def classify(events) when is_list(events) do
+    case Enum.count(events, &InferenceEvent.terminal?/1) do
+      0 -> :zero
+      1 -> :exactly_one
+      _multiple -> :multiple
+    end
+  end
+end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,8 @@ controller-bearing installs require operator-provided external Postgres and the
 managed Postgres helper remains a guard only.
 
 Terminal inference-turn steps persist `finish_reason` for every observed `Completed` event.
-`Orchard.Requests.classify_missing_terminal_candidate/2` provides a read-only, per-attempt classifier for the current missing-`finish_reason` candidate fingerprint and reports missing, malformed, ambiguous, or state-inconsistent evidence as inconclusive.
+`Orchard.Requests.classify_missing_terminal_candidate/2` provides a read-only, per-attempt classifier for the current missing-`finish_reason` candidate fingerprint and reports missing, malformed, duplicated, or state-inconsistent evidence as inconclusive.
+`Orchard.Requests.audit_missing_terminal_candidates/1` sweeps a window of terminal requests with that classifier and returns candidate matches alongside inconclusive evidence, both of which require adjudication.
 This bounded CP1 audit does not enforce `SPEC.md` §7.5.5, does not replace client-plane terminal-cardinality validation, and remains available only while its `request_events` evidence is retained.
 
 ## Where to make changes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,10 @@ managed Postgres is one supported topology; in the current packaged flow,
 controller-bearing installs require operator-provided external Postgres and the
 managed Postgres helper remains a guard only.
 
+Terminal inference-turn steps persist `finish_reason` for every observed `Completed` event.
+`Orchard.Requests.classify_missing_terminal_candidate/2` provides a read-only, per-attempt classifier for the current missing-`finish_reason` candidate fingerprint and reports missing, malformed, ambiguous, or state-inconsistent evidence as inconclusive.
+This bounded CP1 audit does not enforce `SPEC.md` §7.5.5, does not replace client-plane terminal-cardinality validation, and remains available only while its `request_events` evidence is retained.
+
 ## Where to make changes
 
 - Public API or Console behavior: start in `apps/orchard_controller/` and check

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,8 +190,7 @@ controller-bearing installs require operator-provided external Postgres and the
 managed Postgres helper remains a guard only.
 
 Terminal inference-turn steps persist `finish_reason` for every observed `Completed` event.
-`Orchard.Requests.classify_missing_terminal_candidate/2` provides a read-only, per-attempt classifier for the current missing-`finish_reason` candidate fingerprint and reports missing, malformed, duplicated, or state-inconsistent evidence as inconclusive.
-`Orchard.Requests.audit_missing_terminal_candidates/1` sweeps a window of terminal requests with that classifier and returns candidate matches alongside inconclusive evidence, both of which require adjudication.
+`Orchard.Requests.classify_missing_terminal_candidate/2` provides a read-only, per-attempt classifier for the current missing-`finish_reason` candidate fingerprint and reports missing, malformed, ambiguous, or state-inconsistent evidence as inconclusive.
 This bounded CP1 audit does not enforce `SPEC.md` §7.5.5, does not replace client-plane terminal-cardinality validation, and remains available only while its `request_events` evidence is retained.
 
 ## Where to make changes


### PR DESCRIPTION
## Intent

Deliver a narrow, supporting, non-closing detector proof for Orchard issue #120: prove one accepted stream can end without a terminal event, classify it from durable persistence, and demonstrate zero false positives across at least 100 durable terminal-bearing controls. Preserve the independent raw terminal-cardinality probe for issue #115. Do not implement enforcement, a production audit sweep, retry or earlier-attempt semantics, monitoring surfaces, or close issue #120.

## What Changed

- Added `Orchard.Requests.classify_missing_terminal_candidate/2`, a read-only classifier that reads persisted `request_step.*` inference-turn rows for one turn/attempt and returns `:missing_finish_reason_candidate`, `:not_candidate`, or `{:inconclusive, reason}` for missing, malformed, ambiguous, or state-inconsistent evidence. It classifies only; it adds no enforcement, sweep, or monitoring surface.
- Centralized the terminal request-state → `request_step.*` event-type mapping in `Orchard.Requests.RequestStepEvent` (with a compile-time check that every `Request.terminal_states/0` entry is mapped) and switched `RequestOrchestrator` to it, replacing its private clause list.
- Added a CP1 proof test that persists 105 durable terminal-bearing controls across 7 categories and asserts zero false positives, plus orchestrator tests covering an accepted-only stream that ends with no terminal event and a `length` finish-reason control; kept the raw terminal-cardinality probe for issue #115 as a shared `Orchard.TestSupport.TerminalCardinality` helper. Documented the bounded, non-enforcing scope of the classifier in `docs/architecture.md`.

Test note: the branch's suites pass, but 4 pre-existing `mark_terminal` tests fail against a stale local `orchard_test` database that carries constraints absent from any migration on this branch; the full umbrella suite is green against a freshly migrated database.

## Risk Assessment

✅ Low: The change is additive and well-bounded — one new read-only classifier, a behavior-equivalent extraction of the terminal-state mapping now guarded by a compile-time exhaustiveness check, plus tests and docs — with no production behavior change, and the final commit already removed the audit sweep the intent forbids.

## Testing

Ran the targeted detector tests, the orchestrator suite, and the full umbrella suite (all green after isolating a stale shared test database), then produced product-level evidence by driving the real orchestrator against a live Postgres database: an accepted stream that ends with no terminal event persists a `request_step.completed` row without `finish_reason`, and the detector classifies it as `missing_finish_reason_candidate` from that durable row after the request process is gone, while 105 durable terminal-bearing controls all classify as `not_candidate` (zero false positives) and the raw issue #115 cardinality probe still reports `:zero`/`:exactly_one`/`:multiple` independently of persistence. This is a backend classifier with no user-facing UI surface, so the evidence is a CLI transcript plus a psql dump of persisted rows rather than a screenshot.

<details>
<summary>Evidence: CP1 detector end-to-end evidence transcript (real orchestrator + live Postgres)</summary>

<code>=== PART 1 — real orchestrator run: accepted stream that never emits a terminal event ===&#10;client-visible InferenceEvent stream : [:accepted]&#10;raw terminal cardinality (issue #115): :zero&#10;persisted request state : :completed&#10;persisted http status : 200&#10;request process after completion : exited (evidence is durable, not in-memory)&#10;&#10;=== PART 2 — durable persistence read back from Postgres ===&#10;4 | request_step.started | inference_turn:t1:a1 | {}&#10;6 | request_step.completed | inference_turn:t1:a1 | {&#34;http_status&#34;:200,&#34;input_tokens&#34;:0,&#34;output_tokens&#34;:0}&#10;finish_reason present? : false&#10;&#10;=== PART 3 — detector verdict from durable persistence (issue #120 candidate) ===&#10;classify_missing_terminal_candidate/1 =&gt; {:ok, :missing_finish_reason_candidate}&#10;&#10;=== PART 4 — 105 durable terminal-bearing controls (false-positive check) ===&#10;durable terminal step rows in Postgres for controls: 105&#10;cancellation n=15 verdicts=%{{:ok, :not_candidate} =&gt; 15}&#10;failure n=15 verdicts=%{{:ok, :not_candidate} =&gt; 15}&#10;interruption n=15 verdicts=%{{:ok, :not_candidate} =&gt; 15}&#10;length n=15 verdicts=%{{:ok, :not_candidate} =&gt; 15}&#10;stop n=15 verdicts=%{{:ok, :not_candidate} =&gt; 15}&#10;timeout n=15 verdicts=%{{:ok, :not_candidate} =&gt; 15}&#10;tool_calls n=15 verdicts=%{{:ok, :not_candidate} =&gt; 15}&#10;&#10;=== PART 5 — independent raw terminal-cardinality probe (issue #115), no persistence ===&#10;accepted only =&gt; :zero&#10;accepted + completed =&gt; :exactly_one&#10;completed + failed =&gt; :multiple&#10;&#10;=== SUMMARY ===&#10;missing-terminal request : {:ok, :missing_finish_reason_candidate}&#10;durable terminal-bearing ctrl : 105&#10;false positives : 0</code>

```text

=== PART 1 — real orchestrator run: accepted stream that never emits a terminal event ===
client-visible InferenceEvent stream : [:accepted]
raw terminal cardinality (issue #115): :zero
persisted request state              : :completed
persisted http status                : 200
request process after completion     : exited (evidence is durable, not in-memory)

=== PART 2 — durable persistence read back from Postgres ===
SELECT seq, event_type, payload->>'step_id', payload->'result' FROM request_events ...
  1 | state_transition |  | null
  2 | state_transition |  | null
  3 | state_transition |  | null
  4 | request_step.started | inference_turn:t1:a1 | {}
  5 | state_transition |  | null
  6 | request_step.completed | inference_turn:t1:a1 | {"http_status":200,"input_tokens":0,"output_tokens":0}
  7 | state_transition |  | null
terminal step result keys            : ["http_status", "input_tokens", "output_tokens"]
finish_reason present?               : false

=== PART 3 — detector verdict from durable persistence (issue #120 candidate) ===
request public_id  : cp1-evidence-missing-terminal-request
request db id      : 1f736633-4b65-454d-b046-c0dbdd526cda
classify_missing_terminal_candidate/1 => {:ok, :missing_finish_reason_candidate}

=== PART 4 — 105 durable terminal-bearing controls (false-positive check) ===
durable terminal step rows in Postgres for controls: 105
  cancellation  n=15 verdicts=%{{:ok, :not_candidate} => 15}
  failure       n=15 verdicts=%{{:ok, :not_candidate} => 15}
  interruption  n=15 verdicts=%{{:ok, :not_candidate} => 15}
  length        n=15 verdicts=%{{:ok, :not_candidate} => 15}
  stop          n=15 verdicts=%{{:ok, :not_candidate} => 15}
  timeout       n=15 verdicts=%{{:ok, :not_candidate} => 15}
  tool_calls    n=15 verdicts=%{{:ok, :not_candidate} => 15}
sample durable control rows:
  cp1-control-cancellation-1 | request_step.cancelled | {"error_code":"request_cancelled","error_message":"cancellation control 1","http_status":401}
  cp1-control-failure-1 | request_step.failed | {"error_code":"runtime_failed","error_message":"failure control 1","http_status":401}
  cp1-control-interruption-1 | request_step.interrupted | {"error_code":"request_client_disconnect","error_message":"interruption control 1","http_status":401}
  cp1-control-length-1 | request_step.completed | {"finish_reason":"length","http_status":200,"input_tokens":1,"output_tokens":2}
  cp1-control-stop-1 | request_step.completed | {"finish_reason":"stop","http_status":200,"input_tokens":1,"output_tokens":2}
  cp1-control-timeout-1 | request_step.timed_out | {"error_code":"deadline_exceeded","error_message":"timeout control 1","http_status":401}
  cp1-control-tool_calls-1 | request_step.completed | {"finish_reason":"tool_calls","http_status":200,"input_tokens":1,"output_tokens":2}

=== PART 5 — independent raw terminal-cardinality probe (issue #115), no persistence ===
accepted only              => :zero
accepted + completed       => :exactly_one
completed + failed         => :multiple

=== SUMMARY ===
missing-terminal request      : {:ok, :missing_finish_reason_candidate} (cp1-evidence-missing-terminal-request)
durable terminal-bearing ctrl : 105
false positives               : 0
```
</details>
<details>
<summary>Evidence: psql read-back of committed request_events rows (separate OS process, after BEAM exit)</summary>

<code>public_id | state | event_type | step_id | result&#10;---------------------------------------+-----------+------------------------+----------------------+-------------------------------------------------------------&#10;cp1-evidence-missing-terminal-request | completed | request_step.started | inference_turn:t1:a1 | {}&#10;cp1-evidence-missing-terminal-request | completed | request_step.completed | inference_turn:t1:a1 | {&#34;http_status&#34;: 200, &#34;input_tokens&#34;: 0, &#34;output_tokens&#34;: 0}&#10;(2 rows)&#10;&#10;durable_terminal_controls | with_finish_reason | non_completed_terminals&#10;---------------------------+--------------------+-------------------------&#10;105 | 45 | 60</code>

```text
               public_id               |   state   |       event_type       |       step_id        |                           result                            
---------------------------------------+-----------+------------------------+----------------------+-------------------------------------------------------------
 cp1-evidence-missing-terminal-request | completed | request_step.started   | inference_turn:t1:a1 | {}
 cp1-evidence-missing-terminal-request | completed | request_step.completed | inference_turn:t1:a1 | {"http_status": 200, "input_tokens": 0, "output_tokens": 0}
(2 rows)

 durable_terminal_controls | with_finish_reason | non_completed_terminals 
---------------------------+--------------------+-------------------------
                       105 |                 45 |                      60
(1 row)
```
</details>
<details>
<summary>Evidence: Evidence script used for the manual end-to-end run (not part of the repo)</summary>

```text
defmodule CP1Evidence.StubRuntimeEndpointClient do
  @moduledoc false

  alias Orchard.InferenceEvent
  alias Orchard.RuntimeEndpoint.Operation
  alias Orchard.TestSupport.DispatchCapacityFixtures

  def put_status(target, response) do
    key = {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
    :persistent_term.put({__MODULE__, key}, response)
  end

  def put_events(events), do: :persistent_term.put({__MODULE__, :execute_events}, events)

  def connect(target), do: {:ok, target}

  def status(target, _opts) do
    address = target.address
    key = {Keyword.fetch!(address, :host), Keyword.fetch!(address, :port)}

    case :persistent_term.get({__MODULE__, key}, nil) do
      nil ->
        {:error, :unavailable}

      response ->
        DispatchCapacityFixtures.record_authenticated_probe_evidence(response)
        {:ok, response}
    end
  end

  def ensure_model_loaded(channel, %Operation.EnsureModelLoadedRequest{} = request, _opts) do
    address = channel.address
    key = {Keyword.fetch!(address, :host), Keyword.fetch!(address, :port)}
    response = :persistent_term.get({__MODULE__, key}, %{})

    model = %{model_id: request.model_ref.model_id, version: request.model_ref.version}

    placement = %{
      model_ref: model,
      placement_state: :loaded,
      active_request_count: 0,
      max_concurrency: 4
    }

    :persistent_term.put(
      {__MODULE__, key},
      response
      |> Map.put(:loaded_models, [model])
      |> Map.put(:runtime_model_placements, [placement])
    )

    {:ok,
     %Operation.EnsureModelLoadedResult{
       already_loaded: false,
       placement_state: :loaded,
       worker_supports_prompt_token_ids: true
     }}
  end

  def unload_model(_channel, %Operation.UnloadModelRequest{}, _opts),
    do: {:ok, %Operation.Ack{ok: true}}

  # The issue #120 scenario: the runtime accepts the stream and the stream ends
  # (`runtime_endpoint_done`) without ever emitting a terminal InferenceEvent.
  def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts) do
    owner = Keyword.fetch!(opts, :owner)
    stream_ref = make_ref()
    events = :persistent_term.get({__MODULE__, :execute_events}, [])

    send(owner, {:runtime_endpoint_event, stream_ref, request.request_id, InferenceEvent.accepted(0)})

    Enum.each(events, fn event ->
      send(owner, {:runtime_endpoint_event, stream_ref, request.request_id, event})
    end)

    send(owner, {:runtime_endpoint_done, stream_ref, :ok})

    {:ok, stream_ref}
  end

  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts), do: :ok

  def disconnect(_channel), do: :ok

  def score_prefix_cache(_target, _request, _opts),
    do: {:ok, %{status_code: "unavailable", score_tier: "unknown"}}
end

defmodule CP1Evidence do
  @moduledoc false

  import Orchard.TestSupport.ModelRequestFixtures

  alias CP1Evidence.StubRuntimeEndpointClient
  alias Orchard.ArtifactBundle
  alias Orchard.CanonicalRequest
  alias Orchard.DispatchCapacity
  alias Orchard.DispatchCapacity.Policy
  alias Orchard.Inference.RequestOrchestrator
  alias Orchard.InferenceEvent
  alias Orchard.Node
  alias Orchard.Node.ModelManager
  alias Orchard.Nodes.AdmissionDecision
  alias Orchard.Nodes.Node, as: InventoryNode
  alias Orchard.Repo
  alias Orchard.Requests
  alias Orchard.Requests.RequestServer
  alias Orchard.Requests.RequestStepEvent
  alias Orchard.TestSupport.TerminalCardinality

  @model_id "cp1-evidence-missing-terminal"
  @target [host: "10.0.0.1", port: 50_061]

  @control_categories [
    {:stop, :completed, "request_step.completed", "stop"},
    {:length, :completed, "request_step.completed", "length"},
    {:tool_calls, :completed, "request_step.completed", "tool_calls"},
    {:failure, :failed, "request_step.failed", nil},
    {:cancellation, :cancelled, "request_step.cancelled", nil},
    {:timeout, :timed_out, "request_step.timed_out", nil},
    {:interruption, :interrupted, "request_step.interrupted", nil}
  ]
  @samples_per_category 15

  def run do
    section("PART 1 — real orchestrator run: accepted stream that never emits a terminal event")
    request = run_missing_terminal_request()

    section("PART 2 — durable persistence read back from Postgres")
    dump_durable_events(request)

    section("PART 3 — detector verdict from durable persistence (issue #120 candidate)")
    verdict = Requests.classify_missing_terminal_candidate(request)
    IO.puts("request public_id  : #{request.public_id}")
    IO.puts("request db id      : #{request.id}")
    IO.puts("classify_missing_terminal_candidate/1 => #{inspect(verdict)}")

    section("PART 4 — #{length(@control_categories) * @samples_per_category} durable terminal-bearing controls (false-positive check)")
    controls = persist_controls()
    report_controls(controls)

    section("PART 5 — independent raw terminal-cardinality probe (issue #115), no persistence")
    probe_raw_cardinality()

    section("SUMMARY")

    IO.puts(
      "missing-terminal request      : #{inspect(verdict)} (#{request.public_id})"
    )

    false_positives =
      Enum.count(controls, fn c -> c.classification != {:ok, :not_candidate} end)

    IO.puts("durable terminal-bearing ctrl : #{length(controls)}")
    IO.puts("false positives               : #{false_positives}")
  end

  defp run_missing_terminal_request do
    bundle = stage_bundle!()
    ModelManager.reset()

    node = insert_runtime_node!()
    configure_runtime_endpoint()
    StubRuntimeEndpointClient.put_status(@target, runtime_status(node.id))
    StubRuntimeEndpointClient.put_events([])

    {:ok, model} =
      Orchard.Models.create_model(%{
        model_id: @model_id,
        version: "v1",
        display_name: @model_id,
        artifact_uri: "file:///tmp/#{@model_id}",
        artifact_sha256: bundle.hash,
        artifact_source_uri: "file://#{bundle.source_path}",
        state: :active,
        format: "mlx",
        backend: "mlx",
        capabilities: ["chat"],
        artifact_size_bytes: 1024,
        resident_memory_bytes: 2048,
        kv_cache_bytes_per_token: 128,
        prefill_workspace_bytes_per_token: 64,
        max_context_tokens: 131_072
      })

    canonical = canonical_request(@model_id)

    {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)

    IO.puts("client-visible InferenceEvent stream : #{inspect(Enum.map(events, &InferenceEvent.kind/1))}")
    IO.puts("raw terminal cardinality (issue #115): #{inspect(TerminalCardinality.classify(events))}")

    request = Requests.get_request_by_public_id(canonical.public_id)
    IO.puts("persisted request state              : #{inspect(request.state)}")
    IO.puts("persisted http status                : #{inspect(request.http_status)}")

    wait_until(fn -> RequestServer.get_state(request.id) == {:error, :not_found} end)
    IO.puts("request process after completion     : exited (evidence is durable, not in-memory)")

    request
  end

  defp dump_durable_events(request) do
    {:ok, %{rows: rows}} =
      Repo.query(
        """
        SELECT seq, event_type, payload->>'step_id', payload->'result'
        FROM request_events
        WHERE request_id = $1
        ORDER BY seq
        """,
        [Ecto.UUID.dump!(request.id)]
      )

    IO.puts("SELECT seq, event_type, payload->>'step_id', payload->'result' FROM request_events ...")

    Enum.each(rows, fn [seq, event_type, step_id, result] ->
      IO.puts("  #{seq} | #{event_type} | #{step_id} | #{Jason.encode!(result)}")
    end)

    terminal =
      request
      |> Requests.list_request_step_events()
      |> Enum.filter(&(&1.event_type in RequestStepEvent.terminal_step_event_types()))
      |> List.last()

    IO.puts("terminal step result keys            : #{inspect(Map.keys(terminal.result))}")
    IO.puts("finish_reason present?               : #{Map.has_key?(terminal.result, "finish_reason")}")
  end

  defp persist_controls do
    for {category, request_state, event_type, finish_reason} <- @control_categories,
        sample <- 1..@samples_per_category do
      {:ok, request} =
        Requests.create_request(
          request_attrs(%{
            public_id: "c

... [184 bytes truncated] ...

e: event_type,
        step_id: RequestStepEvent.inference_turn_step_id(1, 1),
        step_type: "inference_turn",
        turn_index: 1,
        attempt: 1,
        parent_step_id: nil,
        boundary: "post_observation",
        result: result
      }

      {:ok, _request} =
        Requests.mark_terminal_with_step_events(request, %{state: request_state}, [step])

      %{
        category: category,
        public_id: request.public_id,
        result: result,
        classification: Requests.classify_missing_terminal_candidate(request)
      }
    end
  end

  defp report_controls(controls) do
    {:ok, %{rows: [[durable_count]]}} =
      Repo.query("""
      SELECT count(*) FROM request_events
      WHERE event_type LIKE 'request_step.%'
        AND payload->>'step_type' = 'inference_turn'
        AND event_type <> 'request_step.started'
        AND payload->>'step_id' = 'inference_turn:t1:a1'
        AND request_id IN (SELECT id FROM requests WHERE public_id LIKE 'cp1-control-%')
      """)

    IO.puts("durable terminal step rows in Postgres for controls: #{durable_count}")

    controls
    |> Enum.group_by(& &1.category)
    |> Enum.sort_by(fn {category, _} -> to_string(category) end)
    |> Enum.each(fn {category, group} ->
      verdicts = group |> Enum.map(& &1.classification) |> Enum.frequencies()
      IO.puts("  #{String.pad_trailing(to_string(category), 13)} n=#{length(group)} verdicts=#{inspect(verdicts)}")
    end)

    IO.puts("sample durable control rows:")

    {:ok, %{rows: rows}} =
      Repo.query("""
      SELECT r.public_id, e.event_type, e.payload->'result'
      FROM request_events e
      JOIN requests r ON r.id = e.request_id
      WHERE r.public_id LIKE 'cp1-control-%-1'
        AND e.event_type <> 'request_step.started'
      ORDER BY r.public_id
      """)

    Enum.each(rows, fn [public_id, event_type, result] ->
      IO.puts("  #{public_id} | #{event_type} | #{Jason.encode!(result)}")
    end)
  end

  defp probe_raw_cardinality do
    zero = [InferenceEvent.accepted(0)]
    one = [InferenceEvent.accepted(0), InferenceEvent.completed(:finish_reason_stop, nil)]

    multiple = [
      InferenceEvent.completed(:finish_reason_stop, nil),
      InferenceEvent.failed("runtime_failed", "failed", false)
    ]

    IO.puts("accepted only              => #{inspect(TerminalCardinality.classify(zero))}")
    IO.puts("accepted + completed       => #{inspect(TerminalCardinality.classify(one))}")
    IO.puts("completed + failed         => #{inspect(TerminalCardinality.classify(multiple))}")
  end

  defp control_result(category, nil, sample) do
    %{
      "error_code" => error_code(category),
      "error_message" => "#{category} control #{sample}",
      "http_status" => 400 + sample
    }
  end

  defp control_result(_category, finish_reason, sample) do
    %{
      "finish_reason" => finish_reason,
      "http_status" => 200,
      "input_tokens" => sample,
      "output_tokens" => sample * 2
    }
  end

  defp error_code(:failure), do: "runtime_failed"
  defp error_code(:cancellation), do: "request_cancelled"
  defp error_code(:timeout), do: "deadline_exceeded"
  defp error_code(:interruption), do: "request_client_disconnect"

  defp canonical_request(model_id) do
    CanonicalRequest.new(%{
      internal_id: Ecto.UUID.generate(),
      public_id: "cp1-evidence-missing-terminal-request",
      endpoint: :chat_completions,
      tenant_id: Ecto.UUID.generate(),
      api_key_id: Ecto.UUID.generate(),
      model_ref: %{model_id: model_id, version: "v1"},
      input_items: [%{"role" => "user", "content" => "hello"}],
      rendered_prompt: "hello",
      input_token_count: 1,
      stream?: false,
      sampling: %{temperature: 1.0, top_p: 1.0, stop: [], max_output_tokens: nil},
      response_format: %{type: :text},
      tooling: %{},
      metadata: %{},
      resolved_policy: %{}
    })
  end

  defp configure_runtime_endpoint do
    inference =
      Application.fetch_env!(:orchard_controller, :inference)
      |> Keyword.merge(
        runtime_client_targets: [@target],
        runtime_endpoint_targets: [],
        runtime_endpoint_client_impl: StubRuntimeEndpointClient,
        scheduler_impl: nil
      )

    Application.put_env(:orchard_controller, :inference, inference)
  end

  defp insert_runtime_node! do
    # The dispatch-capacity policy trigger is DEFERRABLE INITIALLY DEFERRED, so the
    # admission decision and its policy must land in one transaction.
    {:ok, node} = Repo.transaction(fn -> do_insert_runtime_node!() end)

    {:ok, _evidence} =
      DispatchCapacity.record_capacity_evidence(node.id, %{
        active_request_count: 0,
        observed_at: DateTime.utc_now(),
        runtime_concurrency_limit: 4,
        validity: :valid
      })

    node
  end

  defp do_insert_runtime_node! do
    unique = System.unique_integer([:positive])
    observed_at = DateTime.utc_now()

    node =
      %InventoryNode{}
      |> InventoryNode.changeset(%{
        id: Ecto.UUID.generate(),
        hostname: "cp1-evidence-#{unique}.local",
        display_name: "cp1-evidence-#{unique}",
        advertise_addr: Keyword.fetch!(@target, :host),
        rpc_port: Keyword.fetch!(@target, :port),
        state: :active,
        health: :healthy,
        capabilities: %{},
        last_heartbeat_at: observed_at
      })
      |> Repo.insert!()

    decision =
      %AdmissionDecision{}
      |> AdmissionDecision.changeset(%{
        node_id: node.id,
        decision: :admitted,
        actor_type: "system",
        actor_id: "cp1-evidence",
        observed_identity: %{},
        metadata: %{},
        decided_at: observed_at
      })
      |> Repo.insert!()

    %Policy{}
    |> Policy.approved_explicit_changeset(%{
      node_id: node.id,
      admission_decision_id: decision.id,
      controller_dispatch_ceiling: 4,
      approved_by_actor_type: "system",
      approved_by_actor_id: "cp1-evidence",
      approved_at: observed_at,
      approval_reason: "cp1 detector evidence fixture"
    })
    |> Repo.insert!()

    node
  end

  defp runtime_status(node_id) do
    %{
      node_metadata: %{
        node_id: node_id,
        display_name: "cp1-evidence-node",
        hostname: "cp1-evidence-node.local",
        agent_version: "0.1.0",
        listen_host: Keyword.fetch!(@target, :host),
        listen_port: Keyword.fetch!(@target, :port),
        worker_backend: "mlx"
      },
      runtime_health: %{ready: true, health_code: "ok", health_message: "ready"},
      loaded_models: [],
      active_request_count: 0,
      max_concurrency: 4,
      runtime_memory_budgets: [],
      runtime_prefix_cache_statuses: [],
      runtime_model_placements: [],
      supports_prompt_token_ids: false
    }
  end

  defp stage_bundle! do
    models_root = Node.models_root()
    source_path = Path.join([models_root, ".cp1-evidence-source", @model_id])

    File.rm_rf(source_path)
    File.mkdir_p!(source_path)
    File.write!(Path.join(source_path, "config.json"), ~s({"model_type":"test"}))
    File.write!(Path.join(source_path, "tokenizer.json"), ~s({"version":"1.0"}))
    weights_dir = Path.join(source_path, "weights")
    File.mkdir_p!(weights_dir)
    File.write!(Path.join(weights_dir, "model.safetensors"), "fake-weights-data")

    {:ok, hash} = ArtifactBundle.tree_sha256(source_path)

    cache_path = Path.join([models_root, @model_id, "v1"])
    File.rm_rf(cache_path)
    File.mkdir_p!(cache_path)
    :ok = ArtifactBundle.copy_directory(source_path, cache_path)

    %{hash: hash, source_path: source_path, cache_path: cache_path}
  end

  defp wait_until(fun, attempts \\ 100)
  defp wait_until(fun, 0), do: fun.()

  defp wait_until(fun, attempts) do
    if fun.() do
      true
    else
      Process.sleep(50)
      wait_until(fun, attempts - 1)
    end
  end

  defp section(title) do
    IO.puts("")
    IO.puts("=== #{title} ===")
  end
end

repo_config =
  :orchard_controller
  |> Application.get_env(Orchard.Repo)
  |> Keyword.merge(pool: DBConnection.ConnectionPool, pool_size: 5)

Application.put_env(:orchard_controller, Orchard.Repo, repo_config)
{:ok, _pid} = Orchard.Repo.start_link()

CP1Evidence.run()
```
</details>
- Outcome: ⚠️ 1 info across 1 run (20m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 infos</summary>

- ℹ️ `apps/orchard_controller/lib/orchard/requests.ex:97` - The `turn_index`/`attempt` selector accepts any positive turn/attempt, but `validate_terminal_step_state/2` (requests.ex:167) compares the *selected turn&#39;s* step event type against the *request-level* terminal state. Commit 4a3f512 dropped the previous `final?: false` skip, so selecting any non-final turn now yields `{:error, {:inconclusive, :terminal_state_mismatch}}` even when that turn&#39;s evidence is perfectly well-formed — e.g. a request whose turn 1 completed with `tool_calls` but whose overall state is `:failed` would return a mismatch for `turn_index: 1` instead of `:not_candidate`, and a genuine missing-finish_reason on a later turn would be masked. This is latent today because `inference_turn_step_context/1` hardcodes `turn_index: 1, attempt: 1` (request_orchestrator.ex:1312), so the selector can only ever resolve turn 1 attempt 1. Given the intent forbids &#34;retry or earlier-attempt semantics&#34;, the narrower option is to drop the selector opts entirely and pin the detector to turn 1 attempt 1, matching what the orchestrator actually persists. Author&#39;s call.
- ℹ️ `apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs:46` - Two assertions in the proof test carry no information about the system under test. `source_cardinality` (line 99) classifies `source_events`, a literal list the test itself constructed on line 69 and never feeds to the orchestrator or persistence, so `assert Enum.frequencies(...) == %{exactly_one: 105}` (line 46) can only ever restate the test&#39;s own input. Likewise `assert @control_count == 105` (line 32) compares a compile-time `7 * 15` against its own value. Both read as proof dimensions in a test whose purpose is to be evidence for issue #120. The genuinely load-bearing assertions — 105 distinct `durable_result` values read back from Postgres and `%{{:ok, :not_candidate} =&gt; 105}` — already carry the zero-false-positive claim; the #115 probe is independently exercised by lines 49-54 and by the orchestrator tests. Consider dropping the two tautologies so the artifact&#39;s evidence is all real.
- ℹ️ `apps/orchard_controller/lib/orchard/requests.ex:120` - `fetch_detector_request/1` collapses a reference that is not castable to a UUID into `{:error, {:inconclusive, :request_not_found}}`, identical to the reason returned for a well-formed UUID with no matching row. An operator who passes a `public_id` (e.g. &#34;req_abc123&#34;) — the identifier used everywhere else in this context, including `get_request_by_public_id/1` — gets &#34;request not found&#34; and would reasonably conclude the request was purged by retention rather than that they passed the wrong identifier kind. For a classifier whose whole contract is distinguishing kinds of inconclusive evidence, a separate reason such as `:invalid_request_reference` for the `:error` branch of `Ecto.UUID.cast/1` keeps the two failure modes apart. The existing test asserts `:request_not_found` for `Ecto.UUID.generate()`, which stays valid.
- ℹ️ `docs/architecture.md:192` - The new architecture.md paragraph opens with &#34;Terminal inference-turn steps persist `finish_reason` for every observed `Completed` event&#34; and then introduces the classifier, but never states the condition this branch exists to prove: when a dispatch stream ends with zero terminal events, `terminal_attrs_from_events/1` (request_orchestrator.ex:1295-1296) still defaults to `%{state: :completed, http_status: 200}` and persists a `request_step.completed` with no `finish_reason`. A reader gets the detector without the defect it detects, and the leading sentence is easy to misread as &#34;completed steps always carry finish_reason.&#34; One clause naming the accepted-only-stream gap (without claiming any fix or enforcement) would make the paragraph self-contained. Whether the open defect belongs in architecture.md at all versus only in issue #120 is the author&#39;s call.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `apps/orchard_controller/test/orchard/requests_test.exs:464` - The shared local test database `orchard_test` is stale (it carries constraints such as `requests_non_full_content_absent` / `requests_non_full_error_code_stable` that do not exist in any migration on this branch). Running `mix test` against it fails 4 pre-existing `mark_terminal/2` and `mark_terminal_with_step_events/3` tests in `apps/orchard_controller/test/orchard/requests_test.exs` that this change does not touch. I worked around it by creating and migrating an isolated database (`PGDATABASE_TEST=orchard_test_cp1_gate`), where the whole umbrella suite is green; the stale `orchard_test` database itself is untouched and will keep producing those failures until it is dropped and re-migrated.
- <code>`mix test apps/orchard_controller/test/orchard/inference/cp1_terminal_detector_proof_test.exs apps/orchard_controller/test/orchard/requests_test.exs` (57 passed)</code>
- <code>`mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs` (76 passed)</code>
- <code>`mix test` — full umbrella: orchard_shared 290, orchard_controller 3010 (5 skipped), orchard_node_agent 375, orchard_cli 709 (10 excluded); 0 failures</code>
- <code>Manual end-to-end run against a real (non-sandbox) Postgres database: `MIX_ENV=test mix run cp1_detector_evidence.exs` — drives `RequestOrchestrator.execute/3` through a runtime endpoint stub that emits only `accepted` then closes the stream, waits for the request process to exit, then classifies from durable rows</code>
- <code>`psql -d orchard_cp1_evidence` — read the committed `request_events` rows from a separate OS process after the BEAM exited, confirming the missing-`finish_reason` terminal step and 105 control terminal rows (45 with `finish_reason`, 60 non-completed terminals)</code>
- <code>Setup fix: created and migrated an isolated `orchard_test_cp1_gate` database after 4 unrelated `mark_terminal` tests failed against the stale shared `orchard_test` database</code>
- <code>Cleanup: removed the generated `tmp/` model-bundle directory and dropped both databases created for this run; worktree is clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788076224&installation_model_id=428414&pr_number=131&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F131&signature=8ef1203cc9d3c02be9211500907cf4f94d15e449e3a28235306b92db626008ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->