### PR TITLE
feat(inference): enforce output commitment before public event delivery

### DIFF
--- a/apps/orchard_controller/lib/orchard/api/chat_completions_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/chat_completions_controller.ex
@@ -129,6 +129,7 @@ defmodule Orchard.API.ChatCompletionsController do
       conn: conn,
       closed: false,
       errored: false,
+      serializer_failed: false,
       role_sent: false,
       usage: nil
     })
@@ -157,7 +158,12 @@ defmodule Orchard.API.ChatCompletionsController do
     else
       new_state = handle_stream_event(state, event, public_id, model_display, created)
       Process.put(state_key, new_state)
-      if new_state.closed, do: :cancel, else: :ok
+
+      cond do
+        new_state.closed -> :cancel
+        new_state.serializer_failed -> {:error, :serializer_failed}
+        true -> :ok
+      end
     end
   end
 
@@ -250,8 +256,8 @@ defmodule Orchard.API.ChatCompletionsController do
 
   defp emit_internal_stream_error(state, message) do
     case SSE.send_error(state.conn, message, "server_error", code: "internal_error") do
-      {:ok, conn} -> %{state | conn: conn, errored: true}
-      {:error, :closed} -> %{state | closed: true, errored: true}
+      {:ok, conn} -> %{state | conn: conn, errored: true, serializer_failed: true}
+      {:error, :closed} -> %{state | closed: true, errored: true, serializer_failed: true}
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/api/responses_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/responses_controller.ex
@@ -137,6 +137,7 @@ defmodule Orchard.API.ResponsesController do
       conn: conn,
       closed: false,
       terminal_sent: false,
+      serializer_failed: false,
       output_done_sent: false,
       output_delta_sent: false,
       output_chunks: [],
@@ -168,7 +169,12 @@ defmodule Orchard.API.ResponsesController do
     else
       new_state = handle_stream_event(state, event, canonical, created)
       Process.put(state_key, new_state)
-      if new_state.closed, do: :cancel, else: :ok
+
+      cond do
+        new_state.closed -> :cancel
+        new_state.serializer_failed -> {:error, :serializer_failed}
+        true -> :ok
+      end
     end
   end
 
@@ -331,6 +337,7 @@ defmodule Orchard.API.ResponsesController do
           )
         )
         |> Map.put(:terminal_sent, true)
+        |> Map.put(:serializer_failed, true)
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/console/playground.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground.ex
@@ -18,7 +18,11 @@ defmodule OrchardConsole.Playground do
       {:playground, run_ref, :finished, {:error, error_map}}
 
   The `:started` message is sent after `prepare/2` succeeds and dispatch
-  begins. Events are forwarded as they arrive from the dispatcher.
+  begins. Events stay attempt-local until the dispatched attempt is selected
+  for delivery, so the events preceding Output Commitment arrive together, in
+  original order, with the committing event; later events are forwarded as they
+  arrive. An attempt that never commits output flushes its retained events in
+  original order when it resolves.
   `:finished` is always the last message, sent exactly once.
   """
 

--- a/apps/orchard_controller/lib/orchard/dispatch/attempt_event_delivery.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/attempt_event_delivery.ex
@@ -1,0 +1,154 @@
+defmodule Orchard.Dispatch.AttemptEventDelivery do
+  @moduledoc """
+  Immutable attempt-local event retention and public delivery coordination.
+  """
+
+  alias Orchard.Inference.OutputCommitment
+  alias Orchard.InferenceEvent
+
+  @enforce_keys [
+    :request_id,
+    :event_handler,
+    :events_rev,
+    :pending_rev,
+    :commitment,
+    :delivery_state,
+    :delivered_event_count,
+    :failure_reason
+  ]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          request_id: String.t(),
+          event_handler: (String.t(), InferenceEvent.t() -> term()) | nil,
+          events_rev: [InferenceEvent.t()],
+          pending_rev: [InferenceEvent.t()],
+          commitment: OutputCommitment.t(),
+          delivery_state: :pending | :selected | :discarded | :failed,
+          delivered_event_count: non_neg_integer(),
+          failure_reason: atom() | nil
+        }
+
+  @spec new(String.t(), (String.t(), InferenceEvent.t() -> term()) | nil) :: t()
+  def new(request_id, event_handler)
+      when is_binary(request_id) and (is_nil(event_handler) or is_function(event_handler, 2)) do
+    %__MODULE__{
+      request_id: request_id,
+      event_handler: event_handler,
+      events_rev: [],
+      pending_rev: [],
+      commitment: OutputCommitment.new(),
+      delivery_state: :pending,
+      delivered_event_count: 0,
+      failure_reason: nil
+    }
+  end
+
+  @spec record(t(), InferenceEvent.t()) :: t()
+  def record(%__MODULE__{delivery_state: :failed} = delivery, %InferenceEvent{} = event),
+    do: retain(delivery, event)
+
+  def record(%__MODULE__{delivery_state: :selected} = delivery, %InferenceEvent{} = event) do
+    delivery
+    |> observe_and_retain(event)
+    |> deliver_event(event)
+  end
+
+  def record(%__MODULE__{delivery_state: :pending} = delivery, %InferenceEvent{} = event) do
+    updated =
+      delivery
+      |> observe_and_retain(event)
+      |> Map.update!(:pending_rev, &[event | &1])
+
+    if OutputCommitment.committed?(updated.commitment),
+      do: deliver_pending(updated),
+      else: updated
+  end
+
+  def record(%__MODULE__{} = delivery, %InferenceEvent{} = event),
+    do: observe_and_retain(delivery, event)
+
+  @spec select(t()) :: t()
+  def select(%__MODULE__{delivery_state: :pending} = delivery), do: deliver_pending(delivery)
+  def select(%__MODULE__{} = delivery), do: delivery
+
+  @spec discard(t()) :: {:ok, t()} | {:error, :output_committed | :already_selected}
+  def discard(%__MODULE__{} = delivery) do
+    cond do
+      output_committed?(delivery) ->
+        {:error, :output_committed}
+
+      delivery.delivery_state == :pending ->
+        {:ok, %{delivery | delivery_state: :discarded, pending_rev: []}}
+
+      true ->
+        {:error, :already_selected}
+    end
+  end
+
+  @spec events(t()) :: [InferenceEvent.t()]
+  def events(%__MODULE__{events_rev: events_rev}), do: Enum.reverse(events_rev)
+
+  @spec output_committed?(t()) :: boolean()
+  def output_committed?(%__MODULE__{commitment: commitment}),
+    do: OutputCommitment.committed?(commitment)
+
+  @spec commitment_kind(t()) :: OutputCommitment.kind() | nil
+  def commitment_kind(%__MODULE__{commitment: commitment}), do: OutputCommitment.kind(commitment)
+
+  @spec delivery_state(t()) :: :pending | :selected | :discarded | :failed
+  def delivery_state(%__MODULE__{delivery_state: delivery_state}), do: delivery_state
+
+  @spec delivered_event_count(t()) :: non_neg_integer()
+  def delivered_event_count(%__MODULE__{delivered_event_count: count}), do: count
+
+  @spec failure_reason(t()) :: :cancel | :serializer_failed | :event_handler_failed | nil
+  def failure_reason(%__MODULE__{failure_reason: failure_reason}), do: failure_reason
+
+  defp observe_and_retain(delivery, event) do
+    %{
+      delivery
+      | events_rev: [event | delivery.events_rev],
+        commitment: OutputCommitment.observe(delivery.commitment, event)
+    }
+  end
+
+  defp retain(delivery, event), do: %{delivery | events_rev: [event | delivery.events_rev]}
+
+  defp deliver_pending(delivery) do
+    delivery.pending_rev
+    |> Enum.reverse()
+    |> Enum.reduce_while(%{delivery | delivery_state: :selected, pending_rev: []}, fn event,
+                                                                                      state ->
+      case deliver_event(state, event) do
+        %__MODULE__{delivery_state: :failed} = failed -> {:halt, failed}
+        %__MODULE__{} = delivered -> {:cont, delivered}
+      end
+    end)
+  end
+
+  defp deliver_event(delivery, event) do
+    case invoke_handler(delivery.event_handler, delivery.request_id, event) do
+      :ok ->
+        %{delivery | delivered_event_count: delivery.delivered_event_count + 1}
+
+      failure_reason ->
+        %{delivery | delivery_state: :failed, failure_reason: failure_reason}
+    end
+  end
+
+  defp invoke_handler(nil, _request_id, _event), do: :ok
+
+  defp invoke_handler(handler, request_id, event) do
+    case handler.(request_id, event) do
+      :ok -> :ok
+      :cancel -> :cancel
+      {:error, :serializer_failed} -> :serializer_failed
+      _invalid -> :event_handler_failed
+    end
+  rescue
+    _error -> :event_handler_failed
+  catch
+    _kind, _reason -> :event_handler_failed
+  end
+end

--- a/apps/orchard_controller/lib/orchard/dispatch/attempt_outcome.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/attempt_outcome.ex
@@ -3,6 +3,8 @@ defmodule Orchard.Dispatch.AttemptOutcome do
   Typed internal evidence returned by one dispatcher attempt.
   """
 
+  alias Orchard.Dispatch.AttemptEventDelivery
+  alias Orchard.InferenceEvent
   alias Orchard.Requests.InferenceAttemptFailure
 
   @enforce_keys [
@@ -15,13 +17,19 @@ defmodule Orchard.Dispatch.AttemptOutcome do
     :capacity_release_outcome,
     :started_at,
     :ended_at,
-    :first_token_at
+    :first_token_at,
+    :output_committed,
+    :output_commitment_kind,
+    :delivery_state,
+    :delivered_event_count
   ]
   defstruct @enforce_keys
 
   @attempt_outcomes [:completed, :failed, :cancelled, :timed_out, :interrupted]
   @execution_resolutions [:not_started, :terminated, :unresolved]
   @capacity_release_outcomes [:released, :already_released, :not_applicable, :unresolved]
+  @commitment_kinds [:text, :tool_call, :structured_output]
+  @non_text_commitment_kinds @commitment_kinds -- [:text]
 
   @type attempt_outcome :: :completed | :failed | :cancelled | :timed_out | :interrupted
   @type execution_resolution :: :not_started | :terminated | :unresolved
@@ -29,19 +37,25 @@ defmodule Orchard.Dispatch.AttemptOutcome do
   @type capacity_release_outcome ::
           :released | :already_released | :not_applicable | :unresolved
 
+  @type commitment_kind :: :text | :tool_call | :structured_output
+  @type delivery_state :: :pending | :selected | :discarded | :failed
   @type failure :: InferenceAttemptFailure.evidence() | nil
 
   @type t :: %__MODULE__{
           attempt_outcome: attempt_outcome(),
           node_id: Ecto.UUID.t() | nil,
           accepted: boolean(),
-          events: [Orchard.InferenceEvent.t()],
+          events: [InferenceEvent.t()],
           failure: failure(),
           execution_resolution: execution_resolution(),
           capacity_release_outcome: capacity_release_outcome(),
           started_at: DateTime.t(),
           ended_at: DateTime.t(),
-          first_token_at: DateTime.t() | nil
+          first_token_at: DateTime.t() | nil,
+          output_committed: boolean(),
+          output_commitment_kind: commitment_kind() | nil,
+          delivery_state: delivery_state(),
+          delivered_event_count: non_neg_integer()
         }
 
   @spec new(map()) :: {:ok, t()} | {:error, :invalid_attempt_outcome}
@@ -56,17 +70,23 @@ defmodule Orchard.Dispatch.AttemptOutcome do
           capacity_release_outcome: capacity_release_outcome,
           started_at: %DateTime{} = started_at,
           ended_at: %DateTime{} = ended_at,
-          first_token_at: first_token_at
+          first_token_at: first_token_at,
+          output_committed: output_committed,
+          output_commitment_kind: output_commitment_kind,
+          delivery_state: delivery_state,
+          delivered_event_count: delivered_event_count
         } = attrs
       ) do
-    if attempt_outcome in @attempt_outcomes and
-         valid_node_id?(node_id) and
-         is_boolean(accepted) and
-         is_list(events) and
-         valid_failure?(attempt_outcome, failure) and
-         execution_resolution in @execution_resolutions and
-         capacity_release_outcome in @capacity_release_outcomes and
-         ordered_timestamps?(started_at, ended_at, first_token_at) do
+    if valid_identity?(attempt_outcome, node_id, accepted, events) and
+         valid_result?(attempt_outcome, failure, execution_resolution, capacity_release_outcome) and
+         ordered_timestamps?(started_at, ended_at, first_token_at) and
+         valid_commitment?(accepted, output_committed, output_commitment_kind, first_token_at) and
+         valid_delivery?(
+           delivery_state,
+           delivered_event_count,
+           length(events),
+           output_committed
+         ) do
       {:ok, struct!(__MODULE__, attrs)}
     else
       {:error, :invalid_attempt_outcome}
@@ -75,8 +95,112 @@ defmodule Orchard.Dispatch.AttemptOutcome do
 
   def new(_attrs), do: {:error, :invalid_attempt_outcome}
 
+  @spec select(t(), String.t(), (String.t(), InferenceEvent.t() -> term()) | nil) :: t()
+  def select(%__MODULE__{delivery_state: :pending} = outcome, request_id, event_handler) do
+    delivery =
+      Enum.reduce(
+        outcome.events,
+        AttemptEventDelivery.new(request_id, event_handler),
+        &AttemptEventDelivery.record(&2, &1)
+      )
+      |> AttemptEventDelivery.select()
+
+    selected = %{
+      outcome
+      | delivery_state: AttemptEventDelivery.delivery_state(delivery),
+        delivered_event_count: AttemptEventDelivery.delivered_event_count(delivery)
+    }
+
+    case AttemptEventDelivery.failure_reason(delivery) do
+      :cancel ->
+        cancel_delivery(selected, selected.delivered_event_count)
+
+      reason when reason in [:serializer_failed, :event_handler_failed] ->
+        fail_delivery(selected, selected.delivered_event_count)
+
+      nil ->
+        selected
+    end
+  end
+
+  def select(%__MODULE__{} = outcome, _request_id, _event_handler), do: outcome
+
+  @spec discard(t()) :: {:ok, t()} | {:error, :output_committed | :already_selected}
+  def discard(%__MODULE__{output_committed: true}), do: {:error, :output_committed}
+
+  def discard(%__MODULE__{delivery_state: :pending} = outcome),
+    do: {:ok, %{outcome | delivery_state: :discarded}}
+
+  def discard(%__MODULE__{}), do: {:error, :already_selected}
+
+  @spec fail_attempt(t()) :: t()
+  def fail_attempt(%__MODULE__{} = outcome) do
+    attrs = %{
+      outcome
+      | attempt_outcome: :failed,
+        failure:
+          InferenceAttemptFailure.normalize(%{
+            category: :controller,
+            code: :orchestration_error
+          })
+    }
+
+    {:ok, transformed} = new(Map.from_struct(attrs))
+    transformed
+  end
+
+  @spec fail_delivery(t(), non_neg_integer()) :: t()
+  def fail_delivery(%__MODULE__{} = outcome, delivered_event_count) do
+    transform_delivery_failure(
+      outcome,
+      :failed,
+      delivered_event_count,
+      InferenceAttemptFailure.normalize(%{category: :controller, code: :orchestration_error})
+    )
+  end
+
+  @spec cancel_delivery(t(), non_neg_integer()) :: t()
+  def cancel_delivery(%__MODULE__{} = outcome, delivered_event_count) do
+    transform_delivery_failure(
+      outcome,
+      :cancelled,
+      delivered_event_count,
+      InferenceAttemptFailure.normalize(%{
+        category: :cancellation,
+        code: :request_client_disconnect
+      })
+    )
+  end
+
+  defp transform_delivery_failure(outcome, attempt_outcome, delivered_event_count, failure) do
+    attrs = %{
+      outcome
+      | attempt_outcome: attempt_outcome,
+        delivery_state: :failed,
+        delivered_event_count: delivered_event_count,
+        failure: failure
+    }
+
+    {:ok, transformed} = new(Map.from_struct(attrs))
+    transformed
+  end
+
+  defp valid_identity?(attempt_outcome, node_id, accepted, events) do
+    attempt_outcome in @attempt_outcomes and valid_node_id?(node_id) and is_boolean(accepted) and
+      valid_events?(events)
+  end
+
+  defp valid_result?(attempt_outcome, failure, execution_resolution, capacity_release_outcome) do
+    valid_failure?(attempt_outcome, failure) and
+      execution_resolution in @execution_resolutions and
+      capacity_release_outcome in @capacity_release_outcomes
+  end
+
   defp valid_node_id?(nil), do: true
   defp valid_node_id?(node_id), do: match?({:ok, _uuid}, Ecto.UUID.cast(node_id))
