### PR TITLE
fix(models): auto-fill or reject missing chat_template on import

### DIFF
--- a/apps/orchard_cli/lib/orchard_cli/commands/models.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/models.ex
@@ -88,6 +88,9 @@ defmodule OrchardCLI.Commands.Models do
       {:error, {:json_decode, message}} ->
         {:error, "Error: failed to parse manifest.json: #{message}", 1}
 
+      {:error, {:missing_chat_template, message}} ->
+        {:error, "Error: #{message}", 1}
+
       {:error, reason} ->
         {:error, "Error: import failed: #{inspect(reason)}", 1}
     end

--- a/apps/orchard_cli/lib/orchard_cli/commands/models.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/models.ex
@@ -70,31 +70,33 @@ defmodule OrchardCLI.Commands.Models do
       {:ok, model} ->
         {:ok, "Imported #{model.model_id}@#{model.version} (state: #{model.state})"}
 
-      {:error, {:duplicate, message}} ->
-        {:error, "Error: #{message}", 1}
-
-      {:error, {:source_not_found, path}} ->
-        {:error, "Error: source path not found: #{path}", 1}
-
-      {:error, {:source_not_directory, message}} ->
-        {:error, "Error: #{message}", 1}
-
-      {:error, {:manifest_not_found, path}} ->
-        {:error, "Error: manifest.json not found at #{path}", 1}
-
-      {:error, {:validation, message}} ->
-        {:error, "Error: invalid manifest: #{message}", 1}
-
-      {:error, {:json_decode, message}} ->
-        {:error, "Error: failed to parse manifest.json: #{message}", 1}
-
-      {:error, {:missing_chat_template, message}} ->
-        {:error, "Error: #{message}", 1}
-
       {:error, reason} ->
-        {:error, "Error: import failed: #{inspect(reason)}", 1}
+        format_import_error(reason)
     end
   end
+
+  defp format_import_error({:duplicate, message}), do: {:error, "Error: #{message}", 1}
+
+  defp format_import_error({:source_not_found, path}),
+    do: {:error, "Error: source path not found: #{path}", 1}
+
+  defp format_import_error({:source_not_directory, message}),
+    do: {:error, "Error: #{message}", 1}
+
+  defp format_import_error({:manifest_not_found, path}),
+    do: {:error, "Error: manifest.json not found at #{path}", 1}
+
+  defp format_import_error({:validation, message}),
+    do: {:error, "Error: invalid manifest: #{message}", 1}
+
+  defp format_import_error({:json_decode, message}),
+    do: {:error, "Error: failed to parse manifest.json: #{message}", 1}
+
+  defp format_import_error({:missing_chat_template, message}),
+    do: {:error, "Error: #{message}", 1}
+
+  defp format_import_error(reason),
+    do: {:error, "Error: import failed: #{inspect(reason)}", 1}
 
   defp run_delete([]) do
     {:error, "Error: missing model identity\n#{delete_usage()}", 1}

--- a/apps/orchard_controller/lib/orchard/models/importer.ex
+++ b/apps/orchard_controller/lib/orchard/models/importer.ex
@@ -234,6 +234,9 @@ defmodule Orchard.Models.Importer do
       {:ok, _} = result ->
         result
 
+      {:error, _} = err ->
+        err
+
       :none ->
         extract_template_from_tokenizer_config(staged_path)
     end

--- a/apps/orchard_controller/lib/orchard/models/importer.ex
+++ b/apps/orchard_controller/lib/orchard/models/importer.ex
@@ -244,47 +244,60 @@ defmodule Orchard.Models.Importer do
 
   defp find_existing_template(staged_path) do
     Enum.find_value(@template_candidates, :none, fn filename ->
-      path = Path.join(staged_path, filename)
-
-      if File.regular?(path) do
-        case File.read(path) do
-          {:ok, content} when byte_size(content) > 0 ->
-            {:ok, %{path: filename, sha256: sha256_hex(content)}}
-
-          {:ok, _empty} ->
-            nil
-
-          {:error, reason} ->
-            {:error, {:chat_template_read, "Failed to read #{path}: #{inspect(reason)}"}}
-        end
-      end
+      read_existing_template_candidate(Path.join(staged_path, filename), filename)
     end)
