### PR TITLE
docs(openspec): add controller health readiness contract prerequisite

### DIFF
--- a/openspec/changes/health-readiness-contract-prerequisite/.openspec.yaml
+++ b/openspec/changes/health-readiness-contract-prerequisite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/health-readiness-contract-prerequisite/README.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/README.md
@@ -1,3 +1,0 @@
-# health-readiness-contract-prerequisite
-
-Split minimal public health from authenticated operator diagnostics and reconcile readiness with SPEC section 3.1 as the first narrow prerequisite for issue 115.

--- a/openspec/changes/health-readiness-contract-prerequisite/README.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/README.md
@@ -1,0 +1,3 @@
+# health-readiness-contract-prerequisite
+
+Split minimal public health from authenticated operator diagnostics and reconcile readiness with SPEC section 3.1 as the first narrow prerequisite for issue 115.

--- a/openspec/changes/health-readiness-contract-prerequisite/design.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/design.md
@@ -106,13 +106,22 @@ Section 10.7 still classifies `plain_http_localhost` as degraded and unsuitable 
 A readiness `200` means the Controller satisfies section 3.1 service readiness; it does not endorse the configured transport for production.
 The later behavior-changing PR must reconcile this distinction explicitly in `SPEC.md` sections 3.1 and 10.7.
 
-Removing transport from readiness also depends on section 10.7 configuration, wrapper, and boot validation continuing to fail closed for invalid or `unknown` transport modes.
+Removing transport from readiness also depends on section 10.7 configuration, wrapper, and boot validation continuing to fail closed for invalid or unresolvable transport modes.
 Health must not become the fallback validator for a Controller configuration that should not have started.
+That dependency is a contract condition rather than design prose: the fail-closed transport requirement in this change's spec delta blocks the gate removal, and task 2.6 supplies the evidence.
+The assessment must cover configuration sources other than `ORCHARD_TRANSPORT_MODE`, because runtime validation raises on a bad environment value while `Orchard.API.Transport.mode/0` normalizes an unrecognized `:transport_mode` application-environment value to `unknown`, and readiness is currently the only surface that reports that state.
 This is a deliberate posture change rather than an oversight, and it takes effect only in the later atomic migration.
 Current readiness behavior, including the existing transport gate, stays unchanged while this prerequisite is in force.
 
 Alternative considered: keep the transport gate alongside the section 3.1 aggregate.
 This was rejected because it is exactly the milestone-specific readiness subset this contract forbids, and it would keep reporting a permitted transport mode as unready.
+
+### Resolve the constant boot flag in the same migration
+
+`controller_boot_completed` is the other current aggregate member that section 3.1 does not require, and the evaluator hard-codes it to `true`.
+It changes no readiness result today, but it is the exact shape the no-shim rule rejects, and it is a rendered Console check with CLI remediation text.
+Adopting the complete aggregate therefore requires the later migration to decide explicitly whether the key survives as an Operator observation or leaves the check set, rather than carrying a constant into the new contract.
+It is listed in the deferred migration inventory for that reason.
 
 ### Accept a bounded credential-free `orchardctl status` feature loss
 

--- a/openspec/changes/health-readiness-contract-prerequisite/design.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/design.md
@@ -88,13 +88,26 @@ After the blocking authorities are accepted:
 - Runtime, licensing, build, transport, and Console observations remain non-gating unless `SPEC.md` explicitly changes.
 - No public or Operator health response adds tenant or user identifiers.
 
+Alternative considered: content negotiation or a query parameter on `/health/ready`.
+This was rejected because it combines public and protected representations at one security boundary.
+
+Alternative considered: preserve rich public fields for compatibility.
+This was rejected because it preserves the disclosure that the owner decision explicitly removes.
+
 ### Intentionally drop public API transport posture as a readiness gate
 
 The current evaluator gates readiness on `public_api_https_enabled`, which is not a `SPEC.md` section 3.1 readiness condition.
 `SPEC.md` section 10.7 lists `plain_http_localhost` as a permitted public transport mode, so a Controller correctly configured for local development or break-glass recovery is currently reported as not ready.
-Adopting the complete section 3.1 aggregate therefore removes that gate on purpose: a `plain_http_localhost` or `reverse_proxy` Controller that satisfies every section 3.1 condition will return HTTP `200` where it returns HTTP `503` today.
+Adopting the complete section 3.1 aggregate therefore removes that gate on purpose: a `plain_http_localhost` Controller that satisfies every section 3.1 condition will return HTTP `200` where it returns HTTP `503` today.
+`reverse_proxy` already passes the current HTTPS gate and does not undergo that status transition.
 
 Transport posture is retained as an Operator observation, not deleted.
+Section 10.7 still classifies `plain_http_localhost` as degraded and unsuitable for production public transport.
+A readiness `200` means the Controller satisfies section 3.1 service readiness; it does not endorse the configured transport for production.
+The later behavior-changing PR must reconcile this distinction explicitly in `SPEC.md` sections 3.1 and 10.7.
+
+Removing transport from readiness also depends on section 10.7 configuration, wrapper, and boot validation continuing to fail closed for invalid or `unknown` transport modes.
+Health must not become the fallback validator for a Controller configuration that should not have started.
 This is a deliberate posture change rather than an oversight, and it takes effect only in the later atomic migration.
 Current readiness behavior, including the existing transport gate, stays unchanged while this prerequisite is in force.
 
@@ -113,12 +126,6 @@ No unauthenticated version route is added, and no credential is placed in the pu
 
 Alternative considered: add an unauthenticated version or build route.
 This was rejected because it reintroduces the unauthenticated deployment disclosure the owner decision removes.
-
-Alternative considered: content negotiation or a query parameter on `/health/ready`.
-This was rejected because it combines public and protected representations at one security boundary.
-
-Alternative considered: preserve rich public fields for compatibility.
-This was rejected because it preserves the disclosure that the owner decision explicitly removes.
 
 ### Preserve read availability on standby Controllers
 

--- a/openspec/changes/health-readiness-contract-prerequisite/design.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/design.md
@@ -88,6 +88,32 @@ After the blocking authorities are accepted:
 - Runtime, licensing, build, transport, and Console observations remain non-gating unless `SPEC.md` explicitly changes.
 - No public or Operator health response adds tenant or user identifiers.
 
+### Intentionally drop public API transport posture as a readiness gate
+
+The current evaluator gates readiness on `public_api_https_enabled`, which is not a `SPEC.md` section 3.1 readiness condition.
+`SPEC.md` section 10.7 lists `plain_http_localhost` as a permitted public transport mode, so a Controller correctly configured for local development or break-glass recovery is currently reported as not ready.
+Adopting the complete section 3.1 aggregate therefore removes that gate on purpose: a `plain_http_localhost` or `reverse_proxy` Controller that satisfies every section 3.1 condition will return HTTP `200` where it returns HTTP `503` today.
+
+Transport posture is retained as an Operator observation, not deleted.
+This is a deliberate posture change rather than an oversight, and it takes effect only in the later atomic migration.
+Current readiness behavior, including the existing transport gate, stays unchanged while this prerequisite is in force.
+
+Alternative considered: keep the transport gate alongside the section 3.1 aggregate.
+This was rejected because it is exactly the milestone-specific readiness subset this contract forbids, and it would keep reporting a permitted transport mode as unready.
+
+### Accept a bounded credential-free `orchardctl status` feature loss
+
+`orchardctl status` currently reads `version` and `build_ref` from the unauthenticated `/health/ready` body to render a remote Controller version banner.
+The exact minimal public body removes that source, and the CLI probes without Operator credentials.
+
+The accepted resolution is a bounded feature loss.
+Credential-free status may present the local CLI or installed package version, but must not present it as remote Controller identity.
+Remote version and build identity move to authenticated Operator health detail.
+No unauthenticated version route is added, and no credential is placed in the public probe path.
+
+Alternative considered: add an unauthenticated version or build route.
+This was rejected because it reintroduces the unauthenticated deployment disclosure the owner decision removes.
+
 Alternative considered: content negotiation or a query parameter on `/health/ready`.
 This was rejected because it combines public and protected representations at one security boundary.
 
@@ -104,11 +130,22 @@ Write routes retain their own mutation-time leadership authorization.
 Single-controller mode is the only case where the leadership check may be `not_applicable`.
 Active/Standby leadership must come from the existing production authority after it is accepted as sufficient or from a separately resolved demonstrated gap.
 
