### PR TITLE
fix(node-agent): serialize peer grant store initialization

### DIFF
--- a/apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex
@@ -14,7 +14,7 @@ defmodule Orchard.Node.BeamPeerGrantStore do
   @directory_mode 0o700
   @file_mode 0o600
   @lock_command "/usr/bin/lockf"
-  @lock_directory ".install.lock"
+  @lock_file ".beam-peer-grants.install.lock"
   @lock_marker "orchard-peer-grant-lock-ready\n"
   @lock_timeout_seconds 5
   @store_directory "beam-peer-grants"
@@ -31,10 +31,8 @@ defmodule Orchard.Node.BeamPeerGrantStore do
              is_binary(expected_node_name) and is_list(opts) do
     with {:ok, grant} <- validate_grant(identity, delivery, expected_node_name),
          :ok <- ensure_current(grant, current_time(opts)),
-         {:ok, store_root, expected_uid} <- prepare_store(root, opts) do
-      with_store_lock(store_root, expected_uid, opts, fn ->
-        install_under_lock(store_root, grant, expected_uid, opts)
-      end)
+         {:ok, identity_root, expected_uid} <- prepare_identity_root(root) do
+      install_with_store_lock(identity_root, grant, expected_uid, opts)
     end
   rescue
     _error -> {:error, :beam_peer_grant_store_invalid}
@@ -215,15 +213,31 @@ defmodule Orchard.Node.BeamPeerGrantStore do
 
   defp canonical_name?(_prefix, _id, _name), do: false
 
-  defp prepare_store(root, opts) do
-    root = Path.expand(root)
+  defp prepare_identity_root(root) do
+    identity_root = Path.expand(root)
 
-    with :ok <- validate_directory(root),
-         {:ok, root_stat} <- File.stat(root),
-         store_root = Path.join(root, @store_directory),
-         :ok <- create_or_validate_directory(store_root, root, root_stat.uid, opts) do
-      {:ok, store_root, root_stat.uid}
+    with :ok <- validate_directory(identity_root),
+         {:ok, root_stat} <- File.stat(identity_root) do
+      {:ok, identity_root, root_stat.uid}
     else
+      _other -> {:error, :beam_peer_grant_store_invalid}
+    end
+  end
+
+  defp install_with_store_lock(identity_root, grant, expected_uid, opts) do
+    with_store_lock(identity_root, expected_uid, opts, fn ->
+      case prepare_store(identity_root, expected_uid, opts) do
+        {:ok, store_root} -> install_under_lock(store_root, grant, expected_uid, opts)
+        {:error, _reason} = error -> error
+      end
+    end)
+  end
+
+  defp prepare_store(identity_root, expected_uid, opts) do
+    store_root = Path.join(identity_root, @store_directory)
+
+    case create_or_validate_directory(store_root, identity_root, expected_uid, opts) do
+      :ok -> {:ok, store_root}
       _other -> {:error, :beam_peer_grant_store_invalid}
     end
   end
@@ -234,7 +248,7 @@ defmodule Orchard.Node.BeamPeerGrantStore do
         narrow_private_directory(path, expected_uid)
 
       {:error, :enoent} ->
-        with :ok <- create_private_directory(path, expected_uid) do
+        with :ok <- create_private_directory(path, expected_uid, opts) do
           sync_directory(parent, opts)
         end
 
@@ -243,20 +257,43 @@ defmodule Orchard.Node.BeamPeerGrantStore do
     end
   end
 
-  defp create_private_directory(path, expected_uid) do
+  defp create_private_directory(path, expected_uid, opts) do
     case File.mkdir(path) do
-      :ok -> narrow_private_directory(path, expected_uid)
+      :ok -> finish_created_directory(path, expected_uid, opts)
       {:error, :eexist} -> narrow_private_directory(path, expected_uid)
       _other -> {:error, :beam_peer_grant_store_invalid}
     end
   end
 