+  end
+
+  defp read_existing_template_candidate(path, filename) do
+    if File.regular?(path) do
+      read_existing_template_file(path, filename)
+    end
+  end
+
+  defp read_existing_template_file(path, filename) do
+    case File.read(path) do
+      {:ok, content} when byte_size(content) > 0 ->
+        {:ok, %{path: filename, sha256: sha256_hex(content)}}
+
+      {:ok, _empty} ->
+        nil
+
+      {:error, reason} ->
+        {:error, {:chat_template_read, "Failed to read #{path}: #{inspect(reason)}"}}
+    end
   end
 
   defp extract_template_from_tokenizer_config(staged_path) do
     config_path = Path.join(staged_path, @tokenizer_config_name)
 
-    if not File.regular?(config_path) do
-      {:ok, nil}
+    if File.regular?(config_path) do
+      read_tokenizer_config_template(staged_path, config_path)
     else
-      case File.read(config_path) do
-        {:ok, json} ->
-          case Jason.decode(json) do
-            {:ok, config} when is_map(config) ->
-              template_from_tokenizer_config(staged_path, Map.get(config, "chat_template"))
+      {:ok, nil}
+    end
+  end
 
-            {:ok, _other} ->
-              {:error,
-               {:invalid_tokenizer_config, "tokenizer_config.json must decode to an object"}}
+  defp read_tokenizer_config_template(staged_path, config_path) do
+    case File.read(config_path) do
+      {:ok, json} ->
+        decode_tokenizer_config_template(staged_path, json)
 
-            {:error, %Jason.DecodeError{} = err} ->
-              {:error, {:invalid_tokenizer_config, Exception.message(err)}}
-          end
+      {:error, reason} ->
+        {:error,
+         {:invalid_tokenizer_config, "Failed to read tokenizer_config.json: #{inspect(reason)}"}}
+    end
+  end
 
-        {:error, reason} ->
-          {:error,
-           {:invalid_tokenizer_config, "Failed to read tokenizer_config.json: #{inspect(reason)}"}}
-      end
+  defp decode_tokenizer_config_template(staged_path, json) do
+    case Jason.decode(json) do
+      {:ok, config} when is_map(config) ->
+        template_from_tokenizer_config(staged_path, Map.get(config, "chat_template"))
+
+      {:ok, _other} ->
+        {:error, {:invalid_tokenizer_config, "tokenizer_config.json must decode to an object"}}
+
+      {:error, %Jason.DecodeError{} = err} ->
+        {:error, {:invalid_tokenizer_config, Exception.message(err)}}
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/models/importer.ex
+++ b/apps/orchard_controller/lib/orchard/models/importer.ex
@@ -77,19 +77,35 @@ defmodule Orchard.Models.Importer do
          {:ok, source_manifest} <- ManifestParser.parse_from_bundle(source_path),
          :ok <- validate_identity_safe(source_manifest),
          :ok <- check_no_duplicate(source_manifest),
-         {:ok, staged_path} <- stage_bundle(source_path, artifacts_root),
-         {:ok, manifest} <- maybe_top_up_resident_memory(staged_path, source_manifest),
-         {:ok, manifest} <- maybe_run_eager_preflight(staged_path, manifest),
-         {:ok, sha256} <- compute_sha256(staged_path),
-         {:ok, dest_path} <- finalize_staged(staged_path, manifest, artifacts_root) do
-      case insert_catalog_record(manifest, dest_path, sha256, activate?) do
-        {:ok, model} ->
-          {:ok, model}
+         {:ok, staged_path} <- stage_bundle(source_path, artifacts_root) do
+      import_staged_bundle(staged_path, source_manifest, artifacts_root, activate?)
+    end
+  end
 
