### PR TITLE
fix(worker_mlx): tolerate mlx_lm loaders without trust_remote_code

### DIFF
--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
@@ -601,16 +601,22 @@ def _default_mlx_deps() -> MLXDeps:
         import inspect
 
         _reject_model_file_config(model_path)
-        # Prefer disabling model-side remote code when the installed mlx_lm
-        # accepts the kwarg. Newer mlx_lm loaders reject unknown kwargs.
+        # Forced disable when accepted. Never let callers re-enable remote code.
+        # Newer mlx_lm loaders reject unknown kwargs, so strip when unsupported.
         try:
             params = inspect.signature(mlx_lm_load).parameters
-            if "trust_remote_code" in params or any(
+            accepts_trust = "trust_remote_code" in params or any(
                 p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-            ):
-                kwargs.setdefault("trust_remote_code", False)
+            )
         except (TypeError, ValueError):
-            pass
+            # Fail closed: if signature inspection fails, still force disable.
+            accepts_trust = True
+
+        if accepts_trust:
+            kwargs["trust_remote_code"] = False
+        else:
+            kwargs.pop("trust_remote_code", None)
+
         return mlx_lm_load(Path(model_path), **kwargs)
 
     def _load_tokenizer(tokenizer_path: str | Path) -> Any:

--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
@@ -598,18 +598,39 @@ def _default_mlx_deps() -> MLXDeps:
 
     def _load_model(model_path: str | Path, **kwargs: Any) -> tuple[Any, Any]:
         """Wrap mlx_lm.utils.load_model; returns (model, config)."""
+        import inspect
+
         _reject_model_file_config(model_path)
-        # Forced, not defaulted: no caller may re-enable model-side remote code.
-        kwargs["trust_remote_code"] = False
+        # Prefer disabling model-side remote code when the installed mlx_lm
+        # accepts the kwarg. Newer mlx_lm loaders reject unknown kwargs.
+        try:
+            params = inspect.signature(mlx_lm_load).parameters
+            if "trust_remote_code" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            ):
+                kwargs.setdefault("trust_remote_code", False)
+        except (TypeError, ValueError):
+            pass
         return mlx_lm_load(Path(model_path), **kwargs)
 
     def _load_tokenizer(tokenizer_path: str | Path) -> Any:
         # mlx_lm.tokenizer_utils.load expects the bundle directory containing
         # tokenizer assets, not the tokenizer.json file path itself.
-        return mlx_lm_load_tokenizer(
-            Path(tokenizer_path).parent,
-            tokenizer_config_extra={"trust_remote_code": False},
-        )
+        import inspect
+
+        tokenizer_dir = Path(tokenizer_path).parent
+        try:
+            params = inspect.signature(mlx_lm_load_tokenizer).parameters
+            if "tokenizer_config_extra" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            ):
+                return mlx_lm_load_tokenizer(
+                    tokenizer_dir,
+                    tokenizer_config_extra={"trust_remote_code": False},
+                )
+        except (TypeError, ValueError):
+            pass
+        return mlx_lm_load_tokenizer(tokenizer_dir)
 
     return MLXDeps(
         load_model=_load_model,


### PR DESCRIPTION
## Summary

Source-dev load of Qwen3.6 failed on mawarduri because our worker always forced `trust_remote_code=False` into `mlx_lm.load`, and the installed mlx_lm rejects unknown kwargs.

This change only passes `trust_remote_code` / `tokenizer_config_extra` when the live loader signature accepts them. Older mlx_lm keeps the safe-disable behavior. Newer mlx_lm can load again.

## Why

During Topology A smoke on mawarduri (M3 Max, 64 GB):

- catalog import of `mlx-community/Qwen3.6-35B-A3B-4bit` succeeded
- first inference returned `model_load_failed`
- worker log root cause: `load_model() got an unexpected keyword argument 'trust_remote_code'`
- after this patch, non-stream and stream `/v1/chat/completions` both returned 200

## What changed

- `native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py`
  - inspect `mlx_lm` load / tokenizer signatures before passing remote-code kwargs
  - fall back cleanly when those kwargs are unsupported

## Test plan

- [x] Topology A on mawarduri: load Qwen3.6-35B-A3B-4bit
- [x] `POST /v1/chat/completions` non-stream 200
- [x] `POST /v1/chat/completions` stream 200 with SSE chunks
- [ ] `mise exec -- uv run --directory native/orchard_worker_mlx pytest` on the worker package if CI does not already cover it

## Notes

Found on the source-dev pilot smoke path. No SPEC change intended.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788929649&installation_model_id=428414&pr_number=186&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F186&signature=884d4a005d28cf50349a7296ac77f2d849dd450c3ddb16d66b52b8f83301f7d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->