+The no-shim rule and the `not_applicable` path are distinct concerns.
+Determining that the conditional leadership condition does not apply is a deployment-mode question; proving that this Controller currently holds write-path leadership is an authority question.
+A validated deployment mode may answer the first, but a configured role may never answer the second.
+
+`Orchard.ControlPlane.read_only_status/0` currently derives `deployment_mode` solely from the configured `:role`, so today the applicability decision is itself configuration-derived.
+Task 1.4 therefore assesses whether that source can be validated rather than assumed, and must cover a host falsely configured as `single_controller` inside an Active/Standby cluster, an `unknown` normalized role, and a mode inconsistent with cluster membership evidence.
+Each of those cases must either fail closed or be assigned to a separately owned leadership change.
+
 ### Require an atomic health exposure migration
 
 After all prerequisite authorities exist, the health implementation changes the public representation, adds Operator detail, and migrates Console, CLI, packaging, local-development documentation, and tests as one reviewable unit.
 The public representation does not change in advance of the complete aggregate.
 Public probes never receive Operator credentials.
+
+The deferred migration inventory includes `docs/milestones/m0-foundation.md`, which records the M0 readiness subset and the transport-posture reporting that the complete aggregate replaces.
+That document is intentionally left unedited by this prerequisite because it accurately describes current behavior; it is reconciled in the same behavior-changing pull request.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/health-readiness-contract-prerequisite/design.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/design.md
@@ -1,0 +1,139 @@
+## Context
+
+`SPEC.md` section 3.1 requires Controller readiness to cover Postgres, migrations, loaded model, tenant, and API-key caches, plus write-path leadership when Active/Standby mode is enabled.
+The current evaluator checks Postgres, migrations, public HTTPS, and a constant boot flag.
+No `Orchard.CacheSupervisor`, `Orchard.Cache.Models`, `Orchard.Cache.Tenants`, or `Orchard.Cache.ApiKeys` implementation exists.
+The production model, tenant, and API-key paths read Postgres directly, so issue #115 has no authoritative cache-loaded interfaces to consume.
+`Orchard.ControlPlane.authorize_write_path/1` and `read_only_status/0` already provide a write gate and status surface, but their production backing and bounded-read suitability must be assessed before health wiring consumes them.
+
+The public readiness response currently exposes operator-only metadata and is consumed by Console, CLI, packaging documentation, and tests.
+The existing `/ops/v1` pipeline already supplies the required cluster-scoped Operator-or-admin authorization boundary.
+
+The owner has approved minimal unauthenticated health responses and authenticated detailed health, but also requires detailed health to reconcile every `SPEC.md` section 3.1 condition.
+Those decisions cannot be implemented honestly in one narrow observability branch while the required control-plane authorities are absent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Record the approved future public and authenticated health boundary.
+- Preserve `SPEC.md` as the apex contract.
+- Identify the missing control-plane authorities that block issue #115 health wiring.
+- Forbid readiness shims that would create false compliance.
+- Define the evidence required before implementation may resume.
+- Keep this prerequisite review small enough to assess independently.
+
+**Non-Goals:**
+
+- Change production code, tests, runtime behavior, `SPEC.md`, or existing health responses.
+- Design or implement model, tenant, or API-key cache architecture.
+- Design or implement a new leadership authority unless an explicit assessment of the existing surface demonstrates a separately owned gap.
+- Build the issue #115 external probe, terminal-event validator, Collector path, redaction boundary, dashboards, alerts, or Grafana resources.
+- Add `/metrics`, product metric families, tracing, structured logging, or a telemetry vendor SDK.
+- Change Sentry or exactly-one-terminal-event behavior.
+- Add an unauthenticated diagnostic fallback.
+
+## Decisions
+
+### Submit an OpenSpec-only prerequisite
+
+This change package is the only committed artifact in the prerequisite PR.
+It documents the contract conflict and the gate for later implementation.
+It does not claim to implement health behavior or complete any phase of issue #115.
+
+Alternative considered: implement genuine serving-path caches inside issue #115.
+This was rejected because cache preload, coherence, mutation invalidation, revocation, API Client disablement, role changes, multi-controller consistency, and recovery semantics are correctness-sensitive control-plane architecture.
+
+Alternative considered: implement the public health split before the missing readiness authorities.
+This was rejected because the public endpoint would either report a permanently failed Controller or use an incomplete aggregate that contradicts `SPEC.md`.
+
+### Assign missing authorities to separate control-plane changes
+
+Separate accepted changes must own:
+
+- Model cache architecture, serving-path integration, and authoritative loaded-state status.
+- Tenant cache architecture, serving-path integration, and authoritative loaded-state status.
+- API-key cache architecture, authentication-path integration, security, coherence, and authoritative loaded-state status.
+- An assessment of whether the existing `Orchard.ControlPlane` gate and status provide a bounded, production-backed conditional leadership source.
+- A separately owned leadership change only if that assessment demonstrates a gap.
+
+Each cache owner must define startup, failure, recovery, coherence, and test behavior appropriate to its domain.
+Issue #115 consumes the accepted stable status interfaces but does not define their internal architecture.
+
+Alternative considered: let issue #115 define generic cache processes.
+This was rejected because an observability consumer cannot safely own the correctness and security semantics of production serving paths.
+
+### Prohibit readiness substitutes
+
+The later health implementation must not treat any of these as authoritative:
+
+- A hard-coded or configured healthy value.
+- A readiness-only process or ETS table.
+- The unrelated tokenizer compatibility cache.
+- A successful direct database query presented as proof that a cache loaded.
+- Process presence without authoritative hydration state.
+- Configured Controller role, membership state, or process presence presented as proof of current write-path leadership.
+
+An absent, invalid, unavailable, or timed-out authority must block implementation review or fail closed after the real interface exists.
+
+### Preserve the approved future health boundary
+
+After the blocking authorities are accepted:
+
+- `GET /health/live` remains unauthenticated and exact at HTTP `200` with `{"status":"ok"}`.
+- `GET /health/ready` remains unauthenticated and returns only `{"status":"ok"}` with HTTP `200` or `{"status":"error"}` with HTTP `503`.
+- Public readiness and authenticated Operator health consume one complete `SPEC.md` section 3.1 aggregate.
+- `GET /ops/v1/health` uses the existing Operator-or-admin authorization boundary.
+- Operator detail carries stable checks, reasons, bounded remediation, and sanitized observations.
+- Runtime, licensing, build, transport, and Console observations remain non-gating unless `SPEC.md` explicitly changes.
+- No public or Operator health response adds tenant or user identifiers.
+
+Alternative considered: content negotiation or a query parameter on `/health/ready`.
+This was rejected because it combines public and protected representations at one security boundary.
+
+Alternative considered: preserve rich public fields for compatibility.
+This was rejected because it preserves the disclosure that the owner decision explicitly removes.
+
+### Preserve read availability on standby Controllers
+
+The future leadership check describes write-capable readiness.
+A standby may remain live and serve authenticated health plus other authorized read-only APIs while public readiness returns HTTP `503`.
+Readiness must not become middleware that blocks read-only routes.
+Write routes retain their own mutation-time leadership authorization.
+
+Single-controller mode is the only case where the leadership check may be `not_applicable`.
+Active/Standby leadership must come from the existing production authority after it is accepted as sufficient or from a separately resolved demonstrated gap.
+
+### Require an atomic health exposure migration
+
+After all prerequisite authorities exist, the health implementation changes the public representation, adds Operator detail, and migrates Console, CLI, packaging, local-development documentation, and tests as one reviewable unit.
+The public representation does not change in advance of the complete aggregate.
+Public probes never receive Operator credentials.
+
+## Risks / Trade-offs
+
+- [The prerequisite is mistaken for implementation] -> Keep all production tasks blocked, change no runtime files, and state in the PR that issue #115 remains open.
+- [A separate owner introduces a readiness-only cache] -> Require evidence that each loaded-state interface belongs to the corresponding production serving or authentication path.
+- [API-key cache work weakens credential safety] -> Keep its architecture under a separate security-sensitive control-plane review and require revocation, expiry, disablement, role-change, coherence, and recovery tests.
+- [Leadership status diverges from write authorization] -> Assess the existing `Orchard.ControlPlane` gate and status first, require any consumed interface to use the same production authority, and prohibit configured-role inference.
+- [The later public switch breaks clients] -> Audit and migrate every in-repository consumer in the same behavior-changing PR.
+- [Operator diagnostics are unavailable during authentication failure] -> Preserve the authentication boundary and do not add an unauthenticated detailed fallback.
+- [The prerequisite expands into the full observability issue] -> Keep probe, Collector, metrics, tracing, logging, Grafana, and terminal-event work as explicit non-goals.
+
+## Migration Plan
+
+1. Review and merge this OpenSpec-only prerequisite without changing current behavior or claiming issue #115 completion.
+2. Assign and accept separate control-plane changes for the three genuine cache authorities.
+3. Assess the existing `Orchard.ControlPlane` gate and status for production backing, bounded reads, and exact readiness semantics, then assign separate work only for demonstrated gaps.
+4. Verify each dependency through public interfaces and tests rather than implementation-specific assumptions.
+5. Resume issue #115 health wiring only after every dependency is available.
+6. Update `SPEC.md` and implement the approved health boundary in the later behavior-changing PR.
+7. Keep issue #115 open for the external acceptance harness after the health prerequisite lands.
+
+## Open Questions
+
+- Which issue and OpenSpec identifiers will own each cache authority?
+- Does the existing `Orchard.ControlPlane` gate and status already satisfy the bounded production leadership requirement, and if not, which exact gap needs separate ownership?
+- May one control-plane change own all three cache authorities, or do their security and coherence differences require separate reviews?
+
+These ownership questions block implementation but do not change the approved health boundary.