-        {:error, _} = err ->
-          File.rm_rf(dest_path)
-          err
+  defp import_staged_bundle(staged_path, source_manifest, artifacts_root, activate?) do
+    result =
+      with {:ok, manifest} <- maybe_top_up_resident_memory(staged_path, source_manifest),
+           {:ok, manifest} <- ensure_chat_template(staged_path, manifest),
+           {:ok, manifest} <- maybe_run_eager_preflight(staged_path, manifest),
+           {:ok, sha256} <- compute_sha256(staged_path),
+           {:ok, dest_path} <- finalize_staged(staged_path, manifest, artifacts_root) do
+        case insert_catalog_record(manifest, dest_path, sha256, activate?) do
+          {:ok, model} ->
+            {:ok, model}
+
+          {:error, _} = err ->
+            File.rm_rf(dest_path)
+            err
+        end
       end
+
+    case result do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _} = err ->
+        if File.dir?(staged_path), do: File.rm_rf(staged_path)
+        err
     end
   end
 
@@ -153,6 +169,179 @@ defmodule Orchard.Models.Importer do
       {:error, reason} ->
         {:error, {:mkdir_failed, "failed to create staging dir: #{inspect(reason)}"}}
     end
+  end
+
+  # -- Chat template top-up -------------------------------------------------
+
+  @template_candidates ["chat_template.jinja", "chat_template.jinja2"]
+  @generated_template_name "chat_template.jinja"
+  @tokenizer_config_name "tokenizer_config.json"
+
+  defp ensure_chat_template(staged_path, %ModelManifest{} = manifest) do
+    cond do
+      chat_template_present?(manifest.chat_template) ->
+        {:ok, manifest}
+
+      chat_capability?(manifest.capabilities) ->
+        fill_or_reject_chat_template(staged_path)
+
+      true ->
+        {:ok, manifest}
+    end
+  end
+
+  defp chat_template_present?(%{path: path, sha256: sha256})
+       when is_binary(path) and path != "" and is_binary(sha256) and sha256 != "",
+       do: true
+
+  defp chat_template_present?(_), do: false
+
+  defp chat_capability?(capabilities) when is_list(capabilities), do: "chat" in capabilities
+  defp chat_capability?(_), do: false
+
+  defp fill_or_reject_chat_template(staged_path) do
+    case resolve_chat_template_asset(staged_path) do
+      {:ok, %{path: path, sha256: sha256}} ->
+        write_chat_template_manifest(staged_path, path, sha256)
+
+      {:ok, nil} ->
+        {:error,
+         {:missing_chat_template,
+          "chat-capable bundle is missing chat_template; add chat_template.jinja or tokenizer_config.json chat_template"}}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp write_chat_template_manifest(staged_path, path, sha256) do
+    with {:ok, manifest_map} <- read_manifest_map(staged_path),
+         :ok <-
+           write_manifest_map(
+             staged_path,
+             Map.put(manifest_map, "chat_template", %{"path" => path, "sha256" => sha256})
+           ),
+         {:ok, reparsed} <- ManifestParser.parse_from_bundle(staged_path) do
+      {:ok, reparsed}
+    else
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp resolve_chat_template_asset(staged_path) do
+    case find_existing_template(staged_path) do
+      {:ok, _} = result ->
+        result
+
+      :none ->
+        extract_template_from_tokenizer_config(staged_path)
+    end
+  end
+
+  defp find_existing_template(staged_path) do
+    Enum.find_value(@template_candidates, :none, fn filename ->
+      path = Path.join(staged_path, filename)
+
+      if File.regular?(path) do
+        case File.read(path) do
+          {:ok, content} when byte_size(content) > 0 ->
+            {:ok, %{path: filename, sha256: sha256_hex(content)}}
+
+          {:ok, _empty} ->
+            nil
+
+          {:error, reason} ->
+            {:error, {:chat_template_read, "Failed to read #{path}: #{inspect(reason)}"}}
+        end
+      end
+    end)
+  end
+
+  defp extract_template_from_tokenizer_config(staged_path) do
+    config_path = Path.join(staged_path, @tokenizer_config_name)
+
+    if not File.regular?(config_path) do
+      {:ok, nil}
+    else
+      case File.read(config_path) do
+        {:ok, json} ->
+          case Jason.decode(json) do
+            {:ok, config} when is_map(config) ->
+              template_from_tokenizer_config(staged_path, Map.get(config, "chat_template"))
+
+            {:ok, _other} ->
+              {:error,
+               {:invalid_tokenizer_config, "tokenizer_config.json must decode to an object"}}
+
+            {:error, %Jason.DecodeError{} = err} ->
+              {:error, {:invalid_tokenizer_config, Exception.message(err)}}
+          end
+
+        {:error, reason} ->
+          {:error,
+           {:invalid_tokenizer_config, "Failed to read tokenizer_config.json: #{inspect(reason)}"}}
+      end
+    end
+  end
+
+  defp template_from_tokenizer_config(_staged_path, nil), do: {:ok, nil}
+
+  defp template_from_tokenizer_config(staged_path, template)
+       when is_binary(template) and template != "" do
+    write_generated_template(staged_path, template)
+  end
+
+  defp template_from_tokenizer_config(_staged_path, template) when is_binary(template) do
+    {:error, {:invalid_tokenizer_config, "chat_template in tokenizer_config.json is blank."}}
+  end
+
+  defp template_from_tokenizer_config(staged_path, templates) when is_list(templates) do
+    selected =
+      Enum.find(templates, fn
+        %{"name" => "default"} -> true
+        _ -> false
+      end) || List.first(templates)
+
+    case selected do
+      %{"template" => template} when is_binary(template) and template != "" ->
+        write_generated_template(staged_path, template)
+
+      %{"template" => ""} ->
+        {:error, {:invalid_tokenizer_config, "chat_template list entry has blank template."}}
+
+      %{} ->
+        {:error,
+         {:invalid_tokenizer_config,
+          "chat_template list entry missing or invalid template field."}}
+
+      nil ->
+        {:ok, nil}
+
+      _other ->
+        {:error, {:invalid_tokenizer_config, "chat_template list contains non-object entries."}}
+    end
+  end
+
+  defp template_from_tokenizer_config(_staged_path, _other) do
+    {:error,
+     {:invalid_tokenizer_config, "chat_template in tokenizer_config.json has unsupported type."}}
+  end
+
+  defp write_generated_template(staged_path, content) do
+    path = Path.join(staged_path, @generated_template_name)
+
+    case File.write(path, content) do
+      :ok ->
+        {:ok, %{path: @generated_template_name, sha256: sha256_hex(content)}}
+
+      {:error, reason} ->
+        {:error, {:chat_template_write, "Failed to write #{path}: #{inspect(reason)}"}}
+    end
+  end
+
+  defp sha256_hex(content) when is_binary(content) do
+    :crypto.hash(:sha256, content) |> Base.encode16(case: :lower)
   end
 
   # -- Manifest top-up ------------------------------------------------------

