### PR TITLE
fix(lifecycle): make node-agent stop durable

### DIFF
--- a/apps/orchard_cli/c_src/Makefile
+++ b/apps/orchard_cli/c_src/Makefile
@@ -1,25 +1,31 @@
 PRIV_DIR := $(MIX_APP_PATH)/priv
-TARGET := $(PRIV_DIR)/orchard-secret-tty
-TEST_TARGET := $(PRIV_DIR)/orchard-secret-tty-test
-SOURCE := orchard_secret_tty.c
+TTY_TARGET := $(PRIV_DIR)/orchard-secret-tty
+TTY_TEST_TARGET := $(PRIV_DIR)/orchard-secret-tty-test
+TTY_SOURCE := orchard_secret_tty.c
+LIFECYCLE_TARGET := $(PRIV_DIR)/orchard-lifecycle-helper
+LIFECYCLE_SOURCE := orchard_lifecycle_helper.c
 
 .PHONY: all clean
 
-TARGETS := $(TARGET)
+TARGETS := $(TTY_TARGET) $(LIFECYCLE_TARGET)
 ifeq ($(MIX_ENV),test)
-TARGETS += $(TEST_TARGET)
+TARGETS += $(TTY_TEST_TARGET)
 endif
 
 all: $(TARGETS)
 
-$(TARGET): $(SOURCE)
+$(TTY_TARGET): $(TTY_SOURCE)
 	mkdir -p $(PRIV_DIR)
-	xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic -O2 $(SOURCE) -o $(TARGET)
+	xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic -O2 $(TTY_SOURCE) -o $(TTY_TARGET)
 
-$(TEST_TARGET): $(SOURCE)
+$(TTY_TEST_TARGET): $(TTY_SOURCE)
 	mkdir -p $(PRIV_DIR)
 	xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic -O2 \
-		-DORCHARD_SECRET_TTY_TEST $(SOURCE) -o $(TEST_TARGET)
+		-DORCHARD_SECRET_TTY_TEST $(TTY_SOURCE) -o $(TTY_TEST_TARGET)
+
+$(LIFECYCLE_TARGET): $(LIFECYCLE_SOURCE)
+	mkdir -p $(PRIV_DIR)
+	xcrun clang -std=c11 -Wall -Wextra -Werror -pedantic -O2 $(LIFECYCLE_SOURCE) -o $(LIFECYCLE_TARGET)
 
 clean:
-	rm -f $(TARGET) $(TEST_TARGET)
+	rm -f $(TTY_TARGET) $(TTY_TEST_TARGET) $(LIFECYCLE_TARGET)

