### PR TITLE
test(node_agent): anchor beam peer grant fixtures to a relative window

### DIFF
--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -579,6 +579,31 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
              BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
   end
 
+  test "SPEC.md §7.5.0 ordinary store fixture remains valid after its former calendar expiry" do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-node-peer-grant-calendar-independent-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir!(root)
+    File.chmod!(root, 0o700)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    identity = identity()
+    after_former_expiry = ~U[2026-08-12 08:00:01.000000Z]
+    delivery = delivery(identity, after_former_expiry)
+
+    assert {:ok, _stored} =
+             BeamPeerGrantStore.install(
+               root,
+               identity,
+               delivery,
+               delivery.node_beam_name,
+               now: fn -> after_former_expiry end
+             )
+  end
+
   test "SPEC.md §7.5.0 a freshly delivered expired grant is never persisted" do
     root =
       Path.join(
@@ -603,7 +628,40 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
       })
 
     assert {:error, :beam_peer_grant_expired} =
-             BeamPeerGrantStore.install(root, identity, expired, expired.node_beam_name)
+             BeamPeerGrantStore.install(
+               root,
+               identity,
+               expired,
+               expired.node_beam_name,
+               now: fn -> now end
+             )
+
+    refute File.exists?(Path.join([root, "beam-peer-grants", "#{identity.controller_id}.json"]))
+  end
+
+  test "SPEC.md §7.5.0 a not-yet-active grant is never persisted" do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-node-peer-grant-not-active-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir!(root)
+    File.chmod!(root, 0o700)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    identity = identity()
+    delivery = delivery(identity)
+    before_activation = DateTime.add(delivery.not_before_at, -1, :second)
+
+    assert {:error, :beam_peer_grant_not_active} =
+             BeamPeerGrantStore.install(
+               root,
+               identity,
+               delivery,
+               delivery.node_beam_name,
+               now: fn -> before_activation end
+             )
 
     refute File.exists?(Path.join([root, "beam-peer-grants", "#{identity.controller_id}.json"]))
   end
@@ -913,8 +971,11 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
     }
   end
 
-  defp delivery(identity) do
+  defp delivery(identity), do: delivery(identity, DateTime.utc_now())
+
+  defp delivery(identity, reference_time) do
     encoded_secret = Base.url_encode64(:binary.copy(<<5>>, 32), padding: false)
+    not_before_at = DateTime.add(reference_time, -1, :second)
 
     %{
       grant_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
@@ -931,10 +992,10 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
       node_certificate_fingerprint_sha256: identity.certificate_fingerprint,
       contract_version: 1,
       purpose: "runtime_endpoint",
-      issued_at: ~U[2026-07-13 08:00:00.000000Z],
-      not_before_at: ~U[2026-07-13 08:00:00.000000Z],
+      issued_at: not_before_at,
+      not_before_at: not_before_at,
       cutover_at: nil,
-      expires_at: ~U[2026-08-12 08:00:00.000000Z],
+      expires_at: DateTime.add(not_before_at, 30 * 24 * 60 * 60, :second),
       encoded_secret: encoded_secret,
       secret_hash: :crypto.hash(:sha256, encoded_secret)
     }

--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -7,6 +7,10 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
   alias Orchard.Node.{BeamPeerGrantClient, BeamPeerGrantStore}
   alias Orchard.Node.BeamPeerGrantClient.GRPCTransport
 
+  @fixture_activation_backdate_seconds 60
+  @fixture_validity_seconds 30 * 24 * 60 * 60
+  @fixture_anchor_tolerance_seconds 3600
+
   defmodule FakeControlTransport do
     def retrieve(target, credential, request) do
       send(self(), {:grant_control_retrieve, target, credential, request})
@@ -579,7 +583,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
              BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
   end
 