--- a/apps/orchard_controller/lib/orchard/models/importer.ex
+++ b/apps/orchard_controller/lib/orchard/models/importer.ex
@@ -197,7 +197,6 @@ defmodule Orchard.Models.Importer do
   defp chat_template_present?(_), do: false
 
   defp chat_capability?(capabilities) when is_list(capabilities), do: "chat" in capabilities
-  defp chat_capability?(_), do: false
 
   defp fill_or_reject_chat_template(staged_path) do
     case resolve_chat_template_asset(staged_path) do

--- a/apps/orchard_controller/test/orchard/models/importer_test.exs
+++ b/apps/orchard_controller/test/orchard/models/importer_test.exs
@@ -306,6 +306,56 @@ defmodule Orchard.Models.ImporterTest do
       assert persisted_model.resident_memory_bytes == 0
     end
 
+    test "auto-fills missing chat_template from chat_template.jinja for chat bundles", %{
+      artifacts_root: artifacts_root
+    } do
+      template = "{{ messages[0].content }}"
+      expected_sha = hash_string(template)
+
+      source_dir =
+        create_bundle_with_manifest(
+          artifacts_root,
+          base_manifest_without_resident()
+          |> Map.put("version", "chat-template-autofill")
+          |> Map.put("entrypoint", ".")
+        )
+
+      File.write!(Path.join(source_dir, "tokenizer.json"), ~s({"version":"1.0"}))
+      File.write!(Path.join(source_dir, "chat_template.jinja"), template)
+      File.write!(Path.join(source_dir, "model.safetensors"), "fake-weights")
+
+      assert {:ok, model} = Importer.import_bundle(source_dir, artifacts_root: artifacts_root)
+
+      imported = read_imported_manifest!(model)
+      assert imported["chat_template"]["path"] == "chat_template.jinja"
+      assert imported["chat_template"]["sha256"] == expected_sha
+    end
+
+    test "fails closed when chat bundle has no resolvable chat_template", %{
+      artifacts_root: artifacts_root
+    } do
+      source_dir = Path.join(artifacts_root, "chat_template_missing_bundle")
+      File.mkdir_p!(source_dir)
+
+      File.write!(
+        Path.join(source_dir, "manifest.json"),
+        Jason.encode!(
+          base_manifest_without_resident()
+          |> Map.put("version", "chat-template-missing")
+          |> Map.put("entrypoint", ".")
+        )
+      )
+
+      File.write!(Path.join(source_dir, "tokenizer.json"), ~s({"version":"1.0"}))
+      File.write!(Path.join(source_dir, "model.safetensors"), "fake-weights")
+
+      assert {:error, {:missing_chat_template, message}} =
+               Importer.import_bundle(source_dir, artifacts_root: artifacts_root)
+
+      assert message =~ "chat_template"
+      assert staging_dirs_under(artifacts_root) == []
+    end
+
     test "eager preflight writes compatibility fields on import", %{
       artifacts_root: artifacts_root
     } do
