### PR TITLE
feat(controller): detect active-node loss with a background liveness observer

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -798,8 +798,11 @@ Active-Node liveness SHALL be maintained by a leader-owned background status obs
 Endpoint Nodes on a bounded interval strictly below both heartbeat thresholds, independent
 of request traffic. Successful authenticated observations advance `last_heartbeat_at`,
 re-derive health, and refresh aggregate capacity evidence in one write. Transport failures
-and a periodic heartbeat-age sweep demote health through the graded path (`degraded`, then
-`unreachable` past the unreachable threshold). Non-healthy observations from already-active
+and a periodic heartbeat-age sweep over `:active` Nodes demote health through the graded path
+(`degraded`, then `unreachable` past the unreachable threshold); a Node already recorded
+`unhealthy` SHALL keep that health until a successful observation clears it, and `:admitted`
+Nodes SHALL NOT be swept because a stalled admitted heartbeat usually means the observation
+seam is rejecting a reachable Node. Non-healthy observations from already-active
 Nodes SHALL be recorded; `:admitted` to `:active` promotion remains healthy-gated.
 A standby Controller SHALL write nothing on this path.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -793,6 +793,16 @@ Health derivation:
 * `unhealthy`: fresh heartbeat, but serious local error
 * `unreachable`: heartbeat older than 15s
 
+Active-Node liveness SHALL be maintained by a leader-owned background status observer
+(`Orchard.RuntimeEndpoint.ActivationProbe`) that probes admitted and active Runtime
+Endpoint Nodes on a bounded interval strictly below both heartbeat thresholds, independent
+of request traffic. Successful authenticated observations advance `last_heartbeat_at`,
+re-derive health, and refresh aggregate capacity evidence in one write. Transport failures
+and a periodic heartbeat-age sweep demote health through the graded path (`degraded`, then
+`unreachable` past the unreachable threshold). Non-healthy observations from already-active
+Nodes SHALL be recorded; `:admitted` to `:active` promotion remains healthy-gated.
+A standby Controller SHALL write nothing on this path.
+
 Warning conditions:
 
 * swap used > 2 GiB
@@ -809,6 +819,15 @@ Serious conditions:
 * free disk < 5 GiB
 
 ### 4.6 Heartbeat payload
