### PR TITLE
fix(runtime): bootstrap BEAM admission inventory from configured targets

### DIFF
--- a/apps/orchard_controller/lib/orchard/inference.ex
+++ b/apps/orchard_controller/lib/orchard/inference.ex
@@ -307,6 +307,33 @@ defmodule Orchard.Inference do
     end
   end
 
+  @doc """
+  Returns configured static-fallback BEAM Runtime Endpoint targets for discovery.
+
+  Used only when trusted admitted/active inventory is empty and static fallback is
+  enabled. Successful observations create or refresh admission candidates; they do
+  not auto-admit Nodes. gRPC compatibility configured targets stay out of this path
+  so MultiNode compatibility probes remain ephemeral.
+  """
+  @spec discovery_runtime_endpoint_targets() :: [Target.t()]
+  def discovery_runtime_endpoint_targets do
+    if static_runtime_target_fallback_enabled?() do
+      case Nodes.activation_probe_runtime_endpoint_targets() do
+        {:ok, []} ->
+          configured_runtime_endpoint_targets()
+          |> Enum.filter(&(&1.transport == :beam))
+
+        {:ok, [_target | _rest]} ->
+          []
+
+        {:error, :node_inventory_unavailable} ->
+          []
+      end
+    else
+      []
+    end
+  end
+
   @spec request_timeout_ms() :: pos_integer() | nil
   def request_timeout_ms, do: config()[:request_timeout_ms]
 

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -432,7 +432,7 @@ defmodule Orchard.Nodes do
   """
   @spec observe_status(keyword() | Target.t(), map() | struct(), DateTime.t()) ::
           {:ok, Node.t()} | :noop
-  @spec observe_status(keyword(), map() | struct(), DateTime.t(), keyword()) ::
+  @spec observe_status(keyword() | Target.t(), map() | struct(), DateTime.t(), keyword()) ::
           {:ok, Node.t()} | :noop
   def observe_status(target, status_response, observed_at, opts \\ []) do
     if repo_available?() do
@@ -452,6 +452,27 @@ defmodule Orchard.Nodes do
       end
     else
       :noop
+    end
+  rescue
+    _ -> :noop
+  end
+
+  @doc """
+  Persists unauthenticated Runtime Endpoint observation evidence as an admission candidate only.
+
+  Used by controller discovery bootstrap for configured BEAM targets. This path never
+  updates Node rows, never refreshes queue capacity sources, and never clears capacity
+  sources. Invalid or conflicting evidence returns `:noop`.
+  """
+  @spec observe_admission_candidate(keyword() | Target.t(), map() | struct(), DateTime.t()) ::
+          :ok | :noop
+  def observe_admission_candidate(target, status_response, observed_at) do
+    with true <- repo_available?(),
+         {:ok, observation} <- normalize_observation(target, status_response, observed_at),
+         {:ok, :candidate_persisted} <- execute_candidate_only_observe(observation) do
+      :ok
+    else
+      _other -> :noop
     end
   rescue
     _ -> :noop
@@ -1052,7 +1073,7 @@ defmodule Orchard.Nodes do
 
   defp normalize_observation(target, status_response, observed_at) do
     endpoint_transport = target_transport(target)
-    target = target_address(target)
+    target_address = target_address(target)
     metadata = extract_metadata(status_response)
 
     with {:metadata, %{} = meta} <- {:metadata, metadata},
@@ -1060,7 +1081,7 @@ defmodule Orchard.Nodes do
          {:display_name, display_name} when display_name != nil <-
            {:display_name, resolve_display_name(meta)},
          {:port, port} when is_integer(port) and port in 1..65_535 <-
-           {:port, resolve_port(meta, target)} do
+           {:port, resolve_port(meta, target_address)} do
       hostname = map_get(meta, :hostname)
       listen_host = map_get(meta, :listen_host)
 
@@ -1068,12 +1089,13 @@ defmodule Orchard.Nodes do
        %{
          id: node_id,
          display_name: display_name,
-         hostname: non_empty_or(hostname, target_host(target)),
-         advertise_addr: non_empty_or(listen_host, target_host(target)),
+         hostname: non_empty_or(hostname, target_host(target_address)),
+         advertise_addr: non_empty_or(listen_host, target_host(target_address)),
          rpc_port: port,
-         connect_host: connect_host(target),
-         connect_port: connect_port(target),
+         connect_host: connect_host(target_address),
+         connect_port: connect_port(target_address),
          endpoint_transport: endpoint_transport,
+         beam_address: beam_target_address(target),
          health: derive_health(extract_runtime_health(status_response)),
          agent_version: non_empty_or(map_get(meta, :agent_version), nil),
          capabilities: build_capabilities(meta, status_response),
@@ -1538,6 +1560,35 @@ defmodule Orchard.Nodes do
       {:noop, :constraint_conflict}
   end
 
+  defp execute_candidate_only_observe(observation) do
+    Repo.transaction(fn ->
+      conflicting = load_conflicting_nodes(observation)
+      existing = classify_conflicting_nodes(conflicting, observation)
+
+      case ensure_no_identity_conflict(existing, observation) do
+        :ok ->
+          # Candidate-only path never mutates Node rows, even when a provisioned
+          # or registered placeholder already owns the claimed identity.
+          upsert_observed_admission_candidate(observation)
+          :candidate_persisted
+
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, :candidate_persisted} -> {:ok, :candidate_persisted}
+      {:error, :identity_conflict} -> {:noop, :identity_conflict}
+    end
+  rescue
+    error in Ecto.ConstraintError ->
+      Logger.debug(
+        "Candidate-only observation lost concurrent insert race: #{inspect(error.constraint)}"
+      )
+
+      {:noop, :constraint_conflict}
+  end
+
   defp execute_authenticated_observe(
          %Target{transport: :beam} = target,
          observation,
@@ -1743,13 +1794,17 @@ defmodule Orchard.Nodes do
   defp ensure_fresh_observation(_existing, _observation), do: :ok
 
   defp upsert_observation(%{existing_by_id: %Node{} = existing}, observation) do
-    existing
-    |> Node.changeset(
+    attrs =
       observation
       |> Map.delete(:id)
       |> Map.delete(:last_heartbeat_at)
+      |> Map.delete(:endpoint_transport)
+      |> Map.delete(:beam_address)
       |> Map.put(:state, existing.state)
-    )
+      |> preserve_beam_connection_inventory(existing, observation)
+
+    existing
+    |> Node.changeset(attrs)
     |> Repo.update!()
   end
 
@@ -1898,6 +1953,14 @@ defmodule Orchard.Nodes do
     end
   end
 
+  defp preserve_beam_connection_inventory(attrs, node, %{endpoint_transport: :beam}) do
+    attrs
+    |> Map.put(:connect_host, node.connect_host)
+    |> Map.put(:connect_port, node.connect_port)
+  end
+
+  defp preserve_beam_connection_inventory(attrs, _node, _observation), do: attrs
+
   defp preserve_beam_connection_inventory(node, %{endpoint_transport: :beam} = observation) do
     Map.merge(observation, %{
       connect_host: node.connect_host,
@@ -1975,6 +2038,18 @@ defmodule Orchard.Nodes do
     claimed_node_id = observation.id
     endpoint_target = endpoint_target(observation)
 
+    case lock_open_observed_candidate_by_endpoint(observation, claimed_node_id, endpoint_target) do
+      %AdmissionCandidate{} = candidate ->
+        candidate
+
+      nil ->
+        # Pre-#192 BEAM candidates may still use advertise_addr:rpc_port keys.
+        # Reconcile those open rows onto the configured service@host identity.
+        lock_legacy_beam_observed_candidate(observation, claimed_node_id)
+    end
+  end
+
+  defp lock_open_observed_candidate_by_endpoint(observation, claimed_node_id, endpoint_target) do
     AdmissionCandidate
     |> where([candidate], candidate.source == :runtime_endpoint_observation)
     |> where([candidate], candidate.admission_category in [:pending_observed, :rejected])
@@ -1990,6 +2065,29 @@ defmodule Orchard.Nodes do
     |> Repo.one()
   end
 
+  defp lock_legacy_beam_observed_candidate(
+         %{endpoint_transport: :beam} = observation,
+         claimed_node_id
+       ) do
+    endpoint_target = endpoint_target(observation)
+
+    AdmissionCandidate
+    |> where([candidate], candidate.source == :runtime_endpoint_observation)
+    |> where([candidate], candidate.admission_category in [:pending_observed, :rejected])
+    |> where([candidate], candidate.endpoint_transport == :beam)
+    |> where([candidate], candidate.endpoint_target != ^endpoint_target)
+    |> where(
+      [candidate],
+      fragment("?->>'claimed_node_id' = ?", candidate.observed_identity, ^claimed_node_id)
+    )
+    |> order_by([candidate], desc: candidate.updated_at)
+    |> limit(1)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+  end
+
+  defp lock_legacy_beam_observed_candidate(_observation, _claimed_node_id), do: nil
+
   defp observed_candidate_attrs(observation) do
     %{
       source: :runtime_endpoint_observation,
@@ -2003,6 +2101,10 @@ defmodule Orchard.Nodes do
       last_observed_at: observation.last_heartbeat_at
     }
   end
+
+  defp endpoint_target(%{endpoint_transport: :beam, beam_address: address})
+       when is_binary(address) and address != "",
+       do: address
 
   defp endpoint_target(observation) do
     case {observation.connect_host, observation.connect_port} do
@@ -3038,6 +3140,15 @@ defmodule Orchard.Nodes do
     end
   end
 
+  defp beam_target_address(%Target{transport: :beam, address: address}) when is_atom(address),
+    do: Atom.to_string(address)
+
+  defp beam_target_address(%Target{transport: :beam, address: address})
+       when is_binary(address) and address != "",
+       do: address
+
+  defp beam_target_address(_target), do: nil
+
   defp map_get(map, key) when is_map(map) and is_atom(key) do
     case Map.fetch(map, key) do
       {:ok, value} -> value
@@ -3136,7 +3247,8 @@ defmodule Orchard.Nodes do
 
   defp target_address(%Target{transport: :grpc_compat, address: address}), do: address
   defp target_address(%Target{transport: :beam}), do: []
-  defp target_address(target), do: target
+  defp target_address(target) when is_list(target), do: target
+  defp target_address(_target), do: []
 
   defp valid_connect_target?(host, port), do: non_empty?(host) and is_integer(port)
 

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/activation_probe.ex
@@ -1,10 +1,16 @@
 defmodule Orchard.RuntimeEndpoint.ActivationProbe do
   @moduledoc """
