### PR TITLE
docs(pilots): define CP1 recurring HTTP-only consumer and probe-loss contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,8 @@ large spec sections.
 ### I want to run a pilot
 
 - [`pilots/README.md`](pilots/README.md) — pilot artifact pin ownership,
-  producer commit and configuration digest contract, update and rollback.
+  producer commit and configuration digest contract, the CP1 recurring
+  HTTP-only consumer and probe-loss evidence contract, update and rollback.
 - [`local-dev.md`](local-dev.md) — Phase 0 observability probe invocation and
   exit semantics.
 

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -40,16 +40,29 @@ digest for the retained result set.
 
 Compute that digest over the exact retained bytes of one UTC day's results,
 using bytewise filename ordering so the same retained set always reproduces the
-same value:
+same value. Run it as a script. It digests every regular file under the day
+directory and fails closed: if any of them cannot be hashed, or the day
+retained nothing, it exits nonzero without emitting a digest instead of
+recording one that covers only part of the set.
 
-```sh
-cd "$day_result_dir" &&
-  LC_ALL=C ls -1 |
-  LC_ALL=C sort |
-  tr '\n' '\0' |
-  xargs -0 shasum -a 256 |
-  shasum -a 256
+```bash
+set -euo pipefail
+
+manifest=$(
+  cd "$day_result_dir" &&
+    find . -type f -print0 |
+    LC_ALL=C sort -z |
+    xargs -0 -r shasum -a 256
+)
+
+[ -n "$manifest" ] || { echo "no retained results to digest" >&2; exit 1; }
+
+printf '%s\n' "$manifest" | shasum -a 256
 ```
+
+Accept a day's digest only from a run that exited zero. A nonzero exit means
+the retained set was unreadable or empty, which is a retention failure to
+investigate rather than a value to record.
 
 Probe freshness advances only when the result sink receives one parseable
 schema-version-1 result object whose `probe_id` equals the `probe_id` in the

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -30,6 +30,38 @@ configuration:
 shasum -a 256 pilot-owned/issue-118-cp1-observability-probe.json
 ```
 
+## Issue #118 recurring HTTP-only consumer
+
+The CP1 remote consumer runs the pinned probe over HTTPS every five minutes
+with configuration and result schema version 1 and
+`terminal_validation: "http_only"`. It retains each stdout result separately
+from stderr without overwriting earlier runs and produces an immutable daily
+digest for the retained result set.
+
+Probe freshness advances only when the result sink receives one parseable
+schema-version-1 result object. Both `pass` and `fail` outcomes prove that the
+consumer is still publishing observations. Starting the scheduled process,
+creating an output file, or receiving missing or malformed stdout does not
+advance freshness.
+
+Transport, HTTP, and invalid-stream failures normally produce a `fail` result,
+so they are probe observations rather than probe loss. The no-data alert fires
+after 12 minutes without a qualifying result. Prove that alert by interrupting
+the consumer or its result-publication path, then restore publication and
+record the alert recovery. Breaking the inference endpoint alone is not
+probe-loss proof when the consumer retains a failure result.
+
+The actual pin, byte-exact non-secret configuration, scheduler definition,
+protected result location, retained results, daily digests, and operational
+screenshots are site-local evidence. Record sanitized references and outcomes
+on issue #118 or child issue #182; do not commit them, credentials, raw
+results, machine-specific paths, hostnames, tenant or user identifiers, or
+response content.
+
+This recurring consumer and no-data proof do not satisfy #118's separate
+Controller-local reconciliation cadence or its independent readiness-failure
+and inference-failure alert proofs.
+
 ## Update and rollback
 
 For an update, review the producer change, copy the new configuration if its

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -38,18 +38,41 @@ with configuration and result schema version 1 and
 from stderr without overwriting earlier runs and produces an immutable daily
 digest for the retained result set.
 
+Compute that digest over the exact retained bytes of one UTC day's results,
+using bytewise filename ordering so the same retained set always reproduces the
+same value:
+
+```sh
+cd "$day_result_dir" &&
+  LC_ALL=C ls -1 |
+  LC_ALL=C sort |
+  tr '\n' '\0' |
+  xargs -0 shasum -a 256 |
+  shasum -a 256
+```
+
 Probe freshness advances only when the result sink receives one parseable
-schema-version-1 result object. Both `pass` and `fail` outcomes prove that the
-consumer is still publishing observations. Starting the scheduled process,
-creating an output file, or receiving missing or malformed stdout does not
+schema-version-1 result object whose `probe_id` equals the `probe_id` in the
+pinned configuration. A result carrying a null or mismatched `probe_id` does
+not identify the accepted pin and is not a qualifying result. Both `pass` and
+`fail` outcomes prove that the consumer is still publishing observations.
+Starting the scheduled process, creating an output file, or receiving missing
+or malformed stdout does not advance freshness.
+
+Transport, HTTP, invalid-stream, and configuration or environment refusal
+failures normally produce a `fail` result, so they are probe observations
+rather than probe loss whenever that identity check passes. Unsetting the
+credential environment variable still emits an `invalid_config` result carrying
+the pinned `probe_id`, so it is an observation and does not induce probe loss.
+A refusal that loses the pinned identity, such as an unreadable or
+non-parseable configuration, emits a null `probe_id` and therefore does not
 advance freshness.
 
