### PR TITLE
fix(console): gate Playground on model readiness

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/model_hub_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/model_hub_live.ex
@@ -444,10 +444,17 @@ defmodule OrchardConsole.ModelHubLive do
             <div class="space-y-2">
               <p class="text-sm font-medium text-emerald-800 dark:text-emerald-200">
                 <%= if @download_result[:state] == :active do %>
-                  Model is now active.
+                  Model is now catalog-active.
                 <% else %>
                   Model imported successfully.
                 <% end %>
+              </p>
+              <p
+                :if={@download_result[:state] == :active}
+                id="model-hub-download-readiness-note"
+                class="text-sm text-slate-600 dark:text-slate-300"
+              >
+                Catalog activation is not runtime readiness. Playground enables Send only when a node reports a loaded placement for this model.
               </p>
               <p :if={@download_result} class="text-sm text-slate-600 dark:text-slate-300">
                 <span id="model-hub-download-model-id" class="font-mono text-xs">

--- a/apps/orchard_controller/lib/orchard/console/playground.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground.ex
@@ -25,8 +25,21 @@ defmodule OrchardConsole.Playground do
   alias Orchard.Inference.{ChatError, ChatOrchestrator}
   alias Orchard.InferenceEvent
   alias Orchard.Models
+  alias OrchardConsole.Runtime
 
-  @type model_option :: %{model_id: String.t(), version: String.t()}
+  @type readiness_fact :: :unknown | :present | :missing
+  @type placement_state :: :loaded | :none | :unknown
+
+  @type model_option :: %{
+          model_id: String.t(),
+          version: String.t(),
+          catalog_state: :active,
+          remote_availability: readiness_fact(),
+          placement_state: placement_state(),
+          loaded: boolean(),
+          inference_ready: boolean(),
+          not_ready_reason: String.t() | nil
+        }
 
   @type stream_error :: %{
           phase: :prepare | :execute | :stream,
@@ -41,20 +54,24 @@ defmodule OrchardConsole.Playground do
   # ===========================================================================
 
   @doc """
-  Returns active models for the playground model picker.
+  Returns active models for the playground model picker with readiness facts.
 
-  Models are projected to plain maps and sorted by `{model_id, version}`
-  for deterministic display order.
+  Catalog-active models are always listed. Inference readiness is projected
+  from authoritative Runtime Endpoint loaded placements only. Missing or
+  unknown readiness facts fail closed as non-ready.
   """
   @spec list_models() :: {:ok, [model_option()]} | {:error, map()}
   def list_models do
+    readiness_index = runtime_readiness_index()
+
     models =
       models_impl().list_active_models()
       |> Enum.map(fn model ->
-        %{
-          model_id: safe_string(model.model_id),
-          version: safe_string(model.version)
-        }
+        project_model_option(
+          safe_string(model.model_id),
+          safe_string(model.version),
+          readiness_index
+        )
       end)
       |> Enum.sort_by(&{&1.model_id, &1.version})
 
@@ -68,6 +85,33 @@ defmodule OrchardConsole.Playground do
          message: "Active model list unavailable."
        }}
   end