--- a/openspec/changes/health-readiness-contract-prerequisite/proposal.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/proposal.md
@@ -8,6 +8,8 @@ Issue #115 cannot safely implement its approved public-health split until separa
 - Record the approved future contract for exact minimal unauthenticated `GET /health/live` and `GET /health/ready` responses.
 - Record the approved future `GET /ops/v1/health` detail route under the existing cluster-scoped Operator-or-admin authorization boundary.
 - Require one complete aggregate readiness evaluation for both public readiness and Operator health detail.
+- Record the intentional future removal of public API transport posture as a readiness gate, because `SPEC.md` section 10.7 permits `plain_http_localhost` and `SPEC.md` section 3.1 does not list transport as a readiness condition, while transport remains an Operator observation.
+- Record the accepted bounded feature loss where credential-free `orchardctl status` no longer reports remote Controller version or build identity, without adding an unauthenticated route or a probe credential.
 - Identify authoritative model, tenant, and API-key cache hydration as blocking dependencies owned by separate control-plane changes.
 - Require an explicit adequacy assessment of the existing `Orchard.ControlPlane` write gate and status surface, with separate ownership only for demonstrated gaps.
 - Forbid constants, configuration flags, readiness-only caches, unrelated caches, or successful database queries from standing in for the missing authorities.

--- a/openspec/changes/health-readiness-contract-prerequisite/proposal.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Orchard's unauthenticated readiness endpoint currently discloses build, transport, Console, runtime, licensing, check, reason, and remediation details while evaluating only an M0 subset of the readiness conditions required by `SPEC.md` section 3.1.
+Issue #115 cannot safely implement its approved public-health split until separate control-plane owners provide authoritative model, tenant, and API-key cache hydration and the existing write-path leadership surface is confirmed to provide bounded production authority.
+
+## What Changes
+
+- Record the approved future contract for exact minimal unauthenticated `GET /health/live` and `GET /health/ready` responses.
+- Record the approved future `GET /ops/v1/health` detail route under the existing cluster-scoped Operator-or-admin authorization boundary.
+- Require one complete aggregate readiness evaluation for both public readiness and Operator health detail.
+- Identify authoritative model, tenant, and API-key cache hydration as blocking dependencies owned by separate control-plane changes.
+- Require an explicit adequacy assessment of the existing `Orchard.ControlPlane` write gate and status surface, with separate ownership only for demonstrated gaps.
+- Forbid constants, configuration flags, readiness-only caches, unrelated caches, or successful database queries from standing in for the missing authorities.
+- Define the consumer migration and validation gates that must pass when the health behavior is implemented.
+- Make no production code, test, `SPEC.md`, or runtime behavior change in this prerequisite proposal.
+- Do not add the external probe, terminal-event validator, OpenTelemetry Collector, product metrics, tracing, logs, dashboards, alerts, or Grafana resources in this change.
+
+SPEC.md impact: none in this prerequisite proposal.
+`SPEC.md` remains authoritative and unchanged until the blocking authorities exist and the accepted health behavior is implemented.
+
+## Capabilities
+
+### New Capabilities
+
+- `controller-health-prerequisites`: Defines the approved future health boundary, its authoritative dependencies, no-shim rule, and implementation gates without changing runtime behavior.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a collaborator-reviewable OpenSpec contract only.
+- Requires separate control-plane change ownership for genuine cache hydration and an explicit assessment of the existing leadership surface before issue #115 implements health wiring.
+- Preserves existing Controller routes, readiness behavior, Console, CLI, packaging, documentation, tests, and `SPEC.md`.
+- Adds no dependency, vendor SDK, telemetry backend, exported identifier, or Grafana Cloud resource.

--- a/openspec/changes/health-readiness-contract-prerequisite/proposal.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/proposal.md
@@ -9,6 +9,8 @@ Issue #115 cannot safely implement its approved public-health split until separa
 - Record the approved future `GET /ops/v1/health` detail route under the existing cluster-scoped Operator-or-admin authorization boundary.
 - Require one complete aggregate readiness evaluation for both public readiness and Operator health detail.
 - Record the intentional future removal of public API transport posture as a readiness gate, because `SPEC.md` section 10.7 permits `plain_http_localhost` and `SPEC.md` section 3.1 does not list transport as a readiness condition, while transport remains an Operator observation.
+- Condition that removal on confirmed fail-closed `SPEC.md` section 10.7 validation for invalid or unresolvable transport modes from any configuration source, so health never becomes the fallback validator.
+- Require the later migration to resolve the constant `controller_boot_completed` check explicitly, since it is the other current aggregate member that `SPEC.md` section 3.1 does not require.
 - Record the accepted bounded feature loss where credential-free `orchardctl status` no longer reports remote Controller version or build identity, without adding an unauthenticated route or a probe credential.
 - Identify authoritative model, tenant, and API-key cache hydration as blocking dependencies owned by separate control-plane changes.
 - Require an explicit adequacy assessment of the existing `Orchard.ControlPlane` write gate and status surface, with separate ownership only for demonstrated gaps.

--- a/openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md
@@ -2,29 +2,30 @@
 
 ### Requirement: Health implementation remains blocked on authoritative readiness sources
 
-Issue #115 health wiring MUST NOT begin until separate accepted control-plane changes expose authoritative model, tenant, and API-key cache hydration status and the existing production write-path leadership surface is accepted as a bounded readiness source or its demonstrated gaps are resolved.
+Controller health wiring MUST NOT begin until separate accepted control-plane changes expose authoritative model, tenant, and API-key cache hydration status and the existing production write-path leadership surface is accepted as a bounded readiness source or its demonstrated gaps are resolved.
 
 #### Scenario: A cache authority is absent
 
 - **WHEN** any required serving-path cache and its loaded-state interface do not exist
-- **THEN** issue #115 health implementation remains blocked
+- **THEN** Controller health implementation remains blocked
 - **AND** the missing authority is assigned to a separate control-plane change
 
 #### Scenario: Existing leadership surface has not been assessed
 
 - **WHEN** the production backing, bounded-read behavior, or readiness semantics of `Orchard.ControlPlane` have not been explicitly assessed
-- **THEN** issue #115 health implementation remains blocked
+- **THEN** Controller health implementation remains blocked
 - **AND** no new authority is commissioned until that assessment identifies a concrete gap
 
 #### Scenario: Existing leadership surface has a demonstrated gap
 
 - **WHEN** the assessment identifies a missing production provider, missing timeout bound, or semantic mismatch with write authorization
 - **THEN** the exact gap is assigned to a separate control-plane change
-- **AND** issue #115 remains a consumer rather than the owner of that authority
+- **AND** the health implementation remains a consumer rather than the owner of that authority
 
 ### Requirement: Readiness shims are prohibited
 
-Issue #115 MUST consume authoritative readiness sources and MUST NOT invent substitutes for unimplemented `SPEC.md` section 3.1 conditions.
+The Controller health implementation MUST consume authoritative readiness sources and MUST NOT invent substitutes for unimplemented `SPEC.md` section 3.1 conditions.
+A validated deployment mode MAY determine whether the conditional leadership condition applies, but a configured role MUST NOT be accepted as proof that this Controller currently holds write-path leadership.
 
 #### Scenario: Constant or configuration flag is proposed
 
@@ -45,6 +46,13 @@ Issue #115 MUST consume authoritative readiness sources and MUST NOT invent subs
 
 - **WHEN** a configured role, membership record, or process-presence check is proposed as proof of current write-path leadership
 - **THEN** the proposal is rejected
+
+#### Scenario: Deployment mode determines whether the leadership condition applies
+
+- **WHEN** a deployment-mode source is proposed only to decide whether the conditional `SPEC.md` section 3.1 leadership condition applies
+- **THEN** the proposal is permitted
+- **AND** it does not authorize that source to report `pass` for write-path leadership in Active/Standby mode
+- **AND** the accepted assessment records how a mode value is validated rather than assumed correct
 
 ### Requirement: Future public health responses are exact and minimal
 
