### PR TITLE
docs: specify Organization developer API key portal

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -174,6 +174,7 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 | Tray/menu bar app       | `.app` + LaunchAgent         | local status, onboarding, logs, support bundle entry point |
 | `orchardctl` CLI            | binary                       | admin/operator automation, bootstrap, diagnostics          |
 | Orchard Console         | controller LiveView          | local/operator UI for runtime status, node inventory and admission review, action previews, requests, Organizations, API Tokens, and API Clients |
+| Developer Portal        | controller LiveView          | Organization-scoped self-service mint, list, and revoke of tenant-direct API Keys after an operator-set portal password |
 | Managed Postgres helper | LaunchDaemon in managed mode | local DB lifecycle only                                    |
 
 ### 2.4 Repository structure
@@ -2007,7 +2008,7 @@ If memory is insufficient for all pinned models:
 
 ## 7.1 API surfaces
 
-The platform SHALL expose four API surfaces:
+The platform SHALL expose five API surfaces:
 
 1. **Public Inference API**
 
@@ -2030,7 +2031,14 @@ The platform SHALL expose four API surfaces:
    * loopback HTTP only in degraded `plain_http_localhost` mode for local development or break-glass recovery
    * admin/tenant-admin auth
 
-4. **Runtime Endpoint and Worker Interfaces**
+4. **Developer Portal**
+
+   * Organization-scoped browser surface at `/portal/:organization_slug`
+   * TLS-only in `reverse_proxy` and `direct_https` transport modes
+   * unavailable in degraded `plain_http_localhost` mode
+   * operator-set Organization portal password, not Console Basic Auth and not a Public Inference Bearer
+
+5. **Runtime Endpoint and Worker Interfaces**
 
    * controller↔Runtime Endpoint Interface for model readiness, inference execution, cancellation, status, runtime telemetry, and Placement Capacity
    * admitted first-party production Controller and Node Agent services use the BEAM Runtime Endpoint adapter under the production identity and authorization contract in §7.5 and §10.6
@@ -2678,6 +2686,48 @@ PATCH /admin/v1/observability
 
 Metrics exposure is not configurable through this endpoint; §9.1 fixes the
 shared HTTP listener and the operator-or-admin bearer boundary for `/metrics`.
+
+---
+
+### 7.4a Developer Portal
+
+Base path: `/portal/:organization_slug`
+
+The Developer Portal SHALL be a distinct browser surface from Orchard Console.
+It SHALL NOT render operator Console chrome, other Organizations, nodes, license state, or cluster administration.
+Portal sessions SHALL NOT authorize Public Inference, Operator API, Admin API, or Console access.
+
+Routes:
+
+```text
+GET  /portal/:organization_slug
+POST /portal/:organization_slug/session
+POST /portal/:organization_slug/logout
+LIVE /portal/:organization_slug/keys
+```
+
+The portal SHALL identify the Organization by slug first, then verify that Organization's portal password.
+An Organization with no portal password SHALL have no open portal.
+`GET /portal/:organization_slug` SHALL be response-indistinguishable for open, closed, and unknown slugs.
+
+The operator SHALL set, rotate, or clear the portal password from the existing Console Organization detail surface.
+Clearing or rotating the password SHALL increment `portal_session_epoch` and end standing portal sessions for that Organization.
+Password rotation and clear SHALL NOT revoke minted API Keys.
+
+The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'`.
+An Organization MAY have at most 10 active portal-minted tenant-direct keys.
+Operator-minted tenant-direct keys SHALL NOT count toward that ceiling and SHALL NOT be revocable from the portal.
+The portal MAY list operator-minted tenant-direct keys read-only.
+Portal revoke SHALL take effect on the next Public Inference authentication.
+
+Key secrets SHALL be shown once at creation and SHALL NOT be recoverable later.
+After mint, the portal SHALL show one `POST /v1/chat/completions` curl using a deterministic callable model already authorized for the Organization, or state that no test curl is available.
+
+Failed portal logins SHALL be limited per Organization fingerprint and source fingerprint.
+They SHALL NOT use an Organization-wide lockout.
+
+The portal SHALL be served only when public API HTTPS is enabled and the effective request scheme is HTTPS.
+Degraded `plain_http_localhost` SHALL return `404` for every portal route and SHALL reject operator portal-password mutations.
 
 ---
 
