### PR TITLE
fix(packaging): make packaged Python launchers relocatable

### DIFF
--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -644,7 +644,7 @@ validate_expanded_pkg_provenance() {
         return 1
     fi
 
-    if ! "$REPO_ROOT/scripts/verify-staged-venv-closure.sh" --no-smoke "$expanded_dir"; then
+    if ! "$REPO_ROOT/scripts/verify-staged-venv-closure.sh" --forbid-path "$REPO_ROOT" "$expanded_dir"; then
         rm -rf "$expanded_parent"
         log_error "Mach-O dependency closure failed for $label expanded package"
         return 1
@@ -1656,7 +1656,7 @@ if ! COPYFILE_DISABLE=1 COPY_EXTENDED_ATTRIBUTES_DISABLE=1 "$REPO_ROOT/scripts/m
     log_error "Failed to materialize staged Python venv interpreters"
     exit 1
 fi
-if ! "$REPO_ROOT/scripts/verify-staged-venv-closure.sh" "$STAGING_BASE"; then
+if ! "$REPO_ROOT/scripts/verify-staged-venv-closure.sh" --forbid-path "$REPO_ROOT" "$STAGING_BASE"; then
     log_error "Staged native payload closure verification failed"
     exit 1
 fi
@@ -1731,7 +1731,7 @@ log_info "Scrubbing macOS metadata after payload signing window..."
 scrub_macos_metadata "$STAGING_BASE"
 
 log_info "Verifying whole-payload Mach-O dependency closure..."
-if ! "$REPO_ROOT/scripts/verify-staged-venv-closure.sh" --no-smoke "$STAGING_BASE"; then
+if ! "$REPO_ROOT/scripts/verify-staged-venv-closure.sh" --no-smoke --forbid-path "$REPO_ROOT" "$STAGING_BASE"; then
     log_error "Whole-payload Mach-O dependency closure verification failed"
     exit 1
 fi

--- a/scripts/materialize-staged-venv-interpreters.sh
+++ b/scripts/materialize-staged-venv-interpreters.sh
@@ -161,6 +161,24 @@ def loader_path_rpath(macho: pathlib.Path, candidate_dir: pathlib.Path) -> str:
     return "@loader_path/" + relative.replace(os.sep, "/")
 
 
+def python_launcher_body(text: str) -> Optional[str]:
+    lines = text.splitlines(keepends=True)
+    if not lines or not lines[0].startswith("#!"):
+        return None
+    if "python" in lines[0]:
+        return "".join(lines[1:])
+    if (
+        len(lines) >= 3
+        and lines[0].rstrip("\r\n") in {"#!/bin/sh", "#!/usr/bin/env sh"}
+        and lines[1].lstrip().startswith("'''exec' ")
+        and "python" in lines[1]
+        and '"$0" "$@"' in lines[1]
+        and lines[2].strip() == "' '''"
+    ):
+        return "".join(lines[3:])
+    return None
+
+
 def remediate_venv_rpath_deps(venv: pathlib.Path) -> None:
     executable_dir = venv / "bin"
     added_rpaths: set[tuple[pathlib.Path, str]] = set()
@@ -245,13 +263,11 @@ for venv in venvs:
             text = raw.decode("utf-8")
         except UnicodeDecodeError:
             continue
-        if not text.startswith("#!"):
+        body = python_launcher_body(text)
+        if body is None:
             continue
-        first, sep, rest = text.partition("\n")
-        if "python" not in first:
-            continue
-        launcher = "#!/bin/sh\n'''exec' \"$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)/python\" \"$0\" \"$@\"\n' '''"
-        script.write_text(launcher + (sep + rest if sep else "\n"))
+        launcher = "#!/bin/sh\n'''exec' \"$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)/python\" \"$0\" \"$@\"\n' '''\n"
+        script.write_text(launcher + body)
         os.chmod(script, mode)
 
     cfg = venv / "pyvenv.cfg"

--- a/scripts/test-payload-signing-contracts.sh
+++ b/scripts/test-payload-signing-contracts.sh
@@ -518,6 +518,9 @@ exit 0
 PY
 cat > "$venv/bin/$bin_name" <<'BIN'
 #!/bin/sh
+if [ "${1:-}" = "--request-json" ]; then
+  printf '%s\n' '{"ok":true,"result":{"compatible":true}}'
+fi
 exit 0
 BIN
 chmod +x "$venv/bin/python" "$venv/bin/$bin_name"
@@ -635,6 +638,9 @@ exit 0
 PY
       cat > "$target/.venv-pkg/bin/$bin_name" <<'BIN'
 #!/bin/sh
+if [ "${1:-}" = "--request-json" ]; then
+  printf '%s\n' '{"ok":true,"result":{"compatible":true}}'
+fi
 exit 0
 BIN
       chmod +x "$target/.venv-pkg/bin/python" "$target/.venv-pkg/bin/$bin_name"
@@ -1331,6 +1337,9 @@ exit 0
 PY
     cat > ".venv-pkg/bin/$bin_name" <<'BIN'
 #!/bin/sh
+if [ "${1:-}" = "--request-json" ]; then
+  printf '%s\n' '{"ok":true,"result":{"compatible":true}}'
+fi
 exit 0
 BIN
     chmod +x ".venv-pkg/bin/python" ".venv-pkg/bin/$bin_name"

--- a/scripts/test-staged-venv-closure.sh
+++ b/scripts/test-staged-venv-closure.sh
@@ -140,6 +140,82 @@ site_packages_dir() {
     find "$venv/lib" -type d -path '*/site-packages' -print -quit
 }
 
+PYTHON_TAG="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+PYTHON_BASE_PREFIX="$(python3 -c 'import sys; print(sys.base_prefix)')"
+
+make_python_runtime_prefix() {
+    local prefix="$1"
+    mkdir -p "$prefix/bin" "$prefix/lib"
+    cp -L "$PYTHON_BASE_PREFIX/bin/python$PYTHON_TAG" "$prefix/bin/python$PYTHON_TAG"
+    chmod +x "$prefix/bin/python$PYTHON_TAG"
+    local lib
+    for lib in "$PYTHON_BASE_PREFIX"/lib/libpython*.dylib; do
+        [[ -e "$lib" ]] || continue
+        cp -L "$lib" "$prefix/lib/"
+    done
+    python3 - "$PYTHON_BASE_PREFIX/lib/python$PYTHON_TAG" "$prefix/lib/python$PYTHON_TAG" <<'PY'
+import shutil
+import sys
+
+shutil.copytree(
+    sys.argv[1],
+    sys.argv[2],
+    symlinks=True,
+    ignore=shutil.ignore_patterns(
+        "test",
+        "idlelib",
+        "tkinter",
+        "_tkinter*",
+        "turtledemo",
+        "lib2to3",
+        "ensurepip",
+        "pydoc_data",
+        "site-packages",
+        "__pycache__",
+        "config-*",
+    ),
+)
+PY
+}
+
+make_uv_style_venv() {
+    local venv="$1"
+    local prefix="$2"
+    mkdir -p "$venv/bin" "$venv/lib/python$PYTHON_TAG/site-packages"
+    ln -s "$prefix/bin/python$PYTHON_TAG" "$venv/bin/python$PYTHON_TAG"
+    ln -s "python$PYTHON_TAG" "$venv/bin/python3"
+    ln -s "python3" "$venv/bin/python"
+    printf 'home = %s
+include-system-site-packages = false
+version = %s
+' "$prefix/bin" "$PYTHON_TAG" > "$venv/pyvenv.cfg"
+}
+
+STAGED_VENV_TEMPLATE=""
+
+ensure_staged_venv_template() {
+    if [[ -n "$STAGED_VENV_TEMPLATE" ]]; then
+        return
+    fi
+    local template_root="$TMP_ROOT/staged-venv-template"
+    local template_venv="$template_root/native/template/.venv"
+    make_python_runtime_prefix "$template_root/runtime"
+    make_uv_style_venv "$template_venv" "$template_root/runtime"
+    "$REPO_ROOT/scripts/materialize-staged-venv-interpreters.sh" "$template_root/native" >/dev/null
+    STAGED_VENV_TEMPLATE="$template_venv"
+}
+
+clone_staged_venv() {
+    local dest="$1"
+    ensure_staged_venv_template
+    mkdir -p "$(dirname "$dest")"
+    rm -rf "$dest"
+    if ! cp -Rc "$STAGED_VENV_TEMPLATE" "$dest" 2>/dev/null; then
+        rm -rf "$dest"
+        cp -R "$STAGED_VENV_TEMPLATE" "$dest"
+    fi
+}
+
 make_stub_tokenizers_package() {
     local site_packages="$1"
     mkdir -p "$site_packages/tokenizers"
@@ -198,7 +274,7 @@ make_known_helper_venv_fixture() {
         entry_name="orchard-worker-mlx"
     fi
     local venv="$root/Library/Application Support/Orchard/native/$helper/.venv"
-    python3 -m venv --copies "$venv"
+    clone_staged_venv "$venv"
     if [[ -L "$venv/bin/python" ]]; then
         echo "fixture setup failed: expected non-symlink venv/bin/python" >&2
         exit 1
@@ -314,12 +390,15 @@ assert_no_grep '/Users/buildhost' "$venv/bin/tool"
 case_dir="$TMP_ROOT/materialize-relocated-console-entrypoints"
 source_native="$case_dir/source/native"
 relocated_native="$case_dir/relocated/native"
+make_python_runtime_prefix "$case_dir/runtime"
 for helper_spec in \
     "orchard_tokenizer:orchard-tokenizer:--version" \
     "orchard_worker_mlx:orchard-worker-mlx:--help"; do
     IFS=: read -r helper entry_name smoke_arg <<<"$helper_spec"
     source_venv="$source_native/$helper/.venv"
-    python3 -m venv --copies "$source_venv"
+    make_uv_style_venv "$source_venv" "$case_dir/runtime"
+    test -L "$source_venv/bin/python"
+    test ! -e "$source_venv/lib/python$PYTHON_TAG/os.py"
     site_packages="$(site_packages_dir "$source_venv")"
     mkdir -p "$site_packages/$helper"
     printf '' > "$site_packages/$helper/__init__.py"
@@ -346,12 +425,17 @@ done
 "$REPO_ROOT/scripts/materialize-staged-venv-interpreters.sh" "$source_native" >/dev/null
 mkdir -p "$(dirname "$relocated_native")"
 cp -R "$source_native" "$relocated_native"
-rm -rf "$case_dir/source" "$case_dir/build/.venv-pkg"
+rm -rf "$case_dir/source" "$case_dir/build/.venv-pkg" "$case_dir/runtime"
 for helper_spec in \
     "orchard_tokenizer:orchard-tokenizer:--version" \
     "orchard_worker_mlx:orchard-worker-mlx:--help"; do
     IFS=: read -r helper entry_name smoke_arg <<<"$helper_spec"
-    relocated_entry="$relocated_native/$helper/.venv/bin/$entry_name"
+    relocated_venv="$relocated_native/$helper/.venv"
+    relocated_entry="$relocated_venv/bin/$entry_name"
+    test ! -L "$relocated_venv/bin/python"
+    test ! -L "$relocated_venv/bin/python3"
+    test -f "$relocated_venv/lib/python$PYTHON_TAG/os.py"
+    assert_no_grep 'home = ' "$relocated_venv/pyvenv.cfg"
     env -i PATH=/usr/bin:/bin HOME="$case_dir/home" "$relocated_entry" "$smoke_arg" >"$case_dir/$entry_name.out"
     assert_no_grep "$case_dir" "$relocated_entry"
     assert_no_grep '.venv-pkg' "$relocated_entry"

--- a/scripts/test-staged-venv-closure.sh
+++ b/scripts/test-staged-venv-closure.sh
@@ -176,6 +176,24 @@ PY
 #!/bin/sh
 case "${1:-}" in
   --help) exit 0 ;;
+  --request-json)
+    printf '%s\n' '{"ok":true,"result":{"compatible":true}}'
+    exit 0
+    ;;
+esac
+exit 0
+SH
+        chmod +x "$venv/bin/$entry_name"
+        ;;
+      safe_fail)
+        cat > "$venv/bin/$entry_name" <<'SH'
+#!/bin/sh
+case "${1:-}" in
+  --help) exit 0 ;;
+  --request-json)
+    printf '%s\n' '{"ok":false,"error":{"category":"invalid_response"}}'
+    exit 0
+    ;;
 esac
 exit 0
 SH
