### PR TITLE
feat(dispatch): return typed attempt outcomes

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch/attempt_outcome.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/attempt_outcome.ex
@@ -1,0 +1,105 @@
+defmodule Orchard.Dispatch.AttemptOutcome do
+  @moduledoc """
+  Typed internal evidence returned by one dispatcher attempt.
+  """
+
+  alias Orchard.Requests.InferenceAttemptFailure
+
+  @enforce_keys [
+    :attempt_outcome,
+    :node_id,
+    :accepted,
+    :events,
+    :failure,
+    :execution_resolution,
+    :capacity_release_outcome,
+    :started_at,
+    :ended_at,
+    :first_token_at
+  ]
+  defstruct @enforce_keys
+
+  @attempt_outcomes [:completed, :failed, :cancelled, :timed_out, :interrupted]
+  @execution_resolutions [:not_started, :terminated, :unresolved]
+  @capacity_release_outcomes [:released, :already_released, :not_applicable, :unresolved]
+
+  @type attempt_outcome :: :completed | :failed | :cancelled | :timed_out | :interrupted
+  @type execution_resolution :: :not_started | :terminated | :unresolved
+
+  @type capacity_release_outcome ::
+          :released | :already_released | :not_applicable | :unresolved
+
+  @type failure :: InferenceAttemptFailure.evidence() | nil
+
+  @type t :: %__MODULE__{
+          attempt_outcome: attempt_outcome(),
+          node_id: Ecto.UUID.t() | nil,
+          accepted: boolean(),
+          events: [Orchard.InferenceEvent.t()],
+          failure: failure(),
+          execution_resolution: execution_resolution(),
+          capacity_release_outcome: capacity_release_outcome(),
+          started_at: DateTime.t(),
+          ended_at: DateTime.t(),
+          first_token_at: DateTime.t() | nil
+        }
+
+  @spec new(map()) :: {:ok, t()} | {:error, :invalid_attempt_outcome}
+  def new(
+        %{
+          attempt_outcome: attempt_outcome,
+          node_id: node_id,
+          accepted: accepted,
+          events: events,
+          failure: failure,
+          execution_resolution: execution_resolution,
+          capacity_release_outcome: capacity_release_outcome,
+          started_at: %DateTime{} = started_at,
+          ended_at: %DateTime{} = ended_at,
+          first_token_at: first_token_at
+        } = attrs
+      ) do
+    if attempt_outcome in @attempt_outcomes and
+         valid_node_id?(node_id) and
+         is_boolean(accepted) and
+         is_list(events) and
+         valid_failure?(attempt_outcome, failure) and
+         execution_resolution in @execution_resolutions and
+         capacity_release_outcome in @capacity_release_outcomes and
+         ordered_timestamps?(started_at, ended_at, first_token_at) do
+      {:ok, struct!(__MODULE__, attrs)}
+    else
+      {:error, :invalid_attempt_outcome}
+    end
+  end
+
+  def new(_attrs), do: {:error, :invalid_attempt_outcome}
+
+  defp valid_node_id?(nil), do: true
+  defp valid_node_id?(node_id), do: match?({:ok, _uuid}, Ecto.UUID.cast(node_id))
+
+  defp valid_failure?(:completed, nil), do: true
+
+  defp valid_failure?(attempt_outcome, %{
+         "failure_class" => failure_class,
+         "failure_code" => failure_code
+       })
+       when attempt_outcome != :completed do
+    failure_class in InferenceAttemptFailure.failure_classes() and
+      failure_code in InferenceAttemptFailure.stable_error_codes()
+  end
+
+  defp valid_failure?(_attempt_outcome, _failure), do: false
+
+  defp ordered_timestamps?(started_at, ended_at, nil) do
+    DateTime.compare(ended_at, started_at) != :lt
+  end
+
+  defp ordered_timestamps?(started_at, ended_at, %DateTime{} = first_token_at) do
+    DateTime.compare(ended_at, started_at) != :lt and
+      DateTime.compare(first_token_at, started_at) != :lt and
+      DateTime.compare(first_token_at, ended_at) != :gt
+  end
+
+  defp ordered_timestamps?(_started_at, _ended_at, _first_token_at), do: false
+end

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -45,6 +45,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   use Orchard.DispatchCapacity.Consumer, wiring: :final_dispatch_revalidation
 
+  alias Orchard.Dispatch.AttemptOutcome
   alias Orchard.DomainMetrics
   alias Orchard.Inference
   alias Orchard.Inference.{ModelLoadFailure, QueueManager, RequestDeadline}
@@ -58,13 +59,13 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     Target
   }
 
+  alias Orchard.Requests.InferenceAttemptFailure
   alias Orchard.SentryContext
   alias Orchard.Tokenizer.Telemetry
 
   require Logger
 
   @maximum_cancel_drain_timeout_ms 5_000
