### PR TITLE
fix(node-agent): serialize peer grant loads during publication

### DIFF
--- a/apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex
@@ -46,19 +46,17 @@ defmodule Orchard.Node.BeamPeerGrantStore do
     controller_id = value(identity, :controller_id)
 
     with true <- valid_uuid?(controller_id),
-         root = Path.expand(root),
-         :ok <- validate_directory(root),
-         {:ok, root_stat} <- File.stat(root),
-         store_root = Path.join(root, @store_directory),
-         :ok <- validate_directory(store_root, root_stat.uid),
-         path = grant_path(store_root, controller_id),
-         :ok <- validate_file(path, root_stat.uid),
-         {:ok, json} <- File.read(path),
-         {:ok, persisted} <- Jason.decode(json),
-         {:ok, grant} <- decode_persisted(persisted),
-         true <- grant.controller_id == controller_id,
-         {:ok, grant} <- validate_grant(identity, grant, expected_node_name),
-         :ok <- ensure_current(grant) do
+         {:ok, identity_root, expected_uid} <- prepare_identity_root(root),
+         {:ok, grant} <-
+           with_store_lock(identity_root, expected_uid, [], fn ->
+             load_under_lock(
+               identity_root,
+               expected_uid,
+               controller_id,
+               identity,
+               expected_node_name
+             )
+           end) do
       {:ok, grant}
     else
       {:error, :enoent} -> {:error, :beam_peer_grant_missing}
@@ -221,6 +219,28 @@ defmodule Orchard.Node.BeamPeerGrantStore do
       {:ok, identity_root, root_stat.uid}
     else
       _other -> {:error, :beam_peer_grant_store_invalid}
+    end
+  end
+
+  defp load_under_lock(
+         identity_root,
+         expected_uid,
+         controller_id,
+         identity,
+         expected_node_name
+       ) do
+    store_root = Path.join(identity_root, @store_directory)
+    path = grant_path(store_root, controller_id)
+
+    with :ok <- validate_directory(store_root, expected_uid),
+         :ok <- validate_file(path, expected_uid),
+         {:ok, json} <- File.read(path),
+         {:ok, persisted} <- Jason.decode(json),
+         {:ok, grant} <- decode_persisted(persisted),
+         true <- grant.controller_id == controller_id,
+         {:ok, grant} <- validate_grant(identity, grant, expected_node_name),
+         :ok <- ensure_current(grant) do
+      {:ok, grant}
     end
   end
 

--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -266,14 +266,24 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
 
     loader =
       Task.async(fn ->
-        send(parent, :loader_started)
         BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
       end)
 
     try do
-      assert_receive :loader_started
-      assert Task.yield(loader, 250) == nil
+      wait_until(fn ->
+        case Process.info(loader.pid, :current_stacktrace) do
+          {:current_stacktrace, stacktrace} ->
+            Enum.any?(stacktrace, fn
+              {BeamPeerGrantStore, :await_lock, 1, _location} -> true
+              _frame -> false
+            end)
 
+          nil ->
+            false
+        end
+      end)
+
+      refute File.exists?(grant_path)
       send(installer_pid, :resume_publication)
       assert {:ok, ^delivery} = Task.await(installer, 5_000)
       assert {:ok, ^delivery} = Task.await(loader, 5_000)

--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -222,6 +222,178 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
     end
   end
 
