### PR TITLE
fix(worker): pin audited MLX-LM revision and force remote-code distrust

### DIFF
--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -69,8 +69,13 @@ jobs:
       - name: Bootstrap native environments from lockfiles
         run: |
           mise exec -- uv sync --locked --directory native/orchard_tokenizer
-          mise exec -- uv sync --locked --directory native/orchard_worker_mlx
+          mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx
           mise exec -- native/orchard_worker_mlx/bin/orchard-worker-mlx --help >/dev/null
+
+      - name: Validate MLX-LM security baseline
+        run: |
+          mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx \
+            pytest
 
       - name: Install OpenSpec dependencies
         run: make setup-openspec

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ setup-elixir:
 	ERL_AFLAGS="$(MIX_BOOTSTRAP_ERL_AFLAGS)" mise exec -- mix deps.get
 
 setup-native:
-	mise exec -- uv sync --directory native/orchard_tokenizer
-	mise exec -- uv sync --directory native/orchard_worker_mlx
+	mise exec -- uv sync --locked --directory native/orchard_tokenizer
+	mise exec -- uv sync --locked --directory native/orchard_worker_mlx
 
 setup-openspec:
 	mise exec -- npm ci --ignore-scripts

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -161,6 +161,10 @@ No current acquisition path authenticates publisher provenance.
 The `SPEC.md` target requires hash validation, while detached model signatures remain optional.
 A computed digest alone must not be represented as proof of a trusted publisher.
 
+The MLX worker resolves MLX-LM from an audited full Git revision through the committed uv lock.
+It rejects `model_file` configurations before upstream loading and explicitly disables remote code at the model and tokenizer boundaries.
+The pinned source and these controls do not authenticate model publishers or make MLX execution a sandbox.
+
 Secret-bearing environment files, private keys, Node identity custody, and Peer Grant material are intended to remain owner-only.
 Certificates, metadata, logs, and other non-secret operational files may have broader read permissions.
 Prompt and response bodies may be retained only according to the configured Tenant Payload Capture Mode, and secrets must never be logged.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -851,7 +851,7 @@ export ORCHARD_MLX_SMOKE_MODEL_PATH=/path/to/your/orchard-bundle
 
 # Python only
 cd native/orchard_worker_mlx
-mise exec -- uv sync --extra mlx
+mise exec -- uv sync --locked --extra mlx
 mise exec -- uv run pytest tests/test_cli.py -k mlx_backend_real -v
 
 # Elixir only, from the repo root

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -686,7 +686,7 @@ BEAM split-role default promotion was accepted on 2026-07-05 after the smoke evi
 | Requests to an admitted Node return busy instead of dispatching | The Controller could not assemble that Node's capacity facts from current authenticated evidence — probe failure, stale observation, or missing policy — so capacity authorization fails closed rather than trusting telemetry | Check the Node's trust, lifecycle, health, and observation freshness, and read the persisted scheduler explanation for `dispatch_capacity_facts_unavailable` with `orchardctl requests inspect <request-id>`. |
 | A Node stops taking any dispatch after a cancelled or timed-out request | The Controller could not resolve whether that request's runtime execution ended, so the allocation authority quarantined the Node and now evaluates it as unreachable | Expected fail-closed behavior in source dev: confirm the Node has no orphaned execution, then restart the Controller, since quarantine has no expiry and no operator-release seam yet. |
 | Every Node stops taking dispatch at once with no capacity change | The Controller-local quarantine store stopped; it is a temporary child that is not restarted, and the authority blocks all dispatch rather than resuming from a clean quarantine set | Restart the Controller and check its logs for `dispatch-capacity quarantine store stopped`, or for `dispatch-capacity authority started without a reachable quarantine store` when the store was already gone at boot. |
-| Remote node fails on MLX | mise toolchain not installed or no `uv sync` | Use `ORCHARD_WORKER_BACKEND=stub` or run `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx`. |
+| Remote node fails on MLX | mise toolchain not installed or no `uv sync` | Use `ORCHARD_WORKER_BACKEND=stub` or run `mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx`. |
 | Port conflict on remote gRPC node-agent | Another BEAM or node-agent owns the gRPC port | Change `ORCHARD_NODE_AGENT_LISTEN_PORT`. |
 
 > **Security note:** Binding gRPC to `0.0.0.0` exposes the gRPC server on all interfaces.
@@ -1086,12 +1086,12 @@ diagnostics.
 |---------|-------------|---------------|
 | `Bundle is missing manifest.json` | Bundle not prepared correctly | Re-run bundle prep steps above |
 | `bundle_path_escape` | Symlinks in bundle dir | Use `cp -L` instead of `ln -s` |
-| `model_load_failed` | MLX/mlx-lm version mismatch | Check `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx` ran, inspect worker logs |
+| `model_load_failed` | MLX/mlx-lm version mismatch | Check `mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx` ran, inspect worker logs |
 | `unsupported_runtime_adapter` | Wrong `adapter` in manifest | Must be `"mlx_lm"` |
 | `tokenizer_missing` | Wrong `tokenizer.path` | Check `tokenizer.json` exists in bundle |
 | Python smoke timeout | Model too large for hardware | Use smaller model (1B recommended) |
 | Elixir smoke failure | Node-agent/worker lifecycle issue | Check worker stdout/stderr |
-| `mlx_backend_unavailable` | MLX extras not installed | Run `mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx` |
+| `mlx_backend_unavailable` | MLX extras not installed | Run `mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx` |
 
 ## Releases (Production)
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -50,8 +50,8 @@ mise install
 ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.hex --if-missing --force
 ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.rebar --if-missing --force
 ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix deps.get
-mise exec -- uv sync --directory native/orchard_tokenizer
-mise exec -- uv sync --directory native/orchard_worker_mlx
+mise exec -- uv sync --locked --directory native/orchard_tokenizer
+mise exec -- uv sync --locked --directory native/orchard_worker_mlx
 mise exec -- npm ci --ignore-scripts
 mise exec -- bin/dev
 ```

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -141,7 +141,7 @@ mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx \
 ```
 
 The resolved-environment guard verifies the exact MLX-LM source revision, loader signatures, tokenizer registration, and explicit model and tokenizer distrust on the sharded loading surface without downloading a model.
-It asserts explicit distrust, not an upstream default: MLX-LM's `sharded_load` still falls back to a trusting tokenizer config when `tokenizer_config` is omitted or empty, so any future sharded caller must pass `{"trust_remote_code": False}` itself.
+See the "MLX-LM security baseline" section of `native/orchard_worker_mlx/README.md` for the pinned revision, the remote-code controls, and the residual the guard asserts against.
 
 Package builds should run through the same toolchain:
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -129,18 +129,18 @@ required gate; add `ty` to the relevant `pyproject.toml` first, then run it as
 MLX extras remain opt-in because they pull the real inference stack:
 
 ```bash
-mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx
+mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx
 ```
 