--- a/apps/orchard_cli/c_src/orchard_lifecycle_helper.c
+++ b/apps/orchard_cli/c_src/orchard_lifecycle_helper.c
@@ -1,0 +1,760 @@
+#define _DARWIN_C_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libproc.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <time.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define EX_TEMPFAIL 75
+#define EX_IOERR 74
+#define RELEASE_NAME "RELEASE_NAME=orchard_node_agent"
+#define RELEASE_ROOT "RELEASE_ROOT=/Library/Application Support/Orchard/releases/orchard_node_agent"
+#define BOOT_PREFIX "/Library/Application Support/Orchard/releases/orchard_node_agent/releases/"
+
+struct process_identity {
+  pid_t pid;
+  long start_sec;
+  int start_usec;
+  dev_t device;
+  ino_t inode;
+  char executable[PROC_PIDPATHINFO_MAXSIZE];
+};
+
+static int read_identity(pid_t pid, struct process_identity *identity) {
+  int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+  struct kinfo_proc process;
+  size_t process_size = sizeof(process);
+  struct stat executable_stat;
+
+  memset(&process, 0, sizeof(process));
+  memset(identity, 0, sizeof(*identity));
+
+  if (sysctl(mib, 4, &process, &process_size, NULL, 0) != 0) {
+    return errno == ESRCH ? 1 : -1;
+  }
+  if (process_size == 0 || process.kp_proc.p_pid != pid) {
+    return 1;
+  }
+  if (proc_pidpath(pid, identity->executable, sizeof(identity->executable)) <= 0) {
+    return -1;
+  }
+  if (stat(identity->executable, &executable_stat) != 0) {
+    return -1;
+  }
+
+  identity->pid = pid;
+  identity->start_sec = process.kp_proc.p_starttime.tv_sec;
+  identity->start_usec = process.kp_proc.p_starttime.tv_usec;
+  identity->device = executable_stat.st_dev;
+  identity->inode = executable_stat.st_ino;
+  return 0;
+}
+
+static int has_suffix(const char *value, const char *suffix) {
+  size_t value_size = strlen(value);
+  size_t suffix_size = strlen(suffix);
+
+  return value_size >= suffix_size &&
+         strcmp(value + value_size - suffix_size, suffix) == 0;
+}
+
+static int trusted_release_executable(const char *executable) {
+  char resolved[PATH_MAX];
+  char component[PATH_MAX];
+  char *slash;
+  struct stat path_stat;
+
+  if (realpath(executable, resolved) == NULL ||
+      strncmp(resolved, RELEASE_ROOT "/", strlen(RELEASE_ROOT) + 1) != 0 ||
+      strlen(resolved) >= sizeof(component)) {
+    return 0;
+  }
+
+  strcpy(component, resolved);
+  slash = strchr(component + 1, '/');
+  while (slash != NULL) {
+    char saved = *slash;
+    *slash = '\0';
+    if (lstat(component, &path_stat) != 0 ||
+        !S_ISDIR(path_stat.st_mode) ||
+        path_stat.st_uid != 0 ||
+        (path_stat.st_mode & 0022) != 0) {
+      return 0;
+    }
+    *slash = saved;
+    slash = strchr(slash + 1, '/');
+  }
+
+  if (lstat(resolved, &path_stat) != 0 ||
+      !S_ISREG(path_stat.st_mode) ||
+      path_stat.st_uid != 0 ||
+      (path_stat.st_mode & 0022) != 0) {
+    return 0;
+  }
+  return 1;
+}
+
+static int process_is_managed(pid_t pid, const char *executable) {
+  int mib[3] = {CTL_KERN, KERN_PROCARGS2, pid};
+  size_t size = 0;
+  char *buffer;
+  int has_release_name = 0;
+  int has_release_identity = 0;
+
+  if (sysctl(mib, 3, NULL, &size, NULL, 0) != 0 || size <= sizeof(int)) {
+    return errno == ESRCH ? 0 : -1;
+  }
+  buffer = malloc(size);
+  if (buffer == NULL) {
+    return -1;
+  }
+  if (sysctl(mib, 3, buffer, &size, NULL, 0) != 0) {
+    int result = errno == ESRCH ? 0 : -1;
+    free(buffer);
+    return result;
+  }
+
+  for (size_t index = sizeof(int); index < size;) {
+    const char *token = buffer + index;
+    size_t remaining = size - index;
+    size_t token_size = strnlen(token, remaining);
+
+    if (token_size == remaining) {
+      free(buffer);
+      return -1;
+    }
+    if (strcmp(token, RELEASE_NAME) == 0) {
+      has_release_name = 1;
+    }
+    if (strcmp(token, RELEASE_ROOT) == 0 ||
+        (strncmp(token, BOOT_PREFIX, strlen(BOOT_PREFIX)) == 0 &&
+         (has_suffix(token, "/start") || has_suffix(token, "/start_clean")))) {
+      has_release_identity = 1;
+    }
+    index += token_size + 1;
+  }
+
+  free(buffer);
+  return has_release_name && has_release_identity &&
+         trusted_release_executable(executable);
+}
+
+static int is_beam(const char *path) {
+  const char *name = strrchr(path, '/');
+  name = name == NULL ? path : name + 1;
+  return strcmp(name, "beam.smp") == 0;
+}
+
+static void print_json_string(const char *value) {
+  const unsigned char *cursor = (const unsigned char *)value;
+  putchar('"');
+  while (*cursor != '\0') {
+    switch (*cursor) {
+    case '"':
+      fputs("\\\"", stdout);
+      break;
+    case '\\':
+      fputs("\\\\", stdout);
+      break;
+    case '\n':
+      fputs("\\n", stdout);
+      break;
+    case '\r':
+      fputs("\\r", stdout);
+      break;
+    case '\t':
+      fputs("\\t", stdout);
+      break;
+    default:
+      if (*cursor < 0x20) {
+        printf("\\u%04x", *cursor);
+      } else {
+        putchar(*cursor);
+      }
+    }
+    cursor++;
+  }
+  putchar('"');
+}
+
+static void print_identity(const struct process_identity *identity) {
+  printf("{\"pid\":%d,\"start_sec\":%ld,\"start_usec\":%d,"
+         "\"device\":%llu,\"inode\":%llu,\"executable\":",
+         identity->pid, identity->start_sec, identity->start_usec,
+         (unsigned long long)identity->device,
+         (unsigned long long)identity->inode);
+  print_json_string(identity->executable);
+  putchar('}');
+}
+
+static int command_private_directory(const char *path);
+static int command_publish(const char *temporary, const char *destination);
+static int command_signal(const char *pid_text, const char *sec_text,
+                          const char *usec_text);
+
+static long long monotonic_milliseconds(void) {
+  struct timespec time;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &time) != 0) {
+    return -1;
+  }
+  return (long long)time.tv_sec * 1000 + time.tv_nsec / 1000000;
+}
+
+static int run_launchctl(int lock_descriptor, const char *action, const char *target) {
+  int output_pipe[2];
+  pid_t child;
+  int status = 0;
+  int flags;
+  long long deadline;
+  char output[4096];
+  char chunk[1024];
+  size_t output_size = 0;
+
+  if (pipe(output_pipe) != 0) {
+    return -1;
+  }
+  flags = fcntl(output_pipe[0], F_GETFL);
+  if (flags < 0 || fcntl(output_pipe[0], F_SETFL, flags | O_NONBLOCK) != 0) {
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    return -1;
+  }
+  child = fork();
+  if (child < 0) {
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    return -1;
+  }
+  if (child == 0) {
+    close(lock_descriptor);
+    close(output_pipe[0]);
+    if (dup2(output_pipe[1], STDOUT_FILENO) < 0 ||
+        dup2(output_pipe[1], STDERR_FILENO) < 0) {
+      _exit(127);
+    }
+    close(output_pipe[1]);
+    execl("/bin/launchctl", "launchctl", action, target, (char *)NULL);
+    _exit(127);
+  }
+
+  close(output_pipe[1]);
+  deadline = monotonic_milliseconds() + 10000;
+  for (;;) {
+    ssize_t read_size = read(output_pipe[0], chunk, sizeof(chunk));
+    if (read_size > 0 && output_size < sizeof(output) - 1) {
+      size_t available = sizeof(output) - output_size - 1;
+      size_t copy_size = (size_t)read_size < available ? (size_t)read_size : available;
+      memcpy(output + output_size, chunk, copy_size);
+      output_size += copy_size;
+    }
+    if (waitpid(child, &status, WNOHANG) == child) {
+      break;
+    }
+    if (monotonic_milliseconds() < 0 ||
+        monotonic_milliseconds() >= deadline) {
+      kill(child, SIGKILL);
+      waitpid(child, &status, 0);
+      close(output_pipe[0]);
+      return -1;
+    }
+    usleep(10000);
+  }
+  for (;;) {
+    ssize_t read_size = read(output_pipe[0], chunk, sizeof(chunk));
+    if (read_size <= 0) {
+      break;
+    }
+    if (output_size < sizeof(output) - 1) {
+      size_t available = sizeof(output) - output_size - 1;
+      size_t copy_size = (size_t)read_size < available ? (size_t)read_size : available;
+      memcpy(output + output_size, chunk, copy_size);
+      output_size += copy_size;
+    }
+  }
+  close(output_pipe[0]);
+  output[output_size] = '\0';
+
+  if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+    return 0;
+  }
+  if (strstr(output, "Could not find service") != NULL ||
+      strstr(output, "service not found") != NULL) {
+    return 1;
+  }
+  return -1;
+}
+
+static int command_lock(const char *path) {
+  int descriptor = open(path, O_CREAT | O_RDWR | O_NOFOLLOW | O_CLOEXEC, 0600);
+  struct process_identity guard_identity;
+  struct stat lock_stat;
+  char buffer[PATH_MAX + 16];
+
+  if (descriptor < 0) {
+    return EX_IOERR;
+  }
+  if (fstat(descriptor, &lock_stat) != 0 || !S_ISREG(lock_stat.st_mode)) {
+    close(descriptor);
+    return EX_IOERR;
+  }
+  if (flock(descriptor, LOCK_EX | LOCK_NB) != 0) {
+    int code = errno == EWOULDBLOCK || errno == EAGAIN ? EX_TEMPFAIL : EX_IOERR;
+    close(descriptor);
+    return code;
+  }
+  if (fchmod(descriptor, 0600) != 0 ||
+      (geteuid() == 0 && fchown(descriptor, 0, 0) != 0) ||
+      fstat(descriptor, &lock_stat) != 0 ||
+      read_identity(getpid(), &guard_identity) != 0) {
+    flock(descriptor, LOCK_UN);
+    close(descriptor);
+    return EX_IOERR;
+  }
+
+  fputs("READY {\"guard_identity\":", stdout);
+  print_identity(&guard_identity);
+  printf(",\"lock_device\":%llu,\"lock_inode\":%llu}\n",
+         (unsigned long long)lock_stat.st_dev,
+         (unsigned long long)lock_stat.st_ino);
+  fflush(stdout);
+  while (fgets(buffer, sizeof(buffer), stdin) != NULL) {
+    struct stat current;
+    struct stat canonical;
+
+    if (fstat(descriptor, &current) != 0 ||
+        lstat(path, &canonical) != 0 ||
+        !S_ISREG(canonical.st_mode) ||
+        canonical.st_uid != geteuid() ||
+        (canonical.st_mode & 0777) != 0600 ||
+        canonical.st_nlink != 1 ||
+        current.st_dev != lock_stat.st_dev ||
+        current.st_ino != lock_stat.st_ino ||
+        canonical.st_dev != lock_stat.st_dev ||
+        canonical.st_ino != lock_stat.st_ino ||
+        flock(descriptor, LOCK_EX | LOCK_NB) != 0) {
+      close(descriptor);
+      return EX_IOERR;
+    }
+
+    if (strcmp(buffer, "CHECK\n") == 0) {
+      fputs("LOCKED\n", stdout);
+      fflush(stdout);
+    } else if (strcmp(buffer, "PRIVATE\n") == 0) {
+      char path[PATH_MAX + 1];
+
+      if (fgets(path, sizeof(path), stdin) == NULL) {
+        close(descriptor);
+        return EX_IOERR;
+      }
+      path[strcspn(path, "\n")] = '\0';
+
+      if (path[0] == '\0' || command_private_directory(path) != 0) {
+        fputs("PRIVATE_FAILED\n", stdout);
+      } else {
+        fputs("PRIVATE_READY\n", stdout);
+      }
+      fflush(stdout);
+    } else if (strcmp(buffer, "PUBLISH\n") == 0) {
+      char temporary[PATH_MAX + 1];
+      char destination[PATH_MAX + 1];
+
+      if (fgets(temporary, sizeof(temporary), stdin) == NULL ||
+          fgets(destination, sizeof(destination), stdin) == NULL) {
+        close(descriptor);
+        return EX_IOERR;
+      }
+      temporary[strcspn(temporary, "\n")] = '\0';
+      destination[strcspn(destination, "\n")] = '\0';
+
+      if (temporary[0] == '\0' || destination[0] == '\0' ||
+          command_publish(temporary, destination) != 0) {
+        fputs("PUBLISH_FAILED\n", stdout);
+      } else {
+        fputs("PUBLISHED\n", stdout);
+      }
+      fflush(stdout);
+    } else if (strcmp(buffer, "DISABLE\n") == 0) {
+      char label[PATH_MAX + 1];
+      char target[PATH_MAX + 1];
+
+      if (fgets(label, sizeof(label), stdin) == NULL) {
+        close(descriptor);
+        return EX_IOERR;
+      }
+      label[strcspn(label, "\n")] = '\0';
+      if (label[0] == '\0' ||
+          snprintf(target, sizeof(target), "system/%s", label) >=
+              (int)sizeof(target) ||
+          run_launchctl(descriptor, "disable", target) != 0) {
+        fputs("DISABLE_FAILED\n", stdout);
+      } else {
+        fputs("DISABLED\n", stdout);
+      }
+      fflush(stdout);
+    } else if (strcmp(buffer, "BOOTOUT\n") == 0) {
+      char plist[PATH_MAX + 1];
+      int result;
+
+      if (fgets(plist, sizeof(plist), stdin) == NULL) {
+        close(descriptor);
+        return EX_IOERR;
+      }
+      plist[strcspn(plist, "\n")] = '\0';
+      result =
+          plist[0] == '\0' ? -1 : run_launchctl(descriptor, "bootout", plist);
+      if (result == 0) {
+        fputs("BOOTED_OUT\n", stdout);
+      } else if (result == 1) {
+        fputs("BOOTOUT_ABSENT\n", stdout);
+      } else {
+        fputs("BOOTOUT_FAILED\n", stdout);
+      }
+      fflush(stdout);
+    } else if (strcmp(buffer, "SIGNAL\n") == 0) {
+      char pid[32];
+      char sec[32];
+      char usec[32];
+      int result;
+
+      if (fgets(pid, sizeof(pid), stdin) == NULL ||
+          fgets(sec, sizeof(sec), stdin) == NULL ||
+          fgets(usec, sizeof(usec), stdin) == NULL) {
+        close(descriptor);
+        return EX_IOERR;
+      }
+      pid[strcspn(pid, "\n")] = '\0';
+      sec[strcspn(sec, "\n")] = '\0';
+      usec[strcspn(usec, "\n")] = '\0';
+      result = command_signal(pid, sec, usec);
+      if (result == 0) {
+        fputs("SIGNALED\n", stdout);
+      } else if (result == 3) {
+        fputs("SIGNAL_EXITED\n", stdout);
+      } else {
+        fputs("SIGNAL_FAILED\n", stdout);
+      }
+      fflush(stdout);
+    } else if (strcmp(buffer, "RELEASE\n") == 0) {
+      if (flock(descriptor, LOCK_UN) != 0 || close(descriptor) != 0) {
+        return EX_IOERR;
+      }
+      return 0;
+    } else {
+      flock(descriptor, LOCK_UN);
+      close(descriptor);
+      return EX_IOERR;
+    }
+  }
+  close(descriptor);
+  return 0;
+}
+
+static int command_identity(const char *pid_text) {
+  char *end = NULL;
+  long parsed = strtol(pid_text, &end, 10);
+  struct process_identity identity;
+  int result;
+
+  if (end == pid_text || *end != '\0' || parsed <= 1 || parsed > INT_MAX) {
+    return EX_IOERR;
+  }
+  result = read_identity((pid_t)parsed, &identity);
+  if (result != 0) {
+    return result == 1 ? 3 : EX_IOERR;
+  }
+  print_identity(&identity);
+  putchar('\n');
+  return 0;
+}
+
+static int command_snapshot(const char *expected_pid_text) {
+  int byte_count = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
+  int capacity;
+  pid_t expected_pid = -1;
+  int expected_seen = 0;
+  pid_t *pids;
+  int count;
+  int emitted = 0;
+
+  if (expected_pid_text != NULL) {
+    char *end = NULL;
+    long parsed = strtol(expected_pid_text, &end, 10);
+
+    if (end == expected_pid_text || *end != '\0' || parsed <= 1 ||
+        parsed > INT_MAX) {
+      return EX_IOERR;
+    }
+    expected_pid = (pid_t)parsed;
+  }
+  if (byte_count <= 0 || byte_count > INT_MAX / 2) {
+    return EX_IOERR;
+  }
+  capacity = byte_count * 2;
+  pids = calloc(1, (size_t)capacity);
+  if (pids == NULL) {
+    return EX_IOERR;
+  }
+  byte_count = proc_listpids(PROC_ALL_PIDS, 0, pids, capacity);
+  if (byte_count <= 0 || byte_count >= capacity) {
+    free(pids);
+    return EX_IOERR;
+  }
+
+  count = byte_count / (int)sizeof(pid_t);
+  putchar('[');
+  for (int index = 0; index < count; index++) {
+    char executable[PROC_PIDPATHINFO_MAXSIZE];
+    struct process_identity identity;
+    int managed;
+    int identity_result;
+
+    if (pids[index] <= 1) {
+      continue;
+    }
+    if (pids[index] == expected_pid) {
+      expected_seen = 1;
+    }
+    if (proc_pidpath(pids[index], executable, sizeof(executable)) <= 0) {
+      char process_name[PROC_PIDPATHINFO_MAXSIZE];
+      int path_error = errno;
+      int name_size = proc_name(pids[index], process_name, sizeof(process_name));
+
+      if (path_error == ESRCH || (name_size <= 0 && errno == ESRCH)) {
+        continue;
+      }
+      if (pids[index] != expected_pid && name_size > 0 &&
+          strcmp(process_name, "beam.smp") != 0) {
+        continue;
+      }
+      free(pids);
+      return EX_IOERR;
+    }
+    if (!is_beam(executable)) {
+      if (pids[index] == expected_pid) {
+        free(pids);
+        return EX_IOERR;
+      }
+      continue;
+    }
+    managed =
+        pids[index] == expected_pid ? 1 : process_is_managed(pids[index], executable);
+    if (managed < 0) {
+      free(pids);
+      return EX_IOERR;
+    }
+    if (managed == 0) {
+      continue;
+    }
+    identity_result = read_identity(pids[index], &identity);
+    if (identity_result == 1) {
+      continue;
+    }
+    if (identity_result != 0) {
+      free(pids);
+      return EX_IOERR;
+    }
+    if (emitted != 0) {
+      putchar(',');
+    }
+    print_identity(&identity);
+    emitted++;
+  }
+  if (expected_pid > 1 && !expected_seen) {
+    struct process_identity expected_identity;
+    int expected_result = read_identity(expected_pid, &expected_identity);
+
+    if (expected_result != 1) {
+      if (expected_result != 0) {
+        free(pids);
+        return EX_IOERR;
+      }
+      if (emitted != 0) {
+        putchar(',');
+      }
+      print_identity(&expected_identity);
+    }
+  }
+  puts("]");
+  free(pids);
+  return 0;
+}
+
+static int command_identity_state(const char *pid_text, const char *sec_text,
+                                  const char *usec_text) {
+  char *pid_end = NULL;
+  char *sec_end = NULL;
+  char *usec_end = NULL;
+  long pid = strtol(pid_text, &pid_end, 10);
+  long sec = strtol(sec_text, &sec_end, 10);
+  long usec = strtol(usec_text, &usec_end, 10);
+  struct process_identity identity;
+  int result;
+
+  if (*pid_end != '\0' || *sec_end != '\0' || *usec_end != '\0' || pid <= 1 ||
+      pid > INT_MAX) {
+    return EX_IOERR;
+  }
+  result = read_identity((pid_t)pid, &identity);
+  if (result == 1) {
+    puts("EXITED");
+    return 0;
+  }
+  if (result != 0) {
+    puts("UNKNOWN");
+    return 0;
+  }
+  if (identity.start_sec == sec && identity.start_usec == usec) {
+    puts("ALIVE");
+  } else {
+    puts("REUSED");
+  }
+  return 0;
+}
+
+static int command_signal(const char *pid_text, const char *sec_text,
+                          const char *usec_text) {
+  char *pid_end = NULL;
+  char *sec_end = NULL;
+  char *usec_end = NULL;
+  long pid = strtol(pid_text, &pid_end, 10);
+  long sec = strtol(sec_text, &sec_end, 10);
+  long usec = strtol(usec_text, &usec_end, 10);
+  struct process_identity identity;
+  int result;
+
+  if (*pid_end != '\0' || *sec_end != '\0' || *usec_end != '\0' || pid <= 1 ||
+      pid > INT_MAX) {
+    return EX_IOERR;
+  }
+  result = read_identity((pid_t)pid, &identity);
+  if (result == 1) {
+    return 3;
+  }
+  if (result != 0) {
+    return EX_IOERR;
+  }
+  if (identity.start_sec != sec || identity.start_usec != usec) {
+    return 4;
+  }
+  return kill((pid_t)pid, SIGTERM) == 0 ? 0 : EX_IOERR;
+}
+
+static int command_private_directory(const char *path) {
+  int descriptor;
+  int parent_descriptor = -1;
+  int created = 0;
+  char parent[PATH_MAX];
+  char *slash;
+  struct stat directory_stat;
+
+  if (mkdir(path, 0700) == 0) {
+    created = 1;
+  } else if (errno != EEXIST) {
+    return EX_IOERR;
+  }
+  descriptor = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (descriptor < 0 || fstat(descriptor, &directory_stat) != 0 ||
+      !S_ISDIR(directory_stat.st_mode) ||
+      directory_stat.st_uid != geteuid() ||
+      fchmod(descriptor, 0700) != 0 ||
+      fsync(descriptor) != 0) {
+    if (descriptor >= 0) {
+      close(descriptor);
+    }
+    return EX_IOERR;
+  }
+  if (close(descriptor) != 0) {
+    return EX_IOERR;
+  }
+  if (!created) {
+    return 0;
+  }
+  if (strlen(path) >= sizeof(parent)) {
+    return EX_IOERR;
+  }
+  strcpy(parent, path);
+  slash = strrchr(parent, '/');
+  if (slash == NULL) {
+    return EX_IOERR;
+  }
+  *slash = '\0';
+  parent_descriptor =
+      open(parent, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (parent_descriptor < 0 || fsync(parent_descriptor) != 0) {
+    if (parent_descriptor >= 0) {
+      close(parent_descriptor);
+    }
+    return EX_IOERR;
+  }
+  return close(parent_descriptor) == 0 ? 0 : EX_IOERR;
+}
+
+static int command_publish(const char *temporary, const char *destination) {
+  int descriptor = open(temporary, O_RDWR | O_NOFOLLOW | O_CLOEXEC);
+  char directory[PATH_MAX];
+  char *slash;
+  int directory_descriptor;
+  struct stat temporary_stat;
+
+  if (descriptor < 0 || fstat(descriptor, &temporary_stat) != 0 ||
+      !S_ISREG(temporary_stat.st_mode) || fchmod(descriptor, 0600) != 0 ||
+      (geteuid() == 0 && fchown(descriptor, 0, 0) != 0) || fsync(descriptor) != 0) {
+    if (descriptor >= 0) {
+      close(descriptor);
+    }
+    return EX_IOERR;
+  }
+  if (close(descriptor) != 0) {
+    return EX_IOERR;
+  }
+
+  if (strlen(destination) >= sizeof(directory)) {
+    return EX_IOERR;
+  }
+  strcpy(directory, destination);
+  slash = strrchr(directory, '/');
+  if (slash == NULL) {
+    return EX_IOERR;
+  }
+  *slash = '\0';
+
+  if (rename(temporary, destination) != 0) {
+    return EX_IOERR;
+  }
+  directory_descriptor = open(directory, O_RDONLY | O_CLOEXEC);
+  if (directory_descriptor < 0 || fsync(directory_descriptor) != 0) {
+    if (directory_descriptor >= 0) {
+      close(directory_descriptor);
+    }
+    return EX_IOERR;
+  }
+  return close(directory_descriptor) == 0 ? 0 : EX_IOERR;
+}
+
+int main(int argc, char **argv) {
+  if (argc == 3 && strcmp(argv[1], "lock") == 0) {
+    return command_lock(argv[2]);
+  }
+  if (argc == 3 && strcmp(argv[1], "identity") == 0) {
+    return command_identity(argv[2]);
+  }
+  if ((argc == 2 || argc == 3) && strcmp(argv[1], "snapshot") == 0) {
+    return command_snapshot(argc == 3 ? argv[2] : NULL);
+  }
+  if (argc == 5 && strcmp(argv[1], "identity-state") == 0) {
+    return command_identity_state(argv[2], argv[3], argv[4]);
+  }
+  return 64;
+}

--- a/apps/orchard_cli/lib/orchard_cli/commands/managed_node_agent_stop.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/managed_node_agent_stop.ex
@@ -1,0 +1,417 @@
+defmodule OrchardCLI.Commands.ManagedNodeAgentStop do
+  @moduledoc false
+
+  alias Orchard.ManagedNodeAgent.LifecycleState
+  alias OrchardCLI.LifecycleSystem
+
+  @type stop_result ::
+          {:stopped | :already_stopped, map()} | {:error, String.t(), 1}
+
+  @spec stop(map(), map()) :: stop_result()
+  def stop(service, runtime) do
+    deps = dependencies(runtime)
+
+    case deps.with_lock.(fn lock -> stop_locked(service, lock, deps) end) do
+      {:error, :locked} ->
+        {:error,
+         "Error: another Orchard lifecycle operation is already in progress.\n" <>
+           "Wait for it to finish, then run: sudo orchardctl stop", 1}
+
+      {:error, reason} ->
+        stop_error(service, reason)
+
+      result ->
+        result
+    end
+  end
+
+  defp stop_locked(service, lock, deps) do
+    context = %{service: service, lock: lock, deps: deps}
+
+    with {:ok, context} <- record_initial(context),
+         {:ok, context} <- establish_suppression(context),
+         {:ok, context} <- observe_process(context),
+         {:ok, context} <- prove_unload(context),
+         {:ok, context} <- prove_exit(context),
+         {:ok, context} <- prove_terminal(context) do
+      result = if context.already_stopped?, do: :already_stopped, else: :stopped
+      {result, service}
+    else
+      {:error, context, reason} ->
+        record_failure(context, reason)
+        stop_error(service, reason)
+    end
+  end
+
+  defp record_initial(context) do
+    deps = context.deps
+
+    with {:ok, coordinator} <- deps.owner_identity.(),
+         owner <- owner_identity(coordinator, context.lock),
+         start_state <- deps.read_start_state.(),
+         :ok <- admissible_prior_start_state(start_state),
+         job_state <- deps.job_state.(context.service),
+         process_state <- deps.process_snapshot.(context.service),
+         {:ok, records} <- deps.read_evidence.() do
+      evidence =
+        LifecycleState.new_managed_stop(
+          deps.uuid.(),
+          owner,
+          context.service,
+          %{
+            eligibility: LifecycleState.observed_eligibility(start_state),
+            launchd_job: observed_job(job_state),
+            managed_process: observed_process(process_state)
+          },
+          LifecycleState.reconciliations(records),
+          deps.wall_time.()
+        )
+
+      context = Map.put(context, :evidence, evidence)
+
+      case publish_evidence(context, evidence) do
+        :ok ->
+          {:ok,
+           context
+           |> Map.put(:prior_start_state, start_state)
+           |> Map.put(:evidence_persisted?, true)}
+
+        {:error, reason} ->
+          {:error, context, {:initial_evidence, reason}}
+      end
+    else
+      {:error, reason} -> {:error, context, {:initial_observation, reason}}
+    end
+  end
+
+  defp establish_suppression(context) do
+    deps = context.deps
+    state = LifecycleState.suppressed_state(context.prior_start_state)
+
+    with :ok <- validate_lock(context),
+         :ok <- deps.write_start_state.(context.lock, state),
+         {:ok, context} <-
+           advance(context, "eligibility_suppressed", %{
+             eligibility: state.eligibility,
+             one_shot_authorization: nil
+           }),
+         :ok <- validate_lock(context) do
+      prove_disablement(context, state)
+    else
+      {:error, context, reason} -> {:error, context, reason}
+      {:error, reason} -> {:error, context, {:suppression, reason}}
+    end
+  end
+
+  defp prove_disablement(context, state) do
+    disable_result = context.deps.disable_job.(context.lock, context.service)
+
+    case context.deps.job_disabled?.(context.service) do
+      true ->
+        case advance(context, "suppression_proven", %{
+               persistent_disablement: true,
+               disable_result: inspect(disable_result)
+             }) do
+          {:ok, context} -> {:ok, Map.put(context, :suppressed_state, state)}
+          {:error, context, reason} -> {:error, context, reason}
+        end
+
+      false ->
+        {:error, context, {:disablement_unproven, disable_result}}
+
+      other ->
+        {:error, context, {:disablement_unproven, {disable_result, other}}}
+    end
+  end
+
+  defp observe_process(context) do
+    deps = context.deps
+    job_state = deps.job_state.(context.service)
+    first = deps.process_snapshot.(context.service)
+    second = deps.process_snapshot.(context.service)
+
+    with {:ok, capture} <- stable_capture(first, second),
+         {:ok, context} <-
+           advance(context, "process_observed", %{
+             pre_shutdown_job: observed_job(job_state),
+             captured_process: capture
+           }) do
+      {:ok,
+       context
+       |> Map.put(:pre_shutdown_job, job_state)
+       |> Map.put(:capture, capture)
+       |> Map.put(:already_stopped?, job_state == :unloaded and capture == :absent)}
+    else
+      {:error, context, reason} -> {:error, context, reason}
+      {:error, reason} -> {:error, context, {:process_observation, reason}}
+    end
+  end
+
+  defp prove_unload(%{pre_shutdown_job: :loaded} = context) do
+    case validate_lock(context) do
+      :ok ->
+        bootout_result = context.deps.bootout.(context.lock, context.service)
+
+        with :ok <- wait_for_job_unload(context),
+             {:ok, context} <-
+               advance(context, "unload_proven", %{
+                 job_unloaded: true,
+                 bootout_result: inspect(bootout_result)
+               }) do
+          {:ok, context}
+        else
+          {:error, context, reason} -> {:error, context, reason}
+          {:error, reason} -> {:error, context, {:unload, {bootout_result, reason}}}
+        end
+
+      {:error, reason} ->
+        {:error, context, {:unload, reason}}
+    end
+  end
+
+  defp prove_unload(%{pre_shutdown_job: :unloaded, capture: :absent} = context) do
+    advance(context, "unload_proven", %{job_unloaded: true})
+  end
+
+  defp prove_unload(%{pre_shutdown_job: :unloaded, capture: identity} = context) do
+    with :ok <- validate_lock(context),
+         :ok <- context.deps.signal_process.(context.lock, identity),
+         {:ok, context} <-
+           advance(context, "unload_proven", %{
+             job_unloaded: true,
+             exact_orphan_signal: identity
+           }) do
+      {:ok, context}
+    else
+      {:error, context, reason} -> {:error, context, reason}
+      {:error, reason} -> {:error, context, {:unload, {:orphan_signal, reason}}}
+    end
+  end
+
+  defp prove_unload(context), do: {:error, context, {:unload, :unknown_job_state}}
+
+  defp prove_exit(%{capture: :absent} = context) do
+    with :ok <- require_no_process(context),
+         {:ok, context} <- advance(context, "exit_proven", %{affirmative_absence: true}) do
+      {:ok, context}
+    else
+      {:error, context, reason} -> {:error, context, reason}
+      {:error, reason} -> {:error, context, {:exit, reason}}
+    end
+  end
+
+  defp prove_exit(%{capture: identity} = context) do
+    with :ok <- wait_for_exit(context, identity),
+         :ok <- require_no_process(context),
+         {:ok, context} <- advance(context, "exit_proven", %{captured_exit: identity}) do
+      {:ok, context}
+    else
+      {:error, context, reason} -> {:error, context, reason}
+      {:error, reason} -> {:error, context, {:exit, reason}}
+    end
+  end
+
+  defp prove_terminal(context) do
+    deps = context.deps
+
+    with {:ok, state} <- deps.read_start_state.(),
+         true <- state == context.suppressed_state,
+         true <- deps.job_disabled?.(context.service),
+         :unloaded <- deps.job_state.(context.service),
+         :ok <- require_no_process(context),
+         {:ok, context} <-
+           advance(context, "terminal_coherent", %{
+             outcome: "stopped",
+             suppression_generation: state.eligibility.generation
+           }),
+         :ok <- validate_lock(context) do
+      {:ok, context}
+    else
+      {:error, context, reason} -> {:error, context, reason}
+      {:error, reason} -> {:error, context, {:terminal_proof, reason}}
+      false -> {:error, context, {:terminal_proof, :suppression_missing}}
+      other -> {:error, context, {:terminal_proof, other}}
+    end
+  end
+
+  defp wait_for_job_unload(context) do
+    wait_until(context, context.deps.unload_timeout_ms, fn ->
+      case context.deps.job_state.(context.service) do
+        :unloaded -> :done
+        :loaded -> :wait
+        other -> {:error, other}
+      end
+    end)
+  end
+
+  defp wait_for_exit(context, identity) do
+    wait_until(context, context.deps.exit_timeout_ms, fn ->
+      identity_state = context.deps.process_identity_state.(identity)
+      snapshot = context.deps.process_snapshot.(context.service)
+
+      case {identity_state, snapshot} do
+        {:alive, {:ok, [^identity]}} -> :wait
+        {state, {:ok, []}} when state in [:exited, :reused] -> :done
+        {{:unknown, reason}, _snapshot} -> {:error, {:identity_unknown, reason}}
+        {_state, {:error, reason}} -> {:error, {:process_unknown, reason}}
+        {state, {:ok, processes}} -> {:error, {:replacement_process, state, processes}}
+        {state, _snapshot} -> {:error, {:identity_unknown, state}}
+      end
+    end)
+  end
+
+  defp wait_until(context, timeout_ms, check) do
+    deadline = context.deps.monotonic_ms.() + timeout_ms
+    do_wait(context, deadline, check)
+  end
+
+  defp do_wait(context, deadline, check) do
+    case check.() do
+      :done ->
+        :ok
+
+      :wait ->
+        if context.deps.monotonic_ms.() >= deadline do
+          {:error, :timeout}
+        else
+          context.deps.sleep.(context.deps.poll_interval_ms)
+          do_wait(context, deadline, check)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp require_no_process(context) do
+    case context.deps.process_snapshot.(context.service) do
+      {:ok, []} -> :ok
+      {:ok, processes} -> {:error, {:replacement_process, processes}}
+      {:error, reason} -> {:error, {:process_unknown, reason}}
+    end
+  end
+
+  defp stable_capture({:ok, []}, {:ok, []}), do: {:ok, :absent}
+  defp stable_capture({:ok, [identity]}, {:ok, [identity]}), do: {:ok, identity}
+  defp stable_capture({:ok, first}, {:ok, second}), do: {:error, {:unstable, first, second}}
+  defp stable_capture({:error, reason}, _second), do: {:error, {:unknown, reason}}
+  defp stable_capture(_first, {:error, reason}), do: {:error, {:unknown, reason}}
+
+  defp advance(context, phase, proofs) do
+    evidence = LifecycleState.advance(context.evidence, phase, proofs, context.deps.wall_time.())
+
+    case publish_evidence(context, evidence) do
+      :ok -> {:ok, Map.put(context, :evidence, evidence)}
+      {:error, reason} -> {:error, context, {:evidence, phase, reason}}
+    end
+  end
+
+  defp publish_evidence(context, evidence) do
+    with :ok <- validate_lock(context) do
+      context.deps.write_evidence.(context.lock, evidence)
+    end
+  end
+
+  defp validate_lock(context), do: context.deps.lock_valid.(context.lock)
+
+  defp record_failure(%{evidence: evidence, evidence_persisted?: true} = context, reason) do
+    failed =
+      LifecycleState.advance(
+        evidence,
+        "terminal_failed",
+        %{failure: inspect(reason)},
+        context.deps.wall_time.()
+      )
+
+    if validate_lock(context) == :ok do
+      _result = context.deps.write_evidence.(context.lock, failed)
+    end
+
+    :ok
+  end
+
+  defp record_failure(_context, _reason), do: :ok
+
+  defp observed_job(:loaded), do: "loaded"
+  defp observed_job(:unloaded), do: "unloaded"
+  defp observed_job(other), do: %{"unknown" => inspect(other)}
+
+  defp observed_process({:ok, []}), do: "absent"
+  defp observed_process({:ok, [identity]}), do: %{"identity" => identity}
+  defp observed_process({:ok, identities}), do: %{"multiple" => identities}
+  defp observed_process({:error, reason}), do: %{"unknown" => inspect(reason)}
+
+  defp admissible_prior_start_state({:ok, state}),
+    do: LifecycleState.validate_start_state(state)
+
+  defp admissible_prior_start_state({:error, reason}) when reason in [:missing, :malformed],
+    do: :ok
+
+  defp admissible_prior_start_state({:error, reason}), do: {:error, {:unsafe_start_state, reason}}
+
+  defp stop_error(service, reason) do
+    {:error,
+     "Error: failed to stop #{service.display_name} (#{service.label}).\n" <>
+       "Managed Node Agent stop proof failed: #{inspect(reason)}.\n" <>
+       "Do not restart the Node Agent until managed recovery verifies suppression.", 1}
+  end
+
+  defp owner_identity(coordinator, %{
+         guard_identity: guard,
+         lock_device: device,
+         lock_inode: inode
+       }) do
+    %{
+      coordinator_identity: coordinator,
+      lock_guard_identity: guard,
+      lock_device: device,
+      lock_inode: inode
+    }
+  end
+
+  defp owner_identity(coordinator, _test_lock), do: coordinator
+
+  defp dependencies(runtime) do
+    %{
+      with_lock: Map.get(runtime, :with_lifecycle_lock, &LifecycleSystem.with_lock/1),
+      lock_valid: Map.get(runtime, :lock_valid, &LifecycleSystem.lock_valid/1),
+      owner_identity: Map.get(runtime, :owner_identity, &LifecycleSystem.owner_identity/0),
+      read_start_state: Map.get(runtime, :read_start_state, &LifecycleSystem.read_start_state/0),
+      read_evidence: Map.get(runtime, :read_evidence, &LifecycleSystem.read_evidence/0),
+      write_evidence: Map.get(runtime, :write_evidence, &LifecycleSystem.write_evidence/2),
+      write_start_state:
+        Map.get(runtime, :write_start_state, &LifecycleSystem.write_start_state/2),
+      disable_job: Map.get(runtime, :disable_job, &LifecycleSystem.disable_job/2),
+      job_disabled?: Map.get(runtime, :job_disabled?, &LifecycleSystem.job_disabled?/1),
+      job_state: Map.get(runtime, :job_state, &LifecycleSystem.job_state/1),
+      process_snapshot: Map.get(runtime, :process_snapshot, &LifecycleSystem.process_snapshot/1),
+      bootout: Map.get(runtime, :bootout, &LifecycleSystem.bootout/2),
+      process_identity_state:
+        Map.get(runtime, :process_identity_state, &LifecycleSystem.process_identity_state/1),
+      signal_process: Map.get(runtime, :signal_process, &LifecycleSystem.signal_process/2),
+      uuid: Map.get(runtime, :uuid, &uuid4/0),
+      wall_time:
+        Map.get(runtime, :wall_time, fn -> DateTime.utc_now() |> DateTime.to_iso8601() end),
+      monotonic_ms:
+        Map.get(runtime, :monotonic_ms, fn -> System.monotonic_time(:millisecond) end),
+      sleep: Map.get(runtime, :sleep, &Process.sleep/1),
+      unload_timeout_ms: Map.get(runtime, :unload_timeout_ms, 5_000),
+      exit_timeout_ms: Map.get(runtime, :exit_timeout_ms, 30_000),
+      poll_interval_ms: Map.get(runtime, :poll_interval_ms, 100)
+    }
+  end
+
+  defp uuid4 do
+    <<part1::32, part2::16, part3::16, part4::16, part5::48>> =
+      :crypto.strong_rand_bytes(16)
+
+    part3 = Bitwise.bor(Bitwise.band(part3, 0x0FFF), 0x4000)
+    part4 = Bitwise.bor(Bitwise.band(part4, 0x3FFF), 0x8000)
+
+    :io_lib.format(
+      "~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b",
+      [part1, part2, part3, part4, part5]
+    )
+    |> IO.iodata_to_binary()
+  end
+end

--- a/apps/orchard_cli/lib/orchard_cli/commands/stop.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/stop.ex
@@ -6,7 +6,7 @@ defmodule OrchardCLI.Commands.Stop do
   Boots out the controller and node agent in reverse dependency order.
   """
 
-  alias OrchardCLI.Commands.LifecycleSupport
+  alias OrchardCLI.Commands.{LifecycleSupport, ManagedNodeAgentStop}
 
   # ── Public API ──────────────────────────────────────────────────────
 
@@ -45,6 +45,14 @@ defmodule OrchardCLI.Commands.Stop do
     end
   end
 
+  defp stop_service(%{id: :node_agent} = service, runtime) do
+    runtime
+    |> Map.get(:managed_node_agent_stop, &ManagedNodeAgentStop.stop/2)
+    |> then(& &1.(service, runtime))
+  end
+
+  defp stop_service(service, runtime), do: LifecycleSupport.ensure_stopped(service, runtime)
+
   defp stop_services(runtime, role) do
     services = LifecycleSupport.services(:stop, runtime)
 
@@ -60,7 +68,7 @@ defmodule OrchardCLI.Commands.Stop do
   defp bootout_all([], _runtime, acc), do: {:ok, Enum.reverse(acc)}
 
   defp bootout_all([svc | rest], runtime, acc) do
-    case LifecycleSupport.ensure_stopped(svc, runtime) do
+    case stop_service(svc, runtime) do
       {:stopped, _} = result ->
         bootout_all(rest, runtime, [result | acc])
 

--- a/apps/orchard_cli/lib/orchard_cli/lifecycle_native.ex
+++ b/apps/orchard_cli/lib/orchard_cli/lifecycle_native.ex
@@ -1,0 +1,312 @@
+defmodule OrchardCLI.LifecycleNative do
+  @moduledoc false
+
+  @lock_timeout_ms 5_000
+
+  @type lock :: %{
+          required(:port) => port(),
+          required(:owner) => pid(),
+          required(:path) => String.t(),
+          required(:guard_identity) => process_identity(),
+          required(:lock_device) => non_neg_integer(),
+          required(:lock_inode) => non_neg_integer()
+        }
+  @type process_identity :: %{required(String.t()) => integer() | String.t()}
+
+  @spec with_lock(String.t(), (lock() -> result)) :: result | {:error, term()} when result: var
+  def with_lock(path, callback) when is_binary(path) and is_function(callback, 1) do
+    with {:ok, port} <- open_lock(path),
+         {:ok, metadata} <- await_lock(port) do
+      lock = Map.merge(metadata, %{port: port, owner: self(), path: path})
+
+      try do
+        result = callback.(lock)
+
+        case release_lock(port) do
+          :ok -> result
+          {:error, reason} -> {:error, reason}
+        end
+      catch
+        kind, reason ->
+          stacktrace = __STACKTRACE__
+          _release_result = release_lock(port)
+          :erlang.raise(kind, reason, stacktrace)
+      end
+    end
+  end
+
+  @spec lock_valid(lock()) :: :ok | {:error, :exclusion_lost | :not_owner}
+  def lock_valid(%{port: port, owner: owner}) do
+    cond do
+      owner != self() -> {:error, :not_owner}
+      Port.info(port) == nil -> {:error, :exclusion_lost}
+      Port.command(port, "CHECK\n") -> await_lock_check(port)
+      true -> {:error, :exclusion_lost}
+    end
+  rescue
+    ArgumentError -> {:error, :exclusion_lost}
+  end
+
+  @spec ensure_private_directory(lock(), String.t()) :: :ok | {:error, term()}
+  def ensure_private_directory(%{port: port, owner: owner}, path) do
+    guard_command(port, owner, ["PRIVATE\n", path, "\n"], "PRIVATE_READY")
+  end
+
+  @spec atomic_publish(lock(), String.t(), iodata(), keyword()) :: :ok | {:error, term()}
+  def atomic_publish(%{port: port, owner: owner}, destination, contents, options \\ []) do
+    directory = Path.dirname(destination)
+    staging_directory = Keyword.get(options, :staging_directory, directory)
+
+    temporary =
+      Path.join(staging_directory, ".#{Path.basename(destination)}.tmp-#{random_suffix()}")
+
+    try do
+      with :ok <- write_temporary(temporary, contents) do
+        guard_command(
+          port,
+          owner,
+          ["PUBLISH\n", temporary, "\n", destination, "\n"],
+          "PUBLISHED"
+        )
+      end
+    after
+      File.rm(temporary)
+    end
+  end
+
+  @spec disable_job(lock(), String.t()) :: :ok | {:error, term()}
+  def disable_job(%{port: port, owner: owner}, label) do
+    guard_command(port, owner, ["DISABLE\n", label, "\n"], "DISABLED", 12_000)
+  end
+
+  @spec bootout(lock(), String.t()) :: :ok | {:error, term()}
+  def bootout(%{port: port, owner: owner}, plist_path) do
+    guard_command(
+      port,
+      owner,
+      ["BOOTOUT\n", plist_path, "\n"],
+      ["BOOTED_OUT", "BOOTOUT_ABSENT"],
+      12_000
+    )
+  end
+
+  @spec process_identity(String.t() | pos_integer()) ::
+          {:ok, process_identity()} | {:error, term()}
+  def process_identity(pid) do
+    case helper_command(["identity", to_string(pid)]) do
+      {output, 0} -> Jason.decode(output)
+      {_output, 3} -> {:error, :exited}
+      {output, code} -> {:error, {:identity_failed, code, String.trim(output)}}
+    end
+  end
+
+  @spec process_snapshot(pos_integer() | nil) ::
+          {:ok, [process_identity()]} | {:error, term()}
+  def process_snapshot(expected_pid \\ nil) do
+    args = if is_nil(expected_pid), do: ["snapshot"], else: ["snapshot", to_string(expected_pid)]
+
+    case helper_command(args) do
+      {output, 0} -> Jason.decode(output)
+      {output, code} -> {:error, {:snapshot_failed, code, String.trim(output)}}
+    end
+  end
+
+  @spec process_identity_state(process_identity()) ::
+          :alive | :exited | :reused | {:unknown, term()}
+  def process_identity_state(identity) do
+    args = [
+      "identity-state",
+      to_string(identity["pid"] || identity[:pid]),
+      to_string(identity["start_sec"] || identity[:start_sec]),
+      to_string(identity["start_usec"] || identity[:start_usec])
+    ]
+
+    case helper_command(args) do
+      {"ALIVE\n", 0} -> :alive
+      {"EXITED\n", 0} -> :exited
+      {"REUSED\n", 0} -> :reused
+      {output, code} -> {:unknown, {:identity_state_failed, code, String.trim(output)}}
+    end
+  end
+
+  @spec signal_process(lock(), process_identity()) :: :ok | {:error, term()}
+  def signal_process(%{port: port, owner: owner}, identity) do
+    command = [
+      "SIGNAL\n",
+      to_string(identity["pid"] || identity[:pid]),
+      "\n",
+      to_string(identity["start_sec"] || identity[:start_sec]),
+      "\n",
+      to_string(identity["start_usec"] || identity[:start_usec]),
+      "\n"
+    ]
+
+    guard_command(port, owner, command, ["SIGNALED", "SIGNAL_EXITED"])
+  end
+
+  defp open_lock(path) do
+    port =
+      Port.open(
+        {:spawn_executable, helper_path()},
+        [
+          :binary,
+          :exit_status,
+          :use_stdio,
+          :stderr_to_stdout,
+          {:line, 1024},
+          args: ["lock", path]
+        ]
+      )
+
+    {:ok, port}
+  rescue
+    error in ArgumentError -> {:error, {:helper_open_failed, Exception.message(error)}}
+  end
+
+  defp await_lock(port) do
+    receive do
+      {^port, {:data, {:eol, "READY " <> encoded}}} ->
+        case Jason.decode(encoded) do
+          {:ok,
+           %{
+             "guard_identity" => guard_identity,
+             "lock_device" => lock_device,
+             "lock_inode" => lock_inode
+           }} ->
+            {:ok,
+             %{
+               guard_identity: guard_identity,
+               lock_device: lock_device,
+               lock_inode: lock_inode
+             }}
+
+          _invalid ->
+            Port.close(port)
+            {:error, :invalid_lock_metadata}
+        end
+
+      {^port, {:exit_status, 75}} ->
+        {:error, :locked}
+
+      {^port, {:exit_status, code}} ->
+        {:error, {:lock_failed, code}}
+    after
+      @lock_timeout_ms ->
+        Port.close(port)
+        {:error, :lock_timeout}
+    end
+  end
+
+  defp await_lock_check(port) do
+    receive do
+      {^port, {:data, {:eol, "LOCKED"}}} -> :ok
+      {^port, {:exit_status, _code}} -> {:error, :exclusion_lost}
+      {^port, {:data, _data}} -> {:error, :exclusion_lost}
+    after
+      @lock_timeout_ms -> {:error, :exclusion_lost}
+    end
+  end
+
+  defp guard_command(port, owner, command, expected, timeout \\ @lock_timeout_ms) do
+    expected = List.wrap(expected)
+
+    cond do
+      owner != self() ->
+        {:error, :not_owner}
+
+      Port.info(port) == nil ->
+        {:error, :exclusion_lost}
+
+      Port.command(port, command) ->
+        receive do
+          {^port, {:data, {:eol, response}}} ->
+            if response in expected, do: :ok, else: {:error, {:guard_rejected, response}}
+
+          {^port, {:exit_status, _code}} ->
+            {:error, :exclusion_lost}
+
+          {^port, {:data, _data}} ->
+            {:error, :exclusion_lost}
+        after
+          timeout -> {:error, :guard_timeout}
+        end
+
+      true ->
+        {:error, :exclusion_lost}
+    end
+  rescue
+    ArgumentError -> {:error, :exclusion_lost}
+  end
+
+  defp release_lock(port) do
+    if Port.info(port) != nil and Port.command(port, "RELEASE\n") do
+      await_exit(port)
+    else
+      {:error, :lock_release_lost}
+    end
+  rescue
+    ArgumentError -> {:error, :lock_release_lost}
+  end
+
+  defp await_exit(port) do
+    receive do
+      {^port, {:exit_status, 0}} -> :ok
+      {^port, {:exit_status, code}} -> {:error, {:lock_release_failed, code}}
+      {^port, {:data, _data}} -> await_exit(port)
+    after
+      @lock_timeout_ms ->
+        Port.close(port)
+        {:error, :lock_release_timeout}
+    end
+  end
+
+  defp write_temporary(path, contents) do
+    with {:ok, file} <- File.open(path, [:write, :binary, :exclusive]),
+         :ok <- IO.binwrite(file, contents),
+         :ok <- :file.sync(file),
+         :ok <- File.close(file) do
+      File.chmod(path, 0o600)
+    end
+  end
+
+  @spec run_command(String.t(), [String.t()], non_neg_integer()) :: {String.t(), integer()}
+  def run_command(executable, args, timeout_ms) do
+    port =
+      Port.open(
+        {:spawn_executable, executable},
+        [:binary, :exit_status, :use_stdio, :stderr_to_stdout, args: args]
+      )
+
+    await_command(port, [], System.monotonic_time(:millisecond) + timeout_ms)
+  rescue
+    error in ArgumentError -> {Exception.message(error), 127}
+  end
+
+  defp helper_command(args), do: run_command(helper_path(), args, @lock_timeout_ms)
+
+  defp await_command(port, output, deadline) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {^port, {:data, data}} -> await_command(port, [output, data], deadline)
+      {^port, {:exit_status, code}} -> {IO.iodata_to_binary(output), code}
+    after
+      remaining ->
+        Port.close(port)
+        {IO.iodata_to_binary(output), 124}
+    end
+  end
+
+  defp helper_path do
+    :orchard_cli
+    |> :code.priv_dir()
+    |> List.to_string()
+    |> Path.join("orchard-lifecycle-helper")
+  end
+
+  defp random_suffix do
+    12
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16(case: :lower)
+  end
+end

--- a/apps/orchard_cli/lib/orchard_cli/lifecycle_system.ex
+++ b/apps/orchard_cli/lib/orchard_cli/lifecycle_system.ex
@@ -1,0 +1,322 @@
+defmodule OrchardCLI.LifecycleSystem do
+  @moduledoc false
+
+  alias Orchard.ManagedNodeAgent.LifecycleState
+  alias OrchardCLI.LifecycleNative
+
+  @support_root "/Library/Application Support/Orchard/support"
+  @lock_path Path.join(@support_root, ".app-lifecycle.lock")
+  @start_state_path Path.join(@support_root, ".managed-node-agent-start-state.json")
+  @evidence_dir Path.join(@support_root, ".managed-node-agent-lifecycle-evidence")
+  @max_evidence_records 1_024
+  @max_document_bytes 1_048_576
+
+  @spec with_lock((LifecycleNative.lock() -> result)) :: result | {:error, term()}
+        when result: var
+  def with_lock(callback) do
+    with :ok <- ensure_trusted_directory(@support_root) do
+      LifecycleNative.with_lock(@lock_path, callback)
+    end
+  end
+
+  @spec lock_valid(LifecycleNative.lock()) :: :ok | {:error, term()}
+  def lock_valid(lock), do: LifecycleNative.lock_valid(lock)
+
+  @spec owner_identity() :: {:ok, map()} | {:error, term()}
+  def owner_identity, do: LifecycleNative.process_identity(System.pid())
+
+  @spec read_start_state() :: {:ok, map()} | {:error, term()}
+  def read_start_state do
+    case read_json(@start_state_path) do
+      {:ok, document} -> normalize_start_state(document)
+      error -> error
+    end
+  end
+
+  @spec read_evidence() :: {:ok, [map()]} | {:error, term()}
+  def read_evidence do
+    case File.ls(@evidence_dir) do
+      {:ok, entries} -> read_evidence_entries(entries)
+      {:error, :enoent} -> {:ok, []}
+      {:error, reason} -> {:error, {:evidence_directory, reason}}
+    end
+  end
+
+  @spec write_start_state(LifecycleNative.lock(), map()) :: :ok | {:error, term()}
+  def write_start_state(lock, state) do
+    with :ok <- LifecycleState.validate_start_state(state) do
+      publish_json(lock, @start_state_path, state)
+    end
+  end
+
+  @spec write_evidence(LifecycleNative.lock(), map()) :: :ok | {:error, term()}
+  def write_evidence(lock, %{operation_id: operation_id} = evidence) do
+    with :ok <- LifecycleState.validate_evidence(evidence),
+         true <-
+           Regex.match?(
+             ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/,
+             operation_id
+           ) do
+      publish_json(lock, Path.join(@evidence_dir, operation_id <> ".json"), evidence)
+    else
+      false -> {:error, :invalid_operation_id}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec disable_job(LifecycleNative.lock(), map()) :: :ok | {:error, term()}
+  def disable_job(lock, service), do: LifecycleNative.disable_job(lock, service.label)
+
+  @spec job_disabled?(map()) :: boolean() | {:error, term()}
+  def job_disabled?(service) do
+    case launchctl(["print-disabled", "system"]) do
+      {output, 0} ->
+        case disabled_state(output, service.label) do
+          :disabled -> true
+          state when state in [:enabled, :missing] -> false
+          :ambiguous -> {:error, :ambiguous_disablement_state}
+        end
+
+      {output, code} ->
+        {:error, {:disablement_observation_failed, code, summary(output)}}
+    end
+  end
+
+  @doc "Parses one service's persistent disabled state from launchctl output."
+  @spec disabled_state(String.t(), String.t()) :: :disabled | :enabled | :missing | :ambiguous
+  def disabled_state(output, label) do
+    pattern = ~r/"#{Regex.escape(label)}"\s*=>\s*([^,;\n}]+)/
+
+    matches =
+      pattern
+      |> Regex.scan(output, capture: :all_but_first)
+      |> Enum.map(fn [state] -> String.trim(state) end)
+
+    case matches do
+      ["true"] -> :disabled
+      ["false"] -> :enabled
+      [] -> :missing
+      _matches -> :ambiguous
+    end
+  end
+
+  @spec job_state(map()) :: :loaded | :unloaded | {:unknown, term()}
+  def job_state(service) do
+    case launchctl(["print", "system/#{service.label}"]) do
+      {_output, 0} ->
+        :loaded
+
+      {output, 113} ->
+        if(not_found?(output), do: :unloaded, else: {:unknown, {113, summary(output)}})
+
+      {output, code} ->
+        {:unknown, {code, summary(output)}}
+    end
+  end
+
+  @spec process_snapshot(map()) :: {:ok, [map()]} | {:error, term()}
+  def process_snapshot(service) do
+    case launchctl(["print", "system/#{service.label}"]) do
+      {output, 0} ->
+        case job_pid(output) do
+          pid when is_integer(pid) -> LifecycleNative.process_snapshot(pid)
+          :missing -> LifecycleNative.process_snapshot()
+          :ambiguous -> {:error, :ambiguous_launchd_pid}
+        end
+
+      {output, 113} ->
+        if not_found?(output),
+          do: LifecycleNative.process_snapshot(),
+          else: {:error, {:launchd_pid_observation_failed, 113, summary(output)}}
+
+      {output, code} ->
+        {:error, {:launchd_pid_observation_failed, code, summary(output)}}
+    end
+  end
+
+  @doc "Parses one service's PID from launchctl print output."
+  @spec job_pid(String.t()) :: pos_integer() | :missing | :ambiguous
+  def job_pid(output) do
+    case Regex.scan(~r/^\s*pid\s*=\s*(\d+)\s*$/m, output, capture: :all_but_first) do
+      [[pid]] ->
+        case Integer.parse(pid) do
+          {value, ""} when value > 1 -> value
+          _invalid -> :ambiguous
+        end
+
+      [] ->
+        :missing
+
+      _matches ->
+        :ambiguous
+    end
+  end
+
+  @spec bootout(LifecycleNative.lock(), map()) :: :ok | {:error, term()}
+  def bootout(lock, service) do
+    LifecycleNative.bootout(lock, "system/#{service.label}")
+  end
+
+  @spec signal_process(LifecycleNative.lock(), map()) :: :ok | {:error, term()}
+  def signal_process(lock, identity), do: LifecycleNative.signal_process(lock, identity)
+
+  @spec process_identity_state(map()) :: :alive | :exited | :reused | {:unknown, term()}
+  def process_identity_state(identity), do: LifecycleNative.process_identity_state(identity)
+
+  defp read_evidence_entries(entries) when length(entries) > @max_evidence_records,
+    do: {:error, :too_many_evidence_records}
+
+  defp read_evidence_entries(entries) do
+    result =
+      entries
+      |> Enum.filter(&String.ends_with?(&1, ".json"))
+      |> Enum.sort()
+      |> Enum.reduce_while({:ok, []}, fn entry, {:ok, records} ->
+        case read_evidence_entry(entry) do
+          {:ok, record} -> {:cont, {:ok, [record | records]}}
+          {:error, reason} -> {:halt, {:error, {:evidence_entry, entry, reason}}}
+        end
+      end)
+
+    case result do
+      {:ok, records} -> {:ok, Enum.reverse(records)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp read_evidence_entry(entry) do
+    path = Path.join(@evidence_dir, entry)
+
+    with {:ok, contents} <- read_trusted_contents(path) do
+      record =
+        case Jason.decode(contents) do
+          {:ok, decoded} ->
+            validate_evidence_entry(decoded, entry, contents)
+
+          {:error, reason} ->
+            invalid_evidence_entry(entry, contents, reason)
+        end
+
+      {:ok, record}
+    end
+  end
+
+  defp validate_evidence_entry(decoded, entry, contents) do
+    case LifecycleState.validate_evidence(decoded) do
+      :ok -> decoded
+      {:error, reason} -> invalid_evidence_entry(entry, contents, reason)
+    end
+  end
+
+  defp invalid_evidence_entry(entry, contents, reason) do
+    %{
+      operation_id: Path.rootname(entry),
+      kind: "unknown",
+      phase: "invalid",
+      filename: entry,
+      sha256: Base.encode16(:crypto.hash(:sha256, contents), case: :lower),
+      invalid_reason: inspect(reason)
+    }
+  end
+
+  defp publish_json(lock, path, document) do
+    with :ok <- LifecycleNative.ensure_private_directory(lock, @evidence_dir),
+         {:ok, encoded} <- Jason.encode(document),
+         true <- byte_size(encoded) <= @max_document_bytes,
+         :ok <-
+           LifecycleNative.atomic_publish(lock, path, encoded, staging_directory: @evidence_dir) do
+      :ok
+    else
+      false -> {:error, :document_too_large}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp read_json(path) do
+    with {:ok, contents} <- read_trusted_contents(path) do
+      Jason.decode(contents)
+    end
+  end
+
+  defp read_trusted_contents(path) do
+    with {:ok, stat} <- File.lstat(path),
+         :regular <- stat.type,
+         true <- stat.size <= @max_document_bytes,
+         true <- trusted_owner?(stat),
+         true <- Bitwise.band(stat.mode, 0o077) == 0,
+         {:ok, contents} <- File.read(path) do
+      {:ok, contents}
+    else
+      {:error, :enoent} -> {:error, :missing}
+      false -> {:error, :unsafe_metadata}
+      type when is_atom(type) -> {:error, {:unsafe_type, type}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_start_state(%{
+         "schema_version" => 1,
+         "eligibility" => %{"state" => state, "generation" => generation},
+         "one_shot_authorization" => authorization
+       })
+       when state in ["suppressed", "one_shot_pending", "enabled"] and is_integer(generation) and
+              generation > 0 and (is_map(authorization) or is_nil(authorization)) do
+    {:ok,
+     %{
+       schema_version: 1,
+       eligibility: %{state: state, generation: generation},
+       one_shot_authorization: authorization
+     }}
+  end
+
+  defp normalize_start_state(_document), do: {:error, :malformed}
+
+  defp ensure_trusted_directory(path) do
+    path
+    |> Path.split()
+    |> Enum.reduce_while({:ok, ""}, fn component, {:ok, current} ->
+      candidate = if component == "/", do: "/", else: Path.join(current, component)
+
+      case File.lstat(candidate) do
+        {:ok, stat} ->
+          trusted_directory_component(stat, candidate)
+
+        {:error, reason} ->
+          {:halt, {:error, {reason, candidate}}}
+      end
+    end)
+    |> case do
+      {:ok, _path} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp trusted_directory_component(stat, candidate) do
+    if stat.type == :directory and trusted_owner?(stat) and
+         Bitwise.band(stat.mode, 0o022) == 0 do
+      {:cont, {:ok, candidate}}
+    else
+      {:halt, {:error, {:unsafe_directory_component, candidate}}}
+    end
+  end
+
+  defp trusted_owner?(stat), do: stat.uid == 0
+
+  defp launchctl(args), do: LifecycleNative.run_command("/bin/launchctl", args, 5_000)
+
+  defp not_found?(output) do
+    String.contains?(output, "Could not find service") or
+      String.contains?(output, "service not found")
+  end
+
+  defp summary(output) do
+    output
+    |> String.trim()
+    |> String.split("\n", trim: true)
+    |> List.first()
+    |> case do
+      nil -> "no output"
+      line -> line
+    end
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/managed_node_agent_stop_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/managed_node_agent_stop_test.exs
@@ -1,0 +1,527 @@
+defmodule OrchardCLI.Commands.ManagedNodeAgentStopTest do
+  use ExUnit.Case, async: true
+
+  alias OrchardCLI.Commands.Stop
+
+  @service %{
+    id: :node_agent,
+    label: "com.orchard.node-agent",
+    plist_path: "/tmp/com.orchard.node-agent.plist",
+    display_name: "Node Agent"
+  }
+
+  test "SPEC 11.4 lock contention fails without managed mutation" do
+    parent = self()
+
+    runtime =
+      base_runtime(%{
+        with_lifecycle_lock: fn _callback -> {:error, :locked} end,
+        write_evidence: fn _lock, _evidence -> mutation(parent, :write_evidence).(nil) end,
+        write_start_state: fn _lock, _state -> mutation(parent, :write_start_state).(nil) end,
+        disable_job: fn _lock, _service -> mutation(parent, :disable_job).(nil) end,
+        bootout: fn _lock, _service -> mutation(parent, :bootout).(nil) end
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "lifecycle operation is already in progress"
+    refute_receive {:mutation, _operation}
+  end
+
+  test "SPEC 11.4 records suppression and exact exit before coherent success" do
+    parent = self()
+    identity = %{pid: 4242, start_time: 91, executable: "/tmp/beam.smp", device: 1, inode: 2}
+
+    start_state = %{
+      schema_version: 1,
+      eligibility: %{state: "suppressed", generation: 1},
+      one_shot_authorization: nil
+    }
+
+    runtime =
+      base_runtime(%{
+        with_lifecycle_lock: fn callback -> callback.(:lock) end,
+        lock_valid: fn :lock -> event(parent, :lock_valid, :ok) end,
+        owner_identity: fn -> {:ok, %{pid: 10, start_time: 20}} end,
+        read_start_state: sequence([{:error, :missing}, {:ok, start_state}]),
+        read_evidence: fn -> {:ok, []} end,
+        write_evidence: fn :lock, evidence ->
+          send(parent, {:event, {:evidence, evidence.phase}})
+          :ok
+        end,
+        write_start_state: fn :lock, state ->
+          send(parent, {:event, {:start_state, state.eligibility.state}})
+          :ok
+        end,
+        disable_job: fn :lock, _service -> event(parent, :disable, :ok) end,
+        job_disabled?: fn _service -> event(parent, :disabled_proof, true) end,
+        job_state: sequence1([:loaded, :loaded, :unloaded, :unloaded]),
+        process_snapshot:
+          sequence1([
+            {:ok, [identity]},
+            {:ok, [identity]},
+            {:ok, [identity]},
+            {:ok, []},
+            {:ok, []},
+            {:ok, []}
+          ]),
+        bootout: fn :lock, _service -> event(parent, :bootout, :ok) end,
+        process_identity_state: fn ^identity -> :exited end,
+        uuid: fn -> "00000000-0000-4000-8000-000000000001" end,
+        wall_time: fn -> "2026-08-14T00:00:00Z" end
+      })
+
+    assert {:ok, message} = Stop.run([], runtime)
+    assert message =~ "Stopped Orchard services."
+
+    assert collect_events() == [
+             :lock_valid,
+             {:evidence, "initial"},
+             :lock_valid,
+             {:start_state, "suppressed"},
+             :lock_valid,
+             {:evidence, "eligibility_suppressed"},
+             :lock_valid,
+             :disable,
+             :disabled_proof,
+             :lock_valid,
+             {:evidence, "suppression_proven"},
+             :lock_valid,
+             {:evidence, "process_observed"},
+             :lock_valid,
+             :bootout,
+             :lock_valid,
+             {:evidence, "unload_proven"},
+             :lock_valid,
+             {:evidence, "exit_proven"},
+             :disabled_proof,
+             :lock_valid,
+             {:evidence, "terminal_coherent"},
+             :lock_valid
+           ]
+  end
+
+  test "initial evidence failure performs no managed mutation" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        write_evidence: fn _lock, _evidence -> {:error, :disk_full} end
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "initial_evidence"
+    refute_receive {:event, :start_state}
+    refute_receive {:event, :disable}
+    refute_receive {:event, :bootout}
+  end
+
+  test "unproven disablement fails before final process observation or bootout" do
+    parent = self()
+    runtime = managed_runtime(parent, %{job_disabled?: fn _service -> false end})
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "disablement_unproven"
+    refute_receive {:event, :bootout}
+    refute Enum.member?(collect_events(), {:evidence, "process_observed"})
+  end
+
+  test "exclusion loss immediately before disablement fails without further mutation" do
+    parent = self()
+    counter = :counters.new(1, [])
+
+    runtime =
+      managed_runtime(parent, %{
+        lock_valid: fn :lock ->
+          :counters.add(counter, 1, 1)
+          if :counters.get(counter, 1) <= 3, do: :ok, else: {:error, :exclusion_lost}
+        end
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "exclusion_lost"
+    assert_receive {:event, :start_state}
+    refute_receive {:event, :disable}
+    refute_receive {:event, :bootout}
+  end
+
+  test "disable command failure may proceed only when persistent disablement is proven" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        disable_job: fn :lock, _service ->
+          event(parent, :disable, {:error, {:disable_failed, 5}})
+        end
+      })
+
+    assert {:ok, message} = Stop.run([], runtime)
+    assert message =~ "Stopped Orchard services."
+    assert Enum.member?(collect_events(), {:evidence, "terminal_coherent"})
+  end
+
+  test "multiple stable managed instances fail closed without bootout" do
+    parent = self()
+    first = process_identity(4242)
+    second = process_identity(4343)
+
+    runtime =
+      managed_runtime(parent, %{
+        process_snapshot:
+          sequence1([{:ok, [first]}, {:ok, [first, second]}, {:ok, [first, second]}])
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "unstable"
+    refute_receive {:event, :bootout}
+  end
+
+  test "bootout command failure may succeed only when unload and exit are independently proven" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        bootout: fn :lock, _service ->
+          event(parent, :bootout, {:error, {:bootout_failed, 5}})
+        end
+      })
+
+    assert {:ok, message} = Stop.run([], runtime)
+    assert message =~ "Stopped Orchard services."
+    assert Enum.member?(collect_events(), {:evidence, "terminal_coherent"})
+  end
+
+  test "captured process timeout fails without coherent stopped evidence" do
+    parent = self()
+    identity = process_identity(4242)
+
+    runtime =
+      managed_runtime(parent, %{
+        process_snapshot:
+          sequence1([
+            {:ok, [identity]},
+            {:ok, [identity]},
+            {:ok, [identity]},
+            {:ok, [identity]}
+          ]),
+        process_identity_state: fn ^identity -> :alive end,
+        exit_timeout_ms: 0,
+        monotonic_ms: fn -> 0 end
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "timeout"
+    refute Enum.member?(collect_events(), {:evidence, "terminal_coherent"})
+  end
+
+  test "already stopped path reasserts suppression and records coherent evidence" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        job_state: sequence1([:unloaded, :unloaded, :unloaded]),
+        process_snapshot: sequence1(List.duplicate({:ok, []}, 5))
+      })
+
+    assert {:ok, message} = Stop.run([], runtime)
+    assert message =~ "already stopped"
+    events = collect_events()
+    assert Enum.member?(events, :start_state)
+    assert Enum.member?(events, :disable)
+    assert Enum.member?(events, {:evidence, "terminal_coherent"})
+    refute Enum.member?(events, :bootout)
+  end
+
+  test "replacement process after captured exit fails closed" do
+    parent = self()
+    first = process_identity(4242)
+    replacement = process_identity(4343)
+
+    runtime =
+      managed_runtime(parent, %{
+        process_snapshot:
+          sequence1([
+            {:ok, [first]},
+            {:ok, [first]},
+            {:ok, [first]},
+            {:ok, [replacement]}
+          ])
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "replacement_process"
+    refute Enum.member?(collect_events(), {:evidence, "terminal_coherent"})
+  end
+
+  test "unloaded live orphan is signaled only after exact capture and exits boundedly" do
+    parent = self()
+    identity = process_identity(4242)
+
+    runtime =
+      managed_runtime(parent, %{
+        job_state: sequence1([:unloaded, :unloaded, :unloaded]),
+        process_snapshot:
+          sequence1([
+            {:ok, [identity]},
+            {:ok, [identity]},
+            {:ok, [identity]},
+            {:ok, []},
+            {:ok, []},
+            {:ok, []}
+          ]),
+        signal_process: fn :lock, ^identity -> event(parent, :signal, :ok) end
+      })
+
+    assert {:ok, message} = Stop.run([], runtime)
+    assert message =~ "Stopped Orchard services."
+    assert Enum.member?(collect_events(), :signal)
+    refute_receive {:event, :bootout}
+  end
+
+  test "loaded job with affirmative pre-shutdown absence still proves stopped" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        process_snapshot: sequence1(List.duplicate({:ok, []}, 5))
+      })
+
+    assert {:ok, message} = Stop.run([], runtime)
+    assert message =~ "Stopped Orchard services."
+    assert Enum.member?(collect_events(), :bootout)
+  end
+
+  test "unknown unload observation fails without terminal success" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        job_state: sequence1([:loaded, :loaded, {:unknown, :launchctl_failed}])
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "unload"
+    refute Enum.member?(collect_events(), {:evidence, "terminal_coherent"})
+  end
+
+  test "unload timeout is bounded and cannot publish terminal success" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        job_state: sequence1(List.duplicate(:loaded, 4)),
+        unload_timeout_ms: 0,
+        monotonic_ms: fn -> 0 end
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "timeout"
+    refute Enum.member?(collect_events(), {:evidence, "terminal_coherent"})
+  end
+
+  test "failed final observation is not repaired by later absence" do
+    parent = self()
+    identity = process_identity(4242)
+
+    runtime =
+      managed_runtime(parent, %{
+        process_snapshot: sequence1([{:ok, [identity]}, {:error, :unknown}, {:ok, []}])
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "process_observation"
+    refute_receive {:event, :bootout}
+  end
+
+  test "SPEC 11.4 resumes an interrupted suppression under the new lock owner" do
+    parent = self()
+
+    suppressed = %{
+      schema_version: 1,
+      eligibility: %{state: "suppressed", generation: 7},
+      one_shot_authorization: nil
+    }
+
+    written = put_in(suppressed.eligibility.generation, 8)
+
+    runtime =
+      managed_runtime(parent, %{
+        read_start_state: sequence([{:ok, suppressed}, {:ok, written}])
+      })
+
+    assert {:ok, message} = Stop.run([], runtime)
+    assert message =~ "Stopped Orchard services."
+    assert Enum.member?(collect_events(), {:evidence, "terminal_coherent"})
+  end
+
+  test "public stop supersedes interrupted and securely referenced invalid evidence" do
+    parent = self()
+
+    interrupted = %{
+      operation_id: "interrupted",
+      kind: "managed_stop",
+      phase: "suppression_proven"
+    }
+
+    invalid = %{
+      operation_id: "broken",
+      kind: "unknown",
+      phase: "invalid",
+      filename: "broken.json",
+      sha256: "abcd"
+    }
+
+    runtime =
+      managed_runtime(parent, %{
+        read_evidence: fn -> {:ok, [interrupted, invalid]} end,
+        write_evidence: fn :lock, evidence ->
+          send(parent, {:written_evidence, evidence})
+          :ok
+        end
+      })
+
+    assert {:ok, _message} = Stop.run([], runtime)
+
+    assert_receive {:written_evidence,
+                    %{
+                      phase: "initial",
+                      reconciles: [
+                        %{operation_id: "interrupted"},
+                        %{operation_id: "broken", filename: "broken.json", sha256: "abcd"}
+                      ]
+                    }}
+  end
+
+  test "terminal publication failure cannot report stopped" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        write_evidence: fn :lock, evidence ->
+          if evidence.phase == "terminal_coherent" do
+            {:error, :disk_full}
+          else
+            send(parent, {:event, {:evidence, evidence.phase}})
+            :ok
+          end
+        end
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "terminal_coherent"
+    refute_receive {:event, {:evidence, "terminal_coherent"}}
+  end
+
+  test "unsafe prior lifecycle state fails before evidence or mutation" do
+    parent = self()
+
+    runtime =
+      managed_runtime(parent, %{
+        read_start_state: fn -> {:error, :unsafe_metadata} end
+      })
+
+    assert {:error, message, 1} = Stop.run([], runtime)
+    assert message =~ "unsafe_start_state"
+    refute_receive {:event, {:evidence, _phase}}
+    refute_receive {:event, :start_state}
+    refute_receive {:event, :disable}
+    refute_receive {:event, :bootout}
+  end
+
+  defp managed_runtime(parent, overrides) do
+    identity = process_identity(4242)
+
+    defaults = %{
+      with_lifecycle_lock: fn callback -> callback.(:lock) end,
+      lock_valid: fn :lock -> :ok end,
+      owner_identity: fn -> {:ok, process_identity(10)} end,
+      read_start_state:
+        sequence([
+          {:error, :missing},
+          {:ok,
+           %{
+             schema_version: 1,
+             eligibility: %{state: "suppressed", generation: 1},
+             one_shot_authorization: nil
+           }}
+        ]),
+      read_evidence: fn -> {:ok, []} end,
+      write_evidence: fn :lock, evidence ->
+        send(parent, {:event, {:evidence, evidence.phase}})
+        :ok
+      end,
+      write_start_state: fn :lock, _state -> event(parent, :start_state, :ok) end,
+      disable_job: fn :lock, _service -> event(parent, :disable, :ok) end,
+      job_disabled?: fn _service -> true end,
+      job_state: sequence1([:loaded, :loaded, :unloaded, :unloaded]),
+      process_snapshot:
+        sequence1([
+          {:ok, [identity]},
+          {:ok, [identity]},
+          {:ok, [identity]},
+          {:ok, []},
+          {:ok, []},
+          {:ok, []}
+        ]),
+      bootout: fn :lock, _service -> event(parent, :bootout, :ok) end,
+      process_identity_state: fn ^identity -> :exited end,
+      uuid: fn -> "00000000-0000-4000-8000-000000000001" end,
+      wall_time: fn -> "2026-08-14T00:00:00Z" end
+    }
+
+    defaults
+    |> Map.merge(overrides)
+    |> base_runtime()
+  end
+
+  defp process_identity(pid) do
+    %{pid: pid, start_sec: 91, start_usec: 2, executable: "/tmp/beam.smp", device: 1, inode: 2}
+  end
+
+  defp event(parent, name, result) do
+    send(parent, {:event, name})
+    result
+  end
+
+  defp sequence(values) do
+    {:ok, agent} = Agent.start_link(fn -> values end)
+
+    fn ->
+      Agent.get_and_update(agent, fn
+        [value | rest] -> {value, rest}
+        [] -> raise "sequence exhausted"
+      end)
+    end
+  end
+
+  defp sequence1(values) do
+    next = sequence(values)
+    fn _value -> next.() end
+  end
+
+  defp collect_events(acc \\ []) do
+    receive do
+      {:event, event} -> collect_events([event | acc])
+    after
+      10 -> Enum.reverse(acc)
+    end
+  end
+
+  defp base_runtime(overrides) do
+    Map.merge(
+      %{
+        uid: fn -> 0 end,
+        services: [@service],
+        read_install_role: fn -> {:ok, "node-agent"} end,
+        file_regular?: fn _path -> true end
+      },
+      overrides
+    )
+  end
+
+  defp mutation(parent, operation) do
+    fn _value ->
+      send(parent, {:mutation, operation})
+      :ok
+    end
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/stop_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/stop_test.exs
@@ -1,7 +1,7 @@
 defmodule OrchardCLI.Commands.StopTest do
   use ExUnit.Case, async: true
 
-  alias OrchardCLI.Commands.Stop
+  alias OrchardCLI.Commands.{LifecycleSupport, Stop}
 
   # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -29,6 +29,7 @@ defmodule OrchardCLI.Commands.StopTest do
         services: test_services(),
         read_install_role: fn -> {:ok, "all"} end,
         file_regular?: fn _path -> true end,
+        managed_node_agent_stop: &LifecycleSupport.ensure_stopped/2,
         cmd: fn _prog, _args, _opts -> {"\n", 0} end
       },
       overrides
@@ -138,6 +139,29 @@ defmodule OrchardCLI.Commands.StopTest do
     bootout_calls = Enum.filter(cmds, fn {_, args} -> match?(["bootout" | _], args) end)
     assert [{_, ["bootout", target]}] = bootout_calls
     assert target =~ "controller"
+  end
+
+  test "SPEC 11.4 routes Node Agent stop through the managed process fence" do
+    parent = self()
+
+    runtime =
+      base_runtime(%{
+        read_install_role: fn -> {:ok, "node-agent"} end,
+        managed_node_agent_stop: fn service, _runtime ->
+          send(parent, {:managed_stop, service.id})
+          {:stopped, service}
+        end,
+        cmd: fn prog, args, _opts ->
+          send(parent, {:cmd, prog, args})
+          {"\n", 0}
+        end
+      })
+
+    assert {:ok, msg} = Stop.run([], runtime)
+    assert msg =~ "Stopped Orchard services."
+    assert_receive {:managed_stop, :node_agent}
+
+    refute Enum.any?(collect_cmds(), fn {_program, args} -> match?(["bootout" | _], args) end)
   end
 
   test "node-agent role stops node-agent only" do

--- a/apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs
@@ -1,0 +1,269 @@
+defmodule OrchardCLI.LifecycleNativeTest do
+  use ExUnit.Case, async: false
+
+  alias OrchardCLI.LifecycleNative
+  alias OrchardCLI.TestTemp
+
+  test "SPEC 11.4 uses nonblocking crash-released flock without inheritance" do
+    with_temp("lifecycle-lock", fn directory ->
+      lock_path = Path.join(directory, ".app-lifecycle.lock")
+      parent = self()
+
+      holder =
+        spawn(fn ->
+          LifecycleNative.with_lock(lock_path, fn lock ->
+            send(parent, {:locked, self(), lock, LifecycleNative.lock_valid(lock)})
+            Process.sleep(:infinity)
+          end)
+        end)
+
+      assert_receive {:locked, ^holder, lock, :ok}
+      assert is_map(lock.guard_identity)
+      assert is_integer(lock.lock_device)
+      assert is_integer(lock.lock_inode)
+      assert {:error, :locked} = LifecycleNative.with_lock(lock_path, fn _lock -> :unexpected end)
+
+      ref = Process.monitor(holder)
+      Process.exit(holder, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^holder, :killed}
+
+      assert :reacquired = LifecycleNative.with_lock(lock_path, fn _lock -> :reacquired end)
+      assert File.stat!(lock_path).mode |> Bitwise.band(0o777) == 0o600
+    end)
+  end
+
+  test "child commands do not inherit the lifecycle lock descriptor" do
+    with_temp("lifecycle-cloexec", fn directory ->
+      lock_path = Path.join(directory, ".app-lifecycle.lock")
+
+      child =
+        LifecycleNative.with_lock(lock_path, fn _lock ->
+          Port.open({:spawn_executable, "/bin/sleep"}, [:exit_status, args: ["2"]])
+        end)
+
+      assert Port.info(child) != nil
+      assert :reacquired = LifecycleNative.with_lock(lock_path, fn _lock -> :reacquired end)
+      Port.close(child)
+    end)
+  end
+
+  test "canonical flock interoperates with Orchard.app's Swift lock family" do
+    with_temp("lifecycle-swift-flock", fn directory ->
+      lock_path = Path.join(directory, ".app-lifecycle.lock")
+      holder = compile_swift_holder(directory)
+
+      swift_port = open_swift_holder(holder, lock_path)
+      assert_receive {^swift_port, {:data, {:eol, "READY"}}}, 1_000
+      assert {:error, :locked} = LifecycleNative.with_lock(lock_path, fn _lock -> :unexpected end)
+      Port.command(swift_port, "RELEASE\n")
+      assert_receive {^swift_port, {:exit_status, 0}}, 1_000
+
+      assert :ok =
+               LifecycleNative.with_lock(lock_path, fn _lock ->
+                 contender = open_swift_holder(holder, lock_path)
+                 assert_receive {^contender, {:exit_status, 75}}, 1_000
+                 :ok
+               end)
+    end)
+  end
+
+  test "durable publication atomically replaces the destination" do
+    with_temp("lifecycle-publish", fn directory ->
+      destination = Path.join(directory, "state.json")
+      lock_path = Path.join(directory, ".app-lifecycle.lock")
+
+      assert :ok =
+               LifecycleNative.with_lock(lock_path, fn lock ->
+                 assert :ok =
+                          LifecycleNative.atomic_publish(lock, destination, ~s({"generation":1}))
+
+                 assert File.read!(destination) == ~s({"generation":1})
+
+                 assert :ok =
+                          LifecycleNative.atomic_publish(lock, destination, ~s({"generation":2}))
+               end)
+
+      assert File.read!(destination) == ~s({"generation":2})
+      assert File.stat!(destination).mode |> Bitwise.band(0o777) == 0o600
+    end)
+  end
+
+  test "guard death after validation prevents protected publication" do
+    with_temp("lifecycle-publish-guard", fn directory ->
+      destination = Path.join(directory, "state.json")
+      lock_path = Path.join(directory, ".app-lifecycle.lock")
+
+      assert {:error, _reason} =
+               LifecycleNative.with_lock(lock_path, fn lock ->
+                 assert :ok = LifecycleNative.lock_valid(lock)
+                 Port.close(lock.port)
+                 LifecycleNative.atomic_publish(lock, destination, ~s({"generation":1}))
+               end)
+
+      refute File.exists?(destination)
+    end)
+  end
+
+  test "process identity includes a non-reusable start time" do
+    assert {:ok, identity} = LifecycleNative.process_identity(System.pid())
+    assert identity["pid"] == String.to_integer(System.pid())
+    assert is_integer(identity["start_sec"])
+    assert is_integer(identity["start_usec"])
+    assert identity["executable"] != ""
+    assert :alive = LifecycleNative.process_identity_state(identity)
+  end
+
+  test "orphan census rejects spoofed release environment outside the trusted release root" do
+    executable = System.find_executable("elixir")
+
+    port =
+      Port.open(
+        {:spawn_executable, executable},
+        [
+          :binary,
+          :exit_status,
+          args: ["-e", "Process.sleep(:infinity)"],
+          env: [
+            {~c"RELEASE_NAME", ~c"orchard_node_agent"},
+            {~c"RELEASE_ROOT",
+             ~c"/Library/Application Support/Orchard/releases/orchard_node_agent"}
+          ]
+        ]
+      )
+
+    {:os_pid, child_pid} = Port.info(port, :os_pid)
+
+    try do
+      assert {:ok, identities} = LifecycleNative.process_snapshot()
+      refute Enum.any?(identities, &(&1["pid"] == child_pid))
+      refute Enum.any?(identities, &(&1["pid"] == String.to_integer(System.pid())))
+    after
+      System.cmd("/bin/kill", ["-KILL", Integer.to_string(child_pid)])
+      if Port.info(port) != nil, do: Port.close(port)
+    end
+  end
+
+  test "launchd PID census and exact-identity signal cover an unmarked managed process" do
+    with_temp("lifecycle-signal", fn directory ->
+      source =
+        :orchard_cli
+        |> :code.priv_dir()
+        |> List.to_string()
+        |> Path.join("orchard-lifecycle-helper")
+
+      executable = Path.join(directory, "beam.smp")
+      File.cp!(source, executable)
+      File.chmod!(executable, 0o700)
+
+      port =
+        Port.open(
+          {:spawn_executable, executable},
+          [
+            :binary,
+            :exit_status,
+            :use_stdio,
+            args: ["lock", Path.join(directory, "process.lock")]
+          ]
+        )
+
+      {:os_pid, child_pid} = Port.info(port, :os_pid)
+
+      try do
+        assert {:ok, identities} = await_expected_snapshot(child_pid, 50)
+        assert [identity] = Enum.filter(identities, &(&1["pid"] == child_pid))
+
+        assert :ok =
+                 LifecycleNative.with_lock(
+                   Path.join(directory, ".app-lifecycle.lock"),
+                   &LifecycleNative.signal_process(&1, identity)
+                 )
+
+        assert :exited = await_identity_exit(identity, 100)
+      after
+        if Port.info(port) != nil, do: Port.close(port)
+      end
+    end)
+  end
+
+  defp await_identity_exit(_identity, 0), do: :timeout
+
+  defp await_identity_exit(identity, attempts) do
+    case LifecycleNative.process_identity_state(identity) do
+      :alive ->
+        Process.sleep(50)
+        await_identity_exit(identity, attempts - 1)
+
+      state ->
+        state
+    end
+  end
+
+  defp await_expected_snapshot(_pid, 0), do: {:error, :timeout}
+
+  defp await_expected_snapshot(pid, attempts) do
+    case LifecycleNative.process_snapshot(pid) do
+      {:ok, identities} = result ->
+        if Enum.any?(identities, &(&1["pid"] == pid)) do
+          result
+        else
+          Process.sleep(20)
+          await_expected_snapshot(pid, attempts - 1)
+        end
+
+      {:error, _reason} ->
+        Process.sleep(20)
+        await_expected_snapshot(pid, attempts - 1)
+    end
+  end
+
+  test "lock release handshake failure is returned instead of callback success" do
+    with_temp("lifecycle-release-failure", fn directory ->
+      lock_path = Path.join(directory, ".app-lifecycle.lock")
+
+      assert {:error, reason} =
+               LifecycleNative.with_lock(lock_path, fn lock ->
+                 assert Port.command(lock.port, "INVALID\n")
+                 Process.sleep(20)
+                 :callback_success
+               end)
+
+      assert reason in [:lock_release_lost, {:lock_release_failed, 74}]
+      assert :ok = LifecycleNative.with_lock(lock_path, fn _lock -> :ok end)
+    end)
+  end
+
+  test "command custody terminates a child at the bounded deadline" do
+    started = System.monotonic_time(:millisecond)
+    {_output, code} = LifecycleNative.run_command("/bin/sleep", ["10"], 20)
+
+    assert code == 124
+    assert System.monotonic_time(:millisecond) - started < 1_000
+  end
+
+  defp compile_swift_holder(directory) do
+    source = Path.expand("../support/flock_holder.swift", __DIR__)
+    binary = Path.join(directory, "flock-holder")
+
+    assert {_output, 0} =
+             System.cmd("xcrun", ["swiftc", source, "-o", binary], stderr_to_stdout: true)
+
+    binary
+  end
+
+  defp open_swift_holder(binary, lock_path) do
+    Port.open(
+      {:spawn_executable, binary},
+      [:binary, :exit_status, :use_stdio, {:line, 1024}, args: [lock_path]]
+    )
+  end
+
+  defp with_temp(prefix, callback) do
+    owner = TestTemp.create_run!(prefix: prefix)
+
+    try do
+      callback.(TestTemp.root(owner))
+    after
+      TestTemp.cleanup!(owner)
+    end
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/lifecycle_system_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/lifecycle_system_test.exs
@@ -1,0 +1,35 @@
+defmodule OrchardCLI.LifecycleSystemTest do
+  use ExUnit.Case, async: true
+
+  alias OrchardCLI.LifecycleSystem
+
+  @label "com.orchard.node-agent"
+
+  test "parses actual launchctl print-disabled system booleans exactly" do
+    assert :disabled =
+             LifecycleSystem.disabled_state(
+               ~s(disabled services = {\n\t"#{@label}" => true\n}\n),
+               @label
+             )
+
+    assert :enabled =
+             LifecycleSystem.disabled_state(
+               ~s(disabled services = {\n\t"#{@label}" => false\n}\n),
+               @label
+             )
+
+    assert :missing = LifecycleSystem.disabled_state(~s("other" => true\n), @label)
+  end
+
+  test "duplicate or malformed disablement evidence fails closed" do
+    output = ~s("#{@label}" => true\n"#{@label}" => false\n)
+    assert :ambiguous = LifecycleSystem.disabled_state(output, @label)
+    assert :ambiguous = LifecycleSystem.disabled_state(~s("#{@label}" => disabled\n), @label)
+  end
+
+  test "parses one exact launchd PID and rejects duplicate PID state" do
+    assert 4242 = LifecycleSystem.job_pid("state = running\n\tpid = 4242\n")
+    assert :missing = LifecycleSystem.job_pid("state = waiting\n")
+    assert :ambiguous = LifecycleSystem.job_pid("pid = 4242\npid = 4343\n")
+  end
+end

--- a/apps/orchard_cli/test/support/flock_holder.swift
+++ b/apps/orchard_cli/test/support/flock_holder.swift
@@ -1,0 +1,20 @@
+import Darwin
+import Foundation
+
+let path = CommandLine.arguments[1]
+let descriptor = open(path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+
+guard descriptor >= 0 else {
+  exit(74)
+}
+
+guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+  close(descriptor)
+  exit(errno == EWOULDBLOCK ? 75 : 74)
+}
+
+print("READY")
+fflush(stdout)
+_ = readLine()
+flock(descriptor, LOCK_UN)
+close(descriptor)

--- a/apps/orchard_shared/lib/orchard/managed_node_agent/lifecycle_state.ex
+++ b/apps/orchard_shared/lib/orchard/managed_node_agent/lifecycle_state.ex
@@ -1,0 +1,256 @@
+defmodule Orchard.ManagedNodeAgent.LifecycleState do
+  @moduledoc """
+  Shared durable state vocabulary for managed Node Agent lifecycle operations.
+  """
+
+  @schema_version 1
+  @operation_kinds ~w(handover managed_recovery start_attempt managed_stop)
+  @terminal_phases ~w(terminal_coherent)
+  @managed_stop_phases ~w(
+    initial
+    eligibility_suppressed
+    suppression_proven
+    process_observed
+    unload_proven
+    exit_proven
+    terminal_coherent
+    terminal_failed
+  )
+
+  @managed_stop_forbidden_fields [
+    :staging_generation,
+    :activation,
+    :rollback,
+    :start_policy,
+    "staging_generation",
+    "activation",
+    "rollback",
+    "start_policy"
+  ]
+
+  @type start_state :: %{
+          required(:schema_version) => 1,
+          required(:eligibility) => %{
+            required(:state) => String.t(),
+            required(:generation) => pos_integer()
+          },
+          required(:one_shot_authorization) => map() | nil
+        }
+
+  @spec operation_kinds() :: [String.t()]
+  def operation_kinds, do: @operation_kinds
+
+  @spec new_managed_stop(
+          String.t(),
+          map(),
+          map(),
+          map(),
+          [map()],
+          String.t()
+        ) :: map()
+  def new_managed_stop(operation_id, owner, service, observed, reconciles, timestamp) do
+    %{
+      schema_version: @schema_version,
+      operation_id: operation_id,
+      kind: "managed_stop",
+      phase: "initial",
+      owner_identity: owner,
+      target_identity: %{
+        launchd_domain: "system",
+        label: service.label,
+        plist_path: service.plist_path,
+        active_support_root: "/Library/Application Support/Orchard",
+        release_name: "orchard_node_agent",
+        release_root: "/Library/Application Support/Orchard/releases/orchard_node_agent",
+        release_launcher:
+          "/Library/Application Support/Orchard/releases/orchard_node_agent/bin/orchard_node_agent",
+        executable_basename: "beam.smp"
+      },
+      observed_before: observed,
+      intended_mutations: [
+        "suppress_start_eligibility",
+        "invalidate_one_shot_authorization",
+        "disable_launchd_job_domain",
+        "unload_launchd_job"
+      ],
+      reconciles: reconciles,
+      proofs: %{},
+      outcome: nil,
+      failure: nil,
+      created_at: timestamp,
+      updated_at: timestamp
+    }
+  end
+
+  @spec advance(map(), String.t(), map(), String.t()) :: map()
+  def advance(evidence, phase, proof, timestamp) do
+    evidence
+    |> Map.put(:phase, phase)
+    |> Map.put(:updated_at, timestamp)
+    |> Map.update(:proofs, proof, &Map.merge(&1, proof))
+    |> put_terminal_fields(phase, proof)
+  end
+
+  @spec validate_evidence(map()) :: :ok | {:error, term()}
+  def validate_evidence(evidence) when is_map(evidence) do
+    with 1 <- field(evidence, :schema_version),
+         kind when kind in @operation_kinds <- field(evidence, :kind),
+         operation_id when is_binary(operation_id) <- field(evidence, :operation_id),
+         phase when is_binary(phase) <- field(evidence, :phase),
+         owner when is_map(owner) <- field(evidence, :owner_identity),
+         target when is_map(target) <- field(evidence, :target_identity),
+         observed when is_map(observed) <- field(evidence, :observed_before),
+         intended when is_list(intended) <- field(evidence, :intended_mutations),
+         :ok <- validate_kind_fields(kind, evidence),
+         :ok <- validate_phase(kind, phase, evidence) do
+      :ok
+    else
+      _invalid -> {:error, :invalid_evidence}
+    end
+  end
+
+  def validate_evidence(_evidence), do: {:error, :invalid_evidence}
+
+  @spec observed_eligibility({:ok, map()} | {:error, term()}) :: String.t() | map()
+  def observed_eligibility({:ok, %{eligibility: %{state: state, generation: generation}}})
+      when state in ["suppressed", "one_shot_pending", "enabled"] and
+             is_integer(generation) and generation > 0 do
+    %{"state" => state, "generation" => generation}
+  end
+
+  def observed_eligibility({:error, :missing}), do: "missing"
+  def observed_eligibility(other), do: %{"unknown" => inspect(other)}
+
+  @spec suppressed_state({:ok, map()} | {:error, term()}) :: start_state()
+  def suppressed_state(prior) do
+    %{
+      schema_version: @schema_version,
+      eligibility: %{state: "suppressed", generation: prior_generation(prior) + 1},
+      one_shot_authorization: nil
+    }
+  end
+
+  @spec suppressed?(map()) :: boolean()
+  def suppressed?(%{
+        schema_version: @schema_version,
+        eligibility: %{state: "suppressed", generation: generation},
+        one_shot_authorization: nil
+      })
+      when is_integer(generation) and generation > 0,
+      do: true
+
+  def suppressed?(_state), do: false
+
+  @spec validate_start_state(map()) :: :ok | {:error, :invalid_start_state}
+  def validate_start_state(%{
+        schema_version: @schema_version,
+        eligibility: %{state: state, generation: generation},
+        one_shot_authorization: authorization
+      })
+      when state in ["suppressed", "one_shot_pending", "enabled"] and
+             is_integer(generation) and generation > 0 and
+             (is_map(authorization) or is_nil(authorization)) do
+    if state == "suppressed" and not is_nil(authorization) do
+      {:error, :invalid_start_state}
+    else
+      :ok
+    end
+  end
+
+  def validate_start_state(_state), do: {:error, :invalid_start_state}
+
+  @spec reconciliations([map()]) :: [map()]
+  def reconciliations(records) do
+    records
+    |> Enum.reject(&terminal?/1)
+    |> Enum.map(fn record ->
+      reconciliation = %{
+        operation_id: field(record, :operation_id),
+        kind: field(record, :kind),
+        phase: field(record, :phase),
+        disposition: "supersedes_without_trust"
+      }
+
+      Enum.reduce([:filename, :sha256], reconciliation, &put_reference_field(record, &1, &2))
+    end)
+  end
+
+  defp put_reference_field(record, key, reconciliation) do
+    case field(record, key) do
+      nil -> reconciliation
+      value -> Map.put(reconciliation, key, value)
+    end
+  end
+
+  @spec terminal?(map()) :: boolean()
+  def terminal?(record) do
+    validate_evidence(record) == :ok and field(record, :phase) in @terminal_phases
+  end
+
+  @spec denies_later_start?(map()) :: boolean()
+  def denies_later_start?(record) do
+    not (terminal?(record) and field(record, :kind) == "managed_stop" and
+           field(record, :outcome) == "stopped")
+  end
+
+  defp prior_generation({:ok, %{eligibility: %{generation: generation}}})
+       when is_integer(generation) and generation > 0,
+       do: generation
+
+  defp prior_generation(_prior), do: 0
+
+  defp put_terminal_fields(evidence, "terminal_coherent", proof) do
+    evidence
+    |> Map.put(:outcome, Map.get(proof, :outcome, "stopped"))
+    |> Map.put(:failure, nil)
+  end
+
+  defp put_terminal_fields(evidence, "terminal_failed", proof) do
+    Map.put(evidence, :failure, Map.get(proof, :failure, "unknown"))
+  end
+
+  defp put_terminal_fields(evidence, _phase, _proof), do: evidence
+
+  defp validate_kind_fields("managed_stop", evidence) do
+    if Enum.any?(@managed_stop_forbidden_fields, &Map.has_key?(evidence, &1)) do
+      {:error, :managed_stop_forbidden_field}
+    else
+      :ok
+    end
+  end
+
+  defp validate_kind_fields(_kind, _evidence), do: :ok
+
+  defp validate_phase("managed_stop", phase, evidence) when phase in @managed_stop_phases do
+    if phase == "terminal_coherent", do: validate_terminal_proof(evidence), else: :ok
+  end
+
+  defp validate_phase("managed_stop", _phase, _evidence),
+    do: {:error, :invalid_managed_stop_phase}
+
+  defp validate_phase(_kind, _phase, _evidence), do: :ok
+
+  defp validate_terminal_proof(evidence) do
+    proofs = field(evidence, :proofs)
+
+    if valid_stopped_proof?(evidence, proofs) do
+      :ok
+    else
+      {:error, :invalid_terminal_proof}
+    end
+  end
+
+  defp valid_stopped_proof?(evidence, proofs) when is_map(proofs) do
+    generation = field(proofs, :suppression_generation)
+
+    field(evidence, :outcome) == "stopped" and
+      field(proofs, :persistent_disablement) == true and
+      field(proofs, :job_unloaded) == true and
+      is_integer(generation) and generation > 0 and
+      (field(proofs, :affirmative_absence) == true or is_map(field(proofs, :captured_exit)))
+  end
+
+  defp valid_stopped_proof?(_evidence, _proofs), do: false
+
+  defp field(record, key), do: Map.get(record, key) || Map.get(record, Atom.to_string(key))
+end

--- a/apps/orchard_shared/test/orchard/managed_node_agent/lifecycle_state_test.exs
+++ b/apps/orchard_shared/test/orchard/managed_node_agent/lifecycle_state_test.exs
@@ -1,0 +1,147 @@
+defmodule Orchard.ManagedNodeAgent.LifecycleStateTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.ManagedNodeAgent.LifecycleState
+
+  test "managed stop evidence uses the shared closed operation vocabulary" do
+    assert LifecycleState.operation_kinds() ==
+             ["handover", "managed_recovery", "start_attempt", "managed_stop"]
+
+    evidence = evidence()
+
+    assert evidence.kind == "managed_stop"
+    assert evidence.phase == "initial"
+
+    assert evidence.intended_mutations == [
+             "suppress_start_eligibility",
+             "invalidate_one_shot_authorization",
+             "disable_launchd_job_domain",
+             "unload_launchd_job"
+           ]
+
+    refute Map.has_key?(evidence, :staging_generation)
+    refute Map.has_key?(evidence, :activation)
+    refute Map.has_key?(evidence, :rollback)
+    refute Map.has_key?(evidence, :start_policy)
+
+    assert evidence.target_identity.active_support_root ==
+             "/Library/Application Support/Orchard"
+
+    assert evidence.target_identity.release_name == "orchard_node_agent"
+    assert evidence.target_identity.executable_basename == "beam.smp"
+
+    assert :ok = LifecycleState.validate_evidence(evidence)
+  end
+
+  test "managed stop evidence rejects fields owned by other operation kinds" do
+    assert {:error, :invalid_evidence} =
+             evidence()
+             |> Map.put(:activation, %{generation: 2})
+             |> LifecycleState.validate_evidence()
+  end
+
+  test "suppression invalidates authorization and advances generation" do
+    prior =
+      {:ok,
+       %{
+         schema_version: 1,
+         eligibility: %{state: "one_shot_pending", generation: 8},
+         one_shot_authorization: %{attempt_id: "stale"}
+       }}
+
+    assert %{
+             eligibility: %{state: "suppressed", generation: 9},
+             one_shot_authorization: nil
+           } = LifecycleState.suppressed_state(prior)
+
+    assert LifecycleState.suppressed_state({:error, :missing}).eligibility.generation == 1
+
+    assert :ok =
+             prior
+             |> LifecycleState.suppressed_state()
+             |> LifecycleState.validate_start_state()
+
+    assert {:error, :invalid_start_state} =
+             prior
+             |> LifecycleState.suppressed_state()
+             |> Map.put(:one_shot_authorization, %{attempt_id: "stale"})
+             |> LifecycleState.validate_start_state()
+  end
+
+  test "terminal coherent managed stop never denies a later managed start" do
+    terminal =
+      evidence()
+      |> LifecycleState.advance("terminal_coherent", terminal_proof(), timestamp())
+
+    refute LifecycleState.denies_later_start?(terminal)
+  end
+
+  test "new evidence supersedes interrupted and failed records without trusting them" do
+    terminal =
+      evidence()
+      |> Map.put(:operation_id, "done")
+      |> LifecycleState.advance("terminal_coherent", terminal_proof(), timestamp())
+
+    records = [
+      %{"operation_id" => "old", "kind" => "handover", "phase" => "suppression_proven"},
+      %{"operation_id" => "failed", "kind" => "managed_stop", "phase" => "terminal_failed"},
+      %{
+        operation_id: "broken",
+        kind: "unknown",
+        phase: "invalid",
+        filename: "broken.json",
+        sha256: "abcd"
+      },
+      terminal
+    ]
+
+    assert LifecycleState.reconciliations(records) == [
+             %{
+               operation_id: "old",
+               kind: "handover",
+               phase: "suppression_proven",
+               disposition: "supersedes_without_trust"
+             },
+             %{
+               operation_id: "failed",
+               kind: "managed_stop",
+               phase: "terminal_failed",
+               disposition: "supersedes_without_trust"
+             },
+             %{
+               operation_id: "broken",
+               kind: "unknown",
+               phase: "invalid",
+               disposition: "supersedes_without_trust",
+               filename: "broken.json",
+               sha256: "abcd"
+             }
+           ]
+  end
+
+  defp terminal_proof do
+    %{
+      outcome: "stopped",
+      persistent_disablement: true,
+      job_unloaded: true,
+      suppression_generation: 2,
+      affirmative_absence: true
+    }
+  end
+
+  defp evidence do
+    LifecycleState.new_managed_stop(
+      "00000000-0000-4000-8000-000000000001",
+      %{pid: 10, start_sec: 20, start_usec: 30},
+      %{
+        label: "com.orchard.node-agent",
+        plist_path: "/Library/LaunchDaemons/com.orchard.node-agent.plist"
+      },
+      %{eligibility: "missing", launchd_job: "loaded", managed_process: "absent"},
+      [],
+      timestamp()
+    )
+  end
+
+  defp timestamp, do: "2026-08-14T00:00:00Z"
+end

--- a/packaging/app/Sources/OrchardServiceLifecycle/LifecycleTransactionCoordinator.swift
+++ b/packaging/app/Sources/OrchardServiceLifecycle/LifecycleTransactionCoordinator.swift
@@ -309,7 +309,11 @@ extension LifecycleService {
       at: paths.lifecycleLock.deletingLastPathComponent(),
       withIntermediateDirectories: true
     )
-    let descriptor = open(paths.lifecycleLock.path, O_CREAT | O_RDWR | O_NOFOLLOW, 0o600)
+    let descriptor = open(
+      paths.lifecycleLock.path,
+      O_CREAT | O_RDWR | O_NOFOLLOW | O_CLOEXEC,
+      0o600
+    )
     guard descriptor >= 0 else {
       throw LifecycleServiceError.invalidLifecycleLock(paths.lifecycleLock.path)
     }

--- a/packaging/app/Tests/OrchardServiceLifecycleTests/LifecycleServiceTests.swift
+++ b/packaging/app/Tests/OrchardServiceLifecycleTests/LifecycleServiceTests.swift
@@ -439,6 +439,20 @@ final class LifecycleServiceTests: XCTestCase {
     }
   }
 
+  func testLifecycleLockDescriptorIsCloseOnExec() throws {
+    let fixture = try makeFixture()
+    let service = LifecycleService(
+      contract: fixture.contract,
+      payloadRoot: fixture.payload
+    )
+    let lock = try service.acquireLifecycleLock(
+      at: LifecyclePaths(root: fixture.root, contract: fixture.contract)
+    )
+    defer { lock.release() }
+
+    XCTAssertNotEqual(fcntl(lock.descriptor, F_GETFD) & FD_CLOEXEC, 0)
+  }
+
   func testInstallNormalizesModesAndRecordsSystemOwnershipIntent() throws {
     let fixture = try makeFixture()
     _ = try LifecycleService(


### PR DESCRIPTION
## Summary

`sudo orchardctl stop` now gives the managed Node Agent a durable, crash-released stop transaction under Orchard.app's canonical lifecycle lock.
The command records initial evidence, suppresses later starts, proves persistent launchd disablement, captures exact process identity, proves unload and exit, and only then reports success.

Controller stop behavior remains unchanged.
The implementation is limited to the managed stop tasks already owned by the merged `managed-node-agent-handover` OpenSpec change.

## What changed

- Added a small native lifecycle helper that holds the canonical BSD `flock` for the full transaction and owns protected publication, launchd mutation, and exact-identity signaling.
- Revalidates lock path identity, root ownership, permissions, link count, and lock custody before every protected operation.
- Persists suppression before disable or bootout, invalidates one-shot authorization, and records phase evidence through terminal proof.
- Captures launchd-reported PID identity plus a fail-closed managed-process census, then rejects ambiguous, replaced, or untrusted processes.
- Reconciles interrupted evidence without trusting it and requires exact suppression, disablement, unload, and process-absence proof before returning stopped.
- Routes only Node Agent stop through the managed coordinator. Ordinary Controller and other service stop paths keep their existing behavior.
- Marks both Elixir and Orchard.app lifecycle lock descriptors close-on-exec to prevent child processes from extending lock custody.

## Risk Assessment

⚠️ **Medium**

- The blast radius is limited to privileged Node Agent stop plus the shared lifecycle lock descriptor flags, but this path mutates durable suppression state, launchd state, and a managed process.
- Every uncertain state fails closed. Missing or invalid evidence, ambiguous process identity, unproven disablement, unload timeout, exit timeout, or lock loss returns an error without reporting success.
- No database schema, external API, Node Agent start, handover, recovery, PKG activation, or Controller stop behavior changes.
- Root-owned publication and live system launchd mutation cannot run in the unprivileged test harness. The compiled helper is exercised directly for lock interoperability, owner-death release, descriptor noninheritance, exact identity signaling, and bounded command custody.
- The evidence directory currently fails closed after 1,024 records rather than compacting old terminal records. This is a non-blocking operational follow-up for high lifecycle-operation volumes.

## Verification

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `mise exec -- mix test`: 308 shared, 3,461 controller with 5 skipped, 389 node-agent, and 772 CLI with 10 excluded passed
- `mise exec -- mix test --cover`: same test totals; coverage reports generated successfully
- `xcrun swift-format lint --recursive packaging/app/Sources packaging/app/Tests`
- `swift build --package-path packaging/app`
- `swift test --package-path packaging/app`: 31 passed
- `swift test --package-path packaging/app --enable-code-coverage`: 31 passed
- `scripts/test-app-service-lifecycle.sh`
- `scripts/test-build-app.sh`
- `scripts/test-app-signing.sh`
- `scripts/test-build-dmg.sh`

Closes #174

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol_(High)-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789291095&installation_model_id=428414&pr_number=216&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F216&signature=e2caf20f016d5bc909211f63335e2cffb5f0d0be22e38871d8a6591fbbac0aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->