@@ -74,11 +82,19 @@ After the blocking authorities are accepted, the health implementation SHALL pro
 
 After the blocking authorities are accepted, the public readiness endpoint and authenticated Operator health endpoint SHALL consume one complete aggregate evaluation of every readiness condition required by `SPEC.md` section 3.1.
 A reduced milestone-specific readiness subset MUST NOT be used.
+A condition that `SPEC.md` section 3.1 does not require MUST NOT gate the aggregate, so public API transport posture ceases to be a readiness gate when the aggregate is adopted.
 
 #### Scenario: Future required condition fails
 
 - **WHEN** any required or applicable readiness source reports failure
 - **THEN** public readiness and Operator health report the same aggregate failure
+
+#### Scenario: Future transport posture is observational only
+
+- **WHEN** the Controller serves the public API in a `SPEC.md` section 10.7 `plain_http_localhost` or `reverse_proxy` transport mode and every `SPEC.md` section 3.1 condition passes
+- **THEN** public readiness returns HTTP `200`
+- **AND** transport posture appears only as an Operator observation
+- **AND** transport posture does not fail the aggregate
 
 #### Scenario: Future readiness source is invalid or unavailable
 
@@ -159,12 +175,25 @@ Authorized responses SHALL set `Cache-Control: no-store`.
 
 When the health behavior is implemented, in-repository public health consumers SHALL treat `/health/ready` as a status-only endpoint and SHALL NOT require Operator credentials.
 Console diagnostics SHALL use the shared readiness evaluator or authenticated Operator contract without reimplementing readiness policy.
+Remote Controller version and build identity cease to be available without credentials, and that loss SHALL NOT be replaced by a new unauthenticated route or by placing a credential in a public probe.
 
 #### Scenario: orchardctl status probes public readiness
 
 - **WHEN** `orchardctl status` probes a Controller without an Operator credential
 - **THEN** it derives Controller reachability and readiness from the exact public health response
 - **AND** it does not expect build, runtime, licensing, reason, remediation, or check detail from `/health/ready`
+
+#### Scenario: Credential-free status reports no remote Controller identity
+
+- **WHEN** `orchardctl status` renders a version banner without an Operator credential
+- **THEN** it may present only the local CLI or installed package version
+- **AND** it does not present that local value as the remote Controller version or build reference
+- **AND** the migration adds no unauthenticated version route and no credential to the public probe path
+
+#### Scenario: Remote Controller identity is requested
+
+- **WHEN** an Operator needs remote Controller version or build identity
+- **THEN** it is obtained from the authenticated Operator health detail
 
 #### Scenario: Console renders readiness
 

--- a/openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md
@@ -82,7 +82,7 @@ After the blocking authorities are accepted, the health implementation SHALL pro
 
 After the blocking authorities are accepted, the public readiness endpoint and authenticated Operator health endpoint SHALL consume one complete aggregate evaluation of every readiness condition required by `SPEC.md` section 3.1.
 A reduced milestone-specific readiness subset MUST NOT be used.
-A condition that `SPEC.md` section 3.1 does not require MUST NOT gate the aggregate, so public API transport posture ceases to be a readiness gate when the aggregate is adopted.
+A condition that `SPEC.md` section 3.1 does not require MUST NOT gate the aggregate, so public API transport posture and the constant Controller boot flag both cease to be readiness gates when the aggregate is adopted.
 
 #### Scenario: Future required condition fails
 
@@ -96,11 +96,40 @@ A condition that `SPEC.md` section 3.1 does not require MUST NOT gate the aggreg
 - **AND** transport posture appears only as an Operator observation
 - **AND** transport posture does not fail the aggregate
 
+#### Scenario: Future constant boot flag is not a gate
+
+- **WHEN** a hard-coded or otherwise constant Controller boot flag is proposed as a member of the readiness aggregate
+- **THEN** it does not gate the aggregate
+- **AND** it survives only as an Operator observation or is removed from the check set by the same atomic migration
+
 #### Scenario: Future readiness source is invalid or unavailable
 
 - **WHEN** a readiness source raises, exits, times out, or returns an invalid value
 - **THEN** the aggregate fails closed
 - **AND** the public endpoint returns its stable HTTP `503` representation rather than an internal error response
+
+### Requirement: Removing the transport readiness gate depends on fail-closed transport validation
+
+The public API transport readiness gate MUST NOT be removed until `SPEC.md` section 10.7 configuration, wrapper, and boot validation are confirmed to fail closed for every invalid or unresolvable public transport mode, through any configuration source rather than the `ORCHARD_TRANSPORT_MODE` environment variable alone.
+Health MUST NOT become the fallback validator for a Controller configuration that should not have started.
+
+#### Scenario: Invalid transport mode fails closed before boot completes
+
+- **WHEN** an invalid, unrecognized, or unresolvable public transport mode is configured through any source
+- **THEN** the Controller fails closed at wrapper preflight or boot per `SPEC.md` section 10.7
+- **AND** no running Controller resolves an unresolved public transport mode
+
+#### Scenario: Transport validation gap is demonstrated
+
+- **WHEN** an invalid or unresolvable public transport mode can reach a running Controller instead of failing closed
+- **THEN** the existing transport readiness gate is retained until that validation gap is resolved
+- **AND** the exact gap is assigned to a separate transport change rather than to the health implementation
+
+#### Scenario: Transport observation reports posture honestly
+
+- **WHEN** authorized Operator health detail renders public transport posture
+- **THEN** it reports the resolved `SPEC.md` section 10.7 mode and its degraded classification
+- **AND** an unresolved mode is not presented as a compliant transport posture
 
 ### Requirement: Future leadership status preserves read availability
 