-The default `pytest` run above skips `tests/test_mlx_import_smoke.py` because the
-`mlx` extra is absent. When refreshing the `transformers`/`mlx-lm` pins (for
-example lifting the issue #57 `transformers<5.13` cap), exercise the import
-regression guard with the extra installed:
+The default `pytest` run above skips `tests/test_mlx_import_smoke.py` because the `mlx` extra is absent.
+When refreshing the `transformers`/`mlx-lm` pins, exercise the import and remote-code security guards with the exact locked extra installed:
 
 ```bash
-mise exec -- uv run --directory native/orchard_worker_mlx --extra mlx \
+mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx \
   pytest tests/test_mlx_import_smoke.py
 ```
+
+The resolved-environment guard verifies the exact MLX-LM source revision, loader signatures, tokenizer registration, and explicit model and tokenizer distrust on the sharded loading surface without downloading a model.
 
 Package builds should run through the same toolchain:
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -141,6 +141,7 @@ mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx \
 ```
 
 The resolved-environment guard verifies the exact MLX-LM source revision, loader signatures, tokenizer registration, and explicit model and tokenizer distrust on the sharded loading surface without downloading a model.
+It asserts explicit distrust, not an upstream default: MLX-LM's `sharded_load` still falls back to a trusting tokenizer config when `tokenizer_config` is omitted or empty, so any future sharded caller must pass `{"trust_remote_code": False}` itself.
 
 Package builds should run through the same toolchain:
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -52,8 +52,8 @@ tool resolution matters.
 ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.hex --if-missing --force
 ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix local.rebar --if-missing --force
 ERL_AFLAGS="-ssl protocol_version \"['tlsv1.2']\"" mise exec -- mix deps.get
-mise exec -- uv sync --directory native/orchard_tokenizer
-mise exec -- uv sync --directory native/orchard_worker_mlx
+mise exec -- uv sync --locked --directory native/orchard_tokenizer
+mise exec -- uv sync --locked --directory native/orchard_worker_mlx
 mise exec -- npm ci --ignore-scripts
 mise exec -- bin/dev
 ```

--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -53,6 +53,9 @@ The production loader also passes `trust_remote_code=False` for model loading an
 Resolved-environment tests verify the same explicit settings on MLX-LM's sharded loading surface.
 These controls reduce dynamic-code exposure but do not make model execution a security sandbox.
 
+Residual: MLX-LM's `sharded_load` falls back to `{"trust_remote_code": True}` for the tokenizer whenever `tokenizer_config` is omitted or empty, so its model-side `trust_remote_code=False` does not cover the tokenizer by itself.
+Orchard does not reach that path today; issue #116 sharded loading must pass an explicit `{"trust_remote_code": False}` tokenizer config rather than relying on the upstream default.
+
 ## Proto contract
 
 The worker runtime proto lives at:

--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -27,7 +27,7 @@ runtime defaults `ORCHARD_WORKER_BACKEND` to `mlx`. Install MLX extras before
 using the real backend:
 
 ```bash
-mise exec -- uv sync --directory native/orchard_worker_mlx --extra mlx
+mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx
 ```
 
 The CLI also supports `--generation-mode stream|batch`. The stub backend uses
@@ -40,6 +40,18 @@ That limit is configured with `ORCHARD_WORKER_MAX_CONCURRENT_REQUESTS_PER_MODEL`
 The worker `GetStatus` path reports overlapping `Generate` calls and effective worker capacity through `WorkerStatusResponse.active_request_count` and `WorkerStatusResponse.max_concurrency`.
 The node-agent publishes aggregate capacity through cluster `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`, plus loaded-placement capacity through `StatusResponse.runtime_model_placements`.
 Aggregate capacity is the conservative limit the node agent enforces across loaded workers, while each loaded placement keeps its own reported capacity.
+
+## MLX-LM security baseline
+
+The `mlx` extra pins MLX-LM commit `ab1806e8f5d6aa035973af194a1b9198ab4754dc`.
+The reviewed source range contains 15 commits and 35 changed files after the `v0.31.3` tag.
+The dependency still reports version `0.31.3`, so the full Git revision and committed uv lock are the runtime provenance authority.
+Transformers remains constrained to `>=5.7,<5.13` until its broader compatibility matrix is accepted separately.
+
+Orchard rejects model configurations containing `model_file` before upstream loading.
+The production loader also passes `trust_remote_code=False` for model loading and `tokenizer_config_extra={"trust_remote_code": False}` for tokenizer loading.
+Resolved-environment tests verify the same explicit settings on MLX-LM's sharded loading surface.
+These controls reduce dynamic-code exposure but do not make model execution a security sandbox.
 
 ## Proto contract
 

--- a/native/orchard_worker_mlx/pyproject.toml
+++ b/native/orchard_worker_mlx/pyproject.toml
@@ -15,13 +15,16 @@ dependencies = [
 [project.optional-dependencies]
 mlx = [
   "mlx>=0.31.2",
-  "mlx-lm>=0.31.3",
-  # Issue #57: transformers 5.13 tightens _LazyAutoMapping.register, so mlx-lm
-  # 0.31.3's string NewlineTokenizer config key fails at import. Lift once mlx-lm fixes it.
-  "transformers>=5.0.0,<5.13",
+  "mlx-lm==0.31.3",
+  # Issue #98 pins the audited 15-commit / 35-file delta from v0.31.3.
+  # Keep the Transformers 5.13 compatibility matrix as a separate lock change.
+  "transformers>=5.7,<5.13",
   "protobuf>=6.33.5",
   "numpy>=1.26.0",
 ]
+
+[tool.uv.sources]
+mlx-lm = { git = "https://github.com/ml-explore/mlx-lm.git", rev = "ab1806e8f5d6aa035973af194a1b9198ab4754dc" }
 
 [project.scripts]
 orchard-worker-mlx = "orchard_worker_mlx.cli:main"

--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
@@ -599,6 +599,7 @@ def _default_mlx_deps() -> MLXDeps:
     def _load_model(model_path: str | Path, **kwargs: Any) -> tuple[Any, Any]:
         """Wrap mlx_lm.utils.load_model; returns (model, config)."""
         _reject_model_file_config(model_path)
+        kwargs["trust_remote_code"] = False
         return mlx_lm_load(Path(model_path), **kwargs)
 
     def _load_tokenizer(tokenizer_path: str | Path) -> Any:

--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
@@ -599,6 +599,7 @@ def _default_mlx_deps() -> MLXDeps:
     def _load_model(model_path: str | Path, **kwargs: Any) -> tuple[Any, Any]:
         """Wrap mlx_lm.utils.load_model; returns (model, config)."""
         _reject_model_file_config(model_path)
+        # Forced, not defaulted: no caller may re-enable model-side remote code.
         kwargs["trust_remote_code"] = False
         return mlx_lm_load(Path(model_path), **kwargs)
 

--- a/native/orchard_worker_mlx/tests/test_dependency_security_contract.py
+++ b/native/orchard_worker_mlx/tests/test_dependency_security_contract.py
@@ -1,0 +1,84 @@
+"""Dependency security contract tests for the MLX worker."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _PACKAGE_ROOT / "pyproject.toml"
+_LOCKFILE = _PACKAGE_ROOT / "uv.lock"
+_MLX_LM_COMMIT = "ab1806e8f5d6aa035973af194a1b9198ab4754dc"
+_MLX_LM_GIT = "https://github.com/ml-explore/mlx-lm.git"
+
+
+def _read_toml(path: Path) -> dict:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _packages_named(lock: dict, name: str) -> list[dict]:
+    return [package for package in lock["package"] if package["name"] == name]
+
+
+def test_mlx_extra_uses_the_approved_source_and_transformers_range() -> None:
+    project = _read_toml(_PYPROJECT)
+
+    assert project["project"]["optional-dependencies"]["mlx"] == [
+        "mlx>=0.31.2",
+        "mlx-lm==0.31.3",
+        "transformers>=5.7,<5.13",
+        "protobuf>=6.33.5",
+        "numpy>=1.26.0",
+    ]
+    assert project["tool"]["uv"]["sources"]["mlx-lm"] == {
+        "git": _MLX_LM_GIT,
+        "rev": _MLX_LM_COMMIT,
+    }
+
+
+def test_lock_resolves_the_approved_mlx_lm_commit() -> None:
+    lock = _read_toml(_LOCKFILE)
+    packages = _packages_named(lock, "mlx-lm")
+
+    assert len(packages) == 1
+    package = packages[0]
+    assert package["version"] == "0.31.3"
+    source = package["source"]
+    assert "registry" not in source
+    assert source["git"].startswith(f"{_MLX_LM_GIT}?rev={_MLX_LM_COMMIT}")
+    assert source["git"].endswith(f"#{_MLX_LM_COMMIT}")
+
+    project_package = _packages_named(lock, "orchard-worker-mlx")
+    assert len(project_package) == 1
+    requirements = project_package[0]["metadata"]["requires-dist"]
+    assert {
+        "name": "mlx-lm",
+        "marker": "extra == 'mlx'",
+        "git": f"{_MLX_LM_GIT}?rev={_MLX_LM_COMMIT}",
+    } in requirements
+    assert {
+        "name": "transformers",
+        "marker": "extra == 'mlx'",
+        "specifier": ">=5.7,<5.13",
+    } in requirements
+
+
+def test_lock_keeps_transformers_in_the_approved_hashed_registry_range() -> None:
+    lock = _read_toml(_LOCKFILE)
+    packages = _packages_named(lock, "transformers")
+
+    assert len(packages) == 1
+    package = packages[0]
+    major, minor, *_ = (int(part) for part in package["version"].split("."))
+    assert major == 5
+    assert 7 <= minor < 13
+    assert package["source"]["registry"] == "https://pypi.org/simple"
+    assert package["sdist"]["url"].startswith("https://files.pythonhosted.org/")
+    assert package["sdist"]["hash"].startswith("sha256:")
+    assert package["sdist"]["size"] > 0
+    assert package["wheels"]
+    assert all(
+        wheel["url"].startswith("https://files.pythonhosted.org/") for wheel in package["wheels"]
+    )
+    assert all(wheel["hash"].startswith("sha256:") for wheel in package["wheels"])
+    assert all(wheel["size"] > 0 for wheel in package["wheels"])

--- a/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
+++ b/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
@@ -1,13 +1,14 @@
-"""Import smoke tests for optional MLX runtime dependencies.
+"""Import and remote-code guards for the optional MLX runtime dependencies.
 
-The issue #57 regression guard is only exercised when the optional ``mlx`` extra
-is installed. Run it with::
+These guards are only exercised when the optional ``mlx`` extra is installed.
+Run them with::
 
-    mise exec -- uv run --directory native/orchard_worker_mlx --extra mlx \\
+    mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx \\
         pytest tests/test_mlx_import_smoke.py
 
 Dependency-refresh validation MUST run this way; the default dev-only environment
-lacks the extra and the test skips.
+lacks the extra and the tests skip. See ``../README.md`` for the MLX-LM security
+baseline these guards protect.
 """
 
 from __future__ import annotations

--- a/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
+++ b/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
@@ -78,6 +78,12 @@ def test_mlx_lm_install_and_loader_signatures_match_the_approved_commit() -> Non
     sharded_signature = inspect.signature(mlx_lm_utils.sharded_load)
     assert sharded_signature.parameters["tokenizer_config"].default is None
 
+    mlx_lm_tokenizer_utils = importlib.import_module("mlx_lm.tokenizer_utils")
+    tokenizer_signature = inspect.signature(mlx_lm_tokenizer_utils.load)
+    tokenizer_extra = tokenizer_signature.parameters["tokenizer_config_extra"]
+    assert tokenizer_extra.default is None
+    assert tokenizer_extra.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
 
 def test_orchard_rejects_model_file_without_executing_it(tmp_path: Path) -> None:
     """Issue #98: production dependency wiring rejects custom model code."""

--- a/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
+++ b/native/orchard_worker_mlx/tests/test_mlx_import_smoke.py
@@ -13,13 +13,19 @@ lacks the extra and the test skips.
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
 import importlib.util
+import inspect
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from orchard_worker_mlx.model_loader import ModelLoaderError, _default_mlx_deps
+
 _MLX_STACK = ("mlx", "mlx_lm", "transformers", "tokenizers")
+_MLX_LM_COMMIT = "ab1806e8f5d6aa035973af194a1b9198ab4754dc"
 _missing = [name for name in _MLX_STACK if importlib.util.find_spec(name) is None]
 
 pytestmark = pytest.mark.skipif(
@@ -49,3 +55,119 @@ def test_mlx_lm_imports_with_autotokenizer_path(tmp_path: Path) -> None:
     loaded = transformers.AutoTokenizer.from_pretrained(tokenizer_dir, local_files_only=True)
 
     assert loaded.unk_token == "[UNK]"
+
+
+def test_mlx_lm_install_and_loader_signatures_match_the_approved_commit() -> None:
+    """Issue #98: the resolved runtime exposes the audited default-off gates."""
+    distribution = importlib.metadata.distribution("mlx-lm")
+    direct_url = json.loads(distribution.read_text("direct_url.json") or "{}")
+
+    assert direct_url["url"] == "https://github.com/ml-explore/mlx-lm.git"
+    assert direct_url["vcs_info"] == {
+        "vcs": "git",
+        "commit_id": _MLX_LM_COMMIT,
+        "requested_revision": _MLX_LM_COMMIT,
+    }
+
+    mlx_lm_utils = importlib.import_module("mlx_lm.utils")
+    for function_name in ("load_model", "load", "sharded_load"):
+        signature = inspect.signature(getattr(mlx_lm_utils, function_name))
+        parameter = signature.parameters["trust_remote_code"]
+        assert parameter.default is False
+
+    sharded_signature = inspect.signature(mlx_lm_utils.sharded_load)
+    assert sharded_signature.parameters["tokenizer_config"].default is None
+
+
+def test_orchard_rejects_model_file_without_executing_it(tmp_path: Path) -> None:
+    """Issue #98: production dependency wiring rejects custom model code."""
+    side_effect = tmp_path / "custom-model-code-executed"
+    model_file = tmp_path / "modeling_custom.py"
+    model_file.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(side_effect)!r}).write_text('executed', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_file": model_file.name,
+                "model_type": "custom_mlx_arch",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    mlx_lm_utils = importlib.import_module("mlx_lm.utils")
+    with pytest.raises(ValueError, match="trust_remote_code=True"):
+        mlx_lm_utils.load_model(tmp_path, lazy=True, strict=False)
+
+    assert not side_effect.exists()
+
+    deps = _default_mlx_deps()
+    with pytest.raises(ModelLoaderError, match="model_file"):
+        deps.load_model(tmp_path, lazy=True, strict=False)
+
+    assert not side_effect.exists()
+
+
+def test_sharded_load_propagates_explicit_remote_code_distrust(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Issue #98: safe sharded loading keeps both trust controls disabled."""
+    mlx_lm_utils = importlib.import_module("mlx_lm.utils")
+    tensor_group = object()
+    model_calls: list[dict] = []
+    tokenizer_calls: list[dict] = []
+
+    class FakeModel:
+        def parameters(self) -> dict:
+            return {}
+
+        def shard(self, group: object) -> None:
+            assert group is tensor_group
+
+    def fake_load_model(model_path: Path, **kwargs):
+        assert model_path == tmp_path
+        model_calls.append(kwargs)
+        return FakeModel(), {"eos_token_id": 2}
+
+    def fake_load_tokenizer(model_path: Path, tokenizer_config: dict, **kwargs):
+        assert model_path == tmp_path
+        tokenizer_calls.append(
+            {
+                "tokenizer_config": tokenizer_config,
+                **kwargs,
+            }
+        )
+        return object()
+
+    fake_mx = SimpleNamespace(
+        array=lambda value: value,
+        cpu=object(),
+        distributed=SimpleNamespace(all_sum=lambda value, stream: value),
+        eval=lambda value: None,
+    )
+    monkeypatch.setattr(mlx_lm_utils, "_download", lambda *args, **kwargs: tmp_path)
+    monkeypatch.setattr(mlx_lm_utils, "load_model", fake_load_model)
+    monkeypatch.setattr(mlx_lm_utils, "load_tokenizer", fake_load_tokenizer)
+    monkeypatch.setattr(mlx_lm_utils, "mx", fake_mx)
+
+    mlx_lm_utils.sharded_load(
+        "local-model",
+        tensor_group=tensor_group,
+        tokenizer_config={"trust_remote_code": False},
+        trust_remote_code=False,
+    )
+
+    assert model_calls == [
+        {"lazy": True, "strict": False, "trust_remote_code": False},
+        {"lazy": True, "strict": False, "trust_remote_code": False},
+    ]
+    assert tokenizer_calls == [
+        {
+            "tokenizer_config": {"trust_remote_code": False},
+            "eos_token_ids": 2,
+        }
+    ]

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -2156,6 +2156,46 @@ class TestDefaultMlxDepsSamplerWiring:
             tokenizer_config_extra={"trust_remote_code": False},
         )
 
+    def test_default_mlx_deps_model_disables_remote_code(self, monkeypatch, tmp_path: Path):
+        """Default model loading explicitly disables custom model code."""
+        import orchard_worker_mlx.model_loader as ml
+
+        fake_mx = types.SimpleNamespace(
+            eval=lambda t: None,
+            clear_cache=lambda: None,
+        )
+        fake_stream_generate = MagicMock(name="stream_generate")
+        fake_load_model = MagicMock(name="load_model")
+        fake_load_tokenizer = MagicMock(name="load_tokenizer", return_value=MagicMock())
+
+        def _fake_import_required():
+            return (fake_mx, fake_stream_generate, fake_load_model, fake_load_tokenizer)
+
+        monkeypatch.setattr(ml, "_import_required_mlx_runtime_modules", _fake_import_required)
+        sys.modules["mlx_lm"] = types.SimpleNamespace()
+        sys.modules.pop("mlx_lm.sample_utils", None)
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+
+        try:
+            deps = _default_mlx_deps()
+            deps.load_model(
+                model_dir,
+                lazy=True,
+                strict=False,
+                trust_remote_code=True,
+            )
+        finally:
+            sys.modules.pop("mlx_lm", None)
+
+        fake_load_model.assert_called_once_with(
+            model_dir,
+            lazy=True,
+            strict=False,
+            trust_remote_code=False,
+        )
+
     def test_default_mlx_deps_rejects_model_file_config_before_upstream_load_model(
         self,
         monkeypatch,

--- a/native/orchard_worker_mlx/uv.lock
+++ b/native/orchard_worker_mlx/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 [[package]]
 name = "mlx-lm"
 version = "0.31.3"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/ml-explore/mlx-lm.git?rev=ab1806e8f5d6aa035973af194a1b9198ab4754dc#ab1806e8f5d6aa035973af194a1b9198ab4754dc" }
 dependencies = [
     { name = "jinja2" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
@@ -536,10 +536,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sentencepiece" },
     { name = "transformers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
 ]
 
 [[package]]
@@ -660,10 +656,10 @@ dev = [
 requires-dist = [
     { name = "grpcio", specifier = ">=1.78.0" },
     { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.31.2" },
-    { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.31.3" },
+    { name = "mlx-lm", marker = "extra == 'mlx'", git = "https://github.com/ml-explore/mlx-lm.git?rev=ab1806e8f5d6aa035973af194a1b9198ab4754dc" },
     { name = "numpy", marker = "extra == 'mlx'", specifier = ">=1.26.0" },
     { name = "protobuf", marker = "extra == 'mlx'", specifier = ">=6.33.5" },
-    { name = "transformers", marker = "extra == 'mlx'", specifier = ">=5.0.0,<5.13" },
+    { name = "transformers", marker = "extra == 'mlx'", specifier = ">=5.7,<5.13" },
 ]
 provides-extras = ["mlx"]
 
@@ -1134,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.5.0"
+version = "5.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1147,9 +1143,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/9d/fb46e729b461985f41a5740167688b924a4019141e5c164bea77548d3d9e/transformers-5.5.0.tar.gz", hash = "sha256:c8db656cf51c600cd8c75f06b20ef85c72e8b8ff9abc880c5d3e8bc70e0ddcbd", size = 8237745, upload-time = "2026-04-02T16:13:08.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/28/35f7411ff80a3640c1f4fc907dcbb6a65061ebb82f66950e38bfc9f7f740/transformers-5.5.0-py3-none-any.whl", hash = "sha256:821a9ff0961abbb29eb1eb686d78df1c85929fdf213a3fe49dc6bd94f9efa944", size = 10245591, upload-time = "2026-04-02T16:13:03.462Z" },
+    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Intent

Deliver the narrow non-closing Orchard issue #98 exact-pin-first MLX-LM security baseline only: immutable full Git SHA source, lock proof, audited upstream commit/file delta, forced trust_remote_code=false at reachable production model and tokenizer boundaries, packaging and CI closure, and documented residuals. Do not implement #116 sharded loading, Transformers 5.13+ migration, real-model Metal evidence, broad air-gap mirroring, and keep issue #98 open. Address only attributable P0/P1, security, or validation blockers; accept informational or non-blocking findings when fixing them would create diminishing returns. Drive through push, non-closing PR, and CI if clean.

## What Changed

- Pins the MLX extra to the audited MLX-LM full Git SHA `ab1806e8` (15 commits / 35 files past PyPI `v0.31.3`, containing the remote-code fix) via `[tool.uv.sources]` plus a regenerated `uv.lock`, and narrows `transformers` to `>=5.7,<5.13`; the deferred Transformers 5.13+ migration and #116 sharded loading are recorded as residuals in `native/orchard_worker_mlx/README.md`, `docs/tooling.md`, and `SECURITY.md`.
- Forces `trust_remote_code=False` in `_default_mlx_deps()`'s `load_model` wrapper so no caller can re-enable model-side remote code, complementing the existing tokenizer-side `tokenizer_config_extra` distrust.
- Closes the provenance loop end to end: `make setup-native` and CI bootstrap now run `uv sync --locked` (matching `scripts/build-pkg.sh`), CI installs the `mlx` extra and runs a new `Validate MLX-LM security baseline` pytest step, and new tests assert the locked commit/registry-hash contract (`test_dependency_security_contract.py`) plus real upstream signature guards for `trust_remote_code` and `tokenizer_config_extra` (`test_mlx_import_smoke.py`). Setup docs in `docs/tooling.md` and `docs/local-dev.md` were updated to the locked form so the documented authority matches the Makefile and CI.

## Risk Assessment

⚠️ Medium: Every source-verifiable claim in the change now checks out and all accepted review findings are applied consistently, but the substance is still a supply-chain shift — the production inference dependency moves from a hash-pinned PyPI wheel to a git-built source carrying only a commit SHA, and locked Transformers jumps 5.5.0 to 5.12.1 beneath the tokenizer path — a runtime surface that static review cannot fully prove.

## Testing

Ran the exact CI and Makefile native commands plus the full `--extra mlx` pytest suite (636 passed, 2 skipped — the pre-existing real-model MLX smoke tests gated on `ORCHARD_MLX_SMOKE_MODEL_PATH`, explicitly out of scope), then went beyond unit tests to demonstrate the security behavior as an operator would hit it: a hostile model bundle whose `config.json` declares `model_file` executes attacker Python under the PyPI `mlx-lm==0.31.3` wheel the base commit resolved, and is refused without execution under the pinned git SHA — both reporting the identical version string, which is exactly the point of the SHA-plus-lock provenance. I verified the documented 15-commit/35-file audit delta against a fresh upstream clone (it contains the CVE-2026-5843 fix), confirmed `--locked` refuses a drifted rev, confirmed the PKG payload venv resolves the same SHA, and confirmed the disclosed `sharded_load` tokenizer residual is real in the pinned source and honestly documented against #116 rather than silently fixed. No visual artifacts apply — this change has no UI surface; the reviewer-visible evidence is CLI transcripts. Worktree left clean and ~830 MB of transient venvs removed.

<details>
<summary>Evidence: Evidence summary (start here)</summary>

```text
# Issue #98 MLX-LM security baseline — validation evidence

Branch `najibninaba/issue-98-mlx-lm-security-baseline` (`dc73b55` → `fbc05f6`), run on
Apple Silicon (arm64) macOS with the pinned `mise` toolchain.

## What the change is worth, in one transcript

`cve-2026-5843-before-after.txt` — both builds report `mlx-lm 0.31.3`, but only one is safe:

| | source | `load_model(bundle)` with **no** trust flag |
|---|---|---|
| base `dc73b55` (`mlx-lm>=0.31.3`) | PyPI registry wheel | **attacker payload executed: True** |
| this change (`rev=ab1806e8…`) | git SHA | refused; **payload executed: False** |

The audited range (`upstream-audit-delta.txt`) contains upstream commit
`bfa25a1 Fix CVE-2026-5843: gate model_file execution behind trust_remote_code (#1385)`.
The identical version string on both sides is exactly why the README says the full Git
revision and committed lock — not the version — are the provenance authority.

## Evidence files

| File | Shows |
|---|---|
| `cve-2026-5843-before-after.txt` | The vulnerability the pin closes, before vs. after |
| `mlx-security-baseline-e2e.txt` | Live hostile model/tokenizer bundles against the real production loader |
| `upstream-audit-delta.txt` | Pinned SHA reachable upstream; **15 commits / 35 files** after `v0.31.3` — matches README exactly |
| `lock-drift-guard.txt` | `--locked` refuses a silently drifted `rev` |
| `packaging-closure.txt` | PKG payload venv resolves the same SHA |
| `ci-packaging-closure.txt` | Exact CI + `make setup-native` native commands |
| `verify_mlx_security_baseline.py` | The manual verification script (all sections PASS) |

## End-to-end security behaviour (`mlx-security-baseline-e2e.txt`)

- Installed runtime carries `direct_url.json` pinning commit `ab1806e8…`; `uv.lock` has no
  registry source for `mlx-lm`; `transformers 5.12.1` stays on hashed PyPI artifacts in `>=5.7,<5.13`.
- Hostile bundle whose `config.json` declares `model_file`: raw upstream with
  `trust_remote_code=True` **executes** the payload; the Orchard production path refuses with
  `ModelLoaderError(model_load_failed)` and the payload is **never executed**.
- A caller passing `trust_remote_code=True` is overridden — upstream receives
  `{'lazy': True, 'strict': False, 'trust_remote_code': False}`.
- Hostile tokenizer bundle with an `auto_map` custom tokenizer class is refused by the
  tokenizer boundary; payload not executed.
- Documented residual is real: the pinned `mlx_lm.utils.sharded_load` still contains
  `tokenizer_config or {"trust_remote_code": True}`, and that is disclosed in
  `native/orchard_worker_mlx/README.md` against issue #116.

## Automated suite

`uv run --locked --directory native/orchard_worker_mlx --extra mlx pytest` — 636 passed,
2 skipped (the CI step verbatim). The two skips are the pre-existing real-model MLX smoke
tests gated on `ORCHARD_MLX_SMOKE_MODEL_PATH`, which the intent explicitly leaves out of
scope. The `--extra mlx` install is what un-skips the security guards in
`tests/test_mlx_import_smoke.py`.
```
</details>
<details>
<summary>Evidence: CVE-2026-5843 before/after — same version string, opposite outcome</summary>

<code>### CVE-2026-5843 before/after: does mlx-lm load_model execute a config-declared model_file&#10;### when the caller passes NO trust flag? (this is the vulnerability the pin closes)&#10;&#10;--- BEFORE: base commit dc73b55 had &#39;mlx-lm&gt;=0.31.3&#39; + uv.lock pointing at the PyPI wheel ---&#10;mlx-lm version under test: 0.31.3&#10;source: PyPI registry wheel&#10;calling load_model(bundle, lazy=True, strict=False) # NO trust flag passed&#10;-&gt; TypeError: Model() takes no arguments&#10;attacker payload executed: True&#10;&#10;--- AFTER: this change pins git rev ab1806e8, which contains upstream fix bfa25a1 ---&#10;--- &#39;Fix CVE-2026-5843: gate model_file execution behind trust_remote_code (#1385)&#39; ---&#10;mlx-lm version under test: 0.31.3&#10;source: {&#34;url&#34;:&#34;https://github.com/ml-explore/mlx-lm.git&#34;,&#34;vcs_info&#34;:{&#34;vcs&#34;:&#34;git&#34;,&#34;commit_id&#34;:&#34;ab1806e8f5d6aa035973af194a1b9198ab4754dc&#34;,&#34;requested_revision&#34;:&#34;ab1806e8f5d6aa035973af194a1b9198ab4754dc&#34;}}&#10;calling load_model(bundle, lazy=True, strict=False) # NO trust flag passed&#10;-&gt; ValueError: The model at /var/.../m requires importing and running a custom module (&#39;modeling_evil.py&#39;) to build its architecture. This is d&#10;attacker payload executed: False</code>

```text
### CVE-2026-5843 before/after: does mlx-lm load_model execute a config-declared model_file
### when the caller passes NO trust flag?  (this is the vulnerability the pin closes)

--- BEFORE: base commit dc73b55 had 'mlx-lm>=0.31.3' + uv.lock pointing at the PyPI wheel ---
mlx-lm version under test: 0.31.3
source: PyPI registry wheel
calling load_model(bundle, lazy=True, strict=False)  # NO trust flag passed
  -> TypeError: Model() takes no arguments
  attacker payload executed: True

--- AFTER: this change pins git rev ab1806e8, which contains upstream fix bfa25a1 ---
---        'Fix CVE-2026-5843: gate model_file execution behind trust_remote_code (#1385)' ---
mlx-lm version under test: 0.31.3
source: {"url":"https://github.com/ml-explore/mlx-lm.git","vcs_info":{"vcs":"git","commit_id":"ab1806e8f5d6aa035973af194a1b9198ab4754dc","requested_revision":"ab1806e8f5d6aa035973af194a1b9198ab4754dc"}}
calling load_model(bundle, lazy=True, strict=False)  # NO trust flag passed
  -> ValueError: The model at /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp6985kt2g/m requires importing and running a custom module ('modeling_evil.py') to build its architecture. This is d
  attacker payload executed: False
```
</details>
<details>
<summary>Evidence: End-to-end hostile bundle verification against the production loader</summary>

<code>1. RUNTIME PROVENANCE&#10;[PASS] installed mlx-lm came from the audited full Git SHA (not PyPI)&#10;[PASS] uv.lock pins mlx-lm to an immutable git rev&#10;[PASS] uv.lock keeps transformers on hashed PyPI artifacts inside &gt;=5.7,&lt;5.13 -- transformers==5.12.1&#10;&#10;2. HOSTILE MODEL BUNDLE -- config.json declares custom model code&#10;[A] BASELINE ATTACK -- raw upstream load_model(trust_remote_code=True):&#10;attacker payload executed: True&#10;[PASS] baseline attack is real (upstream executes bundle-supplied code)&#10;[B] ORCHARD PRODUCTION PATH -- caller deliberately passes trust_remote_code=True:&#10;-&gt; ModelLoaderError(model_load_failed): custom model architecture requires remote code,&#10;but Orchard loads bundled MLX models with trust_remote_code=False ...&#10;attacker payload executed: False&#10;[PASS] attacker payload was NOT executed on the production path&#10;&#10;3. CALLER-SUPPLIED trust_remote_code=True IS OVERRIDDEN, NOT FORWARDED&#10;caller passed : trust_remote_code=True&#10;upstream actually saw: [{&#39;lazy&#39;: True, &#39;strict&#39;: False, &#39;trust_remote_code&#39;: False}]&#10;[PASS]&#10;&#10;4. HOSTILE TOKENIZER BUNDLE -- auto_map declares custom tokenizer code&#10;-&gt; ValueError: The repository ... contains custom code which must be executed ...&#10;[PASS] custom tokenizer code was NOT executed&#10;&#10;5. DOCUMENTED RESIDUAL -- upstream sharded_load tokenizer default&#10;mlx_lm.utils.sharded_load tokenizer arg: tokenizer_config or {&#34;trust_remote_code&#34;: True},&#10;[PASS] documented residual is real in the pinned upstream source&#10;[PASS] residual is disclosed in native/orchard_worker_mlx/README.md&#10;&#10;RESULT: ALL CHECKS PASSED</code>

```text
[transformers] You are using a model of type `evil_tok` to instantiate a model of type ``. This may be expected if you are loading a checkpoint that shares a subset of the architecture (e.g., loading a `sam2_video` checkpoint into `Sam2Model`), but is otherwise not supported and can yield errors. Please verify that the checkpoint is compatible with the model you are instantiating.
==============================================================================
1. RUNTIME PROVENANCE -- what is actually installed in the locked env
==============================================================================
  mlx-lm reported version : 0.31.3
  installed from          : {
  "url": "https://github.com/ml-explore/mlx-lm.git",
  "vcs_info": {
    "vcs": "git",
    "commit_id": "ab1806e8f5d6aa035973af194a1b9198ab4754dc",
    "requested_revision": "ab1806e8f5d6aa035973af194a1b9198ab4754dc"
  }
}
  [PASS] installed mlx-lm came from the audited full Git SHA (not PyPI)
  uv.lock mlx-lm source   : {'git': 'https://github.com/ml-explore/mlx-lm.git?rev=ab1806e8f5d6aa035973af194a1b9198ab4754dc#ab1806e8f5d6aa035973af194a1b9198ab4754dc'}
  uv.lock transformers    : 5.12.1 from {'registry': 'https://pypi.org/simple'}
  [PASS] uv.lock pins mlx-lm to an immutable git rev
  [PASS] uv.lock keeps transformers on hashed PyPI artifacts inside >=5.7,<5.13 -- transformers==5.12.1
  transformers imported   : 5.12.1

==============================================================================
2. HOSTILE MODEL BUNDLE -- config.json declares custom model code
==============================================================================
  bundle config.json      : {
  "model_type": "evil_arch",
  "model_file": "modeling_evil.py"
}
  payload modeling_evil.py: writes a marker file the moment it is imported

  [A] BASELINE ATTACK -- raw upstream mlx_lm.utils.load_model(
      trust_remote_code=True), i.e. what Orchard forbids:
      -> TypeError: Model() takes no arguments
      attacker payload executed: True
  [PASS] baseline attack is real (upstream executes bundle-supplied code)

  [B] ORCHARD PRODUCTION PATH -- _default_mlx_deps().load_model, with a
      caller deliberately passing trust_remote_code=True:
      -> ModelLoaderError(model_load_failed): model load failed: custom model architecture requires remote code, but Orchard loads bundled MLX models with trust_remote_code=False. Use a registry-supported MLX architecture or convert the bundle before import; config /var/folders/xy/bmzx
  [PASS] production loader refused the hostile bundle before upstream load
      attacker payload executed: False
  [PASS] attacker payload was NOT executed on the production path

==============================================================================
3. CALLER-SUPPLIED trust_remote_code=True IS OVERRIDDEN, NOT FORWARDED
==============================================================================
  caller passed           : trust_remote_code=True
  upstream actually saw   : [{'lazy': True, 'strict': False, 'trust_remote_code': False}]
  [PASS] trust_remote_code=False is what reaches upstream mlx-lm

==============================================================================
4. HOSTILE TOKENIZER BUNDLE -- auto_map declares custom tokenizer code
==============================================================================
  tokenizer_config.json   : {
  "tokenizer_class": "EvilTokenizer",
  "auto_map": {
    "AutoTokenizer": [
      "tokenization_evil.EvilTokenizer",
      null
    ]
  }
}
  calling production deps.load_tokenizer(<bundle>/tokenizer.json)
  -> ValueError: The repository /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp9tl_s_de/evil-tokenizer contains custom code which must be executed to correctly load the model. You can inspect the repository content at /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp9tl_s_de/evil-tokenizer .
 You can inspect
  [PASS] tokenizer load did not succeed with remote code
  [PASS] custom tokenizer code was NOT executed

==============================================================================
5. DOCUMENTED RESIDUAL -- upstream sharded_load tokenizer default
==============================================================================
  mlx_lm.utils.sharded_load tokenizer arg: tokenizer_config or {"trust_remote_code": True},
  [PASS] documented residual is real in the pinned upstream source -- sharded_load falls back to a TRUSTING tokenizer config when tokenizer_config is empty
  [PASS] residual is disclosed in native/orchard_worker_mlx/README.md
  Orchard does not reach sharded_load today (see README residual note).

==============================================================================
RESULT: ALL CHECKS PASSED
==============================================================================
```
</details>
<details>
<summary>Evidence: Upstream audit delta — 15 commits / 35 files matches README exactly</summary>

<code>$ git rev-list --count v0.31.3..ab1806e8&#10;15 (README claims: 15)&#10;&#10;$ git diff --name-only v0.31.3..ab1806e8 | wc -l&#10;35 (README claims: 35)&#10;&#10;$ git log --oneline v0.31.3..ab1806e8&#10;ab1806e Fix syntax error by removing quotes from NewLineTokenizer (#1465)&#10;2ed2231 Fix deepseek indexer rope argument (#1431)&#10;2c008fd feat: add return_logprobs and return_token_ids to batch_generate (#1359)&#10;c89c93c transformers&gt;=5.7 (#1356)&#10;bfa25a1 Fix CVE-2026-5843: gate model_file execution behind trust_remote_code (#1385)&#10;df48987 fix(sample_utils): correct top_k error message to the exclusive (0, vocab_size) bound (#1377)&#10;39c4019 Fix server 404 on short prompts: clamp negative start in think-token search (#1327)&#10;... (8 more)&#10;&#10;$ git diff --stat v0.31.3..ab1806e8 -- mlx_lm/utils.py mlx_lm/tokenizer_utils.py&#10;mlx_lm/tokenizer_utils.py | 16 +++++++---------&#10;mlx_lm/utils.py | 36 ++++++++++++++++++++++++++++++++----</code>

```text
### Upstream audit delta: does the pinned SHA match the documented '15 commits / 35 files after v0.31.3'?
(verified against a fresh clone of https://github.com/ml-explore/mlx-lm.git)

$ git cat-file -t ab1806e8f5d6aa035973af194a1b9198ab4754dc
commit

$ git rev-list --count v0.31.3..ab1806e8
15
README claims: 15

$ git diff --name-only v0.31.3..ab1806e8 | wc -l
      35
README claims: 35

$ git log --oneline v0.31.3..ab1806e8
ab1806e Fix syntax error by removing quotes from NewLineTokenizer (#1465)
2ed2231 Fix deepseek indexer rope argument (#1431)
2c008fd feat: add return_logprobs and return_token_ids to batch_generate (#1359)
c89c93c transformers>=5.7 (#1356)
bfa25a1 Fix CVE-2026-5843: gate model_file execution behind trust_remote_code (#1385)
df48987 fix(sample_utils): correct top_k error message to the exclusive (0, vocab_size) bound (#1377)
39c4019 Fix server 404 on short prompts: clamp negative start in think-token search (#1327)
e476a22 Add Mellum (Mellum 2) model support (#1339)
bdb77da New UI for chat and lora (#1344)
d39cfec fix: add sanitize method to Granite model for tied embeddings (#1298)
04a1910 Fix LFM2 MoE routing to match the HF reference (sigmoid gating) (#1354)
8239c72 Fix gemma4_unified model type not supported (#1349)
fe468f9 Add pipelining for Qwen 3.5  (#1345)
2edfb81 Fix cleanup space (#1347)
df1d3f3 Fix Gemma 4 sanitize() not stripping KV projections for shared layers (#1240)

$ git diff --stat v0.31.3..ab1806e8 -- '*utils*' '*tokenizer*'   (security-relevant surface)
 mlx_lm/tokenizer_utils.py | 16 +++++++---------
 mlx_lm/utils.py           | 36 ++++++++++++++++++++++++++++++++----
 2 files changed, 39 insertions(+), 13 deletions(-)
```
</details>
<details>
<summary>Evidence: Lock-drift guard — --locked refuses a silently swapped rev</summary>

<code>$ uv sync --locked --extra mlx (unmodified copy)&#10;Resolved 46 packages in 29ms&#10;Installed 44 packages in 115ms&#10;&#10;-- silently swap the pinned rev in pyproject.toml to a different upstream commit --&#10;[tool.uv.sources]&#10;mlx-lm = { git = &#34;https://github.com/ml-explore/mlx-lm.git&#34;, rev = &#34;2ed2231&#34; }&#10;&#10;$ uv sync --locked --extra mlx (drifted copy)&#10;The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.</code>

```text
### Lock proof: does '--locked' actually refuse a drifted pin?
(temp copy of the package; worktree source untouched)

$ uv sync --locked --extra mlx   (unmodified copy)
Resolved 46 packages in 29ms
Installed 44 packages in 115ms

-- now silently swap the pinned rev in pyproject.toml to a different upstream commit --
[tool.uv.sources]
mlx-lm = { git = "https://github.com/ml-explore/mlx-lm.git", rev = "2ed2231" }


$ uv sync --locked --extra mlx   (drifted copy)
Resolved 46 packages in 1.53s
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
exit status: 
```
</details>
<details>
<summary>Evidence: Packaging closure — PKG payload venv resolves the pinned SHA</summary>

<code>$ UV_PROJECT_ENVIRONMENT=.venv-pkg uv sync --locked --no-editable --extra mlx&#10;Resolved 46 packages in 25ms&#10;Installed 44 packages in 136ms&#10;+ mlx-lm==0.31.3 (from git+https://github.com/ml-explore/mlx-lm.git@ab1806e8f5d6aa035973af194a1b9198ab4754dc)&#10;+ transformers==5.12.1&#10;&#10;$ packaged venv mlx-lm provenance:&#10;version: 0.31.3&#10;direct_url.json: {&#34;url&#34;:&#34;https://github.com/ml-explore/mlx-lm.git&#34;,&#34;vcs_info&#34;:{&#34;vcs&#34;:&#34;git&#34;,&#34;commit_id&#34;:&#34;ab1806e8f5d6aa035973af194a1b9198ab4754dc&#34;,&#34;requested_revision&#34;:&#34;ab1806e8f5d6aa035973af194a1b9198ab4754dc&#34;}}</code>

```text
### Packaging closure: does the PKG payload venv also resolve the pinned SHA?
(reproducing scripts/build-pkg.sh sync_packaging_venv 'orchard_worker_mlx' --extra mlx)

$ UV_PROJECT_ENVIRONMENT=.venv-pkg uv sync --locked --no-editable --extra mlx
Resolved 46 packages in 25ms
Installed 44 packages in 136ms
 + mlx-lm==0.31.3 (from git+https://github.com/ml-explore/mlx-lm.git@ab1806e8f5d6aa035973af194a1b9198ab4754dc)
 + transformers==5.12.1

$ packaged venv mlx-lm provenance:
  version: 0.31.3
  direct_url.json: {"url":"https://github.com/ml-explore/mlx-lm.git","vcs_info":{"vcs":"git","commit_id":"ab1806e8f5d6aa035973af194a1b9198ab4754dc","requested_revision":"ab1806e8f5d6aa035973af194a1b9198ab4754dc"}}

$ packaged worker entrypoint smoke:
usage: orchard-worker-mlx [-h] --socket-path SOCKET_PATH
                          [--backend {mlx,stub}] [--log-file LOG_FILE]
```
</details>
<details>
<summary>Evidence: CI + Makefile native command closure</summary>

```text
### CI/Makefile closure: exact commands from .github/workflows/required-validation.yml + Makefile setup-native

$ uv sync --locked --directory native/orchard_tokenizer   (Makefile setup-native, now --locked)
Resolved 35 packages in 30ms
Checked 33 packages in 13ms

$ uv sync --locked --directory native/orchard_worker_mlx --extra mlx   (CI bootstrap)
Resolved 46 packages in 6ms

$ native/orchard_worker_mlx/bin/orchard-worker-mlx --help   (CI smoke)
usage: orchard-worker-mlx [-h] --socket-path SOCKET_PATH
                          [--backend {mlx,stub}] [--log-file LOG_FILE]
                          [--version] [--prefix-cache-mode {disabled,kv,trie}]
                          [--prefix-cache-max-entries PREFIX_CACHE_MAX_ENTRIES]
                          [--prefix-cache-max-bytes PREFIX_CACHE_MAX_BYTES]
                          [--max-fingerprint-buffer-size MAX_FINGERPRINT_BUFFER_SIZE]

$ uv sync --locked --directory native/orchard_worker_mlx   (Makefile setup-native, no extra)
 - tqdm==4.67.3
 - transformers==5.12.1
 - typer==0.24.1
```
</details>
<details>
<summary>Evidence: Manual verification script (reproducible)</summary>

```text
"""Manual end-to-end verification of the Orchard issue #98 MLX-LM security baseline.

Runs inside the locked `--extra mlx` environment and exercises the real
production dependency wiring (`orchard_worker_mlx.model_loader._default_mlx_deps`)
against hostile model/tokenizer bundles that try to execute custom Python.
"""

from __future__ import annotations

import importlib
import importlib.metadata
import json
import tempfile
import tomllib
from pathlib import Path

from orchard_worker_mlx.model_loader import ModelLoaderError, _default_mlx_deps

import orchard_worker_mlx  # noqa: E402

# The installed package is an editable link back into the repo checkout.
REPO_PKG = Path(orchard_worker_mlx.__file__).resolve().parents[2]

OK = "PASS"
BAD = "FAIL"
failures: list[str] = []


def check(label: str, condition: bool, detail: str = "") -> None:
    status = OK if condition else BAD
    if not condition:
        failures.append(label)
    print(f"  [{status}] {label}" + (f" -- {detail}" if detail else ""))


print("=" * 78)
print("1. RUNTIME PROVENANCE -- what is actually installed in the locked env")
print("=" * 78)
dist = importlib.metadata.distribution("mlx-lm")
direct_url = json.loads(dist.read_text("direct_url.json") or "{}")
print(f"  mlx-lm reported version : {dist.version}")
print(f"  installed from          : {json.dumps(direct_url, indent=2)}")
check(
    "installed mlx-lm came from the audited full Git SHA (not PyPI)",
    direct_url.get("url") == "https://github.com/ml-explore/mlx-lm.git"
    and direct_url.get("vcs_info", {}).get("commit_id")
    == "ab1806e8f5d6aa035973af194a1b9198ab4754dc",
)

lock = tomllib.loads((REPO_PKG / "uv.lock").read_text())
mlx_lm_lock = next(p for p in lock["package"] if p["name"] == "mlx-lm")
tf_lock = next(p for p in lock["package"] if p["name"] == "transformers")
print(f"  uv.lock mlx-lm source   : {mlx_lm_lock['source']}")
print(f"  uv.lock transformers    : {tf_lock['version']} from {tf_lock['source']}")
check("uv.lock pins mlx-lm to an immutable git rev", "registry" not in mlx_lm_lock["source"])
check(
    "uv.lock keeps transformers on hashed PyPI artifacts inside >=5.7,<5.13",
    tf_lock["source"]["registry"] == "https://pypi.org/simple"
    and tf_lock["sdist"]["hash"].startswith("sha256:"),
    f"transformers=={tf_lock['version']}",
)

import transformers  # noqa: E402

print(f"  transformers imported   : {transformers.__version__}")

print()
print("=" * 78)
print("2. HOSTILE MODEL BUNDLE -- config.json declares custom model code")
print("=" * 78)
PAYLOAD = (
    "from pathlib import Path\n"
    "Path({marker!r}).write_text('pwned', encoding='utf-8')\n"
    "class Model:\n    pass\n"
    "class ModelArgs:\n"
    "    @staticmethod\n"
    "    def from_dict(d):\n        return None\n"
)


def build_hostile_model_bundle(root: Path) -> tuple[Path, Path]:
    bundle = root / "evil-model"
    bundle.mkdir()
    marker = root / "MODEL_CODE_EXECUTED"
    (bundle / "modeling_evil.py").write_text(PAYLOAD.format(marker=str(marker)), encoding="utf-8")
    (bundle / "config.json").write_text(
        json.dumps({"model_type": "evil_arch", "model_file": "modeling_evil.py"}, indent=2),
        encoding="utf-8",
    )
    return bundle, marker


mlx_lm_utils = importlib.import_module("mlx_lm.utils")

with tempfile.TemporaryDirectory() as td:
    bundle, marker = build_hostile_model_bundle(Path(td))
    print(f"  bundle config.json      : {(bundle / 'config.json').read_text().strip()}")
    print("  payload modeling_evil.py: writes a marker file the moment it is imported")
    print()
    print("  [A] BASELINE ATTACK -- raw upstream mlx_lm.utils.load_model(")
    print("      trust_remote_code=True), i.e. what Orchard forbids:")
    try:
        mlx_lm_utils.load_model(bundle, lazy=True, strict=False, trust_remote_code=True)
    except Exception as exc:  # noqa: BLE001 -- capturing upstream failure shape
        print(f"      -> {type(exc).__name__}: {str(exc)[:160]}")
    print(f"      attacker payload executed: {marker.exists()}")
    check("baseline attack is real (upstream executes bundle-supplied code)", marker.exists())

with tempfile.TemporaryDirectory() as td:
    bundle, marker = build_hostile_model_bundle(Path(td))
    print()
    print("  [B] ORCHARD PRODUCTION PATH -- _default_mlx_deps().load_model, with a")
    print("      caller deliberately passing trust_remote_code=True:")
    deps = _default_mlx_deps()
    try:
        deps.load_model(bundle, lazy=True, strict=False, trust_remote_code=True)
        check("production loader refused the hostile bundle", False, "no error raised")
    except ModelLoaderError as exc:
        print(f"      -> ModelLoaderError({exc.code}): {str(exc)[:240]}")
        check(
            "production loader refused the hostile bundle before upstream load",
            exc.code == "model_load_failed" and "model_file" in str(exc),
        )
    print(f"      attacker payload executed: {marker.exists()}")
    check("attacker payload was NOT executed on the production path", not marker.exists())

print()
print("=" * 78)
print("3. CALLER-SUPPLIED trust_remote_code=True IS OVERRIDDEN, NOT FORWARDED")
print("=" * 78)
forwarded: list[dict] = []


def _spy_load_model(model_path, **kwargs):
    forwarded.append(kwargs)
    raise RuntimeError("spy: upstream load short-circuited")


with tempfile.TemporaryDirectory() as td:
    clean = Path(td) / "clean-model"
    clean.mkdir()
    (clean / "config.json").write_text(json.dumps({"model_type": "llama"}), encoding="utf-8")
    original = mlx_lm_utils.load_model
    ml_mod = importlib.import_module("orchard_worker_mlx.model_loader")
    real_import = ml_mod._import_required_mlx_runtime_modules
    ml_mod._import_required_mlx_runtime_modules = lambda: (
        real_import()[0],
        real_import()[1],
        _spy_load_model,
        real_import()[3],
    )
    try:
        deps = _default_mlx_deps()
        try:
            deps.load_model(clean, lazy=True, strict=False, trust_remote_code=True)
        except RuntimeError:
            pass
    finally:
        ml_mod._import_required_mlx_runtime_modules = real_import
    print(f"  caller passed           : trust_remote_code=True")
    print(f"  upstream actually saw   : {forwarded}")
    check(
        "trust_remote_code=False is what reaches upstream mlx-lm",
        forwarded and forwarded[0].get("trust_remote_code") is False,
    )

print()
print("=" * 78)
print("4. HOSTILE TOKENIZER BUNDLE -- auto_map declares custom tokenizer code")
print("=" * 78)
with tempfile.TemporaryDirectory() as td:
    bundle = Path(td) / "evil-tokenizer"
    bundle.mkdir()
    marker = Path(td) / "TOKENIZER_CODE_EXECUTED"
    (bundle / "tokenization_evil.py").write_text(
        "from pathlib import Path\n"
        f"Path({str(marker)!r}).write_text('pwned', encoding='utf-8')\n"
        "from transformers import PreTrainedTokenizer\n"
        "class EvilTokenizer(PreTrainedTokenizer):\n    pass\n",
        encoding="utf-8",
    )
    (bundle / "tokenizer_config.json").write_text(
        json.dumps(
            {
                "tokenizer_class": "EvilTokenizer",
                "auto_map": {"AutoTokenizer": ["tokenization_evil.EvilTokenizer", None]},
            },
            indent=2,
        ),
        encoding="utf-8",
    )
    (bundle / "config.json").write_text(
        json.dumps(
            {
                "model_type": "evil_tok",
                "auto_map": {"AutoTokenizer": ["tokenization_evil.EvilTokenizer", None]},
            },
            indent=2,
        ),
        encoding="utf-8",
    )
    (bundle / "tokenizer.json").write_text("{}", encoding="utf-8")
    print(f"  tokenizer_config.json   : {(bundle / 'tokenizer_config.json').read_text().strip()}")

    deps = _default_mlx_deps()
    print("  calling production deps.load_tokenizer(<bundle>/tokenizer.json)")
    try:
        deps.load_tokenizer(bundle / "tokenizer.json")
        raised = None
    except Exception as exc:  # noqa: BLE001
        raised = exc
        print(f"  -> {type(exc).__name__}: {str(exc)[:300]}")
    check("tokenizer load did not succeed with remote code", raised is not None)
    check("custom tokenizer code was NOT executed", not marker.exists())

print()
print("=" * 78)
print("5. DOCUMENTED RESIDUAL -- upstream sharded_load tokenizer default")
print("=" * 78)
import inspect  # noqa: E402

src = inspect.getsource(mlx_lm_utils.sharded_load)
residual_line = next(
    (ln.strip() for ln in src.splitlines() if 'tokenizer_config or {"trust_remote_code"' in ln),
    "",
)
print(f"  mlx_lm.utils.sharded_load tokenizer arg: {residual_line}")
check(
    "documented residual is real in the pinned upstream source",
    residual_line == 'tokenizer_config or {"trust_remote_code": True},',
    "sharded_load falls back to a TRUSTING tokenizer config when tokenizer_config is empty",
)
readme = (REPO_PKG / "README.md").read_text(encoding="utf-8")
check(
    "residual is disclosed in native/orchard_worker_mlx/README.md",
    "sharded_load` falls back to `{\"trust_remote_code\": True}`" in readme
    and "#116" in readme,
)
print("  Orchard does not reach sharded_load today (see README residual note).")

print()
print("=" * 78)
print(f"RESULT: {'ALL CHECKS PASSED' if not failures else 'FAILURES: ' + ', '.join(failures)}")
print("=" * 78)
raise SystemExit(1 if failures else 0)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `native/orchard_worker_mlx/tests/test_mlx_import_smoke.py:73` - The new resolved-environment guard asserts `trust_remote_code` defaults on `mlx_lm.utils.{load_model,load,sharded_load}`, but never checks `mlx_lm.tokenizer_utils.load`&#39;s `tokenizer_config_extra` parameter — the sole mechanism enforcing tokenizer-side distrust in production (`model_loader.py:610`). The only test covering that boundary (`test_model_loader.py::test_default_mlx_deps_tokenizer_disables_remote_code`) asserts against a `MagicMock`, so it passes regardless of the real upstream signature. A future pin bump that renames or drops `tokenizer_config_extra` would fail closed with a TypeError surfaced as a generic `model_load_failed`, and no guard would attribute it to the security control. Add `inspect.signature(mlx_lm.tokenizer_utils.load).parameters[&#34;tokenizer_config_extra&#34;]` to the same guard.
- ⚠️ `Makefile:29` - This change makes `--locked` the rule everywhere else — CI bootstrap and the new pytest step, `docs/tooling.md`, `docs/local-dev.md` (both rows), and `native/orchard_worker_mlx/README.md` — but `make setup-native` still runs bare `uv sync --directory native/orchard_worker_mlx`. `uv sync` re-locks instead of failing when `pyproject.toml` and `uv.lock` diverge, so the standard `make setup` path is the one remaining entrypoint that can silently rewrite the audited lock (uv locks universally, so this rewrites the mlx-extra resolution even though the extra is not requested). Add `--locked` to both lines in the target to match CI and `scripts/build-pkg.sh:1514`.
- ⚠️ `native/orchard_worker_mlx/README.md:53` - At the pinned commit, `sharded_load` calls `load_tokenizer(model_path, tokenizer_config or {&#34;trust_remote_code&#34;: True}, ...)` — omitting `tokenizer_config`, or passing an empty dict, silently re-enables remote code for the tokenizer even when `trust_remote_code=False` is passed for the model. The new test only exercises the explicit `{&#34;trust_remote_code&#34;: False}` path, and README.md:53 / docs/tooling.md:143 describe the sharded surface as verified-distrust without noting that the upstream default is trust-on. Since #116 sharded loading is explicitly deferred, record this as a residual next to the other documented ones so the follow-up cannot inherit remote-code trust by omission.
- ℹ️ `native/orchard_worker_mlx/pyproject.toml:17` - `mlx-lm==0.31.3` is redirected to the audited commit only by `[tool.uv.sources]`, which non-uv resolvers ignore. A `pip install &#39;orchard-worker-mlx[mlx]&#39;` satisfies the specifier with the PyPI 0.31.3 artifact, whose `load_model` has no `trust_remote_code` parameter and no `model_file` gate — so `model_loader.py:602` would raise `TypeError` on every load and surface as a misleading `model_load_failed`. This fails closed (Orchard&#39;s own `_reject_model_file_config` still applies, so there is no trust bypass), uv is the mandated toolchain, and both packaging and CI use `uv sync --locked`, so the exposure is a documented-residual footgun rather than a reachable defect. Noting the tradeoff only.
- ℹ️ `native/orchard_worker_mlx/tests/test_model_loader.py:2159` - `test_default_mlx_deps_model_disables_remote_code` is the fourth near-identical copy of the same ~15-line scaffold in `TestDefaultMlxDepsSamplerWiring` (alongside the sampler-wiring, tokenizer-distrust, and model_file-rejection tests): same `fake_mx`, same four MagicMocks, same `_fake_import_required`, same `sys.modules[&#34;mlx_lm&#34;]` set/pop dance. A single fixture returning the fakes plus handling the `sys.modules` teardown would remove roughly 45 lines and make the per-test assertion the only thing that varies. Purely non-functional test cleanup.

🔧 Fix: guard tokenizer signature, lock native sync, document sharded residual
2 issues (1 warning, 1 info) still open:
- ⚠️ `docs/tooling.md:55` - The round-2 fix added `--locked` to `Makefile:28-29`, but the authoritative docs that define the manual equivalent of `make setup-native` still show the un-locked form: `docs/tooling.md:55-56` and `docs/local-dev.md:53-54` both list bare `mise exec -- uv sync --directory native/orchard_tokenizer` / `native/orchard_worker_mlx`. This inverts the repo&#39;s own stated authority rule against the fix: `docs/tooling.md:71` says &#34;Use the documented `mise exec --` commands as the authority when a Makefile target and this guide disagree,&#34; and AGENTS.md says &#34;If a `Makefile` target and the docs disagree, treat the docs as authoritative and fix the `Makefile`.&#34; So a contributor following the rule would revert the Makefile rather than update the docs. `packaging/pkg/README.md:1371` compounds this by routing PKG builders to &#34;the equivalent manual setup commands from `docs/local-dev.md`&#34;, which is the un-locked pair. Add `--locked` to those four doc lines so the documented authority matches the Makefile, CI, and `scripts/build-pkg.sh:1514`.
- ℹ️ `scripts/smoke-mlx.sh:130` - `scripts/smoke-mlx.sh:130` runs `mise exec -- uv sync --extra mlx` without `--locked`, and `docs/local-dev.md:854` documents the same bare form for the standalone Python smoke. After the round-2 Makefile change this is the last executable entrypoint that materializes the audited MLX extra without lock enforcement, so it regenerates `native/orchard_worker_mlx/uv.lock` on pyproject/lock divergence instead of failing loudly the way CI, packaging, and `make setup-native` now do. Impact is low: it is a local-dev-only script requiring a real model bundle, and a regenerated lock shows up as a dirty file in `git status`. Adding `--locked` in both places would complete the sweep, but the branch&#39;s stated deliverable is CI and packaging closure, which is already met.

🔧 Fix: align setup docs with locked native uv sync
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx` (CI bootstrap step verbatim)</code>
- <code>`mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx pytest` — 636 passed, 2 skipped (the new CI &#34;Validate MLX-LM security baseline&#34; step verbatim)</code>
- <code>`mise exec -- uv sync --locked --directory native/orchard_tokenizer` and `... native/orchard_worker_mlx` (both `make setup-native` commands, now `--locked`)</code>
- <code>`mise exec -- native/orchard_worker_mlx/bin/orchard-worker-mlx --help` (CI native smoke)</code>
- <code>Manual end-to-end script `verify_mlx_security_baseline.py` driving the real `_default_mlx_deps()` against hostile `model_file` and `auto_map` tokenizer bundles — all 10 checks PASS</code>
- <code>CVE-2026-5843 before/after probe: `uv run --no-project --with mlx-lm==0.31.3` (PyPI wheel, payload executes) vs. the pinned git-SHA env (payload refused)</code>
- <code>Upstream audit: fresh clone of ml-explore/mlx-lm, `git rev-list --count v0.31.3..ab1806e8` = 15, `git diff --name-only v0.31.3..ab1806e8 | wc -l` = 35, plus `git show bfa25a1` confirming the CVE fix is inside the pinned range</code>
- <code>Lock-drift negative test: swapped `rev` in a temp package copy, `uv sync --locked` correctly failed with &#34;The lockfile at `uv.lock` needs to be updated&#34;</code>
- <code>Packaging closure: reproduced `sync_packaging_venv &#34;orchard_worker_mlx&#34; --extra mlx` (`UV_PROJECT_ENVIRONMENT=.venv-pkg uv sync --locked --no-editable --extra mlx`) and confirmed the PKG payload venv carries the same pinned SHA</code>
- <code>Parsed `.github/workflows/required-validation.yml` to confirm the new security-baseline step is valid YAML and matches the commands executed locally</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `scripts/smoke-mlx.sh:130` - This change made `uv sync --locked` the documented contract everywhere (Makefile, required-validation CI, docs/tooling.md, docs/local-dev.md, worker README) because the committed uv lock is now the MLX-LM provenance authority. `scripts/smoke-mlx.sh` still runs `mise exec -- uv sync --extra mlx` without `--locked`, so the MLX smoke can silently re-resolve transformers within `&gt;=5.7,&lt;5.13` instead of proving the locked baseline. docs/local-dev.md:806 accurately describes the script as-is, so I left both alone rather than documenting behavior the script does not have. Adding `--locked` to the script is a behavior change (it starts failing on a stale lock) and is outside this documentation/lint pass.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788078045&installation_model_id=428414&pr_number=132&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F132&signature=d23829b8037cb9c05f50f2d67f61f1c9cbf6f57305e5e5dee79e4b67b4bb3f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
