### PR TITLE
fix(runtime): allow explicit Source-dev BEAM networks

### DIFF
--- a/apps/orchard_controller/lib/orchard/application.ex
+++ b/apps/orchard_controller/lib/orchard/application.ex
@@ -189,7 +189,8 @@ defmodule Orchard.Application do
       private_ipv4: Keyword.get(membership, :private_ipv4),
       membership_scope: Keyword.get(membership, :scope),
       node_trust_root: Keyword.get(trust, :root),
-      authorization_root_path: Keyword.get(membership, :authorization_root_path)
+      authorization_root_path: Keyword.get(membership, :authorization_root_path),
+      source_dev_address_policy: Keyword.get(membership, :source_dev_address_policy)
     ]
   end
 

--- a/apps/orchard_controller/lib/orchard/controller_instances.ex
+++ b/apps/orchard_controller/lib/orchard/controller_instances.ex
@@ -254,13 +254,30 @@ defmodule Orchard.ControllerInstances do
   end
 
   defp validated_private_ipv4(opts, allow_loopback) do
-    with value when is_binary(value) <- Keyword.get(opts, :private_ipv4),
-         {:ok, _address} <- BeamNodeName.private_ipv4(value, allow_loopback: allow_loopback) do
+    value = Keyword.get(opts, :private_ipv4)
+    source_dev_policy = Keyword.get(opts, :source_dev_address_policy)
+
+    if valid_membership_ipv4?(value, source_dev_policy, allow_loopback) do
       {:ok, value}
     else
-      _other -> {:error, :beam_controller_private_ipv4_invalid}
+      {:error, :beam_controller_private_ipv4_invalid}
     end
   end
+
+  defp valid_membership_ipv4?(value, nil, allow_loopback) when is_binary(value) do
+    match?(
+      {:ok, _address},
+      BeamNodeName.private_ipv4(value, allow_loopback: allow_loopback)
+    )
+  end
+
+  defp valid_membership_ipv4?(value, source_dev_policy, allow_loopback)
+       when is_binary(value) and is_map(source_dev_policy) do
+    (allow_loopback or value != "127.0.0.1") and
+      BeamNodeName.allowed_ipv4?(value, source_dev_policy)
+  end
+
+  defp valid_membership_ipv4?(_value, _source_dev_policy, _allow_loopback), do: false
 
   defp membership_scope(opts) do
     case Keyword.get(opts, :membership_scope) do

--- a/apps/orchard_controller/test/application_test.exs
+++ b/apps/orchard_controller/test/application_test.exs
@@ -544,6 +544,23 @@ defmodule OrchardApplicationTest do
     assert initializer_opts[:authorization_root_path] == "/protected/authorization-root"
   end
 
+  test "Source-dev membership owner receives the resolved address policy" do
+    Application.put_env(:orchard_controller, :start_repo, true)
+    policy = %{additional_cidrs: [{{203, 0, 113, 0}, 24}]}
+
+    Application.put_env(:orchard_controller, :controller_membership,
+      private_ipv4: "203.0.113.10",
+      scope: :remote_beam,
+      authorization_root_path: "/protected/authorization-root",
+      source_dev_address_policy: policy
+    )
+
+    assert [{Orchard.ControllerInstances.MembershipOwner, opts}] =
+             membership_owner_specs(Orchard.Application.child_specs())
+
+    assert opts[:source_dev_address_policy] == policy
+  end
+
   test "SPEC.md §8.3 membership identity is never defaulted when config resolved no scope" do
     Application.put_env(:orchard_controller, :start_repo, true)
     Application.delete_env(:orchard_controller, :controller_membership)

--- a/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
+++ b/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
@@ -396,7 +396,7 @@ defmodule Orchard.BeamPeerGrantsTest do
     trust_root: trust_root,
     authorization_root: authorization_root
   } do
-    now = ~U[2026-07-13 08:00:00.000000Z]
+    now = DateTime.utc_now()
     assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
 
     assert {:ok, _controller} =
@@ -672,7 +672,7 @@ defmodule Orchard.BeamPeerGrantsTest do
     trust_root: trust_root,
     authorization_root: authorization_root
   } do
-    now = ~U[2026-07-13 08:00:00.000000Z]
+    now = DateTime.utc_now()
     assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
 
     assert {:ok, _controller} =
@@ -1010,7 +1010,7 @@ defmodule Orchard.BeamPeerGrantsTest do
     trust_root: trust_root,
     authorization_root: authorization_root
   } do
-    now = ~U[2026-07-13 08:00:00.000000Z]
+    now = DateTime.utc_now()
     assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
 
     assert {:ok, _controller} =
@@ -1512,7 +1512,7 @@ defmodule Orchard.BeamPeerGrantsTest do
     trust_root: trust_root,
     authorization_root: authorization_root
   } do
-    now = ~U[2026-07-13 08:00:00.000000Z]
+    now = DateTime.utc_now()
     assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
 
     assert {:ok, _controller} =
@@ -2498,7 +2498,7 @@ defmodule Orchard.BeamPeerGrantsTest do
   end
 
   defp pending_grant!(trust_root, authorization_root) do
-    now = ~U[2026-07-13 08:00:00.000000Z]
+    now = DateTime.utc_now()
     assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
 
     assert {:ok, _controller} =