-  @pending_cancel_reconciliation_key {__MODULE__, :pending_cancel_reconciliation}
 
   @doc "Revalidates a recognized dispatch claim through the production QueueManager seam."
   @spec revalidate_dispatch_capacity(
@@ -93,6 +94,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
               ensure_model_loaded_ms: :na,
               accepted_monotonic_ms: nil,
               first_delta_monotonic_ms: nil,
+              first_token_at: nil,
               terminal_monotonic_ms: nil,
               accepted_to_first_delta_ms: :na,
               accepted_to_terminal_ms: :na,
@@ -116,6 +118,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
             ensure_model_loaded_ms: non_neg_integer() | :na,
             accepted_monotonic_ms: integer() | nil,
             first_delta_monotonic_ms: integer() | nil,
+            first_token_at: DateTime.t() | nil,
             terminal_monotonic_ms: integer() | nil,
             accepted_to_first_delta_ms: non_neg_integer() | :na,
             accepted_to_terminal_ms: non_neg_integer() | :na,
@@ -142,6 +145,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         ensure_model_loaded_ms: :na,
         accepted_monotonic_ms: nil,
         first_delta_monotonic_ms: nil,
+        first_token_at: nil,
         terminal_monotonic_ms: nil,
         accepted_to_first_delta_ms: :na,
         accepted_to_terminal_ms: :na,
@@ -177,10 +181,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     end
   end
 
-  @type dispatch_result ::
-          {:ok, [InferenceEvent.t()]}
-          | {:error,
-             {:model_load_failed, ModelLoadFailure.t()} | {:dispatch_failed, term()} | term()}
+  @type dispatch_result :: AttemptOutcome.t()
 
   @doc """
   Dispatch an inference request to a Runtime Endpoint and stream events back to the caller.
@@ -215,12 +216,11 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   - `:cancel_drain_timeout_ms` - bounded cancellation reconciliation grace period
                                  (default: the lesser of request timeout and 5 seconds)
 
-  Returns `{:ok, events}` with the caller-visible event sequence and exactly one
-  terminal event. Invalid duplicate or post-terminal worker events are withheld
-  and replaced by a stable conformance failure. Returns `{:error, reason}` if
-  dispatch fails before streaming begins.
-  Runtime Endpoint disconnect cleanup failures are logged and ignored after the
-  dispatch outcome is known.
+  Returns one `Orchard.Dispatch.AttemptOutcome` containing the ordered caller-visible
+  events and the evidence needed to persist this attempt. Invalid duplicate or
+  post-terminal worker events are withheld and replaced by a stable conformance
+  failure. Runtime Endpoint disconnect cleanup is reflected in execution and
+  release evidence when termination cannot be proved.
   """
   @spec dispatch(
           schedule :: map(),
@@ -282,21 +282,26 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       on_node_resolved: on_node_resolved
     }
 
-    try do
-      if timeout_ms <= 0 do
-        {:error, {:dispatch_failed, :dispatch_timeout}}
-      else
-        case preensure_prompt_token_ids_gate(execute_request, schedule, model_load_request) do
-          :ok ->
-            dispatch_with_capacity_claim(context)
+    started_at = DateTime.truncate(now, :microsecond)
 
-          {:error, reason} ->
-            error_metrics = finalize_metrics(metrics, {:error, {:dispatch_failed, reason}})
-            put_dispatch_terminal_context(error_metrics, target)
-            emit_timing_log(error_metrics, {:error, {:dispatch_failed, reason}})
-            {:error, {:dispatch_failed, reason}}
+    try do
+      {result, release_outcome} =
+        if timeout_ms <= 0 do
+          {{:error, {:dispatch_failed, :dispatch_timeout}}, :not_applicable}
+        else
+          case preensure_prompt_token_ids_gate(execute_request, schedule, model_load_request) do
+            :ok ->
+              dispatch_with_capacity_claim(context)
+
+            {:error, reason} ->
+              error_metrics = finalize_metrics(metrics, {:error, {:dispatch_failed, reason}})
+              put_dispatch_terminal_context(error_metrics, target)
+              emit_timing_log(error_metrics, {:error, {:dispatch_failed, reason}})
+              {{:error, {:dispatch_failed, reason}}, :not_applicable}
+          end
         end
-      end
+
+      build_attempt_outcome(result, release_outcome, started_at, schedule)
     after
       Process.demonitor(caller_ref, [:flush])
     end
@@ -304,9 +309,178 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   # -- Private ---------------------------------------------------------------
 
+  defp build_attempt_outcome(result, release_outcome, started_at, schedule) do
+    {result, execution_evidence, safety_state, first_token_at} = attempt_evidence(result)
+    ended_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    events = result_events(result)
+    accepted = Enum.any?(events, &match?(%InferenceEvent{event: %InferenceEvent.Accepted{}}, &1))
+    terminal = List.last(events)
+    attempt_outcome = attempt_outcome(result, terminal)
+
+    attrs = %{
+      attempt_outcome: attempt_outcome,
+      node_id: trusted_node_id(schedule),
+      accepted: accepted,
+      events: events,
+      failure: attempt_failure(result, terminal, attempt_outcome),
+      execution_resolution: execution_evidence || execution_resolution(result, terminal),
+      capacity_release_outcome:
+        effective_release_outcome(release_outcome, execution_evidence, safety_state),
+      started_at: started_at,
+      ended_at: ended_at,
+      first_token_at: first_token_at
+    }
+
+    {:ok, outcome} = AttemptOutcome.new(attrs)
+    outcome
+  end
+
+  defp attempt_evidence(
+         {:attempt_evidence, {:attempt_timing, result, first_token_at}, execution_resolution,
+          safety_state}
+       ),
+       do: {result, execution_resolution, safety_state, first_token_at}
+
+  defp attempt_evidence({:attempt_evidence, result, execution_resolution, safety_state}),
+    do: {result, execution_resolution, safety_state, nil}
+
+  defp attempt_evidence({:attempt_timing, result, first_token_at}),
+    do: {result, nil, :available, first_token_at}
+
+  defp attempt_evidence(result), do: {result, nil, :available, nil}
+
+  defp effective_release_outcome(_release_outcome, :unresolved, _safety_state), do: :unresolved
+
+  defp effective_release_outcome(_release_outcome, _execution_resolution, :unavailable),
+    do: :unresolved
+
+  defp effective_release_outcome(release_outcome, _execution_resolution, _safety_state),
+    do: release_outcome
+
+  defp result_events({:ok, events}) when is_list(events), do: events
+  defp result_events(_result), do: []
+
+  defp attempt_outcome(_result, %InferenceEvent{event: %InferenceEvent.Completed{}}),
+    do: :completed
+
+  defp attempt_outcome(_result, %InferenceEvent{event: %InferenceEvent.Failed{code: code}})
+       when code in ["deadline_exceeded", "request_timeout", "request_timed_out", "timed_out"],
+       do: :timed_out
+
+  defp attempt_outcome(_result, %InferenceEvent{event: %InferenceEvent.Failed{code: code}})
+       when code in [
+              "cancelled",
+              "request_cancelled",
+              "request_caller_disconnect",
+              "request_client_disconnect"
+            ],
+       do: :cancelled
+
+  defp attempt_outcome(_result, %InferenceEvent{event: %InferenceEvent.Failed{}}), do: :failed
+
+  defp attempt_outcome({:error, {:dispatch_failed, reason}}, _terminal)
+       when reason in [:dispatch_timeout, :request_timeout],
+       do: :timed_out
+
+  defp attempt_outcome({:error, {:dispatch_failed, reason}}, _terminal)
+       when reason in [:caller_disconnect, :request_caller_disconnect],
+       do: :cancelled
+
+  defp attempt_outcome(_result, _terminal), do: :failed
+
+  defp attempt_failure(_result, _terminal, :completed), do: nil
+
+  defp attempt_failure(
+         _result,
+         %InferenceEvent{event: %InferenceEvent.Failed{code: code}},
+         _outcome
+       ) do
+    InferenceAttemptFailure.normalize(failure_source(code))
+  end
+
+  defp attempt_failure(
+         {:error, {:model_load_failed, %ModelLoadFailure{} = failure}},
+         _terminal,
+         _outcome
+       ) do
+    evidence =
+      InferenceAttemptFailure.normalize(%{
+        category: :model_load,
+        code: failure.category,
+        phase: :model_load
+      })
+
+    if failure.code == evidence["failure_code"] do
+      evidence
+    else
+      Map.put(evidence, "raw_source_code", failure.code)
+    end
+  end
+
+  defp attempt_failure({:error, {:dispatch_failed, reason}}, _terminal, _outcome) do
+    InferenceAttemptFailure.normalize(failure_source(reason))
+  end
+
+  defp attempt_failure(_result, _terminal, _outcome),
+    do: InferenceAttemptFailure.normalize(%{category: :controller, code: :internal_error})
+
+  defp failure_source(reason) when reason in [:dispatch_timeout, :request_timeout],
+    do: %{category: :deadline, code: :request_timeout}
+
+  defp failure_source(reason) when reason in [:caller_disconnect, :request_caller_disconnect],
+    do: %{category: :cancellation, code: :request_caller_disconnect}
+
+  defp failure_source(code)
+       when code in ["deadline_exceeded", "request_timeout", "request_timed_out", "timed_out"],
+       do: %{category: :deadline, code: code}
+
+  defp failure_source(code)
+       when code in [
+              "cancelled",
+              "request_cancelled",
+              "request_caller_disconnect",
+              "request_client_disconnect"
+            ],
+       do: %{category: :cancellation, code: code}
+
+  defp failure_source(code)
+       when code in [
+              "runtime_endpoint_missing_terminal",
+              "runtime_endpoint_duplicate_terminal",
+              "runtime_endpoint_post_terminal_event"
+            ],
+       do: %{category: :terminal_conformance, code: code}
+
+  defp failure_source(reason)
+       when reason in [
+              :dispatch_capacity_unavailable,
+              :dispatch_capacity_facts_unavailable,
+              :dispatch_capacity_request_already_claimed,
+              :dispatch_capacity_revalidation_failed,
+              :dispatch_capacity_acceptance_gate_busy,
+              :dispatch_capacity_node_identity_mismatch,
+              :dispatch_capacity_quarantine_store_unavailable
+            ],
+       do: %{category: :capacity, code: reason}
+
+  defp failure_source(reason), do: %{category: :runtime, code: reason}
+
+  defp execution_resolution({:ok, _events}, %InferenceEvent{}), do: :terminated
+  defp execution_resolution(_result, _terminal), do: :not_started
+
+  defp trusted_node_id(schedule) do
+    case Map.get(schedule, :node_id) do
+      node_id when is_binary(node_id) ->
+        if match?({:ok, _uuid}, Ecto.UUID.cast(node_id)), do: node_id, else: nil
+
+      _node_id ->
+        nil
+    end
+  end
+
   defp dispatch_with_capacity_claim(%{schedule: schedule} = context) do
     if deadline_expired?(context) do
-      dispatch_timeout_result(context)
+      {dispatch_timeout_result(context), :not_applicable}
     else
       dispatch_with_live_capacity_claim(context, schedule)
     end
@@ -315,23 +489,40 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp dispatch_with_live_capacity_claim(context, schedule) do
     case acquire_capacity_claim(schedule) do
       {:ok, nil} ->
-        dispatch_after_preensure_gate(context)
+        result = dispatch_after_preensure_gate(context)
+        {result, effective_release_from_result(result, :not_applicable)}
 
       {:ok, claim} ->
         try do
-          dispatch_after_preensure_gate(Map.put(context, :capacity_claim, claim))
+          result = dispatch_after_preensure_gate(Map.put(context, :capacity_claim, claim))
+
+          release_outcome =
+            effective_release_from_result(result, release_capacity_claim(schedule, claim))
+
+          {result, release_outcome}
         after
-          release_capacity_claim(schedule, claim)
+          _defensive_release = release_capacity_claim(schedule, claim)
         end
 
       {:error, reason} ->
-        handle_dispatch_result(
-          {:error, {:dispatch_failed, reason}},
-          context.metrics,
-          context.target
-        )
+        result =
+          handle_dispatch_result(
+            {:error, {:dispatch_failed, reason}},
+            context.metrics,
+            context.target
+          )
+
+        {result, :not_applicable}
     end
   end
+
+  defp effective_release_from_result(
+         {:attempt_evidence, _result, execution_resolution, safety_state},
+         release_outcome
+       ),
+       do: effective_release_outcome(release_outcome, execution_resolution, safety_state)
+
+  defp effective_release_from_result(_result, release_outcome), do: release_outcome
 
   defp acquire_capacity_claim(
          %{
@@ -478,14 +669,44 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp dispatch_with_channel(%{client: client, channel: channel} = context) do
-    Process.delete(@pending_cancel_reconciliation_key)
+    dispatch_result =
+      try do
+        {:ok, do_dispatch_with_channel(context)}
+      catch
+        kind, reason -> {:raised, kind, reason, __STACKTRACE__}
+      end
 
-    try do
-      do_dispatch_with_channel(context)
-    after
-      disconnect_result = disconnect_best_effort(client, channel)
-      finalize_pending_cancel_reconciliation(disconnect_result)
+    disconnect_result = disconnect_best_effort(client, channel)
+
+    case dispatch_result do
+      {:ok, result} ->
+        resolve_cancel_reconciliation(result, disconnect_result)
+
+      {:raised, kind, reason, stacktrace} ->
+        :erlang.raise(kind, reason, stacktrace)
     end
+  end
+
+  defp resolve_cancel_reconciliation(
+         {:cancel_reconciliation, result, authority, node_id, failure_result},
+         disconnect_result
+       ) do
+    if disconnect_result == :ok or durable_reconciliation_confirmed?(failure_result, node_id) do
+      {:attempt_evidence, result, :terminated, :available}
+    else
+      {:attempt_evidence, result, :unresolved, quarantine_safety_state(authority, node_id)}
+    end
+  end
+
+  defp resolve_cancel_reconciliation(result, _disconnect_result), do: result
+
+  defp quarantine_safety_state(authority, node_id) do
+    case AllocationAuthority.quarantine_node(authority, node_id) do
+      :ok -> :available
+      {:error, _reason} -> :unavailable
+    end
+  catch
+    :exit, _reason -> :unavailable
   end
 
   defp disconnect_best_effort(client, channel) do
@@ -735,7 +956,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
             caller_ref: context.caller_ref,
             cancel_drain_timeout_ms: context.cancel_drain_timeout_ms,
             capacity_authority: capacity_authority(context.schedule),
-            capacity_node_id: Map.get(context.schedule, :node_id),
+            capacity_node_id: metrics.node_id,
             channel: context.channel,
             client: context.client,
             event_handler: context.event_handler,
@@ -848,11 +1069,29 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     QueueManager.release_acceptance_gate(lease, opts)
   end
 
+  defp handle_dispatch_result(
+         {:attempt_evidence, result, execution_resolution, safety_state},
+         metrics,
+         target
+       ) do
+    normalized_result = handle_dispatch_result(result, metrics, target)
+    {:attempt_evidence, normalized_result, execution_resolution, safety_state}
+  end
+
+  defp handle_dispatch_result(
+         {:cancel_reconciliation, result, authority, node_id, failure_result},
+         metrics,
+         target
+       ) do
+    normalized_result = handle_dispatch_result(result, metrics, target)
+    {:cancel_reconciliation, normalized_result, authority, node_id, failure_result}
+  end
+
   defp handle_dispatch_result({:ok, events, final_metrics}, _metrics, target) do
     final_metrics = finalize_metrics(final_metrics, :ok)
     put_dispatch_terminal_context(final_metrics, target)
     emit_timing_log(final_metrics, :ok)
-    {:ok, events}
+    {:attempt_timing, {:ok, events}, final_metrics.first_token_at}
   end
 
   defp handle_dispatch_result({:error, reason}, metrics, target) do
@@ -1142,28 +1381,34 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       else
         case client.execute_inference(channel, execute_request, owner: self()) do
           {:ok, task_ref} ->
-            receive_loop(
-              %{
-                caller_ref: caller_ref,
-                channel: channel,
-                client: client,
-                controller_session_id: execute_request.controller_session_id,
-                event_handler: event_handler,
-                accepted?: false,
-                acceptance_gate: acceptance_gate,
-                cancel_drain_timeout_ms: cancel_drain_timeout_ms,
-                capacity_authority: capacity_authority,
-                capacity_node_id: capacity_node_id,
-                cancellation_started_before_acceptance?: false,
-                conformance_defect: :none,
-                metrics: metrics,
-                target: target,
-                task_ref: task_ref,
-                terminal_event: nil,
-                timer_ref: timer_ref
-              },
-              []
-            )
+            result =
+              receive_loop(
+                %{
+                  caller_ref: caller_ref,
+                  channel: channel,
+                  client: client,
+                  controller_session_id: execute_request.controller_session_id,
+                  event_handler: event_handler,
+                  accepted?: false,
+                  acceptance_gate: acceptance_gate,
+                  cancel_drain_timeout_ms: cancel_drain_timeout_ms,
+                  capacity_authority: capacity_authority,
+                  capacity_node_id: capacity_node_id,
+                  cancellation_started_before_acceptance?: false,
+                  conformance_defect: :none,
+                  metrics: metrics,
+                  target: target,
+                  task_ref: task_ref,
+                  terminal_event: nil,
+                  timer_ref: timer_ref
+                },
+                []
+              )
+
+            case result do
+              {:cancel_reconciliation, _result, _authority, _node_id, _failure_result} -> result
+              _resolved -> {:attempt_evidence, result, :terminated, :available}
+            end
 
           {:error, reason} ->
             {:error, {:dispatch_failed, reason}}
@@ -1485,6 +1730,14 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     synthesize_terminal_contract_failure(loop_ctx, events, loop_ctx.metrics, defect)
   end
 
+  defp drain_done_result(loop_ctx, events, cancel_reason)
+       when cancel_reason in [:timeout, :caller_disconnect, :client_disconnect] do
+    normalized_reason =
+      if cancel_reason == :timeout, do: :timeout, else: :caller_disconnect
+
+    synthesize_cancel_terminal(loop_ctx, events, normalized_reason, "")
+  end
+
   defp drain_done_result(
          %{terminal_event: %InferenceEvent{} = terminal_event} = loop_ctx,
          events,
@@ -1505,12 +1758,16 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     do: synthesize_cancel_terminal(loop_ctx, events, cancel_reason, "")
 
   defp cancel_drain_timeout_result(loop_ctx, events, cancel_reason) do
-    reconcile_cancel_drain_timeout(loop_ctx)
+    result =
+      case loop_ctx.conformance_defect do
+        :none ->
+          synthesize_cancel_terminal(loop_ctx, events, cancel_reason, " after drain timeout")
 
-    case loop_ctx.conformance_defect do
-      :none -> synthesize_cancel_terminal(loop_ctx, events, cancel_reason, " after drain timeout")
-      defect -> synthesize_terminal_contract_failure(loop_ctx, events, loop_ctx.metrics, defect)
-    end
+        defect ->
+          synthesize_terminal_contract_failure(loop_ctx, events, loop_ctx.metrics, defect)
+      end
+
+    reconcile_cancel_drain_timeout(loop_ctx, result)
   end
 
   defp synthesize_cancel_terminal(loop_ctx, events, cancel_reason, message_suffix) do
@@ -1535,32 +1792,16 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     stream_terminal_result(loop_ctx, [timeout_event | events], metrics, cancel_reason)
   end
 
-  defp reconcile_cancel_drain_timeout(%{
-         capacity_authority: authority,
-         capacity_node_id: node_id,
-         client: client,
-         channel: channel,
-         target: target
-       }) do
-    disconnect_result = disconnect_best_effort(client, channel)
+  defp reconcile_cancel_drain_timeout(
+         %{
+           capacity_authority: authority,
+           capacity_node_id: node_id,
+           target: target
+         },
+         result
+       ) do
     failure_result = mark_transport_failure(target, :node_timeout)
-
-    unless disconnect_result == :ok or
-             durable_reconciliation_confirmed?(failure_result, node_id) do
-      Process.put(@pending_cancel_reconciliation_key, {authority, node_id})
-    end
-
-    :ok
-  end
-
-  defp finalize_pending_cancel_reconciliation(disconnect_result) do
-    case Process.delete(@pending_cancel_reconciliation_key) do
-      {authority, node_id} when disconnect_result != :ok ->
-        AllocationAuthority.quarantine_node(authority, node_id)
-
-      _reconciled_or_not_pending ->
-        :ok
-    end
+    {:cancel_reconciliation, result, authority, node_id, failure_result}
   end
 
   defp durable_reconciliation_confirmed?(
@@ -1845,7 +2086,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
        )
        when delta != "" do
     now_ms = System.monotonic_time(:millisecond)
-    metrics = %{metrics | first_delta_monotonic_ms: now_ms}
+    first_token_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    metrics = %{metrics | first_delta_monotonic_ms: now_ms, first_token_at: first_token_at}
 
     metrics =
       case metrics.accepted_monotonic_ms do

--- a/apps/orchard_controller/lib/orchard/dispatch_capacity/allocation_authority.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch_capacity/allocation_authority.ex
@@ -21,12 +21,21 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
   defmodule Claim do
     @moduledoc "Opaque ownership proof for one live Node capacity claim."
 
-    @enforce_keys [:token, :node_id, :request_id, :kind, :owner, :monitor_ref]
+    @enforce_keys [
+      :token,
+      :authority_incarnation,
+      :node_id,
+      :request_id,
+      :kind,
+      :owner,
+      :monitor_ref
+    ]
     defstruct @enforce_keys
 
     @type kind :: :f11 | :legacy
     @type t :: %__MODULE__{
             token: reference(),
+            authority_incarnation: reference(),
             node_id: Ecto.UUID.t(),
             request_id: String.t(),
             kind: kind(),
@@ -64,6 +73,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
           | {:error, :dispatch_capacity_request_already_claimed, Evaluator.Result.t()}
 
   @type quarantine_error :: :dispatch_capacity_quarantine_store_unavailable
+  @type release_outcome :: :released | :already_released | :unresolved
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
@@ -86,15 +96,15 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
     GenServer.call(server, {:acquire, node_id, request_id, input})
   end
 
-  @doc "Releases a claim idempotently."
-  @spec release(Claim.t()) :: :ok
+  @doc "Releases a claim idempotently and reports whether ownership was resolved."
+  @spec release(Claim.t()) :: release_outcome()
   def release(%Claim{} = claim), do: release(__MODULE__, claim)
 
-  @spec release(GenServer.server(), Claim.t()) :: :ok
+  @spec release(GenServer.server(), Claim.t()) :: release_outcome()
   def release(server, %Claim{} = claim) do
-    GenServer.call(server, {:release, claim.token})
+    GenServer.call(server, {:release, claim})
   catch
-    :exit, _reason -> :ok
+    :exit, _reason -> :unresolved
   end
 
   @doc """
@@ -399,6 +409,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
   @impl true
   def init(%{quarantine_store: quarantine_store}) do
     base = %{
+      authority_incarnation: make_ref(),
       claims: %{},
       claim_counts: %{},
       request_claims: %{},
@@ -441,6 +452,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
 
           claim = %Claim{
             token: make_ref(),
+            authority_incarnation: state.authority_incarnation,
             node_id: node_id,
             request_id: request_id,
             kind: kind,
@@ -468,8 +480,9 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
     end
   end
 
-  def handle_call({:release, token}, _from, state) do
-    {:reply, :ok, remove_claim(state, token)}
+  def handle_call({:release, %Claim{} = claim}, _from, state) do
+    {outcome, state} = release_claim(state, claim)
+    {:reply, outcome, state}
   end
 
   def handle_call({:quarantine_node, node_id}, _from, state) when is_binary(node_id) do
@@ -722,6 +735,23 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
 
   defp apply_claim_delta({f11, legacy}, :f11, delta), do: {f11 + delta, legacy}
   defp apply_claim_delta({f11, legacy}, :legacy, delta), do: {f11, legacy + delta}
+
+  defp release_claim(%{quarantine_store_available?: false} = state, %Claim{}) do
+    {:unresolved, state}
+  end
+
+  defp release_claim(state, %Claim{authority_incarnation: incarnation})
+       when incarnation != state.authority_incarnation do
+    {:unresolved, state}
+  end
+
+  defp release_claim(state, %Claim{} = claim) do
+    case Map.get(state.claims, claim.token) do
+      ^claim -> {:released, remove_claim(state, claim.token)}
+      nil -> {:already_released, state}
+      _conflicting_claim -> {:unresolved, state}
+    end
+  end
 
   defp remove_claim(state, token) do
     case Map.pop(state.claims, token) do

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -127,7 +127,7 @@ defmodule Orchard.Inference.ChatError do
     do: build(:request_timed_out, source_code: "request_timeout")
 
   def from_execute_error({:dispatch_failed, :request_caller_disconnect}),
-    do: build(:request_interrupted, source_code: "request_caller_disconnect")
+    do: build(:request_cancelled, source_code: "request_caller_disconnect")
 
   def from_execute_error(reason), do: build(:internal, detail: reason)
 
@@ -301,6 +301,21 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def api_mapping(%__MODULE__{
+        kind: :request_cancelled,
+        source_code: source_code,
+        source_message: message
+      })
+      when source_code in ["request_client_disconnect", "request_caller_disconnect"] do
+    %{
+      status: :internal_server_error,
+      type: "server_error",
+      code: "internal_error",
+      message: "Inference failed: #{message}",
+      param: nil
+    }
+  end
+
   def api_mapping(%__MODULE__{kind: :request_cancelled}) do
     %{
       status: :internal_server_error,
@@ -467,6 +482,21 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def terminal_attrs(
+        %__MODULE__{
+          kind: :request_cancelled,
+          source_code: source_code
+        } = error
+      )
+      when source_code in ["request_client_disconnect", "request_caller_disconnect"] do
+    %{
+      state: :cancelled,
+      http_status: 499,
+      error_code: "request_caller_disconnect",
+      error_message: error.source_message || "Caller disconnected"
+    }
+  end
+
   def terminal_attrs(%__MODULE__{kind: :request_cancelled} = error) do
     %{
       state: :cancelled,
@@ -549,7 +579,7 @@ defmodule Orchard.Inference.ChatError do
 
   defp failed_event_kind(code)
        when code in ["request_client_disconnect", "request_caller_disconnect"],
-       do: :request_interrupted
+       do: :request_cancelled
 
   defp failed_event_kind(code)
        when code in [

--- a/apps/orchard_controller/lib/orchard/inference/model_load_failure.ex
+++ b/apps/orchard_controller/lib/orchard/inference/model_load_failure.ex
@@ -82,6 +82,36 @@ defmodule Orchard.Inference.ModelLoadFailure do
   end
 
   @doc """
+  Rebuilds the Controller-owned public model-load failure for a normalized
+  attempt failure category.
+
+  Attempt evidence deliberately stores the stable category default rather than
+  trusting a Runtime Endpoint failure code or message to control public output.
+  """
+  @spec from_category(category() | String.t()) :: t()
+  def from_category("model_invalid"), do: from_category(:model_invalid)
+  def from_category("acquisition_failed"), do: from_category(:acquisition_failed)
+  def from_category("runtime_unavailable"), do: from_category(:runtime_unavailable)
+  def from_category("timeout"), do: from_category(:timeout)
+  def from_category("resource_exhausted"), do: from_category(:resource_exhausted)
+  def from_category("internal_error"), do: from_category(:internal)
+
+  def from_category(category)
+      when category in [
+             :model_invalid,
+             :acquisition_failed,
+             :runtime_unavailable,
+             :timeout,
+             :resource_exhausted,
+             :internal
+           ] do
+    {code, message} = defaults_for_category(category)
+    %__MODULE__{category: category, code: code, message: message}
+  end
+
+  def from_category(_category), do: from_category(:internal)
+
+  @doc """
   Converts a transport-level error reason into a failure struct.
 
   Accepts normalized error shapes from Runtime Endpoint clients.

--- a/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
+++ b/apps/orchard_controller/lib/orchard/inference/queue_manager.ex
@@ -50,10 +50,14 @@ defmodule Orchard.Inference.QueueManager do
 
   @doc "Releases one live Node capacity claim idempotently."
   @spec release_dispatch_capacity(
-          AllocationAuthority.Claim.t(),
+          AllocationAuthority.Claim.t() | nil,
           keyword()
-        ) :: :ok
-  def release_dispatch_capacity(claim, opts \\ []) do
+        ) :: AllocationAuthority.release_outcome() | :not_applicable
+  def release_dispatch_capacity(claim, opts \\ [])
+
+  def release_dispatch_capacity(nil, _opts), do: :not_applicable
+
+  def release_dispatch_capacity(%AllocationAuthority.Claim{} = claim, opts) do
     authority = Keyword.get(opts, :authority, AllocationAuthority)
     AllocationAuthority.release(authority, claim)
   end

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -9,7 +9,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   alias Orchard.CanonicalRequest
   alias Orchard.Cluster.V1.{EnsureModelLoadedRequest, ExecuteInferenceRequest, GenerationParams}
-  alias Orchard.Dispatch.RequestDispatcher
+  alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.DomainMetrics
   alias Orchard.Inference
 
@@ -17,6 +17,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
     CacheAffinity,
     CanonicalRequestSerializer,
     ChatError,
+    ModelLoadFailure,
     QueueManager,
     RequestDeadline,
     ToolCallAccumulator,
@@ -27,11 +28,16 @@ defmodule Orchard.Inference.RequestOrchestrator do
   alias Orchard.Governance
   alias Orchard.InferenceEvent
   alias Orchard.Requests
-  alias Orchard.Requests.CapturePolicy
-  alias Orchard.Requests.Idempotency
-  alias Orchard.Requests.Request
-  alias Orchard.Requests.RequestServer
-  alias Orchard.Requests.RequestStepEvent
+
+  alias Orchard.Requests.{
+    CapturePolicy,
+    Idempotency,
+    InferenceAttemptResult,
+    Request,
+    RequestServer,
+    RequestStepEvent
+  }
+
   alias Orchard.Runtime.{MemoryBudget, PrefixCacheScore, PrefixCacheStatus}
   alias Orchard.SentryContext
 
@@ -619,15 +625,19 @@ defmodule Orchard.Inference.RequestOrchestrator do
            execution_opts.event_handler,
            Map.get(execution_opts, :queue_grant)
          ) do
-      {:ok, events, first_token_at} ->
-        finalize_started_inference_turn(
-          db_request,
-          canonical,
-          events,
-          first_token_at,
-          execution_opts,
-          step_context
-        )
+      %AttemptOutcome{events: events} = outcome ->
+        if Enum.any?(events, &InferenceEvent.terminal?/1) do
+          finalize_started_inference_turn(
+            db_request,
+            canonical,
+            outcome,
+            execution_opts,
+            step_context
+          )
+        else
+          {:error, public_dispatch_reason(outcome),
+           Map.put(step_context, :attempt_outcome, outcome)}
+        end
 
       {:error, reason} ->
         {:error, reason, step_context}
@@ -637,12 +647,11 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp finalize_started_inference_turn(
          db_request,
          canonical,
-         events,
-         first_token_at,
+         %AttemptOutcome{} = outcome,
          execution_opts,
          step_context
        ) do
-    case finalize(db_request, canonical, events, first_token_at, execution_opts, step_context) do
+    case finalize(db_request, canonical, outcome, execution_opts, step_context) do
       {:ok, _, _} = success -> success
       {:error, reason} -> {:error, reason, step_context}
     end
@@ -1014,36 +1023,19 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp dispatch(db_request, canonical, model, schedule, caller, event_handler, queue_grant) do
     execute_request = build_execute_request(canonical, schedule)
     model_load_request = build_model_load_request(model, schedule)
-    capture_key = make_ref()
+    wrapped_handler = wrap_event_handler(event_handler, queue_grant)
 
-    try do
-      Process.put(capture_key, nil)
+    maybe_mark_grant_node(queue_grant, map_value(schedule, :node_id), promote?: false)
 
-      wrapped_handler =
-        wrap_event_handler_for_first_token(event_handler, capture_key, queue_grant)
-
-      maybe_mark_grant_node(queue_grant, map_value(schedule, :node_id), promote?: false)
-
-      result =
-        dispatch_request(
-          schedule,
-          execute_request,
-          model_load_request,
-          caller,
-          wrapped_handler,
-          db_request.id,
-          queue_grant
-        )
-
-      first_token_at = Process.get(capture_key)
-
-      case result do
-        {:ok, events} -> {:ok, events, first_token_at}
-        {:error, _} = error -> error
-      end
-    after
-      Process.delete(capture_key)
-    end
+    dispatch_request(
+      schedule,
+      execute_request,
+      model_load_request,
+      caller,
+      wrapped_handler,
+      db_request.id,
+      queue_grant
+    )
   end
 
   defp dispatch_request(
@@ -1064,7 +1056,6 @@ defmodule Orchard.Inference.RequestOrchestrator do
     dispatch = &RequestDispatcher.dispatch/4
 
     dispatch.(schedule, execute_request, model_load_request, opts)
-    |> normalize_dispatch_result()
   rescue
     error ->
       log_warn("dispatch crashed: #{exception_name(error)}")
@@ -1079,19 +1070,32 @@ defmodule Orchard.Inference.RequestOrchestrator do
       {:error, orchestration_crash(:dispatch, :throw)}
   end
 
-  defp normalize_dispatch_result({:ok, _events} = success), do: success
+  defp public_dispatch_reason(%AttemptOutcome{
+         failure: %{
+           "failure_class" => "model_load_failure",
+           "failure_code" => failure_code
+         }
+       }) do
+    {:model_load_failed, ModelLoadFailure.from_category(failure_code)}
+  end
 
-  defp normalize_dispatch_result({:error, {:dispatch_failed, :dispatch_timeout}}),
-    do: {:error, {:dispatch_failed, :request_timeout}}
+  defp public_dispatch_reason(%AttemptOutcome{
+         attempt_outcome: :timed_out,
+         failure: %{"failure_code" => "request_timeout"}
+       }),
+       do: {:dispatch_failed, :request_timeout}
 
-  defp normalize_dispatch_result({:error, _reason} = error), do: error
+  defp public_dispatch_reason(%AttemptOutcome{
+         attempt_outcome: :cancelled,
+         failure: %{"failure_code" => "request_caller_disconnect"}
+       }),
+       do: {:dispatch_failed, :request_caller_disconnect}
 
-  defp normalize_dispatch_result(_other),
-    do: {:error, orchestration_crash(:dispatch, :invalid_return)}
+  defp public_dispatch_reason(%AttemptOutcome{failure: %{"failure_code" => failure_code}}),
+    do: {:dispatch_failed, failure_code}
 
-  defp wrap_event_handler_for_first_token(downstream_handler, capture_key, queue_grant) do
+  defp wrap_event_handler(downstream_handler, queue_grant) do
     fn request_id, event ->
-      maybe_capture_first_token(event, capture_key)
       maybe_mark_capacity_source_observed(queue_grant, event)
 
       if downstream_handler do
@@ -1118,20 +1122,6 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp maybe_mark_capacity_source_observed(_grant, _event), do: :ok
-
-  defp maybe_capture_first_token(
-         %InferenceEvent{event: %InferenceEvent.OutputTextDelta{delta: delta}},
-         capture_key
-       )
-       when delta != "" do
-    if Process.get(capture_key) == nil do
-      Process.put(capture_key, DateTime.utc_now() |> DateTime.truncate(:microsecond))
-    end
-
-    :ok
-  end
-
-  defp maybe_capture_first_token(_event, _capture_key), do: :ok
 
   defp put_request_validated_context(canonical) do
     if SentryContext.controller_enabled?() do
@@ -1246,7 +1236,13 @@ defmodule Orchard.Inference.RequestOrchestrator do
       :ok
   end
 
-  defp finalize(db_request, canonical, events, first_token_at, execution_opts, step_context) do
+  defp finalize(
+         db_request,
+         canonical,
+         %AttemptOutcome{events: events, first_token_at: first_token_at} = outcome,
+         execution_opts,
+         step_context
+       ) do
     case build_terminal_attrs(
            canonical,
            events,
@@ -1259,7 +1255,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
           canonical,
           events,
           terminal_attrs,
-          step_context,
+          Map.put(step_context, :attempt_outcome, outcome),
           execution_opts.step_event_appender,
           execution_opts.terminal_persister
         )
@@ -1477,15 +1473,24 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp terminal_inference_turn_step(events, terminal_attrs, step_context) do
+    event_type = RequestStepEvent.terminal_step_event_type!(terminal_attrs.state)
+
     %{
-      event_type: RequestStepEvent.terminal_step_event_type!(terminal_attrs.state),
+      event_type: event_type,
       step_id: step_context.step_id,
       step_type: "inference_turn",
       turn_index: step_context.turn_index,
       attempt: step_context.attempt,
       parent_step_id: nil,
       boundary: "post_observation",
-      result: terminal_step_result(events, terminal_attrs),
+      result:
+        terminal_step_result(
+          events,
+          terminal_attrs,
+          Map.get(step_context, :attempt_outcome),
+          event_type,
+          step_context.attempt
+        ),
       model_id: step_context.model_id,
       model_version: step_context.model_version
     }
@@ -1537,15 +1542,75 @@ defmodule Orchard.Inference.RequestOrchestrator do
     }
   end
 
-  defp terminal_step_result(events, terminal_attrs) do
+  defp terminal_step_result(events, terminal_attrs, nil, _event_type, _attempt) do
+    events
+    |> legacy_terminal_step_result(terminal_attrs)
+    |> maybe_put_result("error_code", Map.get(terminal_attrs, :error_code))
+  end
+
+  defp terminal_step_result(
+         events,
+         terminal_attrs,
+         %AttemptOutcome{} = outcome,
+         event_type,
+         attempt
+       ) do
+    result =
+      outcome
+      |> attempt_result_fields()
+      |> Map.merge(legacy_terminal_step_result(events, terminal_attrs))
+
+    {:ok, normalized} = InferenceAttemptResult.new(event_type, attempt, result)
+    normalized
+  end
+
+  defp legacy_terminal_step_result(events, terminal_attrs) do
     %{}
     |> maybe_put_result("finish_reason", terminal_finish_reason(events))
     |> maybe_put_result("input_tokens", Map.get(terminal_attrs, :input_tokens))
     |> maybe_put_result("output_tokens", Map.get(terminal_attrs, :output_tokens))
-    |> maybe_put_result("error_code", Map.get(terminal_attrs, :error_code))
     |> maybe_put_result("error_message", Map.get(terminal_attrs, :error_message))
     |> maybe_put_result("http_status", Map.get(terminal_attrs, :http_status))
   end
+
+  defp attempt_result_fields(%AttemptOutcome{} = outcome) do
+    base = %{
+      "attempt_outcome" => Atom.to_string(outcome.attempt_outcome),
+      "started_at" => outcome.started_at,
+      "ended_at" => outcome.ended_at,
+      "accepted" => outcome.accepted,
+      "output_committed" => false,
+      "execution_resolution" => Atom.to_string(outcome.execution_resolution),
+      "capacity_release_outcome" => Atom.to_string(outcome.capacity_release_outcome),
+      "excluded_node_ids" => []
+    }
+
+    base
+    |> maybe_put_result("node_id", outcome.node_id)
+    |> put_attempt_failure(outcome)
+  end
+
+  defp put_attempt_failure(result, %AttemptOutcome{attempt_outcome: :completed}), do: result
+
+  defp put_attempt_failure(result, %AttemptOutcome{failure: failure} = outcome) do
+    result
+    |> Map.merge(failure)
+    |> Map.put("retry_decision", attempt_retry_decision(outcome))
+  end
+
+  defp attempt_retry_decision(%AttemptOutcome{attempt_outcome: :cancelled}), do: "cancelled"
+
+  defp attempt_retry_decision(%AttemptOutcome{
+         failure: %{"failure_class" => "identity_unresolved"}
+       }),
+       do: "identity_unresolved"
+
+  defp attempt_retry_decision(%AttemptOutcome{
+         failure: %{"failure_class" => "occupancy_unresolved"}
+       }),
+       do: "occupancy_unresolved"
+
+  defp attempt_retry_decision(%AttemptOutcome{}), do: "not_retryable"
 
   defp terminal_finish_reason(events) do
     case Enum.find(events, &(InferenceEvent.kind(&1) == :completed)) do

--- a/apps/orchard_controller/test/application_test.exs
+++ b/apps/orchard_controller/test/application_test.exs
@@ -308,7 +308,7 @@ defmodule OrchardApplicationTest do
                ConformanceFixture.input()
              )
 
-    assert :ok =
+    assert :released =
              QueueManager.release_dispatch_capacity(clean_claim,
                authority: replacement_authority
              )

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -1481,7 +1481,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert conn.status == 503
       body = Jason.decode!(conn.resp_body)
       assert body["error"]["type"] == "server_error"
-      assert body["error"]["code"] != nil
+      assert body["error"]["code"] == "acquisition_failed"
       assert body["error"]["message"] != nil
 
       # Verify persisted request row has mapped terminal fields
@@ -1490,7 +1490,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert length(failed_requests) == 1
       [request] = failed_requests
       assert request.http_status == 503
-      assert request.error_code != nil
+      assert request.error_code == "acquisition_failed"
       assert request.error_message == nil
       assert request.canonical_request == nil
       assert request.request_shape["capture_mode"] == "metadata"
@@ -1542,7 +1542,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert length(error_events) == 1
       {:error, error_payload} = hd(error_events)
       assert error_payload["error"]["type"] == "server_error"
-      assert error_payload["error"]["code"] != nil
+      assert error_payload["error"]["code"] == "acquisition_failed"
       assert error_payload["error"]["message"] != nil
 
       # Must NOT emit [DONE] after error

--- a/apps/orchard_controller/test/orchard/dispatch/attempt_outcome_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/attempt_outcome_test.exs
@@ -1,0 +1,52 @@
+defmodule Orchard.Dispatch.AttemptOutcomeTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Dispatch.AttemptOutcome
+  alias Orchard.Requests.InferenceAttemptFailure
+
+  test "SPEC 3.7.1 validates narrow typed single-attempt evidence" do
+    started_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    ended_at = DateTime.add(started_at, 5, :millisecond)
+    first_token_at = DateTime.add(started_at, 2, :millisecond)
+    node_id = Ecto.UUID.generate()
+
+    failure =
+      InferenceAttemptFailure.normalize(%{
+        category: :runtime_failure,
+        code: :worker_down
+      })
+
+    assert {:ok, outcome} =
+             AttemptOutcome.new(%{
+               attempt_outcome: :failed,
+               node_id: node_id,
+               accepted: true,
+               events: [],
+               failure: failure,
+               execution_resolution: :terminated,
+               capacity_release_outcome: :released,
+               started_at: started_at,
+               ended_at: ended_at,
+               first_token_at: first_token_at
+             })
+
+    assert %AttemptOutcome{} = outcome
+    assert outcome.node_id == node_id
+    assert outcome.failure == failure
+    assert outcome.first_token_at == first_token_at
+
+    assert {:error, :invalid_attempt_outcome} =
+             AttemptOutcome.new(%{
+               attempt_outcome: :unknown,
+               node_id: nil,
+               accepted: false,
+               events: [],
+               failure: nil,
+               execution_resolution: :not_started,
+               capacity_release_outcome: :not_applicable,
+               started_at: started_at,
+               ended_at: ended_at,
+               first_token_at: nil
+             })
+  end
+end

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs
@@ -67,7 +67,7 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
   use Orchard.DataCase, async: false
 
   alias Orchard.Cluster.V1.{EnsureModelLoadedRequest, ExecuteInferenceRequest}
-  alias Orchard.Dispatch.RequestDispatcher
+  alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.Inference
   alias Orchard.RuntimeEndpoint.Operation
   alias Orchard.TestSupport.DispatchCapacityFixtures
@@ -85,7 +85,8 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: true)
 
     with_tokenizer_safe_mode(:on, fn ->
-      assert {:ok, _events} = dispatch("req-token-ids-on-capable")
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
+               dispatch("req-token-ids-on-capable")
     end)
 
     assert_receive {^attach_ref, [:orchard, :tokenizer, :prompt_token_ids_dispatched],
@@ -104,7 +105,8 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: true)
 
     with_tokenizer_safe_mode(:on, fn ->
-      assert {:ok, _events} = dispatch_without_prompt_token_ids("req-token-ids-on-empty-capable")
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
+               dispatch_without_prompt_token_ids("req-token-ids-on-empty-capable")
     end)
 
     refute_receive {^dispatched_ref, [:orchard, :tokenizer, :prompt_token_ids_dispatched], _, _}
@@ -117,7 +119,8 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: false)
 
     with_tokenizer_safe_mode(:on, fn ->
-      assert {:ok, _events} = dispatch("req-token-ids-on-legacy")
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
+               dispatch("req-token-ids-on-legacy")
     end)
 
     assert_receive {^attach_ref, [:orchard, :tokenizer, :unsafe_mode_active], %{count: 1},
@@ -134,7 +137,8 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: true)
 
     with_tokenizer_safe_mode(:off, fn ->
-      assert {:ok, _events} = dispatch("req-token-ids-off")
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
+               dispatch("req-token-ids-off")
     end)
 
     refute_receive {^dispatched_ref, [:orchard, :tokenizer, :prompt_token_ids_dispatched], _, _}
