### PR TITLE
docs(packaging): record worker model staging in the multi-Mac runbook

### DIFF
--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -153,7 +153,20 @@ Verification:
 - On each host, `orchardctl status` should show the role-selected service state.
 - On the controller, readiness should report PostgreSQL reachable and migrations current.
 - On the controller, Runtime Endpoint target configuration should match each remote node-agent BEAM node name in `ORCHARD_RUNTIME_ENDPOINT_TARGETS`.
-- After admin credentials, tenant/API access, model import, and model activation are configured, use `/v1/models` and a single chat completion request as the external-site API smoke test.
+- Stage the model on every worker before attempting inference; controller import and activation do not distribute the artifact.
+- After admin credentials, tenant/API access, model import, model activation, and worker model staging are configured, use `/v1/models` and a single chat completion request as the external-site API smoke test.
+
+Worker model staging:
+
+- Controller import is not controller-hosted model distribution. The importer stores the bundle under the controller's artifacts root and records that controller-local path as the model's artifact source, so a remote node-agent resolves the same absolute path on its own filesystem and fails when it does not exist.
+- On the controller, the imported bundle is at `/Library/Application Support/Orchard/bundles/<model_id>/<version>`. `<model_id>` may contain a slash, so the layout is nested.
+- Copy that bundle directory to the identical absolute path on every worker Mac before the first request for the model, preserving directory structure and file contents.
+- On the first request, the node-agent copies the staged bundle into its own cache under `/Library/Application Support/Orchard/models`, verifies it against the recorded artifact digest, and fails closed on mismatch.
+- This repeats per model and per worker. A catalog-active but unstaged model still appears in `/v1/models` and is not blocked before dispatch, so a missed staging step surfaces only on the first request that the scheduler places on the unstaged worker.
+- How that failure is reported depends on whether the request streams, because the streaming response commits its HTTP status before the model load is attempted:
+  - Non-streaming: HTTP `503` with error type `server_error` and code `source_not_found`.
+  - Streaming: the response has already returned HTTP `200` and opened the event stream, so the failure arrives as an SSE `data: {"error":{...}}` event carrying the same `server_error` type and `source_not_found` code, and the stream then closes without a `[DONE]` line. Check the event payload, not just the HTTP status; a streaming smoke test that only asserts on `200` reads this failure as a success.
+- `acquisition_failed` is the internal failure category recorded against the load failure, not a public error type. The operator-visible identifier in both paths is the `source_not_found` code.
 
 gRPC compatibility fallback:
 


### PR DESCRIPTION


<!-- refresh closing references -->## Summary

- Add worker model staging to the Verification list in `packaging/pkg/README.md` §Packaged External-Sites Multi-Mac First Cut, so the list no longer moves from model import and activation directly to the chat-completion smoke test.
- Add a `Worker model staging:` block in that section's existing flat-label style (alongside `gRPC compatibility fallback:` and `Explicit deferrals:`) covering the controller bundle layout, the per-model/per-worker copy to an identical absolute path, digest verification on first load, and how a missed staging step is reported on the first request, split by streaming and non-streaming behavior.
- State plainly that controller import is not controller-hosted model distribution.

## Documentation reconciliation

The multi-Mac verification list implied that controller import distributes the model artifact. It does not, and the behavior on `main` is unambiguous:

