### PR TITLE
docs(openspec): record deferred portal evidence

### DIFF
--- a/openspec/changes/archive/2026-08-14-self-service-api-key-portal/tasks.md
+++ b/openspec/changes/archive/2026-08-14-self-service-api-key-portal/tasks.md
@@ -10,7 +10,8 @@
 - [x] 2.2 Add `portal_invite_tokens` with hash-only single-use tokens, expiry, redemption, and invalidation state.
 - [x] 2.3 Add Copy invite reissue that invalidates prior unused tokens, extends expiry, and returns plaintext only in the new URL.
 - [x] 2.4 Add invite redemption and password replacement with a slow password KDF and no SMTP dependency.
-- [x] 2.5 Add focused persistence and invite lifecycle tests for expiry, single use, reissue invalidation, and absent plaintext storage.
+- [ ] 2.5 Add focused persistence and invite lifecycle tests for expiry, single use, reissue invalidation, and absent plaintext storage.
+  Deferred because the landed tests cover single use, reissue invalidation, and hash-only storage, but do not exercise invite expiry.
 
 ## 3. Portal User Sessions And Login Throttle
 
@@ -19,7 +20,8 @@
 - [x] 3.3 Add throttle reservation by Organization fingerprint, Portal User or email fingerprint, and source fingerprint.
 - [x] 3.4 Add the bounded verifier pool and dummy-verify path with the same password-hasher cost.
 - [x] 3.5 Store only an opaque portal session token in the Phoenix session so LiveView mount can revalidate.
-- [x] 3.6 Add session, disable, replacement-invite, throttle, and verifier tests.
+- [ ] 3.6 Add session, disable, replacement-invite, throttle, and verifier tests.
+  Deferred because the landed tests do not exercise replacement-invite termination of an existing Portal User session.
 
 ## 4. Portal User-Owned Keys And Activation Curl
 
@@ -30,15 +32,18 @@
 - [x] 4.5 Keep operator-minted and legacy unowned portal keys absent from Developer Portal list and revoke paths.
 - [x] 4.6 Keep legacy unowned portal keys valid on the unchanged Bearer path and visible to operators.
 - [x] 4.7 Add deterministic activation-curl construction with untrusted model-identifier quoting and show-once secret handling.
-- [x] 4.8 Add cross-user isolation, per-user cap, legacy-key, operator-mint, revoke, and Bearer integration tests.
+- [ ] 4.8 Add cross-user isolation, per-user cap, legacy-key, operator-mint, revoke, and Bearer integration tests.
+  Deferred because the landed portal tests do not cover operator mint isolation or prove that portal revoke rejects the next Bearer request.
 
 ## 5. Isolated Developer Portal Surface
 
 - [x] 5.1 Register TLS-guarded invite, login, logout, and key routes with CSRF, secure headers, and no Console auth marker.
 - [x] 5.2 Add invite redemption and email-plus-password login without a shared Organization password fallback.
 - [x] 5.3 Add `OrchardPortal.KeysLive` with own-key list, show-once secret, isolated layouts, and chrome-absence tests.
-- [x] 5.4 Prove Portal User sessions cannot authorize Console, Operator API, Admin API, or Public Inference.
-- [x] 5.5 Prove `plain_http_localhost` returns `404` for every Developer Portal route.
+- [ ] 5.4 Prove Portal User sessions cannot authorize Console, Operator API, Admin API, or Public Inference.
+  Deferred because the landed tests prove isolated portal chrome and token storage, but do not present a Portal User session to each other authority surface.
+- [ ] 5.5 Prove `plain_http_localhost` returns `404` for every Developer Portal route.
+  Deferred because the landed degraded-mode tests cover login and invite GET routes, but not logout, session POST, invite POST, or key routes.
 
 ## 6. Operator Surface And Adjacent Docs
 


### PR DESCRIPTION
## Context

kapitan-ai/orchard#212 archived the shipped Developer Portal OpenSpec package and synced its capability spec.
This follow-up corrects the archived task ledger so it does not claim test evidence that is absent from the landed suite.

## What changed

The archive now records 27 of 32 tasks complete and leaves 5 test-evidence tasks unchecked with durable notes.

- Invite expiry lacks focused lifecycle coverage.
- Replacement-invite termination of an existing Portal User session is not tested.
- Portal tests do not cover operator mint isolation or prove that portal revoke rejects the next Bearer request.
- Cross-authority tests do not present a Portal User session to Console, Operator API, Admin API, and Public Inference.
- Degraded-mode tests do not exercise every portal route.

The shipped implementation contract and synced main capability spec are unchanged.

## Verification

- `git diff --check`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
- Strict archived-change validation through a transient live-path symlink after the archive move

The strict all-spec validation passed 21 items with 0 failures.
The archived change passed strict change validation.

## Risk Assessment

Low.

This changes one archived OpenSpec task ledger and makes its status more conservative.
No product code, tests, `SPEC.md`, accepted capability spec, or unrelated documentation changes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789255500&installation_model_id=428414&pr_number=213&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F213&signature=5556d291914f972679fd0aae161f2d2e623d13c1d5e48ed9a106438a1fc5ac67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->