### PR TITLE
fix(runtime): use controller time for BEAM observations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -940,6 +940,9 @@ Rules:
 
 * the durable implementation seam for runtime status SHALL be a Runtime Endpoint Observation produced through the Runtime Endpoint Interface
 * the current gRPC Compatibility Adapter SHALL derive Runtime Endpoint Observations from `NodeRuntimeService.GetStatus` returning `StatusResponse`
+* Controller-facing Runtime Endpoint adapters SHALL assign scheduling-authoritative observation time when a successful status response is received and normalized.
+* Endpoint-provided wall-clock timestamps SHALL NOT be freshness authority.
+* For authenticated observations, the adapter SHALL reuse the exact Controller-assigned timestamp in both the returned Runtime Endpoint Observation and authenticated persistence.
 * controller-owned active-Node liveness and inventory freshness SHALL be refreshed by a leader-owned background status probe on a bounded interval independent of request traffic, consuming authenticated observations through the same seam
 * heartbeat payloads MAY carry equivalent hosted-tool data in a later slice, but controller-owned hosted-tool observation SHALL currently be derived from Runtime Endpoint status-probe ingestion
 * this contract defines future hosted routing inputs only; it SHALL NOT by itself enable controller-owned hosted `/v1/responses` execution or any other hosted execution behavior

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
@@ -89,20 +89,28 @@ defmodule Orchard.RuntimeEndpoint.BeamClient do
   def status(connection, opts \\ [])
 
   def status(%__MODULE__{authenticated_peer: nil, target: target} = connection, opts) do
-    rpc(connection, :status, [target, opts], opts)
+    receive_status_observation(connection, target, opts)
   end
 
   def status(
         %__MODULE__{authenticated_peer: peer, target: target} = connection,
         opts
       ) do
-    with {:ok, response} <- rpc(connection, :status, [target, opts], opts),
+    with {:ok, response} <- receive_status_observation(connection, target, opts),
          {:ok, _node} <-