@@ -3664,8 +3714,12 @@ create table tenants (
   default_pool_id uuid references node_pools(id),
   request_body_capture_mode payload_capture_mode not null default 'metadata',
   settings jsonb not null default '{}'::jsonb,
+  portal_password_hash text,
+  portal_session_epoch bigint not null default 0,
   inserted_at timestamptz not null default now(),
-  updated_at timestamptz not null default now()
+  updated_at timestamptz not null default now(),
+  check (portal_session_epoch >= 0),
+  check (portal_password_hash is null or length(portal_password_hash) > 0)
 );
 
 create table service_accounts (
@@ -3693,6 +3747,7 @@ create table api_keys (
   name text not null,
   token_prefix text not null unique,
   secret_hash bytea not null,
+  issuance_surface text not null default 'governance',
   expires_at timestamptz,
   last_used_at timestamptz,
   revoked_at timestamptz,
@@ -3702,7 +3757,41 @@ create table api_keys (
     (tenant_id is not null and service_account_id is null)
     or
     (tenant_id is null and service_account_id is not null)
+  ),
+  check (issuance_surface in ('governance', 'developer_portal')),
+  check (
+    issuance_surface <> 'developer_portal'
+    or (tenant_id is not null and service_account_id is null)
   )
+);
+
+create table portal_sessions (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  token_hash bytea not null unique,
+  password_epoch bigint not null,
+  issued_at timestamptz not null,
+  last_seen_at timestamptz not null,
+  absolute_expires_at timestamptz not null,
+  inserted_at timestamptz not null default now(),
+  check (octet_length(token_hash) = 32),
+  check (password_epoch >= 0),
+  check (last_seen_at >= issued_at),
+  check (absolute_expires_at > issued_at)
+);
+
+create table portal_login_throttles (
+  organization_fingerprint bytea not null,
+  source_fingerprint bytea not null,
+  failure_count integer not null default 0,
+  blocked_until timestamptz,
+  last_failed_at timestamptz,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (organization_fingerprint, source_fingerprint),
+  check (octet_length(organization_fingerprint) = 32),
+  check (octet_length(source_fingerprint) = 32),
+  check (failure_count >= 0)
 );
 
 create table quotas (
@@ -4325,7 +4414,8 @@ Requirements:
 Previously issued `orch_<public>.<secret>` API Tokens SHALL remain valid compatibility credentials.
 Compatibility authentication SHALL preserve their existing `orch_<public>` lookup prefix and complete-token SHA-256 semantics without rewriting persisted credentials.
 
-Tenant-direct API Keys SHALL remain supported for manual, bootstrap, and compatibility paths.
+Tenant-direct API Keys SHALL remain supported for manual, bootstrap, compatibility, and Developer Portal paths.
+Developer Portal minting SHALL persist `issuance_surface = 'developer_portal'` and SHALL count only those active tenant-direct keys toward the portal cap of 10.
 Bulk provisioning SHALL create service-account-owned API Tokens by default.
 API Tokens owned by the same Service Account SHALL NOT have duplicate active names unless explicit Key Rotation mode creates a replacement and revokes the previous active token or tokens.
 
@@ -4445,6 +4535,11 @@ Secrets SHALL be stored:
 * in Postgres only as hashes, never plaintext
 * private keys SHOULD be stored in macOS Keychain or protected filesystem paths
 * bootstrap tokens stored only as hash
+* Developer Portal passwords stored only as a password hash, never plaintext
+* Developer Portal session tokens stored only as a hash
+
+Portal password hashing SHALL use a slow password KDF.
+It SHALL NOT reuse API key SHA-256 hashing.
 
 ### 10.9 Audit requirements
 
@@ -4452,6 +4547,7 @@ Audit logs SHALL capture:
 
 * tenant creation/update/suspend
 * API key create/revoke
+* Developer Portal password set, rotate, and clear
 * service account changes
 * API Client Disablement
 * provisioning batch start/completion/failure
@@ -4470,7 +4566,7 @@ Audit logs SHALL capture:
 * support bundle generation
 * upgrade actions
 
-Audit payloads SHALL exclude plaintext API Token secrets.
+Audit payloads SHALL exclude plaintext API Token secrets and plaintext portal passwords.
 Provisioning Batch records SHALL include non-secret counts, status, input hash, timestamps, and sanitized error summaries only.
 Observed target references and admission-candidate metadata in audit payloads SHALL be sanitized and MUST NOT include secrets.
 

--- a/openspec/changes/self-service-api-key-portal/.openspec.yaml
+++ b/openspec/changes/self-service-api-key-portal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/self-service-api-key-portal/design.md
+++ b/openspec/changes/self-service-api-key-portal/design.md
@@ -1,0 +1,72 @@
+## Context
+
+Orchard already has hashed show-once tenant-direct API Keys, tenant quotas, and an operator Console Organization page that can mint and revoke keys.
+There is no Organization-scoped login, no portal password field, no issuance provenance, and no password hasher in `orchard_controller`.
+Console auth is cluster-wide Basic Auth. Reusing that shell for a weaker session would leak operator chrome.
+
+Origin: `docs/brainstorms/2026-08-13-self-service-api-key-portal-requirements.md`.
+Implementation plan: `docs/plans/2026-08-13-001-feat-self-service-api-key-portal-plan.md`.
+UI note: `docs/designs/2026-08-13-self-service-api-key-portal.md`.
+
+## Goals
+
+- Give a human developer a working key and one curl without operator help, when the Organization already has a callable model.
+- Keep operator Console as the only cluster surface.
+- Fail closed on TLS, enumeration, and secret retention.
+
+## Non-Goals
+
+- Named portal users, SSO, agent mint APIs, and API Client tokens from the portal remain later cuts.
+- This change does not invent a second key format.
+
+## Decision 1: Separate Portal, Shared Phoenix Session Cookie
+
+The portal is a distinct `/portal/:organization_slug` namespace with its own layouts and `live_session`.
+CSRF and LiveView still ride the existing Phoenix session cookie `_orchard_console_key` because a second cookie is invisible to LiveView `connect_info`.
+Isolation is enforced above that layer: never read `_orchard_console_authenticated`, never render Console chrome.
+
+Rejected: org-scoped slice of Console. Operator Basic Auth is cluster-wide.
+
+## Decision 2: Shared Organization Password Plus Epoch
+
+One operator-set password per Organization. No user table.
+Password hash plus monotonic `portal_session_epoch`.
+Rotate or clear increments the epoch and deletes `portal_sessions`.
+It does not revoke minted keys.
+
+Login identifies the Organization by slug first, then verifies that password.
+Unknown, closed, and wrong-password cases share one generic failure and the same hasher cost through the same verifier pool.
+
+## Decision 3: Portal-Mint Provenance And Cap
+
+`api_keys.issuance_surface` is `governance` or `developer_portal`.
+Existing keys backfill to `governance`.
+The 10-key cap counts only active portal-minted tenant-direct keys.
+Operator mint is exempt.
+Portal revoke requires `issuance_surface = 'developer_portal'` so a leaked portal password cannot kill operator recovery keys.
+The portal may list operator-minted tenant-direct keys read-only.
+
+## Decision 4: Slow Password KDF With Packaging Gate
+
+Prefer Argon2id via `argon2_elixir` (64 MiB, 3 iterations, parallelism 1).
+That would be the first compiled NIF in `orchard_controller`.
+If it cannot load in the controller release, use documented `:crypto` PBKDF2-HMAC-SHA512 before any password row exists.
+Do not hash portal passwords with API-key SHA-256.
+
+## Decision 5: TLS-Only And Per-Source Backoff
+
+Portal routes and operator password mutations require `public_api_https_enabled?` and effective HTTPS scheme.
+`plain_http_localhost` returns 404 and rejects password mutations.
+
+Failed logins are limited per Organization fingerprint plus source fingerprint:
+1-4 free, then 30s / 60s / 120s / 240s / 480s / 900s.
+No Organization-wide lockout.
+
+Sessions last 8 hours absolute and 30 minutes idle.
+Auth ticks do not refresh idle.
+
+## Decision 6: Deterministic Activation Curl
+
+After mint, choose the first tenant-authorized active model from the exact `GET /v1/models` visibility query, sorted by public identifier then UUID.
+If authorization cannot be proven, mint still succeeds and the portal states that no curl is available.
+The model identifier is untrusted interpolation in the shell snippet.

--- a/openspec/changes/self-service-api-key-portal/proposal.md
+++ b/openspec/changes/self-service-api-key-portal/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+App developers who call Orchard's Public Inference API need a long-lived bearer key without asking a cluster operator each time.
+Today minting is operator-only: Console Organization detail, `orchardctl api-keys`, and `POST /admin/v1/api-keys`.
+Those paths already satisfy `SPEC.md` §10.2.
+
+A weaker Organization-scoped session is the missing minting gate.
+It is not public signup, SSO, named users, or API Client minting.
+Bulk API Client provisioning explicitly excluded human login and self-service token creation, so this change introduces a new capability rather than reusing Owner Contact or Team metadata as identity.
+
+## What Changes
+
+- Add a TLS-only Developer Portal at `/portal/:organization_slug` with its own layouts, pipeline, and LiveView session.
+- Let an operator set, rotate, or clear one Organization portal password from Console Organization detail.
+- Let a developer who presents that password mint, list, and revoke tenant-direct API Keys for that Organization only.
+- Persist portal password hash, session epoch, portal session rows, login throttle fingerprints, and API key `issuance_surface`.
+- Cap active portal-minted tenant-direct keys at 10. Operator mint stays uncapped and operator-only.
+- Show the key secret once. After mint, show one activation curl or state that no callable model exists.
+- Keep Public Inference Bearer format, Admin/Operator auth, and Console Basic Auth unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `developer-api-key-portal`: Organization-scoped self-service minting gate for tenant-direct API Keys.
+
+### Modified Capabilities
+
+- None.
+  No accepted OpenSpec capability currently owns an Organization-scoped developer session.
+
+## Impact
+
+- SPEC.md impact: this change refines `SPEC.md` §2.3, §7.1, §7.4a, §8, §10.2, §10.8, and §10.9.
+- Implementation impact: additive Postgres migration, `Orchard.Governance` password and portal-key facade, isolated `OrchardPortal` web namespace, and a Developer Portal card on `OrchardConsole.TenantDetailLive`.
+- Security impact: slow password KDF, per-source login backoff, epoch-bound sessions, TLS-only availability, show-once secrets, and portal revoke limited to portal-minted keys.
+- Non-impact: Public Inference `/v1/*`, Operator API, Admin API, Console Basic Auth, API Client provisioning, and Node TLS/BEAM credentials.
+
+## Non-Goals
+
+- No public signup, payment, named developer accounts, SSO, or `tenant_admin` Console login.
+- No agent minting API or non-operator CLI mint.
+- No API Client create, disable, or token mint from the portal.
+- No quota, model-access, or Organization administration from the portal.
+- No per-key rate limits.
+- No change to the Public Inference key format or Bearer contract.

--- a/openspec/changes/self-service-api-key-portal/specs/developer-api-key-portal/spec.md
+++ b/openspec/changes/self-service-api-key-portal/specs/developer-api-key-portal/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Developer Portal Is Isolated From Operator Console
+
+Orchard SHALL expose a Developer Portal browser surface at `/portal/:organization_slug` that is distinct from Orchard Console.
+The portal SHALL NOT render operator Console chrome, other Organizations, nodes, license state, or cluster administration.
+Portal sessions SHALL NOT authorize Public Inference, Operator API, Admin API, or Console access.
+This refines `SPEC.md` §2.3, §7.1, and §7.4a.
+
+#### Scenario: Portal session cannot reach Console
+
+- **WHEN** a developer holds a valid portal session cookie for one Organization
+- **THEN** requests to `/console` SHALL NOT be authorized by that session
+- **AND** the portal HTML SHALL NOT include Console sidebar, license badge, or `/console` navigation
+
+#### Scenario: Portal session cannot call Operator or Admin APIs
+
+- **WHEN** a caller presents only a Developer Portal session
+- **THEN** Operator API and Admin API requests SHALL fail closed
+- **AND** the failure SHALL NOT treat the portal session as a Bearer API Token
+
+### Requirement: Organization Slug Is Identified Before Password Check
+
+The portal SHALL identify the Organization from the route slug first, then verify that Organization's portal password.
+An Organization with no portal password SHALL have no open portal.
+`GET /portal/:organization_slug` SHALL be response-indistinguishable for open, closed, and unknown slugs.
+Unknown slug, closed portal, and wrong password SHALL share one generic login failure.
+This refines `SPEC.md` §7.4a.
+
+#### Scenario: Closed and unknown slugs share the GET login shape
+
+- **WHEN** an unauthenticated caller requests `GET /portal/:organization_slug` for an open Organization, a closed Organization, and an unknown slug
+- **THEN** Orchard SHALL return the same status, body shape, and headers in all three cases
+- **AND** the page SHALL show the slug from the URL, not the Organization name
+
+#### Scenario: Closed portal cannot mint keys
+
+- **WHEN** an Organization has no portal password hash
+- **THEN** a password submission SHALL fail with the generic login error
+- **AND** Orchard SHALL NOT create a portal session
+
+### Requirement: Operator Sets Rotates And Clears The Portal Password
+
+An operator SHALL set, rotate, or clear the portal password from Console Organization detail.
+The password SHALL be stored only as a slow password-hash, never plaintext.
+Clearing or rotating the password SHALL increment `portal_session_epoch` and end standing portal sessions for that Organization.
+Password rotation and clear SHALL NOT revoke minted API Keys.
+Operator password mutations SHALL be rejected when public API HTTPS is not enabled.
+This refines `SPEC.md` §7.4a, §10.8, and §10.9.
+
+#### Scenario: Rotate ends sessions and leaves keys valid
+
+- **WHEN** an operator rotates an Organization portal password
+- **THEN** existing portal sessions for that Organization SHALL fail revalidation
+- **AND** previously minted API Keys SHALL remain valid Bearer credentials until explicitly revoked
+
+#### Scenario: Degraded transport rejects password set
+
+- **WHEN** transport mode is `plain_http_localhost`
+- **THEN** Orchard SHALL reject portal password set, rotate, and clear
+- **AND** Orchard SHALL NOT persist a new password hash
+
+### Requirement: Portal Mints Tenant-Direct Keys With A Portal-Only Cap
+
+The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'` using the existing `orchard_sk_*` show-once contract.
+An Organization MAY have at most 10 active portal-minted tenant-direct keys.
+Operator-minted tenant-direct keys SHALL NOT count toward that ceiling.
+Operator mint paths SHALL remain available and operator-only.
+This refines `SPEC.md` §7.4a, §8, and §10.2.
+
+#### Scenario: Eleventh active portal key is rejected
+
+- **WHEN** an Organization already has 10 active portal-minted tenant-direct keys
+- **AND** a portal session attempts to mint another key
+- **THEN** Orchard SHALL reject the mint
+- **AND** Orchard SHALL NOT insert a new API Key row
+
+#### Scenario: Operator mint remains uncapped
+
+- **WHEN** an Organization already has 10 active portal-minted tenant-direct keys
+- **AND** an operator mints a tenant-direct key through Console, CLI, or Admin API
+- **THEN** the operator mint SHALL succeed
+- **AND** the new key SHALL have `issuance_surface = 'governance'`
+
+### Requirement: Portal Lists Organization Keys And Revokes Only Portal-Minted Keys
+
+The portal SHALL list tenant-direct keys for the signed-in Organization, including operator-minted keys, with name, prefix, created time, last used time, status, and lifetime persisted-inference request count.
+The portal SHALL NOT list service-account-owned API Tokens.
+Portal revoke SHALL require `issuance_surface = 'developer_portal'` and SHALL take effect on the next Public Inference authentication.
+This refines `SPEC.md` §7.4a and §10.2.
+
+#### Scenario: Portal cannot revoke an operator key
+
+- **WHEN** a portal session attempts to revoke an operator-minted tenant-direct key
+- **THEN** Orchard SHALL treat the key as not found
+- **AND** the key SHALL remain active
+
+#### Scenario: Portal revoke fails the next Bearer request
+
+- **WHEN** a portal session revokes a portal-minted key
+- **AND** the next Public Inference request presents that key
+- **THEN** authentication SHALL fail with `401 invalid_api_key`
+
+### Requirement: Activation Curl Uses One Deterministic Callable Model
+
+After a successful mint, the portal SHALL show one `POST /v1/chat/completions` curl that uses a deterministic callable model already authorized for the Organization, or state that no test curl is available.
+If no callable model can be proven, the key mint SHALL still succeed.
+The full secret SHALL appear only at creation and SHALL NOT be recoverable later.
+This refines `SPEC.md` §7.2.3, §7.2.4, and §7.4a.
+
+#### Scenario: No callable model still mints the key
+
+- **WHEN** a portal session mints a key for an Organization with no proven callable model
+- **THEN** Orchard SHALL persist the key
+- **AND** the portal SHALL state that no test curl is available
+- **AND** the secret SHALL still be shown once
+
+### Requirement: Portal Traffic Is TLS-Only And Login Failures Are Per-Source
+
+The portal SHALL be served only when public API HTTPS is enabled and the effective request scheme is HTTPS.
+Degraded `plain_http_localhost` SHALL return `404` for every portal route.
+Failed portal logins SHALL be limited per Organization fingerprint and source fingerprint.
+They SHALL NOT use an Organization-wide lockout.
+This refines `SPEC.md` §7.4a and §10.7.
+
+#### Scenario: Degraded mode hides the portal
+
+- **WHEN** transport mode is `plain_http_localhost`
+- **THEN** every `/portal/:organization_slug` route SHALL return `404`
+- **AND** Orchard SHALL NOT set a portal session
+
+#### Scenario: One source cannot lock the whole Organization
+
+- **WHEN** one client source exceeds the failed-login backoff for an Organization
+- **THEN** a different source MAY still attempt login for that Organization
+- **AND** the throttled source SHALL receive a retryable failure distinct from the generic credential error

--- a/openspec/changes/self-service-api-key-portal/tasks.md
+++ b/openspec/changes/self-service-api-key-portal/tasks.md
@@ -1,0 +1,41 @@
+## 1. Contract
+
+- [x] 1.1 Update `SPEC.md` §2.3, §7.1, §7.4a, §8, §10.2, §10.8, and §10.9 for the Developer Portal.
+- [x] 1.2 Add this OpenSpec proposal, design, tasks, and requirement delta.
+- [x] 1.3 Validate the change with strict OpenSpec.
+
+## 2. Persistence And Password Lifecycle
+
+- [ ] 2.1 Prove Argon2id loads in the controller environment or switch to documented PBKDF2-HMAC-SHA512 before any password row exists.
+- [ ] 2.2 Add additive migration for tenant portal fields, `issuance_surface`, `portal_sessions`, `portal_login_throttles`, and `requests.api_key_id` index if missing.
+- [ ] 2.3 Add `lock_tenant/1` and portal password set/rotate/clear with epoch increment, session deletion, TLS rejection, and redacted audit.
+- [ ] 2.4 Add focused password and governance tests from the implementation plan Unit 2 scenarios.
+
+## 3. Sessions And Throttle
+
+- [ ] 3.1 Add portal session create/validate/logout and per-source throttle reservation.
+- [ ] 3.2 Add the bounded verifier pool and dummy-verify path with the same hasher cost.
+- [ ] 3.3 Store the opaque portal token in the Phoenix session so LiveView mount can revalidate.
+- [ ] 3.4 Add session, throttle, and verifier tests from the implementation plan Unit 3 scenarios.
+
+## 4. Portal Keys And Activation Curl
+
+- [ ] 4.1 Add `create_portal_api_key/3` with tenant lock and portal-only cap of 10.
+- [ ] 4.2 Add `list_portal_api_keys/1` with grouped persisted-inference request counts.
+- [ ] 4.3 Add `revoke_portal_api_key/3` limited to `issuance_surface = 'developer_portal'`.
+- [ ] 4.4 Add deterministic activation-curl construction with untrusted model-identifier quoting.
+- [ ] 4.5 Add governance, curl, and Bearer integration tests from the implementation plan Unit 4 scenarios.
+
+## 5. Isolated Portal Surface
+
+- [ ] 5.1 Register TLS-guarded `/portal/:organization_slug` routes with CSRF, secure headers, and no Console auth marker.
+- [ ] 5.2 Add indistinguishable GET login for open, closed, and unknown slugs.
+- [ ] 5.3 Add `OrchardPortal.KeysLive` with show-once secret, dark-pinned layouts, and chrome-absence tests.
+- [ ] 5.4 Follow `docs/designs/2026-08-13-self-service-api-key-portal.md` except slug-in-URL login.
+
+## 6. Operator Surface And Docs
+
+- [ ] 6.1 Add the Developer Portal card to Organization detail: set, rotate, clear, HTTPS URL, active portal-key count.
+- [ ] 6.2 Document the containment runbook in `docs/operator-journey.md`.
+- [ ] 6.3 Add a narrow portal-surface section to `docs/DESIGN.md`.
+- [ ] 6.4 Run the Elixir quality workflow for the changed surface.


### PR DESCRIPTION
Developers who call `/v1` still have to ask an operator for a key. This PR locks the minting-gate contract before any schema or LiveView work.

The product is a weaker Organization-scoped session, not a new key format and not public signup.

## What changed

- `SPEC.md` now names Developer Portal as a fifth surface at `/portal/:organization_slug`.
- Schema additions: portal password hash, session epoch, `issuance_surface`, `portal_sessions`, and `portal_login_throttles`.
- OpenSpec change `self-service-api-key-portal` covers isolation, slug-first login, portal-only 10-key cap, show-once secrets, TLS-only availability, and rotate-does-not-revoke.

Intentionally not in this PR: migration, Argon2/PBKDF2, portal LiveView, or operator password UI.

## Risk Assessment

✅ **Low**

- Docs and OpenSpec only. No runtime behavior change.
- Public Inference Bearer contract is unchanged.
- Portal sessions are specified as unable to authorize Console, Operator, or Admin surfaces.
- Residual: implementation still has to prove Argon2 packaging or fall back to documented PBKDF2 before any password row exists.

## Test plan

```sh
OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate self-service-api-key-portal --type change --strict --no-interactive
```

Passed locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789188796&installation_model_id=428414&pr_number=208&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F208&signature=ad95a2fde4db929ea12dddbb60455b9a18434da527072adde2880b5ad24a9ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->