-Transport, HTTP, and invalid-stream failures normally produce a `fail` result,
-so they are probe observations rather than probe loss. The no-data alert fires
-after 12 minutes without a qualifying result. Prove that alert by interrupting
-the consumer or its result-publication path, then restore publication and
-record the alert recovery. Breaking the inference endpoint alone is not
-probe-loss proof when the consumer retains a failure result.
+The no-data alert fires after 12 minutes without a qualifying result. Prove
+that alert by interrupting the consumer or its result-publication path, then
+restore publication and record the alert recovery. Breaking the inference
+endpoint alone is not probe-loss proof when the consumer retains a failure
+result.
 
 The actual pin, byte-exact non-secret configuration, scheduler definition,
 protected result location, retained results, daily digests, and operational


### PR DESCRIPTION
## Intent

Advance epic #118 by defining the narrow consumer-side CP1 contract for issue #182 without duplicating #115 or broadening into other pilot gates. Document the pinned remote HTTPS probe cadence (every five minutes), schema-v1 http_only mode, the 12-minute no-data threshold, result-arrival freshness semantics, correct probe-loss induction, and the boundary that actual configuration, credentials, machine paths, results, digests, scheduler state, and operational screenshots remain site-local evidence. Preserve the producer implementation, schemas, SPEC.md, OpenSpec contract, and the separate #118 reconciliation/readiness-failure/inference-failure obligations. Validate the focused docs change, push it, create a PR linked to #182, and include sanitized screenshot evidence without committing transient evidence.

## What Changed

- Added an "Issue #118 recurring HTTP-only consumer" section to `docs/pilots/README.md` covering the pinned five-minute HTTPS probe cadence, schema-version-1 `http_only` mode, result-arrival freshness keyed on a `probe_id` match against the pinned configuration, the 12-minute no-data alert and how to correctly induce probe loss (interrupt the consumer or its publication path, not the inference endpoint), and the boundary that pins, configuration, scheduler state, retained results, digests, and screenshots stay site-local evidence.
- Specified the daily digest as SHA-256 over the exact retained bytes of one UTC day in bytewise filename order, with a script that enumerates via `find -print0 | sort -z` under `set -euo pipefail` and fails closed (nonzero, no digest) on an unhashable file or an empty day, so a partial digest can never be recorded as that day's evidence.
- Indexed the new consumer/probe-loss contract in the `docs/README.md` "I want to run a pilot" entry.
- Scoped strictly to documentation: the producer probe script, schemas, `SPEC.md`, the OpenSpec contract, and `apps/` are unchanged, and the section explicitly disclaims #118's separate reconciliation, readiness-failure, and inference-failure obligations.

## Risk Assessment

✅ Low: Docs-only change to one pilot README section whose every factual claim I verified against the probe implementation, with the newly added digest procedure confirmed to fail closed on unreadable, empty, and unset-input cases on the target platform.

## Testing

I compiled the umbrella (the only setup step needed in this fresh worktree) and then validated the docs-only CP1 consumer contract end-to-end rather than by unit tests, since no existing test covers a documentation contract. Running the real producer entrypoint `scripts/smoke-observability-probe.sh` against a loopback SSE stub reproduced all six documented cases exactly as written: a healthy pass, an unset credential env var still emitting `invalid_config` with the pinned `probe_id` (an observation, not probe loss), unreadable and non-parseable configs emitting a null `probe_id` that does not advance freshness, and transport/HTTP-503 failures emitting `fail` with the pinned `probe_id`. I extracted the documented digest snippet byte-for-byte from the doc and ran it over a real retained UTC day: it is deterministic across creation order and parent path, sensitive to a one-byte mutation, and fails closed with no digest on an empty day, an unhashable file, and a missing directory — where the pre-fix snippet from db6525e6 emitted digests, which is the regression this change closes. A minute-by-minute freshness evaluation over those real results showed the no-data alert firing exactly 12 minutes after the last qualifying result, unaffected by zero-byte, malformed, foreign-pin, and null-pin arrivals, and recovering when publication resumed. A scope check confirmed SPEC.md, the producer, schemas, OpenSpec, and apps/ are untouched and that the added lines carry no credentials, machine paths, hostnames, or tenant identifiers. Because the change is documentation, I also rendered the file as GitHub-flavored HTML and captured a screenshot of the reviewer-visible surface. I deliberately kept both executable harnesses in the evidence directory rather than the repo, since the intent and AGENTS.md forbid committing transient smoke scaffolding; I did not run the producer unit suite, which needs the test database and covers producer behavior I exercised directly. Everything passed and the working tree is clean.