-           Nodes.observe_authenticated_status(target, response, DateTime.utc_now(), peer) do
+           Nodes.observe_authenticated_status(target, response, response.observed_at, peer) do
       {:ok, response}
     else
       :noop -> {:error, :beam_peer_observation_rejected}
       {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp receive_status_observation(connection, target, opts) do
+    with {:ok, response} when is_map(response) <-
+           rpc(connection, :status, [target, opts], opts) do
+      observed_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      {:ok, Map.put(response, :observed_at, observed_at)}
     end
   end
 

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/authorization_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/authorization_test.exs
@@ -105,6 +105,44 @@ defmodule Orchard.DispatchCapacity.AuthorizationTest do
     assert :runtime_capacity_observation_stale in result.reason_codes
   end
 
+  test "issue #201 SPEC 4.6.2 keeps strict future evidence and exact freshness boundaries" do
+    node = active_node()
+
+    cases = [
+      {:materially_future, DateTime.add(@now, 53, :millisecond), false},
+      {:equal_to_now, @now, true},
+      {:exact_threshold, DateTime.add(@now, -30_000, :millisecond), true},
+      {:older_than_threshold, DateTime.add(@now, -30_001, :millisecond), false}
+    ]
+
+    for {boundary, observed_at, expected_fresh?} <- cases do
+      capacity_evidence = %{evidence(node.id) | observed_at: observed_at}
+
+      assert {:ok, input} =
+               Authorization.input(node,
+                 authority: %Authority{enforcement_phase: :enforcing},
+                 policy: %Policy{policy_state: :enforcing, controller_dispatch_ceiling: 2},
+                 evidence: capacity_evidence,
+                 placement_capacity: {:valid, 0, 2},
+                 now: @now,
+                 freshness_threshold_ms: 30_000
+               )
+
+      assert input.capacity_observation_fresh? == expected_fresh?,
+             "#{boundary} freshness mismatch"
+
+      evaluation = Evaluator.evaluate(input)
+
+      if expected_fresh? do
+        assert evaluation.eligible?, "#{boundary} should remain eligible"
+        refute :runtime_capacity_observation_stale in evaluation.reason_codes
+      else
+        refute evaluation.eligible?, "#{boundary} should fail closed"
+        assert :runtime_capacity_observation_stale in evaluation.reason_codes
+      end
+    end
+  end
+
   test "SPEC 4.6.2 rejects live production evidence for a different Node identity" do
     node = active_node()
     other_node_id = Ecto.UUID.generate()

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
@@ -1,9 +1,27 @@
 defmodule Orchard.RuntimeEndpoint.BeamClientTest do
   use Orchard.DataCase, async: false
 
+  alias Orchard.BeamPeerGrants
+  alias Orchard.ControllerInstances
+  alias Orchard.DispatchCapacity
   alias Orchard.Inference
   alias Orchard.InferenceEvent
-  alias Orchard.RuntimeEndpoint.{BeamClient, ModelRef, Observation, Operation, Target}
+  alias Orchard.NodeEnrollment.PKI
+  alias Orchard.NodeEnrollments
+  alias Orchard.Nodes
+  alias Orchard.Nodes.{Enrollment, Node}
+  alias Orchard.NodeTrust
+
+  alias Orchard.RuntimeEndpoint.{
+    AuthenticatedPeer,
+    BeamClient,
+    ModelRef,
+    Observation,
+    Operation,
+    Target
+  }
+
+  alias Orchard.TransportTLS.CertificateIdentity
 
   @node_id "550e8400-e29b-41d4-a716-446655440000"
 
@@ -51,6 +69,50 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
 
     def score_prefix_cache(%Operation.PrefixCacheScoreRequest{}, _opts) do
       {:ok, %Operation.PrefixCacheScoreResult{status_code: "ok", score_tier: "resident"}}
+    end
+  end
+
+  defmodule FutureObservationServer do
+    alias Orchard.Nodes.Node
+    alias Orchard.Repo
+    alias Orchard.RuntimeEndpoint.Observation
+
+    def status(target, _opts) do
+      remote_observed_at = Process.get({__MODULE__, :remote_observed_at})
+
+      attrs =
+        case Repo.get(Node, target.node_id) do
+          nil ->
+            %{
+              endpoint_id: target.id,
+              target: target,
+              observed_at: remote_observed_at,
+              availability: :available,
+              aggregate_active_request_count: 0,
+              aggregate_max_concurrency: 2
+            }
+
+          node ->
+            %{
+              endpoint_id: target.id,
+              target: target,
+              observed_at: remote_observed_at,
+              availability: :available,
+              aggregate_active_request_count: 0,
+              aggregate_max_concurrency: 2,
+              metadata: %{
+                node_id: node.id,
+                display_name: node.display_name,
+                hostname: node.hostname,
+                listen_host: node.connect_host,
+                listen_port: node.connect_port,
+                agent_version: "0.5.0-dev"
+              },
+              health: %{ready: true, health_code: "", health_message: ""}
+            }
+        end
+
+      {:ok, Observation.new(attrs)}
     end
   end
 
@@ -243,6 +305,52 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
     assert :ok = BeamClient.disconnect(connection)
   end
 
+  test "issue #201 SPEC §4.6.1 source-dev BEAM status uses Controller receive time" do
+    target =
+      Target.beam(@node_id,
+        address: node(),
+        metadata: %{server_module: FutureObservationServer, source_dev: true}
+      )
+
+    remote_observed_at = DateTime.add(DateTime.utc_now(), 5, :minute)
+    Process.put({FutureObservationServer, :remote_observed_at}, remote_observed_at)
+    on_exit(fn -> Process.delete({FutureObservationServer, :remote_observed_at}) end)
+
+    assert {:ok, connection} = BeamClient.connect(target)
+    before_status = DateTime.utc_now()
+    assert {:ok, observation} = BeamClient.status(connection, [])
+    after_status = DateTime.utc_now()
+
+    assert DateTime.compare(observation.observed_at, before_status) in [:eq, :gt]
+    assert DateTime.compare(observation.observed_at, after_status) in [:eq, :lt]
+    refute observation.observed_at == remote_observed_at
+  end
+
+  test "issue #201 SPEC §4.6.2 authenticated BEAM status shares Controller receive time with evidence" do
+    {target, peer} = authenticated_beam_fixture!()
+    target = put_in(target.metadata[:server_module], FutureObservationServer)
+    remote_observed_at = DateTime.add(DateTime.utc_now(), 5, :minute)
+    Process.put({FutureObservationServer, :remote_observed_at}, remote_observed_at)
+    on_exit(fn -> Process.delete({FutureObservationServer, :remote_observed_at}) end)
+
+    connection = %BeamClient{
+      authenticated_peer: peer,
+      node: node(),
+      server_module: FutureObservationServer,
+      target: target
+    }
+
+    before_status = DateTime.utc_now()
+    assert {:ok, observation} = BeamClient.status(connection, [])
+    after_status = DateTime.utc_now()
+    evidence = DispatchCapacity.get_capacity_evidence(target.node_id)
+
+    assert DateTime.compare(observation.observed_at, before_status) in [:eq, :gt]
+    assert DateTime.compare(observation.observed_at, after_status) in [:eq, :lt]
+    refute observation.observed_at == remote_observed_at
+    assert evidence.observed_at == observation.observed_at
+  end
+
   test "prefix-cache scoring fails open when a BEAM target is unavailable" do
     model_ref = ModelRef.new!("mlx-community/phi-3", "main")
     target = Target.beam(@node_id, address: :definitely_missing@localhost)
@@ -304,6 +412,135 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
     assert {:ok, %Operation.PrefixCacheScoreResult{status_code: "error"}} =
              BeamClient.score_prefix_cache(connection, request, [])
   end
+
+  defp authenticated_beam_fixture! do
+    previous_control_plane = Application.get_env(:orchard_controller, :control_plane)
+    previous_node_trust = Application.get_env(:orchard_controller, :node_trust)
+
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-beam-client-issue-201-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    trust_root = Path.join(root, "node-trust")
+    authorization_root = Path.join(root, "beam-authorization-root")
+    File.mkdir_p!(root)
+    Application.put_env(:orchard_controller, :control_plane, role: :single_controller)
+    Application.put_env(:orchard_controller, :node_trust, root: trust_root)
+
+    Application.put_env(:orchard_controller, :beam_peer_grants,
+      enabled: true,
+      authorization_root_path: authorization_root
+    )
+
+    on_exit(fn ->
+      File.rm_rf!(root)
+      restore_application_env(:control_plane, previous_control_plane)
+      restore_application_env(:node_trust, previous_node_trust)
+    end)
+
+    now = DateTime.utc_now()
+    assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
+
+    assert {:ok, _controller} =
+             ControllerInstances.ensure_local(
+               private_ipv4: "10.0.0.10",
+               membership_scope: :remote_beam,
+               node_trust_root: trust_root,
+               authorization_root_path: authorization_root,
+               now: now
+             )
+
+    node = register_authenticated_node!(trust, now)
+
+    admission_attrs = %{
+      trust_evidence_ref: "registration-audit:#{Ecto.UUID.generate()}",
+      pool_id: Ecto.UUID.generate(),
+      routing_policy_id: Ecto.UUID.generate(),
+      capacity_policy_reason: "approved for issue #201 regression"
+    }
+
+    assert {:ok, %{grants: [grant]}} =
+             Nodes.admit_node(node.id, admission_attrs, now: now)
+
+    peer = authenticated_peer!(node.id)
+
+    assert {:ok, _delivery} =
+             BeamPeerGrants.deliver(
+               %{
+                 grant_id: grant.id,
+                 generation: grant.generation,
+                 controller_id: grant.controller_id
+               },
+               peer,
+               now: now
+             )
+
+    assert {:ok, [target]} = Nodes.activation_probe_runtime_endpoint_targets()
+    {target, peer}
+  end
+
+  defp register_authenticated_node!(trust, now) do
+    assert {:ok, created} =
+             NodeEnrollments.create(
+               %{
+                 cluster_id: trust.cluster_id,
+                 expected_controller_id: trust.controller_id,
+                 trust_authority_id: trust.trust_authority_id,
+                 creator_type: "operator",
+                 expires_at: DateTime.add(now, 1, :hour),
+                 node: %{display_name: "beam-client-issue-201"}
+               },
+               now: now
+             )
+
+    assert {:ok, _enrollment} = NodeEnrollments.mark_issued(created.enrollment.id, now: now)
+    assert {:ok, csr} = PKI.generate_csr(trust.cluster_id, created.enrollment.node_id)
+    Process.put({:node_private_key, created.enrollment.node_id}, csr.private_key_pem)
+
+    assert {:ok, _response} =
+             NodeEnrollments.redeem(
+               created.enrollment.id,
+               %{
+                 cluster_id: trust.cluster_id,
+                 controller_id: trust.controller_id,
+                 csr_pem: csr.csr_pem,
+                 node_id: created.enrollment.node_id,
+                 runtime_endpoint: %{
+                   host: "10.0.0.20",
+                   hostname: "beam-client-issue-201.orchard.test",
+                   port: 50_071
+                 },
+                 token: created.bootstrap_token
+               },
+               now: now
+             )
+
+    Repo.get!(Node, created.enrollment.node_id)
+  end
+
+  defp authenticated_peer!(node_id) do
+    enrollment = Repo.one!(from(enrollment in Enrollment, where: enrollment.node_id == ^node_id))
+    result = enrollment.certificate_result
+    assert {:ok, certificate} = CertificateIdentity.from_pem(result["node_certificate_pem"])
+
+    %AuthenticatedPeer{
+      node_id: node_id,
+      node_uri_san: result["node_uri_san"],
+      enrollment_id: enrollment.id,
+      certificate_identifier: enrollment.certificate_identifier,
+      certificate_serial: certificate.serial,
+      certificate_fingerprint: certificate.fingerprint,
+      runtime_trust_spki_sha256: result["runtime_trust_spki_sha256"]
+    }
+  end
+
+  defp restore_application_env(key, nil),
+    do: Application.delete_env(:orchard_controller, key)
+
+  defp restore_application_env(key, value),
+    do: Application.put_env(:orchard_controller, key, value)
 
   defp put_beam_config(config) do
     Application.put_env(:orchard_controller, :runtime_endpoint, beam: config)

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -32,6 +32,42 @@ defmodule Orchard.Scheduler.MultiNodeTest do
 
   # -- Stub Status Client --
 
+  defmodule FutureBeamStatusServer do
+    @moduledoc false
+
+    alias Orchard.RuntimeEndpoint.{Observation, Placement}
+
+    def status(target, _opts) do
+      placement =
+        Placement.new(%{
+          model_ref: %{model_id: "test-model", version: "v1"},
+          state: :loaded,
+          capacity: %{active_request_count: 0, max_concurrency: 2, status: :available}
+        })
+
+      {:ok,
+       Observation.new(%{
+         endpoint_id: target.id,
+         target: target,
+         observed_at: DateTime.add(DateTime.utc_now(), 5, :minute),
+         availability: :available,
+         worker_state: :idle,
+         aggregate_active_request_count: 0,
+         aggregate_max_concurrency: 2,
+         metadata: %{
+           node_id: "00000000-0000-4000-a000-000000000201",
+           display_name: "issue-201-source-dev",
+           hostname: "issue-201-source-dev.local",
+           listen_host: "127.0.0.1",
+           listen_port: 50_071,
+           agent_version: "0.5.0-dev"
+         },
+         health: %{ready: true, health_code: "", health_message: ""},
+         placements: [placement]
+       })}
+    end
+  end
+
   defmodule StubClient do
     @moduledoc false
 
@@ -1192,6 +1228,36 @@ defmodule Orchard.Scheduler.MultiNodeTest do
         Process.delete({ProcessLocalCompatibilityProbeClient, :owner})
         Process.delete({ProcessLocalCompatibilityProbeClient, :response})
       end
+    end
+
+    test "issue #201 SPEC §4.6.1 selects future-skewed source-dev BEAM status by Controller receive time" do
+      target =
+        Target.normalize(
+          transport: :beam,
+          address: node(),
+          metadata: %{server_module: FutureBeamStatusServer, source_dev: true}
+        )
+
+      put_inference(
+        allow_static_runtime_target_fallback: true,
+        runtime_endpoint_targets: [target],
+        runtime_client_targets: []
+      )
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(),
+                 status_client: Orchard.RuntimeEndpoint.BeamClient,
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, []} end,
+                 runtime_endpoint_targets_provider: fn {:ok, []} -> [target] end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   flunk("production snapshot must not run for empty trusted inventory")
+                 end
+               )
+
+      assert schedule.runtime_endpoint_target.id == target.id
+
+      reason_codes = schedule.dispatch_capacity_evaluation.reason_codes
+      refute :runtime_capacity_observation_stale in reason_codes
     end
 
     test "ADR 0017 bounds, deduplicates, filters, and concurrently probes static targets once" do