--- a/openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md
@@ -1,0 +1,179 @@
+## ADDED Requirements
+
+### Requirement: Health implementation remains blocked on authoritative readiness sources
+
+Issue #115 health wiring MUST NOT begin until separate accepted control-plane changes expose authoritative model, tenant, and API-key cache hydration status and the existing production write-path leadership surface is accepted as a bounded readiness source or its demonstrated gaps are resolved.
+
+#### Scenario: A cache authority is absent
+
+- **WHEN** any required serving-path cache and its loaded-state interface do not exist
+- **THEN** issue #115 health implementation remains blocked
+- **AND** the missing authority is assigned to a separate control-plane change
+
+#### Scenario: Existing leadership surface has not been assessed
+
+- **WHEN** the production backing, bounded-read behavior, or readiness semantics of `Orchard.ControlPlane` have not been explicitly assessed
+- **THEN** issue #115 health implementation remains blocked
+- **AND** no new authority is commissioned until that assessment identifies a concrete gap
+
+#### Scenario: Existing leadership surface has a demonstrated gap
+
+- **WHEN** the assessment identifies a missing production provider, missing timeout bound, or semantic mismatch with write authorization
+- **THEN** the exact gap is assigned to a separate control-plane change
+- **AND** issue #115 remains a consumer rather than the owner of that authority
+
+### Requirement: Readiness shims are prohibited
+
+Issue #115 MUST consume authoritative readiness sources and MUST NOT invent substitutes for unimplemented `SPEC.md` section 3.1 conditions.
+
+#### Scenario: Constant or configuration flag is proposed
+
+- **WHEN** a constant or configuration flag is proposed as evidence that a required cache is loaded
+- **THEN** the proposal is rejected
+
+#### Scenario: Unrelated or readiness-only cache is proposed
+
+- **WHEN** an unrelated cache or a process unused by the production serving path is proposed as a required cache authority
+- **THEN** the proposal is rejected
+
+#### Scenario: Database query is proposed as cache evidence
+
+- **WHEN** a successful direct Postgres query is proposed as proof that a required cache is loaded
+- **THEN** the proposal is rejected
+
+#### Scenario: Configured role is proposed as leadership evidence
+
+- **WHEN** a configured role, membership record, or process-presence check is proposed as proof of current write-path leadership
+- **THEN** the proposal is rejected
+
+### Requirement: Future public health responses are exact and minimal
+
+After the blocking authorities are accepted, the health implementation SHALL provide unauthenticated public health responses that disclose only stable status.
+
+#### Scenario: Future liveness response
+
+- **WHEN** the Controller HTTP process serves `GET /health/live`
+- **THEN** it returns HTTP `200`
+- **AND** the JSON body is exactly `{"status":"ok"}`
+- **AND** it does not evaluate dependency or observational health
+
+#### Scenario: Future public readiness passes
+
+- **WHEN** the complete `SPEC.md` section 3.1 readiness evaluation passes
+- **THEN** `GET /health/ready` returns HTTP `200`
+- **AND** the JSON body is exactly `{"status":"ok"}`
+
+#### Scenario: Future public readiness fails
+
+- **WHEN** any applicable `SPEC.md` section 3.1 readiness condition fails or cannot be evaluated safely
+- **THEN** `GET /health/ready` returns HTTP `503`
+- **AND** the JSON body is exactly `{"status":"error"}`
+- **AND** the response exposes no diagnostic detail
+
+### Requirement: Future public and Operator health share the complete readiness aggregate
+
+After the blocking authorities are accepted, the public readiness endpoint and authenticated Operator health endpoint SHALL consume one complete aggregate evaluation of every readiness condition required by `SPEC.md` section 3.1.
+A reduced milestone-specific readiness subset MUST NOT be used.
+
+#### Scenario: Future required condition fails
+
+- **WHEN** any required or applicable readiness source reports failure
+- **THEN** public readiness and Operator health report the same aggregate failure
+
+#### Scenario: Future readiness source is invalid or unavailable
+
+- **WHEN** a readiness source raises, exits, times out, or returns an invalid value
+- **THEN** the aggregate fails closed
+- **AND** the public endpoint returns its stable HTTP `503` representation rather than an internal error response
+
+### Requirement: Future leadership status preserves read availability
+
+After the existing leadership surface is accepted as sufficient or a demonstrated gap is resolved, the health implementation SHALL derive conditional write-path leadership from that production authority without blocking authorized read-only routes.
+
+#### Scenario: Future single-controller mode
+
+- **WHEN** the accepted authority reports single-controller mode
+- **THEN** `write_path_leadership` reports `not_applicable`
+- **AND** it does not fail the aggregate
+
+#### Scenario: Future standby remains live and readable
+
+- **WHEN** the accepted authority reports this Controller as standby and health is requested
+- **THEN** public readiness returns HTTP `503`
+- **AND** authenticated Operator health returns HTTP `503` with reason `controller_standby`
+- **AND** public liveness remains HTTP `200`
+- **AND** authorized read-only routes remain callable
+
+#### Scenario: Future leadership is unproven
+
+- **WHEN** the accepted authority cannot prove current local write-path leadership in Active/Standby mode
+- **THEN** `write_path_leadership` reports `fail`
+- **AND** the failure reason is `controller_leadership_unproven`
+
+### Requirement: Future Operator health detail uses the existing protected boundary
+
+After the blocking authorities are accepted, `GET /ops/v1/health` SHALL use the existing Operator API authentication contract from `SPEC.md` section 7.3 and ADR 0007.
+Authentication and authorization SHALL complete before readiness or observational probes run.
+Authorized responses SHALL set `Cache-Control: no-store`.
+
+#### Scenario: Credential is missing or invalid
+
+- **WHEN** a request does not present a valid API Client bearer credential
+- **THEN** it returns HTTP `401`
+- **AND** the stable error code is `invalid_api_key`
+- **AND** no health probe runs
+
+#### Scenario: Principal is not an Operator
+
+- **WHEN** an authenticated principal lacks a cluster-scoped `operator` or `admin` RoleBinding
+- **THEN** it returns HTTP `403`
+- **AND** the stable error code is `operator_required`
+- **AND** no health probe runs
+
+#### Scenario: Authorized detail passes
+
+- **WHEN** a cluster-scoped Operator or admin requests health detail and the shared aggregate passes
+- **THEN** the endpoint returns HTTP `200`
+- **AND** the response object is `operator_health`
+- **AND** the contract version is `orchard.operator_health.v1`
+- **AND** every `SPEC.md` section 3.1 check appears exactly once in stable causal order
+
+#### Scenario: Authorized detail fails
+
+- **WHEN** a cluster-scoped Operator or admin requests health detail and the shared aggregate fails
+- **THEN** the endpoint returns HTTP `503`
+- **AND** it includes the first stable failure reason and bounded remediation
+- **AND** its aggregate status matches public readiness for the same evaluation
+
+#### Scenario: Detail contains observational metadata
+
+- **WHEN** authorized health detail includes build, transport, Console, runtime, licensing, or control-plane observations
+- **THEN** those observations do not alter the aggregate readiness result unless `SPEC.md` explicitly makes them readiness conditions
+
+#### Scenario: Detail is sanitized
+
+- **WHEN** authorized health detail is serialized
+- **THEN** it contains no bearer credential, plaintext secret, DSN, raw exception, tenant identifier, user identifier, prompt, response content, or machine-local path
+
+### Requirement: Future in-repository consumers preserve the health boundary
+
+When the health behavior is implemented, in-repository public health consumers SHALL treat `/health/ready` as a status-only endpoint and SHALL NOT require Operator credentials.
+Console diagnostics SHALL use the shared readiness evaluator or authenticated Operator contract without reimplementing readiness policy.
+
+#### Scenario: orchardctl status probes public readiness
+
+- **WHEN** `orchardctl status` probes a Controller without an Operator credential
+- **THEN** it derives Controller reachability and readiness from the exact public health response
+- **AND** it does not expect build, runtime, licensing, reason, remediation, or check detail from `/health/ready`
+
+#### Scenario: Console renders readiness
+
+- **WHEN** the Console renders Controller readiness
+- **THEN** it presents every check from the shared complete evaluation
+- **AND** it supports `pass`, `fail`, and the single-controller `not_applicable` leadership state
+
+#### Scenario: Existing public probes continue without credentials
+
+- **WHEN** packaging, launchd, local development, or an external black-box probe checks public health
+- **THEN** it can use the stable unauthenticated status and exact body
+- **AND** no Operator credential is placed in the probe configuration

--- a/openspec/changes/health-readiness-contract-prerequisite/tasks.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/tasks.md
@@ -12,13 +12,14 @@
 - [ ] 2.1 Verify that each cache owner rejects constants, configuration flags, readiness-only caches, unrelated caches, and direct database queries presented as hydration evidence.
 - [ ] 2.2 Verify that the accepted leadership source derives from the same production authority used by write authorization and does not infer authority from configured role, membership, or process presence, while permitting a validated deployment mode to decide only whether the conditional leadership condition applies.
 - [ ] 2.3 Verify that issue #115 remains blocked until every dependency exposes a stable tested status interface.
-- [ ] 2.4 Re-run the issue #115 RP Investigate workflow against the exact dependency heads before starting production health changes.
-- [ ] 2.5 Verify that the deferred atomic migration inventory covers Console, CLI, packaging, local-development documentation, tests, and `docs/milestones/m0-foundation.md`, and that the recorded transport-gate removal and credential-free `orchardctl status` identity loss are carried into that pull request.
+- [ ] 2.4 Re-run the issue #115 readiness-source investigation against the exact dependency heads before starting production health changes.
+- [ ] 2.5 Verify that the deferred atomic migration inventory covers Console, CLI, packaging, local-development documentation, tests, and `docs/milestones/m0-foundation.md`, and that the recorded transport-gate removal, the disposition of the constant `controller_boot_completed` check, and the credential-free `orchardctl status` identity loss are carried into that pull request.
+- [ ] 2.6 Verify that `SPEC.md` section 10.7 configuration, wrapper, and boot validation fail closed for every invalid or unresolvable public transport mode, including a `:transport_mode` application-environment value that never passes through `ORCHARD_TRANSPORT_MODE`, and assign any demonstrated gap to a separate transport change before the transport readiness gate is removed.
 
 ## 3. Validate and Hand Off
 
 - [ ] 3.1 Run strict OpenSpec validation after dependency identifiers are recorded.
-- [ ] 3.2 Run exact-diff RepoPrompt Review and Oracle follow-up, then resolve all blocking findings.
+- [ ] 3.2 Complete an exact-diff review of this package against the exact dependency heads and resolve every blocking finding.
 - [ ] 3.3 Run the no-mistakes gate before publishing any update to this prerequisite package.
 - [ ] 3.4 Confirm the pull request changes only this OpenSpec package and excludes transient investigation, review, prompt-export, and machine-local artifacts.
 - [ ] 3.5 State in the pull request that no production behavior changes, `SPEC.md` remains unchanged, and issue #115 remains open.

--- a/openspec/changes/health-readiness-contract-prerequisite/tasks.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/tasks.md
@@ -3,16 +3,17 @@
 - [ ] 1.1 Record the accepted issue and OpenSpec owner for the genuine model cache, serving-path integration, and authoritative loaded-state interface.
 - [ ] 1.2 Record the accepted issue and OpenSpec owner for the genuine tenant cache, serving-path integration, and authoritative loaded-state interface.
 - [ ] 1.3 Record the accepted issue and OpenSpec owner for the genuine API-key cache, authentication-path integration, security, coherence, and authoritative loaded-state interface.
