### PR TITLE
docs: replace shared portal password with Portal User identity

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -174,7 +174,7 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 | Tray/menu bar app       | `.app` + LaunchAgent         | local status, onboarding, logs, support bundle entry point |
 | `orchardctl` CLI            | binary                       | admin/operator automation, bootstrap, diagnostics          |
 | Orchard Console         | controller LiveView          | local/operator UI for runtime status, node inventory and admission review, action previews, requests, Organizations, API Tokens, and API Clients |
-| Developer Portal        | controller LiveView          | Organization-scoped self-service mint, list, and revoke of tenant-direct API Keys after an operator-set portal password |
+| Developer Portal        | controller LiveView          | Invite-only, Organization-scoped self-service mint, list, and revoke of a Portal User's tenant-direct API Keys |
 | Managed Postgres helper | LaunchDaemon in managed mode | local DB lifecycle only                                    |
 
 ### 2.4 Repository structure
@@ -2036,7 +2036,7 @@ The platform SHALL expose five API surfaces:
    * Organization-scoped browser surface at `/portal/:organization_slug`
    * TLS-only in `reverse_proxy` and `direct_https` transport modes
    * unavailable in degraded `plain_http_localhost` mode
-   * operator-set Organization portal password, not Console Basic Auth and not a Public Inference Bearer
+   * invite-only Portal User email-and-password authentication, not Console Basic Auth and not a Public Inference Bearer
 
 5. **Runtime Endpoint and Worker Interfaces**
 
@@ -2695,39 +2695,61 @@ Base path: `/portal/:organization_slug`
 
 The Developer Portal SHALL be a distinct browser surface from Orchard Console.
 It SHALL NOT render operator Console chrome, other Organizations, nodes, license state, or cluster administration.
+A Portal User SHALL be an interactive identity scoped to one Organization and SHALL authorize only Developer Portal access.
+A Portal User SHALL NOT be treated as an Operator, Service Account, Owner Contact, Tenant Admin, Public Inference principal, or authority for Console, Operator API, or Admin API access.
 Portal sessions SHALL NOT authorize Public Inference, Operator API, Admin API, or Console access.
 
 Routes:
 
 ```text
 GET  /portal/:organization_slug
+GET  /portal/:organization_slug/invites/:token
+POST /portal/:organization_slug/invites/:token/redeem
 POST /portal/:organization_slug/session
 POST /portal/:organization_slug/logout
 LIVE /portal/:organization_slug/keys
 ```
 
-The portal SHALL identify the Organization by slug first, then verify that Organization's portal password.
-An Organization with no portal password SHALL have no open portal.
-`GET /portal/:organization_slug` SHALL be response-indistinguishable for open, closed, and unknown slugs.
+Portal User accounts SHALL be operator-invite only, with no public signup or self-registration.
+Email SHALL be the Portal User identifier and SHALL be unique by normalized value within one Organization.
+SMTP SHALL NOT be required.
+For a Portal User in `invited` status, the Console SHALL provide Copy invite.
+Each Copy invite action SHALL mint a fresh single-use token, persist only its hash, extend the invite expiry, and invalidate every prior unused invite token for that Portal User.
+Orchard SHALL NOT persist the plaintext invite token or URL.
+The operator SHALL deliver the copied invite URL out of band.
+Redeeming a valid unexpired invite SHALL set the Portal User's password, mark the invite redeemed, activate the Portal User, and end that Portal User's standing portal sessions.
+A replacement invite SHALL use the same reissue flow for password reset and SHALL end that Portal User's standing portal sessions.
 
-The operator SHALL set, rotate, or clear the portal password from the existing Console Organization detail surface.
-Clearing or rotating the password SHALL increment `portal_session_epoch` and end standing portal sessions for that Organization.
-Password rotation and clear SHALL NOT revoke minted API Keys.
+The portal SHALL identify the Organization by slug, then authenticate one active Portal User by normalized email and password.
+Unknown Organization, unknown email, disabled Portal User, and wrong-password submissions SHALL have indistinguishable status, body shape, headers, and generic credential failure.
+`GET /portal/:organization_slug` SHALL be response-indistinguishable for Organizations with or without invited or active Portal Users and for unknown slugs.
+Failed portal logins SHALL be limited per Organization fingerprint, Portal User or email fingerprint, and source fingerprint.
+They SHALL NOT use an Organization-wide lockout.
 
-The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'`.
-An Organization MAY have at most 10 active portal-minted tenant-direct keys.
-Operator-minted tenant-direct keys SHALL NOT count toward that ceiling and SHALL NOT be revocable from the portal.
-The portal MAY list operator-minted tenant-direct keys read-only.
+The operator SHALL invite and disable Portal Users from the existing Console Organization detail surface.
+Disabling a Portal User SHALL end only that Portal User's portal sessions.
+Disabling a Portal User SHALL NOT revoke that Portal User's API Keys.
+Invite reissue, invite redemption, password replacement, and Portal User disablement SHALL NOT revoke minted API Keys.
+
+The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'` and `portal_user_id` equal to the signed-in Portal User.
+A Portal User MAY have at most 10 active portal-minted tenant-direct keys.
+Revoked and expired keys SHALL NOT count toward that ceiling.
+The mint transaction SHALL serialize on the Portal User, not the Organization.
+Operator-minted tenant-direct keys SHALL NOT count toward that ceiling, SHALL remain operator-only, and SHALL NOT be visible or revocable from the portal.
+The portal SHALL list and revoke only portal-minted keys owned by the signed-in Portal User.
+Keys owned by another Portal User SHALL be indistinguishable from missing keys on portal list and revoke paths.
 Portal revoke SHALL take effect on the next Public Inference authentication.
+
+Legacy portal-minted keys with `portal_user_id IS NULL` SHALL remain valid `orchard_sk_*` Bearer credentials until explicitly revoked.
+Legacy unowned portal-minted keys SHALL remain operator-visible only, SHALL NOT be claimable by a Portal User, and SHALL NOT be listed or revoked from the portal.
+The portal SHALL NOT mint a new key without `portal_user_id`.
+Public Inference Bearer authentication SHALL continue to resolve every tenant-direct key as `principal_type = tenant` and SHALL NOT consult `portal_user_id`.
 
 Key secrets SHALL be shown once at creation and SHALL NOT be recoverable later.
 After mint, the portal SHALL show one `POST /v1/chat/completions` curl using a deterministic callable model already authorized for the Organization, or state that no test curl is available.
 
-Failed portal logins SHALL be limited per Organization fingerprint and source fingerprint.
-They SHALL NOT use an Organization-wide lockout.
-
 The portal SHALL be served only when public API HTTPS is enabled and the effective request scheme is HTTPS.
-Degraded `plain_http_localhost` SHALL return `404` for every portal route and SHALL reject operator portal-password mutations.
+Degraded `plain_http_localhost` SHALL return `404` for every portal route.
 
 ---
 
@@ -3433,6 +3455,7 @@ create type request_state as enum (
 );
 
 create type tenant_status as enum ('active', 'suspended', 'deleted');
+create type portal_user_status as enum ('invited', 'active', 'disabled');
 create type api_key_status as enum ('active', 'revoked', 'expired');
 create type actor_type as enum ('user', 'operator', 'service_account', 'api_key', 'node', 'system');
 create type payload_capture_mode as enum ('none', 'metadata', 'full');