### PR DESCRIPTION
## Summary

A small clock difference between the Controller and Node Agent could make a fresh BEAM Runtime Endpoint observation look stale.
The scheduler then rejected the only ready split-host candidate with `runtime_capacity_observation_stale` and returned `cluster_busy`.

This fix makes the Controller assign the scheduling-authoritative timestamp when it receives a successful BEAM status response.
Authenticated persistence reuses that exact timestamp, while the strict future-evidence rejection remains unchanged.
The gRPC path already creates observations on the Controller after receipt, so it does not change.

## What changed

- Stamp successful BEAM status maps and observations at the Controller receive boundary.
- Reuse the same timestamp for the returned observation and authenticated Node evidence.
- Clarify Controller clock authority in `SPEC.md` §4.6.1.
- Cover source-dev and authenticated BEAM paths, the real MultiNode compatibility probe, strict freshness boundaries, and existing legacy map responses.

## Verification

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `mise exec -- mix test` - 301 shared, 3370 controller, 389 node-agent, and 738 CLI tests passed. 5 controller tests skipped and 10 CLI integration tests excluded by the suite.
- `mise exec -- mix test --cover` - passed with 69.71% shared, 85.0% controller, 77.80% node-agent, and 76.80% CLI coverage.
- Focused issue regression - 5 receive-time, scheduler, authorization, and legacy map tests passed.
- RepoPrompt Review - approved after increasing the scheduler skew fixture to five minutes for deterministic failure on pre-fix code.
- OMP Advisor - approved the production fix and identified only post-merge split-host smoke as residual operational proof.

## Risk Assessment

✅ **Low**

- Blast radius is limited to successful BEAM `status/2` responses at the Controller adapter boundary.
- Strict freshness checks and materially future evidence rejection remain unchanged.
- Authenticated persistence and returned observations share one timestamp, which preserves evidence ordering.
- No schema, configuration, migration, gRPC production, or public API change.
- The fresh-database tamingsari-to-mawarduri pilot smoke remains the promotion gate before creating a new immutable pilot tag.

Closes #201

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789045970&installation_model_id=428414&pr_number=202&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F202&signature=619e9f58b12b79f2fe54a0ff48a0fbec23915b5fe6ea584fc22e7c65cf053ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->