-  # `File.mkdir/1` applies the process umask, so the store directory is created
-  # wider than owner-only and is narrowed a moment later. Every installer
-  # narrows it rather than rejecting that window, otherwise a concurrent
-  # installer that observes it mid-creation fails closed. `File.chmod/2` fails
-  # for a directory this process does not own, and owner plus mode are
-  # revalidated afterwards.
+  defp finish_created_directory(path, expected_uid, opts) do
+    hook_result = after_store_directory_created(path, opts)
+    narrow_result = narrow_private_directory(path, expected_uid)
+
+    if hook_result == :ok and narrow_result == :ok do
+      :ok
+    else
+      {:error, :beam_peer_grant_store_invalid}
+    end
+  end
+
+  defp after_store_directory_created(path, opts) do
+    case Keyword.get(opts, :after_store_directory_created) do
+      hook when is_function(hook, 1) -> normalize_creation_hook(hook, path)
+      _other -> :ok
+    end
+  end
+
+  defp normalize_creation_hook(hook, path) do
+    case hook.(path) do
+      :ok -> :ok
+      _other -> {:error, :beam_peer_grant_store_invalid}
+    end
+  rescue
+    _error -> {:error, :beam_peer_grant_store_invalid}
+  catch
+    _kind, _reason -> {:error, :beam_peer_grant_store_invalid}
+  end
+
   defp narrow_private_directory(path, expected_uid) do
     with {:ok, %{type: :directory}} <- File.lstat(path),
          :ok <- File.chmod(path, @directory_mode),
@@ -267,8 +304,8 @@ defmodule Orchard.Node.BeamPeerGrantStore do
     end
   end
 
-  defp with_store_lock(store_root, expected_uid, opts, operation) do
-    lock_path = Path.join(store_root, @lock_directory)
+  defp with_store_lock(identity_root, expected_uid, opts, operation) do
+    lock_path = Path.join(identity_root, @lock_file)
     lock_command = Keyword.get(opts, :lock_command, @lock_command)
 
     with {:ok, lock_port} <- acquire_store_lock(lock_path, expected_uid, lock_command) do

--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -143,6 +143,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
 
     File.mkdir!(root)
     File.chmod!(root, 0o700)
+    identity_root_uid = File.stat!(root).uid
     on_exit(fn -> File.rm_rf!(root) end)
 
     marker_path = Path.join(root, "second-lock-attempted")
@@ -199,8 +200,8 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
       end)
 
     try do
-      wait_until(fn -> File.exists?(marker_path) end)
-      refute_receive {:second_installer_finished, _result}, 250
+      wait_until(fn -> File.exists?(marker_path) end, 250)
+      assert private_mode(store_root) == 0o755
 
       send(first_pid, :resume_first_installer)
       assert {:ok, ^delivery} = Task.await(first, 5_000)
@@ -210,6 +211,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
       lock_path = Path.join(root, ".beam-peer-grants.install.lock")
 
       assert private_mode(store_root) == 0o700
+      assert File.stat!(store_root).uid == identity_root_uid
       assert private_mode(grant_path) == 0o600
       assert private_mode(lock_path) == 0o600
       assert {:ok, ^delivery} = BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)

--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -100,6 +100,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
     assert stored.encoded_secret == delivery.encoded_secret
     assert stored.generation == delivery.generation
     assert private_mode(Path.join(root, "beam-peer-grants")) == 0o700
+    assert private_mode(Path.join(root, ".beam-peer-grants.install.lock")) == 0o600
 
     grant_path = Path.join([root, "beam-peer-grants", "#{identity.controller_id}.json"])
     assert private_mode(grant_path) == 0o600
@@ -131,6 +132,92 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
              BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
 
     assert private_mode(store_root) == 0o700
