### PR TITLE
fix(console): tolerate missing Sentry.LiveViewHook

### DIFF
--- a/apps/orchard_controller/lib/orchard/application.ex
+++ b/apps/orchard_controller/lib/orchard/application.ex
@@ -46,6 +46,7 @@ defmodule Orchard.Application do
         Logger.warning("Sentry handler install failed, continuing without: #{inspect(reason)}")
     end
 
+    warn_if_sentry_live_view_hook_unavailable()
     attach_startup_license_context()
 
     Supervisor.start_link(child_specs(),
@@ -74,6 +75,19 @@ defmodule Orchard.Application do
   def config_change(changed, _new, removed) do
     Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp warn_if_sentry_live_view_hook_unavailable do
+    if OrchardConsole.sentry_live_view_hook_available?() do
+      :ok
+    else
+      Logger.warning(
+        "Sentry.LiveViewHook is unavailable; Console mounts without Sentry LiveView context. " <>
+          "If this is unexpected, recompile LiveView then Sentry " <>
+          "(`mix deps.compile phoenix_live_view` and `mix deps.compile sentry --force`) " <>
+          "and restart the controller. See issue #191."
+      )
+    end
   end
 
   defp attach_startup_license_context do

--- a/apps/orchard_controller/lib/orchard/console.ex
+++ b/apps/orchard_controller/lib/orchard/console.ex
@@ -51,12 +51,20 @@ defmodule OrchardConsole do
   end
 
   @doc """
-  LiveView `on_mount` hook that gates console access on mount/reconnect.
+  LiveView `on_mount` hooks shared by Console LiveViews.
 
-  Checks both the feature flag (`console_enabled`) and the session auth
-  marker (for `:basic` auth mode). Redirects to `/console` on denial,
-  which re-enters the HTTP plug for proper 404 or 401 handling.
+  - `:ensure_console_access` gates console access on mount/reconnect. Checks the
+    feature flag (`console_enabled`) and the session auth marker (for `:basic`
+    auth mode). Redirects to `/console` on denial, which re-enters the HTTP plug
+    for proper 404 or 401 handling.
+  - `:maybe_sentry_live_view_hook` optionally attaches Sentry LiveView context.
+    Sentry compiles `Sentry.LiveViewHook` only when `Phoenix.LiveView` is already
+    loaded on Sentry's compile path (`phoenix_live_view` is optional there). A
+    hard `on_mount(Sentry.LiveViewHook)` turns that compile-order footgun into a
+    Console-wide mount 500. Delegate only when the hook module is available.
   """
+  @spec on_mount(atom(), map() | :not_mounted_at_router, map(), Phoenix.LiveView.Socket.t()) ::
+          {:cont, Phoenix.LiveView.Socket.t()} | {:halt, Phoenix.LiveView.Socket.t()}
   def on_mount(:ensure_console_access, _params, session, socket) do
     config = OrchardConsole.Auth.console_config()
 
@@ -69,6 +77,41 @@ defmodule OrchardConsole do
         {:halt, Phoenix.LiveView.redirect(socket, to: "/console")}
     end
   end
+
+  def on_mount(:maybe_sentry_live_view_hook, params, session, socket) do
+    maybe_attach_sentry_live_view_hook(params, session, socket)
+  end
+
+  @doc """
+  Returns true when Sentry's optional LiveView hook module is loaded.
+
+  Used by Console mount and controller boot diagnostics.
+  """
+  @spec sentry_live_view_hook_available?(module()) :: boolean()
+  def sentry_live_view_hook_available?(hook_module \\ sentry_live_view_hook_module())
+      when is_atom(hook_module) do
+    Code.ensure_loaded?(hook_module) and function_exported?(hook_module, :on_mount, 4)
+  end
+
+  @doc false
+  @spec maybe_attach_sentry_live_view_hook(
+          map() | :not_mounted_at_router,
+          map(),
+          Phoenix.LiveView.Socket.t(),
+          keyword()
+        ) :: {:cont, Phoenix.LiveView.Socket.t()} | {:halt, Phoenix.LiveView.Socket.t()}
+  def maybe_attach_sentry_live_view_hook(params, session, socket, opts \\ []) do
+    hook_module = Keyword.get(opts, :hook_module, sentry_live_view_hook_module())
+
+    if sentry_live_view_hook_available?(hook_module) do
+      hook_module.on_mount(:default, params, session, socket)
+    else
+      {:cont, socket}
+    end
+  end
+
+  @spec sentry_live_view_hook_module() :: module()
+  def sentry_live_view_hook_module, do: Module.concat([Sentry, LiveViewHook])
 
   @doc """
   Shared helpers for console LiveViews and components.
@@ -84,7 +127,9 @@ defmodule OrchardConsole do
       use Phoenix.LiveView,
         layout: {OrchardConsole.Layouts, :app}
 
-      on_mount(Sentry.LiveViewHook)
+      # Runtime-gated: Sentry.LiveViewHook is omitted when Sentry compiled without
+      # Phoenix.LiveView on its path. See issue #191.
+      on_mount({OrchardConsole, :maybe_sentry_live_view_hook})
 
       unquote(html_helpers())
     end

--- a/apps/orchard_controller/test/orchard/console_test.exs
+++ b/apps/orchard_controller/test/orchard/console_test.exs
@@ -1,3 +1,18 @@
+defmodule OrchardConsoleTest.MissingSentryLiveViewHook do
+  @moduledoc false
+end
+
+defmodule OrchardConsoleTest.StubSentryLiveViewHook do
+  @moduledoc false
+
+  @spec on_mount(atom(), map(), map(), Phoenix.LiveView.Socket.t()) ::
+          {:cont, Phoenix.LiveView.Socket.t()}
+  def on_mount(hook_id, params, session, socket) do
+    send(self(), {:stub_sentry_live_view_hook, hook_id, params, session, socket})
+    {:cont, %{socket | id: socket.id <> "-hooked"}}
+  end
+end
+
 defmodule OrchardConsoleTest do
   use ExUnit.Case, async: true
 
@@ -22,6 +37,92 @@ defmodule OrchardConsoleTest do
 
     test "stays short enough for the fixed-width sidebar" do
       assert String.length(OrchardConsole.display_version()) <= 24
+    end
+  end
+
+  describe "optional Sentry LiveView hook (issue #191)" do
+    @missing_hook_module :"Elixir.OrchardConsoleTest.MissingSentryLiveViewHookNeverDefined"
+
+    test "live_view quote mounts the runtime-gated OrchardConsole hook" do
+      source = OrchardConsole.live_view() |> Macro.to_string()
+
+      assert source =~ "maybe_sentry_live_view_hook"
+      refute source =~ "on_mount(Sentry.LiveViewHook)"
+      refute source =~ "on_mount(Sentry.LiveViewHook,"
+    end
+
+    test "reports unavailable when the Sentry hook module is not loaded" do
+      refute OrchardConsole.sentry_live_view_hook_available?(@missing_hook_module)
+    end
+
+    test "reports unavailable when the module loads without on_mount/4" do
+      assert Code.ensure_loaded?(OrchardConsoleTest.MissingSentryLiveViewHook)
+
+      refute OrchardConsole.sentry_live_view_hook_available?(
+               OrchardConsoleTest.MissingSentryLiveViewHook
+             )
+    end
+
+    test "reports available for the real Sentry LiveView hook when compiled in" do
+      # Normal umbrella compile order loads LiveView before Sentry, so the hook
+      # exists in test. Issue #191 is the inverted compile-order failure mode.
+      assert Code.ensure_loaded?(Sentry.LiveViewHook)
+      assert function_exported?(Sentry.LiveViewHook, :on_mount, 4)
+      assert OrchardConsole.sentry_live_view_hook_available?()
+      assert OrchardConsole.sentry_live_view_hook_available?(Sentry.LiveViewHook)
+    end
+
+    test "continues mount when the Sentry LiveView hook module is missing" do
+      socket = %Phoenix.LiveView.Socket{}
+
+      assert {:cont, ^socket} =
+               OrchardConsole.maybe_attach_sentry_live_view_hook(
+                 %{},
+                 %{},
+                 socket,
+                 hook_module: @missing_hook_module
+               )
+    end
+
+    test "continues mount when the module lacks on_mount/4" do
+      socket = %Phoenix.LiveView.Socket{}
+
+      assert {:cont, ^socket} =
+               OrchardConsole.maybe_attach_sentry_live_view_hook(
+                 %{},
+                 %{},
+                 socket,
+                 hook_module: OrchardConsoleTest.MissingSentryLiveViewHook
+               )
+    end
+
+    test "delegates to the Sentry LiveView hook when the module is loaded" do
+      assert Code.ensure_loaded?(OrchardConsoleTest.StubSentryLiveViewHook)
+      assert function_exported?(OrchardConsoleTest.StubSentryLiveViewHook, :on_mount, 4)
+
+      assert OrchardConsole.sentry_live_view_hook_available?(
+               OrchardConsoleTest.StubSentryLiveViewHook
+             )
+
+      socket = %Phoenix.LiveView.Socket{id: "console-sentry-hook"}
+
+      assert {:cont, returned} =
+               OrchardConsole.maybe_attach_sentry_live_view_hook(
+                 %{"id" => "1"},
+                 %{"token" => "session"},
+                 socket,
+                 hook_module: OrchardConsoleTest.StubSentryLiveViewHook
+               )
+
+      assert returned.id == "console-sentry-hook-hooked"
+
+      assert_received {
+        :stub_sentry_live_view_hook,
+        :default,
+        %{"id" => "1"},
+        %{"token" => "session"},
+        ^socket
+      }
     end
   end
 end

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -748,9 +748,9 @@ Run this before the first Topology B / two-Mac BEAM smoke on macOS.
    - Ensure the worker can read the same artifact path the controller recorded (copy/rsync the complete bundle, including `tokenizer.json` and weight shards).
    - Incomplete copies show up as tokenizer failures or `artifact_hash_mismatch` during model load.
 
-7. **Console compile footgun**
-   - If every `/console` LiveView returns 500 with `Sentry.LiveViewHook` undefined, recompile LiveView then Sentry (`mix deps.compile phoenix_live_view` and `mix deps.compile sentry --force`) and restart the controller.
-   - Tracked by issue #191.
+7. **Console Sentry LiveView context**
+   - Console LiveViews mount even when `Sentry.LiveViewHook` is missing (issue #191).
+   - If controller boot logs that the hook is unavailable, or Console crashes lack LiveView Sentry context, recompile LiveView then Sentry (`mix deps.compile phoenix_live_view` and `mix deps.compile sentry --force`) and restart the controller so Sentry sees LiveView on its compile path.
 
 8. **Admission inventory gap**
    - Configured BEAM targets can serve inference before durable `nodes` rows exist.
@@ -781,7 +781,7 @@ BEAM split-role default promotion was accepted on 2026-07-05 after the smoke evi
 | BEAM boot rejects `100.x` / Tailscale node names | Host is Tailscale CGNAT; validator accepts RFC1918 only today | Use LAN RFC1918 BEAM names. Keep Tailscale for SSH/scp. See issue #193. |
 | BEAM `connect` / `:gen_tcp` returns `:ehostunreach` while `ping` works | macOS Local Network Privacy blocked the BEAM launch context | Relaunch controller/node-agent from Terminal.app (or another GUI app with Local Network allowed). |
 | Source-dev BEAM bootstrap reports wildcard-bound EPMD | Another `epmd` is listening on `0.0.0.0`/`*` for that port | `ERL_EPMD_PORT=<port> epmd -kill`, confirm only the address-constrained listener remains, rerun. |
-| Console every route 500 with `Sentry.LiveViewHook` undefined | Sentry was compiled without LiveView on the compile path | `mix deps.compile phoenix_live_view` then `mix deps.compile sentry --force`, restart controller. Issue #191. |
+| Console boot warns `Sentry.LiveViewHook` unavailable / LiveView crashes lack Sentry context | Sentry was compiled without LiveView on the compile path | Console still mounts. To restore LiveView Sentry context: `mix deps.compile phoenix_live_view` then `mix deps.compile sentry --force`, restart controller. Issue #191. |
 | Live Cluster healthy but Registered Nodes inventory is zero / candidates stuck `pending_observed` | Configured-target observation is not bootstrapping durable admission inventory yet | Inference may still work via configured targets. See issue #192. |
 | Model load fails with missing `tokenizer.json` or `artifact_hash_mismatch` | Incomplete artifact copy on controller or worker | Re-import a complete bundle and sync the full artifact directory to the worker path. |
 | All-in-one `bin/dev` rejects BEAM mode | `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam` was set with the all-in-one entrypoint | Use `bin/dev-controller` and `bin/dev-node-agent` for BEAM mode. |


### PR DESCRIPTION
## Summary

Closes #191.

Source-dev Console hard-500ed on every LiveView route when `Sentry.LiveViewHook` was missing. API health stayed green while `/console` and nested LiveViews died with:

```text
UndefinedFunctionError function Sentry.LiveViewHook.on_mount/4 is undefined
(module Sentry.LiveViewHook is not available)
```

Root cause: `OrchardConsole.live_view/0` always did `on_mount(Sentry.LiveViewHook)`. Sentry marks `phoenix_live_view` optional and only defines `Sentry.LiveViewHook` when `Phoenix.LiveView` is already loaded on Sentry's compile path. A clean `_build` / dep recompile order can omit the hook and take Console down until:

```bash
mise exec -- mix deps.compile phoenix_live_view
mise exec -- mix deps.compile sentry --force
# restart controller
```

## What changed

- Console LiveViews mount a runtime-gated hook: `{OrchardConsole, :maybe_sentry_live_view_hook}`.
- If `Sentry.LiveViewHook` is loaded and exports `on_mount/4`, existing Sentry LiveView context behavior is preserved.
- If the hook module is missing, mount continues with `{:cont, socket}` instead of 500ing.
- Controller boot logs a warning when the hook is unavailable, so the failure is loud before first page load.
- `docs/local-dev.md` now says Console still mounts; the recompile path restores Sentry LiveView context only.
- Regression coverage for missing module, module without `on_mount/4`, present stub delegation, and the live_view quote no longer hard-wiring `Sentry.LiveViewHook`.

Non-goals: DSN/policy changes, broad Sentry feature work, catch-all rescues on LiveViews.

## Risk Assessment

✅ **Low**

- Console-only mount path. API Sentry plugs/filter/enrichment are untouched.
- When the hook is present (normal umbrella compile order), behavior is the same as before: delegate to `Sentry.LiveViewHook.on_mount/4`.
- Missing-hook path fails open for Console availability and fails loud at boot via warning.
- No schema, auth, scheduler, or packaging changes.
- Residual non-blockers:
  - Boot warning does not hard-fail the controller. That matches the acceptance goal (Console mounts) and keeps API healthy.
  - Restoring Sentry LiveView context still needs the documented recompile when Sentry omitted the module.

## Test plan

Local quality gates from worktree `fix/issue-191-console-sentry-liveview-hook`:

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict` (0 issues)
- `mise exec -- mix dialyzer` (passed)
- Focused + adjacent:
  - `ORCHARD_TEST_NODE_AGENT_PORT=60791 mise exec -- mix test apps/orchard_controller/test/orchard/console_test.exs apps/orchard_controller/test/orchard/console/overview_live_test.exs apps/orchard_controller/test/orchard/console/auth_test.exs`
  - Result: **136 passed**
- Full suite:
  - `ORCHARD_TEST_NODE_AGENT_PORT=60791 mise exec -- mix test`
  - Result: **738 passed, 10 excluded**, exit 0

## Acceptance

- [x] LiveViews do not crash mount when `Sentry.LiveViewHook` is missing
- [x] When hook module is present, existing Sentry LiveView context behavior is preserved
- [x] Regression covers missing-hook path
- [x] Boot warning + docs cover the compile-order recovery path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789007596&installation_model_id=428414&pr_number=198&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F198&signature=39198743e9e01ab097ecfc57e45642eba25486308b1b02eda45bae89b53d3991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->