-  test "SPEC.md §7.5.0 ordinary store fixture remains valid after its former calendar expiry" do
+  test "SPEC.md §7.5.0 the ordinary store fixture anchors its window to the current clock" do
     root =
       Path.join(
         System.tmp_dir!(),
@@ -591,17 +595,22 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
     on_exit(fn -> File.rm_rf!(root) end)
 
     identity = identity()
-    after_former_expiry = ~U[2026-08-12 08:00:01.000000Z]
-    delivery = delivery(identity, after_former_expiry)
+    before_build = DateTime.utc_now()
+    delivery = delivery(identity)
+
+    assert DateTime.compare(delivery.not_before_at, before_build) == :lt
+
+    assert DateTime.diff(before_build, delivery.not_before_at, :second) <
+             @fixture_anchor_tolerance_seconds
+
+    assert DateTime.diff(delivery.expires_at, delivery.not_before_at, :second) ==
+             @fixture_validity_seconds
 
     assert {:ok, _stored} =
-             BeamPeerGrantStore.install(
-               root,
-               identity,
-               delivery,
-               delivery.node_beam_name,
-               now: fn -> after_former_expiry end
-             )
+             BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
+
+    assert {:ok, loaded} = BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
+    assert loaded.grant_id == delivery.grant_id
   end
 
   test "SPEC.md §7.5.0 a freshly delivered expired grant is never persisted" do
@@ -975,7 +984,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
 
   defp delivery(identity, reference_time) do
     encoded_secret = Base.url_encode64(:binary.copy(<<5>>, 32), padding: false)
-    not_before_at = DateTime.add(reference_time, -1, :second)
+    not_before_at = DateTime.add(reference_time, -@fixture_activation_backdate_seconds, :second)
 
     %{
       grant_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
@@ -995,7 +1004,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
       issued_at: not_before_at,
       not_before_at: not_before_at,
       cutover_at: nil,
-      expires_at: DateTime.add(not_before_at, 30 * 24 * 60 * 60, :second),
+      expires_at: DateTime.add(not_before_at, @fixture_validity_seconds, :second),
       encoded_secret: encoded_secret,
       secret_hash: :crypto.hash(:sha256, encoded_secret)
     }


### PR DESCRIPTION
## Intent

Fix Orchard issue #143 by removing the fixed 2026-08-12 expiry from shared BEAM peer-grant test fixtures. Keep production Peer Grant validity semantics, SPEC.md, ADRs, OpenSpec, dependencies, and production code unchanged. Make ordinary store and client tests calendar and timezone independent with a bounded relative 30-day fixture, retain deterministic expired and exact-boundary coverage, and add explicit not-yet-active coverage through BeamPeerGrantStore.install/5. Validate the final branch with the full Orchard Elixir workflow, exact-head RepoPrompt review, No Mistakes, PR, and CI.

## What Changed

- Replaced the hardcoded `~U[2026-07-13 …]` / `~U[2026-08-12 …]` literals in the shared `delivery/1` fixture in `apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs` with a window derived from `DateTime.utc_now()` — activation backdated 60s, validity fixed at 30 days — so every store and client test that builds on that fixture is calendar- and timezone-independent.
- Pinned the "freshly delivered expired grant is never persisted" case to an injected `now:` clock on `BeamPeerGrantStore.install/5`, keeping its expiry assertion deterministic now that the fixture window moves with the clock.
- Added two cases: one asserting the fixture's window is anchored to the current clock (backdate within tolerance, exact 30-day span, install + load round trip), and one driving `install/5` at `not_before_at - 1s` to cover `:beam_peer_grant_not_active` with nothing written to node custody.

No production code, `SPEC.md`, ADR, OpenSpec, or dependency changes — the diff is confined to the single test file, and Peer Grant validity semantics are untouched.

## Risk Assessment

✅ Low: The branch remains a single test-file change that leaves production Peer Grant validity semantics untouched, and the follow-up commit replaced the weak regression marker with live-clock anchor assertions plus a 60-second activation margin, resolving both prior findings.

## Testing

I reproduced the actual defect before validating the fix: a copy of the base-commit test file with its fixture window shifted -31 days (exactly equivalent to running it on 2026-09-01) fails 14 of 23 tests with `beam_peer_grant_expired`, across both ordinary store and client `retrieve_and_install` paths. Against the branch, I drove the real `BeamPeerGrantStore.install/5`/`load/3` across simulated host clocks from today through 2031 and showed the relative 30-day fixture installs and persists at every one while the old fixed window fails at every clock past 2026-08-12, with deterministic not-yet-active, exact-`not_before_at`, and exact-`expires_at` boundary verdicts retained and no plaintext persisted on rejection. The changed file also passes under seven timezones spanning UTC-11 to UTC+14 and across 10 random-seed reruns, the full umbrella suite is green (4438 passed), and the diff is confined to the single test file. This is a test-fixture change with no user-visible surface, so there is no UI to screenshot; the reviewer-visible artifacts are the failure log from the emulated post-expiry clock, the clock/edge matrix with persisted grant JSON, and the timezone matrix.

<details>
<summary>Evidence: Clock matrix: base fixed window vs. branch relative window through production install/load, plus edge coverage and persisted grant state</summary>

<code>Orchard issue #143 — BEAM peer-grant store fixture vs. the host clock&#10;real host clock now: 2026-08-01T14:53:20Z TZ=(unset)&#10;&#10;Ordinary install of the shared store fixture, per simulated host clock:&#10;&#10;simulated host clock base b6ec92f (fixed 2026-07-13 -&gt; 2026-08-12) this branch (relative 30-day window)&#10;--------------------------------------------------------------------------------------------------------------&#10;today (real host clock) ok: grant persisted ok: grant persisted&#10;2026-08-12T08:00:00Z error: beam_peer_grant_expired / not persisted ok: grant persisted&#10;2026-08-13T09:00:00Z error: beam_peer_grant_expired / not persisted ok: grant persisted&#10;2026-12-25T00:00:00Z error: beam_peer_grant_expired / not persisted ok: grant persisted&#10;2027-06-15T23:59:59Z error: beam_peer_grant_expired / not persisted ok: grant persisted&#10;2031-02-28T12:00:00Z error: beam_peer_grant_expired / not persisted ok: grant persisted&#10;&#10;Deterministic edge coverage retained on the relative fixture (simulated clock 2031-02-28T12:00:00Z):&#10;&#10;not_before_at - 1s (not yet active) error: beam_peer_grant_not_active / not persisted&#10;not_before_at exactly (active) ok: grant persisted&#10;expires_at - 1s (still valid) ok: grant persisted&#10;expires_at exactly (expired boundary) error: beam_peer_grant_expired / not persisted&#10;expires_at + 1s (expired) error: beam_peer_grant_expired / not persisted&#10;&#10;relative fixture window at that clock: 2031-02-28T11:59:00.000000Z -&gt; 2031-03-30T11:59:00.000000Z (30.0 days)&#10;&#10;Persisted node custody after an ordinary install on the real host clock:&#10;&#10;path &lt;node-identity-root&gt;/beam-peer-grants/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.json&#10;mode 0600&#10;load/3 {:ok, grant_id: dddddddd-dddd-4ddd-8ddd-dddddddddddd, generation: 1}&#10;&#10;{&#10;&#34;cluster_id&#34;: &#34;aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa&#34;,&#10;&#34;controller_id&#34;: &#34;bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb&#34;,&#10;&#34;cutover_at&#34;: null,&#10;&#34;encoded_secret&#34;: &#34;&lt;redacted&gt;&#34;,&#10;&#34;expires_at&#34;: &#34;2026-08-31T14:53:20.209970Z&#34;,&#10;&#34;generation&#34;: 1,&#10;&#34;grant_id&#34;: &#34;dddddddd-dddd-4ddd-8ddd-dddddddddddd&#34;,&#10;&#34;issued_at&#34;: &#34;2026-08-01T14:53:20.209970Z&#34;,&#10;&#34;not_before_at&#34;: &#34;2026-08-01T14:53:20.209970Z&#34;,&#10;&#34;purpose&#34;: &#34;runtime_endpoint&#34;,&#10;&#34;secret_hash&#34;: &#34;&lt;redacted&gt;&#34;&#10;}</code>

```text
Orchard issue #143 — BEAM peer-grant store fixture vs. the host clock
real host clock now: 2026-08-01T14:54:20.131356Z   TZ=(unset)

Ordinary install of the shared store fixture, per simulated host clock:

simulated host clock      base b6ec92f (fixed 2026-07-13 -> 2026-08-12)   this branch (relative 30-day window)
--------------------------------------------------------------------------------------------------------------
today (real host clock)   ok: grant persisted                             ok: grant persisted
2026-08-12T08:00:00Z      error: beam_peer_grant_expired / not persisted  ok: grant persisted
2026-08-13T09:00:00Z      error: beam_peer_grant_expired / not persisted  ok: grant persisted
2026-12-25T00:00:00Z      error: beam_peer_grant_expired / not persisted  ok: grant persisted
2027-06-15T23:59:59Z      error: beam_peer_grant_expired / not persisted  ok: grant persisted
2031-02-28T12:00:00Z      error: beam_peer_grant_expired / not persisted  ok: grant persisted

Deterministic edge coverage retained on the relative fixture (simulated clock 2031-02-28T12:00:00Z):

  not_before_at - 1s (not yet active)     error: beam_peer_grant_not_active / not persisted
  not_before_at exactly (active)          ok: grant persisted
  expires_at - 1s (still valid)           ok: grant persisted
  expires_at exactly (expired boundary)   error: beam_peer_grant_expired / not persisted
  expires_at + 1s (expired)               error: beam_peer_grant_expired / not persisted

relative fixture window at that clock: 2031-02-28T11:59:00.000000Z -> 2031-03-30T11:59:00.000000Z (30.0 days)

Persisted node custody after an ordinary install on the real host clock:

  path      <node-identity-root>/beam-peer-grants/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.json
  mode      0600
  load/3    {:ok, grant_id: dddddddd-dddd-4ddd-8ddd-dddddddddddd, generation: 1}

  {
    "beam_authorization_root_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
    "cluster_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
    "contract_version": 1,
    "controller_beam_name": "orchard_controller_bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb@10.0.0.10",
    "controller_certificate_fingerprint_sha256": "sha256-controller",
    "controller_certificate_identifier": "serial:100",
    "controller_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
    "cutover_at": null,
    "encoded_secret": "<redacted>",
    "expires_at": "2026-08-31T14:53:20.209970Z",
    "generation": 1,
    "grant_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
    "issued_at": "2026-08-01T14:53:20.209970Z",
    "node_beam_name": "orchard_node_agent_cccccccccccc4ccc8ccccccccccccccc@10.0.0.20",
    "node_certificate_fingerprint_sha256": "sha256-node",
    "node_certificate_identifier": "node-cert-1",
    "node_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
    "not_before_at": "2026-08-01T14:53:20.209970Z",
    "purpose": "runtime_endpoint",
    "secret_hash": "<redacted>"
  }
```
</details>
<details>
<summary>Evidence: Issue #143 reproduced: base-commit fixture fails 14/23 once the clock passes 2026-08-12</summary>

<code>Result: 9/23 passed&#10;Failed: 14 tests&#10;&#10;10) test SPEC.md §7.5.0 stores one exact delivered grant atomically under owner-only modes&#10;match (=) failed&#10;code: assert {:ok, stored} = BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)&#10;left: {:ok, stored}&#10;right: {:error, :beam_peer_grant_expired}&#10;&#10;14) test SPEC.md §7.5.0 Node retrieves with its certificate and exact Controller verifier&#10;code: assert {:ok, installed} = BeamPeerGrantClient.retrieve_and_install(...)&#10;left: {:ok, installed}&#10;right: {:error, :beam_peer_grant_expired}&#10;&#10;(also failing: install sweeps orphaned plaintext temporaries; install fails closed when plaintext/published&#10;temporary cleanup fails; first installation syncs both durable directory entries; concurrent identical&#10;installations are idempotent; concurrent install cannot sweep an active publisher temporary; a child BEAM&#10;cannot sweep an active publisher temporary; install reuses a lock file left by a dead BEAM OS process;&#10;install uses baseline macOS lockf arguments; install fails closed when the lock process exits before&#10;teardown; installs the certificate-authenticated control response owner-only; restart rejects a stored&#10;secret that no longer matches its hash)</code>

```text
==> orchard_shared
warning: the following files do not match any of the configured `:test_load_filters` / `:test_ignore_filters`:

/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs

This might indicate a typo in a test file name (for example, using "foo_tests.exs" instead of "foo_test.exs").

See the configuration for `:test_pattern` under `mix help test` for more information.

Running ExUnit with seed: 499916, max_cases: 16

.

  1) test SPEC.md §7.5.0 install fails closed when published temporary cleanup fails (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:187
     match (=) failed
     code:  assert {:error, :beam_peer_grant_store_invalid} =
              BeamPeerGrantStore.install(
                root,
                identity,
                delivery,
                delivery.node_beam_name,
                remove_file: fn _temporary -> {:error, :eacces} end
              )
     left:  {:error, :beam_peer_grant_store_invalid}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:201: (test)



  2) test SPEC.md §7.5.0 Node retrieves with its certificate and exact Controller verifier (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:720
     match (=) failed
     code:  assert {:ok, installed} =
              BeamPeerGrantClient.retrieve_and_install(
                root,
                identity,
                delivery.node_beam_name,
                "10.0.0.10:50072",
                request, transport: FakeControlTransport)
     left:  {:ok, installed}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:751: (test)



  3) test SPEC.md §7.5.0 installs the certificate-authenticated control response owner-only (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:690
     match (=) failed
     code:  assert {:ok, installed} =
              BeamPeerGrantClient.install_response(
                root,
                identity,
                delivery.node_beam_name,
                response
              )
     left:  {:ok, installed}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:706: (test)

.

  4) test SPEC.md §7.5.0 install reuses a lock file left by a dead BEAM OS process (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:434
     match (=) failed
     The following variables were pinned:
       delivery = %{node_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", node_beam_name: "orchard_node_agent_cccccccccccc4ccc8ccccccccccccccc@10.0.0.20", expires_at: ~U[2026-07-12 08:00:00.000000Z], grant_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd", contract_version: 1, controller_certificate_identifier: "serial:100", cluster_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", controller_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", encoded_secret: "BQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU", generation: 1, controller_beam_name: "orchard_controller_bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb@10.0.0.10", issued_at: ~U[2026-06-12 08:00:00.000000Z], not_before_at: ~U[2026-06-12 08:00:00.000000Z], controller_certificate_fingerprint_sha256: "sha256-controller", beam_authorization_root_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee", node_certificate_identifier: "node-cert-1", node_certificate_fingerprint_sha256: "sha256-node", purpose: "runtime_endpoint", cutover_at: nil, secret_hash: <<137, 78, 53, 45, 29, 140, 193, 12, 48, 61, 248, 253, 69, 165, 158, 233, 123, 48, 132, 27, 219, 246, 11, 71, 250, 49, 124, 127, 164, 201, 88, 89>>}
     code:  assert {:ok, ^delivery} = BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
     left:  {:ok, ^delivery}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:448: (test)

..

  5) test SPEC.md §7.5.0 install fails closed when the lock process exits before teardown (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:519
     match (=) failed
     code:  assert {:error, :beam_peer_grant_store_invalid} =
              BeamPeerGrantStore.install(
                root,
                identity,
                delivery,
                delivery.node_beam_name,
                lock_command: wrapper
              )
     left:  {:error, :beam_peer_grant_store_invalid}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:548: (test)

.

  6) test SPEC.md §7.5.0 concurrent identical installations are idempotent (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:273
     Expected truthy, got false
     code: assert Enum.all?(results, &match?({:ok, ^delivery}, &1))
     arguments:

         # 1
         [
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired,
           error: :beam_peer_grant_expired
         ]

         # 2
         #Function<20.66360572/1 in BasePeerGrantStoreClock20260901Test."test SPEC.md §7.5.0 concurrent identical installations are idempotent"/1>

     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:309: (test)

..

  7) test SPEC.md §7.5.0 concurrent install cannot sweep an active publisher temporary (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:313
     Assertion failed, no matching message after 5000ms
     Showing 2 of 2 messages in the mailbox
     code: assert_receive {:publisher_cleanup, first_pid, temporary}
     mailbox:
       pattern: {:publisher_cleanup, first_pid, temporary}
       value:   {#Reference<0.0.82563.2024715228.472186883.148422>,
                 {:error, :beam_peer_grant_expired}}

       pattern: {:publisher_cleanup, first_pid, temporary}
       value:   {:DOWN, #Reference<0.0.82563.2024715228.472186883.148422>,
                 :process, #PID<0.646.0>, :normal}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:347: (test)

.

  8) test SPEC.md §7.5.0 install fails closed when plaintext temporary cleanup fails (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:148
     match (=) failed
     code:  assert {:ok, _stored} = BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
     left:  {:ok, _stored}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:162: (test)



  9) test SPEC.md §7.5.0 first installation syncs both durable directory entries (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:240
     match (=) failed
     code:  assert {:ok, _stored} =
              BeamPeerGrantStore.install(
                root,
                identity,
                delivery,
                delivery.node_beam_name,
                sync_directory: fn path ->
                  send(test_pid, {:directory_synced, path})
                  :ok
                end
              )
     left:  {:ok, _stored}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:255: (test)



 10) test SPEC.md §7.5.0 stores one exact delivered grant atomically under owner-only modes (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:74
     match (=) failed
     code:  assert {:ok, stored} =
              BeamPeerGrantStore.install(
                root,
                identity,
                delivery,
                delivery.node_beam_name
              )
     left:  {:ok, stored}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:88: (test)



 11) test SPEC.md §7.5.0 install sweeps orphaned plaintext temporaries left by a crash (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:114
     match (=) failed
     code:  assert {:ok, _stored} = BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
     left:  {:ok, _stored}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:128: (test)

.

 12) test SPEC.md §7.5.0 a child BEAM cannot sweep an active publisher temporary (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:365
     Assertion failed, no matching message after 5000ms
     Showing 2 of 2 messages in the mailbox
     code: assert_receive {:child_test_publisher_cleanup, first_pid, temporary}
     mailbox:
       pattern: {:child_test_publisher_cleanup, first_pid, temporary}
       value:   {#Reference<0.0.85123.2024715228.472186883.148648>,
                 {:error, :beam_peer_grant_expired}}

       pattern: {:child_test_publisher_cleanup, first_pid, temporary}
       value:   {:DOWN, #Reference<0.0.85123.2024715228.472186883.148648>,
                 :process, #PID<0.666.0>, :normal}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:399: (test)



 13) test SPEC.md §7.5.0 install uses baseline macOS lockf arguments (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:465
     match (=) failed
     The following variables were pinned:
       delivery = %{node_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", node_beam_name: "orchard_node_agent_cccccccccccc4ccc8ccccccccccccccc@10.0.0.20", expires_at: ~U[2026-07-12 08:00:00.000000Z], grant_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd", contract_version: 1, controller_certificate_identifier: "serial:100", cluster_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", controller_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", encoded_secret: "BQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU", generation: 1, controller_beam_name: "orchard_controller_bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb@10.0.0.10", issued_at: ~U[2026-06-12 08:00:00.000000Z], not_before_at: ~U[2026-06-12 08:00:00.000000Z], controller_certificate_fingerprint_sha256: "sha256-controller", beam_authorization_root_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee", node_certificate_identifier: "node-cert-1", node_certificate_fingerprint_sha256: "sha256-node", purpose: "runtime_endpoint", cutover_at: nil, secret_hash: <<137, 78, 53, 45, 29, 140, 193, 12, 48, 61, 248, 253, 69, 165, 158, 233, 123, 48, 132, 27, 219, 246, 11, 71, 250, 49, 124, 127, 164, 201, 88, 89>>}
     code:  assert {:ok, ^delivery} =
              BeamPeerGrantStore.install(
                root,
                identity,
                delivery,
                delivery.node_beam_name,
                lock_command: wrapper
              )
     left:  {:ok, ^delivery}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:497: (test)



 14) test SPEC.md §7.5.0 restart rejects a stored secret that no longer matches its hash (BasePeerGrantStoreClock20260901Test)
     apps/orchard_shared/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:564
     match (=) failed
     code:  assert {:ok, _stored} = BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
     left:  {:ok, _stored}
     right: {:error, :beam_peer_grant_expired}
     stacktrace:
       /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs:578: (test)


Finished in 10.5 seconds (10.5s async, 0.00s sync)

Result: 9/23 passed
Failed: 14 tests
```
</details>
<details>
<summary>Evidence: Timezone matrix — changed test file across UTC-11 to UTC+14</summary>

<code>Branch test file: apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs&#10;Host clock: 2026-08-01T14:43:00Z UTC&#10;&#10;TZ local date mix test result&#10;---------------------------------------------------------------------&#10;UTC 2026-08-01 14:43 Result: 25 passed&#10;Pacific/Kiritimati 2026-08-02 04:43 Result: 25 passed&#10;Pacific/Midway 2026-08-01 03:43 Result: 25 passed&#10;Asia/Kolkata 2026-08-01 20:13 Result: 25 passed&#10;Australia/Lord_Howe 2026-08-02 01:13 Result: 25 passed&#10;America/Sao_Paulo 2026-08-01 11:43 Result: 25 passed&#10;Asia/Kathmandu 2026-08-01 20:28 Result: 25 passed</code>

```text
Branch test file: apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
Host clock: 2026-08-01T14:43:00Z UTC

TZ                       local date     mix test result
---------------------------------------------------------------------
UTC                      2026-08-01 14:43 Result: 25 passed
Pacific/Kiritimati       2026-08-02 04:43 Result: 25 passed
Pacific/Midway           2026-08-01 03:43 Result: 25 passed
Asia/Kolkata             2026-08-01 20:13 Result: 25 passed
Australia/Lord_Howe      2026-08-02 01:13 Result: 25 passed
America/Sao_Paulo        2026-08-01 11:43 Result: 25 passed
Asia/Kathmandu           2026-08-01 20:28 Result: 25 passed
```
</details>
<details>
<summary>Evidence: Full umbrella suite (mix test) — per-app results</summary>

Source: Full umbrella suite (mix test) — per-app results (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/full-suite.log</code>)

```text
==> orchard_shared Result: 290 passed
==> orchard_controller Result: 3061 passed, 5 skipped
==> orchard_node_agent Result: 378 passed
==> orchard_cli Result: 709 passed, 10 excluded
exit=0
```
</details>
<details>
<summary>Evidence: Repeat-run stability of the changed test file (10 random seeds)</summary>

<code>run 1 (random seed): Result: 25 passed&#10;run 2 (random seed): Result: 25 passed&#10;run 3 (random seed): Result: 25 passed&#10;run 4 (random seed): Result: 25 passed&#10;run 5 (random seed): Result: 25 passed&#10;run 6 (random seed): Result: 25 passed&#10;run 7 (random seed): Result: 25 passed&#10;run 8 (random seed): Result: 25 passed&#10;run 9 (random seed): Result: 25 passed&#10;run 10 (random seed): Result: 25 passed</code>

```text
run 1 (random seed): Result: 25 passed
run 2 (random seed): Result: 25 passed
run 3 (random seed): Result: 25 passed
run 4 (random seed): Result: 25 passed
run 5 (random seed): Result: 25 passed
run 6 (random seed): Result: 25 passed
run 7 (random seed): Result: 25 passed
run 8 (random seed): Result: 25 passed
run 9 (random seed): Result: 25 passed
run 10 (random seed): Result: 25 passed
```
</details>
<details>
<summary>Evidence: Evidence harness: simulated-clock driver over production BeamPeerGrantStore</summary>

```text
# Drives the real Orchard.Node.BeamPeerGrantStore.install/5 + load/3 across simulated host
# clocks, comparing the base-commit fixed fixture window against this branch's relative window.
#
# `install/5` takes its clock from the `now:` option, so injecting a simulated clock reproduces
# exactly what a host whose wall clock reads that instant would observe.

alias Orchard.Node.BeamPeerGrantStore

identity = %{
  cluster_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
  controller_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
  controller_certificate_identifier: "serial:100",
  controller_certificate_fingerprint: "sha256-controller",
  node_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
  certificate_identifier: "node-cert-1",
  certificate_fingerprint: "sha256-node"
}

encoded_secret = Base.url_encode64(:binary.copy(<<5>>, 32), padding: false)

grant = fn not_before_at, expires_at ->
  %{
    grant_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
    generation: 1,
    cluster_id: identity.cluster_id,
    controller_id: identity.controller_id,
    controller_beam_name: "orchard_controller_bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb@10.0.0.10",
    controller_certificate_identifier: identity.controller_certificate_identifier,
    controller_certificate_fingerprint_sha256: identity.controller_certificate_fingerprint,
    beam_authorization_root_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
    node_id: identity.node_id,
    node_beam_name: "orchard_node_agent_cccccccccccc4ccc8ccccccccccccccc@10.0.0.20",
    node_certificate_identifier: identity.certificate_identifier,
    node_certificate_fingerprint_sha256: identity.certificate_fingerprint,
    contract_version: 1,
    purpose: "runtime_endpoint",
    issued_at: not_before_at,
    not_before_at: not_before_at,
    cutover_at: nil,
    expires_at: expires_at,
    encoded_secret: encoded_secret,
    secret_hash: :crypto.hash(:sha256, encoded_secret)
  }
end

# base commit b6ec92f: two calendar literals, identical no matter when the suite runs
base_fixture = fn _run_clock ->
  grant.(~U[2026-07-13 08:00:00.000000Z], ~U[2026-08-12 08:00:00.000000Z])
end

# this branch: window anchored to the clock the suite actually runs on
backdate = 60
validity = 30 * 24 * 60 * 60

branch_fixture = fn run_clock ->
  not_before_at = DateTime.add(run_clock, -backdate, :second)
  grant.(not_before_at, DateTime.add(not_before_at, validity, :second))
end

with_root = fn fun ->
  root =
    Path.join(
      System.tmp_dir!(),
      "orchard-peer-grant-matrix-#{System.unique_integer([:positive, :monotonic])}"
    )

  File.mkdir!(root)
  File.chmod!(root, 0o700)

  try do
    fun.(root)
  after
    File.rm_rf!(root)
  end
end

verdict = fn delivery, clock ->
  with_root.(fn root ->
    case BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name,
           now: fn -> clock end
         ) do
      {:ok, _stored} ->
        persisted? =
          File.exists?(Path.join([root, "beam-peer-grants", "#{identity.controller_id}.json"]))

        if persisted?, do: "ok: grant persisted", else: "ok: BUT NOTHING PERSISTED"

      {:error, reason} ->
        persisted? =
          File.exists?(Path.join([root, "beam-peer-grants", "#{identity.controller_id}.json"]))

        "error: #{reason}" <> if(persisted?, do: " (LEAKED PLAINTEXT)", else: " / not persisted")
    end
  end)
end

clocks = [
  {"today (real host clock)", DateTime.utc_now()},
  {"2026-08-12T08:00:00Z", ~U[2026-08-12 08:00:00.000000Z]},
  {"2026-08-13T09:00:00Z", ~U[2026-08-13 09:00:00.000000Z]},
  {"2026-12-25T00:00:00Z", ~U[2026-12-25 00:00:00.000000Z]},
  {"2027-06-15T23:59:59Z", ~U[2027-06-15 23:59:59.000000Z]},
  {"2031-02-28T12:00:00Z", ~U[2031-02-28 12:00:00.000000Z]}
]

pad = fn text, width -> String.pad_trailing(text, width) end

IO.puts("Orchard issue #143 — BEAM peer-grant store fixture vs. the host clock")
IO.puts("real host clock now: #{DateTime.utc_now() |> DateTime.to_iso8601()}   TZ=#{System.get_env("TZ") || "(unset)"}")
IO.puts("")
IO.puts("Ordinary install of the shared store fixture, per simulated host clock:")
IO.puts("")

IO.puts(
  pad.("simulated host clock", 26) <>
    pad.("base b6ec92f (fixed 2026-07-13 -> 2026-08-12)", 48) <>
    "this branch (relative 30-day window)"
)

IO.puts(String.duplicate("-", 26 + 48 + 36))

Enum.each(clocks, fn {label, clock} ->
  IO.puts(
    pad.(label, 26) <>
      pad.(verdict.(base_fixture.(clock), clock), 48) <>
      verdict.(branch_fixture.(clock), clock)
  )
end)

IO.puts("")
IO.puts("Deterministic edge coverage retained on the relative fixture (simulated clock 2031-02-28T12:00:00Z):")
IO.puts("")

edge_clock = ~U[2031-02-28 12:00:00.000000Z]
edge = branch_fixture.(edge_clock)

edges = [
  {"not_before_at - 1s (not yet active)", DateTime.add(edge.not_before_at, -1, :second)},
  {"not_before_at exactly (active)", edge.not_before_at},
  {"expires_at - 1s (still valid)", DateTime.add(edge.expires_at, -1, :second)},
  {"expires_at exactly (expired boundary)", edge.expires_at},
  {"expires_at + 1s (expired)", DateTime.add(edge.expires_at, 1, :second)}
]

Enum.each(edges, fn {label, clock} ->
  IO.puts(pad.("  " <> label, 42) <> verdict.(edge, clock))
end)

IO.puts("")

IO.puts(
  "relative fixture window at that clock: #{DateTime.to_iso8601(edge.not_before_at)} -> #{DateTime.to_iso8601(edge.expires_at)} (#{DateTime.diff(edge.expires_at, edge.not_before_at, :second) / 86_400} days)"
)

IO.puts("")
IO.puts("Persisted node custody after an ordinary install on the real host clock:")
IO.puts("")

with_root.(fn root ->
  delivery = branch_fixture.(DateTime.utc_now())

  {:ok, _stored} =
    BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)

  {:ok, loaded} = BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
  path = Path.join([root, "beam-peer-grants", "#{identity.controller_id}.json"])
  stat = File.stat!(path)

  IO.puts("  path      #{Path.join("<node-identity-root>", Path.relative_to(path, root))}")
  IO.puts("  mode      #{stat.mode |> Bitwise.band(0o777) |> Integer.to_string(8) |> String.pad_leading(4, "0")}")
  IO.puts("  load/3    {:ok, grant_id: #{loaded.grant_id}, generation: #{loaded.generation}}")
  IO.puts("")

  path
  |> File.read!()
  |> Jason.decode!()
  |> Map.put("encoded_secret", "<redacted>")
  |> Map.put("secret_hash", "<redacted>")
  |> Jason.encode!(pretty: true)
  |> String.split("\n")
  |> Enum.each(&IO.puts("  " <> &1))
end)
```
</details>
- Evidence: Base-commit test file emulating a 2026-09-01 host clock (fixture literals shifted -31 days) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYYV5VEXTH78QDX2WRZH6RNW/base_store_test_clock_2026-09-01.exs</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs:595` - The new &#34;ordinary store fixture remains valid after its former calendar expiry&#34; test never calls the arity-1 `delivery/1` helper that the other ~20 tests in the file actually use — it calls `delivery(identity, after_former_expiry)` and then pins `now:` to that same reference, so the grant window is constructed to be valid at the assertion time. It does catch a wholesale revert of `delivery/2` back to hardcoded literals, but it cannot catch a regression that hardcodes only the `delivery/1` default while leaving `delivery/2` relative — which is the fixture path every other test depends on. Consider asserting through `delivery(identity)` directly, or renaming the test so it does not claim coverage of the &#34;ordinary store fixture&#34;.
- ℹ️ `apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs:978` - `not_before_at = DateTime.add(reference_time, -1, :second)` leaves only a 1-second activation margin. The ~15 tests that call `install/4` or `load/3` without pinning `now:` re-read the OS wall clock inside the store (`beam_peer_grant_store.ex:33`, `:358`, `:463`), and the cross-VM test at line 368 spawns a child `elixir` VM that installs against its own real clock. A backwards wall-clock adjustment larger than 1s between fixture construction and the store&#39;s `DateTime.utc_now()` call would return `:beam_peer_grant_not_active` and flake the suite. Widening the backdate (e.g. 60s) removes the exposure at zero cost and does not affect the not-yet-active test, which pins `now:` relative to `delivery.not_before_at`.

🔧 Fix: test(node_agent): anchor peer grant fixture window to live clock
1 info still open:
- ℹ️ `apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs:985` - `delivery/2` was introduced in the prior commit so the calendar test could pin a reference time, but that test now calls `delivery(identity)` instead. At HEAD the only caller of `delivery/2` is `delivery/1` on line 983, which just passes `DateTime.utc_now()`. The two clauses can collapse into a single `defp delivery(identity)` that computes `not_before_at` from `DateTime.utc_now()` directly, removing an unused seam. Purely mechanical, no behavior change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs --trace` — 25 passed, including the new `the ordinary store fixture anchors its window to the current clock` and `a not-yet-active grant is never persisted` cases</code>
- <code>Reproduced issue #143 on the base commit: copied `b6ec92f:.../beam_peer_grant_store_test.exs` and shifted its two fixture literals -31 days (algebraically identical to running the unmodified base file on 2026-09-01), then `mise exec -- mix test &lt;copy&gt;` → 14 of 23 tests fail with `{:error, :beam_peer_grant_expired}`, covering both ordinary store installs and `BeamPeerGrantClient.retrieve_and_install` client tests</code>
- <code>`mise exec -- mix run --no-start peer_grant_clock_matrix.exs` — drove real `BeamPeerGrantStore.install/5` + `load/3` with injected clocks (today, 2026-08-12, 2026-08-13, 2026-12-25, 2027-06-15, 2031-02-28): base fixed window expires at every clock &gt;= 2026-08-12; branch relative window installs and persists at all of them</code>
- <code>Same harness, edge matrix at a simulated 2031 clock: `not_before_at - 1s` → `beam_peer_grant_not_active`, exactly `not_before_at` → ok, `expires_at - 1s` → ok, exactly `expires_at` → `beam_peer_grant_expired`, `expires_at + 1s` → expired; no plaintext persisted on any rejection</code>
- <code>Timezone matrix: `TZ=&lt;zone&gt; mise exec -- mix test apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs --seed 0` for UTC, Pacific/Kiritimati, Pacific/Midway, Asia/Kolkata, Australia/Lord_Howe, America/Sao_Paulo, Asia/Kathmandu — 25 passed in each</code>
- <code>`mise exec -- mix compile` then full `mise exec -- mix test` — 290 + 3061 + 378 + 709 passed across orchard_shared/controller/node_agent/cli, exit 0</code>
- `Repeat-run stability: 10 consecutive random-seed runs of the changed file — 25 passed each time`
- <code>Inspected persisted node custody after an ordinary install: `&lt;root&gt;/beam-peer-grants/&lt;controller_id&gt;.json` at mode 0600 with a 2026-08-01 → 2026-08-31 window, reloaded via `BeamPeerGrantStore.load/3`</code>
- <code>`git diff --name-only b6ec92f..HEAD` — only the one test file; no SPEC.md, ADR, OpenSpec, mix.lock, or production-code changes</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788188390&installation_model_id=428414&pr_number=147&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F147&signature=4abe820d9234300036f2d44dd12dc7020d1475aac57b430fde7220983ff2c8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


---

Fixes #143