@@ -897,6 +947,7 @@ defmodule Orchard.Models.ImporterTest do
   defp write_bundle_builder_input(source_dir, config_map) do
     File.write!(Path.join(source_dir, "config.json"), Jason.encode!(config_map))
     File.write!(Path.join(source_dir, "tokenizer.json"), ~s({"version": "1.0"}))
+    File.write!(Path.join(source_dir, "chat_template.jinja"), "{{ messages[0].content }}")
     File.write!(Path.join(source_dir, "model.safetensors"), "fake-weights")
   end
 
@@ -912,6 +963,7 @@ defmodule Orchard.Models.ImporterTest do
     bundle_dir = Path.join(root, "test_bundle_#{:rand.uniform(1_000_000)}")
     File.mkdir_p!(bundle_dir)
     write_manifest(bundle_dir, manifest_overrides)
+    ensure_default_chat_template_file!(bundle_dir)
     bundle_dir
   end
 
@@ -919,7 +971,16 @@ defmodule Orchard.Models.ImporterTest do
     bundle_dir = Path.join(root, "test_bundle_#{:rand.uniform(1_000_000)}")
     File.mkdir_p!(bundle_dir)
     File.write!(Path.join(bundle_dir, "manifest.json"), Jason.encode!(manifest_map))
+    ensure_default_chat_template_file!(bundle_dir)
     bundle_dir
+  end
+
+  defp ensure_default_chat_template_file!(bundle_dir) do
+    path = Path.join(bundle_dir, "chat_template.jinja")
+
+    unless File.exists?(path) do
+      File.write!(path, "{{ messages[0].content }}")
+    end
   end
 
   defp create_safe_bundle(root, manifest_overrides \\ %{}) do

--- a/apps/orchard_controller/test/orchard/models/importer_test.exs
+++ b/apps/orchard_controller/test/orchard/models/importer_test.exs
@@ -331,6 +331,41 @@ defmodule Orchard.Models.ImporterTest do
       assert imported["chat_template"]["sha256"] == expected_sha
     end
 