@@ -146,10 +150,16 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: false)
 
     with_tokenizer_safe_mode(:reject, fn ->
-      assert {:error, {:dispatch_failed, {:legacy_worker_no_capability, metadata}}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               events: [],
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "internal_error"
+               }
+             } =
                dispatch("req-token-ids-reject-legacy")
-
-      assert metadata.model_id == "test/model"
     end)
 
     refute_receive {:captured_execute_request, %Operation.ExecuteRequest{}}
@@ -159,11 +169,16 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: true)
 
     with_tokenizer_safe_mode(:reject, fn ->
-      assert {:error, {:dispatch_failed, {:missing_prompt_token_ids, metadata}}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               events: [],
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "internal_error"
+               }
+             } =
                dispatch_without_prompt_token_ids("req-token-ids-reject-missing")
-
-      assert metadata.reason == :missing_prompt_token_ids
-      assert metadata.model_id == "test/model"
     end)
 
     refute_receive {:captured_ensure_model_loaded_request, %Operation.EnsureModelLoadedRequest{}},
@@ -176,11 +191,16 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: true)
 
     with_tokenizer_safe_mode(:reject, fn ->
-      assert {:error, {:dispatch_failed, {:missing_prompt_token_ids, metadata}}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               events: [],
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "internal_error"
+               }
+             } =
                dispatch_without_prompt_token_ids("req-token-ids-reject-short-circuit")