- `Models.create_model/1` has a single caller, the importer (`apps/orchard_controller/lib/orchard/models/importer.ex:750`), which sets both `artifact_uri` and `artifact_source_uri` to `"file://#{dest_path}"` (`:727-728`) under the controller's artifacts root (`config/runtime.exs:459`).
- The node-agent resolves a `file://` source against its own filesystem (`apps/orchard_node_agent/lib/orchard/node/model_acquisition/source/file.ex:18-21,42-55`).
- An unstaged model is not blocked before dispatch, so the first request placed on that worker fails the load. The node-agent raises the failure with category `ACQUISITION_FAILED` and code `source_not_found` (`apps/orchard_node_agent/lib/orchard/node/model_load_failure.ex:195-201`).
- How the caller sees that failure depends on the request mode, because the category maps to an HTTP status and a public error type only on the non-streaming path:
  - Non-streaming: `Orchard.Inference.ModelLoadFailure.api_mapping/1` yields status `503` and type `server_error`, carrying the node-supplied code `source_not_found` (`apps/orchard_controller/lib/orchard/inference/model_load_failure.ex:169-178,280,287`).
  - Streaming: `Orchard.API.SSE.start/1` has already sent `send_chunked(200)` (`apps/orchard_controller/lib/orchard/api/sse.ex:36`) before the orchestrator runs (`apps/orchard_controller/lib/orchard/api/chat_completions_controller.ex:113,141`), so the status is already committed. `ChatError.sse_mapping/1` drops `:status` (`apps/orchard_controller/lib/orchard/inference/chat_error.ex:341-345`) and the same `server_error` / `source_not_found` pair is emitted as a `data: {"error":{...}}` event, then the stream closes without `[DONE]`, per `SPEC.md` §7.2.4 (`SPEC.md:1971-1975`).
- `acquisition_failed` is therefore the internal failure category, and is only the fallback code when the node supplies no valid one (`apps/orchard_controller/lib/orchard/inference/model_load_failure.ex:265-266`). It is not a public error type, so the runbook does not present it as one.

`docs/operator-journey.md` already carries this constraint — in its topology table, its "Organization, Model, And First Inference" steps, and its recovery-point table. The packaging runbook did not. This PR brings the packaging runbook in line with documentation that is already correct; it does not introduce new product guidance and does not change documented product behavior.

Issue #126 cites the packaging runbook's guidance as one reason an operator gets directed into a request path that cannot succeed. See also the operator-effort note on #118 (comment 5140815683).

This PR changes documentation only. It does not change product code, tests, migrations, runtime configuration, packaging behavior, or dependencies.

## Validation

- `git diff --name-only origin/main...HEAD` returns exactly `packaging/pkg/README.md` and nothing else. Untracked local files in the working tree were deliberately excluded from the commit.
- `git diff --check origin/main...HEAD` reports no whitespace or conflict-marker errors.
- Rendered Markdown structure confirmed by reading the section: the `Worker model staging:` block sits between `Verification:` and `gRPC compatibility fallback:`, is a bold-free label followed by a bullet list matching the sibling blocks, and the section's heading structure is unchanged. No new `###` heading was introduced, so the sibling blocks after it are not nested under the addition. The streaming and non-streaming cases are two-space nested bullets, which is the existing nesting style in this file (see the payload component list at `packaging/pkg/README.md:20-23`).
- Error type, code, status, and streaming ordering were each read off `main` rather than inferred, at the file and line references cited above under Documentation reconciliation.
- The branch was amended and force-pushed with `--force-with-lease` to drop the agent `Co-Authored-By` trailer. The branch is still a single commit touching a single file, and `git log origin/main..HEAD --format='%B' | grep -i co-auth` now returns nothing.
- No Elixir quality workflow applies to this change. It is Markdown-only, so `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, and `mix test` were not run locally. `.github/workflows/required-validation.yml` runs the full Elixir workflow on every PR regardless of changed paths, so CI exercises those gates against this branch.
- No OpenSpec change package and no ADR. Per `AGENTS.md`, documentation clarifications go directly through issue/PR review, so `openspec validate` does not apply.

## Residual

- The manual staging step itself is unchanged by this PR. This documents the current limitation rather than removing it. Removing the manual step via controller-hosted model distribution is tracked as #127.
- No closing keywords are used. This PR leaves #126 and #127 unresolved.

## PR Checklist

- [x] I checked whether this changes `SPEC.md` behavior. It does not; `SPEC.md` was not edited, and the documented behavior matches the implementation on `main`.
- [x] I updated docs, tests, or decisions that the change affects. Only `packaging/pkg/README.md` needed updating; `docs/operator-journey.md` was already correct and was left alone.
- [x] I ran relevant validation and recorded outcomes above, including which gates do not apply and why.
- [x] I did not commit active goal packages or private local artifacts.
- [x] I did not introduce dependencies on private workbench/session context.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788078114&installation_model_id=428414&pr_number=133&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F133&signature=0dd5946941d4e59a907139213102663e07c8044a582825e2a8cf85c5c57f0f0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