+
+  defp valid_events?(events),
+    do: is_list(events) and Enum.all?(events, &match?(%InferenceEvent{}, &1))
 
   defp valid_failure?(:completed, nil), do: true
 
@@ -90,6 +214,28 @@ defmodule Orchard.Dispatch.AttemptOutcome do
   end
 
   defp valid_failure?(_attempt_outcome, _failure), do: false
+
+  defp valid_commitment?(true, true, :text, %DateTime{}), do: true
+
+  defp valid_commitment?(true, true, kind, first_token_at)
+       when kind in @non_text_commitment_kinds and
+              (is_nil(first_token_at) or is_struct(first_token_at, DateTime)),
+       do: true
+
+  defp valid_commitment?(_accepted, false, nil, nil), do: true
+  defp valid_commitment?(_accepted, _committed, _kind, _first_token_at), do: false
+
+  defp valid_delivery?(:pending, 0, _event_count, false), do: true
+  defp valid_delivery?(:discarded, 0, _event_count, false), do: true
+  defp valid_delivery?(:selected, event_count, event_count, _output_committed), do: true
+
+  defp valid_delivery?(:failed, delivered_event_count, event_count, _output_committed),
+    do:
+      is_integer(delivered_event_count) and delivered_event_count >= 0 and
+        delivered_event_count < event_count
+
+  defp valid_delivery?(_state, _delivered_event_count, _event_count, _output_committed),
+    do: false
 
   defp ordered_timestamps?(started_at, ended_at, nil) do
     DateTime.compare(ended_at, started_at) != :lt

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -318,14 +318,14 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     accepted = Enum.any?(events, &match?(%InferenceEvent{event: %InferenceEvent.Accepted{}}, &1))
     terminal = List.last(events)
     delivery = result_delivery(result)
-    attempt_outcome = delivery_attempt_outcome(delivery, attempt_outcome(result, terminal))
+    attempt_outcome = attempt_outcome(result, terminal)
 
     attrs = %{
       attempt_outcome: attempt_outcome,
       node_id: trusted_node_id(schedule),
       accepted: accepted,
       events: events,
-      failure: delivery_failure(delivery) || attempt_failure(result, terminal, attempt_outcome),
+      failure: attempt_failure(result, terminal, attempt_outcome),
       execution_resolution: execution_evidence || execution_resolution(result, terminal),
       capacity_release_outcome:
         effective_release_outcome(release_outcome, execution_evidence, safety_state),
@@ -339,7 +339,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     }
 
     {:ok, outcome} = AttemptOutcome.new(attrs)
-    outcome
+    apply_delivery_failure(outcome, delivery)
   end
 
   defp attempt_evidence(
@@ -370,36 +370,20 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp result_delivery({:ok, _events, %AttemptEventDelivery{} = delivery}), do: delivery
   defp result_delivery(_result), do: nil
 
-  defp delivery_attempt_outcome(%AttemptEventDelivery{} = delivery, attempt_outcome) do
-    case AttemptEventDelivery.failure_reason(delivery) do
-      :cancel -> :cancelled
-      reason when reason in [:serializer_failed, :event_handler_failed] -> :failed
-      nil -> attempt_outcome
-    end
-  end
-
-  defp delivery_attempt_outcome(nil, attempt_outcome), do: attempt_outcome
-
-  defp delivery_failure(%AttemptEventDelivery{} = delivery) do
+  defp apply_delivery_failure(outcome, %AttemptEventDelivery{} = delivery) do
     case AttemptEventDelivery.failure_reason(delivery) do
       :cancel ->
-        InferenceAttemptFailure.normalize(%{
-          category: :cancellation,
-          code: :request_client_disconnect
-        })
+        AttemptOutcome.cancel_delivery(outcome, outcome.delivered_event_count)
 
       reason when reason in [:serializer_failed, :event_handler_failed] ->
-        InferenceAttemptFailure.normalize(%{
-          category: :controller,
-          code: :orchestration_error
-        })
+        AttemptOutcome.fail_delivery(outcome, outcome.delivered_event_count)
 
       nil ->
-        nil
+        outcome
     end
   end
 
-  defp delivery_failure(nil), do: nil
+  defp apply_delivery_failure(outcome, nil), do: outcome
 
   defp delivery_output_committed?(%AttemptEventDelivery{} = delivery),
     do: AttemptEventDelivery.output_committed?(delivery)
@@ -1531,7 +1515,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   defp handle_stream_event(%{terminal_event: nil} = loop_ctx, events, event) do
     cond do
-      pre_acceptance_nonterminal_event?(loop_ctx, event) ->
+      isolated_nonterminal_event?(loop_ctx, event) ->
         metrics = increment_event_count(loop_ctx.metrics)
         receive_loop(%{loop_ctx | metrics: metrics}, events)
 
@@ -1571,11 +1555,16 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     receive_loop(loop_ctx, events)
   end
 
-  defp pre_acceptance_nonterminal_event?(%{accepted?: false}, event) do
-    not InferenceEvent.terminal?(event) and InferenceEvent.kind(event) != :accepted
+  defp isolated_nonterminal_event?(loop_ctx, event) do
+    isolated_attempt?(loop_ctx) and not InferenceEvent.terminal?(event) and
+      InferenceEvent.kind(event) != :accepted
   end
 
-  defp pre_acceptance_nonterminal_event?(_loop_ctx, _event), do: false
+  defp isolated_attempt?(%{
+         accepted?: accepted?,
+         cancellation_started_before_acceptance?: cancellation_started_before_acceptance?
+       }),
+       do: not accepted? or cancellation_started_before_acceptance?
 
   defp first_conformance_defect(:none, defect), do: defect
   defp first_conformance_defect(defect, _later_defect), do: defect
@@ -1735,23 +1724,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     cancel_deadline =
       System.monotonic_time(:millisecond) + loop_ctx.cancel_drain_timeout_ms
 
-    result = drain_until_terminal_or_done(loop_ctx, events, cancel_reason, cancel_deadline)
-
-    if cancel_reason == :event_handler_failed do
-      case result do
-        {:ok, _events, %Metrics{conformance_defect: defect}, _delivery}
-        when defect != :none ->
-          result
-
-        {:ok, _events, _metrics, _delivery} ->
-          result
-
-        {:error, _reason} = error ->
-          error
-      end
-    else
-      result
-    end
+    drain_until_terminal_or_done(loop_ctx, events, cancel_reason, cancel_deadline)
   end
 
   defp cancel_inference_safely(client, channel, request_id, controller_session_id) do
@@ -1790,25 +1763,32 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp handle_drain_event(%{terminal_event: nil} = loop_ctx, events, event, reason, deadline) do
-    metrics = update_metrics_for_event(loop_ctx.metrics, event)
+    cond do
+      isolated_nonterminal_event?(loop_ctx, event) ->
+        metrics = increment_event_count(loop_ctx.metrics)
+        drain_until_terminal_or_done(%{loop_ctx | metrics: metrics}, events, reason, deadline)
 
-    if InferenceEvent.terminal?(event) do
-      drain_until_terminal_or_done(
-        %{loop_ctx | metrics: metrics, terminal_event: event},
-        events,
-        reason,
-        deadline
-      )
-    else
-      loop_ctx = maybe_record_acceptance(loop_ctx, event)
-      loop_ctx = loop_ctx |> record_delivery(event) |> Map.put(:metrics, metrics)
+      InferenceEvent.terminal?(event) ->
+        metrics = update_metrics_for_event(loop_ctx.metrics, event)
 
-      drain_until_terminal_or_done(
-        loop_ctx,
-        [event | events],
-        reason,
-        deadline
-      )
+        drain_until_terminal_or_done(
+          %{loop_ctx | metrics: metrics, terminal_event: event},
+          events,
+          reason,
+          deadline
+        )
+
+      true ->
+        metrics = update_metrics_for_event(loop_ctx.metrics, event)
+        loop_ctx = maybe_record_acceptance(loop_ctx, event)
+        loop_ctx = loop_ctx |> record_delivery(event) |> Map.put(:metrics, metrics)
+
+        drain_until_terminal_or_done(
+          loop_ctx,
+          [event | events],
+          reason,
+          deadline
+        )
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -45,7 +45,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   use Orchard.DispatchCapacity.Consumer, wiring: :final_dispatch_revalidation
 
-  alias Orchard.Dispatch.AttemptOutcome
+  alias Orchard.Dispatch.{AttemptEventDelivery, AttemptOutcome}
   alias Orchard.DomainMetrics
   alias Orchard.Inference
   alias Orchard.Inference.{ModelLoadFailure, QueueManager, RequestDeadline}
@@ -204,9 +204,9 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   Options:
   - `:caller` - PID to monitor for disconnect (default: `self()`)
-  - `:event_handler` - function called with each `InferenceEvent`.
-                        Return `:cancel` to abort dispatch (e.g. on SSE client disconnect).
-                        (default: sends `{:inference_event, request_id, event}` to caller)
+  - `:event_handler` - public delivery callback called only after attempt selection.
+                        It must return `:ok`, `:cancel`, or `{:error, :serializer_failed}`.
+  - `:on_accepted` - immediate internal callback for validated acceptance observation.
   - `:on_node_resolved` - optional callback `(node_id :: String.t() -> any())`.
                            Called when the pre-dispatch status probe discovers a
                            valid node UUID. Synchronous, lightweight, observational only.
@@ -247,6 +247,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     caller = Keyword.get(opts, :caller, self())
     caller_ref = Process.monitor(caller)
     event_handler = Keyword.get(opts, :event_handler)
+    on_accepted = Keyword.get(opts, :on_accepted)
     on_node_resolved = Keyword.get(opts, :on_node_resolved)
     client = Keyword.get(opts, :client_impl, Inference.runtime_endpoint_client())
 
@@ -279,6 +280,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       caller_ref: caller_ref,
       cancel_drain_timeout_ms: cancel_drain_timeout_ms,
       event_handler: event_handler,
+      on_accepted: on_accepted,
       on_node_resolved: on_node_resolved
     }
 
@@ -315,20 +317,25 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     events = result_events(result)
     accepted = Enum.any?(events, &match?(%InferenceEvent{event: %InferenceEvent.Accepted{}}, &1))
     terminal = List.last(events)
-    attempt_outcome = attempt_outcome(result, terminal)
+    delivery = result_delivery(result)
+    attempt_outcome = delivery_attempt_outcome(delivery, attempt_outcome(result, terminal))
 
     attrs = %{
       attempt_outcome: attempt_outcome,
       node_id: trusted_node_id(schedule),
       accepted: accepted,
       events: events,
-      failure: attempt_failure(result, terminal, attempt_outcome),
+      failure: delivery_failure(delivery) || attempt_failure(result, terminal, attempt_outcome),
       execution_resolution: execution_evidence || execution_resolution(result, terminal),
       capacity_release_outcome:
         effective_release_outcome(release_outcome, execution_evidence, safety_state),
       started_at: started_at,
       ended_at: ended_at,
-      first_token_at: first_token_at
+      first_token_at: first_token_at,
+      output_committed: delivery_output_committed?(delivery),
+      output_commitment_kind: delivery_commitment_kind(delivery),
+      delivery_state: delivery_state(delivery),
+      delivered_event_count: delivered_event_count(delivery)
     }
 
     {:ok, outcome} = AttemptOutcome.new(attrs)
@@ -357,8 +364,62 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp effective_release_outcome(release_outcome, _execution_resolution, _safety_state),
     do: release_outcome
 
-  defp result_events({:ok, events}) when is_list(events), do: events
+  defp result_events({:ok, events, %AttemptEventDelivery{}}) when is_list(events), do: events
   defp result_events(_result), do: []
+
+  defp result_delivery({:ok, _events, %AttemptEventDelivery{} = delivery}), do: delivery
+  defp result_delivery(_result), do: nil
+
+  defp delivery_attempt_outcome(%AttemptEventDelivery{} = delivery, attempt_outcome) do
+    case AttemptEventDelivery.failure_reason(delivery) do
+      :cancel -> :cancelled
+      reason when reason in [:serializer_failed, :event_handler_failed] -> :failed
+      nil -> attempt_outcome
+    end
+  end
+
+  defp delivery_attempt_outcome(nil, attempt_outcome), do: attempt_outcome
+
+  defp delivery_failure(%AttemptEventDelivery{} = delivery) do
+    case AttemptEventDelivery.failure_reason(delivery) do
+      :cancel ->
+        InferenceAttemptFailure.normalize(%{
+          category: :cancellation,
+          code: :request_client_disconnect
+        })
+
+      reason when reason in [:serializer_failed, :event_handler_failed] ->
+        InferenceAttemptFailure.normalize(%{
+          category: :controller,
+          code: :orchestration_error
+        })
+
+      nil ->
+        nil
+    end
+  end
+
+  defp delivery_failure(nil), do: nil
+
+  defp delivery_output_committed?(%AttemptEventDelivery{} = delivery),
+    do: AttemptEventDelivery.output_committed?(delivery)
+
+  defp delivery_output_committed?(nil), do: false
+
+  defp delivery_commitment_kind(%AttemptEventDelivery{} = delivery),
+    do: AttemptEventDelivery.commitment_kind(delivery)
+
+  defp delivery_commitment_kind(nil), do: nil
+
+  defp delivery_state(%AttemptEventDelivery{} = delivery),
+    do: AttemptEventDelivery.delivery_state(delivery)
+
+  defp delivery_state(nil), do: :pending
+
+  defp delivered_event_count(%AttemptEventDelivery{} = delivery),
+    do: AttemptEventDelivery.delivered_event_count(delivery)
+
+  defp delivered_event_count(nil), do: 0
 
   defp attempt_outcome(_result, %InferenceEvent{event: %InferenceEvent.Completed{}}),
     do: :completed
@@ -465,7 +526,9 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   defp failure_source(reason), do: %{category: :runtime, code: reason}
 
-  defp execution_resolution({:ok, _events}, %InferenceEvent{}), do: :terminated
+  defp execution_resolution({:ok, _events, %AttemptEventDelivery{}}, %InferenceEvent{}),
+    do: :terminated
+
   defp execution_resolution(_result, _terminal), do: :not_started
 
   defp trusted_node_id(schedule) do
@@ -960,6 +1023,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
             channel: context.channel,
             client: context.client,
             event_handler: context.event_handler,
+            on_accepted: context.on_accepted,
             target: context.target,
             timeout_ms: timeout_ms
           }
@@ -1087,11 +1151,15 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     {:cancel_reconciliation, normalized_result, authority, node_id, failure_result}
   end
 
-  defp handle_dispatch_result({:ok, events, final_metrics}, _metrics, target) do
+  defp handle_dispatch_result(
+         {:ok, events, final_metrics, %AttemptEventDelivery{} = delivery},
+         _metrics,
+         target
+       ) do
     final_metrics = finalize_metrics(final_metrics, :ok)
     put_dispatch_terminal_context(final_metrics, target)
     emit_timing_log(final_metrics, :ok)
-    {:attempt_timing, {:ok, events}, final_metrics.first_token_at}
+    {:attempt_timing, {:ok, events, delivery}, final_metrics.first_token_at}
   end
 
   defp handle_dispatch_result({:error, reason}, metrics, target) do
@@ -1388,7 +1456,8 @@ defmodule Orchard.Dispatch.RequestDispatcher do
                   channel: channel,
                   client: client,
                   controller_session_id: execute_request.controller_session_id,
-                  event_handler: event_handler,
+                  delivery: AttemptEventDelivery.new(metrics.request_id, event_handler),
+                  on_accepted: Map.get(stream_context, :on_accepted),
                   accepted?: false,
                   acceptance_gate: acceptance_gate,
                   cancel_drain_timeout_ms: cancel_drain_timeout_ms,
