### PR TITLE
fix(console): remove unsupported LiveView long-poll fallback

### DIFF
--- a/apps/orchard_controller/assets/js/app.js
+++ b/apps/orchard_controller/assets/js/app.js
@@ -561,7 +561,6 @@ const FORMAT_OPTIONS = {
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {
-  longPollFallbackMs: 2500,
   hooks: Hooks,
   params: {_csrf_token: csrfToken}
 })


### PR DESCRIPTION
## Summary

Orchard Console now stays on WebSocket when the initial LiveView connection is slow.
The client previously switched to `/live/longpoll` after 2.5 seconds, but the Endpoint exposes only the WebSocket transport.
Removing the unused fallback keeps the client aligned with the existing server contract and avoids adding a transport Orchard does not need.

## Browser evidence

| Scenario | Before | After |
|---|---|---|
| Initial WebSocket open delayed by 4 seconds | Browser requested `GET /live/longpoll`; server logged `Phoenix.Router.NoRouteError` | No `/live/longpoll` request; the delayed WebSocket connected and the Console became interactive |
| Established WebSocket interrupted | Not part of the failing path | Console entered its disconnected state, recovered through WebSocket, and issued no long-poll request |
| LiveView navigation | Primary WebSocket path worked | Navigation from Overview to Playground stayed connected; browser console and page-error logs were empty |

The fresh isolated source-dev database had no catalog model or loaded MLX placement.
Playground rendered over WebSocket with an empty Model selector and disabled Send control, so the inference, streaming, terminal state, and Request Details portion was not faked.
That flow requires a real Orchard model bundle and loaded MLX runtime placement.

There is no committed browser, asset, Playwright, or JavaScript test seam on this branch.
This PR uses the deterministic before-and-after browser network scenario instead of adding a framework or a source-text assertion for a one-line fix.

## Validation

- `mise exec -- mix format` passed.
- `mise exec -- mix compile --warnings-as-errors` passed.
- `mise exec -- mix credo --strict` passed with 0 issues across 672 source files.
- `mise exec -- mix dialyzer` passed with 0 errors.
- `mise exec -- mix test apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs apps/orchard_controller/test/orchard/api/router_test.exs apps/orchard_controller/test/orchard/console/playground_live_test.exs apps/orchard_controller/test/orchard/console/playground_test.exs apps/orchard_controller/test/orchard/console/request_live_test.exs` passed: 144 tests.
- `mise exec -- mix test` passed: `orchard_shared` 301, `orchard_controller` 3,370 with 5 skipped, `orchard_node_agent` 389, `orchard_cli` 738 with 10 excluded.
- `mise exec -- mix test --cover` passed with the same test counts. Coverage totals: `orchard_shared` 69.71%, `orchard_controller` 85.0%, `orchard_node_agent` 77.77%, `orchard_cli` 76.82%.
- RP Oracle plan gate: go for the one-line removal with no server, SPEC, ADR, OpenSpec, or documentation change.
- RP Review workflow: go, with no blocker, important finding, or cleanup.

## Risk Assessment

✅ **Low**

- Blast radius is one LiveSocket option in the Console asset.
- WebSocket connection and reconnect behavior remain owned by Phoenix LiveView.
- No server transport, route, UI, persistence, migration, API, or documentation contract changed.
- Browsers or proxies that block WebSocket remain disconnected instead of attempting a server transport Orchard never supported.
- The only unexercised path is real-model Playground inference because this isolated environment had no loaded MLX placement.

Closes #203

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol_(high_reasoning)-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789085049&installation_model_id=428414&pr_number=204&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F204&signature=aade55dde4c586d2ebc7579f61097d961290975d6d5884444c6b9b06caeb806a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->