### PR TITLE
fix: enforce inference terminal event contract

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -101,7 +101,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
               terminal_source: :none,
               terminal_detail: :na,
               event_count: 0,
-              anomaly: :none
+              anomaly: :none,
+              conformance_defect: :none
 
     @type t :: %__MODULE__{
             request_id: String.t(),
@@ -117,12 +118,13 @@ defmodule Orchard.Dispatch.RequestDispatcher do
             terminal_monotonic_ms: integer() | nil,
             accepted_to_first_delta_ms: non_neg_integer() | :na,
             accepted_to_terminal_ms: non_neg_integer() | :na,
-            outcome: :ok | :model_load_failed | :dispatch_failed,
+            outcome: :ok | :model_load_failed | :dispatch_failed | :conformance_failed,
             terminal_kind: :completed | :failed | :none,
             terminal_source: :stream | :synthesized | :none,
             terminal_detail: String.t() | :na,
             event_count: non_neg_integer(),
-            anomaly: :none | :delta_before_accepted | :terminal_before_accepted
+            anomaly: :none | :delta_before_accepted | :terminal_before_accepted,
+            conformance_defect: :none | :missing_terminal | :duplicate_terminal | :post_terminal
           }
 
     @spec new(keyword()) :: t()
@@ -146,7 +148,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         terminal_source: :none,
         terminal_detail: :na,
         event_count: 0,
-        anomaly: :none
+        anomaly: :none,
+        conformance_defect: :none
       }
     end
   end
@@ -211,8 +214,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   - `:cancel_drain_timeout_ms` - bounded cancellation reconciliation grace period
                                  (default: the lesser of request timeout and 5 seconds)
 