-
-      assert metadata.reason == :missing_prompt_token_ids
-      assert metadata.model_id == "test/model"
     end)
 
     refute_receive :connect_called, 200
@@ -197,7 +217,8 @@ defmodule Orchard.Dispatch.DispatchCapabilityGateTest do
     configure_stub(worker_supports_prompt_token_ids: true)
 
     with_tokenizer_safe_mode(:reject, fn ->
-      assert {:ok, _events} = dispatch("req-token-ids-reject-capable")
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
+               dispatch("req-token-ids-reject-capable")
     end)
 
     assert_receive {^attach_ref, [:orchard, :tokenizer, :prompt_token_ids_dispatched],

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_parity_drift_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_parity_drift_test.exs
@@ -73,7 +73,7 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest do
   use Orchard.DataCase, async: false
 
   alias Orchard.Cluster.V1.{EnsureModelLoadedRequest, ExecuteInferenceRequest}
-  alias Orchard.Dispatch.RequestDispatcher
+  alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.Inference
   alias Orchard.InferenceEvent
   alias Orchard.RuntimeEndpoint.Operation
@@ -101,7 +101,16 @@ defmodule Orchard.Dispatch.DispatchParityDriftTest do
     attach_ref = attach_telemetry(@event)
 
     with_tokenizer_safe_mode(:on, fn ->
-      assert {:ok, events} = dispatch("req-parity-drift-stream")
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: true,
+               events: events,
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "internal_error",
+                 "raw_source_code" => "prompt_token_ids_length_mismatch"
+               }
+             } = dispatch("req-parity-drift-stream")
 
       assert Enum.any?(events, fn
                %InferenceEvent{

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -165,12 +165,12 @@ defmodule Orchard.Dispatch.DispatchTest do
     StatusResponse
   }
 
+  alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.Dispatch.GrpcNodeRuntimeClient, as: Client
-  alias Orchard.Dispatch.RequestDispatcher
   alias Orchard.DispatchCapacity.{AllocationAuthority, ConformanceFixture, Evaluator}
   alias Orchard.DispatchCapacity.Evaluator.Input
   alias Orchard.Inference
-  alias Orchard.Inference.ModelLoadFailure
+
   alias Orchard.InferenceEvent
   alias Orchard.Node
   alias Orchard.Node.ModelManager
@@ -309,7 +309,15 @@ defmodule Orchard.Dispatch.DispatchTest do
         |> Map.put(:node_id, target.node_id)
         |> put_capacity_input(ConformanceFixture.input())
 
-      assert {:error, {:dispatch_failed, :node_not_active}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "internal_error",
+                 "raw_source_code" => "node_not_active"
+               }
+             } =
                RequestDispatcher.dispatch(
                  schedule,
                  execute_request("req-admitted-dispatch-rejected"),
@@ -323,7 +331,8 @@ defmodule Orchard.Dispatch.DispatchTest do
       execute = execute_request("req-dispatch-e2e")
       model_load = model_load_request(bundle)
 
-      assert {:ok, events} = RequestDispatcher.dispatch(schedule, execute, model_load)
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true, events: events} =
+               RequestDispatcher.dispatch(schedule, execute, model_load)
 
       assert length(events) >= 3
       assert InferenceEvent.kind(hd(events)) == :accepted
@@ -347,7 +356,16 @@ defmodule Orchard.Dispatch.DispatchTest do
         send(self(), {:handler_event, received_request_id, event})
       end
 
-      assert {:ok, [accepted, failed]} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: true,
+               events: [accepted, failed],
+               failure: %{
+                 "failure_class" => "terminal_conformance",
+                 "failure_code" => "orchestration_error",
+                 "raw_source_code" => "runtime_endpoint_missing_terminal"
+               }
+             } =
                RequestDispatcher.dispatch(
                  build_schedule(request_id),
                  execute_request(request_id),
@@ -373,7 +391,16 @@ defmodule Orchard.Dispatch.DispatchTest do
         send(self(), {:handler_event, received_request_id, event})
       end
 
-      assert {:ok, [accepted, failed]} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: true,
+               events: [accepted, failed],
+               failure: %{
+                 "failure_class" => "terminal_conformance",
+                 "failure_code" => "orchestration_error",
+                 "raw_source_code" => "runtime_endpoint_duplicate_terminal"
+               }
+             } =
                RequestDispatcher.dispatch(
                  build_schedule(request_id),
                  execute_request(request_id),
@@ -400,7 +427,16 @@ defmodule Orchard.Dispatch.DispatchTest do
           send(self(), {:handler_event, received_request_id, event})
         end
 
-        assert {:ok, [accepted, failed]} =
+        assert %AttemptOutcome{
+                 attempt_outcome: :failed,
+                 accepted: true,
+                 events: [accepted, failed],
+                 failure: %{
+                   "failure_class" => "terminal_conformance",
+                   "failure_code" => "orchestration_error",
+                   "raw_source_code" => "runtime_endpoint_post_terminal_event"
+                 }
+               } =
                  RequestDispatcher.dispatch(
                    build_schedule(request_id),
                    execute_request(request_id),
@@ -423,7 +459,16 @@ defmodule Orchard.Dispatch.DispatchTest do
     } do
       request_id = "req-dispatch-post-terminal-error"
 
-      assert {:ok, [accepted, failed]} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: true,
+               events: [accepted, failed],
+               failure: %{
+                 "failure_class" => "terminal_conformance",
+                 "failure_code" => "orchestration_error",
+                 "raw_source_code" => "runtime_endpoint_post_terminal_event"
+               }
+             } =
                RequestDispatcher.dispatch(
                  build_schedule(request_id),
                  execute_request(request_id),
@@ -451,7 +496,15 @@ defmodule Orchard.Dispatch.DispatchTest do
       for {request_id, defect} <- defects do
         log =
           capture_log([level: :info], fn ->
-            assert {:ok, [_accepted, %InferenceEvent{event: %InferenceEvent.Failed{}}]} =
+            assert %AttemptOutcome{
+                     attempt_outcome: :failed,
+                     accepted: true,
+                     events: [_accepted, %InferenceEvent{event: %InferenceEvent.Failed{}}],
+                     failure: %{
+                       "failure_class" => "terminal_conformance",
+                       "failure_code" => "orchestration_error"
+                     }
+                   } =
                      RequestDispatcher.dispatch(
                        build_schedule(request_id),
                        execute_request(request_id),
@@ -474,7 +527,7 @@ defmodule Orchard.Dispatch.DispatchTest do
       execute = execute_request("req-dispatch-cleanup-raises")
       model_load = model_load_request(bundle)
 
-      assert {:ok, events} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true, events: events} =
                RequestDispatcher.dispatch(schedule, execute, model_load,
                  client_impl: Orchard.Dispatch.DispatchTest.DisconnectRaisingClient
                )
@@ -489,7 +542,9 @@ defmodule Orchard.Dispatch.DispatchTest do
       execute = execute_request("req-dispatch-sentry")
       model_load = model_load_request(bundle)
 
-      assert {:ok, events} = RequestDispatcher.dispatch(schedule, execute, model_load)
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true, events: events} =
+               RequestDispatcher.dispatch(schedule, execute, model_load)
+
       assert Enum.any?(events, &InferenceEvent.terminal?/1)
 
       context = sentry_context()
@@ -526,7 +581,7 @@ defmodule Orchard.Dispatch.DispatchTest do
         send(test_pid, {:handler_event, request_id, event})
       end
 
-      assert {:ok, events} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true, events: events} =
                RequestDispatcher.dispatch(schedule, execute, model_load, event_handler: handler)
 
       assert length(events) >= 3
@@ -545,7 +600,15 @@ defmodule Orchard.Dispatch.DispatchTest do
       execute = execute_request("req-dispatch-timeout")
       model_load = model_load_request(bundle)
 
-      assert {:error, {:dispatch_failed, :request_timeout}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :timed_out,
+               accepted: false,
+               events: [],
+               failure: %{
+                 "failure_class" => "deadline",
+                 "failure_code" => "request_timeout"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, execute, model_load,
                  client_impl: Orchard.Dispatch.DispatchTest.NeverAcceptClient
                )
@@ -592,7 +655,7 @@ defmodule Orchard.Dispatch.DispatchTest do
       Process.exit(caller, :kill)
 
       # Dispatch should complete with events
-      assert_receive {:dispatch_result, {:ok, events}}, 10_000
+      assert_receive {:dispatch_result, %AttemptOutcome{events: events}}, 10_000
       assert events != []
       terminal = List.last(events)
       assert InferenceEvent.terminal?(terminal)
@@ -634,12 +697,16 @@ defmodule Orchard.Dispatch.DispatchTest do
           version: "v1"
         }
 
-      assert {:error, {:model_load_failed, %ModelLoadFailure{} = failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "runtime_unavailable",
+                 "raw_source_code" => "node_unavailable"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, execute, model_load)
-
-      assert failure.category == :runtime_unavailable
-      assert failure.code == "node_unavailable"
-      assert failure.message == "node runtime is unavailable"
     end
 
     test "dispatch returns error when ensure-load placement state is not LOADED" do
@@ -662,20 +729,16 @@ defmodule Orchard.Dispatch.DispatchTest do
           version: "v1"
         }
 
-      assert {:error, {:model_load_failed, %ModelLoadFailure{} = failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "model_invalid",
+                 "raw_source_code" => "missing_artifact_sha256"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, execute, model_load)
-
-      assert failure.category in [
-               :model_invalid,
-               :acquisition_failed,
-               :runtime_unavailable,
-               :timeout,
-               :resource_exhausted,
-               :internal
-             ]
-
-      assert is_binary(failure.code) and failure.code != ""
-      assert is_binary(failure.message) and failure.message != ""
     end
   end
 

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -128,7 +128,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
     ExecuteInferenceRequest
   }
 
-  alias Orchard.Dispatch.RequestDispatcher
+  alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.DispatchCapacity.{ConformanceFixture, Policy}
   alias Orchard.Inference
   alias Orchard.Inference.QueueManager
@@ -348,7 +348,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
            }}
       })
 
