### PR TITLE
feat(requests): persist deadline and attempt evidence

### DIFF
--- a/apps/orchard_cli/test/orchard_cli/commands/models_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/models_test.exs
@@ -64,7 +64,7 @@ defmodule OrchardCLI.Commands.ModelsTest do
           input_tokens: 0,
           output_tokens: 0,
           reserved_output_tokens: 128,
-          timeout_at: ~U[2026-03-10 00:00:00.000000Z]
+          timeout_at: DateTime.utc_now() |> DateTime.add(120_000, :millisecond)
         },
         overrides
       )

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -17,12 +17,11 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   dispatcher takes that Node's acceptance gate, revalidates the recognized
   claim without counting it twice, and holds the gate until the node accepts or
   the attempt fails pre-acceptance. Gate acquisition is bounded by the time left
-  on the request deadline, which the schedule's required `:request_timeout_ms`
-  opens at dispatch entry, and fails the dispatch with
-  `:dispatch_capacity_acceptance_gate_busy` rather than waiting behind another
-  in-flight dispatch to the same Node indefinitely. An already-elapsed deadline
-  fails as `:dispatch_timeout` without taking the gate. Unavailable capacity fails
-  the dispatch rather than proceeding, and reports the authority's own reason —
+  on the persisted Request deadline carried as `:timeout_at`, and fails the
+  dispatch with `:dispatch_capacity_acceptance_gate_busy` rather than waiting
+  behind another in-flight dispatch to the same Node indefinitely. An
+  already-elapsed deadline fails as `:dispatch_timeout` without taking the gate.
+  Unavailable capacity fails the dispatch rather than proceeding, and reports
   `:dispatch_capacity_unavailable`, `:dispatch_capacity_request_already_claimed`
   for a request whose prior claim was never released, or
   `:dispatch_capacity_facts_unavailable` when the schedule carries no
@@ -48,8 +47,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   alias Orchard.DomainMetrics
   alias Orchard.Inference
-  alias Orchard.Inference.ModelLoadFailure
-  alias Orchard.Inference.QueueManager
+  alias Orchard.Inference.{ModelLoadFailure, QueueManager, RequestDeadline}
   alias Orchard.InferenceEvent
 
   alias Orchard.RuntimeEndpoint.{
@@ -191,10 +189,9 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   - `:runtime_endpoint_target` - typed Runtime Endpoint target for new schedulers
   - `:runtime_client_target` - legacy `[host: ..., port: ...]` gRPC compatibility target
   - `:request_id` - the canonical request ID
-  - `:request_timeout_ms` - maximum wall-clock time for the dispatch excluding
-    model load, which is bounded separately by `:model_load_timeout_ms`. The
-    deadline runs from dispatch entry and covers connect, probe, acceptance-gate
-    acquisition, and streaming, so a slow cold start cannot starve the stream.
+  - `:timeout_at` - the persisted absolute logical Request deadline. It covers
+    queueing, scheduling, model loading, connect, probe, acceptance-gate
+    acquisition, and streaming.
 
   BEAM schedules may omit `:runtime_client_target`.
   If a configured BEAM target node ID conflicts with observed endpoint metadata,
@@ -239,9 +236,14 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       ) do
     target = runtime_endpoint_target(schedule)
     request_id = Map.fetch!(schedule, :request_id)
-    timeout_ms = Map.fetch!(schedule, :request_timeout_ms)
-    deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
-    model_load_timeout = Map.get(schedule, :model_load_timeout_ms, 120_000)
+    timeout_at = Map.fetch!(schedule, :timeout_at)
+    now = DateTime.utc_now()
+    system_ms = DateTime.to_unix(now, :millisecond)
+    monotonic_ms = System.monotonic_time(:millisecond)
+    timeout_ms = RequestDeadline.remaining_ms(timeout_at, now)
+    deadline_ms = RequestDeadline.to_monotonic_ms(timeout_at, system_ms, monotonic_ms)
+
+    model_load_timeout_cap_ms = Map.get(schedule, :model_load_timeout_ms, 120_000)
     caller = Keyword.get(opts, :caller, self())
     caller_ref = Process.monitor(caller)
     event_handler = Keyword.get(opts, :event_handler)
@@ -270,7 +272,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       execute_request: execute_request,
       model_load_request: model_load_request,
       metrics: metrics,
-      model_load_timeout: model_load_timeout,
+      model_load_timeout_cap_ms: model_load_timeout_cap_ms,
       timeout_ms: timeout_ms,
       deadline_ms: deadline_ms,
       caller: caller,
@@ -281,15 +283,19 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     }
 
     try do
-      case preensure_prompt_token_ids_gate(execute_request, schedule, model_load_request) do
-        :ok ->
-          dispatch_with_capacity_claim(context)
+      if timeout_ms <= 0 do
+        {:error, {:dispatch_failed, :dispatch_timeout}}
+      else
+        case preensure_prompt_token_ids_gate(execute_request, schedule, model_load_request) do
+          :ok ->
+            dispatch_with_capacity_claim(context)
 
-        {:error, reason} ->
-          error_metrics = finalize_metrics(metrics, {:error, {:dispatch_failed, reason}})
-          put_dispatch_terminal_context(error_metrics, target)
-          emit_timing_log(error_metrics, {:error, {:dispatch_failed, reason}})
-          {:error, {:dispatch_failed, reason}}
+          {:error, reason} ->
+            error_metrics = finalize_metrics(metrics, {:error, {:dispatch_failed, reason}})
+            put_dispatch_terminal_context(error_metrics, target)
+            emit_timing_log(error_metrics, {:error, {:dispatch_failed, reason}})
+            {:error, {:dispatch_failed, reason}}
+        end
       end
     after
       Process.demonitor(caller_ref, [:flush])
@@ -299,6 +305,14 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   # -- Private ---------------------------------------------------------------
 
   defp dispatch_with_capacity_claim(%{schedule: schedule} = context) do
+    if deadline_expired?(context) do
+      dispatch_timeout_result(context)
+    else
+      dispatch_with_live_capacity_claim(context, schedule)
+    end
+  end
+
+  defp dispatch_with_live_capacity_claim(context, schedule) do
     case acquire_capacity_claim(schedule) do
       {:ok, nil} ->
         dispatch_after_preensure_gate(context)
@@ -416,29 +430,37 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     do: Map.get(schedule, :dispatch_capacity_authority, AllocationAuthority)
 
   defp dispatch_after_preensure_gate(%{client: client, target: target} = context) do
-    case authorize_dispatch_target(target) do
-      :ok ->
-        case client.connect(target) do
-          {:ok, channel} ->
-            dispatch_with_channel(Map.put(context, :channel, channel))
+    if deadline_expired?(context) do
+      dispatch_timeout_result(context)
+    else
+      case authorize_dispatch_target(target) do
+        :ok ->
+          connect_for_dispatch(client, target, context)
 
-          {:error, reason} ->
-            handle_dispatch_connect_failure(target, reason, context.metrics)
-        end
+        {:error, :runtime_target_not_active} ->
+          handle_dispatch_result(
+            {:error, {:dispatch_failed, :node_not_active}},
+            context.metrics,
+            target
+          )
 
-      {:error, :runtime_target_not_active} ->
-        handle_dispatch_result(
-          {:error, {:dispatch_failed, :node_not_active}},
-          context.metrics,
-          target
-        )
+        {:error, :node_inventory_unavailable} ->
+          handle_dispatch_result(
+            {:error, {:dispatch_failed, :node_inventory_unavailable}},
+            context.metrics,
+            target
+          )
+      end
+    end
+  end
 
-      {:error, :node_inventory_unavailable} ->
-        handle_dispatch_result(
-          {:error, {:dispatch_failed, :node_inventory_unavailable}},
-          context.metrics,
-          target
-        )
+  defp connect_for_dispatch(client, target, context) do
+    case client.connect(target) do
+      {:ok, channel} ->
+        dispatch_with_channel(Map.put(context, :channel, channel))
+
+      {:error, reason} ->
+        handle_dispatch_connect_failure(target, reason, context.metrics)
     end
   end
 
@@ -487,23 +509,45 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp do_dispatch_with_channel(%{} = context) do
+    if deadline_expired?(context) do
+      dispatch_timeout_result(context)
+    else
+      dispatch_after_live_channel(context)
+    end
+  end
+
+  defp dispatch_after_live_channel(context) do
     case prepare_dispatch_identity(context) do
       {:ok, model_load_request, metrics} ->
         context = %{context | model_load_request: model_load_request, metrics: metrics}
-        ensure_start = System.monotonic_time(:millisecond)
-        put_ensure_model_load_started_context(metrics)
-
-        context.client
-        |> ensure_loaded_for_dispatch(
-          context.channel,
-          context.target,
-          model_load_request,
-          context.model_load_timeout
-        )
-        |> handle_ensure_result(context, ensure_start)
+        ensure_loaded_before_deadline(context, model_load_request, metrics)
 
       {:error, reason, metrics} ->
         handle_dispatch_result({:error, {:dispatch_failed, reason}}, metrics, context.target)
+    end
+  end
+
+  defp ensure_loaded_before_deadline(context, model_load_request, metrics) do
+    model_load_timeout =
+      min(
+        context.model_load_timeout_cap_ms,
+        remaining_request_timeout_ms(context.deadline_ms)
+      )
+
+    if model_load_timeout <= 0 do
+      dispatch_timeout_result(%{context | metrics: metrics})
+    else
+      ensure_start = System.monotonic_time(:millisecond)
+      put_ensure_model_load_started_context(metrics)
+
+      context.client
+      |> ensure_loaded_for_dispatch(
+        context.channel,
+        context.target,
+        model_load_request,
+        model_load_timeout
+      )
+      |> handle_ensure_result(context, ensure_start)
     end
   end
 
@@ -622,14 +666,15 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       DomainMetrics.model_load(metrics.node_id, metrics.model_id, metrics.ensure_model_loaded_ms)
     end
 
-    context =
+    context = Map.put(context, :ensure_model_loaded_result, ensure_load_meta)
+
+    if deadline_expired?(context) do
+      dispatch_timeout_result(%{context | metrics: metrics})
+    else
       context
-      |> Map.put(:ensure_model_loaded_result, ensure_load_meta)
-      |> Map.update!(:deadline_ms, &(&1 + ensure_end - ensure_start))
-
-    result = execute_loaded_request(context, ensure_load_meta, metrics)
-
-    handle_dispatch_result(result, metrics, context.target)
+      |> execute_loaded_request(ensure_load_meta, metrics)
+      |> handle_dispatch_result(metrics, context.target)
+    end
   end
 
   defp handle_ensure_result({:error, reason}, context, ensure_start) do
@@ -641,11 +686,15 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         model_already_loaded: false
     }
 
-    error_metrics = finalize_metrics(metrics, {:error, {:model_load_failed, reason}})
-    DomainMetrics.model_load(metrics.node_id, metrics.model_id, metrics.ensure_model_loaded_ms)
-    put_dispatch_terminal_context(error_metrics, context.target)
-    emit_timing_log(error_metrics, {:error, {:model_load_failed, reason}})
-    {:error, {:model_load_failed, reason}}
+    if deadline_expired?(context) do
+      dispatch_timeout_result(%{context | metrics: metrics})
+    else
+      error_metrics = finalize_metrics(metrics, {:error, {:model_load_failed, reason}})
+      DomainMetrics.model_load(metrics.node_id, metrics.model_id, metrics.ensure_model_loaded_ms)
+      put_dispatch_terminal_context(error_metrics, context.target)
+      emit_timing_log(error_metrics, {:error, {:model_load_failed, reason}})
+      {:error, {:model_load_failed, reason}}
+    end
   end
 
   defp execute_loaded_request(context, ensure_load_meta, metrics) do
@@ -676,20 +725,26 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp stream_under_acceptance_gate(context, gated_execute_request, metrics, acceptance_gate) do
     case revalidate_capacity_claim(context) do
       :ok ->
-        stream_context = %{
-          acceptance_gate: acceptance_gate,
-          caller_ref: context.caller_ref,
-          cancel_drain_timeout_ms: context.cancel_drain_timeout_ms,
-          capacity_authority: capacity_authority(context.schedule),
-          capacity_node_id: Map.get(context.schedule, :node_id),
-          channel: context.channel,
-          client: context.client,
-          event_handler: context.event_handler,
-          target: context.target,
-          timeout_ms: remaining_request_timeout_ms(context.deadline_ms)
-        }
+        timeout_ms = remaining_request_timeout_ms(context.deadline_ms)
 
-        do_execute_and_stream(stream_context, gated_execute_request, metrics)
+        if timeout_ms <= 0 do
+          {:error, {:dispatch_failed, :dispatch_timeout}}
+        else
+          stream_context = %{
+            acceptance_gate: acceptance_gate,
+            caller_ref: context.caller_ref,
+            cancel_drain_timeout_ms: context.cancel_drain_timeout_ms,
+            capacity_authority: capacity_authority(context.schedule),
+            capacity_node_id: Map.get(context.schedule, :node_id),
+            channel: context.channel,
+            client: context.client,
+            event_handler: context.event_handler,
+            target: context.target,
+            timeout_ms: timeout_ms
+          }
+
+          do_execute_and_stream(stream_context, gated_execute_request, metrics)
+        end
 
       {:error, :dispatch_capacity_revalidation_failed, _result} ->
         {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}}
@@ -767,10 +822,24 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     end
   end
 
-  defp acquire_dispatch_acceptance_gate(_context), do: {:ok, nil}
+  defp acquire_dispatch_acceptance_gate(context) do
+    if remaining_request_timeout_ms(context.deadline_ms) <= 0,
+      do: {:error, :dispatch_timeout},
+      else: {:ok, nil}
+  end
 
   defp remaining_request_timeout_ms(deadline_ms) do
     max(deadline_ms - System.monotonic_time(:millisecond), 0)
+  end
+
+  defp deadline_expired?(context), do: remaining_request_timeout_ms(context.deadline_ms) <= 0
+
+  defp dispatch_timeout_result(context) do
+    handle_dispatch_result(
+      {:error, {:dispatch_failed, :dispatch_timeout}},
+      context.metrics,
+      context.target
+    )
   end
 
   defp release_dispatch_acceptance_gate(nil), do: :ok

--- a/apps/orchard_controller/lib/orchard/inference/attempt_context.ex
+++ b/apps/orchard_controller/lib/orchard/inference/attempt_context.ex
@@ -1,0 +1,97 @@
+defmodule Orchard.Inference.AttemptContext do
+  @moduledoc """
+  Immutable durable identity and start evidence for one inference attempt.
+  """
+
+  alias Orchard.Requests.RequestStepEvent
+
+  @enforce_keys [
+    :turn_index,
+    :attempt,
+    :step_id,
+    :excluded_node_ids,
+    :model_id,
+    :model_version
+  ]
+  defstruct @enforce_keys ++ [:started_at]
+
+  @type t :: %__MODULE__{
+          turn_index: 1,
+          attempt: 1 | 2,
+          step_id: String.t(),
+          excluded_node_ids: [Ecto.UUID.t()],
+          model_id: String.t(),
+          model_version: String.t(),
+          started_at: DateTime.t() | nil
+        }
+
+  @spec new(map()) :: {:ok, t()} | {:error, String.t()}
+  def new(attrs) when is_map(attrs) do
+    turn_index = value(attrs, :turn_index)
+    attempt = value(attrs, :attempt)
+    excluded_node_ids = value(attrs, :excluded_node_ids)
+    model_id = value(attrs, :model_id)
+    model_version = value(attrs, :model_version)
+
+    with :ok <- validate_identity(turn_index, attempt),
+         :ok <- validate_exclusions(attempt, excluded_node_ids),
+         :ok <- validate_model_identity(model_id, model_version),
+         {:ok, started_at} <- optional_datetime(value(attrs, :started_at)) do
+      {:ok,
+       %__MODULE__{
+         turn_index: turn_index,
+         attempt: attempt,
+         step_id: RequestStepEvent.inference_turn_step_id(turn_index, attempt),
+         excluded_node_ids: excluded_node_ids,
+         model_id: model_id,
+         model_version: model_version,
+         started_at: started_at
+       }}
+    end
+  end
+
+  def new(_attrs), do: {:error, "attempt context attrs must be a map"}
+
+  @spec put_started_at(t(), DateTime.t()) :: {:ok, t()} | {:error, String.t()}
+  def put_started_at(%__MODULE__{started_at: nil} = context, %DateTime{} = started_at),
+    do: {:ok, %{context | started_at: started_at}}
+
+  def put_started_at(%__MODULE__{}, %DateTime{}),
+    do: {:error, "started_at is immutable once assigned"}
+
+  def put_started_at(%__MODULE__{}, _started_at), do: {:error, "started_at must be a DateTime"}
+
+  defp validate_identity(1, attempt) when attempt in [1, 2], do: :ok
+
+  defp validate_identity(_turn_index, _attempt),
+    do: {:error, "only turn 1 attempts 1 and 2 are supported"}
+
+  defp validate_exclusions(1, []), do: :ok
+
+  defp validate_exclusions(2, [node_id]) do
+    case Ecto.UUID.cast(node_id) do
+      {:ok, _uuid} -> :ok
+      :error -> {:error, "attempt 2 requires one valid excluded Node UUID"}
+    end
+  end
+
+  defp validate_exclusions(1, _node_ids),
+    do: {:error, "attempt 1 requires an empty exclusion list"}
+
+  defp validate_exclusions(2, _node_ids),
+    do: {:error, "attempt 2 requires exactly one valid excluded Node UUID"}
+
+  defp validate_model_identity(model_id, model_version)
+       when is_binary(model_id) and model_id != "" and is_binary(model_version) and
+              model_version != "",
+       do: :ok
+
+  defp validate_model_identity(_model_id, _model_version),
+    do: {:error, "model_id and model_version must be non-empty strings"}
+
+  defp optional_datetime(nil), do: {:ok, nil}
+  defp optional_datetime(%DateTime{} = datetime), do: {:ok, datetime}
+  defp optional_datetime(_datetime), do: {:error, "started_at must be a DateTime"}
+
+  defp value(attrs, key), do: Map.get(attrs, key, Map.get(attrs, Atom.to_string(key)))
+end