-  Leader-side status-only probes for admitted and active Runtime Endpoint Nodes.
+  Leader-side status probes for Runtime Endpoint Nodes and configured discovery targets.
 
-  Refreshes authenticated heartbeats and capacity evidence on a bounded interval
-  independent of request traffic, and demotes idle Node loss through transport
-  failure recording plus a heartbeat-age sweep (ADR 0015 / issue #148).
+  For admitted and active inventory, refreshes authenticated heartbeats and capacity
+  evidence on a bounded interval independent of request traffic, and demotes idle Node
+  loss through transport failure recording plus a heartbeat-age sweep (ADR 0015 /
+  issue #148).
+
+  When trusted admitted/active inventory is empty and static runtime target fallback is
+  enabled, also probes configured Runtime Endpoint targets and persists successful
+  unauthenticated observations as `pending_observed` admission candidates (issue #192).
+  Discovery never auto-admits a Node.
   """
 
   use GenServer
@@ -15,7 +21,7 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
   alias Orchard.Inference
   alias Orchard.NodeHeartbeats
   alias Orchard.Nodes
-  alias Orchard.RuntimeEndpoint.{BeamClient, GrpcCompatibilityClient}
+  alias Orchard.RuntimeEndpoint.{BeamClient, GrpcCompatibilityClient, Target}
 
   @default_interval_ms 5_000
   @default_timeout_ms 5_000
@@ -71,19 +77,33 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
 
     with :ok <- ControlPlane.authorize_write_path(:node_lifecycle),
          true <- allowed_client?(client) do
-      targets =
+      trusted_targets =
         Keyword.get_lazy(opts, :targets, fn ->
           Inference.activation_probe_runtime_endpoint_targets()
         end)
 
-      results =
-        targets
-        |> Enum.flat_map(&probe_target(&1, client, timeout, observed_at))
+      discovery_targets =
+        if Keyword.has_key?(opts, :targets) do
+          Keyword.get(opts, :discovery_targets, [])
+        else
+          Keyword.get_lazy(opts, :discovery_targets, fn ->
+            Inference.discovery_runtime_endpoint_targets()
+          end)
+        end
+
+      trusted_results =
+        Enum.flat_map(trusted_targets, &probe_target(&1, client, timeout, observed_at, :trusted))
+
+      discovery_results =
+        Enum.flat_map(
+          discovery_targets,
+          &probe_target(&1, client, timeout, observed_at, :discovery)
+        )
 
       _ = Nodes.sweep_stale_node_heartbeats(observed_at)
       safe_prune_heartbeats(heartbeat_context, observed_at)
 
-      {:ok, results}
+      {:ok, trusted_results ++ discovery_results}
     else
       false -> {:error, :activation_probe_transport_disabled}
       {:error, reason} -> {:error, reason}
@@ -136,30 +156,60 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbe do
       :ok
   end
 
-  defp probe_target(target, client, timeout, observed_at) do
+  defp probe_target(target, client, timeout, observed_at, mode) do
     case client.connect(target) do
       {:ok, connection} ->
         try do
           case client.status(connection, timeout: timeout) do
-            {:ok, _observation} ->
+            {:ok, observation} ->
+              maybe_persist_discovery_observation(mode, target, observation, observed_at)
               [%{target_id: target.id, status: :observed}]
 
             {:error, reason} ->
-              record_probe_failure(target, reason, observed_at)
+              record_probe_failure(mode, target, reason, observed_at)
           end
         after
           disconnect(client, connection)
         end
 
       {:error, reason} ->
-        record_probe_failure(target, reason, observed_at)
+        record_probe_failure(mode, target, reason, observed_at)
     end
   end
 
-  defp record_probe_failure(target, reason, observed_at) do
+  defp maybe_persist_discovery_observation(
+         :discovery,
+         %Target{transport: :beam} = target,
+         observation,
+         observed_at
+       ) do
+    case Nodes.observe_admission_candidate(target, observation, observed_at) do
+      :ok ->
+        :ok
+
+      :noop ->
+        Logger.info("Discovery observation did not persist a candidate for #{target.id}")
+
+        :ok
+    end
+  end
+
+  # gRPC compatibility discovery stays ephemeral even if a caller injects it.
+  defp maybe_persist_discovery_observation(:discovery, _target, _observation, _observed_at),
+    do: :ok
+
+  defp maybe_persist_discovery_observation(:trusted, _target, _observation, _observed_at), do: :ok
+
+  defp record_probe_failure(:trusted, target, reason, observed_at) do
     # Pass the raw reason so transport_failure_reason?/1 classifies correctly.
     # Seam rejections are ignored by Nodes.record_transport_failure/3.
     _ = Nodes.record_transport_failure(target, reason, observed_at)
+    log_probe_failure(target.id, reason)
+  end
+
+  defp record_probe_failure(:discovery, target, reason, _observed_at) do
+    # Discovery targets are not yet trusted inventory. Failures stay ephemeral so
+    # a missing configured peer does not invent Node demotion rows.
     log_probe_failure(target.id, reason)
   end
 

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -303,6 +303,42 @@ defmodule Orchard.InferenceTest do
     end
   end
 
+  describe "discovery_runtime_endpoint_targets/0" do
+    @tag :db
+    test "issue #192 returns only BEAM configured targets when inventory empty and fallback on" do
+      put_inference(
+        allow_static_runtime_target_fallback: true,
+        runtime_endpoint_targets: [
+          %{
+            transport: :beam,
+            address: "orchard_node_agent@10.0.0.9",
+            metadata: %{source_dev: true}
+          },
+          [host: "10.0.0.9", port: 50_071]
+        ]
+      )
+
+      assert [
+               %Target{
+                 transport: :beam,
+                 address: "orchard_node_agent@10.0.0.9"
+               }
+             ] = Inference.discovery_runtime_endpoint_targets()
+    end
+
+    @tag :db
+    test "issue #192 returns empty when static fallback is disabled" do
+      put_inference(
+        allow_static_runtime_target_fallback: false,
+        runtime_endpoint_targets: [
+          %{transport: :beam, address: "orchard_node_agent@10.0.0.9"}
+        ]
+      )
+
+      assert Inference.discovery_runtime_endpoint_targets() == []
+    end
+  end
+
   describe "source-dev runtime endpoint transport config" do
     test "SPEC.md §7.5.0 peer-grant mode selects BEAM without legacy targets" do
       inference =

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -1050,7 +1050,7 @@ defmodule Orchard.NodesTest do
 
     test "SPEC.md §4.2 first BEAM observation creates a BEAM admission candidate" do
       node_id = Ecto.UUID.generate()
-      target = Target.beam(node_id, address: :orchard_node_agent@localhost)
+      target = Target.beam(node_id, address: :"orchard_node_agent@192.168.88.9")
       observed_at = DateTime.utc_now()
 
       observation =
@@ -1064,8 +1064,8 @@ defmodule Orchard.NodesTest do
             node_id: node_id,
             display_name: "beam-candidate",
             hostname: "beam-candidate.local",
-            listen_host: "10.0.0.16",
-            listen_port: 9444
+            listen_host: "127.0.0.1",
+            listen_port: 50_071
           },
           health: %{ready: true},
           placements: []
@@ -1078,8 +1078,114 @@ defmodule Orchard.NodesTest do
       assert candidate.source == :runtime_endpoint_observation
       assert candidate.admission_category == :pending_observed
       assert candidate.endpoint_transport == :beam
-      assert candidate.endpoint_target == "10.0.0.16:9444"
+      assert candidate.endpoint_target == "orchard_node_agent@192.168.88.9"
+      assert candidate.target_ref == "orchard_node_agent@192.168.88.9"
       assert candidate.observed_identity["claimed_node_id"] == node_id
+    end
+
+    test "issue #192 candidate-only observation never mutates an existing placeholder node" do
+      node_id = Ecto.UUID.generate()
+
+      node =
+        insert_node!(%{
+          id: node_id,
+          state: :registered,
+          display_name: "placeholder-node",
+          hostname: "placeholder.local",
+          advertise_addr: "10.0.0.50",
+          rpc_port: 9444,
+          health: :unreachable,
+          agent_version: "0.1.0"
+        })
+
+      target = Target.beam(node_id, address: :"orchard_node_agent@192.168.88.9")
+      observed_at = DateTime.utc_now()
+
+      observation =
+        Observation.new(%{
+          endpoint_id: target.id,
+          target: target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 1,
+          metadata: %{
+            node_id: node_id,
+            display_name: "discovered-spoof",
+            hostname: "discovered.local",
+            listen_host: "127.0.0.1",
+            listen_port: 50_071,
+            agent_version: "9.9.9"
+          },
+          health: %{ready: true},
+          placements: []
+        })
+
+      assert :ok = Nodes.observe_admission_candidate(target, observation, observed_at)
+
+      reloaded = Repo.get!(Node, node.id)
+      assert reloaded.display_name == "placeholder-node"
+      assert reloaded.hostname == "placeholder.local"
+      assert reloaded.advertise_addr == "10.0.0.50"
+      assert reloaded.rpc_port == 9444
+      assert reloaded.agent_version == "0.1.0"
+      assert reloaded.health == :unreachable
+      assert reloaded.state == :registered
+
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+      assert candidate.admission_category == :pending_observed
+      assert candidate.endpoint_target == "orchard_node_agent@192.168.88.9"
+      assert candidate.observed_identity["display_name"] == "discovered-spoof"
+    end
+
+    test "issue #192 legacy BEAM host:port candidates reconcile onto service@host" do
+      node_id = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+
+      {:ok, legacy} =
+        %AdmissionCandidate{}
+        |> AdmissionCandidate.changeset(%{
+          source: :runtime_endpoint_observation,
+          admission_category: :pending_observed,
+          observed_identity: %{
+            "claimed_node_id" => node_id,
+            "display_name" => "legacy-beam"
+          },
+          target_ref: "127.0.0.1:50071",
+          endpoint_transport: :beam,
+          endpoint_target: "127.0.0.1:50071",
+          inventory: %{},
+          compatibility_evidence: %{},
+          last_observed_at: DateTime.add(now, -5, :second)
+        })
+        |> Repo.insert()
+
+      target = Target.beam(node_id, address: :"orchard_node_agent@192.168.88.9")
+
+      observation =
+        Observation.new(%{
+          endpoint_id: target.id,
+          target: target,
+          availability: :available,
+          aggregate_active_request_count: 0,
+          aggregate_max_concurrency: 1,
+          metadata: %{
+            node_id: node_id,
+            display_name: "legacy-beam",
+            hostname: "legacy-beam.local",
+            listen_host: "127.0.0.1",
+            listen_port: 50_071
+          },
+          health: %{ready: true},
+          placements: []
+        })
+
+      assert :ok = Nodes.observe_admission_candidate(target, observation, now)
+
+      assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+      assert candidate.id == legacy.id
+      assert candidate.endpoint_target == "orchard_node_agent@192.168.88.9"
+      assert candidate.target_ref == "orchard_node_agent@192.168.88.9"
+      assert Repo.get(Node, node_id) == nil
     end
 
     test "SPEC.md §4.3 rejection clear appends history before registered node admission" do

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs
@@ -3,9 +3,9 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
 
   alias Orchard.Inference
   alias Orchard.Nodes
-  alias Orchard.Nodes.{Node, NodeHeartbeat}
+  alias Orchard.Nodes.{AdmissionCandidate, Node, NodeHeartbeat}
   alias Orchard.RuntimeEndpoint.ActivationProbe
-  alias Orchard.RuntimeEndpoint.Target
+  alias Orchard.RuntimeEndpoint.{Observation, Target}
 
   defmodule FailingClient do
     def connect(_target), do: {:error, :authenticated_transport_failed}
@@ -26,6 +26,33 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
     def status(_connection, _opts), do: {:ok, %{}}
   end
 
+  defmodule DiscoveryClient do
+    def connect(target), do: {:ok, %{target: target}}
+    def disconnect(_connection), do: :ok
+
+    def status(%{target: target}, _opts) do
+      node_id = Process.get(:activation_probe_discovery_node_id)
+
+      {:ok,
+       Observation.new(%{
+         endpoint_id: target.id,
+         target: target,
+         availability: :available,
+         aggregate_active_request_count: 0,
+         aggregate_max_concurrency: 1,
+         metadata: %{
+           node_id: node_id,
+           display_name: "discovered-beam",
+           hostname: "discovered-beam.local",
+           listen_host: "127.0.0.1",
+           listen_port: 50_071
+         },
+         health: %{ready: true},
+         placements: []
+       })}
+    end
+  end
+
   defmodule RaisingHeartbeatContext do
     def prune_expired(_observed_at), do: raise("retention unavailable")
   end
@@ -37,7 +64,7 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
       :orchard_controller,
       :activation_probe,
       Keyword.merge(previous,
-        allowed_clients: [FailingClient, RejectingClient, IdleClient],
+        allowed_clients: [FailingClient, RejectingClient, IdleClient, DiscoveryClient],
         interval_ms: 5_000
       )
     )
@@ -216,6 +243,174 @@ defmodule Orchard.RuntimeEndpoint.ActivationProbeTest do
              ActivationProbe.run_once(client: IdleClient, timeout: 50)
 
     assert Nodes.sweep_stale_node_heartbeats() == :noop
+  end
+
+  test "issue #192 configured discovery bootstrap creates pending_observed candidate" do
+    node_id = Ecto.UUID.generate()
+    Process.put(:activation_probe_discovery_node_id, node_id)
+
+    target =
+      Target.normalize(%{
+        transport: :beam,
+        address: :"orchard_node_agent@192.168.88.9",
+        metadata: %{source_dev: true}
+      })
+
+    assert Repo.aggregate(Node, :count) == 0
+    assert Nodes.list_admission_candidates() == []
+
+    assert {:ok, [%{target_id: target_id, status: :observed}]} =
+             ActivationProbe.run_once(
+               client: DiscoveryClient,
+               timeout: 50,
+               targets: [],
+               discovery_targets: [target]
+             )
+
+    assert target_id == target.id
+    assert Repo.get(Node, node_id) == nil
+
+    assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+    assert candidate.admission_category == :pending_observed
+    assert candidate.endpoint_transport == :beam
+    assert candidate.endpoint_target == "orchard_node_agent@192.168.88.9"
+    assert candidate.target_ref == "orchard_node_agent@192.168.88.9"
+    assert candidate.observed_identity["claimed_node_id"] == node_id
+  end
+
+  test "issue #192 discovery failures do not invent node demotion rows" do
+    target =
+      Target.normalize(%{
+        transport: :beam,
+        address: :"orchard_node_agent@192.168.88.10",
+        metadata: %{source_dev: true}
+      })
+
+    assert {:ok, []} =
+             ActivationProbe.run_once(
+               client: FailingClient,
+               timeout: 50,
+               targets: [],
+               discovery_targets: [target]
+             )
+
+    assert Repo.aggregate(Node, :count) == 0
+    assert Nodes.list_admission_candidates() == []
+  end
+
+  test "issue #192 gRPC compatibility discovery stays ephemeral" do
+    node_id = Ecto.UUID.generate()
+    Process.put(:activation_probe_discovery_node_id, node_id)
+
+    target =
+      Target.grpc_compat(
+        host: "10.0.0.42",
+        port: 50_071,
+        metadata: %{source_dev: true}
+      )
+
+    assert {:ok, [%{target_id: target_id, status: :observed}]} =
+             ActivationProbe.run_once(
+               client: DiscoveryClient,
+               timeout: 50,
+               targets: [],
+               discovery_targets: [target]
+             )
+
+    assert target_id == target.id
+    assert Repo.get(Node, node_id) == nil
+    assert Nodes.list_admission_candidates() == []
+  end
+
+  test "issue #192 binary and atom BEAM addresses normalize to one candidate identity" do
+    node_id = Ecto.UUID.generate()
+    Process.put(:activation_probe_discovery_node_id, node_id)
+
+    atom_target =
+      Target.normalize(%{
+        transport: :beam,
+        address: :"orchard_node_agent@10.0.0.9",
+        metadata: %{source_dev: true}
+      })
+
+    binary_target =
+      Target.normalize(%{
+        transport: :beam,
+        address: "orchard_node_agent@10.0.0.9",
+        metadata: %{source_dev: true}
+      })
+
+    assert {:ok, [%{status: :observed}]} =
+             ActivationProbe.run_once(
+               client: DiscoveryClient,
+               timeout: 50,
+               targets: [],
+               discovery_targets: [atom_target]
+             )
+
+    assert {:ok, [%{status: :observed}]} =
+             ActivationProbe.run_once(
+               client: DiscoveryClient,
+               timeout: 50,
+               targets: [],
+               discovery_targets: [binary_target],
+               observed_at: DateTime.add(DateTime.utc_now(), 1, :second)
+             )
+
+    assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+    assert candidate.endpoint_target == "orchard_node_agent@10.0.0.9"
+    assert candidate.target_ref == "orchard_node_agent@10.0.0.9"
+    assert Repo.get(Node, node_id) == nil
+  end
+
+  test "issue #192 discovery does not mutate existing registered placeholder nodes" do
+    node_id = Ecto.UUID.generate()
+    Process.put(:activation_probe_discovery_node_id, node_id)
+
+    node =
+      insert_active_node!(%{
+        id: node_id,
+        state: :registered,
+        display_name: "registered-placeholder",
+        hostname: "registered-placeholder.local",
+        advertise_addr: "10.0.1.20",
+        rpc_port: 9444,
+        connect_host: "10.0.1.20",
+        connect_port: 9444,
+        health: :unreachable,
+        last_heartbeat_at: nil
+      })
+
+    # insert_active_node! forces active; rewrite to registered placeholder shape.
+    node =
+      node
+      |> Ecto.Changeset.change(%{state: :registered, health: :unreachable})
+      |> Repo.update!()
+
+    target =
+      Target.normalize(%{
+        transport: :beam,
+        address: :"orchard_node_agent@192.168.88.9",
+        metadata: %{source_dev: true}
+      })
+
+    assert {:ok, [%{status: :observed}]} =
+             ActivationProbe.run_once(
+               client: DiscoveryClient,
+               timeout: 50,
+               targets: [],
+               discovery_targets: [target]
+             )
+
+    reloaded = Repo.get!(Node, node.id)
+    assert reloaded.state == :registered
+    assert reloaded.display_name == "registered-placeholder"
+    assert reloaded.advertise_addr == "10.0.1.20"
+    assert reloaded.health == :unreachable
+
+    assert [%AdmissionCandidate{} = candidate] = Nodes.list_admission_candidates()
+    assert candidate.endpoint_target == "orchard_node_agent@192.168.88.9"
+    assert candidate.observed_identity["claimed_node_id"] == node_id
   end
 
   defp put_unreachable_threshold!(previous, threshold_ms) do

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -752,10 +752,11 @@ Run this before the first Topology B / two-Mac BEAM smoke on macOS.
    - If every `/console` LiveView returns 500 with `Sentry.LiveViewHook` undefined, recompile LiveView then Sentry (`mix deps.compile phoenix_live_view` and `mix deps.compile sentry --force`) and restart the controller.
    - Tracked by issue #191.
 
-8. **Admission inventory gap**
-   - Configured BEAM targets can serve inference before durable `nodes` rows exist.
-   - Console may show Live Cluster health while Registered Nodes inventory stays empty and candidates remain `pending_observed`.
-   - Tracked by issue #192.
+8. **Admission inventory bootstrap**
+   - With static runtime target fallback enabled, the controller ActivationProbe probes configured Runtime Endpoint targets when trusted admitted/active inventory is empty.
+   - Successful observations create or refresh durable `pending_observed` admission candidates without auto-admit.
+   - BEAM candidate `endpoint_target` / `target_ref` keep the configured `service@host` identity instead of collapsing to loopback gRPC listen metadata.
+   - Operators still review and admit through the normal admission path (#128 covers policy/decision detail).
 
 ### Verification
 


### PR DESCRIPTION
## Summary

Closes #192.

On multi-host source-dev, configured BEAM Runtime Endpoint targets can be healthy for transport and inference while durable admission inventory stays empty. Console Live Cluster can look fine while Registered Nodes stays at 0. Candidate identity also collapsed to loopback gRPC listen metadata (`127.0.0.1:50071`) even when the real target was `orchard_node_agent@LAN`.

This change bootstraps durable `pending_observed` candidates from configured BEAM targets on the normal controller probe path, without auto-admit.

## What changed

- `ActivationProbe` still owns trusted admitted/active liveness.
- When trusted admitted/active inventory is empty and static fallback is enabled, it also probes configured **BEAM** discovery targets.
- Successful discovery observations go through a new candidate-only API: `Nodes.observe_admission_candidate/3`.
  - Creates or refreshes `pending_observed` candidates.
  - Never updates Node rows.
  - Never refreshes or clears queue capacity sources.
- BEAM candidate `endpoint_target` / `target_ref` keep configured `service@host` identity instead of falling back to advertise/listen host:port.
- Open legacy BEAM candidates keyed as `host:port` are reconciled onto `service@host` by claimed node id.
- gRPC compatibility discovery stays ephemeral at both selection and persistence boundaries.
- `docs/local-dev.md` admission gap note updated.

Policy/admission decision remains #128. This PR is discovery bootstrap only.

## Risk Assessment

✅ **Low**

- Default-off outside source-dev/static fallback: production `allow_static_runtime_target_fallback` stays false.
- Discovery is BEAM-only and candidate-only. No auto-admit. No Node mutation. No capacity publish/clear on this path.
- Trusted ActivationProbe demotion path is unchanged.
- MultiNode ephemeral gRPC compatibility probes remain ephemeral.
- Residual non-blockers:
  - Discovery still depends on status metadata providing a valid port for observation normalization.
  - Inventory can change between the empty-inventory snapshot and probe completion. Evidence remains pending_observed either way.

## Test plan

Local quality gates:

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `ORCHARD_TEST_NODE_AGENT_PORT=60752 mise exec -- mix test`
  - Result: **738 passed, 10 excluded**, exit 0
- Adjacent controller suite:
  - `ORCHARD_TEST_NODE_AGENT_PORT=60752 mise exec -- mix test apps/orchard_controller/test/orchard/runtime_endpoint/activation_probe_test.exs apps/orchard_controller/test/orchard/nodes_test.exs apps/orchard_controller/test/orchard/inference_test.exs apps/orchard_controller/test/orchard/console/runtime_test.exs`
  - Result: **294 passed**

Focused regressions cover:

- configured BEAM discovery creates `pending_observed`
- discovery failures create no demotion rows
- gRPC discovery stays ephemeral
- atom/binary BEAM addresses normalize to one candidate
- candidate-only path does not mutate registered placeholders
- legacy `host:port` BEAM candidates reconcile to `service@host`
- discovery target gating (fallback off / BEAM-only filter)

Manual multi-host smoke still useful after merge:

1. empty `nodes` + configured `ORCHARD_RUNTIME_ENDPOINT_TARGETS`
2. wait one ActivationProbe cycle
3. confirm admission candidate appears with `service@host`
4. confirm no auto-admit and Console inventory is no longer all-zero when Live Cluster is healthy