-- [ ] 1.4 Assess the existing `Orchard.ControlPlane.authorize_write_path/1` and `read_only_status/0` surface for production provider backing, bounded-read behavior, and exact readiness semantics.
+- [ ] 1.4 Assess the existing `Orchard.ControlPlane.authorize_write_path/1` and `read_only_status/0` surface for production provider backing, bounded-read behavior, and exact readiness semantics, including whether `deployment_mode` can be validated rather than assumed when a host is falsely configured as `single_controller` inside an Active/Standby cluster, when the normalized role is `unknown`, and when the configured mode is inconsistent with cluster membership evidence.
 - [ ] 1.5 Record a separate issue and OpenSpec owner only for leadership gaps demonstrated by task 1.4.
 - [ ] 1.6 Link every accepted dependency from this change package and issue #115 without adding implementation details owned by those changes.
 
 ## 2. Verify the Prerequisite Gate
 
 - [ ] 2.1 Verify that each cache owner rejects constants, configuration flags, readiness-only caches, unrelated caches, and direct database queries presented as hydration evidence.
-- [ ] 2.2 Verify that the accepted leadership source derives from the same production authority used by write authorization and does not infer authority from configured role, membership, or process presence.
+- [ ] 2.2 Verify that the accepted leadership source derives from the same production authority used by write authorization and does not infer authority from configured role, membership, or process presence, while permitting a validated deployment mode to decide only whether the conditional leadership condition applies.
 - [ ] 2.3 Verify that issue #115 remains blocked until every dependency exposes a stable tested status interface.
 - [ ] 2.4 Re-run the issue #115 RP Investigate workflow against the exact dependency heads before starting production health changes.
+- [ ] 2.5 Verify that the deferred atomic migration inventory covers Console, CLI, packaging, local-development documentation, tests, and `docs/milestones/m0-foundation.md`, and that the recorded transport-gate removal and credential-free `orchardctl status` identity loss are carried into that pull request.
 
 ## 3. Validate and Hand Off
 

--- a/openspec/changes/health-readiness-contract-prerequisite/tasks.md
+++ b/openspec/changes/health-readiness-contract-prerequisite/tasks.md
@@ -1,0 +1,25 @@
+## 1. Record Blocking Ownership
+
+- [ ] 1.1 Record the accepted issue and OpenSpec owner for the genuine model cache, serving-path integration, and authoritative loaded-state interface.
+- [ ] 1.2 Record the accepted issue and OpenSpec owner for the genuine tenant cache, serving-path integration, and authoritative loaded-state interface.
+- [ ] 1.3 Record the accepted issue and OpenSpec owner for the genuine API-key cache, authentication-path integration, security, coherence, and authoritative loaded-state interface.
+- [ ] 1.4 Assess the existing `Orchard.ControlPlane.authorize_write_path/1` and `read_only_status/0` surface for production provider backing, bounded-read behavior, and exact readiness semantics.
+- [ ] 1.5 Record a separate issue and OpenSpec owner only for leadership gaps demonstrated by task 1.4.
+- [ ] 1.6 Link every accepted dependency from this change package and issue #115 without adding implementation details owned by those changes.
+
+## 2. Verify the Prerequisite Gate
+
+- [ ] 2.1 Verify that each cache owner rejects constants, configuration flags, readiness-only caches, unrelated caches, and direct database queries presented as hydration evidence.
+- [ ] 2.2 Verify that the accepted leadership source derives from the same production authority used by write authorization and does not infer authority from configured role, membership, or process presence.
+- [ ] 2.3 Verify that issue #115 remains blocked until every dependency exposes a stable tested status interface.
+- [ ] 2.4 Re-run the issue #115 RP Investigate workflow against the exact dependency heads before starting production health changes.
+
+## 3. Validate and Hand Off
+
+- [ ] 3.1 Run strict OpenSpec validation after dependency identifiers are recorded.
+- [ ] 3.2 Run exact-diff RepoPrompt Review and Oracle follow-up, then resolve all blocking findings.
+- [ ] 3.3 Run the no-mistakes gate before publishing any update to this prerequisite package.
+- [ ] 3.4 Confirm the pull request changes only this OpenSpec package and excludes transient investigation, review, prompt-export, and machine-local artifacts.
+- [ ] 3.5 State in the pull request that no production behavior changes, `SPEC.md` remains unchanged, and issue #115 remains open.
+- [ ] 3.6 Hand future cache, leadership-gap, health implementation, consumer migration, and observability-harness tasks to their owning change packages rather than adding them here.
+- [ ] 3.7 After any later sync or archive, review generated main specs and remove incomplete placeholder prose such as `Purpose TBD`.


### PR DESCRIPTION
## Intent

Issue #115 observability acceptance harness. Keep scope narrowly limited to the OpenSpec-only readiness prerequisite contract because required model, tenant, and API-key cache authorities are not implemented and the existing ControlPlane leadership authority must be assessed before behavior changes. Preserve SPEC.md as apex. Do not change production behavior, do not configure Grafana Cloud, and do not claim issue #115 complete. Validate the exact branch head, OpenSpec package, tests, documentation consistency, and PR evidence. Treat the public health boundary, authenticated operator detail, no tenant/user identifiers, exactly one terminal event, SPEC section 3.1 readiness conditions, SPEC section 10.7 transport posture, CLI identity loss, and fail-closed invalid transport validation as review-critical.

## What Changed

- Adds the `health-readiness-contract-prerequisite` OpenSpec package (`proposal.md`, `design.md`, `tasks.md`, and a new `controller-health-prerequisites` spec delta) recording the approved future health boundary: exact minimal unauthenticated `GET /health/live` and `GET /health/ready` bodies, an authenticated `GET /ops/v1/health` detail route under the existing cluster-scoped Operator-or-admin authorization, one complete aggregate readiness evaluation shared by both, and a no-shim rule barring constants, config flags, readiness-only caches, or bare database queries from standing in for missing model, tenant, and API-key cache authorities.
- Records the contract's deferred edges: removal of public transport posture as a readiness gate is bound to a task requiring demonstrated fail-closed `SPEC.md` 10.7 validation for invalid or unresolvable modes from any configuration source (including a `:transport_mode` app-env value that never passes through `ORCHARD_TRANSPORT_MODE`); the constant `controller_boot_completed` check must be explicitly resolved in the later atomic migration; and the credential-free `orchardctl status` version/build-identity loss is accepted rather than papered over with an unauthenticated route or probe credential.
- Restates the verification tasks in tool-neutral terms (exact-diff review against dependency heads, blocking findings resolved) instead of naming local agent accelerators, per `AGENTS.md`. No production code, config, docs, tests, or `SPEC.md` change — `git diff --name-only dc73b55..bcde0af` is confined to this OpenSpec package, strict OpenSpec validation passes (11 changes), and issue #115 remains open and blocked on its dependency owners.

## Risk Assessment

✅ Low: The delta is documentation-only (four OpenSpec files, no production, test, or SPEC.md changes), it resolves all three round-1 findings with contract-level bindings whose factual claims about `Transport.mode/0` and `config/runtime.exs` I re-verified, and the sole remaining finding is a wording clarification in a future-facing contract.

## Testing

Validated an OpenSpec-only prerequisite by combining contract validation, scope verification, and live-system checks of every premise the contract asserts. Strict OpenSpec validation passes for the change and repo-wide; the diff touches only the OpenSpec package, leaving SPEC.md and all production code untouched. I booted a real Controller against an isolated database and captured the actual end-user surfaces the contract governs: the unauthenticated /health/ready response (12 disclosed keys, 503 under the permitted plain_http_localhost mode), /ops/v1/health returning 404 since the Operator detail route is described rather than added, the credential-free orchardctl status banner deriving remote version and build ref from the public body, and a full-page Console screenshot of the Readiness panel rendering the current M0 check subset including the hard-coded controller_boot_completed. I exercised both transport-validation paths the spec delta distinguishes and confirmed the residual application-environment gap is real, so the readiness gate correctly stays in place. Targeted test slices for health, control plane, CLI status, Console, readiness, and runtime transport all pass. Transient artifacts were removed and the worktree is clean.

- Evidence: Console Readiness panel — current M0 check subset (rendered UI) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYVN4QHSMA23NR78G4WQFH75/04-console-readiness-current.png</code>)
<details>
<summary>Evidence: Live unauthenticated public health surface (curl transcript)</summary>