--- a/apps/orchard_controller/lib/orchard/inference/request_deadline.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_deadline.ex
@@ -1,0 +1,28 @@
+defmodule Orchard.Inference.RequestDeadline do
+  @moduledoc """
+  Converts the persisted logical Request deadline into bounded stage budgets.
+  """
+
+  @spec timeout_at(pos_integer(), DateTime.t()) :: DateTime.t()
+  def timeout_at(timeout_ms, %DateTime{} = now) when is_integer(timeout_ms) and timeout_ms > 0 do
+    DateTime.add(now, timeout_ms, :millisecond)
+  end
+
+  @spec remaining_ms(DateTime.t(), DateTime.t()) :: non_neg_integer()
+  def remaining_ms(%DateTime{} = timeout_at, %DateTime{} = now) do
+    max(DateTime.diff(timeout_at, now, :millisecond), 0)
+  end
+
+  @spec cap_ms(non_neg_integer(), DateTime.t(), DateTime.t()) :: non_neg_integer()
+  def cap_ms(configured_ms, %DateTime{} = timeout_at, %DateTime{} = now)
+      when is_integer(configured_ms) and configured_ms >= 0 do
+    min(configured_ms, remaining_ms(timeout_at, now))
+  end
+
+  @spec to_monotonic_ms(DateTime.t(), integer(), integer()) :: integer()
+  def to_monotonic_ms(%DateTime{} = timeout_at, system_ms, monotonic_ms)
+      when is_integer(system_ms) and is_integer(monotonic_ms) do
+    remaining_ms = max(DateTime.to_unix(timeout_at, :millisecond) - system_ms, 0)
+    monotonic_ms + remaining_ms
+  end
+end

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -18,6 +18,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
     CanonicalRequestSerializer,
     ChatError,
     QueueManager,
+    RequestDeadline,
     ToolCallAccumulator,
     ToolExecutionSemantics,
     ToolingValidation
@@ -325,6 +326,14 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp acquire_queue_grant(db_request, canonical, caller) do
     request = queue_admission_request(db_request, canonical, caller)
 
+    if RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) <= 0 do
+      {:error, {:dispatch_failed, :request_timeout}}
+    else
+      acquire_queue_grant(request, db_request)
+    end
+  end
+
+  defp acquire_queue_grant(request, db_request) do
     case Inference.queue_manager().acquire(request) do
       {:ok, %QueueManager.Grant{} = grant} ->
         {:ok, grant}
@@ -345,16 +354,23 @@ defmodule Orchard.Inference.RequestOrchestrator do
       model_id: canonical.model_ref.model_id,
       version: canonical.model_ref.version,
       max_active_per_tenant: tenant_active_limit(canonical),
-      max_wait_ms: queue_wait_budget_ms(canonical),
+      max_wait_ms: queue_wait_budget_ms(db_request, canonical),
       caller_pid: caller
     }
   end
 
-  defp queue_wait_budget_ms(%{admission: %{queue_wait_ms: wait}})
-       when is_integer(wait) and wait >= 0,
-       do: wait
+  defp queue_wait_budget_ms(db_request, canonical) do
+    now = DateTime.utc_now()
+    remaining_ms = RequestDeadline.remaining_ms(db_request.timeout_at, now)
 
-  defp queue_wait_budget_ms(_canonical), do: nil
+    case canonical do
+      %{admission: %{queue_wait_ms: wait}} when is_integer(wait) and wait >= 0 ->
+        min(wait, remaining_ms)
+
+      _canonical ->
+        remaining_ms
+    end
+  end
 
   defp tenant_active_limit(canonical) do
     case canonical.resolved_policy.max_active_requests do
@@ -560,25 +576,29 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp execute_inference_turn(db_request, canonical, model, schedule, execution_opts) do
-    step_context = inference_turn_step_context(canonical)
+    if RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) <= 0 do
+      {:error, {:dispatch_failed, :request_timeout}}
+    else
+      step_context = inference_turn_step_context(canonical)
 
-    case persist_inference_turn_started(
-           db_request,
-           step_context,
-           execution_opts.step_event_appender
-         ) do
-      {:ok, persisted_step_context} ->
-        dispatch_started_inference_turn(
-          db_request,
-          canonical,
-          model,
-          schedule,
-          execution_opts,
-          persisted_step_context
-        )
+      case persist_inference_turn_started(
+             db_request,
+             step_context,
+             execution_opts.step_event_appender
+           ) do
+        {:ok, persisted_step_context} ->
+          dispatch_started_inference_turn(
+            db_request,
+            canonical,
+            model,
+            schedule,
+            execution_opts,
+            persisted_step_context
+          )
 
-      {:error, reason} ->
-        {:error, {:request_step_start_failed, reason}}
+        {:error, reason} ->
+          {:error, {:request_step_start_failed, reason}}
+      end
     end
   end
 
@@ -669,7 +689,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
       request_payload: %{"prompt" => canonical.rendered_prompt},
       sampling_params: CanonicalRequestSerializer.sampling_params(canonical.sampling),
       response_format: %{"type" => Atom.to_string(canonical.response_format.type)},
-      input_tokens: canonical.input_token_count
+      input_tokens: canonical.input_token_count,
+      timeout_at:
+        RequestDeadline.timeout_at(
+          canonical.admission.timeout_ms,
+          DateTime.utc_now() |> DateTime.truncate(:microsecond)
+        )
     }
   end
 
@@ -732,9 +757,19 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp schedule_request(db_request, canonical) do
+    if RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) <= 0 do
+      {:error, {:dispatch_failed, :request_timeout}}
+    else
+      schedule_live_request(db_request, canonical)
+    end
+  end
+
+  defp schedule_live_request(db_request, canonical) do
     case call_scheduler(canonical) do
       {:ok, schedule} when is_map(schedule) ->
-        {:ok, schedule}
+        if RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) > 0,
+          do: {:ok, Map.put(schedule, :timeout_at, db_request.timeout_at)},
+          else: {:error, {:dispatch_failed, :request_timeout}}
 
       {:error, reason, decision} when is_map(decision) ->
         persist_rejected_scheduler_decision(db_request, decision)
@@ -885,6 +920,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   defp strip_scheduler_runtime_metadata(schedule) do
     schedule
+    |> Map.drop([:timeout_at, "timeout_at"])
     |> strip_runtime_endpoint_metadata()
     |> strip_dispatch_capacity_metadata()
     |> strip_prefix_cache_metadata()
@@ -1044,6 +1080,10 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp normalize_dispatch_result({:ok, _events} = success), do: success
+
+  defp normalize_dispatch_result({:error, {:dispatch_failed, :dispatch_timeout}}),
+    do: {:error, {:dispatch_failed, :request_timeout}}
+
   defp normalize_dispatch_result({:error, _reason} = error), do: error
 
   defp normalize_dispatch_result(_other),
@@ -1549,8 +1589,9 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   defp build_execute_request(canonical, schedule) do
     deadline_ms =
-      System.system_time(:millisecond) +
-        Map.get(schedule, :request_timeout_ms, Inference.request_timeout_ms())
+      schedule
+      |> Map.fetch!(:timeout_at)
+      |> DateTime.to_unix(:millisecond)
 
     %ExecuteInferenceRequest{
       request_id: canonical.public_id,
@@ -1586,8 +1627,9 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   defp build_model_load_request(model, schedule) do
     deadline_ms =
-      System.system_time(:millisecond) +
-        Map.get(schedule, :model_load_timeout_ms, Inference.model_load_timeout_ms())
+      schedule
+      |> Map.fetch!(:timeout_at)
+      |> DateTime.to_unix(:millisecond)
 
     node_id =
       case Map.get(schedule, :node_id) do

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -302,12 +302,7 @@ defmodule Orchard.Requests do
 
       case %RequestEvent{} |> RequestEvent.changeset(event_attrs) |> Repo.insert() do
         {:ok, request_event} ->
-          persisted_step_event = %{
-            step_event
-            | request_id: request_event.request_id,
-              seq: request_event.seq,
-              occurred_at: request_event.occurred_at
-          }
+          persisted_step_event = RequestStepEvent.from_request_event!(request_event)
 
           {:cont, [persisted_step_event | acc]}
 

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -24,55 +24,7 @@ defmodule Orchard.Requests.CapturePolicy do
     result_not_observed
     timeout_after_start
   )