@@ -1461,25 +1530,32 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp handle_stream_event(%{terminal_event: nil} = loop_ctx, events, event) do
-    metrics = update_metrics_for_event(loop_ctx.metrics, event)
+    cond do
+      pre_acceptance_nonterminal_event?(loop_ctx, event) ->
+        metrics = increment_event_count(loop_ctx.metrics)
+        receive_loop(%{loop_ctx | metrics: metrics}, events)
 
-    if InferenceEvent.terminal?(event) do
-      receive_loop(%{loop_ctx | metrics: metrics, terminal_event: event}, events)
-    else
-      loop_ctx = maybe_record_acceptance(loop_ctx, event)
-      handler_result = emit_event_safely(event, metrics.request_id, loop_ctx.event_handler)
-      events = [event | events]
+      InferenceEvent.terminal?(event) ->
+        metrics = update_metrics_for_event(loop_ctx.metrics, event)
+        receive_loop(%{loop_ctx | metrics: metrics, terminal_event: event}, events)
 
-      cond do
-        handler_failed?(handler_result) ->
-          cancel_and_drain(%{loop_ctx | metrics: metrics}, events, :event_handler_failed)
+      true ->
+        metrics = update_metrics_for_event(loop_ctx.metrics, event)
+        loop_ctx = maybe_record_acceptance(loop_ctx, event)
+        delivery = AttemptEventDelivery.record(loop_ctx.delivery, event)
+        loop_ctx = %{loop_ctx | delivery: delivery, metrics: metrics}
+        events = [event | events]
 
-        cancelled_by_handler?(handler_result) ->
-          cancel_and_drain(%{loop_ctx | metrics: metrics}, events, :client_disconnect)
+        case AttemptEventDelivery.failure_reason(delivery) do
+          reason when reason in [:event_handler_failed, :serializer_failed] ->
+            cancel_and_drain(loop_ctx, events, :event_handler_failed)
 
-        true ->
-          receive_loop(%{loop_ctx | metrics: metrics}, events)
-      end
+          :cancel ->
+            cancel_and_drain(loop_ctx, events, :client_disconnect)
+
+          nil ->
+            receive_loop(loop_ctx, events)
+        end
     end
   end
 
@@ -1495,18 +1571,40 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     receive_loop(loop_ctx, events)
   end
 
+  defp pre_acceptance_nonterminal_event?(%{accepted?: false}, event) do
+    not InferenceEvent.terminal?(event) and InferenceEvent.kind(event) != :accepted
+  end
+
+  defp pre_acceptance_nonterminal_event?(_loop_ctx, _event), do: false
+
   defp first_conformance_defect(:none, defect), do: defect
   defp first_conformance_defect(defect, _later_defect), do: defect
 
   defp maybe_record_acceptance(
          %{acceptance_gate: acceptance_gate} = loop_ctx,
-         %InferenceEvent{event: %InferenceEvent.Accepted{}}
+         %InferenceEvent{event: %InferenceEvent.Accepted{}} = event
        ) do
     release_dispatch_acceptance_gate(acceptance_gate)
+    notify_accepted(loop_ctx.on_accepted, loop_ctx.metrics.request_id, event)
     %{loop_ctx | acceptance_gate: nil, accepted?: true}
   end
 
   defp maybe_record_acceptance(loop_ctx, _event), do: loop_ctx
+
+  defp notify_accepted(nil, _request_id, _event), do: :ok
+
+  defp notify_accepted(callback, request_id, event) when is_function(callback, 2) do
+    _result = callback.(request_id, event)
+    :ok
+  rescue
+    _error -> :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp record_delivery(loop_ctx, event) do
+    %{loop_ctx | delivery: AttemptEventDelivery.record(loop_ctx.delivery, event)}
+  end
 
   defp stream_error_result(
          %{
@@ -1535,7 +1633,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         false
       )
 
-    _handler_result = emit_event_safely(failed_event, metrics.request_id, loop_ctx.event_handler)
+    loop_ctx = record_delivery(loop_ctx, failed_event)
     metrics = update_metrics_for_terminal(metrics, failed_event, :stream)
     stream_terminal_result(loop_ctx, [failed_event | events], metrics)
   end
@@ -1553,9 +1651,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         synthesize_terminal_contract_failure(loop_ctx, events, metrics, :missing_terminal)
 
       {%InferenceEvent{} = terminal_event, :none} ->
-        _handler_result =
-          emit_event_safely(terminal_event, metrics.request_id, loop_ctx.event_handler)
-
+        loop_ctx = record_delivery(loop_ctx, terminal_event)
         stream_terminal_result(loop_ctx, [terminal_event | events], metrics)
 
       {%InferenceEvent{}, defect} ->
@@ -1572,8 +1668,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     failed_event =
       InferenceEvent.failed(code, message, false)
 
-    _handler_result =
-      emit_event_safely(failed_event, metrics.request_id, loop_ctx.event_handler)
+    loop_ctx = record_delivery(loop_ctx, failed_event)
 
     metrics =
       metrics
@@ -1603,12 +1698,16 @@ defmodule Orchard.Dispatch.RequestDispatcher do
     do: stream_terminal_result(loop_ctx, events, metrics, nil)
 
   defp stream_terminal_result(
-         %{accepted?: true, cancellation_started_before_acceptance?: false},
+         %{
+           accepted?: true,
+           cancellation_started_before_acceptance?: false,
+           delivery: delivery
+         },
          events,
          metrics,
          _cancel_reason
        ),
-       do: {:ok, Enum.reverse(events), metrics}
+       do: {:ok, Enum.reverse(events), metrics, delivery}
 
   defp stream_terminal_result(_loop_ctx, _events, _metrics, cancel_reason),
     do: {:error, {:dispatch_failed, pre_acceptance_failure_reason(cancel_reason)}}
@@ -1640,9 +1739,15 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
     if cancel_reason == :event_handler_failed do
       case result do
-        {:ok, _events, %Metrics{conformance_defect: defect}} when defect != :none -> result
-        {:ok, _events, _metrics} -> {:error, {:dispatch_failed, :event_handler_failed}}
-        {:error, _reason} = error -> error
+        {:ok, _events, %Metrics{conformance_defect: defect}, _delivery}
+        when defect != :none ->
+          result
+
+        {:ok, _events, _metrics, _delivery} ->
+          result
+
+        {:error, _reason} = error ->
+          error
       end
     else
       result
@@ -1696,10 +1801,10 @@ defmodule Orchard.Dispatch.RequestDispatcher do
       )
     else
       loop_ctx = maybe_record_acceptance(loop_ctx, event)
-      _handler_result = emit_event_safely(event, metrics.request_id, loop_ctx.event_handler)
+      loop_ctx = loop_ctx |> record_delivery(event) |> Map.put(:metrics, metrics)
 
       drain_until_terminal_or_done(
-        %{loop_ctx | metrics: metrics},
+        loop_ctx,
         [event | events],
         reason,
         deadline
@@ -1743,8 +1848,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
          events,
          cancel_reason
        ) do
