### PR TITLE
docs: add ADR 0015 for thin active-node liveness monitor before scheduler decoupling

### DIFF
--- a/docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md
+++ b/docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md
@@ -1,0 +1,215 @@
+# Active-node liveness lands as a thin background monitor before scheduler decoupling
+
+## Status
+
+Accepted.
+
+Owner decision recorded 2026-08-02. Implementation proceeds through a single
+OpenSpec change package with ordered slices; this record fixes the decomposition
+and the pilot-blocking boundary ahead of that authoring.
+
+## Context
+
+Active-node liveness is observed today only as a side effect of scheduling a
+request. `Orchard.Scheduler.MultiNode` probes every configured target
+sequentially on the request path, and the observation that probe persists is what
+refreshes `last_heartbeat_at` so the freshness gate in `Nodes.schedulable_nodes/0`
+passes. Between requests nothing observes an `:active` Node, so a Node that dies
+while the cluster is idle stays `:active`/`:healthy` in inventory until the next
+request pays to discover it. The only recurring prober, `ActivationProbe`, targets
+`:admitted` Nodes and discards its return values; it persists anything only as a
+client-internal side effect on authenticated transports, and only for healthy
+responses.
+
+The M5 closed internal pilot (issue #118) needs this gap closed: its readiness gate
+requires that liveness be tracked on a bounded interval and that the loss of either
+Node be detected without depending on an inline probe on the request path. Issue
+#122 proposed both a background monitor and taking the scheduler off the inline
+probe. The question this record settles is how to decompose #122 so the pilot is
+unblocked as fast as is defensible, without over-building.
+
+An implementation proposal asserted a hard constraint: the background-observation
+slice must first create the SPEC §8 `node_heartbeats` table and persist the full
+candidate-construction fact set (availability, loaded-model status, active-request
+counts, maximum concurrency, placement capacity, prefix-cache status, memory
+budget, and an acquirability fact), because otherwise the scheduler-decoupling
+slice would require a second migration. That constraint was tested against the code,
+`SPEC.md`, ADR 0001, and ADR 0013 through independent review, and it does not hold.
+
+This decision is hard to reverse because it fixes where the liveness authority for
+scheduling eligibility lives and what the pilot may claim. It is surprising because
+the intuitive "persist everything the scheduler uses" instinct is both unnecessary
+and slower here. It resolves a real trade-off between front-loading a durable
+contract now and deferring it until its only consumer exists.
+
+## Decision
+
+Decompose #122 into two ordered slices, A then B, in one OpenSpec package.
+
+Slice A is the only pilot-blocking build item and is deliberately thin. It
+generalizes the existing supervised, leader-authorized `ActivationProbe` to observe
+`:active` Nodes in addition to `:admitted` Nodes, on a bounded interval strictly
+below the unreachable threshold.
+
+Slice A consumes probe outcomes through the authenticated observation path
+(`observe_authenticated_status/5`), not the plain `observe_status/4` upsert. This
+distinction is load bearing. Plain `observe_status/4` writes only the Node row;
+aggregate capacity evidence is persisted only by the authenticated path. The
+dispatch authority check requires durable capacity evidence to be at least as
+current as `last_heartbeat_at`, so a monitor that advanced the heartbeat without
+co-writing evidence would make evidence non-current and force dispatch closed with
+unavailable facts. A successful monitor observation therefore advances
+`last_heartbeat_at`, re-derives health, and refreshes aggregate capacity evidence in
+one authenticated write, keeping heartbeat freshness and evidence currency in
+lockstep.
+
+Slice A carries one real code change beyond generalizing the prober. The
+authenticated seam today double-gates on health and rejects any non-healthy
+observation, so a `:degraded` or `:unhealthy` already-`:active` Node is dropped and
+ages out of `schedulable_nodes/0` even under traffic. Slice A must relax those gates
+to accept and record a non-healthy observation from an already-`:active` Node, while
+keeping the `:admitted` to `:active` promotion healthy-gated so a non-healthy
+`:admitted` Node still cannot activate.
+
+Failure handling must separate two cases that look alike. A genuine transport
+failure, where the Node did not respond, routes through the graded demotion path:
+`:degraded`, then `:unreachable` once the last heartbeat exceeds the 15-second
+threshold. The demotion classifier must also recognize the authenticated and BEAM
+transport failures it does not classify today (`:authenticated_transport_failed`,
+`:beam_peer_grant_authorization_unavailable`). An observation the seam rejected
+because the Node was non-healthy (`:authenticated_observation_rejected`,
+`:beam_peer_observation_rejected`) is not a transport failure, the Node responded,
+and it must be handled by the gate relaxation above rather than swept into demotion.
+A periodic heartbeat-age sweep bounds detection at approximately the unreachable
+threshold plus the sweep interval. The scheduler and its inline probe are untouched
+in slice A.
+
+Slice A adds no migration. The persistence seam and the schema columns it needs
+already exist. It does not create `node_heartbeats`, does not implement the §8.5
+retention job, and does not implement the §9.1 heartbeat-lag metric; those are real
+SPEC obligations but serve operator forensics and the metrics floor, not the two
+gate properties, and #118 already spun the metrics floor out of the pilot gate.
+They land with slice B or the metrics-floor work.
+
+Slice A must name the `SPEC.md` §4.6 push-versus-pull divergence in its OpenSpec
+delta. §4.6 says the Node Agent sends heartbeats every 2 seconds, while §4.6.1
+already blesses status-probe ingestion as the durable seam, so SPEC is internally
+split and the evidence favors reconciling to pull. The implementation, inline and
+background alike, pulls status probes. Slice A extends that existing divergence
+rather than creating it, and the delta must either reconcile SPEC to pull-based
+observation or explicitly defer the reconciliation. The §8 `node_heartbeats` columns
+mirror the §4.6 push payload, so the deferred §8 work and this reconciliation are
+coupled and should be resolved together. Silent divergence is not acceptable.
+
+Slice B decouples the scheduler from the inline probe: it serves candidates from a
+monitor-refreshed source and removes or bounds the inline sequential probe. Whether
+the durable `node_heartbeats` history, a leader-local in-memory mirror of the
+persisted observation, or both back that source is slice B's design question, to be
+settled when B's snapshot-freshness and dispatch-time revalidation contracts are
+designed. Enriching what an observation payload carries is a payload-contract change
+absorbed by the spec-fixed `payload jsonb` column, not a schema migration. The full
+candidate fact set is slice B's deliverable, defined against a real consumer.
+
+The pilot (#118) is blocked by slice A only, not by whole-#122. Retargeting the
+blocker to slice A matches the readiness-gate text, which requires detection without
+the inline probe rather than scheduling-path purity. The pilot's official claim is
+2-node liveness and observability stability plus failure-classification
+correctness. Scheduler latency is exploratory only and is not an official baseline,
+because the inline probe remains on the request path through the frozen window;
+multi-node placement-optimization behavior is deferred to slice B. The pilot
+findings must disclose the inline-probe latency overhead and the up-to-15-second
+window in which a `:degraded` Node remains schedulable as known, bounded
+limitations of the frozen artifact.
+
+Issue #128 (scheduler failure reclassification) is decoupled from slice A and from
+the pilot build. Acquirability is a time-sensitive property derived Controller-side
+from catalog, artifact, policy, and live capacity state; it is not an observation
+fact, does not belong in a heartbeat row, and must not be persisted as a boolean or
+computed by a second eligibility formula. #128 ships on its own track, ideally
+before the pilot midpoint because a misclassified `model_busy` is the defect the
+client team is most likely to hit.
+
+Pre-loading the pinned catalog on both Nodes before the window opens reduces, but
+does not eliminate, #128 contamination of the failure denominator. It removes the
+specific cold-path misclassification, catalog-active but not loaded returning
+`model_busy`, so the `model_busy` that remains is genuine capacity exhaustion, which
+is classified correctly before #128 lands. Pre-loading is a reduction, not a
+guarantee: residency can be lost mid-window to a worker crash, a Node restart, or a
+memory-pressure unload, so the window must assert model residency periodically and
+disclose any eviction as a known limitation. Two residual gaps must be disclosed in
+the findings. Pre-loading means the pilot never exercises the cold-load path, so
+cold-start behavior is out of the pilot evidence base. And #128 is broader than this
+one path, since it also covers queue admission that ignores canonical policy and the
+absence of a recorded scheduler explanation, so some failures in the window will
+still lack explanations. Window-open is not gated on #128 code landing; the
+contamination it addresses is bounded operationally instead.
+
+## Rejected alternatives
+
+Persisting the full candidate-construction fact set in slice A is rejected. It is
+not required by ADR 0001, which constrains where authority lives (durable in
+Postgres, not in BEAM signals) rather than mandating that every ranking input be
+schema-modeled before anything consumes it; the current inline path already
+persists durable authority and uses the live observation for ranking annotations,
+and a thin monitor through the same seam cannot be less compliant than that
+accepted pattern. It is not required by ADR 0013, which demotes the richest parts of
+the proposed payload (placement capacity, active counts) from authority to evidence
+and keeps capacity authority Controller-owned. Its second-migration cost argument is
+wrong: thin A requires zero migrations, so the comparison is one migration total
+either way, taken in A or in B. And it finalizes a payload contract whose only
+consumer, slice B's cached candidate construction, is not yet designed, which
+guarantees rather than avoids a later review pass.
+
+Landing all of #122 before the pilot is rejected: it holds a stability finding
+hostage to a latency optimization that is irrelevant at two Nodes.
+
+Adding a second background poller instead of generalizing `ActivationProbe` is
+rejected: the existing prober is already supervised and leader-gated via
+`ControlPlane.authorize_write_path(:node_lifecycle)`, and reuse inherits
+single-writer semantics for free.
+
+Coupling #128 to slice A or to window-open is rejected: acquirability is not a
+heartbeat fact, #128 is not in the #118 gate, and #128's real scope is a
+multi-module admission-policy and reason-code change that would put a scheduler and
+orchestrator redesign on the pilot's critical path for no gate benefit.
+
+Framing the accompanying ADR as a reconciliation of ADR 0001 and ADR 0013 is
+rejected: the two do not conflict. Both point the same direction — durable
+observations in Postgres as scheduler and operator input, capacity authority
+Controller-owned and fail-closed on missing facts — and there is nothing to
+reconcile.
+
+## Consequences
+
+The pilot build shrinks to one GenServer generalization, result consumption
+through the authenticated seam, the health-gate relaxation for `:active` Nodes, an
+interval-versus-threshold invariant, and a small OpenSpec delta plus this record.
+Every gate property the stability finding must prove maps to a test: an idle cluster
+stays schedulable with zero traffic, a Node killed while idle is demoted within the
+asserted bound, a recovered Node returns to `:healthy`, a standby Controller writes
+nothing, the interval stays below the freshness and unreachable thresholds, a
+`:degraded` `:active` Node is recorded rather than dropped while a non-healthy
+`:admitted` Node still cannot activate, and a seam rejection is not treated as a
+transport demotion.
+
+Double probing exists during slice A: the inline probe and the background monitor
+both write observations. Existing staleness and concurrent-insert guards make this
+safe, and the extra RPC load at two Nodes is negligible.
+
+The SPEC §4.6 push-versus-pull divergence becomes an explicit, named obligation
+rather than an undocumented drift, carried by slice B or a dedicated reconciliation.
+
+The `node_heartbeats` table, its §8.5 retention, and the §9.1 heartbeat-lag metric
+remain unimplemented after slice A and are tracked with slice B and the metrics
+floor. Heartbeat lag stays computable from `nodes.last_heartbeat_at` once the metric
+lands.
+
+## SPEC.md impact
+
+Confirm or update the Node liveness and heartbeat observation language in `SPEC.md`
+§7 (Node lifecycle, health, and freshness) to state that active-node liveness is
+maintained by a leader-owned background observer independent of request traffic.
+Name and resolve the §4.6 push-versus-pull heartbeat divergence, either by
+reconciling SPEC to pull-based observation or by recording an explicit deferral.
+The §8 `node_heartbeats` schema, §8.5 retention, and §9.1 heartbeat-lag metric are
+unchanged and remain future obligations tracked with slice B and the metrics floor.

--- a/docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md
+++ b/docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md
@@ -44,7 +44,8 @@ contract now and deferring it until its only consumer exists.
 
 ## Decision
 
-Decompose #122 into two ordered slices, A then B, in one OpenSpec package.
+Decompose #122 into two ordered slices, A then B, in one OpenSpec package. Slice A
+is tracked by issue #148 and slice B by issue #149.
 
 Slice A is the only pilot-blocking build item and is deliberately thin. It
 generalizes the existing supervised, leader-authorized `ActivationProbe` to observe
@@ -81,8 +82,18 @@ because the Node was non-healthy (`:authenticated_observation_rejected`,
 `:beam_peer_observation_rejected`) is not a transport failure, the Node responded,
 and it must be handled by the gate relaxation above rather than swept into demotion.
 A periodic heartbeat-age sweep bounds detection at approximately the unreachable
-threshold plus the sweep interval. The scheduler and its inline probe are untouched
-in slice A.
+threshold plus one sweep interval, roughly 20 seconds at the 15-second threshold
+and the existing 5-second probe interval.
+
+Slice A leaves the scheduler's control flow, candidate selection, ranking, and the
+inline probe path in place. It does not, however, leave the inline probe's observed
+behavior identical: the health gate slice A relaxes lives in the shared
+`observe_authenticated_status/5` seam, which the inline probe also drives through
+its transport client's status call, so the relaxation applies to the background
+monitor and the inline probe alike. That is intended and safe. Its only effect is
+that a non-healthy observation from an already-`:active` Node is recorded rather
+than dropped, and it does not change the `:admitted` to `:active` promotion, which
+stays healthy-gated.
 
 Slice A adds no migration. The persistence seam and the schema columns it needs
 already exist. It does not create `node_heartbeats`, does not implement the §8.5
@@ -117,9 +128,10 @@ the inline probe rather than scheduling-path purity. The pilot's official claim 
 correctness. Scheduler latency is exploratory only and is not an official baseline,
 because the inline probe remains on the request path through the frozen window;
 multi-node placement-optimization behavior is deferred to slice B. The pilot
-findings must disclose the inline-probe latency overhead and the up-to-15-second
-window in which a `:degraded` Node remains schedulable as known, bounded
-limitations of the frozen artifact.
+findings must disclose the inline-probe latency overhead and the window in which a
+`:degraded` Node remains schedulable, the unreachable threshold plus one sweep
+interval and so roughly 20 seconds at the default 5-second interval, as known,
+bounded limitations of the frozen artifact.
 
 Issue #128 (scheduler failure reclassification) is decoupled from slice A and from
 the pilot build. Acquirability is a time-sensitive property derived Controller-side
@@ -207,8 +219,9 @@ lands.
 ## SPEC.md impact
 
 Confirm or update the Node liveness and heartbeat observation language in `SPEC.md`
-§7 (Node lifecycle, health, and freshness) to state that active-node liveness is
-maintained by a leader-owned background observer independent of request traffic.
+§4.2 (Node lifecycle states), §4.5 (Node health model), and §4.6 (Heartbeat
+payload) to state that active-node liveness is maintained by a leader-owned
+background observer independent of request traffic.
 Name and resolve the §4.6 push-versus-pull heartbeat divergence, either by
 reconciling SPEC to pull-based observation or by recording an explicit deferral.
 The §8 `node_heartbeats` schema, §8.5 retention, and §9.1 heartbeat-lag metric are

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -440,6 +440,10 @@ _Avoid_: live BEAM session, durable cluster truth by itself, provider billing ev
 A periodic durable observation used by the Controller to record first-party Node Agent health, inventory, workers, placements, and Runtime Endpoint Availability.
 _Avoid_: Node Lifecycle State, readiness probe, live BEAM session
 
+**Active-Node Liveness Monitor**:
+The traffic-independent mechanism that tracks whether each active Node is still alive, so the Controller can distinguish a degraded cluster from a silently half-dead one, and an idle Node loss is detected without a request paying for discovery.
+_Avoid_: inline request-path probe, readiness probe, Controller Membership Heartbeat
+
 **Node Pool**:
 A scheduling group where each v1 Node belongs to exactly one pool.
 _Avoid_: Tenant, cluster


### PR DESCRIPTION
## Intent

Land a standalone docs-only PR recording the decision from a grilling session on how to decompose Orchard issue #122 (active-node liveness monitoring) to unblock the M5 pilot #118 without delaying it. Two deliberate outputs: ADR 0015 in docs/decisions/, and a new 'Active-Node Liveness Monitor' glossary term in docs/glossary/CONTEXT.md. All decisions are deliberate and code-grounded, verified via RP investigate, an RP design agent, and grok/kimi red-team. Deliberate choices a diff-only reviewer would not know: (1) split #122 into thin slice A (issue #148, background liveness monitor, the only pilot-blocking item) and slice B (issue #149, scheduler decoupling); (2) slice A intentionally needs ZERO migrations by reusing the existing authenticated observation seam observe_authenticated_status/5, rejecting the original proposal to persist the full candidate payload in A; (3) the ADR deliberately states ADR 0001 and ADR 0013 do NOT conflict and need no reconciliation; (4) #128 is deliberately decoupled from the pilot build and mitigated operationally by pre-loading the catalog, not gated on #128 code; (5) latency is deliberately exploratory-only for the pilot with the inline probe left in place. This PR is docs-only: no code, SPEC, or dependency changes. The transient docs/reviews and docs/investigations notes are intentionally left uncommitted per AGENTS.md; their durable conclusions are promoted into ADR 0015.

## What Changed

- Adds `docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md`, recording the decomposition of issue #122 into two ordered slices: slice A (#148), a thin background liveness monitor that generalizes the existing supervised `ActivationProbe` to observe `:active` Nodes and is the only item blocking the M5 pilot (#118), and slice B (#149), decoupling the scheduler from the inline request-path probe. The ADR fixes slice A at zero migrations by consuming probe outcomes through the existing authenticated observation seam `observe_authenticated_status/5` — so heartbeat freshness and aggregate capacity evidence advance in one write — explicitly rejecting the proposal to persist the full candidate payload and create the SPEC §8 `node_heartbeats` table in slice A. It also records that ADR 0001 and ADR 0013 do not conflict and need no reconciliation, that #128 is decoupled from the pilot build and mitigated operationally by pre-loading the catalog rather than gated on #128 code, and that latency stays exploratory-only for the pilot with the inline probe left in place.
- Adds an **Active-Node Liveness Monitor** term to `docs/glossary/CONTEXT.md`, with `_Avoid_` guidance separating it from the inline request-path probe, readiness probe, and Controller Membership Heartbeat.
- Docs-only: no code, `SPEC.md`, config, packaging, or dependency changes (`git diff --name-only` over those paths is empty). Review-pass follow-ups tightened the record itself — correcting the slice-A scope claim about the shared seam reaching the scheduler's inline probe, fixing a mistyped `SPEC.md` §7 pointer to §4.2/§4.5/§4.6, reconciling the schedulable-while-dead window with the probe interval, and naming issues #148/#149 at the decomposition line. The transient investigation and review notes behind the decision are deliberately left uncommitted per `AGENTS.md`; their durable conclusions live in the ADR.

## Risk Assessment

✅ Low: Docs-only change (ADR 0015 plus one glossary term, no code, SPEC, or dependency edits) whose remaining technical claims I verified against the controller source, SPEC.md section headings, and the referenced GitHub issues, with all four round-1 findings correctly addressed in the fix commit.

## Testing

Because this change is docs-only, I tested whether the ADR's claims actually match the codebase rather than running the Elixir suite (zero code changed, so it would produce noise instead of evidence). I wrote and ran a 37-check harness tying every load-bearing assertion in ADR 0015 to a file:line in the repo, SPEC.md, or the prior ADRs it cites — all 37 pass, including the intent's flagged deliberate choices: no migration defines node_heartbeats (so slice A genuinely needs zero migrations), observe_authenticated_status/5 exists at that exact arity, and the dispatch-authority evidence-currency rule is a real ordering comparison against last_heartbeat_at. I additionally spot-checked the one claim the harness didn't cover — that ActivationProbe is the only recurring prober — and it holds. I rendered both changed docs to GitHub-styled HTML and captured full-page screenshots as the reviewer-visible surface, and confirmed the docs-only scope, the uncommitted transient notes, and that all five referenced issues resolve with titles matching the recorded decomposition. Worktree left clean; all evidence lives in the evidence directory.

- Evidence: ADR 0015 rendered as a reviewer sees it (full page) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYZZWF53QXV58FSQX6XY1AY4/adr-0015-rendered.png</code>)
- Evidence: New glossary term rendered in surrounding context (shows it matches the neighbouring **Term** / _Avoid_ convention) (local file: <code>/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KYZZWF53QXV58FSQX6XY1AY4/glossary-term-rendered.png</code>)
<details>
<summary>Evidence: ADR 0015 claim-to-code verification transcript (37 passed, 0 failed)</summary>

<code>PASS reuses existing seam observe_authenticated_status/5 (arity 5)&#10;evidence (def + @spec): 439: @spec observe_authenticated_status(&#10;PASS slice A needs ZERO migrations: node_heartbeats table not yet created&#10;evidence: no matches, as the ADR states&#10;PASS dispatch authority needs evidence &gt;= last_heartbeat_at&#10;evidence: 1035: minimum_evidence_observed_at: node.last_heartbeat_at&#10;PASS ...enforced by an ordering comparison, not a freshness window&#10;evidence: 369: DateTime.compare(observed_at, minimum_observed_at) in [:eq, :gt]&#10;PASS authenticated seam DOUBLE-gates on health (outer: status_response)&#10;evidence: 457: true &lt;- authenticated_healthy_status?(status_response),&#10;PASS authenticated seam DOUBLE-gates on health (inner: observation)&#10;evidence: 1367: true &lt;- authenticated_healthy_observation?(observation),&#10;PASS SPEC §4.6 really says PUSH every 2s (the named divergence)&#10;evidence: 813:Node agent SHALL send heartbeats every 2 seconds with:&#10;PASS ADR states 0001 and 0013 do NOT conflict (no reconciliation)&#10;evidence: 189:rejected: the two do not conflict. Both point the same direction — durable&#10;&#10;====&#10;RESULT: 37 passed, 0 failed</code>

```text
=== ADR 0015 claim -> code grounding ===============================

PASS  reuses existing seam observe_authenticated_status/5 (arity 5)
        evidence (def + @spec): 439:  @spec observe_authenticated_status(
PASS  plain path is observe_status/4
        evidence (def): 408:  def observe_status(target, status_response, observed_at, opts \\ []) do
PASS  freshness gate lives in Nodes.schedulable_nodes/0
        evidence (def + health filter): 169:  def schedulable_nodes do
PASS  ActivationProbe targets :admitted Nodes only
        evidence (state filter): 191:  def activation_probe_runtime_endpoint_targets do
PASS  ActivationProbe is leader-gated via authorize_write_path(:node_lifecycle)
        evidence (guard): 29:    with :ok <- ControlPlane.authorize_write_path(:node_lifecycle),
PASS  ActivationProbe discards its return values
        evidence (wildcard bind): 76:            {:ok, _observation} -> [%{target_id: target.id, status: :activated}]
PASS  existing probe interval is 5 seconds
        evidence (@default_interval_ms): 14:  @default_interval_ms 5_000
PASS  unreachable threshold is 15 seconds
        evidence (runtime default): 309:  def node_unreachable_threshold_ms, do: config()[:node_unreachable_threshold_ms] || 15_000
PASS  authenticated seam DOUBLE-gates on health (outer: status_response)
        evidence (gate 1): 457:         true <- authenticated_healthy_status?(status_response),
PASS  authenticated seam DOUBLE-gates on health (inner: observation)
        evidence (gate 2, both clauses): 1367:           true <- authenticated_healthy_observation?(observation),
PASS  aggregate capacity evidence is written ONLY on the authenticated path
        evidence (persist fn): 1551:  defp persist_authenticated_capacity_evidence(node, observation) do
PASS  dispatch authority needs evidence >= last_heartbeat_at
        evidence (minimum_evidence_observed_at): 1035:          minimum_evidence_observed_at: node.last_heartbeat_at
PASS  ...enforced by an ordering comparison, not a freshness window
        evidence (compare in [:eq, :gt]): 369:    DateTime.compare(observed_at, minimum_observed_at) in [:eq, :gt]
PASS  MultiNode probes targets on the request path
        evidence (Enum.map probe_target): 125:      |> Enum.map(&probe_target(&1, client, timeout, observed_at, request))
PASS  failure atom :authenticated_transport_failed exists
        evidence (definition site): apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_client.ex:200:    do: {:error, :authenticated_transport_failed}
PASS  failure atom :beam_peer_grant_authorization_unavailable exists
        evidence (definition site): apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex:77:    {:error, :beam_peer_grant_authorization_unavailable}
PASS  failure atom :authenticated_observation_rejected exists
        evidence (definition site): apps/orchard_controller/lib/orchard/runtime_endpoint/grpc_compatibility_client.ex:193:      :noop -> {:error, :authenticated_observation_rejected}
PASS  failure atom :beam_peer_observation_rejected exists
        evidence (definition site): apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex:104:      :noop -> {:error, :beam_peer_observation_rejected}
PASS  slice A needs ZERO migrations: node_heartbeats table not yet created
        evidence: no matches, as the ADR states

=== ADR 0015 claim -> SPEC.md grounding ============================

PASS  SPEC §4.2 Node lifecycle states exists
        evidence (heading): 668:### 4.2 Node lifecycle states
PASS  SPEC §4.5 Node health model exists
        evidence (heading): 766:### 4.5 Node health model
PASS  SPEC §4.6 Heartbeat payload exists
        evidence (heading): 811:### 4.6 Heartbeat payload
PASS  SPEC §4.6.1 blesses status-probe ingestion
        evidence (heading): 855:### 4.6.1 Runtime Endpoint capability and readiness observation
PASS  SPEC §4.6 really says PUSH every 2s (the named divergence)
        evidence (push language): 813:Node agent SHALL send heartbeats every 2 seconds with:
PASS  SPEC §8 defines node_heartbeats
        evidence (create table): 3335:create table node_heartbeats (
PASS  ...with a spec-fixed payload jsonb column
        evidence (column): 3345:  payload jsonb not null default '{}'::jsonb
PASS  SPEC §8.5 sets node_heartbeats retention
        evidence (retention entry): 3905:* `node_heartbeats`: 7 days
PASS  SPEC §9.1 metrics endpoint exists
        evidence (heading): 3928:### 9.1 Metrics endpoint

=== ADR 0015 claim -> prior-ADR grounding ==========================

PASS  ADR 0001 constrains WHERE authority lives (durable in Postgres)
        evidence (0001 text): 30:Persist Runtime Endpoint Observations in Postgres for inventory, lifecycle, availability, scheduling, and operator-visible history.
PASS  ADR 0013 keeps capacity authority Controller-owned, fail-closed
        evidence (0013 text): 62:A consumer that cannot assemble the Controller-owned facts for that evaluation from current authenticated evidence fails closed with the stable scheduler rejection reason code `dispatch_capacity_facts_unavailable` instead of falling back to telemetry or a permissive default.

=== intent constraints =============================================

PASS  ADR states 0001 and 0013 do NOT conflict (no reconciliation)
        evidence (ADR text): 189:rejected: the two do not conflict. Both point the same direction — durable
PASS  ADR splits #122 into slice A (#148) and slice B (#149)
        evidence (ADR text): 48:is tracked by issue #148 and slice B by issue #149.
PASS  ADR states slice A adds no migration
        evidence (ADR text): 98:Slice A adds no migration. The persistence seam and the schema columns it needs
PASS  ADR rejects persisting the full candidate fact set in slice A
        evidence (ADR text): 161:Persisting the full candidate-construction fact set in slice A is rejected. It is
PASS  ADR decouples #128 and mitigates it by pre-loading the catalog
        evidence (ADR text): 156:still lack explanations. Window-open is not gated on #128 code landing; the
PASS  ADR makes latency exploratory-only, inline probe left in place
        evidence (ADR text): 128:correctness. Scheduler latency is exploratory only and is not an official baseline,
PASS  new glossary term added
        evidence (glossary): 443:**Active-Node Liveness Monitor**:

===================================================================
RESULT: 37 passed, 0 failed
```
</details>
<details>
<summary>Evidence: Reproducible claim-verification harness (kept out of the repo so the PR stays docs-only)</summary>

```text
#!/usr/bin/env bash
# Verifies that every load-bearing, code-grounded claim in ADR 0015 matches the
# repository it describes. Docs-only PRs have no unit tests; this is the
# equivalent check — does the prose actually describe this codebase?
#
# Usage: verify-adr-0015-claims.sh <repo-root>

set -uo pipefail
ROOT="${1:?usage: $0 <repo-root>}"
cd "$ROOT" || exit 1
ADR=docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md
pass=0; fail=0

ck() { # ck "<claim>" "<evidence label>" <cmd...>
  local claim="$1" label="$2"; shift 2
  local out
  if out="$("$@" 2>/dev/null)" && [ -n "$out" ]; then
    printf 'PASS  %s\n        evidence (%s): %s\n' "$claim" "$label" "$(head -1 <<<"$out")"
    pass=$((pass+1))
  else
    printf 'FAIL  %s\n        expected %s, found nothing\n' "$claim" "$label"
    fail=$((fail+1))
  fi
}

ckabsent() { # inverse: claim holds only if nothing matches
  local claim="$1"; shift
  if [ -z "$("$@" 2>/dev/null)" ]; then
    printf 'PASS  %s\n        evidence: no matches, as the ADR states\n' "$claim"
    pass=$((pass+1))
  else
    printf 'FAIL  %s\n        expected no matches, got some\n' "$claim"
    fail=$((fail+1))
  fi
}

echo "=== ADR 0015 claim -> code grounding ==============================="
echo

ck "reuses existing seam observe_authenticated_status/5 (arity 5)" "def + @spec" \
  grep -n -A9 "@spec observe_authenticated_status(" apps/orchard_controller/lib/orchard/nodes.ex

ck "plain path is observe_status/4" "def" \
  grep -n "def observe_status(target, status_response, observed_at, opts" apps/orchard_controller/lib/orchard/nodes.ex

ck "freshness gate lives in Nodes.schedulable_nodes/0" "def + health filter" \
  grep -n "def schedulable_nodes" apps/orchard_controller/lib/orchard/nodes.ex

ck "ActivationProbe targets :admitted Nodes only" "state filter" \
  grep -n -A2 "def activation_probe_runtime_endpoint_targets do" apps/orchard_controller/lib/orchard/nodes.ex

ck "ActivationProbe is leader-gated via authorize_write_path(:node_lifecycle)" "guard" \
  grep -n "ControlPlane.authorize_write_path(:node_lifecycle)" apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex

ck "ActivationProbe discards its return values" "wildcard bind" \
  grep -n "{:ok, _observation} ->" apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex

ck "existing probe interval is 5 seconds" "@default_interval_ms" \
  grep -n "@default_interval_ms 5_000" apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex

ck "unreachable threshold is 15 seconds" "runtime default" \
  grep -n "node_unreachable_threshold_ms, do: config()\[:node_unreachable_threshold_ms\] || 15_000" apps/orchard_controller/lib/orchard/inference.ex

ck "authenticated seam DOUBLE-gates on health (outer: status_response)" "gate 1" \
  grep -n "true <- authenticated_healthy_status?(status_response)," apps/orchard_controller/lib/orchard/nodes.ex

ck "authenticated seam DOUBLE-gates on health (inner: observation)" "gate 2, both clauses" \
  grep -n "true <- authenticated_healthy_observation?(observation)," apps/orchard_controller/lib/orchard/nodes.ex

ck "aggregate capacity evidence is written ONLY on the authenticated path" "persist fn" \
  grep -n "defp persist_authenticated_capacity_evidence" apps/orchard_controller/lib/orchard/nodes.ex

ck "dispatch authority needs evidence >= last_heartbeat_at" "minimum_evidence_observed_at" \
  grep -n "minimum_evidence_observed_at: node.last_heartbeat_at" apps/orchard_controller/lib/orchard/nodes.ex

ck "...enforced by an ordering comparison, not a freshness window" "compare in [:eq, :gt]" \
  grep -n "DateTime.compare(observed_at, minimum_observed_at) in \[:eq, :gt\]" apps/orchard_controller/lib/orchard/dispatch_capacity/authorization.ex

ck "MultiNode probes targets on the request path" "Enum.map probe_target" \
  grep -n "Enum.map(&probe_target(" apps/orchard_controller/lib/orchard/scheduler/multi_node.ex

for a in authenticated_transport_failed beam_peer_grant_authorization_unavailable \
         authenticated_observation_rejected beam_peer_observation_rejected; do
  ck "failure atom :$a exists" "definition site" \
    grep -rn --include=*.ex ":$a" apps/
done

ckabsent "slice A needs ZERO migrations: node_heartbeats table not yet created" \
  grep -rl "node_heartbeats" apps/orchard_controller/priv/repo/migrations/

echo
echo "=== ADR 0015 claim -> SPEC.md grounding ============================"
echo
ck "SPEC §4.2 Node lifecycle states exists" "heading" grep -n "^### 4.2 Node lifecycle states" SPEC.md
ck "SPEC §4.5 Node health model exists" "heading" grep -n "^### 4.5 Node health model" SPEC.md
ck "SPEC §4.6 Heartbeat payload exists" "heading" grep -n "^### 4.6 Heartbeat payload" SPEC.md
ck "SPEC §4.6.1 blesses status-probe ingestion" "heading" grep -n "^### 4.6.1 Runtime Endpoint capability and readiness observation" SPEC.md
ck "SPEC §4.6 really says PUSH every 2s (the named divergence)" "push language" grep -n "SHALL send heartbeats every 2 seconds" SPEC.md
ck "SPEC §8 defines node_heartbeats" "create table" grep -n "create table node_heartbeats" SPEC.md
ck "...with a spec-fixed payload jsonb column" "column" grep -n "  payload jsonb not null default" SPEC.md
ck "SPEC §8.5 sets node_heartbeats retention" "retention entry" grep -n "node_heartbeats\`: 7 days" SPEC.md
ck "SPEC §9.1 metrics endpoint exists" "heading" grep -n "^### 9.1 Metrics endpoint" SPEC.md

echo
echo "=== ADR 0015 claim -> prior-ADR grounding =========================="
echo
ck "ADR 0001 constrains WHERE authority lives (durable in Postgres)" "0001 text" \
  grep -n "Persist Runtime Endpoint Observations in Postgres" docs/decisions/0001-runtime-endpoints-beam-first.md
ck "ADR 0013 keeps capacity authority Controller-owned, fail-closed" "0013 text" \
  grep -n "fails closed with the stable scheduler rejection reason code" docs/decisions/0013-controller-dispatch-capacity-authority.md

echo
echo "=== intent constraints ============================================="
echo
ck "ADR states 0001 and 0013 do NOT conflict (no reconciliation)" "ADR text" \
  grep -n "the two do not conflict" "$ADR"
ck "ADR splits #122 into slice A (#148) and slice B (#149)" "ADR text" \
  grep -n "tracked by issue #148 and slice B by issue #149" "$ADR"
ck "ADR states slice A adds no migration" "ADR text" \
  grep -n "^Slice A adds no migration" "$ADR"
ck "ADR rejects persisting the full candidate fact set in slice A" "ADR text" \
  grep -n "fact set in slice A is rejected" "$ADR"
ck "ADR decouples #128 and mitigates it by pre-loading the catalog" "ADR text" \
  grep -n "Window-open is not gated on #128 code landing" "$ADR"
ck "ADR makes latency exploratory-only, inline probe left in place" "ADR text" \
  grep -n "Scheduler latency is exploratory only" "$ADR"
ck "new glossary term added" "glossary" \
  grep -n "^\*\*Active-Node Liveness Monitor\*\*:" docs/glossary/CONTEXT.md

echo
echo "==================================================================="
printf 'RESULT: %d passed, %d failed\n' "$pass" "$fail"
[ "$fail" -eq 0 ]
```
</details>
<details>
<summary>Evidence: Docs-only scope check + GitHub issue resolution</summary>

<code>$ git diff --stat b6ec92f..9b13eec&#10;...liveness-monitor-before-scheduler-decoupling.md | 228 +++++++++++++++++++++&#10;docs/glossary/CONTEXT.md | 4 +&#10;2 files changed, 232 insertions(+)&#10;&#10;# intent: docs-only -- no code, SPEC, or dependency changes&#10;non-docs files changed: 0&#10;$ git diff --name-only ... -- SPEC.md mix.exs mix.lock &#39;apps/**&#39; &#39;native/**&#39; &#39;packaging/**&#39; &#39;config/**&#39;&#10;(no output = none touched)&#10;&#10;# intent: transient docs/reviews + docs/investigations notes stay uncommitted&#10;$ git ls-files docs/reviews docs/investigations&#10;(no output = not committed)&#10;&#10;# referenced GitHub issues resolve and match the ADR&#39;s characterization&#10;#118 [OPEN] Define and run a closed internal test of Orchard with an internal client team&#10;#122 [OPEN] Monitor active-node liveness in the background and take the scheduler off the inline probe path&#10;#128 [OPEN] Resolve canonical admission policy and preserve actionable scheduler failure reasons&#10;#148 [OPEN] Thin active-node liveness monitor (slice A of #122)&#10;#149 [OPEN] Decouple the scheduler from the inline probe (slice B of #122)</code>

```text
$ git diff --stat b6ec92f..9b13eec
 ...liveness-monitor-before-scheduler-decoupling.md | 228 +++++++++++++++++++++
 docs/glossary/CONTEXT.md                           |   4 +
 2 files changed, 232 insertions(+)

# intent: docs-only -- no code, SPEC, or dependency changes
$ git diff --name-only b6ec92f..9b13eec | grep -vE '^docs/' | wc -l   # non-docs files changed
0
$ git diff --name-only b6ec92f..9b13eec -- SPEC.md mix.exs mix.lock 'apps/**' 'native/**' 'packaging/**' 'config/**'
(no output above = none touched)

# intent: transient docs/reviews + docs/investigations notes stay uncommitted
$ git ls-files docs/reviews docs/investigations
(no output above = not committed)

# referenced GitHub issues resolve and match the ADR's characterization
  #118 [OPEN] Define and run a closed internal test of Orchard with an internal client team
  #122 [OPEN] Monitor active-node liveness in the background and take the scheduler off the inline probe path
  #128 [OPEN] Resolve canonical admission policy and preserve actionable scheduler failure reasons
  #148 [OPEN] Thin active-node liveness monitor (slice A of #122)
  #149 [OPEN] Decouple the scheduler from the inline probe (slice B of #122)

$ git status --porcelain   # worktree clean after testing
(no output above = clean)
```
</details>
<details>
<summary>Evidence: Rendered ADR 0015 (HTML source for the screenshot)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="gh.css"></head><body><div class="wrap">
<div class="filehdr">docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md &nbsp;·&nbsp; NEW FILE (+228)</div><div class="body">
<h1
id="active-node-liveness-lands-as-a-thin-background-monitor-before-scheduler-decoupling">Active-node
liveness lands as a thin background monitor before scheduler
decoupling</h1>
<h2 id="status">Status</h2>
<p>Accepted.</p>
<p>Owner decision recorded 2026-08-02. Implementation proceeds through a
single OpenSpec change package with ordered slices; this record fixes
the decomposition and the pilot-blocking boundary ahead of that
authoring.</p>
<h2 id="context">Context</h2>
<p>Active-node liveness is observed today only as a side effect of
scheduling a request. <code>Orchard.Scheduler.MultiNode</code> probes
every configured target sequentially on the request path, and the
observation that probe persists is what refreshes
<code>last_heartbeat_at</code> so the freshness gate in
<code>Nodes.schedulable_nodes/0</code> passes. Between requests nothing
observes an <code>:active</code> Node, so a Node that dies while the
cluster is idle stays <code>:active</code>/<code>:healthy</code> in
inventory until the next request pays to discover it. The only recurring
prober, <code>ActivationProbe</code>, targets <code>:admitted</code>
Nodes and discards its return values; it persists anything only as a
client-internal side effect on authenticated transports, and only for
healthy responses.</p>
<p>The M5 closed internal pilot (issue #118) needs this gap closed: its
readiness gate requires that liveness be tracked on a bounded interval
and that the loss of either Node be detected without depending on an
inline probe on the request path. Issue #122 proposed both a background
monitor and taking the scheduler off the inline probe. The question this
record settles is how to decompose #122 so the pilot is unblocked as
fast as is defensible, without over-building.</p>
<p>An implementation proposal asserted a hard constraint: the
background-observation slice must first create the SPEC §8
<code>node_heartbeats</code> table and persist the full
candidate-construction fact set (availability, loaded-model status,
active-request counts, maximum concurrency, placement capacity,
prefix-cache status, memory budget, and an acquirability fact), because
otherwise the scheduler-decoupling slice would require a second
migration. That constraint was tested against the code,
<code>SPEC.md</code>, ADR 0001, and ADR 0013 through independent review,
and it does not hold.</p>
<p>This decision is hard to reverse because it fixes where the liveness
authority for scheduling eligibility lives and what the pilot may claim.
It is surprising because the intuitive "persist everything the scheduler
uses" instinct is both unnecessary and slower here. It resolves a real
trade-off between front-loading a durable contract now and deferring it
until its only consumer exists.</p>
<h2 id="decision">Decision</h2>
<p>Decompose #122 into two ordered slices, A then B, in one OpenSpec
package. Slice A is tracked by issue #148 and slice B by issue #149.</p>
<p>Slice A is the only pilot-blocking build item and is deliberately
thin. It generalizes the existing supervised, leader-authorized
<code>ActivationProbe</code> to observe <code>:active</code> Nodes in
addition to <code>:admitted</code> Nodes, on a bounded interval strictly
below the unreachable threshold.</p>
<p>Slice A consumes probe outcomes through the authenticated observation
path (<code>observe_authenticated_status/5</code>), not the plain
<code>observe_status/4</code> upsert. This distinction is load bearing.
Plain <code>observe_status/4</code> writes only the Node row; aggregate
capacity evidence is persisted only by the authenticated path. The
dispatch authority check requires durable capacity evidence to be at
least as current as <code>last_heartbeat_at</code>, so a monitor that
advanced the heartbeat without co-writing evidence would make evidence
non-current and force dispatch closed with unavailable facts. A
successful monitor observation therefore advances
<code>last_heartbeat_at</code>, re-derives health, and refreshes
aggregate capacity evidence in one authenticated write, keeping
heartbeat freshness and evidence currency in lockstep.</p>
<p>Slice A carries one real code change beyond generalizing the prober.
The authenticated seam today double-gates on health and rejects any
non-healthy observation, so a <code>:degraded</code> or
<code>:unhealthy</code> already-<code>:active</code> Node is dropped and
ages out of <code>schedulable_nodes/0</code> even under traffic. Slice A
must relax those gates to accept and record a non-healthy observation
from an already-<code>:active</code> Node, while keeping the
<code>:admitted</code> to <code>:active</code> promotion healthy-gated
so a non-healthy <code>:admitted</code> Node still cannot activate.</p>
<p>Failure handling must separate two cases that look alike. A genuine
transport failure, where the Node did not respond, routes through the
graded demotion path: <code>:degraded</code>, then
<code>:unreachable</code> once the last heartbeat exceeds the 15-second
threshold. The demotion classifier must also recognize the authenticated
and BEAM transport failures it does not classify today
(<code>:authenticated_transport_failed</code>,
<code>:beam_peer_grant_authorization_unavailable</code>). An observation
the seam rejected because the Node was non-healthy
(<code>:authenticated_observation_rejected</code>,
<code>:beam_peer_observation_rejected</code>) is not a transport
failure, the Node responded, and it must be handled by the gate
relaxation above rather than swept into demotion. A periodic
heartbeat-age sweep bounds detection at approximately the unreachable
threshold plus one sweep interval, roughly 20 seconds at the 15-second
threshold and the existing 5-second probe interval.</p>
<p>Slice A leaves the scheduler's control flow, candidate selection,
ranking, and the inline probe path in place. It does not, however, leave
the inline probe's observed behavior identical: the health gate slice A
relaxes lives in the shared <code>observe_authenticated_status/5</code>
seam, which the inline probe also drives through its transport client's
status call, so the relaxation applies to the background monitor and the
inline probe alike. That is intended and safe. Its only effect is that a
non-healthy observation from an already-<code>:active</code> Node is
recorded rather than dropped, and it does not change the
<code>:admitted</code> to <code>:active</code> promotion, which stays
healthy-gated.</p>
<p>Slice A adds no migration. The persistence seam and the schema
columns it needs already exist. It does not create
<code>node_heartbeats</code>, does not implement the §8.5 retention job,
and does not implement the §9.1 heartbeat-lag metric; those are real
SPEC obligations but serve operator forensics and the metrics floor, not
the two gate properties, and #118 already spun the metrics floor out of
the pilot gate. They land with slice B or the metrics-floor work.</p>
<p>Slice A must name the <code>SPEC.md</code> §4.6 push-versus-pull
divergence in its OpenSpec delta. §4.6 says the Node Agent sends
heartbeats every 2 seconds, while §4.6.1 already blesses status-probe
ingestion as the durable seam, so SPEC is internally split and the
evidence favors reconciling to pull. The implementation, inline and
background alike, pulls status probes. Slice A extends that existing
divergence rather than creating it, and the delta must either reconcile
SPEC to pull-based observation or explicitly defer the reconciliation.
The §8 <code>node_heartbeats</code> columns mirror the §4.6 push
payload, so the deferred §8 work and this reconciliation are coupled and
should be resolved together. Silent divergence is not acceptable.</p>
<p>Slice B decouples the scheduler from the inline probe: it serves
candidates from a monitor-refreshed source and removes or bounds the
inline sequential probe. Whether the durable
<code>node_heartbeats</code> history, a leader-local in-memory mirror of
the persisted observation, or both back that source is slice B's design
question, to be settled when B's snapshot-freshness and dispatch-time
revalidation contracts are designed. Enriching what an observation
payload carries is a payload-contract change absorbed by the spec-fixed
<code>payload jsonb</code> column, not a schema migration. The full
candidate fact set is slice B's deliverable, defined against a real
consumer.</p>
<p>The pilot (#118) is blocked by slice A only, not by whole-#122.
Retargeting the blocker to slice A matches the readiness-gate text,
which requires detection without the inline probe rather than
scheduling-path purity. The pilot's official claim is 2-node liveness
and observability stability plus failure-classification correctness.
Scheduler latency is exploratory only and is not an official baseline,
because the inline probe remains on the request path through the frozen
window; multi-node placement-optimization behavior is deferred to slice
B. The pilot findings must disclose the inline-probe latency overhead
and the window in which a <code>:degraded</code> Node remains
schedulable, the unreachable threshold plus one sweep interval and so
roughly 20 seconds at the default 5-second interval, as known, bounded
limitations of the frozen artifact.</p>
<p>Issue #128 (scheduler failure reclassification) is decoupled from
slice A and from the pilot build. Acquirability is a time-sensitive
property derived Controller-side from catalog, artifact, policy, and
live capacity state; it is not an observation fact, does not belong in a
heartbeat row, and must not be persisted as a boolean or computed by a
second eligibility formula. #128 ships on its own track, ideally before
the pilot midpoint because a misclassified <code>model_busy</code> is
the defect the client team is most likely to hit.</p>
<p>Pre-loading the pinned catalog on both Nodes before the window opens
reduces, but does not eliminate, #128 contamination of the failure
denominator. It removes the specific cold-path misclassification,
catalog-active but not loaded returning <code>model_busy</code>, so the
<code>model_busy</code> that remains is genuine capacity exhaustion,
which is classified correctly before #128 lands. Pre-loading is a
reduction, not a guarantee: residency can be lost mid-window to a worker
crash, a Node restart, or a memory-pressure unload, so the window must
assert model residency periodically and disclose any eviction as a known
limitation. Two residual gaps must be disclosed in the findings.
Pre-loading means the pilot never exercises the cold-load path, so
cold-start behavior is out of the pilot evidence base. And #128 is
broader than this one path, since it also covers queue admission that
ignores canonical policy and the absence of a recorded scheduler
explanation, so some failures in the window will still lack
explanations. Window-open is not gated on #128 code landing; the
contamination it addresses is bounded operationally instead.</p>
<h2 id="rejected-alternatives">Rejected alternatives</h2>
<p>Persisting the full candidate-construction fact set in slice A is
rejected. It is not required by ADR 0001, which constrains where
authority lives (durable in Postgres, not in BEAM signals) rather than
mandating that every ranking input be schema-modeled before anything
consumes it; the current inline path already persists durable authority
and uses the live observation for ranking annotations, and a thin
monitor through the same seam cannot be less compliant than that
accepted pattern. It is not required by ADR 0013, which demotes the
richest parts of the proposed payload (placement capacity, active
counts) from authority to evidence and keeps capacity authority
Controller-owned. Its second-migration cost argument is wrong: thin A
requires zero migrations, so the comparison is one migration total
either way, taken in A or in B. And it finalizes a payload contract
whose only consumer, slice B's cached candidate construction, is not yet
designed, which guarantees rather than avoids a later review pass.</p>
<p>Landing all of #122 before the pilot is rejected: it holds a
stability finding hostage to a latency optimization that is irrelevant
at two Nodes.</p>
<p>Adding a second background poller instead of generalizing
<code>ActivationProbe</code> is rejected: the existing prober is already
supervised and leader-gated via
<code>ControlPlane.authorize_write_path(:node_lifecycle)</code>, and
reuse inherits single-writer semantics for free.</p>
<p>Coupling #128 to slice A or to window-open is rejected: acquirability
is not a heartbeat fact, #128 is not in the #118 gate, and #128's real
scope is a multi-module admission-policy and reason-code change that
would put a scheduler and orchestrator redesign on the pilot's critical
path for no gate benefit.</p>
<p>Framing the accompanying ADR as a reconciliation of ADR 0001 and ADR
0013 is rejected: the two do not conflict. Both point the same direction
— durable observations in Postgres as scheduler and operator input,
capacity authority Controller-owned and fail-closed on missing facts —
and there is nothing to reconcile.</p>
<h2 id="consequences">Consequences</h2>
<p>The pilot build shrinks to one GenServer generalization, result
consumption through the authenticated seam, the health-gate relaxation
for <code>:active</code> Nodes, an interval-versus-threshold invariant,
and a small OpenSpec delta plus this record. Every gate property the
stability finding must prove maps to a test: an idle cluster stays
schedulable with zero traffic, a Node killed while idle is demoted
within the asserted bound, a recovered Node returns to
<code>:healthy</code>, a standby Controller writes nothing, the interval
stays below the freshness and unreachable thresholds, a
<code>:degraded</code> <code>:active</code> Node is recorded rather than
dropped while a non-healthy <code>:admitted</code> Node still cannot
activate, and a seam rejection is not treated as a transport
demotion.</p>
<p>Double probing exists during slice A: the inline probe and the
background monitor both write observations. Existing staleness and
concurrent-insert guards make this safe, and the extra RPC load at two
Nodes is negligible.</p>
<p>The SPEC §4.6 push-versus-pull divergence becomes an explicit, named
obligation rather than an undocumented drift, carried by slice B or a
dedicated reconciliation.</p>
<p>The <code>node_heartbeats</code> table, its §8.5 retention, and the
§9.1 heartbeat-lag metric remain unimplemented after slice A and are
tracked with slice B and the metrics floor. Heartbeat lag stays
computable from <code>nodes.last_heartbeat_at</code> once the metric
lands.</p>
<h2 id="specmd-impact">SPEC.md impact</h2>
<p>Confirm or update the Node liveness and heartbeat observation
language in <code>SPEC.md</code> §4.2 (Node lifecycle states), §4.5
(Node health model), and §4.6 (Heartbeat payload) to state that
active-node liveness is maintained by a leader-owned background observer
independent of request traffic. Name and resolve the §4.6
push-versus-pull heartbeat divergence, either by reconciling SPEC to
pull-based observation or by recording an explicit deferral. The §8
<code>node_heartbeats</code> schema, §8.5 retention, and §9.1
heartbeat-lag metric are unchanged and remain future obligations tracked
with slice B and the metrics floor.</p>
</div></div></body></html>
```
</details>
<details>
<summary>Evidence: Rendered glossary term in context (HTML source for the screenshot)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="gh.css">
<style>.new{background:#1f6feb26;border-left:3px solid #3fb950;padding:12px 16px;border-radius:6px}
.tag{background:#3fb950;color:#0d1117;font:600 11px/1 -apple-system,sans-serif;padding:4px 8px;border-radius:4px;letter-spacing:.04em}
h2.sec{font-size:1.1em;color:#8b949e;border:0;margin:0 0 20px;text-transform:uppercase;letter-spacing:.06em}</style>
</head><body><div class="wrap">
<div class="filehdr">docs/glossary/CONTEXT.md &nbsp;·&nbsp; +4 lines &nbsp;·&nbsp; § Language (lines 436&ndash;450)</div>
<div class="body"><h2 class="sec">New term shown in surrounding context</h2><p>A durable Controller-recorded snapshot of Runtime Endpoint status,
capability, availability, placement, and capacity signals.
<em>Avoid</em>: live BEAM session, durable cluster truth by itself,
provider billing event</p>
<p><strong>Heartbeat</strong>: A periodic durable observation used by
the Controller to record first-party Node Agent health, inventory,
workers, placements, and Runtime Endpoint Availability. <em>Avoid</em>:
Node Lifecycle State, readiness probe, live BEAM session</p>
<p class="new"><span class="tag">NEW in this PR</span><br><strong>Active-Node Liveness Monitor</strong>: The
traffic-independent mechanism that tracks whether each active Node is
still alive, so the Controller can distinguish a degraded cluster from a
silently half-dead one, and an idle Node loss is detected without a
request paying for discovery. <em>Avoid</em>: inline request-path probe,
readiness probe, Controller Membership Heartbeat</p>
<p><strong>Node Pool</strong>: A scheduling group where each v1 Node
belongs to exactly one pool. <em>Avoid</em>: Tenant, cluster</p>
</div>
</div></body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md:84` - The ADR asserts &#34;The scheduler and its inline probe are untouched in slice A&#34; (line 84), but the health-gate relaxation slice A mandates (lines 66-72) lives in the shared seam `Nodes.observe_authenticated_status/5`, which is invoked from `BeamClient.status/2` (apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex:101) and `GrpcCompatibilityClient` (grpc_compatibility_client.ex:186) on every authenticated status probe — including the scheduler&#39;s inline probe at apps/orchard_controller/lib/orchard/scheduler/multi_node.ex:454. Relaxing the gate changes inline scheduling behavior even though no scheduler code is edited. Consider either scoping the relaxation so only the background monitor observes non-healthy `:active` Nodes, or amending the ADR to state that slice A intentionally widens the inline candidate set.
- ⚠️ `docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md:210` - The &#34;SPEC.md impact&#34; section directs follow-on work at `SPEC.md` §7 &#34;(Node lifecycle, health, and freshness)&#34;, but SPEC.md §7 is &#34;APIs&#34; (SPEC.md:1808). Node lifecycle states, the health model, and heartbeat observation are §4.2 (SPEC.md:668), §4.5 (SPEC.md:766), and §4.6 (SPEC.md:811) under &#34;## 4. Node Management&#34;. Every other SPEC reference in the ADR (§4.6, §4.6.1, §8, §8.5, §9.1) is correct, so this looks like a single mistyped pointer that would send an implementer to the wrong section.
- ℹ️ `docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md:120` - The pilot-disclosure requirement names &#34;the up-to-15-second window in which a `:degraded` Node remains schedulable&#34;, but the ADR&#39;s own detection bound five paragraphs earlier is &#34;approximately the unreachable threshold plus the sweep interval&#34; (lines 83-84). Demotion to `:unreachable` only happens on a probe/sweep tick where heartbeat age already exceeds 15s, so with the existing 5s ActivationProbe interval (activation_probe.ex:14) the real schedulable-while-dead window is up to ~20s. Since the ADR exists to fix what the pilot may claim, the two bounds should agree.
- ℹ️ `docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md:47` - The ADR references issues #122, #118, and #128 by number but never names the two slice-tracking issues it created (#148 &#34;Thin active-node liveness monitor (slice A of #122)&#34; and #149 &#34;Decouple the scheduler from the inline probe (slice B of #122)&#34;), both of which exist and are open. Since fixing the A/B decomposition boundary is the whole point of this record, adding the issue numbers at the &#34;Decompose #122 into two ordered slices&#34; line would make the boundary traceable to the work items that implement it.

🔧 Fix: correct ADR 0015 slice-A scope, SPEC refs, and bounds
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash verify-adr-0015-claims.sh &lt;repo&gt;` — 37-check ADR-claim-to-code/SPEC/ADR grounding harness, 37 passed / 0 failed</code>
- <code>`grep -n -A9 &#39;@spec observe_authenticated_status(&#39; apps/orchard_controller/lib/orchard/nodes.ex` — confirms the reused seam exists at arity 5 (nodes.ex:439)</code>
- <code>`grep -rl &#39;node_heartbeats&#39; apps/orchard_controller/priv/repo/migrations/` — returns nothing, confirming the zero-migrations claim for slice A</code>
- <code>`grep -n &#39;minimum_evidence_observed_at: node.last_heartbeat_at&#39; apps/orchard_controller/lib/orchard/nodes.ex` + `grep -n &#39;DateTime.compare(observed_at, minimum_observed_at) in \[:eq, :gt\]&#39; apps/orchard_controller/lib/orchard/dispatch_capacity/authorization.ex` — confirms evidence-currency is an ordering comparison, not a freshness window</code>
- <code>`grep -n &#39;authenticated_healthy_status?(status_response)&#39; and &#39;authenticated_healthy_observation?(observation)&#39; apps/orchard_controller/lib/orchard/nodes.ex` — confirms the ADR&#39;s &#39;double-gates on health&#39; wording (nodes.ex:457, :1367, :1390)</code>
- <code>`grep -n &#39;SHALL send heartbeats every 2 seconds&#39; SPEC.md` vs `### 4.6.1 Runtime Endpoint capability and readiness observation` — confirms the named push-vs-pull divergence is real</code>
- <code>Manual check that `ActivationProbe` is the only recurring prober: cross-referenced modules calling `client.status(`/`client.connect(` against those using `Process.send_after`; `request_dispatcher`&#39;s timer is a per-dispatch timeout (request_dispatcher.ex:1289), not a periodic probe</code>
- <code>`git diff --name-only b6ec92f..9b13eec -- SPEC.md mix.exs mix.lock &#39;apps/**&#39; &#39;config/**&#39; &#39;packaging/**&#39; &#39;native/**&#39;` — empty, confirming docs-only scope</code>
- <code>`git ls-files docs/reviews docs/investigations` — empty, confirming transient notes stay uncommitted per AGENTS.md</code>
- <code>`gh issue view 118/122/128/148/149` — all resolve; #148 and #149 titles match the slice A / slice B decomposition the ADR records</code>
- <code>`pandoc ... -f gfm -t html5` + `agent-browser screenshot --full` — rendered ADR 0015 and the glossary term in context, captured as reviewer-visible PNGs</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md:113` - ADR 0015 names an unresolved SPEC contradiction it deliberately defers: SPEC.md §4.6 (line 813) and §7 (line 1125) still state the Node Agent pushes heartbeats every 2 seconds, while the implementation — inline and background alike — pulls status probes, a seam §4.6.1 already blesses. This divergence pre-dates the change and this docs-only PR correctly does not touch SPEC.md, but AGENTS.md treats SPEC/implementation disagreement as branch-blocking, so the reconciliation (or an explicit deferral recorded in SPEC.md) is worth a follow-up on the slice B / OpenSpec delta track that ADR 0015&#39;s &#39;SPEC.md impact&#39; section assigns it to. No action taken here.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788225741&installation_model_id=428414&pr_number=150&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F150&signature=ceae4d3f69e471b047b9c44fa472d6fa11030cb684aeec76c40542278534ec82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->