-      assert {:ok, _events} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -359,7 +359,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
     test "dispatch succeeds and keeps original node_id", ctx do
       configure_stub(%{status: {:ok, old_agent_status()}})
 
-      assert {:ok, _events} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -372,7 +372,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       configure_stub(%{status: {:ok, old_agent_status()}})
       callback = fn node_id -> send(self(), {:node_resolved, node_id}) end
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client,
                  on_node_resolved: callback
@@ -386,7 +386,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
     test "dispatch succeeds and keeps original node_id", ctx do
       configure_stub(%{status: {:ok, full_status("not-a-uuid")}})
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -400,7 +400,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
     test "model_load receives discovered UUID", ctx do
       configure_stub(%{status: {:ok, full_status(@valid_uuid)}})
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -414,7 +414,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       enable_controller_sentry()
       configure_stub(%{status: {:ok, full_status(@valid_uuid)}})
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -434,7 +434,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       configure_stub(%{status: {:ok, full_status(@other_uuid)}})
       callback = fn node_id -> send(self(), {:node_resolved, node_id}) end
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client,
                  on_node_resolved: callback
@@ -457,7 +457,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
         exit({:noproc, {GenServer, :call, [:queue_manager, :mark, 5_000]}})
       end
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client,
                  on_node_resolved: callback
@@ -528,7 +528,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
         assert :ok = QueueManager.release(first_grant)
       end
 
-      assert {:ok, _events} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client,
                  on_node_resolved: callback
@@ -565,7 +565,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
            })}
       })
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -587,12 +587,19 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
 
       configure_stub(%{connect: {:error, {:rpc_exit, :nodedown}}})
 
-      assert {:error, {:model_load_failed, failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "runtime_unavailable",
+                 "raw_source_code" => "node_unavailable"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
 
-      assert failure.code == "node_unavailable"
       assert_received {:connect_called, ^beam_target}
       refute_received {:connect_called, ^legacy_target}
       refute_received {:ensure_model_loaded_called, _request}
@@ -612,12 +619,19 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
         ensure_model_loaded: {:error, :node_unavailable}
       })
 
-      assert {:error, {:model_load_failed, failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "runtime_unavailable",
+                 "raw_source_code" => "node_unavailable"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
 
-      assert failure.code == "node_unavailable"
       assert_received {:connect_called, ^beam_target}
       refute_received {:connect_called, ^legacy_target}
       assert_received {:ensure_model_loaded_called, _request}
@@ -637,7 +651,14 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
         execute: {:error, :node_timeout}
       })
 
-      assert {:error, {:dispatch_failed, :node_timeout}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "node_timeout"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -657,7 +678,15 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
 
       configure_stub(%{status: {:ok, full_status(@other_uuid)}})
 
-      assert {:error, {:dispatch_failed, :beam_node_identity_mismatch}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "internal_error",
+                 "raw_source_code" => "beam_node_identity_mismatch"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -672,7 +701,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       insert_target_node!(ctx.schedule.runtime_client_target)
       configure_stub(%{status: {:error, :node_timeout}})
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -694,7 +723,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       insert_target_node!(ctx.schedule.runtime_client_target, last_heartbeat_at: stale_hb)
       configure_stub(%{status: {:error, :node_timeout}})
 
-      assert {:ok, _} =
+      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -714,7 +743,15 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       insert_target_node!(ctx.schedule.runtime_client_target)
       configure_stub(%{status: {:error, :authenticated_observation_rejected}})
 
-      assert {:error, {:dispatch_failed, :authenticated_observation_rejected}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "internal_error",
+                 "raw_source_code" => "authenticated_observation_rejected"
+               }
+             } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -736,7 +773,15 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       configure_stub(%{execute: :accepted_until_cancel})
       schedule = %{ctx.schedule | request_timeout_ms: 100}
 
-      assert {:ok, events} =
+      assert %AttemptOutcome{
+               attempt_outcome: :timed_out,
+               accepted: true,
+               events: events,
+               failure: %{
+                 "failure_class" => "deadline",
+                 "failure_code" => "request_timeout"
+               }
+             } =
                RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -758,7 +803,15 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
         if Orchard.InferenceEvent.kind(event) == :accepted, do: :cancel, else: :ok
       end
 
-      assert {:ok, events} =
+      assert %AttemptOutcome{
+               attempt_outcome: :cancelled,
+               accepted: true,
+               events: events,
+               failure: %{
+                 "failure_class" => "cancellation",
+                 "failure_code" => "request_caller_disconnect"
+               }
+             } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client,
                  event_handler: handler
@@ -779,12 +832,18 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       insert_target_node!(ctx.schedule.runtime_client_target)
       configure_stub(%{connect: {:error, {:connect_failed, :econnrefused}}})
 
-      assert {:error, {:model_load_failed, failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "runtime_unavailable",
+                 "raw_source_code" => "node_unavailable"
+               }
+             } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
-
-      assert failure.code == "node_unavailable"
 
       marked =
         Repo.get_by!(Node,
@@ -800,12 +859,18 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       insert_target_node!(ctx.schedule.runtime_client_target)
       configure_stub(%{connect: {:error, :node_unavailable}})
 
-      assert {:error, {:model_load_failed, failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "runtime_unavailable",
+                 "raw_source_code" => "node_unavailable"
+               }
+             } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
-
-      assert failure.code == "node_unavailable"
 
       marked =
         Repo.get_by!(Node,
@@ -828,12 +893,18 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
 
       configure_stub(%{connect: {:error, {:connect_failed, :econnrefused}}})
 
-      assert {:error, {:model_load_failed, failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "runtime_unavailable",
+                 "raw_source_code" => "node_unavailable"
+               }
+             } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
-
-      assert failure.code == "node_unavailable"
 
       marked = Repo.get!(Node, node.id)
       assert marked.advertise_addr == "0.0.0.0"
@@ -844,12 +915,18 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       insert_target_node!(ctx.schedule.runtime_client_target)
       configure_stub(%{ensure_model_loaded: {:error, :node_unavailable}})
 
-      assert {:error, {:model_load_failed, failure}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "model_load_failure",
+                 "failure_code" => "runtime_unavailable",
+                 "raw_source_code" => "node_unavailable"
+               }
+             } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
-
-      assert failure.code == "node_unavailable"
 
       marked =
         Repo.get_by!(Node,
@@ -864,7 +941,14 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       insert_target_node!(ctx.schedule.runtime_client_target)
       configure_stub(%{execute: {:error, :node_timeout}})
 
-      assert {:error, {:dispatch_failed, :node_timeout}} =
+      assert %AttemptOutcome{
+               attempt_outcome: :failed,
+               accepted: false,
+               failure: %{
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "node_timeout"
+               }
+             } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                  client_impl: @stub_client
                )
@@ -911,7 +995,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
       Process.unregister(Orchard.Repo)
 
       try do
-        assert {:ok, _} =
+        assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
                  RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
                    client_impl: @stub_client
                  )

--- a/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs
@@ -152,7 +152,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
     StatusResponse
   }
 
-  alias Orchard.Dispatch.RequestDispatcher
+  alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.DispatchCapacity.Policy
   alias Orchard.ModelManifest
   alias Orchard.ModelManifest.{ChatTemplate, RuntimeRequirements, SafeTokenization, Tokenizer}
@@ -214,7 +214,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
     execute_request = execute_request(schedule.request_id)
     assert execute_request.request_id == schedule.request_id
 
-    assert {:ok, _events} =
+    assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
              RequestDispatcher.dispatch(
                schedule,
                execute_request,
@@ -277,7 +277,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
     execute_request = execute_request(schedule.request_id)
     assert execute_request.request_id == schedule.request_id
 
-    assert {:ok, _events} =
+    assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
              RequestDispatcher.dispatch(
                schedule,
                execute_request,
@@ -306,7 +306,7 @@ defmodule Orchard.Dispatch.SafeTokenizationSmokeTest do
       status_response(legacy_id, legacy_target, supports_prompt_token_ids: false)
     )
 
-    assert {:ok, _events} =
+    assert %AttemptOutcome{attempt_outcome: :completed, accepted: true} =
              RequestDispatcher.dispatch(
                single_node_schedule("req-legacy-only", legacy_target),
                execute_request("req-legacy-only"),

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs
@@ -13,6 +13,90 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
     assert Process.alive?(authority)
   end
 
+  test "SPEC 4.6.2 release reports one live transition and an idempotent duplicate" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = Ecto.UUID.generate()
+
+    assert {:ok, claim, _result} =
+             AllocationAuthority.acquire(
+               authority,
+               node_id,
+               "request-observable-release",
+               enforcing_input({:valid, 0, 4})
+             )
+
+    assert is_reference(claim.authority_incarnation)
+    assert :released = AllocationAuthority.release(authority, claim)
+    assert :already_released = AllocationAuthority.release(authority, claim)
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC 4.6.2 stale incarnation and conflicting same-token evidence are unresolved" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = Ecto.UUID.generate()
+
+    assert {:ok, claim, _result} =
+             AllocationAuthority.acquire(
+               authority,
+               node_id,
+               "request-opaque-release",
+               enforcing_input({:valid, 0, 4})
+             )
+
+    stale_claim = %{claim | authority_incarnation: make_ref()}
+    conflicting_claim = %{claim | request_id: "conflicting-request"}
+
+    assert :unresolved = AllocationAuthority.release(authority, stale_claim)
+    assert :unresolved = AllocationAuthority.release(authority, conflicting_claim)
+    assert AllocationAuthority.claim_count(authority, node_id) == 1
+    assert :released = AllocationAuthority.release(authority, claim)
+  end
+
+  test "SPEC 4.6.2 a dead authority makes release unresolved" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = Ecto.UUID.generate()
+
+    assert {:ok, claim, _result} =
+             AllocationAuthority.acquire(
+               authority,
+               node_id,
+               "request-dead-authority",
+               enforcing_input({:valid, 0, 4})
+             )
+
+    Process.unlink(authority)
+    monitor_ref = Process.monitor(authority)
+    Process.exit(authority, :kill)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^authority, :killed}
+    assert :unresolved = AllocationAuthority.release(authority, claim)
+  end
+
+  test "SPEC 4.6.2 owner death makes later release an affirmative duplicate" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = Ecto.UUID.generate()
+    parent = self()
+
+    {owner, owner_ref} =
+      spawn_monitor(fn ->
+        {:ok, claim, _result} =
+          AllocationAuthority.acquire(
+            authority,
+            node_id,
+            "request-owner-down",
+            enforcing_input({:valid, 0, 4})
+          )
+
+        send(parent, {:owner_claim, claim})
+        receive do: (:stop -> :ok)
+      end)
+
+    assert_receive {:owner_claim, claim}
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^owner_ref, :process, ^owner, :killed}
+    assert :already_released = AllocationAuthority.release(authority, claim)
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
   test "SPEC 4.5 local Node quarantine blocks replacement acquisition and revalidation" do
     authority = start_supervised!({AllocationAuthority, name: nil})
     node_id = Ecto.UUID.generate()
@@ -43,7 +127,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
              QueueManager.revalidate_dispatch_capacity(claim, input, authority: authority)
 
     refute revalidation.eligible?
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
   end
 
   test "SPEC 4.6.2 QueueManager shares one Node allocation bound across placements and lanes" do
@@ -88,7 +172,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
              :dispatch_headroom_exhausted
            ]
 