+  end
+
+  test "SPEC.md §7.5.0 first-store initialization is serialized before permission narrowing" do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-node-peer-grant-first-store-race-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir!(root)
+    File.chmod!(root, 0o700)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    marker_path = Path.join(root, "second-lock-attempted")
+    wrapper = Path.join(root, "lockf-marker-wrapper")
+
+    File.write!(
+      wrapper,
+      """
+      #!/bin/sh
+      : > "#{marker_path}"
+      exec /usr/bin/lockf "$@"
+      """
+    )
+
+    File.chmod!(wrapper, 0o700)
+    identity = identity()
+    delivery = delivery(identity)
+    parent = self()
+
+    first =
+      Task.async(fn ->
+        BeamPeerGrantStore.install(
+          root,
+          identity,
+          delivery,
+          delivery.node_beam_name,
+          after_store_directory_created: fn store_root ->
+            File.chmod!(store_root, 0o755)
+            send(parent, {:store_directory_created, self(), store_root})
+
+            receive do
+              :resume_first_installer -> :ok
+            end
+          end
+        )
+      end)
+
+    assert_receive {:store_directory_created, first_pid, store_root}, 5_000
+    assert private_mode(store_root) == 0o755
+
+    second =
+      Task.async(fn ->
+        result =
+          BeamPeerGrantStore.install(
+            root,
+            identity,
+            delivery,
+            delivery.node_beam_name,
+            lock_command: wrapper
+          )
+
+        send(parent, {:second_installer_finished, result})
+        result
+      end)
+
+    try do
+      wait_until(fn -> File.exists?(marker_path) end)
+      refute_receive {:second_installer_finished, _result}, 250
+
+      send(first_pid, :resume_first_installer)
+      assert {:ok, ^delivery} = Task.await(first, 5_000)
+      assert {:ok, ^delivery} = Task.await(second, 5_000)
+
+      grant_path = Path.join(store_root, "#{identity.controller_id}.json")
+      lock_path = Path.join(root, ".beam-peer-grants.install.lock")
+
+      assert private_mode(store_root) == 0o700
+      assert private_mode(grant_path) == 0o600
+      assert private_mode(lock_path) == 0o600
+      assert {:ok, ^delivery} = BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
+    after
+      send(first_pid, :resume_first_installer)
+      Task.shutdown(first, :brutal_kill)
+      Task.shutdown(second, :brutal_kill)
+    end
   end
 
   test "SPEC.md §7.5.0 install sweeps orphaned plaintext temporaries left by a crash" do
@@ -470,9 +557,9 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
     assert {:ok, ^delivery} =
              BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
 
-    lock_path = Path.join([root, "beam-peer-grants", ".install.lock"])
+    lock_path = Path.join(root, ".beam-peer-grants.install.lock")
     File.write!(lock_path, "99999999\ndead-owner-token\n")
-    File.chmod!(lock_path, 0o600)
+    File.chmod!(lock_path, 0o644)
 
     install =
       Task.async(fn ->
@@ -482,6 +569,79 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
     assert {:ok, ^delivery} = Task.await(install, 1_000)
     assert File.exists?(lock_path)
     assert private_mode(lock_path) == 0o600
+  end
+
+  test "SPEC.md §7.5.0 install rejects non-regular parent lock candidates before store creation" do
+    Enum.each([:directory, :symlink], fn candidate_type ->
+      root =
+        Path.join(
+          System.tmp_dir!(),
+          "orchard-node-peer-grant-lock-candidate-#{candidate_type}-#{System.unique_integer([:positive, :monotonic])}"
+        )
+
+      File.mkdir!(root)
+      File.chmod!(root, 0o700)
+      on_exit(fn -> File.rm_rf!(root) end)
+
+      lock_path = Path.join(root, ".beam-peer-grants.install.lock")
+
+      target_path =
+        case candidate_type do
+          :directory ->
+            File.mkdir!(lock_path)
+            nil
+
+          :symlink ->
+            target = Path.join(root, "lock-target")
+            File.write!(target, "unchanged")
+            File.chmod!(target, 0o600)
+            File.ln_s!(target, lock_path)
+            target
+        end
+
+      identity = identity()
+      delivery = delivery(identity)
+
+      assert {:error, :beam_peer_grant_store_invalid} =
+               BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
+
+      refute File.exists?(Path.join(root, "beam-peer-grants"))
+      assert File.lstat!(lock_path).type == candidate_type
+
+      if target_path do
+        assert File.read!(target_path) == "unchanged"
+      end
+    end)
+  end
+
+  test "SPEC.md §7.5.0 a failed creation hook still narrows the store directory" do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-node-peer-grant-hook-failure-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir!(root)
+    File.chmod!(root, 0o700)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    identity = identity()
+    delivery = delivery(identity)
+    store_root = Path.join(root, "beam-peer-grants")
+
+    assert {:error, :beam_peer_grant_store_invalid} =
+             BeamPeerGrantStore.install(
+               root,
+               identity,
+               delivery,
+               delivery.node_beam_name,
+               after_store_directory_created: fn ^store_root ->
+                 File.chmod!(store_root, 0o755)
+                 {:error, :test_hook_failed}
+               end
+             )
+
+    assert private_mode(store_root) == 0o700
   end
 
   test "SPEC.md §7.5.0 install uses baseline macOS lockf arguments" do
@@ -533,7 +693,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
              "-s",
              "-t",
              "5",
-             Path.join([root, "beam-peer-grants", ".install.lock"]),
+             Path.join(root, ".beam-peer-grants.install.lock"),
              "/bin/cat"
            ]
   end