-    _handler_result =
-      emit_event_safely(terminal_event, loop_ctx.metrics.request_id, loop_ctx.event_handler)
+    loop_ctx = record_delivery(loop_ctx, terminal_event)
 
     stream_terminal_result(
       loop_ctx,
@@ -1771,8 +1875,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp synthesize_cancel_terminal(loop_ctx, events, cancel_reason, message_suffix) do
-    %{metrics: metrics, event_handler: event_handler} = loop_ctx
-    request_id = metrics.request_id
+    %{metrics: metrics} = loop_ctx
 
     timeout_event =
       InferenceEvent.failed(
@@ -1781,7 +1884,7 @@ defmodule Orchard.Dispatch.RequestDispatcher do
         false
       )
 
-    _handler_result = emit_event_safely(timeout_event, request_id, event_handler)
+    loop_ctx = record_delivery(loop_ctx, timeout_event)
 
     metrics =
       metrics
@@ -1835,25 +1938,6 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   end
 
   defp exception_name(%{__struct__: module}) when is_atom(module), do: Atom.to_string(module)
-
-  defp emit_event(_event, _request_id, nil), do: :ok
-
-  defp emit_event(event, request_id, handler) when is_function(handler, 2) do
-    handler.(request_id, event)
-  end
-
-  defp emit_event_safely(event, request_id, handler) do
-    {:ok, emit_event(event, request_id, handler)}
-  rescue
-    _error -> {:error, :event_handler_failed}
-  catch
-    _kind, _reason -> {:error, :event_handler_failed}
-  end
-
-  defp cancelled_by_handler?({:ok, handler_result}), do: handler_result == :cancel
-
-  defp handler_failed?({:error, :event_handler_failed}), do: true
-  defp handler_failed?(_handler_result), do: false
 
   defp start_timeout_timer(timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0 do
     ref = make_ref()

--- a/apps/orchard_controller/lib/orchard/inference/chat_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_orchestrator.ex
@@ -71,8 +71,9 @@ defmodule Orchard.Inference.ChatOrchestrator do
 
   ## Options
 
-    * `:event_handler` — optional callback `fun(request_id, event)` called
-      with each `InferenceEvent` as it arrives from dispatch
+    * `:event_handler` - optional callback `fun(request_id, event)` called for
+      selected attempt events in order. It must return `:ok`, `:cancel`, or
+      `{:error, :serializer_failed}`.
     * `:caller` — optional pid to monitor for dispatch cancellation semantics
       (defaults to the current process)
     * `:idempotency` — optional tenant-scoped idempotency context built from
@@ -106,9 +107,10 @@ defmodule Orchard.Inference.ChatOrchestrator do
 
   ## Options
 
-    * `:event_handler` — optional callback `fun(request_id, event)` for
-      streaming-style event delivery
-    * `:caller` — optional pid forwarded to the dispatcher for cancellation
+    * `:event_handler` - optional callback `fun(request_id, event)` for selected,
+      ordered delivery. It must return `:ok`, `:cancel`, or
+      `{:error, :serializer_failed}`.
+    * `:caller` - optional pid forwarded to the dispatcher for cancellation
       monitoring
   """
   @spec orchestrate(map(), keyword()) :: orchestrate_result()

--- a/apps/orchard_controller/lib/orchard/inference/output_commitment.ex
+++ b/apps/orchard_controller/lib/orchard/inference/output_commitment.ex
@@ -1,0 +1,37 @@
+defmodule Orchard.Inference.OutputCommitment do
+  @moduledoc """
+  Pure monotonic classification of validated externally meaningful inference output.
+  """
+
+  alias Orchard.InferenceEvent
+  alias Orchard.InferenceEvent.{OutputTextDelta, ToolCallDelta}
+
+  @enforce_keys [:kind]
+  defstruct kind: nil
+
+  @type kind :: :text | :tool_call | :structured_output
+  @type t :: %__MODULE__{kind: kind() | nil}
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{kind: nil}
+
+  @spec observe(t(), InferenceEvent.t()) :: t()
+  def observe(%__MODULE__{kind: kind} = commitment, %InferenceEvent{}) when not is_nil(kind),
+    do: commitment
+
+  def observe(%__MODULE__{} = commitment, %InferenceEvent{event: %OutputTextDelta{delta: delta}})
+      when delta != "",
+      do: %__MODULE__{commitment | kind: :text}
+
+  def observe(%__MODULE__{} = commitment, %InferenceEvent{event: %ToolCallDelta{}}),
+    do: %__MODULE__{commitment | kind: :tool_call}
+
+  def observe(%__MODULE__{} = commitment, %InferenceEvent{}), do: commitment
+
+  @spec committed?(t()) :: boolean()
+  def committed?(%__MODULE__{kind: nil}), do: false
+  def committed?(%__MODULE__{}), do: true
+
+  @spec kind(t()) :: kind() | nil
+  def kind(%__MODULE__{kind: kind}), do: kind
+end

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -42,7 +42,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
   alias Orchard.SentryContext
 
   @type event_handler ::
-          (Ecto.UUID.t(), InferenceEvent.t() -> :ok | :cancel)
+          (Ecto.UUID.t(), InferenceEvent.t() ->
+             :ok | :cancel | {:error, :serializer_failed})
   @type success_persistence ::
           (CanonicalRequest.t(), [InferenceEvent.t()] -> map())
   @type step_event_appender ::
@@ -266,6 +267,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp fail_and_return_error(db_request, reason, step_context, terminal_persister) do
+    advance_attempt_fsm_best_effort(db_request.id, step_context)
+
     case fail_request(db_request, reason, step_context, terminal_persister) do
       :ok -> {:error, reason}
       {:error, {:terminal_persist_failed, _} = persist_error} -> {:error, persist_error}
@@ -625,18 +628,31 @@ defmodule Orchard.Inference.RequestOrchestrator do
            execution_opts.event_handler,
            Map.get(execution_opts, :queue_grant)
          ) do
-      %AttemptOutcome{events: events} = outcome ->
-        if Enum.any?(events, &InferenceEvent.terminal?/1) do
-          finalize_started_inference_turn(
-            db_request,
-            canonical,
-            outcome,
-            execution_opts,
-            step_context
+      %AttemptOutcome{} = pending_outcome ->
+        outcome =
+          AttemptOutcome.select(
+            pending_outcome,
+            canonical.public_id,
+            execution_opts.event_handler
           )
-        else
-          {:error, public_dispatch_reason(outcome),
-           Map.put(step_context, :attempt_outcome, outcome)}
+
+        cond do
+          outcome.delivery_state == :failed ->
+            {:error, public_dispatch_reason(outcome),
+             Map.put(step_context, :attempt_outcome, outcome)}
+
+          Enum.any?(outcome.events, &InferenceEvent.terminal?/1) ->
+            finalize_started_inference_turn(
+              db_request,
+              canonical,
+              outcome,
+              execution_opts,
+              step_context
+            )
+
+          true ->
+            {:error, public_dispatch_reason(outcome),
+             Map.put(step_context, :attempt_outcome, outcome)}
         end
 
       {:error, reason} ->
@@ -652,8 +668,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
          step_context
        ) do
     case finalize(db_request, canonical, outcome, execution_opts, step_context) do
-      {:ok, _, _} = success -> success
-      {:error, reason} -> {:error, reason, step_context}
+      {:ok, _, _} = success ->
+        success
+
+      {:error, reason} ->
+        failed_outcome = AttemptOutcome.fail_attempt(outcome)
+        {:error, reason, Map.put(step_context, :attempt_outcome, failed_outcome)}
     end
   end
 
@@ -1023,7 +1043,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp dispatch(db_request, canonical, model, schedule, caller, event_handler, queue_grant) do
     execute_request = build_execute_request(canonical, schedule)
     model_load_request = build_model_load_request(model, schedule)
-    wrapped_handler = wrap_event_handler(event_handler, queue_grant)
+    on_accepted = build_accepted_callback(queue_grant)
 
     maybe_mark_grant_node(queue_grant, map_value(schedule, :node_id), promote?: false)
 
@@ -1032,7 +1052,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
       execute_request,
       model_load_request,
       caller,
-      wrapped_handler,
+      event_handler,
+      on_accepted,
       db_request.id,
       queue_grant
     )
@@ -1043,13 +1064,15 @@ defmodule Orchard.Inference.RequestOrchestrator do
          execute_request,
          model_load_request,
          caller,
-         wrapped_handler,
+         event_handler,
+         on_accepted,
          request_id,
          queue_grant
        ) do
     opts = [
       caller: caller,
-      event_handler: wrapped_handler,
+      event_handler: event_handler,
+      on_accepted: on_accepted,
       on_node_resolved: build_node_resolved_callback(request_id, queue_grant)
     ]
 
@@ -1094,16 +1117,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp public_dispatch_reason(%AttemptOutcome{failure: %{"failure_code" => failure_code}}),
     do: {:dispatch_failed, failure_code}
 
-  defp wrap_event_handler(downstream_handler, queue_grant) do
-    fn request_id, event ->
-      maybe_mark_capacity_source_observed(queue_grant, event)
-
-      if downstream_handler do
-        downstream_handler.(request_id, event)
-      else
-        :ok
-      end
-    end
+  defp build_accepted_callback(queue_grant) do
+    fn _request_id, event -> maybe_mark_capacity_source_observed(queue_grant, event) end
   end
 
   defp maybe_mark_capacity_source_observed(
@@ -1289,7 +1304,10 @@ defmodule Orchard.Inference.RequestOrchestrator do
       other -> {:error, {:invalid_success_persistence, other}}
     end
   rescue
-    error -> {:error, {:success_persistence_failed, error}}
+    error -> {:error, {:success_persistence_failed, {:exception, error}}}
+  catch
+    :exit, reason -> {:error, {:success_persistence_failed, {:exit, reason}}}
+    kind, reason -> {:error, {:success_persistence_failed, {kind, reason}}}
   end
 
   defp merge_success_attrs({:ok, success_attrs}, terminal_attrs),
@@ -1307,7 +1325,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          _step_event_appender,
          terminal_persister
        ) do
-    advance_fsm_best_effort(db_request.id, events)
+    advance_fsm_best_effort(db_request.id, events, step_context[:attempt_outcome])
 
     case terminal_persister.(
            db_request,
@@ -1351,12 +1369,29 @@ defmodule Orchard.Inference.RequestOrchestrator do
     end
   end
 
-  defp advance_fsm_best_effort(request_id, events) do
-    has_delta? = Enum.any?(events, &(InferenceEvent.kind(&1) == :output_text_delta))
+  defp advance_attempt_fsm_best_effort(
+         request_id,
+         %{attempt_outcome: %AttemptOutcome{} = outcome}
+       ) do
+    advance_fsm_best_effort(request_id, outcome.events, outcome)
+  end
 
+  defp advance_attempt_fsm_best_effort(_request_id, _step_context), do: :ok
+
+  defp advance_fsm_best_effort(request_id, _events, %AttemptOutcome{} = outcome) do
+    if outcome.accepted do
+      try_advance(request_id, :running)
+
+      if outcome.output_committed do
+        try_advance(request_id, :streaming)
+      end
+    end
+  end
+
+  defp advance_fsm_best_effort(request_id, events, nil) do
     try_advance(request_id, :running)
 
-    if has_delta? do
+    if Enum.any?(events, &(InferenceEvent.kind(&1) == :output_text_delta)) do
       try_advance(request_id, :streaming)
     end
   end
@@ -1579,13 +1614,17 @@ defmodule Orchard.Inference.RequestOrchestrator do
       "started_at" => outcome.started_at,
       "ended_at" => outcome.ended_at,
       "accepted" => outcome.accepted,
-      "output_committed" => false,
+      "output_committed" => outcome.output_committed,
       "execution_resolution" => Atom.to_string(outcome.execution_resolution),
       "capacity_release_outcome" => Atom.to_string(outcome.capacity_release_outcome),
       "excluded_node_ids" => []
     }
 
     base
+    |> maybe_put_result(
+      "output_commitment_kind",
+      commitment_kind_string(outcome.output_commitment_kind)
+    )
     |> maybe_put_result("node_id", outcome.node_id)
     |> put_attempt_failure(outcome)
   end
@@ -1598,6 +1637,10 @@ defmodule Orchard.Inference.RequestOrchestrator do
     |> Map.put("retry_decision", attempt_retry_decision(outcome))
   end
 
+  defp commitment_kind_string(nil), do: nil
+  defp commitment_kind_string(kind), do: Atom.to_string(kind)
+
+  defp attempt_retry_decision(%AttemptOutcome{output_committed: true}), do: "output_committed"
   defp attempt_retry_decision(%AttemptOutcome{attempt_outcome: :cancelled}), do: "cancelled"
 
   defp attempt_retry_decision(%AttemptOutcome{

--- a/apps/orchard_controller/lib/orchard/inference/responses_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/responses_orchestrator.ex
@@ -26,6 +26,12 @@ defmodule Orchard.Inference.ResponsesOrchestrator do
     )
   end
 
+  @doc """
+  Executes the shared request pipeline for a prepared Responses request.
+
+  The optional `:event_handler` receives selected attempt events in order and
+  must return `:ok`, `:cancel`, or `{:error, :serializer_failed}`.
+  """
   @spec execute(CanonicalRequest.t(), map(), keyword()) :: orchestrate_result()
   def execute(canonical, model, opts \\ []) do
     response_created_at = Keyword.get(opts, :response_created_at, System.system_time(:second))

--- a/apps/orchard_controller/lib/orchard/metrics/supervisor.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/supervisor.ex
@@ -15,6 +15,13 @@ defmodule Orchard.Metrics.Supervisor do
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts), do: Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
 
+  @doc false
+  @spec start_reporter({module(), atom(), [term()]}) :: term()
+  def start_reporter({module, function, args}) do
+    detach_orphaned_reporter_handlers()
+    apply(module, function, args)
+  end
+
   @impl true
   def init(opts) do
     reporter = Keyword.get(opts, :reporter, TelemetryMetricsPrometheus.Core)
@@ -22,8 +29,7 @@ defmodule Orchard.Metrics.Supervisor do
     children = [
       Status,
       CardinalityLedger,
-      {reporter,
-       metrics: Catalog.reporter_metrics(), name: Orchard.Metrics.Reporter, start_async: false},
+      reporter_child(reporter),
       SeriesAdmission,
       WorkerCrashDeduplicator,
       GaugeSnapshotStore,
@@ -42,4 +48,34 @@ defmodule Orchard.Metrics.Supervisor do
 
     Supervisor.init(children, strategy: :one_for_all, max_restarts: 2, max_seconds: 5)
   end
+
+  defp reporter_child(reporter) do
+    spec =
+      Supervisor.child_spec(
+        {reporter,
+         metrics: Catalog.reporter_metrics(), name: Orchard.Metrics.Reporter, start_async: false},
+        []
+      )
+
+    %{spec | start: {__MODULE__, :start_reporter, [spec.start]}}
+  end
+
+  # A reporter generation detaches its telemetry handlers from `terminate/2` only.
+  # A generation killed without terminating leaves handlers bound to the reporter
+  # table name, so they keep writing into the table the next generation registers
+  # and every observation is counted once per orphaned generation.
+  defp detach_orphaned_reporter_handlers do
+    for descriptor <- Catalog.descriptors(),
+        handler <- :telemetry.list_handlers(Catalog.event_name(descriptor.family)),
+        orphaned_handler?(handler.id) do
+      :telemetry.detach(handler.id)
+    end
+
+    :ok
+  end
+
+  defp orphaned_handler?({_module, owner, _metric_name}) when is_pid(owner),
+    do: not Process.alive?(owner)
+
+  defp orphaned_handler?(_id), do: false
 end

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
@@ -92,7 +92,7 @@ defmodule Orchard.Requests.InferenceAttemptResult do
          :ok <- validate_acceptance_resolution(normalized),
          :ok <- validate_outcome_fields(attempt, normalized),
          :ok <- validate_outcome_failure_consistency(normalized),
-         :ok <- validate_retry_consistency(attempt, normalized) do
+         :ok <- validate_retry_consistency(normalized) do
       validate_node_evidence(attempt, normalized)
     end
   end
@@ -281,8 +281,6 @@ defmodule Orchard.Requests.InferenceAttemptResult do
     do: {:error, "cancelled attempts require cancellation failure evidence"}
 
   defp validate_outcome_failure_consistency(_result), do: :ok
-
-  defp validate_retry_consistency(_attempt, result), do: validate_retry_consistency(result)
 
   defp validate_retry_consistency(%{
          "output_committed" => true,

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
@@ -91,7 +91,8 @@ defmodule Orchard.Requests.InferenceAttemptResult do
          :ok <- validate_commitment(normalized),
          :ok <- validate_acceptance_resolution(normalized),
          :ok <- validate_outcome_fields(attempt, normalized),
-         :ok <- validate_retry_consistency(normalized) do
+         :ok <- validate_outcome_failure_consistency(normalized),
+         :ok <- validate_retry_consistency(attempt, normalized) do
       validate_node_evidence(attempt, normalized)
     end
   end
@@ -270,6 +271,19 @@ defmodule Orchard.Requests.InferenceAttemptResult do
   defp validate_retry_decision(attempt, _decision),
     do: {:error, "retry_decision is invalid for attempt #{attempt}"}
 
+  defp validate_outcome_failure_consistency(%{
+         "attempt_outcome" => "cancelled",
+         "failure_class" => "cancellation"
+       }),
+       do: :ok
+
+  defp validate_outcome_failure_consistency(%{"attempt_outcome" => "cancelled"}),
+    do: {:error, "cancelled attempts require cancellation failure evidence"}
+
+  defp validate_outcome_failure_consistency(_result), do: :ok
+
+  defp validate_retry_consistency(_attempt, result), do: validate_retry_consistency(result)
+
   defp validate_retry_consistency(%{
          "output_committed" => true,
          "retry_decision" => decision
@@ -279,10 +293,11 @@ defmodule Orchard.Requests.InferenceAttemptResult do
 
   defp validate_retry_consistency(%{
          "attempt_outcome" => "cancelled",
+         "output_committed" => false,
          "retry_decision" => decision
        })
        when decision != "cancelled",
-       do: {:error, "cancelled attempts require cancelled retry decision"}
+       do: {:error, "uncommitted cancelled attempts require cancelled retry decision"}
 
   defp validate_retry_consistency(%{
          "retry_decision" => "retried",

--- a/apps/orchard_controller/test/application_test.exs
+++ b/apps/orchard_controller/test/application_test.exs
@@ -143,7 +143,7 @@ defmodule OrchardApplicationTest do
     assert {:ok, _apps} = Application.ensure_all_started(:orchard_controller)
     assert is_pid(Process.whereis(Orchard.Supervisor))
     assert is_pid(Process.whereis(Orchard.Metrics.Bootstrap))
-    assert Process.whereis(Orchard.Metrics.Supervisor) == nil
+    refute_metrics_generation()
   end
 
   test "SPEC.md §9.1 metrics raises and exits cannot exhaust root Controller supervision" do
@@ -164,7 +164,7 @@ defmodule OrchardApplicationTest do
       Process.sleep(20)
       assert Process.alive?(root)
       assert Process.alive?(bootstrap)
-      assert Process.whereis(Orchard.Metrics.Supervisor) == nil
+      refute_metrics_generation()
 
       :ok = Application.stop(:orchard_controller)
     end
@@ -206,7 +206,7 @@ defmodule OrchardApplicationTest do
 
     assert {:ok, _apps} = Application.ensure_all_started(:orchard_controller)
     assert is_pid(Process.whereis(Orchard.Metrics.Bootstrap))
-    assert is_pid(wait_for_replacement(Orchard.Metrics.Supervisor, nil))
+    assert is_pid(wait_for_replacement(&metrics_generation/0, nil))
     refute :persistent_term.get({OrchardApplicationTest.FlakyMetricsReporter, :fail?})
   end
 
@@ -708,6 +708,21 @@ defmodule OrchardApplicationTest do
     assert String.ends_with?(licensing[:node_identity_path], "/tmp/test/data/node-id")
   end
 
+  defp refute_metrics_generation do
+    assert metrics_generation() == nil
+    assert Process.whereis(Orchard.Metrics.Supervisor) == nil
+  end
+
+  # The bootstrap starts a generation from `handle_continue/2`, so
+  # `Orchard.Metrics.Supervisor` is registered for the whole start attempt —
+  # including attempts that go on to fail — and that attempt can outlast the
+  # rest of Controller boot. `:sys.get_state/1` is ordered behind the continue,
+  # so it settles the attempt and reports the generation the bootstrap owns.
+  defp metrics_generation do
+    %{supervisor: supervisor} = :sys.get_state(Orchard.Metrics.Bootstrap)
+    supervisor
+  end
+
   defp membership_owner_specs(child_specs) do
     Enum.filter(child_specs, &match?({Orchard.ControllerInstances.MembershipOwner, _opts}, &1))
   end
@@ -742,7 +757,7 @@ defmodule OrchardApplicationTest do
   defp wait_for_replacement(_name, _previous, 0), do: flunk("supervised process was not replaced")
 
   defp wait_for_replacement(name, previous, attempts) do
-    case Process.whereis(name) do
+    case resolve_process(name) do
       replacement when is_pid(replacement) and replacement != previous ->
         replacement
 
@@ -751,6 +766,9 @@ defmodule OrchardApplicationTest do
         wait_for_replacement(name, previous, attempts - 1)
     end
   end
+
+  defp resolve_process(resolver) when is_function(resolver, 0), do: resolver.()
+  defp resolve_process(name), do: Process.whereis(name)
 
   defp test_runtime_client_target do
     [host: "127.0.0.1", port: test_node_agent_port()]

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -272,6 +272,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert request.response_payload == nil
       assert request.response_preview == nil
       assert request.response_hash != nil
+      assert_text_commitment!(request)
 
       tenant
       |> Tenant.changeset(%{request_body_capture_mode: :full})
@@ -292,6 +293,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert full_request.payload_capture_mode == :full
       assert full_request.canonical_request["rendered_prompt"] =~ "retain in full mode"
       assert full_request.response_payload == full_body
+      assert_text_commitment!(full_request)
 
       %{token: none_token, tenant: none_tenant} =
         create_api_key_with_token!("non-stream-none")
@@ -315,6 +317,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert none_request.canonical_request == nil
       assert none_request.request_shape == nil
       assert none_request.response_payload == nil
+      assert_text_commitment!(none_request)
     end
 
     @tag :db
@@ -1175,6 +1178,9 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       error_events = Enum.filter(events, fn {type, _} -> type == :error end)
       assert error_events == []
 
+      request = Requests.get_request_by_public_id(first_chunk["id"])
+      assert_text_commitment!(request)
+
       assert Sentry.Context.get_all().extra == %{}
       assert Sentry.Context.get_all().breadcrumbs == []
     end
@@ -1240,8 +1246,10 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
         prepare: {:ok, stub_chat_canonical(), %{}},
         events: [
           InferenceEvent.accepted(1_710_000_123_000),
-          InferenceEvent.tool_call_delta("call_0", "not-json")
+          InferenceEvent.tool_call_delta("call_0", "not-json"),
+          InferenceEvent.completed(:finish_reason_tool_calls, nil)
         ],
+        capture_handler_pid: self(),
         execute: {:ok, stub_chat_canonical(), []}
       )
 
@@ -1261,6 +1269,56 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
              end)
 
       refute Enum.any?(events, fn {type, _payload} -> type == :done end)
+
+      assert_receive {:handler_result, :accepted, :ok}
+      assert_receive {:handler_result, :tool_call_delta, {:error, :serializer_failed}}
+      refute_receive {:handler_result, :completed, _result}
+    end
+
+    test "post-commit serializer failure keeps public SSE shape and durable commitment",
+         %{bundle: bundle} do
+      put_queue_admission_config!()
+
+      put_blocking_runtime_adapter!(self(),
+        events: [
+          InferenceEvent.tool_call_delta("call-stable", "not-json"),
+          InferenceEvent.completed(:finish_reason_tool_calls, nil)
+        ]
+      )
+
+      create_queue_model!(bundle, "chat-queue-overlap-model")
+      %{token: token} = create_api_key_with_token!("chat-tool-serializer-failure")
+
+      task =
+        Task.async(fn ->
+          post_chat(
+            %{
+              "model" => "chat-queue-overlap-model@v1",
+              "messages" => [%{"role" => "user", "content" => "call a tool"}],
+              "stream" => true
+            },
+            token
+          )
+        end)
+
+      assert_receive {:queue_admission_runtime_started, runtime_pid, request_id,
+                      "chat-queue-overlap-model"},
+                     2_000
+
+      send(runtime_pid, :queue_admission_runtime_release)
+      conn = Task.await(task, 5_000)
+      events = parse_sse_body(conn.resp_body)
+
+      assert Enum.any?(events, fn
+               {:error, payload} -> payload["error"]["message"] == "Malformed tool call delta"
+               _other -> false
+             end)
+
+      refute Enum.any?(events, fn {type, _payload} -> type == :done end)
+
+      request = Requests.get_request_by_public_id(request_id)
+      assert request.state == :failed
+      assert_tool_serializer_failure!(request)
     end
 
     test "SPEC 7.5.5 streaming terminal conformance failure emits one generic SSE error" do
@@ -1726,14 +1784,34 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       end
 
       if event_handler = Keyword.get(opts, :event_handler) do
-        Enum.each(Keyword.get(config, :events, []), fn event ->
-          event_handler.(canonical.public_id, event)
-        end)
+        _handler_result =
+          Enum.reduce_while(Keyword.get(config, :events, []), :ok, fn event, _acc ->
+            deliver_event(
+              event_handler,
+              canonical.public_id,
+              event,
+              Keyword.get(config, :capture_handler_pid)
+            )
+          end)
       end
 
       case Keyword.get(config, :execute) do
         nil -> {:ok, canonical, Keyword.get(config, :events, [])}
         result -> result
+      end
+    end
+
+    defp deliver_event(event_handler, request_id, event, capture_pid) do
+      result = event_handler.(request_id, event)
+
+      if capture_pid do
+        send(capture_pid, {:handler_result, Orchard.InferenceEvent.kind(event), result})
+      end
+
+      case result do
+        :ok -> {:cont, :ok}
+        :cancel -> {:halt, :cancel}
+        {:error, :serializer_failed} = error -> {:halt, error}
       end
     end
   end

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -206,7 +206,7 @@ defmodule Orchard.API.ResponsesControllerTest do
 
     # first_token_at must be persisted for successful requests with output
     request = Requests.get_request_by_public_id(body["id"])
-    assert request.first_token_at != nil
+    assert_text_commitment!(request)
 
     full_conn =
       post_responses(
@@ -224,6 +224,7 @@ defmodule Orchard.API.ResponsesControllerTest do
     assert full_request.payload_capture_mode == :full
     assert full_request.canonical_request["endpoint"] == "responses"
     assert full_request.response_payload == full_body
+    assert_text_commitment!(full_request)
 
     for params <- [
           %{"model" => "responses-success-model@v1", "input" => "store omitted"},
@@ -275,6 +276,7 @@ defmodule Orchard.API.ResponsesControllerTest do
     assert none_request.canonical_request == nil
     assert none_request.request_shape == nil
     assert none_request.response_payload == nil
+    assert_text_commitment!(none_request)
   end
 
   test "successful non-stream request can return function_call output items" do
@@ -895,7 +897,7 @@ defmodule Orchard.API.ResponsesControllerTest do
     # first_token_at must be persisted for successful streaming requests
     response_id = terminal.data["response"]["id"]
     request = Requests.get_request_by_public_id(response_id)
-    assert request.first_token_at != nil
+    assert_text_commitment!(request)
     assert request.payload_capture_mode == :full
     assert request.canonical_request["stream"] == true
     assert request.response_payload == terminal.data["response"]
@@ -1196,8 +1198,10 @@ defmodule Orchard.API.ResponsesControllerTest do
       prepare: {:ok, stub_responses_canonical(true), %{}},
       events: [
         InferenceEvent.accepted(1_710_000_123_000),
-        InferenceEvent.tool_call_delta("call_0", "not-json")
+        InferenceEvent.tool_call_delta("call_0", "not-json"),
+        InferenceEvent.completed(:finish_reason_tool_calls, nil)
       ],
+      capture_handler_pid: self(),
       execute: {:ok, stub_responses_canonical(true), []}
     )
 
@@ -1234,6 +1238,54 @@ defmodule Orchard.API.ResponsesControllerTest do
 
     body = collect_chunked_body(conn)
     refute String.contains?(body, "[DONE]")
+
+    assert_receive {:handler_result, :accepted, :ok}
+    assert_receive {:handler_result, :tool_call_delta, {:error, :serializer_failed}}
+    refute_receive {:handler_result, :completed, _result}
+  end
+
+  test "post-commit serializer failure keeps typed SSE shape and durable commitment",
+       %{bundle: bundle} do
+    put_queue_admission_config!()
+
+    put_blocking_runtime_adapter!(self(),
+      events: [
+        InferenceEvent.tool_call_delta("call-stable", "not-json"),
+        InferenceEvent.completed(:finish_reason_tool_calls, nil)
+      ]
+    )
+
+    create_queue_model!(bundle, "responses-queue-overlap-model")
+    %{token: token} = create_api_key_with_token!("responses-tool-serializer-failure")
+
+    task =
+      Task.async(fn ->
+        post_responses(
+          %{
+            "model" => "responses-queue-overlap-model@v1",
+            "input" => "call a tool",
+            "stream" => true
+          },
+          token
+        )
+      end)
+
+    assert_receive {:queue_admission_runtime_started, runtime_pid, request_id,
+                    "responses-queue-overlap-model"},
+                   2_000
+
+    send(runtime_pid, :queue_admission_runtime_release)
+    conn = Task.await(task, 5_000)
+    events = parse_typed_sse_events(conn)
+
+    assert Enum.map(events, & &1.type) == ["response.created", "response.failed"]
+    assert hd(events).data["response"]["status"] == "in_progress"
+    assert List.last(events).data["response"]["status"] == "failed"
+    refute String.contains?(collect_chunked_body(conn), "[DONE]")
+
+    request = Requests.get_request_by_public_id(request_id)
+    assert request.state == :failed
+    assert_tool_serializer_failure!(request)
   end
 
   test "SPEC 7.5.5 streaming terminal conformance failure emits response.failed" do
@@ -1552,14 +1604,34 @@ defmodule Orchard.API.ResponsesControllerTest do
       end
 
       if event_handler = Keyword.get(opts, :event_handler) do
-        Enum.each(Keyword.get(config, :events, []), fn event ->
-          event_handler.(canonical.public_id, event)
-        end)
+        _handler_result =
+          Enum.reduce_while(Keyword.get(config, :events, []), :ok, fn event, _acc ->
+            deliver_event(
+              event_handler,
+              canonical.public_id,
+              event,
+              Keyword.get(config, :capture_handler_pid)
+            )
+          end)
       end
 
       case Keyword.get(config, :execute) do
         nil -> {:ok, canonical, Keyword.get(config, :events, [])}
         result -> result
+      end
+    end
+
+    defp deliver_event(event_handler, request_id, event, capture_pid) do
+      result = event_handler.(request_id, event)
+
+      if capture_pid do
+        send(capture_pid, {:handler_result, Orchard.InferenceEvent.kind(event), result})
+      end
+
+      case result do
+        :ok -> {:cont, :ok}
+        :cancel -> {:halt, :cancel}
+        {:error, :serializer_failed} = error -> {:halt, error}
       end
     end
   end

--- a/apps/orchard_controller/test/orchard/dispatch/attempt_event_delivery_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/attempt_event_delivery_test.exs
@@ -1,0 +1,135 @@
+defmodule Orchard.Dispatch.AttemptEventDeliveryTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Dispatch.AttemptEventDelivery
+  alias Orchard.InferenceEvent
+
+  test "SPEC 5.8 normalizes cancellation and handler failures with partial flush accounting" do
+    accepted = InferenceEvent.accepted(1)
+    committing = InferenceEvent.tool_call_delta("call-1", "{")
+    terminal = InferenceEvent.completed(:finish_reason_tool_calls, nil)
+
+    cases = [
+      {:cancel, fn -> :cancel end},
+      {:serializer_failed, fn -> {:error, :serializer_failed} end},
+      {:event_handler_failed, fn -> :invalid_return end},
+      {:event_handler_failed, fn -> raise "handler failed" end},
+      {:event_handler_failed, fn -> throw(:handler_failed) end},
+      {:event_handler_failed, fn -> exit(:handler_failed) end}
+    ]
+
+    for {expected_reason, fail} <- cases do
+      handler = fn _request_id, event ->
+        if event == accepted, do: :ok, else: fail.()
+      end
+
+      failed =
+        AttemptEventDelivery.new("request-failure", handler)
+        |> AttemptEventDelivery.record(accepted)
+        |> AttemptEventDelivery.record(committing)
+        |> AttemptEventDelivery.record(terminal)
+
+      assert AttemptEventDelivery.output_committed?(failed)
+      assert AttemptEventDelivery.commitment_kind(failed) == :tool_call
+      assert AttemptEventDelivery.delivery_state(failed) == :failed
+      assert AttemptEventDelivery.delivered_event_count(failed) == 1
+      assert AttemptEventDelivery.failure_reason(failed) == expected_reason
+      assert AttemptEventDelivery.events(failed) == [accepted, committing, terminal]
+    end
+  end
+
+  test "SPEC 5.8 selects a final uncommitted attempt or discards it without delivery" do
+    owner = self()
+
+    handler = fn request_id, event ->
+      send(owner, {:delivered, request_id, event})
+      :ok
+    end
+
+    events = [InferenceEvent.accepted(1), InferenceEvent.output_text_delta("")]
+
+    pending =
+      Enum.reduce(events, AttemptEventDelivery.new("request-select", handler), fn event,
+                                                                                  delivery ->
+        AttemptEventDelivery.record(delivery, event)
+      end)
+
+    selected = AttemptEventDelivery.select(pending)
+    assert AttemptEventDelivery.delivery_state(selected) == :selected
+    assert AttemptEventDelivery.delivered_event_count(selected) == 2
+    assert_receive {:delivered, "request-select", first}
+    assert_receive {:delivered, "request-select", second}
+    assert [first, second] == events
+
+    pending_discard =
+      AttemptEventDelivery.new("request-discard", handler)
+      |> AttemptEventDelivery.record(InferenceEvent.progress("prefill", "working"))
+
+    assert {:ok, discarded} = AttemptEventDelivery.discard(pending_discard)
+    assert AttemptEventDelivery.delivery_state(discarded) == :discarded
+    assert AttemptEventDelivery.delivered_event_count(discarded) == 0
+    refute_received {:delivered, "request-discard", _}
+
+    committed =
+      AttemptEventDelivery.new("request-committed", handler)
+      |> AttemptEventDelivery.record(InferenceEvent.output_text_delta("committed"))
+
+    assert {:error, :output_committed} = AttemptEventDelivery.discard(committed)
+    assert AttemptEventDelivery.select(committed) == committed
+  end
+
+  @tag timeout: 2_000
+  test "selected delivery records a long stream without rescanning delivered history" do
+    first = InferenceEvent.output_text_delta("first")
+    next = InferenceEvent.output_text_delta("next")
+
+    delivery =
+      AttemptEventDelivery.new("request-long-stream", nil)
+      |> AttemptEventDelivery.record(first)
+
+    final =
+      Enum.reduce(1..50_000, delivery, fn _index, state ->
+        AttemptEventDelivery.record(state, next)
+      end)
+
+    assert AttemptEventDelivery.delivered_event_count(final) == 50_001
+    assert length(AttemptEventDelivery.events(final)) == 50_001
+    assert hd(AttemptEventDelivery.events(final)) == first
+    assert List.last(AttemptEventDelivery.events(final)) == next
+  end
+
+  test "SPEC 5.8 buffers pre-commit events and flushes them before the committing event" do
+    owner = self()
+
+    handler = fn request_id, event ->
+      send(owner, {:delivered, request_id, event})
+      :ok
+    end
+
+    accepted = InferenceEvent.accepted(1)
+    empty_text = InferenceEvent.output_text_delta("")
+    committing_text = InferenceEvent.output_text_delta("hello")
+
+    delivery =
+      AttemptEventDelivery.new("request-1", handler)
+      |> AttemptEventDelivery.record(accepted)
+      |> AttemptEventDelivery.record(empty_text)
+
+    assert AttemptEventDelivery.events(delivery) == [accepted, empty_text]
+    refute AttemptEventDelivery.output_committed?(delivery)
+    assert AttemptEventDelivery.delivery_state(delivery) == :pending
+    refute_received {:delivered, _, _}
+
+    committed = AttemptEventDelivery.record(delivery, committing_text)
+
+    assert AttemptEventDelivery.events(committed) == [accepted, empty_text, committing_text]
+    assert AttemptEventDelivery.output_committed?(committed)
+    assert AttemptEventDelivery.commitment_kind(committed) == :text
+    assert AttemptEventDelivery.delivery_state(committed) == :selected
+    assert AttemptEventDelivery.delivered_event_count(committed) == 3
+
+    assert_receive {:delivered, "request-1", ^accepted}
+    assert_receive {:delivered, "request-1", ^empty_text}
+    assert_receive {:delivered, "request-1", ^committing_text}
+  end
+end

--- a/apps/orchard_controller/test/orchard/dispatch/attempt_outcome_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/attempt_outcome_test.exs
@@ -4,6 +4,111 @@ defmodule Orchard.Dispatch.AttemptOutcomeTest do
   alias Orchard.Dispatch.AttemptOutcome
   alias Orchard.Requests.InferenceAttemptFailure
 
+  test "SPEC 5.8 validates commitment, delivery accounting, and failure transformations" do
+    started_at = ~U[2026-08-14 10:00:00.000000Z]
+    ended_at = DateTime.add(started_at, 1, :second)
+
+    events = [
+      Orchard.InferenceEvent.accepted(1),
+      Orchard.InferenceEvent.tool_call_delta("call-1", "")
+    ]
+
+    attrs = %{
+      attempt_outcome: :completed,
+      node_id: Ecto.UUID.generate(),
+      accepted: true,
+      events: events,
+      failure: nil,
+      execution_resolution: :terminated,
+      capacity_release_outcome: :released,
+      started_at: started_at,
+      ended_at: ended_at,
+      first_token_at: nil,
+      output_committed: true,
+      output_commitment_kind: :tool_call,
+      delivery_state: :selected,
+      delivered_event_count: 2
+    }
+
+    assert {:ok, committed} = AttemptOutcome.new(attrs)
+    assert committed.output_committed
+    assert committed.output_commitment_kind == :tool_call
+    assert committed.first_token_at == nil
+
+    assert {:error, :invalid_attempt_outcome} =
+             attrs |> Map.delete(:output_commitment_kind) |> AttemptOutcome.new()
+
+    assert {:error, :invalid_attempt_outcome} =
+             attrs
+             |> Map.put(:output_commitment_kind, :text)
+             |> Map.put(:first_token_at, nil)
+             |> AttemptOutcome.new()
+
+    assert {:error, :invalid_attempt_outcome} =
+             attrs |> Map.put(:accepted, false) |> AttemptOutcome.new()
+
+    assert {:error, :invalid_attempt_outcome} =
+             attrs |> Map.put(:delivered_event_count, 1) |> AttemptOutcome.new()
+
+    failed = AttemptOutcome.fail_delivery(committed, 1)
+    assert failed.attempt_outcome == :failed
+    assert failed.delivery_state == :failed
+    assert failed.delivered_event_count == 1
+    assert failed.output_committed
+    assert failed.output_commitment_kind == :tool_call
+    assert failed.failure["failure_class"] == "controller_failure"
+
+    cancelled = AttemptOutcome.cancel_delivery(committed, 1)
+    assert cancelled.attempt_outcome == :cancelled
+    assert cancelled.delivery_state == :failed
+    assert cancelled.delivered_event_count == 1
+    assert cancelled.output_committed
+    assert cancelled.failure["failure_class"] == "cancellation"
+  end
+
+  test "SPEC 5.8 discards only pending uncommitted outcomes without delivery" do
+    started_at = ~U[2026-08-14 10:00:00.000000Z]
+    ended_at = DateTime.add(started_at, 1, :second)
+
+    attrs = %{
+      attempt_outcome: :completed,
+      node_id: Ecto.UUID.generate(),
+      accepted: true,
+      events: [Orchard.InferenceEvent.accepted(1), Orchard.InferenceEvent.output_text_delta("")],
+      failure: nil,
+      execution_resolution: :terminated,
+      capacity_release_outcome: :released,
+      started_at: started_at,
+      ended_at: ended_at,
+      first_token_at: nil,
+      output_committed: false,
+      output_commitment_kind: nil,
+      delivery_state: :pending,
+      delivered_event_count: 0
+    }
+
+    assert {:ok, pending} = AttemptOutcome.new(attrs)
+    assert {:ok, discarded} = AttemptOutcome.discard(pending)
+    assert discarded.delivery_state == :discarded
+    assert discarded.events == pending.events
+    assert discarded.delivered_event_count == 0
+
+    selected = AttemptOutcome.select(pending, "request-selected", nil)
+    assert {:error, :already_selected} = AttemptOutcome.discard(selected)
+
+    {:ok, committed} =
+      attrs
+      |> Map.put(:events, [Orchard.InferenceEvent.output_text_delta("committed")])
+      |> Map.put(:output_committed, true)
+      |> Map.put(:output_commitment_kind, :text)
+      |> Map.put(:first_token_at, started_at)
+      |> Map.put(:delivery_state, :selected)
+      |> Map.put(:delivered_event_count, 1)
+      |> AttemptOutcome.new()
+
+    assert {:error, :output_committed} = AttemptOutcome.discard(committed)
+  end
+
   test "SPEC 3.7.1 validates narrow typed single-attempt evidence" do
     started_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
     ended_at = DateTime.add(started_at, 5, :millisecond)
@@ -16,19 +121,30 @@ defmodule Orchard.Dispatch.AttemptOutcomeTest do
         code: :worker_down
       })
 
-    assert {:ok, outcome} =
-             AttemptOutcome.new(%{
-               attempt_outcome: :failed,
-               node_id: node_id,
-               accepted: true,
-               events: [],
-               failure: failure,
-               execution_resolution: :terminated,
-               capacity_release_outcome: :released,
-               started_at: started_at,
-               ended_at: ended_at,
-               first_token_at: first_token_at
-             })
+    attrs = %{
+      attempt_outcome: :failed,
+      node_id: node_id,
+      accepted: true,
+      events: [],
+      failure: failure,
+      execution_resolution: :terminated,
+      capacity_release_outcome: :released,
+      started_at: started_at,
+      ended_at: ended_at,
+      first_token_at: first_token_at,
+      output_committed: true,
+      output_commitment_kind: :text,
+      delivery_state: :selected,
+      delivered_event_count: 0
+    }
+
+    assert {:ok, outcome} = AttemptOutcome.new(attrs)
+
+    assert {:error, :invalid_attempt_outcome} =
+             attrs
+             |> Map.put(:output_committed, false)
+             |> Map.put(:output_commitment_kind, nil)
+             |> AttemptOutcome.new()
 
     assert %AttemptOutcome{} = outcome
     assert outcome.node_id == node_id
@@ -46,7 +162,11 @@ defmodule Orchard.Dispatch.AttemptOutcomeTest do
                capacity_release_outcome: :not_applicable,
                started_at: started_at,
                ended_at: ended_at,
-               first_token_at: nil
+               first_token_at: nil,
+               output_committed: false,
+               output_commitment_kind: nil,
+               delivery_state: :selected,
+               delivered_event_count: 0
              })
   end
 end

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -86,6 +86,31 @@ defmodule Orchard.Dispatch.DispatchTest.TerminalContractClient do
     ]
   end
 
+  defp events_for(request_id)
+       when request_id in [
+              "req-dispatch-tool",
+              "req-dispatch-handler-commit-failure",
+              "req-dispatch-handler-post-commit-failure"
+            ] do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.tool_call_delta("call-stable", ""),
+      InferenceEvent.output_text_delta("later text"),
+      InferenceEvent.completed(:finish_reason_tool_calls, nil)
+    ]
+  end
+
+  defp events_for(request_id)
+       when request_id in ["req-dispatch-uncommitted", "req-dispatch-final-flush-failure"] do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.progress("prefill", "working"),
+      InferenceEvent.usage_update(%Usage{input_tokens: 1, output_tokens: 0, total_tokens: 1}),
+      InferenceEvent.output_text_delta(""),
+      InferenceEvent.completed(:finish_reason_stop, nil)
+    ]
+  end
+
   defp events_for("req-dispatch-post-terminal-error") do
     [
       InferenceEvent.accepted(0),
@@ -354,6 +379,7 @@ defmodule Orchard.Dispatch.DispatchTest do
 
       handler = fn received_request_id, event ->
         send(self(), {:handler_event, received_request_id, event})
+        :ok
       end
 
       assert %AttemptOutcome{
@@ -366,6 +392,7 @@ defmodule Orchard.Dispatch.DispatchTest do
                  "raw_source_code" => "runtime_endpoint_missing_terminal"
                }
              } =
+               outcome =
                RequestDispatcher.dispatch(
                  build_schedule(request_id),
                  execute_request(request_id),
@@ -377,6 +404,10 @@ defmodule Orchard.Dispatch.DispatchTest do
       assert InferenceEvent.kind(accepted) == :accepted
       assert %InferenceEvent{event: %InferenceEvent.Failed{code: code}} = failed
       assert code == "runtime_endpoint_missing_terminal"
+      assert outcome.delivery_state == :pending
+      refute_received {:handler_event, ^request_id, _event}
+      selected = AttemptOutcome.select(outcome, request_id, handler)
+      assert selected.delivery_state == :selected
       assert_received {:handler_event, ^request_id, ^accepted}
       assert_received {:handler_event, ^request_id, ^failed}
       refute_received {:handler_event, ^request_id, _event}
@@ -389,6 +420,7 @@ defmodule Orchard.Dispatch.DispatchTest do
 
       handler = fn received_request_id, event ->
         send(self(), {:handler_event, received_request_id, event})
+        :ok
       end
 
       assert %AttemptOutcome{
@@ -401,6 +433,7 @@ defmodule Orchard.Dispatch.DispatchTest do
                  "raw_source_code" => "runtime_endpoint_duplicate_terminal"
                }
              } =
+               outcome =
                RequestDispatcher.dispatch(
                  build_schedule(request_id),
                  execute_request(request_id),
@@ -412,6 +445,10 @@ defmodule Orchard.Dispatch.DispatchTest do
       assert InferenceEvent.kind(accepted) == :accepted
       assert %InferenceEvent{event: %InferenceEvent.Failed{code: code}} = failed
       assert code == "runtime_endpoint_duplicate_terminal"
+      assert outcome.delivery_state == :pending
+      refute_received {:handler_event, ^request_id, _event}
+      selected = AttemptOutcome.select(outcome, request_id, handler)
+      assert selected.delivery_state == :selected
       assert_received {:handler_event, ^request_id, ^accepted}
       assert_received {:handler_event, ^request_id, ^failed}
       refute_received {:handler_event, ^request_id, _event}
@@ -425,6 +462,7 @@ defmodule Orchard.Dispatch.DispatchTest do
 
         handler = fn received_request_id, event ->
           send(self(), {:handler_event, received_request_id, event})
+          :ok
         end
 
         assert %AttemptOutcome{
@@ -437,6 +475,7 @@ defmodule Orchard.Dispatch.DispatchTest do
                    "raw_source_code" => "runtime_endpoint_post_terminal_event"
                  }
                } =
+                 outcome =
                  RequestDispatcher.dispatch(
                    build_schedule(request_id),
                    execute_request(request_id),
@@ -448,6 +487,10 @@ defmodule Orchard.Dispatch.DispatchTest do
         assert InferenceEvent.kind(accepted) == :accepted
         assert %InferenceEvent{event: %InferenceEvent.Failed{code: code}} = failed
         assert code == "runtime_endpoint_post_terminal_event"
+        assert outcome.delivery_state == :pending
+        refute_received {:handler_event, ^request_id, _event}
+        selected = AttemptOutcome.select(outcome, request_id, handler)
+        assert selected.delivery_state == :selected
         assert_received {:handler_event, ^request_id, ^accepted}
         assert_received {:handler_event, ^request_id, ^failed}
         refute_received {:handler_event, ^request_id, _event}
@@ -570,6 +613,117 @@ defmodule Orchard.Dispatch.DispatchTest do
       refute inspect(context) =~ "127.0.0.1"
     end
 
+    test "SPEC 5.8 coordinates uncommitted, tool, and handler-failed dispatch delivery", %{
+      bundle: bundle
+    } do
+      owner = self()
+
+      handler = fn request_id, event ->
+        send(owner, {:handler_event, request_id, event})
+        :ok
+      end
+
+      uncommitted =
+        RequestDispatcher.dispatch(
+          build_schedule("req-dispatch-uncommitted"),
+          execute_request("req-dispatch-uncommitted"),
+          model_load_request(bundle),
+          client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient,
+          event_handler: handler,
+          on_accepted: fn request_id, _event ->
+            send(owner, {:accepted, request_id})
+            :ok
+          end
+        )
+
+      assert_received {:accepted, "req-dispatch-uncommitted"}
+      refute uncommitted.output_committed
+      assert uncommitted.delivery_state == :pending
+      assert uncommitted.first_token_at == nil
+      refute_received {:handler_event, "req-dispatch-uncommitted", _event}
+
+      selected = AttemptOutcome.select(uncommitted, "req-dispatch-uncommitted", handler)
+      assert selected.delivery_state == :selected
+      assert selected.delivered_event_count == length(selected.events)
+
+      tool =
+        RequestDispatcher.dispatch(
+          build_schedule("req-dispatch-tool"),
+          execute_request("req-dispatch-tool"),
+          model_load_request(bundle),
+          client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient,
+          event_handler: handler
+        )
+
+      assert tool.output_committed
+      assert tool.output_commitment_kind == :tool_call
+      assert %DateTime{} = tool.first_token_at
+      assert tool.delivery_state == :selected
+
+      commit_failure_handler = fn _request_id, event ->
+        if InferenceEvent.kind(event) == :accepted, do: raise("flush failed"), else: :ok
+      end
+
+      commit_failure =
+        RequestDispatcher.dispatch(
+          build_schedule("req-dispatch-handler-commit-failure"),
+          execute_request("req-dispatch-handler-commit-failure"),
+          model_load_request(bundle),
+          client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient,
+          event_handler: commit_failure_handler
+        )
+
+      assert commit_failure.attempt_outcome == :failed
+      assert commit_failure.output_committed
+      assert commit_failure.delivery_state == :failed
+      assert commit_failure.delivered_event_count == 0
+      assert commit_failure.failure["failure_class"] == "controller_failure"
+
+      post_commit_handler = fn _request_id, event ->
+        if InferenceEvent.kind(event) == :output_text_delta,
+          do: {:error, :serializer_failed},
+          else: :ok
+      end
+
+      post_commit_failure =
+        RequestDispatcher.dispatch(
+          build_schedule("req-dispatch-handler-post-commit-failure"),
+          execute_request("req-dispatch-handler-post-commit-failure"),
+          model_load_request(bundle),
+          client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient,
+          event_handler: post_commit_handler
+        )
+
+      assert post_commit_failure.attempt_outcome == :failed
+      assert post_commit_failure.output_commitment_kind == :tool_call
+      assert post_commit_failure.delivery_state == :failed
+      assert post_commit_failure.delivered_event_count == 2
+
+      pending_flush =
+        RequestDispatcher.dispatch(
+          build_schedule("req-dispatch-final-flush-failure"),
+          execute_request("req-dispatch-final-flush-failure"),
+          model_load_request(bundle),
+          client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient
+        )
+
+      final_flush_handler = fn _request_id, event ->
+        if InferenceEvent.terminal?(event), do: {:error, :serializer_failed}, else: :ok
+      end
+
+      final_flush_failure =
+        AttemptOutcome.select(
+          pending_flush,
+          "req-dispatch-final-flush-failure",
+          final_flush_handler
+        )
+
+      refute final_flush_failure.output_committed
+      assert final_flush_failure.attempt_outcome == :failed
+      assert final_flush_failure.delivery_state == :failed
+      assert final_flush_failure.delivered_event_count == 4
+    end
+
     test "dispatches with event_handler callback", %{bundle: bundle} do
       schedule = build_schedule("req-dispatch-handler")
       execute = execute_request("req-dispatch-handler")
@@ -579,12 +733,21 @@ defmodule Orchard.Dispatch.DispatchTest do
 
       handler = fn request_id, event ->
         send(test_pid, {:handler_event, request_id, event})
+        :ok
       end
 
-      assert %AttemptOutcome{attempt_outcome: :completed, accepted: true, events: events} =
-               RequestDispatcher.dispatch(schedule, execute, model_load, event_handler: handler)
+      assert %AttemptOutcome{
+               attempt_outcome: :completed,
+               accepted: true,
+               events: events,
+               output_committed: true,
+               output_commitment_kind: :text,
+               delivery_state: :selected,
+               delivered_event_count: delivered_event_count
+             } = RequestDispatcher.dispatch(schedule, execute, model_load, event_handler: handler)
 
       assert length(events) >= 3
+      assert delivered_event_count == length(events)
 
       # Verify handler received all events
       Enum.each(events, fn event ->
@@ -632,18 +795,15 @@ defmodule Orchard.Dispatch.DispatchTest do
       # Dispatch in a separate process, monitoring the caller
       dispatch_pid =
         spawn(fn ->
-          event_handler = fn
-            _request_id, %InferenceEvent{event: %InferenceEvent.Accepted{}} ->
-              send(test_pid, :dispatch_accepted)
-
-            _request_id, _event ->
-              :ok
+          on_accepted = fn _request_id, _event ->
+            send(test_pid, :dispatch_accepted)
+            :ok
           end
 
           result =
             RequestDispatcher.dispatch(schedule, execute, model_load,
               caller: caller,
-              event_handler: event_handler
+              on_accepted: on_accepted
             )
 
           send(test_pid, {:dispatch_result, result})
@@ -700,6 +860,10 @@ defmodule Orchard.Dispatch.DispatchTest do
       assert %AttemptOutcome{
                attempt_outcome: :failed,
                accepted: false,
+               output_committed: false,
+               output_commitment_kind: nil,
+               delivery_state: :pending,
+               delivered_event_count: 0,
                failure: %{
                  "failure_class" => "model_load_failure",
                  "failure_code" => "runtime_unavailable",
@@ -732,6 +896,10 @@ defmodule Orchard.Dispatch.DispatchTest do
       assert %AttemptOutcome{
                attempt_outcome: :failed,
                accepted: false,
+               output_committed: false,
+               output_commitment_kind: nil,
+               delivery_state: :pending,
+               delivered_event_count: 0,
                failure: %{
                  "failure_class" => "model_load_failure",
                  "failure_code" => "model_invalid",

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -63,10 +63,12 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
           send(owner, {:runtime_endpoint_event, ref, request.request_id, accepted})
           send(owner, {:runtime_endpoint_done, ref, {:error, reason}})
 
-        :accepted_until_cancel ->
+        mode when mode in [:accepted_until_cancel, :text_until_cancel] ->
           Registry.register(@registry, {:stream, request.request_id}, {owner, ref})
           send(parent, {:stream_registered, ref})
           send(owner, {:runtime_endpoint_event, ref, request.request_id, accepted})
+
+          maybe_emit_committed_text(mode, owner, ref, request.request_id)
 
           receive do
             :finish_after_cancel ->
@@ -78,7 +80,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
       end
     end)
 
-    if execute == :accepted_until_cancel do
+    if execute in [:accepted_until_cancel, :text_until_cancel] do
       receive do
         {:stream_registered, ^ref} -> :ok
       after
@@ -88,6 +90,15 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest.StubClient do
 
     {:ok, ref}
   end
+
+  defp maybe_emit_committed_text(:text_until_cancel, owner, ref, request_id) do
+    send(
+      owner,
+      {:runtime_endpoint_event, ref, request_id, InferenceEvent.output_text_delta("committed")}
+    )
+  end
+
+  defp maybe_emit_committed_text(_mode, _owner, _ref, _request_id), do: :ok
 
   def cancel_inference(_channel, %Operation.CancelRequest{} = request, opts) do
     send(config().capture_pid, {:cancel_inference_called, request, opts})
@@ -797,10 +808,10 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
 
     test "handler cancellation records cancel and synthesized terminal breadcrumbs", ctx do
       enable_controller_sentry()
-      configure_stub(%{execute: {:accepted_then_error, :client_closed}})
+      configure_stub(%{execute: :text_until_cancel})
 
       handler = fn _request_id, event ->
-        if Orchard.InferenceEvent.kind(event) == :accepted, do: :cancel, else: :ok
+        if Orchard.InferenceEvent.kind(event) == :output_text_delta, do: :cancel, else: :ok
       end
 
       assert %AttemptOutcome{

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -497,6 +497,21 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest.PreAcceptanceCance
                 )
 
                 send(owner, {:runtime_endpoint_done, task_ref, :ok})
+
+              :finish_cancel_with_output ->
+                send(
+                  owner,
+                  {:runtime_endpoint_event, task_ref, request.request_id,
+                   InferenceEvent.output_text_delta("drained output")}
+                )
+
+                send(
+                  owner,
+                  {:runtime_endpoint_event, task_ref, request.request_id,
+                   InferenceEvent.failed("cancelled", "cancelled", false)}
+                )
+
+                send(owner, {:runtime_endpoint_done, task_ref, :ok})
             end
         end
       end)
@@ -1706,6 +1721,45 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
              capacity_release_outcome: :released
            } = Task.await(dispatch)
 
+    assert AllocationAuthority.claim_count(authority, node_id) == 0
+  end
+
+  test "SPEC 5.9 output drained after pre-acceptance cancel is never delivered publicly" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    node_id = claim_node_id()
+    request_id = "request-drain-output-before-accepted"
+    test_pid = self()
+
+    schedule = %{
+      capacity_schedule(authority, node_id, request_id)
+      | request_timeout_ms: @expiring_request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
+    }
+
+    dispatch =
+      Task.async(fn ->
+        dispatch_with_deadline(schedule, execute_request(request_id), model_load_request(node_id),
+          client_impl: @pre_acceptance_cancel_client,
+          event_handler: fn _request_id, event ->
+            send(test_pid, {:drained_public_event, event})
+            :ok
+          end
+        )
+      end)
+
+    assert_receive {:pre_acceptance_cancel_received, emitter}, 1_000
+    send(emitter, :finish_cancel_with_output)
+
+    assert %AttemptOutcome{
+             attempt_outcome: :timed_out,
+             accepted: false,
+             output_committed: false,
+             output_commitment_kind: nil,
+             delivery_state: :pending,
+             delivered_event_count: 0
+           } = Task.await(dispatch)
+
+    refute_receive {:drained_public_event, _event}
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -1441,16 +1441,23 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = claim_node_id()
     request_id = "request-delta-before-acceptance-error"
 
+    test_pid = self()
+
     assert_dispatch_failure(
       dispatch_with_deadline(
         capacity_schedule(authority, node_id, request_id),
         execute_request(request_id),
         model_load_request(node_id),
-        client_impl: @nonterminal_then_error_client
+        client_impl: @nonterminal_then_error_client,
+        event_handler: fn _request_id, event ->
+          send(test_pid, {:pre_accepted_public_event, event})
+          :ok
+        end
       ),
       :stream_failed
     )
 
+    refute_receive {:pre_accepted_public_event, _event}
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1480,7 +1487,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel)
 
-    assert_dispatch_failure(Task.await(dispatch), :event_handler_failed)
+    assert_dispatch_failure(Task.await(dispatch), :orchestration_error)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1510,7 +1517,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel)
 
-    assert_dispatch_failure(Task.await(dispatch), :event_handler_failed)
+    assert_dispatch_failure(Task.await(dispatch), :orchestration_error)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -1702,27 +1709,22 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
-  test "SPEC 5.9 handler exception before Accepted remains failed after late Accepted" do
+  test "SPEC 5.9 raising handler is not invoked before Accepted" do
     authority = start_supervised!({AllocationAuthority, name: nil})
     node_id = claim_node_id()
-    request_id = "request-handler-failure-before-late-acceptance"
+    request_id = "request-handler-failure-before-acceptance"
 
-    dispatch =
-      Task.async(fn ->
-        dispatch_with_deadline(
-          capacity_schedule(authority, node_id, request_id),
-          execute_request(request_id),
-          model_load_request(node_id),
-          client_impl: @pre_acceptance_cancel_client,
-          event_handler: fn _request_id, _event -> raise "handler failed before acceptance" end
-        )
-      end)
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @nonterminal_then_error_client,
+        event_handler: fn _request_id, _event -> raise "handler failed before acceptance" end
+      ),
+      :stream_failed
+    )
 
-    assert_receive {:pre_acceptance_cancel_received, emitter}, 1_000
-    assert AllocationAuthority.claim_count(authority, node_id) == 1
-    send(emitter, :finish_cancel_after_acceptance)
-
-    assert_dispatch_failure(Task.await(dispatch), :node_acceptance_missing)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 
@@ -2048,27 +2050,22 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert :node_health_unhealthy in quarantined.reason_codes
   end
 
-  test "SPEC 5.9 handler cancellation before Accepted remains a pre-acceptance failure" do
+  test "SPEC 5.9 cancelling handler is not invoked before Accepted" do
     authority = start_supervised!({AllocationAuthority, name: nil})
     node_id = claim_node_id()
     request_id = "request-handler-cancel-before-accepted"
 
-    dispatch =
-      Task.async(fn ->
-        dispatch_with_deadline(
-          capacity_schedule(authority, node_id, request_id),
-          execute_request(request_id),
-          model_load_request(node_id),
-          client_impl: @pre_acceptance_cancel_client,
-          event_handler: fn _request_id, _event -> :cancel end
-        )
-      end)
+    assert_dispatch_failure(
+      dispatch_with_deadline(
+        capacity_schedule(authority, node_id, request_id),
+        execute_request(request_id),
+        model_load_request(node_id),
+        client_impl: @nonterminal_then_error_client,
+        event_handler: fn _request_id, _event -> :cancel end
+      ),
+      :stream_failed
+    )
 
-    assert_receive {:pre_acceptance_cancel_received, emitter}, 1_000
-    assert AllocationAuthority.claim_count(authority, node_id) == 1
-    send(emitter, :finish_cancel_after_acceptance)
-
-    assert_dispatch_failure(Task.await(dispatch), :request_caller_disconnect)
     assert AllocationAuthority.claim_count(authority, node_id) == 0
   end
 

--- a/apps/orchard_controller/test/orchard/inference/output_commitment_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/output_commitment_test.exs
@@ -1,0 +1,51 @@
+defmodule Orchard.Inference.OutputCommitmentTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Inference.OutputCommitment
+  alias Orchard.InferenceEvent
+  alias Orchard.InferenceEvent.Usage
+
+  test "SPEC 5.8 classifies validated output monotonically without owning time" do
+    control_events = [
+      InferenceEvent.accepted(1),
+      InferenceEvent.progress("loading", "readying model"),
+      InferenceEvent.usage_update(%Usage{input_tokens: 1, output_tokens: 0, total_tokens: 1}),
+      InferenceEvent.completed(:finish_reason_stop, nil),
+      InferenceEvent.failed("runtime_unavailable", "worker unavailable", true),
+      InferenceEvent.output_text_delta("")
+    ]
+
+    uncommitted =
+      Enum.reduce(control_events, OutputCommitment.new(), fn event, commitment ->
+        OutputCommitment.observe(commitment, event)
+      end)
+
+    refute OutputCommitment.committed?(uncommitted)
+    assert OutputCommitment.kind(uncommitted) == nil
+    refute Map.has_key?(uncommitted, :committed_at)
+    refute Map.has_key?(uncommitted, :first_token_at)
+
+    text = OutputCommitment.observe(uncommitted, InferenceEvent.output_text_delta("   "))
+    assert OutputCommitment.committed?(text)
+    assert OutputCommitment.kind(text) == :text
+
+    assert text ==
+             OutputCommitment.observe(
+               text,
+               InferenceEvent.tool_call_delta("call-later", "{")
+             )
+
+    for arguments <- ["", "{", "not json"] do
+      tool =
+        OutputCommitment.observe(
+          OutputCommitment.new(),
+          InferenceEvent.tool_call_delta("call-stable", arguments)
+        )
+
+      assert OutputCommitment.committed?(tool)
+      assert OutputCommitment.kind(tool) == :tool_call
+    end
+
+    assert_raise ArgumentError, fn -> InferenceEvent.tool_call_delta("", "{}") end
+  end
+end

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -2429,6 +2429,149 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert length(Orchard.Repo.all(Orchard.Requests.Request)) == 1
   end
 
+  test "SPEC 5.8 selects and flushes the sole final uncommitted attempt before persistence", %{
+    bundle: bundle
+  } do
+    put_capturing_runtime_adapter_config()
+
+    put_runtime_events([
+      InferenceEvent.progress("prefill", "working"),
+      InferenceEvent.output_text_delta(""),
+      InferenceEvent.completed(:finish_reason_stop, nil)
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-final-uncommitted")
+    canonical = canonical_request("request-orchestrator-final-uncommitted", stream?: false)
+    owner = self()
+
+    handler = fn request_id, event ->
+      send(owner, {:delivered, request_id, event})
+      :ok
+    end
+
+    assert {:ok, ^canonical, events} =
+             RequestOrchestrator.execute(canonical, model, event_handler: handler)
+
+    delivered =
+      Enum.map(events, fn expected ->
+        assert_receive {:delivered, request_id, event}
+        assert request_id == canonical.public_id
+        assert event == expected
+        event
+      end)
+
+    assert delivered == events
+    refute_receive {:delivered, _, _}
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+
+    terminal_result =
+      Requests.list_request_step_events(request) |> List.last() |> Map.fetch!(:result)
+
+    assert terminal_result["output_committed"] == false
+    refute Map.has_key?(terminal_result, "output_commitment_kind")
+    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
+  end
+
+  test "SPEC 5.8 persists text and tool commitment and advances tool output through streaming", %{
+    bundle: bundle
+  } do
+    put_capturing_runtime_adapter_config()
+
+    cases = [
+      {:text, InferenceEvent.output_text_delta("hello"), :finish_reason_stop},
+      {:tool_call, InferenceEvent.tool_call_delta("call-stable", ""), :finish_reason_tool_calls}
+    ]
+
+    for {kind, output_event, finish_reason} <- cases do
+      put_runtime_events([
+        output_event,
+        InferenceEvent.completed(finish_reason, nil)
+      ])
+
+      model =
+        create_active_model!(bundle, "request-orchestrator-commitment-#{kind}",
+          capabilities: ["chat", "tool_calling"]
+        )
+
+      canonical =
+        canonical_request("request-orchestrator-commitment-#{kind}", stream?: false)
+
+      owner = self()
+
+      assert {:ok, ^canonical, events} =
+               RequestOrchestrator.execute(canonical, model,
+                 event_handler: fn request_id, event ->
+                   send(owner, {:committed_delivery, request_id, event})
+                   :ok
+                 end
+               )
+
+      Enum.each(events, fn expected ->
+        assert_receive {:committed_delivery, request_id, ^expected}
+        assert request_id == canonical.public_id
+      end)
+
+      refute_receive {:committed_delivery, _, _}
+
+      request = Requests.get_request_by_public_id(canonical.public_id)
+
+      terminal_result =
+        Requests.list_request_step_events(request) |> List.last() |> Map.fetch!(:result)
+
+      assert terminal_result["output_committed"]
+      assert terminal_result["output_commitment_kind"] == Atom.to_string(kind)
+      refute Map.has_key?(terminal_result, "retry_decision")
+      assert :streaming in request_event_states(request)
+
+      if kind == :text do
+        assert %DateTime{} = request.first_token_at
+      else
+        assert request.first_token_at == nil
+      end
+    end
+  end
+
+  test "SPEC 5.8 persists committed handler failure as non-retryable attempt evidence", %{
+    bundle: bundle
+  } do
+    put_capturing_runtime_adapter_config()
+
+    put_runtime_events([
+      InferenceEvent.output_text_delta("committed"),
+      InferenceEvent.completed(:finish_reason_stop, nil)
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-handler-failure")
+    canonical = canonical_request("request-orchestrator-handler-failure", stream?: true)
+
+    handler = fn _request_id, event ->
+      if InferenceEvent.kind(event) == :output_text_delta,
+        do: {:error, :serializer_failed},
+        else: :ok
+    end
+
+    assert {:error, {:dispatch_failed, "orchestration_error"}} =
+             RequestOrchestrator.execute(canonical, model, event_handler: handler)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :failed
+
+    states = request_event_states(request)
+    assert state_before?(states, :running, :streaming)
+    assert state_before?(states, :streaming, :failed)
+
+    terminal_result =
+      Requests.list_request_step_events(request) |> List.last() |> Map.fetch!(:result)
+
+    assert terminal_result["attempt_outcome"] == "failed"
+    assert terminal_result["output_committed"]
+    assert terminal_result["output_commitment_kind"] == "text"
+    assert terminal_result["failure_class"] == "controller_failure"
+    assert terminal_result["retry_decision"] == "output_committed"
+    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
+  end
+
   test "execute/3 persists first_token_at for successful requests with output", %{bundle: bundle} do
     model = create_active_model!(bundle, "request-orchestrator-success")
     canonical = canonical_request("request-orchestrator-success", stream?: false)
@@ -2828,6 +2971,11 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
        %{bundle: bundle} do
     put_capturing_runtime_adapter_config()
 
+    put_runtime_events([
+      InferenceEvent.output_text_delta("committed"),
+      InferenceEvent.completed(:finish_reason_stop, nil)
+    ])
+
     model = create_active_model!(bundle, "request-orchestrator-success-persistence-failure")
 
     canonical =
@@ -2846,10 +2994,52 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request.state == :failed
 
-    assert Enum.map(Requests.list_request_step_events(request), & &1.event_type) == [
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, & &1.event_type) == [
              "request_step.started",
              "request_step.failed"
            ]
+
+    terminal_result = List.last(step_events).result
+    assert terminal_result["output_committed"]
+    assert terminal_result["output_commitment_kind"] == "text"
+    assert terminal_result["retry_decision"] == "output_committed"
+  end
+
+  test "execute/3 catches success_persistence exception, exit, and throw after commitment",
+       %{bundle: bundle} do
+    put_capturing_runtime_adapter_config()
+
+    put_runtime_events([
+      InferenceEvent.output_text_delta("committed"),
+      InferenceEvent.completed(:finish_reason_stop, nil)
+    ])
+
+    cases = [
+      {:exception, fn _canonical_request, _events -> raise "persistence exception" end},
+      {:exit, fn _canonical_request, _events -> exit(:persistence_exit) end},
+      {:throw, fn _canonical_request, _events -> throw(:persistence_throw) end}
+    ]
+
+    Enum.each(cases, fn {kind, success_persistence} ->
+      id = "request-orchestrator-success-persistence-#{kind}"
+      model = create_active_model!(bundle, id)
+      canonical = canonical_request(id, stream?: false)
+
+      assert {:error, {:success_persistence_failed, {^kind, _reason}}} =
+               RequestOrchestrator.execute(canonical, model,
+                 success_persistence: success_persistence
+               )
+
+      request = Requests.get_request_by_public_id(canonical.public_id)
+      assert request.state == :failed
+
+      terminal_result = request |> Requests.list_request_step_events() |> List.last()
+      assert terminal_result.result["output_committed"]
+      assert terminal_result.result["output_commitment_kind"] == "text"
+      assert terminal_result.result["retry_decision"] == "output_committed"
+    end)
   end
 
   test "execute/3 surfaces terminal persistence failures on dispatch-error failure paths and leaves FSM non-terminal",

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -353,7 +353,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScoreSchedule
        |> Map.put(:prefix_cache_score, %{
          status_code: "ok",
          status_message:
-           "request req_123 hmac-sha256:#{String.duplicate("d", 64)} /tmp/orchard tokens: [1,2,3]",
+           "request req_leaked_identifier hmac-sha256:#{String.duplicate("d", 64)} " <>
+             "/tmp/orchard tokens: [1,2,3]",
          resident_fingerprint_match: true,
          score_tier: "no_match",
          session_started_unix_ms: 1_713_726_400_123
@@ -1426,7 +1427,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     refute inspect(decision) =~ "hmac-sha256"
     refute inspect(decision) =~ "/tmp/orchard"
-    refute inspect(decision) =~ "req_123"
+    refute inspect(decision) =~ "req_leaked_identifier"
   end
 
   test "execute/3 strips selected-prefix-cache-score fields when scoring gate is disabled", %{

--- a/apps/orchard_controller/test/orchard/metrics/metrics_test.exs
+++ b/apps/orchard_controller/test/orchard/metrics/metrics_test.exs
@@ -255,6 +255,35 @@ defmodule Orchard.MetricsTest do
              ~s(orchard_worker_crashes_total{model="model-a",node="node-a"} 7)
   end
 
+  test "SPEC.md §9.1 a replacement reporter never inherits a killed generation's handlers" do
+    admission = Process.whereis(SeriesAdmission)
+    reporter = Process.whereis(Orchard.Metrics.Reporter)
+    reporter_ref = Process.monitor(reporter)
+
+    Process.exit(reporter, :kill)
+
+    assert_receive {:DOWN, ^reporter_ref, :process, ^reporter, :killed}
+
+    wait_until_replaced(SeriesAdmission, admission)
+
+    assert :ok =
+             SeriesAdmission.emit(:input_tokens, 7, %{tenant: "tenant-a", model: "model-a"})
+
+    assert :ok =
+             SeriesAdmission.emit(:http_request_duration, 0.02, %{
+               endpoint: "health",
+               status: 200
+             })
+
+    exposition = TelemetryMetricsPrometheus.Core.scrape(Orchard.Metrics.Reporter)
+
+    assert exposition =~
+             ~s(orchard_input_tokens_total{model="model-a",tenant="tenant-a"} 7)
+
+    assert exposition =~
+             ~s(orchard_http_request_duration_seconds_count{endpoint="health",status="success"} 1)
+  end
+
   test "SPEC.md §9.1 HTTP duration exposition contains the immutable buckets" do
     assert :ok =
              SeriesAdmission.emit(:http_request_duration, 0.02, %{
@@ -419,6 +448,21 @@ defmodule Orchard.MetricsTest do
     else
       Process.sleep(5)
       wait_until_polled()
+    end
+  end
+
+  defp wait_until_replaced(name, previous, attempts \\ 200)
+
+  defp wait_until_replaced(name, _previous, 0), do: flunk("#{inspect(name)} was never replaced")
+
+  defp wait_until_replaced(name, previous, attempts) do
+    case Process.whereis(name) do
+      pid when is_pid(pid) and pid != previous ->
+        pid
+
+      _pending ->
+        Process.sleep(5)
+        wait_until_replaced(name, previous, attempts - 1)
     end
   end
 

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
@@ -174,6 +174,67 @@ defmodule Orchard.Requests.InferenceAttemptResultTest do
              )
   end
 
+  test "SPEC 5.8 gives attempt 1 commitment precedence while preserving closed attempt 2 rules" do
+    committed_failure =
+      failed_result(%{
+        "accepted" => true,
+        "output_committed" => true,
+        "output_commitment_kind" => "tool_call",
+        "execution_resolution" => "terminated",
+        "capacity_release_outcome" => "released",
+        "node_id" => @node_1,
+        "retry_decision" => "output_committed"
+      })
+
+    assert {:ok, _result} =
+             InferenceAttemptResult.new("request_step.failed", 1, committed_failure)
+
+    assert {:ok, _result} =
+             InferenceAttemptResult.new(
+               "request_step.cancelled",
+               1,
+               Map.merge(committed_failure, %{
+                 "attempt_outcome" => "cancelled",
+                 "failure_class" => "cancellation",
+                 "failure_code" => "request_caller_disconnect"
+               })
+             )
+
+    assert {:error, "cancelled attempts require cancellation failure evidence"} =
+             InferenceAttemptResult.new(
+               "request_step.cancelled",
+               1,
+               Map.merge(committed_failure, %{
+                 "attempt_outcome" => "cancelled",
+                 "failure_class" => "runtime_failure",
+                 "failure_code" => "runtime_unavailable"
+               })
+             )
+
+    assert {:ok, _result} =
+             InferenceAttemptResult.new(
+               "request_step.cancelled",
+               1,
+               failed_result(%{
+                 "attempt_outcome" => "cancelled",
+                 "failure_class" => "cancellation",
+                 "failure_code" => "request_caller_disconnect",
+                 "retry_decision" => "cancelled"
+               })
+             )
+
+    assert {:ok, _result} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               2,
+               failed_result(%{
+                 "node_id" => @node_2,
+                 "excluded_node_ids" => [@node_1],
+                 "retry_decision" => "retry_exhausted"
+               })
+             )
+  end
+
   test "event outcome and attempt 2 exclusions fail closed" do
     failed = failed_result(%{"retry_decision" => "not_retryable"})
 

--- a/apps/orchard_controller/test/support/queue_admission_api_support.ex
+++ b/apps/orchard_controller/test/support/queue_admission_api_support.ex
@@ -50,17 +50,29 @@ defmodule Orchard.TestSupport.QueueAdmissionRuntimeAdapter do
   def finish_generation(adapter_state, _generation_ref, _opts), do: adapter_state
 
   defp runtime_events(request) do
-    [
-      InferenceEvent.output_text_delta("queued ok"),
-      InferenceEvent.completed(
-        :finish_reason_stop,
-        %InferenceEvent.Usage{
-          input_tokens: request.input_tokens,
-          output_tokens: 2,
-          total_tokens: request.input_tokens + 2
-        }
-      )
-    ]
+    case configured_runtime_events() do
+      nil ->
+        [
+          InferenceEvent.output_text_delta("queued ok"),
+          InferenceEvent.completed(
+            :finish_reason_stop,
+            %InferenceEvent.Usage{
+              input_tokens: request.input_tokens,
+              output_tokens: 2,
+              total_tokens: request.input_tokens + 2
+            }
+          )
+        ]
+
+      events ->
+        events
+    end
+  end
+
+  defp configured_runtime_events do
+    :orchard_node_agent
+    |> Application.fetch_env!(:runtime)
+    |> Keyword.get(:queue_admission_test_events)
   end
 
   defp configured_max_concurrency do
@@ -100,6 +112,7 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
   alias Orchard.Inference
   alias Orchard.Inference.QueueManager
   alias Orchard.Repo
+  alias Orchard.Requests
   alias Orchard.Requests.Request
   alias Orchard.TestSupport.ModelRequestFixtures
   alias Orchard.TestSupport.QueueAdmissionRuntimeAdapter
@@ -131,6 +144,7 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
 
   def put_blocking_runtime_adapter!(test_owner, opts \\ []) do
     max_concurrent_requests = Keyword.get(opts, :max_concurrent_requests, 3)
+    events = Keyword.get(opts, :events)
 
     runtime =
       Application.fetch_env!(:orchard_node_agent, :runtime)
@@ -140,9 +154,37 @@ defmodule Orchard.TestSupport.QueueAdmissionAPI do
       |> Keyword.put(:worker_generation_mode, "batch")
       |> Keyword.put(:worker_max_concurrent_requests_per_model, max_concurrent_requests)
       |> Keyword.put(:test_only_allow_batch_admission_for_non_worker_adapters?, true)
+      |> Keyword.put(:queue_admission_test_events, events)
 
     Application.put_env(:orchard_node_agent, :runtime, runtime)
     Application.put_env(:orchard_controller, :queue_admission_api_runtime_owner, test_owner)
+  end
+
+  def assert_text_commitment!(request) do
+    attempt_event =
+      request
+      |> Requests.list_request_events()
+      |> Enum.find(&(&1.event_type == "request_step.completed"))
+
+    assert attempt_event.payload["result"]["output_committed"] == true
+    assert attempt_event.payload["result"]["output_commitment_kind"] == "text"
+    assert request.first_token_at != nil
+  end
+
+  def assert_tool_serializer_failure!(request) do
+    attempt_event =
+      request
+      |> Requests.list_request_events()
+      |> Enum.find(&(&1.event_type == "request_step.failed"))
+
+    result = attempt_event.payload["result"]
+    assert result["attempt_outcome"] == "failed"
+    assert result["output_committed"] == true
+    assert result["output_commitment_kind"] == "tool_call"
+    assert result["failure_class"] == "controller_failure"
+    assert result["failure_code"] == "orchestration_error"
+    assert result["retry_decision"] == "output_committed"
+    assert request.first_token_at == nil
   end
 
   def create_queue_model!(bundle, model_id) do

--- a/apps/orchard_node_agent/test/orchard/node/license_enforcer_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/license_enforcer_test.exs
@@ -122,7 +122,10 @@ defmodule Orchard.Node.LicenseEnforcerTest do
       end)
 
     assert_received :licensing_inspected
-    assert log == ""
+    # `capture_log/2` captures every process in the umbrella test VM, so
+    # unrelated background warnings (metrics degradation, for one) land in this
+    # window. Assert the enforcer stayed silent instead of the whole VM.
+    refute log =~ "Node-agent startup license"
   end
 
   test "invalid enforcement values fail fast before license inspection", %{

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -19,7 +19,7 @@
 
 ## 3. Typed single-attempt dispatcher outcome and release acknowledgement
 
-- [ ] 3.1 Return a typed dispatcher outcome with identity, acceptance, events, failure, execution resolution, release outcome, and timing
+- [x] 3.1 Return a typed dispatcher outcome with identity, acceptance, events, failure, execution resolution, release outcome, and timing
 - [ ] 3.2 Make allocation release distinguish released, already released, not applicable, and unresolved
 - [ ] 3.3 Preserve idempotent defensive cleanup without converting authority failure into confirmed release
 - [ ] 3.4 Preserve quarantine for unresolved accepted execution
@@ -27,12 +27,14 @@
 
 ## 4. Output Commitment and event isolation
 
-- [ ] 4.1 Add a pure monotonic Output Commitment classifier
-- [ ] 4.2 Commit on non-empty text, stable tool-call identity, and future content-bearing structured output
-- [ ] 4.3 Keep accepted, progress, usage, model-load, empty text, and terminal events uncommitted
-- [ ] 4.4 Record commitment before public handler or serializer delivery
-- [ ] 4.5 Buffer pre-commit attempt events, flush earlier events before a committing event, discard attempt 1 events on retry, and flush the final uncommitted attempt in order
-- [ ] 4.6 Preserve text-specific `first_token_at`
+- [x] 4.1 Add a pure monotonic Output Commitment classifier
+- [x] 4.2 Commit on non-empty text and stable tool-call identity
+- [ ] 4.2a Commit on future content-bearing structured output
+- [x] 4.3 Keep accepted, progress, usage, model-load, empty text, and terminal events uncommitted
+- [x] 4.4 Record commitment before public handler or serializer delivery
+- [x] 4.5 Buffer pre-commit attempt events, flush earlier events before a committing event, expose a safe discard seam, and flush the final uncommitted attempt in order
+- [ ] 4.5a Discard attempt 1 events when attempt 2 is integrated
+- [x] 4.6 Preserve text-specific `first_token_at`
 
 ## 5. Closed failure taxonomy and cancellation
 
@@ -84,17 +86,17 @@
 - [ ] 10.3 Cover no alternative, deadline exhaustion, cancellation races, unresolved release, and same-Node defense
 - [ ] 10.4 Cover one quota reservation, idempotent duplicate observation, unchanged capture policy, and attempt-event ordering
 - [ ] 10.5 Cover breaker attribution and logical-versus-attempt metrics
-- [ ] 10.6 Cover Chat Completions and Responses in streaming and non-streaming modes
+- [x] 10.6 Cover Chat Completions and Responses in streaming and non-streaming modes
 - [ ] 10.7 Cover terminal-conformance failures as non-retryable
 
 ## 11. Quality and completion
 
-- [ ] 11.1 Run focused tests for each changed seam
-- [ ] 11.2 Run `mise exec -- mix format`
-- [ ] 11.3 Run `mise exec -- mix compile --warnings-as-errors`
-- [ ] 11.4 Run `mise exec -- mix credo --strict`
-- [ ] 11.5 Run `mise exec -- mix dialyzer`
-- [ ] 11.6 Run `mise exec -- mix test`
-- [ ] 11.7 Run `mise exec -- mix test --cover`
-- [ ] 11.8 Rerun strict OpenSpec change validation after implementation updates
+- [x] 11.1 Run focused tests for each changed seam
+- [x] 11.2 Run `mise exec -- mix format`
+- [x] 11.3 Run `mise exec -- mix compile --warnings-as-errors`
+- [x] 11.4 Run `mise exec -- mix credo --strict`
+- [x] 11.5 Run `mise exec -- mix dialyzer`
+- [x] 11.6 Run `mise exec -- mix test`
+- [x] 11.7 Run `mise exec -- mix test --cover`
+- [x] 11.8 Rerun strict OpenSpec change validation after implementation updates
 - [ ] 11.9 After all tickets land, validate all OpenSpec specs strictly and review synchronized main specs for placeholders


### PR DESCRIPTION
## Summary

Implement transport-independent Output Commitment for issue #167.

Orchard now uses one shared classifier and one attempt-local delivery coordinator for text and tool output.
Commitment is recorded before public handler or serializer delivery.
Post-commit delivery failures and final-flush failures are terminal and non-retryable.
`first_token_at` remains text-only.

## What changed

- Added `Orchard.Inference.OutputCommitment` as a pure monotonic classifier for non-empty text and validated stable tool-call identity.
- Added `Orchard.Dispatch.AttemptEventDelivery` to retain pre-commit events per attempt, flush selected events in original order, and prevent committed output from being discarded.
- Extended `AttemptOutcome` and persisted attempt evidence with commitment kind, delivery state, and delivered-event count.
- Updated RequestDispatcher and RequestOrchestrator so accepted and committed observations reach the FSM before terminal failure persistence.
- Updated Chat Completions, Responses, and Playground delivery contracts to report serializer failure after commitment without starting another attempt.
- Added focused dispatcher, orchestrator, persistence, and real HTTP coverage across streaming and non-streaming paths.

## SPEC and OpenSpec impact

- `SPEC.md` is unchanged.
- This implements the existing Output Commitment and attempt-local delivery contract in `SPEC.md` section 5.8 while preserving the pre-acceptance isolation and terminal failure rules in the surrounding dispatch contract.
- `openspec/changes/automatic-attempt-retry/tasks.md` now records the completed issue #167 classifier, delivery, API coverage, and quality work.
- The OpenSpec ledger keeps future structured-output commitment as task 4.2a and attempt-1 discard integration with real attempt 2 as task 4.5a.
- The broader boundary matrix remains open under task 10.2.

## Resolved RP and Oracle findings

- FSM observation ordering: accepted and committed evidence now advances `running -> streaming -> failed` before a committed delivery failure is persisted.
- Strict cross-field validation: cancelled outcomes must carry cancellation failure evidence, while `output_committed` retains retry-decision precedence for committed attempt 1.
- Linear delivery coordination: retained evidence and pending delivery use reverse-order buffers, selected events deliver directly, and the 50,001-event regression avoids repeated history scans.
- Retracted tool-call JSON interpretation: commitment requires a validated stable non-empty tool-call identity, not valid accumulated argument JSON.
  Empty, partial, or malformed argument bytes may commit, and a later serializer failure is terminal and non-retryable.

## No-mistakes fixes

- Applied the same pre-acceptance isolation rule in the cancel drain loop and centralized delivery-failure outcome mapping.
- Removed redundant retry-validation and drain-loop branches.
- Updated the Playground stream contract documentation.
- Detached orphaned telemetry reporter handlers before replacement startup and added a regression for duplicate metric observations.
- Stabilized the metrics bootstrap lifecycle assertions, the request-redaction assertion, and the node-agent license-log assertion after CI reproduced their race or capture conditions.

## Intentionally out of scope

- No attempt 2 execution.
- No scheduler exclusion.
- No new structured-output Runtime Endpoint event.
- No database migration or public API schema change.

## Verification

- `ORCHARD_TEST_NODE_AGENT_PORT=50167 mise exec -- mix test <focused classifier, coordinator, outcome, persistence, orchestrator, and API files>` - 179 passed before final review.
- `mise exec -- mix format` - passed.
- `mise exec -- mix compile --warnings-as-errors` - passed.
- `mise exec -- mix credo --strict` - passed with zero issues.
- `mise exec -- mix dialyzer` - passed with zero errors.
- `ORCHARD_TEST_NODE_AGENT_PORT=50167 mise exec -- mix test` - 303 shared, 3,478 controller with 5 skipped, 389 node-agent, and 738 CLI with 10 excluded passed after pipeline fixes.
- `ORCHARD_TEST_NODE_AGENT_PORT=50167 mise exec -- mix test --cover` - passed and generated all application coverage reports.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate automatic-attempt-retry --type change --strict --no-interactive` - `Change 'automatic-attempt-retry' is valid`.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` - 20 passed, 0 failed during CI remediation.
- `no-mistakes axi run --yes ...` - `checks-passed` after review, test, document, lint, push, PR, and CI gates.
- [Required Orchard validation](https://github.com/kapitan-ai/orchard/actions/runs/31812255973/job/94805450755) - passed on final commit `813dd365`.
- Final RP Review and Oracle follow-up - no blocker or important finding.

## Risk Assessment

⚠️ **Medium**

- Blast radius includes Controller dispatch, both public inference streaming paths, persisted attempt evidence, FSM ordering, and metrics reporter replacement cleanup found by CI.
- The external API shapes, database schema, Runtime Endpoint protocol, scheduler policy, and retry execution remain unchanged.
- Delivery and persistence fail closed after commitment, so Orchard does not retry after caller-visible output may have escaped.
- The review and CI regressions cover cancel-drain isolation, serializer failure, attempt evidence, linear delivery, telemetry handler replacement, and lifecycle race conditions.
- Residual work is limited to the explicit future slices for structured output and actual attempt 2 integration.

Closes #167