@@ -3714,12 +3737,41 @@ create table tenants (
   default_pool_id uuid references node_pools(id),
   request_body_capture_mode payload_capture_mode not null default 'metadata',
   settings jsonb not null default '{}'::jsonb,
-  portal_password_hash text,
-  portal_session_epoch bigint not null default 0,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table portal_users (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  email text not null,
+  normalized_email text not null,
+  password_hash text,
+  status portal_user_status not null default 'invited',
+  session_epoch bigint not null default 0,
+  disabled_at timestamptz,
   inserted_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  check (portal_session_epoch >= 0),
-  check (portal_password_hash is null or length(portal_password_hash) > 0)
+  unique(tenant_id, normalized_email),
+  check (length(normalized_email) > 0),
+  check (password_hash is null or length(password_hash) > 0),
+  check (session_epoch >= 0),
+  check ((status = 'active' and password_hash is not null and disabled_at is null)
+    or (status = 'invited' and disabled_at is null)
+    or (status = 'disabled' and disabled_at is not null))
+);
+
+create table portal_invite_tokens (
+  id uuid primary key default gen_random_uuid(),
+  portal_user_id uuid not null references portal_users(id) on delete cascade,
+  token_hash bytea not null unique,
+  expires_at timestamptz not null,
+  redeemed_at timestamptz,
+  invalidated_at timestamptz,
+  inserted_at timestamptz not null default now(),
+  check (octet_length(token_hash) = 32),
+  check (expires_at > inserted_at),
+  check (redeemed_at is null or invalidated_at is null)
 );
 
 create table service_accounts (
@@ -3744,6 +3796,7 @@ create table api_keys (
   id uuid primary key default gen_random_uuid(),
   tenant_id uuid references tenants(id),
   service_account_id uuid references service_accounts(id),
+  portal_user_id uuid references portal_users(id) on delete set null,
   name text not null,
   token_prefix text not null unique,
   secret_hash bytea not null,
@@ -3760,36 +3813,40 @@ create table api_keys (
   ),
   check (issuance_surface in ('governance', 'developer_portal')),
   check (
-    issuance_surface <> 'developer_portal'
-    or (tenant_id is not null and service_account_id is null)
+    (issuance_surface = 'governance' and portal_user_id is null)
+    or
+    (issuance_surface = 'developer_portal' and tenant_id is not null and service_account_id is null)
   )
 );
 
 create table portal_sessions (
   id uuid primary key default gen_random_uuid(),
   tenant_id uuid not null references tenants(id) on delete cascade,
+  portal_user_id uuid not null references portal_users(id) on delete cascade,
   token_hash bytea not null unique,
-  password_epoch bigint not null,
+  session_epoch bigint not null,
   issued_at timestamptz not null,
   last_seen_at timestamptz not null,
   absolute_expires_at timestamptz not null,
   inserted_at timestamptz not null default now(),
   check (octet_length(token_hash) = 32),
-  check (password_epoch >= 0),
+  check (session_epoch >= 0),
   check (last_seen_at >= issued_at),
   check (absolute_expires_at > issued_at)
 );
 
 create table portal_login_throttles (
   organization_fingerprint bytea not null,
+  user_fingerprint bytea not null,
   source_fingerprint bytea not null,
   failure_count integer not null default 0,
   blocked_until timestamptz,
   last_failed_at timestamptz,
   inserted_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  primary key (organization_fingerprint, source_fingerprint),
+  primary key (organization_fingerprint, user_fingerprint, source_fingerprint),
   check (octet_length(organization_fingerprint) = 32),
+  check (octet_length(user_fingerprint) = 32),
   check (octet_length(source_fingerprint) = 32),
   check (failure_count >= 0)
 );
@@ -4164,6 +4221,16 @@ create index idx_service_accounts_tenant_team
 create index idx_api_keys_service_account_inserted_at
   on api_keys(service_account_id, inserted_at);
 
+create index idx_api_keys_portal_user_inserted_at
+  on api_keys(portal_user_id, inserted_at)
+  where portal_user_id is not null;
+
+create index idx_portal_sessions_user_expiry
+  on portal_sessions(portal_user_id, absolute_expires_at);
+
+create index idx_portal_invite_tokens_user_expiry
+  on portal_invite_tokens(portal_user_id, expires_at desc);
+
 create extension if not exists btree_gist;
 
 alter table api_keys
@@ -4415,7 +4482,11 @@ Previously issued `orch_<public>.<secret>` API Tokens SHALL remain valid compati
 Compatibility authentication SHALL preserve their existing `orch_<public>` lookup prefix and complete-token SHA-256 semantics without rewriting persisted credentials.
 
 Tenant-direct API Keys SHALL remain supported for manual, bootstrap, compatibility, and Developer Portal paths.
-Developer Portal minting SHALL persist `issuance_surface = 'developer_portal'` and SHALL count only those active tenant-direct keys toward the portal cap of 10.
+Developer Portal minting SHALL persist `issuance_surface = 'developer_portal'` and the signed-in Portal User's `portal_user_id`.
+The portal SHALL enforce at most 10 active portal-minted tenant-direct keys per Portal User, excluding revoked and expired keys.
+Portal User ownership SHALL remain minting-gate provenance only.
+Public Inference Bearer authentication SHALL continue to resolve `orchard_sk_*` tenant-direct keys as `principal_type = tenant` without consulting `portal_user_id`.
+Legacy portal-minted keys with null `portal_user_id` SHALL remain valid Bearer credentials until explicitly revoked and SHALL remain operator-visible only.
 Bulk provisioning SHALL create service-account-owned API Tokens by default.
 API Tokens owned by the same Service Account SHALL NOT have duplicate active names unless explicit Key Rotation mode creates a replacement and revokes the previous active token or tokens.
 
@@ -4535,11 +4606,13 @@ Secrets SHALL be stored:
 * in Postgres only as hashes, never plaintext
 * private keys SHOULD be stored in macOS Keychain or protected filesystem paths
 * bootstrap tokens stored only as hash
-* Developer Portal passwords stored only as a password hash, never plaintext
+* Portal User passwords stored only as a password hash, never plaintext
+* Portal Invite tokens stored only as a hash, with plaintext shown only in the newly issued URL
 * Developer Portal session tokens stored only as a hash
 
-Portal password hashing SHALL use a slow password KDF.
+Portal User password hashing SHALL use a slow password KDF.
 It SHALL NOT reuse API key SHA-256 hashing.
+Copy invite SHALL mint a fresh token, invalidate prior unused tokens, extend expiry, and SHALL NOT persist the plaintext token or invite URL.
 
 ### 10.9 Audit requirements
 
@@ -4547,7 +4620,7 @@ Audit logs SHALL capture:
 
 * tenant creation/update/suspend
 * API key create/revoke
-* Developer Portal password set, rotate, and clear
+* Portal User invite, invite reissue, invite redemption, disable, and password replacement
 * service account changes
 * API Client Disablement
 * provisioning batch start/completion/failure
@@ -4566,7 +4639,7 @@ Audit logs SHALL capture:
 * support bundle generation
 * upgrade actions
 
-Audit payloads SHALL exclude plaintext API Token secrets and plaintext portal passwords.
+Audit payloads SHALL exclude plaintext API Token secrets, Portal User passwords, Portal Invite tokens and URLs, and Developer Portal session tokens.
 Provisioning Batch records SHALL include non-secret counts, status, input hash, timestamps, and sanitized error summaries only.
 Observed target references and admission-candidate metadata in audit payloads SHALL be sanitized and MUST NOT include secrets.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -523,6 +523,26 @@ Use the existing card surface vocabulary and keep grouped candidate or evidence 
 Render stable machine-readable codes as compact mono badges that stay visible or inspectable.
 When raw decision debug JSON is shown, apply the same key-based unsafe-key deny-list used for diagnostics and components, and render only a safe error category rather than echoing an offending raw token.
 
+### 6.7 Portal User Management and Portal Isolation
+
+The Organization detail surface manages Portal Users through three stacked Console cards.
+The first card is the Portal User invite form, with an email field and a navy primary **Invite** action.
+The second card is a transient sibling that appears only after an invite is issued or reissued and shows the Portal Invite URL once with its expiry and a navy **Copy invite** action.
+The show-once card is not a flash, modal, or recoverable secret store.
+After it disappears, **Copy invite** reissues a fresh hashed token, invalidates the previous unused token, extends expiry, and opens a new show-once card.
+The operator delivers the copied URL out of band.
+The third card contains the Portal Users table with email, status, invite state, and contextual actions.
+Use a forest badge for active users, an amber badge for invited users, and a neutral badge for disabled users.
+Invited rows expose **Copy invite**.
+Active rows expose **Disable**, and disabling a Portal User ends that user's portal sessions without automatically revoking minted API Keys.
+Do not expose set, rotate, clear, reveal, or copy password actions as an operator seam.
+The operator manages developer access through Portal Invites and Portal User disablement instead.
+
+The Developer Portal remains a separate, dark-pinned surface and does not inherit the Console theme preference.
+It must not render Console chrome or operator controls.
+It remains isolated to the Organization named by the route and to the portal-minted keys owned by the signed-in Portal User.
+The three operator cards remain Console surfaces and use the existing Console card, tactile-well, table, focus, and navy primary-action tokens in both Console theme modes.
+
 ---
 
 ## 7. Motion

--- a/docs/decisions/0002-service-account-owned-bulk-api-access.md
+++ b/docs/decisions/0002-service-account-owned-bulk-api-access.md
@@ -5,6 +5,7 @@ Accepted.
 Bulk API access provisioning will create service-account-owned API Tokens by default, using the canonical API Key schema and the product labels API Clients and API Tokens in operator-facing surfaces.
 Owner Contact and Team are descriptive API Client metadata only; they do not authenticate, authorize, own quota, or define routing policy.
 Tenant-direct API Keys remain supported for manual, bootstrap, and compatibility paths, but bulk provisioning uses API Clients so Orchard can audit, disable, and rotate non-interactive client access without introducing first-class human users.
+A Portal User is a portal-scoped interactive identity, not a bulk-provisioning identity, and does not weaken this decision for API Clients, Owner Contacts, or non-interactive access.
 Each bulk-provisioned API Client receives an explicit tenant-scoped `inference_client` Access Level by default.
 The first provisioning surface is CLI-first so One-time Secret Output can be written to an operator-chosen local file.
 Console may show and manage Organizations, Teams, API Clients, Owner Contacts, API Token prefixes, revocation, and API Client Disablement, but bulk secret export does not require an Admin API endpoint in the first slice.

--- a/docs/decisions/0020-portal-user-is-not-a-platform-principal.md
+++ b/docs/decisions/0020-portal-user-is-not-a-platform-principal.md
@@ -19,8 +19,12 @@ Public Inference authentication stays `principal_type = tenant`.
 `portal_user_id` is not consulted on the Bearer path.
 A Portal User is not an Operator, Service Account, Owner Contact, or Tenant Admin.
 Accounts are operator-invite only.
-Invite URLs are shown once in Console and delivered out of band.
+Console keeps a Copy invite action while the Portal User is invited.
+Each copy mints a fresh hashed token and extends expiry.
+The previous unused token dies.
+The operator delivers the URL out of band.
 SMTP is not required.
+Orchard never stores the plaintext invite URL.
 Disable ends that Portal User's sessions.
 It does not automatically revoke owned keys.
 Operator Console remains the surface that can list and revoke those keys.

--- a/docs/decisions/0020-portal-user-is-not-a-platform-principal.md
+++ b/docs/decisions/0020-portal-user-is-not-a-platform-principal.md
@@ -1,0 +1,39 @@
+# ADR: Portal User is a portal-scoped minting-gate identity
+
+## Status
+
+Accepted.
+
+## Context
+
+`SPEC.md` §7.4a currently describes a shared Organization portal password.
+ADR 0002 refused first-class human users for bulk API Client provisioning and kept Owner Contact as metadata.
+Developers still need isolated self-service keys.
+A named portal login is required so one person cannot list or revoke another person's keys.
+
+## Decision
+
+Introduce **Portal User** as an interactive, Organization-scoped identity that may sign in only to the Developer Portal.
+A Portal User may own portal-minted tenant-direct API Keys as minting-gate provenance.
+Public Inference authentication stays `principal_type = tenant`.
+`portal_user_id` is not consulted on the Bearer path.
+A Portal User is not an Operator, Service Account, Owner Contact, or Tenant Admin.
+Accounts are operator-invite only.
+Invite URLs are shown once in Console and delivered out of band.
+SMTP is not required.
+Disable ends that Portal User's sessions.
+It does not automatically revoke owned keys.
+Operator Console remains the surface that can list and revoke those keys.
+
+The shared Organization portal password is withdrawn as a login factor.
+Do not run shared-password and named-login together.
+
+## Consequences
+
+ADR 0002 still holds for API Clients and bulk provisioning.
+SPEC.md §2.3, §7.1, §7.4a, §8, §10.2, §10.8, and §10.9 must be updated.
+Legacy unowned portal-minted keys remain valid Bearers and operator-visible only.
+
+## SPEC.md impact
+
+Update required in §2.3, §7.1, §7.4a, §8, §10.2, §10.8, and §10.9.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,4 +23,4 @@ Start from [`_template.md`](_template.md) when useful. Decisions already fixed b
 
 ## Decision index
 
-The current sequence ends with [ADR 0019: Automatic inference retry is one fail-closed alternate-node attempt within the original Request](0019-one-request-bounded-alternate-node-retry.md).
+The current sequence ends with [ADR 0020: Portal User is a portal-scoped minting-gate identity](0020-portal-user-is-not-a-platform-principal.md).

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -182,6 +182,10 @@ _Avoid_: Runtime Endpoint Interface, Worker Runtime Interface, scheduler ranking
 The product-facing LiveView console for local and operator UI.
 _Avoid_: Kapitan Orchard UI, admin panel
 
+**Developer Portal**:
+The Organization-scoped browser surface where an invited Portal User mints, lists, and revokes their own tenant-direct API Keys.
+_Avoid_: Orchard Console, Admin API, public signup
+
 **Orchard CLI**:
 The `orchardctl` command-line interface for operator and admin automation.
 _Avoid_: Shell scripts as product interface
@@ -190,8 +194,8 @@ _Avoid_: Shell scripts as product interface
 
 **Operator**:
 A human or local administrative actor who configures, governs, or operates Orchard through Console, CLI, Operator API, or Admin API surfaces.
-An Operator is not a Service Account, API Client, API Key, or Tenant.
-_Avoid_: Service Account, API Client, API Key, Tenant
+An Operator is not a Service Account, API Client, API Key, Tenant, or Portal User.
+_Avoid_: Service Account, API Client, API Key, Tenant, Portal User
 
 **Tenant**:
 A governance boundary for model access, quotas, keys, retention, and usage accounting.
@@ -205,7 +209,16 @@ _Avoid_: Tenant, Quota boundary, Routing Policy, RBAC Role
 **Service Account**:
 A non-interactive principal that may own API Tokens and tenant-scoped or cluster-scoped RBAC Roles.
 Product-facing label: API Client.
-_Avoid_: User account, Tenant, API Key, Team
+_Avoid_: User account, Tenant, API Key, Team, Portal User
+
+**Portal User**:
+An interactive, Organization-scoped identity that may sign in only to the Developer Portal and own portal-minted tenant-direct API Keys.
+A Portal User is not a Public Inference principal, Operator, Service Account, or Owner Contact.
+_Avoid_: User account, Portal Developer, Tenant Admin, Owner Contact, Service Account
+
+**Portal Invite**:
+A one-time expiring token the operator copies from Console and delivers out of band so a Portal User can set a portal password.
+_Avoid_: Magic link email, SMTP invite, Owner Contact
 
 **API Key**:
 A bearer credential scoped directly to a Tenant or Service Account.
@@ -226,7 +239,8 @@ _Avoid_: database id, API Token, Owner Contact
 
 **Tenant-direct API Key**:
 An API Key scoped directly to a Tenant without a Service Account owner.
-_Avoid_: Service-account-owned API Key, Service Account, Owner Contact
+It may record a Portal User as minting-gate owner without changing the Public Inference principal.
+_Avoid_: Service-account-owned API Key, Service Account, Owner Contact, Portal User as principal
 
 **Service-account-owned API Key**:
 An API Key whose effective principal is the Service Account that owns it.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -217,8 +217,10 @@ A Portal User is not a Public Inference principal, Operator, Service Account, or
 _Avoid_: User account, Portal Developer, Tenant Admin, Owner Contact, Service Account
 
 **Portal Invite**:
-A one-time expiring token the operator copies from Console and delivers out of band so a Portal User can set a portal password.
-_Avoid_: Magic link email, SMTP invite, Owner Contact
+A single-use expiring token the operator can recopy from Console while the Portal User is invited.
+Each copy replaces the unused token.
+Orchard stores only the hash.
+_Avoid_: Persisted plaintext invite URL, magic link email, SMTP invite, Owner Contact
 
 **API Key**:
 A bearer credential scoped directly to a Tenant or Service Account.

--- a/docs/operator-journey.md
+++ b/docs/operator-journey.md
@@ -207,6 +207,15 @@ It is not a claim about the current build.
 9. Orchard verifies, places, and loads the model on the local Node Agent.
 10. Playground runs a small inference and shows the selected Node and model version.
 
+### Target Developer Portal Access
+
+1. The operator opens the Organization in Console and invites a Portal User by email.
+2. Console shows the newly issued Portal Invite URL once, and the operator delivers it to that developer through an out-of-band channel.
+3. While the Portal User remains invited, **Copy invite** reissues the invite with a fresh hashed token and extended expiry, invalidates the previous unused token, and shows the replacement URL once for copying.
+4. The developer redeems the Portal Invite, chooses a password, and signs in to the Organization-scoped Developer Portal.
+5. When access must end, the operator disables that Portal User, which ends only that user's portal sessions without automatically revoking minted API Keys.
+6. The operator reviews that Portal User's portal-minted keys in Console and may revoke selected keys by displayed prefix when key access must also end.
+
 ### Target Controller-Only Journey
 
 The Controller setup is identical through first Console access, but setup labels the cluster **No inference capacity** until a Node becomes active and model-ready.

--- a/openspec/changes/self-service-api-key-portal/design.md
+++ b/openspec/changes/self-service-api-key-portal/design.md
@@ -1,72 +1,106 @@
 ## Context
 
 Orchard already has hashed show-once tenant-direct API Keys, tenant quotas, and an operator Console Organization page that can mint and revoke keys.
-There is no Organization-scoped login, no portal password field, no issuance provenance, and no password hasher in `orchard_controller`.
-Console auth is cluster-wide Basic Auth. Reusing that shell for a weaker session would leak operator chrome.
+The first Developer Portal contract used one shared Organization password and one Organization-wide pool of portal-minted keys.
+That login cannot prevent one developer from listing or revoking another developer's keys.
+ADR 0020 defines Portal User as a portal-scoped minting-gate identity rather than a platform principal.
 
-Origin: `docs/brainstorms/2026-08-13-self-service-api-key-portal-requirements.md`.
-Implementation plan: `docs/plans/2026-08-13-001-feat-self-service-api-key-portal-plan.md`.
-UI note: `docs/designs/2026-08-13-self-service-api-key-portal.md`.
+Origin: `docs/brainstorms/2026-08-13-named-developer-portal-identity-requirements.md`.
+Implementation plan: `docs/plans/2026-08-13-002-feat-named-portal-user-identity-plan.md`.
+Decision record: `docs/decisions/0020-portal-user-is-not-a-platform-principal.md`.
 
 ## Goals
 
-- Give a human developer a working key and one curl without operator help, when the Organization already has a callable model.
-- Keep operator Console as the only cluster surface.
-- Fail closed on TLS, enumeration, and secret retention.
+- Give each operator-invited Portal User an isolated Developer Portal login and an own-keys-only self-service surface.
+- Let an operator copy an invite URL without SMTP and without storing a plaintext invite token.
+- Keep the Public Inference Bearer key and tenant-principal contracts unchanged.
+- Fail closed on transport, enumeration, cross-user key access, and secret retention.
+- Preserve legacy unowned portal-minted keys as operator-visible Bearer credentials until explicit revocation.
 
 ## Non-Goals
 
-- Named portal users, SSO, agent mint APIs, and API Client tokens from the portal remain later cuts.
-- This change does not invent a second key format.
+- Public signup, SMTP, magic-link email, SSO, OAuth, and Tenant Admin login remain out of scope.
+- A Portal User does not authorize Console, Operator API, Admin API, or Public Inference access.
+- This change does not invent a second key format or a new Public Inference principal.
+- Disable does not automatically revoke API Keys.
 
-## Decision 1: Separate Portal, Shared Phoenix Session Cookie
+## Decision 1: Separate Portal And Portal-Only Session
 
 The portal is a distinct `/portal/:organization_slug` namespace with its own layouts and `live_session`.
-CSRF and LiveView still ride the existing Phoenix session cookie `_orchard_console_key` because a second cookie is invisible to LiveView `connect_info`.
-Isolation is enforced above that layer: never read `_orchard_console_authenticated`, never render Console chrome.
+CSRF and LiveView may use the existing Phoenix cookie transport, but Portal User authentication state is a separate opaque hash-backed session.
+Portal code never reads Console authentication as Portal User authority and never renders Console chrome.
+A valid Portal User session authorizes only Developer Portal routes for that session's Portal User and Organization.
 
-Rejected: org-scoped slice of Console. Operator Basic Auth is cluster-wide.
+Rejected: an Organization-scoped slice of Console.
+Operator Basic Auth is cluster-wide.
+Rejected: allowing a Portal User session to authorize Console, Operator API, Admin API, or Public Inference.
 
-## Decision 2: Shared Organization Password Plus Epoch
+## Decision 2: Invite-Only Named Portal User
 
-One operator-set password per Organization. No user table.
-Password hash plus monotonic `portal_session_epoch`.
-Rotate or clear increments the epoch and deletes `portal_sessions`.
-It does not revoke minted keys.
+A Portal User belongs to one Organization and is identified by email unique on `(tenant_id, normalized_email)`.
+Accounts are created only by an operator.
+There is no public signup and no shared Organization portal password fallback.
+An active Portal User signs in with email plus password.
+Unknown Organization, unknown email, disabled Portal User, and wrong password use the same generic response shape and the same password-verification cost.
 
-Login identifies the Organization by slug first, then verifies that password.
-Unknown, closed, and wrong-password cases share one generic failure and the same hasher cost through the same verifier pool.
+`portal_users` stores Organization ownership, original and normalized email, password hash, status, session epoch, disable timestamp, and timestamps.
+A Portal User password uses a slow password KDF and never API key SHA-256.
 
-## Decision 3: Portal-Mint Provenance And Cap
+## Decision 3: Hash-Only Invite Reissue
 
-`api_keys.issuance_surface` is `governance` or `developer_portal`.
-Existing keys backfill to `governance`.
-The 10-key cap counts only active portal-minted tenant-direct keys.
-Operator mint is exempt.
-Portal revoke requires `issuance_surface = 'developer_portal'` so a leaked portal password cannot kill operator recovery keys.
-The portal may list operator-minted tenant-direct keys read-only.
+`portal_invite_tokens` belongs to one Portal User and stores only a token hash, expiry, redemption or invalidation state, and timestamps.
+The plaintext token exists only in the newly generated Copy invite URL.
+Orchard never stores the plaintext token or URL in Postgres, logs, audit payloads, or support artifacts.
 
-## Decision 4: Slow Password KDF With Packaging Gate
+Each Copy invite action mints a fresh token, invalidates every prior unused token for that Portal User, and extends expiry from the reissue time.
+The operator delivers the copied URL out of band.
+Redeeming a valid unexpired token sets the Portal User password, marks the token redeemed, activates the Portal User, and ends that Portal User's existing sessions.
+Password reset uses the same invite reissue and redemption flow.
+SMTP and magic-link email are not required.
 
-Prefer Argon2id via `argon2_elixir` (64 MiB, 3 iterations, parallelism 1).
-That would be the first compiled NIF in `orchard_controller`.
-If it cannot load in the controller release, use documented `:crypto` PBKDF2-HMAC-SHA512 before any password row exists.
-Do not hash portal passwords with API-key SHA-256.
+## Decision 4: Portal User-Owned Sessions And Disable
 
-## Decision 5: TLS-Only And Per-Source Backoff
-
-Portal routes and operator password mutations require `public_api_https_enabled?` and effective HTTPS scheme.
-`plain_http_localhost` returns 404 and rejects password mutations.
-
-Failed logins are limited per Organization fingerprint plus source fingerprint:
-1-4 free, then 30s / 60s / 120s / 240s / 480s / 900s.
-No Organization-wide lockout.
+Each `portal_sessions` row belongs to one `portal_user_id` and one `tenant_id` and stores only an opaque token hash.
+Session validation checks that the Portal User is active, belongs to the route Organization, and has the current session epoch.
+Invite reissue, invite redemption, password replacement, and disable end only that Portal User's sessions.
+Disable does not revoke owned API Keys.
+The operator can inspect and deliberately revoke those keys through Console.
 
 Sessions last 8 hours absolute and 30 minutes idle.
 Auth ticks do not refresh idle.
 
-## Decision 6: Deterministic Activation Curl
+## Decision 5: Own-Key Provenance And Per-User Cap
 
-After mint, choose the first tenant-authorized active model from the exact `GET /v1/models` visibility query, sorted by public identifier then UUID.
+`api_keys.portal_user_id` is nullable minting-gate provenance.
+Every new Developer Portal mint stores `issuance_surface = 'developer_portal'` and the signed-in Portal User's ID.
+The portal list and revoke queries require both the signed-in `portal_user_id` and its `tenant_id`.
+A key owned by another Portal User, an operator-minted key, and a missing key have the same portal-facing not-found behavior.
+
+The cap is 10 active portal-minted tenant-direct keys per Portal User.
+Revoked and expired keys do not count.
+The mint transaction locks the Portal User row before counting and inserting.
+Operator mint remains uncapped and operator-only.
+
+Public Inference authentication continues to accept `orchard_sk_*` and resolve the API Key to `principal_type = tenant`.
+It does not consult `portal_user_id`.
+A Portal User is not an API Key principal.
+
+Legacy Developer Portal keys with null `portal_user_id` remain valid Bearer credentials until explicitly revoked.
+They remain visible only to operators, cannot be claimed, and cannot be listed or revoked by a Portal User.
+No new Developer Portal mint may create an unowned key.
+
+## Decision 6: TLS-Only And Per-Identity Backoff
+
+Portal routes require `public_api_https_enabled?` and an effective HTTPS request scheme.
+`plain_http_localhost` returns `404` for every portal route.
+
+Failed logins are limited per Organization fingerprint, Portal User or normalized-email fingerprint, and source fingerprint.
+This prevents one source from causing an Organization-wide lockout.
+Unknown email uses a derived email fingerprint so the throttle does not disclose whether a Portal User exists.
+
+## Decision 7: Show-Once Key And Deterministic Activation Curl
+
+After mint, the portal chooses the first tenant-authorized active model from the exact `GET /v1/models` visibility query, sorted by public identifier then UUID.
 If authorization cannot be proven, mint still succeeds and the portal states that no curl is available.
+The key secret appears only at creation and is never recoverable later.
 The model identifier is untrusted interpolation in the shell snippet.

--- a/openspec/changes/self-service-api-key-portal/proposal.md
+++ b/openspec/changes/self-service-api-key-portal/proposal.md
@@ -1,44 +1,48 @@
 ## Why
 
-App developers who call Orchard's Public Inference API need a long-lived bearer key without asking a cluster operator each time.
-Today minting is operator-only: Console Organization detail, `orchardctl api-keys`, and `POST /admin/v1/api-keys`.
-Those paths already satisfy `SPEC.md` §10.2.
-
-A weaker Organization-scoped session is the missing minting gate.
-It is not public signup, SSO, named users, or API Client minting.
-Bulk API Client provisioning explicitly excluded human login and self-service token creation, so this change introduces a new capability rather than reusing Owner Contact or Team metadata as identity.
+App developers who call Orchard's Public Inference API need long-lived Bearer keys without asking a cluster operator for every key.
+A shared Organization portal password gives every password holder access to one Organization-wide key pool.
+That model cannot isolate one developer's keys from another developer.
+Orchard needs an invite-only named Portal User as the Developer Portal minting gate while keeping the Public Inference principal model unchanged.
 
 ## What Changes
 
 - Add a TLS-only Developer Portal at `/portal/:organization_slug` with its own layouts, pipeline, and LiveView session.
-- Let an operator set, rotate, or clear one Organization portal password from Console Organization detail.
-- Let a developer who presents that password mint, list, and revoke tenant-direct API Keys for that Organization only.
-- Persist portal password hash, session epoch, portal session rows, login throttle fingerprints, and API key `issuance_surface`.
-- Cap active portal-minted tenant-direct keys at 10. Operator mint stays uncapped and operator-only.
-- Show the key secret once. After mint, show one activation curl or state that no callable model exists.
-- Keep Public Inference Bearer format, Admin/Operator auth, and Console Basic Auth unchanged.
+- Let an operator invite a Portal User by email and copy a single-use expiring invite URL for out-of-band delivery.
+- Make each Copy invite action reissue a fresh hash-only token, extend expiry, and invalidate prior unused tokens.
+- Let an invited Portal User redeem the invite, set a password, and sign in with email plus password.
+- Let a signed-in Portal User mint, list, and revoke only their own tenant-direct API Keys.
+- Persist `portal_users`, `portal_invite_tokens`, Portal User-owned session rows, login throttle fingerprints, API key `issuance_surface`, and nullable `api_keys.portal_user_id`.
+- Cap active portal-minted tenant-direct keys at 10 per Portal User.
+- End a disabled Portal User's sessions without automatically revoking their keys.
+- Keep legacy portal-minted keys with null `portal_user_id` valid as Bearer credentials and visible only to operators.
+- Show each key secret once and then show one activation curl or state that no callable model exists.
+- Keep `orchard_sk_*`, Public Inference `principal_type = tenant`, Admin and Operator authentication, and Console Basic Auth unchanged.
+- Remove the shared Organization portal password as a Developer Portal login factor.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `developer-api-key-portal`: Organization-scoped self-service minting gate for tenant-direct API Keys.
+- `developer-api-key-portal`: Invite-only, Organization-scoped self-service minting gate for Portal User-owned tenant-direct API Keys.
 
 ### Modified Capabilities
 
 - None.
-  No accepted OpenSpec capability currently owns an Organization-scoped developer session.
+  No accepted OpenSpec capability currently owns a named Developer Portal identity.
 
 ## Impact
 
 - SPEC.md impact: this change refines `SPEC.md` §2.3, §7.1, §7.4a, §8, §10.2, §10.8, and §10.9.
-- Implementation impact: additive Postgres migration, `Orchard.Governance` password and portal-key facade, isolated `OrchardPortal` web namespace, and a Developer Portal card on `OrchardConsole.TenantDetailLive`.
-- Security impact: slow password KDF, per-source login backoff, epoch-bound sessions, TLS-only availability, show-once secrets, and portal revoke limited to portal-minted keys.
-- Non-impact: Public Inference `/v1/*`, Operator API, Admin API, Console Basic Auth, API Client provisioning, and Node TLS/BEAM credentials.
+- Implementation impact: additive and contract migrations for Portal Users, invite tokens, Portal User-owned sessions and keys, isolated `OrchardPortal` web namespace, and Portal User controls on Console Organization detail.
+- Security impact: slow password KDF, hash-only invite and session tokens, indistinguishable credential failures, per-identity-and-source login backoff, TLS-only availability, own-key authorization, and show-once secrets.
+- Migration impact: the shared Organization portal password no longer authenticates any portal route, while legacy unowned portal keys remain valid until explicitly revoked.
+- Non-impact: Public Inference `/v1/*`, `orchard_sk_*`, Bearer `principal_type = tenant`, Operator API, Admin API, Console Basic Auth, API Client provisioning, and Node TLS or BEAM credentials.
 
 ## Non-Goals
 
-- No public signup, payment, named developer accounts, SSO, or `tenant_admin` Console login.
+- No public signup, SMTP delivery, magic-link email, SSO, OAuth, or `tenant_admin` Console login.
+- No Portal User authority for Console, Operator API, Admin API, or Public Inference sessions.
 - No agent minting API or non-operator CLI mint.
 - No API Client create, disable, or token mint from the portal.
 - No quota, model-access, or Organization administration from the portal.

--- a/openspec/changes/self-service-api-key-portal/specs/developer-api-key-portal/spec.md
+++ b/openspec/changes/self-service-api-key-portal/specs/developer-api-key-portal/spec.md
@@ -1,105 +1,186 @@
 ## ADDED Requirements
 
-### Requirement: Developer Portal Is Isolated From Operator Console
+### Requirement: Developer Portal Is Isolated From Every Platform Authority
 
 Orchard SHALL expose a Developer Portal browser surface at `/portal/:organization_slug` that is distinct from Orchard Console.
 The portal SHALL NOT render operator Console chrome, other Organizations, nodes, license state, or cluster administration.
-Portal sessions SHALL NOT authorize Public Inference, Operator API, Admin API, or Console access.
+A Portal User SHALL authorize only the Developer Portal for that Portal User's Organization.
+A Portal User session SHALL NOT authorize Public Inference, Operator API, Admin API, or Console access.
 This refines `SPEC.md` §2.3, §7.1, and §7.4a.
 
-#### Scenario: Portal session cannot reach Console
+#### Scenario: Portal User cannot authorize Console
 
-- **WHEN** a developer holds a valid portal session cookie for one Organization
-- **THEN** requests to `/console` SHALL NOT be authorized by that session
-- **AND** the portal HTML SHALL NOT include Console sidebar, license badge, or `/console` navigation
+- **WHEN** a caller presents only a valid Portal User session
+- **THEN** requests to Console SHALL NOT be authorized by that session
+- **AND** the portal HTML SHALL NOT include Console navigation or operator chrome
 
-#### Scenario: Portal session cannot call Operator or Admin APIs
+#### Scenario: Portal User cannot authorize Operator or Admin APIs
 
-- **WHEN** a caller presents only a Developer Portal session
-- **THEN** Operator API and Admin API requests SHALL fail closed
-- **AND** the failure SHALL NOT treat the portal session as a Bearer API Token
+- **WHEN** a caller presents only a valid Portal User session to the Operator API or Admin API
+- **THEN** Orchard SHALL fail closed
+- **AND** Orchard SHALL NOT treat the session as Operator, Admin, Tenant Admin, or Bearer authority
 
-### Requirement: Organization Slug Is Identified Before Password Check
+#### Scenario: Portal User session is not Public Inference authority
 
-The portal SHALL identify the Organization from the route slug first, then verify that Organization's portal password.
-An Organization with no portal password SHALL have no open portal.
-`GET /portal/:organization_slug` SHALL be response-indistinguishable for open, closed, and unknown slugs.
-Unknown slug, closed portal, and wrong password SHALL share one generic login failure.
+- **WHEN** a caller presents a Portal User session without an `orchard_sk_*` Bearer credential to Public Inference
+- **THEN** Public Inference authentication SHALL fail
+- **AND** Orchard SHALL NOT treat `portal_user_id` as a Public Inference principal
+
+### Requirement: Portal Users Are Operator-Invited Named Identities
+
+A Portal User SHALL belong to exactly one Organization and use email as an identifier unique by normalized value within that Organization.
+An operator SHALL create Portal User accounts.
+The Developer Portal SHALL NOT offer public signup, self-registration, or shared Organization password authentication.
+SMTP SHALL NOT be required.
+This refines `SPEC.md` §7.4a and §8.
+
+#### Scenario: Public signup is unavailable
+
+- **WHEN** an unauthenticated caller visits any Developer Portal route
+- **THEN** Orchard SHALL offer only invite redemption or email-plus-password login
+- **AND** Orchard SHALL NOT create a Portal User without an operator-created invitation
+
+#### Scenario: Same email can identify users in different Organizations
+
+- **WHEN** two Organizations invite the same normalized email
+- **THEN** each Organization MAY have its own Portal User for that email
+- **AND** each Portal User SHALL remain scoped to its own Organization
+
+### Requirement: Copy Invite Reissues A Hash-Only Token
+
+Console SHALL provide Copy invite for a Portal User in `invited` status.
+Each Copy invite action SHALL mint a fresh single-use token, extend expiry from reissue, invalidate all prior unused tokens for that Portal User, and persist only the new token hash.
+Orchard SHALL NOT persist the plaintext token or invite URL.
+The operator SHALL deliver the URL out of band without an SMTP dependency.
+This refines `SPEC.md` §7.4a, §8, §10.8, and §10.9.
+
+#### Scenario: Recopy invalidates the previous invite
+
+- **WHEN** an operator uses Copy invite twice for the same invited Portal User
+- **THEN** the second action SHALL return a newly issued plaintext URL
+- **AND** Orchard SHALL extend the invite expiry
+- **AND** the first unused token SHALL no longer redeem
+- **AND** durable storage SHALL contain only token hashes
+
+#### Scenario: Valid invite is redeemed once
+
+- **WHEN** an invited Portal User submits a valid unexpired invite token and a valid new password
+- **THEN** Orchard SHALL store only the password hash
+- **AND** Orchard SHALL mark the invite redeemed and activate the Portal User
+- **AND** Orchard SHALL create no session from a second redemption attempt with the same token
+
+### Requirement: Named Login Failures Are Indistinguishable
+
+The Developer Portal SHALL authenticate an active Portal User with Organization slug, normalized email, and password.
+Unknown Organization, unknown email, disabled Portal User, and wrong password SHALL produce indistinguishable status, body shape, headers, and generic credential failure.
+`GET /portal/:organization_slug` SHALL be response-indistinguishable for Organizations with invited users, Organizations with active users, Organizations with no users, and unknown slugs.
+Failed login limits SHALL be keyed by Organization fingerprint, Portal User or email fingerprint, and source fingerprint without an Organization-wide lockout.
 This refines `SPEC.md` §7.4a.
 
-#### Scenario: Closed and unknown slugs share the GET login shape
+#### Scenario: Credential failures share one response contract
 
-- **WHEN** an unauthenticated caller requests `GET /portal/:organization_slug` for an open Organization, a closed Organization, and an unknown slug
-- **THEN** Orchard SHALL return the same status, body shape, and headers in all three cases
-- **AND** the page SHALL show the slug from the URL, not the Organization name
+- **WHEN** callers submit an unknown Organization, unknown email, disabled Portal User, and wrong password
+- **THEN** every submission SHALL receive the same credential-failure status, body shape, and headers
+- **AND** Orchard SHALL perform a bounded password-verification path without disclosing which identity exists
 
-#### Scenario: Closed portal cannot mint keys
+#### Scenario: One identity and source cannot lock the Organization
 
-- **WHEN** an Organization has no portal password hash
-- **THEN** a password submission SHALL fail with the generic login error
-- **AND** Orchard SHALL NOT create a portal session
+- **WHEN** one source exceeds failed-login backoff for one Portal User or email fingerprint
+- **THEN** another Portal User or source MAY still attempt login for the Organization
+- **AND** Orchard SHALL NOT create an Organization-wide lockout
 
-### Requirement: Operator Sets Rotates And Clears The Portal Password
+### Requirement: Portal Sessions Belong To One Portal User
 
-An operator SHALL set, rotate, or clear the portal password from Console Organization detail.
-The password SHALL be stored only as a slow password-hash, never plaintext.
-Clearing or rotating the password SHALL increment `portal_session_epoch` and end standing portal sessions for that Organization.
-Password rotation and clear SHALL NOT revoke minted API Keys.
-Operator password mutations SHALL be rejected when public API HTTPS is not enabled.
-This refines `SPEC.md` §7.4a, §10.8, and §10.9.
+Every Developer Portal session SHALL belong to one `portal_user_id` and that Portal User's Organization.
+Invite reissue, invite redemption, password replacement, and Portal User disablement SHALL end that Portal User's standing sessions.
+Disabling a Portal User SHALL NOT automatically revoke owned API Keys.
+This refines `SPEC.md` §7.4a and §8.
 
-#### Scenario: Rotate ends sessions and leaves keys valid
+#### Scenario: Disable ends sessions without revoking keys
 
-- **WHEN** an operator rotates an Organization portal password
-- **THEN** existing portal sessions for that Organization SHALL fail revalidation
-- **AND** previously minted API Keys SHALL remain valid Bearer credentials until explicitly revoked
+- **WHEN** an operator disables an active Portal User who has a standing session and active owned keys
+- **THEN** that Portal User's session SHALL fail revalidation
+- **AND** other Portal Users' sessions SHALL remain valid
+- **AND** the disabled Portal User's keys SHALL remain valid Bearer credentials until explicitly revoked
 
-#### Scenario: Degraded transport rejects password set
+### Requirement: Portal Mints Tenant-Direct Keys Owned By The Portal User
 
-- **WHEN** transport mode is `plain_http_localhost`
-- **THEN** Orchard SHALL reject portal password set, rotate, and clear
-- **AND** Orchard SHALL NOT persist a new password hash
-
-### Requirement: Portal Mints Tenant-Direct Keys With A Portal-Only Cap
-
-The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'` using the existing `orchard_sk_*` show-once contract.
-An Organization MAY have at most 10 active portal-minted tenant-direct keys.
-Operator-minted tenant-direct keys SHALL NOT count toward that ceiling.
-Operator mint paths SHALL remain available and operator-only.
+The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'`, the signed-in `portal_user_id`, and the existing `orchard_sk_*` show-once contract.
+`portal_user_id` SHALL be minting-gate provenance only.
+Public Inference SHALL continue to resolve the key as `principal_type = tenant` without consulting `portal_user_id`.
+Operator mint paths SHALL remain uncapped and operator-only.
 This refines `SPEC.md` §7.4a, §8, and §10.2.
 
-#### Scenario: Eleventh active portal key is rejected
+#### Scenario: Portal mint preserves tenant Bearer principal
 
-- **WHEN** an Organization already has 10 active portal-minted tenant-direct keys
-- **AND** a portal session attempts to mint another key
+- **WHEN** a Portal User mints a key and presents it as an `orchard_sk_*` Bearer credential
+- **THEN** Public Inference SHALL authenticate the key as `principal_type = tenant`
+- **AND** Public Inference SHALL NOT authorize from the Portal User session or `portal_user_id`
+
+#### Scenario: Operator mint remains operator-only
+
+- **WHEN** an operator mints a tenant-direct key through Console, CLI, or Admin API
+- **THEN** the mint SHALL remain available without the Portal User cap
+- **AND** a Portal User SHALL NOT gain access to that operator mint path or key
+
+### Requirement: Active Key Cap Is Ten Per Portal User
+
+Each Portal User SHALL NOT have more than 10 active portal-minted tenant-direct keys.
+Revoked and expired keys SHALL NOT count toward the ceiling.
+The mint operation SHALL serialize cap enforcement on the Portal User rather than the Organization.
+This refines `SPEC.md` §7.4a and §10.2.
+
+#### Scenario: Eleventh active key for one Portal User is rejected
+
+- **WHEN** one Portal User already owns 10 active portal-minted keys
+- **AND** that Portal User attempts to mint another key
 - **THEN** Orchard SHALL reject the mint
 - **AND** Orchard SHALL NOT insert a new API Key row
 
-#### Scenario: Operator mint remains uncapped
+#### Scenario: One user's cap does not consume another user's allowance
 
-- **WHEN** an Organization already has 10 active portal-minted tenant-direct keys
-- **AND** an operator mints a tenant-direct key through Console, CLI, or Admin API
-- **THEN** the operator mint SHALL succeed
-- **AND** the new key SHALL have `issuance_surface = 'governance'`
+- **WHEN** one Portal User owns 10 active portal-minted keys
+- **AND** another Portal User in the same Organization has fewer than 10 active portal-minted keys
+- **THEN** the second Portal User MAY mint another owned key
 
-### Requirement: Portal Lists Organization Keys And Revokes Only Portal-Minted Keys
+### Requirement: Portal List And Revoke Are Own-Keys-Only
 
-The portal SHALL list tenant-direct keys for the signed-in Organization, including operator-minted keys, with name, prefix, created time, last used time, status, and lifetime persisted-inference request count.
-The portal SHALL NOT list service-account-owned API Tokens.
-Portal revoke SHALL require `issuance_surface = 'developer_portal'` and SHALL take effect on the next Public Inference authentication.
+The portal SHALL list and revoke only keys whose `portal_user_id` and `tenant_id` match the signed-in Portal User and Organization.
+Keys owned by another Portal User, operator-minted keys, and missing keys SHALL be indistinguishable on portal list and revoke paths.
+Portal revoke SHALL take effect on the next Public Inference authentication.
 This refines `SPEC.md` §7.4a and §10.2.
 
-#### Scenario: Portal cannot revoke an operator key
+#### Scenario: Portal Users cannot see each other's keys
 
-- **WHEN** a portal session attempts to revoke an operator-minted tenant-direct key
+- **WHEN** two Portal Users belong to the same Organization and each owns portal-minted keys
+- **THEN** each Portal User SHALL list only their own keys
+- **AND** neither Portal User SHALL learn the other Portal User's key names, prefixes, or status
+
+#### Scenario: Portal User cannot revoke another user's key
+
+- **WHEN** a Portal User attempts to revoke a key owned by another Portal User
 - **THEN** Orchard SHALL treat the key as not found
-- **AND** the key SHALL remain active
+- **AND** the other Portal User's key SHALL remain active
 
-#### Scenario: Portal revoke fails the next Bearer request
+#### Scenario: Own-key revoke fails the next Bearer request
 
-- **WHEN** a portal session revokes a portal-minted key
+- **WHEN** a Portal User revokes their own portal-minted key
 - **AND** the next Public Inference request presents that key
 - **THEN** authentication SHALL fail with `401 invalid_api_key`
+
+### Requirement: Legacy Unowned Portal Keys Remain Operator-Visible Bearers
+
+Portal-minted keys with null `portal_user_id` SHALL remain valid `orchard_sk_*` Bearer credentials until explicitly revoked.
+Legacy unowned portal keys SHALL remain visible only to operators and SHALL NOT be claimable, listed, or revoked by a Portal User.
+The portal SHALL NOT mint a new unowned key.
+This refines `SPEC.md` §7.4a, §8, and §10.2.
+
+#### Scenario: Legacy unowned key remains valid but absent from portal
+
+- **WHEN** an existing portal-minted key has null `portal_user_id`
+- **THEN** Public Inference SHALL continue to accept it as a tenant Bearer credential until explicit revocation
+- **AND** operators SHALL be able to inspect and revoke it
+- **AND** every Portal User SHALL be unable to list, claim, or revoke it
 
 ### Requirement: Activation Curl Uses One Deterministic Callable Model
 
@@ -110,27 +191,19 @@ This refines `SPEC.md` §7.2.3, §7.2.4, and §7.4a.
 
 #### Scenario: No callable model still mints the key
 
-- **WHEN** a portal session mints a key for an Organization with no proven callable model
+- **WHEN** a Portal User mints a key for an Organization with no proven callable model
 - **THEN** Orchard SHALL persist the key
 - **AND** the portal SHALL state that no test curl is available
 - **AND** the secret SHALL still be shown once
 
-### Requirement: Portal Traffic Is TLS-Only And Login Failures Are Per-Source
+### Requirement: Portal Traffic Is TLS-Only
 
 The portal SHALL be served only when public API HTTPS is enabled and the effective request scheme is HTTPS.
 Degraded `plain_http_localhost` SHALL return `404` for every portal route.
-Failed portal logins SHALL be limited per Organization fingerprint and source fingerprint.
-They SHALL NOT use an Organization-wide lockout.
 This refines `SPEC.md` §7.4a and §10.7.
 
-#### Scenario: Degraded mode hides the portal
+#### Scenario: Degraded mode hides every portal route
 
 - **WHEN** transport mode is `plain_http_localhost`
-- **THEN** every `/portal/:organization_slug` route SHALL return `404`
-- **AND** Orchard SHALL NOT set a portal session
-
-#### Scenario: One source cannot lock the whole Organization
-
-- **WHEN** one client source exceeds the failed-login backoff for an Organization
-- **THEN** a different source MAY still attempt login for that Organization
-- **AND** the throttled source SHALL receive a retryable failure distinct from the generic credential error
+- **THEN** invite, login, logout, and key routes under `/portal/:organization_slug` SHALL return `404`
+- **AND** Orchard SHALL NOT create a Portal User session

--- a/openspec/changes/self-service-api-key-portal/tasks.md
+++ b/openspec/changes/self-service-api-key-portal/tasks.md
@@ -1,41 +1,49 @@
 ## 1. Contract
 
-- [x] 1.1 Update `SPEC.md` §2.3, §7.1, §7.4a, §8, §10.2, §10.8, and §10.9 for the Developer Portal.
-- [x] 1.2 Add this OpenSpec proposal, design, tasks, and requirement delta.
-- [x] 1.3 Validate the change with strict OpenSpec.
+- [x] 1.1 Update `SPEC.md` §2.3, §7.1, §7.4a, §8, §10.2, §10.8, and §10.9 for invite-only Portal Users.
+- [x] 1.2 Amend this live OpenSpec proposal, design, tasks, and requirement delta instead of creating a second change.
+- [x] 1.3 Validate the amended change with strict OpenSpec.
 
-## 2. Persistence And Password Lifecycle
+## 2. Portal User And Invite Persistence
 
-- [ ] 2.1 Prove Argon2id loads in the controller environment or switch to documented PBKDF2-HMAC-SHA512 before any password row exists.
-- [ ] 2.2 Add additive migration for tenant portal fields, `issuance_surface`, `portal_sessions`, `portal_login_throttles`, and `requests.api_key_id` index if missing.
-- [ ] 2.3 Add `lock_tenant/1` and portal password set/rotate/clear with epoch increment, session deletion, TLS rejection, and redacted audit.
-- [ ] 2.4 Add focused password and governance tests from the implementation plan Unit 2 scenarios.
+- [ ] 2.1 Add the Portal User status enum, `portal_users`, and Organization-scoped normalized-email uniqueness.
+- [ ] 2.2 Add `portal_invite_tokens` with hash-only single-use tokens, expiry, redemption, and invalidation state.
+- [ ] 2.3 Add Copy invite reissue that invalidates prior unused tokens, extends expiry, and returns plaintext only in the new URL.
+- [ ] 2.4 Add invite redemption and password replacement with a slow password KDF and no SMTP dependency.
+- [ ] 2.5 Add focused persistence and invite lifecycle tests for expiry, single use, reissue invalidation, and absent plaintext storage.
 
-## 3. Sessions And Throttle
+## 3. Portal User Sessions And Login Throttle
 
-- [ ] 3.1 Add portal session create/validate/logout and per-source throttle reservation.
-- [ ] 3.2 Add the bounded verifier pool and dummy-verify path with the same hasher cost.
-- [ ] 3.3 Store the opaque portal token in the Phoenix session so LiveView mount can revalidate.
-- [ ] 3.4 Add session, throttle, and verifier tests from the implementation plan Unit 3 scenarios.
+- [ ] 3.1 Add Portal User-owned session create, validate, logout, and user-scoped session termination.
+- [ ] 3.2 Add email-plus-password login with indistinguishable unknown Organization, unknown email, disabled user, and wrong-password responses.
+- [ ] 3.3 Add throttle reservation by Organization fingerprint, Portal User or email fingerprint, and source fingerprint.
+- [ ] 3.4 Add the bounded verifier pool and dummy-verify path with the same password-hasher cost.
+- [ ] 3.5 Store only an opaque portal session token in the Phoenix session so LiveView mount can revalidate.
+- [ ] 3.6 Add session, disable, replacement-invite, throttle, and verifier tests.
 
-## 4. Portal Keys And Activation Curl
+## 4. Portal User-Owned Keys And Activation Curl
 
-- [ ] 4.1 Add `create_portal_api_key/3` with tenant lock and portal-only cap of 10.
-- [ ] 4.2 Add `list_portal_api_keys/1` with grouped persisted-inference request counts.
-- [ ] 4.3 Add `revoke_portal_api_key/3` limited to `issuance_surface = 'developer_portal'`.
-- [ ] 4.4 Add deterministic activation-curl construction with untrusted model-identifier quoting.
-- [ ] 4.5 Add governance, curl, and Bearer integration tests from the implementation plan Unit 4 scenarios.
+- [ ] 4.1 Add nullable `api_keys.portal_user_id` without changing `orchard_sk_*` or Public Inference `principal_type = tenant`.
+- [ ] 4.2 Add Portal User-owned mint with `issuance_surface = 'developer_portal'` and a Portal User row lock.
+- [ ] 4.3 Enforce at most 10 active portal-minted keys per Portal User, excluding revoked and expired keys.
+- [ ] 4.4 Add own-keys-only list and revoke queries scoped by both `portal_user_id` and `tenant_id`.
+- [ ] 4.5 Keep operator-minted and legacy unowned portal keys absent from Developer Portal list and revoke paths.
+- [ ] 4.6 Keep legacy unowned portal keys valid on the unchanged Bearer path and visible to operators.
+- [ ] 4.7 Add deterministic activation-curl construction with untrusted model-identifier quoting and show-once secret handling.
+- [ ] 4.8 Add cross-user isolation, per-user cap, legacy-key, operator-mint, revoke, and Bearer integration tests.
 
-## 5. Isolated Portal Surface
+## 5. Isolated Developer Portal Surface
 
-- [ ] 5.1 Register TLS-guarded `/portal/:organization_slug` routes with CSRF, secure headers, and no Console auth marker.
-- [ ] 5.2 Add indistinguishable GET login for open, closed, and unknown slugs.
-- [ ] 5.3 Add `OrchardPortal.KeysLive` with show-once secret, dark-pinned layouts, and chrome-absence tests.
-- [ ] 5.4 Follow `docs/designs/2026-08-13-self-service-api-key-portal.md` except slug-in-URL login.
+- [ ] 5.1 Register TLS-guarded invite, login, logout, and key routes with CSRF, secure headers, and no Console auth marker.
+- [ ] 5.2 Add invite redemption and email-plus-password login without a shared Organization password fallback.
+- [ ] 5.3 Add `OrchardPortal.KeysLive` with own-key list, show-once secret, isolated layouts, and chrome-absence tests.
+- [ ] 5.4 Prove Portal User sessions cannot authorize Console, Operator API, Admin API, or Public Inference.
+- [ ] 5.5 Prove `plain_http_localhost` returns `404` for every Developer Portal route.
 
-## 6. Operator Surface And Docs
+## 6. Operator Surface And Adjacent Docs
 
-- [ ] 6.1 Add the Developer Portal card to Organization detail: set, rotate, clear, HTTPS URL, active portal-key count.
-- [ ] 6.2 Document the containment runbook in `docs/operator-journey.md`.
-- [ ] 6.3 Add a narrow portal-surface section to `docs/DESIGN.md`.
-- [ ] 6.4 Run the Elixir quality workflow for the changed surface.
+- [ ] 6.1 Add Portal User invite, Copy invite, disable, and owned-key visibility to Console Organization detail.
+- [ ] 6.2 Ensure disable ends only that Portal User's sessions and does not revoke owned keys.
+- [ ] 6.3 Update `docs/operator-journey.md` in its separately reviewed unit.
+- [ ] 6.4 Update `docs/DESIGN.md` in its separately reviewed unit.
+- [ ] 6.5 Run the Elixir quality workflow for the implementation changes.


### PR DESCRIPTION
## Context

PR #208 landed a Developer Portal that opens with one Organization password. That gives every password holder the same key pool. Self-service here means each invited person owns their own keys.

This PR rewrites the contract only. No Elixir yet.

## What changed

- Developer Portal login is an invite-only Portal User. Email plus password. Email is an identifier, not a mail address we have to deliver to.
- Console keeps Copy invite while the person is invited. Each copy mints a new hashed token and extends expiry. The unused old token dies. We do not store the plaintext URL.
- Portal list, mint, and revoke are own-keys-only. Console still sees every tenant-direct key.
- Cap is 10 active portal-minted keys per Portal User. Revoked and expired keys do not count.
- Disable ends that user's portal sessions. It does not revoke their keys. The operator can still revoke by prefix.
- Shared Organization portal password is withdrawn as a login factor.
- Legacy unowned portal-minted keys stay valid `orchard_sk_*` Bearers and stay operator-visible only.
- Public Inference principal stays `tenant`. `portal_user_id` is minting-gate ownership only.
- ADR 0020 records that a Portal User is not an Operator, API Client, or Owner Contact. ADR 0002 still holds for bulk API Clients.

## Out of scope

- Schema, login, Console invite UI, and key ownership code.
- `feat/developer-portal-impl` stays parked. Reusable TLS/show-once work can be ported after this contract lands.
- SMTP / magic-link email.

## Verification

- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate self-service-api-key-portal --type change --strict --no-interactive` passed.
- Spec and docs review: no leftover operator instruction to share one Organization portal password.
- Screenshots: none. This PR is contract and docs. The named-identity prototype used for review is local and not in this diff.

## Risk Assessment

✅ **Medium**

- Blast radius is the published Developer Portal contract on `main`, not runtime behavior. Packaged inference and existing Bearer keys do not change.
- Fail-closed intent: no dual login. Shared-password prose is deleted, not layered.
- Residual: until the follow-on impl lands, `SPEC.md` describes named Portal Users while the only code path still on `feat/developer-portal-impl` is the withdrawn shared-password model. Do not merge that impl branch as-is.
- Residual: disable-without-revoke can leave live keys after offboarding. That is intentional. Operator must revoke by prefix when that is the goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789211337&installation_model_id=428414&pr_number=209&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F209&signature=cf664aa59409ce6d516396dce54bd6283fe3d34380062db4d8e7a47a4063ffa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->