-    assert :ok = QueueManager.release_dispatch_capacity(first_claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(first_claim, authority: authority)
 
     assert {:ok, third_claim, available_again} =
              QueueManager.acquire_dispatch_capacity(
@@ -99,8 +183,8 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
              )
 
     assert available_again.controller_accounted_allocation == 1
-    assert :ok = QueueManager.release_dispatch_capacity(second_claim, authority: authority)
-    assert :ok = QueueManager.release_dispatch_capacity(third_claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(second_claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(third_claim, authority: authority)
   end
 
   test "SPEC 4.6.2 two F11 requests racing for the final unit allow one acquisition" do
@@ -141,7 +225,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
 
     Enum.each(results, fn
       {:ok, claim, _result} ->
-        assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+        assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
 
       {:error, :dispatch_capacity_unavailable, result} ->
         assert result.dispatch_headroom == 0
@@ -190,7 +274,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
         assert claim.kind == :legacy
         assert result.authority_decision == :legacy_pre_cutover
         assert result.dispatch_headroom == 0
-        assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+        assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
 
       {:error, :dispatch_capacity_unavailable, result} ->
         assert result.legacy_pre_cutover_available_slots == 0
@@ -222,7 +306,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
                authority: authority
              )
 
-    assert :ok = QueueManager.release_dispatch_capacity(first_claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(first_claim, authority: authority)
 
     assert {:ok, retry_claim, _result} =
              QueueManager.acquire_dispatch_capacity(
@@ -232,7 +316,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
                authority: authority
              )
 
-    assert :ok = QueueManager.release_dispatch_capacity(retry_claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(retry_claim, authority: authority)
   end
 
   test "SPEC 5.9 policy mutation linearizes before held-claim dispatch revalidation" do
@@ -297,7 +381,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
     assert result.controller_dispatch_ceiling == 0
     assert result.dispatch_headroom == 0
     assert :controller_dispatch_ceiling_zero in result.reason_codes
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
   end
 
   test "SPEC 4.5 unresolved execution quarantine cannot expire or be released without reconciliation" do
@@ -385,7 +469,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
                authority: replacement
              )
 
-    assert :ok = QueueManager.release_dispatch_capacity(other_claim, authority: replacement)
+    assert :released = QueueManager.release_dispatch_capacity(other_claim, authority: replacement)
   end
 
   test "SPEC 4.5 quarantine store loss keeps dispatch globally fail-closed" do
@@ -455,6 +539,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
 
     refute revalidation.eligible?
     assert :node_health_unhealthy in revalidation.reason_codes
+    assert :unresolved = QueueManager.release_dispatch_capacity(claim, authority: authority)
 
     assert {:error, :dispatch_capacity_unavailable, blocked} =
              QueueManager.acquire_dispatch_capacity(
@@ -686,7 +771,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
     stop_supervised!(AllocationAuthority)
 
     assert :ok = AllocationAuthority.release_acceptance_gate(authority, lease)
-    assert :ok = AllocationAuthority.release(authority, claim)
+    assert :unresolved = AllocationAuthority.release(authority, claim)
   end
 
   test "SPEC 5.9 bounded acceptance-gate waiters are granted in arrival order" do

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/five_consumer_conformance_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/five_consumer_conformance_test.exs
@@ -100,6 +100,6 @@ defmodule Orchard.DispatchCapacity.FiveConsumerConformanceTest do
     assert hd(results).legacy_pre_cutover_claim_count == 1
     assert hd(results).available_slots == 1
     assert hd(results).eligible?
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
   end
 end

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -318,6 +318,23 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.CancellableStreamC
           {:runtime_endpoint_event, task_ref, request.request_id, InferenceEvent.accepted(0)}
         )
 
+        if request.request_id == "request-accepted-handler-cancel" do
+          send(
+            owner,
+            {:runtime_endpoint_event, task_ref, request.request_id,
+             InferenceEvent.output_text_delta("")}
+          )
+
+          send(
+            owner,
+            {:runtime_endpoint_event, task_ref, request.request_id,
+             InferenceEvent.tool_call_delta("call-before-text", "{}")}
+          )
+
+          send(test_pid, {:pre_text_events_sent, self()})
+          receive do: (:emit_first_text -> :ok)
+        end
+
         send(
           owner,
           {:runtime_endpoint_event, task_ref, request.request_id,
@@ -745,13 +762,46 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.CompatibilitySingl
   defdelegate cancel_inference(channel, request, opts), to: GateClient
 end
 
+defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.RaisingAfterConnectClient do
+  @moduledoc false
+
+  alias Orchard.DispatchCapacity.RequestDispatcherClaimTest.GateClient
+  alias Orchard.RuntimeEndpoint.Operation
+
+  def configure(test_pid), do: :persistent_term.put({__MODULE__, :test_pid}, test_pid)
+
+  def configure_handler(handler),
+    do: :persistent_term.put({__MODULE__, :raising_handler}, handler)
+
+  def clear do
+    :persistent_term.erase({__MODULE__, :test_pid})
+    :persistent_term.erase({__MODULE__, :raising_handler})
+  end
+
+  defdelegate connect(target), to: GateClient
+  defdelegate status(channel, opts), to: GateClient
+
+  def disconnect(_channel) do
+    send(:persistent_term.get({__MODULE__, :test_pid}), :raising_path_disconnected)
+    {:ok, :disconnected}
+  end
+
+  def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{}, _opts) do
+    handler = :persistent_term.get({__MODULE__, :raising_handler})
+    handler.("request-raising-handler-cleanup", Orchard.InferenceEvent.accepted(0))
+  end
+
+  defdelegate execute_inference(channel, request, opts), to: GateClient
+  defdelegate cancel_inference(channel, request, opts), to: GateClient
+end
+
 defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
   use Orchard.DataCase, async: false
 
   alias Orchard.CanonicalRequest
   alias Orchard.CanonicalRequest.ModelRef
   alias Orchard.Cluster.V1.{EnsureModelLoadedRequest, ExecuteInferenceRequest}
-  alias Orchard.Dispatch.RequestDispatcher
+  alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.DispatchCapacity.AllocationAuthority
   alias Orchard.DispatchCapacity.Evaluator
   alias Orchard.DispatchCapacity.Evaluator.Input
@@ -777,6 +827,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     NoisyCancelClient,
     NonterminalThenErrorClient,
     PreAcceptanceCancelClient,
+    RaisingAfterConnectClient,
     ProductionFreshStatusClient,
     SlowLoadClient,
     TimedOutLoadClient,
@@ -793,6 +844,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
   @terminal_before_accepted_client TerminalBeforeAcceptedClient
   @nonterminal_then_error_client NonterminalThenErrorClient
   @cancellable_stream_client CancellableStreamClient
+  @raising_after_connect_client RaisingAfterConnectClient
   @monitor_snapshot_client MonitorSnapshotClient
   @noisy_cancel_client NoisyCancelClient
   @pre_acceptance_cancel_client PreAcceptanceCancelClient
@@ -816,6 +868,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     @monitor_snapshot_client.configure(self())
     @noisy_cancel_client.configure(self())
     @pre_acceptance_cancel_client.configure(self())
+    @raising_after_connect_client.configure(self())
 
     on_exit(fn ->
       Application.put_env(:orchard_controller, :inference, previous_inference)
@@ -827,6 +880,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       @monitor_snapshot_client.clear()
       @noisy_cancel_client.clear()
       @pre_acceptance_cancel_client.clear()
+      @raising_after_connect_client.clear()
       @production_fresh_status_client.clear()
       DispatchCapacityFixtures.clear_probe_node_id()
     end)
@@ -878,7 +932,16 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
 
     send(emitter, :finish)
-    assert {:ok, _events} = Task.await(dispatch_task)
+    assert %AttemptOutcome{} = outcome = Task.await(dispatch_task)
+    assert outcome.attempt_outcome == :completed
+    assert outcome.node_id == node_id
+    assert outcome.accepted
+    assert Enum.map(outcome.events, &InferenceEvent.kind/1) == [:accepted, :completed]
+    assert outcome.failure == nil
+    assert outcome.execution_resolution == :terminated
+    assert outcome.capacity_release_outcome == :released
+    assert DateTime.compare(outcome.ended_at, outcome.started_at) in [:eq, :gt]
+    assert outcome.first_token_at == nil
     assert AllocationAuthority.claim_count(authority, node_id) == 0
 
     assert {:ok, final_claim, _result} =
@@ -889,7 +952,66 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
                authority: authority
              )
 
-    assert :ok = QueueManager.release_dispatch_capacity(final_claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(final_claim, authority: authority)
+  end
+
+  test "SPEC 4.6.2 same-Request held claim fails closed without releasing the owner" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-held-claim"
+
+    assert {:ok, held_claim, _result} =
+             QueueManager.acquire_dispatch_capacity(
+               node_id,
+               request_id,
+               enforcing_input(),
+               authority: authority
+             )
+
+    assert %AttemptOutcome{
+             attempt_outcome: :failed,
+             node_id: ^node_id,
+             accepted: false,
+             execution_resolution: :not_started,
+             capacity_release_outcome: :not_applicable,
+             failure: %{"failure_class" => "occupancy_unresolved"}
+           } =
+             dispatch_with_deadline(
+               capacity_schedule(authority, node_id, request_id),
+               execute_request(request_id),
+               model_load_request(node_id),
+               client_impl: @client
+             )
+
+    assert AllocationAuthority.claim_count(authority, node_id) == 1
+    assert :released = QueueManager.release_dispatch_capacity(held_claim, authority: authority)
+  end
+
+  test "SPEC 4.6.2 authority loss while a claim is held is unresolved" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-authority-loss"
+
+    dispatch =
+      Task.async(fn ->
+        dispatch_with_deadline(
+          capacity_schedule(authority, node_id, request_id),
+          execute_request(request_id),
+          model_load_request(node_id),
+          client_impl: @client
+        )
+      end)
+
+    assert_receive {:model_load_started, dispatcher_pid}
+    Process.unlink(authority)
+    Process.exit(authority, :kill)
+    send(dispatcher_pid, :continue_model_load)
+
+    assert %AttemptOutcome{
+             attempt_outcome: :failed,
+             node_id: ^node_id,
+             capacity_release_outcome: :unresolved
+           } = Task.await(dispatch)
   end
 
   test "SPEC 4.6.2 dispatch owner death releases its claim exactly once" do
@@ -934,8 +1056,8 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
                authority: authority
              )
 
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :already_released = QueueManager.release_dispatch_capacity(claim, authority: authority)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -991,10 +1113,31 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     send(mutation_pid, :commit_mutation)
     assert :ok = Task.await(mutation)
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :dispatch_capacity_revalidation_failed)
 
     refute_receive :execute_called
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "disconnect cleanup runs when dispatch raises with a raising event handler configured" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-raising-handler-cleanup"
+
+    raising_handler = fn _request_id, _event -> raise "handler failed" end
+    @raising_after_connect_client.configure_handler(raising_handler)
+
+    assert_raise RuntimeError, "handler failed", fn ->
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @raising_after_connect_client,
+        event_handler: raising_handler
+      )
+    end
+
+    assert_receive :raising_path_disconnected
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1003,13 +1146,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = claim_node_id()
     request_id = "request-execute-error"
 
-    assert {:error, {:dispatch_failed, :execution_refused}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, node_id, request_id),
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @execute_error_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @execute_error_client
+      ),
+      :execution_refused
+    )
 
     assert AllocationAuthority.claim_count(authority, node_id) == 0
 
@@ -1021,7 +1166,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
                authority: authority
              )
 
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
   end
 
   test "SPEC 4.6 runtime completion before Accepted is a pre-acceptance failure" do
@@ -1029,13 +1174,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = claim_node_id()
     request_id = "request-missing-acceptance"
 
-    assert {:error, {:dispatch_failed, :node_acceptance_missing}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, node_id, request_id),
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @done_before_accepted_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @done_before_accepted_client
+      ),
+      :node_acceptance_missing
+    )
 
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
@@ -1047,16 +1194,21 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       node_id = claim_node_id()
       request_id = "request-terminal-defect-#{defect}"
 
-      assert {:ok, events} =
-               dispatch_with_deadline(
-                 capacity_schedule(authority, node_id, request_id),
-                 execute_request(request_id),
-                 model_load_request(node_id),
-                 client_impl: @terminal_defect_client
-               )
+      outcome =
+        dispatch_with_deadline(
+          capacity_schedule(authority, node_id, request_id),
+          execute_request(request_id),
+          model_load_request(node_id),
+          client_impl: @terminal_defect_client
+        )
+
+      events = assert_dispatch_success(outcome)
 
       assert [%InferenceEvent{event: %InferenceEvent.Failed{}}] =
                Enum.filter(events, &InferenceEvent.terminal?/1)
+
+      assert outcome.failure["failure_class"] == "terminal_conformance"
+      assert outcome.failure["failure_code"] == "orchestration_error"
 
       assert AllocationAuthority.claim_count(authority, node_id) == 0
       assert {:ok, lease} = QueueManager.acquire_acceptance_gate(node_id, authority: authority)
@@ -1079,13 +1231,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         :dispatch_capacity_input_provider
       ])
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_facts_unavailable}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :dispatch_capacity_facts_unavailable
+    )
 
     refute_receive :execute_called
   end
@@ -1105,13 +1259,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       |> capacity_schedule(node_id, request_id)
       |> Map.put(:dispatch_capacity_acquisition_input_provider, fn -> unavailable_input end)
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_unavailable}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :dispatch_capacity_unavailable
+    )
 
     refute_receive :model_loaded
     refute_receive :execute_called
@@ -1135,13 +1291,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       dispatch_capacity_evaluation: Evaluator.evaluate(input)
     }
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(Ecto.UUID.generate()),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(Ecto.UUID.generate()),
+        client_impl: @gate_client
+      ),
+      :dispatch_capacity_revalidation_failed
+    )
 
     assert_receive :model_loaded
     refute_receive :execute_called
@@ -1159,13 +1317,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         model_load_timeout_ms: 5_000
     }
 
-    assert {:error, {:dispatch_failed, :dispatch_timeout}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @timed_out_load_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @timed_out_load_client
+      ),
+      :request_timeout
+    )
 
     refute_receive :execute_called
     assert AllocationAuthority.claim_count(authority, node_id) == 0
@@ -1187,13 +1347,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         end
     }
 
-    assert {:error, {:dispatch_failed, :dispatch_timeout}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :request_timeout
+    )
 
     assert_receive :model_loaded
     refute_receive :execute_called
@@ -1217,13 +1379,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         model_load_timeout_ms: 5_000
     }
 
-    assert {:error, {:dispatch_failed, :dispatch_timeout}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @slow_load_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @slow_load_client
+      ),
+      :request_timeout
+    )
 
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
@@ -1237,13 +1401,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       Orchard.InferenceEvent.completed(:finish_reason_stop, nil)
     )
 
-    assert {:error, {:dispatch_failed, :node_acceptance_missing}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, node_id, request_id),
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @terminal_before_accepted_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @terminal_before_accepted_client
+      ),
+      :node_acceptance_missing
+    )
 
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
@@ -1257,13 +1423,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       Orchard.InferenceEvent.failed("runtime_failed", "runtime failed before acceptance", false)
     )
 
-    assert {:error, {:dispatch_failed, :node_acceptance_missing}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, node_id, request_id),
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @terminal_before_accepted_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @terminal_before_accepted_client
+      ),
+      :node_acceptance_missing
+    )
 
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
@@ -1273,13 +1441,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = claim_node_id()
     request_id = "request-delta-before-acceptance-error"
 
-    assert {:error, {:dispatch_failed, :stream_failed}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, node_id, request_id),
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @nonterminal_then_error_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @nonterminal_then_error_client
+      ),
+      :stream_failed
+    )
 
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
@@ -1310,7 +1480,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel)
 
-    assert {:error, {:dispatch_failed, :event_handler_failed}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :event_handler_failed)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1340,8 +1510,57 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel)
 
-    assert {:error, {:dispatch_failed, :event_handler_failed}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :event_handler_failed)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC 5.9 accepted handler cancellation records explicit cancellation evidence" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-accepted-handler-cancel"
+
+    test_pid = self()
+
+    dispatch =
+      Task.async(fn ->
+        dispatch_with_deadline(
+          capacity_schedule(authority, node_id, request_id),
+          execute_request(request_id),
+          model_load_request(node_id),
+          client_impl: @cancellable_stream_client,
+          event_handler: fn
+            _request_id, %InferenceEvent{event: %InferenceEvent.OutputTextDelta{delta: delta}}
+            when delta != "" ->
+              send(test_pid, {:first_text_handler_entered, DateTime.utc_now()})
+              :cancel
+
+            _request_id, _event ->
+              :ok
+          end
+        )
+      end)
+
+    assert_receive {:pre_text_events_sent, emitter}
+    observed_before_first_text_at = DateTime.utc_now()
+    send(emitter, :emit_first_text)
+    assert_receive {:first_text_handler_entered, observed_after_first_text_at}
+    assert_receive {:cancel_received, ^emitter}
+    send(emitter, :finish_cancel)
+
+    assert %AttemptOutcome{
+             attempt_outcome: :cancelled,
+             accepted: true,
+             failure: %{
+               "failure_class" => "cancellation",
+               "failure_code" => "request_caller_disconnect"
+             },
+             execution_resolution: :terminated,
+             capacity_release_outcome: :released
+           } = outcome = Task.await(dispatch)
+
+    assert DateTime.compare(outcome.first_token_at, observed_before_first_text_at) in [:gt, :eq]
+    assert DateTime.compare(outcome.first_token_at, observed_after_first_text_at) in [:lt, :eq]
+    assert DateTime.compare(outcome.ended_at, observed_after_first_text_at) in [:gt, :eq]
   end
 
   test "SPEC 7.5.5 cancellation drain detects an event after terminal" do
@@ -1367,7 +1586,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel)
 
-    assert {:ok, events} = Task.await(dispatch)
+    events = assert_dispatch_success(Task.await(dispatch))
 
     assert [%InferenceEvent{event: %InferenceEvent.Failed{code: code}}] =
              Enum.filter(events, &InferenceEvent.terminal?/1)
@@ -1406,7 +1625,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel)
 
-    assert {:ok, events} = Task.await(dispatch)
+    events = assert_dispatch_success(Task.await(dispatch))
 
     assert [%InferenceEvent{event: %InferenceEvent.Failed{code: code}}] =
              Enum.filter(events, &InferenceEvent.terminal?/1)
@@ -1441,7 +1660,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel)
 
-    assert {:ok, events} = Task.await(dispatch)
+    events = assert_dispatch_success(Task.await(dispatch))
 
     assert [%InferenceEvent{event: %InferenceEvent.Failed{code: code}}] =
              Enum.filter(events, &InferenceEvent.terminal?/1)
@@ -1472,7 +1691,14 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel_after_acceptance)
 
-    assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+    assert %AttemptOutcome{
+             attempt_outcome: :timed_out,
+             node_id: ^node_id,
+             accepted: false,
+             execution_resolution: :terminated,
+             capacity_release_outcome: :released
+           } = Task.await(dispatch)
+
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1496,7 +1722,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel_after_acceptance)
 
-    assert {:error, {:dispatch_failed, :node_acceptance_missing}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :node_acceptance_missing)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1527,7 +1753,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       assert AllocationAuthority.claim_count(authority, node_id) == 1
       send(emitter, :finish_cancel)
 
-      assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+      assert %AttemptOutcome{
+               attempt_outcome: :timed_out,
+               node_id: ^node_id,
+               execution_resolution: :terminated,
+               capacity_release_outcome: :released
+             } = Task.await(dispatch)
+
       assert AllocationAuthority.claim_count(authority, node_id) == 0
     end
   end