@@ -234,6 +252,54 @@ if command -v xattr >/dev/null 2>&1; then
 fi
 head -3 "$venv/bin/tool" | grep -F '#!/bin/sh' >/dev/null
 assert_no_grep '/Users/buildhost' "$venv/bin/tool"
+
+# materializer: uv's two-line shell trampolines remain runnable after the source venv is removed.
+case_dir="$TMP_ROOT/materialize-relocated-console-entrypoints"
+source_native="$case_dir/source/native"
+relocated_native="$case_dir/relocated/native"
+for helper_spec in \
+    "orchard_tokenizer:orchard-tokenizer:--version" \
+    "orchard_worker_mlx:orchard-worker-mlx:--help"; do
+    IFS=: read -r helper entry_name smoke_arg <<<"$helper_spec"
+    source_venv="$source_native/$helper/.venv"
+    python3 -m venv --copies "$source_venv"
+    site_packages="$(site_packages_dir "$source_venv")"
+    mkdir -p "$site_packages/$helper"
+    printf '' > "$site_packages/$helper/__init__.py"
+    cat > "$site_packages/$helper/cli.py" <<'PY'
+import sys
+
+
+def main():
+    if "--version" in sys.argv:
+        print("0.1.0")
+    return 0
+PY
+    cat > "$source_venv/bin/$entry_name" <<SH
+#!/bin/sh
+'''exec' $case_dir/build/.venv-pkg/bin/python "\$0" "\$@"
+' '''
+from $helper.cli import main
+raise SystemExit(main())
+SH
+    mkdir -p "$case_dir/build/.venv-pkg/bin"
+    ln -sf "$source_venv/bin/python" "$case_dir/build/.venv-pkg/bin/python"
+    chmod +x "$source_venv/bin/$entry_name"
+done
+"$REPO_ROOT/scripts/materialize-staged-venv-interpreters.sh" "$source_native" >/dev/null
+mkdir -p "$(dirname "$relocated_native")"
+cp -R "$source_native" "$relocated_native"
+rm -rf "$case_dir/source" "$case_dir/build/.venv-pkg"
+for helper_spec in \
+    "orchard_tokenizer:orchard-tokenizer:--version" \
+    "orchard_worker_mlx:orchard-worker-mlx:--help"; do
+    IFS=: read -r helper entry_name smoke_arg <<<"$helper_spec"
+    relocated_entry="$relocated_native/$helper/.venv/bin/$entry_name"
+    env -i PATH=/usr/bin:/bin HOME="$case_dir/home" "$relocated_entry" "$smoke_arg" >"$case_dir/$entry_name.out"
+    assert_no_grep "$case_dir" "$relocated_entry"
+    assert_no_grep '.venv-pkg' "$relocated_entry"
+done
+assert_grep '0.1.0' "$case_dir/orchard-tokenizer.out"
 
 # materializer: unresolved in-venv @rpath support dylibs get a relative rpath.
 case_dir="$TMP_ROOT/materialize-rpath-support-dylib"
@@ -406,7 +472,41 @@ chmod +x "$venv/bin/tool"
 make_fake_tools "$tools" '#!/bin/sh
 cat <<'"'"'OUT'"'"'
 OUT'
-assert_verifier_fails_with 'script shebang has build-host path fragment' "$tools" "$root" "$case_dir/out"
+assert_verifier_fails_with 'script launcher has build-host path fragment' "$tools" "$root" "$case_dir/out"
+
+# verifier: caller-supplied build roots are rejected even outside standard macOS home paths.
+case_dir="$TMP_ROOT/explicit-build-root"
+tools="$case_dir/tools"
+root="$case_dir/root"
+venv="$(make_venv_fixture "$root")"
+cat > "$venv/bin/tool" <<'SH'
+#!/bin/sh
+'''exec' /Volumes/orchard-build/native/foo/.venv/bin/python "$0" "$@"
+' '''
+print('bad')
+SH
+chmod +x "$venv/bin/tool"
+make_fake_tools "$tools" '#!/bin/sh
+cat <<'"'"'OUT'"'"'
+OUT'
+assert_verifier_fails_with 'script launcher has build-host path fragment' "$tools" "$root" "$case_dir/out" --forbid-path /Volumes/orchard-build
+
+# verifier: inspect the complete launcher, including uv's second-line Python trampoline.
+case_dir="$TMP_ROOT/two-line-shell-trampoline"
+tools="$case_dir/tools"
+root="$case_dir/root"
+venv="$(make_venv_fixture "$root")"
+cat > "$venv/bin/tool" <<'SH'
+#!/bin/sh
+'''exec' /Users/buildhost/orchard/native/foo/.venv-pkg/bin/python "$0" "$@"
+' '''
+print('bad')
+SH
+chmod +x "$venv/bin/tool"
+make_fake_tools "$tools" '#!/bin/sh
+cat <<'"'"'OUT'"'"'
+OUT'
+assert_verifier_fails_with 'script launcher has build-host path fragment' "$tools" "$root" "$case_dir/out"
 
 # verifier: temp build-root absolute dependency is rejected.
 case_dir="$TMP_ROOT/temp-root"