-  @stable_error_codes ~w(
-    acquisition_failed
-    artifact_not_found
-    cancelled
-    checksum_mismatch
-    cluster_busy
-    deadline_exceeded
-    insufficient_memory
-    internal_error
-    load_timeout
-    manifest_not_found
-    mlx_backend_unavailable
-    model_busy
-    model_invalid
-    node_timeout
-    node_unavailable
-    orchestration_error
-    queue_full
-    queue_timeout
-    request_cancelled
-    request_caller_disconnect
-    request_client_disconnect
-    request_controller_restarted
-    request_interrupted
-    request_timeout
-    resource_exhausted
-    rpc_error
-    rpc_resource_exhausted
-    rpc_unavailable
-    runtime_incompatible
-    runtime_unavailable
-    timed_out
-    timeout
-    tool_execution_cancelled
-    tool_execution_failed
-    tool_execution_indeterminate_cancel_ack_missing
-    tool_execution_indeterminate_controller_restarted
-    tool_execution_indeterminate_executor_unreachable
-    tool_execution_indeterminate_result_not_observed
-    tool_execution_indeterminate_timeout_after_start
-    tool_execution_timed_out
-    tool_failed
-    tool_timeout
-    tooling_not_supported
-    unexpected_placement_state
-    worker_down
-    worker_unavailable
-    worker_unloaded
-  )
+  @stable_error_codes Orchard.Requests.InferenceAttemptFailure.stable_error_codes()
   @scheduler_candidate_facts ~w(
     active_target_node_id_missing
     aggregate_capacity_facts_unavailable
@@ -168,7 +120,7 @@ defmodule Orchard.Requests.CapturePolicy do
 
   alias Orchard.ClusterManagement.ReasonCodes
   alias Orchard.Inference.ToolExecutionOutcome
-  alias Orchard.Requests.RequestStepEvent
+  alias Orchard.Requests.{InferenceAttemptResult, RequestStepEvent}
 
   @spec resolve(mode(), boolean()) :: mode()
   def resolve(mode, true) when mode in @capture_modes, do: mode
@@ -240,22 +192,10 @@ defmodule Orchard.Requests.CapturePolicy do
   end
 
   @spec event_attrs(mode(), map()) :: map()
-  def event_attrs(:full, attrs), do: attrs
+  def event_attrs(:full, attrs), do: update_event_payload(attrs, &strict_full_event_payload/2)
 
-  def event_attrs(mode, attrs) when mode in [:none, :metadata] do
-    event_type = fetch_value(attrs, :event_type)
-
-    cond do
-      Map.has_key?(attrs, :payload) ->
-        Map.update!(attrs, :payload, &sanitize_event_payload(&1, event_type))
-
-      Map.has_key?(attrs, "payload") ->
-        Map.update!(attrs, "payload", &sanitize_event_payload(&1, event_type))
-
-      true ->
-        attrs
-    end
-  end
+  def event_attrs(mode, attrs) when mode in [:none, :metadata],
+    do: update_event_payload(attrs, &sanitize_event_payload/2)
 
   @spec schedule_attrs(mode(), map()) :: map()
   def schedule_attrs(:full, attrs), do: attrs
@@ -502,6 +442,35 @@ defmodule Orchard.Requests.CapturePolicy do
 
   defp codepoint_length(value), do: value |> String.codepoints() |> length()
 
+  defp update_event_payload(attrs, sanitizer) do
+    event_type = fetch_value(attrs, :event_type)
+
+    cond do
+      Map.has_key?(attrs, :payload) ->
+        Map.update!(attrs, :payload, &sanitizer.(&1, event_type))
+
+      Map.has_key?(attrs, "payload") ->
+        Map.update!(attrs, "payload", &sanitizer.(&1, event_type))
+
+      true ->
+        attrs
+    end
+  end
+
+  defp strict_full_event_payload(payload, event_type) when is_map(payload) do
+    result = fetch_value(payload, :result)
+    attempt = fetch_value(payload, :attempt)
+
+    if fetch_value(payload, :step_type) == "inference_turn" and
+         InferenceAttemptResult.enriched?(result) do
+      put_key(payload, :result, inference_step_result(result, event_type, attempt, :full))
+    else
+      payload
+    end
+  end
+
+  defp strict_full_event_payload(payload, _event_type), do: payload
+
   defp sanitize_event_payload(payload, event_type) when is_map(payload) do
     if RequestStepEvent.request_step_event_type?(event_type) do
       sanitize_step_event_payload(payload, event_type)
@@ -530,10 +499,78 @@ defmodule Orchard.Requests.CapturePolicy do
 
   defp step_result(sanitized, payload, event_type) do
     result = fetch_value(payload, :result)
+    attempt = fetch_value(payload, :attempt)
 
     case Map.get(sanitized, "step_type") do
-      "tool_execution" -> tool_execution_result(result, event_type)
-      _step_type -> inference_step_result(result)
+      "tool_execution" ->
+        tool_execution_result(result, event_type)
+
+      "inference_turn" ->
+        if InferenceAttemptResult.enriched?(result),
+          do: inference_step_result(result, event_type, attempt, :restricted),
+          else: inference_step_result(result)
+
+      _step_type ->
+        inference_step_result(result)
+    end
+  end
+
+  defp inference_step_result(result, event_type, attempt, mode)
+       when is_map(result) and mode in [:restricted, :full] do
+    case InferenceAttemptResult.new(event_type, attempt, result) do
+      {:ok, validated} ->
+        validated
+        |> sanitize_attempt_result(mode)
+        |> revalidate_attempt_result(event_type, attempt)
+
+      {:error, _reason} ->
+        %{"result_invalid" => true}
+    end
+  end
+
+  defp inference_step_result(_result, _event_type, _attempt, _mode),
+    do: %{"result_invalid" => true}
+
+  defp sanitize_attempt_result(result, :full) do
+    case Map.get(result, "target_ref") do
+      nil ->
+        result
+
+      target_ref when is_binary(target_ref) ->
+        if stable_target_ref?(target_ref), do: result, else: %{"result_invalid" => true}
+    end
+  end
+
+  defp sanitize_attempt_result(result, :restricted) do
+    result
+    |> Map.drop(["raw_source_code", "error_message"])
+    |> hash_attempt_target()
+  end
+
+  defp stable_target_ref?("sha256:" <> digest),
+    do: byte_size(digest) == 64 and String.match?(digest, ~r/\A[0-9a-f]{64}\z/)
+
+  defp stable_target_ref?(target_ref), do: match?({:ok, _uuid}, Ecto.UUID.cast(target_ref))
+
+  defp hash_attempt_target(result) do
+    case Map.get(result, "target_ref") do
+      "sha256:" <> digest = target_ref when byte_size(digest) == 64 ->
+        if String.match?(digest, ~r/\A[0-9a-f]{64}\z/),
+          do: result,
+          else: Map.put(result, "target_ref", "sha256:" <> sha256_hex(target_ref))
+
+      target_ref when is_binary(target_ref) ->
+        Map.put(result, "target_ref", "sha256:" <> sha256_hex(target_ref))
+
+      _target_ref ->
+        result
+    end
+  end
+
+  defp revalidate_attempt_result(result, event_type, attempt) do
+    case InferenceAttemptResult.new(event_type, attempt, result) do
+      {:ok, validated} -> validated
+      {:error, _reason} -> %{"result_invalid" => true}
     end
   end
 
@@ -694,10 +731,11 @@ defmodule Orchard.Requests.CapturePolicy do
 
   defp put_tool_call_identity(sanitized, payload) do
     turn_index = fetch_value(payload, :turn_index)
+    attempt = fetch_value(payload, :attempt)
     call_id = fetch_value(payload, :call_id)
 
-    if positive_integer?(turn_index) and is_binary(call_id) do
-      put_tool_identity(sanitized, "tool_call", turn_index, call_id, nil)
+    if positive_integer?(turn_index) and positive_integer?(attempt) and is_binary(call_id) do
+      put_tool_identity(sanitized, "tool_call", turn_index, call_id, attempt)
     else
       sanitized
     end
@@ -731,13 +769,7 @@ defmodule Orchard.Requests.CapturePolicy do
     sanitized
     |> Map.put("call_id", safe_call_id)
     |> Map.put("step_id", step_id)
-    |> Map.put(
-      "parent_step_id",
-      if(step_type == "tool_call",
-        do: RequestStepEvent.inference_turn_step_id(turn_index, 1),
-        else: parent_step_id
-      )
-    )
+    |> Map.put("parent_step_id", RequestStepEvent.inference_turn_step_id(turn_index, attempt))
   end
 
   defp maybe_put_score_components(sanitized, candidate) do

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
@@ -1,0 +1,173 @@
+defmodule Orchard.Requests.InferenceAttemptFailure do
+  @moduledoc """
+  Normalizes structured attempt failures to the closed durable evidence vocabulary.
+  """
+
+  @stable_error_codes ~w(
+    acquisition_failed artifact_not_found cancelled checksum_mismatch cluster_busy
+    deadline_exceeded insufficient_memory internal_error load_timeout manifest_not_found
+    mlx_backend_unavailable model_busy model_invalid node_timeout node_unavailable
+    orchestration_error queue_full queue_timeout request_cancelled request_caller_disconnect
+    request_client_disconnect request_controller_restarted request_interrupted request_timeout
+    resource_exhausted rpc_error rpc_resource_exhausted rpc_unavailable runtime_incompatible
+    runtime_unavailable timed_out timeout tool_execution_cancelled tool_execution_failed
+    tool_execution_indeterminate_cancel_ack_missing
+    tool_execution_indeterminate_controller_restarted
+    tool_execution_indeterminate_executor_unreachable
+    tool_execution_indeterminate_result_not_observed
+    tool_execution_indeterminate_timeout_after_start tool_execution_timed_out tool_failed
+    tool_timeout tooling_not_supported unexpected_placement_state worker_down worker_unavailable
+    worker_unloaded
+  )
+
+  @failure_classes ~w(
+    pre_acceptance_unavailable model_load_failure worker_or_node_loss runtime_failure
+    terminal_conformance capacity_rejection cancellation deadline controller_failure
+    occupancy_unresolved identity_unresolved
+  )
+  @type evidence :: %{required(String.t()) => String.t()}
+
+  @spec stable_error_codes() :: [String.t()]
+  def stable_error_codes, do: @stable_error_codes
+
+  @spec failure_classes() :: [String.t()]
+  def failure_classes, do: @failure_classes
+
+  @spec normalize(map()) :: evidence()
+  def normalize(source) when is_map(source) do
+    category = value(source, :category)
+    code = normalize_code(value(source, :code))
+    phase = value(source, :phase)
+
+    {failure_class, failure_code} = classify(category, code, phase)
+
+    %{"failure_class" => failure_class, "failure_code" => failure_code}
+    |> maybe_put_raw_source_code(code, failure_code)
+  end
+
+  def normalize(_source),
+    do: %{"failure_class" => "controller_failure", "failure_code" => "internal_error"}
+
+  defp classify(category, code, phase) do
+    case classify_primary(category, code) do
+      nil -> classify_secondary(category, code, phase)
+      classification -> classification
+    end
+  end
+
+  defp classify_primary(category, code) do
+    cond do
+      category in [:cancellation, "cancellation", :caller_disconnect, "caller_disconnect"] ->
+        {"cancellation", cancellation_code(code)}
+
+      category in [:deadline, "deadline", :timeout, "timeout"] ->
+        {"deadline", deadline_code(code)}
+
+      category in [:terminal_conformance, "terminal_conformance"] ->
+        {"terminal_conformance", "orchestration_error"}
+
+      category in [:capacity, "capacity", :capacity_rejection, "capacity_rejection"] ->
+        {capacity_failure_class(code), capacity_code(code)}
+
+      true ->
+        nil
+    end
+  end
+
+  defp classify_secondary(category, code, phase) do
+    cond do
+      category in [:model_load, "model_load"] or phase in [:model_load, "model_load"] ->
+        {"model_load_failure", model_load_code(code)}
+
+      category in [:worker_or_node_loss, "worker_or_node_loss", :node_loss, "node_loss"] ->
+        {"worker_or_node_loss", allowlisted_or_internal(code)}
+
+      category in [:runtime, "runtime", :runtime_failure, "runtime_failure"] ->
+        {"runtime_failure", allowlisted_or_internal(code)}
+
+      category in [:pre_acceptance, "pre_acceptance", :transport, "transport"] ->
+        {"pre_acceptance_unavailable", pre_acceptance_code(code)}
+
+      category in [:identity_unresolved, "identity_unresolved"] ->
+        {"identity_unresolved", allowlisted_or_internal(code)}
+
+      category in [:occupancy_unresolved, "occupancy_unresolved"] ->
+        {"occupancy_unresolved", allowlisted_or_internal(code)}
+
+      true ->
+        {"controller_failure", controller_code(code)}
+    end
+  end
+
+  defp normalize_code(code) when is_atom(code), do: Atom.to_string(code)
+  defp normalize_code(code) when is_binary(code) and code != "", do: code
+  defp normalize_code(_code), do: nil
+
+  defp allowlisted_or_internal(code) when code in @stable_error_codes, do: code
+  defp allowlisted_or_internal(_code), do: "internal_error"
+
+  defp cancellation_code(code)
+       when code in ["request_caller_disconnect", "request_client_disconnect"],
+       do: "request_caller_disconnect"
+
+  defp cancellation_code("request_cancelled"), do: "request_cancelled"
+  defp cancellation_code(_code), do: "request_cancelled"
+
+  defp deadline_code(code)
+       when code in ["deadline_exceeded", "request_timeout", "timeout", "timed_out"],
+       do: code
+
+  defp deadline_code(_code), do: "request_timeout"
+
+  defp model_load_code(code)
+       when code in [
+              "acquisition_failed",
+              "runtime_unavailable",
+              "resource_exhausted",
+              "timeout",
+              "model_invalid"
+            ],
+       do: code
+
+  defp model_load_code(_code), do: "internal_error"
+
+  defp pre_acceptance_code(code)
+       when code in ["node_unavailable", "node_timeout", "runtime_unavailable", "rpc_unavailable"],
+       do: code
+
+  defp pre_acceptance_code(_code), do: "internal_error"
+
+  defp capacity_failure_class("dispatch_capacity_caller_down"), do: "cancellation"
+
+  defp capacity_failure_class("dispatch_capacity_node_identity_mismatch"),
+    do: "identity_unresolved"
+
+  defp capacity_failure_class(code)
+       when code in [
+              "dispatch_capacity_request_already_claimed",
+              "dispatch_capacity_quarantine_store_unavailable"
+            ],
+       do: "occupancy_unresolved"
+
+  defp capacity_failure_class(_code), do: "capacity_rejection"
+
+  defp capacity_code("dispatch_capacity_caller_down"), do: "request_caller_disconnect"
+  defp capacity_code("dispatch_capacity_acceptance_gate_busy"), do: "resource_exhausted"
+  defp capacity_code("dispatch_capacity_unavailable"), do: "resource_exhausted"
+  defp capacity_code("dispatch_capacity_facts_unavailable"), do: "orchestration_error"
+  defp capacity_code("dispatch_capacity_node_identity_mismatch"), do: "unexpected_placement_state"
+  defp capacity_code("dispatch_capacity_request_already_claimed"), do: "orchestration_error"
+  defp capacity_code("dispatch_capacity_quarantine_store_unavailable"), do: "orchestration_error"
+  defp capacity_code(code), do: allowlisted_or_internal(code)
+
+  defp controller_code(code) when code in ["orchestration_error", "request_interrupted"], do: code
+  defp controller_code(_code), do: "internal_error"
+
+  defp maybe_put_raw_source_code(evidence, nil, _stable), do: evidence
+  defp maybe_put_raw_source_code(evidence, stable, stable), do: evidence
+
+  defp maybe_put_raw_source_code(evidence, raw_source_code, _stable),
+    do: Map.put(evidence, "raw_source_code", raw_source_code)
+
+  defp value(source, key), do: Map.get(source, key, Map.get(source, Atom.to_string(key)))
+end

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
@@ -1,0 +1,396 @@
+defmodule Orchard.Requests.InferenceAttemptResult do
+  @moduledoc """
+  Strict JSON-safe persistence contract for terminal inference attempt evidence.
+  """
+
+  alias Orchard.Requests.InferenceAttemptFailure
+
+  @required_fields ~w(
+    attempt_outcome started_at ended_at accepted output_committed execution_resolution
+    capacity_release_outcome excluded_node_ids
+  )
+  @optional_fields ~w(
+    output_commitment_kind node_id target_ref failure_class failure_code runtime_retryable
+    retry_decision raw_source_code finish_reason input_tokens output_tokens http_status error_message
+  )
+  @fields @required_fields ++ @optional_fields
+  @marker_fields MapSet.new(@required_fields ++ ~w(
+    output_commitment_kind node_id target_ref failure_class failure_code runtime_retryable
+    retry_decision raw_source_code
+  ))
+
+  @attempt_outcomes ~w(completed failed cancelled timed_out interrupted)
+  @commitment_kinds ~w(text tool_call structured_output)
+  @execution_resolutions ~w(not_started terminated unresolved)
+  @capacity_release_outcomes ~w(released already_released not_applicable unresolved)
+  @retry_decisions ~w(
+    retried not_retryable output_committed cancelled budget_exhausted identity_unresolved
+    occupancy_unresolved no_alternative_node retry_exhausted
+  )
+  @attempt_one_decisions @retry_decisions -- ["retry_exhausted"]
+  @attempt_two_decisions ~w(retry_exhausted cancelled)
+  @finish_reasons ~w(cancelled content_filter error length stop tool_calls)
+  @maximum_integer 2_147_483_647
+  @event_outcomes %{
+    "request_step.completed" => "completed",
+    "request_step.failed" => "failed",
+    "request_step.cancelled" => "cancelled",
+    "request_step.timed_out" => "timed_out",
+    "request_step.interrupted" => "interrupted"
+  }
+
+  @type t :: map()
+
+  @spec enriched?(map()) :: boolean()
+  def enriched?(result) when is_map(result),
+    do: Enum.any?(Map.keys(result), &marker_field?/1)
+
+  def enriched?(_result), do: false
+
+  defp marker_field?(key) when is_atom(key),
+    do: MapSet.member?(@marker_fields, Atom.to_string(key))
+
+  defp marker_field?(key) when is_binary(key), do: MapSet.member?(@marker_fields, key)
+  defp marker_field?(_key), do: false
+
+  @spec fields() :: [String.t()]
+  def fields, do: @fields
+
+  @spec new(String.t(), 1 | 2, map()) :: {:ok, t()} | {:error, String.t()}
+  def new(event_type, attempt, result) when is_map(result) do
+    with :ok <- validate_attempt(attempt),
+         {:ok, normalized} <- normalize_keys(result),
+         :ok <- validate_required_fields(normalized),
+         :ok <- validate_enum(normalized, "attempt_outcome", @attempt_outcomes),
+         :ok <- validate_event_outcome(event_type, normalized),
+         {:ok, started_at, normalized} <- normalize_datetime(normalized, "started_at"),
+         {:ok, ended_at, normalized} <- normalize_datetime(normalized, "ended_at"),
+         :ok <- validate_time_order(started_at, ended_at),
+         :ok <- validate_boolean(normalized, "accepted"),
+         :ok <- validate_boolean(normalized, "output_committed"),
+         :ok <- validate_optional_boolean(normalized, "runtime_retryable"),
+         :ok <- validate_enum(normalized, "execution_resolution", @execution_resolutions),
+         :ok <-
+           validate_enum(normalized, "capacity_release_outcome", @capacity_release_outcomes),
+         :ok <- validate_optional_enum(normalized, "output_commitment_kind", @commitment_kinds),
+         :ok <-
+           validate_optional_enum(
+             normalized,
+             "failure_class",
+             InferenceAttemptFailure.failure_classes()
+           ),
+         :ok <-
+           validate_optional_enum(
+             normalized,
+             "failure_code",
+             InferenceAttemptFailure.stable_error_codes()
+           ),
+         :ok <- validate_optional_enum(normalized, "finish_reason", @finish_reasons),
+         :ok <- validate_optional_strings(normalized),
+         :ok <- validate_optional_integers(normalized),
+         :ok <- validate_commitment(normalized),
+         :ok <- validate_acceptance_resolution(normalized),
+         :ok <- validate_outcome_fields(attempt, normalized),
+         :ok <- validate_retry_consistency(normalized) do
+      validate_node_evidence(attempt, normalized)
+    end
+  end
+
+  def new(_event_type, _attempt, _result), do: {:error, "inference attempt result must be a map"}
+
+  defp validate_attempt(attempt) when attempt in [1, 2], do: :ok
+  defp validate_attempt(_attempt), do: {:error, "attempt must be 1 or 2"}
+
+  defp normalize_keys(result) do
+    Enum.reduce_while(result, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      normalized_key = if is_atom(key), do: Atom.to_string(key), else: key
+
+      cond do
+        normalized_key not in @fields ->
+          {:halt, {:error, "unexpected inference attempt result field #{inspect(key)}"}}
+
+        Map.has_key?(acc, normalized_key) ->
+          {:halt, {:error, "duplicate inference attempt result field #{inspect(normalized_key)}"}}
+
+        true ->
+          {:cont, {:ok, Map.put(acc, normalized_key, value)}}
+      end
+    end)
+  end
+
+  defp validate_required_fields(result) do
+    case Enum.find(@required_fields, &(not Map.has_key?(result, &1))) do
+      nil -> :ok
+      field -> {:error, "inference attempt result requires #{field}"}
+    end
+  end
+
+  defp normalize_datetime(result, field) do
+    case Map.fetch!(result, field) do
+      %DateTime{} = datetime ->
+        normalized = DateTime.to_iso8601(datetime)
+        {:ok, datetime, Map.put(result, field, normalized)}
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, 0} ->
+            {:ok, datetime, Map.put(result, field, DateTime.to_iso8601(datetime))}
+
+          _error ->
+            {:error, "#{field} must be a canonical UTC timestamp"}
+        end
+
+      _value ->
+        {:error, "#{field} must be a canonical UTC timestamp"}
+    end
+  end
+
+  defp validate_time_order(started_at, ended_at) do
+    if DateTime.compare(ended_at, started_at) == :lt,
+      do: {:error, "ended_at must not precede started_at"},
+      else: :ok
+  end
+
+  defp validate_event_outcome(event_type, result) do
+    case Map.fetch(@event_outcomes, event_type) do
+      {:ok, expected} ->
+        if expected == result["attempt_outcome"],
+          do: :ok,
+          else: {:error, "attempt_outcome must be #{expected} for #{event_type}"}
+
+      :error ->
+        {:error, "event_type does not close an inference attempt"}
+    end
+  end
+
+  defp validate_boolean(result, field) do
+    if is_boolean(result[field]), do: :ok, else: {:error, "#{field} must be a boolean"}
+  end
+
+  defp validate_optional_boolean(result, field) do
+    case Map.fetch(result, field) do
+      :error -> :ok
+      {:ok, value} when is_boolean(value) -> :ok
+      {:ok, _value} -> {:error, "#{field} must be a boolean"}
+    end
+  end
+
+  defp validate_enum(result, field, values) do
+    if result[field] in values,
+      do: :ok,
+      else: {:error, "#{field} must be one of #{Enum.join(values, ", ")}"}
+  end
+
+  defp validate_optional_enum(result, field, values) do
+    case Map.fetch(result, field) do
+      :error ->
+        :ok
+
+      {:ok, value} ->
+        if value in values,
+          do: :ok,
+          else: {:error, "#{field} must be one of #{Enum.join(values, ", ")}"}
+    end
+  end
+
+  defp validate_optional_strings(result) do
+    Enum.reduce_while(~w(target_ref raw_source_code error_message), :ok, fn field, :ok ->
+      case Map.fetch(result, field) do
+        :error -> {:cont, :ok}
+        {:ok, value} when is_binary(value) and value != "" -> {:cont, :ok}
+        {:ok, _value} -> {:halt, {:error, "#{field} must be a non-empty string"}}
+      end
+    end)
+  end
+
+  defp validate_optional_integers(result) do
+    Enum.reduce_while(~w(input_tokens output_tokens http_status), :ok, fn field, :ok ->
+      case Map.fetch(result, field) do
+        :error ->
+          {:cont, :ok}
+
+        {:ok, value} when is_integer(value) and value >= 0 and value <= @maximum_integer ->
+          {:cont, :ok}
+
+        {:ok, _value} ->
+          {:halt, {:error, "#{field} must be a bounded non-negative integer"}}
+      end
+    end)
+  end
+
+  defp validate_commitment(%{"output_committed" => true} = result) do
+    if result["output_commitment_kind"] in @commitment_kinds,
+      do: :ok,
+      else: {:error, "committed output requires output_commitment_kind"}
+  end
+
+  defp validate_commitment(%{"output_committed" => false} = result) do
+    if Map.has_key?(result, "output_commitment_kind"),
+      do: {:error, "uncommitted output must omit output_commitment_kind"},
+      else: :ok
+  end
+
+  defp validate_acceptance_resolution(%{"accepted" => false, "output_committed" => true}),
+    do: {:error, "unaccepted attempts cannot commit output"}
+
+  defp validate_acceptance_resolution(%{
+         "accepted" => true,
+         "execution_resolution" => "not_started"
+       }),
+       do: {:error, "not_started execution requires accepted to be false"}
+
+  defp validate_acceptance_resolution(_result), do: :ok
+
+  defp validate_outcome_fields(_attempt, %{"attempt_outcome" => "completed"} = result) do
+    forbidden =
+      ~w(failure_class failure_code retry_decision raw_source_code error_message runtime_retryable)
+
+    if Enum.any?(forbidden, &Map.has_key?(result, &1)),
+      do: {:error, "completed attempts must omit failure and retry fields"},
+      else: :ok
+  end
+
+  defp validate_outcome_fields(attempt, result) do
+    with :ok <- require_failure_field(result, "failure_class"),
+         :ok <- require_failure_field(result, "failure_code"),
+         :ok <- require_failure_field(result, "retry_decision") do
+      validate_retry_decision(attempt, result["retry_decision"])
+    end
+  end
+
+  defp require_failure_field(result, field) do
+    if Map.has_key?(result, field),
+      do: :ok,
+      else: {:error, "unsuccessful attempts require #{field}"}
+  end
+
+  defp validate_retry_decision(1, decision) when decision in @attempt_one_decisions, do: :ok
+  defp validate_retry_decision(2, decision) when decision in @attempt_two_decisions, do: :ok
+
+  defp validate_retry_decision(attempt, _decision),
+    do: {:error, "retry_decision is invalid for attempt #{attempt}"}
+
+  defp validate_retry_consistency(%{
+         "output_committed" => true,
+         "retry_decision" => decision
+       })
+       when decision != "output_committed",
+       do: {:error, "committed output requires output_committed retry decision"}
+
+  defp validate_retry_consistency(%{
+         "attempt_outcome" => "cancelled",
+         "retry_decision" => decision
+       })
+       when decision != "cancelled",
+       do: {:error, "cancelled attempts require cancelled retry decision"}
+
+  defp validate_retry_consistency(%{
+         "retry_decision" => "retried",
+         "output_committed" => true
+       }),
+       do: {:error, "retried attempts cannot have committed output"}
+
+  defp validate_retry_consistency(%{
+         "retry_decision" => "retried",
+         "node_id" => node_id,
+         "execution_resolution" => execution_resolution,
+         "capacity_release_outcome" => release_outcome
+       })
+       when is_binary(node_id) and execution_resolution != "unresolved" and
+              release_outcome in ["released", "already_released", "not_applicable"],
+       do: :ok
+
+  defp validate_retry_consistency(%{"retry_decision" => "retried"}),
+    do: {:error, "retried attempts require resolved Node, execution, and capacity evidence"}
+
+  defp validate_retry_consistency(%{
+         "retry_decision" => "output_committed",
+         "output_committed" => false
+       }),
+       do: {:error, "output_committed retry decision requires committed output"}
+
+  defp validate_retry_consistency(%{
+         "retry_decision" => "cancelled",
+         "attempt_outcome" => outcome,
+         "failure_class" => failure_class
+       })
+       when outcome != "cancelled" or failure_class != "cancellation",
+       do: {:error, "cancelled retry decision requires a cancelled attempt"}
+
+  defp validate_retry_consistency(%{
+         "retry_decision" => "identity_unresolved",
+         "failure_class" => failure_class
+       })
+       when failure_class != "identity_unresolved",
+       do: {:error, "identity_unresolved retry decision requires matching failure class"}
+
+  defp validate_retry_consistency(%{
+         "retry_decision" => "occupancy_unresolved",
+         "failure_class" => failure_class
+       })
+       when failure_class != "occupancy_unresolved",
+       do: {:error, "occupancy_unresolved retry decision requires matching failure class"}
+
+  defp validate_retry_consistency(_result), do: :ok
+
+  defp validate_node_evidence(attempt, result) do
+    with {:ok, node_id} <- optional_uuid(result["node_id"], "node_id"),
+         {:ok, excluded_node_ids} <- uuid_list(result["excluded_node_ids"]) do
+      cond do
+        attempt == 1 and excluded_node_ids != [] ->
+          {:error, "attempt 1 requires an empty exclusion list"}
+
+        attempt == 2 and length(excluded_node_ids) != 1 ->
+          {:error, "attempt 2 requires exactly one excluded Node UUID"}
+
+        attempt == 2 and node_id in excluded_node_ids ->
+          {:error, "attempt 2 selected Node must differ from its exclusion"}
+
+        true ->
+          normalized =
+            result
+            |> Map.put("excluded_node_ids", excluded_node_ids)
+            |> put_optional_node_id(node_id)
+
+          {:ok, normalized}
+      end
+    end
+  end
+
+  defp put_optional_node_id(result, nil), do: Map.delete(result, "node_id")
+  defp put_optional_node_id(result, node_id), do: Map.put(result, "node_id", node_id)
+
+  defp optional_uuid(nil, _field), do: {:ok, nil}
+
+  defp optional_uuid(value, field) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, "#{field} must be a valid UUID"}
+    end
+  end
+
+  defp uuid_list(values) when is_list(values) do
+    with {:ok, uuids} <- cast_uuids(values),
+         true <- length(uuids) == MapSet.size(MapSet.new(uuids)) do
+      {:ok, uuids}
+    else
+      false -> {:error, "excluded_node_ids must not contain duplicates"}
+      :error -> {:error, "excluded_node_ids must contain valid UUIDs"}
+    end
+  end
+
+  defp uuid_list(_values), do: {:error, "excluded_node_ids must be a list"}
+
+  defp cast_uuids(values) do
+    Enum.reduce_while(values, {:ok, []}, fn value, {:ok, acc} ->
+      case Ecto.UUID.cast(value) do
+        {:ok, uuid} -> {:cont, {:ok, [uuid | acc]}}
+        :error -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, uuids} -> {:ok, Enum.reverse(uuids)}
+      :error -> :error
+    end
+  end
+end