--- a/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
+++ b/apps/orchard_controller/test/orchard/config/source_dev_beam_test.exs
@@ -3,7 +3,10 @@ Code.require_file(Path.expand("../../../../../config/source_dev_beam.exs", __DIR
 defmodule Orchard.Config.SourceDevBeamTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   alias Orchard.Config.SourceDevBeam
+  alias Orchard.RuntimeEndpoint.BeamNodeName
 
   describe "transport!/1" do
     test "defaults unset and blank transport to gRPC" do
@@ -24,6 +27,155 @@ defmodule Orchard.Config.SourceDevBeamTest do
     end
   end
 
+  describe "address_policy!/1 and host_allowed?/2" do
+    test "accepts RFC1918, shared CGNAT boundaries, and loopback by default" do
+      policy = SourceDevBeam.address_policy!(nil)
+
+      for host <- [
+            "10.0.0.0",
+            "10.255.255.255",
+            "172.16.0.0",
+            "172.31.255.255",
+            "192.168.0.0",
+            "192.168.255.255",
+            "100.64.0.0",
+            "100.127.255.255",
+            "127.0.0.1"
+          ] do
+        assert SourceDevBeam.host_allowed?(host, policy), host
+      end
+    end
+
+    test "config and runtime policy evaluators stay aligned" do
+      policy = SourceDevBeam.address_policy!("203.0.113.0/24")
+
+      for host <- [
+            "127.0.0.1",
+            "10.0.0.1",
+            "100.64.0.0",
+            "100.127.255.255",
+            "203.0.113.10",
+            "100.128.0.0",
+            "224.0.0.1",
+            "255.255.255.255",
+            "worker.tailnet.ts.net"
+          ] do
+        assert SourceDevBeam.host_allowed?(host, policy) ==
+                 BeamNodeName.allowed_ipv4?(host, policy)
+      end
+    end
+
+    test "rejects addresses adjacent to shared CGNAT and public addresses by default" do
+      policy = SourceDevBeam.address_policy!("")
+
+      refute SourceDevBeam.host_allowed?("100.63.255.255", policy)
+      refute SourceDevBeam.host_allowed?("100.128.0.0", policy)
+      refute SourceDevBeam.host_allowed?("203.0.113.10", policy)
+    end
+
+    test "accepts hosts inside additive operator CIDRs only" do
+      policy =
+        SourceDevBeam.address_policy!("203.0.113.0/24, 198.51.100.10/32")
+
+      assert SourceDevBeam.host_allowed?("203.0.113.10", policy)
+      assert SourceDevBeam.host_allowed?("198.51.100.10", policy)
+      refute SourceDevBeam.host_allowed?("198.51.100.11", policy)
+    end
+
+    test "rejects malformed and unrestricted additive CIDRs" do
+      for cidr <- ["not-a-cidr", "10.0.0.0/33", "0.0.0.0/0"] do
+        assert_raise RuntimeError,
+                     ~r/ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS contains invalid IPv4 CIDR #{Regex.escape(inspect(cidr))}/,
+                     fn ->
+                       SourceDevBeam.address_policy!(cidr)
+                     end
+      end
+    end
+
+    test "rejects invalid host classes even inside an additive CIDR" do
+      policy = SourceDevBeam.address_policy!("0.0.0.0/8,224.0.0.0/4,255.255.255.255/32")
+
+      refute SourceDevBeam.host_allowed?("0.0.0.0", policy)
+      refute SourceDevBeam.host_allowed?("224.0.0.1", policy)
+      refute SourceDevBeam.host_allowed?("255.255.255.255", policy)
+      refute SourceDevBeam.host_allowed?("worker.tailnet.ts.net", policy)
+      refute SourceDevBeam.host_allowed?("::1", policy)
+    end
+  end
+
+  test "warns when operator CIDRs expand the shared-cookie network boundary" do
+    policy = SourceDevBeam.address_policy!("8.8.8.0/24")
+
+    assert capture_io(:stderr, fn ->
+             assert SourceDevBeam.warn_expanded_network(policy) == :ok
+           end) =~
+             "shared-cookie BEAM may expose EPMD and BEAM Distribution; restrict their ports to configured peers"
+
+    assert capture_io(:stderr, fn ->
+             assert SourceDevBeam.warn_expanded_network(SourceDevBeam.address_policy!(nil)) ==
+                      :ok
+           end) == ""
+  end
+
+  describe "validate_node_name!/3" do
+    test "accepts CGNAT and operator-authorized Source-dev node names" do
+      default_policy = SourceDevBeam.address_policy!(nil)
+      custom_policy = SourceDevBeam.address_policy!("203.0.113.0/24")
+
+      assert SourceDevBeam.validate_node_name!(
+               :controller,
+               "orchard_controller@100.64.1.10",
+               default_policy
+             ) == "100.64.1.10"
+
+      assert SourceDevBeam.validate_node_name!(
+               :node_agent,
+               "orchard_node_agent@203.0.113.10",
+               custom_policy
+             ) == "203.0.113.10"
+    end
+
+    test "rejects public, MagicDNS, and role-invalid Source-dev node names" do
+      policy = SourceDevBeam.address_policy!(nil)
+
+      assert_raise RuntimeError,
+                   ~r/must use same-host loopback, RFC1918, Tailscale CGNAT 100\.64\.0\.0\/10, or ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS/,
+                   fn ->
+                     SourceDevBeam.validate_node_name!(
+                       :node_agent,
+                       "orchard_node_agent@203.0.113.10",
+                       policy
+                     )
+                   end
+
+      assert_raise RuntimeError, ~r/host must be an IPv4 literal/, fn ->
+        SourceDevBeam.validate_node_name!(
+          :node_agent,
+          "orchard_node_agent@worker.tailnet.ts.net",
+          policy
+        )
+      end
+
+      assert_raise RuntimeError, ~r/service must be exactly orchard_node_agent/, fn ->
+        SourceDevBeam.validate_node_name!(
+          :node_agent,
+          "other@100.64.1.10",
+          policy
+        )
+      end
+
+      assert_raise RuntimeError,
+                   ~r/controller BEAM node service contains invalid characters/,
+                   fn ->
+                     SourceDevBeam.validate_node_name!(
+                       :controller,
+                       "orchard_controller x@100.64.1.10",
+                       policy
+                     )
+                   end
+    end
+  end
+
   describe "controller_beam_targets!/2" do
     test "parses comma-separated BEAM node-name targets with IPv4-literal hosts" do
       assert SourceDevBeam.controller_beam_targets!(
@@ -41,6 +193,34 @@ defmodule Orchard.Config.SourceDevBeamTest do
                  metadata: %{source_dev: true}
                }
              ]
+    end
+
+    test "accepts shared CGNAT targets and rejects public targets by default" do
+      assert [%{address: :"orchard_node_agent@100.64.1.10"}] =
+               SourceDevBeam.controller_beam_targets!(
+                 "orchard_node_agent@100.64.1.10",
+                 "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+               )
+
+      assert_raise RuntimeError,
+                   ~r/must use same-host loopback, RFC1918, Tailscale CGNAT 100\.64\.0\.0\/10, or ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS/,
+                   fn ->
+                     SourceDevBeam.controller_beam_targets!(
+                       "orchard_node_agent@203.0.113.10",
+                       "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
+                     )
+                   end
+    end
+
+    test "accepts a public target through an additive operator CIDR" do
+      policy = SourceDevBeam.address_policy!("203.0.113.0/24")
+
+      assert [%{address: :"orchard_node_agent@203.0.113.10"}] =
+               SourceDevBeam.controller_beam_targets!(
+                 "orchard_node_agent@203.0.113.10",
+                 "ORCHARD_RUNTIME_ENDPOINT_TARGETS",
+                 policy
+               )
     end
 
     test "bounds legacy BEAM target atom materialization" do
@@ -143,6 +323,24 @@ defmodule Orchard.Config.SourceDevBeamTest do
              ]
     end
 
+    test "accepts operator-authorized Controller and target hosts with exact guardrails" do
+      policy = SourceDevBeam.address_policy!("203.0.113.0/24")
+
+      targets =
+        SourceDevBeam.controller_beam_targets!(
+          "orchard_node_agent@203.0.113.20",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS",
+          policy
+        )
+
+      assert SourceDevBeam.beam_guardrail_config!(
+               "orchard_controller@203.0.113.10",
+               "/tmp/orchard-cookie",
+               targets,
+               policy
+             )[:allowed_cidrs] == ["203.0.113.20/32"]
+    end
+
     test "rejects IPv6 local controller hosts" do
       targets =
         SourceDevBeam.controller_beam_targets!(
@@ -150,7 +348,7 @@ defmodule Orchard.Config.SourceDevBeamTest do
           "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
         )
 
-      assert_raise RuntimeError, ~r/requires IPv4-literal local controller host/, fn ->
+      assert_raise RuntimeError, ~r/host must be an IPv4 literal/, fn ->
         SourceDevBeam.beam_guardrail_config!(
           "orchard_controller@::1",
           "/tmp/orchard-cookie",

--- a/apps/orchard_controller/test/orchard/controller_instances_test.exs
+++ b/apps/orchard_controller/test/orchard/controller_instances_test.exs
@@ -1,6 +1,8 @@
 defmodule Orchard.ControllerInstancesTest do
   use Orchard.DataCase, async: false
+  Code.require_file(Path.expand("../../../../config/source_dev_beam.exs", __DIR__))
 
+  alias Orchard.Config.SourceDevBeam
   alias Orchard.ControllerInstances
   alias Orchard.ControllerInstances.ControllerInstance
   alias Orchard.NodeTrust
@@ -60,6 +62,39 @@ defmodule Orchard.ControllerInstancesTest do
     refute inspect(instance) =~ authorization_root
     refute inspect(instance) =~ "authorization-root.bin"
     refute inspect(instance) =~ "key:"
+  end
+
+  test "Source-dev shared-cookie policy admits a Tailscale Controller identity", %{root: root} do
+    trust_root = Path.join(root, "node-trust")
+    authorization_root = Path.join(root, "beam-authorization-root")
+    now = ~U[2026-07-13 08:00:00.000000Z]
+
+    assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
+
+    opts = [
+      private_ipv4: "100.70.81.109",
+      membership_scope: :remote_beam,
+      node_trust_root: trust_root,
+      authorization_root_path: authorization_root,
+      now: now
+    ]
+
+    assert {:error, :beam_controller_private_ipv4_invalid} =
+             ControllerInstances.ensure_local(opts)
+
+    assert {:ok, instance} =
+             ControllerInstances.ensure_local(
+               Keyword.put(
+                 opts,
+                 :source_dev_address_policy,
+                 SourceDevBeam.address_policy!(nil)
+               )
+             )
+
+    assert instance.id == trust.controller_id
+
+    assert instance.canonical_beam_name ==
+             "orchard_controller_#{String.replace(trust.controller_id, "-", "")}@100.70.81.109"
   end
 
   test "SPEC.md §8.3 local-only membership persists a complete loopback identity", %{root: root} do

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -494,6 +494,51 @@ defmodule Orchard.InferenceTest do
              ]
     end
 
+    test "dev.exs configures Tailscale CGNAT identities and exact target guardrails" do
+      controller_config =
+        read_dev_controller_config!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@100.64.1.11",
+          "ORCHARD_BEAM_NODE_NAME" => "orchard_controller@100.64.1.10",
+          "ORCHARD_BEAM_COOKIE_FILE" => "/tmp/orchard-dev-cookie"
+        })
+
+      assert Keyword.fetch!(controller_config, :runtime_endpoint)[:beam][:listen_host] ==
+               "100.64.1.10"
+
+      assert Keyword.fetch!(controller_config, :runtime_endpoint)[:beam][:allowed_cidrs] ==
+               ["100.64.1.11/32"]
+    end
+
+    test "dev.exs requires an operator CIDR for public identities and targets" do
+      assert_raise RuntimeError,
+                   ~r/ORCHARD_RUNTIME_ENDPOINT_TARGETS.*ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS/,
+                   fn ->
+                     read_dev_controller_config!(%{
+                       "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+                       "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+                       "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@203.0.113.11",
+                       "ORCHARD_BEAM_NODE_NAME" => "orchard_controller@203.0.113.10"
+                     })
+                   end
+
+      controller_config =
+        read_dev_controller_config!(%{
+          "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_RUNTIME_ENDPOINT_TARGETS" => "orchard_node_agent@203.0.113.11",
+          "ORCHARD_BEAM_NODE_NAME" => "orchard_controller@203.0.113.10",
+          "ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS" => "203.0.113.0/24"
+        })
+
+      assert Keyword.fetch!(controller_config, :runtime_endpoint)[:beam][:listen_host] ==
+               "203.0.113.10"
+
+      assert Keyword.fetch!(controller_config, :runtime_endpoint)[:beam][:allowed_cidrs] ==
+               ["203.0.113.11/32"]
+    end
+
     test "dev.exs beam controller mode rejects local controller node names with wrong services" do
       assert_raise RuntimeError,
                    ~r/local controller BEAM node service must start with orchard_controller/,
@@ -508,7 +553,7 @@ defmodule Orchard.InferenceTest do
     end
 
     test "dev.exs beam controller mode rejects local controller node names with hostnames" do