@@ -486,6 +586,16 @@ make_fake_tools "$tools" '#!/bin/sh
 cat <<'"'"'OUT'"'"'
 OUT'
 assert_verifier_succeeds "$tools" "$root" "$case_dir/out"
+
+# verifier: installed tokenizer entrypoint must complete a safe-tokenization preflight.
+case_dir="$TMP_ROOT/known-helper-safe-tokenization-preflight"
+tools="$case_dir/tools"
+root="$case_dir/root"
+make_known_helper_venv_fixture "$root" present safe_fail >/dev/null
+make_fake_tools "$tools" '#!/bin/sh
+cat <<'"'"'OUT'"'"'
+OUT'
+assert_verifier_fails_with 'installed tokenizer safe-tokenization preflight smoke failed' "$tools" "$root" "$case_dir/out"
 
 # verifier: known helper console entrypoints must smoke under sanitized env.
 case_dir="$TMP_ROOT/known-helper-entrypoint-smoke"

--- a/scripts/test-staged-venv-closure.sh
+++ b/scripts/test-staged-venv-closure.sh
@@ -140,6 +140,54 @@ site_packages_dir() {
     find "$venv/lib" -type d -path '*/site-packages' -print -quit
 }
 
+make_stub_tokenizers_package() {
+    local site_packages="$1"
+    mkdir -p "$site_packages/tokenizers"
+    cat > "$site_packages/tokenizers/__init__.py" <<'PY'
+import json
+
+
+class Tokenizer:
+    def __init__(self, model):
+        self.model = model
+        self.pre_tokenizer = None
+        self.decoder = None
+
+    def train(self, files, trainer):
+        self.files = list(files)
+        self.trainer = trainer
+
+    def save(self, path):
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump({"version": "1.0", "model": {"type": "BPE"}}, handle)
+PY
+    cat > "$site_packages/tokenizers/models.py" <<'PY'
+class BPE:
+    def __init__(self, unk_token=None):
+        self.unk_token = unk_token
+PY
+    cat > "$site_packages/tokenizers/decoders.py" <<'PY'
+class ByteLevel:
+    pass
+PY
+    cat > "$site_packages/tokenizers/pre_tokenizers.py" <<'PY'
+class ByteLevel:
+    def __init__(self, add_prefix_space=False):
+        self.add_prefix_space = add_prefix_space
+
+    @staticmethod
+    def alphabet():
+        return []
+PY
+    cat > "$site_packages/tokenizers/trainers.py" <<'PY'
+class BpeTrainer:
+    def __init__(self, vocab_size=0, initial_alphabet=None, special_tokens=None):
+        self.vocab_size = vocab_size
+        self.initial_alphabet = list(initial_alphabet or [])
+        self.special_tokens = list(special_tokens or [])
+PY
+}
+
 make_known_helper_venv_fixture() {
     local root="$1"
     local package_state="${2:-present}"
@@ -161,6 +209,9 @@ make_known_helper_venv_fixture() {
     local site_packages
     site_packages="$(site_packages_dir "$venv")"
     find "$site_packages" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+    if [[ "$helper" == "orchard_tokenizer" ]]; then
+        make_stub_tokenizers_package "$site_packages"
+    fi
     if [[ "$package_state" == "present" ]]; then
         mkdir -p "$site_packages/$helper"
         printf '' > "$site_packages/$helper/__init__.py"
@@ -209,6 +260,12 @@ SH
       sleep)
         cat > "$venv/bin/$entry_name" <<'SH'
 #!/bin/sh
+case "${1:-}" in
+  --request-json)
+    printf '%s\n' '{"ok":true,"result":{"compatible":true}}'
+    exit 0
+    ;;
+esac
 sleep 30
 SH
         chmod +x "$venv/bin/$entry_name"

--- a/scripts/verify-staged-venv-closure.sh
+++ b/scripts/verify-staged-venv-closure.sh
@@ -61,7 +61,21 @@ from typing import Optional
 
 root = pathlib.Path(sys.argv[1]).resolve()
 run_smoke = sys.argv[2] == "true"
-forbidden_roots = tuple(str(pathlib.Path(path).resolve()) for path in sys.argv[3:] if path)
+
+
+def forbidden_root_variants(values: list[str]) -> tuple[str, ...]:
+    variants: list[str] = []
+    for value in values:
+        if not value:
+            continue
+        candidate = pathlib.Path(value)
+        for form in (str(candidate), str(candidate.resolve(strict=False))):
+            if form not in variants:
+                variants.append(form)
+    return tuple(variants)
+
+
+forbidden_roots = forbidden_root_variants(sys.argv[3:])
 payload_rel = pathlib.Path("Library/Application Support/Orchard")
 install_prefix = pathlib.Path("/Library/Application Support/Orchard")
 allowed_system_prefixes = ("/usr/lib/", "/System/Library/")
@@ -73,8 +87,8 @@ forbidden_path_fragments = (
     "/private/var/",
     "/var/folders/",
 )
-forbidden_cfg_fragments = forbidden_path_fragments + (".local/share/uv",)
-forbidden_launcher_fragments = forbidden_cfg_fragments + (".venv-pkg", str(root)) + forbidden_roots
+forbidden_cfg_fragments = forbidden_path_fragments + (".local/share/uv",) + forbidden_roots
+forbidden_launcher_fragments = forbidden_cfg_fragments + (".venv-pkg", str(root))
 errors: list[str] = []
 
 
@@ -369,7 +383,16 @@ def orchard_editable_pth(pth: pathlib.Path, pkg: str) -> bool:
     return False
 
 
-def run_smoke_command(args: list[str], env: dict[str, str], timeout_label: str) -> Optional[subprocess.CompletedProcess[str]]:
+default_smoke_timeout = 10
+tokenizer_preflight_timeout = 180
+
+
+def run_smoke_command(
+    args: list[str],
+    env: dict[str, str],
+    timeout_label: str,
+    timeout_seconds: int = default_smoke_timeout,
+) -> Optional[subprocess.CompletedProcess[str]]:
     try:
         return subprocess.run(
             args,
@@ -377,10 +400,10 @@ def run_smoke_command(args: list[str], env: dict[str, str], timeout_label: str) 
             capture_output=True,
             check=False,
             env=env,
-            timeout=10,
+            timeout=timeout_seconds,
         )
     except subprocess.TimeoutExpired:
-        errors.append(f"{timeout_label} timed out after 10s")
+        errors.append(f"{timeout_label} timed out after {timeout_seconds}s")
         return None
 
 
@@ -419,6 +442,7 @@ tokenizer.save(str(root / "tokenizer.json"))
             [str(python), "-c", generator, str(bundle)],
             env,
             f"installed tokenizer smoke fixture generation failed: {rel(python)}",
+            tokenizer_preflight_timeout,
         )
         if generated is None:
             return
@@ -447,6 +471,7 @@ tokenizer.save(str(root / "tokenizer.json"))
             [str(entry), "--request-json", json.dumps(payload)],
             env,
             f"installed tokenizer safe-tokenization preflight smoke failed: {rel(entry)}",
+            tokenizer_preflight_timeout,
         )
         if preflight is None:
             return

--- a/scripts/verify-staged-venv-closure.sh
+++ b/scripts/verify-staged-venv-closure.sh
@@ -2,6 +2,9 @@
 #
 # Verify Orchard staged or expanded PKG payload Mach-O dependency closure.
 # Usage: scripts/verify-staged-venv-closure.sh [--no-smoke] [--forbid-path <path>]... <staging-or-expanded-root>