-  Returns `{:ok, events}` with the list of all events received (including terminal),
-  or `{:error, reason}` if dispatch fails before streaming begins.
+  Returns `{:ok, events}` with the caller-visible event sequence and exactly one
+  terminal event. Invalid duplicate or post-terminal worker events are withheld
+  and replaced by a stable conformance failure. Returns `{:error, reason}` if
+  dispatch fails before streaming begins.
   Runtime Endpoint disconnect cleanup failures are logged and ignored after the
   dispatch outcome is known.
   """
@@ -966,9 +971,11 @@ defmodule Orchard.Dispatch.RequestDispatcher do
                 capacity_authority: capacity_authority,
                 capacity_node_id: capacity_node_id,
                 cancellation_started_before_acceptance?: false,
+                conformance_defect: :none,
                 metrics: metrics,
                 target: target,
                 task_ref: task_ref,
+                terminal_event: nil,
                 timer_ref: timer_ref
               },
               []
@@ -1000,43 +1007,17 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       metrics: metrics,
       task_ref: task_ref,
       timer_ref: timer_ref,
-      caller_ref: caller_ref,
-      event_handler: event_handler
+      caller_ref: caller_ref
     } = loop_ctx
 
     request_id = metrics.request_id
 
     receive do
       {:runtime_endpoint_event, ^task_ref, ^request_id, %InferenceEvent{} = event} ->
-        loop_ctx = maybe_record_acceptance(loop_ctx, event)
-        events = [event | events]
-        metrics = update_metrics_for_event(metrics, event)
-        handler_result = emit_event_safely(event, request_id, event_handler)
-
-        cond do
-          InferenceEvent.terminal?(event) ->
-            stream_terminal_result(loop_ctx, events, metrics)
-
-          handler_failed?(handler_result) ->
-            cancel_and_drain(
-              %{loop_ctx | metrics: metrics},
-              events,
-              :event_handler_failed
-            )
-
-          cancelled_by_handler?(handler_result) ->
-            cancel_and_drain(
-              %{loop_ctx | metrics: metrics},
-              events,
-              :client_disconnect
-            )
-
-          true ->
-            receive_loop(%{loop_ctx | metrics: metrics}, events)
-        end
+        handle_stream_event(loop_ctx, events, event)
 
       {:runtime_endpoint_done, ^task_ref, :ok} ->
-        stream_terminal_result(loop_ctx, events, metrics)
+        stream_done_result(loop_ctx, events, metrics)
 
       {:runtime_endpoint_done, ^task_ref, {:error, reason}} ->
         mark_transport_failure(target, reason)
@@ -1050,6 +1031,44 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     end
   end
 
+  defp handle_stream_event(%{terminal_event: nil} = loop_ctx, events, event) do
+    metrics = update_metrics_for_event(loop_ctx.metrics, event)
+
+    if InferenceEvent.terminal?(event) do
+      receive_loop(%{loop_ctx | metrics: metrics, terminal_event: event}, events)
+    else
+      loop_ctx = maybe_record_acceptance(loop_ctx, event)
+      handler_result = emit_event_safely(event, metrics.request_id, loop_ctx.event_handler)
+      events = [event | events]
+
+      cond do
+        handler_failed?(handler_result) ->
+          cancel_and_drain(%{loop_ctx | metrics: metrics}, events, :event_handler_failed)
+
+        cancelled_by_handler?(handler_result) ->
+          cancel_and_drain(%{loop_ctx | metrics: metrics}, events, :client_disconnect)
+
+        true ->
+          receive_loop(%{loop_ctx | metrics: metrics}, events)
+      end
+    end
+  end
+
+  defp handle_stream_event(%{terminal_event: %InferenceEvent{}} = loop_ctx, events, event) do
+    defect = if InferenceEvent.terminal?(event), do: :duplicate_terminal, else: :post_terminal
+
+    loop_ctx = %{
+      loop_ctx
+      | conformance_defect: first_conformance_defect(loop_ctx.conformance_defect, defect),
+        metrics: increment_event_count(loop_ctx.metrics)
+    }
+
+    receive_loop(loop_ctx, events)
+  end
+
+  defp first_conformance_defect(:none, defect), do: defect
+  defp first_conformance_defect(defect, _later_defect), do: defect
+
   defp maybe_record_acceptance(
          %{acceptance_gate: acceptance_gate} = loop_ctx,
          %InferenceEvent{event: %InferenceEvent.Accepted{}}
@@ -1059,6 +1078,20 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp maybe_record_acceptance(loop_ctx, _event), do: loop_ctx
+
+  defp stream_error_result(
+         %{
+           accepted?: true,
+           cancellation_started_before_acceptance?: false,
+           conformance_defect: defect
+         } = loop_ctx,
+         events,
+         metrics,
+         _reason
+       )
+       when defect != :none do
+    synthesize_terminal_contract_failure(loop_ctx, events, metrics, defect)
+  end
 
   defp stream_error_result(
          %{accepted?: true, cancellation_started_before_acceptance?: false} = loop_ctx,
@@ -1080,6 +1113,62 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   defp stream_error_result(_loop_ctx, _events, _metrics, reason),
     do: {:error, {:dispatch_failed, reason}}
+
+  defp stream_done_result(
+         %{accepted?: true, cancellation_started_before_acceptance?: false} = loop_ctx,
+         events,
+         metrics
+       ) do
+    case {loop_ctx.terminal_event, loop_ctx.conformance_defect} do
+      {nil, :none} ->
+        synthesize_terminal_contract_failure(loop_ctx, events, metrics, :missing_terminal)
+
+      {%InferenceEvent{} = terminal_event, :none} ->
+        _handler_result =
+          emit_event_safely(terminal_event, metrics.request_id, loop_ctx.event_handler)
+
+        stream_terminal_result(loop_ctx, [terminal_event | events], metrics)
+
+      {%InferenceEvent{}, defect} ->
+        synthesize_terminal_contract_failure(loop_ctx, events, metrics, defect)
+    end
+  end
+
+  defp stream_done_result(loop_ctx, events, metrics),
+    do: stream_terminal_result(loop_ctx, events, metrics)
+
+  defp synthesize_terminal_contract_failure(loop_ctx, events, metrics, defect) do
+    {code, message} = terminal_contract_failure(defect)
+
+    failed_event =
+      InferenceEvent.failed(code, message, false)
+
+    _handler_result =
+      emit_event_safely(failed_event, metrics.request_id, loop_ctx.event_handler)
+
+    metrics =
+      metrics
+      |> increment_event_count()
+      |> update_metrics_for_terminal(failed_event, :synthesized)
+      |> Map.put(:conformance_defect, defect)
+
+    stream_terminal_result(loop_ctx, [failed_event | events], metrics)
+  end
+
+  defp terminal_contract_failure(:missing_terminal),
+    do:
+      {"runtime_endpoint_missing_terminal",
+       "Runtime Endpoint stream ended without a terminal event"}
+
+  defp terminal_contract_failure(:duplicate_terminal),
+    do:
+      {"runtime_endpoint_duplicate_terminal",
+       "Runtime Endpoint stream emitted more than one terminal event"}
+
+  defp terminal_contract_failure(:post_terminal),
+    do:
+      {"runtime_endpoint_post_terminal_event",
+       "Runtime Endpoint stream emitted an event after its terminal event"}
 
   defp stream_terminal_result(loop_ctx, events, metrics),
     do: stream_terminal_result(loop_ctx, events, metrics, nil)
@@ -1122,6 +1211,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
     if cancel_reason == :event_handler_failed do
       case result do
+        {:ok, _events, %Metrics{conformance_defect: defect}} when defect != :none -> result
         {:ok, _events, _metrics} -> {:error, {:dispatch_failed, :event_handler_failed}}
         {:error, _reason} = error -> error
       end
@@ -1144,8 +1234,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp drain_until_terminal_or_done(%{} = loop_ctx, events, cancel_reason, cancel_deadline) do
     %{
       task_ref: task_ref,
-      metrics: metrics,
-      event_handler: event_handler
+      metrics: metrics
     } = loop_ctx
 
     request_id = metrics.request_id
@@ -1154,24 +1243,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     if remaining_ms > 0 do
       receive do
         {:runtime_endpoint_event, ^task_ref, ^request_id, %InferenceEvent{} = event} ->
-          loop_ctx = maybe_record_acceptance(loop_ctx, event)
-          _handler_result = emit_event_safely(event, request_id, event_handler)
-          events = [event | events]
-          metrics = update_metrics_for_event(metrics, event)
-
-          if InferenceEvent.terminal?(event) do
-            stream_terminal_result(loop_ctx, events, metrics, cancel_reason)
-          else
-            drain_until_terminal_or_done(
-              %{loop_ctx | metrics: metrics},
-              events,
-              cancel_reason,
-              cancel_deadline
-            )
-          end
+          handle_drain_event(loop_ctx, events, event, cancel_reason, cancel_deadline)
 
         {:runtime_endpoint_done, ^task_ref, _result} ->
-          synthesize_cancel_terminal(loop_ctx, events, cancel_reason, "")
+          drain_done_result(loop_ctx, events, cancel_reason)
       after
         remaining_ms -> cancel_drain_timeout_result(loop_ctx, events, cancel_reason)
       end
@@ -1180,9 +1255,78 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     end
   end
 
+  defp handle_drain_event(%{terminal_event: nil} = loop_ctx, events, event, reason, deadline) do
+    metrics = update_metrics_for_event(loop_ctx.metrics, event)
+
+    if InferenceEvent.terminal?(event) do
+      drain_until_terminal_or_done(
+        %{loop_ctx | metrics: metrics, terminal_event: event},
+        events,
+        reason,
+        deadline
+      )
+    else
+      loop_ctx = maybe_record_acceptance(loop_ctx, event)
+      _handler_result = emit_event_safely(event, metrics.request_id, loop_ctx.event_handler)
+
+      drain_until_terminal_or_done(
+        %{loop_ctx | metrics: metrics},
+        [event | events],
+        reason,
+        deadline
+      )
+    end
+  end
+
+  defp handle_drain_event(
+         %{terminal_event: %InferenceEvent{}} = loop_ctx,
+         events,
+         event,
+         reason,
+         deadline
+       ) do
+    defect = if InferenceEvent.terminal?(event), do: :duplicate_terminal, else: :post_terminal
+
+    loop_ctx = %{
+      loop_ctx
+      | conformance_defect: first_conformance_defect(loop_ctx.conformance_defect, defect),
+        metrics: increment_event_count(loop_ctx.metrics)
+    }
+
+    drain_until_terminal_or_done(loop_ctx, events, reason, deadline)
+  end
+
+  defp drain_done_result(%{conformance_defect: defect} = loop_ctx, events, _cancel_reason)
+       when defect != :none do
+    synthesize_terminal_contract_failure(loop_ctx, events, loop_ctx.metrics, defect)
+  end
+
+  defp drain_done_result(
+         %{terminal_event: %InferenceEvent{} = terminal_event} = loop_ctx,
+         events,
+         cancel_reason
+       ) do
+    _handler_result =
+      emit_event_safely(terminal_event, loop_ctx.metrics.request_id, loop_ctx.event_handler)
+
+    stream_terminal_result(
+      loop_ctx,
+      [terminal_event | events],
+      loop_ctx.metrics,
+      cancel_reason
+    )
+  end
+
+  defp drain_done_result(loop_ctx, events, cancel_reason),
+    do: synthesize_cancel_terminal(loop_ctx, events, cancel_reason, "")
+
   defp cancel_drain_timeout_result(loop_ctx, events, cancel_reason) do
     reconcile_cancel_drain_timeout(loop_ctx)
-    synthesize_cancel_terminal(loop_ctx, events, cancel_reason, " after drain timeout")
+
+    case loop_ctx.conformance_defect do
+      :none -> synthesize_cancel_terminal(loop_ctx, events, cancel_reason, " after drain timeout")
+      defect -> synthesize_terminal_contract_failure(loop_ctx, events, loop_ctx.metrics, defect)
+    end
   end
 
   defp synthesize_cancel_terminal(loop_ctx, events, cancel_reason, message_suffix) do
@@ -1619,11 +1763,16 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         "terminal_detail=#{serialize_na(metrics.terminal_detail)} " <>
         "outcome=#{metrics.outcome} " <>
         "event_count=#{metrics.event_count} " <>
-        "anomaly=#{metrics.anomaly}"
+        "anomaly=#{metrics.anomaly} " <>
+        "conformance_defect=#{metrics.conformance_defect}"
     )
   end
 
-  # For successful streams, finalize_metrics is not used - result already has final_metrics
+  defp finalize_metrics(%Metrics{conformance_defect: defect} = metrics, :ok)
+       when defect != :none do
+    %{metrics | outcome: :conformance_failed}
+  end
+
   defp finalize_metrics(%Metrics{} = metrics, :ok) do
     %{metrics | outcome: :ok}
   end

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -29,6 +29,7 @@ defmodule Orchard.Inference.ChatError do
           | :request_cancelled
           | :request_interrupted
           | :request_failed
+          | :runtime_endpoint_conformance
           | :orchestration_crash
           | :internal
 
@@ -310,6 +311,16 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def api_mapping(%__MODULE__{kind: :runtime_endpoint_conformance}) do
+    %{
+      status: :internal_server_error,
+      type: "api_error",
+      code: "internal_error",
+      message: "Internal error",
+      param: nil
+    }
+  end
+
   def api_mapping(%__MODULE__{kind: :orchestration_crash}) do
     %{
       status: :internal_server_error,
@@ -343,6 +354,15 @@ defmodule Orchard.Inference.ChatError do
     |> ModelLoadFailure.api_mapping()
     |> Map.delete(:status)
     |> Map.put(:param, nil)
+  end
+
+  def sse_mapping(%__MODULE__{kind: :runtime_endpoint_conformance}) do
+    %{
+      type: "server_error",
+      code: "internal_error",
+      message: "Internal error",
+      param: nil
+    }
   end
 
   def sse_mapping(%__MODULE__{kind: kind} = error) when kind in @sse_passthrough_kinds do
@@ -445,6 +465,15 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def terminal_attrs(%__MODULE__{kind: :runtime_endpoint_conformance} = error) do
+    %{
+      state: :failed,
+      http_status: 500,
+      error_code: error.source_code,
+      error_message: error.source_message
+    }
+  end
+
   def terminal_attrs(%__MODULE__{kind: :request_failed} = error) do
     %{
       state: :failed,
@@ -500,6 +529,14 @@ defmodule Orchard.Inference.ChatError do
   defp failed_event_kind(code)
        when code in ["request_client_disconnect", "request_caller_disconnect"],
        do: :request_interrupted
+
+  defp failed_event_kind(code)
+       when code in [
+              "runtime_endpoint_missing_terminal",
+              "runtime_endpoint_duplicate_terminal",
+              "runtime_endpoint_post_terminal_event"
+            ],
+       do: :runtime_endpoint_conformance
 
   defp failed_event_kind(_code), do: :request_failed
 

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -1312,7 +1312,10 @@ defmodule Orchard.Inference.RequestOrchestrator do
     base_attrs =
       case Enum.find(events, &InferenceEvent.terminal?/1) do
         nil ->
-          %{state: :completed, http_status: 200}
+          terminal_conformance_failure_attrs(
+            "runtime_endpoint_missing_terminal",
+            "Runtime Endpoint stream ended without a terminal event"
+          )
 
         %{event: %InferenceEvent.Completed{}} ->
           %{state: :completed, http_status: 200}
@@ -1324,6 +1327,13 @@ defmodule Orchard.Inference.RequestOrchestrator do
       end
 
     Map.merge(base_attrs, usage)
+  end
+
+  defp terminal_conformance_failure_attrs(code, message) do
+    code
+    |> InferenceEvent.failed(message, false)
+    |> ChatError.from_failed_event()
+    |> ChatError.terminal_attrs()
   end
 
   defp inference_turn_step_context(canonical) do

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -813,6 +813,36 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
                "Inference failed: model did not emit any required tool calls"
     end
 
+    test "SPEC 7.5.5 non-stream terminal conformance failure is a generic 500" do
+      canonical = stub_chat_canonical(false)
+
+      stub_chat_orchestrator(
+        prepare: {:ok, canonical, %{}},
+        execute:
+          {:ok, canonical,
+           [
+             InferenceEvent.accepted(1_710_000_123_000),
+             InferenceEvent.failed(
+               "runtime_endpoint_missing_terminal",
+               "Runtime Endpoint stream ended without a terminal event",
+               false
+             )
+           ]}
+      )
+
+      conn =
+        post_chat(%{
+          "model" => "stub-tool-model@v1",
+          "messages" => [%{"role" => "user", "content" => "hello"}]
+        })
+
+      assert conn.status == 500
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"]["type"] == "api_error"
+      assert body["error"]["code"] == "internal_error"
+      assert body["error"]["message"] == "Internal error"
+    end
+
     @tag :db
     test "queue admission enabled queues overlapping same-model chat completions", %{
       bundle: bundle
@@ -1230,6 +1260,37 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
                _other -> false
              end)
 
+      refute Enum.any?(events, fn {type, _payload} -> type == :done end)
+    end
+
+    test "SPEC 7.5.5 streaming terminal conformance failure emits one generic SSE error" do
+      stub_chat_orchestrator(
+        prepare: {:ok, stub_chat_canonical(), %{}},
+        events: [
+          InferenceEvent.accepted(1_710_000_123_000),
+          InferenceEvent.failed(
+            "runtime_endpoint_missing_terminal",
+            "Runtime Endpoint stream ended without a terminal event",
+            false
+          )
+        ],
+        execute: {:ok, stub_chat_canonical(), []}
+      )
+
+      conn =
+        post_chat(%{
+          "model" => "stub-tool-model@v1",
+          "messages" => [%{"role" => "user", "content" => "hello"}],
+          "stream" => true
+        })
+
+      assert conn.status == 200
+      events = parse_sse_body(conn.resp_body)
+
+      assert [{:error, payload}] = Enum.filter(events, fn {type, _payload} -> type == :error end)
+      assert payload["error"]["type"] == "server_error"
+      assert payload["error"]["code"] == "internal_error"
+      assert payload["error"]["message"] == "Internal error"
       refute Enum.any?(events, fn {type, _payload} -> type == :done end)
     end
 

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -452,6 +452,32 @@ defmodule Orchard.API.ResponsesControllerTest do
              "Inference failed: model emitted tool call outside required function lookup_weather"
   end
 
+  test "SPEC 7.5.5 sync terminal conformance failure is a generic 500" do
+    canonical = stub_responses_canonical(false)
+
+    stub_responses_orchestrator(
+      prepare: {:ok, canonical, %{}},
+      execute:
+        {:ok, canonical,
+         [
+           InferenceEvent.accepted(1_710_000_123_000),
+           InferenceEvent.failed(
+             "runtime_endpoint_missing_terminal",
+             "Runtime Endpoint stream ended without a terminal event",
+             false
+           )
+         ]}
+    )
+
+    conn = post_responses(%{"model" => "stub-tool-model@v1", "input" => "hello"})
+
+    assert conn.status == 500
+    body = Jason.decode!(conn.resp_body)
+    assert body["error"]["type"] == "api_error"
+    assert body["error"]["code"] == "internal_error"
+    assert body["error"]["message"] == "Internal error"
+  end
+
   test "queue admission enabled queues overlapping same-model responses requests", %{
     bundle: bundle
   } do
@@ -1208,6 +1234,39 @@ defmodule Orchard.API.ResponsesControllerTest do
 
     body = collect_chunked_body(conn)
     refute String.contains?(body, "[DONE]")
+  end
+
+  test "SPEC 7.5.5 streaming terminal conformance failure emits response.failed" do
+    stub_responses_orchestrator(
+      prepare: {:ok, stub_responses_canonical(true), %{}},
+      events: [
+        InferenceEvent.accepted(1_710_000_123_000),
+        InferenceEvent.failed(
+          "runtime_endpoint_missing_terminal",
+          "Runtime Endpoint stream ended without a terminal event",
+          false
+        )
+      ],
+      execute: {:ok, stub_responses_canonical(true), []}
+    )
+
+    conn =
+      post_responses(%{
+        "model" => "stub-tool-model@v1",
+        "input" => "hello",
+        "stream" => true
+      })
+
+    assert conn.status == 200
+    events = parse_typed_sse_events(conn)
+    assert Enum.map(events, & &1.type) == ["response.created", "response.failed"]
+
+    terminal = List.last(events)
+    assert terminal.data["response"]["status"] == "failed"
+    assert terminal.data["response"]["error"]["type"] == "server_error"
+    assert terminal.data["response"]["error"]["code"] == "internal_error"
+    assert terminal.data["response"]["error"]["message"] == "Internal error"
+    refute String.contains?(collect_chunked_body(conn), "[DONE]")
   end
 
   test "post-start failure emits response.created then response.failed with no [DONE]" do

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -46,6 +46,78 @@ defmodule Orchard.Dispatch.DispatchTest.DisconnectRaisingClient do
   def cancel_inference(_channel, %Operation.CancelRequest{}, _opts \\ []), do: :ok
 end
 
+defmodule Orchard.Dispatch.DispatchTest.TerminalContractClient do
+  @moduledoc false
+
+  alias Orchard.Dispatch.DispatchTest.DisconnectRaisingClient
+  alias Orchard.InferenceEvent
+  alias Orchard.InferenceEvent.Usage
+  alias Orchard.RuntimeEndpoint.Operation
+
+  def connect(_target), do: {:ok, :terminal_contract_channel}
+
+  defdelegate status(channel, opts), to: DisconnectRaisingClient
+  defdelegate ensure_model_loaded(channel, request, opts), to: DisconnectRaisingClient
+
+  def disconnect(_channel), do: {:ok, :disconnected}
+
+  def execute_inference(_channel, %Operation.ExecuteRequest{} = request, opts \\ []) do
+    owner = Keyword.get(opts, :owner, self())
+    ref = make_ref()
+
+    request.request_id
+    |> events_for()
+    |> Enum.each(fn event ->
+      send(owner, {:runtime_endpoint_event, ref, request.request_id, event})
+    end)
+
+    send(owner, {:runtime_endpoint_done, ref, done_result(request.request_id)})
+
+    {:ok, ref}
+  end
+
+  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts \\ []), do: :ok
+
+  defp events_for("req-dispatch-duplicate-terminal") do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.completed(:finish_reason_stop, nil),
+      InferenceEvent.failed("late_terminal", "late terminal", false)
+    ]
+  end
+
+  defp events_for("req-dispatch-post-terminal-error") do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.completed(:finish_reason_stop, nil),
+      InferenceEvent.output_text_delta("late")
+    ]
+  end
+
+  defp events_for("req-dispatch-post-terminal-" <> event_kind) do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.completed(:finish_reason_stop, nil),
+      post_terminal_event(event_kind)
+    ]
+  end
+
+  defp events_for(_request_id), do: [InferenceEvent.accepted(0)]
+
+  defp done_result("req-dispatch-post-terminal-error"), do: {:error, :stream_failed}
+  defp done_result(_request_id), do: :ok
+
+  defp post_terminal_event("accepted"), do: InferenceEvent.accepted(1)
+  defp post_terminal_event("output-text-delta"), do: InferenceEvent.output_text_delta("late")
+  defp post_terminal_event("tool-call-delta"), do: InferenceEvent.tool_call_delta("call-1", "{}")
+
+  defp post_terminal_event("usage") do
+    InferenceEvent.usage_update(%Usage{input_tokens: 1, output_tokens: 1, total_tokens: 2})
+  end
+
+  defp post_terminal_event("progress"), do: InferenceEvent.progress("late", "late progress")
+end
+
 defmodule Orchard.Dispatch.DispatchTest.NoConnectClient do
   @moduledoc false
 
@@ -80,6 +152,7 @@ defmodule Orchard.Dispatch.DispatchTest do
 
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
   import Orchard.TestSupport.SentryContextHelpers
 
   alias Orchard.ArtifactBundle
@@ -265,6 +338,137 @@ defmodule Orchard.Dispatch.DispatchTest do
       assert deltas == ["orchard ", "ready"]
     end
 
+    test "SPEC 7.5.5: accepted stream without a terminal becomes one failed terminal", %{
+      bundle: bundle
+    } do
+      request_id = "req-dispatch-missing-terminal"
+
+      handler = fn received_request_id, event ->
+        send(self(), {:handler_event, received_request_id, event})
+      end
+
+      assert {:ok, [accepted, failed]} =
+               RequestDispatcher.dispatch(
+                 build_schedule(request_id),
+                 execute_request(request_id),
+                 model_load_request(bundle),
+                 client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient,
+                 event_handler: handler
+               )
+
+      assert InferenceEvent.kind(accepted) == :accepted
+      assert %InferenceEvent{event: %InferenceEvent.Failed{code: code}} = failed
+      assert code == "runtime_endpoint_missing_terminal"
+      assert_received {:handler_event, ^request_id, ^accepted}
+      assert_received {:handler_event, ^request_id, ^failed}
+      refute_received {:handler_event, ^request_id, _event}
+    end
+
+    test "SPEC 7.5.5: duplicate terminal becomes one conformance failure", %{
+      bundle: bundle
+    } do
+      request_id = "req-dispatch-duplicate-terminal"
+
+      handler = fn received_request_id, event ->
+        send(self(), {:handler_event, received_request_id, event})
+      end
+
+      assert {:ok, [accepted, failed]} =
+               RequestDispatcher.dispatch(
+                 build_schedule(request_id),
+                 execute_request(request_id),
+                 model_load_request(bundle),
+                 client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient,
+                 event_handler: handler
+               )
+
+      assert InferenceEvent.kind(accepted) == :accepted
+      assert %InferenceEvent{event: %InferenceEvent.Failed{code: code}} = failed
+      assert code == "runtime_endpoint_duplicate_terminal"
+      assert_received {:handler_event, ^request_id, ^accepted}
+      assert_received {:handler_event, ^request_id, ^failed}
+      refute_received {:handler_event, ^request_id, _event}
+    end
+
+    test "SPEC 7.5.5: every nonterminal event after terminal becomes one failure", %{
+      bundle: bundle
+    } do
+      for event_kind <- ["accepted", "output-text-delta", "tool-call-delta", "usage", "progress"] do
+        request_id = "req-dispatch-post-terminal-#{event_kind}"
+
+        handler = fn received_request_id, event ->
+          send(self(), {:handler_event, received_request_id, event})
+        end
+
+        assert {:ok, [accepted, failed]} =
+                 RequestDispatcher.dispatch(
+                   build_schedule(request_id),
+                   execute_request(request_id),
+                   model_load_request(bundle),
+                   client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient,
+                   event_handler: handler
+                 )
+
+        assert InferenceEvent.kind(accepted) == :accepted
+        assert %InferenceEvent{event: %InferenceEvent.Failed{code: code}} = failed
+        assert code == "runtime_endpoint_post_terminal_event"
+        assert_received {:handler_event, ^request_id, ^accepted}
+        assert_received {:handler_event, ^request_id, ^failed}
+        refute_received {:handler_event, ^request_id, _event}
+      end
+    end
+
+    test "SPEC 7.5.5: observed post-terminal defect survives a later stream error", %{
+      bundle: bundle
+    } do
+      request_id = "req-dispatch-post-terminal-error"
+
+      assert {:ok, [accepted, failed]} =
+               RequestDispatcher.dispatch(
+                 build_schedule(request_id),
+                 execute_request(request_id),
+                 model_load_request(bundle),
+                 client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient
+               )
+
+      assert InferenceEvent.kind(accepted) == :accepted
+      assert %InferenceEvent{event: %InferenceEvent.Failed{code: code}} = failed
+      assert code == "runtime_endpoint_post_terminal_event"
+    end
+
+    test "terminal conformance metrics distinguish each protocol defect", %{bundle: bundle} do
+      previous_level = Logger.level()
+      Logger.configure(level: :info)
+      on_exit(fn -> Logger.configure(level: previous_level) end)
+      enable_controller_sentry()
+
+      defects = [
+        {"req-dispatch-missing-terminal", "missing_terminal"},
+        {"req-dispatch-duplicate-terminal", "duplicate_terminal"},
+        {"req-dispatch-post-terminal-output-text-delta", "post_terminal"}
+      ]
+
+      for {request_id, defect} <- defects do
+        log =
+          capture_log([level: :info], fn ->
+            assert {:ok, [_accepted, %InferenceEvent{event: %InferenceEvent.Failed{}}]} =
+                     RequestDispatcher.dispatch(
+                       build_schedule(request_id),
+                       execute_request(request_id),
+                       model_load_request(bundle),
+                       client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient
+                     )
+          end)
+
+        assert log =~ "conformance_defect=#{defect}"
+        assert log =~ "outcome=conformance_failed"
+
+        context = sentry_context()
+        assert context.tags.failure_category == "conformance_failed"
+        assert context.extra.orchard_conformance_defect == String.to_existing_atom(defect)
+      end
+    end
+
     test "returns streamed events when disconnect cleanup raises", %{bundle: bundle} do
       schedule = build_schedule("req-dispatch-cleanup-raises")
       execute = execute_request("req-dispatch-cleanup-raises")
@@ -365,14 +569,24 @@ defmodule Orchard.Dispatch.DispatchTest do
       # Dispatch in a separate process, monitoring the caller
       dispatch_pid =
         spawn(fn ->
+          event_handler = fn
+            _request_id, %InferenceEvent{event: %InferenceEvent.Accepted{}} ->
+              send(test_pid, :dispatch_accepted)
+
+            _request_id, _event ->
+              :ok
+          end
+
           result =
-            RequestDispatcher.dispatch(schedule, execute, model_load, caller: caller)
+            RequestDispatcher.dispatch(schedule, execute, model_load,
+              caller: caller,
+              event_handler: event_handler
+            )
 
           send(test_pid, {:dispatch_result, result})
         end)
 
-      # Give dispatch a moment to connect and start
-      Process.sleep(50)
+      assert_receive :dispatch_accepted, 10_000
 
       # Kill the caller to simulate disconnect
       Process.exit(caller, :kill)

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -224,6 +224,52 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.NonterminalThenErr
   defdelegate cancel_inference(channel, request, opts), to: GateClient
 end
 
+defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.TerminalDefectClient do
+  @moduledoc false
+
+  alias Orchard.DispatchCapacity.RequestDispatcherClaimTest.GateClient
+  alias Orchard.InferenceEvent
+
+  defdelegate connect(target), to: GateClient
+  defdelegate disconnect(channel), to: GateClient
+  defdelegate status(channel, opts), to: GateClient
+  defdelegate ensure_model_loaded(channel, request, opts), to: GateClient
+
+  def execute_inference(_channel, request, opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    task_ref = make_ref()
+
+    request.request_id
+    |> events_for()
+    |> Enum.each(fn event ->
+      send(owner, {:runtime_endpoint_event, task_ref, request.request_id, event})
+    end)
+
+    send(owner, {:runtime_endpoint_done, task_ref, :ok})
+    {:ok, task_ref}
+  end
+
+  defdelegate cancel_inference(channel, request, opts), to: GateClient
+
+  defp events_for("request-terminal-defect-missing"), do: [InferenceEvent.accepted(0)]
+
+  defp events_for("request-terminal-defect-duplicate") do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.completed(:finish_reason_stop, nil),
+      InferenceEvent.failed("late_terminal", "late terminal", false)
+    ]
+  end
+
+  defp events_for("request-terminal-defect-post") do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.completed(:finish_reason_stop, nil),
+      InferenceEvent.output_text_delta("late")
+    ]
+  end
+end
+
 defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.CancellableStreamClient do
   @moduledoc false
 
@@ -272,7 +318,21 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.CancellableStreamC
                    InferenceEvent.failed("cancelled", "cancelled", false)}
                 )
 
-                send(owner, {:runtime_endpoint_done, task_ref, :ok})
+                if request.request_id in [
+                     "request-cancel-post-terminal",
+                     "request-cancel-post-terminal-timeout",
+                     "request-handler-failure-post-terminal"
+                   ] do
+                  send(
+                    owner,
+                    {:runtime_endpoint_event, task_ref, request.request_id,
+                     InferenceEvent.output_text_delta("late after cancellation terminal")}
+                  )
+                end
+
+                unless request.request_id == "request-cancel-post-terminal-timeout" do
+                  send(owner, {:runtime_endpoint_done, task_ref, :ok})
+                end
             end
         end
       end)
@@ -609,6 +669,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     PreAcceptanceCancelClient,
     ProductionFreshStatusClient,
     SlowLoadClient,
+    TerminalDefectClient,
     TerminalBeforeAcceptedClient,
     UnprobeableClient
   }
@@ -625,6 +686,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
   @unprobeable_client UnprobeableClient
   @production_fresh_status_client ProductionFreshStatusClient
   @slow_load_client SlowLoadClient
+  @terminal_defect_client TerminalDefectClient
 
   # The request timeout now bounds connect, probe, and acceptance-gate waiting
   # as well as streaming, so it must outlast dispatch setup or the request
@@ -867,6 +929,30 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
+  test "SPEC 7.5.5 terminal defects release claim and acceptance gate resources" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+
+    for defect <- ["missing", "duplicate", "post"] do
+      node_id = claim_node_id()
+      request_id = "request-terminal-defect-#{defect}"
+
+      assert {:ok, events} =
+               RequestDispatcher.dispatch(
+                 capacity_schedule(authority, node_id, request_id),
+                 execute_request(request_id),
+                 model_load_request(node_id),
+                 client_impl: @terminal_defect_client
+               )
+
+      assert [%InferenceEvent{event: %InferenceEvent.Failed{}}] =
+               Enum.filter(events, &InferenceEvent.terminal?/1)
+
+      assert AllocationAuthority.claim_count(authority, node_id) == 0
+      assert {:ok, lease} = QueueManager.acquire_acceptance_gate(node_id, authority: authority)
+      assert :ok = QueueManager.release_acceptance_gate(lease, authority: authority)
+    end
+  end
+
   test "SPEC 5.9 managed dispatch rejects cached capacity without fresh providers" do
     node_id = claim_node_id()
     request_id = "request-cached-capacity-authorization"
@@ -1086,6 +1172,112 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     send(emitter, :finish_cancel)
 
     assert {:error, {:dispatch_failed, :event_handler_failed}} = Task.await(dispatch)
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC 7.5.5 cancellation drain detects an event after terminal" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-cancel-post-terminal"
+
+    dispatch =
+      Task.async(fn ->
+        RequestDispatcher.dispatch(
+          capacity_schedule(authority, node_id, request_id),
+          execute_request(request_id),
+          model_load_request(node_id),
+          client_impl: @cancellable_stream_client,
+          event_handler: fn
+            _request_id, %InferenceEvent{event: %InferenceEvent.OutputTextDelta{}} -> :cancel
+            _request_id, _event -> :ok
+          end
+        )
+      end)
+
+    assert_receive {:cancel_received, emitter}
+    assert AllocationAuthority.claim_count(authority, node_id) == 1
+    send(emitter, :finish_cancel)
+
+    assert {:ok, events} = Task.await(dispatch)
+
+    assert [%InferenceEvent{event: %InferenceEvent.Failed{code: code}}] =
+             Enum.filter(events, &InferenceEvent.terminal?/1)
+
+    assert code == "runtime_endpoint_post_terminal_event"
+
+    refute Enum.any?(
+             events,
+             &(InferenceEvent.kind(&1) == :output_text_delta and &1.event.delta =~ "late")
+           )
+
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC 7.5.5 cancellation drain timeout preserves an observed post-terminal defect" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-cancel-post-terminal-timeout"
+
+    dispatch =
+      Task.async(fn ->
+        RequestDispatcher.dispatch(
+          capacity_schedule(authority, node_id, request_id),
+          execute_request(request_id),
+          model_load_request(node_id),
+          client_impl: @cancellable_stream_client,
+          cancel_drain_timeout_ms: 20,
+          event_handler: fn
+            _request_id, %InferenceEvent{event: %InferenceEvent.OutputTextDelta{}} -> :cancel
+            _request_id, _event -> :ok
+          end
+        )
+      end)
+
+    assert_receive {:cancel_received, emitter}
+    assert AllocationAuthority.claim_count(authority, node_id) == 1
+    send(emitter, :finish_cancel)
+
+    assert {:ok, events} = Task.await(dispatch)
+
+    assert [%InferenceEvent{event: %InferenceEvent.Failed{code: code}}] =
+             Enum.filter(events, &InferenceEvent.terminal?/1)
+
+    assert code == "runtime_endpoint_post_terminal_event"
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC 7.5.5 handler failure preserves a post-terminal defect observed while draining" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-handler-failure-post-terminal"
+
+    dispatch =
+      Task.async(fn ->
+        RequestDispatcher.dispatch(
+          capacity_schedule(authority, node_id, request_id),
+          execute_request(request_id),
+          model_load_request(node_id),
+          client_impl: @cancellable_stream_client,
+          event_handler: fn
+            _request_id, %InferenceEvent{event: %InferenceEvent.OutputTextDelta{}} ->
+              raise "delta handler failed"
+
+            _request_id, _event ->
+              :ok
+          end
+        )
+      end)
+
+    assert_receive {:cancel_received, emitter}
+    assert AllocationAuthority.claim_count(authority, node_id) == 1
+    send(emitter, :finish_cancel)
+
+    assert {:ok, events} = Task.await(dispatch)
+
+    assert [%InferenceEvent{event: %InferenceEvent.Failed{code: code}}] =
+             Enum.filter(events, &InferenceEvent.terminal?/1)
+
+    assert code == "runtime_endpoint_post_terminal_event"
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 

--- a/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
@@ -137,6 +137,43 @@ defmodule Orchard.Inference.ChatErrorTest do
            }
   end
 
+  test "terminal conformance failures stay generic publicly and specific durably" do
+    failures = [
+      {"runtime_endpoint_missing_terminal", "stream ended without a terminal"},
+      {"runtime_endpoint_duplicate_terminal", "stream emitted duplicate terminals"},
+      {"runtime_endpoint_post_terminal_event", "stream emitted a late event"}
+    ]
+
+    for {code, message} <- failures do
+      error =
+        code
+        |> InferenceEvent.failed(message, false)
+        |> ChatError.from_failed_event()
+
+      assert ChatError.api_mapping(error) == %{
+               status: :internal_server_error,
+               type: "api_error",
+               code: "internal_error",
+               message: "Internal error",
+               param: nil
+             }
+
+      assert ChatError.sse_mapping(error) == %{
+               type: "server_error",
+               code: "internal_error",
+               message: "Internal error",
+               param: nil
+             }
+
+      assert ChatError.terminal_attrs(error) == %{
+               state: :failed,
+               http_status: 500,
+               error_code: code,
+               error_message: message
+             }
+    end
+  end
+
   test "cancelled event persists cancelled state and controller message" do
     event = InferenceEvent.failed("request_cancelled", "request was cancelled upstream", false)
     error = ChatError.from_failed_event(event)

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -2180,7 +2180,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
   end
 
-  test "execute/3 leaves a durable missing-terminal detector candidate after the request process exits",
+  test "SPEC 7.5.5: execute/3 persists a missing terminal as a durable failure",
        %{bundle: bundle} do
     target = [host: "10.0.0.1", port: 50_061]
     node = insert_runtime_node!(target)
@@ -2195,24 +2195,30 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       canonical_request("request-orchestrator-missing-terminal-detector", stream?: false)
 
     assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
-    assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted]
-    assert TerminalCardinality.classify(events) == :zero
+    assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted, :failed]
+    assert TerminalCardinality.classify(events) == :exactly_one
+
+    assert %InferenceEvent{
+             event: %InferenceEvent.Failed{code: "runtime_endpoint_missing_terminal"}
+           } = List.last(events)
 
     request = Requests.get_request_by_public_id(canonical.public_id)
-    assert request.state == :completed
-    assert request.http_status == 200
+    assert request.state == :failed
+    assert request.http_status == 500
+    assert request.error_code == "runtime_endpoint_missing_terminal"
+    assert request.error_message == "Runtime Endpoint stream ended without a terminal event"
 
     assert [started_step, terminal_step] = Requests.list_request_step_events(request)
     assert started_step.event_type == "request_step.started"
-    assert terminal_step.event_type == "request_step.completed"
+    assert terminal_step.event_type == "request_step.failed"
     refute Map.has_key?(terminal_step.result, "finish_reason")
+    assert terminal_step.result["error_code"] == "runtime_endpoint_missing_terminal"
 
     assert wait_until(fn ->
              RequestServer.get_state(request.id) == {:error, :not_found}
            end)
 
-    assert {:ok, :missing_finish_reason_candidate} =
-             Requests.classify_missing_terminal_candidate(request)
+    assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
   end
 
   test "execute/3 aborts before dispatch side effects when request_step.started persistence fails",

--- a/apps/orchard_shared/lib/orchard/sentry_context.ex
+++ b/apps/orchard_shared/lib/orchard/sentry_context.ex
@@ -84,7 +84,8 @@ defmodule Orchard.SentryContext do
       orchard_accepted_to_first_delta_ms: field(metrics, :accepted_to_first_delta_ms),
       orchard_accepted_to_terminal_ms: field(metrics, :accepted_to_terminal_ms),
       orchard_event_count: field(metrics, :event_count),
-      orchard_anomaly: field(metrics, :anomaly)
+      orchard_anomaly: field(metrics, :anomaly),
+      orchard_conformance_defect: field(metrics, :conformance_defect)
     }
     |> compact_absent_values()
   end

--- a/apps/orchard_shared/test/orchard/sentry_context_test.exs
+++ b/apps/orchard_shared/test/orchard/sentry_context_test.exs
@@ -140,7 +140,8 @@ defmodule Orchard.SentryContextTest do
       accepted_to_first_delta_ms: :na,
       accepted_to_terminal_ms: 80,
       event_count: 3,
-      anomaly: :none
+      anomaly: :none,
+      conformance_defect: :post_terminal
     }
 
     assert SentryContext.build_dispatch_extra(metrics,
@@ -154,7 +155,8 @@ defmodule Orchard.SentryContextTest do
              orchard_model_already_loaded: false,
              orchard_ensure_model_loaded_ms: 25,
              orchard_accepted_to_terminal_ms: 80,
-             orchard_event_count: 3
+             orchard_event_count: 3,
+             orchard_conformance_defect: :post_terminal
            }
   end
 


### PR DESCRIPTION
## Summary

- enforce `SPEC.md` §7.5.5 at the transport-neutral Runtime Endpoint dispatcher boundary
- replace accepted streams with missing, duplicate, or post-terminal events by one stable failed terminal
- preserve precise durable failure reasons while keeping public HTTP/SSE failures generic
- distinguish conformance defects in dispatch metrics and Sentry context
- preserve allocation, acceptance-gate, cancellation-drain, and connection cleanup across every covered defect exit

## Contract impact

This is a conformance bug fix under the existing `SPEC.md` §7.5.5 contract. It does not change the Runtime Endpoint protocol shape or Orchard's public failure contract, so no OpenSpec package is required.

## TDD and review

Regression tests were written red-first for:

- accepted `done(:ok)` without a terminal
- duplicate terminals and every nonterminal event family after terminal
- conformance defects followed by transport error, cancellation-drain timeout, or event-handler failure
- durable Request/step failure state
- synchronous and streaming Chat Completions and Responses API behavior
- distinct metrics/Sentry evidence
- exactly-once capacity release and gate reacquisition

Independent Standards and Spec reviews are clean. The Spec reviewer ran 16 focused contract/API/persistence/resource tests; all passed.

## Validation

- `mise exec -- mix format` — passed
- `mise exec -- mix compile --warnings-as-errors` — passed
- `mise exec -- mix credo --strict` — passed, zero findings
- `mise exec -- mix dialyzer` — passed, zero errors
- `ORCHARD_TEST_NODE_AGENT_PORT=50120 mise exec -- mix test` — passed
  - shared: 290 passed
  - controller: 3,175 passed, 5 skipped
  - node-agent: 386 passed
  - CLI: 695 passed, 10 excluded
- `ORCHARD_TEST_NODE_AGENT_PORT=50120 mise exec -- mix test --cover` — passed
  - shared: 69.42%
  - controller: 85.1% (`RequestDispatcher`: 92.0%)
  - node-agent: 77.55%
  - CLI: 79.03%

The first fresh-worktree full-test attempt hit one setup-order failure because the pinned MLX worker `.venv` did not yet exist; the suite materialized it, and the unchanged full test rerun passed.

Closes #120

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788412424&installation_model_id=428414&pr_number=160&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F160&signature=0ac818831dc498ba490b8b16587b8886357ab61019a5db6bd7375a790bf32d14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->