<code>$ curl -i http://127.0.0.1:4011/health/live&#10;HTTP/1.1 200 OK&#10;{&#34;status&#34;:&#34;ok&#34;}&#10;&#10;$ curl -i http://127.0.0.1:4011/health/ready&#10;HTTP/1.1 503 Service Unavailable&#10;{&#34;reason&#34;:&#34;public_api_https_enabled&#34;,&#34;runtime&#34;:{...&#34;node_id&#34;:&#34;883fc712-...&#34;,&#34;display_name&#34;:&#34;tamingsari&#34;...},&#34;status&#34;:&#34;error&#34;,&#34;version&#34;:&#34;0.5.0-dev&#34;,&#34;console&#34;:{&#34;enabled&#34;:true,&#34;auth_mode&#34;:&#34;disabled&#34;},&#34;transport&#34;:{&#34;mode&#34;:&#34;plain_http_localhost&#34;,&#34;degraded&#34;:true,&#34;cert_source&#34;:&#34;unknown&#34;},&#34;build_channel&#34;:&#34;dev&#34;,&#34;build_date&#34;:&#34;2026-07-31&#34;,&#34;build_ref&#34;:&#34;bcde0af&#34;,&#34;checks&#34;:{&#34;controller_boot_completed&#34;:true,&#34;migrations_current&#34;:true,&#34;postgres_reachable&#34;:true,&#34;public_api_https_enabled&#34;:false},&#34;license&#34;:{...},&#34;remediation&#34;:{...}}&#10;&#10;$ curl -s .../health/ready | jq &#39;keys&#39; # disclosed WITHOUT credentials&#10;[&#34;build_channel&#34;,&#34;build_date&#34;,&#34;build_ref&#34;,&#34;checks&#34;,&#34;console&#34;,&#34;license&#34;,&#34;reason&#34;,&#34;remediation&#34;,&#34;runtime&#34;,&#34;status&#34;,&#34;transport&#34;,&#34;version&#34;]&#10;&#10;$ curl -o /dev/null -w &#39;%{http_code}&#39; .../ops/v1/health # future Operator route: not added&#10;404</code>

```text
### Current unauthenticated public health surface on branch head bcde0af (issue #115 prerequisite: OpenSpec-only, no behavior change)

$ curl -i http://127.0.0.1:4011/health/live
HTTP/1.1 200 OK
date: Fri, 31 Jul 2026 08:51:44 GMT
content-length: 15
vary: accept-encoding
content-type: application/json; charset=utf-8
cache-control: max-age=0, private, must-revalidate
x-request-id: GMdTygULoZ5eTHsAACth

{"status":"ok"}

$ curl -i http://127.0.0.1:4011/health/ready
HTTP/1.1 503 Service Unavailable
date: Fri, 31 Jul 2026 08:51:44 GMT
content-length: 1098
vary: accept-encoding
content-type: application/json; charset=utf-8
cache-control: max-age=0, private, must-revalidate
x-request-id: GMdTygfkAXwyo0UAAC0B

{
  "reason":"public_api_https_enabled","runtime":{"message":null,"status":"ok","node_id":"883fc712-7316-479d-85bd-79b1521fe710","display_name":"tamingsari","health":"healthy","worker_state":"idle","counts":{"loaded_models":0,"active_requests":0}},"status":"error","version":"0.5.0-dev","console":{"enabled":true,"auth_mode":"disabled"},"transport":{"mode":"plain_http_localhost","degraded":true,"cert_source":"unknown"},"build_channel":"dev","build_date":"2026-07-31","build_ref":"bcde0af","checks":{"controller_boot_completed":true,"migrations_current":true,"postgres_reachable":true,"public_api_https_enabled":false},"license":{"message":"No local license bundle is installed.","reason":"missing_bundle","status":"missing","expires_at":null},"remediation":{"reason":"public_api_https_enabled","commands":["sudo orchardctl transport enable-local-https --host <host> --port 8443","configure a reverse proxy with HTTPS"],"summary":"The public API is not configured for HTTPS. Enable local HTTPS or configure a reverse proxy before declaring the controller ready.","docs_anchor":"readiness-transport"}}

$ curl -s http://127.0.0.1:4011/health/ready | jq 'keys'   # fields disclosed WITHOUT credentials
[
  "build_channel",
  "build_date",
  "build_ref",
  "checks",
  "console",
  "license",
  "reason",
  "remediation",
  "runtime",
  "status",
  "transport",
  "version"
]

$ curl -s -o /dev/null -w '%{http_code}
' http://127.0.0.1:4011/ops/v1/health   # future Operator detail route: not added by this change
404
```
</details>
<details>
<summary>Evidence: Credential-free orchardctl status — the accepted CLI identity loss</summary>

<code>$ orchardctl status # no Operator credential presented&#10;🌳 Orchard v0.5.0-dev (bcde0af)&#10;Role: controller&#10;Console: http://localhost:4011/console (enabled)&#10;API: http://localhost:4011/v1&#10;Status: degraded (public_api_https_enabled, 1 node, idle, 0 models loaded)&#10;Transport: plain_http_localhost (degraded: true, cert: unknown)&#10;Remediation: The public API is not configured for HTTPS. Enable local HTTPS or configure a reverse proxy before declaring the controller ready.&#10;License: missing — No local license bundle is installed. (reason: missing_bundle)&#10;&#10;The banner&#39;s version and build ref are the REMOTE Controller identity, read from the unauthenticated /health/ready body (status.ex:105-107).</code>

```text
### Credential-free 'orchardctl status' today (spec delta: 'Credential-free status reports no remote Controller identity')

$ orchardctl status      # no Operator credential presented
🌳 Orchard v0.5.0-dev (bcde0af)
   Role:    controller
   Console: http://localhost:4011/console (enabled)
   API:     http://localhost:4011/v1
   Status:  degraded (public_api_https_enabled, 1 node, idle, 0 models loaded)
   Transport: plain_http_localhost (degraded: true, cert: unknown)
   Remediation: The public API is not configured for HTTPS. Enable local HTTPS or configure a reverse proxy before declaring the controller ready.
   Run: sudo orchardctl transport enable-local-https --host <host> --port 8443
   Run: configure a reverse proxy with HTTPS
   License: missing — No local license bundle is installed. (reason: missing_bundle)

The banner's 'v0.5.0-dev (bcde0af)' is the REMOTE Controller version and build_ref, read from the
unauthenticated /health/ready body (status.ex:105-107). Transport posture, remediation commands and
license state are likewise credential-free. The accepted future contract removes all of this from the
public body, which is the bounded CLI identity loss recorded in design.md. Unchanged by this PR.
```
</details>
<details>
<summary>Evidence: SPEC 10.7 transport fail-closed posture — both configuration sources</summary>

<code>A. Invalid mode via ORCHARD_TRANSPORT_MODE: already fails closed&#10;$ mix test apps/orchard_controller/test/runtime_transport_test.exs:768 --trace&#10;* test SPEC 10.7: invalid transport mode fails closed (12.8ms) [L#768]&#10;Result: 1 passed, 39 excluded&#10;&#10;B. Invalid :transport_mode set directly in the application environment&#10;Orchard.API.Transport.mode() =&gt; :unknown&#10;Orchard.API.Transport.metadata() =&gt; %{mode: &#34;unknown&#34;, cert_source: &#34;unknown&#34;, degraded: true}&#10;Orchard.API.Transport.public_api_https_enabled? =&gt; false&#10;&#10;=&gt; Does NOT fail closed; normalizes to :unknown, and readiness is today the only surface reporting it. Exactly the gap tasks.md 2.6 must close before the transport readiness gate may be removed.</code>

```text
### SPEC 10.7 transport fail-closed posture
Spec delta requirement: 'Removing the transport readiness gate depends on fail-closed transport validation'
tasks.md 2.6 requires the assessment to cover sources other than ORCHARD_TRANSPORT_MODE.

--- A. Invalid mode via ORCHARD_TRANSPORT_MODE: already fails closed (prod runtime config) ---
$ mix test apps/orchard_controller/test/runtime_transport_test.exs:768 --trace
  * test SPEC 10.7: invalid transport mode fails closed [L#768]  * test SPEC 10.7: invalid transport mode fails closed (12.8ms) [L#768]
Result: 1 passed, 39 excluded

--- B. Invalid :transport_mode set directly in the application environment ---
Orchard.API.Transport.mode()                    => :unknown
Orchard.API.Transport.metadata()                => %{mode: "unknown", cert_source: "unknown", degraded: true}
Orchard.API.Transport.public_api_https_enabled? => false

An unresolvable application-environment transport mode does NOT fail closed: it normalizes to :unknown,
and today the readiness gate is the only surface that reports it. That is precisely the residual gap
design.md records and tasks.md 2.6 must close BEFORE the transport readiness gate may be removed.
This prerequisite changes no code, so the gate and the gap both remain exactly as they are today.
```
</details>
<details>
<summary>Evidence: Scope + OpenSpec strict validation</summary>