+
+> **Implementation note (ADR 0015 / issue #148):** `SPEC.md` §4.6 historically describes a
+> Node-push heartbeat every 2 seconds, while §4.6.1 and the shipped Controller implement
+> pull-based Runtime Endpoint status-probe ingestion (inline scheduler probes and the
+> leader-owned background `ActivationProbe`). Slice A of the thin active-node liveness
+> monitor extends that existing pull-based path and does not introduce a push loop.
+> Full reconciliation of §4.6 to pull-based observation (or an explicit dual-path contract)
+> is deferred and coupled to the deferred §8 `node_heartbeats` work (slice B / metrics floor).
+> Silent divergence is not acceptable; this note is the explicit deferral.
 
 Node agent SHALL send heartbeats every 2 seconds with:
 
@@ -860,6 +879,7 @@ Rules:
 
 * the durable implementation seam for runtime status SHALL be a Runtime Endpoint Observation produced through the Runtime Endpoint Interface
 * the current gRPC Compatibility Adapter SHALL derive Runtime Endpoint Observations from `NodeRuntimeService.GetStatus` returning `StatusResponse`
+* controller-owned active-Node liveness and inventory freshness SHALL also be refreshed by a leader-owned background status probe on a bounded interval independent of request traffic, consuming authenticated observations through the same seam
 * heartbeat payloads MAY carry equivalent hosted-tool data in a later slice, but controller-owned hosted-tool observation SHALL currently be derived from Runtime Endpoint status-probe ingestion
 * this contract defines future hosted routing inputs only; it SHALL NOT by itself enable controller-owned hosted `/v1/responses` execution or any other hosted execution behavior
 * Runtime Endpoint Observations are observational until reconciled to a trusted Node

--- a/apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs
@@ -534,7 +534,7 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
 
     assert active.id == node_id
     assert active.state == :active
-    assert Inference.activation_probe_runtime_endpoint_targets() == []
+    assert [%Target{node_id: ^node_id}] = Inference.activation_probe_runtime_endpoint_targets()
     assert [%Target{node_id: ^node_id} = active_target] = Inference.runtime_endpoint_targets()
     assert active_target.metadata.authorization == :inference_dispatch
     assert Enum.map(NodeInventory.schedulable_nodes(), & &1.id) == [node_id]
@@ -549,7 +549,7 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
 
     assert Repo.get!(InventoryNode, context.bundle["node_id"]).state == :admitted
 
-    assert {:ok, [%{target_id: target_id, status: :activated}]} =
+    assert {:ok, [%{target_id: target_id, status: :observed}]} =
              ActivationProbe.run_once()
 
     assert target_id == target.id

--- a/apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs
@@ -70,6 +70,25 @@ defmodule OrchardCLI.Commands.NodeJoinTest.Task28Endpoint do
   run(Orchard.Node.RuntimeServer)
 end
 
+defmodule OrchardCLI.Commands.NodeJoinTest.StalledRuntimeServer do
+  @moduledoc false
+
+  use GRPC.Server, service: Orchard.Cluster.V1.NodeRuntimeService.Service
+
+  alias Orchard.Cluster.V1.StatusRequest
+
+  @spec get_status(StatusRequest.t(), GRPC.Server.Stream.t()) :: no_return()
+  def get_status(%StatusRequest{}, _stream) do
+    raise GRPC.RPCError, status: :unavailable, message: "runtime status unavailable"
+  end
+end
+
+defmodule OrchardCLI.Commands.NodeJoinTest.StalledRuntimeEndpoint do
+  use GRPC.Endpoint
+
+  run(OrchardCLI.Commands.NodeJoinTest.StalledRuntimeServer)
+end
+
 defmodule OrchardCLI.Commands.NodeJoinTest do
   use ExUnit.Case, async: false
 
@@ -78,7 +97,9 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
   import ExUnit.CaptureLog
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.ClusterManagement.StatusBuilder
   alias Orchard.Dispatch.GrpcNodeRuntimeClient, as: TransportClient
+  alias Orchard.DispatchCapacity
   alias Orchard.Inference
   alias Orchard.Node.Supervisor, as: NodeSupervisor
   alias Orchard.NodeEnrollment.PKI
@@ -557,6 +578,115 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
     node_id = context.bundle["node_id"]
     assert Repo.get!(InventoryNode, node_id).state == :active
     assert Enum.map(NodeInventory.schedulable_nodes(), & &1.id) == [node_id]
+  end
+
+  @tag :liveness_evidence
+  test "SPEC.md §4.5 leader-owned probe keeps an idle active Node live and demotes idle Node loss",
+       context do
+    port = free_tcp_port()
+    _target = join_admit_and_configure_runtime!(context, port)
+    start_enrolled_tls_server!(port)
+    node_id = context.bundle["node_id"]
+    unreachable_ms = Inference.node_unreachable_threshold_ms()
+
+    IO.puts("""
+
+    === issue #148 slice A: idle active-Node liveness over the real mTLS probe ===
+    node_id=#{node_id} runtime endpoint=127.0.0.1:#{port}
+    unreachable_threshold_ms=#{unreachable_ms} freshness_threshold_ms=#{Inference.node_freshness_threshold_ms()} probe_interval_ms=#{ActivationProbe.interval_ms()}
+    No inference request is dispatched anywhere in this scenario. Probe cycles observe
+    the Node over real mutual TLS; cycles that age past a threshold inject observed_at
+    instead of sleeping through it.
+    """)
+
+    assert Repo.get!(InventoryNode, node_id).state == :admitted
+    emit_liveness_row("admitted, before any probe cycle", node_id)
+
+    assert {:ok, [%{status: :observed}]} = ActivationProbe.run_once()
+    first = Repo.get!(InventoryNode, node_id)
+    first_evidence = DispatchCapacity.get_capacity_evidence(node_id)
+    assert first.state == :active
+    assert first.health == :healthy
+    assert Enum.map(NodeInventory.schedulable_nodes(), & &1.id) == [node_id]
+    emit_liveness_row("probe cycle 1: admitted -> active", node_id)
+
+    Process.sleep(1_100)
+
+    assert {:ok, [%{status: :observed}]} = ActivationProbe.run_once()
+    idle = Repo.get!(InventoryNode, node_id)
+    idle_evidence = DispatchCapacity.get_capacity_evidence(node_id)
+    assert idle.state == :active
+    assert idle.health == :healthy
+    assert DateTime.compare(idle.last_heartbeat_at, first.last_heartbeat_at) == :gt
+    assert DateTime.compare(idle_evidence.observed_at, first_evidence.observed_at) == :gt
+    assert Enum.map(NodeInventory.schedulable_nodes(), & &1.id) == [node_id]
+    emit_liveness_row("probe cycle 2: idle refresh, no request traffic", node_id)
+
+    aged_at = DateTime.add(idle.last_heartbeat_at, unreachable_ms + 1_000, :millisecond)
+    Application.put_env(:orchard_controller, :control_plane, role: :standby)
+
+    assert {:error, :controller_standby} =
+             ActivationProbe.run_once(observed_at: aged_at, timeout: 1_000)
+
+    assert :noop = NodeInventory.sweep_stale_node_heartbeats(aged_at)
+    assert Repo.get!(InventoryNode, node_id).health == :healthy
+    assert Repo.get!(InventoryNode, node_id).last_heartbeat_at == idle.last_heartbeat_at
+    emit_liveness_row("standby Controller cycle: writes nothing", node_id)
+
+    Application.put_env(:orchard_controller, :control_plane, role: :single_controller)
+
+    assert {:ok, []} = ActivationProbe.run_once(targets: [], observed_at: aged_at)
+    swept = Repo.get!(InventoryNode, node_id)
+    assert swept.state == :active
+    assert swept.health == :unreachable
+    assert NodeInventory.schedulable_nodes() == []
+    emit_liveness_row("sweep cycle: heartbeat aged past threshold", node_id)
+
+    assert {:ok, [%{status: :observed}]} = ActivationProbe.run_once()
+    recovered = Repo.get!(InventoryNode, node_id)
+    assert recovered.health == :healthy
+    assert Enum.map(NodeInventory.schedulable_nodes(), & &1.id) == [node_id]
+    emit_liveness_row("probe cycle 3: observation clears demotion", node_id)
+
+    fresh_failure_at = DateTime.add(recovered.last_heartbeat_at, 5, :second)
+    stop_supervised!({:task_2_8_grpc_server, port})
+    start_stalled_tls_server!(port)
+
+    stalled_log =
+      with_debug_logging(fn ->
+        assert {:ok, []} = ActivationProbe.run_once(observed_at: fresh_failure_at, timeout: 1_000)
+      end)
+
+    assert probe_failure_reason(stalled_log) == "authenticated_transport_failed"
+
+    degraded = Repo.get!(InventoryNode, node_id)
+    assert degraded.health == :degraded
+    assert Enum.map(NodeInventory.schedulable_nodes(), & &1.id) == [node_id]
+
+    emit_liveness_row(
+      "node runtime status fails (#{probe_failure_reason(stalled_log)})",
+      node_id
+    )
+
+    stop_supervised!({:stalled_grpc_server, port})
+
+    aged_failure_at =
+      DateTime.add(recovered.last_heartbeat_at, unreachable_ms + 1_000, :millisecond)
+
+    lost_log =
+      with_debug_logging(fn ->
+        assert {:ok, []} =
+                 ActivationProbe.run_once(observed_at: aged_failure_at, timeout: 1_000)
+      end)
+
+    lost = Repo.get!(InventoryNode, node_id)
+    assert lost.health == :unreachable
+    assert NodeInventory.schedulable_nodes() == []
+
+    emit_liveness_row(
+      "node agent gone, past threshold (#{probe_failure_reason(lost_log)})",
+      node_id
+    )
   end
 
   @tag :task_2_10
@@ -1086,6 +1216,21 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
     start_grpc_server!(port, opts)
   end
 
+  # Same enrolled mTLS identity, but GetStatus fails: the Node is reachable and
+  # authenticated while its runtime status RPC is unavailable.
+  defp start_stalled_tls_server!(port) do
+    opts =
+      NodeSupervisor.grpc_server_opts()
+      |> Keyword.put(:endpoint, OrchardCLI.Commands.NodeJoinTest.StalledRuntimeEndpoint)
+
+    start_supervised!(
+      Supervisor.child_spec(
+        {GRPC.Server.Supervisor, opts},
+        id: {:stalled_grpc_server, port}
+      )
+    )
+  end
+
   defp start_test_tls_server!(port, identity, expected_controller_uri) do
     credential =
       GRPC.Credential.new(
@@ -1181,6 +1326,57 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
 
       {:error, _reason} ->
         :ok
+    end
+  end
+
+  defp emit_liveness_row(label, node_id) do
+    node = Repo.get!(InventoryNode, node_id)
+    schedulable = Enum.map(NodeInventory.schedulable_nodes(), & &1.id)
+    status = StatusBuilder.node_status_map(node)
+
+    IO.puts(
+      [
+        String.pad_trailing(label, 52),
+        String.pad_trailing("state=#{node.state}", 15),
+        String.pad_trailing("health=#{node.health}", 20),
+        String.pad_trailing("heartbeat=#{node.last_heartbeat_at}", 40),
+        String.pad_trailing(capacity_summary(node_id), 44),
+        String.pad_trailing("schedulable=#{schedulable == [node_id]}", 19),
+        "operator_status=#{operator_scheduling_summary(status)}"
+      ]
+      |> Enum.join(" ")
+    )
+  end
+
+  defp operator_scheduling_summary(%{scheduling: scheduling}) do
+    "eligible=#{scheduling[:eligible]} reasons=#{inspect(scheduling[:reason_codes])}"
+  end
+
+  defp with_debug_logging(fun) do
+    previous = Logger.level()
+    Logger.configure(level: :debug)
+
+    try do
+      capture_log([level: :debug], fun)
+    after
+      Logger.configure(level: previous)
+    end
+  end
+
+  defp probe_failure_reason(log) do
+    case Regex.run(~r/Activation status probe failed for \S+: (\w+)/, log) do
+      [_match, reason] -> reason
+      nil -> "unlogged"
+    end
+  end
+
+  defp capacity_summary(node_id) do
+    case DispatchCapacity.get_capacity_evidence(node_id) do
+      nil ->
+        "capacity=none"
+
+      evidence ->
+        "capacity=#{evidence.active_request_count}/#{evidence.runtime_concurrency_limit}@#{evidence.observed_at}"
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -287,7 +287,11 @@ defmodule Orchard.Inference do
       end)
   end
 
-  @doc "Returns admitted certificate-backed targets for authenticated status probes only."
+  @doc """
+  Returns certificate-backed targets for leader-side liveness and activation probes.
+
+  Includes both admitted (activation) and active (idle liveness) Nodes.
+  """
   @spec activation_probe_runtime_endpoint_targets() :: [Target.t()]
   def activation_probe_runtime_endpoint_targets do
     case Nodes.activation_probe_runtime_endpoint_targets() do

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -185,11 +185,16 @@ defmodule Orchard.Nodes do
     _ -> []
   end
 
-  @doc "Returns certificate-backed targets for status-only activation probes."
+  @doc """
+  Returns certificate-backed targets for status-only liveness and activation probes.
+
+  Includes both `:admitted` (activation) and `:active` (idle liveness) Nodes so the
+  single supervised probe can refresh heartbeats without a second poller.
+  """
   @spec activation_probe_runtime_endpoint_targets() ::
           {:ok, [Target.t()]} | {:error, :node_inventory_unavailable}
   def activation_probe_runtime_endpoint_targets do
-    trusted_runtime_endpoint_targets_for_states([:admitted])
+    trusted_runtime_endpoint_targets_for_states([:admitted, :active])
   end
 
   @doc "Returns certificate-backed targets authorized for inference and dispatch."
@@ -454,7 +459,7 @@ defmodule Orchard.Nodes do
     with true <- repo_available?(),
          :ok <- ControlPlane.authorize_write_path(:node_lifecycle),
          {:ok, peer_identity} <- normalize_authenticated_peer_identity(peer_identity),
-         true <- authenticated_healthy_status?(status_response),
+         true <- authenticated_status_health_present?(status_response),
          {:ok, observation} <- normalize_observation(target, status_response, observed_at),
          true <- observation.id == peer_identity.node_id do
       handle_observation_result(
@@ -759,6 +764,11 @@ defmodule Orchard.Nodes do
   - `{:connect_failed, _}` - gRPC channel could not be established
   - `:node_unavailable` / `:beam_node_unavailable` - node not reachable
   - `:node_timeout` / `:beam_node_timeout` - probe or RPC timed out
+  - `:authenticated_transport_failed` - authenticated gRPC transport failed
+  - `:beam_peer_grant_authorization_unavailable` - BEAM peer grant/connect failed
+
+  Non-transport seam rejections (`:authenticated_observation_rejected`,
+  `:beam_peer_observation_rejected`) are ignored and do not demote.
 
   Returns:
   - `{:ok, %Node{}}` when health was updated
@@ -781,6 +791,56 @@ defmodule Orchard.Nodes do
     end
   rescue
     _ -> :noop
+  end
+
+  @doc """
+  Demotes Nodes whose last heartbeat is older than the unreachable threshold.
+
+  Leader-gated. Uses the same graded health path as transport failure recording so
+  idle Node loss is detected even when no probe failure is observed in the current
+  cycle. Bounds detection at approximately `unreachable_threshold + sweep_interval`.
+  """
+  @spec sweep_stale_node_heartbeats(DateTime.t()) :: {:ok, non_neg_integer()} | :noop
+  def sweep_stale_node_heartbeats(observed_at \\ DateTime.utc_now()) do
+    with true <- repo_available?(),
+         :ok <- ControlPlane.authorize_write_path(:node_lifecycle),
+         true <- is_struct(observed_at, DateTime) do
+      cutoff = DateTime.add(observed_at, -unreachable_threshold_ms(), :millisecond)
+
+      updated =
+        cutoff
+        |> stale_heartbeat_node_ids()
+        |> Enum.reduce(0, fn node_id, count ->
+          demote_stale_heartbeat_node(node_id, observed_at, count)
+        end)
+
+      {:ok, updated}
+    else
+      _ -> :noop
+    end
+  rescue
+    _ -> :noop
+  end
+
+  defp stale_heartbeat_node_ids(cutoff) do
+    Node
+    |> where([n], n.state in [:admitted, :active])
+    |> where([n], not is_nil(n.last_heartbeat_at))
+    |> where([n], n.last_heartbeat_at < ^cutoff)
+    |> where([n], n.health not in [:unreachable, :unhealthy])
+    |> select([n], n.id)
+    |> Repo.all()
+  end
+
+  defp demote_stale_heartbeat_node(node_id, observed_at, count) do
+    case mark_target_unreachable_without_queue_cleanup({:node_id, node_id}, observed_at) do
+      {:ok, %Node{} = node} ->
+        clear_node_queue_capacity_sources(node)
+        count + 1
+
+      :noop ->
+        count
+    end
   end
 
   @doc """
@@ -825,6 +885,17 @@ defmodule Orchard.Nodes do
     end
   rescue
     _ -> :noop
+  end
+
+  defp mark_target_unreachable_without_queue_cleanup(
+         {:node_id, _node_id} = target_lookup,
+         observed_at
+       ) do
+    if repo_available?() do
+      execute_mark_unreachable(target_lookup, observed_at)
+    else
+      :noop
+    end
   end
 
   defp mark_target_unreachable_without_queue_cleanup(target, observed_at) do
@@ -1364,7 +1435,7 @@ defmodule Orchard.Nodes do
            :ok <- ensure_authenticated_enrollment(enrollment, peer_identity),
            :ok <- ensure_authenticated_node(node, observation, peer_identity),
            :ok <- ensure_authenticated_beam_target(target, node, enrollment, grant, controller),
-           true <- authenticated_healthy_observation?(observation),
+           true <- accept_authenticated_observation_health?(node, observation),
            true <- fresh_authenticated_observation?(observation.last_heartbeat_at),
            :ok <- ensure_fresh_observation(%{existing_by_id: node}, observation),
            :ok <- BeamPeerGrants.ensure_active_grant_current(grant.id, opts) do
@@ -1387,7 +1458,7 @@ defmodule Orchard.Nodes do
            :ok <- ensure_authenticated_enrollment(enrollment, peer_identity),
            :ok <- ensure_authenticated_node(node, observation, peer_identity),
            :ok <- ensure_authenticated_target(target, node, enrollment),
-           true <- authenticated_healthy_observation?(observation),
+           true <- accept_authenticated_observation_health?(node, observation),
            true <- fresh_authenticated_observation?(observation.last_heartbeat_at),
            :ok <- ensure_fresh_observation(%{existing_by_id: node}, observation) do
         update_authenticated_observation(node, observation)
@@ -2619,20 +2690,25 @@ defmodule Orchard.Nodes do
     }
   end
 
-  defp authenticated_healthy_status?(status_response) do
+  # Require a boolean ready flag so empty/garbage health maps cannot derive to
+  # a false healthy observation through the authenticated seam.
+  defp authenticated_status_health_present?(status_response) do
     case extract_runtime_health(status_response) do
-      %{} = health ->
-        map_get(health, :ready) == true and
-          not non_empty?(map_get(health, :health_code)) and
-          not non_empty?(map_get(health, :health_message))
-
-      _other ->
-        false
+      %{} = health -> is_boolean(map_get(health, :ready))
+      _other -> false
     end
   end
 
-  defp authenticated_healthy_observation?(%{health: :healthy}), do: true
-  defp authenticated_healthy_observation?(_observation), do: false
+  # Already-:active Nodes may record degraded/unhealthy observations.
+  # :admitted → :active promotion remains healthy-gated.
+  defp accept_authenticated_observation_health?(%Node{state: :active}, %{health: health})
+       when health in [:healthy, :degraded, :unhealthy],
+       do: true
+
+  defp accept_authenticated_observation_health?(%Node{state: :admitted}, %{health: :healthy}),
+    do: true
+
+  defp accept_authenticated_observation_health?(_node, _observation), do: false
 
   defp fresh_authenticated_observation?(%DateTime{} = observed_at) do
     now = DateTime.utc_now()
@@ -2849,5 +2925,7 @@ defmodule Orchard.Nodes do
   defp transport_failure_reason?(:node_timeout), do: true
   defp transport_failure_reason?(:beam_node_unavailable), do: true
   defp transport_failure_reason?(:beam_node_timeout), do: true
+  defp transport_failure_reason?(:authenticated_transport_failed), do: true
+  defp transport_failure_reason?(:beam_peer_grant_authorization_unavailable), do: true
   defp transport_failure_reason?(_reason), do: false
 end

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -794,11 +794,15 @@ defmodule Orchard.Nodes do
   end
 
   @doc """
-  Demotes Nodes whose last heartbeat is older than the unreachable threshold.
+  Demotes `:active` Nodes whose last heartbeat is older than the unreachable threshold.
 
   Leader-gated. Uses the same graded health path as transport failure recording so
   idle Node loss is detected even when no probe failure is observed in the current
   cycle. Bounds detection at approximately `unreachable_threshold + sweep_interval`.
+
+  `:admitted` Nodes are excluded: a stalled admitted heartbeat usually means the
+  controller-side observation seam is rejecting a reachable Node, not Node loss.
+  Nodes already recorded `:unhealthy` keep that health until an observation clears it.
   """
   @spec sweep_stale_node_heartbeats(DateTime.t()) :: {:ok, non_neg_integer()} | :noop
   def sweep_stale_node_heartbeats(observed_at \\ DateTime.utc_now()) do
@@ -810,9 +814,7 @@ defmodule Orchard.Nodes do
       updated =
         cutoff
         |> stale_heartbeat_node_ids()
-        |> Enum.reduce(0, fn node_id, count ->
-          demote_stale_heartbeat_node(node_id, observed_at, count)
-        end)
+        |> Enum.count(&demote_stale_heartbeat_node(&1, observed_at))
 
       {:ok, updated}
     else
@@ -824,7 +826,7 @@ defmodule Orchard.Nodes do
 
   defp stale_heartbeat_node_ids(cutoff) do
     Node
-    |> where([n], n.state in [:admitted, :active])
+    |> where([n], n.state == :active)
     |> where([n], not is_nil(n.last_heartbeat_at))
     |> where([n], n.last_heartbeat_at < ^cutoff)
     |> where([n], n.health not in [:unreachable, :unhealthy])
@@ -832,14 +834,14 @@ defmodule Orchard.Nodes do
     |> Repo.all()
   end
 
-  defp demote_stale_heartbeat_node(node_id, observed_at, count) do
-    case mark_target_unreachable_without_queue_cleanup({:node_id, node_id}, observed_at) do
+  defp demote_stale_heartbeat_node(node_id, observed_at) do
+    case execute_mark_unreachable({:node_id, node_id}, observed_at) do
       {:ok, %Node{} = node} ->
         clear_node_queue_capacity_sources(node)
-        count + 1
+        true
 
       :noop ->
-        count
+        false
     end
   end
 
@@ -885,17 +887,6 @@ defmodule Orchard.Nodes do
     end
   rescue
     _ -> :noop
-  end
-
-  defp mark_target_unreachable_without_queue_cleanup(
-         {:node_id, _node_id} = target_lookup,
-         observed_at
-       ) do
-    if repo_available?() do
-      execute_mark_unreachable(target_lookup, observed_at)
-    else
-      :noop
-    end
   end
 
   defp mark_target_unreachable_without_queue_cleanup(target, observed_at) do

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
@@ -1,6 +1,10 @@
 defmodule Orchard.RuntimeEndpoint.ActivationProbe do
   @moduledoc """
-  Performs leader-side status-only probes for admitted Runtime Endpoint Nodes.
+  Leader-side status-only probes for admitted and active Runtime Endpoint Nodes.
+
+  Refreshes authenticated heartbeats and capacity evidence on a bounded interval
+  independent of request traffic, and demotes idle Node loss through transport
+  failure recording plus a heartbeat-age sweep (ADR 0015 / issue #148).
   """
 
   use GenServer
@@ -9,28 +13,66 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
 
   alias Orchard.ControlPlane
   alias Orchard.Inference
+  alias Orchard.Nodes
   alias Orchard.RuntimeEndpoint.{BeamClient, GrpcCompatibilityClient}
 
   @default_interval_ms 5_000
   @default_timeout_ms 5_000
 
-  @type result :: %{required(:target_id) => String.t(), required(:status) => :activated}
+  @type result :: %{required(:target_id) => String.t(), required(:status) => :observed}
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
+  @doc "Configured probe interval in milliseconds."
+  @spec interval_ms() :: pos_integer()
+  def interval_ms, do: configured_interval()
+
+  @doc """
+  Asserts the probe interval is strictly below freshness and unreachable thresholds.
+
+  Raises `ArgumentError` when the configured interval would void the detection bound.
+  """
+  @spec assert_interval_contract!(pos_integer()) :: :ok
+  def assert_interval_contract!(interval \\ interval_ms())
+      when is_integer(interval) and interval > 0 do
+    unreachable = Inference.node_unreachable_threshold_ms()
+    freshness = Inference.node_freshness_threshold_ms()
+
+    cond do
+      interval >= unreachable ->
+        raise ArgumentError,
+              "activation_probe interval_ms=#{interval} must be < node_unreachable_threshold_ms=#{unreachable}"
+
+      interval >= freshness ->
+        raise ArgumentError,
+              "activation_probe interval_ms=#{interval} must be < node_freshness_threshold_ms=#{freshness}"
+
+      true ->
+        :ok
+    end
+  end
+
   @spec run_once(keyword()) :: {:ok, [result()]} | {:error, atom()}
   def run_once(opts \\ []) do
     client = Keyword.get(opts, :client, Inference.runtime_endpoint_client())
     timeout = Keyword.get(opts, :timeout, @default_timeout_ms)
+    observed_at = Keyword.get(opts, :observed_at, DateTime.utc_now())
 
     with :ok <- ControlPlane.authorize_write_path(:node_lifecycle),
-         true <- client in [BeamClient, GrpcCompatibilityClient] do
+         true <- allowed_client?(client) do
+      targets =
+        Keyword.get_lazy(opts, :targets, fn ->
+          Inference.activation_probe_runtime_endpoint_targets()
+        end)
+
       results =
-        Inference.activation_probe_runtime_endpoint_targets()
-        |> Enum.flat_map(&probe_target(&1, client, timeout))
+        targets
+        |> Enum.flat_map(&probe_target(&1, client, timeout, observed_at))
+
+      _ = Nodes.sweep_stale_node_heartbeats(observed_at)
 
       {:ok, results}
     else
@@ -42,6 +84,7 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
   @impl true
   def init(opts) do
     interval = Keyword.get(opts, :interval, configured_interval())
+    assert_interval_contract!(interval)
     schedule_probe(interval)
     {:ok, %{interval: interval}}
   end
@@ -68,21 +111,31 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
       :ok
   end
 
-  defp probe_target(target, client, timeout) do
+  defp probe_target(target, client, timeout, observed_at) do
     case client.connect(target) do
       {:ok, connection} ->
         try do
           case client.status(connection, timeout: timeout) do
-            {:ok, _observation} -> [%{target_id: target.id, status: :activated}]
-            {:error, reason} -> log_probe_failure(target.id, reason)
+            {:ok, _observation} ->
+              [%{target_id: target.id, status: :observed}]
+
+            {:error, reason} ->
+              record_probe_failure(target, reason, observed_at)
           end
         after
           disconnect(client, connection)
         end
 
       {:error, reason} ->
-        log_probe_failure(target.id, reason)
+        record_probe_failure(target, reason, observed_at)
     end
+  end
+
+  defp record_probe_failure(target, reason, observed_at) do
+    # Pass the raw reason so transport_failure_reason?/1 classifies correctly.
+    # Seam rejections are ignored by Nodes.record_transport_failure/3.
+    _ = Nodes.record_transport_failure(target, reason, observed_at)
+    log_probe_failure(target.id, reason)
   end
 
   defp disconnect(client, connection) do
@@ -104,6 +157,17 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
   defp probe_failure_code(reason) when is_atom(reason), do: reason
   defp probe_failure_code({reason, _detail}) when is_atom(reason), do: reason
   defp probe_failure_code(_reason), do: :activation_probe_failed
+
+  defp allowed_client?(client) do
+    defaults = [BeamClient, GrpcCompatibilityClient]
+
+    extras =
+      :orchard_controller
+      |> Application.get_env(:activation_probe, [])
+      |> Keyword.get(:allowed_clients, [])
+
+    client in (defaults ++ extras)
+  end
 
   defp configured_interval do
     :orchard_controller

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
@@ -18,6 +18,7 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
 
   @default_interval_ms 5_000
   @default_timeout_ms 5_000
+  @min_interval_ms 1_000
   @transport_clients [BeamClient, GrpcCompatibilityClient]
 
   @type result :: %{required(:target_id) => String.t(), required(:status) => :observed}
@@ -36,7 +37,9 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
 
   Raises `ArgumentError` when the given interval would void the detection bound.
   `init/1` clamps instead of raising so a threshold misconfiguration degrades
-  liveness detection rather than blocking Controller boot.
+  liveness detection rather than blocking Controller boot. Clamping holds a 1s
+  floor; thresholds too small to admit a safe interval fall back to the default
+  interval and log an error rather than busy-looping the probe timer.
   """
   @spec assert_interval_contract!(pos_integer()) :: :ok
   def assert_interval_contract!(interval \\ interval_ms())
@@ -187,16 +190,26 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
     ceiling =
       min(Inference.node_unreachable_threshold_ms(), Inference.node_freshness_threshold_ms())
 
-    if interval < ceiling do
-      interval
-    else
-      clamped = clamped_interval(ceiling)
+    cond do
+      interval < ceiling ->
+        interval
 
-      Logger.warning(
-        "activation_probe interval_ms=#{interval} must be < #{ceiling}; clamping to #{clamped}"
-      )
+      is_integer(ceiling) and ceiling > @min_interval_ms ->
+        clamped = clamped_interval(ceiling)
 
-      clamped
+        Logger.warning(
+          "activation_probe interval_ms=#{interval} must be < #{ceiling}; clamping to #{clamped}"
+        )
+
+        clamped
+
+      true ->
+        Logger.error(
+          "activation_probe cannot satisfy interval_ms < #{inspect(ceiling)} above the " <>
+            "#{@min_interval_ms}ms floor; using #{@default_interval_ms} and degrading liveness detection"
+        )
+
+        @default_interval_ms
     end
   end
 
@@ -209,10 +222,12 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
     contract_safe_interval(@default_interval_ms)
   end
 
-  defp clamped_interval(ceiling) when is_integer(ceiling) and ceiling > 1,
-    do: min(@default_interval_ms, div(ceiling, 2))
-
-  defp clamped_interval(_ceiling), do: 1
+  defp clamped_interval(ceiling) do
+    ceiling
+    |> div(2)
+    |> min(@default_interval_ms)
+    |> max(@min_interval_ms)
+  end
 
   defp schedule_probe(interval) when is_integer(interval) and interval > 0 do
     Process.send_after(self(), :probe, interval)

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
@@ -194,7 +194,7 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
       interval < ceiling ->
         interval
 
-      is_integer(ceiling) and ceiling > @min_interval_ms ->
+      ceiling > @min_interval_ms ->
         clamped = clamped_interval(ceiling)
 
         Logger.warning(

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
@@ -18,6 +18,7 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
 
   @default_interval_ms 5_000
   @default_timeout_ms 5_000
+  @transport_clients [BeamClient, GrpcCompatibilityClient]
 
   @type result :: %{required(:target_id) => String.t(), required(:status) => :observed}
 
@@ -33,7 +34,9 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
   @doc """
   Asserts the probe interval is strictly below freshness and unreachable thresholds.
 
-  Raises `ArgumentError` when the configured interval would void the detection bound.
+  Raises `ArgumentError` when the given interval would void the detection bound.
+  `init/1` clamps instead of raising so a threshold misconfiguration degrades
+  liveness detection rather than blocking Controller boot.
   """
   @spec assert_interval_contract!(pos_integer()) :: :ok
   def assert_interval_contract!(interval \\ interval_ms())
@@ -83,8 +86,11 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
 
   @impl true
   def init(opts) do
-    interval = Keyword.get(opts, :interval, configured_interval())
-    assert_interval_contract!(interval)
+    interval =
+      opts
+      |> Keyword.get(:interval, configured_interval())
+      |> contract_safe_interval()
+
     schedule_probe(interval)
     {:ok, %{interval: interval}}
   end
@@ -158,15 +164,17 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
   defp probe_failure_code({reason, _detail}) when is_atom(reason), do: reason
   defp probe_failure_code(_reason), do: :activation_probe_failed
 
-  defp allowed_client?(client) do
-    defaults = [BeamClient, GrpcCompatibilityClient]
+  if Mix.env() == :test do
+    defp allowed_client?(client) do
+      extras =
+        :orchard_controller
+        |> Application.get_env(:activation_probe, [])
+        |> Keyword.get(:allowed_clients, [])
 
-    extras =
-      :orchard_controller
-      |> Application.get_env(:activation_probe, [])
-      |> Keyword.get(:allowed_clients, [])
-
-    client in (defaults ++ extras)
+      client in (@transport_clients ++ extras)
+    end
+  else
+    defp allowed_client?(client), do: client in @transport_clients
   end
 
   defp configured_interval do
@@ -174,6 +182,37 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
     |> Application.get_env(:activation_probe, [])
     |> Keyword.get(:interval_ms, @default_interval_ms)
   end
+
+  defp contract_safe_interval(interval) when is_integer(interval) and interval > 0 do
+    ceiling =
+      min(Inference.node_unreachable_threshold_ms(), Inference.node_freshness_threshold_ms())
+
+    if interval < ceiling do
+      interval
+    else
+      clamped = clamped_interval(ceiling)
+
+      Logger.warning(
+        "activation_probe interval_ms=#{interval} must be < #{ceiling}; clamping to #{clamped}"
+      )
+
+      clamped
+    end
+  end
+
+  defp contract_safe_interval(interval) do
+    Logger.warning(
+      "activation_probe interval_ms=#{inspect(interval)} is not a positive integer; " <>
+        "using #{@default_interval_ms}"
+    )
+
+    contract_safe_interval(@default_interval_ms)
+  end
+
+  defp clamped_interval(ceiling) when is_integer(ceiling) and ceiling > 1,
+    do: min(@default_interval_ms, div(ceiling, 2))
+
+  defp clamped_interval(_ceiling), do: 1
 
   defp schedule_probe(interval) when is_integer(interval) and interval > 0 do
     Process.send_after(self(), :probe, interval)

--- a/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
+++ b/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
@@ -1494,6 +1494,84 @@ defmodule Orchard.BeamPeerGrantsTest do
     assert evidence.observed_at == DateTime.truncate(observed_at, :microsecond)
   end
 
+  test "SPEC.md §4.5 degraded authenticated observation is recorded for active nodes", %{
+    trust_root: trust_root,
+    authorization_root: authorization_root
+  } do
+    {_grant, target} = active_grant_target!(trust_root, authorization_root)
+    # Promote admitted -> active first with healthy observation
+    node = Repo.get!(Node, target.node_id)
+    peer = authenticated_peer!(node.id)
+
+    healthy_status = %{
+      node_metadata: %{
+        node_id: node.id,
+        display_name: node.display_name,
+        hostname: node.hostname,
+        listen_host: node.connect_host,
+        listen_port: node.connect_port,
+        agent_version: "0.5.0-dev"
+      },
+      runtime_health: %{ready: true, health_code: "", health_message: ""},
+      active_request_count: 1,
+      max_concurrency: 4
+    }
+
+    first_at = DateTime.utc_now()
+
+    assert {:ok, active} =
+             Nodes.observe_authenticated_status(target, healthy_status, first_at, peer)
+
+    assert active.state == :active
+    assert active.health == :healthy
+
+    degraded_status = %{
+      node_metadata: healthy_status.node_metadata,
+      runtime_health: %{ready: true, health_code: "SLOW", health_message: "warm path degraded"},
+      active_request_count: 2,
+      max_concurrency: 4
+    }
+
+    second_at = DateTime.add(first_at, 1, :second)
+
+    assert {:ok, degraded} =
+             Nodes.observe_authenticated_status(target, degraded_status, second_at, peer)
+
+    assert degraded.state == :active
+    assert degraded.health == :degraded
+    assert degraded.last_heartbeat_at == DateTime.truncate(second_at, :microsecond)
+
+    evidence = DispatchCapacity.get_capacity_evidence(node.id)
+    assert evidence.active_request_count == 2
+    assert evidence.observed_at == DateTime.truncate(second_at, :microsecond)
+  end
+
+  test "SPEC.md §4.5 non-healthy admitted observation does not activate", %{
+    trust_root: trust_root,
+    authorization_root: authorization_root
+  } do
+    {_grant, target} = active_grant_target!(trust_root, authorization_root)
+    node = Repo.get!(Node, target.node_id)
+    peer = authenticated_peer!(node.id)
+
+    status = %{
+      node_metadata: %{
+        node_id: node.id,
+        display_name: node.display_name,
+        hostname: node.hostname,
+        listen_host: node.connect_host,
+        listen_port: node.connect_port,
+        agent_version: "0.5.0-dev"
+      },
+      runtime_health: %{ready: true, health_code: "SLOW", health_message: "not ready to promote"},
+      active_request_count: 0,
+      max_concurrency: 1
+    }
+
+    assert :noop = Nodes.observe_authenticated_status(target, status, DateTime.utc_now(), peer)
+    assert Repo.get!(Node, node.id).state == :admitted
+  end
+
   test "SPEC.md §7.5.0 authenticated activation uses the grant transaction lock order", %{
     trust_root: trust_root,
     authorization_root: authorization_root

--- a/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
+++ b/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
@@ -1546,6 +1546,65 @@ defmodule Orchard.BeamPeerGrantsTest do
     assert evidence.observed_at == DateTime.truncate(second_at, :microsecond)
   end
 
+  test "SPEC.md §4.5 unhealthy authenticated observation is recorded for active nodes", %{
+    trust_root: trust_root,
+    authorization_root: authorization_root
+  } do
+    {_grant, target} = active_grant_target!(trust_root, authorization_root)
+    node = Repo.get!(Node, target.node_id)
+    peer = authenticated_peer!(node.id)
+
+    metadata = %{
+      node_id: node.id,
+      display_name: node.display_name,
+      hostname: node.hostname,
+      listen_host: node.connect_host,
+      listen_port: node.connect_port,
+      agent_version: "0.5.0-dev"
+    }
+
+    healthy_status = %{
+      node_metadata: metadata,
+      runtime_health: %{ready: true, health_code: "", health_message: ""},
+      active_request_count: 0,
+      max_concurrency: 4
+    }
+
+    first_at = DateTime.utc_now()
+
+    assert {:ok, active} =
+             Nodes.observe_authenticated_status(target, healthy_status, first_at, peer)
+
+    assert active.state == :active
+    assert Enum.map(Nodes.schedulable_nodes(), & &1.id) == [node.id]
+
+    unhealthy_status = %{
+      node_metadata: metadata,
+      runtime_health: %{
+        ready: false,
+        health_code: "WORKER_DOWN",
+        health_message: "worker exited"
+      },
+      active_request_count: 0,
+      max_concurrency: 4
+    }
+
+    second_at = DateTime.add(first_at, 1, :second)
+
+    assert {:ok, unhealthy} =
+             Nodes.observe_authenticated_status(target, unhealthy_status, second_at, peer)
+
+    assert unhealthy.state == :active
+    assert unhealthy.health == :unhealthy
+    assert unhealthy.last_heartbeat_at == DateTime.truncate(second_at, :microsecond)
+    assert Nodes.schedulable_nodes() == []
+
+    # Sticky: the sweep leaves :unhealthy for a successful observation to clear.
+    aged_at = DateTime.add(second_at, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+    assert {:ok, 0} = Nodes.sweep_stale_node_heartbeats(aged_at)
+    assert Repo.get!(Node, node.id).health == :unhealthy
+  end
+
   test "SPEC.md §4.5 non-healthy admitted observation does not activate", %{
     trust_root: trust_root,
     authorization_root: authorization_root

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -4646,6 +4646,24 @@ defmodule Orchard.NodesTest do
       assert {:ok, 0} = Nodes.sweep_stale_node_heartbeats(observed_at)
       assert Repo.get!(Node, node.id).health == :unhealthy
     end
+
+    test "SPEC.md §4.5 leaves admitted nodes to the observation seam" do
+      hb_time = DateTime.utc_now()
+
+      node =
+        insert_node!(%{
+          advertise_addr: "10.0.0.83",
+          rpc_port: 9444,
+          state: :admitted,
+          health: :degraded,
+          last_heartbeat_at: hb_time
+        })
+
+      observed_at = DateTime.add(hb_time, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+
+      assert {:ok, 0} = Nodes.sweep_stale_node_heartbeats(observed_at)
+      assert Repo.get!(Node, node.id).health == :degraded
+    end
   end
 
   describe "schedulable_nodes/0" do

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -4270,6 +4270,81 @@ defmodule Orchard.NodesTest do
       assert marked.health == :degraded
     end
 
+    test "SPEC.md §4.5 :authenticated_transport_failed is classified as transport failure" do
+      hb_time = DateTime.utc_now()
+
+      insert_node!(%{
+        advertise_addr: "10.0.0.75",
+        rpc_port: 9444,
+        health: :healthy,
+        last_heartbeat_at: hb_time
+      })
+
+      observed_at = DateTime.add(hb_time, 5, :second)
+
+      assert {:ok, marked} =
+               Nodes.record_transport_failure(
+                 make_target("10.0.0.75", 9444),
+                 :authenticated_transport_failed,
+                 observed_at
+               )
+
+      assert marked.health == :degraded
+    end
+
+    test "SPEC.md §4.5 :beam_peer_grant_authorization_unavailable is classified as transport failure" do
+      hb_time = DateTime.utc_now()
+
+      insert_node!(%{
+        advertise_addr: "10.0.0.76",
+        rpc_port: 9444,
+        health: :healthy,
+        last_heartbeat_at: hb_time
+      })
+
+      observed_at = DateTime.add(hb_time, 5, :second)
+
+      assert {:ok, marked} =
+               Nodes.record_transport_failure(
+                 make_target("10.0.0.76", 9444),
+                 :beam_peer_grant_authorization_unavailable,
+                 observed_at
+               )
+
+      assert marked.health == :degraded
+    end
+
+    test "SPEC.md §4.5 seam observation rejections are not transport demotions" do
+      hb_time = DateTime.utc_now()
+
+      node =
+        insert_node!(%{
+          advertise_addr: "10.0.0.77",
+          rpc_port: 9444,
+          health: :healthy,
+          last_heartbeat_at: hb_time
+        })
+
+      observed_at = DateTime.add(hb_time, 5, :second)
+      target = make_target("10.0.0.77", 9444)
+
+      assert :noop =
+               Nodes.record_transport_failure(
+                 target,
+                 :authenticated_observation_rejected,
+                 observed_at
+               )
+
+      assert :noop =
+               Nodes.record_transport_failure(
+                 target,
+                 :beam_peer_observation_rejected,
+                 observed_at
+               )
+
+      assert Repo.get!(Node, node.id).health == :healthy
+    end
+
     test "SPEC.md §5.5 transport failure clears stale queue capacity sources" do
       QueueManager.reset()
 
@@ -4516,6 +4591,62 @@ defmodule Orchard.NodesTest do
   end
 
   # -- Schedulable nodes --
+
+  describe "sweep_stale_node_heartbeats/1" do
+    test "SPEC.md §4.5 demotes active nodes past unreachable threshold" do
+      hb_time = DateTime.utc_now()
+
+      node =
+        insert_node!(%{
+          advertise_addr: "10.0.0.80",
+          rpc_port: 9444,
+          state: :active,
+          health: :healthy,
+          last_heartbeat_at: hb_time
+        })
+
+      observed_at = DateTime.add(hb_time, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+
+      assert {:ok, 1} = Nodes.sweep_stale_node_heartbeats(observed_at)
+      assert Repo.get!(Node, node.id).health == :unreachable
+    end
+
+    test "SPEC.md §4.5 does not demote when heartbeat is still within threshold" do
+      hb_time = DateTime.utc_now()
+
+      node =
+        insert_node!(%{
+          advertise_addr: "10.0.0.81",
+          rpc_port: 9444,
+          state: :active,
+          health: :healthy,
+          last_heartbeat_at: hb_time
+        })
+
+      observed_at = DateTime.add(hb_time, 5, :second)
+
+      assert {:ok, 0} = Nodes.sweep_stale_node_heartbeats(observed_at)
+      assert Repo.get!(Node, node.id).health == :healthy
+    end
+
+    test "SPEC.md §4.5 leaves sticky unhealthy nodes unchanged" do
+      hb_time = DateTime.utc_now()
+
+      node =
+        insert_node!(%{
+          advertise_addr: "10.0.0.82",
+          rpc_port: 9444,
+          state: :active,
+          health: :unhealthy,
+          last_heartbeat_at: hb_time
+        })
+
+      observed_at = DateTime.add(hb_time, Nodes.unreachable_threshold_ms() + 1_000, :millisecond)
+
+      assert {:ok, 0} = Nodes.sweep_stale_node_heartbeats(observed_at)
+      assert Repo.get!(Node, node.id).health == :unhealthy
+    end
+  end
 
   describe "schedulable_nodes/0" do
     test "returns active, healthy nodes within freshness threshold" do

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
@@ -1,0 +1,203 @@
+defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
+  use Orchard.DataCase, async: false
+
+  alias Orchard.Nodes
+  alias Orchard.Nodes.Node
+  alias Orchard.RuntimeEndpoint.ActivationProbe
+  alias Orchard.RuntimeEndpoint.Target
+
+  defmodule FailingClient do
+    def connect(_target), do: {:error, :authenticated_transport_failed}
+    def disconnect(_connection), do: :ok
+    def status(_connection, _opts), do: {:error, :authenticated_transport_failed}
+  end
+
+  defmodule RejectingClient do
+    def connect(target), do: {:ok, %{target: target}}
+    def disconnect(_connection), do: :ok
+
+    def status(_connection, _opts), do: {:error, :authenticated_observation_rejected}
+  end
+
+  defmodule IdleClient do
+    def connect(target), do: {:ok, %{target: target}}
+    def disconnect(_connection), do: :ok
+    def status(_connection, _opts), do: {:ok, %{}}
+  end
+
+  setup do
+    previous = Application.get_env(:orchard_controller, :activation_probe, [])
+
+    Application.put_env(
+      :orchard_controller,
+      :activation_probe,
+      Keyword.merge(previous,
+        allowed_clients: [FailingClient, RejectingClient, IdleClient],
+        interval_ms: 5_000
+      )
+    )
+
+    on_exit(fn ->
+      if previous == [] do
+        Application.delete_env(:orchard_controller, :activation_probe)
+      else
+        Application.put_env(:orchard_controller, :activation_probe, previous)
+      end
+    end)
+
+    :ok
+  end
+
+  test "SPEC.md §4.5 probe interval is strictly below freshness and unreachable thresholds" do
+    assert ActivationProbe.interval_ms() == 5_000
+    assert :ok = ActivationProbe.assert_interval_contract!(5_000)
+
+    assert_raise ArgumentError, ~r/unreachable/, fn ->
+      ActivationProbe.assert_interval_contract!(15_000)
+    end
+
+    previous = Application.get_env(:orchard_controller, :inference, [])
+
+    Application.put_env(
+      :orchard_controller,
+      :inference,
+      Keyword.merge(previous || [],
+        node_unreachable_threshold_ms: 40_000,
+        node_freshness_threshold_ms: 30_000
+      )
+    )
+
+    on_exit(fn ->
+      if previous in [nil, []] do
+        Application.delete_env(:orchard_controller, :inference)
+      else
+        Application.put_env(:orchard_controller, :inference, previous)
+      end
+    end)
+
+    assert_raise ArgumentError, ~r/freshness/, fn ->
+      ActivationProbe.assert_interval_contract!(30_000)
+    end
+  end
+
+  test "SPEC.md §4.5 transport failure during probe demotes active node" do
+    hb_time = DateTime.utc_now()
+
+    node =
+      insert_active_node!(%{
+        advertise_addr: "10.0.1.10",
+        rpc_port: 9444,
+        connect_host: "10.0.1.10",
+        connect_port: 9444,
+        last_heartbeat_at: hb_time,
+        health: :healthy
+      })
+
+    target =
+      Target.grpc_compat(
+        host: "10.0.1.10",
+        port: 9444,
+        node_id: node.id,
+        metadata: %{authorization: :inference_dispatch, source: :trusted_node_inventory}
+      )
+
+    observed_at = DateTime.add(hb_time, 5, :second)
+
+    assert {:ok, []} =
+             ActivationProbe.run_once(
+               client: FailingClient,
+               timeout: 50,
+               observed_at: observed_at,
+               targets: [target]
+             )
+
+    assert Repo.get!(Node, node.id).health == :degraded
+  end
+
+  test "SPEC.md §4.5 seam rejection during probe does not demote" do
+    hb_time = DateTime.utc_now()
+
+    node =
+      insert_active_node!(%{
+        advertise_addr: "10.0.1.11",
+        rpc_port: 9444,
+        connect_host: "10.0.1.11",
+        connect_port: 9444,
+        last_heartbeat_at: hb_time,
+        health: :healthy
+      })
+
+    target =
+      Target.grpc_compat(
+        host: "10.0.1.11",
+        port: 9444,
+        node_id: node.id,
+        metadata: %{authorization: :inference_dispatch, source: :trusted_node_inventory}
+      )
+
+    # Direct classifier pin used by ActivationProbe.record_probe_failure
+    assert :noop =
+             Nodes.record_transport_failure(
+               target,
+               :authenticated_observation_rejected,
+               DateTime.add(hb_time, 5, :second)
+             )
+
+    assert :noop =
+             Nodes.record_transport_failure(
+               target,
+               :beam_peer_observation_rejected,
+               DateTime.add(hb_time, 5, :second)
+             )
+
+    reloaded = Repo.get!(Node, node.id)
+    assert reloaded.health == :healthy
+  end
+
+  test "SPEC.md §4.5 standby controller run_once writes nothing" do
+    previous = Application.get_env(:orchard_controller, :control_plane, [])
+
+    Application.put_env(
+      :orchard_controller,
+      :control_plane,
+      Keyword.put(previous || [], :role, :standby)
+    )
+
+    on_exit(fn ->
+      if previous in [nil, []] do
+        Application.delete_env(:orchard_controller, :control_plane)
+      else
+        Application.put_env(:orchard_controller, :control_plane, previous)
+      end
+    end)
+
+    assert {:error, :controller_standby} =
+             ActivationProbe.run_once(client: IdleClient, timeout: 50)
+
+    assert Nodes.sweep_stale_node_heartbeats() == :noop
+  end
+
+  defp insert_active_node!(overrides) do
+    unique = System.unique_integer([:positive])
+
+    attrs =
+      Map.merge(
+        %{
+          id: Ecto.UUID.generate(),
+          hostname: "probe-host-#{unique}.local",
+          display_name: "probe-node-#{unique}",
+          advertise_addr: "10.20.#{rem(unique, 200)}.#{rem(unique, 200) + 1}",
+          rpc_port: 9444,
+          state: :active,
+          health: :healthy,
+          capabilities: %{},
+          tool_readiness: %{}
+        },
+        overrides
+      )
+
+    %Node{}
+    |> Node.changeset(attrs)
+    |> Repo.insert!()
+  end
+end

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
@@ -1,6 +1,7 @@
 defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
   use Orchard.DataCase, async: false
 
+  alias Orchard.Inference
   alias Orchard.Nodes
   alias Orchard.Nodes.Node
   alias Orchard.RuntimeEndpoint.ActivationProbe
@@ -80,6 +81,15 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
     end
   end
 
+  test "SPEC.md §4.5 misconfigured interval clamps at init instead of blocking Controller boot" do
+    assert {:ok, pid} = start_supervised({ActivationProbe, interval: 60_000})
+
+    assert %{interval: interval} = :sys.get_state(pid)
+    assert interval < Inference.node_unreachable_threshold_ms()
+    assert interval < Inference.node_freshness_threshold_ms()
+    assert :ok = ActivationProbe.assert_interval_contract!(interval)
+  end
+
   test "SPEC.md §4.5 transport failure during probe demotes active node" do
     hb_time = DateTime.utc_now()
 
@@ -135,19 +145,12 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
         metadata: %{authorization: :inference_dispatch, source: :trusted_node_inventory}
       )
 
-    # Direct classifier pin used by ActivationProbe.record_probe_failure
-    assert :noop =
-             Nodes.record_transport_failure(
-               target,
-               :authenticated_observation_rejected,
-               DateTime.add(hb_time, 5, :second)
-             )
-
-    assert :noop =
-             Nodes.record_transport_failure(
-               target,
-               :beam_peer_observation_rejected,
-               DateTime.add(hb_time, 5, :second)
+    assert {:ok, []} =
+             ActivationProbe.run_once(
+               client: RejectingClient,
+               timeout: 50,
+               observed_at: DateTime.add(hb_time, 5, :second),
+               targets: [target]
              )
 
     reloaded = Repo.get!(Node, node.id)

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
@@ -90,6 +90,29 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
     assert :ok = ActivationProbe.assert_interval_contract!(interval)
   end
 
+  test "SPEC.md §4.5 clamped interval never drops below the busy-loop floor" do
+    previous = Application.get_env(:orchard_controller, :inference, [])
+
+    on_exit(fn ->
+      if previous in [nil, []] do
+        Application.delete_env(:orchard_controller, :inference)
+      else
+        Application.put_env(:orchard_controller, :inference, previous)
+      end
+    end)
+
+    put_unreachable_threshold!(previous, 3_000)
+
+    assert {:ok, tight} = start_supervised({ActivationProbe, interval: 60_000})
+    assert %{interval: 1_500} = :sys.get_state(tight)
+    assert :ok = stop_supervised(ActivationProbe)
+
+    put_unreachable_threshold!(previous, 15)
+
+    assert {:ok, pathological} = start_supervised({ActivationProbe, interval: 60_000})
+    assert %{interval: 5_000} = :sys.get_state(pathological)
+  end
+
   test "SPEC.md §4.5 transport failure during probe demotes active node" do
     hb_time = DateTime.utc_now()
 
@@ -178,6 +201,14 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
              ActivationProbe.run_once(client: IdleClient, timeout: 50)
 
     assert Nodes.sweep_stale_node_heartbeats() == :noop
+  end
+
+  defp put_unreachable_threshold!(previous, threshold_ms) do
+    Application.put_env(
+      :orchard_controller,
+      :inference,
+      Keyword.merge(previous || [], node_unreachable_threshold_ms: threshold_ms)
+    )
   end
 
   defp insert_active_node!(overrides) do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,8 @@ The controller scheduler uses that capacity telemetry to avoid dispatching to fu
 Controller queue admission also consumes fresh Runtime Endpoint Observations as source-scoped capacity, waking queued loaded-placement or cold/no-placement work only from eligible, non-exhausted endpoints.
 Invalid, ineligible, unavailable, or transport-failed observations clear stale endpoint-owned capacity sources before queued work can be promoted.
 For BEAM Runtime Endpoint observations, queue capacity is published only when the target resolves back to the same persisted node identity.
+Active-Node liveness does not depend on request traffic: one supervised, leader-gated background status observer probes trusted admitted and active Runtime Endpoint targets on a bounded interval and advances heartbeat, health, and aggregate capacity evidence through the same authenticated observation seam, while transport failures and a heartbeat-age sweep demote a Node lost while the cluster is idle.
+That observer leaves the scheduler's inline request-path probe in place; see `SPEC.md` §4.5 and `docs/decisions/0015-thin-active-node-liveness-monitor-before-scheduler-decoupling.md` for the liveness contract and the deferred scheduler-decoupling slice.
 Console Nodes live diagnostics probe the configured Runtime Endpoint targets rather than a separate legacy gRPC-only target list.
 Scheduler and dispatch orchestration crashes after request validation terminalize the durable request as a failed `orchestration_error` with sanitized public error payloads instead of leaving it active.
 

--- a/openspec/changes/thin-active-node-liveness-monitor/design.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/design.md
@@ -26,6 +26,8 @@ Reuse `Orchard.RuntimeEndpoint.ActivationProbe` (already supervised and
 6. **Interval contract** — interval must be `<` unreachable and freshness thresholds;
    `assert_interval_contract!/1` is the strict assertion, while GenServer `init` logs and
    clamps so a threshold misconfiguration degrades detection instead of blocking boot.
+   The clamp holds a 1s floor; thresholds too small to admit a safe interval fall back to
+   the default interval so the probe timer cannot busy-loop.
 
 ## SPEC §4.6 push-vs-pull
 

--- a/openspec/changes/thin-active-node-liveness-monitor/design.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/design.md
@@ -20,10 +20,12 @@ Reuse `Orchard.RuntimeEndpoint.ActivationProbe` (already supervised and
 4. **Failure path** — probe passes **raw** failure reasons to
    `Nodes.record_transport_failure/3`. Seam rejections fall through the classifier.
 5. **Sweep** — once per `run_once/1` cycle after probes:
-   `Nodes.sweep_stale_node_heartbeats/1` demotes aged heartbeats via the same graded
-   path as transport failure.
+   `Nodes.sweep_stale_node_heartbeats/1` demotes aged `:active` heartbeats via the same
+   graded path as transport failure. `:admitted` Nodes and sticky `:unhealthy` health are
+   left to the observation seam.
 6. **Interval contract** — interval must be `<` unreachable and freshness thresholds;
-   enforced at GenServer `init` and via `assert_interval_contract!/1`.
+   `assert_interval_contract!/1` is the strict assertion, while GenServer `init` logs and
+   clamps so a threshold misconfiguration degrades detection instead of blocking boot.
 
 ## SPEC §4.6 push-vs-pull
 

--- a/openspec/changes/thin-active-node-liveness-monitor/design.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/design.md
@@ -1,0 +1,37 @@
+# Design: thin active-node liveness monitor
+
+## Decision source
+
+ADR 0015 is accepted. This design records implementation seams for slice A and the
+slice B boundary only.
+
+## Slice A architecture
+
+Reuse `Orchard.RuntimeEndpoint.ActivationProbe` (already supervised and
+`ControlPlane.authorize_write_path(:node_lifecycle)` gated).
+
+1. **Targets** — `Nodes.activation_probe_runtime_endpoint_targets/0` returns
+   trusted certificate-backed targets for states `[:admitted, :active]`, preserving
+   per-state authorization metadata (`:activation_probe` vs `:inference_dispatch`).
+2. **Success path** — authenticated clients already call
+   `Nodes.observe_authenticated_status/5` inside `status/2`. No second write path.
+3. **Health gates** — outer seam requires a well-formed health map with boolean
+   `ready`; inner gate after row lock accepts non-healthy for `:active` only.
+4. **Failure path** — probe passes **raw** failure reasons to
+   `Nodes.record_transport_failure/3`. Seam rejections fall through the classifier.
+5. **Sweep** — once per `run_once/1` cycle after probes:
+   `Nodes.sweep_stale_node_heartbeats/1` demotes aged heartbeats via the same graded
+   path as transport failure.
+6. **Interval contract** — interval must be `<` unreachable and freshness thresholds;
+   enforced at GenServer `init` and via `assert_interval_contract!/1`.
+
+## SPEC §4.6 push-vs-pull
+
+Implementation and §4.6.1 already pull status probes. Slice A names the divergence
+and defers full reconciliation to the §8 `node_heartbeats` work with slice B.
+Silent divergence is forbidden; the SPEC note is the explicit deferral.
+
+## Slice B boundary
+
+Do not assert cached candidates, inline-probe removal, `node_heartbeats` schema,
+or ranking payloads in slice A tests or OpenSpec scenarios.

--- a/openspec/changes/thin-active-node-liveness-monitor/proposal.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/proposal.md
@@ -1,0 +1,64 @@
+# Thin active-node liveness monitor (#122 ordered slices A then B)
+
+## Why
+
+Active-Node liveness is observed today only as a side effect of scheduling a request.
+Between requests nothing observes an `:active` Node, so a Node that dies while the
+cluster is idle stays `:active`/`:healthy` until the next request pays to discover it.
+The M5 closed internal pilot (#118) needs liveness tracked on a bounded interval and
+idle Node loss detected without depending on the inline scheduler probe.
+
+ADR 0015 decomposes #122 into ordered slices A then B in one OpenSpec package.
+Slice A (#148) is the only pilot-blocking build item. Slice B (#149) decouples the
+scheduler from the inline probe and is out of scope for A’s implementation.
+
+## What changes
+
+### Slice A (issue #148) — implement now
+
+- Generalize the supervised, leader-gated `ActivationProbe` to observe `:active` Nodes
+  as well as `:admitted` Nodes (no second poller).
+- Consume probe outcomes through the authenticated observation path
+  (`observe_authenticated_status/5`), advancing heartbeat, health, and aggregate
+  capacity evidence in one write.
+- Route genuine transport failures through graded demotion via
+  `record_transport_failure/3`, including `:authenticated_transport_failed` and
+  `:beam_peer_grant_authorization_unavailable`.
+- Do not treat seam rejections (`:authenticated_observation_rejected`,
+  `:beam_peer_observation_rejected`) as transport demotions.
+- Relax authenticated health gates so already-`:active` Nodes record
+  `:degraded`/`:unhealthy`; keep `:admitted` → `:active` promotion healthy-gated.
+- Add a periodic heartbeat-age sweep so detection is bounded at approximately
+  `unreachable_threshold + probe_interval`.
+- Enforce probe interval strictly below freshness (30s) and unreachable (15s) thresholds.
+- Name the SPEC §4.6 push-versus-pull divergence and explicitly defer reconciliation,
+  coupled to deferred §8 `node_heartbeats` work.
+- Update SPEC §4.5/§4.6.1 language so active-Node liveness is maintained by a
+  leader-owned background observer independent of request traffic.
+
+### Slice B (issue #149) — tasks only, no A assertions
+
+- Decouple the scheduler from the inline sequential probe.
+- Serve candidates from a monitor-refreshed source; remove or bound the inline probe.
+- Settle whether durable `node_heartbeats`, a leader-local mirror, or both back that source.
+- Carry §8 `node_heartbeats`, §8.5 retention, and §9.1 heartbeat-lag metric as coupled work
+  with the §4.6 push-vs-pull reconciliation.
+
+## Out of scope for this package’s Slice A code
+
+- Scheduler MultiNode decoupling (slice B).
+- `node_heartbeats` migration, retention job, heartbeat-lag metric.
+- Candidate/ranking fact-set redesign.
+- Issue #128 scheduler failure reclassification.
+
+## SPEC.md impact
+
+- §4.5 health thresholds: state leader-owned background observation for active Nodes.
+- §4.6: explicit deferral of push-vs-pull reconciliation (ADR 0015).
+- §4.6.1: background status-probe ingestion for active-Node liveness.
+- No §8 schema work in slice A.
+
+## Delivery state
+
+Slice A is the active implementation track for this package. Slice B remains ordered
+after A and must not be asserted by slice A tests or deltas.

--- a/openspec/changes/thin-active-node-liveness-monitor/proposal.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/proposal.md
@@ -32,7 +32,9 @@ scheduler from the inline probe and is out of scope for A’s implementation.
   approximately `unreachable_threshold + probe_interval`, leaving `:admitted` Nodes and
   sticky `:unhealthy` health to the observation seam.
 - Enforce probe interval strictly below freshness (30s) and unreachable (15s) thresholds,
-  clamping with a warning at boot rather than failing Controller startup.
+  clamping with a warning at boot rather than failing Controller startup, and falling back
+  to the default interval with an error log when thresholds sit below the minimum safe
+  interval floor.
 - Name the SPEC §4.6 push-versus-pull divergence and explicitly defer reconciliation,
   coupled to deferred §8 `node_heartbeats` work.
 - Update SPEC §4.5/§4.6.1 language so active-Node liveness is maintained by a

--- a/openspec/changes/thin-active-node-liveness-monitor/proposal.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/proposal.md
@@ -28,9 +28,11 @@ scheduler from the inline probe and is out of scope for A’s implementation.
   `:beam_peer_observation_rejected`) as transport demotions.
 - Relax authenticated health gates so already-`:active` Nodes record
   `:degraded`/`:unhealthy`; keep `:admitted` → `:active` promotion healthy-gated.
-- Add a periodic heartbeat-age sweep so detection is bounded at approximately
-  `unreachable_threshold + probe_interval`.
-- Enforce probe interval strictly below freshness (30s) and unreachable (15s) thresholds.
+- Add a periodic heartbeat-age sweep over `:active` Nodes so detection is bounded at
+  approximately `unreachable_threshold + probe_interval`, leaving `:admitted` Nodes and
+  sticky `:unhealthy` health to the observation seam.
+- Enforce probe interval strictly below freshness (30s) and unreachable (15s) thresholds,
+  clamping with a warning at boot rather than failing Controller startup.
 - Name the SPEC §4.6 push-versus-pull divergence and explicitly defer reconciliation,
   coupled to deferred §8 `node_heartbeats` work.
 - Update SPEC §4.5/§4.6.1 language so active-Node liveness is maintained by a

--- a/openspec/changes/thin-active-node-liveness-monitor/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/specs/runtime-endpoints/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Leader-owned background active-Node liveness observation
+The Active Controller SHALL maintain active-Node liveness on a bounded interval through a
+single supervised, leader-gated status observer that probes both `:admitted` and `:active`
+trusted Runtime Endpoint Nodes.
+The observer interval MUST be strictly below `node_unreachable_threshold_ms` and
+`node_freshness_threshold_ms`.
+Successful authenticated observations MUST advance `last_heartbeat_at`, re-derive health,
+and refresh aggregate capacity evidence in one authenticated write path.
+A standby Controller MUST write nothing on this path.
+This requirement traces to `SPEC.md` §4.5, §4.6.1, and ADR 0015. Scheduler inline probing
+and candidate-source decoupling remain slice B (issue #149) and MUST NOT be required here.
+
+#### Scenario: Idle active Node stays schedulable without request traffic
+- **WHEN** an `:active` Node is observed only by the leader-owned background status observer
+- **AND** the observation is authenticated and within the freshness threshold
+- **THEN** `last_heartbeat_at` and aggregate capacity evidence advance together
+- **AND** the Node remains eligible in `schedulable_nodes/0` without a request-path probe
+
+#### Scenario: Probe interval stays below thresholds
+- **WHEN** the background observer starts or its interval is validated
+- **THEN** the configured interval is strictly less than the unreachable threshold
+- **AND** the configured interval is strictly less than the freshness threshold
+
+#### Scenario: Standby Controller observes nothing
+- **WHEN** a standby Controller would run the background status observer cycle
+- **THEN** `authorize_write_path(:node_lifecycle)` refuses the write path
+- **AND** no Node health, heartbeat, or capacity evidence is updated
+
+### Requirement: Authenticated observation health for active Nodes
+Authenticated Runtime Endpoint status observation SHALL record `:healthy`, `:degraded`, and
+`:unhealthy` health for already-`:active` Nodes.
+Promotion from `:admitted` to `:active` SHALL remain healthy-gated.
+Missing or non-map runtime health, or a health map without a boolean `ready` flag, SHALL
+be rejected without demoting the Node as a transport failure.
+This requirement traces to `SPEC.md` §4.5, §4.6.1, and ADR 0015.
+
+#### Scenario: Degraded active observation is recorded
+- **WHEN** an already-`:active` Node reports ready with a non-empty health code
+- **AND** the observation is authenticated and accepted
+- **THEN** the Node is persisted with health `:degraded`
+- **AND** heartbeat and capacity evidence advance
+
+#### Scenario: Non-healthy admitted Node does not activate
+- **WHEN** an `:admitted` Node reports a non-healthy runtime health observation
+- **THEN** authenticated observation is rejected
+- **AND** the Node remains `:admitted`
+- **AND** the rejection is not treated as a transport demotion
+
+### Requirement: Graded demotion for idle Node loss
+Genuine transport failures observed by the background status observer SHALL route through
+the graded demotion path used by `record_transport_failure/3`, including
+`:authenticated_transport_failed` and `:beam_peer_grant_authorization_unavailable`.
+Seam rejections `:authenticated_observation_rejected` and `:beam_peer_observation_rejected`
+MUST NOT demote health as transport failures.
+A leader-gated heartbeat-age sweep SHALL demote Nodes whose last heartbeat is older than
+`node_unreachable_threshold_ms`, bounding detection at approximately the unreachable
+threshold plus one observer interval.
+This requirement traces to `SPEC.md` §4.5 and ADR 0015.
+
+#### Scenario: Fresh transport failure degrades then ages to unreachable
+- **WHEN** an `:active` Node fails a status probe while its last heartbeat is still within
+  the unreachable threshold
+- **THEN** health becomes `:degraded`
+- **AND WHEN** the last heartbeat later exceeds the unreachable threshold
+- **THEN** a subsequent failure or the heartbeat-age sweep sets health `:unreachable`
+
+#### Scenario: Seam rejection does not demote
+- **WHEN** a status probe returns `:authenticated_observation_rejected` or
+  `:beam_peer_observation_rejected`
+- **THEN** `record_transport_failure/3` is a no-op for demotion
+- **AND** Node health is unchanged by that classification
+
+### Requirement: SPEC §4.6 push-versus-pull observation deferral
+The OpenSpec change and `SPEC.md` SHALL explicitly name the divergence between the
+historical §4.6 Node-push heartbeat wording and the pull-based status-probe ingestion
+implemented under §4.6.1 and in product code.
+Slice A MUST NOT leave that divergence silent.
+Full reconciliation of §4.6 to pull-based observation, or an explicit dual-path contract,
+is deferred and coupled to deferred §8 `node_heartbeats` work (slice B / metrics floor).
+This requirement traces to `SPEC.md` §4.6, §4.6.1, §8, and ADR 0015.
+
+#### Scenario: Divergence is named with an explicit deferral
+- **WHEN** collaborators read `SPEC.md` §4.6 after slice A lands
+- **THEN** the push-versus-pull divergence is named
+- **AND** reconciliation is explicitly deferred with coupling to §8 `node_heartbeats`

--- a/openspec/changes/thin-active-node-liveness-monitor/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/specs/runtime-endpoints/spec.md
@@ -5,7 +5,12 @@ The Active Controller SHALL maintain active-Node liveness on a bounded interval 
 single supervised, leader-gated status observer that probes both `:admitted` and `:active`
 trusted Runtime Endpoint Nodes.
 The observer interval MUST be strictly below `node_unreachable_threshold_ms` and
-`node_freshness_threshold_ms`.
+`node_freshness_threshold_ms` whenever both thresholds are above the minimum safe interval
+floor. When thresholds are configured so low that no interval can stay both below them and
+above that floor, the observer MUST log the unsatisfiable bound and fall back to its default
+interval rather than failing Controller boot or scheduling a busy-looping probe timer;
+liveness detection degrades in that misconfiguration instead of the Controller refusing to
+start.
 Successful authenticated observations MUST advance `last_heartbeat_at`, re-derive health,
 and refresh aggregate capacity evidence in one authenticated write path.
 A standby Controller MUST write nothing on this path.
@@ -20,8 +25,15 @@ and candidate-source decoupling remain slice B (issue #149) and MUST NOT be requ
 
 #### Scenario: Probe interval stays below thresholds
 - **WHEN** the background observer starts or its interval is validated
+- **AND** both thresholds are above the minimum safe interval floor
 - **THEN** the configured interval is strictly less than the unreachable threshold
 - **AND** the configured interval is strictly less than the freshness threshold
+
+#### Scenario: Sub-floor thresholds degrade instead of busy-looping
+- **WHEN** the background observer starts while a threshold is at or below the minimum safe
+  interval floor, so no interval satisfies the bound
+- **THEN** the observer logs the unsatisfiable interval bound
+- **AND** it schedules probes at the default interval rather than failing boot or busy-looping
 
 #### Scenario: Standby Controller observes nothing
 - **WHEN** a standby Controller would run the background status observer cycle

--- a/openspec/changes/thin-active-node-liveness-monitor/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/specs/runtime-endpoints/spec.md
@@ -54,9 +54,13 @@ the graded demotion path used by `record_transport_failure/3`, including
 `:authenticated_transport_failed` and `:beam_peer_grant_authorization_unavailable`.
 Seam rejections `:authenticated_observation_rejected` and `:beam_peer_observation_rejected`
 MUST NOT demote health as transport failures.
-A leader-gated heartbeat-age sweep SHALL demote Nodes whose last heartbeat is older than
-`node_unreachable_threshold_ms`, bounding detection at approximately the unreachable
+A leader-gated heartbeat-age sweep SHALL demote `:active` Nodes whose last heartbeat is older
+than `node_unreachable_threshold_ms`, bounding detection at approximately the unreachable
 threshold plus one observer interval.
+`:admitted` Nodes MUST NOT be swept, because a stalled admitted heartbeat usually means the
+controller-side observation seam is rejecting a reachable Node rather than Node loss.
+Nodes already recorded `:unhealthy` MUST keep that health until a successful observation
+clears it.
 This requirement traces to `SPEC.md` §4.5 and ADR 0015.
 
 #### Scenario: Fresh transport failure degrades then ages to unreachable
@@ -71,6 +75,12 @@ This requirement traces to `SPEC.md` §4.5 and ADR 0015.
   `:beam_peer_observation_rejected`
 - **THEN** `record_transport_failure/3` is a no-op for demotion
 - **AND** Node health is unchanged by that classification
+
+#### Scenario: Sweep spares admitted and sticky-unhealthy Nodes
+- **WHEN** the heartbeat-age sweep runs against an `:admitted` Node, or an `:active` Node
+  already recorded `:unhealthy`, whose last heartbeat exceeds the unreachable threshold
+- **THEN** the Node health is left unchanged
+- **AND** only a successful authenticated observation can clear it
 
 ### Requirement: SPEC §4.6 push-versus-pull observation deferral
 The OpenSpec change and `SPEC.md` SHALL explicitly name the divergence between the

--- a/openspec/changes/thin-active-node-liveness-monitor/tasks.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/tasks.md
@@ -1,0 +1,42 @@
+## 1. Contract and OpenSpec
+
+- [x] 1.1 Record ADR 0015 as the accepted decomposition (merged via #150)
+- [x] 1.2 Author this OpenSpec package with ordered slices A (#148) and B (#149)
+- [x] 1.3 Name SPEC §4.6 push-vs-pull divergence and record explicit deferral
+- [x] 1.4 Update SPEC §4.5 / §4.6.1 for leader-owned background active-Node observation
+- [x] 1.5 Validate package: `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate thin-active-node-liveness-monitor --type change --strict --no-interactive`
+
+## 2. Slice A implementation
+
+- [x] 2.1 Expand activation probe targets to `[:admitted, :active]`
+- [x] 2.2 Relax authenticated health gates for already-`:active` Nodes; keep admission promotion healthy-gated
+- [x] 2.3 Classify `:authenticated_transport_failed` and `:beam_peer_grant_authorization_unavailable`
+- [x] 2.4 Add `Nodes.sweep_stale_node_heartbeats/1`
+- [x] 2.5 Wire `ActivationProbe` to record raw transport failures and run the sweep each cycle
+- [x] 2.6 Enforce probe interval strictly below freshness and unreachable thresholds
+- [x] 2.7 Acceptance and regression tests (see tasks 3.x)
+
+## 3. Slice A tests
+
+- [x] 3.1 New transport-failure reasons demote; seam rejections do not
+- [x] 3.2 Sweep demotes stale heartbeats; race with fresher heartbeat is noop; standby writes nothing
+- [x] 3.3 Probe interval contract tests
+- [x] 3.4 ActivationProbe records failures and invokes sweep (stub client)
+- [x] 3.5 Authenticated degraded/unhealthy active observations recorded; non-healthy admitted not promoted (integration where fixtures allow)
+
+## 4. Slice B (deferred — issue #149)
+
+- [ ] 4.1 Design monitor-refreshed candidate source and snapshot-freshness contracts
+- [ ] 4.2 Remove or bound MultiNode inline sequential probe
+- [ ] 4.3 Decide durable `node_heartbeats` vs leader-local mirror vs both
+- [ ] 4.4 Implement §8 `node_heartbeats`, §8.5 retention, §9.1 heartbeat-lag metric with §4.6 reconciliation
+- [ ] 4.5 Slice B tests against a real scheduler consumer
+
+## 5. Quality gate
+
+- [ ] 5.1 `mise exec -- mix format`
+- [ ] 5.2 `mise exec -- mix compile --warnings-as-errors`
+- [ ] 5.3 `mise exec -- mix credo --strict`
+- [ ] 5.4 `mise exec -- mix dialyzer` (if available for changed surface)
+- [ ] 5.5 Focused then full relevant tests + coverage for changed modules
+- [ ] 5.6 no-mistakes gate and qualified PR for #148

--- a/openspec/changes/thin-active-node-liveness-monitor/tasks.md
+++ b/openspec/changes/thin-active-node-liveness-monitor/tasks.md
@@ -14,6 +14,7 @@
 - [x] 2.4 Add `Nodes.sweep_stale_node_heartbeats/1`
 - [x] 2.5 Wire `ActivationProbe` to record raw transport failures and run the sweep each cycle
 - [x] 2.6 Enforce probe interval strictly below freshness and unreachable thresholds
+      (strict assertion plus boot-safe clamp)
 - [x] 2.7 Acceptance and regression tests (see tasks 3.x)
 
 ## 3. Slice A tests


### PR DESCRIPTION
## Intent

Implement GitHub issue #148 (ADR 0015 slice A): thin active-node liveness monitor as the pilot-blocking build item for #118. Generalize the supervised leader-gated ActivationProbe to observe both admitted and active Nodes (no second poller). Consume successes through observe_authenticated_status so heartbeat, health, and capacity evidence advance together; consume transport failures via record_transport_failure with new reasons :authenticated_transport_failed and :beam_peer_grant_authorization_unavailable; do not demote on seam rejections. Relax authenticated health gates so already-active Nodes record degraded/unhealthy while admitted→active promotion stays healthy-gated. Add heartbeat-age sweep and enforce probe interval below freshness/unreachable thresholds. One OpenSpec package thin-active-node-liveness-monitor with ordered slices A (implement) and B (tasks only); name SPEC §4.6 push-vs-pull divergence and explicitly defer reconciliation. Scheduler MultiNode inline probe untouched. No migration / node_heartbeats. Raise a qualified PR via no-mistakes.

## What Changed

- Generalized the supervised, leader-gated `Orchard.RuntimeEndpoint.ActivationProbe` to probe both `:admitted` and `:active` Runtime Endpoint targets instead of standing up a second poller. Successful probes flow through `observe_authenticated_status` so heartbeat, health, and aggregate capacity evidence advance in one write; transport failures flow through `Nodes.record_transport_failure/3` with two new reasons (`:authenticated_transport_failed`, `:beam_peer_grant_authorization_unavailable`), while seam rejections are ignored and never demote. The probe interval is clamped below the freshness/unreachable thresholds at boot — with a 1s floor and a default-interval fallback plus error log — so a threshold misconfiguration degrades detection rather than failing Controller boot or busy-looping the timer.
- Relaxed the authenticated health gates in `Orchard.Nodes` so already-`:active` Nodes can record `degraded`/`unhealthy` observations while `:admitted → :active` promotion stays healthy-gated, and added `sweep_stale_node_heartbeats/1`: a per-cycle heartbeat-age sweep that demotes `:active` Nodes past the unreachable threshold and clears their queue capacity sources. `:admitted` Nodes are excluded from the sweep, and Nodes already marked `:unhealthy` stay sticky until a successful observation clears them.
- Documented the contract in `SPEC.md` §4.5/§4.6.1 and `docs/architecture.md`, added an explicit §4.6 note naming the push-vs-pull heartbeat divergence and deferring reconciliation to the `node_heartbeats` work, and added the `thin-active-node-liveness-monitor` OpenSpec package (slice A implement, slice B tasks only). Test coverage spans probe interval/clamp/failure-routing units, sweep and authenticated-health cases in `nodes_test` and `beam_peer_grants_test`, and a full idle-liveness lifecycle over real mTLS in the CLI join test. The scheduler's inline MultiNode probe, migrations, and `node_heartbeats` are untouched.

## Risk Assessment

✅ Low: The final commit closes the last outstanding finding with a verified 1s floor and a loud, documented fallback for unsatisfiable thresholds, leaving a well-bounded change that is fully traced to SPEC/ADR/OpenSpec with regression tests for every behavior it introduces.

## Testing

Ran the smallest relevant unit slices first (activation probe, nodes, beam peer grants, node join), then the full umbrella suite twice — all green with no failures or flakes. Because passing unit tests do not show the actual product outcome, I wrote an acceptance test that exercises the real certificate-backed mTLS probe against a live node-agent gRPC server and real Postgres, capturing a per-cycle transcript of persisted Node state (state, health, last_heartbeat_at, capacity evidence) alongside the operator-facing scheduling eligibility: an idle active Node stays live with zero request traffic, a standby Controller writes nothing, the heartbeat-age sweep and transport-failure path demote a lost Node out of scheduling, and a successful observation clears the demotion. I also confirmed the new :authenticated_transport_failed reason fires against a real enrolled server whose GetStatus fails, and added missing coverage for :unhealthy recording at the authenticated seam. This change is control-plane only with no rendered UI surface, so the reviewer-visible artifacts are the CLI/DB transcript and the operator-visible probe interval clamp logs rather than screenshots.

<details>
<summary>Evidence: Idle active-Node liveness lifecycle transcript (real mTLS probe, persisted DB + operator status)</summary>

<code>=== issue #148 slice A: idle active-Node liveness over the real mTLS probe ===&#10;node_id=589e8abc-… runtime endpoint=127.0.0.1:55193&#10;unreachable_threshold_ms=15000 freshness_threshold_ms=30000 probe_interval_ms=5000&#10;No inference request is dispatched anywhere in this scenario.&#10;&#10;admitted, before any probe cycle state=admitted health=unreachable heartbeat= schedulable=false operator_status=eligible=false reasons=[&#34;node_not_active&#34;, &#34;node_health_unreachable&#34;, &#34;node_observation_stale&#34;]&#10;probe cycle 1: admitted -&gt; active state=active health=healthy heartbeat=2026-08-02 07:46:44.610661Z capacity=0/1@…44.610661Z schedulable=true operator_status=eligible=true reasons=[]&#10;probe cycle 2: idle refresh, no request traffic state=active health=healthy heartbeat=2026-08-02 07:46:45.877310Z capacity=0/1@…45.877310Z schedulable=true operator_status=eligible=true reasons=[]&#10;standby Controller cycle: writes nothing state=active health=healthy heartbeat=2026-08-02 07:46:45.877310Z capacity=0/1@…45.877310Z schedulable=true operator_status=eligible=true reasons=[]&#10;sweep cycle: heartbeat aged past threshold state=active health=unreachable heartbeat=2026-08-02 07:46:45.877310Z schedulable=false operator_status=eligible=false reasons=[&#34;node_health_unreachable&#34;]&#10;probe cycle 3: observation clears demotion state=active health=healthy heartbeat=2026-08-02 07:46:45.905667Z schedulable=true operator_status=eligible=true reasons=[]&#10;node runtime status fails (authenticated_transport_failed) state=active health=degraded heartbeat=2026-08-02 07:46:45.905667Z schedulable=true operator_status=eligible=true reasons=[]&#10;node agent gone, past threshold (connect_failed) state=active health=unreachable heartbeat=2026-08-02 07:46:45.905667Z schedulable=false operator_status=eligible=false reasons=[&#34;node_health_unreachable&#34;]&#10;&#10;Result: 1 passed, 19 excluded</code>

```text
==> orchard_cli
Running ExUnit with seed: 373323, max_cases: 16
Excluding tags: [:test, :integration]
Including tags: [:liveness_evidence]


=== issue #148 slice A: idle active-Node liveness over the real mTLS probe ===
node_id=22f355c2-d089-4d64-9107-047e628d823d runtime endpoint=127.0.0.1:56171
unreachable_threshold_ms=15000 freshness_threshold_ms=30000 probe_interval_ms=5000
No inference request is dispatched anywhere in this scenario. Probe cycles observe
the Node over real mutual TLS; cycles that age past a threshold inject observed_at
instead of sleeping through it.

admitted, before any probe cycle                     state=admitted  health=unreachable   heartbeat=                               capacity=none                                schedulable=false   operator_status=eligible=false reasons=["node_not_active", "node_health_unreachable", "node_observation_stale"]
probe cycle 1: admitted -> active                    state=active    health=healthy       heartbeat=2026-08-02 07:52:44.360350Z    capacity=0/1@2026-08-02 07:52:44.360350Z     schedulable=true    operator_status=eligible=true reasons=[]
probe cycle 2: idle refresh, no request traffic      state=active    health=healthy       heartbeat=2026-08-02 07:52:45.493878Z    capacity=0/1@2026-08-02 07:52:45.493878Z     schedulable=true    operator_status=eligible=true reasons=[]
standby Controller cycle: writes nothing             state=active    health=healthy       heartbeat=2026-08-02 07:52:45.493878Z    capacity=0/1@2026-08-02 07:52:45.493878Z     schedulable=true    operator_status=eligible=true reasons=[]
sweep cycle: heartbeat aged past threshold           state=active    health=unreachable   heartbeat=2026-08-02 07:52:45.493878Z    capacity=0/1@2026-08-02 07:52:45.493878Z     schedulable=false   operator_status=eligible=false reasons=["node_health_unreachable"]
probe cycle 3: observation clears demotion           state=active    health=healthy       heartbeat=2026-08-02 07:52:45.519451Z    capacity=0/1@2026-08-02 07:52:45.519451Z     schedulable=true    operator_status=eligible=true reasons=[]
node runtime status fails (authenticated_transport_failed) state=active    health=degraded      heartbeat=2026-08-02 07:52:45.519451Z    capacity=0/1@2026-08-02 07:52:45.519451Z     schedulable=true    operator_status=eligible=true reasons=[]
node agent gone, past threshold (connect_failed)     state=active    health=unreachable   heartbeat=2026-08-02 07:52:45.519451Z    capacity=0/1@2026-08-02 07:52:45.519451Z     schedulable=false   operator_status=eligible=false reasons=["node_health_unreachable"]
.
Finished in 7.3 seconds (0.00s async, 7.3s sync)

Result: 1 passed, 19 excluded
```
</details>
<details>
<summary>Evidence: Operator-visible probe interval clamp logs at Controller boot</summary>

<code>[warning] activation_probe interval_ms=60000 must be &lt; 15000; clamping to 5000&#10;[warning] activation_probe interval_ms=60000 must be &lt; 3000; clamping to 1500&#10;[error] activation_probe cannot satisfy interval_ms &lt; 15 above the 1000ms floor; using 5000 and degrading liveness detection&#10;&#10;Result: 6 passed</code>

```text
==> orchard_controller
Running ExUnit with seed: 943421, max_cases: 16

..15:46:52.051 [warning] activation_probe interval_ms=60000 must be < 15000; clamping to 5000
..15:46:52.054 [warning] activation_probe interval_ms=60000 must be < 3000; clamping to 1500
15:46:52.055 [error] activation_probe cannot satisfy interval_ms < 15 above the 1000ms floor; using 5000 and degrading liveness detection
..
Finished in 0.1 seconds (0.00s async, 0.1s sync)

Result: 6 passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 8 issues found → auto-fixed (2) ✅</summary>

- 🚨 `apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs:537` - Widening `activation_probe_runtime_endpoint_targets/0` to `[:admitted, :active]` (apps/orchard_controller/lib/orchard/nodes.ex:197) invalidates this untagged, non-excluded assertion. After `observe_authenticated_status` promotes the node to `:active`, the probe target list is no longer empty — it now contains that node&#39;s `:inference_dispatch` target. Update the assertion to expect the active target (e.g. `assert [%Target{node_id: ^node_id}] = Inference.activation_probe_runtime_endpoint_targets()`).
- 🚨 `apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs:552` - `ActivationProbe` result status was renamed `:activated` -&gt; `:observed` (apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex:22,120) but this assertion still matches `status: :activated`. The test is tagged `:task_2_8`, which is not in the `exclude` list (only `:integration` is), so it runs and fails. Update to `status: :observed`.
- ⚠️ `apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex:87` - `assert_interval_contract!/1` raises `ArgumentError` inside `init/1`. The probe is a `:one_for_one` child of `Orchard.Supervisor` (apps/orchard_controller/lib/orchard/application.ex:211), so a deterministic init raise fails `Supervisor.start_link` and the controller application never boots. Both thresholds are operator env vars (`ORCHARD_NODE_UNREACHABLE_THRESHOLD_MS`, `ORCHARD_NODE_FRESHNESS_THRESHOLD_MS`, config/runtime.exs:1152-1154) with no lower bound, so setting the unreachable threshold to e.g. 3000 against the default 5000ms interval turns a tuning mistake into a total controller outage rather than degraded liveness detection. Consider clamping the interval below the tightest threshold and logging an error, keeping `assert_interval_contract!/1` as the explicit assertion for tests and validation.
- ⚠️ `apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex:161` - `allowed_client?/1` extends the hardcoded `[BeamClient, GrpcCompatibilityClient]` transport allowlist with arbitrary modules from `Application.get_env(:orchard_controller, :activation_probe)[:allowed_clients]`, with no environment gating. That allowlist was the guard that made the probe refuse (`:activation_probe_transport_disabled`) when `:runtime_endpoint_client_impl` (apps/orchard_controller/lib/orchard/inference.ex:252) is config-overridden, keeping the leader-gated node-health write path on authenticated transports only. The key exists solely for the stub clients in activation_probe_test.exs:35. Gate the extras behind a compile-time test check, following the existing precedent in apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex:330 (`if Mix.env() == :test do`), or pass the stub via the already-supported `client:` opt in tests only.
- ⚠️ `apps/orchard_controller/lib/orchard/nodes.ex:825` - `stale_heartbeat_node_ids/1` selects purely on heartbeat age, so it cannot distinguish &#34;node is gone&#34; from &#34;the controller-side observation seam is rejecting a reachable node&#34; — which partly undoes the seam-rejection rule this same change adds (nodes.ex:770-771). Concrete case: an `:admitted` node that is alive but reports `ready: true` with a non-empty `health_code` derives `:degraded`, is deliberately rejected by the promotion gate at nodes.ex:2708, returns `:authenticated_observation_rejected` (no demotion, correct), never advances `last_heartbeat_at`, and is then swept to `:unreachable` with its queue capacity sources cleared ~15s later even though every probe connected successfully. The same shape applies fleet-wide to any persistent controller-side rejection (capacity-evidence write failure, grant/certificate rotation), taking every node out of `schedulable_nodes/0` within one unreachable window. Consider requiring corroborating evidence — e.g. only sweep nodes whose last probe outcome was a transport failure, or persist a distinct health/reason for &#34;observed but rejected&#34;.
- ⚠️ `apps/orchard_controller/lib/orchard/nodes.ex:830` - The sweep excludes `n.health not in [:unreachable, :unhealthy]`, and `resolve_transport_failure_health/2` (nodes.ex:2429-2430) already pins `:unhealthy` in place, so an `:unhealthy` node can never reach `:unreachable` by aging — only a successful observation can move it. This gate was previously unreachable through the authenticated seam; the relaxation at nodes.ex:2704 makes `:unhealthy` recordable for `:active` nodes for the first time, so it is now live. Scenario: an active node reports `ready: false`, is persisted `:unhealthy`, then the host is powered off — it stays `:unhealthy` forever, and operators reading the Console see &#34;unhealthy&#34; for a machine that is gone. This also does not match the SPEC text added in this change (&#34;a periodic heartbeat-age sweep demote health through the graded path (`degraded`, then `unreachable` past the unreachable threshold)&#34;, SPEC.md:799-800). Dispatch safety is unaffected — both values block dispatch — so this is observability/contract accuracy. The behavior is deliberate (asserted by nodes_test.exs &#34;leaves sticky unhealthy nodes unchanged&#34;), so confirm whether the SPEC wording or the sweep filter should change.
- ℹ️ `apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs:15` - `RejectingClient` is defined and added to `allowed_clients` (line 35) but never used by any test. The &#34;seam rejection during probe does not demote&#34; test bypasses the probe entirely and calls `Nodes.record_transport_failure/3` directly, so `record_probe_failure/3`&#39;s wiring is only exercised for the transport-failure reason, never for seam rejections — the one path the comment at activation_probe.ex:135-136 is specifically defending. Drive that test through `run_once(client: RejectingClient, targets: [target])` so the wiring is covered, or drop the unused stub.
- ℹ️ `apps/orchard_controller/lib/orchard/nodes.ex:890` - The new `{:node_id, _}` clause makes `mark_target_unreachable_without_queue_cleanup/2` accept either a target (`Target.t() | keyword()`, resolved via `target_lookup/1`) or an already-resolved lookup tuple, blurring a private helper&#39;s contract for one caller. `sweep_stale_node_heartbeats/1` has already established `repo_available?()` at nodes.ex:805, so `demote_stale_heartbeat_node/3` can call `execute_mark_unreachable({:node_id, node_id}, observed_at)` directly and this clause can be deleted. The reduce at nodes.ex:813-815 also threads the accumulator through the helper only to increment it; `Enum.count(ids, &amp;demote_stale_heartbeat_node(&amp;1, observed_at))` reads more directly.

🔧 Fix: fix liveness probe boot clamp, sweep scope, test gaps
1 warning still open:
- ⚠️ `apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex:212` - `clamped_interval/1` has no lower bound, so the new boot-safe clamp can produce a pathological probe timer. `ORCHARD_NODE_UNREACHABLE_THRESHOLD_MS=15` (a plausible seconds/milliseconds units typo for 15000) gives `ceiling = 15` and `div(15, 2) = 7`, so `init/1` schedules `:probe` every 7ms; `env_int` (config/runtime.exs:5-19) accepts `0` and negatives with no range check, and `node_unreachable_threshold_ms/0` (inference.ex:313) passes `0` through because `0 || 15_000` is truthy, so `ceiling &lt;= 1` falls to the `do: 1` catch-all at line 215 for a 1ms timer. Each tick runs `run_once/1`: a targets query, a connect+status per node, and the sweep query — `handle_info/2` reschedules immediately after, so the controller busy-loops against Postgres and hammers every node. That is a silent self-inflicted outage replacing the loud boot failure this commit removed. The catch-all also fails to restore the invariant it protects: with `ceiling` of 0 or 1, the clamped value `1` is not strictly below the ceiling, so `assert_interval_contract!(1)` would still raise. Add a floor — e.g. `clamped_interval(ceiling) when ceiling &gt; 1, do: clamp(min(@default_interval_ms, div(ceiling, 2)), 1_000, @default_interval_ms)` — or fall back to `@default_interval_ms` and log when no interval can satisfy the contract, which is the simpler option the review instructions offered.

🔧 Fix: add busy-loop floor to probe interval clamp
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs` — probe interval contract, boot clamp with 1s floor, transport-failure vs seam-rejection handling, standby no-op</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/nodes_test.exs apps/orchard_controller/test/orchard/beam_peer_grants_test.exs` — new transport-failure reasons, sweep semantics (stale/fresh/sticky-unhealthy/admitted-excluded), authenticated health gates</code>
- <code>`mise exec -- mix test apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs` — real join/admit/activate over certificate-backed gRPC, including the changed active-node probe target assertions</code>
- <code>Added `--only liveness_evidence` acceptance test in `apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs`: full idle-liveness lifecycle over real mTLS (activate → idle heartbeat+capacity refresh → standby writes nothing → heartbeat-age sweep demotion → observation clears it → authenticated_transport_failed degrade → connect_failed unreachable), emitting a per-cycle DB + operator-status transcript</code>
- <code>Added `SPEC.md §4.5 unhealthy authenticated observation is recorded for active nodes` in `apps/orchard_controller/test/orchard/beam_peer_grants_test.exs` — covers :unhealthy recording, loss of schedulability, and sweep stickiness</code>
- <code>`mise exec -- mix test` (full umbrella suite, run twice) — 290 / 3077 / 378 / 710 passed, no failures</code>
- `Repeated the new e2e test 3x to check timing/port stability — passed every run`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate thin-active-node-liveness-monitor --type change --strict --no-interactive`
- `Diff inspection confirming no scheduler MultiNode, migration, or node_heartbeats changes`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `SPEC.md:232` - SPEC §4.5 now names `Orchard.RuntimeEndpoint.ActivationProbe` as the owner of active-Node liveness, but the §3.2 OTP supervision tree still does not list it among the Controller root children, even though it is a real supervised child (apps/orchard_controller/lib/orchard/application.ex:211, gated on `start_repo` and non-`grant_control` mode). The omission predates this change; adding a child to the normative supervision tree is a spec-structure decision I left to the author rather than making it as housekeeping.
- ℹ️ `openspec/changes/thin-active-node-liveness-monitor/specs/runtime-endpoints/spec.md:7` - The delta requirement states the observer interval MUST be strictly below `node_unreachable_threshold_ms` and `node_freshness_threshold_ms`, but the boot clamp added in cc61596 holds a 1s floor: with both thresholds configured at or below 1000 ms the probe logs an error and runs at the 5000 ms default, i.e. above the thresholds. design.md records the floor; the normative requirement text and SPEC §4.5 do not. Either wording is defensible (a signalled, logged violation of a MUST vs. an explicit carve-out), so I did not weaken the requirement myself — decide whether the delta should name the degraded-misconfiguration exception.

🔧 Fix: name probe interval floor in OpenSpec delta
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788250136&installation_model_id=428414&pr_number=151&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F151&signature=4ae87018f0512d1dcb04bada031981dcf24db1cba9faecea8ab8f85726d2821e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->