+    test "auto-fills missing chat_template from tokenizer_config.json for chat bundles", %{
+      artifacts_root: artifacts_root
+    } do
+      template = "{{ messages[0].content }}"
+      expected_sha = hash_string(template)
+
+      source_dir = Path.join(artifacts_root, "chat_template_from_tokenizer_config")
+      File.mkdir_p!(source_dir)
+
+      File.write!(
+        Path.join(source_dir, "manifest.json"),
+        Jason.encode!(
+          base_manifest_without_resident()
+          |> Map.put("version", "chat-template-from-config")
+          |> Map.put("entrypoint", ".")
+        )
+      )
+
+      File.write!(Path.join(source_dir, "tokenizer.json"), ~s({"version":"1.0"}))
+
+      File.write!(
+        Path.join(source_dir, "tokenizer_config.json"),
+        Jason.encode!(%{"chat_template" => template})
+      )
+
+      File.write!(Path.join(source_dir, "model.safetensors"), "fake-weights")
+
+      assert {:ok, model} = Importer.import_bundle(source_dir, artifacts_root: artifacts_root)
+
+      imported = read_imported_manifest!(model)
+      assert imported["chat_template"]["path"] == "chat_template.jinja"
+      assert imported["chat_template"]["sha256"] == expected_sha
+      assert File.exists?(Path.join(artifact_path(model), "chat_template.jinja"))
+    end
+
     test "fails closed when chat bundle has no resolvable chat_template", %{
       artifacts_root: artifacts_root
     } do

--- a/apps/orchard_controller/test/orchard/models_test.exs
+++ b/apps/orchard_controller/test/orchard/models_test.exs
@@ -334,6 +334,8 @@ defmodule Orchard.ModelsTest do
 
       File.write!(Path.join(source, "manifest.json"), Jason.encode!(manifest))
       File.write!(Path.join(source, "tokenizer.json"), "{}")
+      File.write!(Path.join(source, "chat_template.jinja"), "{{ messages }}")
+
 
       # First import
       assert {:ok, model} = Importer.import_bundle(source, artifacts_root: root)

--- a/apps/orchard_controller/test/orchard/models_test.exs
+++ b/apps/orchard_controller/test/orchard/models_test.exs
@@ -336,7 +336,6 @@ defmodule Orchard.ModelsTest do
       File.write!(Path.join(source, "tokenizer.json"), "{}")
       File.write!(Path.join(source, "chat_template.jinja"), "{{ messages }}")
 
-
       # First import
       assert {:ok, model} = Importer.import_bundle(source, artifacts_root: root)
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -937,12 +937,23 @@ mkdir -p "$BUNDLE_DIR"
 
 HF_SNAPSHOT="$HOME/.cache/huggingface/hub/models--mlx-community--Llama-3.2-1B-Instruct-4bit/snapshots/<commit-hash>"
 for f in config.json model.safetensors model.safetensors.index.json \
-         tokenizer.json tokenizer_config.json special_tokens_map.json; do
+         tokenizer.json tokenizer_config.json special_tokens_map.json \
+         chat_template.jinja; do
+  if [ -e "$HF_SNAPSHOT/$f" ]; then
     cp -L "$HF_SNAPSHOT/$f" "$BUNDLE_DIR/$f"
+  fi
 done
 
+# If the snapshot has no chat_template.jinja, import can still derive one from
+# tokenizer_config.json when that file embeds chat_template. Chat-capable
+# bundles must resolve a template at import time.
+
 # 3. Create manifest.json