+#
+# --forbid-path names an extra build-host root (for example the repo checkout) that
+# staged pyvenv.cfg and bin/ launcher contents must not reference; repeat per root.
 
 set -euo pipefail
 

--- a/scripts/verify-staged-venv-closure.sh
+++ b/scripts/verify-staged-venv-closure.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 #
 # Verify Orchard staged or expanded PKG payload Mach-O dependency closure.
-# Usage: scripts/verify-staged-venv-closure.sh [--no-smoke] <staging-or-expanded-root>
+# Usage: scripts/verify-staged-venv-closure.sh [--no-smoke] [--forbid-path <path>]... <staging-or-expanded-root>
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 [--no-smoke] <staging-or-expanded-root>" >&2
+    echo "Usage: $0 [--no-smoke] [--forbid-path <path>]... <staging-or-expanded-root>" >&2
 }
 
 RUN_SMOKE=true
-if [[ $# -gt 0 && "$1" == "--no-smoke" ]]; then
-    RUN_SMOKE=false
-    shift
-fi
+FORBIDDEN_ROOTS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-smoke)
+            RUN_SMOKE=false
+            shift
+            ;;
+        --forbid-path)
+            if [[ $# -lt 2 ]]; then
+                usage
+                exit 64
+            fi
+            FORBIDDEN_ROOTS+=("$2")
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 if [[ $# -ne 1 ]]; then
     usage
@@ -33,15 +49,19 @@ for required in python3 file otool; do
     fi
 done
 
-python3 - "$ROOT" "$RUN_SMOKE" <<'PY'
+python3 - "$ROOT" "$RUN_SMOKE" "${FORBIDDEN_ROOTS[@]:-}" <<'PY'
+import hashlib
+import json
 import os
 import pathlib
 import subprocess
 import sys
+import tempfile
 from typing import Optional
 
 root = pathlib.Path(sys.argv[1]).resolve()
 run_smoke = sys.argv[2] == "true"
+forbidden_roots = tuple(str(pathlib.Path(path).resolve()) for path in sys.argv[3:] if path)
 payload_rel = pathlib.Path("Library/Application Support/Orchard")
 install_prefix = pathlib.Path("/Library/Application Support/Orchard")
 allowed_system_prefixes = ("/usr/lib/", "/System/Library/")
@@ -54,6 +74,7 @@ forbidden_path_fragments = (
     "/var/folders/",
 )
 forbidden_cfg_fragments = forbidden_path_fragments + (".local/share/uv",)
+forbidden_launcher_fragments = forbidden_cfg_fragments + (".venv-pkg", str(root)) + forbidden_roots
 errors: list[str] = []
 
 
@@ -363,6 +384,90 @@ def run_smoke_command(args: list[str], env: dict[str, str], timeout_label: str) 
         return None
 
 
+def verify_tokenizer_safe_preflight(python: pathlib.Path, entry: pathlib.Path, env: dict[str, str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="orchard-tokenizer-installed-smoke-") as temp_dir:
+        bundle = pathlib.Path(temp_dir)
+        generator = """
+import pathlib
+import sys
+from tokenizers import Tokenizer
+from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+from tokenizers.models import BPE
+from tokenizers.pre_tokenizers import ByteLevel
+from tokenizers.trainers import BpeTrainer
+
+root = pathlib.Path(sys.argv[1])
+corpus = root / "corpus.txt"
+corpus.write_text("hello orchard user assistant system lookup weather", encoding="utf-8")
+tokenizer = Tokenizer(BPE(unk_token="<unk>"))
+tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=False)
+tokenizer.decoder = ByteLevelDecoder()
+trainer = BpeTrainer(
+    vocab_size=300,
+    initial_alphabet=ByteLevel.alphabet(),
+    special_tokens=["<unk>", "<|im_end|>", "<|im_start|>"],
+)
+tokenizer.train([str(corpus)], trainer)
+tokenizer.save(str(root / "tokenizer.json"))
+(root / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+(root / "chat_template.jinja").write_text(
+    "<|im_start|>{{ messages[0]['role'] }}\\n{{ messages[0]['content'] }}\\n<|im_end|>",
+    encoding="utf-8",
+)
+"""
+        generated = run_smoke_command(
+            [str(python), "-c", generator, str(bundle)],
+            env,
+            f"installed tokenizer smoke fixture generation failed: {rel(python)}",
+        )
+        if generated is None:
+            return
+        if generated.returncode != 0:
+            errors.append(
+                f"installed tokenizer smoke fixture generation failed: {rel(python)}: {detail_from(generated)}"
+            )
+            return
+
+        control_tokens = ["<|im_end|>", "<|im_start|>"]
+        payload = {
+            "contract_version": 3,
+            "command": "preflight_safe_tokenization",
+            "assets": {
+                "tokenizer_kind": "huggingface_tokenizer_json",
+                "tokenizer_path": str(bundle / "tokenizer.json"),
+                "tokenizer_config_path": str(bundle / "tokenizer_config.json"),
+                "chat_template_path": str(bundle / "chat_template.jinja"),
+            },
+            "safe_tokenization": {
+                "control_tokens": control_tokens,
+                "catalog_sha256": hashlib.sha256("\0".join(control_tokens).encode("utf-8")).hexdigest(),
+            },
+        }
+        preflight = run_smoke_command(
+            [str(entry), "--request-json", json.dumps(payload)],
+            env,
+            f"installed tokenizer safe-tokenization preflight smoke failed: {rel(entry)}",
+        )
+        if preflight is None:
+            return
+        try:
+            response = json.loads(preflight.stdout)
+        except json.JSONDecodeError:
+            response = None
+        result = response.get("result") if isinstance(response, dict) else None
+        if (
+            preflight.returncode != 0
+            or not isinstance(response, dict)
+            or response.get("ok") is not True
+            or not isinstance(result, dict)
+            or result.get("compatible") is not True
+        ):
+            errors.append(
+                "installed tokenizer safe-tokenization preflight smoke failed: "
+                f"{rel(entry)}: {detail_from(preflight) or preflight.stdout.strip() or 'invalid response'}"
+            )
+
+
 def verify_known_helper_static(venv: pathlib.Path, helper: dict[str, str]) -> pathlib.Path:
     entry = venv / "bin" / helper["entry"]
     if not entry.is_file() or not os.access(entry, os.X_OK):
@@ -404,6 +509,8 @@ def verify_known_helper_smoke(venv: pathlib.Path, python: pathlib.Path, entry: p
         )
         if entry_smoke is not None and entry_smoke.returncode != 0:
             errors.append(f"{helper['entry']} entrypoint smoke failed: {rel(entry)}: {detail_from(entry_smoke)}")
+        if pkg == "orchard_tokenizer":
+            verify_tokenizer_safe_preflight(python, entry, env)
 
 
 def verify_venv(venv: pathlib.Path) -> None:
@@ -448,15 +555,12 @@ def verify_venv(venv: pathlib.Path) -> None:
         for script in bin_dir.glob("*"):
             if script.is_symlink() or not script.is_file() or is_macho(script):
                 continue
-            try:
-                first_line = script.read_text(errors="replace").splitlines()[0]
-            except IndexError:
+            text = script.read_text(errors="replace")
+            if not text.startswith("#!"):
                 continue
-            if not first_line.startswith("#!"):
-                continue
-            for fragment in forbidden_cfg_fragments:
-                if fragment in first_line:
-                    errors.append(f"script shebang has build-host path fragment {fragment!r}: {rel(script)}")
+            for fragment in forbidden_launcher_fragments:
+                if fragment in text:
+                    errors.append(f"script launcher has build-host path fragment {fragment!r}: {rel(script)}")
                     break
 
     if run_smoke and python.exists() and not python.is_symlink():


### PR DESCRIPTION
## Intent

Fix Orchard issue #125 so packaged Python console launchers remain relocatable after installation. Canonicalize both ordinary Python shebangs and uv-generated two-line shell trampolines to invoke the sibling staged interpreter for orchard-tokenizer and orchard-worker-mlx; reject checkout, staging, /Users/, and .venv-pkg references anywhere in launcher contents; prove relocation after removing the source venv; verify expanded and staged payloads; and run an installed-artifact safe-tokenization preflight. Keep this a focused packaging regression fix with no SPEC or OpenSpec behavior change.

## What Changed

- `scripts/materialize-staged-venv-interpreters.sh` now canonicalizes both ordinary `#!` Python shebangs and uv-generated two-line `#!/bin/sh` + `'''exec'` trampolines through a shared `python_launcher_body` matcher, so `orchard-tokenizer` and `orchard-worker-mlx` always exec the sibling staged interpreter instead of a build-host path (previously the trampoline form was skipped and the rewritten launcher could lose its trailing newline).
- `scripts/verify-staged-venv-closure.sh` gained a repeatable `--forbid-path <root>` flag (documented in its usage banner) and now scans full launcher contents rather than just the shebang line, rejecting the build checkout, staging root, `/Users/`, `/private/var/`, and `.venv-pkg` fragments; it also runs an installed-artifact `preflight_safe_tokenization` smoke against the staged tokenizer entrypoint with its own 180s timeout separate from the 10s default.
- `scripts/build-pkg.sh` passes `--forbid-path "$REPO_ROOT"` at all three closure checks and drops `--no-smoke` from expanded-PKG provenance validation, so the extracted payload is executed as well as inspected; `scripts/test-staged-venv-closure.sh` adds uv-style venv fixtures (separate runtime prefix, symlinked `bin/python`, stub `tokenizers` package, template + `cp -Rc` clone) and relocation, forbidden-fragment, and preflight regression cases. `scripts/test-payload-signing-contracts.sh` stub entrypoints answer `--request-json` so the new preflight passes there.

Validated with `./scripts/test-staged-venv-closure.sh` (passes), plus manual staging, relocation proof under `env -i` after deleting `.venv-pkg`, and a base-vs-fixed diff run on real uv trampoline launchers. `scripts/test-payload-signing-contracts.sh` fails identically at the base commit and on this branch (fake `mix` stub lacks an `assets.setup` branch, stale `pkgutil --payload-files` fixture, and a bash 3.2 `env_args[@]` unbound-variable abort at `build-pkg.sh:220`) — pre-existing and left for a separate PR.

## Risk Assessment

✅ Low: The branch is confined to five packaging scripts, every prior-round finding is resolved, and I empirically confirmed the new fixture machinery reproduces the real uv staging layout and yields a genuinely relocatable interpreter after both the source venv and the runtime prefix are deleted.

## Testing

Ran the materializer/closure regression suite (passes) and then proved the user intent at product level: built real uv packaging venvs for orchard-tokenizer and orchard-worker-mlx, staged and materialized them exactly as build-pkg.sh does, verified closure with the checkout root forbidden, then relocated the payload and deleted the build venv — both console launchers still run, and the relocated tokenizer answers a real safe-tokenization preflight with compatible:true. A base-vs-fixed comparison on uv's two-line trampoline (which uv emits for any path containing a space, i.e. the real install prefix) shows the pre-fix launcher failing with "No such file or directory" while the fixed one prints 0.1.0, and shows the tightened verifier now rejecting the stale build-host launcher that the old first-line-only check accepted. The adjacent scripts/test-payload-signing-contracts.sh suite fails, but it fails the same way on the base commit, so it is pre-existing and not a regression from this change. No visual/UI surface is involved; evidence is CLI transcripts.

<details>
<summary>Evidence: End-to-end relocation proof (orchard-tokenizer, real uv venv)</summary>

<code>===== 1. uv-generated launcher in the build checkout (before staging) =====&#10;#!/Users/najib/.../native/orchard_tokenizer/.venv-pkg/bin/python&#10;bin/python -&gt; /Users/najib/.local/share/mise/installs/python/3.11.15/bin/python3.11&#10;home = /Users/najib/.local/share/mise/installs/python/3.11.15/bin&#10;&#10;===== 3. canonicalized launcher after materialization =====&#10;#!/bin/sh&#10;&#39;&#39;&#39;exec&#39; &#34;$(CDPATH= cd -- &#34;$(dirname -- &#34;$0&#34;)&#34; &amp;&amp; pwd)/python&#34; &#34;$0&#34; &#34;$@&#34;&#10;&#39; &#39;&#39;&#39;&#10;bin/python is symlink: no&#10;staged pyvenv.cfg:&#10;implementation = CPython&#10;version_info = 3.11.15&#10;include-system-site-packages = false&#10;&#10;===== 4. no checkout / staging / /Users/ / .venv-pkg reference in launcher contents =====&#10;clean: no &lt;checkout&gt; reference&#10;clean: no &lt;staging root&gt; reference&#10;clean: no /Users/ reference&#10;clean: no .venv-pkg reference&#10;&#10;===== 5. verify-staged-venv-closure.sh --forbid-path &lt;checkout&gt; on the staged payload =====&#10;ok Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/python&#10;ok Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/libpython3.11.dylib&#10;staged closure + installed-artifact safe-tokenization preflight: PASS&#10;&#10;===== 6. relocate payload and delete the build venv =====&#10;build venv present: no&#10;&#10;===== 7. run the relocated installed launcher with a sanitized environment =====&#10;+ env -i PATH=/usr/bin:/bin HOME=... &#39;.../installed/Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/orchard-tokenizer&#39; --help&#10;usage: orchard-tokenizer [-h] [--request-json REQUEST_JSON] [--version]&#10;&#10;===== 8. installed-artifact safe-tokenization preflight =====&#10;built tokenizer bundle with the relocated interpreter&#10;{&#34;contract_version&#34;: 3, &#34;ok&#34;: true, &#34;result&#34;: {&#34;compatible&#34;: true, &#34;template_compatible&#34;: true, &#34;incompatibility_reason&#34;: null}}&#10;&#10;===== RESULT =====&#10;Relocated packaged launcher ran end-to-end with the build checkout venv deleted.</code>

```text

===== 1. uv-generated launcher in the build checkout (before staging) =====
#!/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/native/orchard_tokenizer/.venv-pkg/bin/python
bin/python -> /Users/najib/.local/share/mise/installs/python/3.11.15/bin/python3.11
home = /Users/najib/.local/share/mise/installs/python/3.11.15/bin

===== 2. stage the packaging venv as .venv (build-pkg.sh stage_packaging_venv) =====
materialized	/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/stage/Library/Application Support/Orchard/native/orchard_tokenizer/.venv

===== 3. canonicalized launcher after materialization =====
#!/bin/sh
'''exec' "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/python" "$0" "$@"
' '''
bin/python is symlink: no
staged pyvenv.cfg:
    implementation = CPython
    uv = 0.11.23
    version_info = 3.11.15
    include-system-site-packages = false
    prompt = orchard-tokenizer

===== 4. no checkout / staging / /Users/ / .venv-pkg reference in launcher contents =====
clean: no /Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9 reference
clean: no /Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence reference
clean: no /Users/ reference
clean: no .venv-pkg reference

===== 5. verify-staged-venv-closure.sh --forbid-path <checkout> on the staged payload =====
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/python
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/ruff
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/itcl4.3.5/libitcl4.3.5.dylib
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/itcl4.3.5/libtcl9itcl4.3.5.dylib
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/libpython3.11.dylib
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/libtcl9.0.dylib
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/thread3.0.4/libthread3.0.4.dylib
staged closure + installed-artifact safe-tokenization preflight: PASS

===== 6. relocate payload and delete the build venv (simulates install + checkout removal) =====
build venv present: no
installed launcher: /Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/installed/Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/orchard-tokenizer

===== 7. run the relocated installed launcher with a sanitized environment =====
+ env -i PATH=/usr/bin:/bin HOME=/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/home '/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/installed/Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/orchard-tokenizer' --help
+ head -5
usage: orchard-tokenizer [-h] [--request-json REQUEST_JSON] [--version]

Orchard exact prompt rendering and token counting helper.

options:
+ set +x

===== 8. installed-artifact safe-tokenization preflight against a real tokenizer bundle =====



built tokenizer bundle with the relocated interpreter
{"contract_version": 3, "ok": true, "result": {"compatible": true, "template_compatible": true, "incompatibility_reason": null}}

===== RESULT =====
Relocated packaged launcher ran end-to-end with the build checkout venv deleted.
```
</details>
<details>
<summary>Evidence: Base vs fixed: uv two-line shell trampoline</summary>

<code>===== uv-generated launcher as it ships from the build host =====&#10;#!/bin/sh&#10;&#39;&#39;&#39;exec&#39; &#39;/Users/najib/.../spaced/Application Support/Orchard/native/orchard_tokenizer/.venv-pkg/bin/python&#39; &#34;$0&#34; &#34;$@&#34;&#10;&#10;===== materialize with the BASE script (c7c6a67) and with the FIXED script =====&#10;BASE launcher:&#10;#!/bin/sh&#10;&#39;&#39;&#39;exec&#39; &#39;/Users/najib/.../.venv-pkg/bin/python&#39; &#34;$0&#34; &#34;$@&#34; &lt;-- unchanged, still build-host absolute&#10;FIXED launcher:&#10;#!/bin/sh&#10;&#39;&#39;&#39;exec&#39; &#34;$(CDPATH= cd -- &#34;$(dirname -- &#34;$0&#34;)&#34; &amp;&amp; pwd)/python&#34; &#34;$0&#34; &#34;$@&#34;&#10;&#10;===== verifier on the BASE payload =====&#10;script launcher has build-host path fragment &#39;/Users/&#39;: .../.venv/bin/orchard-tokenizer&#10;(+12 more launchers)&#10;&#10;===== verifier on the FIXED payload =====&#10;FIXED payload: closure verification PASS&#10;&#10;===== delete the build venv, then run both relocated launchers =====&#10;base launcher --version: .../bin/orchard-tokenizer: line 2: /Users/najib/.../.venv-pkg/bin/python: No such file or directory&#10;head launcher --version: 0.1.0</code>

```text

===== uv-generated launcher as it ships from the build host =====
#!/bin/sh
'''exec' '/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/spaced/Application Support/Orchard/native/orchard_tokenizer/.venv-pkg/bin/python' "$0" "$@"
' '''

===== materialize with the BASE script (c7c6a67) and with the FIXED script =====
BASE launcher:
    #!/bin/sh
    '''exec' '/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/spaced/Application Support/Orchard/native/orchard_tokenizer/.venv-pkg/bin/python' "$0" "$@"
    ' '''
FIXED launcher:
    #!/bin/sh
    '''exec' "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/python" "$0" "$@"
    ' '''

===== verify-staged-venv-closure.sh --forbid-path <checkout> on the BASE payload =====
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/coverage-3.11
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/pytest
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/typer
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/coverage3
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/tiny-agents
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/httpx
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/tqdm
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/markdown-it
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/pygmentize
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/hf
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/orchard-tokenizer
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/coverage
    script launcher has build-host path fragment '/Users/': Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/py.test

===== verify-staged-venv-closure.sh --forbid-path <checkout> on the FIXED payload =====
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/python
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/ruff
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/itcl4.3.5/libitcl4.3.5.dylib
ok	Library/Application Support/Orchard/native/orchard_tokenizer/.venv/lib/thread3.0.4/libthread3.0.4.dylib
FIXED payload: closure verification PASS

===== delete the build venv, then run both relocated launchers =====
base launcher --version: /Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/trampoline/base/Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/orchard-tokenizer: line 2: /Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/spaced/Application Support/Orchard/native/orchard_tokenizer/.venv-pkg/bin/python: No such file or directory
head launcher --version: 0.1.0
```
</details>
<details>
<summary>Evidence: orchard-worker-mlx relocation proof</summary>

<code>===== uv-generated launcher on the build host =====&#10;#!/bin/sh&#10;&#39;&#39;&#39;exec&#39; &#39;/Users/najib/.../spaced-mlx/.../orchard_worker_mlx/.venv-pkg/bin/python&#39; &#34;$0&#34; &#34;$@&#34;&#10;&#10;===== canonicalized launcher =====&#10;#!/bin/sh&#10;&#39;&#39;&#39;exec&#39; &#34;$(CDPATH= cd -- &#34;$(dirname -- &#34;$0&#34;)&#34; &amp;&amp; pwd)/python&#34; &#34;$0&#34; &#34;$@&#34;&#10;&#39; &#39;&#39;&#39;&#10;&#10;===== closure verification with the checkout root forbidden =====&#10;ok Library/Application Support/Orchard/native/orchard_worker_mlx/.venv/bin/python&#10;PASS&#10;&#10;===== relocate, delete build venv, run the installed launcher =====&#10;usage: orchard-worker-mlx [-h] --socket-path SOCKET_PATH&#10;[--backend {mlx,stub}] [--log-file LOG_FILE]&#10;[--version] [--prefix-cache-mode {disabled,kv,trie}]</code>

```text

===== uv-generated launcher on the build host =====
#!/bin/sh
'''exec' '/Users/najib/.no-mistakes/worktrees/2b20bc518d75/01KYY10D0X86S897GDJG1WA7C9/.orchard-relocation-evidence/spaced-mlx/Application Support/Orchard/native/orchard_worker_mlx/.venv-pkg/bin/python' "$0" "$@"

===== canonicalized launcher =====
#!/bin/sh
'''exec' "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/python" "$0" "$@"
' '''

===== closure verification with the checkout root forbidden =====
ok	Library/Application Support/Orchard/native/orchard_worker_mlx/.venv/bin/python
ok	Library/Application Support/Orchard/native/orchard_worker_mlx/.venv/bin/ruff
ok	Library/Application Support/Orchard/native/orchard_worker_mlx/.venv/lib/itcl4.3.5/libitcl4.3.5.dylib
ok	Library/Application Support/Orchard/native/orchard_worker_mlx/.venv/lib/itcl4.3.5/libtcl9itcl4.3.5.dylib
PASS

===== relocate, delete build venv, run the installed launcher =====
usage: orchard-worker-mlx [-h] --socket-path SOCKET_PATH
                          [--backend {mlx,stub}] [--log-file LOG_FILE]
                          [--version] [--prefix-cache-mode {disabled,kv,trie}]
                          [--prefix-cache-max-entries PREFIX_CACHE_MAX_ENTRIES]
                          [--prefix-cache-max-bytes PREFIX_CACHE_MAX_BYTES]
                          [--max-fingerprint-buffer-size MAX_FINGERPRINT_BUFFER_SIZE]
```
</details>
<details>
<summary>Evidence: Safe-tokenization preflight gate fires on a real staged payload</summary>

<code>===== verifier smoke against a real staged payload whose tokenizer entrypoint fails the preflight =====&#10;installed tokenizer safe-tokenization preflight smoke failed: Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/orchard-tokenizer: {&#34;contract_version&#34;:3,&#34;ok&#34;:false,&#34;error&#34;:{&#34;category&#34;:&#34;incompatible_tokenizer&#34;}}&#10;(verifier exited non-zero as expected)</code>

```text
===== verifier smoke against a real staged payload whose tokenizer entrypoint fails the preflight =====
installed tokenizer safe-tokenization preflight smoke failed: Library/Application Support/Orchard/native/orchard_tokenizer/.venv/bin/orchard-tokenizer: {"contract_version":3,"ok":false,"error":{"category":"incompatible_tokenizer"}}
(verifier exited non-zero as expected)
```
</details>
<details>
<summary>Evidence: Evidence driver scripts (reproduce the proofs)</summary>

```text
#!/bin/bash
# End-to-end proof for Orchard issue #125: packaged Python console launchers
# stay runnable after the build checkout venv is gone and the payload moves.
#
# Mirrors scripts/build-pkg.sh: uv sync --> stage as .venv --> materialize -->
# verify closure --> relocate --> run the installed launcher.
set -euo pipefail

REPO_ROOT="${REPO_ROOT:?}"
WORK="${WORK:?}"
INSTALL_REL="Library/Application Support/Orchard"

rule() { printf '\n===== %s =====\n' "$1"; }

rm -rf "$WORK"
STAGE="$WORK/stage/$INSTALL_REL"
INSTALLED="$WORK/installed/$INSTALL_REL"
mkdir -p "$STAGE/native/orchard_tokenizer"

rule "1. uv-generated launcher in the build checkout (before staging)"
head -1 "$REPO_ROOT/native/orchard_tokenizer/.venv-pkg/bin/orchard-tokenizer"
printf 'bin/python -> %s\n' "$(readlink "$REPO_ROOT/native/orchard_tokenizer/.venv-pkg/bin/python")"
grep '^home = ' "$REPO_ROOT/native/orchard_tokenizer/.venv-pkg/pyvenv.cfg"

rule "2. stage the packaging venv as .venv (build-pkg.sh stage_packaging_venv)"
cp -R "$REPO_ROOT/native/orchard_tokenizer/.venv-pkg" "$STAGE/native/orchard_tokenizer/.venv"
COPYFILE_DISABLE=1 COPY_EXTENDED_ATTRIBUTES_DISABLE=1 \
    "$REPO_ROOT/scripts/materialize-staged-venv-interpreters.sh" "$STAGE/native"

rule "3. canonicalized launcher after materialization"
head -3 "$STAGE/native/orchard_tokenizer/.venv/bin/orchard-tokenizer"
printf 'bin/python is symlink: %s\n' "$([ -L "$STAGE/native/orchard_tokenizer/.venv/bin/python" ] && echo yes || echo no)"
printf 'staged pyvenv.cfg:\n'
sed 's/^/    /' "$STAGE/native/orchard_tokenizer/.venv/pyvenv.cfg"

rule "4. no checkout / staging / /Users/ / .venv-pkg reference in launcher contents"
for pattern in "$REPO_ROOT" "$WORK" "/Users/" ".venv-pkg"; do
    if grep -rlF -- "$pattern" "$STAGE/native/orchard_tokenizer/.venv/bin/orchard-tokenizer"; then
        echo "FAIL: launcher still references $pattern"
        exit 1
    fi
    printf 'clean: no %s reference\n' "$pattern"
done

rule "5. verify-staged-venv-closure.sh --forbid-path <checkout> on the staged payload"
"$REPO_ROOT/scripts/verify-staged-venv-closure.sh" --forbid-path "$REPO_ROOT" "$WORK/stage" \
    | sed -n '1,6p;$p'
echo "staged closure + installed-artifact safe-tokenization preflight: PASS"

rule "6. relocate payload and delete the build venv (simulates install + checkout removal)"
mkdir -p "$WORK/installed"
cp -R "$WORK/stage/Library" "$WORK/installed/"
rm -rf "$WORK/stage" "$REPO_ROOT/native/orchard_tokenizer/.venv-pkg"
printf 'build venv present: %s\n' "$([ -e "$REPO_ROOT/native/orchard_tokenizer/.venv-pkg" ] && echo yes || echo no)"
printf 'installed launcher: %s\n' "$INSTALLED/native/orchard_tokenizer/.venv/bin/orchard-tokenizer"

rule "7. run the relocated installed launcher with a sanitized environment"
ENTRY="$INSTALLED/native/orchard_tokenizer/.venv/bin/orchard-tokenizer"
set -x
env -i PATH=/usr/bin:/bin HOME="$WORK/home" "$ENTRY" --help | head -5
set +x

rule "8. installed-artifact safe-tokenization preflight against a real tokenizer bundle"
BUNDLE="$WORK/bundle"
mkdir -p "$BUNDLE"
env -i PATH=/usr/bin:/bin HOME="$WORK/home" \
    "$INSTALLED/native/orchard_tokenizer/.venv/bin/python" - "$BUNDLE" <<'PY'
import pathlib
import sys

from tokenizers import Tokenizer
from tokenizers.decoders import ByteLevel as ByteLevelDecoder
from tokenizers.models import BPE
from tokenizers.pre_tokenizers import ByteLevel
from tokenizers.trainers import BpeTrainer

root = pathlib.Path(sys.argv[1])
corpus = root / "corpus.txt"
corpus.write_text("hello orchard user assistant system lookup weather", encoding="utf-8")
tokenizer = Tokenizer(BPE(unk_token="<unk>"))
tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=False)
tokenizer.decoder = ByteLevelDecoder()
trainer = BpeTrainer(
    vocab_size=300,
    initial_alphabet=ByteLevel.alphabet(),
    special_tokens=["<unk>", "<|im_end|>", "<|im_start|>"],
)
tokenizer.train([str(corpus)], trainer)
tokenizer.save(str(root / "tokenizer.json"))
(root / "tokenizer_config.json").write_text("{}", encoding="utf-8")
(root / "chat_template.jinja").write_text(
    "<|im_start|>{{ messages[0]['role'] }}\n{{ messages[0]['content'] }}\n<|im_end|>",
    encoding="utf-8",
)
print("built tokenizer bundle with the relocated interpreter")
PY

REQUEST=$(BUNDLE="$BUNDLE" /usr/bin/python3 - <<'PY'
import hashlib
import json
import os

bundle = os.environ["BUNDLE"]
control = ["<|im_end|>", "<|im_start|>"]
print(json.dumps({
    "contract_version": 3,
    "command": "preflight_safe_tokenization",
    "assets": {
        "tokenizer_kind": "huggingface_tokenizer_json",
        "tokenizer_path": f"{bundle}/tokenizer.json",
        "tokenizer_config_path": f"{bundle}/tokenizer_config.json",
        "chat_template_path": f"{bundle}/chat_template.jinja",
    },
    "safe_tokenization": {
        "control_tokens": control,
        "catalog_sha256": hashlib.sha256("\0".join(control).encode()).hexdigest(),
    },
}))
PY
)
env -i PATH=/usr/bin:/bin HOME="$WORK/home" "$ENTRY" --request-json "$REQUEST"

rule "RESULT"
echo "Relocated packaged launcher ran end-to-end with the build checkout venv deleted."
```
</details>
- Outcome: ⚠️ 2 warnings across 1 run (17m19s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `scripts/test-staged-venv-closure.sh:598` - The new safe-tokenization preflight regression test can never observe the message it asserts. `make_known_helper_venv_fixture` builds a real interpreter via `python3 -m venv --copies` and then wipes site-packages, so the fixture venv has no `tokenizers`. `verify_tokenizer_safe_preflight` (scripts/verify-staged-venv-closure.sh:418-429) runs the fixture generator with that interpreter first; it exits non-zero with ModuleNotFoundError, the function appends `installed tokenizer smoke fixture generation failed: ...` and returns early, so the `safe_fail` entrypoint is never invoked and `installed tokenizer safe-tokenization preflight smoke failed` is never emitted. `assert_verifier_fails_with` then fails its grep and the whole script exits 1. Verified empirically: a fresh `--copies` venv returns exit 1 on `from tokenizers import Tokenizer`. Fix the fixture so the generator step succeeds (e.g. drop a stub `tokenizers` module into the fixture site-packages, or use a stub `bin/python` like scripts/test-payload-signing-contracts.sh:515 does) rather than weakening the assertion.
- ⚠️ `scripts/verify-staged-venv-closure.sh:446` - The new tokenizer preflight reuses `run_smoke_command`&#39;s hardcoded 10s timeout (line 380), but it is far heavier than the previous `--help` smoke it sits next to: a cold interpreter start plus `tokenizers` + `jinja2` imports, a BPE training run, tokenizer load, and 18 sentinel payloads each dual-rendered through the chat template. Because `validate_expanded_pkg_provenance` now runs with smoke enabled, this executes against a freshly `pkgutil --expand-full`-extracted payload with no bytecode cache and first-launch Gatekeeper assessment on each Mach-O, where 10s is a plausible overrun. A timeout here fails the packaging build with `installed tokenizer safe-tokenization preflight smoke failed ... timed out after 10s` and is indistinguishable from a genuine contract regression. Give this step its own, larger timeout (parameterize `run_smoke_command`).
- ℹ️ `scripts/verify-staged-venv-closure.sh:64` - Two small gaps in the new `--forbid-path` plumbing. (1) `forbidden_roots` stores only the symlink-resolved form of each root, while `REPO_ROOT` in build-pkg.sh:100 is a logical `cd &amp;&amp; pwd` path; if the checkout is reached through a symlinked component the launcher text will contain the unresolved path and will not match the resolved fragment. Adding both the raw and resolved strings closes this. (2) `forbidden_roots` is applied to launchers (line 77) but not to `pyvenv.cfg` (line 532 still uses `forbidden_cfg_fragments`), so a build-root leak in `pyvenv.cfg`&#39;s `executable`/`command` keys on a non-/Users/ build host is still accepted. The intent only mandates launcher coverage, so this is a hardening opportunity rather than a miss.
- ℹ️ `scripts/build-pkg.sh:647` - Dropping `--no-smoke` from `validate_expanded_pkg_provenance` means every expanded-PKG validation (scratch pkgbuild preflight at line 694 and the unsigned PKG at line 1399) now executes payload interpreters, both console entrypoints, and the tokenizer preflight out of a `$TMPDIR` extraction, largely duplicating the staged-payload smoke already run at build-pkg.sh:1659. This matches the stated intent of proving the installed artifact, so it is a deliberate tradeoff, but it materially lengthens the build and introduces a second place where first-launch execution of extracted binaries can fail. Noting it so the cost is a conscious choice rather than a surprise.

🔧 Fix: fix unreachable preflight test and tighten venv closure checks
2 issues (1 warning, 1 info) still open:
- ⚠️ `scripts/test-staged-venv-closure.sh:322` - The relocation fixture builds its venv with `python3 -m venv --copies`, which makes `bin/python` a real file *inside* the venv. That sends the materializer down a degenerate path: `runtime_prefix` resolves to the venv itself, so the `python.is_symlink()` copy, the `bin/python*` symlink copy, and the `shutil.copytree(runtime_lib, staged_lib)` stdlib copy are all skipped (materialize-staged-venv-interpreters.sh:220-245), while the `home = ` line is still stripped from `pyvenv.cfg`. The relocated venv therefore contains no stdlib and only works if the ambient interpreter&#39;s prefix fallback happens to rescue it. Verified empirically: with Homebrew python 3.14 the relocated interpreter resolves `sys.prefix` to the venv and the test passes; with the repo-pinned mise python 3.11.15 the same sequence dies with `Fatal Python error: init_fs_encoding ... No module named &#39;encodings&#39;` (exit 1), which aborts the whole script under `set -euo pipefail` at line 355. So the test&#39;s outcome depends on which `python3` is first on PATH, and it proves launcher relocation without exercising the interpreter/stdlib materialization the real build depends on. Make the fixture mirror the real uv layout - create the venv with a symlinked interpreter outside the venv tree (or stage a separate runtime prefix and symlink `bin/python` into it) so `runtime_lib != staged_lib` and the copytree path actually runs. Note the pre-existing `make_known_helper_venv_fixture` has the same host-python coupling, so this is an inherited constraint the new test extends rather than one it invents.
- ℹ️ `scripts/verify-staged-venv-closure.sh:413` - The generator heredoc at lines 413-440 plus the request payload at 455-468 are a hand-copy of `_build_segmented_tokenizer` / `_make_segmented_bundle` / `preflight_payload` in native/orchard_tokenizer/tests/test_cli.py:1481-1541 (same corpus string, same `vocab_size=300`, same special tokens, same chat template, same control-token pair). I confirmed the copy is currently faithful and that `catalog_sha256` here matches `safe_segmented.catalog_sha256`, so it works today. The risk is silent drift: if the tokenizer contract gains a required asset or bumps past `contract_version` 3, the pytest suite gets updated and this shell-embedded copy does not, turning the packaging gate into either a confusing hard failure or a vacuous pass. Worth a comment cross-referencing the pytest fixture so the coupling is discoverable.

🔧 Fix: make venv fixtures mirror real uv staging layout
2 infos still open:
- ℹ️ `scripts/test-staged-venv-closure.sh:168` - The `_tkinter*` entry in the ignore list is load-bearing but reads like ordinary size trimming next to `test`/`idlelib`/`turtledemo`. Because the fixture now copies real native extension modules into the runtime prefix, any `lib-dynload` module carrying an `@rpath/*.dylib` dependency whose target is not copied alongside it will make `remediate_venv_rpath_deps` hard-abort with `unresolved @rpath dependency has no in-venv candidate` (materialize-staged-venv-interpreters.sh:196-198), killing the whole script under `set -euo pipefail` with a message that looks like a materializer regression rather than fixture setup. I checked both plausible host interpreters: Homebrew 3.14 has zero `@rpath` deps in `lib-dynload`, and mise 3.11.15 (the pinned toolchain) has exactly one - `_tkinter.cpython-311-darwin.so` with `@rpath/libtcl9.0.dylib` and `@rpath/libtcl9tk9.0.dylib` - which this pattern excludes. So it works today, but the reason is invisible. A one-line comment saying `_tkinter` is excluded because it carries unresolvable `@rpath` Tcl/Tk deps would keep a future trim of this list from breaking the suite mysteriously.
- ℹ️ `scripts/test-staged-venv-closure.sh:146` - Making the fixtures realistic moves this script from near-instant to roughly a minute of setup and walking. Each materialized venv now holds ~645 stdlib files / ~19 MB after the ignore list (measured against Homebrew 3.14); the materializer runs three times (once for the template, twice for the relocation pair) at ~3.3s each (measured), and every one of the ~16 verifier invocations walks the whole tree with one `file` subprocess per file via `discover_machos`. The template-plus-`cp -Rc` design already avoids the worst of it - I confirmed `cp -Rc` is supported here so the clone fast path is taken rather than the `cp -R` fallback at line 215. This is the necessary price of exercising the real materializer path instead of the degenerate one, so it is a deliberate tradeoff worth knowing about, not something to undo.

</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ `scripts/test-payload-signing-contracts.sh:673` - scripts/test-payload-signing-contracts.sh fails at both the target commit (b583fe5) and the base commit (c7c6a67), so it cannot validate the build-pkg.sh wiring this change touches. Three independent causes, in order: (1) the fake `mix` stub has no `assets.setup` branch, so build-pkg.sh:1555 aborts with &#34;unexpected mix invocation&#34;; (2) the fake `pkgutil --payload-files` list omits share/bin/orchard-managed-postgres and both native venv entrypoints that build-pkg.sh&#39;s required_entries now demand (and PackageInfo numberOfFiles is stale at 8); (3) after fixing 1 and 2 the run reaches build-pkg.sh:220, which fails under stock macOS bash 3.2. I confirmed 1 and 2 are locally fixable but reverted those exploratory fixture edits to keep this branch a focused packaging regression fix, since the suite still cannot go green without a product change. Recommend a separate PR.
- ⚠️ `scripts/build-pkg.sh:220` - Pre-existing (not introduced here, but in a file this change edits): build-pkg.sh:220 runs `env &#34;${env_args[@]}&#34; .../verify-payload-signing.sh` where env_args is an empty array whenever no build keychain is configured. Under `set -u` on the stock macOS /bin/bash 3.2 this aborts with &#34;env_args[@]: unbound variable&#34;, so any build that sets ORCHARD_PAYLOAD_SIGNING_IDENTITY without ORCHARD_BUILD_KEYCHAIN fails at the post-scrub payload verification step. Reproduced directly: `/bin/bash -c &#39;set -euo pipefail; a=(); env &#34;${a[@]}&#34; true&#39;` exits 1. The usual fix is `&#34;${env_args[@]+&#34;${env_args[@]}&#34;}&#34;`. Flagging rather than fixing, since product changes are outside this testing pass.
- <code>`mise exec -- ./scripts/test-staged-venv-closure.sh` (full regression suite for the materializer + closure verifier — passes)</code>
- <code>`UV_PROJECT_ENVIRONMENT=.venv-pkg uv sync --locked --no-editable` in `native/orchard_tokenizer` and `native/orchard_worker_mlx`, replicating build-pkg.sh&#39;s `sync_packaging_venv`</code>
- <code>Manual staging + `scripts/materialize-staged-venv-interpreters.sh` over a real staged `Library/Application Support/Orchard/native` tree, then `scripts/verify-staged-venv-closure.sh --forbid-path &lt;checkout&gt;` (smoke enabled)</code>
- <code>Relocation proof: copied the staged payload to a new install path, deleted `.venv-pkg`, ran `orchard-tokenizer --help` and `orchard-tokenizer --request-json &#39;{... preflight_safe_tokenization ...}&#39;` under `env -i`</code>
- <code>Relocation proof for `orchard-worker-mlx --help` under `env -i` after deleting the build venv</code>
- <code>Base-vs-fixed diff run: `git show c7c6a67:scripts/materialize-staged-venv-interpreters.sh` against the fixed script on identical uv trampoline launchers, plus `verify-staged-venv-closure.sh --no-smoke --forbid-path &lt;checkout&gt;` on both payloads</code>
- <code>Negative check: replaced the staged tokenizer entrypoint with one answering `ok:false` and confirmed `verify-staged-venv-closure.sh` reports `installed tokenizer safe-tokenization preflight smoke failed`</code>
- <code>`mise exec -- ./scripts/test-payload-signing-contracts.sh` at target commit b583fe5 and at base commit c7c6a67 (fails identically at both)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788166052&installation_model_id=428414&pr_number=141&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F141&signature=aa44236996497b1c0dd3e72caee64ea5626c747a2773bf1d9ea76e0575866888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->