@@ -1559,7 +1791,14 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     assert_receive :pre_acceptance_disconnected, 1_000
 
-    assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+    assert %AttemptOutcome{
+             attempt_outcome: :timed_out,
+             node_id: ^node_id,
+             accepted: false,
+             execution_resolution: :terminated,
+             capacity_release_outcome: :released
+           } = Task.await(dispatch)
+
     assert AllocationAuthority.claim_count(authority, node_id) == 0
 
     assert {:ok, claim, available} =
@@ -1572,7 +1811,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     assert available.eligible?
     refute :node_health_unhealthy in available.reason_codes
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
   end
 
   test "SPEC 4.5 an unproven disconnect after cancel drain timeout quarantines the Node" do
@@ -1596,7 +1835,13 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     assert_receive {:pre_acceptance_cancel_received, _emitter}, 1_000
     assert_receive :pre_acceptance_disconnected, 1_000
-    assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+
+    assert %AttemptOutcome{
+             attempt_outcome: :timed_out,
+             node_id: ^node_id,
+             execution_resolution: :unresolved,
+             capacity_release_outcome: :unresolved
+           } = Task.await(dispatch)
 
     assert {:error, :dispatch_capacity_unavailable, quarantined} =
              QueueManager.acquire_dispatch_capacity(
@@ -1609,7 +1854,45 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert :node_health_unhealthy in quarantined.reason_codes
   end
 
-  test "SPEC 4.5 a later cleanup disconnect reconciles an earlier disconnect failure" do
+  test "SPEC 4.6.2 unavailable quarantine state keeps may-have-started release unresolved" do
+    store = start_supervised!({Orchard.DispatchCapacity.QuarantineStore, name: nil})
+
+    authority =
+      start_supervised!(
+        {AllocationAuthority, name: nil, quarantine_store: store},
+        id: {:authority, make_ref()}
+      )
+
+    node_id = claim_node_id()
+    request_id = "request-quarantine-unavailable"
+
+    schedule = %{
+      capacity_schedule(authority, node_id, request_id)
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
+    }
+
+    dispatch =
+      Task.async(fn ->
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
+          client_impl: @pre_acceptance_cancel_client,
+          cancel_drain_timeout_ms: 20
+        )
+      end)
+
+    assert_receive {:pre_acceptance_cancel_received, _emitter}, 1_000
+    Process.exit(store, :kill)
+    assert_receive :pre_acceptance_disconnected, 1_000
+
+    assert %AttemptOutcome{
+             attempt_outcome: :timed_out,
+             node_id: ^node_id,
+             execution_resolution: :unresolved,
+             capacity_release_outcome: :unresolved
+           } = Task.await(dispatch)
+  end
+
+  test "SPEC 4.6.2 defensive cleanup cannot upgrade ambiguous release evidence" do
     @pre_acceptance_cancel_client.configure(self(),
       disconnect_results: [{:error, :disconnect_failed}, {:ok, :disconnected}]
     )
@@ -1634,20 +1917,23 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     assert_receive {:pre_acceptance_cancel_received, _emitter}, 1_000
     assert_receive :pre_acceptance_disconnected, 1_000
-    assert_receive :pre_acceptance_disconnected, 1_000
-    assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+    refute_receive :pre_acceptance_disconnected, 50
 
-    assert {:ok, claim, available} =
+    assert %AttemptOutcome{
+             attempt_outcome: :timed_out,
+             execution_resolution: :unresolved,
+             capacity_release_outcome: :unresolved
+           } = Task.await(dispatch)
+
+    assert {:error, :dispatch_capacity_unavailable, quarantined} =
              QueueManager.acquire_dispatch_capacity(
                node_id,
-               "request-after-later-clean-disconnect",
+               "request-after-ambiguous-release",
                enforcing_input(),
                authority: authority
              )
 
-    assert available.eligible?
-    refute :node_health_unhealthy in available.reason_codes
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :node_health_unhealthy in quarantined.reason_codes
   end
 
   test "SPEC 4.5 a durable unhealthy transition reconciles a failed disconnect" do
@@ -1679,7 +1965,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     assert_receive {:pre_acceptance_cancel_received, _emitter}, 1_000
     assert_receive :pre_acceptance_disconnected, 1_000
-    assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :request_timeout)
     assert Repo.get!(Node, node.id).health == :unhealthy
 
     assert {:ok, claim, available} =
@@ -1692,7 +1978,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     assert available.eligible?
     refute :node_health_unhealthy in available.reason_codes
-    assert :ok = QueueManager.release_dispatch_capacity(claim, authority: authority)
+    assert :released = QueueManager.release_dispatch_capacity(claim, authority: authority)
   end
 
   test "SPEC 4.5 cancellation drain deadline is not extended by nonterminal events" do
@@ -1718,7 +2004,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     assert_receive :noisy_cancel_disconnected, 250
 
-    assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :request_timeout)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1748,7 +2034,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       end)
 
     assert_receive {:pre_acceptance_cancel_received, _emitter}, 1_000
-    assert {:error, {:dispatch_failed, :request_timeout}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :request_timeout)
     assert Repo.get!(Node, inventory_node.id).health == :degraded
 
     assert {:error, :dispatch_capacity_unavailable, quarantined} =
@@ -1782,7 +2068,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel_after_acceptance)
 
-    assert {:error, {:dispatch_failed, :request_caller_disconnect}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :request_caller_disconnect)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1809,7 +2095,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel_after_acceptance)
 
-    assert {:error, {:dispatch_failed, :request_caller_disconnect}} = Task.await(dispatch)
+    assert_dispatch_failure(Task.await(dispatch), :request_caller_disconnect)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1833,13 +2119,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
                dispatch_capacity_authority: authority
              )
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @production_fresh_status_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(schedule.request_id),
+        model_load_request(node.id),
+        client_impl: @production_fresh_status_client
+      ),
+      :dispatch_capacity_revalidation_failed
+    )
 
     refute_receive :production_execute_called
     assert AllocationAuthority.claim_count(authority, node.id) == 0
@@ -1915,13 +2203,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       remapped_post_load_status
     )
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_facts_unavailable}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(scheduled_node.id),
-               client_impl: @production_fresh_status_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(schedule.request_id),
+        model_load_request(scheduled_node.id),
+        client_impl: @production_fresh_status_client
+      ),
+      :dispatch_capacity_facts_unavailable
+    )
 
     refute_receive :model_loaded
     refute_receive :production_execute_called
@@ -1938,13 +2228,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert schedule.dispatch_identity_source == :trusted_monitor_snapshot
     assert schedule.node_id == schedule.runtime_endpoint_target.node_id
 
-    assert {:ok, _events} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @monitor_snapshot_client
-             )
+    _events =
+      assert_dispatch_success(
+        dispatch_with_deadline(
+          schedule,
+          execute_request(schedule.request_id),
+          model_load_request(node.id),
+          client_impl: @monitor_snapshot_client
+        )
+      )
 
     assert_receive :monitor_snapshot_model_loaded
     assert_receive :monitor_snapshot_execute_called
@@ -1964,7 +2256,11 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       {schedule, node_id} =
         compatibility_single_wave_schedule(authority, unquote(management_class))
 
-      assert {:ok, _events} =
+      assert %AttemptOutcome{
+               attempt_outcome: :completed,
+               node_id: ^node_id,
+               capacity_release_outcome: :not_applicable
+             } =
                dispatch_with_deadline(
                  schedule,
                  execute_request(schedule.request_id),
@@ -1993,13 +2289,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
             load_result
           )
 
-        assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-                 dispatch_with_deadline(
-                   schedule,
-                   execute_request(schedule.request_id),
-                   model_load_request(node_id),
-                   client_impl: @compatibility_single_wave_client
-                 )
+        assert_dispatch_failure(
+          dispatch_with_deadline(
+            schedule,
+            execute_request(schedule.request_id),
+            model_load_request(node_id),
+            client_impl: @compatibility_single_wave_client
+          ),
+          :dispatch_capacity_revalidation_failed
+        )
 
         assert_receive :compatibility_status_called
         refute_receive :compatibility_status_called
@@ -2020,13 +2318,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
           compatibility_load_result(:legacy_absent)
         )
 
-      assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-               dispatch_with_deadline(
-                 schedule,
-                 execute_request(schedule.request_id),
-                 model_load_request(node_id),
-                 client_impl: @compatibility_single_wave_client
-               )
+      assert_dispatch_failure(
+        dispatch_with_deadline(
+          schedule,
+          execute_request(schedule.request_id),
+          model_load_request(node_id),
+          client_impl: @compatibility_single_wave_client
+        ),
+        :dispatch_capacity_revalidation_failed
+      )
 
       assert_receive :compatibility_status_called
       refute_receive :compatibility_status_called
@@ -2047,13 +2347,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
           :loaded
         )
 
-      assert {:ok, _events} =
-               dispatch_with_deadline(
-                 schedule,
-                 execute_request(schedule.request_id),
-                 model_load_request(node_id),
-                 client_impl: @compatibility_single_wave_client
-               )
+      _events =
+        assert_dispatch_success(
+          dispatch_with_deadline(
+            schedule,
+            execute_request(schedule.request_id),
+            model_load_request(node_id),
+            client_impl: @compatibility_single_wave_client
+          )
+        )
 
       assert_receive :compatibility_status_called
       refute_receive :compatibility_status_called
@@ -2074,13 +2376,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
           :loaded
         )
 
-      assert {:ok, _events} =
-               dispatch_with_deadline(
-                 schedule,
-                 execute_request(schedule.request_id),
-                 model_load_request(node_id),
-                 client_impl: @compatibility_single_wave_client
-               )
+      _events =
+        assert_dispatch_success(
+          dispatch_with_deadline(
+            schedule,
+            execute_request(schedule.request_id),
+            model_load_request(node_id),
+            client_impl: @compatibility_single_wave_client
+          )
+        )
 
       assert_receive :compatibility_status_called
       refute_receive :compatibility_status_called
@@ -2102,13 +2406,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
             :loaded
           )
 
-        assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-                 dispatch_with_deadline(
-                   schedule,
-                   execute_request(schedule.request_id),
-                   model_load_request(node_id),
-                   client_impl: @compatibility_single_wave_client
-                 )
+        assert_dispatch_failure(
+          dispatch_with_deadline(
+            schedule,
+            execute_request(schedule.request_id),
+            model_load_request(node_id),
+            client_impl: @compatibility_single_wave_client
+          ),
+          :dispatch_capacity_revalidation_failed
+        )
 
         assert_receive :compatibility_status_called
         refute_receive :compatibility_status_called
@@ -2137,13 +2443,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         | dispatch_identity_source: {:bounded_compatibility_probe, mismatched_observation}
       }
 
-      assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-               dispatch_with_deadline(
-                 schedule,
-                 execute_request(schedule.request_id),
-                 model_load_request(node_id),
-                 client_impl: @compatibility_single_wave_client
-               )
+      assert_dispatch_failure(
+        dispatch_with_deadline(
+          schedule,
+          execute_request(schedule.request_id),
+          model_load_request(node_id),
+          client_impl: @compatibility_single_wave_client
+        ),
+        :dispatch_capacity_node_identity_mismatch
+      )
 
       assert_receive :compatibility_status_called
       refute_receive :compatibility_status_called
@@ -2160,13 +2468,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     {schedule, node, snapshot_reads} =
       monitor_snapshot_schedule(authority, :degraded_acquisition)
 
-    assert {:ok, _events} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @monitor_snapshot_client
-             )
+    _events =
+      assert_dispatch_success(
+        dispatch_with_deadline(
+          schedule,
+          execute_request(schedule.request_id),
+          model_load_request(node.id),
+          client_impl: @monitor_snapshot_client
+        )
+      )
 
     assert_receive :monitor_snapshot_model_loaded
     assert_receive :monitor_snapshot_execute_called
@@ -2191,13 +2501,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       {schedule, node, snapshot_reads} =
         monitor_snapshot_schedule(authority, unquote(scenario))
 
-      assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-               dispatch_with_deadline(
-                 schedule,
-                 execute_request(schedule.request_id),
-                 model_load_request(node.id),
-                 client_impl: @monitor_snapshot_client
-               )
+      assert_dispatch_failure(
+        dispatch_with_deadline(
+          schedule,
+          execute_request(schedule.request_id),
+          model_load_request(node.id),
+          client_impl: @monitor_snapshot_client
+        ),
+        :dispatch_capacity_revalidation_failed
+      )
 
       assert_receive :monitor_snapshot_model_loaded
       refute_receive :monitor_snapshot_execute_called
@@ -2214,13 +2526,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     {schedule, node, snapshot_reads} =
       monitor_snapshot_schedule(authority, :degraded)
 
-    assert {:ok, _events} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @monitor_snapshot_client
-             )
+    _events =
+      assert_dispatch_success(
+        dispatch_with_deadline(
+          schedule,
+          execute_request(schedule.request_id),
+          model_load_request(node.id),
+          client_impl: @monitor_snapshot_client
+        )
+      )
 
     assert_receive :monitor_snapshot_model_loaded
     assert_receive :monitor_snapshot_execute_called
@@ -2242,13 +2556,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       |> Map.put(:dispatch_identity_source, :trusted_monitor_snapshot)
       |> Map.put(:dispatch_capacity_acquisition_input_provider, fn -> degraded end)
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_unavailable}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :dispatch_capacity_unavailable
+    )
 
     refute_receive :model_loaded
     refute_receive :execute_called
@@ -2267,13 +2583,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       |> capacity_schedule(node_id, request_id)
       |> Map.put(:dispatch_capacity_input_provider, fn -> degraded end)
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :dispatch_capacity_revalidation_failed
+    )
 
     assert_receive :model_loaded
     refute_receive :execute_called
@@ -2287,13 +2605,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     {schedule, node, snapshot_reads} =
       monitor_snapshot_schedule(authority, :target_removed_before_acquisition)
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_facts_unavailable}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @monitor_snapshot_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(schedule.request_id),
+        model_load_request(node.id),
+        client_impl: @monitor_snapshot_client
+      ),
+      :dispatch_capacity_facts_unavailable
+    )
 
     refute_receive :monitor_snapshot_model_loaded
     refute_receive :monitor_snapshot_execute_called
@@ -2309,13 +2629,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     {schedule, node, snapshot_reads} =
       monitor_snapshot_schedule(authority, :target_removed_before_final)
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @monitor_snapshot_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(schedule.request_id),
+        model_load_request(node.id),
+        client_impl: @monitor_snapshot_client
+      ),
+      :dispatch_capacity_revalidation_failed
+    )
 
     assert_receive :monitor_snapshot_model_loaded
     refute_receive :monitor_snapshot_execute_called
@@ -2334,13 +2656,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     mismatched_target = %{schedule.runtime_endpoint_target | node_id: Ecto.UUID.generate()}
     schedule = %{schedule | runtime_endpoint_target: mismatched_target}
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @monitor_snapshot_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(schedule.request_id),
+        model_load_request(node.id),
+        client_impl: @monitor_snapshot_client
+      ),
+      :dispatch_capacity_node_identity_mismatch
+    )
 
     refute_receive :monitor_snapshot_model_loaded
     refute_receive :monitor_snapshot_execute_called
