### PR TITLE
feat(requests): enforce tenant inference capture modes at the persistence boundary

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -337,6 +337,7 @@ All public inference requests SHALL normalize into one internal struct:
   input_items: [map()],
   rendered_prompt: binary() | nil,
   input_token_count: non_neg_integer(),
+  store?: boolean(),
   stream?: boolean(),
   sampling: %{
     temperature: float(),
@@ -533,6 +534,8 @@ Each request-step payload SHALL carry:
 * `result`
 
 When applicable, payloads MAY also carry `call_id`, `tool_name`, `arguments_json`, `model_id`, and `model_version`.
+
+Durable retention of these payload fields is bounded by the Request capture mode in §10.10. Outside `full`, `call_id` persists only as a deterministic hash, the step identifiers derived from it embed that hash, and `tool_name`, `arguments_json`, `model_id`, and `model_version` are not retained.
 
 `tool_execution` steps and `request_step.indeterminate` remain future-facing shapes for later hosted-execution slices, but their durable outcome contract is now defined in §3.7.2. This persistence section MUST NOT be interpreted as enabling controller-owned hosted `/v1/responses` tool-execution loops in the current slice.
 
@@ -3908,7 +3911,7 @@ create index idx_audit_logs_cluster_occurred_at
 * `requests`: 90 days metadata minimum
 * `audit_logs`: 365 days minimum
 
-Payload retention follows tenant capture mode.
+Payload retention follows the effective capture mode snapshotted on each Request; see §10.10.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2258,10 +2258,12 @@ Behavior:
 Rules:
 
 * only terminal failed/cancelled/timed_out/interrupted requests
-* uses stored canonical request
+* uses the stored canonical request only when the source Request retained it under `full`
+* if the source canonical request is unavailable, fail with `retry_source_unavailable`
 * creates new request row
 * `retry_of_request_id` points to original
 * max operator retries per original request default = 3
+* the retry capture mode MUST NOT be wider than either the source Request snapshot or the current Tenant policy
 
 #### 7.3.5 Scheduler explanation
 
@@ -3524,9 +3526,11 @@ create table requests (
   state request_state not null default 'received',
   stream boolean not null default false,
   payload_capture_mode payload_capture_mode not null default 'metadata',
-  canonical_request jsonb not null,
+  canonical_request jsonb,
+  request_shape jsonb,
   request_payload jsonb,
   response_payload jsonb,
+  response_hash bytea,
   response_preview text,
   sampling_params jsonb not null default '{}'::jsonb,
   response_format jsonb not null default '{}'::jsonb,
@@ -3542,7 +3546,17 @@ create table requests (
   error_message text,
   inserted_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  check (principal_type <> 'service_account' or service_account_id is not null)
+  check (principal_type <> 'service_account' or service_account_id is not null),
+  check (
+    payload_capture_mode = 'full'
+    or (
+      canonical_request is null
+      and request_payload is null
+      and response_payload is null
+    )
+  ),
+  check (payload_capture_mode <> 'none' or response_preview is null),
+  check (response_preview is null or char_length(response_preview) <= 512)
 );
 
 create table request_events (
@@ -4183,17 +4197,34 @@ Tenant setting `request_body_capture_mode`:
 
 Default = `metadata`
 
+The capture lattice is `none < metadata < full`.
+The effective mode SHALL resolve before the first Request write and SHALL be snapshotted in `requests.payload_capture_mode`.
+Later Tenant changes, terminal paths, attempts, automatic retries, and operator retries MUST NOT widen that snapshot.
+For the Responses API, `store=false` SHALL cap `full` at `metadata`, SHALL NOT widen a narrower Tenant mode, and SHALL NOT disable required accounting or audit metadata.
+
 `none`:
 
-* store hashes, usage, errors, no prompt/response text
+* store request and response hashes, usage, state, timestamps, and stable error codes
+* store no prompt, response, preview, request shape, raw tool argument, raw runtime error text, or other caller or model content
 
 `metadata`:
 
-* store shape + preview + hashes
+* additionally store a fixed allowlisted request shape containing counts, types, lengths, approved identifiers, and hashes
+* caller metadata values, stop text, tool definitions, tool arguments, rendered prompts, and input content are not shape
+* a content preview is optional and SHALL be stored only when its source exceeds 512 Unicode code points
+* a metadata preview SHALL contain complete source grapheme clusters totaling at most 511 Unicode code points plus one ellipsis and therefore SHALL NOT equal the complete source
 
 `full`:
 
 * store full payloads and final outputs
+* convenience previews remain bounded to 512 Unicode code points without splitting a grapheme cluster
+* a streaming Request stores its assembled final output only at terminal completion and does not durably duplicate individual chunks
+
+Capture enforcement SHALL cover every content-bearing field on `requests` and `request_events`, including canonical input, request payloads, response payloads, previews, sampling stop text, response-format content, scheduler decisions, error text, model-generated tool arguments, and request-step results.
+`body_hash` and `response_hash` are integrity anchors and do not authorize content recovery or replay.
+Idempotent replay requires a retained `response_payload`; otherwise Orchard SHALL return `idempotency_not_replayable`.
+Existing `none` and `metadata` rows that contain forbidden content SHALL be purged in place rather than relabeled as `full`.
+The purge verification SHALL explicitly enumerate every content-bearing Request column and `request_events.payload`, and schema-drift coverage SHALL fail when a new text, JSON, or binary Request column is not classified.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -4222,11 +4222,12 @@ For the Responses API, `store=false` SHALL cap `full` at `metadata`, SHALL NOT w
 
 Capture enforcement SHALL cover every content-bearing field on `requests` and `request_events`, including canonical input, request payloads, response payloads, previews, sampling stop text, response-format content, scheduler decisions, error text, model-generated tool arguments, and request-step results.
 Non-`full` Request-event and scheduler metadata SHALL use field-specific type checks and closed operational vocabularies rather than key-only allowlists.
+Non-`full` scheduler metadata MAY retain the opaque `hmac-sha256:<64 lowercase hex>` cache-affinity key and its closed typed operational fields because the scheduler requires that non-recoverable feedback for later placement.
 Untrusted tool-call identifiers retained for request-step correlation SHALL be replaced with deterministic hashes, and model-generated tool names and raw target references SHALL NOT persist outside `full`.
 `body_hash` and `response_hash` are integrity anchors and do not authorize content recovery or replay.
 Idempotent replay requires a retained `response_payload`; otherwise Orchard SHALL return `idempotency_not_replayable`.
 Existing `none` and `metadata` rows that contain forbidden content SHALL be purged in place rather than relabeled as `full`.
-When legacy nested event or scheduler values cannot be proven safe by the migration, Orchard SHALL discard the entire nested payload rather than copy key-allowlisted values forward.
+When legacy nested event or scheduler values cannot be proven safe by the migration, Orchard SHALL discard the entire nested payload rather than copy key-allowlisted values forward; the migration MAY retain only a syntactically valid cache-affinity HMAC and its closed typed operational fields.
 The purge verification SHALL explicitly enumerate every content-bearing Request column and `request_events.payload`, and schema-drift coverage SHALL fail when a new text, JSON, or binary Request column is not classified.
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -4221,9 +4221,12 @@ For the Responses API, `store=false` SHALL cap `full` at `metadata`, SHALL NOT w
 * a streaming Request stores its assembled final output only at terminal completion and does not durably duplicate individual chunks
 
 Capture enforcement SHALL cover every content-bearing field on `requests` and `request_events`, including canonical input, request payloads, response payloads, previews, sampling stop text, response-format content, scheduler decisions, error text, model-generated tool arguments, and request-step results.
+Non-`full` Request-event and scheduler metadata SHALL use field-specific type checks and closed operational vocabularies rather than key-only allowlists.
+Untrusted tool-call identifiers retained for request-step correlation SHALL be replaced with deterministic hashes, and model-generated tool names and raw target references SHALL NOT persist outside `full`.
 `body_hash` and `response_hash` are integrity anchors and do not authorize content recovery or replay.
 Idempotent replay requires a retained `response_payload`; otherwise Orchard SHALL return `idempotency_not_replayable`.
 Existing `none` and `metadata` rows that contain forbidden content SHALL be purged in place rather than relabeled as `full`.
+When legacy nested event or scheduler values cannot be proven safe by the migration, Orchard SHALL discard the entire nested payload rather than copy key-allowlisted values forward.
 The purge verification SHALL explicitly enumerate every content-bearing Request column and `request_events.payload`, and schema-drift coverage SHALL fail when a new text, JSON, or binary Request column is not classified.
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -3553,9 +3553,66 @@ create table requests (
       canonical_request is null
       and request_payload is null
       and response_payload is null
+      and error_message is null
     )
   ),
-  check (payload_capture_mode <> 'none' or response_preview is null),
+  check (
+    payload_capture_mode <> 'none'
+    or (request_shape is null and response_preview is null)
+  ),
+  check (
+    payload_capture_mode = 'full'
+    or error_code is null
+    or error_code in (
+      'acquisition_failed',
+      'artifact_not_found',
+      'cancelled',
+      'checksum_mismatch',
+      'cluster_busy',
+      'deadline_exceeded',
+      'insufficient_memory',
+      'internal_error',
+      'load_timeout',
+      'manifest_not_found',
+      'mlx_backend_unavailable',
+      'model_busy',
+      'model_invalid',
+      'node_timeout',
+      'node_unavailable',
+      'orchestration_error',
+      'queue_full',
+      'queue_timeout',
+      'request_cancelled',
+      'request_caller_disconnect',
+      'request_client_disconnect',
+      'request_controller_restarted',
+      'request_interrupted',
+      'request_timeout',
+      'resource_exhausted',
+      'rpc_error',
+      'rpc_resource_exhausted',
+      'rpc_unavailable',
+      'runtime_incompatible',
+      'runtime_unavailable',
+      'timed_out',
+      'timeout',
+      'tool_execution_cancelled',
+      'tool_execution_failed',
+      'tool_execution_indeterminate_cancel_ack_missing',
+      'tool_execution_indeterminate_controller_restarted',
+      'tool_execution_indeterminate_executor_unreachable',
+      'tool_execution_indeterminate_result_not_observed',
+      'tool_execution_indeterminate_timeout_after_start',
+      'tool_execution_timed_out',
+      'tool_failed',
+      'tool_timeout',
+      'tooling_not_supported',
+      'unexpected_placement_state',
+      'worker_down',
+      'worker_unavailable',
+      'worker_unloaded'
+    )
+  ),
   check (response_preview is null or char_length(response_preview) <= 512)
 );
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -623,7 +623,7 @@ The controller SHALL support `Idempotency-Key` on both public inference endpoint
 Rules:
 
 * uniqueness scope: `(tenant_id, idempotency_key)`
-* if same key + same body hash already completed and `stream=false`, return stored result
+* if same key + same body hash already completed and `stream=false`, return the stored result when the Request retained its `response_payload`, otherwise return `409 idempotency_not_replayable` (see §10.10 for when payloads are retained)
 * if same key + same body hash is still active, return `409 request_in_progress`
 * if same key reused with different body hash, return `409 idempotency_mismatch`
 * streaming responses SHALL NOT be replayed from persisted token chunks in v1
@@ -2088,7 +2088,7 @@ The Responses API in OpenAI’s current documentation uses typed semantic stream
 
 * accepted for compatibility
 * does **not** disable internal accounting/audit metadata
-* when `store=false`, full prompt/response payload retention SHALL follow tenant retention policy and default to redacted metadata only
+* when `store=false`, payload retention narrows the effective capture mode under the rules in §10.10 Data governance
 
 Example sync response with a function call item:
 
@@ -2272,11 +2272,11 @@ Response example:
 ```json
 {
   "request_id": "resp_01J...",
-  "selected_node_id": "node-2",
+  "selected_node_id": "11111111-1111-4111-8111-111111111111",
   "selection_tier": "loaded",
   "scored_candidates": [
     {
-      "node_id": "node-2",
+      "node_id": "11111111-1111-4111-8111-111111111111",
       "eligible": true,
       "tier": "loaded",
       "score": 842,
@@ -2294,13 +2294,13 @@ Response example:
   ],
   "rejected_candidates": [
     {
-      "node_id": "node-1",
+      "node_id": "22222222-2222-4222-8222-222222222222",
       "reason_codes": ["node_not_active", "insufficient_memory"]
     }
   ],
   "skipped_candidates": [
     {
-      "node_id": "node-3",
+      "node_id": "33333333-3333-4333-8333-333333333333",
       "reason_codes": ["lower_tier_not_considered"]
     }
   ]

--- a/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
@@ -135,6 +135,7 @@ defmodule OrchardCLI.Commands.RequestsTest do
       request =
         create_request!(%{
           public_id: "resp_cli_invalid_scheduler_explanation",
+          payload_capture_mode: :full,
           scheduler_decision: %{
             "request_id" => "resp_cli_invalid_scheduler_explanation",
             "rejected_candidates" => [

--- a/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/requests_test.exs
@@ -11,6 +11,10 @@ defmodule OrchardCLI.Commands.RequestsTest do
 
   import Orchard.TestSupport.ModelRequestFixtures
 
+  @selected_node_id "11111111-1111-4111-8111-111111111111"
+  @rejected_node_id "22222222-2222-4222-8222-222222222222"
+  @skipped_node_id "33333333-3333-4333-8333-333333333333"
+
   setup do
     :ok = Sandbox.checkout(Repo)
     Sandbox.mode(Repo, {:shared, self()})
@@ -47,7 +51,7 @@ defmodule OrchardCLI.Commands.RequestsTest do
         end)
 
       assert stdout =~ "Request: #{request.public_id}"
-      assert stdout =~ "Selected node: node-selected"
+      assert stdout =~ "Selected node: #{@selected_node_id}"
       assert stdout =~ "Rejected candidates:"
       assert stdout =~ "node_not_active,insufficient_memory"
       refute_received {:halt_called, _code}
@@ -82,17 +86,19 @@ defmodule OrchardCLI.Commands.RequestsTest do
       assert {:ok, output} = RequestsCmd.run(["inspect", request.public_id])
 
       assert output =~ "Request: #{request.public_id}"
-      assert output =~ "Selected node: node-selected"
+      assert output =~ "Selected node: #{@selected_node_id}"
       assert output =~ "Selection tier: loaded"
       assert output =~ "Scored candidates:"
-      assert output =~ "node-selected tier=loaded score=842 reason_codes=none"
+      assert output =~ "#{@selected_node_id} tier=loaded score=842 reason_codes=none"
       assert output =~ "Rejected candidates:"
 
       assert output =~
-               "node-rejected tier=- score=- reason_codes=node_not_active,insufficient_memory"
+               "#{@rejected_node_id} tier=- score=- reason_codes=node_not_active,insufficient_memory"
 
       assert output =~ "Skipped candidates:"
-      assert output =~ "node-skipped tier=- score=- reason_codes=lower_tier_not_considered"
+
+      assert output =~
+               "#{@skipped_node_id} tier=- score=- reason_codes=lower_tier_not_considered"
     end
 
     test "SPEC.md §7.3.5 json output reports unknown request id as scheduler explanation not found" do
@@ -183,11 +189,11 @@ defmodule OrchardCLI.Commands.RequestsTest do
     assert {:ok, request} =
              Requests.record_schedule(request, %{
                request_id: request.public_id,
-               selected_node_id: "node-selected",
+               selected_node_id: @selected_node_id,
                selection_tier: :loaded,
                scored_candidates: [
                  %{
-                   node_id: "node-selected",
+                   node_id: @selected_node_id,
                    eligible: true,
                    tier: :loaded,
                    score: 842,
@@ -197,13 +203,13 @@ defmodule OrchardCLI.Commands.RequestsTest do
                ],
                rejected_candidates: [
                  %{
-                   node_id: "node-rejected",
+                   node_id: @rejected_node_id,
                    reason_codes: [:node_not_active, "insufficient_memory"]
                  }
                ],
                skipped_candidates: [
                  %{
-                   node_id: "node-skipped",
+                   node_id: @skipped_node_id,
                    reason_codes: [:lower_tier_not_considered]
                  }
                ]

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -647,7 +647,11 @@ defmodule Orchard.Governance do
 
   defp insert_tenant(attrs) do
     %Tenant{}
-    |> Tenant.changeset(%{slug: Map.get(attrs, "slug"), name: Map.get(attrs, "name")})
+    |> Tenant.changeset(%{
+      slug: Map.get(attrs, "slug"),
+      name: Map.get(attrs, "name"),
+      request_body_capture_mode: Map.get(attrs, "request_body_capture_mode", :metadata)
+    })
     |> Repo.insert()
   end
 

--- a/apps/orchard_controller/lib/orchard/governance/tenant.ex
+++ b/apps/orchard_controller/lib/orchard/governance/tenant.ex
@@ -12,11 +12,18 @@ defmodule Orchard.Governance.Tenant do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
+  @request_body_capture_modes [none: "none", metadata: "metadata", full: "full"]
+
   @type t :: %__MODULE__{}
 
   schema "tenants" do
     field(:slug, :string)
     field(:name, :string)
+
+    field(:request_body_capture_mode, Ecto.Enum,
+      values: @request_body_capture_modes,
+      default: :metadata
+    )
 
     has_many(:api_keys, ApiKey)
     has_many(:audit_logs, AuditLog)
@@ -29,8 +36,8 @@ defmodule Orchard.Governance.Tenant do
   @spec changeset(struct(), map()) :: Ecto.Changeset.t()
   def changeset(tenant, attrs) do
     tenant
-    |> cast(attrs, [:slug, :name])
-    |> validate_required([:slug, :name])
+    |> cast(attrs, [:slug, :name, :request_body_capture_mode])
+    |> validate_required([:slug, :name, :request_body_capture_mode])
     |> unique_constraint(:slug)
   end
 end

--- a/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
@@ -20,6 +20,7 @@ defmodule Orchard.Inference.CanonicalRequestSerializer do
       "input_items" => normalize_plain_data(canonical.input_items),
       "rendered_prompt" => canonical.rendered_prompt,
       "input_token_count" => canonical.input_token_count,
+      "store" => canonical.store?,
       "stream" => canonical.stream?,
       "stream_include_usage" => canonical.stream_include_usage,
       "sampling" => sampling_params(canonical.sampling),

--- a/apps/orchard_controller/lib/orchard/inference/chat_response_serializer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_response_serializer.ex
@@ -42,9 +42,13 @@ defmodule Orchard.Inference.ChatResponseSerializer do
       when is_list(events) do
     content = collect_content(events)
 
+    {response_preview, response_preview_source} =
+      persistence_preview(content, tool_call_preview(events))
+
     %{
       response_payload: completion_payload(canonical, events, created_at_override),
-      response_preview: preview_content(content, tool_call_preview(events))
+      response_preview: response_preview,
+      response_preview_source: response_preview_source
     }
   end
 
@@ -114,8 +118,10 @@ defmodule Orchard.Inference.ChatResponseSerializer do
   defp maybe_put_tool_calls(message, []), do: message
   defp maybe_put_tool_calls(message, tool_calls), do: Map.put(message, :tool_calls, tool_calls)
 
-  defp preview_content("", tool_preview) when tool_preview != "", do: tool_preview
-  defp preview_content(content, _tool_preview), do: content
+  defp persistence_preview("", tool_preview) when tool_preview != "",
+    do: {tool_preview, :tool_call}
+
+  defp persistence_preview(content, _tool_preview), do: {content, :assistant_text}
 
   defp collected_tool_calls(events) do
     events

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -22,8 +22,10 @@ defmodule Orchard.Inference.RequestOrchestrator do
     ToolingValidation
   }
 
+  alias Orchard.Governance
   alias Orchard.InferenceEvent
   alias Orchard.Requests
+  alias Orchard.Requests.CapturePolicy
   alias Orchard.Requests.Idempotency
   alias Orchard.Requests.Request
   alias Orchard.Requests.RequestServer
@@ -594,15 +596,27 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   defp persist_request(canonical, model, idempotency) do
     with {:ok, serialized_canonical} <- serialize_canonical_request(canonical) do
+      capture_mode = effective_capture_mode(canonical)
+
       canonical
-      |> request_attrs(model, serialized_canonical)
+      |> request_attrs(model, serialized_canonical, capture_mode)
       |> put_idempotency_attrs(idempotency)
       |> Requests.create_request()
       |> handle_create_request_result(idempotency)
     end
   end
 
-  defp request_attrs(canonical, model, serialized_canonical) do
+  defp effective_capture_mode(canonical) do
+    case Governance.get_tenant(canonical.tenant_id) do
+      {:ok, tenant} ->
+        CapturePolicy.resolve(tenant.request_body_capture_mode, canonical.store?)
+
+      {:error, :tenant_not_found} ->
+        :none
+    end
+  end
+
+  defp request_attrs(canonical, model, serialized_canonical, capture_mode) do
     %{
       id: canonical.internal_id,
       public_id: canonical.public_id,
@@ -615,12 +629,17 @@ defmodule Orchard.Inference.RequestOrchestrator do
       model_id: model.id,
       state: :received,
       stream: canonical.stream?,
-      payload_capture_mode: :metadata,
+      body_hash: serialized_canonical |> Jason.encode!() |> sha256(),
+      payload_capture_mode: capture_mode,
       canonical_request: serialized_canonical,
+      request_payload: %{"prompt" => canonical.rendered_prompt},
       sampling_params: CanonicalRequestSerializer.sampling_params(canonical.sampling),
+      response_format: %{"type" => Atom.to_string(canonical.response_format.type)},
       input_tokens: canonical.input_token_count
     }
   end
+
+  defp sha256(content), do: :crypto.hash(:sha256, content)
 
   defp put_idempotency_attrs(attrs, %Idempotency.Context{} = idempotency) do
     Map.merge(attrs, %{
@@ -1160,8 +1179,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
     terminal_attrs = terminal_attrs_from_events(events)
 
     result =
-      if terminal_attrs.state == :completed and not canonical.stream? and
-           is_function(success_persistence, 2) do
+      if terminal_attrs.state == :completed and is_function(success_persistence, 2) do
         success_persistence
         |> apply_success_persistence(canonical, events)
         |> merge_success_attrs(terminal_attrs)

--- a/apps/orchard_controller/lib/orchard/inference/responses_request_normalizer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/responses_request_normalizer.ex
@@ -23,12 +23,17 @@ defmodule Orchard.Inference.ResponsesRequestNormalizer do
       |> Keyword.put(:internal_id, internal_id)
       |> Keyword.put(:public_id, public_id)
 
-    {:ok, %CanonicalRequest{} = canonical} =
+    {:ok, canonical} =
       params
       |> build_chat_params()
       |> ChatRequestNormalizer.normalize(normalizer_opts)
 
-    {:ok, %{canonical | endpoint: :responses}}
+    normalized =
+      canonical
+      |> Map.put(:endpoint, :responses)
+      |> Map.put(:store?, normalize_store(params))
+
+    {:ok, normalized}
   end
 
   defp build_chat_params(params) do
@@ -77,6 +82,14 @@ defmodule Orchard.Inference.ResponsesRequestNormalizer do
 
   defp normalize_metadata(nil), do: %{}
   defp normalize_metadata(metadata), do: metadata
+
+  defp normalize_store(%{"store" => false}), do: false
+  defp normalize_store(%{"store" => value}) when value in [true, nil], do: true
+
+  defp normalize_store(%{"store" => value}),
+    do: raise(ArgumentError, "invalid store: #{inspect(value)}")
+
+  defp normalize_store(_params), do: true
 
   defp put_optional(map, _key, nil), do: map
   defp put_optional(map, key, value), do: Map.put(map, key, value)

--- a/apps/orchard_controller/lib/orchard/inference/responses_serializer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/responses_serializer.ex
@@ -42,9 +42,13 @@ defmodule Orchard.Inference.ResponsesSerializer do
       when is_list(events) do
     output_text = collect_output_text(events)
 
+    {response_preview, response_preview_source} =
+      persistence_preview(output_text, tool_call_preview(events))
+
     %{
       response_payload: response_payload(canonical, events, created_at_override),
-      response_preview: preview_content(output_text, tool_call_preview(events))
+      response_preview: response_preview,
+      response_preview_source: response_preview_source
     }
   end
 
@@ -249,8 +253,10 @@ defmodule Orchard.Inference.ResponsesSerializer do
     |> ToolCallAccumulator.preview()
   end
 
-  defp preview_content("", tool_preview) when tool_preview != "", do: tool_preview
-  defp preview_content(content, _tool_preview), do: content
+  defp persistence_preview("", tool_preview) when tool_preview != "",
+    do: {tool_preview, :tool_call}
+
+  defp persistence_preview(content, _tool_preview), do: {content, :assistant_text}
 
   defp tool_call_accumulator!(events) do
     case ToolCallAccumulator.from_events(events) do

--- a/apps/orchard_controller/lib/orchard/inference_contract.ex
+++ b/apps/orchard_controller/lib/orchard/inference_contract.ex
@@ -1,6 +1,10 @@
 defmodule Orchard.InferenceContract do
   @moduledoc false
 
+  alias Orchard.CanonicalRequest
+  alias Orchard.CanonicalRequest.ModelRef
+
+  @spec request_model_ref(CanonicalRequest.t()) :: ModelRef.t()
   defdelegate request_model_ref(request), to: Orchard.SharedContract
   defdelegate event_kind(event), to: Orchard.SharedContract
   defdelegate manifest_proto_model_ref(manifest), to: Orchard.SharedContract

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -7,12 +7,14 @@ defmodule Orchard.Requests do
 
   alias Orchard.ClusterManagement.SchedulerExplanation
   alias Orchard.Repo
-  alias Orchard.Requests.{Request, RequestEvent, RequestStepEvent}
+  alias Orchard.Requests.{CapturePolicy, Request, RequestEvent, RequestStepEvent}
 
   @spec create_request(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_request(attrs) do
+    mode = Map.get(attrs, :payload_capture_mode) || Map.get(attrs, "payload_capture_mode")
+
     %Request{}
-    |> Request.create_changeset(attrs)
+    |> Request.create_changeset(CapturePolicy.create_attrs(mode, attrs))
     |> Repo.insert()
   end
 
@@ -101,6 +103,7 @@ defmodule Orchard.Requests do
     event_attrs =
       attrs
       |> normalize_request_event_attrs()
+      |> then(&CapturePolicy.event_attrs(request.payload_capture_mode, &1))
       |> Map.put("request_id", request_id)
       |> Map.put("seq", next_request_event_seq(request_id))
       |> default_occurred_at()
@@ -115,14 +118,15 @@ defmodule Orchard.Requests do
     |> Repo.insert()
   end
 
-  defp insert_request_step_events(request_id, step_events) do
+  defp insert_request_step_events(request, step_events) do
     step_events
-    |> Enum.with_index(next_request_event_seq(request_id))
+    |> Enum.with_index(next_request_event_seq(request.id))
     |> Enum.reduce_while([], fn {step_event, seq}, acc ->
       event_attrs =
         step_event
         |> RequestStepEvent.to_request_event_attrs!()
-        |> Map.put("request_id", request_id)
+        |> then(&CapturePolicy.event_attrs(request.payload_capture_mode, &1))
+        |> Map.put("request_id", request.id)
         |> Map.put("seq", seq)
         |> default_occurred_at()
 
@@ -141,8 +145,8 @@ defmodule Orchard.Requests do
   defp append_normalized_request_step_events(request_id, normalized_step_events) do
     Repo.transaction(fn ->
       case lock_request(request_id) do
-        {:ok, _request} ->
-          insert_request_step_events(request_id, normalized_step_events)
+        {:ok, request} ->
+          insert_request_step_events(request, normalized_step_events)
 
         {:error, :request_not_found} ->
           Repo.rollback(:request_not_found)
@@ -223,7 +227,7 @@ defmodule Orchard.Requests do
   end
 
   defp append_steps_and_apply_terminal_update(current_request, attrs, normalized_step_events) do
-    {:ok, _step_events} = insert_request_step_events(current_request.id, normalized_step_events)
+    {:ok, _step_events} = insert_request_step_events(current_request, normalized_step_events)
 
     case apply_terminal_update(current_request, attrs) do
       {:ok, updated_request} -> {:ok, updated_request}
@@ -232,6 +236,8 @@ defmodule Orchard.Requests do
   end
 
   defp apply_terminal_update(%Request{} = request, attrs) do
+    attrs = CapturePolicy.terminal_attrs(request.payload_capture_mode, attrs)
+
     # Allow idempotent terminal updates: if the row is already in a terminal
     # state (set by append_request_event's atomic state sync), still apply
     # the terminal metadata (usage, timestamps, error fields). Only reject
@@ -334,7 +340,8 @@ defmodule Orchard.Requests do
 
   defp persist_schedule(request, schedule, normalized_schedule) do
     attrs = %{
-      scheduler_decision: normalized_schedule,
+      scheduler_decision:
+        CapturePolicy.schedule_attrs(request.payload_capture_mode, normalized_schedule),
       node_id: Map.get(schedule, :node_id)
     }
 

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -132,7 +132,14 @@ defmodule Orchard.Requests do
 
       case %RequestEvent{} |> RequestEvent.changeset(event_attrs) |> Repo.insert() do
         {:ok, request_event} ->
-          {:cont, [RequestStepEvent.from_request_event!(request_event) | acc]}
+          persisted_step_event = %{
+            step_event
+            | request_id: request_event.request_id,
+              seq: request_event.seq,
+              occurred_at: request_event.occurred_at
+          }
+
+          {:cont, [persisted_step_event | acc]}
 
         {:error, changeset} ->
           Repo.rollback({:request_event_changeset, changeset})
@@ -341,7 +348,9 @@ defmodule Orchard.Requests do
   defp persist_schedule(request, schedule, normalized_schedule) do
     attrs = %{
       scheduler_decision:
-        CapturePolicy.schedule_attrs(request.payload_capture_mode, normalized_schedule),
+        CapturePolicy.schedule_attrs(request.payload_capture_mode, normalized_schedule, %{
+          requested_model: request.requested_model
+        }),
       node_id: Map.get(schedule, :node_id)
     }
 

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -21,7 +21,7 @@ defmodule Orchard.Requests do
 
     case CapturePolicy.normalize_mode(mode) do
       {:ok, normalized_mode} -> CapturePolicy.create_attrs(normalized_mode, attrs)
-      :error -> attrs
+      :error -> CapturePolicy.create_attrs(CapturePolicy.strictest_mode(), attrs)
     end
   end
 
@@ -197,7 +197,6 @@ defmodule Orchard.Requests do
 
   defp classify_terminal_step(%RequestStepEvent{event_type: "request_step.completed"} = step) do
     case Map.fetch(step.result, "result_invalid") do
-      {:ok, true} -> inconclusive(:invalid_terminal_step)
       {:ok, _invalid_marker} -> inconclusive(:invalid_terminal_step)
       :error -> classify_finish_reason_evidence(step.result)
     end

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -196,7 +196,30 @@ defmodule Orchard.Requests do
     do: inconclusive(:terminal_state_mismatch)
 
   defp classify_terminal_step(%RequestStepEvent{event_type: "request_step.completed"} = step) do
-    case Map.fetch(step.result, "finish_reason") do
+    case Map.fetch(step.result, "result_invalid") do
+      {:ok, true} -> inconclusive(:invalid_terminal_step)
+      {:ok, _invalid_marker} -> inconclusive(:invalid_terminal_step)
+      :error -> classify_finish_reason_evidence(step.result)
+    end
+  end
+
+  defp classify_terminal_step(%RequestStepEvent{}), do: {:ok, :not_candidate}
+
+  defp classify_finish_reason_evidence(result) do
+    case Map.fetch(result, "finish_reason_invalid") do
+      {:ok, true} ->
+        inconclusive(:invalid_finish_reason)
+
+      {:ok, _invalid_marker} ->
+        inconclusive(:invalid_finish_reason_marker)
+
+      :error ->
+        classify_completed_finish_reason(result)
+    end
+  end
+
+  defp classify_completed_finish_reason(result) do
+    case Map.fetch(result, "finish_reason") do
       :error ->
         {:ok, :missing_finish_reason_candidate}
 
@@ -207,8 +230,6 @@ defmodule Orchard.Requests do
         inconclusive(:invalid_finish_reason)
     end
   end
-
-  defp classify_terminal_step(%RequestStepEvent{}), do: {:ok, :not_candidate}
 
   defp inconclusive(reason), do: {:error, {:inconclusive, reason}}
 

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -11,11 +11,18 @@ defmodule Orchard.Requests do
 
   @spec create_request(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_request(attrs) do
+    %Request{}
+    |> Request.create_changeset(capture_create_attrs(attrs))
+    |> Repo.insert()
+  end
+
+  defp capture_create_attrs(attrs) do
     mode = Map.get(attrs, :payload_capture_mode) || Map.get(attrs, "payload_capture_mode")
 
-    %Request{}
-    |> Request.create_changeset(CapturePolicy.create_attrs(mode, attrs))
-    |> Repo.insert()
+    case CapturePolicy.normalize_mode(mode) do
+      {:ok, normalized_mode} -> CapturePolicy.create_attrs(normalized_mode, attrs)
+      :error -> attrs
+    end
   end
 
   @spec get_request!(Ecto.UUID.t()) :: struct()
@@ -59,7 +66,14 @@ defmodule Orchard.Requests do
     )
     |> order_by([event], asc: event.seq)
     |> Repo.all()
-    |> Enum.map(&RequestStepEvent.from_request_event!/1)
+    |> Enum.flat_map(&readable_step_event/1)
+  end
+
+  defp readable_step_event(request_event) do
+    case RequestStepEvent.from_request_event(request_event) do
+      {:ok, step_event} -> [step_event]
+      {:error, _reason} -> []
+    end
   end
 
   @spec append_request_event(struct() | Ecto.UUID.t(), map()) ::

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -8,6 +8,55 @@ defmodule Orchard.Requests.CapturePolicy do
   @event_integer_keys ~w(attempt attempt_index sequence turn_index)
   @result_integer_keys ~w(http_status input_tokens output_tokens)
   @finish_reasons ~w(cancelled content_filter error length stop tool_calls)
+  @stable_error_codes ~w(
+    acquisition_failed
+    artifact_not_found
+    cancelled
+    checksum_mismatch
+    cluster_busy
+    deadline_exceeded
+    insufficient_memory
+    internal_error
+    load_timeout
+    manifest_not_found
+    mlx_backend_unavailable
+    model_busy
+    model_invalid
+    node_timeout
+    node_unavailable
+    orchestration_error
+    queue_full
+    queue_timeout
+    request_cancelled
+    request_caller_disconnect
+    request_client_disconnect
+    request_controller_restarted
+    request_interrupted
+    request_timeout
+    resource_exhausted
+    rpc_error
+    rpc_resource_exhausted
+    rpc_unavailable
+    runtime_incompatible
+    runtime_unavailable
+    timed_out
+    timeout
+    tool_execution_cancelled
+    tool_execution_failed
+    tool_execution_indeterminate_cancel_ack_missing
+    tool_execution_indeterminate_controller_restarted
+    tool_execution_indeterminate_executor_unreachable
+    tool_execution_indeterminate_result_not_observed
+    tool_execution_indeterminate_timeout_after_start
+    tool_execution_timed_out
+    tool_failed
+    tool_timeout
+    tooling_not_supported
+    unexpected_placement_state
+    worker_down
+    worker_unavailable
+    worker_unloaded
+  )
   @schedule_boolean_keys ~w(
     cache_affinity_enabled
     cache_affinity_hint_available
@@ -107,6 +156,7 @@ defmodule Orchard.Requests.CapturePolicy do
   @spec terminal_attrs(mode(), map()) :: map()
   def terminal_attrs(:full, attrs) do
     attrs
+    |> Map.delete(:response_preview_source)
     |> put_response_hash()
     |> Map.update(:response_preview, nil, &bounded_preview/1)
   end
@@ -115,13 +165,15 @@ defmodule Orchard.Requests.CapturePolicy do
     preview =
       case mode do
         :none -> nil
-        :metadata -> metadata_preview(Map.get(attrs, :response_preview))
+        :metadata -> metadata_preview(attrs)
       end
 
     attrs
+    |> Map.delete(:response_preview_source)
     |> put_response_hash()
     |> Map.put(:response_payload, nil)
     |> Map.put(:response_preview, preview)
+    |> Map.update(:error_code, nil, &stable_error_code/1)
     |> Map.put(:error_message, nil)
   end
 
@@ -180,6 +232,10 @@ defmodule Orchard.Requests.CapturePolicy do
       ]
     }
   end
+
+  @doc false
+  @spec stable_error_codes() :: [String.t()]
+  def stable_error_codes, do: @stable_error_codes
 
   @spec safe_columns() :: %{request_events: [atom()], requests: [atom()]}
   def safe_columns do
@@ -290,13 +346,26 @@ defmodule Orchard.Requests.CapturePolicy do
     end
   end
 
-  defp metadata_preview(nil), do: nil
+  defp metadata_preview(%{response_preview_source: :assistant_text} = attrs),
+    do: metadata_preview_value(Map.get(attrs, :response_preview))
 
-  defp metadata_preview(preview) when is_binary(preview) do
+  defp metadata_preview(_attrs), do: nil
+
+  defp metadata_preview_value(nil), do: nil
+
+  defp metadata_preview_value(preview) when is_binary(preview) do
     if codepoint_length(preview) > @preview_limit do
       truncate_preview(preview)
     end
   end
+
+  defp metadata_preview_value(_preview), do: nil
+
+  defp stable_error_code(nil), do: nil
+
+  defp stable_error_code(code) when code in @stable_error_codes, do: code
+
+  defp stable_error_code(_code), do: "internal_error"
 
   defp bounded_preview(nil), do: nil
 

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -145,6 +145,15 @@ defmodule Orchard.Requests.CapturePolicy do
   def resolve(:full, false), do: :metadata
   def resolve(mode, false) when mode in [:none, :metadata], do: mode
 
+  @doc """
+  Returns the most restrictive capture mode.
+
+  Persistence boundaries use it when a request carries no resolvable capture
+  mode so unresolved rows are sanitized fail-closed rather than stored verbatim.
+  """
+  @spec strictest_mode() :: mode()
+  def strictest_mode, do: :none
+
   @spec normalize_mode(term()) :: {:ok, mode()} | :error
   def normalize_mode(mode) when mode in @capture_modes, do: {:ok, mode}
 

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -1,0 +1,432 @@
+defmodule Orchard.Requests.CapturePolicy do
+  @moduledoc """
+  Applies the tenant request-body capture policy at persistence boundaries.
+  """
+
+  @preview_limit 512
+  @capture_modes [:none, :metadata, :full]
+  @safe_result_keys ~w(
+    error_code
+    finish_reason
+    http_status
+    indeterminate_reason
+    input_tokens
+    output_tokens
+    remote_request_id
+    remote_response_id
+  )
+  @safe_schedule_keys ~w(
+    candidate_count
+    capacity_source
+    contract_version
+    fallback_used?
+    memory_admission_enabled
+    memory_admission_tier
+    memory_headroom_ok?
+    model_load_timeout_ms
+    node_id
+    object
+    queue_grant_id
+    queue_granted_at
+    queue_key
+    queue_result
+    queue_wait_ms
+    queue_wait_reason
+    queued_at
+    queueing_enabled
+    request_id
+    request_timeout_ms
+    selected_node_id
+    selected_cache_tier
+    selected_tier
+    selection_tier
+    strategy
+  )
+  @safe_prefix_cache_schedule_keys ~w(
+    selected_prefix_cache_enabled
+    selected_prefix_cache_entry_count
+    selected_prefix_cache_evictions
+    selected_prefix_cache_fingerprint_count
+    selected_prefix_cache_fingerprint_match
+    selected_prefix_cache_hits
+    selected_prefix_cache_implementation
+    selected_prefix_cache_misses
+    selected_prefix_cache_score_source
+    selected_prefix_cache_score_status_code
+    selected_prefix_cache_score_tier
+    selected_prefix_cache_session_started_unix_ms
+    selected_prefix_cache_status_code
+    selected_prefix_cache_stores
+    selected_prefix_cache_total_bytes
+    selected_prefix_cache_warmth_indicator
+  )
+  @safe_score_component_keys ~w(
+    cache_affinity_bonus
+    capable_worker_bonus
+    health_bonus
+    live_fingerprint_bonus
+    load_bonus
+    memory_headroom_bonus
+    pool_bonus
+    rank_base
+    residency_bonus
+  )
+
+  @type mode :: :none | :metadata | :full
+
+  @spec resolve(mode(), boolean()) :: mode()
+  def resolve(mode, true) when mode in @capture_modes, do: mode
+  def resolve(:full, false), do: :metadata
+  def resolve(mode, false) when mode in [:none, :metadata], do: mode
+
+  @spec create_attrs(mode(), map()) :: map()
+  def create_attrs(:full, attrs), do: Map.put(attrs, :request_shape, request_shape(:full, attrs))
+
+  def create_attrs(:none, attrs) do
+    attrs
+    |> Map.put(:canonical_request, nil)
+    |> Map.put(:request_payload, nil)
+    |> Map.put(:request_shape, nil)
+    |> update_existing(:sampling_params, &sanitize_sampling/1)
+    |> update_existing(:response_format, &sanitize_response_format/1)
+    |> then(&terminal_attrs(:none, &1))
+  end
+
+  def create_attrs(:metadata, attrs) do
+    attrs
+    |> Map.put(:canonical_request, nil)
+    |> Map.put(:request_payload, nil)
+    |> Map.put(:request_shape, request_shape(:metadata, attrs))
+    |> update_existing(:sampling_params, &sanitize_sampling/1)
+    |> update_existing(:response_format, &sanitize_response_format/1)
+    |> then(&terminal_attrs(:metadata, &1))
+  end
+
+  @spec terminal_attrs(mode(), map()) :: map()
+  def terminal_attrs(:full, attrs) do
+    attrs
+    |> put_response_hash()
+    |> Map.update(:response_preview, nil, &bounded_preview/1)
+  end
+
+  def terminal_attrs(mode, attrs) when mode in [:none, :metadata] do
+    preview =
+      case mode do
+        :none -> nil
+        :metadata -> metadata_preview(Map.get(attrs, :response_preview))
+      end
+
+    attrs
+    |> put_response_hash()
+    |> Map.put(:response_payload, nil)
+    |> Map.put(:response_preview, preview)
+    |> Map.put(:error_message, nil)
+  end
+
+  @spec event_attrs(mode(), map()) :: map()
+  def event_attrs(:full, attrs), do: attrs
+
+  def event_attrs(mode, attrs) when mode in [:none, :metadata] do
+    cond do
+      Map.has_key?(attrs, :payload) -> Map.update!(attrs, :payload, &sanitize_event_payload/1)
+      Map.has_key?(attrs, "payload") -> Map.update!(attrs, "payload", &sanitize_event_payload/1)
+      true -> attrs
+    end
+  end
+
+  @spec schedule_attrs(mode(), map()) :: map()
+  def schedule_attrs(:full, attrs), do: attrs
+
+  def schedule_attrs(mode, attrs) when mode in [:none, :metadata] do
+    attrs
+    |> take_keys(@safe_schedule_keys ++ @safe_prefix_cache_schedule_keys)
+    |> sanitize_scalar_map()
+    |> put_safe_candidates(attrs, "scored_candidates")
+    |> put_safe_candidates(attrs, "rejected_candidates")
+    |> put_safe_candidates(attrs, "skipped_candidates")
+  end
+
+  @spec content_columns() :: %{request_events: [atom()], requests: [atom()]}
+  def content_columns do
+    %{
+      request_events: [:payload],
+      requests: [
+        :canonical_request,
+        :request_shape,
+        :request_payload,
+        :response_payload,
+        :response_preview,
+        :sampling_params,
+        :response_format,
+        :scheduler_decision,
+        :error_message
+      ]
+    }
+  end
+
+  @spec safe_columns() :: %{request_events: [atom()], requests: [atom()]}
+  def safe_columns do
+    %{
+      request_events: [:event_type, :id, :occurred_at, :request_id, :seq, :state],
+      requests: [
+        :api_key_id,
+        :body_hash,
+        :completed_at,
+        :endpoint,
+        :error_code,
+        :first_token_at,
+        :http_status,
+        :id,
+        :idempotency_key,
+        :input_tokens,
+        :inserted_at,
+        :model_id,
+        :node_id,
+        :output_tokens,
+        :payload_capture_mode,
+        :principal_type,
+        :public_id,
+        :requested_model,
+        :reserved_output_tokens,
+        :response_hash,
+        :retry_of_request_id,
+        :service_account_id,
+        :state,
+        :stream,
+        :tenant_id,
+        :timeout_at,
+        :updated_at,
+        :worker_id
+      ]
+    }
+  end
+
+  defp request_shape(mode, attrs) do
+    canonical = Map.get(attrs, :canonical_request) || %{}
+
+    rendered_prompt =
+      fetch_value(canonical, :rendered_prompt) ||
+        fetch_value(Map.get(attrs, :request_payload) || %{}, :prompt)
+
+    %{
+      "capture_mode" => capture_mode_string(mode),
+      "input_item_count" => input_item_count(canonical),
+      "preview" => nil,
+      "rendered_prompt" => content_shape(rendered_prompt)
+    }
+  end
+
+  defp capture_mode_string(mode), do: Atom.to_string(mode)
+
+  defp input_item_count(canonical) do
+    (fetch_value(canonical, :input_items) || fetch_value(canonical, :input))
+    |> case do
+      value when is_list(value) -> length(value)
+      nil -> 0
+      _value -> 1
+    end
+  end
+
+  defp content_shape(nil), do: nil
+
+  defp content_shape(content) do
+    encoded = encode_content(content)
+
+    %{
+      "bytes" => byte_size(encoded),
+      "graphemes" => String.length(encoded),
+      "sha256" => sha256_hex(encoded)
+    }
+  end
+
+  defp encode_content(content) when is_binary(content), do: content
+  defp encode_content(content), do: Jason.encode!(content)
+
+  defp sanitize_sampling(nil), do: nil
+
+  defp sanitize_sampling(params) when is_map(params) do
+    params
+    |> take_keys(~w(max_output_tokens seed temperature top_p))
+    |> Map.put("stop_count", stop_count(params))
+  end
+
+  defp sanitize_response_format(nil), do: nil
+
+  defp sanitize_response_format(format) when is_map(format) do
+    take_keys(format, ~w(type))
+  end
+
+  defp update_existing(attrs, key, fun) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.update!(attrs, key, fun)
+      Map.has_key?(attrs, string_key) -> Map.update!(attrs, string_key, fun)
+      true -> attrs
+    end
+  end
+
+  defp put_response_hash(attrs) do
+    case Map.get(attrs, :response_payload) do
+      nil -> attrs
+      payload -> Map.put(attrs, :response_hash, payload |> encode_content() |> sha256())
+    end
+  end
+
+  defp metadata_preview(nil), do: nil
+
+  defp metadata_preview(preview) when is_binary(preview) do
+    if codepoint_length(preview) > @preview_limit do
+      truncate_preview(preview)
+    end
+  end
+
+  defp bounded_preview(nil), do: nil
+
+  defp bounded_preview(preview) when is_binary(preview) do
+    if codepoint_length(preview) > @preview_limit do
+      truncate_preview(preview)
+    else
+      preview
+    end
+  end
+
+  defp truncate_preview(preview) do
+    {graphemes, _count} =
+      preview
+      |> String.graphemes()
+      |> Enum.reduce_while({[], 0}, fn grapheme, {acc, count} ->
+        grapheme_size = codepoint_length(grapheme)
+
+        if count + grapheme_size <= @preview_limit - 1 do
+          {:cont, {[grapheme | acc], count + grapheme_size}}
+        else
+          {:halt, {acc, count}}
+        end
+      end)
+
+    graphemes
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
+    |> Kernel.<>("…")
+  end
+
+  defp codepoint_length(value), do: value |> String.codepoints() |> length()
+
+  defp sanitize_event_payload(payload) when is_map(payload) do
+    payload
+    |> take_keys(
+      ~w(attempt attempt_index boundary kind phase request_step_id sequence state step_id step_type turn_index type) ++
+        ~w(call_id model_id model_version parent_step_id tool_name)
+    )
+    |> maybe_put_sanitized_result(payload)
+  end
+
+  defp sanitize_event_payload(_payload), do: %{}
+
+  defp put_safe_candidates(sanitized, attrs, key) do
+    case fetch_value(attrs, key) do
+      candidates when is_list(candidates) ->
+        Map.put(sanitized, key, Enum.map(candidates, &sanitize_candidate/1))
+
+      _candidates ->
+        sanitized
+    end
+  end
+
+  defp sanitize_candidate(candidate) when is_map(candidate) do
+    candidate
+    |> take_keys(~w(eligible node_id reason_codes score target_ref tier))
+    |> Enum.reduce(%{}, fn {key, value}, acc ->
+      if scalar?(value) or (key == "reason_codes" and safe_scalar_list?(value)) do
+        Map.put(acc, key, bound_scalar(value))
+      else
+        acc
+      end
+    end)
+    |> maybe_put_score_components(candidate)
+  end
+
+  defp sanitize_candidate(_candidate), do: %{}
+
+  defp maybe_put_score_components(sanitized, candidate) do
+    case fetch_value(candidate, :components) do
+      components when is_map(components) ->
+        Map.put(sanitized, "components", sanitize_score_components(components))
+
+      _components ->
+        sanitized
+    end
+  end
+
+  defp sanitize_score_components(components) do
+    components
+    |> take_keys(@safe_score_component_keys)
+    |> Map.filter(fn {_key, value} -> is_number(value) end)
+  end
+
+  defp sanitize_scalar_map(map) do
+    Enum.reduce(map, %{}, fn {key, value}, acc ->
+      if scalar?(value), do: Map.put(acc, key, bound_scalar(value)), else: acc
+    end)
+  end
+
+  defp bound_scalar(value) when is_binary(value), do: String.slice(value, 0, 256)
+  defp bound_scalar(value) when is_boolean(value) or is_nil(value), do: value
+  defp bound_scalar(value) when is_atom(value) and not is_nil(value), do: Atom.to_string(value)
+  defp bound_scalar(value) when is_list(value), do: Enum.map(value, &bound_scalar/1)
+  defp bound_scalar(value), do: value
+
+  defp scalar?(value),
+    do: is_binary(value) or is_number(value) or is_atom(value)
+
+  defp safe_scalar_list?(values) when is_list(values), do: Enum.all?(values, &scalar?/1)
+  defp safe_scalar_list?(_values), do: false
+
+  defp maybe_put_sanitized_result(sanitized, payload) do
+    case fetch_value(payload, :result) do
+      result when is_map(result) ->
+        Map.put(sanitized, "result", take_keys(result, @safe_result_keys))
+
+      _result ->
+        sanitized
+    end
+  end
+
+  defp stop_count(params) do
+    case fetch_value(params, :stop) do
+      values when is_list(values) -> length(values)
+      nil -> 0
+      _value -> 1
+    end
+  end
+
+  defp take_keys(map, keys) do
+    Enum.reduce(keys, %{}, fn key, acc ->
+      case fetch_value(map, key) do
+        nil -> acc
+        value -> Map.put(acc, key, value)
+      end
+    end)
+  end
+
+  defp fetch_value(map, key) when is_atom(key) do
+    fetch_first(map, key, Atom.to_string(key))
+  end
+
+  defp fetch_value(map, key) when is_binary(key) do
+    fetch_first(map, key, String.to_existing_atom(key))
+  rescue
+    ArgumentError -> Map.get(map, key)
+  end
+
+  defp fetch_first(map, primary, secondary) do
+    case Map.fetch(map, primary) do
+      {:ok, value} -> value
+      :error -> Map.get(map, secondary)
+    end
+  end
+
+  defp sha256(content), do: :crypto.hash(:sha256, content)
+  defp sha256_hex(content), do: content |> sha256() |> Base.encode16(case: :lower)
+end

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -5,61 +5,54 @@ defmodule Orchard.Requests.CapturePolicy do
 
   @preview_limit 512
   @capture_modes [:none, :metadata, :full]
-  @safe_result_keys ~w(
-    error_code
-    finish_reason
-    http_status
-    indeterminate_reason
-    input_tokens
-    output_tokens
-    remote_request_id
-    remote_response_id
-  )
-  @safe_schedule_keys ~w(
-    candidate_count
-    capacity_source
-    contract_version
+  @event_integer_keys ~w(attempt attempt_index sequence turn_index)
+  @result_integer_keys ~w(http_status input_tokens output_tokens)
+  @finish_reasons ~w(cancelled content_filter error length stop tool_calls)
+  @schedule_boolean_keys ~w(
     fallback_used?
     memory_admission_enabled
-    memory_admission_tier
     memory_headroom_ok?
-    model_load_timeout_ms
-    node_id
-    object
-    queue_grant_id
-    queue_granted_at
-    queue_key
-    queue_result
-    queue_wait_ms
-    queue_wait_reason
-    queued_at
     queueing_enabled
-    request_id
-    request_timeout_ms
-    selected_node_id
-    selected_cache_tier
-    selected_tier
-    selection_tier
-    strategy
-  )
-  @safe_prefix_cache_schedule_keys ~w(
     selected_prefix_cache_enabled
+    selected_prefix_cache_fingerprint_match
+    selected_prefix_cache_score_resident_fingerprint_match
+    selected_prefix_cache_warmth_indicator
+  )
+  @schedule_numeric_keys ~w(
+    candidate_count
+    contract_version
+    model_load_timeout_ms
+    queue_wait_ms
+    request_timeout_ms
     selected_prefix_cache_entry_count
     selected_prefix_cache_evictions
     selected_prefix_cache_fingerprint_count
-    selected_prefix_cache_fingerprint_match
     selected_prefix_cache_hits
-    selected_prefix_cache_implementation
     selected_prefix_cache_misses
-    selected_prefix_cache_score_source
-    selected_prefix_cache_score_status_code
-    selected_prefix_cache_score_tier
+    selected_prefix_cache_score_session_started_unix_ms
     selected_prefix_cache_session_started_unix_ms
-    selected_prefix_cache_status_code
     selected_prefix_cache_stores
     selected_prefix_cache_total_bytes
-    selected_prefix_cache_warmth_indicator
   )
+  @schedule_enums %{
+    "memory_admission_tier" =>
+      ~w(headroom_available headroom_ok headroom_tight headroom_unavailable headroom_unknown),
+    "queue_result" =>
+      ~w(immediate interrupted_before_dispatch interrupted_controller_restarted queue_full queue_timeout queued),
+    "queue_wait_reason" =>
+      ~w(live_node_capacity placement_capacity requested_model_path_capacity),
+    "selected_cache_tier" => ~w(hint_not_selected no_hint warm_prefix),
+    "selected_prefix_cache_implementation" => ~w(disabled kv unknown),
+    "selected_prefix_cache_score_source" => ~w(score_prefix_cache_rpc),
+    "selected_prefix_cache_score_status_code" =>
+      ~w(disabled error invalid_request model_not_loaded ok timeout unavailable unsupported_version),
+    "selected_prefix_cache_score_tier" =>
+      ~w(no_match recent_fingerprint_only resident_fingerprint unknown),
+    "selected_prefix_cache_status_code" => ~w(disabled error invalid_status ok unavailable),
+    "selected_tier" => ~w(cold loaded),
+    "selection_tier" => ~w(cold loaded),
+    "strategy" => ~w(multi_node single_node)
+  }
   @safe_score_component_keys ~w(
     cache_affinity_bonus
     capable_worker_bonus
@@ -73,6 +66,9 @@ defmodule Orchard.Requests.CapturePolicy do
   )
 
   @type mode :: :none | :metadata | :full
+
+  alias Orchard.ClusterManagement.ReasonCodes
+  alias Orchard.Requests.RequestStepEvent
 
   @spec resolve(mode(), boolean()) :: mode()
   def resolve(mode, true) when mode in @capture_modes, do: mode
@@ -137,13 +133,26 @@ defmodule Orchard.Requests.CapturePolicy do
   @spec schedule_attrs(mode(), map()) :: map()
   def schedule_attrs(:full, attrs), do: attrs
 
-  def schedule_attrs(mode, attrs) when mode in [:none, :metadata] do
-    attrs
-    |> take_keys(@safe_schedule_keys ++ @safe_prefix_cache_schedule_keys)
-    |> sanitize_scalar_map()
-    |> put_safe_candidates(attrs, "scored_candidates")
-    |> put_safe_candidates(attrs, "rejected_candidates")
-    |> put_safe_candidates(attrs, "skipped_candidates")
+  def schedule_attrs(mode, attrs) when mode in [:none, :metadata],
+    do: schedule_attrs(mode, attrs, %{})
+
+  @spec schedule_attrs(mode(), map(), map()) :: map()
+  def schedule_attrs(:full, attrs, _approved), do: attrs
+
+  def schedule_attrs(mode, attrs, approved) when mode in [:none, :metadata] do
+    %{}
+    |> put_typed_values(attrs, @schedule_numeric_keys, &number?/1)
+    |> put_typed_values(attrs, @schedule_boolean_keys, &is_boolean/1)
+    |> put_enum_values(attrs, @schedule_enums)
+    |> put_uuid_value(attrs, "node_id")
+    |> put_uuid_value(attrs, "selected_node_id")
+    |> put_uuid_value(attrs, "queue_grant_id")
+    |> put_datetime_value(attrs, "queue_granted_at")
+    |> put_datetime_value(attrs, "queued_at")
+    |> put_exact_value(attrs, "queue_key", Map.get(approved, :requested_model))
+    |> put_safe_candidates(attrs, "scored_candidates", :scheduler_rejection)
+    |> put_safe_candidates(attrs, "rejected_candidates", :scheduler_rejection)
+    |> put_safe_candidates(attrs, "skipped_candidates", :scheduler_skip)
   end
 
   @spec content_columns() :: %{request_events: [atom()], requests: [atom()]}
@@ -314,40 +323,105 @@ defmodule Orchard.Requests.CapturePolicy do
   defp codepoint_length(value), do: value |> String.codepoints() |> length()
 
   defp sanitize_event_payload(payload) when is_map(payload) do
-    payload
-    |> take_keys(
-      ~w(attempt attempt_index boundary kind phase request_step_id sequence state step_id step_type turn_index type) ++
-        ~w(call_id model_id model_version parent_step_id tool_name)
-    )
+    %{}
+    |> put_typed_values(payload, @event_integer_keys, &non_negative_integer?/1)
+    |> put_enum_value(payload, "boundary", ~w(post_observation pre_side_effect))
+    |> put_enum_value(payload, "step_type", ~w(inference_turn tool_call tool_execution))
+    |> put_step_identity(payload)
     |> maybe_put_sanitized_result(payload)
   end
 
   defp sanitize_event_payload(_payload), do: %{}
 
-  defp put_safe_candidates(sanitized, attrs, key) do
+  defp put_safe_candidates(sanitized, attrs, key, vocabulary) do
     case fetch_value(attrs, key) do
       candidates when is_list(candidates) ->
-        Map.put(sanitized, key, Enum.map(candidates, &sanitize_candidate/1))
+        Map.put(sanitized, key, Enum.map(candidates, &sanitize_candidate(&1, vocabulary)))
 
       _candidates ->
         sanitized
     end
   end
 
-  defp sanitize_candidate(candidate) when is_map(candidate) do
-    candidate
-    |> take_keys(~w(eligible node_id reason_codes score target_ref tier))
-    |> Enum.reduce(%{}, fn {key, value}, acc ->
-      if scalar?(value) or (key == "reason_codes" and safe_scalar_list?(value)) do
-        Map.put(acc, key, bound_scalar(value))
-      else
-        acc
-      end
-    end)
+  defp sanitize_candidate(candidate, vocabulary) when is_map(candidate) do
+    %{}
+    |> put_typed_values(candidate, ~w(score), &number?/1)
+    |> put_typed_values(candidate, ~w(eligible), &is_boolean/1)
+    |> put_enum_value(candidate, "tier", ~w(cold loaded))
+    |> put_uuid_value(candidate, "node_id")
+    |> put_reason_codes(candidate, vocabulary)
     |> maybe_put_score_components(candidate)
   end
 
-  defp sanitize_candidate(_candidate), do: %{}
+  defp sanitize_candidate(_candidate, _vocabulary), do: %{}
+
+  defp put_step_identity(sanitized, payload) do
+    case fetch_value(payload, :step_type) do
+      "inference_turn" -> put_inference_turn_identity(sanitized, payload)
+      "tool_call" -> put_tool_call_identity(sanitized, payload)
+      "tool_execution" -> put_tool_execution_identity(sanitized, payload)
+      _step_type -> sanitized
+    end
+  end
+
+  defp put_inference_turn_identity(sanitized, payload) do
+    turn_index = fetch_value(payload, :turn_index)
+    attempt = fetch_value(payload, :attempt)
+
+    if positive_integer?(turn_index) and positive_integer?(attempt) do
+      Map.put(sanitized, "step_id", RequestStepEvent.inference_turn_step_id(turn_index, attempt))
+    else
+      sanitized
+    end
+  end
+
+  defp put_tool_call_identity(sanitized, payload) do
+    turn_index = fetch_value(payload, :turn_index)
+    call_id = fetch_value(payload, :call_id)
+
+    if positive_integer?(turn_index) and is_binary(call_id) do
+      put_tool_identity(sanitized, "tool_call", turn_index, call_id, nil)
+    else
+      sanitized
+    end
+  end
+
+  defp put_tool_execution_identity(sanitized, payload) do
+    turn_index = fetch_value(payload, :turn_index)
+    attempt = fetch_value(payload, :attempt)
+    call_id = fetch_value(payload, :call_id)
+
+    if positive_integer?(turn_index) and positive_integer?(attempt) and is_binary(call_id) do
+      put_tool_identity(sanitized, "tool_execution", turn_index, call_id, attempt)
+    else
+      sanitized
+    end
+  end
+
+  defp put_tool_identity(sanitized, step_type, turn_index, call_id, attempt) do
+    safe_call_id = "sha256:" <> sha256_hex(call_id)
+    parent_step_id = RequestStepEvent.tool_call_step_id(turn_index, safe_call_id)
+
+    step_id =
+      case step_type do
+        "tool_call" ->
+          parent_step_id
+
+        "tool_execution" ->
+          RequestStepEvent.tool_execution_step_id(turn_index, safe_call_id, attempt)
+      end
+
+    sanitized
+    |> Map.put("call_id", safe_call_id)
+    |> Map.put("step_id", step_id)
+    |> Map.put(
+      "parent_step_id",
+      if(step_type == "tool_call",
+        do: RequestStepEvent.inference_turn_step_id(turn_index, 1),
+        else: parent_step_id
+      )
+    )
+  end
 
   defp maybe_put_score_components(sanitized, candidate) do
     case fetch_value(candidate, :components) do
@@ -365,33 +439,87 @@ defmodule Orchard.Requests.CapturePolicy do
     |> Map.filter(fn {_key, value} -> is_number(value) end)
   end
 
-  defp sanitize_scalar_map(map) do
-    Enum.reduce(map, %{}, fn {key, value}, acc ->
-      if scalar?(value), do: Map.put(acc, key, bound_scalar(value)), else: acc
-    end)
-  end
-
-  defp bound_scalar(value) when is_binary(value), do: String.slice(value, 0, 256)
-  defp bound_scalar(value) when is_boolean(value) or is_nil(value), do: value
-  defp bound_scalar(value) when is_atom(value) and not is_nil(value), do: Atom.to_string(value)
-  defp bound_scalar(value) when is_list(value), do: Enum.map(value, &bound_scalar/1)
-  defp bound_scalar(value), do: value
-
-  defp scalar?(value),
-    do: is_binary(value) or is_number(value) or is_atom(value)
-
-  defp safe_scalar_list?(values) when is_list(values), do: Enum.all?(values, &scalar?/1)
-  defp safe_scalar_list?(_values), do: false
-
   defp maybe_put_sanitized_result(sanitized, payload) do
     case fetch_value(payload, :result) do
       result when is_map(result) ->
-        Map.put(sanitized, "result", take_keys(result, @safe_result_keys))
+        safe_result =
+          %{}
+          |> put_typed_values(result, @result_integer_keys, &non_negative_integer?/1)
+          |> put_enum_value(result, "finish_reason", @finish_reasons)
+
+        Map.put(sanitized, "result", safe_result)
 
       _result ->
         sanitized
     end
   end
+
+  defp put_typed_values(sanitized, source, keys, predicate) do
+    Enum.reduce(keys, sanitized, fn key, acc ->
+      put_typed_value(acc, key, fetch_value(source, key), predicate)
+    end)
+  end
+
+  defp put_typed_value(sanitized, _key, nil, _predicate), do: sanitized
+
+  defp put_typed_value(sanitized, key, value, predicate) do
+    if predicate.(value), do: Map.put(sanitized, key, value), else: sanitized
+  end
+
+  defp put_enum_values(sanitized, source, enums) do
+    Enum.reduce(enums, sanitized, fn {key, allowed}, acc ->
+      put_enum_value(acc, source, key, allowed)
+    end)
+  end
+
+  defp put_enum_value(sanitized, source, key, allowed) do
+    case normalize_enum(fetch_value(source, key)) do
+      value when is_binary(value) ->
+        if value in allowed, do: Map.put(sanitized, key, value), else: sanitized
+
+      nil ->
+        sanitized
+    end
+  end
+
+  defp put_uuid_value(sanitized, source, key) do
+    case Ecto.UUID.cast(fetch_value(source, key)) do
+      {:ok, uuid} -> Map.put(sanitized, key, uuid)
+      :error -> sanitized
+    end
+  end
+
+  defp put_datetime_value(sanitized, source, key) do
+    case DateTime.from_iso8601(fetch_value(source, key) || "") do
+      {:ok, datetime, 0} -> Map.put(sanitized, key, DateTime.to_iso8601(datetime))
+      _result -> sanitized
+    end
+  end
+
+  defp put_exact_value(sanitized, _source, _key, nil), do: sanitized
+
+  defp put_exact_value(sanitized, source, key, expected) do
+    if fetch_value(source, key) == expected do
+      Map.put(sanitized, key, expected)
+    else
+      sanitized
+    end
+  end
+
+  defp put_reason_codes(sanitized, source, vocabulary) do
+    case ReasonCodes.validate_codes(vocabulary, fetch_value(source, :reason_codes)) do
+      {:ok, codes} -> Map.put(sanitized, "reason_codes", codes)
+      {:error, _reason} -> sanitized
+    end
+  end
+
+  defp normalize_enum(value) when is_atom(value) and not is_nil(value), do: Atom.to_string(value)
+  defp normalize_enum(value) when is_binary(value), do: value
+  defp normalize_enum(_value), do: nil
+
+  defp number?(value), do: is_integer(value) or is_float(value)
+  defp positive_integer?(value), do: is_integer(value) and value > 0
+  defp non_negative_integer?(value), do: is_integer(value) and value >= 0
 
   defp stop_count(params) do
     case fetch_value(params, :stop) do

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -9,6 +9,9 @@ defmodule Orchard.Requests.CapturePolicy do
   @result_integer_keys ~w(http_status input_tokens output_tokens)
   @finish_reasons ~w(cancelled content_filter error length stop tool_calls)
   @schedule_boolean_keys ~w(
+    cache_affinity_enabled
+    cache_affinity_hint_available
+    cache_affinity_selected_match
     fallback_used?
     memory_admission_enabled
     memory_headroom_ok?
@@ -35,6 +38,7 @@ defmodule Orchard.Requests.CapturePolicy do
     selected_prefix_cache_total_bytes
   )
   @schedule_enums %{
+    "cache_affinity_source" => ~w(recent_completed_request),
     "memory_admission_tier" =>
       ~w(headroom_available headroom_ok headroom_tight headroom_unavailable headroom_unknown),
     "queue_result" =>
@@ -141,6 +145,7 @@ defmodule Orchard.Requests.CapturePolicy do
 
   def schedule_attrs(mode, attrs, approved) when mode in [:none, :metadata] do
     %{}
+    |> put_typed_values(attrs, ~w(cache_affinity_candidate_count), &non_negative_integer?/1)
     |> put_typed_values(attrs, @schedule_numeric_keys, &number?/1)
     |> put_typed_values(attrs, @schedule_boolean_keys, &is_boolean/1)
     |> put_enum_values(attrs, @schedule_enums)
@@ -149,6 +154,7 @@ defmodule Orchard.Requests.CapturePolicy do
     |> put_uuid_value(attrs, "queue_grant_id")
     |> put_datetime_value(attrs, "queue_granted_at")
     |> put_datetime_value(attrs, "queued_at")
+    |> put_cache_affinity_key(attrs)
     |> put_exact_value(attrs, "queue_key", Map.get(approved, :requested_model))
     |> put_safe_candidates(attrs, "scored_candidates", :scheduler_rejection)
     |> put_safe_candidates(attrs, "rejected_candidates", :scheduler_rejection)
@@ -516,6 +522,20 @@ defmodule Orchard.Requests.CapturePolicy do
       Map.put(sanitized, key, expected)
     else
       sanitized
+    end
+  end
+
+  defp put_cache_affinity_key(sanitized, source) do
+    case fetch_value(source, :cache_affinity_key) do
+      "hmac-sha256:" <> digest = value when byte_size(digest) == 64 ->
+        if String.match?(digest, ~r/\A[0-9a-f]{64}\z/) do
+          Map.put(sanitized, "cache_affinity_key", value)
+        else
+          sanitized
+        end
+
+      _value ->
+        sanitized
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -501,10 +501,29 @@ defmodule Orchard.Requests.CapturePolicy do
   defp inference_step_result(result) when is_map(result) do
     %{}
     |> put_typed_values(result, @result_integer_keys, &non_negative_integer?/1)
-    |> put_enum_value(result, "finish_reason", @finish_reasons)
+    |> put_finish_reason_evidence(result)
+    |> put_typed_value(
+      "error_code",
+      stable_error_code(fetch_value(result, :error_code)),
+      &is_binary/1
+    )
   end
 
-  defp inference_step_result(_result), do: %{}
+  defp inference_step_result(_result), do: %{"result_invalid" => true}
+
+  defp put_finish_reason_evidence(sanitized, result) do
+    if has_key?(result, :finish_reason) do
+      case normalize_enum(fetch_value(result, :finish_reason)) do
+        finish_reason when finish_reason in @finish_reasons ->
+          Map.put(sanitized, "finish_reason", finish_reason)
+
+        _invalid ->
+          Map.put(sanitized, "finish_reason_invalid", true)
+      end
+    else
+      sanitized
+    end
+  end
 
   defp tool_execution_result(result, event_type) when is_map(result) do
     case Map.fetch(@tool_execution_statuses, event_type) do
@@ -645,12 +664,7 @@ defmodule Orchard.Requests.CapturePolicy do
   defp maybe_put_sanitized_result(sanitized, payload) do
     case fetch_value(payload, :result) do
       result when is_map(result) ->
-        safe_result =
-          %{}
-          |> put_typed_values(result, @result_integer_keys, &non_negative_integer?/1)
-          |> put_enum_value(result, "finish_reason", @finish_reasons)
-
-        Map.put(sanitized, "result", safe_result)
+        Map.put(sanitized, "result", inference_step_result(result))
 
       _result ->
         sanitized

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -490,7 +490,20 @@ defmodule Orchard.Requests.CapturePolicy do
   end
 
   defp put_datetime_value(sanitized, source, key) do
-    case DateTime.from_iso8601(fetch_value(source, key) || "") do
+    case fetch_value(source, key) do
+      %DateTime{} = datetime ->
+        Map.put(sanitized, key, DateTime.to_iso8601(datetime))
+
+      value when is_binary(value) ->
+        put_iso8601_value(sanitized, key, value)
+
+      _value ->
+        sanitized
+    end
+  end
+
+  defp put_iso8601_value(sanitized, key, value) do
+    case DateTime.from_iso8601(value) do
       {:ok, datetime, 0} -> Map.put(sanitized, key, DateTime.to_iso8601(datetime))
       _result -> sanitized
     end

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -6,8 +6,24 @@ defmodule Orchard.Requests.CapturePolicy do
   @preview_limit 512
   @capture_modes [:none, :metadata, :full]
   @event_integer_keys ~w(attempt attempt_index sequence turn_index)
+  @step_integer_keys ~w(attempt turn_index)
+  @step_types ~w(inference_turn tool_call tool_execution)
+  @boundaries ~w(post_observation pre_side_effect)
   @result_integer_keys ~w(http_status input_tokens output_tokens)
   @finish_reasons ~w(cancelled content_filter error length stop tool_calls)
+  @tool_execution_statuses %{
+    "request_step.failed" => :failed,
+    "request_step.cancelled" => :cancelled,
+    "request_step.timed_out" => :timed_out,
+    "request_step.indeterminate" => :indeterminate
+  }
+  @indeterminate_reasons ~w(
+    cancel_ack_missing
+    controller_restarted
+    executor_unreachable
+    result_not_observed
+    timeout_after_start
+  )
   @stable_error_codes ~w(
     acquisition_failed
     artifact_not_found
@@ -121,6 +137,7 @@ defmodule Orchard.Requests.CapturePolicy do
   @type mode :: :none | :metadata | :full
 
   alias Orchard.ClusterManagement.ReasonCodes
+  alias Orchard.Inference.ToolExecutionOutcome
   alias Orchard.Requests.RequestStepEvent
 
   @spec resolve(mode(), boolean()) :: mode()
@@ -128,14 +145,26 @@ defmodule Orchard.Requests.CapturePolicy do
   def resolve(:full, false), do: :metadata
   def resolve(mode, false) when mode in [:none, :metadata], do: mode
 
+  @spec normalize_mode(term()) :: {:ok, mode()} | :error
+  def normalize_mode(mode) when mode in @capture_modes, do: {:ok, mode}
+
+  def normalize_mode(mode) when is_binary(mode) do
+    case Enum.find(@capture_modes, &(Atom.to_string(&1) == mode)) do
+      nil -> :error
+      normalized -> {:ok, normalized}
+    end
+  end
+
+  def normalize_mode(_mode), do: :error
+
   @spec create_attrs(mode(), map()) :: map()
-  def create_attrs(:full, attrs), do: Map.put(attrs, :request_shape, request_shape(:full, attrs))
+  def create_attrs(:full, attrs), do: put_key(attrs, :request_shape, request_shape(:full, attrs))
 
   def create_attrs(:none, attrs) do
     attrs
-    |> Map.put(:canonical_request, nil)
-    |> Map.put(:request_payload, nil)
-    |> Map.put(:request_shape, nil)
+    |> put_key(:canonical_request, nil)
+    |> put_key(:request_payload, nil)
+    |> put_key(:request_shape, nil)
     |> update_existing(:sampling_params, &sanitize_sampling/1)
     |> update_existing(:response_format, &sanitize_response_format/1)
     |> then(&terminal_attrs(:none, &1))
@@ -144,9 +173,9 @@ defmodule Orchard.Requests.CapturePolicy do
 
   def create_attrs(:metadata, attrs) do
     attrs
-    |> Map.put(:canonical_request, nil)
-    |> Map.put(:request_payload, nil)
-    |> Map.put(:request_shape, request_shape(:metadata, attrs))
+    |> put_key(:canonical_request, nil)
+    |> put_key(:request_payload, nil)
+    |> put_key(:request_shape, request_shape(:metadata, attrs))
     |> update_existing(:sampling_params, &sanitize_sampling/1)
     |> update_existing(:response_format, &sanitize_response_format/1)
     |> then(&terminal_attrs(:metadata, &1))
@@ -156,35 +185,36 @@ defmodule Orchard.Requests.CapturePolicy do
   @spec terminal_attrs(mode(), map()) :: map()
   def terminal_attrs(:full, attrs) do
     attrs
-    |> Map.delete(:response_preview_source)
+    |> delete_key(:response_preview_source)
     |> put_response_hash()
-    |> Map.update(:response_preview, nil, &bounded_preview/1)
+    |> update_existing(:response_preview, &bounded_preview/1)
   end
 
   def terminal_attrs(mode, attrs) when mode in [:none, :metadata] do
-    preview =
-      case mode do
-        :none -> nil
-        :metadata -> metadata_preview(attrs)
-      end
-
     attrs
-    |> Map.delete(:response_preview_source)
     |> put_response_hash()
-    |> Map.put(:response_payload, nil)
-    |> Map.put(:response_preview, preview)
-    |> Map.update(:error_code, nil, &stable_error_code/1)
-    |> Map.put(:error_message, nil)
+    |> put_restricted_preview(mode)
+    |> delete_key(:response_preview_source)
+    |> put_key(:response_payload, nil)
+    |> update_existing(:error_code, &stable_error_code/1)
+    |> put_key(:error_message, nil)
   end
 
   @spec event_attrs(mode(), map()) :: map()
   def event_attrs(:full, attrs), do: attrs
 
   def event_attrs(mode, attrs) when mode in [:none, :metadata] do
+    event_type = fetch_value(attrs, :event_type)
+
     cond do
-      Map.has_key?(attrs, :payload) -> Map.update!(attrs, :payload, &sanitize_event_payload/1)
-      Map.has_key?(attrs, "payload") -> Map.update!(attrs, "payload", &sanitize_event_payload/1)
-      true -> attrs
+      Map.has_key?(attrs, :payload) ->
+        Map.update!(attrs, :payload, &sanitize_event_payload(&1, event_type))
+
+      Map.has_key?(attrs, "payload") ->
+        Map.update!(attrs, "payload", &sanitize_event_payload(&1, event_type))
+
+      true ->
+        attrs
     end
   end
 
@@ -275,11 +305,11 @@ defmodule Orchard.Requests.CapturePolicy do
   end
 
   defp request_shape(mode, attrs) do
-    canonical = Map.get(attrs, :canonical_request) || %{}
+    canonical = fetch_value(attrs, :canonical_request) || %{}
 
     rendered_prompt =
       fetch_value(canonical, :rendered_prompt) ||
-        fetch_value(Map.get(attrs, :request_payload) || %{}, :prompt)
+        fetch_value(fetch_value(attrs, :request_payload) || %{}, :prompt)
 
     %{
       "capture_mode" => capture_mode_string(mode),
@@ -339,17 +369,51 @@ defmodule Orchard.Requests.CapturePolicy do
     end
   end
 
-  defp put_response_hash(attrs) do
-    case Map.get(attrs, :response_payload) do
-      nil -> attrs
-      payload -> Map.put(attrs, :response_hash, payload |> encode_content() |> sha256())
+  defp has_key?(attrs, key),
+    do: Map.has_key?(attrs, key) or Map.has_key?(attrs, Atom.to_string(key))
+
+  defp put_key(attrs, key, value) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(attrs, key) -> Map.put(attrs, key, value)
+      Map.has_key?(attrs, string_key) -> Map.put(attrs, string_key, value)
+      string_keyed?(attrs) -> Map.put(attrs, string_key, value)
+      true -> Map.put(attrs, key, value)
     end
   end
 
-  defp metadata_preview(%{response_preview_source: :assistant_text} = attrs),
-    do: metadata_preview_value(Map.get(attrs, :response_preview))
+  defp delete_key(attrs, key), do: attrs |> Map.delete(key) |> Map.delete(Atom.to_string(key))
 
-  defp metadata_preview(_attrs), do: nil
+  defp string_keyed?(attrs), do: attrs != %{} and Enum.all?(Map.keys(attrs), &is_binary/1)
+
+  defp put_response_hash(attrs) do
+    case fetch_value(attrs, :response_payload) do
+      nil -> attrs
+      payload -> put_key(attrs, :response_hash, payload |> encode_content() |> sha256())
+    end
+  end
+
+  defp put_restricted_preview(attrs, mode) do
+    if has_key?(attrs, :response_preview) do
+      preview =
+        case mode do
+          :none -> nil
+          :metadata -> metadata_preview(attrs)
+        end
+
+      put_key(attrs, :response_preview, preview)
+    else
+      attrs
+    end
+  end
+
+  defp metadata_preview(attrs) do
+    case normalize_enum(fetch_value(attrs, :response_preview_source)) do
+      "assistant_text" -> metadata_preview_value(fetch_value(attrs, :response_preview))
+      _source -> nil
+    end
+  end
 
   defp metadata_preview_value(nil), do: nil
 
@@ -399,16 +463,78 @@ defmodule Orchard.Requests.CapturePolicy do
 
   defp codepoint_length(value), do: value |> String.codepoints() |> length()
 
-  defp sanitize_event_payload(payload) when is_map(payload) do
-    %{}
-    |> put_typed_values(payload, @event_integer_keys, &non_negative_integer?/1)
-    |> put_enum_value(payload, "boundary", ~w(post_observation pre_side_effect))
-    |> put_enum_value(payload, "step_type", ~w(inference_turn tool_call tool_execution))
-    |> put_step_identity(payload)
-    |> maybe_put_sanitized_result(payload)
+  defp sanitize_event_payload(payload, event_type) when is_map(payload) do
+    if RequestStepEvent.request_step_event_type?(event_type) do
+      sanitize_step_event_payload(payload, event_type)
+    else
+      %{}
+      |> put_typed_values(payload, @event_integer_keys, &non_negative_integer?/1)
+      |> put_enum_value(payload, "boundary", @boundaries)
+      |> put_enum_value(payload, "step_type", @step_types)
+      |> put_step_identity(payload)
+      |> maybe_put_sanitized_result(payload)
+    end
   end
 
-  defp sanitize_event_payload(_payload), do: %{}
+  defp sanitize_event_payload(_payload, _event_type), do: %{}
+
+  defp sanitize_step_event_payload(payload, event_type) do
+    sanitized =
+      %{}
+      |> put_typed_values(payload, @step_integer_keys, &positive_integer?/1)
+      |> put_enum_value(payload, "boundary", @boundaries)
+      |> put_enum_value(payload, "step_type", @step_types)
+      |> put_step_identity(payload)
+
+    Map.put(sanitized, "result", step_result(sanitized, payload, event_type))
+  end
+
+  defp step_result(sanitized, payload, event_type) do
+    result = fetch_value(payload, :result)
+
+    case Map.get(sanitized, "step_type") do
+      "tool_execution" -> tool_execution_result(result, event_type)
+      _step_type -> inference_step_result(result)
+    end
+  end
+
+  defp inference_step_result(result) when is_map(result) do
+    %{}
+    |> put_typed_values(result, @result_integer_keys, &non_negative_integer?/1)
+    |> put_enum_value(result, "finish_reason", @finish_reasons)
+  end
+
+  defp inference_step_result(_result), do: %{}
+
+  defp tool_execution_result(result, event_type) when is_map(result) do
+    case Map.fetch(@tool_execution_statuses, event_type) do
+      {:ok, status} -> terminal_tool_execution_result(result, status)
+      :error -> %{}
+    end
+  end
+
+  defp tool_execution_result(_result, _event_type), do: %{}
+
+  defp terminal_tool_execution_result(result, status) do
+    %{"status" => status}
+    |> put_typed_value("error_code", stable_step_error_code(result), &is_binary/1)
+    |> put_enum_value(result, "indeterminate_reason", indeterminate_reasons(status))
+    |> ToolExecutionOutcome.request_step_result()
+    |> case do
+      {:ok, safe_result} -> safe_result
+      {:error, _reason} -> %{}
+    end
+  end
+
+  defp indeterminate_reasons(:indeterminate), do: @indeterminate_reasons
+  defp indeterminate_reasons(_status), do: []
+
+  defp stable_step_error_code(result) do
+    case fetch_value(result, :error_code) do
+      code when code in @stable_error_codes -> code
+      _code -> nil
+    end
+  end
 
   defp put_safe_candidates(sanitized, attrs, key, vocabulary) do
     case fetch_value(attrs, key) do
@@ -433,7 +559,7 @@ defmodule Orchard.Requests.CapturePolicy do
   defp sanitize_candidate(_candidate, _vocabulary), do: %{}
 
   defp put_step_identity(sanitized, payload) do
-    case fetch_value(payload, :step_type) do
+    case Map.get(sanitized, "step_type") do
       "inference_turn" -> put_inference_turn_identity(sanitized, payload)
       "tool_call" -> put_tool_call_identity(sanitized, payload)
       "tool_execution" -> put_tool_execution_identity(sanitized, payload)
@@ -611,16 +737,17 @@ defmodule Orchard.Requests.CapturePolicy do
   end
 
   defp sanitize_initial_schedule(attrs, mode) do
-    case Map.fetch(attrs, :scheduler_decision) do
-      {:ok, decision} when is_map(decision) ->
-        approved = %{requested_model: Map.get(attrs, :requested_model)}
-        Map.put(attrs, :scheduler_decision, schedule_attrs(mode, decision, approved))
+    if has_key?(attrs, :scheduler_decision) do
+      case fetch_value(attrs, :scheduler_decision) do
+        decision when is_map(decision) ->
+          approved = %{requested_model: fetch_value(attrs, :requested_model)}
+          put_key(attrs, :scheduler_decision, schedule_attrs(mode, decision, approved))
 
-      {:ok, _decision} ->
-        Map.put(attrs, :scheduler_decision, nil)
-
-      :error ->
-        attrs
+        _decision ->
+          put_key(attrs, :scheduler_decision, nil)
+      end
+    else
+      attrs
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -90,6 +90,7 @@ defmodule Orchard.Requests.CapturePolicy do
     |> update_existing(:sampling_params, &sanitize_sampling/1)
     |> update_existing(:response_format, &sanitize_response_format/1)
     |> then(&terminal_attrs(:none, &1))
+    |> sanitize_initial_schedule(:none)
   end
 
   def create_attrs(:metadata, attrs) do
@@ -100,6 +101,7 @@ defmodule Orchard.Requests.CapturePolicy do
     |> update_existing(:sampling_params, &sanitize_sampling/1)
     |> update_existing(:response_format, &sanitize_response_format/1)
     |> then(&terminal_attrs(:metadata, &1))
+    |> sanitize_initial_schedule(:metadata)
   end
 
   @spec terminal_attrs(mode(), map()) :: map()
@@ -536,6 +538,20 @@ defmodule Orchard.Requests.CapturePolicy do
 
       _value ->
         sanitized
+    end
+  end
+
+  defp sanitize_initial_schedule(attrs, mode) do
+    case Map.fetch(attrs, :scheduler_decision) do
+      {:ok, decision} when is_map(decision) ->
+        approved = %{requested_model: Map.get(attrs, :requested_model)}
+        Map.put(attrs, :scheduler_decision, schedule_attrs(mode, decision, approved))
+
+      {:ok, _decision} ->
+        Map.put(attrs, :scheduler_decision, nil)
+
+      :error ->
+        attrs
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/requests/request.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request.ex
@@ -191,6 +191,7 @@ defmodule Orchard.Requests.Request do
     |> check_constraint(:response_payload, name: :requests_non_full_content_absent)
     |> check_constraint(:response_preview, name: :requests_none_shape_and_preview_absent)
     |> check_constraint(:response_preview, name: :requests_response_preview_bounded)
+    |> check_constraint(:error_code, name: :requests_non_full_error_code_stable)
   end
 
   @spec schedule_changeset(struct(), map()) :: Ecto.Changeset.t()

--- a/apps/orchard_controller/lib/orchard/requests/request.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request.ex
@@ -54,8 +54,10 @@ defmodule Orchard.Requests.Request do
     field(:stream, :boolean, default: false)
     field(:payload_capture_mode, Ecto.Enum, values: @payload_capture_modes)
     field(:canonical_request, :map)
+    field(:request_shape, :map)
     field(:request_payload, :map)
     field(:response_payload, :map)
+    field(:response_hash, :binary)
     field(:response_preview, :string)
     field(:sampling_params, :map, default: %{})
     field(:response_format, :map, default: %{})
@@ -111,8 +113,10 @@ defmodule Orchard.Requests.Request do
       :stream,
       :payload_capture_mode,
       :canonical_request,
+      :request_shape,
       :request_payload,
       :response_payload,
+      :response_hash,
       :response_preview,
       :sampling_params,
       :response_format,
@@ -146,6 +150,9 @@ defmodule Orchard.Requests.Request do
     |> check_constraint(:service_account_id,
       name: :requests_service_account_principal_requires_id
     )
+    |> check_constraint(:canonical_request, name: :requests_non_full_content_absent)
+    |> check_constraint(:request_shape, name: :requests_none_shape_and_preview_absent)
+    |> check_constraint(:response_preview, name: :requests_response_preview_bounded)
     |> foreign_key_constraint(:model_id)
     |> foreign_key_constraint(:retry_of_request_id)
     |> foreign_key_constraint(:service_account_id)
@@ -164,6 +171,7 @@ defmodule Orchard.Requests.Request do
     |> cast(attrs, [
       :state,
       :response_payload,
+      :response_hash,
       :response_preview,
       :input_tokens,
       :output_tokens,
@@ -180,6 +188,9 @@ defmodule Orchard.Requests.Request do
     |> validate_number(:reserved_output_tokens, greater_than_or_equal_to: 0)
     |> validate_terminal_state()
     |> put_completed_at()
+    |> check_constraint(:response_payload, name: :requests_non_full_content_absent)
+    |> check_constraint(:response_preview, name: :requests_none_shape_and_preview_absent)
+    |> check_constraint(:response_preview, name: :requests_response_preview_bounded)
   end
 
   @spec schedule_changeset(struct(), map()) :: Ecto.Changeset.t()

--- a/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
@@ -1,6 +1,56 @@
 defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
   use Ecto.Migration
 
+  @stable_error_codes ~w(
+    acquisition_failed
+    artifact_not_found
+    cancelled
+    checksum_mismatch
+    cluster_busy
+    deadline_exceeded
+    insufficient_memory
+    internal_error
+    load_timeout
+    manifest_not_found
+    mlx_backend_unavailable
+    model_busy
+    model_invalid
+    node_timeout
+    node_unavailable
+    orchestration_error
+    queue_full
+    queue_timeout
+    request_cancelled
+    request_caller_disconnect
+    request_client_disconnect
+    request_controller_restarted
+    request_interrupted
+    request_timeout
+    resource_exhausted
+    rpc_error
+    rpc_resource_exhausted
+    rpc_unavailable
+    runtime_incompatible
+    runtime_unavailable
+    timed_out
+    timeout
+    tool_execution_cancelled
+    tool_execution_failed
+    tool_execution_indeterminate_cancel_ack_missing
+    tool_execution_indeterminate_controller_restarted
+    tool_execution_indeterminate_executor_unreachable
+    tool_execution_indeterminate_result_not_observed
+    tool_execution_indeterminate_timeout_after_start
+    tool_execution_timed_out
+    tool_failed
+    tool_timeout
+    tooling_not_supported
+    unexpected_placement_state
+    worker_down
+    worker_unavailable
+    worker_unloaded
+  )
+
   def up do
     alter table(:tenants) do
       add(:request_body_capture_mode, :payload_capture_mode,
@@ -41,6 +91,7 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
         request_payload = NULL,
         response_payload = NULL,
         response_preview = NULL,
+        error_code = #{legacy_stable_error_code_sql()},
         error_message = NULL,
         sampling_params = jsonb_strip_nulls(
           jsonb_build_object(
@@ -98,9 +149,17 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
         check: "response_preview IS NULL OR char_length(response_preview) <= 512"
       )
     )
+
+    create(
+      constraint(:requests, :requests_non_full_error_code_stable,
+        check:
+          "payload_capture_mode = 'full' OR error_code IS NULL OR error_code = ANY (#{stable_error_code_array_sql()})"
+      )
+    )
   end
 
   def down do
+    drop_if_exists(constraint(:requests, :requests_non_full_error_code_stable))
     drop_if_exists(constraint(:requests, :requests_response_preview_bounded))
     drop_if_exists(constraint(:requests, :requests_none_shape_and_preview_absent))
     drop_if_exists(constraint(:requests, :requests_non_full_content_absent))
@@ -115,7 +174,9 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
     end
   end
 
-  @doc false
+  @doc """
+  Returns the SQL expression that retains typed cache-affinity metadata while purging legacy scheduler content.
+  """
   @spec legacy_cache_affinity_metadata_sql() :: String.t()
   def legacy_cache_affinity_metadata_sql do
     """
@@ -156,5 +217,30 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
       )
     )
     """
+  end
+
+  @doc """
+  Returns the SQL expression that maps unknown legacy error codes to `internal_error`.
+  """
+  @spec legacy_stable_error_code_sql() :: String.t()
+  def legacy_stable_error_code_sql do
+    """
+    CASE
+      WHEN error_code IS NULL OR error_code = ANY (#{stable_error_code_array_sql()})
+      THEN error_code
+      ELSE 'internal_error'
+    END
+    """
+  end
+
+  @doc """
+  Returns the closed error-code vocabulary accepted on restricted Request rows.
+  """
+  @spec stable_error_codes() :: [String.t()]
+  def stable_error_codes, do: @stable_error_codes
+
+  defp stable_error_code_array_sql do
+    values = Enum.map_join(@stable_error_codes, ", ", &"'#{&1}'")
+    "ARRAY[#{values}]::text[]"
   end
 end

--- a/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
@@ -405,17 +405,44 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
         """
       end)
 
-    """
-    jsonb_strip_nulls(
-      jsonb_build_object(
-        #{integers},
-        'finish_reason',
-          CASE
-            WHEN event.payload -> 'result' ->> 'finish_reason' = ANY (#{text_array_sql(@finish_reasons)})
-            THEN event.payload -> 'result' -> 'finish_reason'
-          END
+    safe_result =
+      """
+      jsonb_strip_nulls(
+        jsonb_build_object(
+          #{integers},
+          'finish_reason',
+            CASE
+              WHEN event.payload -> 'result' ->> 'finish_reason' = ANY (#{text_array_sql(@finish_reasons)})
+              THEN event.payload -> 'result' -> 'finish_reason'
+            END,
+          'finish_reason_invalid',
+            CASE
+              WHEN event.payload -> 'result' ? 'finish_reason'
+                AND NOT (
+                  jsonb_typeof(event.payload -> 'result' -> 'finish_reason') = 'string'
+                  AND event.payload -> 'result' ->> 'finish_reason' = ANY (#{text_array_sql(@finish_reasons)})
+                )
+              THEN to_jsonb(TRUE)
+            END,
+          'error_code',
+            CASE
+              WHEN NOT (event.payload -> 'result' ? 'error_code')
+                OR jsonb_typeof(event.payload -> 'result' -> 'error_code') = 'null'
+              THEN NULL
+              WHEN jsonb_typeof(event.payload -> 'result' -> 'error_code') = 'string'
+                AND event.payload -> 'result' ->> 'error_code' = ANY (#{stable_error_code_array_sql()})
+              THEN event.payload -> 'result' -> 'error_code'
+              ELSE to_jsonb('internal_error'::text)
+            END
+        )
       )
-    )
+      """
+
+    """
+    (CASE
+       WHEN jsonb_typeof(event.payload -> 'result') = 'object' THEN #{safe_result}
+       ELSE '{"result_invalid":true}'::jsonb
+     END)
     """
   end
 

--- a/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
@@ -50,6 +50,42 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
     worker_unavailable
     worker_unloaded
   )
+  @step_event_types ~w(
+    request_step.started
+    request_step.proposed
+    request_step.completed
+    request_step.failed
+    request_step.cancelled
+    request_step.timed_out
+    request_step.interrupted
+    request_step.indeterminate
+  )
+  @step_types ~w(inference_turn tool_call tool_execution)
+  @boundaries ~w(pre_side_effect post_observation)
+  @finish_reasons ~w(cancelled content_filter error length stop tool_calls)
+  @result_integer_keys ~w(http_status input_tokens output_tokens)
+  @tool_execution_defaults %{
+    "request_step.failed" => {"tool_execution_failed", "Tool execution failed"},
+    "request_step.cancelled" => {"tool_execution_cancelled", "Tool execution was cancelled"},
+    "request_step.timed_out" => {"tool_execution_timed_out", "Tool execution timed out"}
+  }
+  @indeterminate_defaults %{
+    "cancel_ack_missing" =>
+      {"tool_execution_indeterminate_cancel_ack_missing",
+       "Tool execution cancellation acknowledgement was not observed"},
+    "controller_restarted" =>
+      {"tool_execution_indeterminate_controller_restarted",
+       "Tool execution became indeterminate after the controller restarted"},
+    "executor_unreachable" =>
+      {"tool_execution_indeterminate_executor_unreachable",
+       "Tool execution became indeterminate after the executor became unreachable"},
+    "result_not_observed" =>
+      {"tool_execution_indeterminate_result_not_observed",
+       "Tool execution result was not observed"},
+    "timeout_after_start" =>
+      {"tool_execution_indeterminate_timeout_after_start",
+       "Tool execution timed out after starting and the final outcome was not observed"}
+  }
 
   def up do
     alter table(:tenants) do
@@ -121,6 +157,16 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
     FROM requests AS request
     WHERE event.request_id = request.id
       AND request.payload_capture_mode IN ('none', 'metadata')
+      AND NOT (event.event_type = ANY (#{step_event_type_array_sql()}))
+    """)
+
+    execute("""
+    UPDATE request_events AS event
+    SET payload = #{legacy_step_event_payload_sql()}
+    FROM requests AS request
+    WHERE event.request_id = request.id
+      AND request.payload_capture_mode IN ('none', 'metadata')
+      AND event.event_type = ANY (#{step_event_type_array_sql()})
     """)
 
     execute("""
@@ -234,13 +280,191 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
   end
 
   @doc """
+  Returns the SQL expression that rebuilds a restricted `request_step.*` payload.
+
+  Retains the typed structural fields `RequestStepEvent` readback requires while
+  dropping model-generated content, raw tool arguments, and raw error text. Rows
+  that cannot be reconstructed into a contract-valid skeleton collapse to `{}`.
+  """
+  @spec legacy_step_event_payload_sql() :: String.t()
+  def legacy_step_event_payload_sql do
+    """
+    CASE
+      WHEN #{step_id_sql()} IS NULL OR #{boundary_sql()} IS NULL THEN '{}'::jsonb
+      ELSE jsonb_strip_nulls(
+             jsonb_build_object(
+               'step_id', to_jsonb(#{step_id_sql()}),
+               'step_type', to_jsonb(#{step_type_sql()}),
+               'turn_index', to_jsonb(#{turn_index_sql()}),
+               'attempt', to_jsonb(#{attempt_sql()}),
+               'parent_step_id', to_jsonb(#{parent_step_id_sql()}),
+               'boundary', to_jsonb(#{boundary_sql()}),
+               'call_id', to_jsonb(#{call_id_sql()})
+             )
+           ) || jsonb_build_object('result', #{step_result_sql()})
+    END
+    """
+  end
+
+  @doc """
   Returns the closed error-code vocabulary accepted on restricted Request rows.
   """
   @spec stable_error_codes() :: [String.t()]
   def stable_error_codes, do: @stable_error_codes
 
-  defp stable_error_code_array_sql do
-    values = Enum.map_join(@stable_error_codes, ", ", &"'#{&1}'")
-    "ARRAY[#{values}]::text[]"
+  @doc """
+  Returns the `request_step.*` event-type vocabulary rebuilt by the legacy purge.
+  """
+  @spec step_event_types() :: [String.t()]
+  def step_event_types, do: @step_event_types
+
+  defp stable_error_code_array_sql, do: text_array_sql(@stable_error_codes)
+
+  defp step_event_type_array_sql, do: text_array_sql(@step_event_types)
+
+  defp text_array_sql(values) do
+    "ARRAY[#{Enum.map_join(values, ", ", &"'#{&1}'")}]::text[]"
+  end
+
+  defp step_type_sql do
+    "(CASE WHEN event.payload ->> 'step_type' = ANY (#{text_array_sql(@step_types)}) THEN event.payload ->> 'step_type' END)"
+  end
+
+  defp boundary_sql do
+    "(CASE WHEN event.payload ->> 'boundary' = ANY (#{text_array_sql(@boundaries)}) THEN event.payload ->> 'boundary' END)"
+  end
+
+  defp turn_index_sql, do: positive_integer_sql("turn_index")
+
+  defp attempt_sql, do: positive_integer_sql("attempt")
+
+  defp positive_integer_sql(key) do
+    """
+    (CASE
+       WHEN jsonb_typeof(event.payload -> '#{key}') = 'number'
+         AND (event.payload ->> '#{key}') ~ '^[1-9][0-9]{0,17}$'
+       THEN (event.payload ->> '#{key}')::bigint
+     END)
+    """
+  end
+
+  defp call_id_sql do
+    """
+    (CASE
+       WHEN jsonb_typeof(event.payload -> 'call_id') = 'string'
+       THEN 'sha256:' || encode(digest(convert_to(event.payload ->> 'call_id', 'UTF8'), 'sha256'), 'hex')
+     END)
+    """
+  end
+
+  defp step_id_sql do
+    """
+    (CASE
+       WHEN #{turn_index_sql()} IS NULL OR #{attempt_sql()} IS NULL THEN NULL
+       WHEN #{step_type_sql()} = 'inference_turn'
+         THEN 'inference_turn:t' || #{turn_index_sql()} || ':a' || #{attempt_sql()}
+       WHEN #{step_type_sql()} = 'tool_call' AND #{call_id_sql()} IS NOT NULL
+         THEN 'tool_call:t' || #{turn_index_sql()} || ':c' || #{call_id_sql()}
+       WHEN #{step_type_sql()} = 'tool_execution' AND #{call_id_sql()} IS NOT NULL
+         THEN 'tool_execution:t' || #{turn_index_sql()} || ':c' || #{call_id_sql()} || ':a' || #{attempt_sql()}
+     END)
+    """
+  end
+
+  defp parent_step_id_sql do
+    """
+    (CASE
+       WHEN #{turn_index_sql()} IS NULL OR #{call_id_sql()} IS NULL THEN NULL
+       WHEN #{step_type_sql()} = 'tool_call'
+         THEN 'inference_turn:t' || #{turn_index_sql()} || ':a1'
+       WHEN #{step_type_sql()} = 'tool_execution'
+         THEN 'tool_call:t' || #{turn_index_sql()} || ':c' || #{call_id_sql()}
+     END)
+    """
+  end
+
+  defp step_result_sql do
+    """
+    (CASE
+       WHEN #{step_type_sql()} = 'tool_execution' THEN #{tool_execution_result_sql()}
+       ELSE #{inference_step_result_sql()}
+     END)
+    """
+  end
+
+  defp inference_step_result_sql do
+    integers =
+      Enum.map_join(@result_integer_keys, ",\n        ", fn key ->
+        """
+        '#{key}',
+          CASE
+            WHEN jsonb_typeof(event.payload -> 'result' -> '#{key}') = 'number'
+              AND (event.payload -> 'result' ->> '#{key}') ~ '^[0-9]{1,18}$'
+            THEN event.payload -> 'result' -> '#{key}'
+          END\
+        """
+      end)
+
+    """
+    jsonb_strip_nulls(
+      jsonb_build_object(
+        #{integers},
+        'finish_reason',
+          CASE
+            WHEN event.payload -> 'result' ->> 'finish_reason' = ANY (#{text_array_sql(@finish_reasons)})
+            THEN event.payload -> 'result' -> 'finish_reason'
+          END
+      )
+    )
+    """
+  end
+
+  defp tool_execution_result_sql do
+    terminal =
+      Enum.map_join(@tool_execution_defaults, "\n", fn {event_type, {code, message}} ->
+        "WHEN event.event_type = '#{event_type}' THEN #{tool_execution_error_sql(code, message)}"
+      end)
+
+    """
+    (CASE
+       #{terminal}
+       WHEN event.event_type = 'request_step.indeterminate'
+         THEN #{indeterminate_result_sql()}
+       ELSE '{}'::jsonb
+     END)
+    """
+  end
+
+  defp indeterminate_result_sql do
+    branches =
+      Enum.map_join(@indeterminate_defaults, "\n", fn {reason, {code, message}} ->
+        """
+        WHEN event.payload -> 'result' ->> 'indeterminate_reason' = '#{reason}'
+          THEN #{tool_execution_error_sql(code, message)} || jsonb_build_object('indeterminate_reason', '#{reason}'::text)\
+        """
+      end)
+
+    """
+    (CASE
+       #{branches}
+       ELSE '{}'::jsonb
+     END)
+    """
+  end
+
+  defp tool_execution_error_sql(default_code, default_message) do
+    """
+    jsonb_build_object(
+      'error_code',
+        COALESCE(
+          CASE
+            WHEN event.payload -> 'result' ->> 'error_code' = ANY (#{stable_error_code_array_sql()})
+            THEN event.payload -> 'result' ->> 'error_code'
+          END,
+          '#{default_code}'
+        ),
+      'error_message', '#{default_message}'::text
+    )\
+    """
   end
 end

--- a/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
@@ -60,7 +60,7 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
         response_format = jsonb_strip_nulls(
           jsonb_build_object('type', response_format -> 'type')
         ),
-    scheduler_decision = NULL
+        scheduler_decision = #{legacy_cache_affinity_metadata_sql()}
     WHERE payload_capture_mode IN ('none', 'metadata')
     """)
 
@@ -113,5 +113,48 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
     alter table(:tenants) do
       remove(:request_body_capture_mode)
     end
+  end
+
+  @doc false
+  @spec legacy_cache_affinity_metadata_sql() :: String.t()
+  def legacy_cache_affinity_metadata_sql do
+    """
+    jsonb_strip_nulls(
+      jsonb_build_object(
+        'cache_affinity_key',
+          CASE
+            WHEN scheduler_decision ->> 'cache_affinity_key'
+                   ~ '^hmac-sha256:[0-9a-f]{64}$'
+            THEN scheduler_decision -> 'cache_affinity_key'
+          END,
+        'cache_affinity_enabled',
+          CASE
+            WHEN jsonb_typeof(scheduler_decision -> 'cache_affinity_enabled') = 'boolean'
+            THEN scheduler_decision -> 'cache_affinity_enabled'
+          END,
+        'cache_affinity_hint_available',
+          CASE
+            WHEN jsonb_typeof(scheduler_decision -> 'cache_affinity_hint_available') = 'boolean'
+            THEN scheduler_decision -> 'cache_affinity_hint_available'
+          END,
+        'cache_affinity_selected_match',
+          CASE
+            WHEN jsonb_typeof(scheduler_decision -> 'cache_affinity_selected_match') = 'boolean'
+            THEN scheduler_decision -> 'cache_affinity_selected_match'
+          END,
+        'cache_affinity_source',
+          CASE
+            WHEN scheduler_decision ->> 'cache_affinity_source' = 'recent_completed_request'
+            THEN scheduler_decision -> 'cache_affinity_source'
+          END,
+        'cache_affinity_candidate_count',
+          CASE
+            WHEN jsonb_typeof(scheduler_decision -> 'cache_affinity_candidate_count') = 'number'
+              AND scheduler_decision ->> 'cache_affinity_candidate_count' ~ '^[0-9]+$'
+            THEN scheduler_decision -> 'cache_affinity_candidate_count'
+          END
+      )
+    )
+    """
   end
 end

--- a/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
@@ -1,0 +1,206 @@
+defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
+  use Ecto.Migration
+
+  def up do
+    alter table(:tenants) do
+      add(:request_body_capture_mode, :payload_capture_mode,
+        null: false,
+        default: "metadata"
+      )
+    end
+
+    alter table(:requests) do
+      add(:request_shape, :map)
+      add(:response_hash, :binary)
+    end
+
+    execute("""
+    UPDATE requests
+    SET response_hash = digest(convert_to(response_payload::text, 'UTF8'), 'sha256')
+    WHERE response_hash IS NULL
+      AND response_payload IS NOT NULL
+    """)
+
+    execute("""
+    UPDATE requests
+    SET body_hash =
+          CASE
+            WHEN body_hash IS NULL AND canonical_request IS NOT NULL
+            THEN digest(convert_to(canonical_request::text, 'UTF8'), 'sha256')
+            WHEN body_hash IS NULL AND request_payload IS NOT NULL
+            THEN digest(convert_to(request_payload::text, 'UTF8'), 'sha256')
+            ELSE body_hash
+          END,
+        response_hash =
+          CASE
+            WHEN response_payload IS NOT NULL
+            THEN digest(convert_to(response_payload::text, 'UTF8'), 'sha256')
+            ELSE response_hash
+          END,
+        canonical_request = NULL,
+        request_payload = NULL,
+        response_payload = NULL,
+        response_preview = NULL,
+        error_message = NULL,
+        sampling_params = jsonb_strip_nulls(
+          jsonb_build_object(
+            'temperature', sampling_params -> 'temperature',
+            'top_p', sampling_params -> 'top_p',
+            'max_output_tokens', sampling_params -> 'max_output_tokens',
+            'seed', sampling_params -> 'seed',
+            'stop_count',
+              CASE
+                WHEN jsonb_typeof(sampling_params -> 'stop') = 'array'
+                THEN jsonb_array_length(sampling_params -> 'stop')
+                WHEN sampling_params ? 'stop' THEN 1
+                ELSE 0
+              END
+          )
+        ),
+        response_format = jsonb_strip_nulls(
+          jsonb_build_object('type', response_format -> 'type')
+        ),
+        scheduler_decision =
+          CASE
+            WHEN scheduler_decision IS NULL THEN NULL
+            WHEN jsonb_typeof(scheduler_decision) = 'object' THEN (
+              SELECT COALESCE(jsonb_object_agg(entry.key, entry.value), '{}'::jsonb)
+              FROM jsonb_each(scheduler_decision) AS entry
+              WHERE entry.key = ANY (
+                ARRAY[
+                  'candidate_count',
+                  'capacity_source',
+                  'contract_version',
+                  'fallback_used?',
+                  'memory_admission_enabled',
+                  'memory_admission_tier',
+                  'memory_headroom_ok?',
+                  'model_load_timeout_ms',
+                  'node_id',
+                  'object',
+                  'queue_grant_id',
+                  'queue_granted_at',
+                  'queue_key',
+                  'queue_result',
+                  'queue_wait_ms',
+                  'queue_wait_reason',
+                  'queued_at',
+                  'queueing_enabled',
+                  'request_id',
+                  'request_timeout_ms',
+                  'selected_node_id',
+                  'selected_cache_tier',
+                  'selected_tier',
+                  'selection_tier',
+                  'selected_prefix_cache_enabled',
+                  'selected_prefix_cache_entry_count',
+                  'selected_prefix_cache_evictions',
+                  'selected_prefix_cache_fingerprint_count',
+                  'selected_prefix_cache_fingerprint_match',
+                  'selected_prefix_cache_hits',
+                  'selected_prefix_cache_implementation',
+                  'selected_prefix_cache_misses',
+                  'selected_prefix_cache_score_source',
+                  'selected_prefix_cache_score_status_code',
+                  'selected_prefix_cache_score_tier',
+                  'selected_prefix_cache_session_started_unix_ms',
+                  'selected_prefix_cache_status_code',
+                  'selected_prefix_cache_stores',
+                  'selected_prefix_cache_total_bytes',
+                  'selected_prefix_cache_warmth_indicator',
+                  'strategy'
+                ]
+              )
+            )
+            ELSE NULL
+          END
+    WHERE payload_capture_mode IN ('none', 'metadata')
+    """)
+
+    execute("""
+    UPDATE request_events AS event
+    SET payload = jsonb_strip_nulls(
+      jsonb_build_object(
+        'attempt', event.payload -> 'attempt',
+        'attempt_index', event.payload -> 'attempt_index',
+        'boundary', event.payload -> 'boundary',
+        'call_id', event.payload -> 'call_id',
+        'kind', event.payload -> 'kind',
+        'model_id', event.payload -> 'model_id',
+        'model_version', event.payload -> 'model_version',
+        'parent_step_id', event.payload -> 'parent_step_id',
+        'request_step_id', event.payload -> 'request_step_id',
+        'sequence', event.payload -> 'sequence',
+        'state', event.payload -> 'state',
+        'step_id', event.payload -> 'step_id',
+        'step_type', event.payload -> 'step_type',
+        'turn_index', event.payload -> 'turn_index',
+        'tool_name', event.payload -> 'tool_name',
+        'type', event.payload -> 'type',
+        'result',
+          CASE
+            WHEN jsonb_typeof(event.payload -> 'result') = 'object'
+            THEN jsonb_strip_nulls(
+              jsonb_build_object(
+                'error_code', event.payload #> '{result,error_code}',
+                'finish_reason', event.payload #> '{result,finish_reason}',
+                'http_status', event.payload #> '{result,http_status}',
+                'indeterminate_reason', event.payload #> '{result,indeterminate_reason}',
+                'input_tokens', event.payload #> '{result,input_tokens}',
+                'output_tokens', event.payload #> '{result,output_tokens}',
+                'remote_request_id', event.payload #> '{result,remote_request_id}',
+                'remote_response_id', event.payload #> '{result,remote_response_id}'
+              )
+            )
+            ELSE NULL
+          END
+      )
+    )
+    FROM requests AS request
+    WHERE event.request_id = request.id
+      AND request.payload_capture_mode IN ('none', 'metadata')
+    """)
+
+    execute("""
+    UPDATE requests
+    SET response_preview = NULL
+    WHERE response_preview IS NOT NULL
+      AND char_length(response_preview) > 512
+    """)
+
+    create(
+      constraint(:requests, :requests_non_full_content_absent,
+        check:
+          "payload_capture_mode = 'full' OR (canonical_request IS NULL AND request_payload IS NULL AND response_payload IS NULL AND error_message IS NULL)"
+      )
+    )
+
+    create(
+      constraint(:requests, :requests_none_shape_and_preview_absent,
+        check:
+          "payload_capture_mode <> 'none' OR (request_shape IS NULL AND response_preview IS NULL)"
+      )
+    )
+
+    create(
+      constraint(:requests, :requests_response_preview_bounded,
+        check: "response_preview IS NULL OR char_length(response_preview) <= 512"
+      )
+    )
+  end
+
+  def down do
+    drop_if_exists(constraint(:requests, :requests_response_preview_bounded))
+    drop_if_exists(constraint(:requests, :requests_none_shape_and_preview_absent))
+    drop_if_exists(constraint(:requests, :requests_non_full_content_absent))
+
+    alter table(:requests) do
+      remove_if_exists(:response_hash)
+      remove_if_exists(:request_shape)
+    end
+
+    alter table(:tenants) do
+      remove(:request_body_capture_mode)
+    end
+  end
+end

--- a/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260731010000_request_body_capture_mode.exs
@@ -60,102 +60,13 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureMode do
         response_format = jsonb_strip_nulls(
           jsonb_build_object('type', response_format -> 'type')
         ),
-        scheduler_decision =
-          CASE
-            WHEN scheduler_decision IS NULL THEN NULL
-            WHEN jsonb_typeof(scheduler_decision) = 'object' THEN (
-              SELECT COALESCE(jsonb_object_agg(entry.key, entry.value), '{}'::jsonb)
-              FROM jsonb_each(scheduler_decision) AS entry
-              WHERE entry.key = ANY (
-                ARRAY[
-                  'candidate_count',
-                  'capacity_source',
-                  'contract_version',
-                  'fallback_used?',
-                  'memory_admission_enabled',
-                  'memory_admission_tier',
-                  'memory_headroom_ok?',
-                  'model_load_timeout_ms',
-                  'node_id',
-                  'object',
-                  'queue_grant_id',
-                  'queue_granted_at',
-                  'queue_key',
-                  'queue_result',
-                  'queue_wait_ms',
-                  'queue_wait_reason',
-                  'queued_at',
-                  'queueing_enabled',
-                  'request_id',
-                  'request_timeout_ms',
-                  'selected_node_id',
-                  'selected_cache_tier',
-                  'selected_tier',
-                  'selection_tier',
-                  'selected_prefix_cache_enabled',
-                  'selected_prefix_cache_entry_count',
-                  'selected_prefix_cache_evictions',
-                  'selected_prefix_cache_fingerprint_count',
-                  'selected_prefix_cache_fingerprint_match',
-                  'selected_prefix_cache_hits',
-                  'selected_prefix_cache_implementation',
-                  'selected_prefix_cache_misses',
-                  'selected_prefix_cache_score_source',
-                  'selected_prefix_cache_score_status_code',
-                  'selected_prefix_cache_score_tier',
-                  'selected_prefix_cache_session_started_unix_ms',
-                  'selected_prefix_cache_status_code',
-                  'selected_prefix_cache_stores',
-                  'selected_prefix_cache_total_bytes',
-                  'selected_prefix_cache_warmth_indicator',
-                  'strategy'
-                ]
-              )
-            )
-            ELSE NULL
-          END
+    scheduler_decision = NULL
     WHERE payload_capture_mode IN ('none', 'metadata')
     """)
 
     execute("""
     UPDATE request_events AS event
-    SET payload = jsonb_strip_nulls(
-      jsonb_build_object(
-        'attempt', event.payload -> 'attempt',
-        'attempt_index', event.payload -> 'attempt_index',
-        'boundary', event.payload -> 'boundary',
-        'call_id', event.payload -> 'call_id',
-        'kind', event.payload -> 'kind',
-        'model_id', event.payload -> 'model_id',
-        'model_version', event.payload -> 'model_version',
-        'parent_step_id', event.payload -> 'parent_step_id',
-        'request_step_id', event.payload -> 'request_step_id',
-        'sequence', event.payload -> 'sequence',
-        'state', event.payload -> 'state',
-        'step_id', event.payload -> 'step_id',
-        'step_type', event.payload -> 'step_type',
-        'turn_index', event.payload -> 'turn_index',
-        'tool_name', event.payload -> 'tool_name',
-        'type', event.payload -> 'type',
-        'result',
-          CASE
-            WHEN jsonb_typeof(event.payload -> 'result') = 'object'
-            THEN jsonb_strip_nulls(
-              jsonb_build_object(
-                'error_code', event.payload #> '{result,error_code}',
-                'finish_reason', event.payload #> '{result,finish_reason}',
-                'http_status', event.payload #> '{result,http_status}',
-                'indeterminate_reason', event.payload #> '{result,indeterminate_reason}',
-                'input_tokens', event.payload #> '{result,input_tokens}',
-                'output_tokens', event.payload #> '{result,output_tokens}',
-                'remote_request_id', event.payload #> '{result,remote_request_id}',
-                'remote_response_id', event.payload #> '{result,remote_response_id}'
-              )
-            )
-            ELSE NULL
-          END
-      )
-    )
+    SET payload = '{}'::jsonb
     FROM requests AS request
     WHERE event.request_id = request.id
       AND request.payload_capture_mode IN ('none', 'metadata')

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -42,6 +42,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
   alias Orchard.API.Router
   alias Orchard.ArtifactBundle
   alias Orchard.Governance
+  alias Orchard.Governance.Tenant
   alias Orchard.Inference.ChatRequestNormalizer
   alias Orchard.Inference.QueueManager
   alias Orchard.InferenceEvent
@@ -226,10 +227,10 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     end
 
     @tag :db
-    test "successful non-stream request persists replay payload equal to returned JSON", %{
+    test "successful metadata-capture request returns JSON without retaining the response", %{
       bundle: bundle
     } do
-      %{token: token} = create_api_key_with_token!("non-stream-persist")
+      %{token: token, tenant: tenant} = create_api_key_with_token!("non-stream-persist")
 
       {:ok, _model} =
         Orchard.Models.create_model(%{
@@ -267,9 +268,53 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
         |> Enum.filter(&(&1.public_id == body["id"]))
 
       assert request.state == :completed
-      assert request.response_payload == body
-      assert request.response_preview != nil
-      assert request.response_preview != ""
+      assert request.payload_capture_mode == :metadata
+      assert request.response_payload == nil
+      assert request.response_preview == nil
+      assert request.response_hash != nil
+
+      tenant
+      |> Tenant.changeset(%{request_body_capture_mode: :full})
+      |> Orchard.Repo.update!()
+
+      full_conn =
+        post_chat(
+          %{
+            "model" => "persist-non-stream-model@v1",
+            "messages" => [%{"role" => "user", "content" => "retain in full mode"}]
+          },
+          token
+        )
+
+      assert full_conn.status == 200
+      full_body = Jason.decode!(full_conn.resp_body)
+      full_request = Requests.get_request_by_public_id(full_body["id"])
+      assert full_request.payload_capture_mode == :full
+      assert full_request.canonical_request["rendered_prompt"] =~ "retain in full mode"
+      assert full_request.response_payload == full_body
+
+      %{token: none_token, tenant: none_tenant} =
+        create_api_key_with_token!("non-stream-none")
+
+      none_tenant
+      |> Tenant.changeset(%{request_body_capture_mode: :none})
+      |> Orchard.Repo.update!()
+
+      none_conn =
+        post_chat(
+          %{
+            "model" => "persist-non-stream-model@v1",
+            "messages" => [%{"role" => "user", "content" => "retain nothing"}]
+          },
+          none_token
+        )
+
+      assert none_conn.status == 200
+      none_request = Requests.get_request_by_public_id(Jason.decode!(none_conn.resp_body)["id"])
+      assert none_request.payload_capture_mode == :none
+      assert none_request.canonical_request == nil
+      assert none_request.request_shape == nil
+      assert none_request.response_payload == nil
     end
 
     @tag :db
@@ -338,10 +383,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert decision["selected_prefix_cache_score_status_code"] == "unsupported_version"
       assert decision["selected_prefix_cache_score_tier"] == "unknown"
 
-      assert decision["selected_prefix_cache_score_status_message"] ==
-               "prefix cache scoring unsupported version"
-
       assert decision["selected_prefix_cache_score_source"] == "score_prefix_cache_rpc"
+      refute Map.has_key?(decision, "selected_prefix_cache_score_status_message")
       refute Map.has_key?(decision, "prefix_cache_score")
       refute Map.has_key?(decision, "selected_prefix_cache_score_resident_fingerprint_match")
       refute Map.has_key?(decision, "selected_prefix_cache_score_session_started_unix_ms")
@@ -356,7 +399,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     end
 
     @tag :db
-    test "SPEC.md §3.9 replays a tenant-scoped non-stream response for the same Idempotency-Key",
+    test "SPEC.md §10.10 metadata capture fails closed when replay content is unavailable",
          %{
            bundle: bundle
          } do
@@ -389,8 +432,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       conn_b = post_chat(params, token, [{"idempotency-key", "tenant-replay"}])
 
       assert conn_a.status == 200
-      assert conn_b.status == 200
-      assert Jason.decode!(conn_a.resp_body) == Jason.decode!(conn_b.resp_body)
+      assert conn_b.status == 409
+      assert Jason.decode!(conn_b.resp_body)["error"]["code"] == "idempotency_not_replayable"
 
       [request] = Orchard.Repo.all(Orchard.Requests.Request)
       assert request.tenant_id == tenant.id
@@ -1226,6 +1269,10 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       %{tenant: tenant, api_key: api_key, token: token} =
         create_api_key_with_token!("persist-request")
 
+      tenant
+      |> Tenant.changeset(%{request_body_capture_mode: :full})
+      |> Orchard.Repo.update!()
+
       {:ok, _model} =
         Orchard.Models.create_model(%{
           model_id: "persist-model",
@@ -1265,21 +1312,11 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert request.requested_model == "persist-model@v1"
       assert request.stream == true
       assert request.endpoint == :chat_completions
-      assert is_map(request.canonical_request)
-      assert request.canonical_request["public_id"] == request.public_id
-
-      assert request.canonical_request["model_ref"] == %{
-               "model_id" => "persist-model",
-               "version" => "v1"
-             }
-
-      assert request.canonical_request["sampling"]["temperature"] == 1.0
-      assert request.canonical_request["response_format"] == %{"type" => "text"}
+      assert request.payload_capture_mode == :full
       assert request.canonical_request["stream"] == true
-      assert request.canonical_request["stream_include_usage"] == false
-      assert request.response_payload == nil
-      assert request.response_preview == nil
-      refute_struct_artifacts!(request.canonical_request)
+      assert request.request_payload["prompt"] =~ "hello"
+      assert request.response_payload["object"] == "chat.completion"
+      assert is_binary(request.response_preview)
       # Terminal state after successful completion
       assert request.state in [:completed, :streaming]
 
@@ -1294,6 +1331,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert length(events) >= 2
       assert Enum.all?(events, &match?(%DateTime{}, &1.occurred_at))
       assert :validated in event_states
+      refute Enum.any?(events, &(&1.event_type == "output_text.delta"))
     end
 
     @tag :db
@@ -1392,13 +1430,9 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       [request] = failed_requests
       assert request.http_status == 503
       assert request.error_code != nil
-      assert request.error_message != nil
-      assert is_map(request.canonical_request)
-
-      assert request.canonical_request["model_ref"] == %{
-               "model_id" => "fail-model",
-               "version" => "v1"
-             }
+      assert request.error_message == nil
+      assert request.canonical_request == nil
+      assert request.request_shape["capture_mode"] == "metadata"
 
       refute_struct_artifacts!(request.canonical_request)
     end

--- a/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
@@ -190,7 +190,7 @@ defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
   end
 
   defp persist_valid_explanation!(public_id, components \\ %{pool_bonus: 200}) do
-    request = create_request!(%{public_id: public_id})
+    request = create_request!(%{public_id: public_id, payload_capture_mode: :full})
 
     assert {:ok, request} =
              Requests.record_schedule(request, %{

--- a/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/scheduler_explanations_controller_test.exs
@@ -91,6 +91,7 @@ defmodule Orchard.API.Ops.SchedulerExplanationsControllerTest do
       request =
         create_request!(%{
           public_id: "resp_scheduler_explanation_invalid",
+          payload_capture_mode: :full,
           scheduler_decision: %{
             "request_id" => "resp_scheduler_explanation_invalid",
             "selected_node_id" => "node-selected",

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -10,6 +10,7 @@ defmodule Orchard.API.ResponsesControllerTest do
   alias Orchard.API.Router
   alias Orchard.ArtifactBundle
   alias Orchard.Governance
+  alias Orchard.Governance.Tenant
   alias Orchard.Inference.QueueManager
   alias Orchard.InferenceEvent
   alias Orchard.Node
@@ -142,7 +143,11 @@ defmodule Orchard.API.ResponsesControllerTest do
 
   test "successful non-stream request returns response payload and persists responses endpoint",
        %{bundle: bundle} do
-    %{token: token} = create_api_key_with_token!("responses-success")
+    %{token: token, tenant: tenant} = create_api_key_with_token!("responses-success")
+
+    tenant
+    |> Tenant.changeset(%{request_body_capture_mode: :full})
+    |> Repo.update!()
 
     _model =
       create_model!(%{
@@ -191,13 +196,85 @@ defmodule Orchard.API.ResponsesControllerTest do
 
     [request] = Repo.all(Request)
     assert request.endpoint == :responses
-    assert request.canonical_request["endpoint"] == "responses"
-    assert request.response_payload == body
-    assert request.response_preview == body["output_text"]
+    assert request.payload_capture_mode == :metadata
+    assert request.canonical_request == nil
+    assert request.request_payload == nil
+    assert request.response_payload == nil
+    assert request.response_preview == nil
+    assert request.request_shape["capture_mode"] == "metadata"
+    assert request.response_hash != nil
 
     # first_token_at must be persisted for successful requests with output
     request = Requests.get_request_by_public_id(body["id"])
     assert request.first_token_at != nil
+
+    full_conn =
+      post_responses(
+        %{
+          "model" => "responses-success-model@v1",
+          "input" => "retain this only in full mode",
+          "store" => true
+        },
+        token
+      )
+
+    assert full_conn.status == 200
+    full_body = Jason.decode!(full_conn.resp_body)
+    full_request = Requests.get_request_by_public_id(full_body["id"])
+    assert full_request.payload_capture_mode == :full
+    assert full_request.canonical_request["endpoint"] == "responses"
+    assert full_request.response_payload == full_body
+
+    for params <- [
+          %{"model" => "responses-success-model@v1", "input" => "store omitted"},
+          %{"model" => "responses-success-model@v1", "input" => "store null", "store" => nil}
+        ] do
+      default_store_conn = post_responses(params, token)
+      assert default_store_conn.status == 200
+
+      default_store_request =
+        default_store_conn.resp_body
+        |> Jason.decode!()
+        |> Map.fetch!("id")
+        |> Requests.get_request_by_public_id()
+
+      assert default_store_request.payload_capture_mode == :full
+      assert default_store_request.canonical_request != nil
+      assert default_store_request.response_payload != nil
+    end
+
+    invalid_store_conn =
+      post_responses(
+        %{
+          "model" => "responses-success-model@v1",
+          "input" => "invalid store",
+          "store" => "false"
+        },
+        token
+      )
+
+    assert invalid_store_conn.status == 400
+    assert Jason.decode!(invalid_store_conn.resp_body)["error"]["param"] == "store"
+
+    %{token: none_token, tenant: none_tenant} =
+      create_api_key_with_token!("responses-none")
+
+    none_tenant
+    |> Tenant.changeset(%{request_body_capture_mode: :none})
+    |> Repo.update!()
+
+    none_conn =
+      post_responses(
+        %{"model" => "responses-success-model@v1", "input" => "retain nothing"},
+        none_token
+      )
+
+    assert none_conn.status == 200
+    none_request = Requests.get_request_by_public_id(Jason.decode!(none_conn.resp_body)["id"])
+    assert none_request.payload_capture_mode == :none
+    assert none_request.canonical_request == nil
+    assert none_request.request_shape == nil
+    assert none_request.response_payload == nil
   end
 
   test "successful non-stream request can return function_call output items" do
@@ -573,7 +650,9 @@ defmodule Orchard.API.ResponsesControllerTest do
     end
   end
 
-  test "replays completed tenant-scoped responses for the same idempotency key", %{bundle: bundle} do
+  test "metadata capture fails closed when idempotency replay content is unavailable", %{
+    bundle: bundle
+  } do
     %{token: token, tenant: tenant} = create_api_key_with_token!("responses-replay")
 
     _model =
@@ -601,8 +680,8 @@ defmodule Orchard.API.ResponsesControllerTest do
     conn_b = post_responses(params, token, [{"idempotency-key", "responses-replay"}])
 
     assert conn_a.status == 200
-    assert conn_b.status == 200
-    assert Jason.decode!(conn_a.resp_body) == Jason.decode!(conn_b.resp_body)
+    assert conn_b.status == 409
+    assert Jason.decode!(conn_b.resp_body)["error"]["code"] == "idempotency_not_replayable"
 
     [request] = Repo.all(Request)
     assert request.tenant_id == tenant.id
@@ -693,7 +772,12 @@ defmodule Orchard.API.ResponsesControllerTest do
   # -- Streaming tests -------------------------------------------------------
 
   test "successful stream emits typed events in correct order", %{bundle: bundle} do
-    %{token: token} = create_api_key_with_token!("responses-stream-success")
+    %{token: token, tenant: tenant} =
+      create_api_key_with_token!("responses-stream-success")
+
+    tenant
+    |> Tenant.changeset(%{request_body_capture_mode: :full})
+    |> Repo.update!()
 
     _model =
       create_model!(%{
@@ -786,6 +870,12 @@ defmodule Orchard.API.ResponsesControllerTest do
     response_id = terminal.data["response"]["id"]
     request = Requests.get_request_by_public_id(response_id)
     assert request.first_token_at != nil
+    assert request.payload_capture_mode == :full
+    assert request.canonical_request["stream"] == true
+    assert request.response_payload == terminal.data["response"]
+
+    request_events = Requests.list_request_events(request)
+    refute Enum.any?(request_events, &(&1.event_type == "response.output_text.delta"))
 
     assert Sentry.Context.get_all().extra == %{}
     assert Sentry.Context.get_all().breadcrumbs == []

--- a/apps/orchard_controller/test/orchard/api/safe_tokenization_lifecycle_test.exs
+++ b/apps/orchard_controller/test/orchard/api/safe_tokenization_lifecycle_test.exs
@@ -218,7 +218,12 @@ defmodule Orchard.API.SafeTokenizationLifecycleTest do
   end
 
   defp create_api_key_with_token!(slug) do
-    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+    {:ok, tenant} =
+      Governance.create_tenant(%{
+        slug: slug,
+        name: String.capitalize(slug),
+        request_body_capture_mode: :full
+      })
 
     {:ok, %{api_key: api_key, token: token}} =
       Governance.create_api_key(tenant.id, %{name: "Primary"})
@@ -535,6 +540,7 @@ defmodule Orchard.API.SafeTokenizationLifecycleTest do
       "input_items",
       "rendered_prompt",
       "input_token_count",
+      "store",
       "stream",
       "stream_include_usage",
       "sampling",

--- a/apps/orchard_controller/test/orchard/console/request_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/request_live_test.exs
@@ -313,12 +313,14 @@ defmodule OrchardConsole.RequestLiveTest do
     end
 
     test "renders multi-node scheduling metadata from scheduler_decision", %{conn: conn} do
+      node_id = Ecto.UUID.generate()
+
       request =
         create_request!(%{
           state: :completed,
           scheduler_decision: %{
             "strategy" => "multi_node",
-            "node_id" => "aaaa-0001",
+            "node_id" => node_id,
             "candidate_count" => 2,
             "selected_tier" => "loaded"
           }
@@ -330,7 +332,7 @@ defmodule OrchardConsole.RequestLiveTest do
       assert strategy_html =~ "multi_node"
 
       node_html = element(view, "#request-schedule-node") |> render()
-      assert node_html =~ "aaaa-0001"
+      assert node_html =~ node_id
 
       candidates_html = element(view, "#request-schedule-candidates") |> render()
       assert candidates_html =~ "2"
@@ -452,6 +454,7 @@ defmodule OrchardConsole.RequestLiveTest do
         create_request!(%{
           state: :completed,
           public_id: "resp_console_scheduler_explanation_invalid",
+          payload_capture_mode: :full,
           scheduler_decision: %{
             "request_id" => "resp_console_scheduler_explanation_invalid",
             "selected_node_id" => "node-selected",

--- a/apps/orchard_controller/test/orchard/console/request_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/request_live_test.exs
@@ -219,6 +219,7 @@ defmodule OrchardConsole.RequestLiveTest do
       request =
         create_request!(%{
           state: :failed,
+          payload_capture_mode: :full,
           http_status: 500,
           error_code: "server_error",
           error_message: "Internal processing failure"
@@ -498,6 +499,7 @@ defmodule OrchardConsole.RequestLiveTest do
       request =
         create_request!(%{
           state: :completed,
+          payload_capture_mode: :full,
           canonical_request: %{"model" => "test-model", "messages" => [%{"role" => "user"}]}
         })
 
@@ -561,6 +563,7 @@ defmodule OrchardConsole.RequestLiveTest do
       request =
         create_request!(%{
           state: :completed,
+          payload_capture_mode: :full,
           canonical_request: canonical_payload
         })
 
@@ -583,6 +586,7 @@ defmodule OrchardConsole.RequestLiveTest do
       request =
         create_request!(%{
           state: :completed,
+          payload_capture_mode: :full,
           response_preview: "Hello! How can I help you today?",
           response_payload: %{"id" => "resp_123", "choices" => [%{"index" => 0}]},
           scheduler_decision: %{"node_id" => "node-1", "reason" => "local_capacity"}
@@ -857,7 +861,7 @@ defmodule OrchardConsole.RequestLiveTest do
 
   describe "event timeline" do
     test "renders events ordered by seq", %{conn: conn} do
-      request = create_request!(%{state: :running})
+      request = create_request!(%{state: :running, payload_capture_mode: :full})
 
       append_event!(request, %{
         event_type: "state_transition",
@@ -920,7 +924,7 @@ defmodule OrchardConsole.RequestLiveTest do
     end
 
     test "renders event payload when present", %{conn: conn} do
-      request = create_request!(%{state: :running})
+      request = create_request!(%{state: :running, payload_capture_mode: :full})
 
       append_event!(request, %{
         event_type: "metadata",
@@ -1296,7 +1300,7 @@ defmodule OrchardConsole.RequestLiveTest do
   end
 
   defp persist_valid_scheduler_explanation!(public_id) do
-    request = create_request!(%{public_id: public_id})
+    request = create_request!(%{public_id: public_id, payload_capture_mode: :full})
 
     assert {:ok, request} =
              Requests.record_schedule(request, %{

--- a/apps/orchard_controller/test/orchard/console/request_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/request_live_test.exs
@@ -937,7 +937,7 @@ defmodule OrchardConsole.RequestLiveTest do
     end
 
     test "renders request_step timeline entries without specialized UI handling", %{conn: conn} do
-      request = create_request!(%{state: :running})
+      request = create_request!(%{state: :running, payload_capture_mode: :full})
       inference_turn_step_id = RequestStepEvent.inference_turn_step_id(1, 1)
 
       assert {:ok, _step_events} =

--- a/apps/orchard_controller/test/orchard/governance/foundation_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/foundation_test.exs
@@ -19,6 +19,37 @@ defmodule Orchard.Governance.FoundationTest do
       assert %{slug: ["can't be blank"], name: ["can't be blank"]} = errors_on(changeset)
     end
 
+    test "SPEC.md §10.10 defaults and validates the durable request body capture mode" do
+      assert {:ok, metadata_tenant} =
+               %Tenant{}
+               |> Tenant.changeset(%{slug: "metadata-tenant", name: "Metadata Tenant"})
+               |> Repo.insert()
+
+      assert metadata_tenant.request_body_capture_mode == :metadata
+
+      for mode <- [:none, :metadata, :full] do
+        assert {:ok, tenant} =
+                 %Tenant{}
+                 |> Tenant.changeset(%{
+                   slug: "explicit-#{mode}-tenant",
+                   name: "#{mode} Tenant",
+                   request_body_capture_mode: mode
+                 })
+                 |> Repo.insert()
+
+        assert tenant.request_body_capture_mode == mode
+      end
+
+      changeset =
+        Tenant.changeset(%Tenant{}, %{
+          slug: "invalid-capture-mode",
+          name: "Invalid Capture Mode",
+          request_body_capture_mode: :everything
+        })
+
+      assert %{request_body_capture_mode: ["is invalid"]} = errors_on(changeset)
+    end
+
     test "insert enforces unique slug" do
       assert {:ok, _tenant} =
                %Tenant{}

--- a/apps/orchard_controller/test/orchard/inference/chat_response_serializer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_response_serializer_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Inference.ChatResponseSerializerTest do
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.ChatResponseSerializer
   alias Orchard.InferenceEvent
+  alias Orchard.Requests.CapturePolicy
 
   test "completion_payload/2 matches chat completion shape and uses accepted timestamp" do
     canonical = build_canonical("chatcmpl_test")
@@ -122,6 +123,34 @@ defmodule Orchard.Inference.ChatResponseSerializerTest do
 
     assert attrs.response_preview ==
              "Tool call: lookup_weather({\"city\":\"Singapore\"})"
+
+    assert attrs.response_preview_source == :tool_call
+  end
+
+  test "restricted capture drops tool-call previews while full keeps a bounded preview" do
+    canonical = build_canonical("chatcmpl_tool_capture")
+    arguments = Jason.encode!(%{"private" => String.duplicate("x", 700)})
+
+    events = [
+      InferenceEvent.accepted(42_000),
+      tool_call_event("call_0", %{index: 0, type: "function", function: %{name: "private_tool"}}),
+      tool_call_event("call_0", %{index: 0, function: %{arguments_delta: arguments}}),
+      InferenceEvent.completed(:finish_reason_tool_calls, nil)
+    ]
+
+    attrs = ChatResponseSerializer.success_persistence_attrs(canonical, events)
+
+    for mode <- [:none, :metadata] do
+      restricted = CapturePolicy.terminal_attrs(mode, attrs)
+      assert restricted.response_preview == nil
+      refute Map.has_key?(restricted, :response_preview_source)
+      refute inspect(restricted) =~ "private_tool"
+    end
+
+    full = CapturePolicy.terminal_attrs(:full, attrs)
+    assert String.starts_with?(full.response_preview, "Tool call: private_tool(")
+    assert String.length(full.response_preview) == 512
+    refute Map.has_key?(full, :response_preview_source)
   end
 
   test "usage_map/1 zero-fills nil usage" do

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -2647,6 +2647,7 @@ defmodule Orchard.Inference.QueueManagerTest do
 
   test "startup reconciliation reclaims pre-dispatch rows after boot-token child restart" do
     boot_token = {__MODULE__, System.unique_integer([:positive])}
+    running_grant_id = Ecto.UUID.generate()
 
     stale =
       create_request!("req_queue_boot_token_stale",
@@ -2660,7 +2661,7 @@ defmodule Orchard.Inference.QueueManagerTest do
         queueing_enabled: true,
         queue_key: "queue-model@v1",
         queue_result: "immediate",
-        queue_grant_id: "grant-boot-token-running",
+        queue_grant_id: running_grant_id,
         queue_granted_at: DateTime.utc_now() |> DateTime.to_iso8601()
       }
     )
@@ -2698,7 +2699,7 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert live.error_code == "request_controller_restarted"
     assert_queue_metadata(live, "interrupted_controller_restarted", queued?: true)
 
-    assert :ok = QueueManager.release("grant-boot-token-running", server: manager)
+    assert :ok = QueueManager.release(running_grant_id, server: manager)
 
     assert {:ok, grant} =
              QueueManager.acquire(admission_request("req-after-child-restart"),
@@ -2716,13 +2717,15 @@ defmodule Orchard.Inference.QueueManagerTest do
   end
 
   test "startup reconciliation reconstructs active grant ownership" do
+    recovered_grant_id = Ecto.UUID.generate()
+
     create_request!("req_queue_recovered_active",
       state: :scheduled,
       scheduler_decision: %{
         queueing_enabled: true,
         queue_key: "queue-model@v1",
         queue_result: "immediate",
-        queue_grant_id: "grant-recovered",
+        queue_grant_id: recovered_grant_id,
         queue_granted_at: DateTime.utc_now() |> DateTime.to_iso8601()
       }
     )
@@ -2736,7 +2739,7 @@ defmodule Orchard.Inference.QueueManagerTest do
                config: queue_config(max_wait_ms: 200)
              )
 
-    assert :ok = QueueManager.release("grant-recovered", server: manager)
+    assert :ok = QueueManager.release(recovered_grant_id, server: manager)
     assert {:ok, grant} = QueueManager.await(ticket)
     assert grant.queue_result == :queued
 
@@ -2746,6 +2749,7 @@ defmodule Orchard.Inference.QueueManagerTest do
   test "SPEC.md §5.5 recovered grant with persisted node does not reserve other nodes" do
     recovered_node_id = Ecto.UUID.generate()
     observed_node_id = Ecto.UUID.generate()
+    recovered_grant_id = Ecto.UUID.generate()
 
     create_request!("req_queue_recovered_known_node",
       state: :running,
@@ -2754,7 +2758,7 @@ defmodule Orchard.Inference.QueueManagerTest do
         queueing_enabled: true,
         queue_key: "queue-model@v1",
         queue_result: "immediate",
-        queue_grant_id: "grant-recovered-known-node",
+        queue_grant_id: recovered_grant_id,
         queue_granted_at: DateTime.utc_now() |> DateTime.to_iso8601()
       }
     )
@@ -2797,11 +2801,12 @@ defmodule Orchard.Inference.QueueManagerTest do
     assert grant.queue_key == "known-node-recovery-other@v1"
 
     assert :ok = QueueManager.release(grant, server: manager)
-    assert :ok = QueueManager.release("grant-recovered-known-node", server: manager)
+    assert :ok = QueueManager.release(recovered_grant_id, server: manager)
   end
 
   test "SPEC.md §5.3 recovered active grants count against tenant concurrency" do
     tenant_id = Ecto.UUID.generate()
+    recovered_grant_id = Ecto.UUID.generate()
 
     recovered_request =
       create_request!("req_queue_recovered_tenant_active",
@@ -2812,7 +2817,7 @@ defmodule Orchard.Inference.QueueManagerTest do
           queueing_enabled: true,
           queue_key: "queue-model-a@v1",
           queue_result: "immediate",
-          queue_grant_id: "grant-recovered-tenant-active",
+          queue_grant_id: recovered_grant_id,
           queue_granted_at: DateTime.utc_now() |> DateTime.to_iso8601()
         }
       )
@@ -3240,7 +3245,7 @@ defmodule Orchard.Inference.QueueManagerTest do
       queueing_enabled: true,
       queue_key: "queue-model@v1",
       queue_result: "immediate",
-      queue_grant_id: "grant-child-restart-admitted",
+      queue_grant_id: Ecto.UUID.generate(),
       queue_granted_at: DateTime.utc_now() |> DateTime.to_iso8601()
     }
   end

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -772,6 +772,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.CanonicalRequest
   alias Orchard.DispatchCapacity
   alias Orchard.DispatchCapacity.Policy
+  alias Orchard.Governance
   alias Orchard.Inference.CacheAffinity
   alias Orchard.Inference.QueueManager
   alias Orchard.Inference.RequestOrchestrator
@@ -807,6 +808,17 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end
 
     Process.register(self(), :request_orchestrator_test_pid)
+
+    tenant_suffix = System.unique_integer([:positive])
+
+    {:ok, full_capture_tenant} =
+      Governance.create_tenant(%{
+        slug: "request-orchestrator-full-#{tenant_suffix}",
+        name: "Request Orchestrator Full #{tenant_suffix}",
+        request_body_capture_mode: :full
+      })
+
+    Process.put(:request_orchestrator_full_capture_tenant_id, full_capture_tenant.id)
 
     on_exit(fn ->
       if Process.whereis(:request_orchestrator_test_pid) == self() do
@@ -917,6 +929,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
         body_hash: idempotency.body_hash,
         stream: false,
         state: :completed,
+        payload_capture_mode: :full,
         requested_model: "request-orchestrator-idem-replay@v1",
         response_payload: %{"id" => "req_existing_replay_sentry"}
       })
@@ -1963,7 +1976,9 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert request.response_preview != nil
   end
 
-  test "execute/3 skips success payload persistence for streaming requests", %{bundle: bundle} do
+  test "execute/3 persists the assembled terminal payload for full-capture streaming requests", %{
+    bundle: bundle
+  } do
     model = create_active_model!(bundle, "request-orchestrator-stream")
     canonical = canonical_request("request-orchestrator-stream", stream?: true)
 
@@ -1981,8 +1996,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request.stream == true
-    assert request.response_payload == nil
-    assert request.response_preview == nil
+    assert request.response_payload == %{"id" => canonical.public_id}
+    assert request.response_preview == "should-not-persist"
   end
 
   test "execute/3 returns an error before insert when canonical serialization fails", %{
@@ -2019,6 +2034,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
         body_hash: idempotency.body_hash,
         stream: false,
         state: :completed,
+        payload_capture_mode: :full,
         requested_model: "request-orchestrator-idem-replay@v1",
         response_payload: %{"id" => "req_existing_replay"}
       })
@@ -3554,7 +3570,15 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     endpoint = Keyword.get(overrides, :endpoint, :chat_completions)
     stream? = Keyword.get(overrides, :stream?, false)
     metadata = Keyword.get(overrides, :metadata, %{})
-    tenant_id = Keyword.get(overrides, :tenant_id, Ecto.UUID.generate())
+
+    tenant_id =
+      Keyword.get(
+        overrides,
+        :tenant_id,
+        Process.get(:request_orchestrator_full_capture_tenant_id) ||
+          raise("full-capture test tenant is not configured")
+      )
+
     public_id = Keyword.get(overrides, :public_id, "req_#{System.unique_integer([:positive])}")
     stop = Keyword.get(overrides, :stop, [])
     max_output_tokens = Keyword.get(overrides, :max_output_tokens)

--- a/apps/orchard_controller/test/orchard/inference/responses_request_normalizer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/responses_request_normalizer_test.exs
@@ -130,4 +130,23 @@ defmodule Orchard.Inference.ResponsesRequestNormalizerTest do
 
     assert request.stream_include_usage == false
   end
+
+  test "store defaults to true and only explicit false narrows persistence" do
+    base = %{"model" => "test-model@v1", "input" => "Hello"}
+
+    assert {:ok, %{store?: true}} = ResponsesRequestNormalizer.normalize(base)
+
+    assert {:ok, %{store?: true}} =
+             ResponsesRequestNormalizer.normalize(Map.put(base, "store", true))
+
+    assert {:ok, %{store?: true}} =
+             ResponsesRequestNormalizer.normalize(Map.put(base, "store", nil))
+
+    assert {:ok, %{store?: false}} =
+             ResponsesRequestNormalizer.normalize(Map.put(base, "store", false))
+
+    assert_raise ArgumentError, "invalid store: \"false\"", fn ->
+      ResponsesRequestNormalizer.normalize(Map.put(base, "store", "false"))
+    end
+  end
 end

--- a/apps/orchard_controller/test/orchard/inference/responses_serializer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/responses_serializer_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Inference.ResponsesSerializerTest do
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.ResponsesSerializer
   alias Orchard.InferenceEvent
+  alias Orchard.Requests.CapturePolicy
 
   test "response_payload/3 builds the bounded response object" do
     canonical = build_canonical(%{public_id: "resp_test", stream?: false})
@@ -80,8 +81,35 @@ defmodule Orchard.Inference.ResponsesSerializerTest do
     attrs = ResponsesSerializer.success_persistence_attrs(canonical, events)
 
     assert attrs.response_preview == "Tool call: lookup_weather({})"
+    assert attrs.response_preview_source == :tool_call
     assert attrs.response_payload.output_text == ""
     assert attrs.response_payload.usage == %{input_tokens: 0, output_tokens: 0, total_tokens: 0}
+  end
+
+  test "restricted capture drops function-call previews while full keeps a bounded preview" do
+    canonical = build_canonical(%{public_id: "resp_tool_capture", stream?: false})
+    arguments = Jason.encode!(%{"private" => String.duplicate("x", 700)})
+
+    events = [
+      InferenceEvent.accepted(42_000),
+      tool_call_event("call_0", %{index: 0, type: "function", function: %{name: "private_tool"}}),
+      tool_call_event("call_0", %{index: 0, function: %{arguments_delta: arguments}}),
+      InferenceEvent.completed(:finish_reason_tool_calls, nil)
+    ]
+
+    attrs = ResponsesSerializer.success_persistence_attrs(canonical, events)
+
+    for mode <- [:none, :metadata] do
+      restricted = CapturePolicy.terminal_attrs(mode, attrs)
+      assert restricted.response_preview == nil
+      refute Map.has_key?(restricted, :response_preview_source)
+      refute inspect(restricted) =~ "private_tool"
+    end
+
+    full = CapturePolicy.terminal_attrs(:full, attrs)
+    assert String.starts_with?(full.response_preview, "Tool call: private_tool(")
+    assert String.length(full.response_preview) == 512
+    refute Map.has_key?(full, :response_preview_source)
   end
 
   test "created_event/2 builds response.created payload" do

--- a/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
@@ -4,9 +4,12 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureModeTest do
   alias Ecto.Adapters.SQL
   alias Orchard.Repo
   alias Orchard.Repo.Migrations.RequestBodyCaptureMode
-  alias Orchard.Requests.CapturePolicy
+  alias Orchard.Requests
+  alias Orchard.Requests.{CapturePolicy, RequestStepEvent}
 
   import Orchard.TestSupport.ModelRequestFixtures
+
+  @secret "private tool argument that must not survive the purge"
 
   @migration_path Path.expand(
                     "../../../../priv/repo/migrations/20260731010000_request_body_capture_mode.exs",
@@ -86,6 +89,77 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureModeTest do
     )
 
     assert Repo.reload!(request).error_code == "internal_error"
+  end
+
+  test "legacy purge keeps request_step events readable without model-generated content" do
+    assert MapSet.new(RequestBodyCaptureMode.step_event_types()) ==
+             MapSet.new(RequestStepEvent.step_event_types())
+
+    request = create_request!(%{payload_capture_mode: :metadata})
+
+    {:ok, _step_events} =
+      Requests.append_request_step_events(request, [
+        %{
+          event_type: "request_step.proposed",
+          step_id: RequestStepEvent.tool_call_step_id(1, "call_1"),
+          step_type: "tool_call",
+          turn_index: 1,
+          attempt: 1,
+          parent_step_id: RequestStepEvent.inference_turn_step_id(1, 1),
+          boundary: "post_observation",
+          call_id: "call_1",
+          tool_name: "lookup",
+          arguments_json: ~s({"city":"#{@secret}"}),
+          result: %{"finish_reason" => "tool_calls"}
+        }
+      ])
+
+    restore_legacy_step_payload!(request.id)
+    run_legacy_step_event_purge!(request.id)
+
+    assert [step_event] = Requests.list_request_step_events(request)
+    assert step_event.step_type == "tool_call"
+    assert step_event.turn_index == 1
+    assert step_event.attempt == 1
+    assert step_event.boundary == "post_observation"
+    assert step_event.parent_step_id == RequestStepEvent.inference_turn_step_id(1, 1)
+    assert step_event.result == %{"finish_reason" => "tool_calls"}
+    assert step_event.arguments_json == nil
+    refute step_event.call_id == "call_1"
+    refute inspect(step_event) =~ @secret
+  end
+
+  defp restore_legacy_step_payload!(request_id) do
+    SQL.query!(
+      Repo,
+      """
+      UPDATE request_events
+      SET payload = payload || jsonb_build_object(
+            'call_id', 'call_1'::text,
+            'tool_name', 'lookup'::text,
+            'arguments_json', $2::text,
+            'step_id', 'tool_call:t1:ccall_1'::text,
+            'result', jsonb_build_object(
+              'finish_reason', 'tool_calls'::text,
+              'error_message', $2::text
+            )
+          )
+      WHERE request_id::text = $1
+      """,
+      [request_id, ~s({"city":"#{@secret}"})]
+    )
+  end
+
+  defp run_legacy_step_event_purge!(request_id) do
+    SQL.query!(
+      Repo,
+      """
+      UPDATE request_events AS event
+      SET payload = #{RequestBodyCaptureMode.legacy_step_event_payload_sql()}
+      WHERE event.request_id::text = $1
+      """,
+      [request_id]
+    )
   end
 
   defp run_legacy_scheduler_purge!(request_id) do

--- a/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
@@ -1,0 +1,77 @@
+defmodule Orchard.Repo.Migrations.RequestBodyCaptureModeTest do
+  use Orchard.DataCase, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Orchard.Repo
+  alias Orchard.Repo.Migrations.RequestBodyCaptureMode
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  @migration_path Path.expand(
+                    "../../../../priv/repo/migrations/20260731010000_request_body_capture_mode.exs",
+                    __DIR__
+                  )
+
+  Code.require_file(@migration_path)
+
+  test "legacy purge retains only typed cache-affinity feedback" do
+    affinity_key = "hmac-sha256:#{String.duplicate("a", 64)}"
+
+    request =
+      create_request!(%{
+        payload_capture_mode: :metadata,
+        scheduler_decision: %{
+          "cache_affinity_enabled" => true,
+          "cache_affinity_key" => affinity_key,
+          "cache_affinity_hint_available" => true,
+          "cache_affinity_selected_match" => false,
+          "cache_affinity_source" => "recent_completed_request",
+          "cache_affinity_candidate_count" => 2,
+          "prompt" => "must be purged",
+          "scored_candidates" => [%{"diagnostics" => "must be purged"}]
+        }
+      })
+
+    run_legacy_scheduler_purge!(request.id)
+
+    assert Repo.reload!(request).scheduler_decision == %{
+             "cache_affinity_enabled" => true,
+             "cache_affinity_key" => affinity_key,
+             "cache_affinity_hint_available" => true,
+             "cache_affinity_selected_match" => false,
+             "cache_affinity_source" => "recent_completed_request",
+             "cache_affinity_candidate_count" => 2
+           }
+  end
+
+  test "legacy purge drops malformed cache-affinity values" do
+    request =
+      create_request!(%{
+        payload_capture_mode: :none,
+        scheduler_decision: %{
+          "cache_affinity_enabled" => "true",
+          "cache_affinity_key" => "hmac-sha256:#{String.duplicate("g", 64)}",
+          "cache_affinity_hint_available" => %{"content" => "secret"},
+          "cache_affinity_selected_match" => ["secret"],
+          "cache_affinity_source" => "caller-controlled",
+          "cache_affinity_candidate_count" => -1
+        }
+      })
+
+    run_legacy_scheduler_purge!(request.id)
+
+    assert Repo.reload!(request).scheduler_decision == %{}
+  end
+
+  defp run_legacy_scheduler_purge!(request_id) do
+    SQL.query!(
+      Repo,
+      """
+      UPDATE requests
+      SET scheduler_decision = #{RequestBodyCaptureMode.legacy_cache_affinity_metadata_sql()}
+      WHERE id::text = $1
+      """,
+      [request_id]
+    )
+  end
+end

--- a/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureModeTest do
   alias Ecto.Adapters.SQL
   alias Orchard.Repo
   alias Orchard.Repo.Migrations.RequestBodyCaptureMode
+  alias Orchard.Requests.CapturePolicy
 
   import Orchard.TestSupport.ModelRequestFixtures
 
@@ -61,6 +62,30 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureModeTest do
     run_legacy_scheduler_purge!(request.id)
 
     assert Repo.reload!(request).scheduler_decision == %{}
+  end
+
+  test "legacy purge normalizes runtime-controlled error codes with application parity" do
+    assert MapSet.new(RequestBodyCaptureMode.stable_error_codes()) ==
+             MapSet.new(CapturePolicy.stable_error_codes())
+
+    request =
+      create_request!(%{
+        payload_capture_mode: :full,
+        error_code: "runtime echoed private content"
+      })
+
+    SQL.query!(
+      Repo,
+      """
+      UPDATE requests
+      SET payload_capture_mode = 'metadata',
+          error_code = #{RequestBodyCaptureMode.legacy_stable_error_code_sql()}
+      WHERE id::text = $1
+      """,
+      [request.id]
+    )
+
+    assert Repo.reload!(request).error_code == "internal_error"
   end
 
   defp run_legacy_scheduler_purge!(request_id) do

--- a/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs
@@ -129,6 +129,51 @@ defmodule Orchard.Repo.Migrations.RequestBodyCaptureModeTest do
     refute inspect(step_event) =~ @secret
   end
 
+  test "legacy inference result purge matches restricted runtime sanitization" do
+    cases = [
+      %{"error_code" => "request_cancelled", "error_message" => @secret},
+      %{"error_code" => @secret, "error_message" => @secret},
+      %{"finish_reason" => "stop"},
+      %{"finish_reason" => nil},
+      %{},
+      @secret
+    ]
+
+    for {result, index} <- Enum.with_index(cases, 1) do
+      request =
+        create_request!(%{
+          public_id: "legacy-inference-result-#{index}",
+          payload_capture_mode: :full
+        })
+
+      event_attrs = legacy_inference_event_attrs(result)
+      assert {:ok, _event} = Requests.append_request_event(request, event_attrs)
+
+      expected_payload = CapturePolicy.event_attrs(:metadata, event_attrs).payload
+
+      run_legacy_step_event_purge!(request.id)
+
+      assert [event] = Requests.list_request_events(request)
+      assert event.payload == expected_payload
+      refute inspect(event.payload) =~ @secret
+    end
+  end
+
+  defp legacy_inference_event_attrs(result) do
+    %{
+      event_type: "request_step.completed",
+      payload: %{
+        "step_id" => RequestStepEvent.inference_turn_step_id(1, 1),
+        "step_type" => "inference_turn",
+        "turn_index" => 1,
+        "attempt" => 1,
+        "parent_step_id" => nil,
+        "boundary" => "post_observation",
+        "result" => result
+      }
+    }
+  end
+
   defp restore_legacy_step_payload!(request_id) do
     SQL.query!(
       Repo,

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -43,13 +43,38 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
     assert scheduled.scheduler_decision["strategy"] == "multi_node"
     refute inspect(scheduled.scheduler_decision) =~ @private_prompt
 
+    assert {:ok, smuggling_attempt} =
+             Requests.record_schedule(request, %{
+               candidate_count: @private_prompt,
+               fallback_used?: %{"secret" => @private_prompt},
+               strategy: @private_prompt,
+               selected_node_id: @private_prompt,
+               scored_candidates: [
+                 %{
+                   node_id: @private_prompt,
+                   eligible: @private_prompt,
+                   score: @private_prompt,
+                   reason_codes: [],
+                   components: %{pool_bonus: @private_prompt}
+                 }
+               ]
+             })
+
+    refute inspect(smuggling_attempt.scheduler_decision) =~ @private_prompt
+
     assert {:ok, event} =
              Requests.append_request_event(request, %{
                event_type: "runtime.failed",
                payload: %{
+                 "attempt" => @private_prompt,
+                 "boundary" => @private_prompt,
+                 "call_id" => @private_prompt,
+                 "step_type" => @private_prompt,
                  "state" => "failed",
                  "result" => %{
-                   "error_code" => "runtime_failure",
+                   "error_code" => @private_prompt,
+                   "finish_reason" => @private_prompt,
+                   "input_tokens" => @private_prompt,
                    "error_message" => @private_prompt,
                    "arguments_json" => ~s({"secret":"#{@private_prompt}"})
                  }
@@ -57,10 +82,8 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
                state: :failed
              })
 
-    assert event.payload == %{
-             "state" => "failed",
-             "result" => %{"error_code" => "runtime_failure"}
-           }
+    assert event.payload == %{"result" => %{}}
+    refute inspect(event.payload) =~ @private_prompt
 
     assert {:ok, terminal} =
              Requests.mark_terminal(request, %{

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -244,6 +244,7 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
 
     constraints = MapSet.new(rows, fn [name] -> name end)
     assert "requests_non_full_content_absent" in constraints
+    assert "requests_non_full_error_code_stable" in constraints
     assert "requests_none_shape_and_preview_absent" in constraints
     assert "requests_response_preview_bounded" in constraints
   end

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -150,6 +150,44 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
     end
   end
 
+  test "none and metadata preserve typed cache-affinity feedback for production lookup" do
+    affinity_key = "hmac-sha256:#{String.duplicate("a", 64)}"
+    model_id = "capture-model"
+
+    for mode <- [:none, :metadata] do
+      tenant_id = Ecto.UUID.generate()
+      node_id = Ecto.UUID.generate()
+      {:ok, request} = Requests.create_request(request_attrs(mode, tenant_id))
+
+      assert {:ok, scheduled} =
+               Requests.record_schedule(request, %{
+                 node_id: node_id,
+                 cache_affinity_enabled: true,
+                 cache_affinity_key: affinity_key,
+                 cache_affinity_hint_available: true,
+                 cache_affinity_selected_match: true,
+                 cache_affinity_source: "recent_completed_request",
+                 cache_affinity_candidate_count: 1
+               })
+
+      assert scheduled.scheduler_decision["cache_affinity_key"] == affinity_key
+
+      assert {:ok, completed} =
+               Requests.mark_terminal(scheduled, %{
+                 state: :completed,
+                 response_payload: %{"output_text" => @private_response}
+               })
+
+      assert Requests.recent_cache_affinity_nodes(
+               tenant_id,
+               model_id,
+               "v1",
+               affinity_key,
+               now: DateTime.add(completed.completed_at, 1, :second)
+             ) == [node_id]
+    end
+  end
+
   test "database constraints reject policy bypasses and remain discoverable for drift checks" do
     {:ok, request} = Requests.create_request(request_attrs(:metadata))
 

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -122,6 +122,34 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
     assert full.response_preview == @private_response
   end
 
+  test "none and metadata schedule persistence accepts valid timestamps and drops malformed values" do
+    timestamp = "2026-07-31T04:00:00Z"
+
+    for mode <- [:none, :metadata] do
+      {:ok, request} = Requests.create_request(request_attrs(mode))
+
+      assert {:ok, scheduled} =
+               Requests.record_schedule(request, %{
+                 queue_granted_at: timestamp,
+                 queued_at: %{"content" => @private_prompt}
+               })
+
+      assert scheduled.scheduler_decision["queue_granted_at"] == timestamp
+      refute Map.has_key?(scheduled.scheduler_decision, "queued_at")
+      refute inspect(scheduled.scheduler_decision) =~ @private_prompt
+
+      assert {:ok, scheduled} =
+               Requests.record_schedule(scheduled, %{
+                 queue_granted_at: [@private_prompt],
+                 queued_at: timestamp
+               })
+
+      assert scheduled.scheduler_decision["queued_at"] == timestamp
+      refute Map.has_key?(scheduled.scheduler_decision, "queue_granted_at")
+      refute inspect(scheduled.scheduler_decision) =~ @private_prompt
+    end
+  end
+
   test "database constraints reject policy bypasses and remain discoverable for drift checks" do
     {:ok, request} = Requests.create_request(request_attrs(:metadata))
 

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -82,7 +82,13 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
                state: :failed
              })
 
-    assert event.payload == %{"result" => %{}}
+    assert event.payload == %{
+             "result" => %{
+               "error_code" => "internal_error",
+               "finish_reason_invalid" => true
+             }
+           }
+
     refute inspect(event.payload) =~ @private_prompt
 
     assert {:ok, terminal} =

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -122,6 +122,31 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
     assert full.response_preview == @private_response
   end
 
+  test "none and metadata sanitize a prefilled scheduler decision during creation" do
+    affinity_key = "hmac-sha256:#{String.duplicate("a", 64)}"
+
+    for mode <- [:none, :metadata] do
+      attrs =
+        mode
+        |> request_attrs()
+        |> Map.put(:scheduler_decision, %{
+          cache_affinity_key: affinity_key,
+          cache_affinity_enabled: true,
+          prompt: @private_prompt,
+          diagnostics: %{"content" => @private_prompt}
+        })
+
+      assert {:ok, request} = Requests.create_request(attrs)
+
+      assert request.scheduler_decision == %{
+               "cache_affinity_enabled" => true,
+               "cache_affinity_key" => affinity_key
+             }
+
+      refute inspect(request.scheduler_decision) =~ @private_prompt
+    end
+  end
+
   test "none and metadata schedule persistence accepts valid timestamps and drops malformed values" do
     timestamp = "2026-07-31T04:00:00Z"
 

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -1,0 +1,160 @@
+defmodule Orchard.Requests.CaptureEnforcementTest do
+  use Orchard.DataCase, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Orchard.Governance
+  alias Orchard.Governance.Tenant
+  alias Orchard.Repo
+  alias Orchard.Requests
+  alias Postgrex.Error, as: PostgrexError
+
+  @private_prompt "private prompt must not survive"
+  @private_response "private response must not survive"
+
+  test "SPEC.md §10.10 metadata is enforced across creation, events, and terminal writes" do
+    suffix = System.unique_integer([:positive])
+
+    {:ok, tenant} =
+      Governance.create_tenant(%{
+        slug: "capture-snapshot-#{suffix}",
+        name: "Capture Snapshot #{suffix}",
+        request_body_capture_mode: :metadata
+      })
+
+    {:ok, request} = Requests.create_request(request_attrs(:metadata, tenant.id))
+
+    assert request.canonical_request == nil
+    assert request.request_payload == nil
+    assert request.request_shape["capture_mode"] == "metadata"
+    refute inspect(request) =~ @private_prompt
+
+    tenant
+    |> Tenant.changeset(%{request_body_capture_mode: :full})
+    |> Repo.update!()
+
+    assert {:ok, scheduled} =
+             Requests.record_schedule(request, %{
+               strategy: :multi_node,
+               node_id: Ecto.UUID.generate(),
+               prompt: @private_prompt,
+               diagnostics: %{"error_message" => @private_prompt}
+             })
+
+    assert scheduled.scheduler_decision["strategy"] == "multi_node"
+    refute inspect(scheduled.scheduler_decision) =~ @private_prompt
+
+    assert {:ok, event} =
+             Requests.append_request_event(request, %{
+               event_type: "runtime.failed",
+               payload: %{
+                 "state" => "failed",
+                 "result" => %{
+                   "error_code" => "runtime_failure",
+                   "error_message" => @private_prompt,
+                   "arguments_json" => ~s({"secret":"#{@private_prompt}"})
+                 }
+               },
+               state: :failed
+             })
+
+    assert event.payload == %{
+             "state" => "failed",
+             "result" => %{"error_code" => "runtime_failure"}
+           }
+
+    assert {:ok, terminal} =
+             Requests.mark_terminal(request, %{
+               state: :failed,
+               response_payload: %{"output_text" => @private_response},
+               response_preview: @private_response,
+               error_code: "runtime_failure",
+               error_message: "runtime echoed #{@private_prompt}"
+             })
+
+    assert terminal.response_payload == nil
+    assert terminal.response_preview == nil
+    assert terminal.error_message == nil
+    assert byte_size(terminal.response_hash) == 32
+    refute inspect(terminal) =~ @private_response
+    refute inspect(terminal) =~ @private_prompt
+  end
+
+  test "SPEC.md §10.10 none omits request shape while full retains approved content" do
+    {:ok, none} = Requests.create_request(request_attrs(:none))
+    assert none.request_shape == nil
+    assert none.canonical_request == nil
+
+    {:ok, full} = Requests.create_request(request_attrs(:full))
+    assert full.canonical_request["rendered_prompt"] == @private_prompt
+    assert full.request_payload == %{"prompt" => @private_prompt}
+
+    assert {:ok, full} =
+             Requests.mark_terminal(full, %{
+               state: :completed,
+               response_payload: %{"output_text" => @private_response},
+               response_preview: @private_response
+             })
+
+    assert full.response_payload == %{"output_text" => @private_response}
+    assert full.response_preview == @private_response
+  end
+
+  test "database constraints reject policy bypasses and remain discoverable for drift checks" do
+    {:ok, request} = Requests.create_request(request_attrs(:metadata))
+
+    assert {:error, %PostgrexError{postgres: %{constraint: constraint}}} =
+             Repo.transaction(fn ->
+               case SQL.query(
+                      Repo,
+                      "UPDATE requests SET response_payload = $1 WHERE id::text = $2",
+                      [%{"output_text" => @private_response}, request.id]
+                    ) do
+                 {:error, error} -> Repo.rollback(error)
+                 {:ok, result} -> result
+               end
+             end)
+
+    assert constraint == "requests_non_full_content_absent"
+
+    %{rows: rows} =
+      SQL.query!(
+        Repo,
+        """
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = 'requests'::regclass
+          AND conname LIKE 'requests_%'
+        """,
+        []
+      )
+
+    constraints = MapSet.new(rows, fn [name] -> name end)
+    assert "requests_non_full_content_absent" in constraints
+    assert "requests_none_shape_and_preview_absent" in constraints
+    assert "requests_response_preview_bounded" in constraints
+  end
+
+  defp request_attrs(mode, tenant_id \\ Ecto.UUID.generate()) do
+    suffix = System.unique_integer([:positive])
+
+    %{
+      public_id: "req_capture_#{suffix}",
+      endpoint: :responses,
+      tenant_id: tenant_id,
+      requested_model: "capture-model@v1",
+      state: :received,
+      stream: false,
+      payload_capture_mode: mode,
+      body_hash: :crypto.hash(:sha256, "request-#{suffix}"),
+      canonical_request: %{
+        "endpoint" => "responses",
+        "input_items" => [%{"role" => "user", "content" => @private_prompt}],
+        "rendered_prompt" => @private_prompt,
+        "sampling" => %{"stop" => ["private stop"]}
+      },
+      request_payload: %{"prompt" => @private_prompt},
+      sampling_params: %{"temperature" => 0.5, "stop" => ["private stop"]},
+      response_format: %{"type" => "text"}
+    }
+  end
+end

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -271,6 +271,8 @@ defmodule Orchard.Requests.CapturePolicyTest do
         |> Map.merge(%{
           "node_id" => secret,
           "selected_node_id" => secret,
+          "queue_granted_at" => %{"secret" => secret},
+          "queued_at" => [secret],
           "scored_candidates" => [
             %{
               "node_id" => secret,
@@ -287,6 +289,28 @@ defmodule Orchard.Requests.CapturePolicyTest do
       for mode <- [:none, :metadata] do
         sanitized = CapturePolicy.schedule_attrs(mode, schedule)
         refute inspect(sanitized) =~ secret
+      end
+    end
+
+    test "none and metadata normalize valid timestamps and reject malformed types" do
+      timestamp = ~U[2026-07-31 04:00:00Z]
+
+      for mode <- [:none, :metadata] do
+        sanitized =
+          CapturePolicy.schedule_attrs(mode, %{
+            queue_granted_at: timestamp,
+            queued_at: DateTime.to_iso8601(timestamp)
+          })
+
+        assert sanitized == %{
+                 "queue_granted_at" => "2026-07-31T04:00:00Z",
+                 "queued_at" => "2026-07-31T04:00:00Z"
+               }
+
+        assert CapturePolicy.schedule_attrs(mode, %{
+                 queue_granted_at: %{"content" => @prompt},
+                 queued_at: [@prompt]
+               }) == %{}
       end
     end
   end

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -7,6 +7,48 @@ defmodule Orchard.Requests.CapturePolicyTest do
   @prompt "private prompt that must not survive metadata capture"
   @response "private response that must not survive metadata capture"
   @arguments ~s({"account":"private-account","amount":42})
+  @event_integer_keys ~w(attempt attempt_index sequence turn_index)
+  @result_integer_keys ~w(http_status input_tokens output_tokens)
+  @schedule_boolean_keys ~w(
+    fallback_used?
+    memory_admission_enabled
+    memory_headroom_ok?
+    queueing_enabled
+    selected_prefix_cache_enabled
+    selected_prefix_cache_fingerprint_match
+    selected_prefix_cache_score_resident_fingerprint_match
+    selected_prefix_cache_warmth_indicator
+  )
+  @schedule_numeric_keys ~w(
+    candidate_count
+    contract_version
+    model_load_timeout_ms
+    queue_wait_ms
+    request_timeout_ms
+    selected_prefix_cache_entry_count
+    selected_prefix_cache_evictions
+    selected_prefix_cache_fingerprint_count
+    selected_prefix_cache_hits
+    selected_prefix_cache_misses
+    selected_prefix_cache_score_session_started_unix_ms
+    selected_prefix_cache_session_started_unix_ms
+    selected_prefix_cache_stores
+    selected_prefix_cache_total_bytes
+  )
+  @schedule_enums ~w(
+    memory_admission_tier
+    queue_result
+    queue_wait_reason
+    selected_cache_tier
+    selected_prefix_cache_implementation
+    selected_prefix_cache_score_source
+    selected_prefix_cache_score_status_code
+    selected_prefix_cache_score_tier
+    selected_prefix_cache_status_code
+    selected_tier
+    selection_tier
+    strategy
+  )
 
   describe "resolve/2" do
     test "SPEC.md §10.10 store=false narrows full and never widens a Tenant mode" do
@@ -147,8 +189,25 @@ defmodule Orchard.Requests.CapturePolicyTest do
         refute encoded =~ @arguments
         refute encoded =~ @prompt
         refute encoded =~ "error_message"
-        assert attrs.payload["step_id"] == "turn-1"
         assert attrs.payload["result"]["finish_reason"] == "tool_calls"
+      end
+    end
+
+    test "none and metadata reject content smuggled under every approved event key" do
+      secret = "prompt-secret"
+
+      payload =
+        Map.new(@event_integer_keys ++ @result_integer_keys, &{&1, secret})
+        |> Map.merge(%{
+          "boundary" => secret,
+          "step_type" => secret,
+          "result" =>
+            Map.new(@result_integer_keys ++ ["finish_reason"], &{&1, %{"secret" => secret}})
+        })
+
+      for mode <- [:none, :metadata] do
+        sanitized = CapturePolicy.event_attrs(mode, %{payload: payload})
+        refute inspect(sanitized) =~ secret
       end
     end
 
@@ -189,7 +248,6 @@ defmodule Orchard.Requests.CapturePolicyTest do
         assert sanitized["scored_candidates"] == [
                  %{
                    "eligible" => true,
-                   "node_id" => "node-a",
                    "reason_codes" => [],
                    "score" => 1.0,
                    "components" => %{"pool_bonus" => 200}
@@ -199,6 +257,36 @@ defmodule Orchard.Requests.CapturePolicyTest do
         refute encoded =~ @prompt
         refute Map.has_key?(sanitized, "prompt")
         refute Map.has_key?(sanitized, "diagnostics")
+      end
+    end
+
+    test "none and metadata reject content smuggled under approved scheduler keys" do
+      secret = "scheduler-secret"
+
+      schedule =
+        Map.new(
+          @schedule_numeric_keys ++ @schedule_boolean_keys ++ @schedule_enums,
+          &{&1, %{"secret" => secret}}
+        )
+        |> Map.merge(%{
+          "node_id" => secret,
+          "selected_node_id" => secret,
+          "scored_candidates" => [
+            %{
+              "node_id" => secret,
+              "target_ref" => secret,
+              "tier" => secret,
+              "score" => secret,
+              "eligible" => secret,
+              "reason_codes" => [secret],
+              "components" => %{"pool_bonus" => secret, "prompt_fragment" => secret}
+            }
+          ]
+        })
+
+      for mode <- [:none, :metadata] do
+        sanitized = CapturePolicy.schedule_attrs(mode, schedule)
+        refute inspect(sanitized) =~ secret
       end
     end
   end

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -2,7 +2,7 @@ defmodule Orchard.Requests.CapturePolicyTest do
   use ExUnit.Case, async: true
 
   alias Orchard.Requests.CapturePolicy
-  alias Orchard.Requests.{Request, RequestEvent}
+  alias Orchard.Requests.{Request, RequestEvent, RequestStepEvent}
 
   @prompt "private prompt that must not survive metadata capture"
   @response "private response that must not survive metadata capture"
@@ -185,6 +185,16 @@ defmodule Orchard.Requests.CapturePolicyTest do
       end
     end
 
+    test "omitted terminal fields stay omitted so repeated updates cannot clear them" do
+      for mode <- [:none, :metadata, :full] do
+        attrs = CapturePolicy.terminal_attrs(mode, %{state: :completed, output_tokens: 7})
+
+        refute Map.has_key?(attrs, :response_preview)
+        refute Map.has_key?(attrs, :error_code)
+        assert attrs.output_tokens == 7
+      end
+    end
+
     test "restricted modes retain only closed stable error codes" do
       for mode <- [:none, :metadata] do
         assert CapturePolicy.terminal_attrs(mode, %{error_code: "queue_timeout"}).error_code ==
@@ -235,6 +245,67 @@ defmodule Orchard.Requests.CapturePolicyTest do
     test "full preserves approved request-step content" do
       attrs = CapturePolicy.event_attrs(:full, event_attrs())
       assert attrs.payload["result"]["arguments_json"] == @arguments
+    end
+
+    test "none and metadata keep restricted request_step events readable" do
+      for mode <- [:none, :metadata], step <- readable_step_events() do
+        sanitized = CapturePolicy.event_attrs(mode, step)
+
+        assert {:ok, step_event} =
+                 RequestStepEvent.from_request_event(%RequestEvent{
+                   event_type: step.event_type,
+                   payload: sanitized.payload,
+                   request_id: Ecto.UUID.generate(),
+                   seq: 1,
+                   occurred_at: ~U[2026-07-31 04:00:00.000000Z]
+                 })
+
+        assert step_event.step_type == step.payload["step_type"]
+        assert step_event.turn_index == step.payload["turn_index"]
+        assert step_event.attempt == step.payload["attempt"]
+        refute inspect(step_event) =~ @prompt
+        refute inspect(step_event) =~ @arguments
+      end
+    end
+
+    test "none and metadata retain stable tool_execution error codes without raw error text" do
+      failed =
+        CapturePolicy.event_attrs(
+          :metadata,
+          tool_execution_step("request_step.failed", %{
+            "error_code" => "tool_execution_timed_out",
+            "error_message" => "runtime echoed #{@prompt}"
+          })
+        )
+
+      assert failed.payload["result"]["error_code"] == "tool_execution_timed_out"
+      assert failed.payload["result"]["error_message"] == "Tool execution failed"
+      refute inspect(failed) =~ @prompt
+
+      unknown =
+        CapturePolicy.event_attrs(
+          :metadata,
+          tool_execution_step("request_step.cancelled", %{
+            "error_code" => "runtime echoed #{@prompt}",
+            "error_message" => @prompt
+          })
+        )
+
+      assert unknown.payload["result"]["error_code"] == "tool_execution_cancelled"
+      refute inspect(unknown) =~ @prompt
+
+      indeterminate =
+        CapturePolicy.event_attrs(
+          :metadata,
+          tool_execution_step("request_step.indeterminate", %{
+            "error_code" => "tool_execution_indeterminate_result_not_observed",
+            "error_message" => @prompt,
+            "indeterminate_reason" => "result_not_observed"
+          })
+        )
+
+      assert indeterminate.payload["result"]["indeterminate_reason"] == "result_not_observed"
+      refute inspect(indeterminate) =~ @prompt
     end
   end
 
@@ -461,6 +532,71 @@ defmodule Orchard.Requests.CapturePolicyTest do
       },
       overrides
     )
+  end
+
+  defp readable_step_events do
+    [
+      %{
+        event_type: "request_step.started",
+        payload: %{
+          "step_id" => "inference_turn:t1:a1",
+          "step_type" => "inference_turn",
+          "turn_index" => 1,
+          "attempt" => 1,
+          "boundary" => "pre_side_effect",
+          "result" => %{},
+          "model_id" => "model",
+          "model_version" => "v1"
+        }
+      },
+      %{
+        event_type: "request_step.completed",
+        payload: %{
+          "step_id" => "inference_turn:t1:a1",
+          "step_type" => "inference_turn",
+          "turn_index" => 1,
+          "attempt" => 1,
+          "boundary" => "post_observation",
+          "result" => %{"finish_reason" => "stop", "output_tokens" => 12, "prompt" => @prompt}
+        }
+      },
+      %{
+        event_type: "request_step.proposed",
+        payload: %{
+          "step_id" => "tool_call:t1:ccall-1",
+          "step_type" => "tool_call",
+          "turn_index" => 1,
+          "attempt" => 1,
+          "parent_step_id" => "inference_turn:t1:a1",
+          "boundary" => "post_observation",
+          "call_id" => "call-1",
+          "tool_name" => "transfer",
+          "arguments_json" => @arguments,
+          "result" => %{"finish_reason" => "tool_calls"}
+        }
+      },
+      tool_execution_step("request_step.completed", %{}),
+      tool_execution_step("request_step.timed_out", %{
+        "error_code" => "tool_execution_timed_out",
+        "error_message" => "runtime echoed #{@prompt}"
+      })
+    ]
+  end
+
+  defp tool_execution_step(event_type, result) do
+    %{
+      event_type: event_type,
+      payload: %{
+        "step_id" => "tool_execution:t1:ccall-1:a1",
+        "step_type" => "tool_execution",
+        "turn_index" => 1,
+        "attempt" => 1,
+        "parent_step_id" => "tool_call:t1:ccall-1",
+        "boundary" => "post_observation",
+        "call_id" => "call-1",
+        "result" => result
+      }
+    }
   end
 
   defp event_attrs do

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -10,6 +10,9 @@ defmodule Orchard.Requests.CapturePolicyTest do
   @event_integer_keys ~w(attempt attempt_index sequence turn_index)
   @result_integer_keys ~w(http_status input_tokens output_tokens)
   @schedule_boolean_keys ~w(
+    cache_affinity_enabled
+    cache_affinity_hint_available
+    cache_affinity_selected_match
     fallback_used?
     memory_admission_enabled
     memory_headroom_ok?
@@ -36,6 +39,7 @@ defmodule Orchard.Requests.CapturePolicyTest do
     selected_prefix_cache_total_bytes
   )
   @schedule_enums ~w(
+    cache_affinity_source
     memory_admission_tier
     queue_result
     queue_wait_reason
@@ -310,6 +314,40 @@ defmodule Orchard.Requests.CapturePolicyTest do
         assert CapturePolicy.schedule_attrs(mode, %{
                  queue_granted_at: %{"content" => @prompt},
                  queued_at: [@prompt]
+               }) == %{}
+      end
+    end
+
+    test "none and metadata retain only typed cache-affinity feedback" do
+      affinity_key = "hmac-sha256:#{String.duplicate("a", 64)}"
+
+      for mode <- [:none, :metadata] do
+        sanitized =
+          CapturePolicy.schedule_attrs(mode, %{
+            cache_affinity_enabled: true,
+            cache_affinity_key: affinity_key,
+            cache_affinity_hint_available: true,
+            cache_affinity_selected_match: false,
+            cache_affinity_source: "recent_completed_request",
+            cache_affinity_candidate_count: 2
+          })
+
+        assert sanitized == %{
+                 "cache_affinity_enabled" => true,
+                 "cache_affinity_key" => affinity_key,
+                 "cache_affinity_hint_available" => true,
+                 "cache_affinity_selected_match" => false,
+                 "cache_affinity_source" => "recent_completed_request",
+                 "cache_affinity_candidate_count" => 2
+               }
+
+        assert CapturePolicy.schedule_attrs(mode, %{
+                 cache_affinity_enabled: @prompt,
+                 cache_affinity_key: "hmac-sha256:#{String.duplicate("g", 64)}",
+                 cache_affinity_hint_available: %{"content" => @prompt},
+                 cache_affinity_selected_match: [@prompt],
+                 cache_affinity_source: @prompt,
+                 cache_affinity_candidate_count: -1
                }) == %{}
       end
     end

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -212,6 +212,88 @@ defmodule Orchard.Requests.CapturePolicyTest do
   end
 
   describe "event_attrs/2" do
+    test "none and metadata retain normalized inference error codes without raw error text" do
+      for mode <- [:none, :metadata] do
+        stable =
+          CapturePolicy.event_attrs(
+            mode,
+            inference_step_result(%{
+              "error_code" => "request_cancelled",
+              "error_message" => @prompt
+            })
+          )
+
+        unknown =
+          CapturePolicy.event_attrs(
+            mode,
+            inference_step_result(%{
+              "error_code" => "runtime echoed #{@prompt}",
+              "error_message" => @prompt
+            })
+          )
+
+        assert stable.payload["result"] == %{"error_code" => "request_cancelled"}
+        assert unknown.payload["result"] == %{"error_code" => "internal_error"}
+        refute inspect(stable) =~ @prompt
+        refute inspect(unknown) =~ @prompt
+      end
+    end
+
+    test "none and metadata distinguish invalid finish reasons from absent evidence" do
+      for mode <- [:none, :metadata] do
+        valid =
+          CapturePolicy.event_attrs(
+            mode,
+            inference_step_result(%{"finish_reason" => "stop"}, "request_step.completed")
+          )
+
+        absent =
+          CapturePolicy.event_attrs(
+            mode,
+            inference_step_result(%{"finish_reason_invalid" => true}, "request_step.completed")
+          )
+
+        invalid_nil =
+          CapturePolicy.event_attrs(
+            mode,
+            inference_step_result(%{"finish_reason" => nil}, "request_step.completed")
+          )
+
+        invalid_content =
+          CapturePolicy.event_attrs(
+            mode,
+            inference_step_result(%{"finish_reason" => @prompt}, "request_step.completed")
+          )
+
+        assert valid.payload["result"] == %{"finish_reason" => "stop"}
+        assert absent.payload["result"] == %{}
+        assert invalid_nil.payload["result"] == %{"finish_reason_invalid" => true}
+        assert invalid_content.payload["result"] == %{"finish_reason_invalid" => true}
+        refute inspect(invalid_content) =~ @prompt
+      end
+    end
+
+    test "generic restricted event results use the same inference sanitizer" do
+      attrs =
+        CapturePolicy.event_attrs(:metadata, %{
+          event_type: "request.completed",
+          payload: %{
+            "result" => %{
+              "finish_reason" => nil,
+              "error_code" => "request_cancelled",
+              "error_message" => @prompt
+            }
+          }
+        })
+
+      assert attrs.payload["result"] == %{
+               "error_code" => "request_cancelled",
+               "finish_reason_invalid" => true
+             }
+
+      refute inspect(attrs) =~ @prompt
+    end
+
     test "none and metadata remove model-generated tool arguments and raw error messages" do
       for mode <- [:none, :metadata] do
         attrs = CapturePolicy.event_attrs(mode, event_attrs())
@@ -307,6 +389,20 @@ defmodule Orchard.Requests.CapturePolicyTest do
       assert indeterminate.payload["result"]["indeterminate_reason"] == "result_not_observed"
       refute inspect(indeterminate) =~ @prompt
     end
+  end
+
+  defp inference_step_result(result, event_type \\ "request_step.failed") do
+    %{
+      event_type: event_type,
+      payload: %{
+        "step_id" => "inference_turn:t1:a1",
+        "step_type" => "inference_turn",
+        "turn_index" => 1,
+        "attempt" => 1,
+        "boundary" => "post_observation",
+        "result" => result
+      }
+    }
   end
 
   describe "schedule_attrs/2" do

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -1,0 +1,316 @@
+defmodule Orchard.Requests.CapturePolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Requests.CapturePolicy
+  alias Orchard.Requests.{Request, RequestEvent}
+
+  @prompt "private prompt that must not survive metadata capture"
+  @response "private response that must not survive metadata capture"
+  @arguments ~s({"account":"private-account","amount":42})
+
+  describe "resolve/2" do
+    test "SPEC.md §10.10 store=false narrows full and never widens a Tenant mode" do
+      assert CapturePolicy.resolve(:full, false) == :metadata
+      assert CapturePolicy.resolve(:metadata, false) == :metadata
+      assert CapturePolicy.resolve(:none, false) == :none
+      assert CapturePolicy.resolve(:full, true) == :full
+    end
+  end
+
+  describe "create_attrs/2" do
+    test "SPEC.md §10.10 none keeps hashes and operational metadata without content" do
+      attrs = CapturePolicy.create_attrs(:none, create_attrs())
+
+      assert attrs.body_hash
+      assert attrs.canonical_request == nil
+      assert attrs.request_shape == nil
+      assert attrs.request_payload == nil
+
+      assert attrs.sampling_params == %{
+               "max_output_tokens" => 64,
+               "seed" => 7,
+               "stop_count" => 1,
+               "temperature" => 0.5,
+               "top_p" => 0.9
+             }
+
+      refute Jason.encode!(attrs) =~ @prompt
+      refute Jason.encode!(attrs) =~ "private stop"
+    end
+
+    test "SPEC.md §10.10 metadata stores bounded shape without the complete request" do
+      attrs = CapturePolicy.create_attrs(:metadata, create_attrs())
+      encoded = Jason.encode!(attrs)
+
+      assert attrs.canonical_request == nil
+      assert attrs.request_payload == nil
+      assert attrs.request_shape["capture_mode"] == "metadata"
+      assert attrs.request_shape["input_item_count"] == 1
+      assert attrs.request_shape["rendered_prompt"]["graphemes"] == String.length(@prompt)
+      assert attrs.request_shape["rendered_prompt"]["sha256"] =~ ~r/^[0-9a-f]{64}$/
+      assert attrs.request_shape["preview"] == nil
+      refute encoded =~ @prompt
+      refute encoded =~ "private stop"
+      refute encoded =~ "private metadata"
+      refute encoded =~ "private tool description"
+    end
+
+    test "SPEC.md §10.10 full preserves the approved request fields" do
+      attrs = CapturePolicy.create_attrs(:full, create_attrs())
+
+      assert attrs.canonical_request["rendered_prompt"] == @prompt
+      assert attrs.canonical_request["sampling"]["stop"] == ["private stop"]
+    end
+  end
+
+  describe "terminal_attrs/2" do
+    test "none and metadata cannot retain a complete response or raw error text" do
+      for mode <- [:none, :metadata] do
+        attrs = CapturePolicy.terminal_attrs(mode, terminal_attrs())
+        encoded = inspect(attrs)
+
+        assert attrs.response_payload == nil
+        assert byte_size(attrs.response_hash) == 32
+        assert attrs.error_message == nil
+        refute encoded =~ @response
+        refute encoded =~ @prompt
+      end
+    end
+
+    test "metadata preview is optional for short content and non-equivalent for long content" do
+      short = CapturePolicy.terminal_attrs(:metadata, terminal_attrs())
+      assert short.response_preview == nil
+
+      long_response = String.duplicate("x", 513)
+
+      long =
+        CapturePolicy.terminal_attrs(
+          :metadata,
+          terminal_attrs(%{
+            response_payload: %{"output_text" => long_response},
+            response_preview: long_response
+          })
+        )
+
+      assert String.length(long.response_preview) == 512
+      assert String.ends_with?(long.response_preview, "…")
+      refute long.response_preview == long_response
+    end
+
+    test "full preserves the response and bounds its convenience preview" do
+      long_response = String.duplicate("x", 700)
+
+      attrs =
+        CapturePolicy.terminal_attrs(
+          :full,
+          terminal_attrs(%{
+            response_payload: %{"output_text" => long_response},
+            response_preview: long_response
+          })
+        )
+
+      assert attrs.response_payload == %{"output_text" => long_response}
+      assert String.length(attrs.response_preview) == 512
+      assert byte_size(attrs.response_hash) == 32
+    end
+
+    test "preview bounds match PostgreSQL code-point length without splitting graphemes" do
+      decomposed = String.duplicate("e\u0301", 300)
+      emoji = String.duplicate("👨‍👩‍👧‍👦", 90)
+
+      for content <- [decomposed, emoji], mode <- [:metadata, :full] do
+        attrs =
+          CapturePolicy.terminal_attrs(
+            mode,
+            terminal_attrs(%{
+              response_payload: %{"output_text" => content},
+              response_preview: content
+            })
+          )
+
+        assert length(String.codepoints(attrs.response_preview)) <= 512
+        assert String.ends_with?(attrs.response_preview, "…")
+
+        prefix = String.trim_trailing(attrs.response_preview, "…")
+        prefix_graphemes = String.graphemes(prefix)
+        assert Enum.take(String.graphemes(content), length(prefix_graphemes)) == prefix_graphemes
+      end
+    end
+  end
+
+  describe "event_attrs/2" do
+    test "none and metadata remove model-generated tool arguments and raw error messages" do
+      for mode <- [:none, :metadata] do
+        attrs = CapturePolicy.event_attrs(mode, event_attrs())
+        encoded = Jason.encode!(attrs)
+
+        refute encoded =~ @arguments
+        refute encoded =~ @prompt
+        refute encoded =~ "error_message"
+        assert attrs.payload["step_id"] == "turn-1"
+        assert attrs.payload["result"]["finish_reason"] == "tool_calls"
+      end
+    end
+
+    test "full preserves approved request-step content" do
+      attrs = CapturePolicy.event_attrs(:full, event_attrs())
+      assert attrs.payload["result"]["arguments_json"] == @arguments
+    end
+  end
+
+  describe "schedule_attrs/2" do
+    test "none and metadata keep only bounded scheduler fields" do
+      schedule = %{
+        strategy: :multi_node,
+        node_id: Ecto.UUID.generate(),
+        selected_prefix_cache_score_status_code: "ok",
+        selected_prefix_cache_prompt: @prompt,
+        prompt: @prompt,
+        diagnostics: %{"error_message" => @prompt},
+        scored_candidates: [
+          %{
+            node_id: "node-a",
+            eligible: true,
+            score: 1.0,
+            reason_codes: [],
+            components: %{pool_bonus: 200, prompt_fragment: @prompt},
+            diagnostics: %{"prompt" => @prompt}
+          }
+        ]
+      }
+
+      for mode <- [:none, :metadata] do
+        sanitized = CapturePolicy.schedule_attrs(mode, schedule)
+        encoded = Jason.encode!(sanitized)
+
+        assert sanitized["strategy"] == "multi_node"
+        assert sanitized["selected_prefix_cache_score_status_code"] == "ok"
+
+        assert sanitized["scored_candidates"] == [
+                 %{
+                   "eligible" => true,
+                   "node_id" => "node-a",
+                   "reason_codes" => [],
+                   "score" => 1.0,
+                   "components" => %{"pool_bonus" => 200}
+                 }
+               ]
+
+        refute encoded =~ @prompt
+        refute Map.has_key?(sanitized, "prompt")
+        refute Map.has_key?(sanitized, "diagnostics")
+      end
+    end
+  end
+
+  test "content_columns/0 explicitly classifies the purge surface" do
+    assert CapturePolicy.content_columns() == %{
+             request_events: [:payload],
+             requests: [
+               :canonical_request,
+               :request_shape,
+               :request_payload,
+               :response_payload,
+               :response_preview,
+               :sampling_params,
+               :response_format,
+               :scheduler_decision,
+               :error_message
+             ]
+           }
+  end
+
+  test "content and safe classifications fail when request schemas drift" do
+    content = CapturePolicy.content_columns()
+    safe = CapturePolicy.safe_columns()
+
+    assert Enum.sort(content.requests ++ safe.requests) ==
+             Enum.sort(Request.__schema__(:fields))
+
+    assert Enum.sort(content.request_events ++ safe.request_events) ==
+             Enum.sort(RequestEvent.__schema__(:fields))
+  end
+
+  defp create_attrs do
+    %{
+      body_hash: <<1, 2, 3>>,
+      canonical_request: %{
+        "endpoint" => "responses",
+        "model_ref" => %{"model_id" => "model", "version" => "v1"},
+        "input_items" => [%{"role" => "user", "content" => @prompt}],
+        "rendered_prompt" => @prompt,
+        "input_token_count" => 12,
+        "stream" => false,
+        "stream_include_usage" => false,
+        "sampling" => %{
+          "temperature" => 0.5,
+          "top_p" => 0.9,
+          "max_output_tokens" => 64,
+          "stop" => ["private stop"],
+          "seed" => 7
+        },
+        "response_format" => %{"type" => "text"},
+        "tooling" => %{
+          "tools" => [
+            %{
+              "function" => %{
+                "name" => "private_tool",
+                "description" => "private tool description"
+              }
+            }
+          ],
+          "requested_tools" => [],
+          "tool_choice" => nil,
+          "registry_snapshot" => %{"entries" => []},
+          "execution_snapshot" => %{"entries" => []}
+        },
+        "metadata" => %{"note" => "private metadata"},
+        "admission" => %{"timeout_ms" => 30_000},
+        "resolved_policy" => %{"residency_preference" => "allow_cold_load"}
+      },
+      request_payload: %{"prompt" => @prompt},
+      sampling_params: %{
+        "temperature" => 0.5,
+        "top_p" => 0.9,
+        "max_output_tokens" => 64,
+        "stop" => ["private stop"],
+        "seed" => 7
+      },
+      response_format: %{"type" => "text"}
+    }
+  end
+
+  defp terminal_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        state: :completed,
+        response_payload: %{
+          "output_text" => @response,
+          "echoed_prompt" => @prompt
+        },
+        response_preview: @response,
+        error_code: "runtime_failure",
+        error_message: "runtime echoed #{@prompt}"
+      },
+      overrides
+    )
+  end
+
+  defp event_attrs do
+    %{
+      event_type: "request_step.proposed",
+      payload: %{
+        "step_id" => "turn-1",
+        "step_type" => "inference_turn",
+        "turn_index" => 0,
+        "attempt" => 1,
+        "boundary" => "post_observation",
+        "result" => %{
+          "finish_reason" => "tool_calls",
+          "arguments_json" => @arguments,
+          "error_message" => "runtime echoed #{@prompt}"
+        }
+      }
+    }
+  end
+end

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -134,7 +134,8 @@ defmodule Orchard.Requests.CapturePolicyTest do
           :metadata,
           terminal_attrs(%{
             response_payload: %{"output_text" => long_response},
-            response_preview: long_response
+            response_preview: long_response,
+            response_preview_source: :assistant_text
           })
         )
 
@@ -170,7 +171,8 @@ defmodule Orchard.Requests.CapturePolicyTest do
             mode,
             terminal_attrs(%{
               response_payload: %{"output_text" => content},
-              response_preview: content
+              response_preview: content,
+              response_preview_source: :assistant_text
             })
           )
 
@@ -180,6 +182,21 @@ defmodule Orchard.Requests.CapturePolicyTest do
         prefix = String.trim_trailing(attrs.response_preview, "…")
         prefix_graphemes = String.graphemes(prefix)
         assert Enum.take(String.graphemes(content), length(prefix_graphemes)) == prefix_graphemes
+      end
+    end
+
+    test "restricted modes retain only closed stable error codes" do
+      for mode <- [:none, :metadata] do
+        assert CapturePolicy.terminal_attrs(mode, %{error_code: "queue_timeout"}).error_code ==
+                 "queue_timeout"
+
+        attrs =
+          CapturePolicy.terminal_attrs(mode, %{
+            error_code: "runtime echoed #{@prompt}"
+          })
+
+        assert attrs.error_code == "internal_error"
+        refute inspect(attrs) =~ @prompt
       end
     end
   end

--- a/apps/orchard_controller/test/orchard/requests/idempotency_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/idempotency_test.exs
@@ -50,6 +50,7 @@ defmodule Orchard.Requests.IdempotencyTest do
         body_hash: context.body_hash,
         stream: false,
         state: :completed,
+        payload_capture_mode: :full,
         response_payload: %{"id" => "req_replay", "object" => "chat.completion"}
       })
 
@@ -71,6 +72,7 @@ defmodule Orchard.Requests.IdempotencyTest do
         body_hash: context.body_hash,
         stream: false,
         state: :completed,
+        payload_capture_mode: :full,
         response_payload: %{"id" => "req_replay_steps", "object" => "chat.completion"}
       })
 
@@ -206,6 +208,7 @@ defmodule Orchard.Requests.IdempotencyTest do
       body_hash: context_a.body_hash,
       stream: false,
       state: :completed,
+      payload_capture_mode: :full,
       response_payload: %{"id" => "req_tenant_a"}
     })
 

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -816,7 +816,8 @@ defmodule Orchard.RequestsTest do
 
   describe "record_schedule/2" do
     test "persists scheduler_decision as normalized JSON-safe map" do
-      request = create_request!(%{public_id: "req_schedule_1"})
+      request =
+        create_request!(%{public_id: "req_schedule_1", payload_capture_mode: :full})
 
       schedule = %{
         strategy: :single_node,
@@ -854,7 +855,9 @@ defmodule Orchard.RequestsTest do
     end
 
     test "recursively normalizes multi-node metadata into JSON-safe values" do
-      request = create_request!(%{public_id: "req_schedule_nested"})
+      request =
+        create_request!(%{public_id: "req_schedule_nested", payload_capture_mode: :full})
+
       node_id = Ecto.UUID.generate()
 
       schedule = %{

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -30,6 +30,26 @@ defmodule Orchard.RequestsTest do
     end
   end
 
+  test "create_request/1 sanitizes fail-closed when the capture mode is unresolvable" do
+    attrs =
+      request_attrs(%{
+        canonical_request: %{"rendered_prompt" => "private prompt"},
+        request_payload: %{"prompt" => "private prompt"},
+        sampling_params: %{"temperature" => 0.7, "stop" => ["private stop"]},
+        scheduler_decision: %{"prompt" => "private prompt"}
+      })
+      |> Map.put(:payload_capture_mode, "everything")
+
+    assert {:error, %Ecto.Changeset{} = changeset} = Requests.create_request(attrs)
+
+    refute Map.has_key?(changeset.changes, :canonical_request)
+    refute Map.has_key?(changeset.changes, :request_payload)
+    refute Map.has_key?(changeset.changes, :request_shape)
+    assert get_change(changeset, :sampling_params) == %{"temperature" => 0.7, "stop_count" => 1}
+    assert get_change(changeset, :scheduler_decision) == %{}
+    refute inspect(changeset) =~ "private"
+  end
+
   test "create_request/1 enforces the capture policy on string-keyed attrs" do
     attrs =
       request_attrs()

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -315,7 +315,12 @@ defmodule Orchard.RequestsTest do
     end
 
     test "atomically commits failure-shaped terminal step rows with the terminal request update" do
-      request = create_request!(%{public_id: "req_terminal_steps_failure", state: :running})
+      request =
+        create_request!(%{
+          public_id: "req_terminal_steps_failure",
+          state: :running,
+          payload_capture_mode: :full
+        })
 
       assert {:ok, updated_request} =
                Requests.mark_terminal_with_step_events(

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -8,6 +8,10 @@ defmodule Orchard.RequestsTest do
   alias Orchard.Requests
   alias Orchard.Requests.{Request, RequestStepEvent}
 
+  @safe_call_id "sha256:" <>
+                  (:crypto.hash(:sha256, "call_1") |> Base.encode16(case: :lower))
+  @safe_tool_call_step_id "tool_call:t1:c#{@safe_call_id}"
+
   test "create_request/1 supports early lifecycle rows before model resolution and canonicalization" do
     attrs = request_attrs()
     assert {:ok, request} = Requests.create_request(attrs)
@@ -120,7 +124,7 @@ defmodule Orchard.RequestsTest do
     assert event.seq == 1
     assert event.event_type == "request.received"
     assert event.occurred_at == occurred_at
-    assert event.payload == %{"phase" => "ingress"}
+    assert event.payload == %{}
   end
 
   test "append_request_event/2 preserves atom-keyed occurred_at when provided" do
@@ -171,7 +175,7 @@ defmodule Orchard.RequestsTest do
 
     assert Enum.map(Requests.list_request_step_events(request), &{&1.seq, &1.step_id}) == [
              {2, "inference_turn:t1:a1"},
-             {3, "tool_call:t1:ccall_1"}
+             {3, @safe_tool_call_step_id}
            ]
 
     assert Enum.map(Requests.list_request_events(request), &{&1.seq, &1.event_type, &1.state}) ==
@@ -275,7 +279,7 @@ defmodule Orchard.RequestsTest do
 
       assert Enum.map(Requests.list_request_step_events(request), &{&1.event_type, &1.step_id}) ==
                [
-                 {"request_step.proposed", "tool_call:t1:ccall_1"},
+                 {"request_step.proposed", @safe_tool_call_step_id},
                  {"request_step.completed", "inference_turn:t1:a1"}
                ]
 
@@ -389,7 +393,7 @@ defmodule Orchard.RequestsTest do
 
       assert Enum.map(Requests.list_request_step_events(request), &{&1.event_type, &1.step_id}) ==
                [
-                 {"request_step.proposed", "tool_call:t1:ccall_1"},
+                 {"request_step.proposed", @safe_tool_call_step_id},
                  {"request_step.completed", "inference_turn:t1:a1"}
                ]
     end

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -382,6 +382,9 @@ defmodule Orchard.RequestsTest do
                  [inference_turn_completed_step_attrs(%{result: %{"finish_reason" => nil}})]
                )
 
+      assert [%RequestStepEvent{result: %{"finish_reason_invalid" => true}}] =
+               Requests.list_request_step_events(invalid_reason)
+
       assert {:error, {:inconclusive, :invalid_finish_reason}} =
                Requests.classify_missing_terminal_candidate(invalid_reason)
 

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -6,7 +6,7 @@ defmodule Orchard.RequestsTest do
   alias Orchard.Governance
   alias Orchard.Models
   alias Orchard.Requests
-  alias Orchard.Requests.{Request, RequestStepEvent}
+  alias Orchard.Requests.{Request, RequestEvent, RequestStepEvent}
 
   @safe_call_id "sha256:" <>
                   (:crypto.hash(:sha256, "call_1") |> Base.encode16(case: :lower))
@@ -20,6 +20,56 @@ defmodule Orchard.RequestsTest do
     assert request.model_id == nil
     assert request.canonical_request == nil
     assert request.requested_model == attrs.requested_model
+  end
+
+  test "create_request/1 returns a changeset error when the capture mode is missing or unknown" do
+    for mode <- [nil, "", "everything", :everything] do
+      attrs = request_attrs() |> Map.put(:payload_capture_mode, mode)
+
+      assert {:error, %Ecto.Changeset{}} = Requests.create_request(attrs)
+    end
+  end
+
+  test "create_request/1 enforces the capture policy on string-keyed attrs" do
+    attrs =
+      request_attrs()
+      |> Map.put(:canonical_request, %{"rendered_prompt" => "private prompt"})
+      |> Map.put(:request_payload, %{"prompt" => "private prompt"})
+      |> Map.put(:scheduler_decision, %{"prompt" => "private prompt"})
+      |> Map.new(fn {key, value} -> {Atom.to_string(key), value} end)
+      |> Map.put("payload_capture_mode", "metadata")
+
+    assert {:ok, request} = Requests.create_request(attrs)
+
+    assert request.payload_capture_mode == :metadata
+    assert request.canonical_request == nil
+    assert request.request_payload == nil
+    assert request.request_shape["capture_mode"] == "metadata"
+    assert request.scheduler_decision == %{}
+    refute inspect(request) =~ "private prompt"
+  end
+
+  test "list_request_step_events/1 skips step rows that legacy purges left unreadable" do
+    request = create_request!(%{payload_capture_mode: :metadata})
+
+    assert {:ok, _step_events} =
+             Requests.append_request_step_events(request, [inference_turn_completed_step_attrs()])
+
+    Repo.update_all(
+      from(event in RequestEvent, where: event.request_id == ^request.id),
+      set: [payload: %{}]
+    )
+
+    assert {:ok, _step_events} =
+             Requests.append_request_step_events(request, [
+               inference_turn_completed_step_attrs(%{
+                 event_type: "request_step.failed",
+                 result: %{"finish_reason" => "error"}
+               })
+             ])
+
+    assert [%RequestStepEvent{event_type: "request_step.failed"}] =
+             Requests.list_request_step_events(request)
   end
 
   test "create_request/1 rejects service-account provenance without service_account_id" do

--- a/apps/orchard_node_agent/lib/orchard/node/shared_contract.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/shared_contract.ex
@@ -1,6 +1,10 @@
 defmodule Orchard.Node.SharedContract do
   @moduledoc false
 
+  alias Orchard.CanonicalRequest
+  alias Orchard.CanonicalRequest.ModelRef
+
+  @spec request_model_ref(CanonicalRequest.t()) :: ModelRef.t()
   defdelegate request_model_ref(request), to: Orchard.SharedContract
   defdelegate event_kind(event), to: Orchard.SharedContract
   defdelegate manifest_proto_model_ref(manifest), to: Orchard.SharedContract

--- a/apps/orchard_shared/lib/orchard/canonical_request.ex
+++ b/apps/orchard_shared/lib/orchard/canonical_request.ex
@@ -109,6 +109,7 @@ defmodule Orchard.CanonicalRequest do
             rendered_prompt: nil,
             input_token_count: 0,
             prompt_token_ids: nil,
+            store?: true,
             stream?: false,
             stream_include_usage: false,
             sampling: nil,
@@ -135,6 +136,7 @@ defmodule Orchard.CanonicalRequest do
           rendered_prompt: binary() | nil,
           input_token_count: non_neg_integer(),
           prompt_token_ids: [non_neg_integer()] | nil,
+          store?: boolean(),
           stream?: boolean(),
           stream_include_usage: boolean(),
           sampling: Sampling.t(),
@@ -177,6 +179,7 @@ defmodule Orchard.CanonicalRequest do
     |> validate_rendered_prompt!()
     |> validate_input_token_count!()
     |> validate_tokenization_state!()
+    |> validate_store!()
     |> validate_stream!()
     |> validate_sampling!()
     |> validate_tooling!()
@@ -382,6 +385,13 @@ defmodule Orchard.CanonicalRequest do
   defp validate_stream!(%__MODULE__{stream?: stream?, stream_include_usage: include_usage}) do
     raise ArgumentError,
           "#{inspect(__MODULE__)} stream? must be a boolean and stream_include_usage must be a boolean, got: #{inspect({stream?, include_usage})}"
+  end
+
+  defp validate_store!(%__MODULE__{store?: store?} = struct) when is_boolean(store?), do: struct
+
+  defp validate_store!(%__MODULE__{store?: store?}) do
+    raise ArgumentError,
+          "#{inspect(__MODULE__)} store? must be a boolean, got: #{inspect(store?)}"
   end
 
   defp validate_sampling!(%__MODULE__{sampling: %Sampling{} = sampling} = struct) do

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -278,7 +278,7 @@ A durable governance or security event record for significant administrative and
 _Avoid_: Support Bundle, debug log, structured log, trace span
 
 **Payload Capture Mode**:
-A tenant setting that controls how much prompt and response payload data Orchard may retain.
+A tenant setting that controls how much prompt and response payload data Orchard may retain, resolved into an effective mode that each Request snapshots for its whole lifetime.
 _Avoid_: Audit Log, Support Bundle, logging level
 
 ### Requests and Inference

--- a/openspec/changes/enforce-inference-capture-modes/design.md
+++ b/openspec/changes/enforce-inference-capture-modes/design.md
@@ -32,6 +32,8 @@ Streaming `full` requests assemble and persist the final response only at termin
 ## Persistence boundary
 
 One pure `Orchard.Requests.CapturePolicy` transforms create attributes, terminal attributes, and request event payloads.
+For non-`full` event and scheduler payloads, the policy validates both field names and values through field-specific numeric, boolean, UUID, timestamp, exact-match, and closed-enum rules.
+Tool-call identifiers needed for step correlation are replaced by deterministic hashes, while tool names and raw target references are removed.
 `Orchard.Requests` applies it after locking or resolving the authoritative Request snapshot and before every database write.
 Serializers remain responsible for API response construction and do not decide retention.
 
@@ -56,7 +58,7 @@ No retry path may consult current Tenant policy to widen a source Request snapsh
 ## Existing-row treatment and purge
 
 Existing `metadata` and `none` rows are treated as mislabeled.
-The migration derives approved hashes and bounded metadata artifacts where possible, removes full request and response payloads, removes raw previews and error text that do not meet the target mode, and strips content-bearing request event results.
+The migration derives approved hashes and bounded metadata artifacts where possible, removes full request and response payloads, removes raw previews and error text that do not meet the target mode, and clears legacy scheduler decisions and Request-event payloads that cannot be proven safe through SQL-level typed validation.
 After cleanup, named constraints are validated.
 
 The regression verifier explicitly classifies `requests.canonical_request`, `requests.request_payload`, `requests.response_payload`, `requests.response_preview`, `requests.request_shape`, `requests.sampling_params`, `requests.response_format`, `requests.scheduler_decision`, `requests.error_message`, and `request_events.payload`.

--- a/openspec/changes/enforce-inference-capture-modes/design.md
+++ b/openspec/changes/enforce-inference-capture-modes/design.md
@@ -36,6 +36,8 @@ Streaming `full` requests assemble and persist the final response only at termin
 One pure `Orchard.Requests.CapturePolicy` transforms create attributes, terminal attributes, and request event payloads.
 For non-`full` event and scheduler payloads, the policy validates both field names and values through field-specific numeric, boolean, UUID, timestamp, exact-match, and closed-enum rules.
 Restricted terminal writes validate error codes against a closed vocabulary and replace unknown runtime values with `internal_error`.
+Restricted inference results retain normalized stable error codes and derive boolean `finish_reason_invalid` or `result_invalid` markers when rejected evidence was present.
+These markers contain none of the rejected value and keep missing-terminal detection inconclusive rather than converting malformed evidence into a candidate.
 The scheduler allowlist retains the opaque cache-affinity HMAC and only its closed typed feedback fields because later placement queries require that non-recoverable key.
 Tool-call identifiers needed for step correlation are replaced by deterministic hashes, while tool names and raw target references are removed.
 `Orchard.Requests` applies it after locking or resolving the authoritative Request snapshot and before every database write.

--- a/openspec/changes/enforce-inference-capture-modes/design.md
+++ b/openspec/changes/enforce-inference-capture-modes/design.md
@@ -22,6 +22,8 @@ It stores no request shape, preview, canonical payload, response payload, raw to
 
 `metadata` additionally keeps a fixed allowlisted request shape and an optional non-equivalent preview.
 The shape contains counts, types, lengths, approved identifiers, and hashes, but no caller metadata values, stop text, tool definitions, tool arguments, rendered prompt, or input content.
+A closed non-persisted provenance marker distinguishes assistant-text previews from tool-derived previews.
+Only explicitly marked assistant text is eligible for a metadata preview; tool-derived, missing, or unknown provenance is dropped.
 A metadata preview is stored only when source text exceeds 512 Unicode code points.
 It contains complete source grapheme clusters totaling at most 511 Unicode code points plus one ellipsis, so the retained preview can never equal the complete source.
 
@@ -33,12 +35,13 @@ Streaming `full` requests assemble and persist the final response only at termin
 
 One pure `Orchard.Requests.CapturePolicy` transforms create attributes, terminal attributes, and request event payloads.
 For non-`full` event and scheduler payloads, the policy validates both field names and values through field-specific numeric, boolean, UUID, timestamp, exact-match, and closed-enum rules.
+Restricted terminal writes validate error codes against a closed vocabulary and replace unknown runtime values with `internal_error`.
 The scheduler allowlist retains the opaque cache-affinity HMAC and only its closed typed feedback fields because later placement queries require that non-recoverable key.
 Tool-call identifiers needed for step correlation are replaced by deterministic hashes, while tool names and raw target references are removed.
 `Orchard.Requests` applies it after locking or resolving the authoritative Request snapshot and before every database write.
 Serializers remain responsible for API response construction and do not decide retention.
 
-Database constraints reject canonical requests, request payloads, or response payloads on a non-`full` row.
+Database constraints reject canonical requests, request payloads, response payloads, raw error messages, or unknown error codes on a non-`full` row.
 They also reject previews over 512 characters and any preview on a `none` row.
 Request events require application enforcement because a row-level CHECK cannot reference the parent Request.
 
@@ -59,7 +62,7 @@ No retry path may consult current Tenant policy to widen a source Request snapsh
 ## Existing-row treatment and purge
 
 Existing `metadata` and `none` rows are treated as mislabeled.
-The migration derives approved hashes and bounded metadata artifacts where possible, removes full request and response payloads, removes raw previews and error text that do not meet the target mode, retains only a syntactically valid cache-affinity HMAC with its closed typed feedback fields, and clears all other legacy scheduler decisions and Request-event payloads that cannot be proven safe through SQL-level typed validation.
+The migration derives approved hashes and bounded metadata artifacts where possible, removes full request and response payloads, removes raw previews and error text that do not meet the target mode, normalizes unknown error codes to `internal_error`, retains only a syntactically valid cache-affinity HMAC with its closed typed feedback fields, and clears all other legacy scheduler decisions and Request-event payloads that cannot be proven safe through SQL-level typed validation.
 After cleanup, named constraints are validated.
 
 The regression verifier explicitly classifies `requests.canonical_request`, `requests.request_payload`, `requests.response_payload`, `requests.response_preview`, `requests.request_shape`, `requests.sampling_params`, `requests.response_format`, `requests.scheduler_decision`, `requests.error_message`, and `request_events.payload`.

--- a/openspec/changes/enforce-inference-capture-modes/design.md
+++ b/openspec/changes/enforce-inference-capture-modes/design.md
@@ -41,6 +41,7 @@ These markers contain none of the rejected value and keep missing-terminal detec
 The scheduler allowlist retains the opaque cache-affinity HMAC and only its closed typed feedback fields because later placement queries require that non-recoverable key.
 Tool-call identifiers needed for step correlation are replaced by deterministic hashes, while tool names and raw target references are removed.
 `Orchard.Requests` applies it after locking or resolving the authoritative Request snapshot and before every database write.
+A write that reaches the boundary without a resolvable mode is sanitized under the strictest mode rather than stored verbatim.
 Serializers remain responsible for API response construction and do not decide retention.
 
 Database constraints reject canonical requests, request payloads, response payloads, raw error messages, or unknown error codes on a non-`full` row.

--- a/openspec/changes/enforce-inference-capture-modes/design.md
+++ b/openspec/changes/enforce-inference-capture-modes/design.md
@@ -1,0 +1,69 @@
+# Design: Enforce inference capture modes
+
+## Context
+
+The current Request row contains multiple content-bearing fields, and `request_events.payload` can carry additional model output.
+Serializer-only enforcement would miss QueueManager and RequestServer write paths.
+The Requests context is the narrowest shared persistence boundary for every current writer.
+
+## Resolution and snapshot
+
+The capture lattice is `none < metadata < full`.
+The Tenant setting resolves at logical Request creation.
+For the Responses API, `store=false` caps the effective mode at `metadata`.
+The resulting mode is stored in `requests.payload_capture_mode` and remains authoritative for later terminal and event writes.
+Later Tenant policy changes do not widen an existing Request.
+A future retry may use only the narrower of its source Request snapshot and the then-current Tenant policy.
+
+## Per-mode data model
+
+`none` keeps request and response hashes, token usage, stable error codes, state, timestamps, and required operational metadata.
+It stores no request shape, preview, canonical payload, response payload, raw tool argument, or raw runtime error text.
+
+`metadata` additionally keeps a fixed allowlisted request shape and an optional non-equivalent preview.
+The shape contains counts, types, lengths, approved identifiers, and hashes, but no caller metadata values, stop text, tool definitions, tool arguments, rendered prompt, or input content.
+A metadata preview is stored only when source text exceeds 512 Unicode code points.
+It contains complete source grapheme clusters totaling at most 511 Unicode code points plus one ellipsis, so the retained preview can never equal the complete source.
+
+`full` may keep the approved canonical request and final response.
+Its convenience preview remains bounded to 512 Unicode code points without splitting a grapheme cluster.
+Streaming `full` requests assemble and persist the final response only at terminal completion, not as per-chunk durable writes.
+
+## Persistence boundary
+
+One pure `Orchard.Requests.CapturePolicy` transforms create attributes, terminal attributes, and request event payloads.
+`Orchard.Requests` applies it after locking or resolving the authoritative Request snapshot and before every database write.
+Serializers remain responsible for API response construction and do not decide retention.
+
+Database constraints reject canonical requests, request payloads, or response payloads on a non-`full` row.
+They also reject previews over 512 characters and any preview on a `none` row.
+Request events require application enforcement because a row-level CHECK cannot reference the parent Request.
+
+## Hashes and previews
+
+`body_hash` remains the request integrity anchor.
+Requests without an idempotency key receive a deterministic hash of the serialized canonical request.
+`response_hash` is SHA-256 over the complete serialized terminal response before capture transformation.
+Hashes do not authorize replay and are never treated as recoverable content.
+
+## Replay and retry
+
+Idempotent replay requires a retained response payload.
+Completed `none` and `metadata` Requests therefore return the existing `idempotency_not_replayable` conflict instead of reconstructing or widening capture.
+Future operator retry returns `retry_source_unavailable` when the source canonical request was not retained.
+No retry path may consult current Tenant policy to widen a source Request snapshot.
+
+## Existing-row treatment and purge
+
+Existing `metadata` and `none` rows are treated as mislabeled.
+The migration derives approved hashes and bounded metadata artifacts where possible, removes full request and response payloads, removes raw previews and error text that do not meet the target mode, and strips content-bearing request event results.
+After cleanup, named constraints are validated.
+
+The regression verifier explicitly classifies `requests.canonical_request`, `requests.request_payload`, `requests.response_payload`, `requests.response_preview`, `requests.request_shape`, `requests.sampling_params`, `requests.response_format`, `requests.scheduler_decision`, `requests.error_message`, and `request_events.payload`.
+It fails when a newly added text, JSON, or binary request column is not classified.
+
+## Rejected alternatives
+
+Relabeling old rows as `full` would preserve content captured under a false metadata label and would not satisfy the owner decision.
+A short-lived replay side table would recreate the same prohibited retention obligation.
+Database triggers for request events add cross-row write complexity and are deferred until application enforcement and drift tests prove insufficient.

--- a/openspec/changes/enforce-inference-capture-modes/design.md
+++ b/openspec/changes/enforce-inference-capture-modes/design.md
@@ -33,6 +33,7 @@ Streaming `full` requests assemble and persist the final response only at termin
 
 One pure `Orchard.Requests.CapturePolicy` transforms create attributes, terminal attributes, and request event payloads.
 For non-`full` event and scheduler payloads, the policy validates both field names and values through field-specific numeric, boolean, UUID, timestamp, exact-match, and closed-enum rules.
+The scheduler allowlist retains the opaque cache-affinity HMAC and only its closed typed feedback fields because later placement queries require that non-recoverable key.
 Tool-call identifiers needed for step correlation are replaced by deterministic hashes, while tool names and raw target references are removed.
 `Orchard.Requests` applies it after locking or resolving the authoritative Request snapshot and before every database write.
 Serializers remain responsible for API response construction and do not decide retention.
@@ -58,7 +59,7 @@ No retry path may consult current Tenant policy to widen a source Request snapsh
 ## Existing-row treatment and purge
 
 Existing `metadata` and `none` rows are treated as mislabeled.
-The migration derives approved hashes and bounded metadata artifacts where possible, removes full request and response payloads, removes raw previews and error text that do not meet the target mode, and clears legacy scheduler decisions and Request-event payloads that cannot be proven safe through SQL-level typed validation.
+The migration derives approved hashes and bounded metadata artifacts where possible, removes full request and response payloads, removes raw previews and error text that do not meet the target mode, retains only a syntactically valid cache-affinity HMAC with its closed typed feedback fields, and clears all other legacy scheduler decisions and Request-event payloads that cannot be proven safe through SQL-level typed validation.
 After cleanup, named constraints are validated.
 
 The regression verifier explicitly classifies `requests.canonical_request`, `requests.request_payload`, `requests.response_payload`, `requests.response_preview`, `requests.request_shape`, `requests.sampling_params`, `requests.response_format`, `requests.scheduler_decision`, `requests.error_message`, and `request_events.payload`.

--- a/openspec/changes/enforce-inference-capture-modes/proposal.md
+++ b/openspec/changes/enforce-inference-capture-modes/proposal.md
@@ -1,0 +1,30 @@
+# Enforce inference capture modes
+
+## Why
+
+Orchard labels every inference Request as `metadata` capture while retaining the full canonical request and, for non-streaming success, the full response.
+Request event payloads can also retain model-generated tool arguments and untrusted error text.
+This conflicts with `SPEC.md` section 10.10 and prevents an accurate privacy or retention statement.
+
+## What changes
+
+- Persist and validate the Tenant request-body capture mode with `metadata` as the default.
+- Resolve an effective mode for each logical Request and snapshot it on the Request row.
+- Enforce `none`, `metadata`, and `full` at the Requests persistence boundary for request rows and request events.
+- Define bounded metadata shape, non-equivalent previews, request and response hashes, stable error codes, and content-bearing column constraints.
+- Make `store=false` narrow `full` to `metadata` and never widen Tenant policy.
+- Define idempotency replay and future operator retry behavior when source payloads are intentionally unavailable.
+- Purge existing mislabeled rows and verify every enumerated content-bearing column.
+
+## SPEC.md impact
+
+This change reconciles `SPEC.md` sections 7.3.4, 7.4.2, the requests schema in section 9, and section 10.10.
+It makes `canonical_request` nullable outside `full`, defines the metadata-only shape and preview bounds, and records fail-safe replay and retry behavior.
+
+## Out of scope
+
+- Automatic inference retry.
+- A general retention scheduler.
+- Backup expiry, WAL recycling, or cryptographic erasure.
+- Sentry or other external telemetry filtering.
+- A new Tenant administration API beyond accepting the capture field in existing governance creation paths.

--- a/openspec/changes/enforce-inference-capture-modes/specs/inference-capture/spec.md
+++ b/openspec/changes/enforce-inference-capture-modes/specs/inference-capture/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Capture Mode Resolution Is Durable And Never Widens
+
+Orchard SHALL persist a validated Tenant request-body capture mode of `none`, `metadata`, or `full`, defaulting to `metadata`.
+Orchard SHALL resolve and snapshot the effective mode on each logical Request before its first persistence write.
+For the Responses API, `store=false` SHALL cap `full` at `metadata` and SHALL NOT widen `none` or `metadata`.
+All attempts and terminal writes for a logical Request MUST use its snapshot.
+This requirement refines `SPEC.md` sections 7.4.2 and 10.10.
+
+#### Scenario: Store false narrows a full Tenant
+
+- **WHEN** a Tenant policy is `full` and a Responses request sets `store=false`
+- **THEN** Orchard snapshots `metadata`
+- **AND** the HTTP response remains complete
+- **AND** durable persistence follows `metadata`
+
+#### Scenario: Later Tenant change does not widen an active Request
+
+- **WHEN** a Request snapshots `none`
+- **AND** the Tenant policy later changes to `full`
+- **THEN** every later event and terminal write remains governed by `none`
+
+### Requirement: Capture Modes Bound Every Persisted Content Field
+
+Orchard SHALL enforce capture policy at the Requests persistence boundary for Request rows and request event payloads.
+`none` SHALL retain hashes, usage, stable error codes, state, timestamps, and required operational metadata but no prompt, response, preview, raw tool argument, or raw runtime error text.
+`metadata` SHALL additionally retain only an allowlisted bounded shape and an optional non-equivalent preview.
+A metadata preview SHALL exist only when its source exceeds 512 Unicode code points and SHALL contain complete source grapheme clusters totaling at most 511 Unicode code points plus one ellipsis.
+`full` MAY retain approved canonical request and response payloads, and its convenience preview SHALL remain at most 512 Unicode code points without splitting a grapheme cluster.
+This requirement refines `SPEC.md` section 10.10.
+
+#### Scenario: Metadata row cannot contain full content
+
+- **WHEN** a caller submits short or long prompt, tool, and response content under `metadata`
+- **THEN** no persisted Request or request event field contains the complete prompt, complete response, tool arguments, caller metadata values, stop text, or raw runtime error
+- **AND** any retained preview is not equal to its complete source
+
+#### Scenario: Full streaming persists one terminal response
+
+- **WHEN** a `full` streaming Request completes
+- **THEN** Orchard persists the approved assembled final response
+- **AND** Orchard does not persist individual stream chunks as separate content copies
+
+### Requirement: Replay And Retry Fail Safely Without Source Content
+
+Idempotent replay SHALL require a retained response payload.
+A matching completed Request without one SHALL return `idempotency_not_replayable`.
+A future operator retry SHALL return `retry_source_unavailable` when its source canonical request is absent.
+Any future retry Request MUST snapshot a mode no wider than both its source Request and the current Tenant policy.
+This requirement refines `SPEC.md` section 7.3.4 and section 10.10.
+
+#### Scenario: Metadata request is not replayable
+
+- **WHEN** a completed `metadata` Request is repeated with the same idempotency key and body hash
+- **THEN** Orchard returns `idempotency_not_replayable`
+- **AND** Orchard does not reconstruct or recover the omitted response
+
+### Requirement: Existing Mislabeled Rows Are Purged And Verifiable
+
+Orchard SHALL purge existing `none` and `metadata` rows that contain content forbidden by their label.
+The purge SHALL cover every classified content-bearing Request column and `request_events.payload`.
+Named database constraints SHALL reject full request or response payloads on non-`full` rows, previews on `none` rows, and previews over 512 characters.
+A schema-drift regression SHALL fail when a newly added text, JSON, or binary Request column is not classified for capture and purge.
+This requirement refines `SPEC.md` section 10.10.
+
+#### Scenario: Post-migration verification names every content column
+
+- **WHEN** the capture migration completes
+- **THEN** verification checks `canonical_request`, `request_payload`, `response_payload`, `response_preview`, `request_shape`, `sampling_params`, `response_format`, `scheduler_decision`, `error_message`, and `request_events.payload`
+- **AND** no `none` or `metadata` row retains forbidden content

--- a/openspec/changes/enforce-inference-capture-modes/specs/inference-capture/spec.md
+++ b/openspec/changes/enforce-inference-capture-modes/specs/inference-capture/spec.md
@@ -26,7 +26,9 @@ This requirement refines `SPEC.md` sections 7.4.2 and 10.10.
 Orchard SHALL enforce capture policy at the Requests persistence boundary for Request rows and request event payloads.
 `none` SHALL retain hashes, usage, stable error codes, state, timestamps, and required operational metadata but no prompt, response, preview, raw tool argument, or raw runtime error text.
 `metadata` SHALL additionally retain only an allowlisted bounded shape and an optional non-equivalent preview.
+A metadata preview SHALL derive only from assistant text and SHALL NOT derive from a model-generated tool call, tool name, target reference, or tool argument.
 A metadata preview SHALL exist only when its source exceeds 512 Unicode code points and SHALL contain complete source grapheme clusters totaling at most 511 Unicode code points plus one ellipsis.
+Restricted-mode error codes SHALL come from a closed stable vocabulary, and unknown runtime-supplied values SHALL normalize to `internal_error`.
 `full` MAY retain approved canonical request and response payloads, and its convenience preview SHALL remain at most 512 Unicode code points without splitting a grapheme cluster.
 This requirement refines `SPEC.md` section 10.10.
 
@@ -60,7 +62,7 @@ This requirement refines `SPEC.md` section 7.3.4 and section 10.10.
 
 Orchard SHALL purge existing `none` and `metadata` rows that contain content forbidden by their label.
 The purge SHALL cover every classified content-bearing Request column and `request_events.payload`.
-Named database constraints SHALL reject full request or response payloads on non-`full` rows, previews on `none` rows, and previews over 512 characters.
+Named database constraints SHALL reject full request or response payloads on non-`full` rows, previews on `none` rows, previews over 512 characters, and unknown error codes on restricted rows.
 A schema-drift regression SHALL fail when a newly added text, JSON, or binary Request column is not classified for capture and purge.
 This requirement refines `SPEC.md` section 10.10.
 

--- a/openspec/changes/enforce-inference-capture-modes/tasks.md
+++ b/openspec/changes/enforce-inference-capture-modes/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+- [x] 1.1 Reconcile `SPEC.md` capture, retry, replay, schema, and purge behavior.
+- [x] 1.2 Validate this OpenSpec change strictly.
+- [x] 2.1 Add and validate the Tenant capture-mode setting and Request capture metadata.
+- [x] 2.2 Implement the pure capture policy with red-first mode, shape, preview, hash, and event tests.
+- [x] 2.3 Enforce the Request snapshot in every Requests create, terminal, schedule, and event write path.
+- [x] 2.4 Make `store=false` narrow capture without changing the HTTP response.
+- [x] 2.5 Persist full terminal output for `full` streaming Requests.
+- [x] 3.1 Purge existing mislabeled rows and validate database constraints.
+- [x] 3.2 Add column-enumerated purge and schema-drift verification.
+- [x] 4.1 Cover Chat Completions and Responses stream and non-stream success and failure across all modes.
+- [x] 4.2 Cover replay, unavailable-source retry semantics, and no-widening invariants.
+- [x] 5.1 Run the full Elixir quality and coverage workflow.
+- [ ] 5.2 Complete independent Fable, Kimi, Grok, Oracle, and No Mistakes reviews.


### PR DESCRIPTION
## Intent

Repair PR #135's deterministic CI integration failures without weakening issue #119 restricted capture or issue #120 detector criteria. Restricted inference results must retain normalized stable error codes, strip raw error text and rejected values, preserve only closed boolean markers for present-invalid finish reasons and malformed results, classify those markers fail-closed, and keep runtime and legacy migration sanitization exactly aligned. Keep the PR narrow with no schema or public API expansion.

## What Changed

- Added `Orchard.Requests.CapturePolicy` and wired it into every request write path (create, terminal update, step events, scheduler persistence) so rows are sanitized against the resolved `none`/`metadata`/`full` mode: restricted rows keep bounded shape, preview, request/response hashes and normalized stable error codes while raw prompts, responses, sampling text, scheduler detail and untrusted error text are dropped. An unresolvable or unrecognized mode now fails closed instead of passing attrs through unsanitized, and `store=false` narrows `full` to `metadata` without ever widening tenant policy.
- Extended the schema narrowly: `tenants.request_body_capture_mode` (`Ecto.Enum`, default `metadata`, accepted by the existing governance creation path) and `requests.request_shape` / `requests.response_hash`, backed by new check constraints for absent non-`full` content, absent `none` shape/preview, bounded previews, and stable non-`full` error codes. The migration backfills modes and purges mislabeled legacy request rows and step-event payloads using SQL kept byte-identical to the runtime `metadata` sanitizer.
- Restricted terminal evidence now retains only closed boolean markers for present-but-invalid finish reasons and malformed results, and the missing-terminal-candidate detector classifies those markers fail-closed; step-event reads tolerate collapsed legacy payloads. Serializers, the request orchestrator, and the responses normalizer thread the capture mode through, and `SPEC.md`, the glossary, and the `enforce-inference-capture-modes` OpenSpec package were reconciled with the implemented behavior — including that idempotent replay is not available when the stored response payload is intentionally absent.

## Risk Assessment

⚠️ Medium: The two accepted fixes landed correctly and introduce no new defects, but the branch as a whole still carries an irreversible legacy data-purge migration and a default-on change to idempotent replay behavior — both deliberate, SPEC-documented, and explicitly accepted by the author, yet significant enough that this is not a low-risk change.

## Testing

Both CI test steps (`mix test` and `mix test --cover`) pass clean across all four umbrella apps with no failures or flakes, so the deterministic CI integration failures the change set out to repair are gone. Beyond the suites, I stood up an isolated dev database and Phoenix server and exercised the behavior the way an operator would experience it: a metadata-mode organization's inference result carrying a raw MLX error message, a runtime-echoed error code, and an out-of-vocabulary finish reason was persisted as only a normalized `internal_error` code plus a bare `finish_reason_invalid` boolean, a non-map result under capture mode `none` collapsed to `result_invalid`, both markers classified fail-closed as inconclusive rather than becoming detector candidates, an unresolvable capture mode was rejected with the changeset already sanitized to the strictest shape, and all seven legacy result shapes produced byte-identical payloads from the migration SQL and the runtime sanitizer. A full pg_dump of the evidence database contained zero occurrences of the seeded secret. Because the Console request detail page is the surface where these payloads reach an operator, I captured screenshots of it for both the restricted and malformed requests showing the sanitized timeline payloads, "Payload Capture: metadata/none", and "Not captured for this request." across every restricted field. Afterwards I stopped the server, closed the browser session, dropped the evidence database, and confirmed the worktree is clean.

- Evidence: Console request detail — restricted (metadata) request showing sanitized timeline payload and &#39;Not captured for this request.&#39; fields (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYW6MZBRR5EBWHADHGE7B3Q1/console-restricted-request.png</code>)
- Evidence: Console request detail — malformed non-map runtime result under capture mode &#39;none&#39; rendering result_invalid (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYW6MZBRR5EBWHADHGE7B3Q1/console-malformed-result-request.png</code>)
<details>
<summary>Evidence: End-to-end restricted capture transcript (persisted DB state, detector classification, fail-closed unresolvable mode, runtime/legacy migration alignment)</summary>

<code>3. Inference step result as offered by the runtime vs. what Postgres stores&#10;runtime offered result: %{&#10;&#34;error_code&#34; =&gt; &#34;runtime echoed SECRET-PROMPT-TEXT-customer-said-my-ssn-is-123-45-6789&#34;,&#10;&#34;error_message&#34; =&gt; &#34;MLX worker crashed while generating: SECRET-PROMPT-TEXT-...&#34;,&#10;&#34;finish_reason&#34; =&gt; &#34;assistant refused because SECRET-PROMPT-TEXT-...&#34;,&#10;&#34;input_tokens&#34; =&gt; 42, &#34;output_tokens&#34; =&gt; 0&#10;}&#10;persisted result: %{&#10;&#34;error_code&#34; =&gt; &#34;internal_error&#34;,&#10;&#34;finish_reason_invalid&#34; =&gt; true,&#10;&#34;input_tokens&#34; =&gt; 42,&#10;&#34;output_tokens&#34; =&gt; 0&#10;}&#10;raw error text stored?: false&#10;rejected finish_reason value stored?: false&#10;secret stored?: false&#10;&#10;4. Issue #120 detector classifies the invalid-finish-reason marker fail-closed&#10;classify_missing_terminal_candidate/1: {:error, {:inconclusive, :invalid_finish_reason}}&#10;&#10;5. Malformed (non-map) runtime result under capture mode :none&#10;persisted result: %{&#34;result_invalid&#34; =&gt; true}&#10;classify_missing_terminal_candidate/1: {:error, {:inconclusive, :invalid_terminal_step}}&#10;&#10;6. Unresolvable capture mode falls back to the strictest mode&#10;CapturePolicy.strictest_mode/0: :none&#10;insert rejected with errors: [payload_capture_mode: &#34;is invalid&#34;]&#10;request_payload change kept?: false&#10;canonical_request change kept?: false&#10;sampling_params change: %{&#34;stop_count&#34; =&gt; 1, &#34;temperature&#34; =&gt; 0.7}&#10;scheduler_decision change: %{}&#10;secret anywhere in changeset?: false&#10;&#10;7. Legacy migration purge vs. runtime sanitization (must be identical)&#10;legacy: %{&#34;error_code&#34; =&gt; &#34;request_cancelled&#34;, &#34;error_message&#34; =&gt; SECRET...}&#10;migration SQL: %{&#34;error_code&#34; =&gt; &#34;request_cancelled&#34;} | runtime: same | aligned: true&#10;legacy: %{&#34;error_code&#34; =&gt; &#34;runtime echoed SECRET...&#34;}&#10;migration SQL: %{&#34;error_code&#34; =&gt; &#34;internal_error&#34;} | runtime: same | aligned: true&#10;legacy: %{&#34;finish_reason&#34; =&gt; &#34;stop&#34;}&#10;migration SQL: %{&#34;finish_reason&#34; =&gt; &#34;stop&#34;} | runtime: same | aligned: true&#10;legacy: %{&#34;finish_reason&#34; =&gt; nil}&#10;migration SQL: %{&#34;finish_reason_invalid&#34; =&gt; true} | runtime: same | aligned: true&#10;legacy: %{&#34;finish_reason&#34; =&gt; SECRET...}&#10;migration SQL: %{&#34;finish_reason_invalid&#34; =&gt; true} | runtime: same | aligned: true&#10;legacy: %{}&#10;migration SQL: %{} | runtime: same | aligned: true&#10;legacy: SECRET... (non-map)&#10;migration SQL: %{&#34;result_invalid&#34; =&gt; true} | runtime: same | aligned: true</code>

```text
22:29:07.689 [info] Controller startup license status
22:29:07.746 [debug] QUERY OK source="cluster_identities" db=0.6ms decode=0.3ms queue=10.7ms idle=0.0ms
SELECT c0."id", c0."singleton", c0."name", c0."runtime_controller_id", c0."inserted_at", c0."updated_at" FROM "cluster_identities" AS c0 []
22:29:07.748 [warning] Controller membership heartbeat failed; capability evidence remains stale (reason=node_trust_not_initialized class=none suppressed_attempts=0)
22:29:07.756 [info] Node identity resolved: 7bed9970-2b76-4715-8c55-d96f8aa36d72
22:29:07.757 [info] Node-agent startup license tracking

==============================================================================
1. Tenant governs capture mode (metadata = restricted)
==============================================================================
  tenant.slug: "restricted-capture-1785508147"
  tenant.request_body_capture_mode: :metadata

==============================================================================
2. Restricted request row persisted (capture mode = metadata)
==============================================================================
  public_id: "req_restricted_1785508147"
  request_payload: nil
  canonical_request: nil
  sampling_params: %{"stop_count" => 1, "temperature" => 0.7}
  scheduler_decision: %{}
  secret present anywhere in row?: false

==============================================================================
3. Inference step result as offered by the runtime vs. what Postgres stores
==============================================================================
  runtime offered result: %{
  "error_code" => "runtime echoed SECRET-PROMPT-TEXT-customer-said-my-ssn-is-123-45-6789",
  "error_message" => "MLX worker crashed while generating: SECRET-PROMPT-TEXT-customer-said-my-ssn-is-123-45-6789",
  "finish_reason" => "assistant refused because SECRET-PROMPT-TEXT-customer-said-my-ssn-is-123-45-6789",
  "input_tokens" => 42,
  "output_tokens" => 0
}
  persisted request_events.payload: %{
  "attempt" => 1,
  "boundary" => "post_observation",
  "result" => %{
    "error_code" => "internal_error",
    "finish_reason_invalid" => true,
    "input_tokens" => 42,
    "output_tokens" => 0
  },
  "step_id" => "inference_turn:t1:a1",
  "step_type" => "inference_turn",
  "turn_index" => 1
}
  persisted result: %{
  "error_code" => "internal_error",
  "finish_reason_invalid" => true,
  "input_tokens" => 42,
  "output_tokens" => 0
}
  raw error text stored?: false
  rejected finish_reason value stored?: false
  secret stored?: false

==============================================================================
4. Issue #120 detector classifies the invalid-finish-reason marker fail-closed
==============================================================================
  classify_missing_terminal_candidate/1: {:error, {:inconclusive, :invalid_finish_reason}}

==============================================================================
5. Malformed (non-map) runtime result under capture mode :none
==============================================================================
  persisted result: %{"result_invalid" => true}
  secret stored?: false
  classify_missing_terminal_candidate/1: {:error, {:inconclusive, :invalid_terminal_step}}

==============================================================================
6. Unresolvable capture mode falls back to the strictest mode
==============================================================================
  CapturePolicy.strictest_mode/0: :none
  insert rejected with errors: [payload_capture_mode: "is invalid"]
  request_payload change kept?: false
  canonical_request change kept?: false
  sampling_params change: %{"stop_count" => 1, "temperature" => 0.7}
  scheduler_decision change: %{}
  secret anywhere in changeset?: false

==============================================================================
7. Legacy migration purge vs. runtime sanitization (must be identical)
==============================================================================

  legacy on-disk result: %{"error_code" => "request_cancelled", "error_message" => "SECRET-PROMPT-TEXT-customer-said-my-ssn-" <> ...}
  migration SQL produced: %{"error_code" => "request_cancelled"}
  runtime sanitizer says: %{"error_code" => "request_cancelled"}
  aligned: true | secret survived: false

  legacy on-disk result: %{"error_code" => "runtime echoed SECRET-PROMPT-TEXT-custom" <> ..., "error_message" => "SECRET-PROMPT-TEXT-customer-said-my-ssn-" <> ...}
  migration SQL produced: %{"error_code" => "internal_error"}
  runtime sanitizer says: %{"error_code" => "internal_error"}
  aligned: true | secret survived: false

  legacy on-disk result: %{"finish_reason" => "stop"}
  migration SQL produced: %{"finish_reason" => "stop"}
  runtime sanitizer says: %{"finish_reason" => "stop"}
  aligned: true | secret survived: false

  legacy on-disk result: %{"finish_reason" => nil}
  migration SQL produced: %{"finish_reason_invalid" => true}
  runtime sanitizer says: %{"finish_reason_invalid" => true}
  aligned: true | secret survived: false

  legacy on-disk result: %{"finish_reason" => "SECRET-PROMPT-TEXT-customer-said-my-ssn-" <> ...}
  migration SQL produced: %{"finish_reason_invalid" => true}
  runtime sanitizer says: %{"finish_reason_invalid" => true}
  aligned: true | secret survived: false

  legacy on-disk result: %{}
  migration SQL produced: %{}
  runtime sanitizer says: %{}
  aligned: true | secret survived: false

  legacy on-disk result: "SECRET-PROMPT-TEXT-customer-said-my-ssn-" <> ...
  migration SQL produced: %{"result_invalid" => true}
  runtime sanitizer says: %{"result_invalid" => true}
  aligned: true | secret survived: false

==============================================================================
Console URL for the restricted request
==============================================================================
  http://127.0.0.1:4010/console/requests/req_restricted_1785508147
```
</details>
<details>
<summary>Evidence: Operator-visible Console timeline payload text + whole-database secret scan</summary>

<code>req_restricted (capture mode: metadata) — rendered in the Console Timeline table:&#10;1 2026-07-31 22:29:07 request_step.completed — {&#34;attempt&#34;:1,&#34;boundary&#34;:&#34;post_observation&#34;,&#34;result&#34;:{&#34;error_code&#34;:&#34;internal_error&#34;,&#34;finish_reason_invalid&#34;:true,&#34;input_tokens&#34;:42,&#34;output_tokens&#34;:0},&#34;step_id&#34;:&#34;inference_turn:t1:a1&#34;,&#34;step_type&#34;:&#34;inference_turn&#34;,&#34;turn_index&#34;:1}&#10;&#10;req_malformed (capture mode: none, non-map runtime result):&#10;1 2026-07-31 22:29:07 request_step.completed completed {&#34;attempt&#34;:1,&#34;boundary&#34;:&#34;post_observation&#34;,&#34;result&#34;:{&#34;result_invalid&#34;:true},&#34;step_id&#34;:&#34;inference_turn:t1:a1&#34;,&#34;step_type&#34;:&#34;inference_turn&#34;,&#34;turn_index&#34;:1}&#10;&#10;occurrences of &#34;SECRET-PROMPT-TEXT&#34; in a full pg_dump of the evidence database: 0</code>

```text
# Operator-visible Console timeline payloads (Orchard Console → Requests → detail)

## req_restricted_1785508147  (organization capture mode: metadata)
Runtime offered result:
  {"finish_reason":"assistant refused because SECRET-PROMPT-TEXT-...","error_code":"runtime echoed SECRET-PROMPT-TEXT-...","error_message":"MLX worker crashed while generating: SECRET-PROMPT-TEXT-...","input_tokens":42,"output_tokens":0}

Rendered in the Console Timeline table (document.querySelector('#request-timeline').innerText):
  1  2026-07-31 22:29:07  request_step.completed  —  {"attempt":1,"boundary":"post_observation","result":{"error_code":"internal_error","finish_reason_invalid":true,"input_tokens":42,"output_tokens":0},"step_id":"inference_turn:t1:a1","step_type":"inference_turn","turn_index":1}

## req_malformed_1785508147  (organization capture mode: none, non-map runtime result)
Rendered in the Console Timeline table:
  1  2026-07-31 22:29:07  request_step.completed  completed  {"attempt":1,"boundary":"post_observation","result":{"result_invalid":true},"step_id":"inference_turn:t1:a1","step_type":"inference_turn","turn_index":1}

## Whole-database scan for the seeded secret
  occurrences of "SECRET-PROMPT-TEXT" in a full pg_dump of the evidence database: 0
```
</details>
<details>
<summary>Evidence: Full `mix test` log (all four umbrella apps, 0 failures)</summary>

```text
==> orchard_shared
Running ExUnit with seed: 822206, max_cases: 16

......................................................................................................................................................................................................................................................................22:23:28.954 [warning] Sentry enrichment context call failed; continuing without enrichment
............................
Finished in 2.1 seconds (2.1s async, 0.06s sync)

Result: 290 passed
==> orchard_controller
Running ExUnit with seed: 822206, max_cases: 16

.............................................................................................22:23:29.759 [warning] Dispatch-capacity fact assembly failed: %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1736.0> ({Orchard.DispatchCapacity.AuthorizationTest, :\"test SPEC 4.6.2 rejects live production evidence for a different Node identity\"})\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}
......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................22:23:34.198 [warning] dispatch-capacity authority quarantined node 712f588d-d552-41e8-bbde-b8571effc6d5 after an unreconciled dispatch; it remains excluded until verified reconciliation proves the runtime execution is absent
...22:23:34.209 [error] dispatch-capacity authority started without a reachable quarantine store; all dispatch remains blocked until the Controller is recovered through a verified reconciliation path
.22:23:34.209 [error] dispatch-capacity authority could not quarantine node 56d38dee-d4c0-4da6-81ad-e9fdea6d0ced after an unreconciled dispatch: :dispatch_capacity_quarantine_store_unavailable; every Node evaluates as unreachable until the Controller is recovered through a verified reconciliation path
.22:23:34.209 [warning] dispatch-capacity authority quarantined node df8b2584-10e9-4a75-abe3-36cb24185ea2 after an unreconciled dispatch; it remains excluded until verified reconciliation proves the runtime execution is absent
......................22:23:34.313 [warning] dispatch-capacity authority quarantined node e04badfe-dce9-4d4e-8084-3565ff5a5bfe after an unreconciled dispatch; it remains excluded until verified reconciliation proves the runtime execution is absent
22:23:34.314 [error] dispatch-capacity quarantine store stopped; all dispatch remains blocked until the Controller is recovered through a verified reconciliation path
..................................................................22:23:34.687 [warning] dispatch-capacity authority quarantined node 3bdc104e-d2cb-4808-98f8-c8acbe84f00c after an unreconciled dispatch; it remains excluded until verified reconciliation proves the runtime execution is absent
.....................................................................................................
╔══════════════════════════════════════════════════════════════╗
║  ⚠️  PLAIN HTTP LOCALHOST MODE                            ║
║                                                            ║
║  ORCHARD_TRANSPORT_MODE=plain_http_localhost               ║
║  Controller listening on HTTP 127.0.0.1:4000              ║
║  This is NOT secure for production use.                    ║
╚══════════════════════════════════════════════════════════════╝


╔══════════════════════════════════════════════════════════════╗
║  ⚠️  PLAIN HTTP LOCALHOST MODE                            ║
║                                                            ║
║  ORCHARD_TRANSPORT_MODE=plain_http_localhost               ║
║  Controller listening on HTTP 127.0.0.1:4000              ║
║  This is NOT secure for production use.                    ║
╚══════════════════════════════════════════════════════════════╝

...............
╔══════════════════════════════════════════════════════════════╗
║  ⚠️  PLAIN HTTP LOCALHOST MODE                            ║
║                                                            ║
║  ORCHARD_TRANSPORT_MODE=plain_http_localhost               ║
║  Controller listening on HTTP 127.0.0.1:4000              ║
║  This is NOT secure for production use.                    ║
╚══════════════════════════════════════════════════════════════╝

.
╔══════════════════════════════════════════════════════════════╗
║  ⚠️  PLAIN HTTP LOCALHOST MODE                            ║
║                                                            ║
║  ORCHARD_TRANSPORT_MODE=plain_http_localhost               ║
║  Controller listening on HTTP 127.0.0.1:4000              ║
║  This is NOT secure for production use.                    ║
╚══════════════════════════════════════════════════════════════╝

........
╔══════════════════════════════════════════════════════════════╗
║  ⚠️  PLAIN HTTP LOCALHOST MODE                            ║
║                                                            ║
║  ORCHARD_TRANSPORT_MODE=plain_http_localhost               ║
║  Controller listening on HTTP 127.0.0.1:4000              ║
║  This is NOT secure for production use.                    ║
╚══════════════════════════════════════════════════════════════╝


╔══════════════════════════════════════════════════════════════╗
║  ⚠️  PLAIN HTTP LOCALHOST MODE                            ║
║                                                            ║
║  ORCHARD_TRANSPORT_MODE=plain_http_localhost               ║
║  Controller listeni

... [94120 bytes truncated] ...

le.all/3
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:163: Ecto.Repo.Queryable.one/3
    (orchard_controller 0.5.0-dev) lib/orchard/dispatch_capacity/diagnostics.ex:218: Orchard.DispatchCapacity.Diagnostics.safe_read/3
    (orchard_controller 0.5.0-dev) lib/orchard/dispatch_capacity/diagnostics.ex:115: Orchard.DispatchCapacity.Diagnostics.snapshots/2
    (orchard_controller 0.5.0-dev) lib/orchard/cluster_management/status_builder.ex:154: Orchard.ClusterManagement.StatusBuilder.node_status_maps/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:325: anonymous fn/1 in OrchardCLI.Commands.Support.nodes_snapshot/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:343: OrchardCLI.Commands.Support.safe_snapshot/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:220: OrchardCLI.Commands.Support.build_stage!/4
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:172: anonymous fn/6 in OrchardCLI.Commands.Support.create_bundle/2
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:683: OrchardCLI.Commands.Support.with_bundle_temp_root/4
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:165: OrchardCLI.Commands.Support.create_bundle/2
    test/orchard_cli/commands/support_test.exs:996: OrchardCLI.Commands.SupportTest."test temporary archive is written under a private directory"/1
    (ex_unit 1.20.0) lib/ex_unit/runner.ex:533: ExUnit.Runner.exec_test/2
    (stdlib 8.0.1) timer.erl:599: :timer.tc/2
    (ex_unit 1.20.0) lib/ex_unit/runner.ex:455: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4

.22:28:19.522 [warning] dispatch-capacity diagnostics could not read the dispatch-capacity authority and fell back to fail-closed facts: ** (DBConnection.OwnershipError) cannot find ownership process for #PID<0.43841.0> ({OrchardCLI.Commands.SupportTest, :"test redaction preserves tokenizer and license diagnostics while redacting credentials"})
using mode :manual.

When using ownership, you must manage connections in one
of the four ways:

* By explicitly checking out a connection
* By explicitly allowing a spawned process
* By running the pool in shared mode
* By using :caller option with allowed process

The first two options require every new process to explicitly
check a connection out or be allowed by calling checkout or
allow respectively.

The third option requires a {:shared, pid} mode to be set.
If using shared mode in tests, make sure your tests are not
async.

The fourth option requires [caller: pid] to be used when
checking out a connection from the pool. The caller process
should already be allowed on a connection.

If you are reading this error, it means you have not done one
of the steps above or that the owner process has crashed.

See Ecto.Adapters.SQL.Sandbox docs for more information.
    (ecto_sql 3.13.5) lib/ecto/adapters/sql.ex:1110: Ecto.Adapters.SQL.raise_sql_call_error/1
    (ecto_sql 3.13.5) lib/ecto/adapters/sql.ex:1011: Ecto.Adapters.SQL.execute/6
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:241: Ecto.Repo.Queryable.execute/4
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:163: Ecto.Repo.Queryable.one/3
    (orchard_controller 0.5.0-dev) lib/orchard/dispatch_capacity/diagnostics.ex:218: Orchard.DispatchCapacity.Diagnostics.safe_read/3
    (orchard_controller 0.5.0-dev) lib/orchard/dispatch_capacity/diagnostics.ex:115: Orchard.DispatchCapacity.Diagnostics.snapshots/2
    (orchard_controller 0.5.0-dev) lib/orchard/cluster_management/status_builder.ex:154: Orchard.ClusterManagement.StatusBuilder.node_status_maps/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:325: anonymous fn/1 in OrchardCLI.Commands.Support.nodes_snapshot/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:343: OrchardCLI.Commands.Support.safe_snapshot/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:220: OrchardCLI.Commands.Support.build_stage!/4
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:172: anonymous fn/6 in OrchardCLI.Commands.Support.create_bundle/2
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:683: OrchardCLI.Commands.Support.with_bundle_temp_root/4
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:165: OrchardCLI.Commands.Support.create_bundle/2
    test/orchard_cli/commands/support_test.exs:436: OrchardCLI.Commands.SupportTest."test redaction preserves tokenizer and license diagnostics while redacting credentials"/1
    (ex_unit 1.20.0) lib/ex_unit/runner.ex:533: ExUnit.Runner.exec_test/2
    (stdlib 8.0.1) timer.erl:599: :timer.tc/2
    (ex_unit 1.20.0) lib/ex_unit/runner.ex:455: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4

...22:28:19.567 [warning] dispatch-capacity diagnostics could not read the dispatch-capacity authority and fell back to fail-closed facts: ** (DBConnection.OwnershipError) cannot find ownership process for #PID<0.43863.0> ({OrchardCLI.Commands.SupportTest, :"test redaction covers env secret values, multiline env blocks, and escaped JSON logs"})
using mode :manual.

When using ownership, you must manage connections in one
of the four ways:

* By explicitly checking out a connection
* By explicitly allowing a spawned process
* By running the pool in shared mode
* By using :caller option with allowed process

The first two options require every new process to explicitly
check a connection out or be allowed by calling checkout or
allow respectively.

The third option requires a {:shared, pid} mode to be set.
If using shared mode in tests, make sure your tests are not
async.

The fourth option requires [caller: pid] to be used when
checking out a connection from the pool. The caller process
should already be allowed on a connection.

If you are reading this error, it means you have not done one
of the steps above or that the owner process has crashed.

See Ecto.Adapters.SQL.Sandbox docs for more information.
    (ecto_sql 3.13.5) lib/ecto/adapters/sql.ex:1110: Ecto.Adapters.SQL.raise_sql_call_error/1
    (ecto_sql 3.13.5) lib/ecto/adapters/sql.ex:1011: Ecto.Adapters.SQL.execute/6
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:241: Ecto.Repo.Queryable.execute/4
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:163: Ecto.Repo.Queryable.one/3
    (orchard_controller 0.5.0-dev) lib/orchard/dispatch_capacity/diagnostics.ex:218: Orchard.DispatchCapacity.Diagnostics.safe_read/3
    (orchard_controller 0.5.0-dev) lib/orchard/dispatch_capacity/diagnostics.ex:115: Orchard.DispatchCapacity.Diagnostics.snapshots/2
    (orchard_controller 0.5.0-dev) lib/orchard/cluster_management/status_builder.ex:154: Orchard.ClusterManagement.StatusBuilder.node_status_maps/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:325: anonymous fn/1 in OrchardCLI.Commands.Support.nodes_snapshot/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:343: OrchardCLI.Commands.Support.safe_snapshot/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:220: OrchardCLI.Commands.Support.build_stage!/4
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:172: anonymous fn/6 in OrchardCLI.Commands.Support.create_bundle/2
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:683: OrchardCLI.Commands.Support.with_bundle_temp_root/4
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/support.ex:165: OrchardCLI.Commands.Support.create_bundle/2
    test/orchard_cli/commands/support_test.exs:282: OrchardCLI.Commands.SupportTest."test redaction covers env secret values, multiline env blocks, and escaped JSON logs"/1
    (ex_unit 1.20.0) lib/ex_unit/runner.ex:533: ExUnit.Runner.exec_test/2
    (stdlib 8.0.1) timer.erl:599: :timer.tc/2
    (ex_unit 1.20.0) lib/ex_unit/runner.ex:455: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4

.....................................................................................................................
Finished in 95.6 seconds (51.6s async, 43.9s sync)

Result: 709 passed, 10 excluded
mise exec -- mix test  78.48s user 25.77s system 34% cpu 5:00.13 total
```
</details>
- Evidence: Full `mix test --cover` log (second CI test step, 0 failures) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYW6MZBRR5EBWHADHGE7B3Q1/mix-test-cover.log</code>)
- Evidence: Evidence-producing script used for the manual end-to-end run (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYW6MZBRR5EBWHADHGE7B3Q1/capture_evidence.exs</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 7 issues found → auto-fixed ✅</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/requests.ex:22` - `capture_create_attrs/1` falls open: when `payload_capture_mode` is absent or unrecognized, `CapturePolicy.normalize_mode/1` returns `:error` and the attrs are passed through with no sanitization at all, while the DB column default silently labels the row `metadata`. The check constraints only cover `canonical_request`/`request_payload`/`response_payload`/`error_message`, so `sampling_params` (including raw `stop` text), `response_format`, `scheduler_decision`, and a non-stable `error_code` are persisted verbatim on a row that reports `payload_capture_mode = :metadata`. Every other write path (`apply_terminal_update`, `insert_event_and_sync_state`, `persist_schedule`) reads the mode from the locked DB row and therefore cannot fail open this way. Default the unresolvable case to the strictest mode (or at minimum `:metadata`, matching the column default) instead of skipping the policy.
- ⚠️ `apps/orchard_controller/lib/orchard/requests/capture_policy.ex:198` - Restricted terminal writes null out `response_payload`, and `Idempotency.classify_matching_request/1` only replays when `response_payload` is a map. Because the tenant default is `metadata`, idempotent replay is now disabled for every tenant unless an operator explicitly opts into `full`: a repeated `Idempotency-Key` that previously returned 200 with the stored result now returns 409 `idempotency_not_replayable` (see the rewritten chat-completions test asserting `conn_b.status == 409`). This is a breaking change to a documented public endpoint behavior that takes effect for all existing tenants immediately after migration. SPEC.md §3.9 was updated to permit it, so this looks deliberate — please confirm the default-on regression is intended rather than gating it behind an explicit tenant opt-out.
- ⚠️ `apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex:632` - `body_hash` now carries three mutually incomparable definitions. `request_attrs/4` sets it to `sha256(Jason.encode!(serialized_canonical))`, but `put_idempotency_attrs/2` immediately overwrites it with `Idempotency.Context.body_hash` (sha256 of the *client request body* under key-sorted normalized JSON) whenever an Idempotency-Key is present, and the migration backfills legacy NULLs as `digest(canonical_request::text)` (Postgres jsonb text form, different key order and spacing from Jason). Two identical requests — one with an Idempotency-Key, one without — therefore get different `body_hash` values. Idempotency comparison itself is safe (it only ever compares rows looked up by idempotency key, and legacy idempotent rows always had a non-NULL hash), but SPEC.md §10.10 now designates `body_hash` as an integrity anchor, and under `none`/`metadata` it is the only remaining anchor for the request. Pick one canonical definition, or document that the column is idempotency-scoped and not a content anchor.
- ℹ️ `apps/orchard_controller/lib/orchard/requests.ex:200` - `classify_terminal_step/1` has two `Map.fetch` branches that return the identical value (`{:ok, true}` and `{:ok, _invalid_marker}` both yield `inconclusive(:invalid_terminal_step)`). Collapse to a single `{:ok, _marker}` clause. Note this is deliberately different from `classify_finish_reason_evidence/1` just below, which does distinguish `:invalid_finish_reason` from `:invalid_finish_reason_marker` — if that distinction is wanted here too, the second clause should return a distinct reason rather than duplicating the first.
- ℹ️ `apps/orchard_controller/lib/orchard/inference/responses_request_normalizer.ex:31` - The normalizer dropped both the `{:ok, %CanonicalRequest{} = canonical}` shape assertion and the struct-update syntax `%{canonical | endpoint: :responses}`, replacing them with `Map.put(:endpoint, ...) |&gt; Map.put(:store?, ...)`. `Map.put/3` on a struct accepts any key, so a future typo silently adds a bogus map key to the `CanonicalRequest` struct instead of failing at compile time, and the struct match that guaranteed the normalizer returned a `CanonicalRequest` is gone. `%{canonical | endpoint: :responses, store?: normalize_store(params)}` restores both checks with no behavior change.
- ℹ️ `apps/orchard_controller/lib/orchard/requests.ex:72` - `list_request_step_events/1` changed from `RequestStepEvent.from_request_event!/1` (raises) to `readable_step_event/1`, which discards any row whose payload no longer parses. That is required for legacy rows the migration collapsed to `{}`, but it also means a future regression that makes restricted step payloads non-round-trippable would make steps silently disappear from the console timeline and the CLI instead of surfacing. Emit a log or telemetry event on the `{:error, _reason}` branch so dropped rows remain observable.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/capture_policy.ex:317` - `request_shape/2` always writes `&#34;preview&#34; =&gt; nil` into the persisted `request_shape` JSON, for `metadata` and `full` alike; nothing in the branch ever populates it. Either populate it (SPEC.md §10.10 describes `metadata` as &#34;shape + preview&#34;) or drop the key so the persisted shape does not advertise a field that is structurally always null.

🔧 Fix: fix: sanitize fail-closed for unresolvable capture mode
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test` (full umbrella: orchard_shared 290, orchard_controller 3053, orchard_node_agent 375, orchard_cli 709 — 0 failures)</code>
- <code>`mise exec -- mix test --cover` (same suites, 0 failures — the second CI test step)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/requests/capture_policy_test.exs apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs apps/orchard_controller/test/orchard/requests_test.exs apps/orchard_controller/test/orchard/repo/migrations/request_body_capture_mode_test.exs` (targeted slice, 95 passed)</code>
- <code>Manual end-to-end script against an isolated dev DB: `MIX_ENV=dev PGDATABASE=orchard_capture_evidence mise exec -- mix run capture_evidence.exs` — seeded a metadata-mode tenant, drove a restricted inference result through `Requests.mark_terminal_with_step_events/3`, and read back the raw `request_events.payload` from Postgres</code>
- <code>Verified issue #120 detector fail-closed classification via `Orchard.Requests.classify_missing_terminal_candidate/1` for both the `finish_reason_invalid` and `result_invalid` markers</code>
- <code>Verified unresolvable capture mode (`payload_capture_mode: &#34;everything&#34;`) is rejected with an already-sanitized changeset (no request_payload/canonical_request, `stop_count` only, empty scheduler_decision)</code>
- <code>Compared migration purge SQL (`RequestBodyCaptureMode.legacy_step_event_payload_sql/0`) against `CapturePolicy.event_attrs(:metadata, ...)` for 7 legacy result shapes — all byte-identical</code>
- <code>`pg_dump -h localhost -U postgres orchard_capture_evidence | grep -c SECRET-PROMPT-TEXT` → 0</code>
- <code>Browser capture of the Console request detail page at `http://127.0.0.1:4010/console/requests/req_restricted_1785508147` and `.../req_malformed_1785508147` via agent-browser, plus `document.querySelector(&#39;#request-timeline&#39;).innerText` to record the exact operator-visible payload text</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `SPEC.md:339` - Pre-existing drift, out of scope for this change: the §3.4 canonical request struct listing is hand-copied from Orchard.CanonicalRequest and still omits `stream_include_usage` and `prompt_token_ids`, which earlier changes added to the struct. This change&#39;s new `store?` field was added to the listing, but the listing has no drift check, so it will keep falling behind. Follow-up worth considering: add a drift test asserting the SPEC listing covers every CanonicalRequest field, or state explicitly that §3.4 is a normative minimum rather than an exhaustive mirror.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