-cat > "$BUNDLE_DIR/manifest.json" << 'EOF'
+# chat_template may be omitted when chat_template.jinja is present in the
+# bundle directory; models import auto-fills path + sha256. Prefer declaring
+# it explicitly for pinned smoke fixtures.
+CHAT_TEMPLATE_SHA=$(shasum -a 256 "$BUNDLE_DIR/chat_template.jinja" | awk '{print $1}')
+cat > "$BUNDLE_DIR/manifest.json" << EOF
 {
   "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
   "version": "08231374eeacb049a0eade7922910865b8fce912",
@@ -956,6 +967,10 @@ cat > "$BUNDLE_DIR/manifest.json" << 'EOF'
   "tokenizer": {
     "kind": "huggingface_tokenizer_json",
     "path": "tokenizer.json"
+  },
+  "chat_template": {
+    "path": "chat_template.jinja",
+    "sha256": "$CHAT_TEMPLATE_SHA"
   },
   "runtime_requirements": {
     "adapter": "mlx_lm",
@@ -981,6 +996,8 @@ bundle-path validation rejects symlinks that resolve outside the bundle root.
 | `max_context_tokens` | From `config.json` `max_position_embeddings` | |
 | `tokenizer.kind` | `"huggingface_tokenizer_json"` | Required |
 | `tokenizer.path` | `"tokenizer.json"` | Relative to bundle root |
+| `chat_template.path` | `"chat_template.jinja"` | Required for chat capability unless import can derive it |
+| `chat_template.sha256` | SHA-256 of template bytes | Auto-filled on import when the template file exists |
 | `runtime_requirements.adapter` | `"mlx_lm"` | Required |
 | `runtime_requirements.min_agent_capability` | `"mlx"` | Required |
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -949,10 +949,22 @@ done
 # bundles must resolve a template at import time.
 
 # 3. Create manifest.json
-# chat_template may be omitted when chat_template.jinja is present in the
-# bundle directory; models import auto-fills path + sha256. Prefer declaring
-# it explicitly for pinned smoke fixtures.
-CHAT_TEMPLATE_SHA=$(shasum -a 256 "$BUNDLE_DIR/chat_template.jinja" | awk '{print $1}')
+# If chat_template.jinja is present, models import can auto-fill path + sha256.
+# You may still declare chat_template explicitly for pinned smoke fixtures.
+# If the file is absent, import derives from tokenizer_config.json when possible.
+if [ -f "$BUNDLE_DIR/chat_template.jinja" ]; then
+  CHAT_TEMPLATE_SHA=$(shasum -a 256 "$BUNDLE_DIR/chat_template.jinja" | awk '{print $1}')
+  CHAT_TEMPLATE_JSON=$(cat <<EOF
+  "chat_template": {
+    "path": "chat_template.jinja",
+    "sha256": "$CHAT_TEMPLATE_SHA"
+  },
+EOF
+)
+else
+  CHAT_TEMPLATE_JSON=""
+fi
+
 cat > "$BUNDLE_DIR/manifest.json" << EOF
 {
   "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
@@ -968,10 +980,7 @@ cat > "$BUNDLE_DIR/manifest.json" << EOF
     "kind": "huggingface_tokenizer_json",
     "path": "tokenizer.json"
   },
-  "chat_template": {
-    "path": "chat_template.jinja",
-    "sha256": "$CHAT_TEMPLATE_SHA"
-  },
+$CHAT_TEMPLATE_JSON
   "runtime_requirements": {
     "adapter": "mlx_lm",
     "min_agent_capability": "mlx"


### PR DESCRIPTION
## Summary

Manual MLX bundle import could succeed without `manifest.chat_template`, then fail later at tokenization. That bit the Topology A smoke on mawarduri with Qwen3.6.

This change makes `models import` resolve `chat_template` at import time for chat-capable bundles:
- auto-fill from `chat_template.jinja` / `.jinja2`
- or derive from `tokenizer_config.json`
- fail closed when nothing resolves
- update the source-dev bundle docs example

Closes #187.

## Why

Hub `BundleBuilder` already handled templates. Plain import did not. Operators got a late 500 instead of an import-time error or autofill.



## Risk Assessment

✅ **Low**

- Import-path only: no scheduler, admission, or public API shape change.
- Fail-closed for chat-capable bundles missing a resolvable template; previously these failed later at tokenization with a generic 500.
- Auto-fill uses the same template sources Hub BundleBuilder already understands (`chat_template.jinja` / `.jinja2`, then `tokenizer_config.json`).
- Staging cleanup on the new failure path is covered by regression tests.
- Residual non-blockers only: duplicated resolver logic with BundleBuilder, list-form tokenizer_config still lightly covered.

## Test plan

- [x] `mise exec -- mix test apps/orchard_controller/test/orchard/models/importer_test.exs` (49 passed)
- [x] autofill from `chat_template.jinja`
- [x] autofill from `tokenizer_config.json`
- [x] fail-closed with no resolvable template + no staging leak
- [x] reviewer agent re-check after feedback: GO

## Notes

Found during Topology A source-dev smoke. No SPEC change intended.