@@ -2358,13 +2682,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     @production_fresh_status_client.configure(self(), status, status)
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, claimed_node_id, request_id),
-               execute_request(request_id),
-               model_load_request(claimed_node_id),
-               client_impl: @production_fresh_status_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, claimed_node_id, request_id),
+        execute_request(request_id),
+        model_load_request(claimed_node_id),
+        client_impl: @production_fresh_status_client
+      ),
+      :dispatch_capacity_node_identity_mismatch
+    )
 
     refute_receive :production_execute_called
     assert AllocationAuthority.claim_count(authority, claimed_node_id) == 0
@@ -2377,13 +2703,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = Ecto.UUID.generate()
     request_id = "request-probe-identity-missing"
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, node_id, request_id),
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :dispatch_capacity_node_identity_mismatch
+    )
 
     refute_receive :execute_called
     assert AllocationAuthority.claim_count(authority, node_id) == 0
@@ -2394,13 +2722,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = claim_node_id()
     request_id = "request-probe-identity-unverified"
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_node_identity_mismatch}} =
-             dispatch_with_deadline(
-               capacity_schedule(authority, node_id, request_id),
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @unprobeable_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @unprobeable_client
+      ),
+      :dispatch_capacity_node_identity_mismatch
+    )
 
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
@@ -2435,13 +2765,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     assert schedule.strategy == :multi_node
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_revalidation_failed}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(schedule.request_id),
-               model_load_request(node.id),
-               client_impl: @production_fresh_status_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(schedule.request_id),
+        model_load_request(node.id),
+        client_impl: @production_fresh_status_client
+      ),
+      :dispatch_capacity_revalidation_failed
+    )
 
     refute_receive :production_execute_called
     assert AllocationAuthority.claim_count(authority, node.id) == 0
@@ -2463,13 +2795,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert %Input{} = schedule.dispatch_capacity_input
     assert %Evaluator.Result{eligible?: true} = schedule.dispatch_capacity_evaluation
 
-    assert {:ok, _events} =
-             dispatch_with_deadline(
-               Map.put(schedule, :request_id, request_id),
-               execute_request(request_id),
-               model_load_request("unmanaged"),
-               client_impl: @gate_client
-             )
+    _events =
+      assert_dispatch_success(
+        dispatch_with_deadline(
+          Map.put(schedule, :request_id, request_id),
+          execute_request(request_id),
+          model_load_request("unmanaged"),
+          client_impl: @gate_client
+        )
+      )
   end
 
   test "SPEC 5.9 a held acceptance gate fails dispatch bounded instead of blocking" do
@@ -2485,13 +2819,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         timeout_at: DateTime.add(DateTime.utc_now(), 60, :millisecond)
     }
 
-    assert {:error, {:dispatch_failed, :dispatch_capacity_acceptance_gate_busy}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :dispatch_capacity_acceptance_gate_busy
+    )
 
     refute_receive :execute_called, 50
     assert :ok = QueueManager.release_acceptance_gate(lease, authority: authority)
@@ -2509,13 +2845,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         timeout_at: DateTime.utc_now()
     }
 
-    assert {:error, {:dispatch_failed, :dispatch_timeout}} =
-             dispatch_with_deadline(
-               schedule,
-               execute_request(request_id),
-               model_load_request(node_id),
-               client_impl: @gate_client
-             )
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        schedule,
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @gate_client
+      ),
+      :request_timeout
+    )
 
     refute_receive :execute_called, 50
 
@@ -2553,8 +2891,8 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       Process.exit(caller, :kill)
       assert :ok = QueueManager.release_acceptance_gate(held_lease, authority: authority)
 
-      assert {:ok, {:error, {:dispatch_failed, :caller_disconnect}}} =
-               Task.yield(dispatch, 250)
+      assert {:ok, outcome} = Task.yield(dispatch, 250)
+      assert_dispatch_failure(outcome, :request_caller_disconnect)
 
       refute_receive :execute_called
       assert AllocationAuthority.claim_count(authority, node_id) == 0
@@ -2605,7 +2943,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       assert System.monotonic_time(:millisecond) - started_at < 1_400
 
       send(emitter, :finish_cancel)
-      assert {:ok, _events} = Task.await(dispatch)
+      _events = assert_dispatch_success(Task.await(dispatch))
       assert AllocationAuthority.claim_count(authority, node_id) == 0
     after
       Task.shutdown(dispatch, :brutal_kill)
@@ -3152,6 +3490,15 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       max_concurrency: 2,
       runtime_model_placements: []
     }
+  end
+
+  defp assert_dispatch_success(%AttemptOutcome{events: events}) when is_list(events), do: events
+
+  defp assert_dispatch_failure(%AttemptOutcome{failure: failure} = outcome, expected_reason)
+       when is_map(failure) and is_atom(expected_reason) do
+    actual_reason = Map.get(failure, "raw_source_code", failure["failure_code"])
+    assert actual_reason == Atom.to_string(expected_reason)
+    outcome
   end
 
   defp enforcing_input do

--- a/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
@@ -110,7 +110,7 @@ defmodule Orchard.Inference.ChatErrorTest do
            }
   end
 
-  test "caller disconnect event persists as interrupted while preserving SSE payload" do
+  test "caller disconnect event persists as cancelled while preserving API and SSE payloads" do
     event = InferenceEvent.failed("request_caller_disconnect", "caller exited", false)
     error = ChatError.from_failed_event(event)
 
@@ -130,8 +130,8 @@ defmodule Orchard.Inference.ChatErrorTest do
            }
 
     assert ChatError.terminal_attrs(error) == %{
-             state: :interrupted,
-             http_status: 500,
+             state: :cancelled,
+             http_status: 499,
              error_code: "request_caller_disconnect",
              error_message: "caller exited"
            }

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Inference.QueueManagerTest do
   import Orchard.TestSupport.QueueAdmissionAPI,
     only: [assert_queue_metadata: 2, assert_queue_metadata: 3]
 
+  alias Orchard.DispatchCapacity.AllocationAuthority
   alias Orchard.Inference.QueueManager
   alias Orchard.Requests
   alias Orchard.Requests.{Request, RequestServer}
@@ -11,6 +12,27 @@ defmodule Orchard.Inference.QueueManagerTest do
   setup do
     QueueManager.reset()
     :ok
+  end
+
+  test "SPEC 4.6.2 dispatch-capacity release maps nil and preserves authority outcomes" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = Ecto.UUID.generate()
+
+    assert :not_applicable =
+             QueueManager.release_dispatch_capacity(nil, authority: authority)
+
+    stale_claim = %AllocationAuthority.Claim{
+      token: make_ref(),
+      authority_incarnation: make_ref(),
+      node_id: node_id,
+      request_id: "request-queue-release",
+      kind: :f11,
+      owner: self(),
+      monitor_ref: make_ref()
+    }
+
+    assert :unresolved =
+             QueueManager.release_dispatch_capacity(stale_claim, authority: authority)
   end
 
   test "grants one active request per model lane and releases idempotently" do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -1783,6 +1783,12 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert state_before?(states, :validated, :failed)
     assert :scheduled in states
     assert :dispatching in states
+
+    assert [started_step, failed_step] = Requests.list_request_step_events(request)
+    assert started_step.event_type == "request_step.started"
+    assert failed_step.event_type == "request_step.failed"
+    assert failed_step.result["error_code"] == "orchestration_error"
+    refute Map.has_key?(failed_step.result, "attempt_outcome")
   end
 
   test "queue admission enabled records immediate grant metadata before dispatch", %{
@@ -2445,12 +2451,33 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     model = create_active_model!(bundle, "request-orchestrator-start-failure")
     canonical = canonical_request("request-orchestrator-start-failure", stream?: false)
 
-    assert {:error, {:model_load_failed, _}} = RequestOrchestrator.execute(canonical, model)
+    assert {:error,
+            {:model_load_failed,
+             %Orchard.Inference.ModelLoadFailure{
+               category: :runtime_unavailable,
+               code: "runtime_unavailable"
+             }}} = RequestOrchestrator.execute(canonical, model)
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request != nil
     assert request.state == :failed
     assert request.first_token_at == nil
+
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, & &1.event_type) == [
+             "request_step.started",
+             "request_step.failed"
+           ]
+
+    terminal_result = List.last(step_events).result
+    assert terminal_result["attempt_outcome"] == "failed"
+    assert terminal_result["accepted"] == false
+    assert terminal_result["execution_resolution"] == "not_started"
+    assert terminal_result["failure_class"] == "model_load_failure"
+    assert terminal_result["failure_code"] == "runtime_unavailable"
+    assert terminal_result["retry_decision"] == "not_retryable"
+    refute Enum.any?(step_events, &(&1.attempt == 2))
   end
 
   test "execute/3 persists inference-turn started and completed request_step events around dispatch",
@@ -2479,15 +2506,18 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
               "inference_turn:t1:a1"}
            ]
 
-    assert Enum.map(step_events, & &1.result) == [
-             %{},
-             %{
-               "finish_reason" => "stop",
-               "http_status" => 200,
-               "input_tokens" => 1,
-               "output_tokens" => 0
-             }
-           ]
+    assert [%{}, terminal_result] = Enum.map(step_events, & &1.result)
+    assert terminal_result["attempt_outcome"] == "completed"
+    assert terminal_result["accepted"]
+    assert terminal_result["execution_resolution"] == "terminated"
+    assert terminal_result["capacity_release_outcome"] in ["released", "not_applicable"]
+    assert terminal_result["excluded_node_ids"] == []
+    assert terminal_result["finish_reason"] == "stop"
+    assert terminal_result["http_status"] == 200
+    assert terminal_result["input_tokens"] == 1
+    assert terminal_result["output_tokens"] == 0
+    assert Enum.count(step_events, &(&1.attempt == 1)) == 2
+    refute Enum.any?(step_events, &(&1.attempt == 2))
 
     assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
   end
@@ -2547,7 +2577,9 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert started_step.event_type == "request_step.started"
     assert terminal_step.event_type == "request_step.failed"
     refute Map.has_key?(terminal_step.result, "finish_reason")
-    assert terminal_step.result["error_code"] == "runtime_endpoint_missing_terminal"
+    assert terminal_step.result["failure_class"] == "terminal_conformance"
+    assert terminal_step.result["failure_code"] == "orchestration_error"
+    assert terminal_step.result["raw_source_code"] == "runtime_endpoint_missing_terminal"
 
     assert wait_until(fn ->
              RequestServer.get_state(request.id) == {:error, :not_found}
@@ -2583,20 +2615,24 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     put_capturing_runtime_adapter_config()
 
     cases = [
-      {"tool_choice_not_satisfied", "tool choice not satisfied", :failed, "request_step.failed"},
-      {"request_cancelled", "request was cancelled", :cancelled, "request_step.cancelled"},
-      {"deadline_exceeded", "request timed out", :timed_out, "request_step.timed_out"},
-      {"request_client_disconnect", "caller disconnected", :interrupted,
-       "request_step.interrupted"}
+      {"tool_choice_not_satisfied", "tool choice not satisfied", :failed, "request_step.failed",
+       "runtime_failure", "internal_error"},
+      {"request_cancelled", "request was cancelled", :cancelled, "request_step.cancelled",
+       "cancellation", "request_cancelled"},
+      {"deadline_exceeded", "request timed out", :timed_out, "request_step.timed_out", "deadline",
+       "deadline_exceeded"},
+      {"request_client_disconnect", "caller disconnected", :cancelled, "request_step.cancelled",
+       "cancellation", "request_caller_disconnect"}
     ]
 
-    Enum.each(cases, fn {code, message, expected_state, expected_event_type} ->
+    Enum.each(cases, fn {code, message, expected_state, expected_event_type, failure_class,
+                         failure_code} ->
       put_runtime_events([InferenceEvent.failed(code, message, false)])
 
-      model = create_active_model!(bundle, "request-orchestrator-terminal-#{expected_state}")
+      model = create_active_model!(bundle, "request-orchestrator-terminal-#{code}")
 
       canonical =
-        canonical_request("request-orchestrator-terminal-#{expected_state}", stream?: false)
+        canonical_request("request-orchestrator-terminal-#{code}", stream?: false)
 
       step_event_appender = started_only_step_event_appender(self())
 
@@ -2613,6 +2649,11 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       assert request.state == expected_state
       assert {:ok, :not_candidate} = Requests.classify_missing_terminal_candidate(request)
 
+      if code == "request_client_disconnect" do
+        assert request.error_code == "request_caller_disconnect"
+        assert request.http_status == 499
+      end
+
       step_events = Requests.list_request_step_events(request)
 
       assert Enum.map(step_events, & &1.event_type) == [
@@ -2621,7 +2662,9 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
              ]
 
       terminal_step = List.last(step_events)
-      assert terminal_step.result["error_code"] == request.error_code
+      assert terminal_step.result["attempt_outcome"] == Atom.to_string(expected_state)
+      assert terminal_step.result["failure_class"] == failure_class
+      assert terminal_step.result["failure_code"] == failure_code
       assert terminal_step.result["error_message"] == request.error_message
       assert terminal_step.result["http_status"] == request.http_status
     end)

--- a/apps/orchard_controller/test/orchard/metrics/gauge_poller_test.exs
+++ b/apps/orchard_controller/test/orchard/metrics/gauge_poller_test.exs
@@ -149,7 +149,7 @@ defmodule Orchard.Metrics.GaugePollerTest do
              entry(%{node: node.id, model: "model-authoritative"}, 1)
            ]
 
-    assert :ok = AllocationAuthority.release(claim)
+    assert :released = AllocationAuthority.release(claim)
 
     assert GaugeSource.snapshots(now).active_requests == [
              entry(%{node: node.id, model: "model-authoritative"}, 0)


### PR DESCRIPTION
## Summary

Dispatch now returns one validated `AttemptOutcome` containing node identity, acceptance, caller-visible events, stable failure evidence, execution resolution, capacity-release truth, and wall-clock timing.
This replaces ambiguous success/error tuples without changing Orchard's single-target, single-attempt behavior.

The same change makes dispatch-capacity release observable and idempotent, so callers can distinguish a real release from an already-released, not-applicable, or unresolved claim.
The orchestrator persists the typed evidence while preserving existing public API and SSE error mappings.

## What changed

- Added the validated `Orchard.Dispatch.AttemptOutcome` contract and migrated every dispatcher caller and direct test.
- Threaded cancellation, timeout, handler failure, and transport-exception reconciliation through explicit return values instead of process-local state.
- Preserved exact first-token timing from the first non-empty text delta.
- Normalized model-load evidence into stable public categories while retaining the raw source code for diagnosis.
- Made allocation-authority release results explicit across dispatcher, queue-manager, metrics, restart, and conformance paths.

## Risk Assessment

⚠️ **Medium**

- Blast radius is limited to Controller dispatch and dispatch-capacity accounting, but this is a clean internal caller-contract cutover across several failure paths.
- No database schema, external API shape, scheduler policy, retry behavior, or alternate-target behavior changes.
- Ambiguous release or execution state remains fail closed through unresolved release evidence and existing quarantine behavior.
- Every direct dispatcher caller is migrated. Final review found no legacy tuple callsites or P0-P2 blockers.

## Verification

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- Focused dispatcher, capacity, orchestrator, and API suite: 265 passed
- `mise exec -- mix test`: 303 shared, 3,461 controller with 5 skipped, 389 node-agent, and 738 CLI with 10 excluded passed
- `mise exec -- mix test --cover`: same test totals; app coverage reports generated successfully

Closes #166

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol_(High)-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789270824&installation_model_id=428414&pr_number=215&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F215&signature=b09b5f0eb89e80e145f7fdb8c16464a45916230cac93137d9090d4a002e62cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->