+
+  @doc """
+  Returns true when a model option is authoritative inference-ready.
+  """
+  @spec inference_ready?(term()) :: boolean()
+  def inference_ready?(%{inference_ready: true}), do: true
+  def inference_ready?(_), do: false
+
+  @doc """
+  Finds a projected model option by picker value (`model_id@version`).
+  """
+  @spec find_model_option([model_option()], String.t()) :: model_option() | nil
+  def find_model_option(models, value) when is_list(models) and is_binary(value) do
+    Enum.find(models, fn model -> model_value(model) == value end)
+  end
+
+  def find_model_option(_models, _value), do: nil
+
+  @doc """
+  Canonical picker value for a model option.
+  """
+  @spec model_value(model_option() | map()) :: String.t()
+  def model_value(%{model_id: model_id, version: version})
+      when is_binary(model_id) and is_binary(version),
+      do: "#{model_id}@#{version}"
+
+  def model_value(_), do: ""
 
   @doc """
   Starts an async streaming chat run.
@@ -95,6 +139,27 @@ defmodule OrchardConsole.Playground do
   # ===========================================================================
 
   defp run_stream(orchestrator, owner, run_ref, params, caller_context) do
+    case ensure_model_inference_ready(params) do
+      :ok ->
+        do_run_stream(orchestrator, owner, run_ref, params, caller_context)
+
+      {:error, error} ->
+        send(owner, {:playground, run_ref, :finished, {:error, error}})
+    end
+  rescue
+    exception ->
+      error = %{
+        phase: :execute,
+        type: "server_error",
+        code: "internal_error",
+        message: "Unexpected error: #{Exception.message(exception)}",
+        param: nil
+      }
+
+      send(owner, {:playground, run_ref, :finished, {:error, error}})
+  end
+
+  defp do_run_stream(orchestrator, owner, run_ref, params, caller_context) do
     case orchestrator.prepare(params, caller_context) do
       {:ok, canonical, model} ->
         send(owner, {:playground, run_ref, :started, %{request_id: canonical.public_id}})
@@ -123,17 +188,48 @@ defmodule OrchardConsole.Playground do
         error = normalize_error(:prepare, reason)
         send(owner, {:playground, run_ref, :finished, {:error, error}})
     end
-  rescue
-    exception ->
-      error = %{
-        phase: :execute,
-        type: "server_error",
-        code: "internal_error",
-        message: "Unexpected error: #{Exception.message(exception)}",
-        param: nil
-      }
+  end
 
-      send(owner, {:playground, run_ref, :finished, {:error, error}})
+  defp ensure_model_inference_ready(params) when is_map(params) do
+    model_value = params |> Map.get("model", "") |> to_string() |> String.trim()
+
+    case list_models() do
+      {:ok, models} ->
+        case find_model_option(models, model_value) do
+          %{inference_ready: true} ->
+            :ok
+
+          %{not_ready_reason: reason} = _option
+          when is_binary(reason) and reason != "" ->
+            {:error, unready_stream_error(reason)}
+
+          %{} ->
+            {:error,
+             unready_stream_error(
+               "Selected model is not inference-ready. Catalog-active is not enough to send."
+             )}
+
+          nil ->
+            {:error, unready_stream_error("Selected model is not available in the catalog.")}
+        end
+
+      {:error, _error} ->
+        {:error, unready_stream_error("Active model list unavailable.")}
+    end
+  end
+
+  defp ensure_model_inference_ready(_params) do
+    {:error, unready_stream_error("Selected model is not inference-ready.")}
+  end
+
+  defp unready_stream_error(message) do
+    %{
+      phase: :prepare,
+      type: "invalid_request_error",
+      code: "model_not_ready",
+      message: message,
+      param: "model"
+    }
   end
 
   # ===========================================================================
@@ -178,6 +274,124 @@ defmodule OrchardConsole.Playground do
   end
 
   # ===========================================================================
+  # Readiness projection
+  # ===========================================================================
+
+  defp project_model_option(model_id, version, readiness_index) do
+    key = {model_id, version}
+
+    case readiness_index do
+      %{status: status, loaded: loaded_set} when status in [:observed, :partial] ->
+        cond do
+          MapSet.member?(loaded_set, key) ->
+            %{
+              model_id: model_id,
+              version: version,
+              catalog_state: :active,
+              remote_availability: :present,
+              placement_state: :loaded,
+              loaded: true,
+              inference_ready: true,
+              not_ready_reason: nil
+            }
+
+          status == :partial ->
+            %{
+              model_id: model_id,
+              version: version,
+              catalog_state: :active,
+              remote_availability: :unknown,
+              placement_state: :unknown,
+              loaded: false,
+              inference_ready: false,
+              not_ready_reason:
+                "Readiness partially observed. Playground cannot confirm a loaded placement for this model."
+            }
+
+          true ->
+            %{
+              model_id: model_id,
+              version: version,
+              catalog_state: :active,
+              remote_availability: :unknown,
+              placement_state: :none,
+              loaded: false,
+              inference_ready: false,
+              not_ready_reason:
+                "Catalog-active, but no loaded placement on any ready node. Catalog activation is not runtime readiness."
+            }
+        end
+
+      %{status: :unknown} ->
+        %{
+          model_id: model_id,
+          version: version,
+          catalog_state: :active,
+          remote_availability: :unknown,
+          placement_state: :unknown,
+          loaded: false,
+          inference_ready: false,
+          not_ready_reason:
+            "Readiness unknown. Playground cannot confirm a loaded placement for this model."
+        }
+    end
+  end
+
+  defp runtime_readiness_index do
+    snapshots = runtime_snapshots()
+    successful = Enum.filter(snapshots, &successful_snapshot?/1)
+
+    cond do
+      successful == [] ->
+        %{status: :unknown}
+
+      length(successful) == length(snapshots) ->
+        %{status: :observed, loaded: loaded_identity_set(successful)}
+
+      true ->
+        %{status: :partial, loaded: loaded_identity_set(successful)}
+    end
+  end
+
+  defp runtime_snapshots do
+    case runtime_impl().cluster_snapshot() do
+      snapshots when is_list(snapshots) -> snapshots
+      _other -> []
+    end
+  rescue
+    _ -> []
+  catch
+    _kind, _reason -> []
+  end
+
+  defp successful_snapshot?(snapshot) do
+    value(snapshot, :status) in [:ok, "ok"]
+  end
+
+  defp loaded_identity_set(snapshots) do
+    snapshots
+    |> Enum.flat_map(&List.wrap(value(&1, :loaded_models)))
+    |> Enum.reduce(MapSet.new(), &put_loaded_identity/2)
+  end
+
+  defp put_loaded_identity(model, identities) do
+    model_id = safe_string(value(model, :model_id))
+    version = safe_string(value(model, :version))
+
+    if model_id == "" or version == "" do
+      identities
+    else
+      MapSet.put(identities, {model_id, version})
+    end
+  end
+
+  defp value(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp value(_other, _key), do: nil
+
+  # ===========================================================================
   # Config seam
   # ===========================================================================
 
@@ -187,6 +401,12 @@ defmodule OrchardConsole.Playground do
 
   defp orchestrator_impl do
     console_config()[:playground_orchestrator_impl] || ChatOrchestrator
+  end
+
+  defp runtime_impl do
+    console_config()[:playground_runtime_impl] ||
+      console_config()[:runtime_impl] ||
+      Runtime
   end
 
   defp console_config do

--- a/apps/orchard_controller/lib/orchard/console/playground_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground_live.ex
@@ -52,6 +52,8 @@ defmodule OrchardConsole.PlaygroundLive do
       models: [],
       models_status: :idle,
       models_error: nil,
+      selected_model: nil,
+      can_submit: false,
       inference_defaults: %{},
       form: to_form(%{"model" => "", "system" => "", "prompt" => ""}, as: :playground),
       form_errors: %{},
@@ -82,41 +84,70 @@ defmodule OrchardConsole.PlaygroundLive do
   defp load_models(socket) do
     case playground_impl().list_models() do
       {:ok, []} ->
-        assign(socket,
+        socket
+        |> assign(
           models: [],
           models_status: :empty,
-          models_error: "No active models available."
+          models_error: "No active models available.",
+          selected_model: nil,
+          can_submit: false
         )
 
       {:ok, models} ->
         options = Enum.map(models, &model_option/1)
-        selected = selected_model_value(options, socket.assigns.inference_defaults)
-        form_data = current_form_data(socket) |> Map.put("model", selected)
+        selected_value = selected_model_value(options, socket.assigns.inference_defaults)
+        form_data = current_form_data(socket) |> Map.put("model", selected_value)
 
         socket
         |> assign(models: options, models_status: :ok, models_error: nil)
         |> assign(form: to_form(form_data, as: :playground))
+        |> assign_selected_model(selected_value)
 
       {:error, error} ->
-        assign(socket,
+        socket
+        |> assign(
           models: [],
           models_status: :error,
-          models_error: error.message || "Active model list unavailable."
+          models_error: error.message || "Active model list unavailable.",
+          selected_model: nil,
+          can_submit: false
         )
     end
   rescue
     _ ->
-      assign(socket,
+      socket
+      |> assign(
         models: [],
         models_status: :error,
-        models_error: "Active model list unavailable."
+        models_error: "Active model list unavailable.",
+        selected_model: nil,
+        can_submit: false
       )
   end
 
-  defp model_option(%{model_id: model_id, version: version}) do
-    label = "#{model_id}@#{version}"
-    %{label: label, value: label, model_id: model_id}
+  defp model_option(model) do
+    value = model_value(model)
+
+    %{
+      label: value,
+      value: value,
+      model_id: Map.get(model, :model_id) || "",
+      version: Map.get(model, :version) || "",
+      catalog_state: Map.get(model, :catalog_state, :active),
+      remote_availability: Map.get(model, :remote_availability, :unknown),
+      placement_state: Map.get(model, :placement_state, :unknown),
+      loaded: Map.get(model, :loaded, false) == true,
+      inference_ready: Map.get(model, :inference_ready, false) == true,
+      not_ready_reason: Map.get(model, :not_ready_reason)
+    }
   end
+
+  defp model_value(%{model_id: model_id, version: version})
+       when is_binary(model_id) and is_binary(version),
+       do: "#{model_id}@#{version}"
+
+  defp model_value(%{value: value}) when is_binary(value), do: value
+  defp model_value(_), do: ""
 
   defp selected_model_value(options, defaults) do
     saved_model = Map.get(defaults, :default_model)
@@ -124,14 +155,49 @@ defmodule OrchardConsole.PlaygroundLive do
     selected =
       if is_binary(saved_model) and String.trim(saved_model) != "" do
         # list_models/0 sorts ascending by {model_id, version}, so the last
-        # match is the newest active version of the saved model.
+        # ready match is the newest ready version of the saved model.
         matches = Enum.filter(options, &(&1.model_id == saved_model))
-        List.last(matches) || List.first(options)
+        ready_matches = Enum.filter(matches, & &1.inference_ready)
+
+        List.last(ready_matches) || List.last(matches) || List.first(options)
       else
         List.first(options)
       end
 
     if selected, do: selected.value, else: ""
+  end
+
+  defp refresh_models(socket) do
+    case playground_impl().list_models() do
+      {:ok, models} ->
+        options = Enum.map(models, &model_option/1)
+        selected_value = current_form_data(socket)["model"]
+
+        refreshed =
+          socket
+          |> assign(models: options, models_status: :ok, models_error: nil)
+          |> assign_selected_model(selected_value)
+
+        {:ok, refreshed}
+
+      {:error, _error} ->
+        :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp assign_selected_model(socket, model_value) do
+    selected =
+      Enum.find(socket.assigns.models, &(&1.value == model_value)) ||
+        List.first(socket.assigns.models)
+
+    can_submit =
+      socket.assigns.active_run == nil and
+        is_map(selected) and
+        selected.inference_ready == true
+
+    assign(socket, selected_model: selected, can_submit: can_submit)
   end
 
   # ===========================================================================
@@ -140,7 +206,12 @@ defmodule OrchardConsole.PlaygroundLive do
 
   @impl true
   def handle_event("validate", %{"playground" => params}, socket) do
-    {:noreply, assign(socket, form: to_form(params, as: :playground), form_errors: %{})}
+    socket =
+      socket
+      |> assign(form: to_form(params, as: :playground), form_errors: %{})
+      |> assign_selected_model(String.trim(params["model"] || ""))
+
+    {:noreply, socket}
   end
 
   def handle_event("submit", %{"playground" => params}, socket) do
@@ -151,6 +222,9 @@ defmodule OrchardConsole.PlaygroundLive do
 
         socket.assigns.models == [] ->
           {:noreply, socket}
+
+        not socket.assigns.can_submit ->
+          reject_unready_submit(socket, params)
 
         true ->
           handle_submit(socket, params)
@@ -207,25 +281,72 @@ defmodule OrchardConsole.PlaygroundLive do
   end
 
   defp handle_submit(socket, params) do
+    case refresh_models(socket) do
+      {:ok, refreshed} -> submit_with_refreshed_models(refreshed, params)
+      :error -> reject_model_refresh_failure(socket, params)
+    end
+  end
+
+  defp submit_with_refreshed_models(socket, params) do
     model = String.trim(params["model"] || "")
     prompt = String.trim(params["prompt"] || "")
     system = String.trim(params["system"] || "")
+    selected = Enum.find(socket.assigns.models, &(&1.value == model))
 
     errors =
       %{}
       |> maybe_error(model == "", :model, "Please select a model")
       |> maybe_error(prompt == "", :prompt, "Please enter a prompt")
+      |> maybe_error(
+        model != "" and (selected == nil or selected.inference_ready != true),
+        :model,
+        unready_model_error(selected)
+      )
 
     if errors != %{} do
       {:noreply,
-       assign(socket,
-         form: to_form(params, as: :playground),
-         form_errors: errors
-       )}
+       socket
+       |> assign(form: to_form(params, as: :playground), form_errors: errors)
+       |> assign_selected_model(model)}
     else
       do_submit(socket, model, system, prompt, params)
     end
   end
+
+  defp reject_model_refresh_failure(socket, params) do
+    message = "Model readiness unavailable. Send remains disabled."
+
+    {:noreply,
+     assign(socket,
+       models: [],
+       models_status: :error,
+       models_error: message,
+       selected_model: nil,
+       can_submit: false,
+       form: to_form(params, as: :playground),
+       form_errors: %{model: message}
+     )}
+  end
+
+  defp reject_unready_submit(socket, params) do
+    model = String.trim(params["model"] || "")
+    selected = Enum.find(socket.assigns.models, &(&1.value == model))
+
+    {:noreply,
+     socket
+     |> assign(
+       form: to_form(params, as: :playground),
+       form_errors: %{model: unready_model_error(selected)}
+     )
+     |> assign_selected_model(model)}
+  end
+
+  defp unready_model_error(%{not_ready_reason: reason})
+       when is_binary(reason) and reason != "",
+       do: reason
+
+  defp unready_model_error(_),
+    do: "Selected model is not inference-ready. Catalog-active is not enough to send."
 
   defp do_submit(socket, model, system, prompt, params) do
     seq = socket.assigns.msg_seq
@@ -266,7 +387,8 @@ defmodule OrchardConsole.PlaygroundLive do
         form: to_form(Map.put(params, "prompt", ""), as: :playground),
         form_errors: %{},
         msg_seq: seq + 2,
-        run_metrics: new_run_metrics()
+        run_metrics: new_run_metrics(),
+        can_submit: false
       )
 
     case playground_impl().start_stream(self(), run_ref, chat_params) do
@@ -286,6 +408,7 @@ defmodule OrchardConsole.PlaygroundLive do
               |> remove_entry(assistant_id)
               |> remove_entry(user_id)
           )
+          |> refresh_can_submit()
 
         {:noreply, socket}
     end
@@ -365,7 +488,7 @@ defmodule OrchardConsole.PlaygroundLive do
         |> mark_assistant(:complete)
       end
 
-    {:noreply, assign(socket, active_run: nil)}
+    {:noreply, refresh_can_submit(assign(socket, active_run: nil))}
   end
 
   defp handle_stream(:finished, {:error, error}, socket) do
@@ -380,7 +503,7 @@ defmodule OrchardConsole.PlaygroundLive do
         |> maybe_remove_unaccepted_user()
       end
 
-    {:noreply, assign(socket, active_run: nil)}
+    {:noreply, refresh_can_submit(assign(socket, active_run: nil))}
   end
 
   # ===========================================================================
@@ -735,6 +858,55 @@ defmodule OrchardConsole.PlaygroundLive do
                 >
                   Selected: {@form[:model].value}
                 </p>
+                <div
+                  :if={@selected_model}
+                  id="playground-model-readiness"
+                  class="-mt-2 space-y-2"
+                  aria-live="polite"
+                >
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span id="playground-readiness-catalog">
+                      <.badge tone={:info}>
+                        Catalog: {catalog_state_label(@selected_model.catalog_state)}
+                      </.badge>
+                    </span>
+                    <span id="playground-readiness-remote">
+                      <.badge tone={fact_tone(@selected_model.remote_availability)}>
+                        Remote: {fact_label(@selected_model.remote_availability)}
+                      </.badge>
+                    </span>
+                    <span id="playground-readiness-placement">
+                      <.badge tone={placement_tone(@selected_model.placement_state)}>
+                        Placement: {placement_label(@selected_model.placement_state)}
+                      </.badge>
+                    </span>
+                    <span id="playground-readiness-loaded">
+                      <.badge tone={if(@selected_model.loaded, do: :success, else: :warning)}>
+                        Loaded: {if(@selected_model.loaded, do: "yes", else: "no")}
+                      </.badge>
+                    </span>
+                    <span id="playground-readiness-ready">
+                      <.badge tone={if(@selected_model.inference_ready, do: :success, else: :warning)}>
+                        Ready: {if(@selected_model.inference_ready, do: "yes", else: "no")}
+                      </.badge>
+                    </span>
+                  </div>
+                  <p
+                    :if={not @selected_model.inference_ready}
+                    id="playground-model-not-ready"
+                    class="text-xs text-amber-700 dark:text-amber-300"
+                  >
+                    {@selected_model.not_ready_reason ||
+                      "Selected model is not inference-ready. Catalog-active is not enough to send."}
+                  </p>
+                  <p
+                    :if={@selected_model.inference_ready}
+                    id="playground-model-ready"
+                    class="text-xs text-slate-500 dark:text-slate-400"
+                  >
+                    Loaded placement confirmed. Send is enabled for this model.
+                  </p>
+                </div>
                 <.input
                   id="playground-system"
                   field={@form[:system]}
@@ -768,6 +940,7 @@ defmodule OrchardConsole.PlaygroundLive do
                   rows={3}
                   errors={List.wrap(@form_errors[:prompt])}
                   phx-hook="SubmitOnModEnter"
+                  disabled={@active_run != nil}
                 />
                 <p id="playground-submit-hint" class="-mt-2 text-xs text-slate-500 dark:text-slate-400">
                   Press Cmd/Ctrl + Enter to send.
@@ -777,7 +950,8 @@ defmodule OrchardConsole.PlaygroundLive do
                     id="playground-send"
                     type="submit"
                     form="playground-form"
-                    disabled={@active_run != nil || @models == []}
+                    disabled={not @can_submit}
+                    title={send_button_title(@can_submit, @selected_model)}
                   >
                     Send
                   </.button>
@@ -919,4 +1093,46 @@ defmodule OrchardConsole.PlaygroundLive do
 
   defp present_text?(value) when is_binary(value), do: String.trim(value) != ""
   defp present_text?(_value), do: false
+
+  defp catalog_state_label(:active), do: "active"
+  defp catalog_state_label(other) when is_atom(other), do: Atom.to_string(other)
+  defp catalog_state_label(_), do: "unknown"
+
+  defp fact_label(:present), do: "present"
+  defp fact_label(:missing), do: "missing"
+  defp fact_label(:unknown), do: "unknown"
+  defp fact_label(_), do: "unknown"
+
+  defp fact_tone(:present), do: :success
+  defp fact_tone(:missing), do: :warning
+  defp fact_tone(_), do: :neutral
+
+  defp placement_label(:loaded), do: "loaded"
+  defp placement_label(:none), do: "none"
+  defp placement_label(:unknown), do: "unknown"
+  defp placement_label(_), do: "unknown"
+
+  defp placement_tone(:loaded), do: :success
+  defp placement_tone(:none), do: :warning
+  defp placement_tone(_), do: :neutral
+
+  defp send_button_title(true, _selected), do: "Send message"
+
+  defp send_button_title(false, %{not_ready_reason: reason})
+       when is_binary(reason) and reason != "",
+       do: reason
+
+  defp send_button_title(false, _selected),
+    do: "Model not ready to run"
+
+  defp refresh_can_submit(socket) do
+    selected = socket.assigns.selected_model
+
+    can_submit =
+      socket.assigns.active_run == nil and
+        is_map(selected) and
+        selected.inference_ready == true
+
+    assign(socket, can_submit: can_submit)
+  end
 end

--- a/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
@@ -1094,10 +1094,12 @@ defmodule OrchardConsole.ModelHubLiveTest do
 
       html = render(view)
       assert html =~ "model-hub-download-complete"
-      assert html =~ "Model is now active."
+      assert html =~ "Model is now catalog-active."
+      assert html =~ "Catalog activation is not runtime readiness"
       assert html =~ "mlx-community/Llama-3.2-1B-Instruct-4bit"
       assert html =~ "abc123def456"
       assert has_element?(view, "#model-hub-download-models-link")
+      assert has_element?(view, "#model-hub-download-readiness-note")
 
       assert has_element?(
                view,
@@ -1515,7 +1517,7 @@ defmodule OrchardConsole.ModelHubLiveTest do
 
       # Success panel visible immediately from rehydration
       assert html =~ "model-hub-download-complete"
-      assert html =~ "Model is now active."
+      assert html =~ "Model is now catalog-active."
       assert html =~ "mlx-community/Llama-3.2-1B-Instruct-4bit"
       assert html =~ "abc123def456"
       assert has_element?(remounted_view, "#model-hub-download-playground-link")

--- a/apps/orchard_controller/test/orchard/console/playground_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_live_test.exs
@@ -33,8 +33,8 @@ defmodule OrchardConsole.PlaygroundLiveTest do
     :persistent_term.put({__MODULE__, :test_pid}, self())
 
     stub_models([
-      %{model_id: "test-model", version: "v1"},
-      %{model_id: "test-model", version: "v2"}
+      ready_model("test-model", "v1"),
+      ready_model("test-model", "v2")
     ])
 
     :ok
@@ -85,6 +85,78 @@ defmodule OrchardConsole.PlaygroundLiveTest do
       {:ok, _view, html} = live(conn, "/console/playground")
 
       assert html =~ "Playground \u2014 Orchard Console"
+    end
+  end
+
+  describe "model readiness gate" do
+    test "shows readiness facts and disables Send for catalog-active unloadable model", %{
+      conn: conn
+    } do
+      stub_models([unready_model("test-model", "v1")])
+
+      {:ok, view, html} = live(conn, "/console/playground")
+
+      assert html =~ "playground-model-readiness"
+      assert html =~ "Catalog: active"
+      assert html =~ "Placement: none"
+      assert html =~ "Loaded: no"
+      assert html =~ "Ready: no"
+      assert html =~ "no loaded placement"
+
+      send_button = view |> element("#playground-send") |> render()
+      assert send_button =~ "disabled"
+    end
+
+    test "server rejects submit for non-ready model without starting a stream", %{conn: conn} do
+      stub_models([unready_model("test-model", "v1")])
+
+      {:ok, view, _html} = live(conn, "/console/playground")
+
+      html =
+        view
+        |> form("#playground-form",
+          playground: %{model: "test-model@v1", prompt: "Should not start"}
+        )
+        |> render_submit()
+
+      assert html =~ "no loaded placement"
+      refute_receive {:stub_run_ref, _}, 200
+      refute_receive {:stub_start_stream, _, _}, 200
+      refute html =~ "playground-message-msg-0"
+    end
+
+    test "ready loaded model remains submittable", %{conn: conn} do
+      stub_models([ready_model("test-model", "v1")])
+
+      {:ok, view, html} = live(conn, "/console/playground")
+
+      assert html =~ "Ready: yes"
+      refute has_element?(view, "#playground-send[disabled]")
+
+      {_ref, params} = submit_prompt_and_capture(view)
+      assert params["model"] == "test-model@v1"
+    end
+
+    test "submit fails closed when readiness refresh becomes unavailable", %{conn: conn} do
+      stub_models([ready_model("test-model", "v1")])
+
+      {:ok, view, html} = live(conn, "/console/playground")
+      refute html =~ "Model readiness unavailable"
+
+      stub_models(:error)
+
+      html =
+        view
+        |> form("#playground-form",
+          playground: %{model: "test-model@v1", prompt: "Should not start"}
+        )
+        |> render_submit()
+
+      assert html =~ "Model readiness unavailable. Send remains disabled."
+      assert has_element?(view, "#playground-send[disabled]")
+      refute_receive {:stub_run_ref, _}, 200
+      refute_receive {:stub_start_stream, _, _}, 200
+      refute html =~ "playground-message-msg-0"
     end
   end
 
@@ -678,7 +750,7 @@ defmodule OrchardConsole.PlaygroundLiveTest do
            }}
 
         models when is_list(models) ->
-          {:ok, models}
+          {:ok, Enum.map(models, &normalize_stub_model/1)}
       end
     end
 
@@ -692,6 +764,34 @@ defmodule OrchardConsole.PlaygroundLiveTest do
 
       # Return a dummy task pid — the test will drive messages manually
       {:ok, spawn(fn -> :timer.sleep(:infinity) end)}
+    end
+
+    defp normalize_stub_model(model) do
+      model_id = Map.get(model, :model_id) || ""
+      version = Map.get(model, :version) || ""
+      inference_ready = Map.get(model, :inference_ready, true) == true
+
+      %{
+        model_id: model_id,
+        version: version,
+        catalog_state: Map.get(model, :catalog_state, :active),
+        remote_availability:
+          Map.get(model, :remote_availability, if(inference_ready, do: :present, else: :unknown)),
+        placement_state:
+          Map.get(model, :placement_state, if(inference_ready, do: :loaded, else: :none)),
+        loaded: Map.get(model, :loaded, inference_ready),
+        inference_ready: inference_ready,
+        not_ready_reason:
+          Map.get(
+            model,
+            :not_ready_reason,
+            if(inference_ready,
+              do: nil,
+              else:
+                "Catalog-active, but no loaded placement on any ready node. Catalog activation is not runtime readiness."
+            )
+          )
+      }
     end
   end
 
@@ -775,6 +875,33 @@ defmodule OrchardConsole.PlaygroundLiveTest do
 
   defp stub_models(data) do
     :persistent_term.put({__MODULE__, :models}, data)
+  end
+
+  defp ready_model(model_id, version) do
+    %{
+      model_id: model_id,
+      version: version,
+      catalog_state: :active,
+      remote_availability: :present,
+      placement_state: :loaded,
+      loaded: true,
+      inference_ready: true,
+      not_ready_reason: nil
+    }
+  end
+
+  defp unready_model(model_id, version) do
+    %{
+      model_id: model_id,
+      version: version,
+      catalog_state: :active,
+      remote_availability: :unknown,
+      placement_state: :none,
+      loaded: false,
+      inference_ready: false,
+      not_ready_reason:
+        "Catalog-active, but no loaded placement on any ready node. Catalog activation is not runtime readiness."
+    }
   end
 
   defp submit_prompt(view, prompt \\ "Test prompt") do

--- a/apps/orchard_controller/test/orchard/console/playground_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_test.exs
@@ -12,11 +12,20 @@ defmodule OrchardConsole.PlaygroundTest do
       :console,
       Keyword.merge(previous,
         playground_models_impl: __MODULE__.StubModels,
-        playground_orchestrator_impl: __MODULE__.StubOrchestrator
+        playground_orchestrator_impl: __MODULE__.StubOrchestrator,
+        playground_runtime_impl: __MODULE__.StubRuntime
       )
     )
 
-    on_exit(fn -> Application.put_env(:orchard_controller, :console, previous) end)
+    on_exit(fn ->
+      Application.put_env(:orchard_controller, :console, previous)
+      :persistent_term.erase({__MODULE__, :models})
+      :persistent_term.erase({__MODULE__, :runtime})
+      :persistent_term.erase({__MODULE__, :orchestrator})
+      :persistent_term.erase({__MODULE__, :test_pid})
+    end)
+
+    :persistent_term.put({__MODULE__, :test_pid}, self())
     :ok
   end
 
@@ -25,36 +34,118 @@ defmodule OrchardConsole.PlaygroundTest do
   # ===========================================================================
 
   describe "list_models/0" do
-    test "projects and sorts active models deterministically" do
+    test "projects and sorts active models with readiness facts" do
       stub_models([
         %{model_id: "z-model", version: "v2"},
         %{model_id: "a-model", version: "v1"},
         %{model_id: "a-model", version: "main"}
       ])
 
+      stub_runtime([
+        %{
+          status: :ok,
+          loaded_models: [%{model_id: "a-model", version: "v1"}]
+        }
+      ])
+
       assert {:ok, models} = Playground.list_models()
 
       assert [
-               %{model_id: "a-model", version: "main"},
-               %{model_id: "a-model", version: "v1"},
-               %{model_id: "z-model", version: "v2"}
+               %{
+                 model_id: "a-model",
+                 version: "main",
+                 catalog_state: :active,
+                 inference_ready: false,
+                 placement_state: :none,
+                 loaded: false
+               },
+               %{
+                 model_id: "a-model",
+                 version: "v1",
+                 catalog_state: :active,
+                 inference_ready: true,
+                 placement_state: :loaded,
+                 loaded: true,
+                 remote_availability: :present,
+                 not_ready_reason: nil
+               },
+               %{
+                 model_id: "z-model",
+                 version: "v2",
+                 catalog_state: :active,
+                 inference_ready: false,
+                 placement_state: :none,
+                 loaded: false
+               }
              ] = models
+    end
+
+    test "marks catalog-active models non-ready when no loaded placement exists" do
+      stub_models([%{model_id: "test-model", version: "v1"}])
+      stub_runtime([%{status: :ok, loaded_models: []}])
+
+      assert {:ok, [model]} = Playground.list_models()
+      assert model.inference_ready == false
+      assert model.placement_state == :none
+      assert model.loaded == false
+      assert model.not_ready_reason =~ "no loaded placement"
+    end
+
+    test "fails closed when runtime readiness is unknown" do
+      stub_models([%{model_id: "test-model", version: "v1"}])
+      stub_runtime(:error)
+
+      assert {:ok, [model]} = Playground.list_models()
+      assert model.inference_ready == false
+      assert model.placement_state == :unknown
+      assert model.not_ready_reason =~ "Readiness unknown"
+    end
+
+    test "marks absence unknown when only some runtime targets respond" do
+      stub_models([%{model_id: "test-model", version: "v1"}])
+
+      stub_runtime([
+        %{status: :error, loaded_models: [%{model_id: "test-model", version: "v1"}]},
+        %{status: :ok, loaded_models: []}
+      ])
+
+      assert {:ok, [model]} = Playground.list_models()
+      assert model.inference_ready == false
+      assert model.placement_state == :unknown
+      assert model.not_ready_reason =~ "partially observed"
+    end
+
+    test "accepts an exact loaded match from a successful target during partial outage" do
+      stub_models([%{model_id: "test-model", version: "v1"}])
+
+      stub_runtime([
+        %{status: :error, loaded_models: []},
+        %{status: :ok, loaded_models: [%{model_id: "test-model", version: "v1"}]}
+      ])
+
+      assert {:ok, [model]} = Playground.list_models()
+      assert model.inference_ready == true
+      assert model.placement_state == :loaded
     end
 
     test "returns empty list when no active models" do
       stub_models([])
+      stub_runtime([%{status: :ok, loaded_models: []}])
 
       assert {:ok, []} = Playground.list_models()
     end
 
     test "normalizes non-binary identity fields defensively" do
       stub_models([%{model_id: nil, version: 42}])
+      stub_runtime([%{status: :ok, loaded_models: []}])
 
-      assert {:ok, [%{model_id: "", version: ""}]} = Playground.list_models()
+      assert {:ok, [%{model_id: "", version: "", inference_ready: false}]} =
+               Playground.list_models()
     end
 
     test "returns normalized error on source exception" do
       stub_models(:raise)
+      stub_runtime([%{status: :ok, loaded_models: []}])
 
       assert {:error, error} = Playground.list_models()
       assert error.code == "models_unavailable"
@@ -67,6 +158,16 @@ defmodule OrchardConsole.PlaygroundTest do
   # ===========================================================================
 
   describe "start_stream/4" do
+    setup do
+      stub_models([%{model_id: "test-model", version: "v1"}])
+
+      stub_runtime([
+        %{status: :ok, loaded_models: [%{model_id: "test-model", version: "v1"}]}
+      ])
+
+      :ok
+    end
+
     test "returns {:ok, pid} immediately" do
       stub_orchestrator(
         prepare: {:ok, fake_canonical(), %{}},
@@ -121,23 +222,54 @@ defmodule OrchardConsole.PlaygroundTest do
       assert_receive {:playground, ^ref, :event, ^delta_event}, 1000
     end
 
-    test "sends :finished with {:ok, summary} on success" do
+    test "rejects non-ready models before prepare or execute" do
+      stub_runtime([%{status: :ok, loaded_models: []}])
       ref = make_ref()
-      canonical = fake_canonical("req_ok")
 
       stub_orchestrator(
-        prepare: {:ok, canonical, %{}},
-        execute: {:ok, canonical, []}
+        prepare: {:ok, fake_canonical(), %{}},
+        execute: {:ok, fake_canonical(), []},
+        capture_opts: true
       )
 
       {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
 
-      assert_receive {:playground, ^ref, :finished, {:ok, summary}}, 1000
-      assert summary.canonical_request == canonical
-      assert summary.events == []
+      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+      assert error.phase == :prepare
+      assert error.code == "model_not_ready"
+      assert error.message =~ "no loaded placement"
+      refute_receive {:playground, ^ref, :started, _}, 100
+      refute_receive {:captured_opts, _}, 100
     end
 
-    test "passes owner pid as :caller option to execute" do
+    test "normalizes prepare errors" do
+      ref = make_ref()
+
+      stub_orchestrator(prepare: {:error, :invalid_request})
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
+
+      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+      assert error.phase == :prepare
+    end
+
+    test "normalizes execute errors after started" do
+      ref = make_ref()
+
+      stub_orchestrator(
+        prepare: {:ok, fake_canonical("req_exec"), %{}},
+        execute: {:error, :model_busy}
+      )
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
+
+      assert_receive {:playground, ^ref, :started, %{request_id: "req_exec"}}, 1000
+      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+      assert error.phase == :execute
+      assert error.code == "model_busy"
+    end
+
+    test "passes caller option to orchestrator execute" do
       ref = make_ref()
       owner = self()
 
@@ -150,49 +282,16 @@ defmodule OrchardConsole.PlaygroundTest do
       {:ok, _pid} = Playground.start_stream(owner, ref, valid_params())
 
       assert_receive {:captured_opts, opts}, 1000
-      assert opts[:caller] == owner
+      assert Keyword.get(opts, :caller) == owner
     end
 
-    test "normalizes prepare failure and sends :finished with :error" do
+    test "rescues unexpected task exceptions" do
       ref = make_ref()
-
-      stub_orchestrator(prepare: {:error, {:model_not_found, "missing@v1"}})
-
-      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
-
-      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
-      assert error.phase == :prepare
-      assert error.code == "model_not_found"
-      assert error.message =~ "missing@v1"
-
-      # Should NOT receive :started
-      refute_received {:playground, ^ref, :started, _}
-    end
-
-    test "normalizes execute failure and sends :finished with :error" do
-      ref = make_ref()
-
-      stub_orchestrator(
-        prepare: {:ok, fake_canonical(), %{}},
-        execute: {:error, :something_went_wrong}
-      )
-
-      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
-
-      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
-      assert error.phase == :execute
-      assert error.type == "api_error"
-    end
-
-    test "handles task-body exceptions gracefully" do
-      ref = make_ref()
-
       stub_orchestrator(prepare: :raise)
 
       {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
 
       assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
-      assert error.type == "server_error"
       assert error.code == "internal_error"
     end
   end
@@ -203,20 +302,26 @@ defmodule OrchardConsole.PlaygroundTest do
 
   defmodule StubModels do
     def list_active_models do
-      [{_pid, config}] =
-        Registry.lookup(OrchardConsole.PlaygroundTest.StubRegistry, :models)
-
-      case config do
+      case :persistent_term.get({OrchardConsole.PlaygroundTest, :models}, []) do
         :raise -> raise "DB unavailable"
-        models -> models
+        models when is_list(models) -> models
+      end
+    end
+  end
+
+  defmodule StubRuntime do
+    def cluster_snapshot(_opts \\ []) do
+      case :persistent_term.get({OrchardConsole.PlaygroundTest, :runtime}, []) do
+        :error -> raise "runtime unavailable"
+        :exit -> exit(:runtime_unavailable)
+        snapshots when is_list(snapshots) -> snapshots
       end
     end
   end
 
   defmodule StubOrchestrator do
     def prepare(_params, _caller_context) do
-      [{_pid, config}] =
-        Registry.lookup(OrchardConsole.PlaygroundTest.StubRegistry, :orchestrator)
+      config = :persistent_term.get({OrchardConsole.PlaygroundTest, :orchestrator}, [])
 
       case config[:prepare] do
         :raise -> raise "Prepare exploded"
@@ -225,16 +330,13 @@ defmodule OrchardConsole.PlaygroundTest do
     end
 
     def execute(canonical, _model, opts) do
-      [{_pid, config}] =
-        Registry.lookup(OrchardConsole.PlaygroundTest.StubRegistry, :orchestrator)
+      config = :persistent_term.get({OrchardConsole.PlaygroundTest, :orchestrator}, [])
+      test_pid = :persistent_term.get({OrchardConsole.PlaygroundTest, :test_pid}, nil)
 
-      # Capture opts if requested
-      if config[:capture_opts] do
-        [{pid, _}] = Registry.lookup(OrchardConsole.PlaygroundTest.StubRegistry, :orchestrator)
-        send(pid, {:captured_opts, opts})
+      if config[:capture_opts] && test_pid do
+        send(test_pid, {:captured_opts, opts})
       end
 
-      # Fire events through the handler if provided
       event_handler = Keyword.get(opts, :event_handler)
 
       if event_handler && config[:events] do
@@ -255,19 +357,15 @@ defmodule OrchardConsole.PlaygroundTest do
   # ===========================================================================
 
   defp stub_models(data) do
-    ensure_registry()
-    Registry.register(__MODULE__.StubRegistry, :models, data)
+    :persistent_term.put({__MODULE__, :models}, data)
+  end
+
+  defp stub_runtime(data) do
+    :persistent_term.put({__MODULE__, :runtime}, data)
   end
 
   defp stub_orchestrator(config) do
-    ensure_registry()
-    Registry.register(__MODULE__.StubRegistry, :orchestrator, config)
-  end
-
-  defp ensure_registry do
-    unless Process.whereis(__MODULE__.StubRegistry) do
-      start_supervised!({Registry, keys: :duplicate, name: __MODULE__.StubRegistry})
-    end
+    :persistent_term.put({__MODULE__, :orchestrator}, config)
   end
 
   defp valid_params do

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -660,6 +660,12 @@ For each pair of `{light, dark} × {sidebar-expanded, sidebar-collapsed}`:
   multi-line.
 - [ ] `<.input type="textarea">` main message - well treatment scales to
   large height; the `SubmitOnModEnter` hook still fires.
+- [ ] The selected model shows catalog, remote observation, placement, loaded,
+  and inference-ready facts separately.
+- [ ] Missing or unknown Runtime Endpoint readiness is visibly non-ready and
+  disables Send; catalog activation alone never reads as inference-ready.
+- [ ] The rendered disabled state and the LiveView submit handler enforce the
+  same exact-model-version loaded-placement requirement.
 - [ ] Send remains a submit control for `#playground-form`; click submission
   routes through `PlaygroundSubmitClick` and respects disabled state.
 - [ ] Cmd/Ctrl + Enter uses the same browser submit path as Send and respects


### PR DESCRIPTION
## Summary

Console Playground now treats catalog activation and runtime readiness as separate facts.
A catalog-active model stays visible, but Send is enabled only when a successfully observed Runtime Endpoint reports the exact model ID and version as loaded.
Missing observations, failed refreshes, and partial target outages fail closed without claiming that placement is definitively absent.

## What changed

- Project catalog, remote observation, placement, loaded, and inference-ready state into the Playground model picker.
- Refresh readiness on submit and enforce the same exact-model-version gate again in the Playground service before request preparation or persistence.
- Disable click and Cmd/Ctrl + Enter submission for non-ready models while retaining a server-side rejection path for stale or scripted submits.
- Clarify Model Hub completion copy so catalog activation does not imply remote readiness.
- Record the readiness and disabled-control contract in `docs/DESIGN.md`.

## Scope

This is a Console-only readiness representation and submit gate.
It does not add remote publication, acquisition, placement, or preload from #127, and it does not change admission policy or scheduler failure taxonomy from #128.
API clients remain unchanged.

## Verification

- `mise exec -- mix format` passed.
- `mise exec -- mix compile --warnings-as-errors` passed.
- `mise exec -- mix credo --strict` passed with no findings.
- `mise exec -- mix dialyzer` passed with 0 errors.
- Focused Playground and Model Hub tests passed, including non-ready submit rejection, submit-time refresh failure, mixed target observations, exact version matching, and the ready path.
- `mise exec -- mix test` passed:
  - `orchard_shared`: 301 passed
  - `orchard_controller`: 3,366 passed, 5 skipped
  - `orchard_node_agent`: 389 passed
  - `orchard_cli`: 738 passed, 10 excluded
- `mise exec -- mix test --cover` passed:
  - `orchard_shared`: 69.71%
  - `orchard_controller`: 85.0%
  - `orchard_node_agent`: 77.80%
  - `orchard_cli`: 76.82%
- Chromium smoke on the connected LiveView confirmed `Catalog: active`, `Remote: unknown`, `Placement: none`, `Loaded: no`, and `Ready: no`; Send remained disabled. A forced raw form submit created no transcript entry.
- Final RepoPrompt blocker review returned GO with no merge blockers.

## Risk Assessment

✅ **Medium**

- Blast radius is limited to Console model presentation and Playground submission.
- The new behavior is intentionally fail-closed when runtime observations are missing, partial, or stale at submit time.
- No schema, migration, public API, scheduler, admission-policy, or artifact-distribution behavior changes.
- Readiness badges can become stale while the page sits idle, but submit refresh and the service-level re-check prevent stale state from creating a request.
- Each accepted submit performs 2 readiness probes for defense in depth. This adds bounded Console latency but does not affect API clients.

Closes #126

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5.6_Sol-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789028789&installation_model_id=428414&pr_number=200&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F200&signature=6c520d576ee363598d9e2f1992173d8eddcb4c3240f1e4004d8d1caf134d92ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->