- Evidence: Rendered docs/pilots/README.md (screenshot of the new &#39;#118 recurring HTTP-only consumer&#39; section as a reviewer sees it) (local file: <code>/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/no-mistakes-evidence/01KZJNCHE6648M49R4Q4TBRWQQ/pilots-readme-rendered.png</code>)
<details>
<summary>Evidence: Rendered docs/pilots/README.md (GitHub-flavored HTML source of the screenshot)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>docs/pilots/README.md</title>
<style>
body{margin:0;background:#0d1117;color:#e6edf3;font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif}
.wrap{max-width:900px;margin:0 auto;padding:32px}
.file{border:1px solid #30363d;border-radius:8px;overflow:hidden}
.hdr{background:#161b22;border-bottom:1px solid #30363d;padding:10px 16px;font:13px ui-monospace,SFMono-Regular,Menlo,monospace;color:#8b949e}
.body{padding:24px 32px}
h1{font-size:2em;border-bottom:1px solid #21262d;padding-bottom:.3em;margin-top:0}
h2{font-size:1.5em;border-bottom:1px solid #21262d;padding-bottom:.3em;margin-top:1.5em}
code{background:#151b23;border-radius:6px;padding:.2em .4em;font:85% ui-monospace,SFMono-Regular,Menlo,monospace}
pre{background:#151b23;border-radius:6px;padding:16px;overflow:auto}
pre code{background:none;padding:0}
a{color:#4493f8;text-decoration:none}
h2#issue-118-recurring-http-only-consumer{background:#1c2b1c;border-left:4px solid #3fb950;padding-left:10px}
</style></head><body><div class="wrap"><div class="file">
<div class="hdr">docs/pilots/README.md &nbsp;·&nbsp; branch docs/182-cp1-probe-consumer &nbsp;·&nbsp; rendered (GitHub GFM)</div>
<div class="body">
<h1>Pilot artifact pins</h1>
<p>Pilot acceptance evidence must identify the exact producer artifact and the<br>
exact non-secret configuration used to collect it. Pins are consumer-owned:<br>
they are not probe results and must never contain credentials or credential<br>
values.</p>
<h2>Issue #115 producer and issue #118 consumer</h2>
<p>Issue #115 owns the versioned Phase 0 probe implementation, its configuration<br>
and result schemas, and the example pin at<br>
<code class="notranslate">issue-118-cp1-observability-probe-pin.example.json</code>. Issue #118 owns the CP1<br>
copy of the probe configuration, the actual pin, the invocation cadence, and<br>
the retained pilot results.</p>
<p>The #118 pin records:</p>
<ul>
<li><code class="notranslate">artifact_git_sha</code>: the 40-character Git commit SHA containing the exact<br>
<code class="notranslate">scripts/support/observability_probe.exs</code> artifact used by the pilot;</li>
<li><code class="notranslate">config_sha256</code>: the lowercase SHA-256 digest of the exact non-secret JSON<br>
configuration bytes used for the run;</li>
<li><code class="notranslate">config_path</code>: the consumer-owned configuration location;</li>
<li><code class="notranslate">result_schema_version</code> and <code class="notranslate">terminal_validation</code>: the interpretation<br>
contract for collected results.</li>
</ul>
<p>Create the digest without resolving either environment variable named by the<br>
configuration:</p>
<div class="highlight highlight-source-shell"><pre class="notranslate">shasum -a 256 pilot-owned/issue-118-cp1-observability-probe.json</pre></div>
<h2>Issue #118 recurring HTTP-only consumer</h2>
<p>The CP1 remote consumer runs the pinned probe over HTTPS every five minutes<br>
with configuration and result schema version 1 and<br>
<code class="notranslate">terminal_validation: "http_only"</code>. It retains each stdout result separately<br>
from stderr without overwriting earlier runs and produces an immutable daily<br>
digest for the retained result set.</p>
<p>Compute that digest over the exact retained bytes of one UTC day's results,<br>
using bytewise filename ordering so the same retained set always reproduces the<br>
same value. Run it as a script. It digests every regular file under the day<br>
directory and fails closed: if any of them cannot be hashed, or the day<br>
retained nothing, it exits nonzero without emitting a digest instead of<br>
recording one that covers only part of the set.</p>
<div class="highlight highlight-source-shell"><pre class="notranslate"><span class="pl-c1">set</span> -euo pipefail

manifest=<span class="pl-s"><span class="pl-pds">$(</span></span>
<span class="pl-s">  <span class="pl-c1">cd</span> <span class="pl-s"><span class="pl-pds">"</span><span class="pl-smi">$day_result_dir</span><span class="pl-pds">"</span></span> <span class="pl-k">&amp;&amp;</span></span>
<span class="pl-s">    find <span class="pl-c1">.</span> -type f -print0 <span class="pl-k">|</span></span>
<span class="pl-s">    LC_ALL=C sort -z <span class="pl-k">|</span></span>
<span class="pl-s">    xargs -0 -r shasum -a 256</span>
<span class="pl-s"><span class="pl-pds">)</span></span>

[ <span class="pl-k">-n</span> <span class="pl-s"><span class="pl-pds">"</span><span class="pl-smi">$manifest</span><span class="pl-pds">"</span></span> ] <span class="pl-k">||</span> { <span class="pl-c1">echo</span> <span class="pl-s"><span class="pl-pds">"</span>no retained results to digest<span class="pl-pds">"</span></span> <span class="pl-k">&gt;&amp;2</span><span class="pl-k">;</span> <span class="pl-c1">exit</span> 1<span class="pl-k">;</span> }

<span class="pl-c1">printf</span> <span class="pl-s"><span class="pl-pds">'</span>%s\n<span class="pl-pds">'</span></span> <span class="pl-s"><span class="pl-pds">"</span><span class="pl-smi">$manifest</span><span class="pl-pds">"</span></span> <span class="pl-k">|</span> shasum -a 256</pre></div>
<p>Accept a day's digest only from a run that exited zero. A nonzero exit means<br>
the retained set was unreadable or empty, which is a retention failure to<br>
investigate rather than a value to record.</p>
<p>Probe freshness advances only when the result sink receives one parseable<br>
schema-version-1 result object whose <code class="notranslate">probe_id</code> equals the <code class="notranslate">probe_id</code> in the<br>
pinned configuration. A result carrying a null or mismatched <code class="notranslate">probe_id</code> does<br>
not identify the accepted pin and is not a qualifying result. Both <code class="notranslate">pass</code> and<br>
<code class="notranslate">fail</code> outcomes prove that the consumer is still publishing observations.<br>
Starting the scheduled process, creating an output file, or receiving missing<br>
or malformed stdout does not advance freshness.</p>
<p>Transport, HTTP, invalid-stream, and configuration or environment refusal<br>
failures normally produce a <code class="notranslate">fail</code> result, so they are probe observations<br>
rather than probe loss whenever that identity check passes. Unsetting the<br>
credential environment variable still emits an <code class="notranslate">invalid_config</code> result carrying<br>
the pinned <code class="notranslate">probe_id</code>, so it is an observation and does not induce probe loss.<br>
A refusal that loses the pinned identity, such as an unreadable or<br>
non-parseable configuration, emits a null <code class="notranslate">probe_id</code> and therefore does not<br>
advance freshness.</p>
<p>The no-data alert fires after 12 minutes without a qualifying result. Prove<br>
that alert by interrupting the consumer or its result-publication path, then<br>
restore publication and record the alert recovery. Breaking the inference<br>
endpoint alone is not probe-loss proof when the consumer retains a failure<br>
result.</p>
<p>The actual pin, byte-exact non-secret configuration, scheduler definition,<br>
protected result location, retained results, daily digests, and operational<br>
screenshots are site-local evidence. Record sanitized references and outcomes<br>
on issue #118 or child issue #182; do not commit them, credentials, raw<br>
results, machine-specific paths, hostnames, tenant or user identifiers, or<br>
response content.</p>
<p>This recurring consumer and no-data proof do not satisfy #118's separate<br>
Controller-local reconciliation cadence or its independent readiness-failure<br>
and inference-failure alert proofs.</p>
<h2>Update and rollback</h2>
<p>For an update, review the producer change, copy the new configuration if its<br>
schema changed, recompute <code class="notranslate">config_sha256</code>, replace <code class="notranslate">artifact_git_sha</code>, and run a<br>
fresh probe before accepting the pin. Never move a pin implicitly with a<br>
branch name or tag.</p>
<p>For rollback, restore the last accepted pin and its byte-identical<br>
configuration, check out the recorded <code class="notranslate">artifact_git_sha</code>, verify the<br>
configuration digest, and run a fresh probe. Keep the failed update's result as<br>
pilot evidence, but do not copy response content, credentials, tenant IDs,<br>
DSNs, or stack traces into the pin.</p></div></div></div></body></html>
```
</details>
<details>
<summary>Evidence: Probe observation vs probe loss — real producer runs for all six documented cases (sanitized)</summary>

<code>--- B. credential environment variable unset (documented: still an observation)&#10;$ env -u ORCHARD_OBSERVABILITY_PROBE_API_KEY scripts/smoke-observability-probe.sh &lt;site-local&gt;/cp1-ok.json&#10;exit=2&#10;stdout (retained result): {&#34;classification&#34;:&#34;invalid_config&#34;, &#34;probe_id&#34;:&#34;probe_7f0c…5f60&#34;, &#34;schema_version&#34;:1, &#34;outcome&#34;:&#34;fail&#34;}&#10;stderr (kept out of the retained result set): observability probe refused configuration: required environment variable ORCHARD_OBSERVABILITY_PROBE_API_KEY is not set&#10;qualifying for freshness? YES — qualifying result, freshness advances&#10;&#10;--- C. pinned configuration unreadable (documented: loses pinned identity)&#10;exit=2 stdout: {&#34;classification&#34;:&#34;invalid_config&#34;, &#34;probe_id&#34;:null, &#34;schema_version&#34;:1}&#10;qualifying for freshness? NO — freshness does not advance&#10;&#10;--- F. inference endpoint returns HTTP 503 (documented: not probe loss)&#10;exit=1 stdout: {&#34;classification&#34;:&#34;http_error&#34;, &#34;http_status&#34;:503, &#34;probe_id&#34;:&#34;probe_7f0c…5f60&#34;}&#10;qualifying for freshness? YES — qualifying result, freshness advances</code>

```text
CP1 consumer contract — probe observation vs probe loss
docs/pilots/README.md, "Issue #118 recurring HTTP-only consumer"
Producer entrypoint: scripts/smoke-observability-probe.sh CONFIG.json
Pinned configuration: schema_version 1, terminal_validation http_only, probe_id probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60
Exit codes: 0=pass 1=probe fail 2=invalid config

--- A. healthy endpoint: pass observation
$ scripts/smoke-observability-probe.sh <site-local>/cp1-ok.json
exit=0
stdout (retained result):
{
  "classification": "completed",
  "finished_at": "2026-08-09T11:59:11.601Z",
  "http_status": 200,
  "latency_ms": 42,
  "outcome": "pass",
  "probe_id": "probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60",
  "public_request_id": "resp_11111111-2222-3333-4444-555555555555",
  "schema_version": 1,
  "started_at": "2026-08-09T11:59:11.558Z",
  "terminal_count": 1,
  "terminal_state": "completed"
}
qualifying for freshness? YES — qualifying result, freshness advances

--- B. credential environment variable unset (documented: still an observation)
$ env -u ORCHARD_OBSERVABILITY_PROBE_API_KEY scripts/smoke-observability-probe.sh <site-local>/cp1-ok.json
exit=2
stdout (retained result):
{
  "classification": "invalid_config",
  "finished_at": "2026-08-09T11:59:12.666Z",
  "http_status": null,
  "latency_ms": 0,
  "outcome": "fail",
  "probe_id": "probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60",
  "public_request_id": null,
  "schema_version": 1,
  "started_at": "2026-08-09T11:59:12.666Z",
  "terminal_count": null,
  "terminal_state": null
}
stderr (kept out of the retained result set): observability probe refused configuration: required environment variable ORCHARD_OBSERVABILITY_PROBE_API_KEY is not set
qualifying for freshness? YES — qualifying result, freshness advances

--- C. pinned configuration unreadable (documented: loses pinned identity)
$ scripts/smoke-observability-probe.sh <site-local>/cp1-unreadable.json
exit=2
stdout (retained result):
{
  "classification": "invalid_config",
  "finished_at": "2026-08-09T11:59:13.883Z",
  "http_status": null,
  "latency_ms": 0,
  "outcome": "fail",
  "probe_id": null,
  "public_request_id": null,
  "schema_version": 1,
  "started_at": "2026-08-09T11:59:13.883Z",
  "terminal_count": null,
  "terminal_state": null
}
stderr (kept out of the retained result set): observability probe refused configuration: cannot read config: eacces
qualifying for freshness? NO — freshness does not advance

--- D. pinned configuration not parseable (documented: loses pinned identity)
$ scripts/smoke-observability-probe.sh <site-local>/cp1-truncated.json
exit=2
stdout (retained result):
{
  "classification": "invalid_config",
  "finished_at": "2026-08-09T11:59:14.985Z",
  "http_status": null,
  "latency_ms": 0,
  "outcome": "fail",
  "probe_id": null,
  "public_request_id": null,
  "schema_version": 1,
  "started_at": "2026-08-09T11:59:14.985Z",
  "terminal_count": null,
  "terminal_state": null
}
stderr (kept out of the retained result set): observability probe refused configuration: config is not valid JSON
qualifying for freshness? NO — freshness does not advance

--- E. inference endpoint unreachable over HTTPS (documented: not probe loss)
$ scripts/smoke-observability-probe.sh <site-local>/cp1-unreachable.json
exit=1
stdout (retained result):
{
  "classification": "transport_error",
  "finished_at": "2026-08-09T11:59:16.108Z",
  "http_status": null,
  "latency_ms": 35,
  "outcome": "fail",
  "probe_id": "probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60",
  "public_request_id": null,
  "schema_version": 1,
  "started_at": "2026-08-09T11:59:16.072Z",
  "terminal_count": null,
  "terminal_state": null
}
qualifying for freshness? YES — qualifying result, freshness advances

--- F. inference endpoint returns HTTP 503 (documented: not probe loss)
$ scripts/smoke-observability-probe.sh <site-local>/cp1-503.json
exit=1
stdout (retained result):
{
  "classification": "http_error",
  "finished_at": "2026-08-09T11:59:17.206Z",
  "http_status": 503,
  "latency_ms": 41,
  "outcome": "fail",
  "probe_id": "probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60",
  "public_request_id": null,
  "schema_version": 1,
  "started_at": "2026-08-09T11:59:17.163Z",
  "terminal_count": null,
  "terminal_state": null
}
qualifying for freshness? YES — qualifying result, freshness advances
```
</details>
<details>
<summary>Evidence: Immutable daily digest — documented snippet run verbatim, incl. fail-closed comparison against the pre-fix form</summary>

<code>1. Digest of the real retained day, computed twice&#10;exit=0 stdout: 8c71e40df454b9bc8256395abc4baaaf413ba6b894e678e8a80502434225fb66 -&#10;exit=0 stdout: 8c71e40df454b9bc8256395abc4baaaf413ba6b894e678e8a80502434225fb66 -&#10;&#10;2. Same retained bytes, different creation order and different parent path (nested file included)&#10;exit=0 stdout: bbe7e65b619ddc24f18fe7c2130b3a98b6b77fe72938d88c5085eecd8b150315 -&#10;exit=0 stdout: bbe7e65b619ddc24f18fe7c2130b3a98b6b77fe72938d88c5085eecd8b150315 -&#10;&#10;3. One retained result mutated by a single byte -&gt; different digest&#10;exit=0 stdout: 712fd50a1a06edf1259d6a0181ea98a874408321624df36ee3894e93963b1cd3 -&#10;&#10;4. Fail-closed: day retained nothing&#10;documented snippet (58e94d68): exit=1 stdout: &lt;no digest emitted&gt; stderr: no retained results to digest&#10;prior snippet (db6525e6): exit=0 stdout: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 -&#10;&#10;5. Fail-closed: one retained result cannot be hashed (partial input)&#10;documented snippet (58e94d68): exit=1 stdout: &lt;no digest emitted&gt; stderr: shasum: ./0010.json: Permission denied&#10;prior snippet (db6525e6): exit=0 stdout: 4c3ebbbacfe53785c630e227baf28b54bf4bd9ec2bc1f7e6b7f5d23cfe99e52a -&#10;&#10;6. Fail-closed: day directory missing&#10;exit=1 stdout: &lt;no digest emitted&gt;</code>

```text
CP1 immutable daily digest — documented snippet run verbatim as a script
Snippet extracted verbatim from the bash block in docs/pilots/README.md

Retained UTC day (real probe stdout results captured at the five-minute cadence):
  1200Z.json  {"schema_version":1,"probe_id":"probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60","outcome":"pass","classification":"completed","http_status":200}
  1205Z.json  {"schema_version":1,"probe_id":"probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60","outcome":"fail","classification":"http_error","http_status":503}
  1210Z.json  {"schema_version":1,"probe_id":"probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60","outcome":"pass","classification":"completed","http_status":200}

1. Digest of the real retained day, computed twice
    exit=0
    stdout: 8c71e40df454b9bc8256395abc4baaaf413ba6b894e678e8a80502434225fb66  -
    exit=0
    stdout: 8c71e40df454b9bc8256395abc4baaaf413ba6b894e678e8a80502434225fb66  -

2. Same retained bytes, different creation order and different parent path (nested file included)
    exit=0
    stdout: bbe7e65b619ddc24f18fe7c2130b3a98b6b77fe72938d88c5085eecd8b150315  -
    exit=0
    stdout: bbe7e65b619ddc24f18fe7c2130b3a98b6b77fe72938d88c5085eecd8b150315  -

3. One retained result mutated by a single byte -> different digest
    exit=0
    stdout: 712fd50a1a06edf1259d6a0181ea98a874408321624df36ee3894e93963b1cd3  -

4. Fail-closed: day retained nothing
   documented snippet (58e94d68):
    exit=1
    stdout: <no digest emitted>
    stderr: no retained results to digest 
   prior snippet (db6525e6):
    exit=0
    stdout: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  -

5. Fail-closed: one retained result cannot be hashed (partial input)
   documented snippet (58e94d68):
    exit=1
    stdout: <no digest emitted>
    stderr: shasum: ./0010.json: Permission denied 
   prior snippet (db6525e6):
    exit=0
    stdout: 4c3ebbbacfe53785c630e227baf28b54bf4bd9ec2bc1f7e6b7f5d23cfe99e52a  -
    stderr: shasum: 0010.json: Permission denied 

6. Fail-closed: day directory missing
    exit=1
    stdout: <no digest emitted>
    stderr: <evidence>/daily-digest.sh: line 9: cd: <site-local>/no-such-day: No such file or directory 
```
</details>
<details>
<summary>Evidence: Result-arrival freshness and 12-minute no-data alert timeline (driven by the real probe results)</summary>

<code>T+min sink event freshness age(min) no-data alert&#10;0 pass_result_arrived advances 0 ok&#10;5 fail_result_arrived(http_503) advances 0 ok&#10;10 pass_result_arrived advances 0 ok&#10;15 scheduled_run_started,no_stdout no advance 5 ok&#10;20 malformed_stdout_arrived no advance 10 ok&#10;22 - 12 FIRING&#10;25 result_with_foreign_probe_id no advance 15 FIRING&#10;30 refusal_with_null_probe_id no advance 20 FIRING&#10;34 - 24 FIRING&#10;35 publication_restored,pass_result advances 0 ok&#10;40 - 5 ok</code>

```text
CP1 result-arrival freshness and 12-minute no-data alert
Rule under test (docs/pilots/README.md): freshness advances only when the result sink
receives one parseable schema-version-1 result object whose probe_id equals the pinned
probe_id; the no-data alert fires after 12 minutes without a qualifying result.
Pinned probe_id: probe_7f0c2c1e-4a3b-4f5d-8c9a-1b2c3d4e5f60

Sink inputs (real probe stdout unless noted):
  T+0,5,10  results from the five-minute cadence (pass, HTTP 503 fail, pass)
  T+15      scheduled run started but publication path interrupted -> zero-byte output
  T+20      malformed (truncated) stdout
  T+25      result carrying a foreign probe_id
  T+30      real refusal result with null probe_id (unreadable pinned configuration)
  T+35      publication restored, qualifying result again

T+min   sink event                         freshness      age(min)  no-data alert
0       pass_result_arrived                advances       0         ok
5       fail_result_arrived(http_503)      advances       0         ok
10      pass_result_arrived                advances       0         ok
15      scheduled_run_started,no_stdout    no advance     5         ok
20      malformed_stdout_arrived           no advance     10        ok
22      -                                                 12        FIRING
23      -                                                 13        FIRING
24      -                                                 14        FIRING
25      result_with_foreign_probe_id       no advance     15        FIRING
26      -                                                 16        FIRING
27      -                                                 17        FIRING
28      -                                                 18        FIRING
29      -                                                 19        FIRING
30      refusal_with_null_probe_id         no advance     20        FIRING
31      -                                                 21        FIRING
32      -                                                 22        FIRING
33      -                                                 23        FIRING
34      -                                                 24        FIRING
35      publication_restored,pass_result   advances       0         ok
40      -                                                 5         ok

Last qualifying result before the gap arrived at T+10; alert fires at T+22 (12 minutes).
Non-qualifying arrivals at T+15/20/25/30 do not reset freshness; recovery at T+35.
```
</details>
<details>
<summary>Evidence: Scope and boundary check (producer/SPEC/OpenSpec preserved; no secrets or machine-local data in added lines)</summary>

<code>$ git diff --stat 3c6353b6..58e94d68&#10;docs/pilots/README.md | 68 +++++++++++++++++++++++++++++++++++++++++++++++++++&#10;1 file changed, 68 insertions(+)&#10;&#10;Untouched surfaces required to be preserved:&#10;SPEC.md: 0 changed file(s)&#10;scripts/support/observability_probe.exs: 0 changed file(s)&#10;scripts/support/observability_probe.example.json: 0 changed file(s)&#10;scripts/smoke-observability-probe.sh: 0 changed file(s)&#10;openspec: 0 changed file(s)&#10;apps: 0 changed file(s)&#10;&#10;Secret / machine-local leakage scan over the added lines: 0 hits for Bearer, api_key, /Users/, /Volumes/, postgres://, PRIVATE KEY, tenant_id, resp_&lt;uuid&gt;, probe_&lt;uuid&gt;&#10;&#10;Working tree state (tracked files): clean</code>

```text
Scope and boundary check (base 3c6353b6 -> target 58e94d68)

$ git diff --stat 3c6353b6..58e94d68
 docs/pilots/README.md | 68 +++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 68 insertions(+)

Untouched surfaces required to be preserved:
  SPEC.md: 0 changed file(s)
  scripts/support/observability_probe.exs: 0 changed file(s)
  scripts/support/observability_probe.example.json: 0 changed file(s)
  scripts/smoke-observability-probe.sh: 0 changed file(s)
  openspec: 0 changed file(s)
  apps: 0 changed file(s)

Secret / machine-local leakage scan over the added lines:
  /Bearer / -> 0 hit(s)
  /api[_-]\?key *[:=]/ -> 0 hit(s)
  //Users// -> 0 hit(s)
  //Volumes// -> 0 hit(s)
  /postgres:/// -> 0 hit(s)
  /BEGIN .*PRIVATE KEY/ -> 0 hit(s)
  /tenant_id/ -> 0 hit(s)
  /resp_[0-9a-f]\{8\}/ -> 0 hit(s)
  /probe_[0-9a-f]\{8\}/ -> 0 hit(s)

Required contract terms present in the added section:
  "every five minutes"         1 occurrence(s)
  "schema version 1"           1 occurrence(s)
  "http_only"                  1 occurrence(s)
  "12 minutes"                 1 occurrence(s)
  "probe_id"                   4 occurrence(s)
  "site-local evidence"        1 occurrence(s)
  "do not commit"              1 occurrence(s)
  "reconciliation cadence"     1 occurrence(s)
  "readiness-failure"          1 occurrence(s)

Working tree state (tracked files):
  clean
```
</details>
<details>
<summary>Evidence: Documented digest snippet, extracted verbatim from the doc and used as the test subject</summary>

```text
set -euo pipefail

manifest=$(
  cd "$day_result_dir" &&
    find . -type f -print0 |
    LC_ALL=C sort -z |
    xargs -0 -r shasum -a 256
)

[ -n "$manifest" ] || { echo "no retained results to digest" >&2; exit 1; }

printf '%s\n' "$manifest" | shasum -a 256
```
</details>
<details>
<summary>Evidence: Freshness / no-data alert evaluator implementing the documented rule</summary>

```text
#!/bin/bash
# CP1 consumer-side freshness rule from docs/pilots/README.md:
#   freshness advances only on one parseable schema-version-1 result object
#   whose probe_id equals the pinned probe_id; no-data alert at 12 minutes.
set -uo pipefail
PIN="$1"; TIMELINE="$2"; THRESHOLD=12

qualifies() {
  local file="$1"
  [ -s "$file" ] || return 1
  jq -e --arg pin "$PIN" \
    'type == "object" and .schema_version == 1 and .probe_id == $pin' \
    "$file" >/dev/null 2>&1
}

last_qualifying=0
while read -r minute label file; do
  EVENT_AT[$minute]=1; EVENT_LABEL[$minute]="$label"; EVENT_FILE[$minute]="$file"
done < "$TIMELINE"

printf '%-7s %-34s %-14s %-9s %s\n' "T+min" "sink event" "freshness" "age(min)" "no-data alert"
for ((m=0; m<=40; m++)); do
  event="-"; verdict=""
  if [ "${EVENT_AT[$m]:-}" = "1" ]; then
    event="${EVENT_LABEL[$m]}"
    file="${EVENT_FILE[$m]}"
    if [ "$file" != "none" ] && qualifies "$file"; then
      last_qualifying=$m; verdict="advances"
    else
      verdict="no advance"
    fi
  fi
  age=$((m - last_qualifying))
  if [ "$age" -ge "$THRESHOLD" ]; then alert="FIRING"; else alert="ok"; fi
  if [ "$event" != "-" ] || [ "$alert" = "FIRING" ] || [ $((m % 5)) -eq 0 ]; then
    printf '%-7s %-34s %-14s %-9s %s\n' "$m" "$event" "$verdict" "$age" "$alert"
  fi
done
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `docs/pilots/README.md:47` - The probe-loss contract omits the configuration/environment-refusal path. `observability_probe.exs:77-93` prints a valid schema-version-1 result (`outcome: &#34;fail&#34;`, `classification: &#34;invalid_config&#34;`, `probe_id` possibly null) to stdout and exits 2, so under this section&#39;s freshness rule (line 41) a refused run still advances freshness. An operator following line 49 (&#34;interrupting the consumer or its result-publication path&#34;) who instead unsets the credential env var or corrupts the pinned config will see freshness keep advancing and the 12-minute alert never fire, and will record that as a broken alert or as invalid probe-loss evidence. Add configuration/environment refusal to the sentence at line 47 alongside transport, HTTP, and invalid-stream failures, and state whether a result whose `probe_id` does not match the pin qualifies for freshness.
- ℹ️ `docs/pilots/README.md:38` - &#34;produces an immutable daily digest for the retained result set&#34; does not name a digest algorithm or a canonical input ordering, unlike the sibling `config_sha256` contract at lines 20-31 which pins `shasum -a 256` over exact bytes. Two operators digesting the same day&#39;s retained results in different file order or with different tooling produce non-comparable values, so the digest cannot be used to verify retention across sites. Specifying SHA-256 over a defined ordering (as the config pin does) would make the evidence checkable while keeping the digest values themselves site-local.

🔧 Fix: pin cp1 probe_id freshness identity and daily digest method
1 info still open:
- ℹ️ `docs/pilots/README.md:50` - The documented daily-digest pipeline reports success even when it digested only part of the day&#39;s results. `xargs -0 shasum -a 256` continues past any file it cannot hash and its non-zero status is discarded by the pipe, so the final `shasum -a 256` still emits a well-formed digest and the pipeline exits 0. Concrete cases: a result file the operator cannot read in the &#34;protected result location&#34; described at line 78, a stray subdirectory in `$day_result_dir` (`shasum: &lt;name&gt;: Is a directory`), or a filename containing a newline, which the `ls -1 | tr &#39;\n&#39; &#39;\0&#39;` parse splits into non-existent paths. Each yields a digest over a subset that is then recorded as that day&#39;s immutable evidence, with only stderr text distinguishing it. Adding `set -o pipefail` (or checking `${PIPESTATUS[@]}`) and enumerating with `find . -type f -print0 | LC_ALL=C sort -z` instead of parsing `ls` makes the failure abort rather than produce silent partial evidence.

🔧 Fix: fail closed on partial daily digest input
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix compile` (setup; exit 0) — required before the probe entrypoint can run in this fresh worktree</code>
- <code>`scripts/smoke-observability-probe.sh &lt;cfg&gt;` against a loopback SSE stub — healthy pass (exit 0, pinned `probe_id`, `terminal_validation: http_only`, schema_version 1)</code>
- <code>`env -u ORCHARD_OBSERVABILITY_PROBE_API_KEY scripts/smoke-observability-probe.sh &lt;cfg&gt;` — emits `invalid_config` carrying the pinned `probe_id` (exit 2), i.e. an observation, not probe loss</code>
- <code>`scripts/smoke-observability-probe.sh &lt;unreadable-cfg&gt;` and `&lt;truncated-json-cfg&gt;` — both emit `probe_id: null`, so freshness does not advance</code>
- <code>`scripts/smoke-observability-probe.sh &lt;unreachable-https-cfg&gt;` — `transport_error` fail with pinned `probe_id`</code>
- <code>`scripts/smoke-observability-probe.sh &lt;503-endpoint-cfg&gt;` — `http_error`/503 fail with pinned `probe_id` (breaking the endpoint is not probe-loss proof)</code>
- <code>Documented digest block extracted verbatim from `docs/pilots/README.md` and run as `day_result_dir=&lt;day&gt; bash daily-digest.sh` over a real retained UTC day of probe stdout results — computed twice, identical</code>
- `Digest determinism: same retained bytes in different creation order and different parent path (with a nested file) produce the same value; a one-byte mutation produces a different value`
- <code>Digest fail-closed: empty day directory (exit 1, `no retained results to digest`), one unhashable file (exit 1, no digest), missing day directory (exit 1) — compared side by side against the pre-fix snippet from `db6525e6`, which emitted digests in the first two cases</code>
- <code>`bash freshness-eval.sh &lt;pinned-probe_id&gt; &lt;timeline&gt;` — minute-by-minute freshness evaluation driven by the real probe results; alert fires at T+22 (12 min after the last qualifying result at T+10), is not reset by zero-byte/malformed/foreign-pin/null-pin arrivals, and recovers at T+35</code>
- <code>`git diff --stat 3c6353b6..58e94d68` plus per-path checks confirming SPEC.md, `scripts/support/observability_probe.exs`, the example config, the smoke script, `openspec/`, and `apps/` are unchanged</code>
- <code>Leakage scan over the added lines for credentials, `/Users/` paths, DSNs, tenant identifiers, and concrete probe/response IDs — zero hits</code>
- <code>Rendered `docs/pilots/README.md` as GitHub-flavored HTML and screenshotted it headless to capture the reviewer-visible surface</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/pilots/README.md:75` - The producer rule that a post-validation refusal keeps the configured probe_id while an unreadable/unparseable config yields a null probe_id now appears in two docs: docs/local-dev.md:121-123 (developer run semantics) and docs/pilots/README.md:75-82 (restated to derive the CP1 freshness conclusion). Left as-is deliberately: the intent requires a self-contained narrow consumer contract, and both copies are currently accurate. Flagging as a judgment call because a future producer change to that rule must update both places; a follow-up could reduce the pilots copy to the consumer consequence plus a pointer to docs/local-dev.md.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788869283&installation_model_id=428414&pr_number=184&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F184&signature=f2512498896f07083fcad097af095eb33e2403f550d8a39b4473110f1364bb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->