-      assert_raise RuntimeError, ~r/requires IPv4-literal local controller host/, fn ->
+      assert_raise RuntimeError, ~r/host must be an IPv4 literal/, fn ->
         read_dev_controller_config!(%{
           "ORCHARD_SOURCE_DEV_ROLE" => "controller",
           "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",

--- a/apps/orchard_controller/test/runtime_transport_test.exs
+++ b/apps/orchard_controller/test/runtime_transport_test.exs
@@ -258,7 +258,7 @@ defmodule Orchard.RuntimeTransportTest do
                  fn -> read_controller_config!(support_root, grant_env) end
 
     assert_raise RuntimeError,
-                 ~r/ORCHARD_CONTROLLER_MEMBERSHIP_HOST must be a private non-loopback IPv4 address/,
+                 ~r/ORCHARD_CONTROLLER_MEMBERSHIP_HOST must be a private non-loopback RFC1918 IPv4 address/,
                  fn ->
                    read_controller_config!(
                      support_root,
@@ -797,6 +797,53 @@ defmodule Orchard.RuntimeTransportTest do
 
     assert config[:controller_membership][:private_ipv4] == "10.0.0.10"
     assert config[:controller_membership][:scope] == :remote_beam
+  end
+
+  test "Source-dev shared-cookie roles accept Tailscale CGNAT IPv4 identities", %{
+    support_root: support_root
+  } do
+    node_agent =
+      read_dev_config!(support_root, %{
+        "ORCHARD_SOURCE_DEV_ROLE" => "node_agent",
+        "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+        "ORCHARD_BEAM_NODE_NAME" => "orchard_node_agent@100.64.1.11"
+      })
+
+    controller =
+      read_dev_config!(support_root, %{
+        "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+        "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+        "ORCHARD_BEAM_NODE_NAME" => "orchard_controller@100.64.1.10"
+      })
+
+    assert node_agent[:controller_membership][:private_ipv4] == nil
+    assert controller[:controller_membership][:private_ipv4] == "100.64.1.10"
+    assert controller[:controller_membership][:scope] == :remote_beam
+  end
+
+  test "Source-dev shared-cookie roles require public identities to use operator CIDRs", %{
+    support_root: support_root
+  } do
+    assert_raise RuntimeError,
+                 ~r/ORCHARD_BEAM_NODE_NAME.*ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS/,
+                 fn ->
+                   read_dev_config!(support_root, %{
+                     "ORCHARD_SOURCE_DEV_ROLE" => "node_agent",
+                     "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+                     "ORCHARD_BEAM_NODE_NAME" => "orchard_node_agent@203.0.113.11"
+                   })
+                 end
+
+    controller =
+      read_dev_config!(support_root, %{
+        "ORCHARD_SOURCE_DEV_ROLE" => "controller",
+        "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+        "ORCHARD_BEAM_NODE_NAME" => "orchard_controller@203.0.113.10",
+        "ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS" => "203.0.113.0/24"
+      })
+
+    assert controller[:controller_membership][:private_ipv4] == "203.0.113.10"
+    assert controller[:controller_membership][:scope] == :remote_beam
   end
 
   test "packaged Controller database configuration ignores PGPORT", %{

--- a/apps/orchard_shared/lib/orchard/config/controller_membership.ex
+++ b/apps/orchard_shared/lib/orchard/config/controller_membership.ex
@@ -21,10 +21,10 @@ defmodule Orchard.Config.ControllerMembership do
   available default is loopback and grants reject a loopback identity.
 
   The resolved scope is explicit rather than defaulted: `Orchard.Application`
-  hands it to `Orchard.ControllerInstances`, which only allows a loopback
-  canonical host under `:local_only`. Classification therefore delegates to
-  `Orchard.RuntimeEndpoint.BeamNodeName`, the same host rule that validates the
-  identity at boot, so a host accepted here cannot be rejected there.
+  hands it to `Orchard.ControllerInstances`, which only allows loopback under
+  `:local_only`. Source-dev classification and durable publication both pass
+  the same plain address-policy data to `Orchard.RuntimeEndpoint.BeamNodeName`,
+  so a host accepted during configuration cannot be rejected at startup.
   """
 
   alias Orchard.RuntimeEndpoint.BeamNodeName
@@ -60,58 +60,96 @@ defmodule Orchard.Config.ControllerMembership do
   def identity!(transport, node_name, opts \\ []) do
     membership_host = optional_trimmed(Keyword.get(opts, :membership_host))
     peer_grants_enabled? = Keyword.get(opts, :peer_grants_enabled?, false)
+    source_dev_policy = source_dev_policy(opts, peer_grants_enabled?)
     node_name = optional_trimmed(node_name)
 
     case membership_host do
-      nil -> default_identity!(transport, node_name, peer_grants_enabled?)
-      host -> explicit_identity!(host, transport, node_name, peer_grants_enabled?)
+      nil ->
+        default_identity!(transport, node_name, peer_grants_enabled?, source_dev_policy)
+
+      host ->
+        explicit_identity!(host, transport, node_name, peer_grants_enabled?, source_dev_policy)
     end
   end
 
-  defp explicit_identity!(host, transport, node_name, peer_grants_enabled?) do
+  defp explicit_identity!(
+         host,
+         transport,
+         node_name,
+         peer_grants_enabled?,
+         source_dev_policy
+       ) do
     require_node_name_agreement!(host, transport, node_name)
 
     cond do
-      remote_host?(host) ->
+      remote_host?(host, source_dev_policy) ->
         {host, :remote_beam}
 
-      not local_host?(host) ->
-        raise "environment variable #{@membership_host_env} Controller membership host must be a private IPv4 address, got #{inspect(host)}"
-
       peer_grants_enabled? ->
-        raise "environment variable #{@membership_host_env} must be a private non-loopback IPv4 address when BEAM Peer Grants are enabled, got #{inspect(host)}"
+        raise "environment variable #{@membership_host_env} must be a private non-loopback RFC1918 IPv4 address when BEAM Peer Grants are enabled, got #{inspect(host)}"
+
+      not local_host?(host) ->
+        raise_invalid_membership_host!(host, source_dev_policy)
 
       true ->
         {host, :local_only}
     end
   end
 
-  defp default_identity!(_transport, _node_name, true) do
+  defp default_identity!(_transport, _node_name, true, _source_dev_policy) do
     raise "environment variable #{@membership_host_env} is required when BEAM Peer Grants are enabled"
   end
 
-  defp default_identity!(:grpc, _node_name, false), do: {"127.0.0.1", :local_only}
-  defp default_identity!(:beam, nil, false), do: {"127.0.0.1", :local_only}
+  defp default_identity!(:grpc, _node_name, false, _source_dev_policy),
+    do: {"127.0.0.1", :local_only}
 
-  defp default_identity!(:beam, node_name, false) do
+  defp default_identity!(:beam, nil, false, _source_dev_policy),
+    do: {"127.0.0.1", :local_only}
+
+  defp default_identity!(:beam, node_name, false, source_dev_policy) do
     {_service, host} = controller_service_host!(node_name)
 
     cond do
-      remote_host?(host) ->
+      remote_host?(host, source_dev_policy) ->
         {host, :remote_beam}
 
       local_host?(host) ->
         {host, :local_only}
 
       true ->
-        raise "environment variable #{@node_name_env} Controller membership host must be a private IPv4 address, got #{inspect(node_name)}"
+        raise_invalid_node_name_host!(node_name, source_dev_policy)
     end
   end
 
-  defp remote_host?(host), do: match?({:ok, _address}, BeamNodeName.private_ipv4(host))
+  defp remote_host?(host, nil), do: match?({:ok, _address}, BeamNodeName.private_ipv4(host))
+
+  defp remote_host?("127.0.0.1", _source_dev_policy), do: false
+
+  defp remote_host?(host, source_dev_policy) do
+    BeamNodeName.allowed_ipv4?(host, source_dev_policy)
+  end
 
   defp local_host?(host) do
     match?({:ok, _address}, BeamNodeName.private_ipv4(host, allow_loopback: true))
+  end
+
+  defp source_dev_policy(_opts, true), do: nil
+  defp source_dev_policy(opts, false), do: Keyword.get(opts, :source_dev_address_policy)
+
+  defp raise_invalid_membership_host!(host, nil) do
+    raise "environment variable #{@membership_host_env} Controller membership host must be a private IPv4 address, got #{inspect(host)}"
+  end
+
+  defp raise_invalid_membership_host!(host, _source_dev_policy) do
+    raise "environment variable #{@membership_host_env} Controller membership host must use same-host loopback, RFC1918, Tailscale CGNAT 100.64.0.0/10, or ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS, got #{inspect(host)}"
+  end
+
+  defp raise_invalid_node_name_host!(node_name, nil) do
+    raise "environment variable #{@node_name_env} Controller membership host must be a private IPv4 address, got #{inspect(node_name)}"
+  end
+
+  defp raise_invalid_node_name_host!(node_name, _source_dev_policy) do
+    raise "environment variable #{@node_name_env} Controller membership host must use same-host loopback, RFC1918, Tailscale CGNAT 100.64.0.0/10, or ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS, got #{inspect(node_name)}"
   end
 
   defp require_node_name_agreement!(_host, :grpc, _node_name), do: :ok

--- a/apps/orchard_shared/lib/orchard/runtime_endpoint/beam_node_name.ex
+++ b/apps/orchard_shared/lib/orchard/runtime_endpoint/beam_node_name.ex
@@ -3,6 +3,8 @@ defmodule Orchard.RuntimeEndpoint.BeamNodeName do
   Validates exact peer-grant BEAM names before they cross an atom boundary.
   """
 
+  import Bitwise
+
   @prefixes ["orchard_controller_", "orchard_node_agent_"]
   @uuid_pattern ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
 
@@ -35,6 +37,23 @@ defmodule Orchard.RuntimeEndpoint.BeamNodeName do
 
   def private_ipv4(_host, _opts), do: {:error, :invalid_private_ipv4}
 
+  @type ipv4_cidr :: {:inet.ip4_address(), 1..32}
+
+  @spec allowed_ipv4?(String.t(), %{allowed_cidrs: [ipv4_cidr()]}) :: boolean()
+  def allowed_ipv4?(host, %{allowed_cidrs: allowed_cidrs})
+      when is_binary(host) and is_list(allowed_cidrs) do
+    case :inet.parse_ipv4strict_address(String.to_charlist(host)) do
+      {:ok, address} ->
+        valid_host_class?(address) and
+          Enum.any?(allowed_cidrs, &cidr_contains?(&1, address))
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  def allowed_ipv4?(_host, _policy), do: false
+
   @spec to_atom(String.t(), String.t(), String.t()) ::
           {:ok, node()} | {:error, :beam_target_unknown}
   def to_atom(name, prefix, id) do
@@ -59,4 +78,16 @@ defmodule Orchard.RuntimeEndpoint.BeamNodeName do
 
   defp allowed_loopback?({127, 0, 0, 1}, opts), do: Keyword.get(opts, :allow_loopback, false)
   defp allowed_loopback?(_address, _opts), do: false
+
+  defp valid_host_class?({0, 0, 0, 0}), do: false
+  defp valid_host_class?({first, _b, _c, _d}) when first in 224..239, do: false
+  defp valid_host_class?({255, 255, 255, 255}), do: false
+  defp valid_host_class?(_address), do: true
+
+  defp cidr_contains?({network, prefix}, address) do
+    mask = ((1 <<< prefix) - 1) <<< (32 - prefix)
+    band(ipv4_integer(network), mask) == band(ipv4_integer(address), mask)
+  end
+
+  defp ipv4_integer({a, b, c, d}), do: (a <<< 24) + (b <<< 16) + (c <<< 8) + d
 end

--- a/apps/orchard_shared/test/orchard/config/controller_membership_test.exs
+++ b/apps/orchard_shared/test/orchard/config/controller_membership_test.exs
@@ -1,7 +1,9 @@
+Code.require_file(Path.expand("../../../../../config/source_dev_beam.exs", __DIR__))
+
 defmodule Orchard.Config.ControllerMembershipTest do
   use ExUnit.Case, async: true
 
-  alias Orchard.Config.ControllerMembership
+  alias Orchard.Config.{ControllerMembership, SourceDevBeam}
 
   describe "identity!/3" do
     test "SPEC.md §8.3 every resolved identity carries an explicit membership scope" do
@@ -38,7 +40,7 @@ defmodule Orchard.Config.ControllerMembershipTest do
 
     test "rejects a loopback membership host when peer grants are enabled" do
       assert_raise RuntimeError,
-                   ~r/must be a private non-loopback IPv4 address when BEAM Peer Grants are enabled/,
+                   ~r/must be a private non-loopback RFC1918 IPv4 address when BEAM Peer Grants are enabled/,
                    fn ->
                      ControllerMembership.identity!(:beam, nil,
                        membership_host: "127.0.0.1",
@@ -75,6 +77,38 @@ defmodule Orchard.Config.ControllerMembershipTest do
                    fn ->
                      ControllerMembership.identity!(:beam, nil, membership_host: "203.0.113.10")
                    end
+    end
+
+    test "accepts Source-dev CGNAT and operator-authorized membership hosts" do
+      default_policy = SourceDevBeam.address_policy!(nil)
+      custom_policy = SourceDevBeam.address_policy!("203.0.113.0/24")
+
+      assert ControllerMembership.identity!(
+               :beam,
+               "orchard_controller@100.64.1.10",
+               source_dev_address_policy: default_policy
+             ) == {"100.64.1.10", :remote_beam}
+
+      assert ControllerMembership.identity!(
+               :beam,
+               "orchard_controller@203.0.113.10",
+               membership_host: "203.0.113.10",
+               source_dev_address_policy: custom_policy
+             ) == {"203.0.113.10", :remote_beam}
+    end
+
+    test "does not apply the Source-dev policy when peer grants are enabled" do
+      policy = SourceDevBeam.address_policy!("203.0.113.0/24")
+
+      assert_raise RuntimeError, ~r/private non-loopback RFC1918 IPv4 address/, fn ->
+        ControllerMembership.identity!(
+          :beam,
+          "orchard_controller_00112233445566778899aabbccddeeff@203.0.113.10",
+          membership_host: "203.0.113.10",
+          peer_grants_enabled?: true,
+          source_dev_address_policy: policy
+        )
+      end
     end
 
     test "classifies a BEAM controller without a node name as local-only" do

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -171,11 +171,26 @@ Orchard.Config.SourceDevBeam.validate_transport_role!(
   source_dev_role
 )
 
+source_dev_address_policy =
+  if runtime_endpoint_transport == :beam and not beam_peer_grants_enabled? do
+    policy =
+      Orchard.Config.SourceDevBeam.address_policy!(
+        System.get_env("ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS")
+      )
+
+    Orchard.Config.SourceDevBeam.warn_expanded_network(policy)
+    policy
+  else
+    Orchard.Config.SourceDevBeam.address_policy!(nil)
+  end
+
 beam_runtime_endpoint_targets =
   if runtime_endpoint_transport == :beam and source_dev_role == :controller and
        not beam_peer_grants_enabled? do
     Orchard.Config.SourceDevBeam.controller_beam_targets!(
-      System.get_env("ORCHARD_RUNTIME_ENDPOINT_TARGETS")
+      System.get_env("ORCHARD_RUNTIME_ENDPOINT_TARGETS"),
+      "ORCHARD_RUNTIME_ENDPOINT_TARGETS",
+      source_dev_address_policy
     )
   else
     []
@@ -518,7 +533,8 @@ cond do
         Orchard.Config.SourceDevBeam.beam_guardrail_config!(
           beam_controller_node_name,
           beam_cookie_file,
-          beam_runtime_endpoint_targets
+          beam_runtime_endpoint_targets,
+          source_dev_address_policy
         )
 
   true ->

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1612,19 +1612,49 @@ if config_env() == :dev do
   source_dev_role =
     Orchard.Config.SourceDevBeam.source_dev_role(env_optional_string.("ORCHARD_SOURCE_DEV_ROLE"))
 
+  runtime_endpoint_transport =
+    Orchard.Config.SourceDevBeam.transport!(
+      env_optional_string.("ORCHARD_RUNTIME_ENDPOINT_TRANSPORT")
+    )
+
+  peer_grants_enabled? = env_bool.("ORCHARD_BEAM_PEER_GRANTS_ENABLED", false)
+
+  source_dev_node_name =
+    env_optional_string.("ORCHARD_BEAM_NODE_NAME") ||
+      case source_dev_role do
+        :node_agent -> "orchard_node_agent@127.0.0.1"
+        _other -> "orchard_controller@127.0.0.1"
+      end
+
+  source_dev_address_policy =
+    if runtime_endpoint_transport == :beam and not peer_grants_enabled? do
+      Orchard.Config.SourceDevBeam.address_policy!(
+        env_optional_string.("ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS")
+      )
+    end
+
+  if runtime_endpoint_transport == :beam and not peer_grants_enabled? and
+       source_dev_role in [:controller, :node_agent] do
+    Orchard.Config.SourceDevBeam.validate_node_name!(
+      source_dev_role,
+      source_dev_node_name,
+      source_dev_address_policy
+    )
+  end
+
   if source_dev_role in [:controller, :all_in_one] do
     {membership_private_ipv4, membership_scope} =
       Orchard.Config.ControllerMembership.identity!(
-        Orchard.Config.SourceDevBeam.transport!(
-          env_optional_string.("ORCHARD_RUNTIME_ENDPOINT_TRANSPORT")
-        ),
-        env_optional_string.("ORCHARD_BEAM_NODE_NAME"),
+        runtime_endpoint_transport,
+        source_dev_node_name,
         membership_host: env_optional_string.("ORCHARD_CONTROLLER_MEMBERSHIP_HOST"),
-        peer_grants_enabled?: env_bool.("ORCHARD_BEAM_PEER_GRANTS_ENABLED", false)
+        peer_grants_enabled?: peer_grants_enabled?,
+        source_dev_address_policy: source_dev_address_policy
       )
 
     config :orchard_controller, :controller_membership,
       private_ipv4: membership_private_ipv4,
-      scope: membership_scope
+      scope: membership_scope,
+      source_dev_address_policy: source_dev_address_policy
   end
 end

--- a/config/source_dev_beam.exs
+++ b/config/source_dev_beam.exs
@@ -1,11 +1,21 @@
 defmodule Orchard.Config.SourceDevBeam do
   @moduledoc false
 
+  import Bitwise
+
   @transport_env "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT"
   @targets_env "ORCHARD_RUNTIME_ENDPOINT_TARGETS"
   @role_env "ORCHARD_SOURCE_DEV_ROLE"
   @node_name_env "ORCHARD_BEAM_NODE_NAME"
   @max_legacy_beam_targets 64
+  @allowed_cidrs_env "ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS"
+  @built_in_cidrs [
+    {{127, 0, 0, 1}, 32},
+    {{10, 0, 0, 0}, 8},
+    {{172, 16, 0, 0}, 12},
+    {{192, 168, 0, 0}, 16},
+    {{100, 64, 0, 0}, 10}
+  ]
 
   def transport!(value) do
     case optional_trimmed(value) do
@@ -42,20 +52,61 @@ defmodule Orchard.Config.SourceDevBeam do
     end
   end
 
+  def address_policy!(value) do
+    additional_cidrs =
+      value
+      |> csv_segments()
+      |> Enum.map(&parse_policy_cidr!/1)
+
+    %{additional_cidrs: additional_cidrs, allowed_cidrs: @built_in_cidrs ++ additional_cidrs}
+  end
+
+  def host_allowed?(host, %{allowed_cidrs: allowed_cidrs})
+      when is_binary(host) and is_list(allowed_cidrs) do
+    case :inet.parse_ipv4strict_address(String.to_charlist(host)) do
+      {:ok, ip} ->
+        valid_host_class?(ip) and Enum.any?(allowed_cidrs, &cidr_contains?(&1, ip))
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  def host_allowed?(_host, _policy), do: false
+
+  def warn_expanded_network(%{additional_cidrs: []}), do: :ok
+
+  def warn_expanded_network(%{additional_cidrs: additional_cidrs})
+      when is_list(additional_cidrs) do
+    IO.warn(
+      "#{@allowed_cidrs_env} expands the trusted Source-dev network boundary; shared-cookie BEAM may expose EPMD and BEAM Distribution; restrict their ports to configured peers"
+    )
+
+    :ok
+  end
+
   def validate_transport_role!(:beam, :all_in_one) do
     raise "all_in_one BEAM source-dev mode is not supported; use bin/dev-controller and bin/dev-node-agent"
   end
 
   def validate_transport_role!(_transport, _source_dev_role), do: :ok
 
-  def controller_beam_targets!(value, env_name \\ @targets_env) do
+  def validate_node_name!(role, node_name, policy)
+      when role in [:controller, :node_agent] and is_binary(node_name) do
+    {service, host} = beam_service_host!(node_name, @node_name_env)
+    require_source_dev_service!(role, service)
+    require_source_dev_host!(host, @node_name_env, node_name, policy)
+    host
+  end
+
+  def controller_beam_targets!(value, env_name \\ @targets_env, policy \\ address_policy!(nil)) do
     segments = csv_segments(value)
 
     if length(segments) > @max_legacy_beam_targets do
       raise "environment variable #{env_name} supports at most #{@max_legacy_beam_targets} BEAM targets"
     end
 
-    targets = Enum.map(segments, &beam_target!(&1, env_name))
+    targets = Enum.map(segments, &beam_target!(&1, env_name, policy))
 
     case targets do
       [] ->
@@ -66,8 +117,8 @@ defmodule Orchard.Config.SourceDevBeam do
     end
   end
 
-  def beam_guardrail_config!(node_name, cookie_file, targets) do
-    {_service, listen_host} = local_controller_service_host!(node_name)
+  def beam_guardrail_config!(node_name, cookie_file, targets, policy \\ address_policy!(nil)) do
+    listen_host = validate_node_name!(:controller, node_name, policy)
 
     [
       enabled: true,
@@ -99,9 +150,7 @@ defmodule Orchard.Config.SourceDevBeam do
   defp local_controller_service_host!(node_name) do
     {service, host} = beam_service_host!(node_name, @node_name_env)
 
-    unless service =~ ~r/^[A-Za-z0-9_.-]+$/ do
-      raise "environment variable #{@node_name_env} local controller BEAM node service contains invalid characters"
-    end
+    require_controller_service_characters!(service)
 
     unless String.starts_with?(service, "orchard_controller") do
       raise "environment variable #{@node_name_env} local controller BEAM node service must start with orchard_controller"
@@ -111,20 +160,42 @@ defmodule Orchard.Config.SourceDevBeam do
     {service, host}
   end
 
-  defp beam_target!(segment, env_name) do
+  defp beam_target!(segment, env_name, policy) do
     {service, host} = beam_service_host!(segment, env_name)
 
     unless service == "orchard_node_agent" do
       raise "environment variable #{env_name} has unsupported BEAM target service in segment #{inspect(segment)}"
     end
 
-    require_ipv4_literal!(host, env_name, segment)
+    require_source_dev_host!(host, env_name, segment, policy)
 
     %{
       transport: :beam,
       address: String.to_atom("#{service}@#{host}"),
       metadata: %{source_dev: true}
     }
+  end
+
+  defp require_source_dev_service!(:controller, service) do
+    require_controller_service_characters!(service)
+
+    unless String.starts_with?(service, "orchard_controller") do
+      raise "environment variable #{@node_name_env} local controller BEAM node service must start with orchard_controller"
+    end
+
+    :ok
+  end
+
+  defp require_source_dev_service!(:node_agent, "orchard_node_agent"), do: :ok
+
+  defp require_source_dev_service!(:node_agent, _service) do
+    raise "environment variable #{@node_name_env} node-agent service must be exactly orchard_node_agent"
+  end
+
+  defp require_controller_service_characters!(service) do
+    unless service =~ ~r/^[A-Za-z0-9_.-]+$/ do
+      raise "environment variable #{@node_name_env} local controller BEAM node service contains invalid characters"
+    end
   end
 
   defp allowed_cidrs(targets) do
@@ -158,6 +229,16 @@ defmodule Orchard.Config.SourceDevBeam do
     :ok
   end
 
+  defp require_source_dev_host!(host, env_name, segment, policy) do
+    require_ipv4_literal!(host, env_name, segment)
+
+    unless host_allowed?(host, policy) do
+      raise "environment variable #{env_name} BEAM host must use same-host loopback, RFC1918, Tailscale CGNAT 100.64.0.0/10, or #{@allowed_cidrs_env}; got segment #{inspect(segment)}"
+    end
+
+    :ok
+  end
+
   defp parse_ipv4!(host, env_name, segment) do
     case :inet.parse_ipv4strict_address(String.to_charlist(host)) do
       {:ok, ip} ->
@@ -170,7 +251,7 @@ defmodule Orchard.Config.SourceDevBeam do
   end
 
   defp raise_ipv4_error!(@node_name_env, node_name) do
-    raise "environment variable #{@node_name_env} requires IPv4-literal local controller host, got #{inspect(node_name)}"
+    raise "environment variable #{@node_name_env} host must be an IPv4 literal, got #{inspect(node_name)}"
   end
 
   defp raise_ipv4_error!(env_name, segment) do
@@ -182,6 +263,33 @@ defmodule Orchard.Config.SourceDevBeam do
       raise "environment variable #{env_name} must not use unspecified or wildcard BEAM hosts, got segment #{inspect(segment)}"
     end
   end
+
+  defp parse_policy_cidr!(cidr) do
+    with [host, prefix_string] <- String.split(cidr, "/", parts: 2),
+         {:ok, ip} <- :inet.parse_ipv4strict_address(String.to_charlist(host)),
+         {prefix, ""} <- Integer.parse(prefix_string),
+         true <- prefix in 1..32 do
+      {ip, prefix}
+    else
+      _other ->
+        raise "environment variable #{@allowed_cidrs_env} contains invalid IPv4 CIDR #{inspect(cidr)}"
+    end
+  end
+
+  # Config is evaluated before compiled app modules are available, so this predicate mirrors
+  # the runtime policy evaluator and the parity test guards their behavior.
+  # ex_dna:disable-for-lines:4
+  defp valid_host_class?({0, 0, 0, 0}), do: false
+  defp valid_host_class?({first, _b, _c, _d}) when first in 224..239, do: false
+  defp valid_host_class?({255, 255, 255, 255}), do: false
+  defp valid_host_class?(_ip), do: true
+
+  defp cidr_contains?({network, prefix}, ip) do
+    mask = ((1 <<< prefix) - 1) <<< (32 - prefix)
+    band(ipv4_integer(network), mask) == band(ipv4_integer(ip), mask)
+  end
+
+  defp ipv4_integer({a, b, c, d}), do: (a <<< 24) + (b <<< 16) + (c <<< 8) + d
 
   defp csv_segments(nil), do: []
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -334,9 +334,10 @@ For a default BEAM controller launch, `ORCHARD_RUNTIME_ENDPOINT_TARGETS` is effe
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT` | `beam` for split-role scripts | Runtime Endpoint transport selector. Leave unset for split-role BEAM source dev, or set `grpc` for compatibility opt-out. |
-| `ORCHARD_RUNTIME_ENDPOINT_TARGETS` | _(empty)_ | Controller-only comma-separated BEAM target list. Each target must be `orchard_node_agent@<ipv4-literal>`. |
-| `ORCHARD_BEAM_NODE_NAME` | `orchard_controller@127.0.0.1` or `orchard_node_agent@127.0.0.1` | Long BEAM node name for the current split-role VM. The host part must be an IPv4 literal. |
-| `ORCHARD_CONTROLLER_MEMBERSHIP_HOST` | the `ORCHARD_BEAM_NODE_NAME` host, or `127.0.0.1` under `grpc`; **required when `ORCHARD_BEAM_PEER_GRANTS_ENABLED=true`** | Controller-only override for the private IPv4 address that names the Controller's durable membership identity. It must be a private IPv4 literal and must match the `ORCHARD_BEAM_NODE_NAME` host under `beam`. When BEAM Peer Grants are enabled there is no default and it must be set explicitly. Only controller and all-in-one roles resolve it; a node-agent-only host ignores it. |
+| `ORCHARD_RUNTIME_ENDPOINT_TARGETS` | _(empty)_ | Controller-only comma-separated BEAM target list. Each target must be `orchard_node_agent@<ipv4-literal>` and pass the shared-cookie Source-dev address policy. |
+| `ORCHARD_BEAM_NODE_NAME` | `orchard_controller@127.0.0.1` or `orchard_node_agent@127.0.0.1` | Long BEAM node name for the current split-role VM. The host must be an IPv4 literal accepted by the active shared-cookie or Peer Grant policy. Hostnames, including Tailscale MagicDNS names, are not supported. |
+| `ORCHARD_CONTROLLER_MEMBERSHIP_HOST` | the `ORCHARD_BEAM_NODE_NAME` host, or `127.0.0.1` under `grpc`; **required when `ORCHARD_BEAM_PEER_GRANTS_ENABLED=true`** | Controller-only override for the durable membership identity. In shared-cookie Source-dev mode it uses the same address policy as the Controller node name and must match that node-name host under `beam`. In Peer Grant mode it must be an RFC1918 non-loopback IPv4 literal. Only controller and all-in-one roles resolve it; a node-agent-only host ignores it. |
+| `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` | _(empty)_ | Shared-cookie Source-dev-only comma-separated IPv4 CIDRs added to the built-in RFC1918 and Tailscale CGNAT policy. `/0` is rejected. Enrolled production and Peer Grant identity validation ignore this setting. |
 | `ORCHARD_BEAM_COOKIE_FILE` | `tmp/dev/beam.cookie` | Cookie file path. Same-host source dev generates it when absent. Two-Mac source dev must provision the same cookie material on each Mac. |
 | `ORCHARD_BEAM_DIST_PORT_MIN` | `52171` for controller, `52172` for node-agent | Lower bound for the BEAM distribution listener port range. Set both min and max together when overriding. |
 | `ORCHARD_BEAM_DIST_PORT_MAX` | `52171` for controller, `52172` for node-agent | Upper bound for the BEAM distribution listener port range. Set both min and max together when overriding. |
@@ -371,10 +372,13 @@ The node-agent defaults to `orchard_node_agent@127.0.0.1` and distribution port 
 Both roles use `ERL_EPMD_PORT=4369` unless `ORCHARD_BEAM_EPMD_PORT` is set.
 
 Two-Mac BEAM source-dev mode requires explicit IPv4-literal node names and the same cookie material on every participating Mac.
-Do not use hostnames such as `worker.local` for BEAM target hosts in this slice.
-BEAM membership and target hosts must currently be RFC1918 private IPv4 literals (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) or loopback for same-host smokes.
-Tailscale CGNAT addresses in `100.64.0.0/10` are rejected by `Orchard.RuntimeEndpoint.BeamNodeName` today, even though Tailscale is fine for SSH and file copy.
-Use LAN RFC1918 addresses for `ORCHARD_BEAM_NODE_NAME` and `ORCHARD_RUNTIME_ENDPOINT_TARGETS` until that validator is intentionally expanded.
+Shared-cookie Source-dev accepts RFC1918 private-use addresses and Tailscale CGNAT `100.64.0.0/10` without extra configuration.
+Loopback remains for same-host development.
+Do not use hostnames such as `worker.local` or Tailscale MagicDNS names; use the device's IPv4 literal.
+For other trusted internal networks, set `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` to the required comma-separated IPv4 CIDRs on each launch that must validate an identity or target from those networks.
+The Controller validates its own identity and every configured target; each Node Agent validates its own identity, so their additive CIDR lists need not be identical.
+Globally routable additions trigger a startup warning.
+Shared-cookie BEAM grants remote code execution to holders of the cookie, so host firewalls or network ACLs must restrict EPMD and BEAM Distribution ports to the configured peers.
 Provision the cookie out of band without pasting the cookie value into docs, tickets, chat, shell history, or evidence files.
 
 From one Mac, create the cookie file if you are not using an existing secret manager output:
@@ -663,6 +667,18 @@ Keep the cookie mode at `0600` or stricter.
 Verify matching cookie files by comparing SHA-256 digests, not by printing cookie contents.
 Do not commit cookie material, raw local evidence logs, or machine-specific paths.
 
+The placeholders in the commands below may be RFC1918 or Tailscale CGNAT IPv4 literals.
+A Tailscale-only smoke needs no `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS`; substitute each device's `100.64.0.0/10` address directly.
+For an operator-routed network outside the built-in ranges, export the same additive setting on each terminal that must validate one of those addresses:
+
+```bash
+export ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS="<trusted-ipv4-cidr>[,<trusted-ipv4-cidr>...]"
+```
+
+This setting authorizes configuration values only.
+The Controller still derives an exact `/32` live guardrail for every configured Runtime Endpoint target.
+Never use a broad additive CIDR as a substitute for host firewall or network ACL rules.
+
 #### Controller Mac local node-agent terminal
 
 ```bash
@@ -696,7 +712,7 @@ mise exec -- bin/dev-controller
 The default controller distribution port is TCP `52171`.
 The default node-agent distribution port is TCP `52172`.
 The default EPMD port is TCP `4369`.
-Those ports must be reachable between the participating private IPs.
+Those ports must be reachable between the participating IPv4 addresses and unreachable from untrusted hosts.
 If another EPMD already owns `4369`, set the same nonstandard `ORCHARD_BEAM_EPMD_PORT` on every participating terminal.
 The validated two-Mac smokes used `ORCHARD_BEAM_EPMD_PORT=43690` on hosts with EPMD conflicts.
 If you override the EPMD or distribution port variables, use the same values in your firewall rules and smoke notes.
@@ -720,9 +736,10 @@ It should not fall back to gRPC.
 Run this before the first Topology B / two-Mac BEAM smoke on macOS.
 
 1. **Address plane**
-   - Pick RFC1918 LAN IPv4 literals for every BEAM node name and target.
-   - Do not put Tailscale `100.x` addresses in `ORCHARD_BEAM_NODE_NAME` or `ORCHARD_RUNTIME_ENDPOINT_TARGETS` with the current validator.
-   - Tailscale remains useful for `ssh` / `scp` only.
+   - Pick explicit RFC1918 or Tailscale CGNAT IPv4 literals for every shared-cookie BEAM node name and target.
+   - For another trusted internal network, set `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` on each affected launch.
+   - Do not use hostnames or Tailscale MagicDNS names.
+   - Peer Grant identities remain RFC1918 non-loopback and ignore the Source-dev additive setting.
 
 2. **Launch context (macOS Local Network Privacy)**
    - Start `bin/dev-controller` and `bin/dev-node-agent` from a GUI terminal session that already has Local Network permission (Terminal.app is the proven path).
@@ -779,7 +796,7 @@ BEAM split-role default promotion was accepted on 2026-07-05 after the smoke evi
 |---------|-------|-----|
 | gRPC controller shows 1 target | `ORCHARD_RUNTIME_CLIENT_TARGETS` unset or malformed | Check env var, use `host:port,host:port` format. |
 | BEAM controller exits before Mix starts | `ORCHARD_RUNTIME_ENDPOINT_TARGETS` is empty, malformed, or uses a hostname or IPv6 address | Use comma-separated `orchard_node_agent@<ipv4-literal>` targets. |
-| BEAM boot rejects `100.x` / Tailscale node names | Host is Tailscale CGNAT; validator accepts RFC1918 only today | Use LAN RFC1918 BEAM names. Keep Tailscale for SSH/scp. See issue #193. |
+| BEAM boot rejects a public or operator-routed IPv4 literal | The host is outside RFC1918 and Tailscale CGNAT, and its network is not explicitly authorized | Add the narrow trusted network to `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` for shared-cookie Source-dev only. Do not use this setting for Peer Grant or enrolled production identity. |
 | BEAM `connect` / `:gen_tcp` returns `:ehostunreach` while `ping` works | macOS Local Network Privacy blocked the BEAM launch context | Relaunch controller/node-agent from Terminal.app (or another GUI app with Local Network allowed). |
 | Source-dev BEAM bootstrap reports wildcard-bound EPMD | Another `epmd` is listening on `0.0.0.0`/`*` for that port | `ERL_EPMD_PORT=<port> epmd -kill`, confirm only the address-constrained listener remains, rerun. |
 | Console boot warns `Sentry.LiveViewHook` unavailable / LiveView crashes lack Sentry context | Sentry was compiled without LiveView on the compile path | Console still mounts. To restore LiveView Sentry context: `mix deps.compile phoenix_live_view` then `mix deps.compile sentry --force`, restart controller. Issue #191. |
@@ -836,14 +853,14 @@ Env surface:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ORCHARD_BEAM_PEER_GRANT_STATE_ROOT` | `tmp/dev/beam-peer-grant` | Owner-only (`0700`) root for per-role launch manifests, `ssl-dist` optfiles, and grant state. |
-| `ORCHARD_BEAM_PEER_GRANT_CONTROL_HOST` | _(required, controller)_ | Private, non-loopback IPv4 address the grant-delivery control listener binds. |
+| `ORCHARD_BEAM_PEER_GRANT_CONTROL_HOST` | _(required, controller)_ | RFC1918 non-loopback IPv4 address the grant-delivery control listener binds. |
 | `ORCHARD_BEAM_PEER_GRANT_CONTROL_PORT` | _(required, controller)_ | Port for the grant-delivery control listener. |
 | `ORCHARD_BEAM_AUTHORIZATION_ROOT_PATH` | _(required, controller)_ | Path to the Controller-local BEAM Authorization Root that derives pair-secret material. |
-| `ORCHARD_CONTROLLER_MEMBERSHIP_HOST` | _(required, controller)_ | Private, non-loopback IPv4 address that fixes the Controller's durable canonical BEAM name across both tracer phases. It is independent of the control listener host and must match the `ORCHARD_BEAM_NODE_NAME` host in `distributed` mode. |
+| `ORCHARD_CONTROLLER_MEMBERSHIP_HOST` | _(required, controller)_ | RFC1918 non-loopback IPv4 address that fixes the Controller's durable canonical BEAM name across both tracer phases. It is independent of the control listener host and must match the `ORCHARD_BEAM_NODE_NAME` host in `distributed` mode. |
 | `ORCHARD_NODE_TRUST_ROOT` | _(required, controller preflight/run)_ | Controller node-trust root used by the distributed controller preflight and run; conventionally `tmp/dev/node-trust` in source dev. |
 | `ORCHARD_NODE_IDENTITY_ROOT` | _(required, node)_ | Owner-only node identity root holding the Node key, Node Certificate, and stored grant; conventionally `tmp/dev/config/node-identity` in source dev. |
 | `ORCHARD_BEAM_PEER_GRANT_DESCRIPTOR` | _(required, node; controller preflight)_ | Path to the grant descriptor that binds the exact Controller-to-Node pair. |
-| `ORCHARD_BEAM_NODE_NAME` | _(required)_ | Long BEAM node name for the current role. In grant mode the node-agent service must be `orchard_node_agent_<32-hex>@<ipv4-literal>` and the distributed controller service must be `orchard_controller_<32-hex>@<ipv4-literal>`. |
+| `ORCHARD_BEAM_NODE_NAME` | _(required)_ | Long BEAM node name for the current role. In grant mode the node-agent service must be `orchard_node_agent_<32-hex>@<rfc1918-ipv4-literal>` and the distributed controller service must be `orchard_controller_<32-hex>@<rfc1918-ipv4-literal>`. |
 
 `ORCHARD_BEAM_PEER_GRANTS_ENABLED`, `ORCHARD_BEAM_PEER_GRANT_MODE`
 (`grant_control` or `distributed`), `ORCHARD_BEAM_DISTRIBUTION_LAUNCH_MANIFEST`,

--- a/openspec/changes/expand-source-dev-beam-address-policy/.openspec.yaml
+++ b/openspec/changes/expand-source-dev-beam-address-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/expand-source-dev-beam-address-policy/design.md
+++ b/openspec/changes/expand-source-dev-beam-address-policy/design.md
@@ -1,0 +1,93 @@
+## Context
+
+Issue #193 exposes a contract split across the shared-cookie Source-dev BEAM operating model.
+`Orchard.Config.SourceDevBeam` accepts any concrete IPv4-literal target and derives exact `/32` Runtime Endpoint guardrails, while `Orchard.Config.ControllerMembership` and `Orchard.RuntimeEndpoint.BeamNodeName.private_ipv4/2` accept only RFC1918 addresses plus optional loopback.
+`docs/local-dev.md` currently describes both identities and targets as RFC1918-only even though the accepted Runtime Endpoints specification requires a Tailscale CGNAT target to pass.
+
+RFC1918 classification is not a trust decision.
+Tailscale uses shared CGNAT space, while an operator-defined trusted network may also use owned globally routable prefixes internally.
+At the same time, accepting every public address by default would make the shared-cookie development path easier to expose accidentally.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give every shared-cookie Source-dev BEAM identity and target one explicit IPv4 network policy.
+- Accept RFC1918 and Tailscale CGNAT IPv4 literals without extra configuration.
+- Support unusual trusted networks through deliberate additive CIDR configuration.
+- Keep live Runtime Endpoint guardrails narrowed to exact configured target hosts.
+- Produce path-specific errors that name accepted address classes.
+- Preserve the stricter enrolled production and Peer Grant identity contracts.
+
+**Non-Goals:**
+
+- Redesigning enrolled production network policy, Node identity, Controller identity, or Peer Grant identity.
+- Making Tailscale mandatory or adding a Tailscale dependency.
+- Adding hostname resolution, including Tailscale MagicDNS, or IPv6 BEAM Distribution support.
+- Changing shared-cookie, EPMD, certificate, or Peer Grant mechanics.
+
+## Decisions
+
+### Use a dedicated Source-dev address policy
+
+The pure policy component will live in the `config/`-loaded Source-dev configuration surface so `config/dev.exs` can use it before compiled application modules are available.
+It will own IPv4/CIDR parsing, built-in networks, additive networks, address classification, and stable rejection reasons.
+Configuration entrypoints will resolve the environment setting once and pass plain policy data explicitly rather than reading environment variables inside domain validation.
+
+`Orchard.Config.SourceDevBeam` will apply the policy to Controller and Node Agent node-name hosts and Runtime Endpoint target hosts.
+The Node Agent runtime configuration branch will invoke this validation; `bin/lib/source-dev-beam.sh` will retain syntax and service-name preflight without duplicating the address-class policy.
+The Source-dev Controller configuration path will pass the same plain policy data into `Orchard.Config.ControllerMembership` for the membership host only when Peer Grants are disabled.
+The membership host must continue to equal the Controller node-name host in BEAM mode.
+Default `ControllerMembership` behavior remains strict when no Source-dev policy is supplied, preventing enrolled production and Peer Grant paths from inheriting the expansion.
+
+Alternative considered: extend `BeamNodeName.private_ipv4/2`.
+Rejected because globally routable operator CIDRs are not private IPv4, and an option-threading mistake could relax Peer Grant validation.
+
+Alternative considered: keep targets permissive and special-case membership.
+Rejected because it preserves inconsistent rules and allows globally routable targets without deliberate opt-in.
+
+### Define safe defaults and additive operator networks
+
+The policy accepts RFC1918 and `100.64.0.0/10` remote hosts by default.
+`127.0.0.1` remains valid for same-host development.
+`ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` adds comma-separated IPv4 CIDRs and does not replace the defaults.
+Explicit additions may include globally routable prefixes so operators using owned address space internally are not forced into RFC1918.
+An unrestricted `/0` addition is rejected; other prefix widths remain an explicit operator trust decision because identities and targets are still named individually.
+
+Any malformed CIDR segment aborts startup and names the offending setting and segment.
+Malformed host IPv4 values, hostnames including Tailscale MagicDNS, IPv6, unspecified or wildcard addresses, multicast, and the limited-broadcast address are rejected even when an added CIDR would otherwise contain them.
+An absent or blank additive setting is equivalent to no additions.
+
+Alternative considered: accept only exact `/32` additions.
+Rejected because the live Runtime Endpoint guardrail is already derived as an exact `/32` for each configured target, while policy CIDRs describe which operator network may supply identities and targets.
+
+### Keep network authorization narrow at runtime
+
+The policy CIDRs authorize configuration values; they do not become BEAM Runtime Endpoint connection guardrails.
+The Controller continues deriving `allowed_cidrs` as unique `/32` entries from configured targets.
+This prevents a broad operator policy CIDR from authorizing unconfigured peers.
+
+### Separate Source-dev and Peer Grant errors
+
+Source-dev rejection errors will name loopback for same-host development where applicable, RFC1918, Tailscale CGNAT `100.64.0.0/10`, and `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS`.
+A globally routable address rejected only because it lacks explicit authorization will report that distinction.
+Peer Grant and strict membership errors will name RFC1918 non-loopback rather than the ambiguous phrase `private IPv4`.
+
+## Risks / Trade-offs
+
+- [Operator authorizes a public prefix and exposes shared-cookie BEAM] -> Require explicit CIDR configuration, reject `/0`, emit a startup warning naming the EPMD and BEAM Distribution exposure, retain exact-target `/32` guardrails, and document that host firewalls or network ACLs must restrict those ports to configured peers.
+- [Source-dev policy leaks into production or Peer Grant mode] -> Keep the policy in a separate component and pass it at the existing Source-dev membership call only when `peer_grants_enabled?` is false.
+- [Configuration paths drift again] -> Exercise Controller membership, both split-role launch paths, target parsing, Runtime Endpoint guardrail derivation, and a live two-host Tailscale CGNAT connection against one boundary matrix.
+- [CIDR terminology implies that the full prefix is admitted] -> Document and test that policy CIDRs authorize configuration only and live target guardrails remain exact `/32` values.
+
+## Migration Plan
+
+Existing RFC1918 and same-host configurations continue working without changes.
+Tailscale CGNAT IPv4-literal configurations become valid without extra settings; Tailscale MagicDNS names remain unsupported.
+Existing globally routable targets, which target parsing previously accepted without a class policy, must be covered by `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS`.
+Each split-role host evaluates the policy needed for its own identity, while the Controller also evaluates every configured target; the CIDR lists need not be identical when those responsibilities differ.
+Rollback removes the additive setting and restores the previous RFC1918-only Controller membership behavior; no persisted data migration is required.
+
+## Open Questions
+
+None.

--- a/openspec/changes/expand-source-dev-beam-address-policy/proposal.md
+++ b/openspec/changes/expand-source-dev-beam-address-policy/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Source-dev BEAM currently conflates RFC1918 address classification with network trust, which rejects Tailscale CGNAT IPv4 literals and legitimate operator-routed networks while different configuration paths already enforce inconsistent rules.
+Issue #193 requires one explicit Source-dev address policy without relaxing enrolled production or BEAM Peer Grant identity boundaries.
+
+## What Changes
+
+- Define one shared-cookie Source-dev BEAM address policy for local node names, Controller membership identity, and explicit Runtime Endpoint targets.
+- Accept RFC1918 private-use IPv4 and Tailscale/shared CGNAT `100.64.0.0/10` by default.
+- Allow operators to add trusted IPv4 CIDRs, including deliberately authorized globally routable prefixes, through a Source-dev-only configuration setting; globally routable use emits an exposure warning and requires network access controls.
+- Keep loopback limited to same-host development and reject malformed, unspecified, wildcard, multicast, limited-broadcast, hostname, IPv6, and unrestricted `/0` values.
+- Keep enrolled production and BEAM Peer Grant identity validation unchanged.
+- Make rejection errors name the accepted address classes and reconcile tests plus `docs/local-dev.md` with the final boundary.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `runtime-endpoints`: Expand and unify the Source-dev BEAM address-policy requirements for shared-cookie identities and targets.
+
+## Impact
+
+- Source-dev configuration parsing and Controller membership resolution in `config/` and `apps/orchard_shared/`.
+- Controller and Node Agent source-dev launch validation, including `bin/lib/source-dev-beam.sh`.
+- Runtime Endpoint target guardrails and their configuration tests.
+- Operator guidance in `docs/local-dev.md`.
+- No change to `SPEC.md` production requirements: production private-network, trusted-inventory, certificate, and Peer Grant requirements remain unchanged; this change refines the Source-dev operating model described by §1.2 and §7.5.

--- a/openspec/changes/expand-source-dev-beam-address-policy/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/expand-source-dev-beam-address-policy/specs/runtime-endpoints/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Shared-cookie Source-dev BEAM Address Policy
+Shared-cookie Source-dev BEAM SHALL apply one IPv4 address policy to Controller and Node Agent `ORCHARD_BEAM_NODE_NAME` hosts, the Source-dev Controller membership host, and `ORCHARD_RUNTIME_ENDPOINT_TARGETS` hosts.
+The policy SHALL accept RFC1918 private-use addresses and shared CGNAT `100.64.0.0/10` by default.
+The policy SHALL accept loopback only for same-host Source-dev use.
+Operators SHALL be able to add trusted IPv4 CIDRs, including explicitly authorized globally routable prefixes, through `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS`.
+An added `/0` CIDR MUST be rejected as unrestricted.
+Added policy CIDRs SHALL authorize configured identities and targets but SHALL NOT replace the exact-host Runtime Endpoint connection guardrails derived from configured targets.
+Malformed CIDR segments MUST abort startup and name the offending setting and segment.
+Malformed host IPv4 values, hostnames including Tailscale MagicDNS, IPv6, unspecified or wildcard addresses, multicast, and the limited-broadcast address MUST be rejected.
+Enrolled production and BEAM Peer Grant identity validation MUST NOT inherit the Source-dev policy or its operator additions.
+Rejection errors SHALL name the address classes and configuration setting accepted by the path that rejected startup.
+This refines Source-dev BEAM Runtime Endpoint behavior in `SPEC.md` §1.2 and §7.5 without changing their production identity and private-network requirements.
+
+#### Scenario: Tailscale CGNAT IPv4 Controller and target are accepted by default
+- **WHEN** shared-cookie Source-dev BEAM uses Controller membership and node-name IPv4 literals plus a Runtime Endpoint target within `100.64.0.0/10`
+- **THEN** Orchard accepts those configured hosts without an additional CIDR setting
+- **THEN** Orchard derives Runtime Endpoint connection guardrails from the exact configured target hosts
+
+#### Scenario: Tailscale MagicDNS remains unsupported
+- **WHEN** a shared-cookie Source-dev identity or target uses a Tailscale MagicDNS hostname
+- **THEN** Orchard rejects startup and directs the operator to use an accepted IPv4 literal
+
+#### Scenario: Operator-authorized internal network is accepted
+- **WHEN** `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` contains a valid IPv4 CIDR and a shared-cookie Source-dev identity or target is inside that CIDR
+- **THEN** Orchard accepts that configured host under the Source-dev address policy
+- **THEN** Orchard does not admit other hosts from that CIDR unless they are configured as Runtime Endpoint targets
+
+#### Scenario: Globally routable operator network warns about exposure
+- **WHEN** `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` authorizes a globally routable prefix used by a shared-cookie Source-dev identity or target
+- **THEN** Orchard emits a startup warning that names the EPMD and BEAM Distribution exposure
+- **THEN** operator guidance requires host firewall or network ACL rules that restrict those ports to configured peers
+
+#### Scenario: Unrestricted or malformed policy CIDR is rejected
+- **WHEN** `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` contains `/0` or a malformed segment
+- **THEN** Orchard rejects startup and names the offending setting and segment
+
+#### Scenario: Globally routable address requires explicit authorization
+- **WHEN** a shared-cookie Source-dev identity or target uses a globally routable IPv4 address outside the built-in and operator-configured CIDRs
+- **THEN** Orchard rejects startup before Runtime Endpoint work begins
+- **THEN** the error names RFC1918, Tailscale CGNAT `100.64.0.0/10`, same-host loopback where applicable, and `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS`
+
+#### Scenario: Invalid host class remains rejected
+- **WHEN** a shared-cookie Source-dev identity or target uses an unspecified, wildcard, multicast, limited-broadcast, malformed, hostname, or IPv6 value
+- **THEN** Orchard rejects startup even when an operator-configured CIDR could otherwise contain the address
+
+#### Scenario: Controller membership and node name disagree
+- **WHEN** the Source-dev Controller membership host differs from the Controller `ORCHARD_BEAM_NODE_NAME` host
+- **THEN** Orchard rejects startup even when both hosts are individually accepted by the Source-dev address policy
+
+#### Scenario: Peer Grant identity remains strict
+- **WHEN** BEAM Peer Grant mode uses a CGNAT, loopback, globally routable, or Source-dev operator-authorized address as its Controller or Node identity
+- **THEN** Orchard rejects that identity under the existing RFC1918 non-loopback Peer Grant policy

--- a/openspec/changes/expand-source-dev-beam-address-policy/tasks.md
+++ b/openspec/changes/expand-source-dev-beam-address-policy/tasks.md
@@ -1,0 +1,25 @@
+## 1. Source-dev Address Policy
+
+- [x] 1.1 Add boundary tests for RFC1918, CGNAT edges and adjacent addresses, custom CIDRs, `/0`, default-public rejection, loopback, malformed list segments, and invalid host classes.
+- [x] 1.2 Implement the pure `config/`-loaded Source-dev IPv4/CIDR policy with RFC1918 and `100.64.0.0/10` defaults plus additive `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` parsing.
+- [x] 1.3 Add stable path-specific error formatting and globally routable exposure warnings that name accepted Source-dev and strict Peer Grant address classes.
+
+## 2. Configuration Integration
+
+- [x] 2.1 Apply the policy to Controller and Node Agent `ORCHARD_BEAM_NODE_NAME` validation and Runtime Endpoint target parsing, keeping shell preflight limited to syntax and service names.
+- [x] 2.2 Pass plain policy data at the existing Source-dev Controller membership call only when Peer Grants are disabled, preserving strict default and Peer Grant behavior.
+- [x] 2.3 Preserve exact `/32` Runtime Endpoint connection guardrails for every configured target, including targets authorized through broader operator CIDRs.
+- [x] 2.4 Reconcile split-role launch and runtime configuration tests for Tailscale CGNAT IPv4 literals, MagicDNS rejection, custom-CIDR topologies, membership/name disagreement, and unchanged Peer Grant rejection.
+
+## 3. Operator Contract
+
+- [x] 3.1 Update `docs/local-dev.md` with zero-config Tailscale CGNAT IPv4 literals, explicit MagicDNS non-support, custom-CIDR migration, trusted-network warnings, EPMD and Distribution firewall obligations, and corrected troubleshooting guidance.
+- [x] 3.2 Ensure configuration examples and errors distinguish shared-cookie Source-dev policy from enrolled production and Peer Grant identity policy.
+
+## 4. Verification
+
+- [x] 4.1 Run the focused Source-dev configuration, Controller membership, Runtime Endpoint guardrail, and split-role launch test slices.
+- [x] 4.2 Run a real two-host Tailscale CGNAT smoke that establishes BEAM Distribution and completes a Runtime Endpoint status call, not only configuration admission.
+- [x] 4.3 Run `mise exec -- mix format`, compile with warnings as errors, strict Credo, Dialyzer, the full test suite, and coverage.
+- [ ] 4.4 Run strict OpenSpec change validation before implementation handoff and strict all-spec validation after accepted behavior is synced or archived.
+- [ ] 4.5 After sync or archive, inspect generated main specs and remove placeholder prose such as `Purpose TBD`.


### PR DESCRIPTION
## Summary

Source-dev BEAM deployments can now use Tailscale and explicitly authorized routed networks without weakening Orchard's production or Peer Grant identity rules.

Issue #193 exposed an inconsistent boundary: Runtime Endpoint targets accepted concrete IPv4 literals, while Controller membership still assumed RFC1918-only networking. This change gives shared-cookie Source-dev BEAM one address policy and applies it consistently to Controller identities, Node Agent identities, Controller membership, and Runtime Endpoint targets.

## What changed

| Address class | Shared-cookie Source-dev | Peer Grant and production |
|---|---:|---:|
| RFC1918 | Allowed | Existing strict policy remains |
| Tailscale CGNAT `100.64.0.0/10` | Allowed | Not added |
| Loopback | Same-host only | Existing strict policy remains |
| `ORCHARD_SOURCE_DEV_BEAM_ALLOWED_CIDRS` | Explicit opt-in | Ignored |
| Public IPv4 without an explicit CIDR | Rejected | Rejected |
| Hostnames, IPv6, wildcard, multicast, and malformed IPv4 | Rejected | Rejected |

- Keeps Controller membership identity aligned with the Controller BEAM node-name host.
- Keeps live Runtime Endpoint Distribution guardrails narrowed to exact configured target hosts through `/32` CIDRs.
- Warns when operator CIDRs expand the trusted Source-dev network boundary and names the EPMD and BEAM Distribution firewall obligation.
- Returns operator-facing errors that name every accepted address class.
- Updates the split-role configuration paths and `docs/local-dev.md` with Tailscale and custom-CIDR recipes.
- Records the accepted boundary in `openspec/changes/expand-source-dev-beam-address-policy/`.

## Verification

Real two-host Tailscale smoke:

- Controller: `orchard_controller@100.90.207.78`
- Node Agent: `orchard_node_agent@100.70.81.109`
- BEAM Distribution connected across the tailnet.
- `Orchard.RuntimeEndpoint.BeamClient.status/1` returned `{:ok, %{health: %{ready: true}, ...}}`.

Quality gates:

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `mise exec -- mix test`
  - 303 shared tests passed
  - 3,388 Controller tests passed, 5 skipped
  - 389 Node Agent tests passed
  - 738 CLI tests passed, 10 integration tests excluded
- `mise exec -- mix test --cover`
  - Shared: 69.65%
  - Controller: 85.0%
  - Node Agent: 77.80%
  - CLI: 76.82%
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate expand-source-dev-beam-address-policy --type change --strict --no-interactive`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
  - 20 OpenSpec items passed, 0 failed

## Risk Assessment

✅ **Medium**

- The change expands the shared-cookie Source-dev network boundary, which can expose EPMD and BEAM Distribution when an operator opts into a routed CIDR.
- Tailscale CGNAT is the only new default remote class. Other networks require an explicit CIDR configuration and emit a warning.
- Runtime Endpoint connections remain restricted to exact configured hosts rather than the full allowed CIDR.
- Peer Grant identity, certificate-authenticated production identity, and enrolled production BEAM policy do not inherit this relaxation.
- There is no database migration or packaged production configuration change.

Closes #193

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/openai--codex%2Fgpt--5.6--sol-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789091038&installation_model_id=428414&pr_number=205&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F205&signature=a6fa5fbecfdea6025464b6dbdd1c72b22975bebe974964a13af42dd88b85c43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->