--- a/apps/orchard_controller/lib/orchard/requests/request.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request.ex
@@ -153,7 +153,8 @@ defmodule Orchard.Requests.Request do
       :requested_model,
       :state,
       :stream,
-      :payload_capture_mode
+      :payload_capture_mode,
+      :timeout_at
     ])
     |> validate_number(:input_tokens, greater_than_or_equal_to: 0)
     |> validate_number(:output_tokens, greater_than_or_equal_to: 0)

--- a/apps/orchard_controller/lib/orchard/requests/request_step_event.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request_step_event.ex
@@ -4,8 +4,7 @@ defmodule Orchard.Requests.RequestStepEvent do
   """
 
   alias Orchard.Inference.ToolExecutionOutcome
-  alias Orchard.Requests.Request
-  alias Orchard.Requests.RequestEvent
+  alias Orchard.Requests.{InferenceAttemptResult, Request, RequestEvent}
 
   @step_event_types [
     "request_step.started",
@@ -161,7 +160,11 @@ defmodule Orchard.Requests.RequestStepEvent do
   @spec new(t() | map()) :: {:ok, t()} | {:error, String.t()}
   def new(%__MODULE__{} = step_event), do: step_event |> Map.from_struct() |> new()
 
-  def new(attrs) when is_map(attrs) do
+  def new(attrs) when is_map(attrs), do: build(attrs, :new_write)
+
+  def new(_attrs), do: {:error, "request step event attrs must be a map"}
+
+  defp build(attrs, identity_mode) when is_map(attrs) do
     with {:ok, normalized} <- normalize_top_level_attrs(attrs),
          {:ok, event_type} <- fetch_required_string(normalized, :event_type),
          :ok <- validate_event_type(event_type),
@@ -184,15 +187,18 @@ defmodule Orchard.Requests.RequestStepEvent do
          {:ok, model_id} <- fetch_optional_string(normalized, :model_id),
          {:ok, model_version} <- fetch_optional_string(normalized, :model_version),
          :ok <-
-           validate_step_identity(%{
-             step_id: step_id,
-             step_type: step_type,
-             turn_index: turn_index,
-             attempt: attempt,
-             call_id: call_id
-           }),
+           validate_step_identity(
+             %{
+               step_id: step_id,
+               step_type: step_type,
+               turn_index: turn_index,
+               attempt: attempt,
+               call_id: call_id
+             },
+             identity_mode
+           ),
          :ok <- validate_parent_step_id(step_type, parent_step_id),
-         :ok <- validate_step_payload(step_type, event_type, result) do
+         {:ok, result} <- normalize_step_payload(step_type, event_type, attempt, result) do
       {:ok,
        %__MODULE__{
          request_id: request_id,
@@ -214,8 +220,6 @@ defmodule Orchard.Requests.RequestStepEvent do
        }}
     end
   end
-
-  def new(_attrs), do: {:error, "request step event attrs must be a map"}
 
   @spec new!(t() | map()) :: t()
   def new!(attrs) do
@@ -269,7 +273,7 @@ defmodule Orchard.Requests.RequestStepEvent do
               state: request_event.state
             })
 
-          new(attrs)
+          build(attrs, :historical_read)
 
         payload ->
           {:error, "request step payload must be a map, got: #{inspect(payload)}"}
@@ -319,33 +323,44 @@ defmodule Orchard.Requests.RequestStepEvent do
      "boundary #{inspect(boundary)} is invalid for the given event_type; started uses pre_side_effect and all other request_step.* events use post_observation"}
   end
 
-  defp validate_step_identity(%{
-         step_id: step_id,
-         step_type: "inference_turn",
-         turn_index: turn_index,
-         attempt: attempt,
-         call_id: nil
-       }) do
-    expected = inference_turn_step_id(turn_index, attempt)
-
-    if step_id == expected do
+  defp validate_step_identity(
+         %{
+           step_id: step_id,
+           step_type: "inference_turn",
+           turn_index: turn_index,
+           attempt: attempt,
+           call_id: nil
+         },
+         identity_mode
+       ) do
+    with :ok <- validate_inference_identity_mode(identity_mode, turn_index, attempt),
+         expected = inference_turn_step_id(turn_index, attempt),
+         true <- step_id == expected do
       :ok
     else
-      {:error, "step_id must equal #{inspect(expected)} for inference_turn steps"}
+      {:error, reason} ->
+        {:error, reason}
+
+      false ->
+        {:error,
+         "step_id must equal #{inspect(inference_turn_step_id(turn_index, attempt))} for inference_turn steps"}
     end
   end
 
-  defp validate_step_identity(%{step_type: "inference_turn", call_id: call_id})
+  defp validate_step_identity(%{step_type: "inference_turn", call_id: call_id}, _identity_mode)
        when is_binary(call_id) and call_id != "" do
     {:error, "inference_turn steps must not include call_id"}
   end
 
-  defp validate_step_identity(%{
-         step_id: step_id,
-         step_type: "tool_call",
-         turn_index: turn_index,
-         call_id: call_id
-       })
+  defp validate_step_identity(
+         %{
+           step_id: step_id,
+           step_type: "tool_call",
+           turn_index: turn_index,
+           call_id: call_id
+         },
+         _identity_mode
+       )
        when is_binary(call_id) and call_id != "" do
     expected = tool_call_step_id(turn_index, call_id)
 
@@ -356,13 +371,16 @@ defmodule Orchard.Requests.RequestStepEvent do
     end
   end
 
-  defp validate_step_identity(%{
-         step_id: step_id,
-         step_type: "tool_execution",
-         turn_index: turn_index,
-         attempt: attempt,
-         call_id: call_id
-       })
+  defp validate_step_identity(
+         %{
+           step_id: step_id,
+           step_type: "tool_execution",
+           turn_index: turn_index,
+           attempt: attempt,
+           call_id: call_id
+         },
+         _identity_mode
+       )
        when is_binary(call_id) and call_id != "" do
     expected = tool_execution_step_id(turn_index, call_id, attempt)
 
@@ -373,10 +391,17 @@ defmodule Orchard.Requests.RequestStepEvent do
     end
   end
 
-  defp validate_step_identity(%{step_type: step_type})
+  defp validate_step_identity(%{step_type: step_type}, _identity_mode)
        when step_type in ["tool_call", "tool_execution"] do
     {:error, "#{step_type} steps require a non-empty call_id"}
   end
+
+  defp validate_inference_identity_mode(:new_write, 1, attempt) when attempt in [1, 2], do: :ok
+
+  defp validate_inference_identity_mode(:new_write, _turn_index, _attempt),
+    do: {:error, "only turn 1 attempts 1 and 2 are supported"}
+
+  defp validate_inference_identity_mode(:historical_read, _turn_index, _attempt), do: :ok
 
   defp validate_parent_step_id("inference_turn", nil), do: :ok
 
@@ -390,15 +415,35 @@ defmodule Orchard.Requests.RequestStepEvent do
     {:error, "#{step_type} steps require a parent_step_id"}
   end
 
-  defp validate_step_payload("tool_execution", "request_step.started", result) do
+  defp normalize_step_payload(
+         "inference_turn",
+         event_type,
+         attempt,
+         result
+       )
+       when event_type in [
+              "request_step.completed",
+              "request_step.failed",
+              "request_step.cancelled",
+              "request_step.timed_out",
+              "request_step.interrupted"
+            ] do
+    if InferenceAttemptResult.enriched?(result) do
+      InferenceAttemptResult.new(event_type, attempt, result)
+    else
+      {:ok, result}
+    end
+  end
+
+  defp normalize_step_payload("tool_execution", "request_step.started", _attempt, result) do
     if result == %{} do
-      :ok
+      {:ok, result}
     else
       {:error, "tool_execution request_step.started result must be an empty map"}
     end
   end
 
-  defp validate_step_payload("tool_execution", event_type, result)
+  defp normalize_step_payload("tool_execution", event_type, _attempt, result)
        when event_type in [
               "request_step.completed",
               "request_step.failed",
@@ -407,17 +452,17 @@ defmodule Orchard.Requests.RequestStepEvent do
               "request_step.indeterminate"
             ] do
     case ToolExecutionOutcome.from_request_step_result(event_type, result) do
-      {:ok, _outcome} -> :ok
+      {:ok, _outcome} -> {:ok, result}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp validate_step_payload("tool_execution", event_type, _result) do
+  defp normalize_step_payload("tool_execution", event_type, _attempt, _result) do
     {:error,
      "tool_execution steps only support request_step.started, request_step.completed, request_step.failed, request_step.cancelled, request_step.timed_out, or request_step.indeterminate; got: #{inspect(event_type)}"}
   end
 
-  defp validate_step_payload(_step_type, _event_type, _result), do: :ok
+  defp normalize_step_payload(_step_type, _event_type, _attempt, result), do: {:ok, result}
 
   defp normalize_top_level_attrs(attrs) do
     Enum.reduce_while(attrs, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
@@ -455,6 +500,8 @@ defmodule Orchard.Requests.RequestStepEvent do
       {key, value} -> {key, normalize_payload_value(value)}
     end)
   end
+
+  defp normalize_payload_value(%DateTime{} = value), do: value
 
   defp normalize_payload_value(value) when is_map(value) do
     Map.new(value, fn

--- a/apps/orchard_controller/test/orchard/dispatch/cold_start_benchmark_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/cold_start_benchmark_test.exs
@@ -260,6 +260,7 @@ defmodule Orchard.Dispatch.ColdStartBenchmarkTest do
       request_id: request_id,
       runtime_client_target: Inference.runtime_client_target(),
       request_timeout_ms: 30_000,
+      timeout_at: DateTime.add(DateTime.utc_now(), 30, :second),
       model_load_timeout_ms: 120_000
     }
   end

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -704,11 +704,14 @@ defmodule Orchard.Dispatch.DispatchTest do
   end
 
   defp build_schedule(request_id, opts \\ []) do
+    timeout_ms = Keyword.get(opts, :request_timeout_ms, 5_000)
+
     %{
       strategy: :single_node,
       request_id: request_id,
       runtime_client_target: Inference.runtime_client_target(),
-      request_timeout_ms: Keyword.get(opts, :request_timeout_ms, 5_000),
+      request_timeout_ms: timeout_ms,
+      timeout_at: DateTime.add(DateTime.utc_now(), timeout_ms, :millisecond),
       model_load_timeout_ms: Keyword.get(opts, :model_load_timeout_ms, 5_000),
       dispatch_capacity_authority: Process.get({__MODULE__, :capacity_authority})
     }

--- a/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
@@ -206,6 +206,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
 
     request = canonical_request()
     assert {:ok, schedule} = MultiNode.schedule(request, status_client: @stub_client)
+    schedule = Map.put(schedule, :timeout_at, DateTime.add(DateTime.utc_now(), 30, :second))
     assert schedule.node_id in [id_a, id_b]
     selected_target = target_key(schedule.runtime_client_target)
     assert selected_target in [capable_a, capable_b]
@@ -269,6 +270,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
 
     request = canonical_request()
     assert {:ok, schedule} = MultiNode.schedule(request, status_client: @stub_client)
+    schedule = Map.put(schedule, :timeout_at, DateTime.add(DateTime.utc_now(), 30, :second))
     assert schedule.node_id == id_capable
     assert target_key(schedule.runtime_client_target) == capable_target
 

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -137,6 +137,24 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.SlowLoadClient do
   end
 end
 
+defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.TimedOutLoadClient do
+  @moduledoc false
+
+  alias Orchard.DispatchCapacity.RequestDispatcherClaimTest.GateClient
+  alias Orchard.RuntimeEndpoint.Operation
+
+  defdelegate connect(target), to: GateClient
+  defdelegate disconnect(channel), to: GateClient
+  defdelegate status(channel, opts), to: GateClient
+  defdelegate execute_inference(channel, request, opts), to: GateClient
+  defdelegate cancel_inference(channel, request, opts), to: GateClient
+
+  def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{}, opts) do
+    Process.sleep(Keyword.fetch!(opts, :timeout))
+    {:error, :timeout}
+  end
+end
+
 defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.ExecuteErrorClient do
   @moduledoc false
 
@@ -761,6 +779,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     PreAcceptanceCancelClient,
     ProductionFreshStatusClient,
     SlowLoadClient,
+    TimedOutLoadClient,
     TerminalDefectClient,
     TerminalBeforeAcceptedClient,
     UnprobeableClient
@@ -780,6 +799,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
   @unprobeable_client UnprobeableClient
   @production_fresh_status_client ProductionFreshStatusClient
   @slow_load_client SlowLoadClient
+  @timed_out_load_client TimedOutLoadClient
   @terminal_defect_client TerminalDefectClient
 
   # The request timeout now bounds connect, probe, and acceptance-gate waiting
@@ -825,6 +845,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       request_id: request_id,
       runtime_client_target: Inference.runtime_client_target(),
       request_timeout_ms: 5_000,
+      timeout_at: DateTime.add(DateTime.utc_now(), 5_000, :millisecond),
       model_load_timeout_ms: 5_000,
       node_id: node_id,
       dispatch_capacity_input: input,
@@ -835,10 +856,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch_task =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @client
         )
       end)
@@ -885,6 +903,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       request_id: request_id,
       runtime_client_target: Inference.runtime_client_target(),
       request_timeout_ms: 5_000,
+      timeout_at: DateTime.add(DateTime.utc_now(), 5_000, :millisecond),
       model_load_timeout_ms: 5_000,
       node_id: node_id,
       dispatch_capacity_input: input,
@@ -895,10 +914,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     {dispatcher_pid, monitor_ref} =
       spawn_monitor(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @client
         )
       end)
@@ -955,6 +971,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       request_id: request_id,
       runtime_client_target: Inference.runtime_client_target(),
       request_timeout_ms: 5_000,
+      timeout_at: DateTime.add(DateTime.utc_now(), 5_000, :millisecond),
       model_load_timeout_ms: 5_000,
       node_id: node_id,
       dispatch_capacity_input: enforcing_input(),
@@ -965,10 +982,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @gate_client
         )
       end)
@@ -990,7 +1004,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     request_id = "request-execute-error"
 
     assert {:error, {:dispatch_failed, :execution_refused}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, node_id, request_id),
                execute_request(request_id),
                model_load_request(node_id),
@@ -1016,7 +1030,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     request_id = "request-missing-acceptance"
 
     assert {:error, {:dispatch_failed, :node_acceptance_missing}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, node_id, request_id),
                execute_request(request_id),
                model_load_request(node_id),
@@ -1034,7 +1048,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       request_id = "request-terminal-defect-#{defect}"
 
       assert {:ok, events} =
-               RequestDispatcher.dispatch(
+               dispatch_with_deadline(
                  capacity_schedule(authority, node_id, request_id),
                  execute_request(request_id),
                  model_load_request(node_id),
@@ -1066,7 +1080,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       ])
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_facts_unavailable}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(node_id),
@@ -1092,7 +1106,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       |> Map.put(:dispatch_capacity_acquisition_input_provider, fn -> unavailable_input end)
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_unavailable}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(node_id),
@@ -1122,7 +1136,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     }
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(Ecto.UUID.generate()),
@@ -1133,7 +1147,60 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     refute_receive :execute_called
   end
 
-  test "SPEC 5.9 a cold model load does not consume the stream's request budget" do
+  test "SPEC.md §12.4 logical deadline wins when model loading times out at the Request boundary" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-model-load-deadline"
+
+    schedule = %{
+      capacity_schedule(authority, node_id, request_id)
+      | request_timeout_ms: 50,
+        timeout_at: DateTime.add(DateTime.utc_now(), 50, :millisecond),
+        model_load_timeout_ms: 5_000
+    }
+
+    assert {:error, {:dispatch_failed, :dispatch_timeout}} =
+             dispatch_with_deadline(
+               schedule,
+               execute_request(request_id),
+               model_load_request(node_id),
+               client_impl: @timed_out_load_client
+             )
+
+    refute_receive :execute_called
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC.md §12.4 expiry during capacity revalidation prevents ExecuteInference" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-post-load-revalidation-deadline"
+    input = enforcing_input()
+
+    schedule = %{
+      capacity_schedule(authority, node_id, request_id)
+      | request_timeout_ms: 50,
+        timeout_at: DateTime.add(DateTime.utc_now(), 50, :millisecond),
+        dispatch_capacity_input_provider: fn ->
+          Process.sleep(75)
+          input
+        end
+    }
+
+    assert {:error, {:dispatch_failed, :dispatch_timeout}} =
+             dispatch_with_deadline(
+               schedule,
+               execute_request(request_id),
+               model_load_request(node_id),
+               client_impl: @gate_client
+             )
+
+    assert_receive :model_loaded
+    refute_receive :execute_called
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC.md §12.4 a cold model load consumes the original Request budget" do
     authority = start_supervised!({AllocationAuthority, name: nil})
     node_id = claim_node_id()
     request_id = "request-cold-load-budget"
@@ -1141,18 +1208,23 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
       | request_timeout_ms: div(@slow_load_client.load_duration_ms(), 2),
+        timeout_at:
+          DateTime.add(
+            DateTime.utc_now(),
+            div(@slow_load_client.load_duration_ms(), 2),
+            :millisecond
+          ),
         model_load_timeout_ms: 5_000
     }
 
-    assert {:ok, events} =
-             RequestDispatcher.dispatch(
+    assert {:error, {:dispatch_failed, :dispatch_timeout}} =
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(node_id),
                client_impl: @slow_load_client
              )
 
-    assert Enum.any?(events, &match?(%InferenceEvent{event: %InferenceEvent.Accepted{}}, &1))
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1166,7 +1238,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     )
 
     assert {:error, {:dispatch_failed, :node_acceptance_missing}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, node_id, request_id),
                execute_request(request_id),
                model_load_request(node_id),
@@ -1186,7 +1258,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     )
 
     assert {:error, {:dispatch_failed, :node_acceptance_missing}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, node_id, request_id),
                execute_request(request_id),
                model_load_request(node_id),
@@ -1202,7 +1274,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     request_id = "request-delta-before-acceptance-error"
 
     assert {:error, {:dispatch_failed, :stream_failed}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, node_id, request_id),
                execute_request(request_id),
                model_load_request(node_id),
@@ -1219,7 +1291,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1249,7 +1321,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1279,7 +1351,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1317,7 +1389,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1350,7 +1422,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1385,15 +1457,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
     }
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @pre_acceptance_cancel_client
         )
       end)
@@ -1413,7 +1483,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1439,12 +1509,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
       schedule = %{
         capacity_schedule(authority, node_id, request_id)
-        | request_timeout_ms: @expiring_request_timeout_ms
+        | request_timeout_ms: @expiring_request_timeout_ms,
+          timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
       }
 
       dispatch =
         Task.async(fn ->
-          RequestDispatcher.dispatch(
+          dispatch_with_deadline(
             schedule,
             execute_request(request_id),
             model_load_request(node_id),
@@ -1472,15 +1543,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
     }
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @pre_acceptance_cancel_client,
           cancel_drain_timeout_ms: 20
         )
@@ -1513,15 +1582,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
     }
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @pre_acceptance_cancel_client,
           cancel_drain_timeout_ms: 20
         )
@@ -1553,15 +1620,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
     }
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @pre_acceptance_cancel_client,
           cancel_drain_timeout_ms: 20
         )
@@ -1600,15 +1665,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node.id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
     }
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node.id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node.id),
           client_impl: @pre_acceptance_cancel_client,
           cancel_drain_timeout_ms: 20
         )
@@ -1639,15 +1702,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
     }
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @noisy_cancel_client,
           cancel_drain_timeout_ms: 20
         )
@@ -1671,12 +1732,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, claimed_node_id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
     }
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           schedule,
           execute_request(request_id),
           model_load_request(claimed_node_id),
@@ -1707,7 +1769,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1732,7 +1794,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -1772,7 +1834,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
              )
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -1854,7 +1916,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     )
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_facts_unavailable}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(scheduled_node.id),
@@ -1877,7 +1939,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert schedule.node_id == schedule.runtime_endpoint_target.node_id
 
     assert {:ok, _events} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -1903,7 +1965,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         compatibility_single_wave_schedule(authority, unquote(management_class))
 
       assert {:ok, _events} =
-               RequestDispatcher.dispatch(
+               dispatch_with_deadline(
                  schedule,
                  execute_request(schedule.request_id),
                  model_load_request(node_id),
@@ -1932,7 +1994,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
           )
 
         assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-                 RequestDispatcher.dispatch(
+                 dispatch_with_deadline(
                    schedule,
                    execute_request(schedule.request_id),
                    model_load_request(node_id),
@@ -1959,7 +2021,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         )
 
       assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-               RequestDispatcher.dispatch(
+               dispatch_with_deadline(
                  schedule,
                  execute_request(schedule.request_id),
                  model_load_request(node_id),
@@ -1986,7 +2048,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         )
 
       assert {:ok, _events} =
-               RequestDispatcher.dispatch(
+               dispatch_with_deadline(
                  schedule,
                  execute_request(schedule.request_id),
                  model_load_request(node_id),
@@ -2013,7 +2075,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         )
 
       assert {:ok, _events} =
-               RequestDispatcher.dispatch(
+               dispatch_with_deadline(
                  schedule,
                  execute_request(schedule.request_id),
                  model_load_request(node_id),
@@ -2041,7 +2103,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
           )
 
         assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-                 RequestDispatcher.dispatch(
+                 dispatch_with_deadline(
                    schedule,
                    execute_request(schedule.request_id),
                    model_load_request(node_id),
@@ -2076,7 +2138,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       }
 
       assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-               RequestDispatcher.dispatch(
+               dispatch_with_deadline(
                  schedule,
                  execute_request(schedule.request_id),
                  model_load_request(node_id),
@@ -2099,7 +2161,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       monitor_snapshot_schedule(authority, :degraded_acquisition)
 
     assert {:ok, _events} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -2130,7 +2192,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         monitor_snapshot_schedule(authority, unquote(scenario))
 
       assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-               RequestDispatcher.dispatch(
+               dispatch_with_deadline(
                  schedule,
                  execute_request(schedule.request_id),
                  model_load_request(node.id),
@@ -2153,7 +2215,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       monitor_snapshot_schedule(authority, :degraded)
 
     assert {:ok, _events} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -2181,7 +2243,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       |> Map.put(:dispatch_capacity_acquisition_input_provider, fn -> degraded end)
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_unavailable}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(node_id),
@@ -2206,7 +2268,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       |> Map.put(:dispatch_capacity_input_provider, fn -> degraded end)
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(node_id),
@@ -2226,7 +2288,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       monitor_snapshot_schedule(authority, :target_removed_before_acquisition)
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_facts_unavailable}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -2248,7 +2310,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       monitor_snapshot_schedule(authority, :target_removed_before_final)
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -2273,7 +2335,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     schedule = %{schedule | runtime_endpoint_target: mismatched_target}
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -2297,7 +2359,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     @production_fresh_status_client.configure(self(), status, status)
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, claimed_node_id, request_id),
                execute_request(request_id),
                model_load_request(claimed_node_id),
@@ -2316,7 +2378,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     request_id = "request-probe-identity-missing"
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, node_id, request_id),
                execute_request(request_id),
                model_load_request(node_id),
@@ -2333,7 +2395,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     request_id = "request-probe-identity-unverified"
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                capacity_schedule(authority, node_id, request_id),
                execute_request(request_id),
                model_load_request(node_id),
@@ -2374,7 +2436,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert schedule.strategy == :multi_node
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(schedule.request_id),
                model_load_request(node.id),
@@ -2402,7 +2464,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert %Evaluator.Result{eligible?: true} = schedule.dispatch_capacity_evaluation
 
     assert {:ok, _events} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                Map.put(schedule, :request_id, request_id),
                execute_request(request_id),
                model_load_request("unmanaged"),
@@ -2417,10 +2479,14 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     {:ok, lease} = QueueManager.acquire_acceptance_gate(node_id, authority: authority)
 
-    schedule = %{capacity_schedule(authority, node_id, request_id) | request_timeout_ms: 60}
+    schedule = %{
+      capacity_schedule(authority, node_id, request_id)
+      | request_timeout_ms: 60,
+        timeout_at: DateTime.add(DateTime.utc_now(), 60, :millisecond)
+    }
 
     assert {:error, {:dispatch_failed, :dispatch_capacity_acceptance_gate_busy}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(node_id),
@@ -2437,10 +2503,14 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = claim_node_id()
     request_id = "request-deadline-exhausted-before-acceptance-gate"
 
-    schedule = %{capacity_schedule(authority, node_id, request_id) | request_timeout_ms: 0}
+    schedule = %{
+      capacity_schedule(authority, node_id, request_id)
+      | request_timeout_ms: 0,
+        timeout_at: DateTime.utc_now()
+    }
 
     assert {:error, {:dispatch_failed, :dispatch_timeout}} =
-             RequestDispatcher.dispatch(
+             dispatch_with_deadline(
                schedule,
                execute_request(request_id),
                model_load_request(node_id),
@@ -2469,7 +2539,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
+        dispatch_with_deadline(
           capacity_schedule(authority, node_id, request_id),
           execute_request(request_id),
           model_load_request(node_id),
@@ -2506,17 +2576,19 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     authority = start_supervised!({AllocationAuthority, name: nil})
     node_id = claim_node_id()
     request_id = "request-shared-acceptance-deadline"
-    schedule = %{capacity_schedule(authority, node_id, request_id) | request_timeout_ms: 1_000}
+
+    schedule = %{
+      capacity_schedule(authority, node_id, request_id)
+      | request_timeout_ms: 1_000,
+        timeout_at: DateTime.add(DateTime.utc_now(), 1_000, :millisecond)
+    }
 
     {:ok, held_lease} = QueueManager.acquire_acceptance_gate(node_id, authority: authority)
     started_at = System.monotonic_time(:millisecond)
 
     dispatch =
       Task.async(fn ->
-        RequestDispatcher.dispatch(
-          schedule,
-          execute_request(request_id),
-          model_load_request(node_id),
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
           client_impl: @cancellable_stream_client
         )
       end)
@@ -2550,6 +2622,14 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = Ecto.UUID.generate()
     DispatchCapacityFixtures.put_probe_node_id(node_id)
     node_id
+  end
+
+  defp dispatch_with_deadline(schedule, execute_request, model_load_request, opts) do
+    timeout_ms = Map.get(schedule, :request_timeout_ms, 5_000)
+
+    schedule
+    |> Map.put_new(:timeout_at, DateTime.add(DateTime.utc_now(), timeout_ms, :millisecond))
+    |> RequestDispatcher.dispatch(execute_request, model_load_request, opts)
   end
 
   defp execute_request(request_id) do
@@ -2975,6 +3055,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       request_id: request_id,
       runtime_client_target: Inference.runtime_client_target(),
       request_timeout_ms: 5_000,
+      timeout_at: DateTime.add(DateTime.utc_now(), 5_000, :millisecond),
       model_load_timeout_ms: 5_000,
       node_id: node_id,
       dispatch_capacity_input: input,

--- a/apps/orchard_controller/test/orchard/inference/attempt_context_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/attempt_context_test.exs
@@ -1,0 +1,46 @@
+defmodule Orchard.Inference.AttemptContextTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Inference.AttemptContext
+
+  @node_id "00000000-0000-4000-a000-000000000001"
+
+  test "SPEC.md §3.7.1 supports only turn 1 attempts 1 and 2" do
+    assert {:ok, attempt_1} = AttemptContext.new(attrs(1, []))
+    assert attempt_1.step_id == "inference_turn:t1:a1"
+
+    assert {:ok, attempt_2} = AttemptContext.new(attrs(2, [@node_id]))
+    assert attempt_2.step_id == "inference_turn:t1:a2"
+
+    assert {:error, _reason} = AttemptContext.new(Map.put(attrs(1, []), :turn_index, 2))
+    assert {:error, _reason} = AttemptContext.new(attrs(3, []))
+  end
+
+  test "attempt exclusion invariants fail closed" do
+    assert {:error, _reason} = AttemptContext.new(attrs(1, [@node_id]))
+    assert {:error, _reason} = AttemptContext.new(attrs(2, []))
+    assert {:error, _reason} = AttemptContext.new(attrs(2, ["not-a-uuid"]))
+    assert {:error, _reason} = AttemptContext.new(attrs(2, [@node_id, Ecto.UUID.generate()]))
+  end
+
+  test "started_at can be assigned exactly once" do
+    assert {:ok, context} = AttemptContext.new(attrs(1, []))
+    started_at = ~U[2026-08-12 10:00:00.000000Z]
+
+    assert {:ok, started} = AttemptContext.put_started_at(context, started_at)
+    assert started.started_at == started_at
+
+    assert {:error, "started_at is immutable once assigned"} =
+             AttemptContext.put_started_at(started, DateTime.add(started_at, 1, :second))
+  end
+
+  defp attrs(attempt, exclusions) do
+    %{
+      turn_index: 1,
+      attempt: attempt,
+      excluded_node_ids: exclusions,
+      model_id: "model-a",
+      model_version: "v1"
+    }
+  end
+end

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -3539,7 +3539,8 @@ defmodule Orchard.Inference.QueueManagerTest do
         requested_model: "queue-model@v1",
         state: :received,
         stream: false,
-        payload_capture_mode: :metadata
+        payload_capture_mode: :metadata,
+        timeout_at: DateTime.utc_now() |> DateTime.add(120_000, :millisecond)
       ],
       overrides
     )

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -3153,7 +3153,7 @@ defmodule Orchard.Inference.QueueManagerTest do
                  public_id: db_request.public_id,
                  caller_pid: caller
                ),
-               config: queue_config(max_wait_ms: 200)
+               config: queue_config(max_wait_ms: 60_000)
              )
 
     awaiter = spawn(fn -> QueueManager.await(ticket) end)
@@ -3162,11 +3162,16 @@ defmodule Orchard.Inference.QueueManagerTest do
     :ok = :sys.suspend(QueueManager)
 
     try do
-      Process.sleep(250)
+      send(QueueManager, {:queue_timeout, ticket.ticket_ref})
       Process.exit(awaiter, :kill)
       resume_manager(QueueManager)
 
-      assert wait_until(fn -> Requests.get_request!(db_request.id).state == :cancelled end)
+      assert wait_until(fn ->
+               request = Requests.get_request!(db_request.id)
+
+               request.state == :cancelled and
+                 request.error_code == "request_caller_disconnect"
+             end)
 
       request = Requests.get_request!(db_request.id)
       assert request.error_code == "request_caller_disconnect"

--- a/apps/orchard_controller/test/orchard/inference/request_deadline_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_deadline_test.exs
@@ -1,0 +1,76 @@
+defmodule Orchard.Inference.RequestDeadlineTest do
+  use Orchard.DataCase, async: false
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  alias Orchard.Inference.RequestDeadline
+  alias Orchard.Requests
+
+  describe "absolute Request deadline" do
+    test "SPEC.md §12.4 creates one UTC deadline from the admitted timeout" do
+      now = ~U[2026-08-12 10:00:00.123456Z]
+
+      assert RequestDeadline.timeout_at(120_000, now) ==
+               ~U[2026-08-12 10:02:00.123456Z]
+    end
+
+    test "SPEC.md §§5.8 and 12.4 clamps remaining and stage budgets at zero" do
+      timeout_at = ~U[2026-08-12 10:00:01.000000Z]
+
+      assert RequestDeadline.remaining_ms(timeout_at, ~U[2026-08-12 10:00:00.250000Z]) == 750
+      assert RequestDeadline.cap_ms(500, timeout_at, ~U[2026-08-12 10:00:00.250000Z]) == 500
+      assert RequestDeadline.cap_ms(1_000, timeout_at, ~U[2026-08-12 10:00:00.250000Z]) == 750
+      assert RequestDeadline.remaining_ms(timeout_at, ~U[2026-08-12 10:00:01.001000Z]) == 0
+      assert RequestDeadline.cap_ms(500, timeout_at, ~U[2026-08-12 10:00:01.001000Z]) == 0
+    end
+
+    test "converts an absolute deadline to one local monotonic deadline from one clock sample" do
+      timeout_at = ~U[2026-08-12 10:00:01.000000Z]
+      system_ms = DateTime.to_unix(~U[2026-08-12 10:00:00.250000Z], :millisecond)
+
+      assert RequestDeadline.to_monotonic_ms(timeout_at, system_ms, 42_000) == 42_750
+      assert RequestDeadline.to_monotonic_ms(timeout_at, system_ms + 1_000, 42_000) == 42_000
+    end
+  end
+
+  describe "Request creation contract" do
+    test "new application rows require timeout_at" do
+      attrs = request_attrs() |> Map.delete(:timeout_at)
+
+      assert {:error, changeset} = Requests.create_request(attrs)
+      assert %{timeout_at: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "schedule, node assignment, and terminal writes cannot replace timeout_at" do
+      original_timeout_at = ~U[2026-08-12 10:02:00.000000Z]
+      replacement_timeout_at = ~U[2099-01-01 00:00:00.000000Z]
+
+      assert {:ok, request} =
+               Requests.create_request(request_attrs(%{timeout_at: original_timeout_at}))
+
+      assert {:ok, scheduled} =
+               Requests.record_schedule(request, %{
+                 strategy: :single_node,
+                 request_id: request.public_id,
+                 runtime_client_target: [host: "10.0.0.1", port: 9444],
+                 request_timeout_ms: 5_000,
+                 model_load_timeout_ms: 120_000,
+                 node_id: nil
+               })
+
+      assert scheduled.timeout_at == original_timeout_at
+
+      assert {:ok, assigned} = Requests.assign_node(scheduled, Ecto.UUID.generate())
+      assert assigned.timeout_at == original_timeout_at
+
+      assert {:ok, terminal} =
+               Requests.mark_terminal(assigned, %{
+                 state: :failed,
+                 error_code: "internal_error",
+                 timeout_at: replacement_timeout_at
+               })
+
+      assert terminal.timeout_at == original_timeout_at
+    end
+  end
+end

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -2075,17 +2075,19 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical =
       canonical_request("request-orchestrator-queue-request-deadline",
         stream?: false,
-        admission: %{queue_wait_ms: 5_000, timeout_ms: 30}
+        admission: %{queue_wait_ms: 5_000, timeout_ms: 250}
       )
 
     assert {:ok, held_grant} = hold_queue_lane(canonical)
+    started_at = System.monotonic_time(:millisecond)
     assert {:error, :queue_timeout} = RequestOrchestrator.execute(canonical, model)
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at
     assert :ok = QueueManager.release(held_grant)
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request.state == :timed_out
     assert request.error_code == "queue_timeout"
-    assert request.scheduler_decision["queue_wait_ms"] <= 30
+    assert elapsed_ms < 2_000
     refute :scheduled in request_event_states(request)
   end
 

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -30,6 +30,19 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler do
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.DelayedScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
+
+  @impl true
+  def schedule(%CanonicalRequest{} = request) do
+    Process.sleep(50)
+    StubMultiNodeScheduler.schedule(request)
+  end
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.StubMalformedExplanationScheduler do
   @behaviour Orchard.Scheduler.SingleNode
 
@@ -948,6 +961,76 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end)
 
     %{bundle: bundle}
+  end
+
+  test "SPEC.md §12.4 execute/3 persists the admission timeout as one absolute deadline", %{
+    bundle: bundle
+  } do
+    put_capturing_runtime_adapter_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-absolute-deadline")
+
+    canonical =
+      canonical_request("request-orchestrator-absolute-deadline",
+        stream?: false,
+        admission: %{timeout_ms: 120_000}
+      )
+
+    before_execute = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+    after_execute = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+
+    assert DateTime.compare(
+             request.timeout_at,
+             DateTime.add(before_execute, 120_000, :millisecond)
+           ) in [
+             :eq,
+             :gt
+           ]
+
+    assert DateTime.compare(
+             request.timeout_at,
+             DateTime.add(after_execute, 120_000, :millisecond)
+           ) in [:eq, :lt]
+
+    assert_receive {:captured_execute_request, execute_request}
+    assert execute_request.deadline_unix_ms == DateTime.to_unix(request.timeout_at, :millisecond)
+    refute Map.has_key?(request.scheduler_decision, "timeout_at")
+  end
+
+  test "SPEC.md §12.4 scheduler time consumes the Request deadline before dispatch", %{
+    bundle: bundle
+  } do
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.put(
+        :scheduler_impl,
+        Orchard.Inference.RequestOrchestratorTest.DelayedScheduler
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+    put_capturing_runtime_adapter_config()
+
+    model = create_active_model!(bundle, "request-orchestrator-scheduler-deadline")
+
+    canonical =
+      canonical_request("request-orchestrator-scheduler-deadline",
+        stream?: false,
+        admission: %{timeout_ms: 20}
+      )
+
+    assert {:error, {:dispatch_failed, :request_timeout}} =
+             RequestOrchestrator.execute(canonical, model)
+
+    refute_receive {:captured_execute_request, _request}
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :timed_out
+    assert request.error_code == "request_timeout"
+    assert request.completed_at != nil
+    assert Requests.list_request_step_events(request) == []
   end
 
   test "execute/3 persists canonical endpoint instead of hardcoding chat", %{bundle: bundle} do
@@ -1982,6 +2065,28 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
              Map.keys(request.scheduler_decision || %{}),
              &String.starts_with?(&1, "selected_prefix_cache_score_")
            )
+  end
+
+  test "SPEC.md §12.4 queue waiting cannot outlive the Request deadline", %{bundle: bundle} do
+    put_queue_admission_config(enabled: true, max_wait_ms: 5_000)
+
+    model = create_active_model!(bundle, "request-orchestrator-queue-request-deadline")
+
+    canonical =
+      canonical_request("request-orchestrator-queue-request-deadline",
+        stream?: false,
+        admission: %{queue_wait_ms: 5_000, timeout_ms: 30}
+      )
+
+    assert {:ok, held_grant} = hold_queue_lane(canonical)
+    assert {:error, :queue_timeout} = RequestOrchestrator.execute(canonical, model)
+    assert :ok = QueueManager.release(held_grant)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :timed_out
+    assert request.error_code == "queue_timeout"
+    assert request.scheduler_decision["queue_wait_ms"] <= 30
+    refute :scheduled in request_event_states(request)
   end
 
   test "pre-await queue terminalization surfaces original queue outcome", %{bundle: bundle} do

--- a/apps/orchard_controller/test/orchard/metrics/gauge_poller_test.exs
+++ b/apps/orchard_controller/test/orchard/metrics/gauge_poller_test.exs
@@ -231,7 +231,8 @@ defmodule Orchard.Metrics.GaugePollerTest do
       requested_model: requested_model,
       state: :dispatching,
       stream: false,
-      payload_capture_mode: :none
+      payload_capture_mode: :none,
+      timeout_at: DateTime.add(DateTime.utc_now(), 30, :second)
     })
     |> Repo.insert!()
   end

--- a/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs
@@ -91,6 +91,46 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
 
     refute inspect(event.payload) =~ @private_prompt
 
+    node_id = Ecto.UUID.generate()
+    raw_target = "grpc://10.0.0.8:50071/#{@private_prompt}"
+
+    assert {:ok, [attempt_event]} =
+             Requests.append_request_step_events(request, [
+               %{
+                 event_type: "request_step.failed",
+                 step_id: "inference_turn:t1:a1",
+                 step_type: "inference_turn",
+                 turn_index: 1,
+                 attempt: 1,
+                 parent_step_id: nil,
+                 boundary: "post_observation",
+                 result: %{
+                   "attempt_outcome" => "failed",
+                   "started_at" => ~U[2026-08-12 10:00:00.000000Z],
+                   "ended_at" => ~U[2026-08-12 10:00:01.000000Z],
+                   "accepted" => true,
+                   "output_committed" => false,
+                   "execution_resolution" => "terminated",
+                   "capacity_release_outcome" => "released",
+                   "excluded_node_ids" => [],
+                   "node_id" => node_id,
+                   "target_ref" => raw_target,
+                   "failure_class" => "runtime_failure",
+                   "failure_code" => "runtime_unavailable",
+                   "retry_decision" => "not_retryable",
+                   "raw_source_code" => "private_runtime_code",
+                   "error_message" => @private_prompt
+                 }
+               }
+             ])
+
+    assert attempt_event.result["failure_class"] == "runtime_failure"
+    assert attempt_event.result["node_id"] == node_id
+    assert attempt_event.result["target_ref"] =~ ~r/\Asha256:[0-9a-f]{64}\z/
+    refute inspect(attempt_event.result) =~ @private_prompt
+    refute Map.has_key?(attempt_event.result, "raw_source_code")
+    refute Map.has_key?(attempt_event.result, "error_message")
+
     assert {:ok, terminal} =
              Requests.mark_terminal(request, %{
                state: :failed,
@@ -275,7 +315,8 @@ defmodule Orchard.Requests.CaptureEnforcementTest do
       },
       request_payload: %{"prompt" => @private_prompt},
       sampling_params: %{"temperature" => 0.5, "stop" => ["private stop"]},
-      response_format: %{"type" => "text"}
+      response_format: %{"type" => "text"},
+      timeout_at: DateTime.utc_now() |> DateTime.add(120_000, :millisecond)
     }
   end
 end

--- a/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/capture_policy_test.exs
@@ -695,6 +695,99 @@ defmodule Orchard.Requests.CapturePolicyTest do
     }
   end
 
+  test "restricted capture retains closed attempt evidence and hashes targets" do
+    raw_target = "grpc://10.0.0.8:50071/private"
+    node_id = "00000000-0000-4000-a000-000000000001"
+    attrs = enriched_attempt_event(raw_target, node_id)
+    expected_target = "sha256:" <> Base.encode16(:crypto.hash(:sha256, raw_target), case: :lower)
+
+    for mode <- [:none, :metadata] do
+      sanitized = CapturePolicy.event_attrs(mode, attrs)
+      result = sanitized.payload["result"]
+
+      assert result["attempt_outcome"] == "failed"
+      assert result["failure_class"] == "runtime_failure"
+      assert result["failure_code"] == "runtime_unavailable"
+      assert result["node_id"] == node_id
+      assert result["target_ref"] == expected_target
+      refute Map.has_key?(result, "raw_source_code")
+      refute Map.has_key?(result, "error_message")
+      refute inspect(sanitized) =~ @prompt
+      refute inspect(sanitized) =~ @arguments
+    end
+  end
+
+  test "full capture permits only strict enriched fields and approved target identifiers" do
+    attrs =
+      enriched_attempt_event(
+        "grpc://10.0.0.8:50071/private",
+        "00000000-0000-4000-a000-000000000001"
+      )
+
+    sanitized = CapturePolicy.event_attrs(:full, attrs)
+    assert sanitized.payload["result"] == %{"result_invalid" => true}
+
+    stable_target = "sha256:" <> String.duplicate("a", 64)
+    stable = put_in(attrs, [:payload, "result", "target_ref"], stable_target)
+
+    assert CapturePolicy.event_attrs(:full, stable).payload["result"]["target_ref"] ==
+             stable_target
+
+    invalid = put_in(stable, [:payload, "result", "content"], @prompt)
+    sanitized = CapturePolicy.event_attrs(:full, invalid)
+    assert sanitized.payload["result"] == %{"result_invalid" => true}
+  end
+
+  test "restricted tool-call parent identity follows the payload attempt" do
+    attrs = %{
+      event_type: "request_step.proposed",
+      payload: %{
+        "step_type" => "tool_call",
+        "turn_index" => 1,
+        "attempt" => 2,
+        "call_id" => "call-private",
+        "boundary" => "post_observation",
+        "result" => %{}
+      }
+    }
+
+    sanitized = CapturePolicy.event_attrs(:metadata, attrs)
+    assert sanitized.payload["parent_step_id"] == "inference_turn:t1:a2"
+  end
+
+  defp enriched_attempt_event(raw_target, node_id) do
+    %{
+      event_type: "request_step.failed",
+      payload: %{
+        "step_id" => "inference_turn:t1:a1",
+        "step_type" => "inference_turn",
+        "turn_index" => 1,
+        "attempt" => 1,
+        "boundary" => "post_observation",
+        "result" => %{
+          "attempt_outcome" => "failed",
+          "started_at" => ~U[2026-08-12 10:00:00.000000Z],
+          "ended_at" => ~U[2026-08-12 10:00:01.000000Z],
+          "accepted" => true,
+          "output_committed" => false,
+          "execution_resolution" => "terminated",
+          "capacity_release_outcome" => "released",
+          "excluded_node_ids" => [],
+          "node_id" => node_id,
+          "target_ref" => raw_target,
+          "failure_class" => "runtime_failure",
+          "failure_code" => "runtime_unavailable",
+          "runtime_retryable" => true,
+          "retry_decision" => "not_retryable",
+          "raw_source_code" => "private-runtime-code",
+          "error_message" => "runtime echoed #{@prompt}"
+        },
+        "arguments_json" => @arguments,
+        "content" => @prompt
+      }
+    }
+  end
+
   defp event_attrs do
     %{
       event_type: "request_step.proposed",

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
@@ -1,0 +1,81 @@
+defmodule Orchard.Requests.InferenceAttemptFailureTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Requests.InferenceAttemptFailure
+
+  test "normalizes structured source categories without inspecting messages" do
+    assert InferenceAttemptFailure.normalize(%{
+             category: :model_load,
+             code: :acquisition_failed,
+             message: "arbitrary private text"
+           }) == %{
+             "failure_class" => "model_load_failure",
+             "failure_code" => "acquisition_failed"
+           }
+
+    assert InferenceAttemptFailure.normalize(%{category: :deadline, code: :foreign_timeout}) == %{
+             "failure_class" => "deadline",
+             "failure_code" => "request_timeout",
+             "raw_source_code" => "foreign_timeout"
+           }
+  end
+
+  test "capacity cancellation, identity, and occupancy retain closed classifications" do
+    assert normalized(:capacity, :dispatch_capacity_caller_down) ==
+             {"cancellation", "request_caller_disconnect"}
+
+    assert normalized(:capacity, :dispatch_capacity_node_identity_mismatch) ==
+             {"identity_unresolved", "unexpected_placement_state"}
+
+    assert normalized(:capacity, :dispatch_capacity_request_already_claimed) ==
+             {"occupancy_unresolved", "orchestration_error"}
+  end
+
+  test "normalizes every durable source category to a closed failure class and code" do
+    cases = [
+      {%{category: :runtime, code: :runtime_unavailable},
+       {"runtime_failure", "runtime_unavailable"}},
+      {%{category: :model_load, code: :model_invalid}, {"model_load_failure", "model_invalid"}},
+      {%{category: :capacity, code: :dispatch_capacity_acceptance_gate_busy},
+       {"capacity_rejection", "resource_exhausted"}},
+      {%{category: :cancellation, code: :request_client_disconnect},
+       {"cancellation", "request_caller_disconnect"}},
+      {%{category: :deadline, code: :deadline_exceeded}, {"deadline", "deadline_exceeded"}},
+      {%{category: :terminal_conformance, code: :private_terminal_code},
+       {"terminal_conformance", "orchestration_error"}},
+      {%{category: :controller, code: :request_interrupted},
+       {"controller_failure", "request_interrupted"}},
+      {%{category: :worker_or_node_loss, code: :worker_down},
+       {"worker_or_node_loss", "worker_down"}},
+      {%{category: :unknown, code: :private_code}, {"controller_failure", "internal_error"}}
+    ]
+
+    for {source, expected} <- cases do
+      assert normalized(source.category, source.code) == expected
+    end
+  end
+
+  test "untrusted pre-acceptance codes do not acquire retryable stable codes" do
+    assert InferenceAttemptFailure.normalize(%{
+             category: :pre_acceptance,
+             code: :private_transport_code
+           }) == %{
+             "failure_class" => "pre_acceptance_unavailable",
+             "failure_code" => "internal_error",
+             "raw_source_code" => "private_transport_code"
+           }
+  end
+
+  test "unknown source failures fail closed" do
+    assert InferenceAttemptFailure.normalize(%{category: :unknown, code: :private_code}) == %{
+             "failure_class" => "controller_failure",
+             "failure_code" => "internal_error",
+             "raw_source_code" => "private_code"
+           }
+  end
+
+  defp normalized(category, code) do
+    evidence = InferenceAttemptFailure.normalize(%{category: category, code: code})
+    {evidence["failure_class"], evidence["failure_code"]}
+  end
+end

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
@@ -1,0 +1,264 @@
+defmodule Orchard.Requests.InferenceAttemptResultTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Requests.InferenceAttemptResult
+
+  @node_1 "00000000-0000-4000-a000-000000000001"
+  @node_2 "00000000-0000-4000-a000-000000000002"
+
+  test "valid attempt 1 and attempt 2 terminal evidence normalize to JSON-safe maps" do
+    assert {:ok, attempt_1} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{"retry_decision" => "not_retryable"})
+             )
+
+    assert attempt_1["started_at"] == "2026-08-12T10:00:00.000000Z"
+
+    assert {:ok, attempt_2} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               2,
+               failed_result(%{
+                 "node_id" => @node_2,
+                 "excluded_node_ids" => [@node_1],
+                 "retry_decision" => "retry_exhausted"
+               })
+             )
+
+    assert attempt_2["excluded_node_ids"] == [@node_1]
+  end
+
+  test "closed retry decisions reject impossible attempt states" do
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{"retry_decision" => "retry_exhausted"})
+             )
+
+    for decision <-
+          ~w(not_retryable output_committed budget_exhausted identity_unresolved occupancy_unresolved no_alternative_node retried) do
+      assert {:error, _reason} =
+               InferenceAttemptResult.new(
+                 "request_step.failed",
+                 2,
+                 failed_result(%{
+                   "node_id" => @node_2,
+                   "excluded_node_ids" => [@node_1],
+                   "retry_decision" => decision
+                 })
+               )
+    end
+  end
+
+  test "orphaned enriched fields and contradictory decisions fail closed" do
+    assert InferenceAttemptResult.enriched?(%{"failure_class" => "runtime_failure"})
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               %{"failure_class" => "runtime_failure"}
+             )
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{"retry_decision" => "output_committed"})
+             )
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{
+                 "attempt_outcome" => "failed",
+                 "failure_class" => "runtime_failure",
+                 "retry_decision" => "cancelled"
+               })
+             )
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.cancelled",
+               2,
+               failed_result(%{
+                 "attempt_outcome" => "cancelled",
+                 "failure_class" => "cancellation",
+                 "failure_code" => "request_caller_disconnect",
+                 "node_id" => @node_2,
+                 "excluded_node_ids" => [@node_1],
+                 "retry_decision" => "retry_exhausted"
+               })
+             )
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{
+                 "accepted" => true,
+                 "output_committed" => true,
+                 "output_commitment_kind" => "text",
+                 "execution_resolution" => "terminated",
+                 "capacity_release_outcome" => "released",
+                 "node_id" => @node_1,
+                 "retry_decision" => "retried"
+               })
+             )
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{
+                 "accepted" => true,
+                 "output_committed" => true,
+                 "output_commitment_kind" => "text",
+                 "execution_resolution" => "terminated",
+                 "capacity_release_outcome" => "released",
+                 "node_id" => @node_1,
+                 "retry_decision" => "budget_exhausted"
+               })
+             )
+  end
+
+  test "success omits retry and failure evidence" do
+    completed =
+      base_result(%{
+        "attempt_outcome" => "completed",
+        "accepted" => true,
+        "execution_resolution" => "terminated"
+      })
+
+    assert {:ok, _result} =
+             InferenceAttemptResult.new("request_step.completed", 1, completed)
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.completed",
+               1,
+               Map.put(completed, "retry_decision", "not_retryable")
+             )
+  end
+
+  test "commitment evidence is internally consistent" do
+    failed = failed_result(%{"retry_decision" => "output_committed"})
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               Map.put(failed, "output_commitment_kind", "text")
+             )
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               Map.put(failed, "output_committed", true)
+             )
+
+    assert {:ok, _result} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed
+               |> Map.put("accepted", true)
+               |> Map.put("execution_resolution", "terminated")
+               |> Map.put("output_committed", true)
+               |> Map.put("output_commitment_kind", "text")
+             )
+  end
+
+  test "event outcome and attempt 2 exclusions fail closed" do
+    failed = failed_result(%{"retry_decision" => "not_retryable"})
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new("request_step.cancelled", 1, failed)
+
+    for exclusions <- [[], ["bad"], [@node_1, @node_1]] do
+      assert {:error, _reason} =
+               InferenceAttemptResult.new(
+                 "request_step.failed",
+                 2,
+                 failed_result(%{
+                   "node_id" => @node_2,
+                   "excluded_node_ids" => exclusions,
+                   "retry_decision" => "retry_exhausted"
+                 })
+               )
+    end
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               2,
+               failed_result(%{
+                 "node_id" => @node_1,
+                 "excluded_node_ids" => [@node_1],
+                 "retry_decision" => "retry_exhausted"
+               })
+             )
+  end
+
+  test "timestamps, booleans, bounded integers, and stable codes fail closed" do
+    result = failed_result(%{"retry_decision" => "not_retryable"})
+
+    invalid_results = [
+      Map.put(result, "ended_at", ~U[2026-08-12 09:59:59.000000Z]),
+      Map.put(result, "accepted", "false"),
+      Map.put(result, "output_tokens", 2_147_483_648),
+      Map.put(result, "failure_code", "private_runtime_code")
+    ]
+
+    for invalid <- invalid_results do
+      assert {:error, _reason} =
+               InferenceAttemptResult.new("request_step.failed", 1, invalid)
+    end
+  end
+
+  test "unexpected and partial enriched shapes fail closed" do
+    assert {:error, _reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               Map.put(failed_result(%{"retry_decision" => "not_retryable"}), "content", "secret")
+             )
+
+    assert {:error, _reason} =
+             InferenceAttemptResult.new("request_step.failed", 1, %{"accepted" => false})
+  end
+
+  defp failed_result(overrides) do
+    base_result(
+      Map.merge(
+        %{
+          "attempt_outcome" => "failed",
+          "failure_class" => "runtime_failure",
+          "failure_code" => "runtime_unavailable"
+        },
+        overrides
+      )
+    )
+  end
+
+  defp base_result(overrides) do
+    Map.merge(
+      %{
+        "attempt_outcome" => "failed",
+        "started_at" => ~U[2026-08-12 10:00:00.000000Z],
+        "ended_at" => ~U[2026-08-12 10:00:01.000000Z],
+        "accepted" => false,
+        "output_committed" => false,
+        "execution_resolution" => "not_started",
+        "capacity_release_outcome" => "not_applicable",
+        "excluded_node_ids" => []
+      },
+      overrides
+    )
+  end
+end

--- a/apps/orchard_controller/test/orchard/requests/request_server_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/request_server_test.exs
@@ -13,7 +13,8 @@ defmodule Orchard.Requests.RequestServerTest do
     requested_model: "test-model@v1",
     state: :received,
     stream: false,
-    payload_capture_mode: :metadata
+    payload_capture_mode: :metadata,
+    timeout_at: ~U[2100-01-01 00:00:00.000000Z]
   }
 
   defp create_request! do

--- a/apps/orchard_controller/test/orchard/requests/request_step_event_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/request_step_event_test.exs
@@ -348,6 +348,133 @@ defmodule Orchard.Requests.RequestStepEventTest do
     )
   end
 
+  test "new/1 accepts only the supported inference-turn identities" do
+    assert {:ok, _step_event} =
+             RequestStepEvent.new(
+               inference_turn_step_attrs(%{
+                 event_type: "request_step.started",
+                 boundary: "pre_side_effect",
+                 result: %{}
+               })
+             )
+
+    assert {:ok, _step_event} =
+             RequestStepEvent.new(
+               inference_turn_step_attrs(%{
+                 event_type: "request_step.started",
+                 step_id: RequestStepEvent.inference_turn_step_id(1, 2),
+                 attempt: 2,
+                 boundary: "pre_side_effect",
+                 result: %{}
+               })
+             )
+
+    for {turn_index, attempt} <- [{2, 1}, {1, 3}] do
+      assert {:error, "only turn 1 attempts 1 and 2 are supported"} =
+               RequestStepEvent.new(
+                 inference_turn_step_attrs(%{
+                   event_type: "request_step.started",
+                   step_id: RequestStepEvent.inference_turn_step_id(turn_index, attempt),
+                   turn_index: turn_index,
+                   attempt: attempt,
+                   boundary: "pre_side_effect",
+                   result: %{}
+                 })
+               )
+    end
+  end
+
+  test "enriched terminal attempts validate while sparse historical rows remain readable" do
+    node_1 = "00000000-0000-4000-a000-000000000001"
+    node_2 = "00000000-0000-4000-a000-000000000002"
+
+    for {attempt, node_id, exclusions, decision} <- [
+          {1, node_1, [], "retried"},
+          {2, node_2, [node_1], "retry_exhausted"}
+        ] do
+      attrs =
+        inference_terminal_attrs(attempt, %{
+          "node_id" => node_id,
+          "excluded_node_ids" => exclusions,
+          "retry_decision" => decision
+        })
+
+      assert {:ok, step_event} = RequestStepEvent.new(attrs)
+      assert step_event.result["excluded_node_ids"] == exclusions
+    end
+
+    assert {:ok, _step_event} =
+             RequestStepEvent.new(%{
+               event_type: "request_step.failed",
+               step_id: RequestStepEvent.inference_turn_step_id(1, 1),
+               step_type: "inference_turn",
+               turn_index: 1,
+               attempt: 1,
+               boundary: "post_observation",
+               result: %{"error_code" => "internal_error"}
+             })
+
+    assert {:error, _reason} =
+             RequestStepEvent.new(%{
+               event_type: "request_step.failed",
+               step_id: RequestStepEvent.inference_turn_step_id(1, 1),
+               step_type: "inference_turn",
+               turn_index: 1,
+               attempt: 1,
+               boundary: "post_observation",
+               result: %{"accepted" => false}
+             })
+  end
+
+  test "from_request_event/1 preserves historical inference identities rejected for new writes" do
+    request_event = %RequestEvent{
+      request_id: Ecto.UUID.generate(),
+      seq: 1,
+      event_type: "request_step.failed",
+      state: nil,
+      occurred_at: ~U[2026-04-11 09:15:00.000000Z],
+      payload: %{
+        "step_id" => RequestStepEvent.inference_turn_step_id(2, 3),
+        "step_type" => "inference_turn",
+        "turn_index" => 2,
+        "attempt" => 3,
+        "parent_step_id" => nil,
+        "boundary" => "post_observation",
+        "result" => %{"error_code" => "internal_error"}
+      }
+    }
+
+    assert {:ok, step_event} = RequestStepEvent.from_request_event(request_event)
+    assert step_event.step_id == "inference_turn:t2:a3"
+    assert step_event.attempt == 3
+  end
+
+  defp inference_terminal_attrs(attempt, overrides) do
+    %{
+      event_type: "request_step.failed",
+      step_id: RequestStepEvent.inference_turn_step_id(1, attempt),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: attempt,
+      boundary: "post_observation",
+      result:
+        Map.merge(
+          %{
+            "attempt_outcome" => "failed",
+            "started_at" => ~U[2026-08-12 10:00:00.000000Z],
+            "ended_at" => ~U[2026-08-12 10:00:01.000000Z],
+            "accepted" => false,
+            "output_committed" => false,
+            "execution_resolution" => "not_started",
+            "capacity_release_outcome" => "not_applicable",
+            "failure_class" => "runtime_failure",
+            "failure_code" => "runtime_unavailable"
+          },
+          overrides
+        )
+    }
+  end
+
   defp tool_execution_step_attrs(overrides) do
     Map.merge(
       %{

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -287,6 +287,33 @@ defmodule Orchard.RequestsTest do
     assert Requests.get_request!(request.id).state == :received
   end
 
+  test "append_request_step_events/2 round-trips closed evidence for both attempt identities" do
+    request =
+      create_request!(%{
+        public_id: "req_attempt_evidence_round_trip",
+        state: :running,
+        payload_capture_mode: :metadata
+      })
+
+    node_1 = "00000000-0000-4000-a000-000000000001"
+    node_2 = "00000000-0000-4000-a000-000000000002"
+
+    events = [
+      enriched_attempt_step(1, node_1, [], "retried"),
+      enriched_attempt_step(2, node_2, [node_1], "retry_exhausted")
+    ]
+
+    assert {:ok, [_attempt_1, _attempt_2]} =
+             Requests.append_request_step_events(request, events)
+
+    assert [attempt_1, attempt_2] = Requests.list_request_step_events(request)
+    assert attempt_1.step_id == "inference_turn:t1:a1"
+    assert attempt_1.result["retry_decision"] == "retried"
+    assert attempt_2.step_id == "inference_turn:t1:a2"
+    assert attempt_2.result["excluded_node_ids"] == [node_1]
+    assert attempt_2.result["retry_decision"] == "retry_exhausted"
+  end
+
   test "append_request_step_events/2 rejects invalid batches atomically" do
     request = create_request!(%{public_id: "req_step_batch_invalid_test", state: :received})
 
@@ -465,9 +492,9 @@ defmodule Orchard.RequestsTest do
                  %{state: :completed},
                  [
                    inference_turn_completed_step_attrs(%{
-                     step_id: RequestStepEvent.inference_turn_step_id(2, 3),
-                     turn_index: 2,
-                     attempt: 3,
+                     step_id: RequestStepEvent.inference_turn_step_id(1, 2),
+                     turn_index: 1,
+                     attempt: 2,
                      result: %{}
                    })
                  ]
@@ -475,8 +502,8 @@ defmodule Orchard.RequestsTest do
 
       assert {:ok, :missing_finish_reason_candidate} =
                Requests.classify_missing_terminal_candidate(request,
-                 turn_index: 2,
-                 attempt: 3
+                 turn_index: 1,
+                 attempt: 2
                )
 
       assert {:error, {:inconclusive, :terminal_step_not_found}} =
@@ -1375,6 +1402,32 @@ defmodule Orchard.RequestsTest do
       },
       overrides
     )
+  end
+
+  defp enriched_attempt_step(attempt, node_id, exclusions, retry_decision) do
+    %{
+      event_type: "request_step.failed",
+      step_id: RequestStepEvent.inference_turn_step_id(1, attempt),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: attempt,
+      parent_step_id: nil,
+      boundary: "post_observation",
+      result: %{
+        "attempt_outcome" => "failed",
+        "started_at" => ~U[2026-08-12 10:00:00.000000Z],
+        "ended_at" => ~U[2026-08-12 10:00:01.000000Z],
+        "accepted" => false,
+        "output_committed" => false,
+        "execution_resolution" => "not_started",
+        "capacity_release_outcome" => "not_applicable",
+        "excluded_node_ids" => exclusions,
+        "node_id" => node_id,
+        "failure_class" => "runtime_failure",
+        "failure_code" => "runtime_unavailable",
+        "retry_decision" => retry_decision
+      }
+    }
   end
 
   defp inference_turn_completed_step_attrs(overrides \\ %{}) do

--- a/apps/orchard_controller/test/support/dispatch_capacity_fixtures.ex
+++ b/apps/orchard_controller/test/support/dispatch_capacity_fixtures.ex
@@ -63,7 +63,12 @@ defmodule Orchard.TestSupport.DispatchCapacityFixtures do
   def authorize_unmanaged_schedule(schedule, opts \\ []) do
     input = unmanaged_input(opts)
 
-    Map.merge(schedule, %{
+    schedule
+    |> Map.put_new(
+      :timeout_at,
+      DateTime.add(DateTime.utc_now(), Map.fetch!(schedule, :request_timeout_ms), :millisecond)
+    )
+    |> Map.merge(%{
       dispatch_capacity_input: input,
       dispatch_capacity_evaluation: Evaluator.evaluate(input),
       dispatch_capacity_acquisition_input_provider: fn -> input end,

--- a/apps/orchard_controller/test/support/model_request_fixtures.ex
+++ b/apps/orchard_controller/test/support/model_request_fixtures.ex
@@ -87,7 +87,7 @@ defmodule Orchard.TestSupport.ModelRequestFixtures do
         input_tokens: 0,
         output_tokens: 0,
         reserved_output_tokens: 128,
-        timeout_at: ~U[2026-03-10 00:00:00.000000Z]
+        timeout_at: DateTime.utc_now() |> DateTime.add(120_000, :millisecond)
       },
       overrides
     )

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -9,13 +9,13 @@
 
 ## 2. Absolute deadline and durable attempt evidence
 
-- [ ] 2.1 Persist one `requests.timeout_at` at Request creation and derive every later budget from it
-- [ ] 2.2 Add an immutable attempt context with closed attempt, commitment, retry, release, and execution-resolution vocabularies
-- [ ] 2.3 Enrich inference-turn terminal result maps without introducing an attempt table
-- [ ] 2.4 Validate enriched attempt results while preserving readability of existing request events
-- [ ] 2.5 Normalize runtime, model-load, capacity, cancellation, deadline, terminal-conformance, and unknown source failures to the stable §8.2 durable vocabulary
-- [ ] 2.6 Extend restricted-capture sanitization so closed attempt evidence remains durable under `none` and `metadata`
-- [ ] 2.7 Prove capture policy does not retain raw targets, messages, content, or arguments outside the allowed mode
+- [x] 2.1 Persist one `requests.timeout_at` at Request creation and derive every later budget from it
+- [x] 2.2 Add an immutable attempt context with closed attempt, commitment, retry, release, and execution-resolution vocabularies
+- [x] 2.3 Enrich inference-turn terminal result maps without introducing an attempt table
+- [x] 2.4 Validate enriched attempt results while preserving readability of existing request events
+- [x] 2.5 Normalize runtime, model-load, capacity, cancellation, deadline, terminal-conformance, and unknown source failures to the stable §8.2 durable vocabulary
+- [x] 2.6 Extend restricted-capture sanitization so closed attempt evidence remains durable under `none` and `metadata`
+- [x] 2.7 Prove capture policy does not retain raw targets, messages, content, or arguments outside the allowed mode
 
 ## 3. Typed single-attempt dispatcher outcome and release acknowledgement
 


### PR DESCRIPTION
## Summary

Every newly admitted Request now carries one immutable absolute deadline through queueing, scheduling, model loading, execution, acceptance-gate waits, and cleanup.
The dispatcher no longer starts a fresh budget at dispatch or refunds model-load time.
Expired Requests stop new external side effects while retaining enough budget-independent persistence work to reach a terminal state.

This also adds the durable evidence contract required before Orchard can implement bounded alternate-node retry.
Attempt 1 and attempt 2 evidence use closed vocabularies, strict cross-field validation, deterministic capture-safe target references, and the existing append-only `request_events` seam.
Historical sparse request-step rows remain readable.
Partially enriched or unknown evidence fails closed.

## What changed

- Persist `requests.timeout_at` at Request creation from the admitted timeout and require it for new application rows while leaving the historical database column nullable.
- Derive every changed later budget from the persisted timestamp, with stage caps taking the smaller of their configured limit and the remaining Request budget.
- Gate queue, scheduler, model-load, acceptance-gate, and execution side effects when the deadline is exhausted.
- Add immutable `AttemptContext` identity for `inference_turn:t1:a1` and `inference_turn:t1:a2`.
- Add closed `InferenceAttemptResult` and `InferenceAttemptFailure` persistence contracts using the SPEC §3.7.1 and §8.2 vocabularies.
- Preserve sparse historical readback while requiring complete validation whenever an enriched marker is present.
- Retain safe typed attempt evidence under `none` and `metadata`, hash raw targets as `sha256:<digest>`, and remove raw targets, source codes, runtime messages, prompt content, and tool arguments.
- Restrict `full` capture to approved enriched fields instead of accepting an arbitrary result map.
- Mark OpenSpec tasks 2.1 through 2.7 complete. Sections 3 through 11 remain open.

## Scope

This is the issue #165 prerequisite slice for parent #121.
It implements the applicable issue boundary from `SPEC.md` §§3.7.1, 5.8-5.9, 10.10, and 12.4.

Live orchestration still emits one attempt-1 start and uses the explicit sparse terminal compatibility seam.
Issues #166 through #168 must first provide truthful typed dispatcher outcomes, Output Commitment, capacity-release acknowledgement, and retry-decision facts before production can emit complete enriched terminal evidence.

This PR does not add automatic retry, attempt-2 dispatch, alternate scheduling, scheduler exclusions, breaker behavior, attempt metrics, a new attempt table, a public API change, or a Request FSM state.

## Verification

Focused contract suite after rebasing onto current `origin/main`:

- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate automatic-attempt-retry --type change --strict --no-interactive` passed.
- 304 deadline, attempt-context, failure/result validation, request-step, capture, persistence, orchestrator, dispatcher-capacity, and migration tests passed.

Orchard quality gates, run in repository-prescribed order:

- `mise exec -- mix format` passed.
- `mise exec -- mix compile --warnings-as-errors` passed.
- `mise exec -- mix credo --strict` passed with 0 issues across 680 source files and 15,889 modules/functions.
- `mise exec -- mix dialyzer` passed with 0 errors, skipped checks, or unnecessary skips.
- `mise exec -- mix test` passed:
  - `orchard_shared`: 303 passed
  - `orchard_controller`: 3,421 passed, 5 skipped
  - `orchard_node_agent`: 389 passed
  - `orchard_cli`: 738 passed, 10 excluded
- `mise exec -- mix test --cover` passed with the same test counts:
  - `orchard_shared`: 69.65%
  - `orchard_controller`: 85.0%
  - `orchard_node_agent`: 77.77%
  - `orchard_cli`: 76.80%

RepoPrompt review identified deadline-side-effect races, incomplete enriched discrimination, legacy readback compatibility, raw full-capture target handling, and fail-open unknown failure normalization.
Those findings were resolved before the final quality run.

The optional `no-mistakes` accelerator completed its rebase and review phases, including one auto-fix commit in its isolated pipeline worktree, but timed out twice during its test phase and never pushed its pipeline head.
It is not counted as verification or included in this branch.
The repository-prescribed quality workflow above is the authoritative gate and was fully green on commit `b895e954`.

The first required CI run exposed two load-sensitive assertions in the changed deadline tests.
The follow-up commit `7298209d` replaces the scheduler metric wall-clock ceiling with an end-to-end deadline bound and drives the queued timeout/DOWN ordering explicitly instead of sleeping.
After stopping orphaned accelerator load loops, the exact failing test command passed locally at CI concurrency and seed:

- `ORCHARD_TEST_NODE_AGENT_PORT=50171 PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres PGDATABASE_TEST=orchard_test mise exec -- mix test --seed 561462 --max-cases 12`
- `orchard_shared`: 303 passed
- `orchard_controller`: 3,421 passed, 5 skipped
- `orchard_node_agent`: 389 passed
- `orchard_cli`: 738 passed, 10 excluded

## Risk Assessment

✅ **Medium**

- Blast radius covers every new Request admission and the Controller queue, scheduler, model-load, dispatch, and capture paths.
- Deadline handling is intentionally fail-closed: exhausted Requests do not start new external work, but terminal evidence persistence remains allowed so active rows are not stranded.
- New enriched evidence is closed and revalidated after sanitization. Malformed or partially enriched shapes persist only through the established invalid-result representation.
- Historical Requests may retain `timeout_at = NULL`, and historical sparse request events remain readable. There is no migration or database-level non-null constraint.
- Public Chat Completions and Responses schemas do not change.
- Production retry remains disabled. The main residual dependency is truthful enriched production emission from issues #166 through #168.

Closes #165

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/openai--codex%2Fgpt--5.6--sol-000000)
