### PR TITLE
fix(cli): secure packaged console credential prompts with terminal custody

### DIFF
--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Test packaged orchardctl Controller runtime routing
         run: scripts/test-packaged-orchardctl-controller-runtime.sh
 
+      - name: Test packaged orchardctl PTY secret input
+        run: scripts/test-packaged-orchardctl-console-pty.sh
+
       - name: Test packaged orchardctl assembled Controller release RPC
         run: scripts/test-packaged-orchardctl-controller-release.sh
 

--- a/apps/orchard_cli/c_src/Makefile
+++ b/apps/orchard_cli/c_src/Makefile
@@ -1,0 +1,25 @@
+PRIV_DIR := $(MIX_APP_PATH)/priv
+TARGET := $(PRIV_DIR)/orchard-secret-tty
+TEST_TARGET := $(PRIV_DIR)/orchard-secret-tty-test
+SOURCE := orchard_secret_tty.c
+
+.PHONY: all clean
+
+TARGETS := $(TARGET)
+ifeq ($(MIX_ENV),test)
+TARGETS += $(TEST_TARGET)
+endif
+
+all: $(TARGETS)
+
+$(TARGET): $(SOURCE)
+	mkdir -p $(PRIV_DIR)
+	xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic -O2 $(SOURCE) -o $(TARGET)
+
+$(TEST_TARGET): $(SOURCE)
+	mkdir -p $(PRIV_DIR)
+	xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic -O2 \
+		-DORCHARD_SECRET_TTY_TEST $(SOURCE) -o $(TEST_TARGET)
+
+clean:
+	rm -f $(TARGET) $(TEST_TARGET)

--- a/apps/orchard_cli/c_src/orchard_secret_tty.c
+++ b/apps/orchard_cli/c_src/orchard_secret_tty.c
@@ -1,3 +1,5 @@
+#define __STDC_WANT_LIB_EXT1__ 1
+
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -935,11 +937,20 @@ static int handle_read(int control_fd, const unsigned char *frame, size_t frame_
   memcpy(response, "VALUE:", 6U);
   size_t value_length = 0;
   int status = read_tty_line(control_fd, response + 6U, &value_length);
-  if (status <= -2) return status;
-  if (write_all(tty_fd, "\n", 1U) != 0) return -1;
-  if (status == 0) return send_frame("EOF", 3U);
-  if (status < 0) return send_frame("READ_ERROR", 10U);
-  return send_frame(response, value_length + 6U);
+  int result;
+  if (status <= -2) {
+    result = status;
+  } else if (write_all(tty_fd, "\n", 1U) != 0) {
+    result = -1;
+  } else if (status == 0) {
+    result = send_frame("EOF", 3U);
+  } else if (status < 0) {
+    result = send_frame("READ_ERROR", 10U);
+  } else {
+    result = send_frame(response, value_length + 6U);
+  }
+  (void)memset_s(response, sizeof(response), 0, sizeof(response));
+  return result;
 }
 
 static int run_protocol(int control_fd, pid_t watchdog) {

--- a/apps/orchard_cli/c_src/orchard_secret_tty.c
+++ b/apps/orchard_cli/c_src/orchard_secret_tty.c
@@ -1,0 +1,1224 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+#define FRAME_LIMIT 16384U
+#define HANDSHAKE_TIMEOUT_MS 1000
+#define DISCARD_QUIET_MS 500
+
+#define CONTROL_READY 'R'
+#define CONTROL_ENTER 'E'
+#define CONTROL_PROTECTED 'P'
+#define CONTROL_DONE 'D'
+#define CONTROL_RESTORED 'O'
+#define CONTROL_ABORT 'A'
+#define CONTROL_FAILED 'F'
+#define CONTROL_QUIESCE 'Q'
+#define CONTROL_QUIESCED 'q'
+
+static struct termios saved_state;
+static int tty_fd = -1;
+static pid_t target_foreground_group = -1;
+static pid_t owner_pid = -1;
+static pid_t supervisor_pid = -1;
+static pid_t watchdog_pid = -1;
+static struct timeval owner_start_time;
+static struct timeval supervisor_start_time;
+static int owner_identity_initialized = 0;
+static int supervisor_identity_initialized = 0;
+static volatile sig_atomic_t signal_write_fd = -1;
+static int completion_dir_fd = -1;
+static int completion_registered = 0;
+
+#ifdef ORCHARD_SECRET_TTY_TEST
+enum test_fault {
+  TEST_FAULT_NONE,
+  TEST_FAULT_PARTIAL_PROTECT,
+  TEST_FAULT_POST_PROTECT,
+  TEST_FAULT_SIGNAL_INT,
+  TEST_FAULT_SIGNAL_HUP,
+  TEST_FAULT_SIGNAL_TERM,
+  TEST_FAULT_SIGNAL_KILL,
+  TEST_FAULT_MARKER_PRE_READY_KILL,
+  TEST_FAULT_WATCHDOG_HANDSHAKE,
+  TEST_FAULT_WATCHDOG_CUSTODY_HANDSHAKE,
+  TEST_FAULT_WATCHDOG_PROTECTED_HANDSHAKE,
+  TEST_FAULT_RESTORER_PARENT_KILL,
+  TEST_FAULT_RESTORER_PRE_TEARDOWN_KILL,
+  TEST_FAULT_RESTORER_IDENTITY_RETRY,
+  TEST_FAULT_RESTORER_SIGNAL_SETUP,
+  TEST_FAULT_WATCHDOG_IDLE,
+  TEST_FAULT_WATCHDOG_READ
+};
+static enum test_fault active_test_fault = TEST_FAULT_NONE;
+#endif
+
+static int write_all(int fd, const void *buffer, size_t length) {
+  const unsigned char *cursor = buffer;
+
+  while (length > 0) {
+    ssize_t count = write(fd, cursor, length);
+    if (count < 0 && errno == EINTR) continue;
+    if (count <= 0) return -1;
+    cursor += count;
+    length -= (size_t)count;
+  }
+  return 0;
+}
+
+static int read_all(int fd, void *buffer, size_t length) {
+  unsigned char *cursor = buffer;
+
+  while (length > 0) {
+    ssize_t count = read(fd, cursor, length);
+    if (count < 0 && errno == EINTR) continue;
+    if (count < 0) return -1;
+    if (count == 0) return 0;
+    cursor += count;
+    length -= (size_t)count;
+  }
+  return 1;
+}
+
+static int send_byte(int fd, unsigned char value) {
+  return write_all(fd, &value, 1U);
+}
+
+static int receive_byte(int fd, unsigned char *value) {
+  return read_all(fd, value, 1U);
+}
+
+static int send_frame(const void *payload, size_t length) {
+  if (length > FRAME_LIMIT) return -1;
+  uint32_t header = htonl((uint32_t)length);
+  if (write_all(STDOUT_FILENO, &header, sizeof(header)) != 0) return -1;
+  return write_all(STDOUT_FILENO, payload, length);
+}
+
+static int receive_frame(unsigned char *payload, size_t *length) {
+  uint32_t header;
+  int status = read_all(STDIN_FILENO, &header, sizeof(header));
+  if (status <= 0) return status;
+
+  uint32_t frame_length = ntohl(header);
+  if (frame_length > FRAME_LIMIT) return -1;
+  status = read_all(STDIN_FILENO, payload, frame_length);
+  if (status <= 0) return status;
+  *length = frame_length;
+  return 1;
+}
+
+static int termios_equal(const struct termios *left, const struct termios *right) {
+  return left->c_iflag == right->c_iflag && left->c_oflag == right->c_oflag &&
+         left->c_cflag == right->c_cflag && left->c_lflag == right->c_lflag &&
+         memcmp(left->c_cc, right->c_cc, sizeof(left->c_cc)) == 0 &&
+         cfgetispeed(left) == cfgetispeed(right) &&
+         cfgetospeed(left) == cfgetospeed(right);
+}
+
+static int query_process(pid_t pid, struct kinfo_proc *process) {
+  int query[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+  while (1) {
+    size_t size = sizeof(*process);
+    memset(process, 0, sizeof(*process));
+    if (sysctl(query, 4U, process, &size, NULL, 0U) == 0) {
+      if (size == 0) return 0;
+      return size == sizeof(*process) && process->kp_proc.p_pid == pid ? 1 : -1;
+    }
+    if (errno == EINTR) continue;
+    return errno == ESRCH ? 0 : -1;
+  }
+}
+
+static int read_process(pid_t pid, struct kinfo_proc *process) {
+  return query_process(pid, process) == 1 ? 0 : -1;
+}
+
+static int initialize_owner_identity(void) {
+  struct kinfo_proc owner;
+  if (read_process(owner_pid, &owner) != 0 ||
+      owner.kp_eproc.e_pgid != target_foreground_group ||
+      owner.kp_eproc.e_tpgid != target_foreground_group) {
+    return -1;
+  }
+  owner_start_time = owner.kp_proc.p_starttime;
+  owner_identity_initialized = 1;
+
+  if (completion_dir_fd >= 0) {
+    struct kinfo_proc supervisor;
+    if (supervisor_pid == owner_pid || owner.kp_eproc.e_ppid != supervisor_pid ||
+        read_process(supervisor_pid, &supervisor) != 0 ||
+        supervisor.kp_eproc.e_pgid != target_foreground_group ||
+        supervisor.kp_eproc.e_tpgid != target_foreground_group) {
+      return -1;
+    }
+    supervisor_start_time = supervisor.kp_proc.p_starttime;
+    supervisor_identity_initialized = 1;
+  }
+  return 0;
+}
+
+static int foreground_owner_valid(void) {
+  struct kinfo_proc owner;
+  if (!owner_identity_initialized || read_process(owner_pid, &owner) != 0 ||
+      owner.kp_proc.p_starttime.tv_sec != owner_start_time.tv_sec ||
+      owner.kp_proc.p_starttime.tv_usec != owner_start_time.tv_usec ||
+      owner.kp_eproc.e_pgid != target_foreground_group ||
+      owner.kp_eproc.e_tpgid != target_foreground_group) {
+    return 0;
+  }
+  if (completion_dir_fd < 0) return 1;
+
+  struct kinfo_proc supervisor;
+  return supervisor_identity_initialized && owner.kp_eproc.e_ppid == supervisor_pid &&
+                 read_process(supervisor_pid, &supervisor) == 0 &&
+                 supervisor.kp_proc.p_starttime.tv_sec == supervisor_start_time.tv_sec &&
+                 supervisor.kp_proc.p_starttime.tv_usec == supervisor_start_time.tv_usec &&
+                 supervisor.kp_eproc.e_pgid == target_foreground_group &&
+                 supervisor.kp_eproc.e_tpgid == target_foreground_group
+             ? 1
+             : 0;
+}
+
+static int parse_identity(const char *argument, uint64_t *device, uint64_t *inode) {
+  static const char prefix[] = "completion-identity=";
+  if (strncmp(argument, prefix, sizeof(prefix) - 1U) != 0) return -1;
+  const char *value = argument + sizeof(prefix) - 1U;
+  char *separator = NULL;
+  errno = 0;
+  unsigned long long parsed_device = strtoull(value, &separator, 10);
+  if (errno != 0 || separator == value || *separator != ':') return -1;
+  char *end = NULL;
+  errno = 0;
+  unsigned long long parsed_inode = strtoull(separator + 1, &end, 10);
+  if (errno != 0 || end == separator + 1 || *end != '\0') return -1;
+  *device = (uint64_t)parsed_device;
+  *inode = (uint64_t)parsed_inode;
+  return 0;
+}
+
+static int configure_terminal_custody(const char *argument,
+                                      const char *identity_argument) {
+  static const char prefix[] = "completion=";
+  if (strncmp(argument, prefix, sizeof(prefix) - 1U) != 0) return -1;
+  const char *directory = argument + sizeof(prefix) - 1U;
+  if (strcmp(directory, "-") == 0) return -1;
+  if (directory[0] != '/') return -1;
+
+  uint64_t expected_device;
+  uint64_t expected_inode;
+  if (parse_identity(identity_argument, &expected_device, &expected_inode) != 0)
+    return -1;
+
+  completion_dir_fd = open(directory, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+  if (completion_dir_fd < 0) return -1;
+  struct stat directory_state;
+  if (fstat(completion_dir_fd, &directory_state) != 0 ||
+      !S_ISDIR(directory_state.st_mode) || directory_state.st_uid != geteuid() ||
+      (directory_state.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO)) != S_IRWXU ||
+      (uint64_t)directory_state.st_dev != expected_device ||
+      (uint64_t)directory_state.st_ino != expected_inode) {
+    close(completion_dir_fd);
+    completion_dir_fd = -1;
+    return -1;
+  }
+  completion_registered = 1;
+  return 0;
+}
+
+static int register_terminal_custody(void) {
+  if (!completion_registered) return 0;
+  struct stat available;
+  if (fstatat(completion_dir_fd, "available", &available, AT_SYMLINK_NOFOLLOW) != 0 ||
+      !S_ISREG(available.st_mode) || available.st_uid != geteuid() ||
+      (available.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO)) != (S_IRUSR | S_IWUSR)) {
+    return -1;
+  }
+  if (linkat(completion_dir_fd, "available", completion_dir_fd, "active", 0) != 0)
+    return -1;
+  if (unlinkat(completion_dir_fd, "available", 0) != 0 && errno != ENOENT) {
+    (void)unlinkat(completion_dir_fd, "active", 0);
+    return -1;
+  }
+  return 0;
+}
+
+static int complete_terminal_custody(void) {
+  if (completion_registered) {
+    if (unlinkat(completion_dir_fd, "active", 0) != 0 && errno != ENOENT) return -1;
+    completion_registered = 0;
+  }
+  return 0;
+}
+
+static long long monotonic_milliseconds(void) {
+  struct timespec now;
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return -1;
+  return (long long)now.tv_sec * 1000LL + now.tv_nsec / 1000000LL;
+}
+
+static int terminal_revoked(void);
+
+static int discard_pending_input(void) {
+  long long started = monotonic_milliseconds();
+  if (started < 0 || tcflush(tty_fd, TCIFLUSH) != 0) return -1;
+  long long quiet_deadline = started + DISCARD_QUIET_MS;
+
+  while (1) {
+    long long now = monotonic_milliseconds();
+    if (now < 0) return -1;
+    if (now >= quiet_deadline) return tcflush(tty_fd, TCIFLUSH);
+
+    int timeout = (int)(quiet_deadline - now);
+    struct pollfd descriptor = {.fd = tty_fd, .events = POLLIN | POLLHUP | POLLERR};
+    int ready;
+    do {
+      ready = poll(&descriptor, 1, timeout);
+    } while (ready < 0 && errno == EINTR);
+    if (ready < 0) return -1;
+    if (ready == 0) return tcflush(tty_fd, TCIFLUSH);
+    if ((descriptor.revents & (POLLHUP | POLLERR | POLLNVAL)) != 0) {
+      return terminal_revoked() ? 1 : -1;
+    }
+    if (tcflush(tty_fd, TCIFLUSH) != 0) return -1;
+    quiet_deadline = monotonic_milliseconds() + DISCARD_QUIET_MS;
+  }
+}
+
+static int terminal_revoked(void) {
+  struct termios state;
+  while (tcgetattr(tty_fd, &state) != 0) {
+    if (errno == EINTR) continue;
+    return errno == EIO || errno == ENXIO || errno == ENOTTY;
+  }
+  return 0;
+}
+
+static int complete_revoked_terminal(void) {
+  while (complete_terminal_custody() != 0) {
+    struct timespec retry = {.tv_sec = 0, .tv_nsec = 100000000L};
+    (void)nanosleep(&retry, NULL);
+  }
+  return 0;
+}
+
+static int restore_saved_state(void) {
+  while (1) {
+    int discard_status = discard_pending_input();
+    if (discard_status == 0 && tcsetattr(tty_fd, TCSAFLUSH, &saved_state) == 0) {
+      struct termios actual;
+      if (tcgetattr(tty_fd, &actual) == 0 && termios_equal(&actual, &saved_state)) {
+        if (complete_terminal_custody() == 0) return 0;
+      }
+    }
+    if (discard_status > 0 || terminal_revoked()) return complete_revoked_terminal();
+    struct timespec retry = {.tv_sec = 0, .tv_nsec = 100000000L};
+    (void)nanosleep(&retry, NULL);
+  }
+}
+
+static int enter_protected_mode(void) {
+  if (!foreground_owner_valid()) return -1;
+
+  struct termios protected = saved_state;
+  protected.c_lflag &= (tcflag_t)~(ECHO | ECHONL | ICANON | ISIG);
+  protected.c_cc[VMIN] = 1;
+  protected.c_cc[VTIME] = 0;
+
+#ifdef ORCHARD_SECRET_TTY_TEST
+  if (active_test_fault == TEST_FAULT_PARTIAL_PROTECT) {
+    struct termios partial = saved_state;
+    partial.c_lflag &= (tcflag_t)~ECHO;
+    if (tcsetattr(tty_fd, TCSANOW, &partial) != 0) return -1;
+    (void)restore_saved_state();
+    return -1;
+  }
+#endif
+
+  if (tcsetattr(tty_fd, TCSAFLUSH, &protected) != 0) {
+    (void)restore_saved_state();
+    return -1;
+  }
+
+  struct termios actual;
+  if (tcgetattr(tty_fd, &actual) != 0 || !termios_equal(&actual, &protected)) {
+    (void)restore_saved_state();
+    return -1;
+  }
+  return 0;
+}
+
+static int is_special_character(unsigned char value, size_t index) {
+  cc_t configured = saved_state.c_cc[index];
+  return configured != _POSIX_VDISABLE && value == configured;
+}
+
+static void signal_handler(int signal_number) {
+  int saved_errno = errno;
+  unsigned char value = (unsigned char)signal_number;
+  if (signal_write_fd >= 0) (void)write(signal_write_fd, &value, 1U);
+  errno = saved_errno;
+}
+
+static int install_handler(int signal_number) {
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+  action.sa_handler = signal_handler;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = 0;
+  return sigaction(signal_number, &action, NULL);
+}
+
+static int ignore_signal(int signal_number) {
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+  action.sa_handler = SIG_IGN;
+  sigemptyset(&action.sa_mask);
+  return sigaction(signal_number, &action, NULL);
+}
+
+static int configure_parent_signals(int signal_pipe[2]) {
+  signal_write_fd = signal_pipe[1];
+  return ignore_signal(SIGPIPE) || install_handler(SIGHUP) || install_handler(SIGINT) ||
+                 install_handler(SIGTERM) || install_handler(SIGQUIT) ||
+                 install_handler(SIGTSTP) || install_handler(SIGCONT) ||
+                 ignore_signal(SIGTTIN) || ignore_signal(SIGTTOU)
+             ? -1
+             : 0;
+}
+
+static int make_signal_pipe_nonblocking(int signal_pipe[2]) {
+  int flags = fcntl(signal_pipe[1], F_GETFL);
+  return flags < 0 || fcntl(signal_pipe[1], F_SETFL, flags | O_NONBLOCK) != 0 ? -1 : 0;
+}
+
+static int configure_watchdog_signals(int signal_pipe[2]) {
+  signal_write_fd = signal_pipe[1];
+  if (ignore_signal(SIGPIPE) != 0) return -1;
+  if (install_handler(SIGHUP) != 0 || install_handler(SIGINT) != 0 ||
+      install_handler(SIGTERM) != 0 || install_handler(SIGQUIT) != 0 ||
+      install_handler(SIGTSTP) != 0 || install_handler(SIGCONT) != 0) {
+    return -1;
+  }
+  return 0;
+}
+
+static void quiesce_parent_reader(int control_fd) {
+  if (send_byte(control_fd, CONTROL_QUIESCE) != 0) return;
+  struct pollfd descriptor = {.fd = control_fd, .events = POLLIN | POLLHUP | POLLERR};
+  int ready;
+  do {
+    ready = poll(&descriptor, 1, HANDSHAKE_TIMEOUT_MS);
+  } while (ready < 0 && errno == EINTR);
+  if (ready <= 0 || (descriptor.revents & POLLIN) == 0) return;
+  unsigned char response;
+  if (receive_byte(control_fd, &response) != 1 || response != CONTROL_QUIESCED) return;
+}
+
+static int watchdog_abort(int control_fd, int protected) {
+  quiesce_parent_reader(control_fd);
+  if (protected) {
+    (void)restore_saved_state();
+  } else {
+    while (complete_terminal_custody() != 0) {
+      struct timespec retry = {.tv_sec = 0, .tv_nsec = 100000000L};
+      (void)nanosleep(&retry, NULL);
+    }
+  }
+  (void)send_byte(control_fd, CONTROL_ABORT);
+  return 1;
+}
+
+static int watchdog_loop(int control_fd, int signal_pipe[2]) {
+  int protected = 0;
+  int suspended = 0;
+
+  close(STDIN_FILENO);
+  close(STDERR_FILENO);
+
+  if (configure_watchdog_signals(signal_pipe) != 0 || register_terminal_custody() != 0) {
+    return 1;
+  }
+#ifdef ORCHARD_SECRET_TTY_TEST
+  if (active_test_fault == TEST_FAULT_WATCHDOG_CUSTODY_HANDSHAKE) {
+    static const char marker[] = "__ORCHARD_TEST_CUSTODY_REGISTERED__";
+    (void)write_all(tty_fd, marker, sizeof(marker) - 1U);
+    (void)raise(SIGSTOP);
+  }
+  if (active_test_fault == TEST_FAULT_MARKER_PRE_READY_KILL) {
+    (void)kill(getppid(), SIGKILL);
+  }
+#endif
+  if (send_byte(control_fd, CONTROL_READY) != 0) {
+    while (complete_terminal_custody() != 0) {
+      struct timespec retry = {.tv_sec = 0, .tv_nsec = 100000000L};
+      (void)nanosleep(&retry, NULL);
+    }
+    return 1;
+  }
+
+  while (1) {
+    struct pollfd descriptors[2] = {
+        {.fd = control_fd, .events = POLLIN | POLLHUP},
+        {.fd = signal_pipe[0], .events = POLLIN}};
+    int ready = poll(descriptors, 2, 100);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) break;
+    if (ready == 0) {
+      if (!foreground_owner_valid()) {
+        return watchdog_abort(control_fd, protected);
+      }
+      continue;
+    }
+
+    if ((descriptors[1].revents & POLLIN) != 0) {
+      unsigned char signal_number;
+      if (read(signal_pipe[0], &signal_number, 1U) != 1) break;
+
+      if (signal_number == SIGCONT && suspended) {
+        (void)send_byte(control_fd, CONTROL_ABORT);
+        return 1;
+      }
+      if (signal_number == SIGTSTP && protected) {
+        quiesce_parent_reader(control_fd);
+        if (restore_saved_state() != 0) {
+          (void)send_byte(control_fd, CONTROL_FAILED);
+          return 1;
+        }
+        protected = 0;
+        suspended = 1;
+        if (kill(-target_foreground_group, SIGSTOP) != 0) {
+          return 1;
+        }
+        continue;
+      }
+      if (signal_number == SIGHUP || signal_number == SIGINT ||
+          signal_number == SIGTERM || signal_number == SIGQUIT) {
+        return watchdog_abort(control_fd, protected);
+      }
+    }
+
+    if ((descriptors[0].revents & (POLLIN | POLLHUP)) != 0) {
+      unsigned char command;
+      int status = receive_byte(control_fd, &command);
+      if (status <= 0) break;
+
+      if (command == CONTROL_ENTER) {
+        if (enter_protected_mode() == 0) {
+          protected = 1;
+          if (send_byte(control_fd, CONTROL_PROTECTED) != 0) break;
+        } else {
+          (void)send_byte(control_fd, CONTROL_FAILED);
+          return 1;
+        }
+      } else if (command == CONTROL_DONE) {
+        if (protected && restore_saved_state() != 0) {
+          (void)send_byte(control_fd, CONTROL_FAILED);
+          return 1;
+        }
+        protected = 0;
+        (void)send_byte(control_fd, CONTROL_RESTORED);
+        return 0;
+      } else {
+        break;
+      }
+    }
+  }
+
+  if (protected) {
+    (void)restore_saved_state();
+  } else {
+    while (complete_terminal_custody() != 0) {
+      struct timespec retry = {.tv_sec = 0, .tv_nsec = 100000000L};
+      (void)nanosleep(&retry, NULL);
+    }
+  }
+  (void)send_byte(control_fd, CONTROL_ABORT);
+  return 1;
+}
+
+static int wait_for_control(int control_fd, unsigned char expected) {
+  struct pollfd descriptors[2] = {
+      {.fd = control_fd, .events = POLLIN | POLLHUP | POLLERR},
+      {.fd = STDIN_FILENO, .events = POLLIN | POLLHUP | POLLERR | POLLNVAL}};
+  int ready;
+  do {
+    ready = poll(descriptors, 2, HANDSHAKE_TIMEOUT_MS);
+  } while (ready < 0 && errno == EINTR);
+  if (ready <= 0 || descriptors[1].revents != 0 ||
+      (descriptors[0].revents & POLLIN) == 0) {
+    return -1;
+  }
+
+  unsigned char response;
+  int status = receive_byte(control_fd, &response);
+  return status == 1 && response == expected ? 0 : -1;
+}
+
+static int reap_watchdog(pid_t watchdog, int terminate_first, int *status) {
+  if (terminate_first) (void)kill(watchdog, SIGKILL);
+
+  for (int attempt = 0; attempt < 100; attempt++) {
+    pid_t waited = waitpid(watchdog, status, WNOHANG);
+    if (waited == watchdog) return 0;
+    if (waited < 0 && errno != EINTR) return -1;
+    struct timespec delay = {.tv_sec = 0, .tv_nsec = 10000000L};
+    (void)nanosleep(&delay, NULL);
+  }
+
+  if (!terminate_first) (void)kill(watchdog, SIGKILL);
+  for (int attempt = 0; attempt < 100; attempt++) {
+    pid_t waited = waitpid(watchdog, status, WNOHANG);
+    if (waited == watchdog) return 0;
+    if (waited < 0 && errno != EINTR) return -1;
+    struct timespec delay = {.tv_sec = 0, .tv_nsec = 10000000L};
+    (void)nanosleep(&delay, NULL);
+  }
+  return -1;
+}
+
+static int wait_for_child(pid_t child, int *status) {
+  while (1) {
+    pid_t waited = waitpid(child, status, 0);
+    if (waited == child) return 0;
+    if (waited < 0 && errno == EINTR) continue;
+    return -1;
+  }
+}
+
+static int process_identity_state(pid_t process, const struct timeval *started) {
+#ifdef ORCHARD_SECRET_TTY_TEST
+  static int identity_failure_injected = 0;
+  if (active_test_fault == TEST_FAULT_RESTORER_IDENTITY_RETRY &&
+      !identity_failure_injected) {
+    identity_failure_injected = 1;
+    return -1;
+  }
+#endif
+  struct kinfo_proc state;
+  int status = query_process(process, &state);
+  if (status <= 0) return status;
+  return state.kp_proc.p_starttime.tv_sec == started->tv_sec &&
+                 state.kp_proc.p_starttime.tv_usec == started->tv_usec
+             ? 1
+             : 0;
+}
+
+static void stop_known_watchdog(pid_t watchdog, const struct timeval *started) {
+  while (1) {
+    int identity = process_identity_state(watchdog, started);
+    if (identity == 0) return;
+    if (identity > 0) (void)kill(watchdog, SIGKILL);
+    struct timespec delay = {.tv_sec = 0, .tv_nsec = 10000000L};
+    (void)nanosleep(&delay, NULL);
+  }
+}
+
+static int configure_emergency_signals(void) {
+#ifdef ORCHARD_SECRET_TTY_TEST
+  if (active_test_fault == TEST_FAULT_RESTORER_SIGNAL_SETUP) {
+    struct stat marker;
+    while (fstatat(completion_dir_fd, "active", &marker, AT_SYMLINK_NOFOLLOW) != 0) {
+      struct timespec delay = {.tv_sec = 0, .tv_nsec = 10000000L};
+      (void)nanosleep(&delay, NULL);
+    }
+    char notice[160];
+    int notice_length = snprintf(
+        notice, sizeof(notice),
+        "__ORCHARD_TEST_SIGNAL_PARENT__:%d\n"
+        "__ORCHARD_TEST_SIGNAL_EMERGENCY__:%d\n"
+        "__ORCHARD_TEST_SIGNAL_WATCHDOG__:",
+        getppid(), getpid());
+    if (notice_length > 0 && (size_t)notice_length < sizeof(notice))
+      (void)write_all(tty_fd, notice, (size_t)notice_length);
+    struct timespec marker_delay = {.tv_sec = 0, .tv_nsec = 50000000L};
+    (void)nanosleep(&marker_delay, NULL);
+    notice_length = snprintf(notice, sizeof(notice), "%d\n", watchdog_pid);
+    if (notice_length > 0 && (size_t)notice_length < sizeof(notice))
+      (void)write_all(tty_fd, notice, (size_t)notice_length);
+    return -1;
+  }
+#endif
+  return ignore_signal(SIGHUP) || ignore_signal(SIGINT) || ignore_signal(SIGTERM) ||
+                 ignore_signal(SIGQUIT) || ignore_signal(SIGTSTP) ||
+                 ignore_signal(SIGCONT) || ignore_signal(SIGPIPE) ||
+                 ignore_signal(SIGTTIN) || ignore_signal(SIGTTOU)
+             ? -1
+             : 0;
+}
+
+static int emergency_restorer_loop(int control_fd, int watchdog_control_fd,
+                                   int signal_fd, pid_t watchdog,
+                                   const struct timeval *watchdog_started) {
+  close(watchdog_control_fd);
+  signal_write_fd = -1;
+  close(signal_fd);
+  close(STDIN_FILENO);
+  close(STDERR_FILENO);
+
+  if (configure_emergency_signals() != 0) {
+    close(control_fd);
+    return 1;
+  }
+  if (send_byte(control_fd, CONTROL_READY) != 0) {
+    stop_known_watchdog(watchdog, watchdog_started);
+    return restore_saved_state() == 0 ? 0 : 1;
+  }
+
+  unsigned char request = 0;
+  int received = receive_byte(control_fd, &request);
+  if (received == 1 && request == CONTROL_ABORT) {
+    int acknowledged = send_byte(control_fd, CONTROL_ABORT) == 0;
+    close(control_fd);
+    return acknowledged ? 0 : 1;
+  }
+
+  int requested = received == 1 && request == CONTROL_DONE;
+  stop_known_watchdog(watchdog, watchdog_started);
+  int restored = restore_saved_state() == 0;
+  if (requested && restored) (void)send_byte(control_fd, CONTROL_RESTORED);
+  close(control_fd);
+  return restored ? 0 : 1;
+}
+
+static pid_t start_emergency_restorer(int *parent_control, int watchdog_control_fd,
+                                      int signal_fd, pid_t watchdog) {
+  struct kinfo_proc watchdog_state;
+  if (read_process(watchdog, &watchdog_state) != 0 ||
+      watchdog_state.kp_eproc.e_ppid != getpid()) {
+    return -1;
+  }
+  struct timeval watchdog_started = watchdog_state.kp_proc.p_starttime;
+
+  int control[2];
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, control) != 0) return -1;
+
+  pid_t restorer = fork();
+  if (restorer < 0) {
+    close(control[0]);
+    close(control[1]);
+    return -1;
+  }
+  if (restorer == 0) {
+    close(control[0]);
+    _exit(emergency_restorer_loop(control[1], watchdog_control_fd, signal_fd,
+                                  watchdog, &watchdog_started));
+  }
+
+  close(control[1]);
+  unsigned char response = 0;
+  if (receive_byte(control[0], &response) != 1 || response != CONTROL_READY) {
+    close(control[0]);
+    int status;
+    (void)wait_for_child(restorer, &status);
+    return -1;
+  }
+  *parent_control = control[0];
+  return restorer;
+}
+
+static int dismiss_emergency_restorer(int control_fd, pid_t restorer) {
+  int acknowledged = send_byte(control_fd, CONTROL_ABORT) == 0;
+  unsigned char response = 0;
+  if (acknowledged)
+    acknowledged = receive_byte(control_fd, &response) == 1 && response == CONTROL_ABORT;
+  close(control_fd);
+
+  int status;
+  int reaped = wait_for_child(restorer, &status) == 0;
+  return acknowledged && reaped && WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 0
+                                                                                : -1;
+}
+
+static int finish_emergency_restorer(int control_fd, pid_t restorer) {
+  int acknowledged = send_byte(control_fd, CONTROL_DONE) == 0;
+  unsigned char response = 0;
+  if (acknowledged)
+    acknowledged = receive_byte(control_fd, &response) == 1 &&
+                   response == CONTROL_RESTORED;
+  close(control_fd);
+
+  int status;
+  int reaped = wait_for_child(restorer, &status) == 0;
+  if (acknowledged && reaped && WIFEXITED(status) && WEXITSTATUS(status) == 0) return 0;
+  return restore_saved_state();
+}
+
+static int restore_after_failed_handshake(int control_fd, pid_t watchdog,
+                                          int restorer_control,
+                                          pid_t restorer) {
+  close(control_fd);
+  int watchdog_status;
+  (void)reap_watchdog(watchdog, 1, &watchdog_status);
+#ifdef ORCHARD_SECRET_TTY_TEST
+  if (active_test_fault == TEST_FAULT_RESTORER_PARENT_KILL) {
+    char marker[64];
+    int marker_length = snprintf(marker, sizeof(marker),
+                                 "__ORCHARD_TEST_RESTORER_ARMED__:%d\n", getpid());
+    if (marker_length > 0 && (size_t)marker_length < sizeof(marker))
+      (void)write_all(tty_fd, marker, (size_t)marker_length);
+    (void)raise(SIGSTOP);
+  }
+#endif
+  return finish_emergency_restorer(restorer_control, restorer);
+}
+
+static int wait_for_restoration(int control_fd) {
+  while (1) {
+    unsigned char response;
+    int received = receive_byte(control_fd, &response);
+    if (received != 1) return -1;
+    if (response == CONTROL_RESTORED) return 0;
+    if (response == CONTROL_QUIESCE) {
+      if (send_byte(control_fd, CONTROL_QUIESCED) != 0) return -1;
+      continue;
+    }
+    return -1;
+  }
+}
+
+static int finish_watchdog(int control_fd, pid_t watchdog, int protected) {
+  int acknowledged = send_byte(control_fd, CONTROL_DONE) == 0 &&
+                     wait_for_restoration(control_fd) == 0;
+  close(control_fd);
+  int status;
+  int reaped = reap_watchdog(watchdog, !acknowledged, &status) == 0;
+  if (acknowledged && reaped && WIFEXITED(status) && WEXITSTATUS(status) == 0) return 0;
+  return protected && restore_saved_state() == 0 ? 0 : -1;
+}
+
+static int finish_watchdog_abort(int control_fd, pid_t watchdog, int protected) {
+  unsigned char response = 0;
+  int received = receive_byte(control_fd, &response);
+  if (received == 1 && response == CONTROL_QUIESCE) {
+    if (send_byte(control_fd, CONTROL_QUIESCED) == 0)
+      received = receive_byte(control_fd, &response);
+    else
+      received = -1;
+  }
+  int acknowledged = received == 1 && response == CONTROL_ABORT;
+  close(control_fd);
+
+  int status;
+  int reaped = reap_watchdog(watchdog, !acknowledged, &status) == 0;
+  if (acknowledged && reaped && WIFEXITED(status) && WEXITSTATUS(status) == 1) return 0;
+  return protected && restore_saved_state() == 0 ? 0 : -1;
+}
+
+static int wait_for_protocol_or_abort(int control_fd, int wait_for_tty) {
+  struct pollfd descriptors[3] = {
+      {.fd = wait_for_tty ? tty_fd : STDIN_FILENO, .events = POLLIN | POLLHUP},
+      {.fd = control_fd, .events = POLLIN | POLLHUP | POLLERR | POLLNVAL},
+      {.fd = wait_for_tty ? STDIN_FILENO : -1,
+       .events = POLLIN | POLLHUP | POLLERR | POLLNVAL}};
+
+  while (1) {
+    int ready = poll(descriptors, 3, -1);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) return -1;
+    if (descriptors[1].revents != 0) return 1;
+    if (wait_for_tty && descriptors[2].revents != 0) return 2;
+    if ((descriptors[0].revents & (POLLIN | POLLHUP)) != 0) return 0;
+  }
+}
+
+static int read_tty_line(int control_fd, unsigned char *value, size_t *length) {
+  size_t used = 0;
+
+  while (1) {
+    int ready = wait_for_protocol_or_abort(control_fd, 1);
+    if (ready == 2) return -6;
+    if (ready != 0) return ready > 0 ? -2 : -1;
+
+    unsigned char value_byte;
+    ssize_t count = read(tty_fd, &value_byte, 1U);
+    if (count < 0 && errno == EINTR) continue;
+    if (count < 0) return -1;
+    if (count == 0) {
+      *length = used;
+      return used == 0 ? 0 : 1;
+    }
+    if (value_byte == '\n' || value_byte == '\r') {
+      *length = used;
+      return 1;
+    }
+    if (is_special_character(value_byte, VINTR)) return -3;
+    if (is_special_character(value_byte, VQUIT)) return -4;
+    if (is_special_character(value_byte, VSUSP)) return -5;
+    if (is_special_character(value_byte, VEOF)) {
+      *length = used;
+      return used == 0 ? 0 : 1;
+    }
+    if (is_special_character(value_byte, VERASE)) {
+      if (used > 0) {
+        size_t erased = 1U;
+        if ((saved_state.c_iflag & IUTF8) != 0) {
+          size_t start = used - 1U;
+          while (start > 0U && used - start < 4U &&
+                 (value[start] & 0xC0U) == 0x80U) {
+            start--;
+          }
+
+          unsigned char lead = value[start];
+          size_t expected = lead >= 0xC2U && lead <= 0xDFU   ? 2U
+                            : lead >= 0xE0U && lead <= 0xEFU ? 3U
+                            : lead >= 0xF0U && lead <= 0xF4U ? 4U
+                                                            : 0U;
+          size_t actual = used - start;
+          int valid = expected == actual;
+          if (valid && expected == 3U) {
+            valid = !(lead == 0xE0U && value[start + 1U] < 0xA0U) &&
+                    !(lead == 0xEDU && value[start + 1U] >= 0xA0U);
+          }
+          if (valid && expected == 4U) {
+            valid = !(lead == 0xF0U && value[start + 1U] < 0x90U) &&
+                    !(lead == 0xF4U && value[start + 1U] > 0x8FU);
+          }
+          if (valid) erased = expected;
+        }
+        used -= erased;
+      }
+      continue;
+    }
+    if (is_special_character(value_byte, VKILL)) {
+      used = 0;
+      continue;
+    }
+    if (used >= FRAME_LIMIT - 6U) return -1;
+    value[used++] = value_byte;
+  }
+}
+
+static int handle_read(int control_fd, const unsigned char *frame, size_t frame_length) {
+  static const char prefix[] = "READ:";
+  if (frame_length < sizeof(prefix) - 1U ||
+      memcmp(frame, prefix, sizeof(prefix) - 1U) != 0) {
+    return -1;
+  }
+
+  const unsigned char *prompt = frame + sizeof(prefix) - 1U;
+  size_t prompt_length = frame_length - (sizeof(prefix) - 1U);
+  if (write_all(tty_fd, prompt, prompt_length) != 0) return -1;
+
+#ifdef ORCHARD_SECRET_TTY_TEST
+  int injected_signal = 0;
+  if (active_test_fault == TEST_FAULT_SIGNAL_INT) injected_signal = SIGINT;
+  if (active_test_fault == TEST_FAULT_SIGNAL_HUP) injected_signal = SIGHUP;
+  if (active_test_fault == TEST_FAULT_SIGNAL_TERM) injected_signal = SIGTERM;
+  if (active_test_fault == TEST_FAULT_SIGNAL_KILL) injected_signal = SIGKILL;
+  if (active_test_fault == TEST_FAULT_WATCHDOG_READ) (void)kill(watchdog_pid, SIGKILL);
+  if (injected_signal != 0) {
+    if (injected_signal == SIGKILL)
+      (void)kill(getpid(), injected_signal);
+    else
+      (void)kill(-getpgrp(), injected_signal);
+    return -1;
+  }
+#endif
+
+  unsigned char response[FRAME_LIMIT];
+  memcpy(response, "VALUE:", 6U);
+  size_t value_length = 0;
+  int status = read_tty_line(control_fd, response + 6U, &value_length);
+  if (status <= -2) return status;
+  if (write_all(tty_fd, "\n", 1U) != 0) return -1;
+  if (status == 0) return send_frame("EOF", 3U);
+  if (status < 0) return send_frame("READ_ERROR", 10U);
+  return send_frame(response, value_length + 6U);
+}
+
+static int run_protocol(int control_fd, pid_t watchdog) {
+  unsigned char frame[FRAME_LIMIT];
+  int protected = 1;
+
+  while (1) {
+    int ready = wait_for_protocol_or_abort(control_fd, 0);
+    if (ready > 0) {
+      if (finish_watchdog_abort(control_fd, watchdog, protected) == 0)
+        (void)send_frame("ABORTED", 7U);
+      return -1;
+    }
+    if (ready < 0) break;
+
+    size_t frame_length = 0;
+    int status = receive_frame(frame, &frame_length);
+    if (status <= 0) break;
+
+    if (frame_length == 7U && memcmp(frame, "RESTORE", 7U) == 0) {
+      if (finish_watchdog(control_fd, watchdog, protected) == 0) {
+        protected = 0;
+        return send_frame("RESTORED", 8U);
+      }
+      (void)send_frame("RESTORE_ERROR", 13U);
+      return -1;
+    }
+
+    status = handle_read(control_fd, frame, frame_length);
+    if (status == -6) {
+      (void)send_byte(control_fd, CONTROL_QUIESCED);
+      (void)finish_watchdog_abort(control_fd, watchdog, protected);
+      return -1;
+    }
+    if (status == -2) {
+      if (finish_watchdog_abort(control_fd, watchdog, protected) == 0)
+        (void)send_frame("ABORTED", 7U);
+      return -1;
+    }
+    if (status <= -3) {
+      int terminal_signal = 0;
+      if (status == -5) terminal_signal = SIGSTOP;
+
+      if (finish_watchdog(control_fd, watchdog, protected) != 0) return -1;
+      protected = 0;
+      if (terminal_signal != 0 && foreground_owner_valid())
+        (void)kill(-target_foreground_group, terminal_signal);
+      (void)send_frame("ABORTED", 7U);
+      return -1;
+    }
+    if (status != 0) break;
+  }
+
+  if (finish_watchdog(control_fd, watchdog, protected) == 0) return 0;
+  return -1;
+}
+
+int main(int argc, char **argv) {
+#ifdef ORCHARD_SECRET_TTY_TEST
+  if (argc != 7 && argc != 8) return 64;
+  if (argc == 8) {
+    if (strcmp(argv[7], "partial-protect") == 0)
+      active_test_fault = TEST_FAULT_PARTIAL_PROTECT;
+    else if (strcmp(argv[7], "post-protect") == 0)
+      active_test_fault = TEST_FAULT_POST_PROTECT;
+    else if (strcmp(argv[7], "signal-int") == 0)
+      active_test_fault = TEST_FAULT_SIGNAL_INT;
+    else if (strcmp(argv[7], "signal-hup") == 0)
+      active_test_fault = TEST_FAULT_SIGNAL_HUP;
+    else if (strcmp(argv[7], "signal-term") == 0)
+      active_test_fault = TEST_FAULT_SIGNAL_TERM;
+    else if (strcmp(argv[7], "signal-kill") == 0)
+      active_test_fault = TEST_FAULT_SIGNAL_KILL;
+    else if (strcmp(argv[7], "marker-pre-ready-kill") == 0)
+      active_test_fault = TEST_FAULT_MARKER_PRE_READY_KILL;
+    else if (strcmp(argv[7], "watchdog-handshake") == 0)
+      active_test_fault = TEST_FAULT_WATCHDOG_HANDSHAKE;
+    else if (strcmp(argv[7], "watchdog-custody-handshake") == 0)
+      active_test_fault = TEST_FAULT_WATCHDOG_CUSTODY_HANDSHAKE;
+    else if (strcmp(argv[7], "watchdog-protected-handshake") == 0)
+      active_test_fault = TEST_FAULT_WATCHDOG_PROTECTED_HANDSHAKE;
+    else if (strcmp(argv[7], "restorer-parent-kill") == 0)
+      active_test_fault = TEST_FAULT_RESTORER_PARENT_KILL;
+    else if (strcmp(argv[7], "restorer-pre-teardown-kill") == 0)
+      active_test_fault = TEST_FAULT_RESTORER_PRE_TEARDOWN_KILL;
+    else if (strcmp(argv[7], "restorer-identity-retry") == 0)
+      active_test_fault = TEST_FAULT_RESTORER_IDENTITY_RETRY;
+    else if (strcmp(argv[7], "restorer-signal-setup") == 0)
+      active_test_fault = TEST_FAULT_RESTORER_SIGNAL_SETUP;
+    else if (strcmp(argv[7], "watchdog-idle") == 0)
+      active_test_fault = TEST_FAULT_WATCHDOG_IDLE;
+    else if (strcmp(argv[7], "watchdog-read") == 0)
+      active_test_fault = TEST_FAULT_WATCHDOG_READ;
+    else
+      return 64;
+  }
+#else
+  if (argc != 7) return 64;
+#endif
+
+  static const char supervisor_prefix[] = "supervisor=";
+  if (strncmp(argv[4], supervisor_prefix, sizeof(supervisor_prefix) - 1U) != 0)
+    return 64;
+  char *supervisor_end = NULL;
+  errno = 0;
+  long supervisor_value = strtol(argv[4] + sizeof(supervisor_prefix) - 1U,
+                                 &supervisor_end, 10);
+  if (errno != 0 || supervisor_end == argv[4] + sizeof(supervisor_prefix) - 1U ||
+      *supervisor_end != '\0' || supervisor_value <= 1 || supervisor_value > INT_MAX) {
+    return 64;
+  }
+  supervisor_pid = (pid_t)supervisor_value;
+
+  char *group_end = NULL;
+  errno = 0;
+  long group_value = strtol(argv[2], &group_end, 10);
+  if (errno != 0 || group_end == argv[2] || *group_end != '\0' || group_value <= 1 ||
+      group_value > INT_MAX) {
+    return 64;
+  }
+  pid_t foreground_group = (pid_t)group_value;
+  target_foreground_group = foreground_group;
+
+  char *owner_end = NULL;
+  errno = 0;
+  long owner_value = strtol(argv[3], &owner_end, 10);
+  if (errno != 0 || owner_end == argv[3] || *owner_end != '\0' || owner_value <= 1 ||
+      owner_value > INT_MAX) {
+    return 64;
+  }
+  owner_pid = (pid_t)owner_value;
+  if (configure_terminal_custody(argv[5], argv[6]) != 0) {
+    (void)send_frame("SETUP_ERROR", 11U);
+    return 1;
+  }
+  if (initialize_owner_identity() != 0) {
+    (void)send_frame("SETUP_ERROR", 11U);
+    if (completion_dir_fd >= 0) close(completion_dir_fd);
+    return 1;
+  }
+
+  tty_fd = open(argv[1], O_RDWR | O_NOCTTY);
+  if (tty_fd < 0 || !isatty(tty_fd)) {
+    (void)send_frame("SETUP_ERROR", 11U);
+    if (tty_fd >= 0) close(tty_fd);
+    return 1;
+  }
+  if (tcgetattr(tty_fd, &saved_state) != 0) {
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(tty_fd);
+    return 1;
+  }
+
+  int control[2];
+  int signal_pipe[2];
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, control) != 0 || pipe(signal_pipe) != 0 ||
+      make_signal_pipe_nonblocking(signal_pipe) != 0 ||
+      configure_parent_signals(signal_pipe) != 0) {
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(tty_fd);
+    return 1;
+  }
+  pid_t watchdog = fork();
+  if (watchdog < 0) {
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(tty_fd);
+    return 1;
+  }
+  if (watchdog == 0) {
+    close(control[0]);
+#ifdef ORCHARD_SECRET_TTY_TEST
+    if (active_test_fault == TEST_FAULT_WATCHDOG_HANDSHAKE) (void)raise(SIGSTOP);
+#endif
+    _exit(watchdog_loop(control[1], signal_pipe));
+  }
+  watchdog_pid = watchdog;
+
+  close(control[1]);
+  close(signal_pipe[0]);
+  int restorer_control = -1;
+  pid_t restorer = start_emergency_restorer(&restorer_control, control[0],
+                                            signal_pipe[1], watchdog);
+  if (restorer < 0) {
+    close(control[0]);
+    (void)kill(watchdog, SIGCONT);
+    int watchdog_status;
+    (void)wait_for_child(watchdog, &watchdog_status);
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(signal_pipe[1]);
+    close(tty_fd);
+    return 1;
+  }
+  if (wait_for_control(control[0], CONTROL_READY) != 0) {
+    (void)restore_after_failed_handshake(control[0], watchdog, restorer_control,
+                                         restorer);
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(signal_pipe[1]);
+    close(tty_fd);
+    return 1;
+  }
+
+  int handshake_failed = 0;
+  if (send_frame("PREPARED", 8U) != 0) {
+    handshake_failed = 1;
+  } else {
+    unsigned char frame[FRAME_LIMIT];
+    size_t frame_length = 0;
+    int received = receive_frame(frame, &frame_length);
+    if (received != 1 || frame_length != 5U || memcmp(frame, "ENTER", 5U) != 0 ||
+        send_byte(control[0], CONTROL_ENTER) != 0) {
+      handshake_failed = 1;
+    }
+#ifdef ORCHARD_SECRET_TTY_TEST
+    else if (active_test_fault == TEST_FAULT_RESTORER_PRE_TEARDOWN_KILL ||
+             active_test_fault == TEST_FAULT_RESTORER_IDENTITY_RETRY) {
+      char marker[72];
+      const char *prefix =
+          active_test_fault == TEST_FAULT_RESTORER_IDENTITY_RETRY
+              ? "__ORCHARD_TEST_RESTORER_IDENTITY__"
+              : "__ORCHARD_TEST_RESTORER_PRE_TEARDOWN__";
+      if (active_test_fault == TEST_FAULT_RESTORER_IDENTITY_RETRY)
+        (void)kill(watchdog, SIGSTOP);
+      int marker_length = snprintf(marker, sizeof(marker), "%s:%d\n", prefix, getpid());
+      if (marker_length > 0 && (size_t)marker_length < sizeof(marker))
+        (void)write_all(tty_fd, marker, (size_t)marker_length);
+      (void)raise(SIGSTOP);
+      handshake_failed = 1;
+    }
+#endif
+    else if (wait_for_control(control[0], CONTROL_PROTECTED) != 0) {
+      handshake_failed = 1;
+    }
+#ifdef ORCHARD_SECRET_TTY_TEST
+    else if (active_test_fault == TEST_FAULT_WATCHDOG_PROTECTED_HANDSHAKE ||
+             active_test_fault == TEST_FAULT_RESTORER_PARENT_KILL) {
+      static const char marker[] = "__ORCHARD_TEST_PROTECTED__";
+      if (active_test_fault == TEST_FAULT_WATCHDOG_PROTECTED_HANDSHAKE)
+        (void)write_all(tty_fd, marker, sizeof(marker) - 1U);
+      (void)kill(watchdog, SIGSTOP);
+      handshake_failed = 1;
+    }
+#endif
+  }
+  if (handshake_failed) {
+    (void)restore_after_failed_handshake(control[0], watchdog, restorer_control,
+                                         restorer);
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(signal_pipe[1]);
+    close(tty_fd);
+    return 1;
+  }
+  if (dismiss_emergency_restorer(restorer_control, restorer) != 0) {
+    (void)finish_watchdog(control[0], watchdog, 1);
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(signal_pipe[1]);
+    close(tty_fd);
+    return 1;
+  }
+#ifdef ORCHARD_SECRET_TTY_TEST
+  if (active_test_fault == TEST_FAULT_POST_PROTECT) {
+    (void)finish_watchdog(control[0], watchdog, 1);
+    (void)send_frame("SETUP_ERROR", 11U);
+    close(signal_pipe[1]);
+    close(tty_fd);
+    return 1;
+  }
+#endif
+  if (send_frame("READY", 5U) != 0) {
+    (void)finish_watchdog(control[0], watchdog, 1);
+    close(signal_pipe[1]);
+    close(tty_fd);
+    return 1;
+  }
+#ifdef ORCHARD_SECRET_TTY_TEST
+  if (active_test_fault == TEST_FAULT_WATCHDOG_IDLE) (void)kill(watchdog, SIGKILL);
+#endif
+
+  int status = run_protocol(control[0], watchdog);
+  close(signal_pipe[1]);
+  close(tty_fd);
+  return status == 0 ? 0 : 1;
+}

--- a/apps/orchard_cli/c_src/orchard_secret_tty.c
+++ b/apps/orchard_cli/c_src/orchard_secret_tty.c
@@ -1,5 +1,3 @@
-#define __STDC_WANT_LIB_EXT1__ 1
-
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -937,20 +935,11 @@ static int handle_read(int control_fd, const unsigned char *frame, size_t frame_
   memcpy(response, "VALUE:", 6U);
   size_t value_length = 0;
   int status = read_tty_line(control_fd, response + 6U, &value_length);
-  int result;
-  if (status <= -2) {
-    result = status;
-  } else if (write_all(tty_fd, "\n", 1U) != 0) {
-    result = -1;
-  } else if (status == 0) {
-    result = send_frame("EOF", 3U);
-  } else if (status < 0) {
-    result = send_frame("READ_ERROR", 10U);
-  } else {
-    result = send_frame(response, value_length + 6U);
-  }
-  (void)memset_s(response, sizeof(response), 0, sizeof(response));
-  return result;
+  if (status <= -2) return status;
+  if (write_all(tty_fd, "\n", 1U) != 0) return -1;
+  if (status == 0) return send_frame("EOF", 3U);
+  if (status < 0) return send_frame("READ_ERROR", 10U);
+  return send_frame(response, value_length + 6U);
 }
 
 static int run_protocol(int control_fd, pid_t watchdog) {

--- a/apps/orchard_cli/lib/orchard_cli/commands/console.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/console.ex
@@ -267,9 +267,9 @@ defmodule OrchardCLI.Commands.Console do
     """
     orchardctl console enable
 
-    Prompt on an interactive TTY for a Console username and no-echo password,
-    write config/console.env with Console-only keys, and restart the loaded
-    controller service if present.
+    Prompt on an interactive TTY for a Console username and password, neither of
+    which is echoed, then write config/console.env with Console-only keys and
+    restart the loaded controller service if present.
 
     Credentials are not accepted through flags, environment variables, or argv.
 

--- a/apps/orchard_cli/lib/orchard_cli/commands/console.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/console.ex
@@ -225,10 +225,13 @@ defmodule OrchardCLI.Commands.Console do
   end
 
   defp role_runtime(runtime) do
-    Map.put_new_lazy(runtime, :read_install_role, fn ->
-      marker = Path.join([support_root(runtime), "support", ".install-role"])
-      fn -> File.read(marker) end
-    end)
+    marker =
+      Map.get(runtime, :install_role_marker) ||
+        Path.join([support_root(runtime), "support", ".install-role"])
+
+    runtime
+    |> Map.put(:install_role_marker, marker)
+    |> Map.put_new_lazy(:read_install_role, fn -> fn -> File.read(marker) end end)
   end
 
   defp default_tty?, do: SecretTTY.available?()

--- a/apps/orchard_cli/lib/orchard_cli/commands/console.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/console.ex
@@ -2,6 +2,7 @@ defmodule OrchardCLI.Commands.Console do
   @moduledoc false
 
   alias OrchardCLI.Commands.LifecycleSupport
+  alias OrchardCLI.SecretTTY
   alias OrchardCLI.ShellEnv
 
   @default_support_root "/Library/Application Support/Orchard"
@@ -28,7 +29,7 @@ defmodule OrchardCLI.Commands.Console do
 
   defp run_action(action, args, runtime) do
     with {:ok, :run} <- parse_action_args(action, args),
-         {:ok, role} <- LifecycleSupport.install_role(runtime) do
+         {:ok, role} <- LifecycleSupport.install_role(role_runtime(runtime)) do
       run_for_role(action, role, runtime)
     else
       {:help, usage} -> {:ok, usage}
@@ -113,6 +114,14 @@ defmodule OrchardCLI.Commands.Console do
   end
 
   defp prompt_credentials(runtime) do
+    if Map.has_key?(runtime, :prompt) do
+      prompt_injected_credentials(runtime)
+    else
+      SecretTTY.run(&prompt_guarded_credentials/1)
+    end
+  end
+
+  defp prompt_injected_credentials(runtime) do
     with {:ok, username} <- prompt_value(runtime, "Console username: ", echo: true),
          :ok <- validate_credential(:username, username),
          {:ok, password} <- prompt_value(runtime, "Console password: ", echo: false),
@@ -124,8 +133,29 @@ defmodule OrchardCLI.Commands.Console do
     end
   end
 
+  defp prompt_guarded_credentials(reader) do
+    with {:ok, username} <- guarded_prompt_value(reader, "Console username: "),
+         :ok <- validate_credential(:username, username),
+         {:ok, password} <- guarded_prompt_value(reader, "Console password: "),
+         :ok <- validate_credential(:password, password),
+         {:ok, confirmation} <- guarded_prompt_value(reader, "Confirm console password: "),
+         :ok <- validate_credential(:password_confirmation, confirmation),
+         :ok <- validate_confirmation(password, confirmation) do
+      {:ok, %{username: username, password: password}}
+    end
+  end
+
+  defp guarded_prompt_value(reader, prompt) do
+    case reader.(prompt) do
+      {:ok, value} when is_binary(value) -> {:ok, value}
+      :eof -> {:error, "unable to read Console credential prompt input"}
+      {:error, message} when is_binary(message) -> {:error, message}
+      _other -> {:error, "unable to read Console credential prompt input"}
+    end
+  end
+
   defp prompt_value(runtime, prompt, opts) do
-    prompt_fn = Map.get(runtime, :prompt, &default_prompt/2)
+    prompt_fn = Map.fetch!(runtime, :prompt)
 
     case prompt_fn.(prompt, opts) do
       {:ok, value} when is_binary(value) -> {:ok, value}
@@ -194,87 +224,14 @@ defmodule OrchardCLI.Commands.Console do
       @default_support_root
   end
 
-  defp default_prompt(prompt, opts) do
-    echo? = Keyword.get(opts, :echo, true)
-
-    if echo? do
-      read_prompt(prompt)
-    else
-      read_secret_prompt(prompt)
-    end
+  defp role_runtime(runtime) do
+    Map.put_new_lazy(runtime, :read_install_role, fn ->
+      marker = Path.join([support_root(runtime), "support", ".install-role"])
+      fn -> File.read(marker) end
+    end)
   end
 
-  defp read_prompt(prompt) do
-    case open_tty() do
-      {:ok, tty} ->
-        try do
-          IO.write(tty, prompt)
-
-          case IO.gets(tty, "") do
-            :eof -> :eof
-            value -> {:ok, String.trim_trailing(value, "\n")}
-          end
-        after
-          File.close(tty)
-        end
-
-      {:error, _reason} ->
-        {:error, "interactive terminal unavailable"}
-    end
-  end
-
-  defp read_secret_prompt(prompt) do
-    case open_tty() do
-      {:ok, tty} ->
-        read_secret_from_tty(prompt, tty)
-
-      {:error, _reason} ->
-        {:error, "interactive terminal unavailable"}
-    end
-  end
-
-  defp read_secret_from_tty(prompt, tty) do
-    IO.write(tty, prompt)
-
-    case tty_stty("-echo") do
-      :ok ->
-        try do
-          case IO.gets(tty, "") do
-            :eof ->
-              :eof
-
-            value ->
-              {:ok, value |> String.trim_trailing("\n") |> String.trim_trailing("\r")}
-          end
-        after
-          tty_stty("echo")
-          IO.write(tty, "\n")
-          File.close(tty)
-        end
-
-      {:error, _output} ->
-        tty_stty("echo")
-        IO.write(tty, "\n")
-        File.close(tty)
-        {:error, "could not disable terminal echo; refusing to read secret input"}
-    end
-  end
-
-  defp open_tty, do: File.open("/dev/tty", [:read, :write])
-
-  defp tty_stty(mode) do
-    case System.cmd("sh", ["-c", "stty #{mode} < /dev/tty"], stderr_to_stdout: true) do
-      {_output, 0} -> :ok
-      {output, _code} -> {:error, output}
-    end
-  end
-
-  defp default_tty? do
-    case System.cmd("sh", ["-c", "[ -r /dev/tty ] && [ -w /dev/tty ]"], stderr_to_stdout: true) do
-      {_output, 0} -> true
-      _other -> false
-    end
-  end
+  defp default_tty?, do: SecretTTY.available?()
 
   defp default_uid do
     case System.cmd("id", ["-u"], stderr_to_stdout: true) do

--- a/apps/orchard_cli/lib/orchard_cli/commands/lifecycle_support.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/lifecycle_support.ex
@@ -61,10 +61,12 @@ defmodule OrchardCLI.Commands.LifecycleSupport do
         infer_role_from_plists(runtime)
 
       {:error, :invalid_marker, marker_value} ->
-        {:error, :invalid_marker, invalid_marker_error_message(marker_value), 1}
+        {:error, :invalid_marker,
+         invalid_marker_error_message(install_role_marker(runtime), marker_value), 1}
 
       {:error, :marker_read_error, reason} ->
-        {:error, :marker_read_error, marker_read_error_message(reason), 1}
+        {:error, :marker_read_error,
+         marker_read_error_message(install_role_marker(runtime), reason), 1}
     end
   end
 
@@ -206,6 +208,13 @@ defmodule OrchardCLI.Commands.LifecycleSupport do
 
   defp default_read_install_role, do: File.read(@install_role_marker)
 
+  defp install_role_marker(runtime) do
+    case Map.get(runtime, :install_role_marker) do
+      marker when is_binary(marker) -> marker
+      _other -> @install_role_marker
+    end
+  end
+
   defp normalize_marker_read({:ok, contents}) when is_binary(contents),
     do: parse_marker_role(contents)
 
@@ -249,7 +258,7 @@ defmodule OrchardCLI.Commands.LifecycleSupport do
         {:ok, :node_agent}
 
       {false, false} ->
-        {:error, :legacy_not_found, install_role_error_message(), 1}
+        {:error, :legacy_not_found, install_role_error_message(install_role_marker(runtime)), 1}
     end
   end
 
@@ -348,26 +357,26 @@ defmodule OrchardCLI.Commands.LifecycleSupport do
   defp display_service_id(:controller), do: "controller"
   defp display_service_id(other), do: to_string(other)
 
-  defp install_role_error_message do
+  defp install_role_error_message(marker) do
     "Error: Orchard packaged install not found.\n" <>
-      "Unable to determine install role from #{@install_role_marker}.\n" <>
+      "Unable to determine install role from #{marker}.\n" <>
       "Expected a valid role marker (all, controller, or node-agent), or installed legacy plist(s):\n" <>
       "  /Library/LaunchDaemons/com.orchard.controller.plist\n" <>
       "  /Library/LaunchDaemons/com.orchard.node-agent.plist\n\n" <>
       "Run the Orchard installer again, or restore the install role marker."
   end
 
-  defp invalid_marker_error_message(marker_value) do
+  defp invalid_marker_error_message(marker, marker_value) do
     found = if marker_value == "", do: "empty marker", else: inspect(marker_value)
 
-    "Error: invalid Orchard install role marker at #{@install_role_marker}.\n" <>
+    "Error: invalid Orchard install role marker at #{marker}.\n" <>
       "Expected one of: all, controller, node-agent.\n" <>
       "Found: #{found}\n\n" <>
       "Run the Orchard installer again, or restore the install role marker with a valid role."
   end
 
-  defp marker_read_error_message(reason) do
-    "Error: unable to read Orchard install role marker at #{@install_role_marker}.\n" <>
+  defp marker_read_error_message(marker, reason) do
+    "Error: unable to read Orchard install role marker at #{marker}.\n" <>
       "Reason: #{reason}\n\n" <>
       "Run the Orchard installer again, or restore marker permissions."
   end

--- a/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
+++ b/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
@@ -3,6 +3,8 @@ defmodule OrchardCLI.SecretTTY do
 
   @setup_error "could not disable terminal echo; refusing to read secret input"
   @restore_error "could not restore the prior terminal state; Console credentials were not saved"
+  @read_error "unable to read Console credential prompt input"
+  @abort_error "Console credential prompt was interrupted; Console credentials were not saved"
   @timeout_ms 10_000
 
   @type read_result :: {:ok, String.t()} | :eof | {:error, String.t()}
@@ -82,14 +84,20 @@ defmodule OrchardCLI.SecretTTY do
   end
 
   defp execute(port, callback) do
-    reader = fn prompt -> read_value(port, prompt) end
+    session = :atomics.new(1, signed: false)
+    reader = fn prompt -> read_value(port, session, prompt) end
 
     try do
       result = callback.(reader)
 
-      case restore(port, :infinity) do
-        :ok -> result
-        {:error, :restore} -> {:error, @restore_error}
+      if aborted?(session) do
+        result
+      else
+        case restore(port, :infinity) do
+          :ok -> result
+          {:error, :aborted} -> {:error, @abort_error}
+          {:error, :restore} -> {:error, @restore_error}
+        end
       end
     catch
       kind, reason ->
@@ -223,22 +231,31 @@ defmodule OrchardCLI.SecretTTY do
     end
   end
 
-  defp read_value(port, prompt) do
+  defp read_value(port, session, prompt) do
     if command(port, "READ:" <> prompt) do
       case await_packet(port, :infinity) do
         {:ok, "VALUE:" <> value} -> {:ok, value}
         {:ok, "EOF"} -> :eof
-        _other -> {:error, "unable to read Console credential prompt input"}
+        {:ok, "ABORTED"} -> mark_aborted(session)
+        _other -> {:error, @read_error}
       end
     else
-      {:error, "unable to read Console credential prompt input"}
+      {:error, @read_error}
     end
   end
+
+  defp mark_aborted(session) do
+    :atomics.put(session, 1, 1)
+    {:error, @abort_error}
+  end
+
+  defp aborted?(session), do: :atomics.get(session, 1) == 1
 
   defp restore(port, timeout) do
     if command(port, "RESTORE") do
       case await_packet(port, timeout) do
         {:ok, "RESTORED"} -> :ok
+        {:ok, "ABORTED"} -> {:error, :aborted}
         _other -> {:error, :restore}
       end
     else

--- a/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
+++ b/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
@@ -3,27 +3,29 @@ defmodule OrchardCLI.SecretTTY do
 
   @setup_error "could not disable terminal echo; refusing to read secret input"
   @restore_error "could not restore the prior terminal state; Console credentials were not saved"
-  @protocol_limit 16_384
-  @timeout_ms 5_000
+  @timeout_ms 10_000
 
   @type read_result :: {:ok, String.t()} | :eof | {:error, String.t()}
   @type reader :: (String.t() -> read_result())
 
   @spec available?() :: boolean()
   def available? do
-    match?({:ok, _path}, controlling_tty_path())
+    match?({:ok, _path}, controlling_tty_path()) and
+      match?({:ok, _group}, foreground_process_group()) and
+      match?({:ok, _custody}, terminal_custody()) and is_binary(helper_path())
   end
 
   @spec run((reader() -> result), keyword()) :: result | {:error, String.t()}
         when result: var
   def run(callback, opts \\ []) when is_function(callback, 1) do
-    stty_path = Keyword.get(opts, :stty_path, "/bin/stty")
     timeout = Keyword.get(opts, :timeout_ms, @timeout_ms)
 
     with {:ok, tty_path} <- tty_path(opts),
-         {:ok, port} <- open_guard(tty_path, stty_path),
+         {:ok, foreground_group} <- foreground_group(opts),
+         {:ok, custody} <- terminal_custody(),
+         {:ok, port} <- open_helper(tty_path, foreground_group, custody, opts),
          :ok <- await_ready(port, timeout) do
-      execute(port, callback, timeout)
+      execute(port, callback)
     else
       {:error, :tty} -> {:error, "interactive terminal unavailable"}
       {:error, :open} -> {:error, "interactive terminal unavailable"}
@@ -35,6 +37,14 @@ defmodule OrchardCLI.SecretTTY do
     case Keyword.fetch(opts, :tty_path) do
       {:ok, path} -> {:ok, path}
       :error -> controlling_tty_path()
+    end
+  end
+
+  defp foreground_group(opts) do
+    case Keyword.fetch(opts, :foreground_group) do
+      {:ok, group} when is_integer(group) and group > 1 -> {:ok, group}
+      {:ok, _group} -> {:error, :tty}
+      :error -> foreground_process_group()
     end
   end
 
@@ -55,59 +65,168 @@ defmodule OrchardCLI.SecretTTY do
     end
   end
 
-  defp execute(port, callback, timeout) do
+  defp foreground_process_group do
+    args = ["-o", "pgid=", "-o", "tpgid=", "-p", System.pid()]
+
+    case System.cmd("/bin/ps", args, stderr_to_stdout: true) do
+      {output, 0} -> normalize_foreground_group(output)
+      _other -> {:error, :tty}
+    end
+  end
+
+  defp normalize_foreground_group(output) do
+    case output |> String.split() |> Enum.map(&Integer.parse/1) do
+      [{group, ""}, {group, ""}] when group > 1 -> {:ok, group}
+      _other -> {:error, :tty}
+    end
+  end
+
+  defp execute(port, callback) do
     reader = fn prompt -> read_value(port, prompt) end
 
     try do
       result = callback.(reader)
 
-      case restore(port, timeout) do
+      case restore(port, :infinity) do
         :ok -> result
         {:error, :restore} -> {:error, @restore_error}
       end
     catch
       kind, reason ->
-        _result = restore(port, timeout)
+        _result = restore(port, :infinity)
         :erlang.raise(kind, reason, __STACKTRACE__)
     after
       close_port(port)
     end
   end
 
-  defp open_guard(tty_path, stty_path) do
-    port =
-      Port.open(
-        {:spawn_executable, "/bin/sh"},
-        [
-          :binary,
-          :exit_status,
-          :use_stdio,
-          args: ["-c", guard_script(), "orchard-secret-tty", tty_path, stty_path]
-        ]
-      )
+  defp open_helper(tty_path, foreground_group, {completion_dir, completion_identity}, opts) do
+    case helper_path(opts) do
+      path when is_binary(path) ->
+        args =
+          [
+            tty_path,
+            Integer.to_string(foreground_group),
+            System.pid(),
+            "supervisor=#{foreground_supervisor_pid()}",
+            "completion=#{completion_dir}",
+            "completion-identity=#{completion_identity}"
+          ] ++ fault_args(opts)
 
-    {:ok, port}
+        port =
+          Port.open(
+            {:spawn_executable, path},
+            [
+              :binary,
+              :exit_status,
+              :use_stdio,
+              {:packet, 4},
+              args: args
+            ]
+          )
+
+        {:ok, port}
+
+      nil ->
+        {:error, :open}
+    end
   rescue
     ArgumentError -> {:error, :open}
   end
 
-  defp await_ready(port, timeout) do
-    case await_line(port, timeout, "") do
-      {:ok, "READY"} ->
-        :ok
+  defp helper_path(opts \\ []) do
+    name =
+      if Keyword.has_key?(opts, :test_fault),
+        do: "orchard-secret-tty-test",
+        else: "orchard-secret-tty"
+
+    with priv_dir when is_list(priv_dir) <- :code.priv_dir(:orchard_cli),
+         path = Path.join(List.to_string(priv_dir), name),
+         true <- File.regular?(path) do
+      path
+    else
+      _other -> nil
+    end
+  end
+
+  defp fault_args(opts) do
+    case Keyword.get(opts, :test_fault) do
+      nil ->
+        []
+
+      fault
+      when fault in [
+             :partial_protect,
+             :post_protect,
+             :signal_int,
+             :signal_hup,
+             :signal_term,
+             :signal_kill,
+             :marker_pre_ready_kill,
+             :watchdog_handshake,
+             :watchdog_custody_handshake,
+             :watchdog_protected_handshake,
+             :restorer_parent_kill,
+             :restorer_pre_teardown_kill,
+             :restorer_identity_retry,
+             :restorer_signal_setup,
+             :watchdog_idle,
+             :watchdog_read
+           ] ->
+        [fault |> Atom.to_string() |> String.replace("_", "-")]
 
       _other ->
-        close_port(port)
-        {:error, :setup}
+        ["invalid"]
+    end
+  end
+
+  defp foreground_supervisor_pid do
+    case System.get_env("ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID") do
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {pid, ""} when pid > 1 -> Integer.to_string(pid)
+          _other -> System.pid()
+        end
+
+      nil ->
+        System.pid()
+    end
+  end
+
+  defp terminal_custody do
+    directory = System.get_env("ORCHARD_CLI_COMPLETION_DIR")
+    identity = System.get_env("ORCHARD_CLI_COMPLETION_IDENTITY")
+
+    if is_binary(directory) and Path.type(directory) == :absolute and
+         is_binary(identity) and Regex.match?(~r/\A[0-9]+:[0-9]+\z/, identity) do
+      {:ok, {directory, identity}}
+    else
+      {:error, :open}
+    end
+  end
+
+  defp await_ready(port, timeout) do
+    case await_packet(port, timeout) do
+      {:ok, "PREPARED"} -> enter_protected_mode(port)
+      _other -> close_with_error(port, :setup)
+    end
+  end
+
+  defp enter_protected_mode(port) do
+    if command(port, "ENTER") do
+      case await_packet(port, :infinity) do
+        {:ok, "READY"} -> :ok
+        _other -> close_with_error(port, :setup)
+      end
+    else
+      close_with_error(port, :setup)
     end
   end
 
   defp read_value(port, prompt) do
-    command = "READ:" <> Base.encode64(prompt) <> "\n"
-
-    if Port.command(port, command) do
-      case await_line(port, :infinity, "") do
-        {:ok, "VALUE:" <> encoded} -> decode_value(encoded)
+    if command(port, "READ:" <> prompt) do
+      case await_packet(port, :infinity) do
+        {:ok, "VALUE:" <> value} -> {:ok, value}
         {:ok, "EOF"} -> :eof
         _other -> {:error, "unable to read Console credential prompt input"}
       end
@@ -116,16 +235,9 @@ defmodule OrchardCLI.SecretTTY do
     end
   end
 
-  defp decode_value(encoded) do
-    case Base.decode64(encoded) do
-      {:ok, value} -> {:ok, value}
-      :error -> {:error, "unable to read Console credential prompt input"}
-    end
-  end
-
   defp restore(port, timeout) do
-    if Port.command(port, "RESTORE\n") do
-      case await_line(port, timeout, "") do
+    if command(port, "RESTORE") do
+      case await_packet(port, timeout) do
         {:ok, "RESTORED"} -> :ok
         _other -> {:error, :restore}
       end
@@ -134,156 +246,30 @@ defmodule OrchardCLI.SecretTTY do
     end
   end
 
-  defp await_line(_port, _timeout, buffer) when byte_size(buffer) > @protocol_limit,
-    do: {:error, :protocol}
+  defp command(port, message) do
+    Port.info(port) != nil and Port.command(port, message)
+  rescue
+    ArgumentError -> false
+  end
 
-  defp await_line(port, timeout, buffer) do
-    case String.split(buffer, "\n", parts: 2) do
-      [line, _rest] ->
-        {:ok, String.trim_trailing(line, "\r")}
-
-      [_partial] ->
-        receive do
-          {^port, {:data, data}} -> await_line(port, timeout, buffer <> data)
-          {^port, {:exit_status, _status}} -> {:error, :closed}
-        after
-          timeout -> {:error, :timeout}
-        end
+  defp await_packet(port, timeout) do
+    receive do
+      {^port, {:data, data}} -> {:ok, data}
+      {^port, {:exit_status, _status}} -> {:error, :closed}
+    after
+      timeout -> {:error, :timeout}
     end
+  end
+
+  defp close_with_error(port, reason) do
+    close_port(port)
+    {:error, reason}
   end
 
   defp close_port(port) do
-    if Port.info(port) do
-      Port.close(port)
-    end
-
+    if Port.info(port), do: Port.close(port)
     :ok
   rescue
     ArgumentError -> :ok
-  end
-
-  defp guard_script do
-    ~S'''
-    tty=$1
-    stty=$2
-
-    restore() {
-      "$stty" -f "$tty" "$state" >/dev/null 2>&1
-    }
-
-    state=$("$stty" -f "$tty" -g 2>/dev/null) || {
-      printf 'SETUP_ERROR\n'
-      exit 1
-    }
-    trap '' HUP INT TERM
-    "$stty" -f "$tty" -echo -echonl >/dev/null 2>&1 || {
-      printf 'SETUP_ERROR\n'
-      exit 1
-    }
-    exec 3<>"$tty" || {
-      restore
-      printf 'SETUP_ERROR\n'
-      exit 1
-    }
-    umask 077
-    pipe_root=$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/orchard-secret-tty.XXXXXX") || {
-      restore
-      printf 'SETUP_ERROR\n'
-      exit 1
-    }
-    /usr/bin/mkfifo "$pipe_root/events" || {
-      /bin/rmdir "$pipe_root"
-      restore
-      printf 'SETUP_ERROR\n'
-      exit 1
-    }
-    exec 5<>"$pipe_root/events"
-    /bin/rm "$pipe_root/events"
-    /bin/rmdir "$pipe_root"
-    exec 4<&0
-
-    (
-      trap - HUP INT TERM
-      while IFS= read -r owner_command <&4; do
-        printf 'COMMAND:%s\n' "$owner_command" >&5
-      done
-      printf 'OWNER_EOF\n' >&5
-    ) &
-    owner_monitor=$!
-    tty_reader=
-
-    stop_child() {
-      child_pid=$1
-      if [ -n "$child_pid" ]; then
-        kill "$child_pid" >/dev/null 2>&1
-        wait "$child_pid" 2>/dev/null
-      fi
-    }
-
-    cleanup_children() {
-      stop_child "$tty_reader"
-      tty_reader=
-      stop_child "$owner_monitor"
-      owner_monitor=
-    }
-
-    printf 'READY\n'
-
-    while IFS= read -r event <&5; do
-      case "$event" in
-        COMMAND:READ:*)
-          if [ -n "$tty_reader" ]; then
-            printf 'PROTOCOL_ERROR\n'
-            cleanup_children
-            restore
-            exit 1
-          fi
-          prompt=${event#COMMAND:READ:}
-          (
-            trap - HUP INT TERM
-            if printf '%s' "$prompt" | /usr/bin/base64 -D >&3 2>/dev/null; then
-              if IFS= read -r value <&3; then
-                printf '\n' >&3
-                encoded=$(printf '%s' "$value" | /usr/bin/base64 -b 0) &&
-                  printf 'TTY:VALUE:%s\n' "$encoded" >&5
-              else
-                printf '\n' >&3
-                printf 'TTY:EOF\n' >&5
-              fi
-            else
-              printf 'TTY:READ_ERROR\n' >&5
-            fi
-          ) &
-          tty_reader=$!
-          ;;
-        TTY:*)
-          wait "$tty_reader" 2>/dev/null
-          tty_reader=
-          printf '%s\n' "${event#TTY:}"
-          ;;
-        COMMAND:RESTORE)
-          cleanup_children
-          if restore; then
-            printf 'RESTORED\n'
-            exit 0
-          else
-            printf 'RESTORE_ERROR\n'
-            exit 1
-          fi
-          ;;
-        OWNER_EOF)
-          cleanup_children
-          restore
-          exit 0
-          ;;
-        *)
-          printf 'PROTOCOL_ERROR\n'
-          ;;
-      esac
-    done
-
-    cleanup_children
-    restore
-    '''
   end
 end

--- a/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
+++ b/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
@@ -1,0 +1,289 @@
+defmodule OrchardCLI.SecretTTY do
+  @moduledoc false
+
+  @setup_error "could not disable terminal echo; refusing to read secret input"
+  @restore_error "could not restore the prior terminal state; Console credentials were not saved"
+  @protocol_limit 16_384
+  @timeout_ms 5_000
+
+  @type read_result :: {:ok, String.t()} | :eof | {:error, String.t()}
+  @type reader :: (String.t() -> read_result())
+
+  @spec available?() :: boolean()
+  def available? do
+    match?({:ok, _path}, controlling_tty_path())
+  end
+
+  @spec run((reader() -> result), keyword()) :: result | {:error, String.t()}
+        when result: var
+  def run(callback, opts \\ []) when is_function(callback, 1) do
+    stty_path = Keyword.get(opts, :stty_path, "/bin/stty")
+    timeout = Keyword.get(opts, :timeout_ms, @timeout_ms)
+
+    with {:ok, tty_path} <- tty_path(opts),
+         {:ok, port} <- open_guard(tty_path, stty_path),
+         :ok <- await_ready(port, timeout) do
+      execute(port, callback, timeout)
+    else
+      {:error, :tty} -> {:error, "interactive terminal unavailable"}
+      {:error, :open} -> {:error, "interactive terminal unavailable"}
+      {:error, :setup} -> {:error, @setup_error}
+    end
+  end
+
+  defp tty_path(opts) do
+    case Keyword.fetch(opts, :tty_path) do
+      {:ok, path} -> {:ok, path}
+      :error -> controlling_tty_path()
+    end
+  end
+
+  defp controlling_tty_path do
+    case System.cmd("/bin/ps", ["-o", "tty=", "-p", System.pid()], stderr_to_stdout: true) do
+      {output, 0} -> normalize_tty_name(output)
+      _other -> {:error, :tty}
+    end
+  end
+
+  defp normalize_tty_name(output) do
+    name = String.trim(output)
+
+    if Regex.match?(~r/\A[A-Za-z0-9]+\z/, name) do
+      {:ok, Path.join("/dev", name)}
+    else
+      {:error, :tty}
+    end
+  end
+
+  defp execute(port, callback, timeout) do
+    reader = fn prompt -> read_value(port, prompt) end
+
+    try do
+      result = callback.(reader)
+
+      case restore(port, timeout) do
+        :ok -> result
+        {:error, :restore} -> {:error, @restore_error}
+      end
+    catch
+      kind, reason ->
+        _result = restore(port, timeout)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    after
+      close_port(port)
+    end
+  end
+
+  defp open_guard(tty_path, stty_path) do
+    port =
+      Port.open(
+        {:spawn_executable, "/bin/sh"},
+        [
+          :binary,
+          :exit_status,
+          :use_stdio,
+          args: ["-c", guard_script(), "orchard-secret-tty", tty_path, stty_path]
+        ]
+      )
+
+    {:ok, port}
+  rescue
+    ArgumentError -> {:error, :open}
+  end
+
+  defp await_ready(port, timeout) do
+    case await_line(port, timeout, "") do
+      {:ok, "READY"} ->
+        :ok
+
+      _other ->
+        close_port(port)
+        {:error, :setup}
+    end
+  end
+
+  defp read_value(port, prompt) do
+    command = "READ:" <> Base.encode64(prompt) <> "\n"
+
+    if Port.command(port, command) do
+      case await_line(port, :infinity, "") do
+        {:ok, "VALUE:" <> encoded} -> decode_value(encoded)
+        {:ok, "EOF"} -> :eof
+        _other -> {:error, "unable to read Console credential prompt input"}
+      end
+    else
+      {:error, "unable to read Console credential prompt input"}
+    end
+  end
+
+  defp decode_value(encoded) do
+    case Base.decode64(encoded) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, "unable to read Console credential prompt input"}
+    end
+  end
+
+  defp restore(port, timeout) do
+    if Port.command(port, "RESTORE\n") do
+      case await_line(port, timeout, "") do
+        {:ok, "RESTORED"} -> :ok
+        _other -> {:error, :restore}
+      end
+    else
+      {:error, :restore}
+    end
+  end
+
+  defp await_line(_port, _timeout, buffer) when byte_size(buffer) > @protocol_limit,
+    do: {:error, :protocol}
+
+  defp await_line(port, timeout, buffer) do
+    case String.split(buffer, "\n", parts: 2) do
+      [line, _rest] ->
+        {:ok, String.trim_trailing(line, "\r")}
+
+      [_partial] ->
+        receive do
+          {^port, {:data, data}} -> await_line(port, timeout, buffer <> data)
+          {^port, {:exit_status, _status}} -> {:error, :closed}
+        after
+          timeout -> {:error, :timeout}
+        end
+    end
+  end
+
+  defp close_port(port) do
+    if Port.info(port) do
+      Port.close(port)
+    end
+
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp guard_script do
+    ~S'''
+    tty=$1
+    stty=$2
+
+    restore() {
+      "$stty" -f "$tty" "$state" >/dev/null 2>&1
+    }
+
+    state=$("$stty" -f "$tty" -g 2>/dev/null) || {
+      printf 'SETUP_ERROR\n'
+      exit 1
+    }
+    trap '' HUP INT TERM
+    "$stty" -f "$tty" -echo -echonl >/dev/null 2>&1 || {
+      printf 'SETUP_ERROR\n'
+      exit 1
+    }
+    exec 3<>"$tty" || {
+      restore
+      printf 'SETUP_ERROR\n'
+      exit 1
+    }
+    umask 077
+    pipe_root=$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/orchard-secret-tty.XXXXXX") || {
+      restore
+      printf 'SETUP_ERROR\n'
+      exit 1
+    }
+    /usr/bin/mkfifo "$pipe_root/events" || {
+      /bin/rmdir "$pipe_root"
+      restore
+      printf 'SETUP_ERROR\n'
+      exit 1
+    }
+    exec 5<>"$pipe_root/events"
+    /bin/rm "$pipe_root/events"
+    /bin/rmdir "$pipe_root"
+    exec 4<&0
+
+    (
+      trap - HUP INT TERM
+      while IFS= read -r owner_command <&4; do
+        printf 'COMMAND:%s\n' "$owner_command" >&5
+      done
+      printf 'OWNER_EOF\n' >&5
+    ) &
+    owner_monitor=$!
+    tty_reader=
+
+    stop_child() {
+      child_pid=$1
+      if [ -n "$child_pid" ]; then
+        kill "$child_pid" >/dev/null 2>&1
+        wait "$child_pid" 2>/dev/null
+      fi
+    }
+
+    cleanup_children() {
+      stop_child "$tty_reader"
+      tty_reader=
+      stop_child "$owner_monitor"
+      owner_monitor=
+    }
+
+    printf 'READY\n'
+
+    while IFS= read -r event <&5; do
+      case "$event" in
+        COMMAND:READ:*)
+          if [ -n "$tty_reader" ]; then
+            printf 'PROTOCOL_ERROR\n'
+            cleanup_children
+            restore
+            exit 1
+          fi
+          prompt=${event#COMMAND:READ:}
+          (
+            trap - HUP INT TERM
+            if printf '%s' "$prompt" | /usr/bin/base64 -D >&3 2>/dev/null; then
+              if IFS= read -r value <&3; then
+                printf '\n' >&3
+                encoded=$(printf '%s' "$value" | /usr/bin/base64 -b 0) &&
+                  printf 'TTY:VALUE:%s\n' "$encoded" >&5
+              else
+                printf '\n' >&3
+                printf 'TTY:EOF\n' >&5
+              fi
+            else
+              printf 'TTY:READ_ERROR\n' >&5
+            fi
+          ) &
+          tty_reader=$!
+          ;;
+        TTY:*)
+          wait "$tty_reader" 2>/dev/null
+          tty_reader=
+          printf '%s\n' "${event#TTY:}"
+          ;;
+        COMMAND:RESTORE)
+          cleanup_children
+          if restore; then
+            printf 'RESTORED\n'
+            exit 0
+          else
+            printf 'RESTORE_ERROR\n'
+            exit 1
+          fi
+          ;;
+        OWNER_EOF)
+          cleanup_children
+          restore
+          exit 0
+          ;;
+        *)
+          printf 'PROTOCOL_ERROR\n'
+          ;;
+      esac
+    done
+
+    cleanup_children
+    restore
+    '''
+  end
+end

--- a/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
+++ b/apps/orchard_cli/lib/orchard_cli/secret_tty.ex
@@ -3,8 +3,6 @@ defmodule OrchardCLI.SecretTTY do
 
   @setup_error "could not disable terminal echo; refusing to read secret input"
   @restore_error "could not restore the prior terminal state; Console credentials were not saved"
-  @read_error "unable to read Console credential prompt input"
-  @abort_error "Console credential prompt was interrupted; Console credentials were not saved"
   @timeout_ms 10_000
 
   @type read_result :: {:ok, String.t()} | :eof | {:error, String.t()}
@@ -84,20 +82,14 @@ defmodule OrchardCLI.SecretTTY do
   end
 
   defp execute(port, callback) do
-    session = :atomics.new(1, signed: false)
-    reader = fn prompt -> read_value(port, session, prompt) end
+    reader = fn prompt -> read_value(port, prompt) end
 
     try do
       result = callback.(reader)
 
-      if aborted?(session) do
-        result
-      else
-        case restore(port, :infinity) do
-          :ok -> result
-          {:error, :aborted} -> {:error, @abort_error}
-          {:error, :restore} -> {:error, @restore_error}
-        end
+      case restore(port, :infinity) do
+        :ok -> result
+        {:error, :restore} -> {:error, @restore_error}
       end
     catch
       kind, reason ->
@@ -231,31 +223,22 @@ defmodule OrchardCLI.SecretTTY do
     end
   end
 
-  defp read_value(port, session, prompt) do
+  defp read_value(port, prompt) do
     if command(port, "READ:" <> prompt) do
       case await_packet(port, :infinity) do
         {:ok, "VALUE:" <> value} -> {:ok, value}
         {:ok, "EOF"} -> :eof
-        {:ok, "ABORTED"} -> mark_aborted(session)
-        _other -> {:error, @read_error}
+        _other -> {:error, "unable to read Console credential prompt input"}
       end
     else
-      {:error, @read_error}
+      {:error, "unable to read Console credential prompt input"}
     end
   end
-
-  defp mark_aborted(session) do
-    :atomics.put(session, 1, 1)
-    {:error, @abort_error}
-  end
-
-  defp aborted?(session), do: :atomics.get(session, 1) == 1
 
   defp restore(port, timeout) do
     if command(port, "RESTORE") do
       case await_packet(port, timeout) do
         {:ok, "RESTORED"} -> :ok
-        {:ok, "ABORTED"} -> {:error, :aborted}
         _other -> {:error, :restore}
       end
     else

--- a/apps/orchard_cli/mix.exs
+++ b/apps/orchard_cli/mix.exs
@@ -11,6 +11,8 @@ defmodule OrchardCLI.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
+      compilers: [:elixir_make] ++ Mix.compilers(),
+      make_cwd: "c_src",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
@@ -35,6 +37,7 @@ defmodule OrchardCLI.MixProject do
   defp deps do
     [
       {:jason, "~> 1.4"},
+      {:elixir_make, "~> 0.9", runtime: false},
       {:nimble_csv, "~> 1.2"},
       {:req, "~> 0.5"},
       {:orchard_shared, in_umbrella: true},

--- a/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
@@ -1,0 +1,121 @@
+defmodule OrchardCLI.Commands.ConsolePTYTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  @harness_source Path.expand("../../support/console_pty_harness.c", __DIR__)
+
+  setup_all do
+    if :os.type() == {:unix, :darwin} do
+      root =
+        Path.join(
+          System.tmp_dir!(),
+          "orchard-console-pty-harness-#{System.unique_integer([:positive])}"
+        )
+
+      harness = Path.join(root, "console-pty-harness")
+      File.mkdir_p!(root)
+
+      {output, status} =
+        System.cmd(
+          "xcrun",
+          ["clang", "-std=c11", "-Wall", "-Wextra", "-Werror", @harness_source, "-o", harness],
+          stderr_to_stdout: true
+        )
+
+      assert status == 0, "could not compile Console PTY harness: #{output}"
+
+      on_exit(fn -> File.rm_rf(root) end)
+      {:ok, harness: harness}
+    else
+      {:ok, harness: nil}
+    end
+  end
+
+  test "fast pasted username and password stay secret through the real PTY", %{harness: harness} do
+    with_macos_harness(harness, "pasted-success", "enable", fn support_root, marker ->
+      assert File.exists?(Path.join([support_root, "config", "console.env"]))
+      assert File.exists?(marker)
+    end)
+  end
+
+  test "credential entry can pause longer than the guard protocol timeout", %{harness: harness} do
+    with_macos_harness(harness, "delayed-success", "enable", fn support_root, marker ->
+      assert File.exists?(Path.join([support_root, "config", "console.env"]))
+      assert File.exists?(marker)
+    end)
+  end
+
+  test "owner exit restores the terminal and reaps the guard reader", %{harness: harness} do
+    with_macos_harness(harness, "owner-exit", "enable", &assert_aborted/2)
+  end
+
+  test "EOF restores the exact state without persistence or restart", %{harness: harness} do
+    with_macos_harness(harness, "eof", "enable", &assert_aborted/2)
+  end
+
+  test "callback exceptions restore the exact state without side effects", %{harness: harness} do
+    with_macos_harness(harness, "exception", "exception", &assert_aborted/2)
+  end
+
+  test "failed no-echo setup renders no prompt and never enters the callback", %{harness: harness} do
+    with_macos_harness(harness, "setup-failure", "setup-failure", &assert_aborted/2)
+  end
+
+  test "interruption restores on owner exit without premature guard restoration", %{
+    harness: harness
+  } do
+    with_macos_harness(harness, "interruption", "enable", &assert_aborted/2)
+  end
+
+  defp with_macos_harness(nil, _scenario, _action, _assertions) do
+    IO.puts("Console PTY regression is macOS-only")
+  end
+
+  defp with_macos_harness(harness, scenario, action, assertions) do
+    support_root = temp_support_root()
+    side_effect_marker = Path.join(support_root, "launchctl-invoked")
+    File.mkdir_p!(support_root)
+
+    on_exit(fn -> File.rm_rf(support_root) end)
+
+    {output, status} =
+      System.cmd(
+        harness,
+        [scenario, "--" | source_child_command(action, support_root, side_effect_marker)],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+    assert output == "console PTY ok: #{scenario}\n"
+    assertions.(support_root, side_effect_marker)
+  end
+
+  defp assert_aborted(support_root, side_effect_marker) do
+    refute File.exists?(Path.join([support_root, "config", "console.env"]))
+    refute File.exists?(side_effect_marker)
+  end
+
+  defp source_child_command(action, support_root, side_effect_marker) do
+    code_paths =
+      Path.wildcard(Path.expand("../../../../../_build/test/lib/*/ebin", __DIR__))
+      |> Enum.flat_map(&["-pa", &1])
+
+    [System.find_executable("elixir") | code_paths] ++
+      [
+        "-e",
+        "OrchardCLI.ConsolePTYProcess.main(System.argv())",
+        "--",
+        action,
+        support_root,
+        side_effect_marker
+      ]
+  end
+
+  defp temp_support_root do
+    Path.join(
+      System.tmp_dir!(),
+      "orchard-console-pty-test-#{System.unique_integer([:positive])}"
+    )
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
@@ -2,6 +2,9 @@ defmodule OrchardCLI.Commands.ConsolePTYTest do
   use ExUnit.Case, async: false
 
   @moduletag :capture_log
+  # Paced-paste scenarios drive a real PTY for tens of seconds once macOS timer
+  # coalescing stretches their sleep intervals, well past the 60s ExUnit default.
+  @moduletag timeout: 180_000
 
   @harness_source Path.expand("../../support/console_pty_harness.c", __DIR__)
 

--- a/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
@@ -19,7 +19,17 @@ defmodule OrchardCLI.Commands.ConsolePTYTest do
       {output, status} =
         System.cmd(
           "xcrun",
-          ["clang", "-std=c11", "-Wall", "-Wextra", "-Werror", @harness_source, "-o", harness],
+          [
+            "clang",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-pedantic",
+            @harness_source,
+            "-o",
+            harness
+          ],
           stderr_to_stdout: true
         )
 
@@ -39,6 +49,28 @@ defmodule OrchardCLI.Commands.ConsolePTYTest do
     end)
   end
 
+  test "direct SecretTTY use fails closed without restoration custody", %{harness: harness} do
+    with_macos_harness(harness, "unwrapped", "enable", &assert_aborted/2)
+  end
+
+  @tag secret_tty_case: :invalid_username_paste
+  test "invalid username paste cannot reach the resumed parent shell", %{harness: harness} do
+    with_macos_harness(harness, "invalid-username-paste", "enable", &assert_aborted/2)
+  end
+
+  test "backpressured invalid paste cannot cross the restore handoff", %{harness: harness} do
+    with_macos_harness(
+      harness,
+      "invalid-username-backpressure",
+      "enable",
+      &assert_aborted/2
+    )
+  end
+
+  test "paced invalid paste cannot outlive the restore handoff", %{harness: harness} do
+    with_macos_harness(harness, "invalid-username-paced", "enable", &assert_aborted/2)
+  end
+
   test "credential entry can pause longer than the guard protocol timeout", %{harness: harness} do
     with_macos_harness(harness, "delayed-success", "enable", fn support_root, marker ->
       assert File.exists?(Path.join([support_root, "config", "console.env"]))
@@ -46,8 +78,19 @@ defmodule OrchardCLI.Commands.ConsolePTYTest do
     end)
   end
 
+  test "configured erase removes a complete UTF-8 character", %{harness: harness} do
+    with_macos_harness(harness, "utf8-erase", "enable", fn support_root, marker ->
+      assert File.exists?(Path.join([support_root, "config", "console.env"]))
+      assert File.exists?(marker)
+    end)
+  end
+
   test "owner exit restores the terminal and reaps the guard reader", %{harness: harness} do
     with_macos_harness(harness, "owner-exit", "enable", &assert_aborted/2)
+  end
+
+  test "owner death cannot release a paced paste to the shell", %{harness: harness} do
+    with_macos_harness(harness, "owner-exit-paced", "enable", &assert_aborted/2)
   end
 
   test "EOF restores the exact state without persistence or restart", %{harness: harness} do
@@ -62,10 +105,151 @@ defmodule OrchardCLI.Commands.ConsolePTYTest do
     with_macos_harness(harness, "setup-failure", "setup-failure", &assert_aborted/2)
   end
 
-  test "interruption restores on owner exit without premature guard restoration", %{
+  test "post-protect setup failure restores before callback entry", %{harness: harness} do
+    with_macos_harness(harness, "post-protect", "post-protect", &assert_aborted/2)
+  end
+
+  test "stalled watchdog handshake is killed and reaped without hanging", %{harness: harness} do
+    with_macos_harness(
+      harness,
+      "watchdog-handshake",
+      "watchdog-handshake",
+      &assert_aborted/2
+    )
+  end
+
+  test "watchdog stall after custody registration cannot strand active custody", %{
+    harness: harness
+  } do
+    with_macos_harness(
+      harness,
+      "watchdog-custody-handshake",
+      "watchdog-custody-handshake",
+      &assert_aborted/2
+    )
+  end
+
+  test "protected setup waits for paced input quiescence before returning", %{harness: harness} do
+    with_macos_harness(
+      harness,
+      "watchdog-protected-handshake",
+      "watchdog-protected-handshake",
+      &assert_aborted/2
+    )
+  end
+
+  test "emergency restorer survives parent death during protected handshake teardown", %{
+    harness: harness
+  } do
+    with_macos_harness(
+      harness,
+      "restorer-parent-kill",
+      "restorer-parent-kill",
+      &assert_aborted/2
+    )
+  end
+
+  test "emergency restorer stops the watchdog before restoring on early parent death", %{
+    harness: harness
+  } do
+    with_macos_harness(
+      harness,
+      "restorer-pre-teardown-kill",
+      "restorer-pre-teardown-kill",
+      &assert_aborted/2
+    )
+  end
+
+  test "emergency restorer retries unknown watchdog identity before restoration", %{
+    harness: harness
+  } do
+    with_macos_harness(
+      harness,
+      "restorer-identity-retry",
+      "restorer-identity-retry",
+      &assert_aborted/2
+    )
+  end
+
+  test "emergency signal setup failure falls back without deadlocking custody", %{
+    harness: harness
+  } do
+    with_macos_harness(
+      harness,
+      "restorer-signal-setup",
+      "restorer-signal-setup",
+      &assert_aborted/2
+    )
+  end
+
+  test "PTY harness waits for a complete fragmented process-exit record", %{harness: harness} do
+    with_macos_harness(
+      harness,
+      "fragmented-record-self-test",
+      "restorer-signal-setup",
+      &assert_aborted/2
+    )
+  end
+
+  test "helper death after custody publication cannot strand the foreground shell", %{
+    harness: harness
+  } do
+    with_macos_harness(
+      harness,
+      "marker-pre-ready-kill",
+      "marker-pre-ready-kill",
+      &assert_aborted/2
+    )
+  end
+
+  for signal <- ~w(int hup term kill) do
+    @tag secret_tty_case: :helper_signal
+    test "helper death under SIG#{String.upcase(signal)} restores without hanging", %{
+      harness: harness
+    } do
+      signal = unquote(signal)
+      scenario = "signal-#{signal}"
+      with_macos_harness(harness, scenario, scenario, &assert_aborted/2)
+    end
+  end
+
+  for point <- ~w(idle read) do
+    @tag secret_tty_case: :watchdog_death
+    test "watchdog death while #{point} falls back to exact restoration", %{harness: harness} do
+      point = unquote(point)
+      scenario = "watchdog-#{point}"
+      with_macos_harness(harness, scenario, scenario, &assert_aborted/2)
+    end
+  end
+
+  @tag secret_tty_case: :port_owner_death
+  test "Port-owner death restores while the BEAM VM remains alive", %{harness: harness} do
+    with_macos_harness(harness, "port-owner-exit", "port-owner-exit", &assert_aborted/2)
+  end
+
+  @tag secret_tty_case: :foreground_interrupt
+  test "foreground Ctrl-C restores before the command exits", %{
     harness: harness
   } do
     with_macos_harness(harness, "interruption", "enable", &assert_aborted/2)
+  end
+
+  @tag secret_tty_case: :foreground_quit
+  test "foreground Ctrl-backslash restores before the command exits", %{harness: harness} do
+    with_macos_harness(harness, "quit", "enable", &assert_aborted/2)
+  end
+
+  @tag secret_tty_case: :foreground_stop
+  test "foreground Ctrl-Z restores before stopping and aborts after resume", %{harness: harness} do
+    with_macos_harness(harness, "stop", "enable", &assert_aborted/2)
+  end
+
+  test "backpressured paste cannot cross the Ctrl-Z restore handoff", %{harness: harness} do
+    with_macos_harness(harness, "stop-backpressure", "enable", &assert_aborted/2)
+  end
+
+  test "paced paste cannot outlive the Ctrl-Z restore handoff", %{harness: harness} do
+    with_macos_harness(harness, "stop-paced", "enable", &assert_aborted/2)
   end
 
   defp with_macos_harness(nil, _scenario, _action, _assertions) do

--- a/apps/orchard_cli/test/orchard_cli/commands/console_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/console_test.exs
@@ -355,6 +355,26 @@ defmodule OrchardCLI.Commands.ConsoleTest do
     end
   end
 
+  test "support root supplies the packaged install-role marker path" do
+    support_root = tmp_support_root()
+    role_marker = Path.join([support_root, "support", ".install-role"])
+    File.mkdir_p!(Path.dirname(role_marker))
+    File.write!(role_marker, "controller\n")
+
+    runtime =
+      base_runtime(%{support_root: support_root})
+      |> Map.delete(:read_install_role)
+
+    try do
+      assert {:ok, _message} = Console.run(["disable"], runtime)
+
+      assert File.read!(Path.join([support_root, "config", "console.env"])) ==
+               "ORCHARD_CONSOLE_ENABLED=\"false\"\n"
+    after
+      File.rm_rf(support_root)
+    end
+  end
+
   test "disable writes only disabled flag with mode 0600 and removes credentials" do
     support_root = tmp_support_root()
     console_env = Path.join([support_root, "config", "console.env"])

--- a/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
@@ -16,7 +16,10 @@ defmodule OrchardCLI.PackagingWrapperTest do
     assert content =~ "set -a"
     assert content =~ ". \"$ENV_FILE\""
     assert content =~ "set +a"
-    assert content =~ "exec \"$ORCHARD_CLI\" eval \"OrchardCLI.main([$args])\""
+    assert content =~ "ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID=$$"
+    assert content =~ "\"$ORCHARD_CLI\" eval \"OrchardCLI.main([$args])\" &"
+    assert content =~ "_cli_pid=$!"
+    assert content =~ "wait \"$_cli_pid\""
   end
 
   test "packaged orchardctl wrapper propagates DATABASE_URL from secure controller.env" do

--- a/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
@@ -17,7 +17,7 @@ defmodule OrchardCLI.PackagingWrapperTest do
     assert content =~ ". \"$ENV_FILE\""
     assert content =~ "set +a"
     assert content =~ "ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID=$$"
-    assert content =~ "\"$ORCHARD_CLI\" eval \"OrchardCLI.main([$args])\" &"
+    assert content =~ "\"$ORCHARD_CLI\" eval \"OrchardCLI.main([$args])\" <&3 3<&- &"
     assert content =~ "_cli_pid=$!"
     assert content =~ "wait \"$_cli_pid\""
   end
@@ -44,6 +44,42 @@ defmodule OrchardCLI.PackagingWrapperTest do
       assert output =~ "group/world bits set"
       assert output =~ "DATABASE_URL="
       refute output =~ "DATABASE_URL=ecto://user:pass@localhost/orchard_controller"
+    end)
+  end
+
+  test "packaged orchardctl wrapper forwards piped stdin to the supervised CLI" do
+    with_temp_wrapper(fn wrapper, _root ->
+      assert {output, 0} =
+               System.cmd(
+                 "sh",
+                 [
+                   "-c",
+                   ~s(printf 'activation-key\\n' | "$1" license activate --key-stdin),
+                   "orchardctl-stdin-regression",
+                   wrapper
+                 ],
+                 stderr_to_stdout: true
+               )
+
+      assert output =~ "STDIN=activation-key"
+    end)
+  end
+
+  test "packaged orchardctl wrapper tolerates a closed standard input" do
+    with_temp_wrapper(fn wrapper, _root ->
+      assert {output, 0} =
+               System.cmd(
+                 "sh",
+                 [
+                   "-c",
+                   ~s("$1" license activate --key-stdin 0<&-),
+                   "orchardctl-closed-stdin-regression",
+                   wrapper
+                 ],
+                 stderr_to_stdout: true
+               )
+
+      assert output =~ "STDIN=<eof>"
     end)
   end
 
@@ -79,6 +115,15 @@ defmodule OrchardCLI.PackagingWrapperTest do
     #!/bin/sh
     printf 'DATABASE_URL=%s\n' "${DATABASE_URL:-}"
     printf 'ARGS=%s\n' "$*"
+    case "$*" in
+      *--key-stdin*)
+        if IFS= read -r _line; then
+          printf 'STDIN=%s\n' "$_line"
+        else
+          printf 'STDIN=<eof>\n'
+        fi
+        ;;
+    esac
     """)
 
     File.chmod!(cli_path, 0o755)

--- a/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
@@ -83,6 +83,29 @@ defmodule OrchardCLI.PackagingWrapperTest do
     end)
   end
 
+  test "packaged orchardctl wrapper runs the CLI in the invocation directory" do
+    with_temp_wrapper(fn wrapper, _root ->
+      workdir = Path.join(Path.dirname(wrapper), "operator-cwd")
+      File.mkdir_p!(workdir)
+      File.write!(Path.join(workdir, "cwd-marker"), "relative-path-resolution\n")
+
+      assert {output, 0} =
+               System.cmd(
+                 "sh",
+                 [
+                   "-c",
+                   ~s(cd "$2" && "$1" upgrade plan),
+                   "orchardctl-cwd-regression",
+                   wrapper,
+                   workdir
+                 ],
+                 stderr_to_stdout: true
+               )
+
+      assert output =~ "CWD_MARKER=relative-path-resolution"
+    end)
+  end
+
   test "packaged orchardctl wrapper remains valid POSIX shell" do
     assert {"", 0} = System.cmd("sh", ["-n", @orchardctl], stderr_to_stdout: true)
   end
@@ -115,6 +138,10 @@ defmodule OrchardCLI.PackagingWrapperTest do
     #!/bin/sh
     printf 'DATABASE_URL=%s\n' "${DATABASE_URL:-}"
     printf 'ARGS=%s\n' "$*"
+    if [ -f ./cwd-marker ]; then
+      IFS= read -r _marker < ./cwd-marker
+      printf 'CWD_MARKER=%s\n' "$_marker"
+    fi
     case "$*" in
       *--key-stdin*)
         if IFS= read -r _line; then

--- a/apps/orchard_cli/test/support/console_pty_harness.c
+++ b/apps/orchard_cli/test/support/console_pty_harness.c
@@ -1,0 +1,475 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+#include <util.h>
+
+#define CAPTURE_LIMIT 65536
+#define PROCESS_LIMIT 2048
+#define TRACKED_PROCESS_LIMIT 32
+#define TIMEOUT_MS 15000
+
+struct capture {
+  char bytes[CAPTURE_LIMIT];
+  size_t length;
+};
+
+struct process_entry {
+  pid_t pid;
+  pid_t ppid;
+  char command[64];
+};
+
+struct tracked_processes {
+  pid_t values[TRACKED_PROCESS_LIMIT];
+  size_t length;
+};
+
+static const char *scenario_name;
+
+static void fail(const char *stage) {
+  fprintf(stderr, "console PTY failure: %s: %s\n", scenario_name, stage);
+  exit(1);
+}
+
+static long long now_ms(void) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) fail("clock");
+  return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+static const char *find_bytes(const struct capture *capture, const char *needle) {
+  size_t needle_length = strlen(needle);
+  if (needle_length == 0 || needle_length > capture->length) return NULL;
+
+  for (size_t index = 0; index + needle_length <= capture->length; index++) {
+    if (memcmp(capture->bytes + index, needle, needle_length) == 0) {
+      return capture->bytes + index;
+    }
+  }
+  return NULL;
+}
+
+static int contains(const struct capture *capture, const char *needle) {
+  return find_bytes(capture, needle) != NULL;
+}
+
+static pid_t owner_pid(const struct capture *capture) {
+  const char *marker = "__ORCHARD_OWNER_PID__:";
+  const char *cursor = find_bytes(capture, marker);
+  if (cursor == NULL) fail("owner-marker");
+  cursor += strlen(marker);
+
+  pid_t owner = 0;
+  while (cursor < capture->bytes + capture->length && *cursor >= '0' && *cursor <= '9') {
+    owner = owner * 10 + (*cursor - '0');
+    cursor++;
+  }
+  if (owner <= 0) fail("owner-marker");
+  return owner;
+}
+
+static pid_t process_parent(const struct process_entry *entries, size_t count,
+                            pid_t pid) {
+  for (size_t index = 0; index < count; index++) {
+    if (entries[index].pid == pid) return entries[index].ppid;
+  }
+  return 0;
+}
+
+static int descendant_of(const struct process_entry *entries, size_t count,
+                         pid_t pid, pid_t ancestor) {
+  for (size_t depth = 0; depth < count; depth++) {
+    pid = process_parent(entries, count, pid);
+    if (pid == ancestor) return 1;
+    if (pid <= 1) return 0;
+  }
+  return 0;
+}
+
+static int shell_command(const char *command) {
+  size_t length = strlen(command);
+  return strcmp(command, "sh") == 0 ||
+         (length >= 3 && strcmp(command + length - 3, "/sh") == 0);
+}
+
+static struct tracked_processes guard_processes(pid_t owner) {
+  struct process_entry entries[PROCESS_LIMIT];
+  size_t count = 0;
+  FILE *processes = popen("/bin/ps -axo pid=,ppid=,comm=", "r");
+  if (processes == NULL) fail("process-scan");
+
+  char line[256];
+  while (count < PROCESS_LIMIT && fgets(line, sizeof(line), processes) != NULL) {
+    int pid = 0;
+    int ppid = 0;
+    char command[64];
+    if (sscanf(line, "%d %d %63s", &pid, &ppid, command) == 3) {
+      entries[count].pid = (pid_t)pid;
+      entries[count].ppid = (pid_t)ppid;
+      memcpy(entries[count].command, command, strlen(command) + 1);
+      count++;
+    }
+  }
+  if (pclose(processes) != 0) fail("process-scan");
+
+  struct tracked_processes tracked = {0};
+  for (size_t index = 0; index < count; index++) {
+    if (shell_command(entries[index].command) &&
+        descendant_of(entries, count, entries[index].pid, owner)) {
+      if (tracked.length == TRACKED_PROCESS_LIMIT) fail("tracked-process-limit");
+      tracked.values[tracked.length++] = entries[index].pid;
+    }
+  }
+  if (tracked.length < 2) fail("guard-processes-not-found");
+  return tracked;
+}
+
+static void wait_for_processes_exit(const struct tracked_processes *tracked) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+
+  while (now_ms() < deadline) {
+    int alive = 0;
+    for (size_t index = 0; index < tracked->length; index++) {
+      if (kill(tracked->values[index], 0) == 0 || errno == EPERM) alive = 1;
+    }
+    if (!alive) return;
+    usleep(10000);
+  }
+  fail("secret-tty-process-survived-owner-exit");
+}
+
+static int read_once(int master, struct capture *capture) {
+  if (capture->length == CAPTURE_LIMIT) fail("capture-limit");
+
+  ssize_t count = read(master, capture->bytes + capture->length,
+                       CAPTURE_LIMIT - capture->length);
+  if (count > 0) {
+    capture->length += (size_t)count;
+    return 1;
+  }
+  if (count == 0) return 0;
+  if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) return 1;
+  if (errno == EIO) return 0;
+  fail("read");
+  return 0;
+}
+
+static void read_until(int master, struct capture *capture, const char *needle,
+                       const char *stage) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+
+  while (!contains(capture, needle)) {
+    int remaining = (int)(deadline - now_ms());
+    if (remaining <= 0) fail(stage);
+
+    struct pollfd descriptor = {.fd = master, .events = POLLIN | POLLHUP};
+    int ready = poll(&descriptor, 1, remaining);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) fail("poll");
+    if (ready == 0) fail(stage);
+    if (!read_once(master, capture) && !contains(capture, needle)) fail(stage);
+  }
+}
+
+static void write_all(int master, const void *bytes, size_t length) {
+  const char *cursor = bytes;
+  while (length > 0) {
+    ssize_t count = write(master, cursor, length);
+    if (count < 0 && errno == EINTR) continue;
+    if (count <= 0) fail("write");
+    cursor += count;
+    length -= (size_t)count;
+  }
+}
+
+static void drain_available(int master, struct capture *capture) {
+  while (1) {
+    struct pollfd descriptor = {.fd = master, .events = POLLIN | POLLHUP};
+    int ready = poll(&descriptor, 1, 0);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) fail("poll");
+    if (ready == 0 || (descriptor.revents & POLLIN) == 0) return;
+    if (!read_once(master, capture)) return;
+  }
+}
+
+static int termios_equal(const struct termios *left, const struct termios *right) {
+  return left->c_iflag == right->c_iflag && left->c_oflag == right->c_oflag &&
+         left->c_cflag == right->c_cflag && left->c_lflag == right->c_lflag &&
+         memcmp(left->c_cc, right->c_cc, sizeof(left->c_cc)) == 0 &&
+         cfgetispeed(left) == cfgetispeed(right) &&
+         cfgetospeed(left) == cfgetospeed(right);
+}
+
+static int echo_disabled(int slave) {
+  struct termios state;
+  if (tcgetattr(slave, &state) != 0) fail("get-live-state");
+  return (state.c_lflag & ECHO) == 0;
+}
+
+static void wait_for_state(int slave, const struct termios *expected) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+  struct termios actual;
+
+  while (now_ms() < deadline) {
+    if (tcgetattr(slave, &actual) == 0 && termios_equal(&actual, expected)) return;
+    usleep(10000);
+  }
+  fail("terminal-state-not-restored");
+}
+
+static pid_t spawn_child(int *master, char *slave_name,
+                         struct termios *initial, char **command) {
+  struct winsize window = {.ws_row = 24, .ws_col = 80};
+  pid_t child = forkpty(master, slave_name, initial, &window);
+  if (child < 0) fail("forkpty");
+  if (child != 0) return child;
+
+  size_t command_count = 0;
+  while (command[command_count] != NULL) command_count++;
+
+  char **shell_args = calloc(command_count + 5, sizeof(char *));
+  if (shell_args == NULL) _exit(126);
+  shell_args[0] = "sh";
+  shell_args[1] = "-c";
+  shell_args[2] =
+      "\"$@\" & owner=$!; trap '' INT; "
+      "printf '__ORCHARD_OWNER_PID__:%s\\n' \"$owner\"; "
+      "wait \"$owner\"; status=$?; "
+      "printf '__ORCHARD_PTY_RESULT__:%s\\n' \"$status\"; "
+      "printf '__ORCHARD_PROCESS_EXIT__:%s\\n' \"$status\"; sleep 30";
+  shell_args[3] = "orchard-pty-owner";
+  for (size_t index = 0; index < command_count; index++) {
+    shell_args[index + 4] = command[index];
+  }
+
+  execv("/bin/sh", shell_args);
+  _exit(127);
+}
+
+static void finish_child(pid_t session, pid_t owner, int master,
+                         struct capture *capture) {
+  if (kill(owner, 0) == 0) kill(owner, SIGKILL);
+  read_until(master, capture, "__ORCHARD_PROCESS_EXIT__:", "owner-exit");
+  kill(session, SIGKILL);
+  if (waitpid(session, NULL, 0) < 0) fail("waitpid");
+}
+
+static void assert_failed_result(const struct capture *capture) {
+  if (contains(capture, "__ORCHARD_PTY_RESULT__:0")) fail("unexpected-success");
+}
+
+static void generated_value(char *output, size_t length, const char *prefix) {
+  snprintf(output, length, "%s-%08x-%08x", prefix, arc4random(), arc4random());
+}
+
+static void run_pasted(int master, int slave, pid_t child,
+                       const struct termios *initial, int expect_success,
+                       int delay_ms) {
+  struct capture capture = {0};
+  char username[48];
+  char password[48];
+  char confirmation[48];
+  char paste[128];
+  generated_value(username, sizeof(username), "operator");
+  generated_value(password, sizeof(password), "credential");
+  generated_value(confirmation, sizeof(confirmation), "confirmation");
+
+  read_until(master, &capture, "Console username: ", "username-prompt");
+  int protected_before_username = echo_disabled(slave);
+  if (delay_ms > 0) {
+    usleep((useconds_t)delay_ms * 1000);
+    drain_available(master, &capture);
+    if (contains(&capture, "__ORCHARD_PTY_RESULT__:")) fail("credential-read-timed-out");
+  }
+  int paste_length = snprintf(paste, sizeof(paste), "%s\n%s\n", username, password);
+  if (paste_length < 0 || (size_t)paste_length >= sizeof(paste)) fail("paste-size");
+  write_all(master, paste, (size_t)paste_length);
+
+  read_until(master, &capture, "Console password: ", "password-prompt");
+  int protected_at_password = echo_disabled(slave);
+  read_until(master, &capture, "Confirm console password: ", "confirmation-prompt");
+  int protected_at_confirmation = echo_disabled(slave);
+
+  const char *final_value = expect_success ? password : confirmation;
+  write_all(master, final_value, strlen(final_value));
+  write_all(master, "\n", 1);
+
+  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:", "result-marker");
+  int successful_result = contains(&capture, "__ORCHARD_PTY_RESULT__:0");
+  wait_for_state(slave, initial);
+
+  pid_t owner = owner_pid(&capture);
+  finish_child(child, owner, master, &capture);
+
+  if (!protected_before_username) fail("echo-enabled-before-username-prompt");
+  if (!protected_at_password) fail("echo-enabled-at-password-prompt");
+  if (!protected_at_confirmation) fail("echo-enabled-at-confirmation-prompt");
+  if (contains(&capture, password) || contains(&capture, confirmation)) fail("secret-captured");
+  if (expect_success && !successful_result) fail("unexpected-exit");
+  if (!expect_success && successful_result) fail("unexpected-success");
+}
+
+static void run_eof(int master, int slave, pid_t child,
+                    const struct termios *initial) {
+  struct capture capture = {0};
+  char username[48];
+  generated_value(username, sizeof(username), "operator");
+
+  read_until(master, &capture, "Console username: ", "username-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-username-prompt");
+  write_all(master, username, strlen(username));
+  write_all(master, "\n", 1);
+  read_until(master, &capture, "Console password: ", "password-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-at-password-prompt");
+  write_all(master, "\004", 1);
+
+  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:", "result-marker");
+  assert_failed_result(&capture);
+  wait_for_state(slave, initial);
+  finish_child(child, owner_pid(&capture), master, &capture);
+}
+
+static void run_exception(int master, int slave, pid_t child,
+                          const struct termios *initial) {
+  struct capture capture = {0};
+  char input[48];
+  generated_value(input, sizeof(input), "input");
+
+  read_until(master, &capture, "Console username: ", "exception-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-at-exception-prompt");
+  write_all(master, input, strlen(input));
+  write_all(master, "\n", 1);
+
+  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:70", "exception-result");
+  wait_for_state(slave, initial);
+  finish_child(child, owner_pid(&capture), master, &capture);
+  if (contains(&capture, input)) fail("exception-input-captured");
+}
+
+static void run_setup_failure(int master, int slave, pid_t child,
+                              const struct termios *initial) {
+  struct capture capture = {0};
+  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:", "setup-result");
+  assert_failed_result(&capture);
+  if (contains(&capture, "Console username: ") ||
+      contains(&capture, "Console password: ")) {
+    fail("prompt-rendered-before-setup");
+  }
+  wait_for_state(slave, initial);
+  finish_child(child, owner_pid(&capture), master, &capture);
+}
+
+static void run_owner_exit(int master, int slave, pid_t child,
+                           const struct termios *initial) {
+  struct capture capture = {0};
+  read_until(master, &capture, "Console username: ", "owner-exit-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-owner-exit");
+
+  pid_t owner = owner_pid(&capture);
+  struct tracked_processes tracked = guard_processes(owner);
+  if (kill(owner, SIGKILL) != 0) fail("owner-kill");
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "owner-exit");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  kill(child, SIGKILL);
+  if (waitpid(child, NULL, 0) < 0) fail("waitpid");
+}
+
+static void run_interruption(int master, int slave, pid_t child,
+                             const struct termios *initial) {
+  struct capture capture = {0};
+  read_until(master, &capture, "Console username: ", "interrupt-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-interruption");
+
+  pid_t owner = owner_pid(&capture);
+  if (kill(-child, SIGINT) != 0) fail("interrupt-signal");
+  usleep(250000);
+
+  if (kill(owner, 0) == 0) {
+    if (!echo_disabled(slave)) fail("premature-interrupt-restoration");
+    kill(owner, SIGKILL);
+  }
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "interrupt-exit");
+  wait_for_state(slave, initial);
+  kill(child, SIGKILL);
+  if (waitpid(child, NULL, 0) < 0) fail("waitpid");
+}
+
+static void configure_initial_state(int slave, struct termios *initial, int echo_on) {
+  if (tcgetattr(slave, initial) != 0) fail("get-initial-state");
+  initial->c_lflag |= ICANON | ISIG;
+  if (echo_on) {
+    initial->c_lflag |= ECHO;
+  } else {
+    initial->c_lflag &= (tcflag_t)~ECHO;
+  }
+  initial->c_lflag &= (tcflag_t)~ECHONL;
+  if (tcsetattr(slave, TCSANOW, initial) != 0) fail("set-initial-state");
+  if (tcgetattr(slave, initial) != 0) fail("confirm-initial-state");
+}
+
+int main(int argc, char **argv) {
+  if (argc < 4 || strcmp(argv[2], "--") != 0) {
+    fprintf(stderr, "usage: console_pty_harness SCENARIO -- COMMAND [ARGS...]\n");
+    return 64;
+  }
+
+  scenario_name = argv[1];
+  int probe_master = -1;
+  int probe_slave = -1;
+  if (openpty(&probe_master, &probe_slave, NULL, NULL, NULL) != 0) fail("openpty");
+
+  struct termios initial;
+  int echo_on = strcmp(scenario_name, "eof") != 0 &&
+                strcmp(scenario_name, "exception") != 0;
+  configure_initial_state(probe_slave, &initial, echo_on);
+  close(probe_master);
+  close(probe_slave);
+
+  int master = -1;
+  char slave_name[128];
+  pid_t child = spawn_child(&master, slave_name, &initial, &argv[3]);
+
+  int slave = open(slave_name, O_RDWR | O_NOCTTY);
+  if (slave < 0) fail("open-slave");
+
+  if (strcmp(scenario_name, "pasted-success") == 0) {
+    run_pasted(master, slave, child, &initial, 1, 0);
+  } else if (strcmp(scenario_name, "pasted-mismatch") == 0) {
+    run_pasted(master, slave, child, &initial, 0, 0);
+  } else if (strcmp(scenario_name, "delayed-success") == 0) {
+    run_pasted(master, slave, child, &initial, 1, 6000);
+  } else if (strcmp(scenario_name, "owner-exit") == 0) {
+    run_owner_exit(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "eof") == 0) {
+    run_eof(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "exception") == 0) {
+    run_exception(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "setup-failure") == 0) {
+    run_setup_failure(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "interruption") == 0) {
+    run_interruption(master, slave, child, &initial);
+  } else {
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+    fail("unknown-scenario");
+  }
+
+  close(master);
+  close(slave);
+  printf("console PTY ok: %s\n", scenario_name);
+  return 0;
+}

--- a/apps/orchard_cli/test/support/console_pty_harness.c
+++ b/apps/orchard_cli/test/support/console_pty_harness.c
@@ -1405,10 +1405,6 @@ static void run_interruption(int master, int slave, pid_t child,
   write_all(master, &initial->c_cc[VINTR], 1U);
   read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "interrupt-exit");
   if (process_exit_status(&capture) == 0) fail("interrupt-succeeded");
-  if (!contains(&capture, "Console credential prompt was interrupted"))
-    fail("interrupt-missing-abort-report");
-  if (contains(&capture, "could not restore the prior terminal state"))
-    fail("interrupt-reported-restore-failure");
   wait_for_state(slave, initial);
   finish_child(child, master, &capture);
 }
@@ -1422,10 +1418,6 @@ static void run_quit(int master, int slave, pid_t child,
   write_all(master, &initial->c_cc[VQUIT], 1U);
   read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "quit-exit");
   if (process_exit_status(&capture) == 0) fail("quit-succeeded");
-  if (!contains(&capture, "Console credential prompt was interrupted"))
-    fail("quit-missing-abort-report");
-  if (contains(&capture, "could not restore the prior terminal state"))
-    fail("quit-reported-restore-failure");
   wait_for_state(slave, initial);
   finish_child(child, master, &capture);
 }

--- a/apps/orchard_cli/test/support/console_pty_harness.c
+++ b/apps/orchard_cli/test/support/console_pty_harness.c
@@ -1405,6 +1405,10 @@ static void run_interruption(int master, int slave, pid_t child,
   write_all(master, &initial->c_cc[VINTR], 1U);
   read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "interrupt-exit");
   if (process_exit_status(&capture) == 0) fail("interrupt-succeeded");
+  if (!contains(&capture, "Console credential prompt was interrupted"))
+    fail("interrupt-missing-abort-report");
+  if (contains(&capture, "could not restore the prior terminal state"))
+    fail("interrupt-reported-restore-failure");
   wait_for_state(slave, initial);
   finish_child(child, master, &capture);
 }
@@ -1418,6 +1422,10 @@ static void run_quit(int master, int slave, pid_t child,
   write_all(master, &initial->c_cc[VQUIT], 1U);
   read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "quit-exit");
   if (process_exit_status(&capture) == 0) fail("quit-succeeded");
+  if (!contains(&capture, "Console credential prompt was interrupted"))
+    fail("quit-missing-abort-report");
+  if (contains(&capture, "could not restore the prior terminal state"))
+    fail("quit-reported-restore-failure");
   wait_for_state(slave, initial);
   finish_child(child, master, &capture);
 }

--- a/apps/orchard_cli/test/support/console_pty_harness.c
+++ b/apps/orchard_cli/test/support/console_pty_harness.c
@@ -652,7 +652,7 @@ static void generated_value(char *output, size_t length, const char *prefix) {
 
 static void run_pasted(int master, int slave, pid_t child,
                        const struct termios *initial, int expect_success,
-                       int delay_ms) {
+                       int delay_ms, const char *expected_output) {
   struct capture capture = {0};
   char username[48];
   char password[48];
@@ -692,6 +692,8 @@ static void run_pasted(int master, int slave, pid_t child,
   if (!protected_at_password) fail("echo-enabled-at-password-prompt");
   if (!protected_at_confirmation) fail("echo-enabled-at-confirmation-prompt");
   if (contains(&capture, password) || contains(&capture, confirmation)) fail("secret-captured");
+  if (expected_output != NULL && !contains(&capture, expected_output))
+    fail("expected-output-missing");
   if (expect_success && !successful_result) fail("unexpected-exit");
   if (!expect_success && successful_result) fail("unexpected-success");
 }
@@ -1631,13 +1633,22 @@ int main(int argc, char **argv) {
   if (slave < 0) fail("open-slave");
 
   if (strcmp(scenario_name, "pasted-success") == 0) {
-    run_pasted(master, slave, child, &initial, 1, 0);
+    run_pasted(master, slave, child, &initial, 1, 0, NULL);
   } else if (strcmp(scenario_name, "pasted-mismatch") == 0) {
-    run_pasted(master, slave, child, &initial, 0, 0);
+    run_pasted(master, slave, child, &initial, 0, 0, NULL);
+  } else if (strcmp(scenario_name, "wrapper-success-not-loaded") == 0) {
+    run_pasted(master, slave, child, &initial, 1, 0,
+               "Controller is not loaded.");
+  } else if (strcmp(scenario_name, "wrapper-success-loaded") == 0) {
+    run_pasted(master, slave, child, &initial, 1, 0,
+               "Controller restarted.");
+  } else if (strcmp(scenario_name, "wrapper-success-rotate") == 0) {
+    run_pasted(master, slave, child, &initial, 1, 0,
+               "Console credentials rotated.");
   } else if (strcmp(scenario_name, "unwrapped") == 0) {
     run_setup_failure(master, slave, child, &initial);
   } else if (strcmp(scenario_name, "delayed-success") == 0) {
-    run_pasted(master, slave, child, &initial, 1, 6000);
+    run_pasted(master, slave, child, &initial, 1, 6000, NULL);
   } else if (strcmp(scenario_name, "utf8-erase") == 0) {
     run_utf8_erase(master, slave, child, &initial);
   } else if (strcmp(scenario_name, "owner-exit") == 0) {

--- a/apps/orchard_cli/test/support/console_pty_harness.c
+++ b/apps/orchard_cli/test/support/console_pty_harness.c
@@ -1,11 +1,13 @@
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <termios.h>
@@ -14,6 +16,7 @@
 #include <util.h>
 
 #define CAPTURE_LIMIT 65536
+#define BACKPRESSURE_LIMIT 262144
 #define PROCESS_LIMIT 2048
 #define TRACKED_PROCESS_LIMIT 32
 #define TIMEOUT_MS 15000
@@ -25,8 +28,7 @@ struct capture {
 
 struct process_entry {
   pid_t pid;
-  pid_t ppid;
-  char command[64];
+  char command[512];
 };
 
 struct tracked_processes {
@@ -34,7 +36,11 @@ struct tracked_processes {
   size_t length;
 };
 
+enum process_state { PROCESS_ABSENT, PROCESS_LIVE, PROCESS_ZOMBIE };
+
 static const char *scenario_name;
+static int fragmented_record_release_fd = -1;
+static int read_once(int master, struct capture *capture);
 
 static void fail(const char *stage) {
   fprintf(stderr, "console PTY failure: %s: %s\n", scenario_name, stage);
@@ -63,59 +69,88 @@ static int contains(const struct capture *capture, const char *needle) {
   return find_bytes(capture, needle) != NULL;
 }
 
-static pid_t owner_pid(const struct capture *capture) {
-  const char *marker = "__ORCHARD_OWNER_PID__:";
+static int complete_record(const struct capture *capture, const char *marker) {
   const char *cursor = find_bytes(capture, marker);
-  if (cursor == NULL) fail("owner-marker");
+  if (cursor == NULL) return 0;
   cursor += strlen(marker);
 
-  pid_t owner = 0;
-  while (cursor < capture->bytes + capture->length && *cursor >= '0' && *cursor <= '9') {
-    owner = owner * 10 + (*cursor - '0');
+  while (cursor < capture->bytes + capture->length) {
+    if (*cursor == '\r' || *cursor == '\n') return 1;
     cursor++;
   }
-  if (owner <= 0) fail("owner-marker");
-  return owner;
-}
-
-static pid_t process_parent(const struct process_entry *entries, size_t count,
-                            pid_t pid) {
-  for (size_t index = 0; index < count; index++) {
-    if (entries[index].pid == pid) return entries[index].ppid;
-  }
   return 0;
 }
 
-static int descendant_of(const struct process_entry *entries, size_t count,
-                         pid_t pid, pid_t ancestor) {
-  for (size_t depth = 0; depth < count; depth++) {
-    pid = process_parent(entries, count, pid);
-    if (pid == ancestor) return 1;
-    if (pid <= 1) return 0;
+static void release_fragmented_record_suffix(const struct capture *capture,
+                                             const char *marker) {
+  if (fragmented_record_release_fd < 0 || find_bytes(capture, marker) == NULL ||
+      complete_record(capture, marker))
+    return;
+
+  while (write(fragmented_record_release_fd, "x", 1U) < 0) {
+    if (errno != EINTR) fail("record-self-test-release");
   }
-  return 0;
+  close(fragmented_record_release_fd);
+  fragmented_record_release_fd = -1;
 }
 
-static int shell_command(const char *command) {
-  size_t length = strlen(command);
-  return strcmp(command, "sh") == 0 ||
-         (length >= 3 && strcmp(command + length - 3, "/sh") == 0);
+static long record_number(const struct capture *capture, const char *marker,
+                          const char *stage) {
+  const char *cursor = find_bytes(capture, marker);
+  if (cursor == NULL || !complete_record(capture, marker)) fail(stage);
+  cursor += strlen(marker);
+  if (cursor == capture->bytes + capture->length || *cursor < '0' || *cursor > '9')
+    fail(stage);
+
+  long value = 0;
+  while (cursor < capture->bytes + capture->length && *cursor >= '0' &&
+         *cursor <= '9') {
+    int digit = *cursor - '0';
+    if (value > (LONG_MAX - digit) / 10L) fail(stage);
+    value = value * 10L + digit;
+    cursor++;
+  }
+  if (cursor == capture->bytes + capture->length ||
+      (*cursor != '\r' && *cursor != '\n'))
+    fail(stage);
+  return value;
 }
 
-static struct tracked_processes guard_processes(pid_t owner) {
+static int process_exit_status(const struct capture *capture) {
+  long status = record_number(capture, "__ORCHARD_PROCESS_EXIT__:",
+                              "process-exit-record");
+  if (status > 255L) fail("process-exit-record");
+  return (int)status;
+}
+
+static void marked_path(const struct capture *capture, const char *marker,
+                        char *output, size_t output_size) {
+  const char *cursor = find_bytes(capture, marker);
+  if (cursor == NULL || !complete_record(capture, marker)) fail("path-marker");
+  cursor += strlen(marker);
+
+  size_t used = 0;
+  while (cursor < capture->bytes + capture->length && *cursor != '\r' &&
+         *cursor != '\n') {
+    if (used + 1U >= output_size) fail("path-marker-size");
+    output[used++] = *cursor++;
+  }
+  if (used == 0) fail("path-marker");
+  output[used] = '\0';
+}
+
+static struct tracked_processes guard_processes(const char *slave_name) {
   struct process_entry entries[PROCESS_LIMIT];
   size_t count = 0;
-  FILE *processes = popen("/bin/ps -axo pid=,ppid=,comm=", "r");
+  FILE *processes = popen("/bin/ps -ww -axo pid=,command=", "r");
   if (processes == NULL) fail("process-scan");
 
   char line[256];
   while (count < PROCESS_LIMIT && fgets(line, sizeof(line), processes) != NULL) {
     int pid = 0;
-    int ppid = 0;
-    char command[64];
-    if (sscanf(line, "%d %d %63s", &pid, &ppid, command) == 3) {
+    char command[512];
+    if (sscanf(line, "%d %511[^\n]", &pid, command) == 2) {
       entries[count].pid = (pid_t)pid;
-      entries[count].ppid = (pid_t)ppid;
       memcpy(entries[count].command, command, strlen(command) + 1);
       count++;
     }
@@ -124,8 +159,8 @@ static struct tracked_processes guard_processes(pid_t owner) {
 
   struct tracked_processes tracked = {0};
   for (size_t index = 0; index < count; index++) {
-    if (shell_command(entries[index].command) &&
-        descendant_of(entries, count, entries[index].pid, owner)) {
+    if (strstr(entries[index].command, "orchard-secret-tty") != NULL &&
+        strstr(entries[index].command, slave_name) != NULL) {
       if (tracked.length == TRACKED_PROCESS_LIMIT) fail("tracked-process-limit");
       tracked.values[tracked.length++] = entries[index].pid;
     }
@@ -134,18 +169,92 @@ static struct tracked_processes guard_processes(pid_t owner) {
   return tracked;
 }
 
+static enum process_state inspect_process(pid_t pid) {
+  char command[64];
+  int length = snprintf(command, sizeof(command), "/bin/ps -o stat= -p %d", pid);
+  if (length < 0 || (size_t)length >= sizeof(command)) fail("process-status-command");
+
+  FILE *status = popen(command, "r");
+  if (status == NULL) fail("process-status");
+  char state[16] = {0};
+  int found = fgets(state, sizeof(state), status) != NULL;
+  if (pclose(status) != 0 && found) fail("process-status");
+  if (!found) return PROCESS_ABSENT;
+  return state[0] == 'Z' ? PROCESS_ZOMBIE : PROCESS_LIVE;
+}
+
+static int process_running(pid_t pid) {
+  return inspect_process(pid) == PROCESS_LIVE;
+}
+
 static void wait_for_processes_exit(const struct tracked_processes *tracked) {
   long long deadline = now_ms() + TIMEOUT_MS;
 
   while (now_ms() < deadline) {
     int alive = 0;
     for (size_t index = 0; index < tracked->length; index++) {
-      if (kill(tracked->values[index], 0) == 0 || errno == EPERM) alive = 1;
+      if (process_running(tracked->values[index])) alive = 1;
     }
     if (!alive) return;
     usleep(10000);
   }
   fail("secret-tty-process-survived-owner-exit");
+}
+
+static void wait_for_process_exit(pid_t pid, const char *stage) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+  while (now_ms() < deadline) {
+    if (!process_running(pid)) return;
+    usleep(10000);
+  }
+  fail(stage);
+}
+
+static void wait_for_process_absence(pid_t pid, const char *stage) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+  while (now_ms() < deadline) {
+    if (inspect_process(pid) == PROCESS_ABSENT) return;
+    usleep(10000);
+  }
+  fail(stage);
+}
+
+static void wait_for_process_absence_while_reading(
+    int master, struct capture *capture, pid_t pid, pid_t wrapper,
+    const char *stage) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+
+  while (now_ms() < deadline) {
+    enum process_state state = inspect_process(pid);
+    int lifecycle_marker = complete_record(capture, "__ORCHARD_CLI_REAPED__:") ||
+                           complete_record(capture, "__ORCHARD_PROCESS_EXIT__:");
+    if (lifecycle_marker) {
+      if (state != PROCESS_ABSENT) fail("lifecycle-marker-before-cli-absence");
+      return;
+    }
+    if (state == PROCESS_ABSENT) return;
+    if (!process_running(wrapper)) fail("wrapper-exited-before-cli");
+
+    struct pollfd descriptor = {.fd = master, .events = POLLIN | POLLHUP};
+    int ready = poll(&descriptor, 1, 10);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) fail("poll");
+    if (ready > 0) (void)read_once(master, capture);
+  }
+  fail(stage);
+}
+
+static int wait_for_child_exit(pid_t child) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+  while (now_ms() < deadline) {
+    int status;
+    pid_t waited = waitpid(child, &status, WNOHANG);
+    if (waited == child) return status;
+    if (waited < 0 && errno != EINTR) fail("child-exit-wait");
+    usleep(10000);
+  }
+  fail("child-exit-timeout");
+  return 0;
 }
 
 static int read_once(int master, struct capture *capture) {
@@ -167,8 +276,19 @@ static int read_once(int master, struct capture *capture) {
 static void read_until(int master, struct capture *capture, const char *needle,
                        const char *stage) {
   long long deadline = now_ms() + TIMEOUT_MS;
+  int process_exit = strcmp(needle, "__ORCHARD_PROCESS_EXIT__:") == 0;
 
-  while (!contains(capture, needle)) {
+  while (!(process_exit ? complete_record(capture, needle) : contains(capture, needle))) {
+    if (process_exit) release_fragmented_record_suffix(capture, needle);
+    if (complete_record(capture, "__ORCHARD_PROCESS_EXIT__:") &&
+        strcmp(stage, "queue-status") != 0 && strcmp(stage, "owner-exit") != 0) {
+      if (contains(capture, "could not disable terminal echo")) fail("helper-setup-error");
+      if (contains(capture, "interactive terminal unavailable")) fail("terminal-unavailable");
+      if (contains(capture, "must not be blank")) fail("blank-rejected-without-result");
+      if (contains(capture, "Console password: ")) fail("continued-to-password-prompt");
+      if (contains(capture, "__ORCHARD_PTY_RESULT__:")) fail("result-before-process-exit");
+      fail("command-exited-before-expected-output");
+    }
     int remaining = (int)(deadline - now_ms());
     if (remaining <= 0) fail(stage);
 
@@ -177,8 +297,108 @@ static void read_until(int master, struct capture *capture, const char *needle,
     if (ready < 0 && errno == EINTR) continue;
     if (ready < 0) fail("poll");
     if (ready == 0) fail(stage);
-    if (!read_once(master, capture) && !contains(capture, needle)) fail(stage);
+    if (!read_once(master, capture) &&
+        !(process_exit ? complete_record(capture, needle) : contains(capture, needle)))
+      fail(stage);
   }
+}
+
+static void read_until_expected_setup_exit(int master, struct capture *capture) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+
+  while (!complete_record(capture, "__ORCHARD_PROCESS_EXIT__:")) {
+    release_fragmented_record_suffix(capture, "__ORCHARD_PROCESS_EXIT__:");
+    int remaining = (int)(deadline - now_ms());
+    if (remaining <= 0) fail("restorer-signal-setup-exit");
+
+    struct pollfd descriptor = {.fd = master, .events = POLLIN | POLLHUP};
+    int ready = poll(&descriptor, 1, remaining);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) fail("poll");
+    if (ready == 0) fail("restorer-signal-setup-exit");
+    if (!read_once(master, capture) &&
+        !complete_record(capture, "__ORCHARD_PROCESS_EXIT__:"))
+      fail("restorer-signal-setup-exit");
+  }
+
+  if (!contains(capture, "could not disable terminal echo"))
+    fail("restorer-signal-setup-error-missing");
+}
+
+static void read_until_complete_record(int master, struct capture *capture,
+                                       const char *marker, const char *stage) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+
+  while (!complete_record(capture, marker)) {
+    release_fragmented_record_suffix(capture, marker);
+    if (complete_record(capture, "__ORCHARD_PROCESS_EXIT__:") &&
+        strcmp(stage, "queue-status") != 0)
+      fail(stage);
+    int remaining = (int)(deadline - now_ms());
+    if (remaining <= 0) fail(stage);
+
+    struct pollfd descriptor = {.fd = master, .events = POLLIN | POLLHUP};
+    int ready = poll(&descriptor, 1, remaining);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) fail("poll");
+    if (ready == 0) fail(stage);
+    if (!read_once(master, capture) && !complete_record(capture, marker)) fail(stage);
+  }
+}
+
+static long read_record_number(int master, struct capture *capture,
+                               const char *marker, const char *stage) {
+  read_until_complete_record(master, capture, marker, stage);
+  return record_number(capture, marker, stage);
+}
+
+static int read_status_record(int master, struct capture *capture,
+                              const char *marker, const char *stage) {
+  long status = read_record_number(master, capture, marker, stage);
+  if (status > 255L) fail(stage);
+  return (int)status;
+}
+
+static pid_t read_marked_pid(int master, struct capture *capture,
+                             const char *marker) {
+  long value = read_record_number(master, capture, marker, marker);
+  if (value <= 0 || value > INT_MAX) fail("pid-marker");
+  return (pid_t)value;
+}
+
+static void read_marked_path(int master, struct capture *capture,
+                             const char *marker, char *output,
+                             size_t output_size) {
+  read_until_complete_record(master, capture, marker, "path-marker");
+  marked_path(capture, marker, output, output_size);
+}
+
+static void read_until_while_process_running(int master, struct capture *capture,
+                                             const char *needle, const char *stage,
+                                             pid_t process) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+
+  while (!contains(capture, needle)) {
+    if (!process_running(process)) fail("wrapper-exited-before-cli");
+    if (complete_record(capture, "__ORCHARD_CLI_REAPED__:"))
+      fail("cli-reaped-before-cli-exit");
+    if (complete_record(capture, "__ORCHARD_PROCESS_EXIT__:"))
+      fail("process-exit-before-cli");
+    int remaining = (int)(deadline - now_ms());
+    if (remaining <= 0) fail(stage);
+
+    struct pollfd descriptor = {.fd = master, .events = POLLIN | POLLHUP};
+    int ready = poll(&descriptor, 1, remaining > 10 ? 10 : remaining);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) fail("poll");
+    if (ready > 0 && !read_once(master, capture) && !contains(capture, needle))
+      fail(stage);
+  }
+  if (!process_running(process)) fail("wrapper-exited-before-cli");
+  if (complete_record(capture, "__ORCHARD_CLI_REAPED__:"))
+    fail("cli-reaped-before-cli-exit");
+  if (complete_record(capture, "__ORCHARD_PROCESS_EXIT__:"))
+    fail("process-exit-before-cli");
 }
 
 static void write_all(int master, const void *bytes, size_t length) {
@@ -190,6 +410,88 @@ static void write_all(int master, const void *bytes, size_t length) {
     cursor += count;
     length -= (size_t)count;
   }
+}
+
+static pid_t spawn_backpressure_writer(int master, unsigned char first,
+                                       const char *secret) {
+  pid_t writer = fork();
+  if (writer < 0) fail("paste-writer-fork");
+  if (writer != 0) return writer;
+
+  char *paste = malloc(BACKPRESSURE_LIMIT);
+  if (paste == NULL) _exit(2);
+  paste[0] = (char)first;
+  size_t used = 1U;
+  size_t secret_length = strlen(secret);
+  while (used + secret_length + 1U <= BACKPRESSURE_LIMIT) {
+    memcpy(paste + used, secret, secret_length);
+    used += secret_length;
+    paste[used++] = '\n';
+  }
+  write_all(master, paste, used);
+  free(paste);
+  _exit(0);
+}
+
+static pid_t spawn_paced_writer_for(int master, unsigned char first,
+                                    const char *secret, int writes) {
+  pid_t writer = fork();
+  if (writer < 0) fail("paced-writer-fork");
+  if (writer != 0) return writer;
+
+  write_all(master, &first, 1U);
+  for (int index = 0; index < writes; index++) {
+    write_all(master, secret, strlen(secret));
+    write_all(master, "\n", 1U);
+    usleep(50000);
+  }
+  _exit(0);
+}
+
+static pid_t spawn_paced_writer(int master, unsigned char first,
+                                const char *secret) {
+  return spawn_paced_writer_for(master, first, secret, 60);
+}
+
+static pid_t spawn_started_paced_writer(int master, unsigned char first,
+                                        const char *secret) {
+  int started[2];
+  if (pipe(started) != 0) fail("paced-writer-pipe");
+  pid_t writer = fork();
+  if (writer < 0) fail("paced-writer-fork");
+  if (writer == 0) {
+    close(started[0]);
+    write_all(master, &first, 1U);
+    write_all(started[1], "x", 1U);
+    close(started[1]);
+    for (int index = 0; index < 60; index++) {
+      write_all(master, secret, strlen(secret));
+      write_all(master, "\n", 1U);
+      usleep(50000);
+    }
+    _exit(0);
+  }
+
+  close(started[1]);
+  char marker;
+  if (read(started[0], &marker, 1U) != 1) fail("paced-writer-start");
+  close(started[0]);
+  return writer;
+}
+
+static void wait_for_writer(pid_t writer) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+  while (now_ms() < deadline) {
+    int status;
+    pid_t waited = waitpid(writer, &status, WNOHANG);
+    if (waited == writer) {
+      if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) fail("paste-writer-status");
+      return;
+    }
+    if (waited < 0 && errno != EINTR) fail("paste-writer-wait");
+    usleep(10000);
+  }
+  fail("paste-writer-timeout");
 }
 
 static void drain_available(int master, struct capture *capture) {
@@ -219,11 +521,38 @@ static int echo_disabled(int slave) {
 
 static void wait_for_state(int slave, const struct termios *expected) {
   long long deadline = now_ms() + TIMEOUT_MS;
-  struct termios actual;
+  struct termios actual = {0};
 
   while (now_ms() < deadline) {
     if (tcgetattr(slave, &actual) == 0 && termios_equal(&actual, expected)) return;
     usleep(10000);
+  }
+  fprintf(stderr,
+          "termios mismatch: iflag=%lx/%lx oflag=%lx/%lx cflag=%lx/%lx "
+          "lflag=%lx/%lx\n",
+          (unsigned long)actual.c_iflag, (unsigned long)expected->c_iflag,
+          (unsigned long)actual.c_oflag, (unsigned long)expected->c_oflag,
+          (unsigned long)actual.c_cflag, (unsigned long)expected->c_cflag,
+          (unsigned long)actual.c_lflag, (unsigned long)expected->c_lflag);
+  fail("terminal-state-not-restored");
+}
+
+static void wait_for_state_while_reading(int master, int slave,
+                                         const struct termios *expected,
+                                         struct capture *capture) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+  struct termios actual;
+
+  while (now_ms() < deadline) {
+    if (tcgetattr(slave, &actual) == 0 && termios_equal(&actual, expected)) return;
+
+    struct pollfd descriptor = {.fd = master, .events = POLLIN | POLLHUP};
+    int ready = poll(&descriptor, 1, 10);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) fail("poll");
+    if (ready > 0 && (descriptor.revents & POLLIN) != 0) {
+      (void)read_once(master, capture);
+    }
   }
   fail("terminal-state-not-restored");
 }
@@ -242,12 +571,56 @@ static pid_t spawn_child(int *master, char *slave_name,
   if (shell_args == NULL) _exit(126);
   shell_args[0] = "sh";
   shell_args[1] = "-c";
-  shell_args[2] =
-      "\"$@\" & owner=$!; trap '' INT; "
-      "printf '__ORCHARD_OWNER_PID__:%s\\n' \"$owner\"; "
-      "wait \"$owner\"; status=$?; "
-      "printf '__ORCHARD_PTY_RESULT__:%s\\n' \"$status\"; "
-      "printf '__ORCHARD_PROCESS_EXIT__:%s\\n' \"$status\"; sleep 30";
+  int foreground_wrapper = strncmp(scenario_name, "wrapper-", 8U) == 0 ||
+                           strcmp(scenario_name, "guard-pre-ready-death") == 0 ||
+                           strcmp(scenario_name, "terminal-close") == 0;
+  if (foreground_wrapper) {
+    shell_args[2] =
+        "ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID=$$; "
+        "export ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID; "
+        "unset ORCHARD_CLI_COMPLETION_DIR ORCHARD_CLI_COMPLETION_IDENTITY; "
+        "trap ':' INT QUIT; "
+        "if \"$@\"; then status=0; else status=$?; fi; "
+        "printf '__ORCHARD_PROCESS_EXIT__:%s\\n' \"$status\"; "
+        "IFS= read -r resumed || resumed=; "
+        "if [ \"$resumed\" = '__ORCHARD_QUEUE_SENTINEL__' ]; then "
+        "printf '__ORCHARD_RESUMED_CLEAN__\\n'; "
+        "else printf '__ORCHARD_RESUMED_DIRTY__\\n'; fi; sleep 30";
+  } else if (strcmp(scenario_name, "unwrapped") == 0) {
+    shell_args[2] =
+        "ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID=$$; "
+        "export ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID; "
+        "unset ORCHARD_CLI_COMPLETION_DIR ORCHARD_CLI_COMPLETION_IDENTITY; "
+        "\"$@\" & command_pid=$!; "
+        "if wait \"$command_pid\"; then status=0; else status=$?; fi; "
+        "printf '__ORCHARD_PROCESS_EXIT__:%s\\n' \"$status\"; "
+        "IFS= read -r resumed || resumed=; "
+        "if [ \"$resumed\" = '__ORCHARD_QUEUE_SENTINEL__' ]; then "
+        "printf '__ORCHARD_RESUMED_CLEAN__\\n'; "
+        "else printf '__ORCHARD_RESUMED_DIRTY__\\n'; fi; sleep 30";
+  } else {
+    shell_args[2] =
+      "ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID=$$; "
+      "export ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID; "
+      "ORCHARD_CLI_COMPLETION_DIR=$(/usr/bin/mktemp -d /private/tmp/orchard-pty.XXXXXX) "
+      "|| exit 126; "
+      "/bin/chmod 0700 \"$ORCHARD_CLI_COMPLETION_DIR\" || exit 126; "
+      "export ORCHARD_CLI_COMPLETION_DIR; "
+      "ORCHARD_CLI_COMPLETION_IDENTITY=$(/usr/bin/stat -f '%d:%i' "
+      "\"$ORCHARD_CLI_COMPLETION_DIR\") || exit 126; "
+      "export ORCHARD_CLI_COMPLETION_IDENTITY; "
+      "(umask 077 && : > \"$ORCHARD_CLI_COMPLETION_DIR/available\") || exit 126; "
+      "\"$@\" & command_pid=$!; "
+      "if wait \"$command_pid\"; then status=0; else status=$?; fi; "
+      "/bin/rm -f \"$ORCHARD_CLI_COMPLETION_DIR/available\" || exit 126; "
+      "while [ -e \"$ORCHARD_CLI_COMPLETION_DIR/active\" ]; do /bin/sleep 0.01; done; "
+      "/bin/rmdir \"$ORCHARD_CLI_COMPLETION_DIR\" || exit 126; "
+      "printf '__ORCHARD_PROCESS_EXIT__:%s\\n' \"$status\"; "
+      "IFS= read -r resumed || resumed=; "
+      "if [ \"$resumed\" = '__ORCHARD_QUEUE_SENTINEL__' ]; then "
+      "printf '__ORCHARD_RESUMED_CLEAN__\\n'; "
+      "else printf '__ORCHARD_RESUMED_DIRTY__\\n'; fi; sleep 30";
+  }
   shell_args[3] = "orchard-pty-owner";
   for (size_t index = 0; index < command_count; index++) {
     shell_args[index + 4] = command[index];
@@ -257,16 +630,15 @@ static pid_t spawn_child(int *master, char *slave_name,
   _exit(127);
 }
 
-static void finish_child(pid_t session, pid_t owner, int master,
-                         struct capture *capture) {
-  if (kill(owner, 0) == 0) kill(owner, SIGKILL);
+static void finish_child(pid_t session, int master, struct capture *capture) {
+  const char *sentinel = "__ORCHARD_QUEUE_SENTINEL__\n";
   read_until(master, capture, "__ORCHARD_PROCESS_EXIT__:", "owner-exit");
+  write_all(master, sentinel, strlen(sentinel));
+  read_until_complete_record(master, capture, "__ORCHARD_RESUMED_", "queue-status");
+  if (contains(capture, "__ORCHARD_RESUMED_DIRTY__")) fail("queued-input-survived");
+  if (!contains(capture, "__ORCHARD_RESUMED_CLEAN__")) fail("queue-clean-marker-missing");
   kill(session, SIGKILL);
   if (waitpid(session, NULL, 0) < 0) fail("waitpid");
-}
-
-static void assert_failed_result(const struct capture *capture) {
-  if (contains(capture, "__ORCHARD_PTY_RESULT__:0")) fail("unexpected-success");
 }
 
 static void generated_value(char *output, size_t length, const char *prefix) {
@@ -305,12 +677,11 @@ static void run_pasted(int master, int slave, pid_t child,
   write_all(master, final_value, strlen(final_value));
   write_all(master, "\n", 1);
 
-  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:", "result-marker");
-  int successful_result = contains(&capture, "__ORCHARD_PTY_RESULT__:0");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "process-exit");
+  int successful_result = process_exit_status(&capture) == 0;
   wait_for_state(slave, initial);
 
-  pid_t owner = owner_pid(&capture);
-  finish_child(child, owner, master, &capture);
+  finish_child(child, master, &capture);
 
   if (!protected_before_username) fail("echo-enabled-before-username-prompt");
   if (!protected_at_password) fail("echo-enabled-at-password-prompt");
@@ -318,6 +689,111 @@ static void run_pasted(int master, int slave, pid_t child,
   if (contains(&capture, password) || contains(&capture, confirmation)) fail("secret-captured");
   if (expect_success && !successful_result) fail("unexpected-exit");
   if (!expect_success && successful_result) fail("unexpected-success");
+}
+
+static void run_wrapper_late_int(int master, int slave, pid_t child,
+                                 const struct termios *initial) {
+  struct capture capture = {0};
+  char username[48];
+  char password[48];
+  char confirmation[48];
+  char paste[128];
+  generated_value(username, sizeof(username), "operator");
+  generated_value(password, sizeof(password), "credential");
+  generated_value(confirmation, sizeof(confirmation), "confirmation");
+
+  read_until(master, &capture, "Console username: ", "late-int-username");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  int paste_length = snprintf(paste, sizeof(paste), "%s\n%s\n", username, password);
+  if (paste_length < 0 || (size_t)paste_length >= sizeof(paste)) fail("paste-size");
+  write_all(master, paste, (size_t)paste_length);
+  read_until(master, &capture, "Console password: ", "late-int-password");
+  read_until(master, &capture, "Confirm console password: ",
+             "late-int-confirmation");
+  write_all(master, confirmation, strlen(confirmation));
+  write_all(master, "\n", 1U);
+
+  read_until(master, &capture, "__ORCHARD_PRE_EXIT__", "late-int-barrier");
+  write_all(master, &initial->c_cc[VINTR], 1U);
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "late-int-exit");
+  if (process_exit_status(&capture) != 130) fail("late-int-status");
+  wait_for_process_absence(wrapper, "late-int-wrapper-survived");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, password) || contains(&capture, confirmation))
+    fail("late-int-secret-captured");
+}
+
+static void run_wrapper_post_wait_int(int master, int slave, pid_t child,
+                                      const struct termios *initial,
+                                      const char *barrier,
+                                      int check_cli_status) {
+  struct capture capture = {0};
+  char username[48];
+  char password[48];
+  char confirmation[48];
+  char paste[128];
+  generated_value(username, sizeof(username), "operator");
+  generated_value(password, sizeof(password), "credential");
+  generated_value(confirmation, sizeof(confirmation), "confirmation");
+
+  read_until(master, &capture, "Console username: ", "post-wait-username");
+  int paste_length = snprintf(paste, sizeof(paste), "%s\n%s\n", username, password);
+  if (paste_length < 0 || (size_t)paste_length >= sizeof(paste)) fail("paste-size");
+  write_all(master, paste, (size_t)paste_length);
+  read_until(master, &capture, "Console password: ", "post-wait-password");
+  read_until(master, &capture, "Confirm console password: ",
+             "post-wait-confirmation");
+  write_all(master, confirmation, strlen(confirmation));
+  write_all(master, "\n", 1U);
+
+  read_until(master, &capture, barrier, "post-wait-barrier");
+  write_all(master, &initial->c_cc[VINTR], 1U);
+  if (!check_cli_status &&
+      read_status_record(master, &capture, "__ORCHARD_GUARD_POST_SIGNAL__:",
+                         "post-wait-guard-signal") != 130)
+    fail("post-wait-guard-signal-status");
+  if (check_cli_status &&
+      read_status_record(master, &capture, "__ORCHARD_CLI_REAPED__:",
+                         "post-wait-cli-reaped") != 1)
+    fail("post-wait-cli-status");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "post-wait-exit");
+  int exit_status = process_exit_status(&capture);
+  if (exit_status != 130) {
+    fprintf(stderr, "post-wait exit status: %d\n", exit_status);
+    fail("post-wait-exit-status");
+  }
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, password) || contains(&capture, confirmation))
+    fail("post-wait-secret-captured");
+}
+
+static void run_utf8_erase(int master, int slave, pid_t child,
+                           const struct termios *initial) {
+  struct capture capture = {0};
+  char password[48];
+  generated_value(password, sizeof(password), "credential");
+
+  read_until(master, &capture, "Console username: ", "username-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-username-prompt");
+  const unsigned char username[] = "operator-\xC3\xA9";
+  write_all(master, username, sizeof(username) - 1U);
+  write_all(master, &initial->c_cc[VERASE], 1U);
+  write_all(master, "x\n", 2U);
+
+  read_until(master, &capture, "Console password: ", "password-prompt");
+  write_all(master, password, strlen(password));
+  write_all(master, "\n", 1U);
+  read_until(master, &capture, "Confirm console password: ", "confirmation-prompt");
+  write_all(master, password, strlen(password));
+  write_all(master, "\n", 1U);
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "process-exit");
+  if (process_exit_status(&capture) != 0) fail("unexpected-exit-status");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, password)) fail("secret-captured");
 }
 
 static void run_eof(int master, int slave, pid_t child,
@@ -334,10 +810,10 @@ static void run_eof(int master, int slave, pid_t child,
   if (!echo_disabled(slave)) fail("echo-enabled-at-password-prompt");
   write_all(master, "\004", 1);
 
-  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:", "result-marker");
-  assert_failed_result(&capture);
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "process-exit");
+  if (process_exit_status(&capture) != 1) fail("unexpected-exit-status");
   wait_for_state(slave, initial);
-  finish_child(child, owner_pid(&capture), master, &capture);
+  finish_child(child, master, &capture);
 }
 
 static void run_exception(int master, int slave, pid_t child,
@@ -351,23 +827,234 @@ static void run_exception(int master, int slave, pid_t child,
   write_all(master, input, strlen(input));
   write_all(master, "\n", 1);
 
-  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:70", "exception-result");
+  if (read_status_record(master, &capture, "__ORCHARD_PTY_RESULT__:",
+                         "exception-result") != 70)
+    fail("exception-result-status");
   wait_for_state(slave, initial);
-  finish_child(child, owner_pid(&capture), master, &capture);
+  finish_child(child, master, &capture);
   if (contains(&capture, input)) fail("exception-input-captured");
 }
 
 static void run_setup_failure(int master, int slave, pid_t child,
                               const struct termios *initial) {
   struct capture capture = {0};
-  read_until(master, &capture, "__ORCHARD_PTY_RESULT__:", "setup-result");
-  assert_failed_result(&capture);
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "setup-exit");
+  if (process_exit_status(&capture) == 0) fail("setup-succeeded");
   if (contains(&capture, "Console username: ") ||
       contains(&capture, "Console password: ")) {
     fail("prompt-rendered-before-setup");
   }
   wait_for_state(slave, initial);
-  finish_child(child, owner_pid(&capture), master, &capture);
+  finish_child(child, master, &capture);
+}
+
+static void run_protected_setup_paced(int master, int slave, pid_t child,
+                                      const struct termios *initial) {
+  struct capture capture = {0};
+  char secret[48];
+  generated_value(secret, sizeof(secret), "credential");
+
+  read_until(master, &capture, "__ORCHARD_TEST_PROTECTED__", "protected-setup-state");
+  if (!echo_disabled(slave)) fail("protected-setup-echo");
+  pid_t writer = spawn_paced_writer_for(master, 'x', secret, 220);
+  wait_for_writer(writer);
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "setup-exit");
+  if (process_exit_status(&capture) == 0) fail("setup-succeeded");
+  if (contains(&capture, "Console username: ") ||
+      contains(&capture, "Console password: ")) {
+    fail("prompt-rendered-before-setup");
+  }
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, secret)) fail("secret-captured");
+}
+
+static void run_restorer_parent_kill(int master, int slave, pid_t child,
+                                     const struct termios *initial) {
+  struct capture capture = {0};
+  char secret[48];
+  generated_value(secret, sizeof(secret), "credential");
+
+  read_until(master, &capture, "__ORCHARD_TEST_RESTORER_ARMED__:",
+             "restorer-armed");
+  if (!echo_disabled(slave)) fail("restorer-parent-echo");
+  pid_t helper = read_marked_pid(master, &capture, "__ORCHARD_TEST_RESTORER_ARMED__:");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  pid_t writer = spawn_paced_writer_for(master, 'x', secret, 220);
+  if (kill(helper, SIGKILL) != 0) fail("restorer-parent-kill");
+
+  wait_for_writer(writer);
+  if (!echo_disabled(slave)) fail("restorer-returned-before-writer-complete");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "restorer-parent-exit");
+  if (process_exit_status(&capture) == 0)
+    fail("restorer-parent-succeeded");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  finish_child(child, master, &capture);
+  if (contains(&capture, secret)) fail("restorer-parent-secret-captured");
+}
+
+static void run_restorer_pre_teardown_kill(int master, int slave, pid_t child,
+                                           const struct termios *initial) {
+  struct capture capture = {0};
+
+  read_until(master, &capture, "__ORCHARD_TEST_RESTORER_PRE_TEARDOWN__:",
+             "restorer-pre-teardown-armed");
+  pid_t helper = read_marked_pid(
+      master, &capture, "__ORCHARD_TEST_RESTORER_PRE_TEARDOWN__:");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  if (kill(helper, SIGKILL) != 0) fail("restorer-pre-teardown-kill");
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:",
+             "restorer-pre-teardown-exit");
+  if (process_exit_status(&capture) == 0)
+    fail("restorer-pre-teardown-succeeded");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  finish_child(child, master, &capture);
+}
+
+static void run_restorer_identity_retry(int master, int slave, pid_t child,
+                                        const struct termios *initial) {
+  struct capture capture = {0};
+
+  read_until(master, &capture, "__ORCHARD_TEST_RESTORER_IDENTITY__:",
+             "restorer-identity-armed");
+  pid_t helper =
+      read_marked_pid(master, &capture, "__ORCHARD_TEST_RESTORER_IDENTITY__:");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  if (kill(helper, SIGKILL) != 0) fail("restorer-identity-parent-kill");
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:",
+             "restorer-identity-exit");
+  if (process_exit_status(&capture) == 0)
+    fail("restorer-identity-succeeded");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  finish_child(child, master, &capture);
+}
+
+static void run_watchdog_custody_handshake(int master, int slave, pid_t child,
+                                           const struct termios *initial) {
+  struct capture capture = {0};
+
+  read_until(master, &capture, "__ORCHARD_TEST_CUSTODY_REGISTERED__",
+             "custody-handshake-registered");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:",
+             "custody-handshake-exit");
+  if (process_exit_status(&capture) == 0)
+    fail("custody-handshake-succeeded");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  finish_child(child, master, &capture);
+}
+
+static void run_restorer_signal_setup(int master, int slave, pid_t child,
+                                      const struct termios *initial) {
+  struct capture capture = {0};
+
+  read_until_complete_record(master, &capture, "__ORCHARD_TEST_SIGNAL_WATCHDOG__:",
+                             "restorer-signal-setup-marker");
+  pid_t parent = read_marked_pid(master, &capture, "__ORCHARD_TEST_SIGNAL_PARENT__:");
+  pid_t emergency =
+      read_marked_pid(master, &capture, "__ORCHARD_TEST_SIGNAL_EMERGENCY__:");
+  pid_t watchdog =
+      read_marked_pid(master, &capture, "__ORCHARD_TEST_SIGNAL_WATCHDOG__:");
+  read_until_expected_setup_exit(master, &capture);
+  if (process_exit_status(&capture) == 0)
+    fail("restorer-signal-setup-succeeded");
+  wait_for_state(slave, initial);
+  wait_for_process_absence(parent, "restorer-signal-parent-survived");
+  wait_for_process_absence(emergency, "restorer-signal-emergency-survived");
+  wait_for_process_absence(watchdog, "restorer-signal-watchdog-survived");
+  finish_child(child, master, &capture);
+}
+
+static void run_helper_signal(int master, int slave, pid_t child,
+                              const struct termios *initial) {
+  struct capture capture = {0};
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "helper-signal-exit");
+  if (process_exit_status(&capture) == 0) fail("helper-signal-succeeded");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+}
+
+static void run_port_owner_exit(int master, int slave, pid_t child,
+                                const struct termios *initial) {
+  struct capture capture = {0};
+  read_until(master, &capture, "__ORCHARD_PORT_OWNER_READY__", "port-owner-ready");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  read_until(master, &capture, "__ORCHARD_PORT_OWNER_DIED__", "port-owner-died");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "port-owner-exit");
+  if (process_exit_status(&capture) == 0) fail("port-owner-succeeded");
+  finish_child(child, master, &capture);
+}
+
+static void run_invalid_username_paste(int master, int slave, pid_t child,
+                                       const struct termios *initial) {
+  struct capture capture = {0};
+  char password[48];
+  char confirmation[48];
+  char paste[160];
+  generated_value(password, sizeof(password), "credential");
+  generated_value(confirmation, sizeof(confirmation), "confirmation");
+
+  read_until(master, &capture, "Console username: ", "username-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-username-prompt");
+
+  int paste_length = snprintf(paste, sizeof(paste), "\n%s\n%s\n",
+                              password, confirmation);
+  if (paste_length < 0 || (size_t)paste_length >= sizeof(paste)) fail("paste-size");
+  write_all(master, paste, (size_t)paste_length);
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "process-exit");
+  if (process_exit_status(&capture) != 1) fail("unexpected-exit-status");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+
+  if (contains(&capture, password) || contains(&capture, confirmation)) {
+    fail("secret-captured");
+  }
+}
+
+static void run_invalid_username_backpressure(int master, int slave, pid_t child,
+                                              const struct termios *initial) {
+  struct capture capture = {0};
+  char secret[48];
+  generated_value(secret, sizeof(secret), "credential");
+
+  read_until(master, &capture, "Console username: ", "username-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-username-prompt");
+  pid_t writer = spawn_backpressure_writer(master, '\n', secret);
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "process-exit");
+  if (process_exit_status(&capture) != 1) fail("unexpected-exit-status");
+  wait_for_writer(writer);
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, secret)) fail("secret-captured");
+}
+
+static void run_invalid_username_paced(int master, int slave, pid_t child,
+                                       const struct termios *initial) {
+  struct capture capture = {0};
+  char secret[48];
+  generated_value(secret, sizeof(secret), "credential");
+
+  read_until(master, &capture, "Console username: ", "username-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-username-prompt");
+  pid_t writer = spawn_paced_writer(master, '\n', secret);
+
+  wait_for_writer(writer);
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "process-exit");
+  if (process_exit_status(&capture) != 1) fail("unexpected-exit-status");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, secret)) fail("secret-captured");
 }
 
 static void run_owner_exit(int master, int slave, pid_t child,
@@ -376,15 +1063,330 @@ static void run_owner_exit(int master, int slave, pid_t child,
   read_until(master, &capture, "Console username: ", "owner-exit-prompt");
   if (!echo_disabled(slave)) fail("echo-enabled-before-owner-exit");
 
-  pid_t owner = owner_pid(&capture);
-  struct tracked_processes tracked = guard_processes(owner);
+  pid_t owner = read_marked_pid(master, &capture, "__ORCHARD_OWNER_PID__:");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
   if (kill(owner, SIGKILL) != 0) fail("owner-kill");
 
   read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "owner-exit");
   wait_for_state(slave, initial);
   wait_for_processes_exit(&tracked);
-  kill(child, SIGKILL);
-  if (waitpid(child, NULL, 0) < 0) fail("waitpid");
+  finish_child(child, master, &capture);
+}
+
+static void run_owner_exit_paced(int master, int slave, pid_t child,
+                                  const struct termios *initial) {
+  struct capture capture = {0};
+  char tail[48];
+  generated_value(tail, sizeof(tail), "paste-tail");
+
+  read_until(master, &capture, "Console username: ", "owner-exit-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-owner-exit");
+  pid_t owner = read_marked_pid(master, &capture, "__ORCHARD_OWNER_PID__:");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  pid_t writer = spawn_started_paced_writer(master, 'x', tail);
+  if (kill(owner, SIGKILL) != 0) fail("owner-kill");
+
+  wait_for_writer(writer);
+  if (!echo_disabled(slave)) fail("owner-exit-restored-before-writer-complete");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "owner-exit");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  finish_child(child, master, &capture);
+  const char *tail_capture = find_bytes(&capture, tail);
+  if (tail_capture != NULL) {
+    const char *process_exit = find_bytes(&capture, "__ORCHARD_PROCESS_EXIT__:");
+    fail(tail_capture < process_exit ? "owner-exit-tail-before-exit"
+                                     : "owner-exit-tail-after-exit");
+  }
+}
+
+static void run_wrapper_signal_paced(int master, int slave, pid_t child,
+                                     const struct termios *initial,
+                                     int signal_number,
+                                     int expected_status) {
+  struct capture capture = {0};
+  char tail[48];
+  generated_value(tail, sizeof(tail), "paste-tail");
+
+  read_until(master, &capture, "Console username: ", "wrapper-term-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-wrapper-term");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  pid_t writer = spawn_started_paced_writer(master, 'x', tail);
+  if (kill(wrapper, signal_number) != 0) fail("wrapper-signal");
+
+  wait_for_writer(writer);
+  if (!echo_disabled(slave)) fail("wrapper-term-restored-before-writer-complete");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "wrapper-term-exit");
+  if (process_exit_status(&capture) != expected_status)
+    fail("wrapper-term-status");
+  wait_for_state(slave, initial);
+  wait_for_processes_exit(&tracked);
+  finish_child(child, master, &capture);
+  if (contains(&capture, tail)) fail("wrapper-term-tail-captured");
+}
+
+static void run_wrapper_path_substitution(int master, int slave, pid_t child,
+                                          const struct termios *initial) {
+  struct capture capture = {0};
+  char completion_dir[PATH_MAX];
+  char moved_dir[PATH_MAX];
+
+  read_until(master, &capture, "Console username: ", "path-substitution-prompt");
+  if (!echo_disabled(slave)) fail("path-substitution-echo");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
+                   sizeof(completion_dir));
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+  int length = snprintf(moved_dir, sizeof(moved_dir), "%s.moved", completion_dir);
+  if (length < 0 || (size_t)length >= sizeof(moved_dir)) fail("moved-path-size");
+  if (rename(completion_dir, moved_dir) != 0) fail("custody-dir-rename");
+  if (mkdir(completion_dir, 0700) != 0) fail("custody-dir-replacement");
+
+  write_all(master, "\n", 1U);
+  wait_for_state_while_reading(master, slave, initial, &capture);
+  wait_for_processes_exit(&tracked);
+  pid_t cli = read_marked_pid(master, &capture, "__ORCHARD_CLI_PID__:");
+  wait_for_process_absence_while_reading(
+      master, &capture, cli, wrapper, "cli-survived-path-substitution");
+  (void)read_status_record(master, &capture, "__ORCHARD_CLI_REAPED__:",
+                           "path-substitution-cli-reaped");
+  if (!process_running(wrapper)) fail("wrapper-released-on-path-substitution");
+
+  if (rmdir(completion_dir) != 0) fail("custody-replacement-remove");
+  if (rename(moved_dir, completion_dir) != 0) fail("custody-dir-restore");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "path-substitution-exit");
+  if (process_exit_status(&capture) != 1)
+    fail("path-substitution-status");
+  wait_for_process_exit(wrapper, "wrapper-survived-path-substitution");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+}
+
+static void run_guard_pre_ready_death(int master, int slave, pid_t child,
+                                      const struct termios *initial) {
+  struct capture capture = {0};
+  char completion_dir[PATH_MAX];
+  char moved_dir[PATH_MAX];
+
+  read_until(master, &capture, "__ORCHARD_GUARD_PID__:",
+             "guard-pid-marker");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  pid_t guard = read_marked_pid(master, &capture, "__ORCHARD_GUARD_PID__:");
+  read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
+                   sizeof(completion_dir));
+  int length = snprintf(moved_dir, sizeof(moved_dir), "%s.moved", completion_dir);
+  if (length < 0 || (size_t)length >= sizeof(moved_dir)) fail("moved-path-size");
+  if (rename(completion_dir, moved_dir) != 0) fail("guard-custody-dir-rename");
+  if (mkdir(completion_dir, 0700) != 0) fail("guard-custody-dir-replacement");
+  if (kill(guard, SIGKILL) != 0) fail("guard-kill");
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "guard-death-exit");
+  if (process_exit_status(&capture) == 0) fail("guard-death-succeeded");
+  if (contains(&capture, "__ORCHARD_CLI_PID__:")) fail("guard-death-started-cli");
+  wait_for_process_exit(wrapper, "wrapper-survived-guard-death");
+  wait_for_state(slave, initial);
+  if (access(completion_dir, F_OK) != 0) fail("guard-death-touched-replacement");
+  if (rmdir(completion_dir) != 0) fail("guard-replacement-remove");
+  if (rename(moved_dir, completion_dir) != 0) fail("guard-custody-dir-restore");
+  if (rmdir(completion_dir) != 0) fail("guard-original-dir-remove");
+  finish_child(child, master, &capture);
+}
+
+static void run_wrapper_wait_reap(int master, int slave, pid_t child,
+                                  const struct termios *initial) {
+  struct capture capture = {0};
+
+  read_until(master, &capture, "__ORCHARD_FIXTURE_PID__:", "fixture-pid-marker");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  pid_t cli = read_marked_pid(master, &capture, "__ORCHARD_CLI_PID__:");
+  pid_t fixture = read_marked_pid(master, &capture, "__ORCHARD_FIXTURE_PID__:");
+  if (cli != fixture) fail("fixture-cli-pid-mismatch");
+  if (kill(wrapper, SIGTERM) != 0) fail("wrapper-term");
+
+  read_until(master, &capture, "__ORCHARD_FIXTURE_TERM__", "fixture-term");
+  if (!process_running(cli)) fail("fixture-exited-without-delay");
+  if (!process_running(wrapper)) fail("wrapper-exited-before-cli");
+  if (complete_record(&capture, "__ORCHARD_PROCESS_EXIT__:"))
+    fail("process-exit-before-cli");
+
+  read_until_while_process_running(master, &capture,
+                                   "__ORCHARD_FIXTURE_EXIT_BARRIER__",
+                                   "fixture-exit-barrier", wrapper);
+  if (!process_running(cli)) fail("fixture-exited-before-exit-barrier");
+  wait_for_process_absence_while_reading(master, &capture, cli, wrapper,
+                                         "cli-survived-wrapper");
+  if (read_status_record(master, &capture, "__ORCHARD_CLI_REAPED__:",
+                         "cli-reaped-marker") != 143)
+    fail("cli-reaped-status");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "wrapper-term-exit");
+  if (process_exit_status(&capture) != 143) fail("wrapper-term-status");
+  wait_for_process_exit(wrapper, "wrapper-survived-cli-reap");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+}
+
+static void run_wrapper_pre_ready_death(int master, int slave, pid_t child,
+                                        const struct termios *initial,
+                                        int signal_number) {
+  struct capture capture = {0};
+  char completion_dir[PATH_MAX];
+
+  read_until(master, &capture, "__ORCHARD_GUARD_PID__:",
+             "wrapper-death-guard-marker");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  pid_t guard = read_marked_pid(master, &capture, "__ORCHARD_GUARD_PID__:");
+  read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
+                   sizeof(completion_dir));
+  if (kill(wrapper, signal_number) != 0) fail("wrapper-kill");
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:",
+             "wrapper-death-exit");
+  if (process_exit_status(&capture) == 0)
+    fail("wrapper-death-succeeded");
+  if (signal_number == SIGTERM) {
+    int status = process_exit_status(&capture);
+    if (status != 143) {
+      fprintf(stderr, "wrapper TERM status: %d\n", status);
+      fail("wrapper-term-status");
+    }
+  }
+  if (contains(&capture, "__ORCHARD_CLI_PID__:"))
+    fail("wrapper-death-started-cli");
+  wait_for_process_absence(wrapper, "wrapper-survived-pre-ready-death");
+  wait_for_process_absence(guard, "guard-survived-wrapper-death");
+  wait_for_state(slave, initial);
+  if (access(completion_dir, F_OK) == 0)
+    fail("wrapper-death-directory-survived");
+  finish_child(child, master, &capture);
+}
+
+static void run_wrapper_pre_launch_signal(int master, int slave, pid_t child,
+                                          const struct termios *initial,
+                                          int signal_number,
+                                          int expected_status) {
+  struct capture capture = {0};
+  char completion_dir[PATH_MAX];
+
+  read_until(master, &capture, "__ORCHARD_PRE_LAUNCH__", "pre-launch-marker");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  pid_t guard = read_marked_pid(master, &capture, "__ORCHARD_GUARD_PID__:");
+  read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
+                   sizeof(completion_dir));
+  if (signal_number == SIGINT) {
+    write_all(master, &initial->c_cc[VINTR], 1U);
+  } else if (signal_number == SIGQUIT) {
+    write_all(master, &initial->c_cc[VQUIT], 1U);
+  } else if (kill(wrapper, signal_number) != 0) {
+    fail("pre-launch-wrapper-signal");
+  }
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "pre-launch-exit");
+  if (process_exit_status(&capture) != expected_status) fail("pre-launch-status");
+  if (contains(&capture, "__ORCHARD_CLI_PID__:")) fail("pre-launch-started-cli");
+  wait_for_process_absence(wrapper, "pre-launch-wrapper-survived");
+  wait_for_process_absence(guard, "pre-launch-guard-survived");
+  wait_for_state(slave, initial);
+  if (access(completion_dir, F_OK) == 0) fail("pre-launch-directory-survived");
+  finish_child(child, master, &capture);
+}
+
+static void run_wrapper_launch_path_substitution(
+    int master, int slave, pid_t child, const struct termios *initial) {
+  struct capture capture = {0};
+  char completion_dir[PATH_MAX];
+  char moved_dir[PATH_MAX];
+  char launch_marker[PATH_MAX];
+
+  read_until(master, &capture, "__ORCHARD_PRE_LAUNCH__",
+             "launch-substitution-barrier");
+  read_until(master, &capture, "__ORCHARD_LAUNCH_WINDOW__",
+             "launch-substitution-window");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  pid_t guard = read_marked_pid(master, &capture, "__ORCHARD_GUARD_PID__:");
+  pid_t launcher =
+      read_marked_pid(master, &capture, "__ORCHARD_LAUNCHER_PID__:");
+  read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
+                   sizeof(completion_dir));
+  int length = snprintf(moved_dir, sizeof(moved_dir), "%s.moved", completion_dir);
+  if (length < 0 || (size_t)length >= sizeof(moved_dir)) fail("moved-path-size");
+  length = snprintf(launch_marker, sizeof(launch_marker), "%s/launch-cli",
+                    completion_dir);
+  if (length < 0 || (size_t)length >= sizeof(launch_marker))
+    fail("launch-marker-size");
+
+  if (rename(completion_dir, moved_dir) != 0) fail("launch-custody-rename");
+  if (mkdir(completion_dir, 0700) != 0) fail("launch-custody-replacement");
+  if (kill(wrapper, SIGKILL) != 0) fail("launch-wrapper-kill");
+  wait_for_process_absence(wrapper, "launch-wrapper-survived");
+  int marker = open(launch_marker, O_WRONLY | O_CREAT | O_EXCL, 0600);
+  if (marker < 0) fail("substitute-launch-marker");
+  close(marker);
+
+  wait_for_process_absence(launcher, "launcher-trusted-substituted-path");
+
+  if (unlink(launch_marker) != 0) fail("substitute-launch-marker-remove");
+  if (rmdir(completion_dir) != 0) fail("launch-replacement-remove");
+  if (rename(moved_dir, completion_dir) != 0) fail("launch-custody-restore");
+  wait_for_process_absence(guard, "launch-guard-survived");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:",
+             "launch-substitution-exit");
+  if (contains(&capture, "__ORCHARD_FIXTURE_PID__:"))
+    fail("substituted-path-launched-cli");
+  if (process_exit_status(&capture) == 0) fail("launch-substitution-succeeded");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+}
+
+static void run_wrapper_setup_failure(int master, int slave, pid_t child,
+                                      const struct termios *initial) {
+  struct capture capture = {0};
+  char completion_dir[PATH_MAX];
+
+  read_until(master, &capture, "__ORCHARD_CUSTODY_DIR__:",
+             "setup-failure-custody-marker");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
+                   sizeof(completion_dir));
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:",
+             "wrapper-setup-failure-exit");
+  if (process_exit_status(&capture) == 0)
+    fail("wrapper-setup-failure-succeeded");
+  if (contains(&capture, "__ORCHARD_GUARD_PID__:"))
+    fail("wrapper-setup-failure-started-guard");
+  if (contains(&capture, "__ORCHARD_CLI_PID__:"))
+    fail("wrapper-setup-failure-started-cli");
+  wait_for_process_absence(wrapper, "wrapper-survived-setup-failure");
+  wait_for_state(slave, initial);
+  if (access(completion_dir, F_OK) == 0)
+    fail("wrapper-setup-failure-directory-survived");
+  finish_child(child, master, &capture);
+}
+
+static void run_terminal_close(int master, int slave, pid_t child) {
+  struct capture capture = {0};
+  char completion_dir[PATH_MAX];
+
+  read_until(master, &capture, "Console username: ", "terminal-close-prompt");
+  pid_t wrapper = read_marked_pid(master, &capture, "__ORCHARD_WRAPPER_PID__:");
+  read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
+                   sizeof(completion_dir));
+  struct tracked_processes tracked = guard_processes(ttyname(slave));
+
+  close(slave);
+  close(master);
+  wait_for_processes_exit(&tracked);
+  wait_for_process_exit(wrapper, "wrapper-survived-terminal-close");
+  int status = wait_for_child_exit(child);
+  if (WIFEXITED(status) && WEXITSTATUS(status) == 0) fail("terminal-close-succeeded");
+
+  char active_marker[PATH_MAX];
+  int length = snprintf(active_marker, sizeof(active_marker), "%s/active", completion_dir);
+  if (length < 0 || (size_t)length >= sizeof(active_marker)) fail("active-marker-size");
+  if (access(active_marker, F_OK) == 0) fail("terminal-close-custody-survived");
+  if (rmdir(completion_dir) != 0 && errno != ENOENT)
+    fail("terminal-close-directory-not-empty");
 }
 
 static void run_interruption(int master, int slave, pid_t child,
@@ -393,19 +1395,96 @@ static void run_interruption(int master, int slave, pid_t child,
   read_until(master, &capture, "Console username: ", "interrupt-prompt");
   if (!echo_disabled(slave)) fail("echo-enabled-before-interruption");
 
-  pid_t owner = owner_pid(&capture);
-  if (kill(-child, SIGINT) != 0) fail("interrupt-signal");
-  usleep(250000);
-
-  if (kill(owner, 0) == 0) {
-    if (!echo_disabled(slave)) fail("premature-interrupt-restoration");
-    kill(owner, SIGKILL);
-  }
-
+  write_all(master, &initial->c_cc[VINTR], 1U);
   read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "interrupt-exit");
+  if (process_exit_status(&capture) == 0) fail("interrupt-succeeded");
   wait_for_state(slave, initial);
-  kill(child, SIGKILL);
-  if (waitpid(child, NULL, 0) < 0) fail("waitpid");
+  finish_child(child, master, &capture);
+}
+
+static void run_quit(int master, int slave, pid_t child,
+                     const struct termios *initial) {
+  struct capture capture = {0};
+  read_until(master, &capture, "Console username: ", "quit-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-quit");
+
+  write_all(master, &initial->c_cc[VQUIT], 1U);
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "quit-exit");
+  if (process_exit_status(&capture) == 0) fail("quit-succeeded");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+}
+
+static void wait_for_stop(pid_t child) {
+  long long deadline = now_ms() + TIMEOUT_MS;
+  while (now_ms() < deadline) {
+    int status;
+    pid_t waited = waitpid(child, &status, WNOHANG | WUNTRACED);
+    if (waited == child && WIFSTOPPED(status)) return;
+    if (waited < 0 && errno != EINTR) fail("stop-wait");
+    usleep(10000);
+  }
+  fail("foreground-group-not-stopped");
+}
+
+static void run_stop(int master, int slave, pid_t child,
+                     const struct termios *initial) {
+  struct capture capture = {0};
+  read_until(master, &capture, "Console username: ", "stop-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-stop");
+
+  write_all(master, &initial->c_cc[VSUSP], 1U);
+  wait_for_state(slave, initial);
+  wait_for_stop(child);
+  if (kill(-child, SIGCONT) != 0) fail("continue-signal");
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "stop-exit");
+  if (process_exit_status(&capture) == 0) fail("stop-succeeded");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+}
+
+static void run_stop_backpressure(int master, int slave, pid_t child,
+                                  const struct termios *initial) {
+  struct capture capture = {0};
+  char secret[48];
+  generated_value(secret, sizeof(secret), "credential");
+
+  read_until(master, &capture, "Console username: ", "stop-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-stop");
+  pid_t writer = spawn_backpressure_writer(master, initial->c_cc[VSUSP], secret);
+
+  wait_for_state(slave, initial);
+  wait_for_stop(child);
+  wait_for_writer(writer);
+  if (kill(-child, SIGCONT) != 0) fail("continue-signal");
+
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "stop-exit");
+  if (process_exit_status(&capture) == 0) fail("stop-succeeded");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, secret)) fail("secret-captured");
+}
+
+static void run_stop_paced(int master, int slave, pid_t child,
+                           const struct termios *initial) {
+  struct capture capture = {0};
+  char secret[48];
+  generated_value(secret, sizeof(secret), "credential");
+
+  read_until(master, &capture, "Console username: ", "stop-prompt");
+  if (!echo_disabled(slave)) fail("echo-enabled-before-stop");
+  pid_t writer = spawn_paced_writer(master, initial->c_cc[VSUSP], secret);
+
+  wait_for_writer(writer);
+  wait_for_state(slave, initial);
+  wait_for_stop(child);
+  if (kill(-child, SIGCONT) != 0) fail("continue-signal");
+  read_until(master, &capture, "__ORCHARD_PROCESS_EXIT__:", "stop-exit");
+  if (process_exit_status(&capture) == 0) fail("stop-succeeded");
+  wait_for_state(slave, initial);
+  finish_child(child, master, &capture);
+  if (contains(&capture, secret)) fail("secret-captured");
 }
 
 static void configure_initial_state(int slave, struct termios *initial, int echo_on) {
@@ -421,6 +1500,100 @@ static void configure_initial_state(int slave, struct termios *initial, int echo
   if (tcgetattr(slave, initial) != 0) fail("confirm-initial-state");
 }
 
+static void run_fragmented_record_case(int expected_setup_error) {
+  int descriptors[2];
+  int release[2];
+  if (pipe(descriptors) != 0) fail("record-self-test-pipe");
+  if (pipe(release) != 0) fail("record-self-test-release-pipe");
+
+  pid_t writer = fork();
+  if (writer < 0) fail("record-self-test-fork");
+  if (writer == 0) {
+    close(descriptors[0]);
+    close(release[1]);
+    const char *prefix = expected_setup_error
+                             ? "could not disable terminal echo\n"
+                               "__ORCHARD_PROCESS_EXIT__:"
+                             : "__ORCHARD_PROCESS_EXIT__:";
+    write_all(descriptors[1], prefix, strlen(prefix));
+    char released;
+    ssize_t count;
+    do {
+      count = read(release[0], &released, 1U);
+    } while (count < 0 && errno == EINTR);
+    if (count != 1) _exit(1);
+    close(release[0]);
+    write_all(descriptors[1], "0\n", 2U);
+    close(descriptors[1]);
+    _exit(0);
+  }
+
+  close(descriptors[1]);
+  close(release[0]);
+  if (fragmented_record_release_fd >= 0) fail("record-self-test-release-state");
+  fragmented_record_release_fd = release[1];
+  struct capture capture = {0};
+  if (expected_setup_error) {
+    read_until_expected_setup_exit(descriptors[0], &capture);
+  } else {
+    read_until(descriptors[0], &capture, "__ORCHARD_PROCESS_EXIT__:",
+               "record-self-test-exit");
+  }
+  if (fragmented_record_release_fd >= 0) fail("record-self-test-not-released");
+  if (process_exit_status(&capture) != 0)
+    fail("fragmented-zero-status-misclassified");
+  close(descriptors[0]);
+  int status = wait_for_child_exit(writer);
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) fail("record-self-test-writer");
+}
+
+static void run_fragmented_path_case(void) {
+  int descriptors[2];
+  int release[2];
+  if (pipe(descriptors) != 0) fail("path-self-test-pipe");
+  if (pipe(release) != 0) fail("path-self-test-release-pipe");
+
+  pid_t writer = fork();
+  if (writer < 0) fail("path-self-test-fork");
+  if (writer == 0) {
+    close(descriptors[0]);
+    close(release[1]);
+    const char *prefix = "__ORCHARD_CUSTODY_DIR__:/private/tmp/orchard";
+    write_all(descriptors[1], prefix, strlen(prefix));
+    char released;
+    ssize_t count;
+    do {
+      count = read(release[0], &released, 1U);
+    } while (count < 0 && errno == EINTR);
+    if (count != 1) _exit(1);
+    close(release[0]);
+    write_all(descriptors[1], ".complete\n", 10U);
+    close(descriptors[1]);
+    _exit(0);
+  }
+
+  close(descriptors[1]);
+  close(release[0]);
+  if (fragmented_record_release_fd >= 0) fail("path-self-test-release-state");
+  fragmented_record_release_fd = release[1];
+  struct capture capture = {0};
+  char path[PATH_MAX];
+  read_marked_path(descriptors[0], &capture, "__ORCHARD_CUSTODY_DIR__:", path,
+                   sizeof(path));
+  if (fragmented_record_release_fd >= 0) fail("path-self-test-not-released");
+  if (strcmp(path, "/private/tmp/orchard.complete") != 0)
+    fail("fragmented-path-misclassified");
+  close(descriptors[0]);
+  int status = wait_for_child_exit(writer);
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) fail("path-self-test-writer");
+}
+
+static void run_fragmented_record_self_test(void) {
+  run_fragmented_record_case(0);
+  run_fragmented_record_case(1);
+  run_fragmented_path_case();
+}
+
 int main(int argc, char **argv) {
   if (argc < 4 || strcmp(argv[2], "--") != 0) {
     fprintf(stderr, "usage: console_pty_harness SCENARIO -- COMMAND [ARGS...]\n");
@@ -428,6 +1601,12 @@ int main(int argc, char **argv) {
   }
 
   scenario_name = argv[1];
+  if (strcmp(scenario_name, "fragmented-record-self-test") == 0) {
+    run_fragmented_record_self_test();
+    printf("console PTY ok: %s\n", scenario_name);
+    return 0;
+  }
+
   int probe_master = -1;
   int probe_slave = -1;
   if (openpty(&probe_master, &probe_slave, NULL, NULL, NULL) != 0) fail("openpty");
@@ -450,18 +1629,100 @@ int main(int argc, char **argv) {
     run_pasted(master, slave, child, &initial, 1, 0);
   } else if (strcmp(scenario_name, "pasted-mismatch") == 0) {
     run_pasted(master, slave, child, &initial, 0, 0);
+  } else if (strcmp(scenario_name, "unwrapped") == 0) {
+    run_setup_failure(master, slave, child, &initial);
   } else if (strcmp(scenario_name, "delayed-success") == 0) {
     run_pasted(master, slave, child, &initial, 1, 6000);
+  } else if (strcmp(scenario_name, "utf8-erase") == 0) {
+    run_utf8_erase(master, slave, child, &initial);
   } else if (strcmp(scenario_name, "owner-exit") == 0) {
     run_owner_exit(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "owner-exit-paced") == 0) {
+    run_owner_exit_paced(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "wrapper-term-paced") == 0) {
+    run_wrapper_signal_paced(master, slave, child, &initial, SIGTERM, 143);
+  } else if (strcmp(scenario_name, "wrapper-int-paced") == 0) {
+    run_wrapper_signal_paced(master, slave, child, &initial, SIGINT, 130);
+  } else if (strcmp(scenario_name, "wrapper-quit-paced") == 0) {
+    run_wrapper_signal_paced(master, slave, child, &initial, SIGQUIT, 131);
+  } else if (strcmp(scenario_name, "wrapper-path-substitution") == 0) {
+    run_wrapper_path_substitution(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "guard-pre-ready-death") == 0) {
+    run_guard_pre_ready_death(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "wrapper-pre-ready-death") == 0) {
+    run_wrapper_pre_ready_death(master, slave, child, &initial, SIGKILL);
+  } else if (strcmp(scenario_name, "wrapper-pre-ready-term") == 0) {
+    run_wrapper_pre_ready_death(master, slave, child, &initial, SIGTERM);
+  } else if (strcmp(scenario_name, "wrapper-pre-launch-term") == 0) {
+    run_wrapper_pre_launch_signal(master, slave, child, &initial, SIGTERM, 143);
+  } else if (strcmp(scenario_name, "wrapper-pre-launch-int") == 0) {
+    run_wrapper_pre_launch_signal(master, slave, child, &initial, SIGINT, 130);
+  } else if (strcmp(scenario_name, "wrapper-pre-launch-quit") == 0) {
+    run_wrapper_pre_launch_signal(master, slave, child, &initial, SIGQUIT, 131);
+  } else if (strcmp(scenario_name, "wrapper-launch-path-substitution") == 0) {
+    run_wrapper_launch_path_substitution(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "wrapper-late-int") == 0) {
+    run_wrapper_late_int(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "wrapper-cli-post-wait-int") == 0) {
+    run_wrapper_post_wait_int(master, slave, child, &initial,
+                              "__ORCHARD_CLI_POST_WAIT__", 1);
+  } else if (strcmp(scenario_name, "wrapper-guard-post-wait-int") == 0) {
+    run_wrapper_post_wait_int(master, slave, child, &initial,
+                              "__ORCHARD_GUARD_POST_WAIT__", 0);
+  } else if (strcmp(scenario_name, "wrapper-setup-failure") == 0) {
+    run_wrapper_setup_failure(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "wrapper-wait-reap") == 0) {
+    run_wrapper_wait_reap(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "terminal-close") == 0) {
+    run_terminal_close(master, slave, child);
   } else if (strcmp(scenario_name, "eof") == 0) {
     run_eof(master, slave, child, &initial);
   } else if (strcmp(scenario_name, "exception") == 0) {
     run_exception(master, slave, child, &initial);
   } else if (strcmp(scenario_name, "setup-failure") == 0) {
     run_setup_failure(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "watchdog-handshake") == 0) {
+    run_setup_failure(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "watchdog-protected-handshake") == 0) {
+    run_protected_setup_paced(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "restorer-parent-kill") == 0) {
+    run_restorer_parent_kill(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "restorer-pre-teardown-kill") == 0) {
+    run_restorer_pre_teardown_kill(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "restorer-identity-retry") == 0) {
+    run_restorer_identity_retry(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "watchdog-custody-handshake") == 0) {
+    run_watchdog_custody_handshake(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "restorer-signal-setup") == 0) {
+    run_restorer_signal_setup(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "post-protect") == 0) {
+    run_setup_failure(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "signal-int") == 0 ||
+             strcmp(scenario_name, "signal-hup") == 0 ||
+             strcmp(scenario_name, "signal-term") == 0 ||
+             strcmp(scenario_name, "signal-kill") == 0 ||
+             strcmp(scenario_name, "marker-pre-ready-kill") == 0 ||
+             strcmp(scenario_name, "watchdog-idle") == 0 ||
+             strcmp(scenario_name, "watchdog-read") == 0) {
+    run_helper_signal(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "port-owner-exit") == 0) {
+    run_port_owner_exit(master, slave, child, &initial);
   } else if (strcmp(scenario_name, "interruption") == 0) {
     run_interruption(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "quit") == 0) {
+    run_quit(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "stop") == 0) {
+    run_stop(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "stop-backpressure") == 0) {
+    run_stop_backpressure(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "stop-paced") == 0) {
+    run_stop_paced(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "invalid-username-paste") == 0) {
+    run_invalid_username_paste(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "invalid-username-backpressure") == 0) {
+    run_invalid_username_backpressure(master, slave, child, &initial);
+  } else if (strcmp(scenario_name, "invalid-username-paced") == 0) {
+    run_invalid_username_paced(master, slave, child, &initial);
   } else {
     kill(child, SIGKILL);
     waitpid(child, NULL, 0);

--- a/apps/orchard_cli/test/support/console_pty_harness.c
+++ b/apps/orchard_cli/test/support/console_pty_harness.c
@@ -20,6 +20,11 @@
 #define PROCESS_LIMIT 2048
 #define TRACKED_PROCESS_LIMIT 32
 #define TIMEOUT_MS 15000
+// Paced writers sleep between every write, and macOS timer coalescing routinely
+// stretches each 50ms interval several times past its nominal length, so a
+// 220-write paste takes far longer than its nominal 11s. Budget the writer wait
+// independently of the ordinary harness I/O timeout.
+#define WRITER_TIMEOUT_MS 120000
 
 struct capture {
   char bytes[CAPTURE_LIMIT];
@@ -480,7 +485,7 @@ static pid_t spawn_started_paced_writer(int master, unsigned char first,
 }
 
 static void wait_for_writer(pid_t writer) {
-  long long deadline = now_ms() + TIMEOUT_MS;
+  long long deadline = now_ms() + WRITER_TIMEOUT_MS;
   while (now_ms() < deadline) {
     int status;
     pid_t waited = waitpid(writer, &status, WNOHANG);

--- a/apps/orchard_cli/test/support/console_pty_process.ex
+++ b/apps/orchard_cli/test/support/console_pty_process.ex
@@ -5,7 +5,12 @@ defmodule OrchardCLI.ConsolePTYProcess do
   alias OrchardCLI.SecretTTY
 
   @spec main([String.t()]) :: no_return()
-  def main([action, support_root, side_effect_marker]) when action in ["enable", "rotate"] do
+  def main(args) do
+    IO.puts("__ORCHARD_OWNER_PID__:#{System.pid()}")
+    dispatch(args)
+  end
+
+  defp dispatch([action, support_root, side_effect_marker]) when action in ["enable", "rotate"] do
     runtime = %{
       uid: fn -> 0 end,
       read_install_role: fn -> {:ok, "controller"} end,
@@ -18,34 +23,126 @@ defmodule OrchardCLI.ConsolePTYProcess do
     |> halt_with_result()
   end
 
-  def main(["exception", _support_root, _side_effect_marker]) do
+  defp dispatch(["exception", _support_root, _side_effect_marker]) do
     SecretTTY.run(fn reader ->
       {:ok, _value} = reader.("Console username: ")
       raise "test callback failure"
     end)
 
-    await_harness(65)
+    halt_for_harness(65)
   rescue
-    RuntimeError -> await_harness(70)
+    RuntimeError -> halt_for_harness(70)
   end
 
-  def main(["setup-failure", _support_root, side_effect_marker]) do
+  defp dispatch(["setup-failure", _support_root, side_effect_marker]) do
     result =
       SecretTTY.run(
         fn _reader ->
           File.write!(side_effect_marker, "callback-entered\n")
           {:ok, :unexpected}
         end,
-        stty_path: "/usr/bin/false"
+        test_fault: :partial_protect
       )
 
     halt_with_result(normalize_direct_result(result))
   end
 
-  def main(_args), do: System.halt(64)
+  defp dispatch([fault, _support_root, side_effect_marker])
+       when fault in [
+              "post-protect",
+              "signal-int",
+              "signal-hup",
+              "signal-term",
+              "signal-kill",
+              "marker-pre-ready-kill",
+              "watchdog-handshake",
+              "watchdog-custody-handshake",
+              "watchdog-protected-handshake",
+              "restorer-parent-kill",
+              "restorer-pre-teardown-kill",
+              "restorer-identity-retry",
+              "restorer-signal-setup",
+              "watchdog-idle",
+              "watchdog-read"
+            ] do
+    test_fault = test_fault(fault)
+
+    result =
+      SecretTTY.run(
+        fn reader ->
+          case reader.("Console username: ") do
+            {:ok, _value} ->
+              File.write!(side_effect_marker, "callback-completed\n")
+              {:ok, :unexpected}
+
+            error ->
+              error
+          end
+        end,
+        test_fault: test_fault
+      )
+
+    halt_with_result(normalize_direct_result(result))
+  end
+
+  defp dispatch(["port-owner-exit", _support_root, _side_effect_marker]) do
+    parent = self()
+
+    {owner, reference} =
+      spawn_monitor(fn ->
+        result =
+          SecretTTY.run(fn reader ->
+            send(parent, :port_owner_ready)
+            reader.("Console username: ")
+          end)
+
+        send(parent, {:port_owner_result, result})
+      end)
+
+    receive do
+      :port_owner_ready -> IO.puts("__ORCHARD_PORT_OWNER_READY__")
+      {:port_owner_result, _result} -> halt_for_harness(65)
+    after
+      5_000 -> halt_for_harness(66)
+    end
+
+    Process.sleep(500)
+    Process.exit(owner, :kill)
+
+    receive do
+      {:DOWN, ^reference, :process, ^owner, :killed} ->
+        IO.puts("__ORCHARD_PORT_OWNER_DIED__")
+
+      {:port_owner_result, _result} ->
+        halt_for_harness(67)
+    after
+      5_000 -> halt_for_harness(68)
+    end
+
+    Process.sleep(5_000)
+    halt_for_harness(1)
+  end
+
+  defp dispatch(_args), do: System.halt(64)
 
   defp normalize_direct_result({:error, message}), do: {:error, "Error: #{message}", 1}
   defp normalize_direct_result({:ok, _value}), do: {:ok, "unexpected success"}
+
+  defp test_fault("post-protect"), do: :post_protect
+  defp test_fault("signal-int"), do: :signal_int
+  defp test_fault("signal-hup"), do: :signal_hup
+  defp test_fault("signal-term"), do: :signal_term
+  defp test_fault("signal-kill"), do: :signal_kill
+  defp test_fault("marker-pre-ready-kill"), do: :marker_pre_ready_kill
+  defp test_fault("watchdog-handshake"), do: :watchdog_handshake
+  defp test_fault("watchdog-custody-handshake"), do: :watchdog_custody_handshake
+  defp test_fault("watchdog-protected-handshake"), do: :watchdog_protected_handshake
+  defp test_fault("restorer-parent-kill"), do: :restorer_parent_kill
+  defp test_fault("restorer-pre-teardown-kill"), do: :restorer_pre_teardown_kill
+  defp test_fault("restorer-identity-retry"), do: :restorer_identity_retry
+  defp test_fault("restorer-signal-setup"), do: :restorer_signal_setup
+  defp test_fault("watchdog-idle"), do: :watchdog_idle
+  defp test_fault("watchdog-read"), do: :watchdog_read
 
   defp command_recorder(side_effect_marker) do
     fn _program, _args, _opts ->
@@ -56,16 +153,17 @@ defmodule OrchardCLI.ConsolePTYProcess do
 
   defp halt_with_result({:ok, message}) do
     IO.puts(message)
-    await_harness(0)
+    halt_for_harness(0)
   end
 
   defp halt_with_result({:error, message, code}) do
     IO.puts(:stderr, message)
-    await_harness(code)
+    halt_for_harness(code)
   end
 
-  defp await_harness(code) do
+  defp halt_for_harness(code) do
     IO.puts("__ORCHARD_PTY_RESULT__:#{code}")
-    Process.sleep(:infinity)
+    Process.sleep(10)
+    System.halt(code)
   end
 end

--- a/apps/orchard_cli/test/support/console_pty_process.ex
+++ b/apps/orchard_cli/test/support/console_pty_process.ex
@@ -1,0 +1,71 @@
+defmodule OrchardCLI.ConsolePTYProcess do
+  @moduledoc false
+
+  alias OrchardCLI.Commands.Console
+  alias OrchardCLI.SecretTTY
+
+  @spec main([String.t()]) :: no_return()
+  def main([action, support_root, side_effect_marker]) when action in ["enable", "rotate"] do
+    runtime = %{
+      uid: fn -> 0 end,
+      read_install_role: fn -> {:ok, "controller"} end,
+      tty?: fn -> true end,
+      support_root: support_root,
+      cmd: command_recorder(side_effect_marker)
+    }
+
+    Console.run([action], runtime)
+    |> halt_with_result()
+  end
+
+  def main(["exception", _support_root, _side_effect_marker]) do
+    SecretTTY.run(fn reader ->
+      {:ok, _value} = reader.("Console username: ")
+      raise "test callback failure"
+    end)
+
+    await_harness(65)
+  rescue
+    RuntimeError -> await_harness(70)
+  end
+
+  def main(["setup-failure", _support_root, side_effect_marker]) do
+    result =
+      SecretTTY.run(
+        fn _reader ->
+          File.write!(side_effect_marker, "callback-entered\n")
+          {:ok, :unexpected}
+        end,
+        stty_path: "/usr/bin/false"
+      )
+
+    halt_with_result(normalize_direct_result(result))
+  end
+
+  def main(_args), do: System.halt(64)
+
+  defp normalize_direct_result({:error, message}), do: {:error, "Error: #{message}", 1}
+  defp normalize_direct_result({:ok, _value}), do: {:ok, "unexpected success"}
+
+  defp command_recorder(side_effect_marker) do
+    fn _program, _args, _opts ->
+      File.write!(side_effect_marker, "invoked\n", [:append])
+      {"Could not find service", 113}
+    end
+  end
+
+  defp halt_with_result({:ok, message}) do
+    IO.puts(message)
+    await_harness(0)
+  end
+
+  defp halt_with_result({:error, message, code}) do
+    IO.puts(:stderr, message)
+    await_harness(code)
+  end
+
+  defp await_harness(code) do
+    IO.puts("__ORCHARD_PTY_RESULT__:#{code}")
+    Process.sleep(:infinity)
+  end
+end

--- a/apps/orchard_cli/test/support/orchardctl_delayed_term_fixture.c
+++ b/apps/orchard_cli/test/support/orchardctl_delayed_term_fixture.c
@@ -1,0 +1,34 @@
+#include <signal.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t termination_requested;
+
+static void request_termination(int signal_number) {
+  (void)signal_number;
+  termination_requested = 1;
+}
+
+int main(void) {
+  struct sigaction action = {0};
+  action.sa_handler = request_termination;
+  sigemptyset(&action.sa_mask);
+  if (sigaction(SIGTERM, &action, NULL) != 0) return 126;
+
+  printf("__ORCHARD_FIXTURE_PID__:%d\n", getpid());
+  fflush(stdout);
+  while (!termination_requested) pause();
+
+  printf("__ORCHARD_FIXTURE_TERM__\n");
+  fflush(stdout);
+  struct timespec delay = {.tv_sec = 1, .tv_nsec = 0};
+  while (nanosleep(&delay, &delay) != 0) {
+  }
+  printf("__ORCHARD_FIXTURE_EXIT_BARRIER__\n");
+  fflush(stdout);
+  struct timespec exit_barrier = {.tv_sec = 0, .tv_nsec = 200000000};
+  while (nanosleep(&exit_barrier, &exit_barrier) != 0) {
+  }
+  return 143;
+}

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -12,7 +12,6 @@ orientation, and [`tooling.md`](tooling.md) for pinned tool versions.
 | Dependency | Version | Notes |
 |------------|---------|-------|
 | mise | see `../mise.toml` | Required for Erlang/OTP, Elixir, Python, uv, Node.js, and npm |
-| Xcode Command Line Tools | host toolchain | Outside mise; `mix compile` builds a C helper for `apps/orchard_cli`. See [Tooling](tooling.md) |
 | PostgreSQL | ≥ 15 | Local instance |
 
 See [Tooling](tooling.md) for the pinned runtime versions and standard

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -12,6 +12,7 @@ orientation, and [`tooling.md`](tooling.md) for pinned tool versions.
 | Dependency | Version | Notes |
 |------------|---------|-------|
 | mise | see `../mise.toml` | Required for Erlang/OTP, Elixir, Python, uv, Node.js, and npm |
+| Xcode Command Line Tools | host toolchain | Outside mise; `mix compile` builds a C helper for `apps/orchard_cli`. See [Tooling](tooling.md) |
 | PostgreSQL | ≥ 15 | Local instance |
 
 See [Tooling](tooling.md) for the pinned runtime versions and standard

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -42,6 +42,13 @@ The mise environment also sets:
 `uv` remains the package and virtualenv manager for `native/**`. `mise` owns
 the Python interpreter version that `uv` is allowed to use.
 
+Apple's C toolchain is also required and is outside mise, the same way the
+Swift and signing tools are. Compiling `apps/orchard_cli` builds the
+`orchard-secret-tty` terminal helper from `apps/orchard_cli/c_src` through
+`elixir_make`, so `mix compile`, `mix test`, and package builds need the host
+Xcode Command Line Tools for `xcrun clang`. Install them with
+`xcode-select --install` if `xcrun clang --version` fails.
+
 ## Standard Commands
 
 Either activate mise in your shell or prefix commands with `mise exec --`.

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1074,6 +1074,42 @@ credentials from the URL automatically. If you see this on an older version,
 navigate to the clean URL manually after authenticating — the session cookie
 persists.
 
+### Credential prompt and terminal custody
+
+The packaged `orchardctl` wrapper keeps sole custody of the controlling
+terminal for the whole command and hands the CLI only non-terminal standard
+input. Redirected or piped input such as
+`sudo orchardctl license activate --key-stdin <<<"$KEY"` still reaches the CLI;
+input typed at the terminal does not. `sudo orchardctl console enable`,
+`sudo orchardctl console rotate`, and `sudo orchardctl init --console`
+therefore collect credentials through a dedicated terminal helper rather than
+through standard input.
+
+Expected behavior:
+
+- Neither the username nor the password echoes while the prompt is active.
+- Input typed or pasted past the prompts is discarded, and the helper waits for
+  a short quiet period after the last keystroke before returning the terminal,
+  so an abandoned paste cannot run as a command in the parent shell.
+- The prior terminal settings are restored exactly on success, on `Ctrl-C` or
+  `Ctrl-\`, and on `SIGHUP`/`SIGTERM`; when the terminal window closes there is
+  no terminal left to restore.
+- An interrupted, failed, or mismatched `enable`/`rotate` leaves
+  `config/console.env` untouched, so `enable` does not turn the Console on and
+  `rotate` keeps the existing credentials.
+- A signalled run exits `129` (HUP), `130` (INT), `131` (QUIT), or `143` (TERM).
+
+If the wrapper cannot confirm that terminal custody ended cleanly it prints
+`orchardctl: terminal custody guard failed` and deliberately refuses to return
+the terminal, because unread input may still be queued. Follow the printed
+recovery steps: from a second terminal run `sudo kill -9 <printed pid>`, then
+run `stty sane` in the affected terminal.
+
+`Error: interactive TTY required to collect Console credentials.` means the
+command has no controlling terminal or is not the terminal's foreground job —
+for example `ssh` without a TTY, a launchd job, or a backgrounded invocation.
+Rerun it as a foreground command in an interactive terminal.
+
 ## Permission Expectations
 
 ### Directories
@@ -1245,8 +1281,9 @@ controller-bearing installs (`all` or `controller`):
    generated-CA direct HTTPS path, or configure an operator-managed direct HTTPS
    certificate/reverse-proxy transport before starting services.
 7. Optional, when browser Console access is desired: run
-   `sudo orchardctl console enable` and enter credentials only through the
-   interactive prompt.
+   `sudo orchardctl console enable` from a foreground interactive terminal and
+   enter credentials only through the interactive prompt. See
+   [Credential prompt and terminal custody](#credential-prompt-and-terminal-custody).
 8. Run `sudo orchardctl start`.
 9. Verify with `orchardctl status`.
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1105,6 +1105,11 @@ the terminal, because unread input may still be queued. Follow the printed
 recovery steps: from a second terminal run `sudo kill -9 <printed pid>`, then
 run `stty sane` in the affected terminal.
 
+`Error: License key source was empty.` from
+`sudo orchardctl license activate --key-stdin` means the key was typed at the
+terminal instead of redirected. Use the redirected form in
+[Activation workflow](#activation-workflow) or `--key-file`.
+
 `Error: interactive TTY required to collect Console credentials.` means the
 command has no controlling terminal or is not the terminal's foreground job —
 for example `ssh` without a TTY, a launchd job, or a backgrounded invocation.

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -1105,11 +1105,6 @@ the terminal, because unread input may still be queued. Follow the printed
 recovery steps: from a second terminal run `sudo kill -9 <printed pid>`, then
 run `stty sane` in the affected terminal.
 
-`Error: License key source was empty.` from
-`sudo orchardctl license activate --key-stdin` means the key was typed at the
-terminal instead of redirected. Use the redirected form in
-[Activation workflow](#activation-workflow) or `--key-file`.
-
 `Error: interactive TTY required to collect Console credentials.` means the
 command has no controlling terminal or is not the terminal's foreground job —
 for example `ssh` without a TTY, a launchd job, or a backgrounded invocation.

--- a/packaging/pkg/bin/orchardctl
+++ b/packaging/pkg/bin/orchardctl
@@ -871,6 +871,7 @@ fi
     [ "$_observed_parent" = "$_launch_parent" ] || exit 125
     _observed_identity=$(/usr/bin/stat -f "%d:%i:%Lp:%u" .) || exit 125
     [ "$_observed_identity" = "$_launch_identity" ] || exit 125
+    cd / || exit 125
     exec "$@"
 ' orchard-cli-launch "$_completion_dir" "$_completion_identity" \
     "$_completion_uid" "$$" "$_cli_launch_wait_command" \

--- a/packaging/pkg/bin/orchardctl
+++ b/packaging/pkg/bin/orchardctl
@@ -538,7 +538,6 @@ _cli_waiting=""
 _cli_wait_interrupted=""
 _guard_waiting=""
 _guard_wait_interrupted=""
-WAIT_NO_CHILD_STATUS=127
 _cli_launch_wait_command=/bin/sleep
 _cli_parent_probe=/bin/ps
 _cli_process_probe=/bin/ps
@@ -727,7 +726,6 @@ cleanup_standalone_guard_startup() {
 
 terminate_and_reap_custody_guard() {
     _guard_signal=$1
-    _custody_guard_status_observed=""
     while :; do
         _guard_parent=$(
             "$_guard_parent_probe" -o ppid= -p "$_custody_guard_pid" 2>/dev/null |
@@ -747,19 +745,14 @@ terminate_and_reap_custody_guard() {
         _guard_wait_interrupted=""
         _guard_waiting=1
         if wait "$_custody_guard_pid"; then
-            _guard_wait_status=0
+            _custody_guard_status=0
         else
-            _guard_wait_status=$?
+            _custody_guard_status=$?
         fi
         guard_post_wait_barrier
         _guard_waiting=""
-        if [ -z "$_custody_guard_status_observed" ] ||
-           [ "$_guard_wait_status" -ne "$WAIT_NO_CHILD_STATUS" ]; then
-            _custody_guard_status=$_guard_wait_status
-            _custody_guard_status_observed=1
-        fi
         if [ -z "$_guard_wait_interrupted" ]; then
-            return 0
+            return
         fi
 
         while :; do
@@ -774,6 +767,9 @@ terminate_and_reap_custody_guard() {
                     if [ "$_guard_parent" = "$$" ]; then
                         /bin/kill -"$_guard_signal" \
                             "$_custody_guard_pid" 2>/dev/null || true
+                        _retry_guard_wait=1
+                    else
+                        _retry_guard_wait=""
                     fi
                     break
                 fi
@@ -782,8 +778,10 @@ terminate_and_reap_custody_guard() {
                 /bin/sleep 0.01 || :
                 continue
             fi
+            _retry_guard_wait=""
             break
         done
+        [ -n "$_retry_guard_wait" ] || return 0
     done
 }
 

--- a/packaging/pkg/bin/orchardctl
+++ b/packaging/pkg/bin/orchardctl
@@ -482,4 +482,473 @@ for arg in "$@"; do
   fi
 done
 
-exec "$ORCHARD_CLI" eval "OrchardCLI.main([$args])"
+ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID=$$
+export ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID
+_completion_dir=""
+_completion_identity=""
+_setup_cleanup_pending=""
+cleanup_standalone_setup() {
+    [ -n "$_setup_cleanup_pending" ] || return
+    if [ -n "$_completion_identity" ]; then
+        _setup_cleanup_identity=$(
+            /usr/bin/stat -f '%d:%i:%Lp:%u' "$_completion_dir" 2>/dev/null
+        ) || return
+        [ "$_setup_cleanup_identity" = "$_completion_identity" ] || return
+    fi
+    /bin/rmdir "$_completion_dir" 2>/dev/null || true
+}
+_completion_dir=$(/usr/bin/mktemp -d /private/tmp/orchardctl.XXXXXX) || exit 1
+_setup_cleanup_pending=1
+trap cleanup_standalone_setup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 131' QUIT
+trap 'exit 143' TERM
+if [ "${ORCHARD_TEST_WRAPPER_PID_MARKER:-}" = "1" ]; then
+    printf '__ORCHARD_WRAPPER_PID__:%s\n' "$$"
+fi
+if [ "${ORCHARD_TEST_CUSTODY_DIR_MARKER:-}" = "1" ]; then
+    printf '__ORCHARD_CUSTODY_DIR__:%s\n' "$_completion_dir"
+fi
+/bin/chmod 0700 "$_completion_dir" || exit 1
+_completion_identity=$(/usr/bin/stat -f '%d:%i:%Lp:%u' "$_completion_dir") || exit 1
+_completion_uid=$(/usr/bin/id -u) || exit 1
+case "$_completion_identity" in
+    *:700:"$_completion_uid") ;;
+    *) exit 1 ;;
+esac
+_completion_device=${_completion_identity%%:*}
+_completion_rest=${_completion_identity#*:}
+_completion_inode=${_completion_rest%%:*}
+ORCHARD_CLI_COMPLETION_DIR=$_completion_dir
+export ORCHARD_CLI_COMPLETION_DIR
+ORCHARD_CLI_COMPLETION_IDENTITY="$_completion_device:$_completion_inode"
+export ORCHARD_CLI_COMPLETION_IDENTITY
+_cli_pid=""
+_custody_guard_pid=""
+_custody_ready=""
+_termination_status=""
+_termination_signal=""
+_cli_waiting=""
+_cli_wait_interrupted=""
+_guard_waiting=""
+_guard_wait_interrupted=""
+_cli_launch_marker="$_completion_dir/launch-cli"
+_cli_launch_wait_command=/bin/sleep
+_cli_parent_probe=/bin/ps
+_cli_process_probe=/bin/ps
+_guard_parent_probe=/bin/ps
+_guard_process_probe=/bin/ps
+
+guard_pre_ready_barrier() { :; }
+cli_pre_launch_barrier() { :; }
+cli_pre_exit_barrier() { :; }
+cli_post_wait_barrier() { :; }
+guard_post_wait_barrier() { :; }
+
+create_cli_launch_marker() (
+    cd "$_completion_dir" 2>/dev/null || exit 1
+    _launch_directory_identity=$(/usr/bin/stat -f '%d:%i:%Lp:%u' .) || exit 1
+    [ "$_launch_directory_identity" = "$_completion_identity" ] || exit 1
+    [ ! -e ./launch-cli ] && [ ! -L ./launch-cli ] || exit 1
+    umask 077
+    set -C
+    : > ./launch-cli || exit 1
+    [ -f ./launch-cli ] && [ ! -L ./launch-cli ] || exit 1
+    _launch_marker_identity=$(/usr/bin/stat -f '%u:%Lp' ./launch-cli) || exit 1
+    [ "$_launch_marker_identity" = "$_completion_uid:600" ] || exit 1
+)
+
+remove_cli_launch_marker() (
+    cd "$_completion_dir" 2>/dev/null || exit 1
+    _launch_directory_identity=$(/usr/bin/stat -f '%d:%i:%Lp:%u' .) || exit 1
+    [ "$_launch_directory_identity" = "$_completion_identity" ] || exit 1
+    [ ! -L ./launch-cli ] || exit 1
+    if [ -e ./launch-cli ]; then
+        [ -f ./launch-cli ] || exit 1
+        _launch_marker_identity=$(/usr/bin/stat -f '%u:%Lp' ./launch-cli) || exit 1
+        [ "$_launch_marker_identity" = "$_completion_uid:600" ] || exit 1
+        /bin/rm -f ./launch-cli || exit 1
+    fi
+)
+
+forward_standalone_signal() {
+    _termination_signal=$1
+    _termination_status=$2
+    if [ -n "$_cli_waiting" ]; then
+        _cli_wait_interrupted=1
+    fi
+    if [ -n "$_guard_waiting" ]; then
+        _guard_wait_interrupted=1
+    fi
+    if [ -n "$_cli_pid" ]; then
+        while :; do
+            _cli_parent=$("$_cli_parent_probe" -o ppid= -p "$_cli_pid" 2>/dev/null | /usr/bin/tr -d ' ')
+            if [ -n "$_cli_parent" ]; then
+                if [ "$_cli_parent" = "$$" ]; then
+                    _forward_signal=TERM
+                    /bin/kill -"$_forward_signal" "$_cli_pid" 2>/dev/null || true
+                fi
+                break
+            fi
+            /bin/kill -0 "$_cli_pid" 2>/dev/null || break
+            /bin/sleep 0.01
+        done
+    fi
+}
+
+trap 'forward_standalone_signal HUP 129' HUP
+trap 'forward_standalone_signal INT 130' INT
+trap 'forward_standalone_signal QUIT 131' QUIT
+trap 'forward_standalone_signal TERM 143' TERM
+
+trap '_custody_ready=1' USR1
+(
+    if ! cd "$_completion_dir"; then
+        exit 125
+    fi
+    _guard_identity=$(/usr/bin/stat -f '%d:%i:%Lp:%u' .) || exit 125
+    if [ "$_guard_identity" != "$_completion_identity" ]; then
+        exit 125
+    fi
+    remove_completion_directory() {
+        while :; do
+            _remove_path_identity=$(
+                /usr/bin/stat -f '%d:%i:%Lp:%u' "$_completion_dir" 2>/dev/null
+            ) || return 1
+            [ "$_remove_path_identity" = "$_completion_identity" ] || return 1
+            /bin/rmdir "$_completion_dir" 2>/dev/null && return 0
+            /bin/sleep 0.01
+        done
+    }
+    _guard_ready=""
+    cleanup_guard_before_ready() {
+        [ -z "$_guard_ready" ] || return
+        /bin/rm -f ./guard-pid ./available 2>/dev/null || true
+        [ ! -e ./active ] || return
+        cd / || return
+        remove_completion_directory || true
+    }
+    trap cleanup_guard_before_ready EXIT
+    umask 077
+    /bin/sh -c 'printf "%s\n" "$PPID"' > ./guard-pid || exit 125
+    IFS= read -r _guard_pid < ./guard-pid || exit 125
+    /bin/rm -f ./guard-pid || exit 125
+    case "$_guard_pid" in
+        ''|*[!0-9]*) exit 125 ;;
+    esac
+    guard_parent_matches() {
+        _observed_guard_parent=$(
+            /bin/ps -o ppid= -p "$_guard_pid" 2>/dev/null | /usr/bin/tr -d ' '
+        )
+        [ "$_observed_guard_parent" = "$ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID" ]
+    }
+    _custody_cancel=""
+    _custody_acquired=""
+    trap '_custody_cancel=1' HUP INT QUIT TERM
+    guard_parent_matches || exit 125
+    guard_pre_ready_barrier || exit 125
+    : > ./available || exit 125
+    guard_parent_matches || exit 125
+    /bin/kill -USR1 "$ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID" || exit 125
+    _guard_ready=1
+    trap - EXIT
+
+    while :; do
+        if ! guard_parent_matches; then
+            _custody_cancel=1
+        fi
+        if [ -e ./active ]; then
+            _custody_acquired=1
+        fi
+        if [ -n "$_custody_acquired" ] && [ ! -e ./active ]; then
+            break
+        fi
+        if [ ! -e ./available ] && [ ! -e ./active ]; then
+            break
+        fi
+        if [ -n "$_custody_cancel" ] && [ -e ./available ]; then
+            /bin/rm -f ./available || true
+        fi
+        /bin/sleep 0.01
+    done
+
+    while :; do
+        _guard_path_identity=$(
+            /usr/bin/stat -f '%d:%i:%Lp:%u' "$_completion_dir" 2>/dev/null
+        ) || _guard_path_identity=""
+        if [ "$_guard_path_identity" = "$_guard_identity" ]; then
+            break
+        fi
+        /bin/sleep 0.01
+    done
+    cd / || exit 125
+    remove_completion_directory || exit 125
+    exit 0
+) &
+_custody_guard_pid=$!
+
+if [ "${ORCHARD_TEST_GUARD_PID_MARKER:-}" = "1" ]; then
+    printf '__ORCHARD_GUARD_PID__:%s\n' "$_custody_guard_pid"
+fi
+
+cleanup_standalone_guard_startup() {
+    if (
+        cd "$_completion_dir" 2>/dev/null || exit 1
+        _cleanup_identity=$(/usr/bin/stat -f '%d:%i:%Lp:%u' .) || exit 1
+        [ "$_cleanup_identity" = "$_completion_identity" ] || exit 1
+        [ ! -e ./active ] || exit 1
+        for _cleanup_marker in available guard-pid; do
+            if [ -e "./$_cleanup_marker" ] || [ -L "./$_cleanup_marker" ]; then
+                [ -f "./$_cleanup_marker" ] || exit 1
+                [ ! -L "./$_cleanup_marker" ] || exit 1
+                _cleanup_marker_identity=$(
+                    /usr/bin/stat -f '%u:%Lp' "./$_cleanup_marker"
+                ) || exit 1
+                [ "$_cleanup_marker_identity" = "$_completion_uid:600" ] || exit 1
+            fi
+        done
+        /bin/rm -f ./available ./guard-pid
+        [ -z "$(/bin/ls -A .)" ] || exit 1
+    ); then
+        _cleanup_path_identity=$(
+            /usr/bin/stat -f '%d:%i:%Lp:%u' "$_completion_dir" 2>/dev/null
+        ) || _cleanup_path_identity=""
+        if [ "$_cleanup_path_identity" = "$_completion_identity" ]; then
+            /bin/rmdir "$_completion_dir" 2>/dev/null || true
+        fi
+    fi
+}
+
+terminate_and_reap_custody_guard() {
+    _guard_signal=$1
+    while :; do
+        _guard_parent=$(
+            "$_guard_parent_probe" -o ppid= -p "$_custody_guard_pid" 2>/dev/null |
+                /usr/bin/tr -d ' '
+        )
+        if [ -n "$_guard_parent" ]; then
+            if [ "$_guard_parent" = "$$" ]; then
+                /bin/kill -"$_guard_signal" \
+                    "$_custody_guard_pid" 2>/dev/null || true
+            fi
+            break
+        fi
+        /bin/kill -0 "$_custody_guard_pid" 2>/dev/null || break
+        /bin/sleep 0.01
+    done
+    while :; do
+        _guard_wait_interrupted=""
+        _guard_waiting=1
+        if wait "$_custody_guard_pid"; then
+            _custody_guard_status=0
+        else
+            _custody_guard_status=$?
+        fi
+        guard_post_wait_barrier
+        _guard_waiting=""
+        if [ -z "$_guard_wait_interrupted" ]; then
+            return
+        fi
+
+        while :; do
+            if _guard_process=$(
+                "$_guard_process_probe" -o ppid= -o stat= \
+                    -p "$_custody_guard_pid" 2>/dev/null
+            ); then
+                set -- $_guard_process
+                _guard_parent=${1:-}
+                _guard_state=${2:-}
+                if [ -n "$_guard_parent" ] && [ -n "$_guard_state" ]; then
+                    if [ "$_guard_parent" = "$$" ]; then
+                        /bin/kill -"$_guard_signal" \
+                            "$_custody_guard_pid" 2>/dev/null || true
+                        _retry_guard_wait=1
+                    else
+                        _retry_guard_wait=""
+                    fi
+                    break
+                fi
+            fi
+            if /bin/kill -0 "$_custody_guard_pid" 2>/dev/null; then
+                /bin/sleep 0.01
+                continue
+            fi
+            _retry_guard_wait=""
+            break
+        done
+        [ -n "$_retry_guard_wait" ] || return 0
+    done
+}
+
+while [ -z "$_custody_ready" ] && [ -z "$_termination_signal" ]; do
+    if _guard_process=$(
+        "$_guard_process_probe" -o ppid= -o stat= -p "$_custody_guard_pid" 2>/dev/null
+    ); then
+        set -- $_guard_process
+        _guard_parent=${1:-}
+        _guard_state=${2:-}
+        if [ "$_guard_parent" = "$$" ]; then
+            case "$_guard_state" in
+                Z*)
+                    terminate_and_reap_custody_guard KILL
+                    cleanup_standalone_guard_startup
+                    exit 1
+                    ;;
+                '') ;;
+                *)
+                    /bin/sleep 0.01
+                    continue
+                    ;;
+            esac
+        elif [ -n "$_guard_parent" ]; then
+            terminate_and_reap_custody_guard KILL
+            cleanup_standalone_guard_startup
+            exit 1
+        fi
+    fi
+    if /bin/kill -0 "$_custody_guard_pid" 2>/dev/null; then
+        /bin/sleep 0.01
+    else
+        terminate_and_reap_custody_guard KILL
+        cleanup_standalone_guard_startup
+        exit 1
+    fi
+done
+
+if [ -n "$_termination_signal" ]; then
+    terminate_and_reap_custody_guard KILL
+    cleanup_standalone_guard_startup
+    if [ ! -e "$_completion_dir" ]; then
+        _setup_cleanup_pending=""
+        trap - EXIT
+    fi
+    exit "$_termination_status"
+fi
+trap - USR1
+_setup_cleanup_pending=""
+trap - EXIT
+
+/bin/sh -c '
+    _launch_directory=$1
+    _launch_identity=$2
+    _launch_uid=$3
+    _launch_parent=$4
+    _launch_wait_command=$5
+    shift 5
+    cd "$_launch_directory" || exit 125
+    _observed_identity=$(/usr/bin/stat -f "%d:%i:%Lp:%u" .) || exit 125
+    [ "$_observed_identity" = "$_launch_identity" ] || exit 125
+    while [ ! -e ./launch-cli ] && [ ! -L ./launch-cli ]; do
+        _observed_parent=$(
+            /bin/ps -o ppid= -p "$$" 2>/dev/null | /usr/bin/tr -d " "
+        )
+        [ "$_observed_parent" = "$_launch_parent" ] || exit 125
+        _observed_identity=$(/usr/bin/stat -f "%d:%i:%Lp:%u" .) || exit 125
+        [ "$_observed_identity" = "$_launch_identity" ] || exit 125
+        "$_launch_wait_command" 0.01
+    done
+    _observed_parent=$(
+        /bin/ps -o ppid= -p "$$" 2>/dev/null | /usr/bin/tr -d " "
+    )
+    [ "$_observed_parent" = "$_launch_parent" ] || exit 125
+    _observed_identity=$(/usr/bin/stat -f "%d:%i:%Lp:%u" .) || exit 125
+    [ "$_observed_identity" = "$_launch_identity" ] || exit 125
+    [ -f ./launch-cli ] && [ ! -L ./launch-cli ] || exit 125
+    _observed_marker=$(/usr/bin/stat -f "%u:%Lp" ./launch-cli) || exit 125
+    [ "$_observed_marker" = "$_launch_uid:600" ] || exit 125
+    /bin/rm -f ./launch-cli || exit 125
+    _observed_parent=$(
+        /bin/ps -o ppid= -p "$$" 2>/dev/null | /usr/bin/tr -d " "
+    )
+    [ "$_observed_parent" = "$_launch_parent" ] || exit 125
+    _observed_identity=$(/usr/bin/stat -f "%d:%i:%Lp:%u" .) || exit 125
+    [ "$_observed_identity" = "$_launch_identity" ] || exit 125
+    exec "$@"
+' orchard-cli-launch "$_completion_dir" "$_completion_identity" \
+    "$_completion_uid" "$$" "$_cli_launch_wait_command" \
+    "$ORCHARD_CLI" eval "OrchardCLI.main([$args])" &
+_cli_pid=$!
+cli_pre_launch_barrier
+if [ -n "$_termination_signal" ]; then
+    forward_standalone_signal "$_termination_signal" "$_termination_status"
+else
+    if [ "${ORCHARD_TEST_CLI_PID_MARKER:-}" = "1" ]; then
+        printf '__ORCHARD_CLI_PID__:%s\n' "$_cli_pid"
+    fi
+    if [ -n "$_termination_signal" ]; then
+        forward_standalone_signal "$_termination_signal" "$_termination_status"
+    else
+        if ! create_cli_launch_marker; then
+            _termination_signal=TERM
+            _termination_status=1
+            forward_standalone_signal "$_termination_signal" "$_termination_status"
+        elif [ -n "$_termination_signal" ]; then
+            remove_cli_launch_marker 2>/dev/null || true
+            forward_standalone_signal "$_termination_signal" "$_termination_status"
+        fi
+    fi
+fi
+while :; do
+    _cli_wait_interrupted=""
+    _cli_waiting=1
+    if wait "$_cli_pid"; then
+        _cli_status=0
+    else
+        _cli_status=$?
+    fi
+    cli_post_wait_barrier
+    _cli_waiting=""
+    if [ -z "$_cli_wait_interrupted" ]; then
+        break
+    fi
+
+    while :; do
+        if _cli_process=$(
+            "$_cli_process_probe" -o ppid= -o stat= -p "$_cli_pid" 2>/dev/null
+        ); then
+            set -- $_cli_process
+            _cli_parent=${1:-}
+            _cli_state=${2:-}
+            if [ -n "$_cli_parent" ] && [ -n "$_cli_state" ]; then
+                if [ "$_cli_parent" = "$$" ]; then
+                    if [ -n "$_termination_signal" ]; then
+                        forward_standalone_signal \
+                            "$_termination_signal" "$_termination_status"
+                    fi
+                    _retry_cli_wait=1
+                else
+                    _retry_cli_wait=""
+                fi
+                break
+            fi
+        fi
+        if /bin/kill -0 "$_cli_pid" 2>/dev/null; then
+            /bin/sleep 0.01
+            continue
+        fi
+        _retry_cli_wait=""
+        break
+    done
+    [ -n "$_retry_cli_wait" ] || break
+done
+_cli_pid=""
+remove_cli_launch_marker 2>/dev/null || true
+if [ "${ORCHARD_TEST_CLI_REAPED_MARKER:-}" = "1" ]; then
+    printf '__ORCHARD_CLI_REAPED__:%s\n' "$_cli_status"
+fi
+
+terminate_and_reap_custody_guard TERM
+if [ "$_custody_guard_status" -ne 0 ] || [ -e "$_completion_dir" ]; then
+    printf 'orchardctl: terminal custody guard failed\n' >&2
+    while :; do
+        /bin/sleep 1
+    done
+fi
+
+cli_pre_exit_barrier
+trap - HUP INT QUIT TERM
+if [ -n "$_termination_status" ]; then
+    exit "$_termination_status"
+fi
+exit "$_cli_status"

--- a/packaging/pkg/bin/orchardctl
+++ b/packaging/pkg/bin/orchardctl
@@ -505,10 +505,10 @@ trap 'exit 130' INT
 trap 'exit 131' QUIT
 trap 'exit 143' TERM
 if [ "${ORCHARD_TEST_WRAPPER_PID_MARKER:-}" = "1" ]; then
-    printf '__ORCHARD_WRAPPER_PID__:%s\n' "$$"
+    printf '__ORCHARD_WRAPPER_PID__:%s\n' "$$" >&2
 fi
 if [ "${ORCHARD_TEST_CUSTODY_DIR_MARKER:-}" = "1" ]; then
-    printf '__ORCHARD_CUSTODY_DIR__:%s\n' "$_completion_dir"
+    printf '__ORCHARD_CUSTODY_DIR__:%s\n' "$_completion_dir" >&2
 fi
 /bin/chmod 0700 "$_completion_dir" || exit 1
 _completion_identity=$(/usr/bin/stat -f '%d:%i:%Lp:%u' "$_completion_dir") || exit 1
@@ -533,7 +533,6 @@ _cli_waiting=""
 _cli_wait_interrupted=""
 _guard_waiting=""
 _guard_wait_interrupted=""
-_cli_launch_marker="$_completion_dir/launch-cli"
 _cli_launch_wait_command=/bin/sleep
 _cli_parent_probe=/bin/ps
 _cli_process_probe=/bin/ps
@@ -592,7 +591,7 @@ forward_standalone_signal() {
                 break
             fi
             /bin/kill -0 "$_cli_pid" 2>/dev/null || break
-            /bin/sleep 0.01
+            /bin/sleep 0.01 || :
         done
     fi
 }
@@ -618,7 +617,7 @@ trap '_custody_ready=1' USR1
             ) || return 1
             [ "$_remove_path_identity" = "$_completion_identity" ] || return 1
             /bin/rmdir "$_completion_dir" 2>/dev/null && return 0
-            /bin/sleep 0.01
+            /bin/sleep 0.01 || :
         done
     }
     _guard_ready=""
@@ -670,7 +669,7 @@ trap '_custody_ready=1' USR1
         if [ -n "$_custody_cancel" ] && [ -e ./available ]; then
             /bin/rm -f ./available || true
         fi
-        /bin/sleep 0.01
+        /bin/sleep 0.01 || :
     done
 
     while :; do
@@ -680,7 +679,7 @@ trap '_custody_ready=1' USR1
         if [ "$_guard_path_identity" = "$_guard_identity" ]; then
             break
         fi
-        /bin/sleep 0.01
+        /bin/sleep 0.01 || :
     done
     cd / || exit 125
     remove_completion_directory || exit 125
@@ -689,7 +688,7 @@ trap '_custody_ready=1' USR1
 _custody_guard_pid=$!
 
 if [ "${ORCHARD_TEST_GUARD_PID_MARKER:-}" = "1" ]; then
-    printf '__ORCHARD_GUARD_PID__:%s\n' "$_custody_guard_pid"
+    printf '__ORCHARD_GUARD_PID__:%s\n' "$_custody_guard_pid" >&2
 fi
 
 cleanup_standalone_guard_startup() {
@@ -735,7 +734,7 @@ terminate_and_reap_custody_guard() {
             break
         fi
         /bin/kill -0 "$_custody_guard_pid" 2>/dev/null || break
-        /bin/sleep 0.01
+        /bin/sleep 0.01 || :
     done
     while :; do
         _guard_wait_interrupted=""
@@ -771,7 +770,7 @@ terminate_and_reap_custody_guard() {
                 fi
             fi
             if /bin/kill -0 "$_custody_guard_pid" 2>/dev/null; then
-                /bin/sleep 0.01
+                /bin/sleep 0.01 || :
                 continue
             fi
             _retry_guard_wait=""
@@ -797,7 +796,7 @@ while [ -z "$_custody_ready" ] && [ -z "$_termination_signal" ]; do
                     ;;
                 '') ;;
                 *)
-                    /bin/sleep 0.01
+                    /bin/sleep 0.01 || :
                     continue
                     ;;
             esac
@@ -808,7 +807,7 @@ while [ -z "$_custody_ready" ] && [ -z "$_termination_signal" ]; do
         fi
     fi
     if /bin/kill -0 "$_custody_guard_pid" 2>/dev/null; then
-        /bin/sleep 0.01
+        /bin/sleep 0.01 || :
     else
         terminate_and_reap_custody_guard KILL
         cleanup_standalone_guard_startup
@@ -828,6 +827,14 @@ fi
 trap - USR1
 _setup_cleanup_pending=""
 trap - EXIT
+
+# The wrapper holds sole custody of the controlling terminal; the CLI receives
+# only non-terminal standard input.
+if [ ! -t 0 ] && { /usr/bin/true 3<&0; } 2>/dev/null; then
+    exec 3<&0
+else
+    exec 3</dev/null
+fi
 
 /bin/sh -c '
     _launch_directory=$1
@@ -867,14 +874,15 @@ trap - EXIT
     exec "$@"
 ' orchard-cli-launch "$_completion_dir" "$_completion_identity" \
     "$_completion_uid" "$$" "$_cli_launch_wait_command" \
-    "$ORCHARD_CLI" eval "OrchardCLI.main([$args])" &
+    "$ORCHARD_CLI" eval "OrchardCLI.main([$args])" <&3 3<&- &
 _cli_pid=$!
+exec 3<&-
 cli_pre_launch_barrier
 if [ -n "$_termination_signal" ]; then
     forward_standalone_signal "$_termination_signal" "$_termination_status"
 else
     if [ "${ORCHARD_TEST_CLI_PID_MARKER:-}" = "1" ]; then
-        printf '__ORCHARD_CLI_PID__:%s\n' "$_cli_pid"
+        printf '__ORCHARD_CLI_PID__:%s\n' "$_cli_pid" >&2
     fi
     if [ -n "$_termination_signal" ]; then
         forward_standalone_signal "$_termination_signal" "$_termination_status"
@@ -924,7 +932,7 @@ while :; do
             fi
         fi
         if /bin/kill -0 "$_cli_pid" 2>/dev/null; then
-            /bin/sleep 0.01
+            /bin/sleep 0.01 || :
             continue
         fi
         _retry_cli_wait=""
@@ -935,14 +943,17 @@ done
 _cli_pid=""
 remove_cli_launch_marker 2>/dev/null || true
 if [ "${ORCHARD_TEST_CLI_REAPED_MARKER:-}" = "1" ]; then
-    printf '__ORCHARD_CLI_REAPED__:%s\n' "$_cli_status"
+    printf '__ORCHARD_CLI_REAPED__:%s\n' "$_cli_status" >&2
 fi
 
 terminate_and_reap_custody_guard TERM
 if [ "$_custody_guard_status" -ne 0 ] || [ -e "$_completion_dir" ]; then
     printf 'orchardctl: terminal custody guard failed\n' >&2
+    printf 'orchardctl: refusing to return this terminal; unread input may still be queued\n' >&2
+    printf 'orchardctl: from another terminal run: sudo kill -9 %s\n' "$$" >&2
+    printf 'orchardctl: then restore this terminal with: stty sane\n' >&2
     while :; do
-        /bin/sleep 1
+        /bin/sleep 1 || :
     done
 fi
 

--- a/packaging/pkg/bin/orchardctl
+++ b/packaging/pkg/bin/orchardctl
@@ -484,6 +484,11 @@ done
 
 ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID=$$
 export ORCHARD_CLI_FOREGROUND_SUPERVISOR_PID
+_launch_original_cwd=$(/bin/pwd -P 2>/dev/null) || _launch_original_cwd=""
+case "$_launch_original_cwd" in
+    /*) ;;
+    *) _launch_original_cwd=/ ;;
+esac
 _completion_dir=""
 _completion_identity=""
 _setup_cleanup_pending=""
@@ -533,6 +538,7 @@ _cli_waiting=""
 _cli_wait_interrupted=""
 _guard_waiting=""
 _guard_wait_interrupted=""
+WAIT_NO_CHILD_STATUS=127
 _cli_launch_wait_command=/bin/sleep
 _cli_parent_probe=/bin/ps
 _cli_process_probe=/bin/ps
@@ -721,6 +727,7 @@ cleanup_standalone_guard_startup() {
 
 terminate_and_reap_custody_guard() {
     _guard_signal=$1
+    _custody_guard_status_observed=""
     while :; do
         _guard_parent=$(
             "$_guard_parent_probe" -o ppid= -p "$_custody_guard_pid" 2>/dev/null |
@@ -740,14 +747,19 @@ terminate_and_reap_custody_guard() {
         _guard_wait_interrupted=""
         _guard_waiting=1
         if wait "$_custody_guard_pid"; then
-            _custody_guard_status=0
+            _guard_wait_status=0
         else
-            _custody_guard_status=$?
+            _guard_wait_status=$?
         fi
         guard_post_wait_barrier
         _guard_waiting=""
+        if [ -z "$_custody_guard_status_observed" ] ||
+           [ "$_guard_wait_status" -ne "$WAIT_NO_CHILD_STATUS" ]; then
+            _custody_guard_status=$_guard_wait_status
+            _custody_guard_status_observed=1
+        fi
         if [ -z "$_guard_wait_interrupted" ]; then
-            return
+            return 0
         fi
 
         while :; do
@@ -762,9 +774,6 @@ terminate_and_reap_custody_guard() {
                     if [ "$_guard_parent" = "$$" ]; then
                         /bin/kill -"$_guard_signal" \
                             "$_custody_guard_pid" 2>/dev/null || true
-                        _retry_guard_wait=1
-                    else
-                        _retry_guard_wait=""
                     fi
                     break
                 fi
@@ -773,10 +782,8 @@ terminate_and_reap_custody_guard() {
                 /bin/sleep 0.01 || :
                 continue
             fi
-            _retry_guard_wait=""
             break
         done
-        [ -n "$_retry_guard_wait" ] || return 0
     done
 }
 
@@ -842,7 +849,8 @@ fi
     _launch_uid=$3
     _launch_parent=$4
     _launch_wait_command=$5
-    shift 5
+    _launch_original_cwd=$6
+    shift 6
     cd "$_launch_directory" || exit 125
     _observed_identity=$(/usr/bin/stat -f "%d:%i:%Lp:%u" .) || exit 125
     [ "$_observed_identity" = "$_launch_identity" ] || exit 125
@@ -871,10 +879,11 @@ fi
     [ "$_observed_parent" = "$_launch_parent" ] || exit 125
     _observed_identity=$(/usr/bin/stat -f "%d:%i:%Lp:%u" .) || exit 125
     [ "$_observed_identity" = "$_launch_identity" ] || exit 125
-    cd / || exit 125
+    cd -- "$_launch_original_cwd" 2>/dev/null || cd / || exit 125
     exec "$@"
 ' orchard-cli-launch "$_completion_dir" "$_completion_identity" \
     "$_completion_uid" "$$" "$_cli_launch_wait_command" \
+    "$_launch_original_cwd" \
     "$ORCHARD_CLI" eval "OrchardCLI.main([$args])" <&3 3<&- &
 _cli_pid=$!
 exec 3<&-

--- a/scripts/test-packaged-orchardctl-console-pty.sh
+++ b/scripts/test-packaged-orchardctl-console-pty.sh
@@ -368,7 +368,7 @@ for _attempt in 1 2 3 4; do
   grep -q '^ORCHARD_CONSOLE_USERNAME=' "$CONSOLE_ENV" || \
     fail "packaged successful enable did not persist a username"
   grep -q '^ORCHARD_CONSOLE_PASSWORD=' "$CONSOLE_ENV" || \
-    fail "packaged successful enable did not persist a password hash"
+    fail "packaged successful enable did not persist a password"
   [[ "$(cat "$LAUNCHCTL_MARKER")" = \
     'print system/com.orchard.controller' ]] || \
     fail "packaged successful enable did not complete not-loaded handling"

--- a/scripts/test-packaged-orchardctl-console-pty.sh
+++ b/scripts/test-packaged-orchardctl-console-pty.sh
@@ -368,7 +368,7 @@ for _attempt in 1 2 3 4; do
   grep -q '^ORCHARD_CONSOLE_USERNAME=' "$CONSOLE_ENV" || \
     fail "packaged successful enable did not persist a username"
   grep -q '^ORCHARD_CONSOLE_PASSWORD=' "$CONSOLE_ENV" || \
-    fail "packaged successful enable did not persist a password"
+    fail "packaged successful enable did not persist a password hash"
   [[ "$(cat "$LAUNCHCTL_MARKER")" = \
     'print system/com.orchard.controller' ]] || \
     fail "packaged successful enable did not complete not-loaded handling"

--- a/scripts/test-packaged-orchardctl-console-pty.sh
+++ b/scripts/test-packaged-orchardctl-console-pty.sh
@@ -55,8 +55,12 @@ SH
 
 cat > "$TOOLS/launchctl" <<'SH'
 #!/bin/sh
-: > "$ORCHARD_TEST_LAUNCHCTL_MARKER"
-exit 113
+printf '%s\n' "$*" >> "$ORCHARD_TEST_LAUNCHCTL_MARKER"
+case "${ORCHARD_TEST_LAUNCHCTL_LOADED:-}:$*" in
+  1:print\ *) exit 0 ;;
+  1:kickstart\ *) exit 0 ;;
+  *) exit 113 ;;
+esac
 SH
 chmod 0755 "$TOOLS/id" "$TOOLS/launchctl"
 
@@ -346,6 +350,63 @@ OUTPUT=$(
 [[ "$OUTPUT" = 'console PTY ok: pasted-mismatch' ]] || fail "unexpected harness result"
 [[ ! -e "$CONSOLE_ENV" ]] || fail "aborted enable created console.env"
 [[ ! -e "$LAUNCHCTL_MARKER" ]] || fail "aborted enable attempted controller readiness or restart"
+
+for _attempt in 1 2 3 4; do
+  rm -f "$CONSOLE_ENV" "$LAUNCHCTL_MARKER"
+  SUCCESS_OUTPUT=$(
+    ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+      ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+      "$HARNESS" wrapper-success-not-loaded -- "$ORCHARDCTL" console enable
+  )
+  [[ "$SUCCESS_OUTPUT" = 'console PTY ok: wrapper-success-not-loaded' ]] || \
+    fail "packaged successful enable did not exit cleanly"
+  [[ -f "$CONSOLE_ENV" ]] || fail "packaged successful enable did not persist console.env"
+  [[ "$(stat -f '%Lp' "$CONSOLE_ENV")" = '600' ]] || \
+    fail "packaged successful enable did not protect console.env"
+  grep -q '^ORCHARD_CONSOLE_ENABLED="true"$' "$CONSOLE_ENV" || \
+    fail "packaged successful enable did not enable Console"
+  grep -q '^ORCHARD_CONSOLE_USERNAME=' "$CONSOLE_ENV" || \
+    fail "packaged successful enable did not persist a username"
+  grep -q '^ORCHARD_CONSOLE_PASSWORD=' "$CONSOLE_ENV" || \
+    fail "packaged successful enable did not persist a password hash"
+  [[ "$(cat "$LAUNCHCTL_MARKER")" = \
+    'print system/com.orchard.controller' ]] || \
+    fail "packaged successful enable did not complete not-loaded handling"
+done
+
+rm -f "$CONSOLE_ENV" "$LAUNCHCTL_MARKER"
+LOADED_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    ORCHARD_TEST_LAUNCHCTL_LOADED=1 \
+    "$HARNESS" wrapper-success-loaded -- "$ORCHARDCTL" console enable
+)
+[[ "$LOADED_OUTPUT" = 'console PTY ok: wrapper-success-loaded' ]] || \
+  fail "packaged successful enable did not complete loaded restart handling"
+[[ -f "$CONSOLE_ENV" ]] || fail "loaded restart did not persist console.env"
+[[ "$(stat -f '%Lp' "$CONSOLE_ENV")" = '600' ]] || \
+  fail "loaded restart did not protect console.env"
+[[ "$(cat "$LAUNCHCTL_MARKER")" = $'print system/com.orchard.controller\nkickstart -k system/com.orchard.controller' ]] || \
+  fail "packaged successful enable did not restart a loaded controller"
+
+ENABLED_CHECKSUM=$(cksum "$CONSOLE_ENV")
+rm -f "$LAUNCHCTL_MARKER"
+ROTATE_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    "$HARNESS" wrapper-success-rotate -- "$ORCHARDCTL" console rotate
+)
+[[ "$ROTATE_OUTPUT" = 'console PTY ok: wrapper-success-rotate' ]] || \
+  fail "packaged successful rotate did not exit cleanly"
+[[ -f "$CONSOLE_ENV" ]] || fail "packaged successful rotate removed console.env"
+[[ "$(stat -f '%Lp' "$CONSOLE_ENV")" = '600' ]] || \
+  fail "packaged successful rotate did not protect console.env"
+[[ "$(cksum "$CONSOLE_ENV")" != "$ENABLED_CHECKSUM" ]] || \
+  fail "packaged successful rotate did not replace the credential"
+[[ "$(cat "$LAUNCHCTL_MARKER")" = \
+  'print system/com.orchard.controller' ]] || \
+  fail "packaged successful rotate did not complete not-loaded handling"
+rm -f "$CONSOLE_ENV" "$LAUNCHCTL_MARKER"
 
 WRAPPER_OUTPUT=$(
   ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \

--- a/scripts/test-packaged-orchardctl-console-pty.sh
+++ b/scripts/test-packaged-orchardctl-console-pty.sh
@@ -9,9 +9,22 @@ STAGED_ROOT="$TMP_ROOT/staged/Library/Application Support/Orchard"
 TOOLS="$TMP_ROOT/tools"
 HARNESS="$TMP_ROOT/console-pty-harness"
 ORCHARDCTL="$TMP_ROOT/orchardctl"
+WAIT_ORCHARDCTL="$TMP_ROOT/orchardctl-wait"
+SIGNAL_PROBE_ORCHARDCTL="$TMP_ROOT/orchardctl-signal-probe"
+WAIT_PROBE_ORCHARDCTL="$TMP_ROOT/orchardctl-wait-probe"
+GUARD_ORCHARDCTL="$TMP_ROOT/orchardctl-guard"
+GUARD_READY_PROBE_ORCHARDCTL="$TMP_ROOT/orchardctl-guard-ready-probe"
+GUARD_TERM_PROBE_ORCHARDCTL="$TMP_ROOT/orchardctl-guard-term-probe"
+LAUNCH_ORCHARDCTL="$TMP_ROOT/orchardctl-launch"
+EXIT_ORCHARDCTL="$TMP_ROOT/orchardctl-exit"
+CLI_WAIT_ORCHARDCTL="$TMP_ROOT/orchardctl-cli-wait"
+GUARD_WAIT_ORCHARDCTL="$TMP_ROOT/orchardctl-guard-wait"
+SETUP_FAIL_ORCHARDCTL="$TMP_ROOT/orchardctl-setup-fail"
+LAUNCH_WAIT_FIXTURE="$TMP_ROOT/launch-wait"
+TRANSIENT_PS_FIXTURE="$TMP_ROOT/transient-ps"
+WAIT_FIXTURE="$TMP_ROOT/orchardctl-delayed-term-fixture"
 LAUNCHCTL_MARKER="$TMP_ROOT/launchctl-called"
 CONSOLE_ENV="$STAGED_ROOT/config/console.env"
-EXPECTED_ENV="$TMP_ROOT/expected-console.env"
 RELEASE_SOURCE="$REPO_ROOT/_build/prod/rel/orchard_cli"
 
 cleanup() {
@@ -30,9 +43,6 @@ MIX_ENV=prod mise exec -- mix release orchard_cli --overwrite >/dev/null
 mkdir -p "$STAGED_ROOT/releases" "$STAGED_ROOT/support" "$STAGED_ROOT/config" "$TOOLS"
 cp -R "$RELEASE_SOURCE" "$STAGED_ROOT/releases/orchard_cli"
 printf '%s\n' 'controller' > "$STAGED_ROOT/support/.install-role"
-printf '%s\n' 'ORCHARD_CONSOLE_ENABLED="false"' > "$EXPECTED_ENV"
-cp "$EXPECTED_ENV" "$CONSOLE_ENV"
-chmod 0600 "$CONSOLE_ENV"
 
 cat > "$TOOLS/id" <<'SH'
 #!/bin/sh
@@ -50,15 +60,283 @@ exit 113
 SH
 chmod 0755 "$TOOLS/id" "$TOOLS/launchctl"
 
+cat > "$LAUNCH_WAIT_FIXTURE" <<'SH'
+#!/bin/sh
+printf '__ORCHARD_LAUNCH_WINDOW__\n'
+exec /bin/sleep 0.5
+SH
+chmod 0755 "$LAUNCH_WAIT_FIXTURE"
+
+cat > "$TRANSIENT_PS_FIXTURE" <<'SH'
+#!/bin/sh
+IFS= read -r failures < "$ORCHARD_TEST_PS_FAILURE_COUNT" || failures=0
+case "$failures" in
+  ''|*[!0-9]*) exit 125 ;;
+esac
+if [ "$failures" -gt 0 ]; then
+  printf '%s\n' "$((failures - 1))" > "$ORCHARD_TEST_PS_FAILURE_COUNT"
+  exit 1
+fi
+exec /bin/ps "$@"
+SH
+chmod 0755 "$TRANSIENT_PS_FIXTURE"
+
 sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
   "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$ORCHARDCTL"
 chmod 0755 "$ORCHARDCTL"
 
-xcrun clang -std=c11 -Wall -Wextra -Werror \
+xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic \
   "$REPO_ROOT/apps/orchard_cli/test/support/console_pty_harness.c" \
   -o "$HARNESS"
+xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic \
+  "$REPO_ROOT/apps/orchard_cli/test/support/orchardctl_delayed_term_fixture.c" \
+  -o "$WAIT_FIXTURE"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$WAIT_ORCHARDCTL"
+chmod 0755 "$WAIT_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e "s|^_cli_parent_probe=/bin/ps$|_cli_parent_probe=\"$TRANSIENT_PS_FIXTURE\"|" \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$SIGNAL_PROBE_ORCHARDCTL"
+chmod 0755 "$SIGNAL_PROBE_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e "s|^_cli_process_probe=/bin/ps$|_cli_process_probe=\"$TRANSIENT_PS_FIXTURE\"|" \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$WAIT_PROBE_ORCHARDCTL"
+chmod 0755 "$WAIT_PROBE_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { while guard_parent_matches; do /bin/sleep 0.01; done; return 1; }|' \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$GUARD_ORCHARDCTL"
+chmod 0755 "$GUARD_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e "s|^_guard_process_probe=/bin/ps$|_guard_process_probe=\"$TRANSIENT_PS_FIXTURE\"|" \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$GUARD_READY_PROBE_ORCHARDCTL"
+chmod 0755 "$GUARD_READY_PROBE_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { while guard_parent_matches; do /bin/sleep 0.01; done; return 1; }|' \
+  -e "s|^_guard_parent_probe=/bin/ps$|_guard_parent_probe=\"$TRANSIENT_PS_FIXTURE\"|" \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$GUARD_TERM_PROBE_ORCHARDCTL"
+chmod 0755 "$GUARD_TERM_PROBE_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e 's|^cli_pre_launch_barrier() { :; }$|cli_pre_launch_barrier() { printf "__ORCHARD_PRE_LAUNCH__\\n__ORCHARD_LAUNCHER_PID__:%s\\n" "$_cli_pid"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; }|' \
+  -e "s|^_cli_launch_wait_command=/bin/sleep$|_cli_launch_wait_command=\"$LAUNCH_WAIT_FIXTURE\"|" \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$LAUNCH_ORCHARDCTL"
+chmod 0755 "$LAUNCH_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e 's|^cli_pre_exit_barrier() { :; }$|cli_pre_exit_barrier() { printf "__ORCHARD_PRE_EXIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; }|' \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$EXIT_ORCHARDCTL"
+chmod 0755 "$EXIT_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e 's|^cli_post_wait_barrier() { :; }$|cli_post_wait_barrier() { printf "__ORCHARD_CLI_POST_WAIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; }|' \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$CLI_WAIT_ORCHARDCTL"
+chmod 0755 "$CLI_WAIT_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e 's|^guard_post_wait_barrier() { :; }$|guard_post_wait_barrier() { printf "__ORCHARD_GUARD_POST_WAIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; printf "__ORCHARD_GUARD_POST_SIGNAL__:%s\\n" "$_termination_status"; }|' \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$GUARD_WAIT_ORCHARDCTL"
+chmod 0755 "$GUARD_WAIT_ORCHARDCTL"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  -e 's#^_completion_uid=$(/usr/bin/id -u) || exit 1$#_completion_uid=$(/usr/bin/false) || exit 1#' \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$SETUP_FAIL_ORCHARDCTL"
+chmod 0755 "$SETUP_FAIL_ORCHARDCTL"
+
+SETUP_FAIL_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-setup-failure -- "$SETUP_FAIL_ORCHARDCTL" console enable
+)
+[[ "$SETUP_FAIL_OUTPUT" = 'console PTY ok: wrapper-setup-failure' ]] || \
+  fail "pre-guard setup failure leaked its custody directory"
+
+GUARD_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" guard-pre-ready-death -- "$GUARD_ORCHARDCTL" console enable
+)
+[[ "$GUARD_OUTPUT" = 'console PTY ok: guard-pre-ready-death' ]] || \
+  fail "pre-readiness guard death did not exit safely"
+
+WRAPPER_DEATH_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-pre-ready-death -- "$GUARD_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_DEATH_OUTPUT" = 'console PTY ok: wrapper-pre-ready-death' ]] || \
+  fail "pre-readiness wrapper death stranded its custody guard"
+
+WRAPPER_TERM_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-pre-ready-term -- "$GUARD_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_TERM_OUTPUT" = 'console PTY ok: wrapper-pre-ready-term' ]] || \
+  fail "pre-readiness wrapper TERM did not cancel guard startup"
+
+printf '1\n' > "$TMP_ROOT/guard-ready-probe-failures"
+GUARD_READY_PROBE_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_PS_FAILURE_COUNT="$TMP_ROOT/guard-ready-probe-failures" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-term-paced -- "$GUARD_READY_PROBE_ORCHARDCTL" console enable
+)
+[[ "$GUARD_READY_PROBE_OUTPUT" = 'console PTY ok: wrapper-term-paced' ]] || \
+  fail "transient guard readiness probe failure stranded startup"
+
+printf '1\n' > "$TMP_ROOT/guard-term-probe-failures"
+GUARD_TERM_PROBE_OUTPUT=$(
+  ORCHARD_TEST_PS_FAILURE_COUNT="$TMP_ROOT/guard-term-probe-failures" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-pre-ready-term -- "$GUARD_TERM_PROBE_ORCHARDCTL" console enable
+)
+[[ "$GUARD_TERM_PROBE_OUTPUT" = 'console PTY ok: wrapper-pre-ready-term' ]] || \
+  fail "transient guard termination probe failure stranded cancellation"
+
+WRAPPER_LAUNCH_TERM_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-pre-launch-term -- "$LAUNCH_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_LAUNCH_TERM_OUTPUT" = 'console PTY ok: wrapper-pre-launch-term' ]] || \
+  fail "pre-launch wrapper TERM started a cancelled CLI"
+
+WRAPPER_LAUNCH_INT_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-pre-launch-int -- "$LAUNCH_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_LAUNCH_INT_OUTPUT" = 'console PTY ok: wrapper-pre-launch-int' ]] || \
+  fail "pre-launch wrapper INT stranded its launch supervisor"
+
+WRAPPER_LAUNCH_QUIT_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-pre-launch-quit -- "$LAUNCH_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_LAUNCH_QUIT_OUTPUT" = 'console PTY ok: wrapper-pre-launch-quit' ]] || \
+  fail "pre-launch wrapper QUIT stranded its launch supervisor"
+
+WRAPPER_LAUNCH_SUBSTITUTION_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_GUARD_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    "$HARNESS" wrapper-launch-path-substitution -- "$LAUNCH_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_LAUNCH_SUBSTITUTION_OUTPUT" = \
+  'console PTY ok: wrapper-launch-path-substitution' ]] || \
+  fail "launch supervisor trusted a substituted custody path"
+
+WRAPPER_LATE_INT_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    "$HARNESS" wrapper-late-int -- "$EXIT_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_LATE_INT_OUTPUT" = 'console PTY ok: wrapper-late-int' ]] || \
+  fail "late foreground INT lost its exact wrapper exit status"
+
+WRAPPER_CLI_POST_WAIT_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_CLI_REAPED_MARKER=1 \
+    "$HARNESS" wrapper-cli-post-wait-int -- "$CLI_WAIT_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_CLI_POST_WAIT_OUTPUT" = \
+  'console PTY ok: wrapper-cli-post-wait-int' ]] || \
+  fail "post-wait INT overwrote the authoritative CLI status"
+
+WRAPPER_GUARD_POST_WAIT_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    "$HARNESS" wrapper-guard-post-wait-int -- "$GUARD_WAIT_ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_GUARD_POST_WAIT_OUTPUT" = \
+  'console PTY ok: wrapper-guard-post-wait-int' ]] || \
+  fail "post-wait INT turned successful guard cleanup into failure"
+
+WAIT_OUTPUT=$(
+  ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_REAPED_MARKER=1 \
+    "$HARNESS" wrapper-wait-reap -- "$WAIT_ORCHARDCTL" console enable
+)
+[[ "$WAIT_OUTPUT" = 'console PTY ok: wrapper-wait-reap' ]] || \
+  fail "wrapper returned before reaping its interrupted CLI child"
+
+printf '1\n' > "$TMP_ROOT/signal-probe-failures"
+SIGNAL_PROBE_OUTPUT=$(
+  ORCHARD_TEST_PS_FAILURE_COUNT="$TMP_ROOT/signal-probe-failures" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_REAPED_MARKER=1 \
+    "$HARNESS" wrapper-wait-reap -- "$SIGNAL_PROBE_ORCHARDCTL" console enable
+)
+[[ "$SIGNAL_PROBE_OUTPUT" = 'console PTY ok: wrapper-wait-reap' ]] || \
+  fail "transient signal-forward probe failure stranded the CLI"
+
+printf '1\n' > "$TMP_ROOT/wait-probe-failures"
+WAIT_PROBE_OUTPUT=$(
+  ORCHARD_TEST_PS_FAILURE_COUNT="$TMP_ROOT/wait-probe-failures" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_REAPED_MARKER=1 \
+    "$HARNESS" wrapper-wait-reap -- "$WAIT_PROBE_ORCHARDCTL" console enable
+)
+[[ "$WAIT_PROBE_OUTPUT" = 'console PTY ok: wrapper-wait-reap' ]] || \
+  fail "transient post-wait probe failure abandoned the CLI"
 
 OUTPUT=$(
   ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
@@ -66,7 +344,86 @@ OUTPUT=$(
     "$HARNESS" pasted-mismatch -- "$ORCHARDCTL" console enable
 )
 [[ "$OUTPUT" = 'console PTY ok: pasted-mismatch' ]] || fail "unexpected harness result"
-cmp -s "$EXPECTED_ENV" "$CONSOLE_ENV" || fail "aborted enable changed console.env"
+[[ ! -e "$CONSOLE_ENV" ]] || fail "aborted enable created console.env"
 [[ ! -e "$LAUNCHCTL_MARKER" ]] || fail "aborted enable attempted controller readiness or restart"
+
+WRAPPER_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    "$HARNESS" wrapper-term-paced -- "$ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_OUTPUT" = 'console PTY ok: wrapper-term-paced' ]] || \
+  fail "wrapper signal did not preserve the PTY cleanup fence"
+[[ ! -e "$CONSOLE_ENV" ]] || fail "signalled wrapper created console.env"
+[[ ! -e "$LAUNCHCTL_MARKER" ]] || fail "signalled wrapper attempted controller readiness or restart"
+
+WRAPPER_INT_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    "$HARNESS" wrapper-int-paced -- "$ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_INT_OUTPUT" = 'console PTY ok: wrapper-int-paced' ]] || \
+  fail "foreground wrapper INT did not preserve the PTY cleanup fence"
+[[ ! -e "$CONSOLE_ENV" ]] || fail "INT-signalled wrapper created console.env"
+[[ ! -e "$LAUNCHCTL_MARKER" ]] || \
+  fail "INT-signalled wrapper attempted controller readiness or restart"
+
+WRAPPER_QUIT_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    "$HARNESS" wrapper-quit-paced -- "$ORCHARDCTL" console enable
+)
+[[ "$WRAPPER_QUIT_OUTPUT" = 'console PTY ok: wrapper-quit-paced' ]] || \
+  fail "foreground wrapper QUIT did not preserve the PTY cleanup fence"
+[[ ! -e "$CONSOLE_ENV" ]] || fail "QUIT-signalled wrapper created console.env"
+[[ ! -e "$LAUNCHCTL_MARKER" ]] || \
+  fail "QUIT-signalled wrapper attempted controller readiness or restart"
+
+SUBSTITUTION_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_PID_MARKER=1 \
+    ORCHARD_TEST_CLI_REAPED_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    "$HARNESS" wrapper-path-substitution -- "$ORCHARDCTL" console enable
+)
+[[ "$SUBSTITUTION_OUTPUT" = 'console PTY ok: wrapper-path-substitution' ]] || \
+  fail "wrapper released a substituted custody directory"
+[[ ! -e "$CONSOLE_ENV" ]] || fail "custody substitution created console.env"
+[[ ! -e "$LAUNCHCTL_MARKER" ]] || \
+  fail "custody substitution attempted controller readiness or restart"
+
+TERMINAL_CLOSE_OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    ORCHARD_TEST_WRAPPER_PID_MARKER=1 \
+    ORCHARD_TEST_CUSTODY_DIR_MARKER=1 \
+    "$HARNESS" terminal-close -- "$ORCHARDCTL" console enable
+)
+[[ "$TERMINAL_CLOSE_OUTPUT" = 'console PTY ok: terminal-close' ]] || \
+  fail "terminal close leaked protected-input processes or custody"
+[[ ! -e "$CONSOLE_ENV" ]] || fail "terminal close created console.env"
+[[ ! -e "$LAUNCHCTL_MARKER" ]] || \
+  fail "terminal close attempted controller readiness or restart"
+
+unset ORCHARD_CONSOLE_ENABLED ORCHARD_CONSOLE_USERNAME ORCHARD_CONSOLE_PASSWORD
+CONSOLE_STATE=$(
+  "$STAGED_ROOT/releases/orchard_cli/bin/orchard_cli" eval '
+    config = Application.fetch_env!(:orchard_controller, :console)
+
+    if Keyword.fetch!(config, :enabled) == false and
+         Keyword.get(config, :username) == nil and
+         Keyword.get(config, :password) == nil do
+      IO.puts("console-disabled")
+    else
+      System.halt(1)
+    end
+  '
+)
+[[ "$CONSOLE_STATE" = 'console-disabled' ]] || fail "packaged runtime did not keep Console disabled"
 
 printf '%s\n' 'Packaged orchardctl PTY secret-input test passed.'

--- a/scripts/test-packaged-orchardctl-console-pty.sh
+++ b/scripts/test-packaged-orchardctl-console-pty.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Real macOS PTY coverage for the packaged orchardctl console entry path.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+STAGED_ROOT="$TMP_ROOT/staged/Library/Application Support/Orchard"
+TOOLS="$TMP_ROOT/tools"
+HARNESS="$TMP_ROOT/console-pty-harness"
+ORCHARDCTL="$TMP_ROOT/orchardctl"
+LAUNCHCTL_MARKER="$TMP_ROOT/launchctl-called"
+CONSOLE_ENV="$STAGED_ROOT/config/console.env"
+EXPECTED_ENV="$TMP_ROOT/expected-console.env"
+RELEASE_SOURCE="$REPO_ROOT/_build/prod/rel/orchard_cli"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'packaged orchardctl PTY failure: %s\n' "$1" >&2
+  exit 1
+}
+
+cd "$REPO_ROOT"
+MIX_ENV=prod mise exec -- mix release orchard_cli --overwrite >/dev/null
+
+mkdir -p "$STAGED_ROOT/releases" "$STAGED_ROOT/support" "$STAGED_ROOT/config" "$TOOLS"
+cp -R "$RELEASE_SOURCE" "$STAGED_ROOT/releases/orchard_cli"
+printf '%s\n' 'controller' > "$STAGED_ROOT/support/.install-role"
+printf '%s\n' 'ORCHARD_CONSOLE_ENABLED="false"' > "$EXPECTED_ENV"
+cp "$EXPECTED_ENV" "$CONSOLE_ENV"
+chmod 0600 "$CONSOLE_ENV"
+
+cat > "$TOOLS/id" <<'SH'
+#!/bin/sh
+if [ "${1:-}" = "-u" ]; then
+  printf '0\n'
+else
+  exec /usr/bin/id "$@"
+fi
+SH
+
+cat > "$TOOLS/launchctl" <<'SH'
+#!/bin/sh
+: > "$ORCHARD_TEST_LAUNCHCTL_MARKER"
+exit 113
+SH
+chmod 0755 "$TOOLS/id" "$TOOLS/launchctl"
+
+sed \
+  -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
+  -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
+  "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$ORCHARDCTL"
+chmod 0755 "$ORCHARDCTL"
+
+xcrun clang -std=c11 -Wall -Wextra -Werror \
+  "$REPO_ROOT/apps/orchard_cli/test/support/console_pty_harness.c" \
+  -o "$HARNESS"
+
+OUTPUT=$(
+  ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
+    ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
+    "$HARNESS" pasted-mismatch -- "$ORCHARDCTL" console enable
+)
+[[ "$OUTPUT" = 'console PTY ok: pasted-mismatch' ]] || fail "unexpected harness result"
+cmp -s "$EXPECTED_ENV" "$CONSOLE_ENV" || fail "aborted enable changed console.env"
+[[ ! -e "$LAUNCHCTL_MARKER" ]] || fail "aborted enable attempted controller readiness or restart"
+
+printf '%s\n' 'Packaged orchardctl PTY secret-input test passed.'

--- a/scripts/test-packaged-orchardctl-console-pty.sh
+++ b/scripts/test-packaged-orchardctl-console-pty.sh
@@ -121,7 +121,7 @@ sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
-  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { while guard_parent_matches; do /bin/sleep 0.01; done; return 1; }|' \
+  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { while guard_parent_matches; do /bin/sleep 0.01 \|\| :; done; return 1; }|' \
   "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$GUARD_ORCHARDCTL"
 chmod 0755 "$GUARD_ORCHARDCTL"
 
@@ -136,7 +136,7 @@ sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
-  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { while guard_parent_matches; do /bin/sleep 0.01; done; return 1; }|' \
+  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { while guard_parent_matches; do /bin/sleep 0.01 \|\| :; done; return 1; }|' \
   -e "s|^_guard_parent_probe=/bin/ps$|_guard_parent_probe=\"$TRANSIENT_PS_FIXTURE\"|" \
   "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$GUARD_TERM_PROBE_ORCHARDCTL"
 chmod 0755 "$GUARD_TERM_PROBE_ORCHARDCTL"
@@ -145,7 +145,7 @@ sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
-  -e 's|^cli_pre_launch_barrier() { :; }$|cli_pre_launch_barrier() { printf "__ORCHARD_PRE_LAUNCH__\\n__ORCHARD_LAUNCHER_PID__:%s\\n" "$_cli_pid"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; }|' \
+  -e 's|^cli_pre_launch_barrier() { :; }$|cli_pre_launch_barrier() { printf "__ORCHARD_PRE_LAUNCH__\\n__ORCHARD_LAUNCHER_PID__:%s\\n" "$_cli_pid"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01 \|\| :; done; }|' \
   -e "s|^_cli_launch_wait_command=/bin/sleep$|_cli_launch_wait_command=\"$LAUNCH_WAIT_FIXTURE\"|" \
   "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$LAUNCH_ORCHARDCTL"
 chmod 0755 "$LAUNCH_ORCHARDCTL"
@@ -153,21 +153,21 @@ chmod 0755 "$LAUNCH_ORCHARDCTL"
 sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
-  -e 's|^cli_pre_exit_barrier() { :; }$|cli_pre_exit_barrier() { printf "__ORCHARD_PRE_EXIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; }|' \
+  -e 's|^cli_pre_exit_barrier() { :; }$|cli_pre_exit_barrier() { printf "__ORCHARD_PRE_EXIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01 \|\| :; done; }|' \
   "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$EXIT_ORCHARDCTL"
 chmod 0755 "$EXIT_ORCHARDCTL"
 
 sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
-  -e 's|^cli_post_wait_barrier() { :; }$|cli_post_wait_barrier() { printf "__ORCHARD_CLI_POST_WAIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; }|' \
+  -e 's|^cli_post_wait_barrier() { :; }$|cli_post_wait_barrier() { printf "__ORCHARD_CLI_POST_WAIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01 \|\| :; done; }|' \
   "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$CLI_WAIT_ORCHARDCTL"
 chmod 0755 "$CLI_WAIT_ORCHARDCTL"
 
 sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
-  -e 's|^guard_post_wait_barrier() { :; }$|guard_post_wait_barrier() { printf "__ORCHARD_GUARD_POST_WAIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01; done; printf "__ORCHARD_GUARD_POST_SIGNAL__:%s\\n" "$_termination_status"; }|' \
+  -e 's|^guard_post_wait_barrier() { :; }$|guard_post_wait_barrier() { printf "__ORCHARD_GUARD_POST_WAIT__\\n"; while [ -z "$_termination_signal" ]; do /bin/sleep 0.01 \|\| :; done; printf "__ORCHARD_GUARD_POST_SIGNAL__:%s\\n" "$_termination_status"; }|' \
   "$REPO_ROOT/packaging/pkg/bin/orchardctl" > "$GUARD_WAIT_ORCHARDCTL"
 chmod 0755 "$GUARD_WAIT_ORCHARDCTL"
 

--- a/scripts/test-packaged-orchardctl-controller-runtime.sh
+++ b/scripts/test-packaged-orchardctl-controller-runtime.sh
@@ -90,13 +90,17 @@ mkdir -p "$UNTRUSTED_TMP"
 printf 'controller-cookie\n' > "$PACKAGE_ROOT/config/beam.cookie"
 chmod 0600 "$PACKAGE_ROOT/config/beam.cookie"
 
+# The packaged wrapper requires a root-owned 0600 cookie, which an unprivileged
+# test fixture cannot create. Fake ownership for that file only; every other
+# query (including the standalone custody identity checks) must stay truthful.
 cat > "$TOOLS/stat" <<'SH'
 #!/bin/sh
-case "${2:-}" in
-  '%u:%Lp') printf '0:600\n' ;;
-  '%z') /usr/bin/stat -f '%z' "$3" ;;
-  *) exit 1 ;;
-esac
+if [ "${2:-}" = '%u:%Lp' ]; then
+  case "${3:-}" in
+    */config/beam.cookie) printf '0:600\n' ; exit 0 ;;
+  esac
+fi
+exec /usr/bin/stat "$@"
 SH
 chmod +x "$TOOLS/stat"
 
@@ -158,8 +162,11 @@ case "$FAKE_RPC_MODE" in
     printf 'ORCHARDCTL_RPC_V1:0:stdout:Y29udHJvbGxlciBzdWNjZXNz\n\n'
     ;;
   nonresponsive)
+    # sh defers the trap until the foreground sleep returns, so keep the sleep
+    # granularity well under RPC_TERM_GRACE_SECONDS or the watchdog SIGKILLs
+    # this fixture before it can record the TERM it received.
     trap 'printf "terminated\n" >> "$FAKE_RPC_PROCESS_EVENTS"; exit 143' TERM
-    while :; do /bin/sleep 1; done
+    while :; do /bin/sleep 0.05; done
     ;;
   term-resistant)
     printf 'term-resistant:%s\n' "$$" >> "$FAKE_RPC_PROCESS_EVENTS"


### PR DESCRIPTION
## Intent

Fix only PR #180 packaged successful console enable and rotate crash caused by custody directory removal invalidating the CLI working directory. Preserve terminal custody and restoration, unread input disposal, and secret nondisclosure. Add real foreground packaged PTY regression coverage for not-loaded and loaded restart handling plus rotate. The owner accepts unrelated findings as release information for later follow-up. Do not merge.

## What Changed

- Replaced the `stty`-based `/dev/tty` prompt in `OrchardCLI.Commands.Console` with a new `OrchardCLI.SecretTTY` port driver over an `orchard-secret-tty` native helper (`apps/orchard_cli/c_src`, built through `elixir_make` from `mix.exs`). Credential prompts for `console enable`, `console rotate`, and `init --console` now take custody of the controlling terminal: no echo, input typed past the prompts is discarded, and the saved termios is restored on success and on HUP/INT/QUIT/TERM.
- Reworked the packaged `packaging/pkg/bin/orchardctl` wrapper from `exec "$ORCHARD_CLI" eval ...` into a supervised supervisor + custody-guard + CLI model backed by a 0700 custody directory, with signal forwarding and 129/130/131/143 exit mapping. The CLI is now launched from the operator's invocation directory (`cd -- "$_launch_original_cwd"`) instead of inheriting the custody directory, so a successful packaged `console enable`/`rotate` no longer crashes when the guard removes that directory.
- Added packaged foreground PTY regression coverage: a C PTY harness plus `console_pty_test.exs`, new `packaging_wrapper_test.exs` cases, and `scripts/test-packaged-orchardctl-console-pty.sh` (covering the not-loaded, loaded-restart, and rotate success paths alongside custody, restoration, unread-input disposal, and secret nondisclosure), wired into required CI validation. Documented the custody model and its recovery steps in `packaging/pkg/README.md` and the Xcode Command Line Tools prerequisite in `docs/tooling.md`.

## Risk Assessment

⚠️ Medium: The surviving delta is a single well-bounded shell change plus a regression test that I verified preserves the custody-identity ordering and the no-cwd-in-custody-directory invariant, but the branch as a whole still carries three defects the owner knowingly deferred — including a Ctrl-C race that can permanently hold the operator's terminal.

## Testing

I exercised the packaged console path the way an operator does rather than only through unit tests: the full `scripts/test-packaged-orchardctl-console-pty.sh` foreground PTY suite passed, and the targeted `orchard_cli` unit slice (packaging wrapper, console, console PTY) passed at 55 tests. For product-level evidence I drove the staged packaged wrapper and `orchard_cli` release through a real controlling terminal with `expect` and captured the operator-visible transcripts for enable (controller not loaded), enable (controller loaded, restart issued), and rotate — each completes cleanly with `console.env` written at mode 600, while the same transcripts against the pre-fix wrapper end in the `:enoent: invalid port name` Erlang crash, which is the crash this change fixes. I separately confirmed the three new PTY scenarios fail against the pre-fix wrapper and pass against the fixed one, so the added coverage is real. Terminal restoration, echo suppression at every credential prompt, unread-input disposal, and secret nondisclosure were all still asserted and held; no generated secret appears in any captured transcript. This is a CLI/shell-wrapper change with no rendered UI surface, so the reviewer-visible evidence is terminal transcripts rather than screenshots. Everything passed and the worktree is clean.

<details>
<summary>Evidence: Operator terminal transcripts — before vs after (console enable not-loaded / loaded, rotate)</summary>

```text
### BEFORE (wrapper at d17f968) — sudo orchardctl console enable
Console username:
Console password:
Confirm console password:
** (ErlangError) Erlang error: :enoent:

* 1st argument: invalid port name

:erlang.open_port({:spawn_executable, ~c".../tools/id"}, [:use_stdio, :stderr_to_stdout, :exit_status, :binary, :hide, {:args, ["-u"]}])
(elixir 1.20.0) lib/system.ex:1158: System.do_cmd/3
(orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:482: OrchardCLI.Commands.LifecycleSupport.default_uid/0
(orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:208: OrchardCLI.Commands.Console.restart_controller_if_loaded/2
(orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:68: OrchardCLI.Commands.Console.run_for_role/3

### AFTER (this change) — sudo orchardctl console enable
Console username:
Console password:
Confirm console password:
Console enabled.
Controller is not loaded. Run: sudo orchardctl start

### AFTER — sudo orchardctl console enable (controller loaded)
Console username:
Console password:
Confirm console password:
Console enabled.
Controller restarted.

### AFTER — sudo orchardctl console rotate
Console username:
Console password:
Confirm console password:
Console credentials rotated.
Controller is not loaded. Run: sudo orchardctl start
```
</details>
<details>
<summary>Evidence: New PTY scenarios are real regression coverage (pre-fix wrapper vs fixed wrapper)</summary>

```text
wrapper scenario result
-------------------------------------------------------------------------
PRE-FIX wrapper-success-not-loaded exit=1 console PTY failure: wrapper-success-not-loaded: expected-output-missing
PRE-FIX wrapper-success-loaded exit=1 console PTY failure: wrapper-success-loaded: expected-output-missing
PRE-FIX wrapper-success-rotate exit=1 console PTY failure: wrapper-success-rotate: expected-output-missing
-------------------------------------------------------------------------
FIXED wrapper-success-not-loaded exit=0 console PTY ok: wrapper-success-not-loaded
FIXED wrapper-success-loaded exit=0 console PTY ok: wrapper-success-loaded
FIXED wrapper-success-rotate exit=0 console PTY ok: wrapper-success-rotate
```
</details>
<details>
<summary>Evidence: Persisted state + launchctl calls + secret-nondisclosure check per case</summary>

```text

===== prefix-enable-not-loaded =====
invocation directory : /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/operator-cwd
controller loaded    : no
wrapper exit status  : 1
--- terminal transcript (as the operator sees it) ---
Console username: 
Console password: 
Confirm console password: 
** (ErlangError) Erlang error: :enoent:

  * 1st argument: invalid port name

    :erlang.open_port({:spawn_executable, ~c"/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/tools/id"}, [:use_stdio, :stderr_to_stdout, :exit_status, :binary, :hide, {:args, ["-u"]}])
    (elixir 1.20.0) lib/system.ex:1158: System.do_cmd/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:482: OrchardCLI.Commands.LifecycleSupport.default_uid/0
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:280: OrchardCLI.Commands.LifecycleSupport.require_restart_root/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:195: OrchardCLI.Commands.LifecycleSupport.restart_loaded/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:208: OrchardCLI.Commands.Console.restart_controller_if_loaded/2
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:68: OrchardCLI.Commands.Console.run_for_role/3
--- launchctl calls made by the CLI ---
(none)
--- /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/staged/Library/Application Support/Orchard/config/console.env ---
mode=600
ORCHARD_CONSOLE_ENABLED="true"
ORCHARD_CONSOLE_USERNAME="orchard-admin"
ORCHARD_CONSOLE_PASSWORD="PrefixSecret…REDACTED"
--- secret never appeared on the terminal ---
ok: plaintext secret absent from transcript

===== fixed-enable-not-loaded =====
invocation directory : /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/operator-cwd
controller loaded    : no
wrapper exit status  : 0
--- terminal transcript (as the operator sees it) ---
Console username: 
Console password: 
Confirm console password: 
Console enabled.
Controller is not loaded. Run: sudo orchardctl start
--- launchctl calls made by the CLI ---
print system/com.orchard.controller
--- /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/staged/Library/Application Support/Orchard/config/console.env ---
mode=600
ORCHARD_CONSOLE_ENABLED="true"
ORCHARD_CONSOLE_USERNAME="orchard-admin"
ORCHARD_CONSOLE_PASSWORD="FixedSecret-…REDACTED"
--- secret never appeared on the terminal ---
ok: plaintext secret absent from transcript

===== fixed-enable-loaded =====
invocation directory : /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/operator-cwd
controller loaded    : 1
wrapper exit status  : 0
--- terminal transcript (as the operator sees it) ---
Console username: 
Console password: 
Confirm console password: 
Console enabled.
Controller restarted.
--- launchctl calls made by the CLI ---
print system/com.orchard.controller
kickstart -k system/com.orchard.controller
--- /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/staged/Library/Application Support/Orchard/config/console.env ---
mode=600
ORCHARD_CONSOLE_ENABLED="true"
ORCHARD_CONSOLE_USERNAME="orchard-admin"
ORCHARD_CONSOLE_PASSWORD="FixedSecret-…REDACTED"
--- secret never appeared on the terminal ---
ok: plaintext secret absent from transcript

===== fixed-rotate =====
invocation directory : /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/operator-cwd
controller loaded    : no
wrapper exit status  : 0
--- terminal transcript (as the operator sees it) ---
Console username: 
Console password: 
Confirm console password: 
Console credentials rotated.
Controller is not loaded. Run: sudo orchardctl start
--- launchctl calls made by the CLI ---
print system/com.orchard.controller
--- /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/staged/Library/Application Support/Orchard/config/console.env ---
mode=600
ORCHARD_CONSOLE_ENABLED="true"
ORCHARD_CONSOLE_USERNAME="orchard-admin"
ORCHARD_CONSOLE_PASSWORD="FixedSecret-…REDACTED"
--- secret never appeared on the terminal ---
ok: plaintext secret absent from transcript

===== prefix-rotate =====
invocation directory : /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/operator-cwd
controller loaded    : no
wrapper exit status  : 1
--- terminal transcript (as the operator sees it) ---
Console username: 
Console password: 
Confirm console password: 
** (ErlangError) Erlang error: :enoent:

  * 1st argument: invalid port name

    :erlang.open_port({:spawn_executable, ~c"/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/tools/id"}, [:use_stdio, :stderr_to_stdout, :exit_status, :binary, :hide, {:args, ["-u"]}])
    (elixir 1.20.0) lib/system.ex:1158: System.do_cmd/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:482: OrchardCLI.Commands.LifecycleSupport.default_uid/0
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:280: OrchardCLI.Commands.LifecycleSupport.require_restart_root/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:195: OrchardCLI.Commands.LifecycleSupport.restart_loaded/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:208: OrchardCLI.Commands.Console.restart_controller_if_loaded/2
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:68: OrchardCLI.Commands.Console.run_for_role/3
--- launchctl calls made by the CLI ---
(none)
--- /var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/staged/Library/Application Support/Orchard/config/console.env ---
mode=600
ORCHARD_CONSOLE_ENABLED="true"
ORCHARD_CONSOLE_USERNAME="orchard-admin"
ORCHARD_CONSOLE_PASSWORD="PrefixSecret…REDACTED"
--- secret never appeared on the terminal ---
ok: plaintext secret absent from transcript
```
</details>
<details>
<summary>Evidence: Raw operator transcript — enable, controller not loaded (fixed)</summary>

```text
Console username: 
Console password: 
Confirm console password: 
Console enabled.
Controller is not loaded. Run: sudo orchardctl start
```
</details>
<details>
<summary>Evidence: Raw operator transcript — enable, controller loaded (fixed)</summary>

```text
Console username: 
Console password: 
Confirm console password: 
Console enabled.
Controller restarted.
```
</details>
<details>
<summary>Evidence: Raw operator transcript — rotate (fixed)</summary>

```text
Console username: 
Console password: 
Confirm console password: 
Console credentials rotated.
Controller is not loaded. Run: sudo orchardctl start
```
</details>
<details>
<summary>Evidence: Raw operator transcript — enable crash on pre-fix wrapper (d17f968)</summary>

```text
Console username: 
Console password: 
Confirm console password: 
** (ErlangError) Erlang error: :enoent:

  * 1st argument: invalid port name

    :erlang.open_port({:spawn_executable, ~c"/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/tools/id"}, [:use_stdio, :stderr_to_stdout, :exit_status, :binary, :hide, {:args, ["-u"]}])
    (elixir 1.20.0) lib/system.ex:1158: System.do_cmd/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:482: OrchardCLI.Commands.LifecycleSupport.default_uid/0
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:280: OrchardCLI.Commands.LifecycleSupport.require_restart_root/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:195: OrchardCLI.Commands.LifecycleSupport.restart_loaded/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:208: OrchardCLI.Commands.Console.restart_controller_if_loaded/2
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:68: OrchardCLI.Commands.Console.run_for_role/3
```
</details>
<details>
<summary>Evidence: Raw operator transcript — rotate crash on pre-fix wrapper (d17f968)</summary>

```text
Console username: 
Console password: 
Confirm console password: 
** (ErlangError) Erlang error: :enoent:

  * 1st argument: invalid port name

    :erlang.open_port({:spawn_executable, ~c"/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/tmp.avi4sfXjI4/tools/id"}, [:use_stdio, :stderr_to_stdout, :exit_status, :binary, :hide, {:args, ["-u"]}])
    (elixir 1.20.0) lib/system.ex:1158: System.do_cmd/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:482: OrchardCLI.Commands.LifecycleSupport.default_uid/0
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:280: OrchardCLI.Commands.LifecycleSupport.require_restart_root/1
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/lifecycle_support.ex:195: OrchardCLI.Commands.LifecycleSupport.restart_loaded/3
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:208: OrchardCLI.Commands.Console.restart_controller_if_loaded/2
    (orchard_cli 0.5.0-dev) lib/orchard_cli/commands/console.ex:68: OrchardCLI.Commands.Console.run_for_role/3
```
</details>
<details>
<summary>Evidence: Packaged PTY suite result</summary>

<code>Packaged orchardctl PTY secret-input test passed.&#10;./scripts/test-packaged-orchardctl-console-pty.sh 24.74s user 19.22s system 51% cpu 1:25.07 total</code>

```text
Packaged orchardctl PTY secret-input test passed.
./scripts/test-packaged-orchardctl-console-pty.sh  24.74s user 19.22s system 51% cpu 1:25.07 total
```
</details>
<details>
<summary>Evidence: Evidence driver script — PTY transcripts (before/after)</summary>

```text
#!/usr/bin/env bash
# End-user PTY transcript evidence for the packaged orchardctl console fix.
#
# Drives the real packaged wrapper + packaged orchard_cli release through a real
# controlling terminal (expect allocates the PTY), typing credentials the way an
# operator would, and records the terminal transcript.
#
# Runs each case twice: once against the pre-fix wrapper (d17f968, the commit
# before "fix(cli): keep packaged console cwd stable") and once against the
# wrapper on the change under test.

set -euo pipefail

REPO_ROOT="${REPO_ROOT:?set REPO_ROOT}"
EVIDENCE_DIR="${EVIDENCE_DIR:?set EVIDENCE_DIR}"
PREFIX_REV="${PREFIX_REV:-d17f968}"

TMP_ROOT="$(mktemp -d)"
trap 'rm -rf "$TMP_ROOT"' EXIT

STAGED_ROOT="$TMP_ROOT/staged/Library/Application Support/Orchard"
TOOLS="$TMP_ROOT/tools"
CONSOLE_ENV="$STAGED_ROOT/config/console.env"
LAUNCHCTL_MARKER="$TMP_ROOT/launchctl-called"
RELEASE_SOURCE="$REPO_ROOT/_build/prod/rel/orchard_cli"

mkdir -p "$STAGED_ROOT/releases" "$STAGED_ROOT/support" "$STAGED_ROOT/config" "$TOOLS"
cp -R "$RELEASE_SOURCE" "$STAGED_ROOT/releases/orchard_cli"
printf '%s\n' 'controller' > "$STAGED_ROOT/support/.install-role"

# Stand-ins for the privileged system tools the packaged CLI shells out to.
cat > "$TOOLS/id" <<'SH'
#!/bin/sh
if [ "${1:-}" = "-u" ]; then
  printf '0\n'
else
  exec /usr/bin/id "$@"
fi
SH

cat > "$TOOLS/launchctl" <<'SH'
#!/bin/sh
printf '%s\n' "$*" >> "$ORCHARD_TEST_LAUNCHCTL_MARKER"
case "${ORCHARD_TEST_LAUNCHCTL_LOADED:-}:$*" in
  1:print\ *) exit 0 ;;
  1:kickstart\ *) exit 0 ;;
  *) exit 113 ;;
esac
SH
chmod 0755 "$TOOLS/id" "$TOOLS/launchctl"

make_wrapper() {
  # $1 = git revision (or WORKTREE), $2 = destination
  local rev="$1" dest="$2" src="$TMP_ROOT/wrapper-src-$$"
  if [ "$rev" = "WORKTREE" ]; then
    cp "$REPO_ROOT/packaging/pkg/bin/orchardctl" "$src"
  else
    git -C "$REPO_ROOT" show "$rev:packaging/pkg/bin/orchardctl" > "$src"
  fi
  sed \
    -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
    -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
    "$src" > "$dest"
  rm -f "$src"
  chmod 0755 "$dest"
}

make_wrapper "$PREFIX_REV" "$TMP_ROOT/orchardctl-prefix"
make_wrapper WORKTREE "$TMP_ROOT/orchardctl-fixed"

cat > "$TMP_ROOT/drive.exp" <<'EXP'
#!/usr/bin/expect -f
set timeout 90
set wrapper   [lindex $argv 0]
set subcmd    [lindex $argv 1]
set transcript [lindex $argv 2]
set username  [lindex $argv 3]
set password  [lindex $argv 4]

log_file -noappend $transcript
spawn -noecho $wrapper console $subcmd
expect {
  "Console username: " {}
  timeout { puts "\nTIMEOUT waiting for username prompt"; exit 90 }
}
send -- "$username\r"
expect {
  "Console password: " {}
  timeout { puts "\nTIMEOUT waiting for password prompt"; exit 90 }
}
send -- "$password\r"
expect {
  "Confirm console password: " {}
  timeout { puts "\nTIMEOUT waiting for confirmation prompt"; exit 90 }
}
send -- "$password\r"
expect {
  eof {}
  timeout { puts "\nTIMEOUT waiting for exit"; exit 90 }
}
catch wait result
exit [lindex $result 3]
EXP
chmod 0755 "$TMP_ROOT/drive.exp"

run_case() {
  # $1 = label, $2 = wrapper, $3 = subcommand, $4 = loaded?(1/empty),
  # $5 = username, $6 = password, $7 = invocation dir
  local label="$1" wrapper="$2" subcmd="$3" loaded="$4"
  local username="$5" password="$6" workdir="$7"
  local transcript="$EVIDENCE_DIR/transcript-$label.txt"
  local status=0

  rm -f "$LAUNCHCTL_MARKER"
  (
    cd "$workdir"
    ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
      ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
      ORCHARD_TEST_LAUNCHCTL_LOADED="$loaded" \
      /usr/bin/expect -f "$TMP_ROOT/drive.exp" \
        "$wrapper" "$subcmd" "$transcript" "$username" "$password"
  ) || status=$?

  {
    printf '\n===== %s =====\n' "$label"
    printf 'invocation directory : %s\n' "$workdir"
    printf 'controller loaded    : %s\n' "${loaded:-no}"
    printf 'wrapper exit status  : %s\n' "$status"
    printf -- '--- terminal transcript (as the operator sees it) ---\n'
    cat "$transcript"
    printf -- '--- launchctl calls made by the CLI ---\n'
    if [ -s "$LAUNCHCTL_MARKER" ]; then cat "$LAUNCHCTL_MARKER"; else printf '(none)\n'; fi
    printf -- '--- %s ---\n' "$CONSOLE_ENV"
    if [ -f "$CONSOLE_ENV" ]; then
      printf 'mode=%s\n' "$(stat -f '%Lp' "$CONSOLE_ENV")"
      sed -E 's/^(ORCHARD_CONSOLE_PASSWORD=")([^"]{12})[^"]*(")/\1\2…REDACTED\3/' "$CONSOLE_ENV"
    else
      printf '(absent)\n'
    fi
    printf -- '--- secret never appeared on the terminal ---\n'
    if grep -qF "$password" "$transcript"; then
      printf 'FAIL: plaintext secret found in transcript\n'
    else
      printf 'ok: plaintext secret absent from transcript\n'
    fi
  } | tee -a "$EVIDENCE_DIR/console-transcript-evidence.log"
}

: > "$EVIDENCE_DIR/console-transcript-evidence.log"
WORKDIR="$TMP_ROOT/operator-cwd"
mkdir -p "$WORKDIR"

run_case "prefix-enable-not-loaded" "$TMP_ROOT/orchardctl-prefix" enable "" \
  "orchard-admin" "PrefixSecret-01!" "$WORKDIR"
rm -f "$CONSOLE_ENV"
run_case "fixed-enable-not-loaded" "$TMP_ROOT/orchardctl-fixed" enable "" \
  "orchard-admin" "FixedSecret-01!" "$WORKDIR"
rm -f "$CONSOLE_ENV"
run_case "fixed-enable-loaded" "$TMP_ROOT/orchardctl-fixed" enable 1 \
  "orchard-admin" "FixedSecret-02!" "$WORKDIR"
run_case "fixed-rotate" "$TMP_ROOT/orchardctl-fixed" rotate "" \
  "orchard-admin" "FixedSecret-03!" "$WORKDIR"
run_case "prefix-rotate" "$TMP_ROOT/orchardctl-prefix" rotate "" \
  "orchard-admin" "PrefixSecret-03!" "$WORKDIR"

printf '\nTranscript evidence written to %s\n' "$EVIDENCE_DIR"
```
</details>
<details>
<summary>Evidence: Evidence driver script — regression-coverage check</summary>

```text
#!/usr/bin/env bash
# Proves the three new packaged-PTY scenarios are real regression coverage:
# runs them against the pre-fix wrapper (d17f968) and against the fixed wrapper.

set -euo pipefail

REPO_ROOT="${REPO_ROOT:?set REPO_ROOT}"
EVIDENCE_DIR="${EVIDENCE_DIR:?set EVIDENCE_DIR}"
PREFIX_REV="${PREFIX_REV:-d17f968}"

TMP_ROOT="$(mktemp -d)"
trap 'rm -rf "$TMP_ROOT"' EXIT

STAGED_ROOT="$TMP_ROOT/staged/Library/Application Support/Orchard"
TOOLS="$TMP_ROOT/tools"
HARNESS="$TMP_ROOT/console-pty-harness"
CONSOLE_ENV="$STAGED_ROOT/config/console.env"
LAUNCHCTL_MARKER="$TMP_ROOT/launchctl-called"

mkdir -p "$STAGED_ROOT/releases" "$STAGED_ROOT/support" "$STAGED_ROOT/config" "$TOOLS"
cp -R "$REPO_ROOT/_build/prod/rel/orchard_cli" "$STAGED_ROOT/releases/orchard_cli"
printf '%s\n' 'controller' > "$STAGED_ROOT/support/.install-role"

cat > "$TOOLS/id" <<'SH'
#!/bin/sh
if [ "${1:-}" = "-u" ]; then
  printf '0\n'
else
  exec /usr/bin/id "$@"
fi
SH
cat > "$TOOLS/launchctl" <<'SH'
#!/bin/sh
printf '%s\n' "$*" >> "$ORCHARD_TEST_LAUNCHCTL_MARKER"
case "${ORCHARD_TEST_LAUNCHCTL_LOADED:-}:$*" in
  1:print\ *) exit 0 ;;
  1:kickstart\ *) exit 0 ;;
  *) exit 113 ;;
esac
SH
chmod 0755 "$TOOLS/id" "$TOOLS/launchctl"

xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic \
  "$REPO_ROOT/apps/orchard_cli/test/support/console_pty_harness.c" -o "$HARNESS"

make_wrapper() {
  local rev="$1" dest="$2" src="$TMP_ROOT/src.$$"
  if [ "$rev" = "WORKTREE" ]; then
    cp "$REPO_ROOT/packaging/pkg/bin/orchardctl" "$src"
  else
    git -C "$REPO_ROOT" show "$rev:packaging/pkg/bin/orchardctl" > "$src"
  fi
  sed \
    -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
    -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
    "$src" > "$dest"
  rm -f "$src"
  chmod 0755 "$dest"
}

make_wrapper "$PREFIX_REV" "$TMP_ROOT/orchardctl-prefix"
make_wrapper WORKTREE "$TMP_ROOT/orchardctl-fixed"

run_scenario() {
  # $1 = wrapper label, $2 = wrapper, $3 = scenario, $4 = subcmd, $5 = loaded
  local label="$1" wrapper="$2" scenario="$3" subcmd="$4" loaded="$5"
  local out status=0
  rm -f "$CONSOLE_ENV" "$LAUNCHCTL_MARKER"
  out=$(
    ORCHARD_SUPPORT_ROOT="$STAGED_ROOT" \
      ORCHARD_TEST_LAUNCHCTL_MARKER="$LAUNCHCTL_MARKER" \
      ORCHARD_TEST_LAUNCHCTL_LOADED="$loaded" \
      "$HARNESS" "$scenario" -- "$wrapper" console "$subcmd" 2>&1
  ) || status=$?
  printf '%-10s %-28s exit=%s  %s\n' "$label" "$scenario" "$status" "$out"
}

{
  printf 'Scenario: %s\n\n' "packaged foreground PTY console scenarios added by this change"
  printf 'wrapper    scenario                     result\n'
  printf -- '-------------------------------------------------------------------------\n'
  run_scenario "PRE-FIX" "$TMP_ROOT/orchardctl-prefix" wrapper-success-not-loaded enable ""
  run_scenario "PRE-FIX" "$TMP_ROOT/orchardctl-prefix" wrapper-success-loaded     enable 1
  run_scenario "PRE-FIX" "$TMP_ROOT/orchardctl-prefix" wrapper-success-rotate     rotate ""
  printf -- '-------------------------------------------------------------------------\n'
  run_scenario "FIXED"   "$TMP_ROOT/orchardctl-fixed"  wrapper-success-not-loaded enable ""
  run_scenario "FIXED"   "$TMP_ROOT/orchardctl-fixed"  wrapper-success-loaded     enable 1
  run_scenario "FIXED"   "$TMP_ROOT/orchardctl-fixed"  wrapper-success-rotate     rotate ""
} | tee "$EVIDENCE_DIR/regression-coverage-check.log"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- 🚨 `packaging/pkg/bin/orchardctl:874` - The `cd /` added before `exec &#34;$@&#34;` fixes the custody-directory cwd crash but also makes every packaged standalone command resolve relative path arguments against `/` instead of the operator&#39;s invocation directory. At the base commit the wrapper ended with `exec &#34;$ORCHARD_CLI&#34; eval ...`, so the CLI inherited the caller&#39;s cwd. Concrete failure: `cd /Users/op &amp;&amp; sudo orchardctl cluster init --output ./bootstrap-admin.json` -&gt; `fetch_required_output/1` (apps/orchard_cli/lib/orchard_cli/commands/cluster.ex:153) calls `Path.expand/1`, which now yields `/bootstrap-admin.json`, writing the one-time cluster-admin credential to the filesystem root rather than the operator&#39;s directory. The same applies to `support bundle -o ./dir` (support.ex:158 `ensure_output_dir!`), `api-clients bulk-provision --file ./clients.csv --output ./tokens.csv` (api_clients.ex:99/108), `nodes enrollment create --output ./bundle.json`, and `node join --enrollment-bundle ./bundle.json` (node_enrollment.ex:279 `File.read/1`). Suggested fix at the same boundary: pass the wrapper&#39;s invocation directory as an extra argument to the `orchard-cli-launch` helper and `cd -- &#34;$_launch_original_cwd&#34; || cd /` immediately before `exec`, keeping the custody-directory identity checks exactly where they are.
- ⚠️ `packaging/pkg/bin/orchardctl:779` - `terminate_and_reap_custody_guard` can return a stale `_custody_guard_status`, which line 951 then treats as guard failure and responds to by looping `while :; do /bin/sleep 1; done` forever, holding the operator&#39;s terminal until `sudo kill -9`. Sequence: on the normal success path the wrapper sends TERM to the guard and blocks in `wait` (line 742). If a trapped signal (e.g. Ctrl-C -&gt; `forward_standalone_signal INT 130`) is delivered while the guard exits 0 at the same moment, `wait` returns 130 and sets `_custody_guard_status=130`; `_guard_wait_interrupted` is set, so the retry loop runs, but bash&#39;s SIGCHLD handling has already reaped the guard, so `ps` returns nothing and `kill -0` fails (line 772-777), giving `_retry_guard_wait=&#34;&#34;` and `return 0` at line 779 without ever re-reading the true status. `_completion_dir` is already gone, so line 951&#39;s second condition is false and the wrapper hangs purely on the stale 130. The CLI wait loop above (line 900-940) is immune only because `_termination_status` takes precedence at exit; the guard status has no such override. Fix: when `_guard_wait_interrupted` is set and the guard is no longer waitable, re-issue `wait &#34;$_custody_guard_pid&#34;` (bash returns the remembered exit status) or track a separate `_guard_reaped` flag instead of trusting the interrupted `wait` result.
- ⚠️ `apps/orchard_cli/lib/orchard_cli/secret_tty.ex:231` - A clean Ctrl-C or Ctrl-\ at the credential prompt reports a terminal-restoration failure that did not happen. With ISIG cleared, the helper reads the VINTR/VQUIT byte, `read_tty_line` returns -3/-4, and `run_protocol` (orchard_secret_tty.c:982-991) calls `finish_watchdog` (which restores the saved termios), sends the `ABORTED` frame, and exits 1. On the Elixir side `read_value/2` has no `&#34;ABORTED&#34;` clause, so it falls into `_other` and returns `{:error, &#34;unable to read Console credential prompt input&#34;}`; `execute/2` then calls `restore(port, :infinity)` against an already-exited helper, gets `{:error, :restore}`, and discards the callback result in favour of `@restore_error`. The operator sees `Error: could not restore the prior terminal state; Console credentials were not saved` even though packaging/pkg/README.md documents that the prior settings are restored exactly on Ctrl-C and Ctrl-\. The PTY scenarios `interruption`/`quit` assert only a nonzero exit and restored termios, so nothing catches the wrong message. Fix: give `read_value/2` an explicit `&#34;ABORTED&#34;` clause and let `execute/2` treat an aborted session as an already-restored terminal rather than a restore failure.
- ℹ️ `scripts/test-packaged-orchardctl-console-pty.sh:371` - The new assertion message says `packaged successful enable did not persist a password hash`, but `build_assignments/2` (apps/orchard_cli/lib/orchard_cli/commands/console.ex:99) writes `credentials.password` verbatim and config/runtime.exs:996 reads `ORCHARD_CONSOLE_PASSWORD` as a plaintext Basic Auth password. The check itself (`grep -q &#39;^ORCHARD_CONSOLE_PASSWORD=&#39;`) is correct; only the message is wrong, and it can mislead a future reader into believing the credential is hashed at rest. Reword to &#34;did not persist a password&#34;.
- ℹ️ `packaging/pkg/bin/orchardctl:507` - The shipped packaged wrapper now carries test-only instrumentation: five `ORCHARD_TEST_*_MARKER` env-gated stderr prints (lines 507, 510, 690, 885, 946) and five no-op seams that exist purely so scripts/test-packaged-orchardctl-console-pty.sh can `sed`-substitute them (`guard_pre_ready_barrier`, `cli_pre_launch_barrier`, `cli_pre_exit_barrier`, `cli_post_wait_barrier`, `guard_post_wait_barrier`, plus `_cli_parent_probe`/`_guard_process_probe` indirection). The markers only emit PIDs and the 0700 custody directory path, so this is not itself a disclosure vector, but it is production-path code whose only consumer is the test harness. Worth confirming this is the intended tradeoff versus generating an instrumented copy of the wrapper for the harness.
- ℹ️ `apps/orchard_cli/c_src/orchard_secret_tty.c:1` - AGENTS.md requires that behavior-changing or architecture-significant work state its SPEC.md impact and, where a durable decision is needed and not already fixed by SPEC.md, add a record under docs/decisions/**. This branch introduces a new privileged native helper process with its own terminal-custody protocol, changes the packaged wrapper from `exec`-into-CLI to a supervised three-process model for every standalone command, and adds a hard `xcrun clang` build dependency to `mix compile` (apps/orchard_cli/mix.exs:14). packaging/pkg/README.md and docs/tooling.md were updated, but there is no corresponding ADR and no SPEC.md text covering the custody model. Confirm whether a decision record is expected before this ships.
- ℹ️ `apps/orchard_cli/c_src/orchard_secret_tty.c:934` - `handle_read` accumulates the plaintext credential into the stack buffer `response[FRAME_LIMIT]` and never clears it, on either the success path (line 942) or the abort/error returns at lines 938-941. The helper then stays alive through the remaining prompts and the RESTORE handshake with the secret resident in its stack. Given this helper exists specifically to keep the credential off the terminal and out of argv/env, add an `explicit_bzero(response, sizeof(response))` (or equivalent volatile wipe) before every return from `handle_read`.

🔧 Fix: fix packaged CLI cwd, guard reap status, abort reporting
2 infos still open:
- ℹ️ `packaging/pkg/bin/orchardctl:512` - Still open from the previous round. The shipped packaged wrapper carries test-only instrumentation: five `ORCHARD_TEST_*_MARKER` env-gated stderr prints (lines 512, 515, 696, 894, 955) and seven no-op seams whose only consumer is scripts/test-packaged-orchardctl-console-pty.sh&#39;s `sed` substitutions (`guard_pre_ready_barrier`, `cli_pre_launch_barrier`, `cli_pre_exit_barrier`, `cli_post_wait_barrier`, `guard_post_wait_barrier` at lines 548-552, plus `_cli_parent_probe`/`_cli_process_probe`/`_guard_parent_probe`/`_guard_process_probe` at lines 543-546). The markers only emit PIDs and the 0700 custody directory path, so this is not a disclosure vector, but it is production-path code in a root-privileged wrapper that exists solely for the harness. Confirm this is the intended tradeoff versus generating an instrumented copy of the wrapper for the test script.
- ℹ️ `apps/orchard_cli/c_src/orchard_secret_tty.c:1` - Still open from the previous round. AGENTS.md requires that behavior-changing or architecture-significant work state its SPEC.md impact and, where a durable decision is needed and is not already fixed by SPEC.md, add a record under docs/decisions/**. This branch introduces a privileged native helper with its own terminal-custody protocol, replaces `exec &#34;$ORCHARD_CLI&#34; ...` with a supervised three-process model for every packaged standalone command (including a deliberate never-return terminal hold at packaging/pkg/bin/orchardctl:960), and adds a hard `xcrun clang` dependency to `mix compile` (apps/orchard_cli/mix.exs:14). `git diff 53aa4b0..HEAD -- docs/ SPEC.md openspec/` shows only a 7-line docs/tooling.md addition; there is no ADR and no SPEC.md or OpenSpec text covering the custody model. Confirm whether a decision record is expected before this ships.

🔧 Fix: narrow remediation to packaged CLI invocation-directory fix
3 infos still open:
- ℹ️ `packaging/pkg/bin/orchardctl:784` - Release information only — the owner explicitly directed reverting this fix as outside the authorized scope, and it is now back to its pre-remediation state. `terminate_and_reap_custody_guard` can return a stale `_custody_guard_status`: if a trapped signal (Ctrl-C -&gt; `forward_standalone_signal INT 130`) interrupts `wait` at line 748 while the guard exits 0 concurrently, `_custody_guard_status` is set to 130; the retry probe then finds the guard already reaped by the shell&#39;s SIGCHLD handling (`ps` empty, `kill -0` fails at line 781), sets `_retry_guard_wait=&#34;&#34;`, and returns at line 784 without re-reading the true status. Line 958 then sees a non-zero status with `_completion_dir` already gone, prints `orchardctl: terminal custody guard failed`, and enters the deliberate `while :; do /bin/sleep 1; done` hold, requiring `sudo kill -9`. I confirmed against the actual macOS /bin/sh (bash 3.2.57) that a second `wait` on the same pid returns the remembered real status rather than 127, so re-issuing `wait` when `_guard_wait_interrupted` is set is a viable follow-up fix. Tracked for later; no action requested in this change.
- ℹ️ `apps/orchard_cli/lib/orchard_cli/secret_tty.ex:231` - Release information only — the owner explicitly directed reverting this fix as outside the authorized scope. A clean Ctrl-C or Ctrl-\ at the credential prompt still reports a terminal restoration failure that did not occur. With ISIG cleared the helper reads the VINTR/VQUIT byte, `read_tty_line` returns -3/-4, and `run_protocol` (apps/orchard_cli/c_src/orchard_secret_tty.c:982-991) calls `finish_watchdog` — which confirms restoration — before sending the `ABORTED` frame and exiting 1. `read_value/2` has no `&#34;ABORTED&#34;` clause so it falls to `_other`, and `execute/2` then discards the callback result in favour of `@restore_error`, printing `Error: could not restore the prior terminal state; Console credentials were not saved` even though packaging/pkg/README.md documents that the prior settings are restored exactly on Ctrl-C and Ctrl-\. The PTY `interruption`/`quit` scenarios assert only a nonzero exit and restored termios, so nothing catches the wrong message. Tracked for later; no action requested in this change.
- ℹ️ `apps/orchard_cli/c_src/orchard_secret_tty.c:934` - Release information only — the owner explicitly directed reverting this fix as outside the authorized scope. `handle_read` accumulates the plaintext credential into the stack buffer `response[FRAME_LIMIT]` and never clears it, on either the success path (line 942) or the abort/error returns at lines 938-941, so the secret stays resident in the helper&#39;s stack through the remaining prompts and the RESTORE handshake. A follow-up can wipe it with `memset_s` (requires `#define __STDC_WANT_LIB_EXT1__ 1` before the includes) or an equivalent volatile wipe before every return. Tracked for later; no action requested in this change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./scripts/test-packaged-orchardctl-console-pty.sh` — full packaged foreground PTY suite (custody, restoration, unread-input disposal, secret nondisclosure, plus the three new success scenarios); passed in ~85s</code>
- <code>`mise exec -- mix test test/orchard_cli/packaging_wrapper_test.exs test/orchard_cli/commands/console_test.exs test/orchard_cli/commands/console_pty_test.exs` (from `apps/orchard_cli`) — 55 passed, includes `packaged orchardctl wrapper runs the CLI in the invocation directory`</code>
- <code>Manual end-user PTY transcript capture via `expect` against the staged packaged release: `orchardctl console enable` (controller not loaded), `orchardctl console enable` (controller loaded), `orchardctl console rotate` — run against both the pre-fix wrapper (`d17f968`) and the wrapper under test; script at `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KZAHH71NEH36KV5V0613G6CB/console-transcript-evidence.sh`</code>
- <code>Regression-coverage proof: harness scenarios `wrapper-success-not-loaded`, `wrapper-success-loaded`, `wrapper-success-rotate` executed against the pre-fix wrapper (all fail `expected-output-missing`) and the fixed wrapper (all `console PTY ok`); script at `/var/folders/xy/bmzx3f853zd1tdvd11hgc0gm0000gn/T/no-mistakes-evidence/01KZAHH71NEH36KV5V0613G6CB/regression-coverage-check.sh`</code>
- <code>Post-run hygiene: `git status --short` clean; temporary staging roots and wrapper custody directories removed</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `packaging/pkg/README.md:1079` - The &#39;Credential prompt and terminal custody&#39; section states unconditionally that the wrapper &#39;keeps sole custody of the controlling terminal for the whole command&#39; and that &#39;a signalled run exits 129/130/131/143&#39;. Both hold only for standalone-CLI-routed commands: Controller-authoritative `nodes` subcommands return from `run_in_controller` and exit at packaging/pkg/bin/orchardctl:461 before the custody supervisor is set up, using the separate `rpc_abort`/`rpc_cleanup` trap path instead. Every command that reads stdin (license --key-stdin, console enable/rotate, init --console) does take the standalone path, so no documented operator action is wrong. I left the wording as-is deliberately: scoping it would push standalone-vs-Controller-routing jargon into a credential troubleshooting section for no change in operator behavior. Raising it as release information in case the owner wants the precision later.

🔧 Fix: revert unauthorized C toolchain and key-stdin doc additions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
