### PR TITLE
docs(pilots): reframe #118 as slim source-dev API pilot runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,8 +57,8 @@ large spec sections.
 
 ### I want to run a pilot
 
-- [`pilots/README.md`](pilots/README.md) — pilot artifact pin ownership,
-  producer commit and configuration digest contract, update and rollback.
+- [`pilots/README.md`](pilots/README.md) — slim source-dev API pilot runbook
+  for issue #118 Revision 6, plus optional synthetic-check pin notes.
 - [`local-dev.md`](local-dev.md) — Phase 0 observability probe invocation and
   exit semantics.
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -122,7 +122,7 @@ A refusal that happens after the configuration validated keeps the configured
 `probe_id` in its `invalid_config` result; a null `probe_id` means no
 configuration validated.
 
-Pilot #118 pin ownership and digest instructions are in
+Pilot #118 runbook and optional synthetic-check pin notes are in
 [`pilots/README.md`](pilots/README.md).
 
 ## Transport Modes

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -1,44 +1,89 @@
-# Pilot artifact pins
+# Pilot runbook
 
-Pilot acceptance evidence must identify the exact producer artifact and the
-exact non-secret configuration used to collect it. Pins are consumer-owned:
-they are not probe results and must never contain credentials or credential
-values.
+This page supports the slim internal source-dev API pilot tracked on issue #118
+(Revision 6).
 
-## Issue #115 producer and issue #118 consumer
+The first pilot is intentionally light:
 
-Issue #115 owns the versioned Phase 0 probe implementation, its configuration
-and result schemas, and the example pin at
-`issue-118-cp1-observability-probe-pin.example.json`. Issue #118 owns the CP1
-copy of the probe configuration, the actual pin, the invocation cadence, and
-the retained pilot results.
+- we install source-dev Orchard on a couple of hosts
+- we choose and load models ourselves
+- clients call `/v1/chat/completions` and/or `/v1/responses`
+- we observe real usage for about two weeks and collect feedback
 
-The #118 pin records:
+It is not a packaged-readiness program and not a full M5 observability gate.
 
-- `artifact_git_sha`: the 40-character Git commit SHA containing the exact
-  `scripts/support/observability_probe.exs` artifact used by the pilot;
-- `config_sha256`: the lowercase SHA-256 digest of the exact non-secret JSON
-  configuration bytes used for the run;
-- `config_path`: the consumer-owned configuration location;
-- `result_schema_version` and `terminal_validation`: the interpretation
-  contract for collected results.
+## Start bar
 
-Create the digest without resolving either environment variable named by the
+Before opening the window:
+
+1. Controller and at least one healthy worker are up.
+2. End-to-end inference works from outside the box on the APIs offered to clients.
+3. One tenant exists, with per-user API clients/tokens where practical.
+4. At least one operator-chosen model is loaded on a schedulable node.
+5. Operators can inspect requests, restart a node, and revoke a token.
+6. Clients have a short note covering allowed content, support hours, contact path, and stop authority.
+
+## Operator note (site-local)
+
+Keep a private note with:
+
+- host roles and install pointers
+- loaded model id(s) and node(s)
+- tenant id and token mint/revoke steps
+- API base URL(s) given to clients
+- capture-mode statement (prefer `metadata`)
+- optional synthetic-check command, if any
+
+Do not commit credentials, tokens, private host paths, raw results, or response
+content.
+
+## Optional synthetic check
+
+A recurring authenticated check is useful so overnight total outage is obvious.
+It is optional for pilot start.
+
+If you use the Phase 0 producer from issue #115:
+
+- producer, schemas, and launcher live with #115
+- example pin format: `issue-118-cp1-observability-probe-pin.example.json`
+- configuration and results stay site-local
+- failed check results are still data; silence means no qualifying result arrived
+
+Issue #182 tracks richer silence-detection hardening. It is deferred and is not
+a #118 start gate.
+
+### Optional pin fields
+
+When you do pin a check configuration, record:
+
+- `artifact_git_sha`: commit that contains the exact producer script
+- `config_sha256`: SHA-256 of the exact non-secret configuration bytes
+- `config_path`: consumer-owned configuration location
+- `result_schema_version` and `terminal_validation`
+
+Create the digest without resolving environment variables named by the
 configuration:
 
 ```sh
-shasum -a 256 pilot-owned/issue-118-cp1-observability-probe.json
+shasum -a 256 path/to/your-non-secret-probe-config.json
 ```
 
-## Update and rollback
+## During the window
 
-For an update, review the producer change, copy the new configuration if its
-schema changed, recompute `config_sha256`, replace `artifact_git_sha`, and run a
-fresh probe before accepting the pin. Never move a pin implicitly with a
-branch name or tag.
+Record:
 
-For rollback, restore the last accepted pin and its byte-identical
-configuration, check out the recorded `artifact_git_sha`, verify the
-configuration digest, and run a fresh probe. Keep the failed update's result as
-pilot evidence, but do not copy response content, credentials, tenant IDs,
-DSNs, or stack traces into the pin.
+- client friction and workarounds
+- API compatibility surprises (error shapes, streaming, cancel, tools)
+- unplanned operator interventions
+- defects to file or extend after the window
+
+## Related issues
+
+| Issue | Role under Revision 6 |
+| --- | --- |
+| #118 | Pilot tracker |
+| #115 | Optional probe producer |
+| #182 | Deferred optional silence-detection hardening |
+| #126 | Console readiness bug; not a client-path start gate |
+| #127 | Post-pilot packaged Model Hub journey |
+| #128 | Scheduler/admission reasons; fix when it hurts |


### PR DESCRIPTION
## Summary

Reframes the committed pilot docs around issue #118 Revision 6: a slim source-dev API observation pilot, not CP1 pin/alert theater.

Operators get a short start bar, a site-local note checklist, and optional synthetic-check pin guidance. Induced probe-loss proof and packaged Model Hub journey language are out of the pilot-start path.

## What changed

- Rewrote `docs/pilots/README.md` as the Revision 6 runbook
- Pointed `docs/README.md` and `docs/local-dev.md` at the lighter pilot posture
- Kept the example pin JSON as an optional format reference for anyone who still wants a recurring check

Tracker updates already landed outside this PR: #118 Revision 6, #182 deferred, #127 post-pilot, and posture comments on #126 / #128 / PR #184.

## Test plan

Docs-only. Skim the three files for broken links and wording consistency with #118 Revision 6.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Grok_4.5-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788923619&installation_model_id=428414&pr_number=185&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F185&signature=e8eecf51a017829bddea1ab4566eb3a44afc35f5d9567cd4a4df61bbf5ca7cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->