### PR DESCRIPTION
## Summary

- Serialize first-store initialization by placing the lockf inode in the validated identity root before creating or narrowing beam-peer-grants/.
- Keep store-directory creation, permission narrowing, directory sync, plaintext-temporary cleanup, and grant installation under that lock.
- Preserve fail-closed ownership, symlink, regular-file, and mode validation for both the parent lock and grant store.
- Add a deterministic regression through BeamPeerGrantStore.install/5 plus focused lock/security coverage.

**SPEC.md impact: none.** This fixes an implementation race while preserving the existing §7.5.0 contract and the issue's non-goals.

Closes #142

## Deterministic red/green regression

Port 55142 was used because the default test node-agent port 50071 was occupied by another worktree.

- **RED:** ORCHARD_TEST_NODE_AGENT_PORT=55142 mise exec -- mix test apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs:136
  - Expected failure reproduced: installer B completed while installer A was paused after first-store creation and before permission narrowing.
- **GREEN:** ORCHARD_TEST_NODE_AGENT_PORT=55142 mise exec -- mix test apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs:137
  - 1 passed, 28 excluded.
- Lock/security slices at lines 543, 574, 617, and 647:
  - 4 passed, 25 excluded.
- Stress validation:
  - 10 iterations of the first-store race and 10 iterations of the existing 16-installer contention test; all 20 passed.
- Full focused file:
  - 29 passed.

## Security and fail-closed coverage

Regression coverage verifies:

- once installer B reaches the wrapper marker, the store is still mode 0755 while B is blocked on the parent lock, proving B cannot narrow the store before lock acquisition;
- the store directory ends at mode 0700 and its UID equals the UID validated on the identity root;
- the grant and parent lock files end at mode 0600;
- non-regular parent lock candidates (directory and symlink) fail closed before store creation;
- a failing creation hook still narrows the newly created store directory;
- existing ownership, symlink, mode, and contention behavior remains covered.

## Validation

- mise exec -- mix format — passed.
- mise exec -- mix compile --warnings-as-errors — passed; 324 files, zero warnings.
- mise exec -- mix credo --strict — passed; 633 files, 90 checks, zero findings, including ex_slop and ex_dna.
- mise exec -- mix dialyzer — passed; 0 errors/skips. It emitted 31 upstream xmerl PLT missing-spec warnings only.
- ORCHARD_TEST_NODE_AGENT_PORT=55142 mise exec -- mix test — passed; 4,528 passed, 5 skipped, 10 excluded, 0 failures.
- ORCHARD_TEST_NODE_AGENT_PORT=55142 mise exec -- mix test --cover — passed; 4,528 passed, 5 skipped, 10 excluded, 0 failures.
  - orchard_shared: 69.42%
  - orchard_controller: 84.9%
  - orchard_node_agent: 77.42%
  - orchard_cli: 79.03%
- git diff --check — passed.

## Review

- Standards review: clean, no findings.
- Spec review: clean, no findings.
- The amended deterministic assertions were reviewed after the initial publication; no further fixes were required.

## Compatibility scope

Same-identity-root coexecution of old and new Node Agent binaries is outside Orchard's current supported contract. The supported upgrade lifecycle stops/unloads the old service before install and restart (SPEC.md §13.4, `packaging/pkg/scripts/preinstall`, and the macOS app service lifecycle). The N/N-1 compatibility requirement describes controller/node interoperability across nodes, not simultaneous Node Agent versions sharing one host identity root.

No legacy nested `beam-peer-grants/.install.lock` was added: doing so would conflict with #142's approved direction to use one cross-VM lock in the validated private parent and avoid lock inodes inside the replaceable store. #158 tracks the durable OpenSpec/SPEC/ADR and packaging-lifecycle design required if same-root live version overlap becomes supported, including process exclusivity, handoff, bounded lock migration/retirement, and cross-version tests.