<code>$ git diff --name-only dc73b55..bcde0af | grep -v &#39;^openspec/changes/health-readiness-contract-prerequisite/&#39;&#10;(empty — SPEC.md, docs/, apps/, config/, tests: all untouched)&#10;&#10;$ openspec validate health-readiness-contract-prerequisite --type change --strict&#10;Change &#39;health-readiness-contract-prerequisite&#39; is valid&#10;&#10;$ openspec validate --all --strict&#10;✓ change/health-readiness-contract-prerequisite&#10;Totals: 11 passed, 0 failed (11 items)&#10;&#10;--- SPEC.md 3.1 required readiness conditions (unchanged, apex) ---&#10;* Postgres reachable&#10;* migrations current&#10;* model/tenant/key caches loaded&#10;* if Active/Standby mode enabled: instance is leader for write paths&#10;&#10;--- What the Controller actually evaluates today ---&#10;postgres_reachable, migrations_current, public_api_https_enabled, controller_boot_completed (hard-coded true)&#10;=&gt; no Orchard.CacheSupervisor / Orchard.Cache.* modules exist, confirming the blocking dependency this proposal records</code>

```text
### Scope + contract validation for the issue #115 OpenSpec-only prerequisite (branch head bcde0af)

$ git diff --stat dc73b55..bcde0af
 .../.openspec.yaml                                 |   2 +
 .../design.md                                      | 192 +++++++++++++++++
 .../proposal.md                                    |  40 ++++
 .../specs/controller-health-prerequisites/spec.md  | 237 +++++++++++++++++++++
 .../tasks.md                                       |  27 +++
 5 files changed, 498 insertions(+)

$ git diff --name-only dc73b55..bcde0af | grep -v '^openspec/changes/health-readiness-contract-prerequisite/'
(empty — SPEC.md, docs/, apps/, config/, tests: all untouched)

$ npm run openspec -- validate health-readiness-contract-prerequisite --type change --strict --no-interactive
Change 'health-readiness-contract-prerequisite' is valid

$ npm run openspec -- validate --all --strict --no-interactive
✓ spec/api-client-provisioning
✓ spec/app-distribution-lifecycle
✓ change/cluster-management-ux-foundation
✓ change/controller-dispatch-capacity-authority
✓ spec/dispatch-capacity
✓ change/harden-sentry-crash-egress
✓ change/health-readiness-contract-prerequisite
✓ change/operator-first-run-journey
✓ spec/packaging-deployment
✓ change/product-versioning-release-governance
✓ spec/runtime-endpoints
Totals: 11 passed, 0 failed (11 items)

--- SPEC.md section 3.1 required readiness conditions (unchanged, apex) ---
**Required readiness conditions**

* Postgres reachable
* migrations current
* model/tenant/key caches loaded
* if Active/Standby mode enabled: instance is leader for write paths


--- What the running Controller actually evaluates today (apps/orchard_controller/lib/orchard/api/readiness.ex) ---
  postgres_reachable, migrations_current, public_api_https_enabled, controller_boot_completed (hard-coded true)
  => model/tenant/API-key cache and write-path leadership conditions have NO authority to consume:
  (no such modules exist — confirms the blocking dependency this proposal records)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md:85` - The spec delta makes transport posture non-gating (&#34;A condition that `SPEC.md` section 3.1 does not require MUST NOT gate the aggregate&#34;), and its only transport scenario (line 94) covers just `plain_http_localhost` and `reverse_proxy`. design.md:109 states this removal &#34;depends on section 10.7 configuration, wrapper, and boot validation continuing to fail closed for invalid or `unknown` transport modes&#34; — but nothing binds that dependency: there is no ADDED requirement and no task for it. Contrast the leadership case, where design.md:145 is bound by task 1.4 and by the &#34;Deployment mode determines whether the leadership condition applies&#34; scenario. Today `Orchard.API.Transport.mode/0` (transport.ex:49) normalizes any unrecognized value to `:unknown`, and readiness is the only surface that reports it (`:unknown` is not in `@https_modes`); `config/runtime.exs:1089` only raises for a bad `ORCHARD_TRANSPORT_MODE` env var, not for a bad `:transport_mode` application-env value. The user intent names &#34;fail-closed invalid transport validation&#34; review-critical, so this belongs in the contract rather than in design prose.
- ⚠️ `openspec/changes/health-readiness-contract-prerequisite/tasks.md:15` - Tasks 2.4 (&#34;Re-run the issue #115 RP Investigate workflow&#34;) and 3.2 (&#34;Run exact-diff RepoPrompt Review and Oracle follow-up&#34;) make local agent accelerators mandatory gates inside a committed, collaborator-reviewable OpenSpec package. AGENTS.md states accelerators such as RepoPrompt &#34;do not own product truth and must not become required human collaborator dependencies&#34;, and its artifact-hygiene guidance forbids referencing RP sessions and Oracle reviews from product docs. A collaborator without those tools cannot satisfy the recorded gate. Restating these as tool-neutral requirements (exact-diff review against the dependency heads, blocking findings resolved) would keep the intent without the tool dependency.
- ℹ️ `openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md:85` - `controller_boot_completed` is the other current readiness gate that SPEC.md section 3.1 does not require, and it is a hard-coded `true` (readiness.ex:37) — exactly the shape the no-shim requirement rejects. The change names only transport posture as the intentional gate removal, and the deferred migration inventory (tasks.md:16) does not mention it, even though it is a rendered check in the Console readiness list (console/overview_live.ex:19) and has CLI remediation text (orchard_cli/commands/status.ex:497). Because it is always `true`, no readiness result changes, but the later atomic migration still has to decide whether the key survives as an Operator observation or disappears from the check set.

🔧 Fix: Bind transport fail-closed gate, boot flag, tool-neutral tasks
1 info still open:
- ℹ️ `openspec/changes/health-readiness-contract-prerequisite/specs/controller-health-prerequisites/spec.md:125` - The &#34;Transport validation gap is demonstrated&#34; scenario says only that &#34;the existing transport readiness gate is retained until that validation gap is resolved&#34;. It does not say the complete section 3.1 aggregate stays unadopted meanwhile, so it is readable as permitting the 3.1 aggregate plus a retained transport gate — the exact hybrid that spec.md:85 forbids (&#34;A condition that `SPEC.md` section 3.1 does not require MUST NOT gate the aggregate&#34;) and that design.md:116-117 explicitly records as a rejected alternative (&#34;keep the transport gate alongside the section 3.1 aggregate ... rejected because it is exactly the milestone-specific readiness subset this contract forbids&#34;). design.md:114 (&#34;Current readiness behavior, including the existing transport gate, stays unchanged while this prerequisite is in force&#34;) suggests the intended reading is that the whole migration stays blocked, but the normative scenario never states it. One added **AND** clause — that the complete aggregate is not adopted until the gap is resolved — would close the ambiguity.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate health-readiness-contract-prerequisite --type change --strict --no-interactive` — valid</code>
- <code>`OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` — 11 passed, 0 failed</code>
- <code>`git diff --name-only dc73b55..bcde0af | grep -v &#39;^openspec/changes/health-readiness-contract-prerequisite/&#39;` — empty, confirming SPEC.md/apps/config/docs/tests untouched</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/api/health_controller_test.exs apps/orchard_controller/test/orchard/control_plane_test.exs apps/orchard_cli/test/orchard_cli/commands/status_test.exs` — 116 passed</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/console/overview_live_test.exs apps/orchard_controller/test/orchard_test.exs apps/orchard_controller/test/runtime_transport_test.exs` — 133 passed</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/runtime_transport_test.exs:768` — SPEC 10.7 invalid transport mode fails closed</code>
- <code>Manual: booted the Controller (`mix phx.server`, isolated DB `orchard_ev115`, port 4011) and captured `curl -i /health/live`, `curl -i /health/ready`, `jq keys` on the public body, and `/ops/v1/health` (404)</code>
- <code>Manual: `mix run --no-start -e &#39;OrchardCLI.main([&#34;status&#34;], ...)&#39;` against the live Controller to capture the credential-free version banner sourced from /health/ready</code>
- <code>Manual: `mix run --no-start -e &#39;Application.put_env(:orchard_controller, :transport_mode, :bogus_mode); Orchard.API.Transport.mode()&#39;` — returns :unknown rather than failing closed</code>
- `Manual: agent-browser full-page screenshot of http://localhost:4011/console showing the Readiness panel and its four current checks`
- <code>Verified design.md claims against source: `apps/orchard_controller/lib/orchard/api/readiness.ex` check set, `Orchard.ControlPlane.read_only_status/0` deriving deployment_mode from configured :role, `Orchard.API.Transport.mode/0` normalization, `status.ex:105-107` reading version/build_ref, absence of `Orchard.Cache.*` modules, SPEC.md 3.1 readiness conditions and 10.7 transport modes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