+  test "SPEC.md §7.5.0 load waits for first-install publication and returns its exact grant" do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-node-peer-grant-load-race-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir!(root)
+    File.chmod!(root, 0o700)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    identity = identity()
+    delivery = delivery(identity)
+    store_root = Path.join(root, "beam-peer-grants")
+    grant_path = Path.join(store_root, "#{identity.controller_id}.json")
+    parent = self()
+
+    installer =
+      Task.async(fn ->
+        BeamPeerGrantStore.install(
+          root,
+          identity,
+          delivery,
+          delivery.node_beam_name,
+          sync_directory: fn path ->
+            if path == root do
+              send(parent, {:first_store_ready_for_publication, self()})
+
+              receive do
+                :resume_publication -> :ok
+              end
+            end
+
+            :ok
+          end
+        )
+      end)
+
+    assert_receive {:first_store_ready_for_publication, installer_pid}, 5_000
+    assert private_mode(store_root) == 0o700
+    refute File.exists?(grant_path)
+
+    loader =
+      Task.async(fn ->
+        send(parent, :loader_started)
+        BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
+      end)
+
+    try do
+      assert_receive :loader_started
+      assert Task.yield(loader, 250) == nil
+
+      send(installer_pid, :resume_publication)
+      assert {:ok, ^delivery} = Task.await(installer, 5_000)
+      assert {:ok, ^delivery} = Task.await(loader, 5_000)
+    after
+      send(installer_pid, :resume_publication)
+      Task.shutdown(installer, :brutal_kill)
+      Task.shutdown(loader, :brutal_kill)
+    end
+  end
+
+  test "SPEC.md §7.5.0 load preserves genuine absence without creating grant custody" do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-node-peer-grant-missing-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir!(root)
+    File.chmod!(root, 0o700)
+    root_uid = File.stat!(root).uid
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    identity = identity()
+    delivery = delivery(identity)
+
+    assert {:error, :beam_peer_grant_missing} =
+             BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
+
+    refute File.exists?(Path.join(root, "beam-peer-grants"))
+
+    lock_path = Path.join(root, ".beam-peer-grants.install.lock")
+    assert File.lstat!(lock_path).type == :regular
+    assert private_mode(lock_path) == 0o600
+    assert File.stat!(lock_path).uid == root_uid
+  end
+
+  test "SPEC.md §7.5.0 load fails closed without repairing unsafe custody" do
+    Enum.each([:wide_store, :store_symlink, :wide_grant, :grant_symlink], fn unsafe_kind ->
+      root =
+        Path.join(
+          System.tmp_dir!(),
+          "orchard-node-peer-grant-unsafe-load-#{unsafe_kind}-#{System.unique_integer([:positive, :monotonic])}"
+        )
+
+      File.mkdir!(root)
+      File.chmod!(root, 0o700)
+      on_exit(fn -> File.rm_rf!(root) end)
+
+      identity = identity()
+      delivery = delivery(identity)
+      store_root = Path.join(root, "beam-peer-grants")
+      grant_path = Path.join(store_root, "#{identity.controller_id}.json")
+
+      case unsafe_kind do
+        :wide_store ->
+          File.mkdir!(store_root)
+          File.chmod!(store_root, 0o755)
+
+        :store_symlink ->
+          target = Path.join(root, "store-target")
+          File.mkdir!(target)
+          File.chmod!(target, 0o700)
+          File.ln_s!(target, store_root)
+
+        :wide_grant ->
+          assert {:ok, ^delivery} =
+                   BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
+
+          File.chmod!(grant_path, 0o644)
+
+        :grant_symlink ->
+          assert {:ok, ^delivery} =
+                   BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
+
+          target = Path.join(root, "grant-target")
+          File.write!(target, "unchanged")
+          File.chmod!(target, 0o600)
+          File.rm!(grant_path)
+          File.ln_s!(target, grant_path)
+      end
+
+      assert {:error, :beam_peer_grant_store_invalid} =
+               BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
+
+      case unsafe_kind do
+        :wide_store -> assert private_mode(store_root) == 0o755
+        :store_symlink -> assert File.lstat!(store_root).type == :symlink
+        :wide_grant -> assert private_mode(grant_path) == 0o644
+        :grant_symlink -> assert File.lstat!(grant_path).type == :symlink
+      end
+    end)
+  end
+
+  test "SPEC.md §7.5.0 load rejects malformed persisted grants" do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-node-peer-grant-malformed-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    File.mkdir!(root)
+    File.chmod!(root, 0o700)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    identity = identity()
+    delivery = delivery(identity)
+
+    assert {:ok, ^delivery} =
+             BeamPeerGrantStore.install(root, identity, delivery, delivery.node_beam_name)
+
+    grant_path = Path.join([root, "beam-peer-grants", "#{identity.controller_id}.json"])
+    File.write!(grant_path, "not-json")
+    File.chmod!(grant_path, 0o600)
+
+    assert {:error, :beam_peer_grant_store_invalid} =
+             BeamPeerGrantStore.load(root, identity, delivery.node_beam_name)
+
+    assert File.read!(grant_path) == "not-json"
+  end
+
   test "SPEC.md §7.5.0 install sweeps orphaned plaintext temporaries left by a crash" do
     root =
       Path.join(


### PR DESCRIPTION
> [!IMPORTANT]
> **INTENTIONAL PARTIAL PRECURSOR.** This PR is approved to merge while issue 145 remains open. It fixes the ordinary first-publication overlap within the existing bounded lock window. Issue 145 remains open, residual, and blocked by #144 for truthful contention/helper classification, bounded caller policy, telemetry, and any required durable contract update.

## What changes

- Serialize `BeamPeerGrantStore.load/3` through PR #157's existing validated parent identity-root lock before inspecting grant custody.
- Preserve the single lock inode, filesystem layout, public API, persisted format, authorization/expiry semantics, and existing error atoms.
- Add first-publication overlap coverage plus genuine-missing, unsafe-mode/symlink, and malformed-grant failure coverage.
- Observe the loader inside the real helper-backed `await_lock/1` path while the installer owns the lock and the grant remains unpublished.

This is a partial implementation of issue 145. The issue remains open after this delivery.

## Known residual and accepted partial-merge tradeoff

The shared lock retains the existing bounded `lockf -t 5` behavior. If a valid installer holds the lock longer than five seconds, the loader can still return `:beam_peer_grant_store_invalid`.

The final review also confirmed a narrower post-publication availability edge: because every load now takes the exclusive lock, a load can fail closed after the timeout even when a valid grant already exists but an idempotent installer or another operation retains the lock during durability work.

These outcomes remain fail-closed and do not weaken custody, authorization, or exact-generation validation. They are accepted only for this partial precursor; they are not the desired long-term contract.

No existing approved atom truthfully represents contention:

- `:beam_peer_grant_missing` must remain genuine absence and can trigger retrieval/install.
- `:beam_peer_grant_store_invalid` denotes unsafe or malformed custody.
- Credential, lifecycle, transport, and node-timeout atoms describe different conditions.

Issue #144 owns stable sanitized contention/helper/timeout classifications, retryability, caller behavior and bounds, telemetry, public-interface coverage, and any required SPEC or decision update. This PR does not invent an atom or steal that scope.

**SPEC impact of this partial diff: none.** No new public or operator-facing failure vocabulary is introduced. If #144 changes externally observable contention behavior, it must update the appropriate durable contract or decision material.

## Deterministic regression

Port `55145` was used for this worktree.

- Original RED reproduced the publication race: a loader returned transient `:beam_peer_grant_missing` while first installation was paused before publication.
- The amended regression pauses the installer while it owns the parent lock, starts `load/3`, and waits until the loader stack contains `BeamPeerGrantStore.await_lock/1`.
- Reaching that frame proves the loader passed identity and lock-candidate checks, opened the configured lock helper, submitted the marker, and entered the real acquisition wait. It does not claim proof of the exact kernel syscall instant.
- The test reasserts the final grant path is absent before resuming publication, then verifies both operations return the exact delivered grant.
- Focused regression: 1 passed, 32 excluded.
- Complete store file: 33 passed.
- Amended regression stress: 100/100 passed.
- Existing contention/publication slices: 2 passed, 31 excluded.

Failure coverage preserves:

- Genuine absence as `:beam_peer_grant_missing` without creating grant custody.
- Regular owner-UID `0600` parent lock custody.
- Unsafe store/grant modes and store/grant symlinks fail closed without repair.
- Malformed JSON remains invalid and unchanged.
- Existing credential-mismatch and expiry behavior.

## Independent review

All reviewers inspected the pinned range `bbd0f10a` → `b8530221` independently before final reconciliation:

| Review | Verdict |
|---|---|
| RP Design — Fable 5 High | `MERGE_AS_PARTIAL` |
| RepoPrompt Review workflow | `MERGE_AS_PARTIAL` |
| Grok adversarial review | `MERGE_AS_PARTIAL` |
| Cold Standards + Spec adjudication | `MERGE_AS_PARTIAL` |

The final adjudicator completed its own Standards + Spec pass before reading the other reports, then verified and reconciled their candidate findings. No code amendment was required.

Merge conditions:

- Keep issue 145 open and do not claim completion.
- Keep issue 145 open, residual, and blocked by #144.
- Preserve #144's taxonomy, retry-policy, telemetry, public-test, and contract-update scope.
- Do not add tests that ossify the current five-second `store_invalid` result as the desired contract.

Transient review reports remain under ignored `prompt-exports/` and are not committed.

## Validation at `b8530221`

Run from the umbrella root in the required order:

- `mise exec -- mix format` — passed.
- `mise exec -- mix compile --warnings-as-errors` — passed; zero warnings.
- `mise exec -- mix credo --strict` — passed; 633 files, 90 checks, zero findings, including ex_slop and ex_dna.
- `mise exec -- mix dialyzer` — passed; 0 errors, 0 skipped, 0 unnecessary skips.
- `ORCHARD_TEST_NODE_AGENT_PORT=55145 mise exec -- mix test` — passed:
  - orchard_shared: 290 passed
  - orchard_controller: 3,161 passed, 5 skipped
  - orchard_node_agent: 386 passed
  - orchard_cli: 695 passed, 10 excluded
  - total: 4,532 passed, 5 skipped, 10 excluded, 0 failures
- `ORCHARD_TEST_NODE_AGENT_PORT=55145 mise exec -- mix test --cover` — passed with the same test counts:
  - orchard_shared: 69.42%
  - orchard_controller: 84.9%
  - orchard_node_agent: 77.58%
  - orchard_cli: 79.03%
- `git diff --check` — passed.
- Required Orchard CI at exact head `b8530221` — passed.

## Commits

- `c25bea97` — serialize peer-grant loads with installation.
- `b8530221` — replace scheduler timing inference with a deterministic acquisition-path barrier.



