### PR TITLE
feat(models): enforce deny-by-default tenant model grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ firewall, with no cloud dependency.
   [MLX](https://github.com/ml-explore/mlx), Apple Silicon's native ML stack.
 - Exposes OpenAI-compatible APIs: `/v1/responses` as the canonical abstraction,
   `/v1/chat/completions` as a compatibility facade, both with SSE streaming.
-- Governs access with multi-tenant RBAC, API Tokens, API Clients, quotas, and
-  audit logs.
+- Governs access with multi-tenant RBAC, deny-by-default Tenant-to-Model
+  access grants, API Tokens, API Clients, quotas, and audit logs.
 - Ships as a native macOS PKG with launchd services — no Kubernetes, no
   containers required.
 - Uses Postgres as the sole persistence and coordination layer (external

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,7 +73,8 @@ Loopback origin or ordinary local user access alone must not be treated as autho
 A Tenant is a governance boundary for model access, quotas, credentials, retention, and usage accounting.
 It is not an isolation boundary against an authorized Operator, a controller-host administrator, or control-plane compromise.
 
-Public inference APIs require a bearer API Token and the effective Tenant's inference authorization.
+Public inference APIs require a bearer API Token, the effective Tenant's inference authorization, and an enabled Tenant-to-Model access grant for the requested Model.
+Model access is deny-by-default: no Tenant, including the seeded `legacy` Tenant, receives an automatic grant, and an ungranted Model is neither listed nor usable.
 The current fail-closed Admin API implementation and [ADR 0004](docs/decisions/0004-admin-api-cluster-admin-auth.md) require an enabled service-account-owned API Token with a cluster-scoped `admin` role.
 The broader Admin API summary in `SPEC.md` still refers to `admin` or `tenant-admin` authorization.
 This policy does not resolve that contract conflict, and changing current behavior requires explicit reconciliation with `SPEC.md`.
@@ -126,6 +127,7 @@ Source development permits an unauthenticated Console and is not a production ac
 
 Console Basic Auth is separate from Tenant, Operator API, and Admin API bearer authorization.
 The repository does not promise per-user Console identities or Tenant isolation within one authenticated Console session.
+The Console Playground is an inference consumer that acts as the seeded `legacy` Tenant, so granting a Model for Playground use also authorizes every existing `legacy`-Tenant API credential for that Model on `/v1`; see [ADR 0021](docs/decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md).
 
 ### Node Agent and Worker Runtime
 

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -96,6 +96,35 @@ with `--output`, read an alternate local state tree with `--support-root`, cap
 per-file log tail bytes with `--max-log-bytes`, and use `--json` for
 machine-readable output.
 
+## Tenant Model access
+
+Public Model discovery and inference are deny-by-default after the
+`tenant-model-grants` migration. The migration creates no grants, including for
+the legacy Tenant. During upgrade, stop or drain public inference, migrate,
+create any non-default routing policies, grant each approved Tenant/Model pair,
+verify positive and negative access, and only then expose the Controller.
+
+```text
+orchardctl models access grant <model_id@version> --tenant <uuid-or-slug> [--routing-policy-id <uuid>]
+orchardctl models access disable <model_id@version> --tenant <uuid-or-slug>
+orchardctl models access revoke <model_id@version> --tenant <uuid-or-slug>
+orchardctl models access list --tenant <uuid-or-slug>
+orchardctl models access inspect <model_id@version> --tenant <uuid-or-slug>
+
+orchardctl models routing-policy create (--tenant <uuid-or-slug> | --global) \
+  --name <name> \
+  --residency-preference <required_loaded|prefer_loaded|allow_cold_load> \
+  [--max-cold-start-ms <n>] [--max-queue-wait-ms <n>]
+orchardctl models routing-policy list (--tenant <uuid-or-slug> | --global)
+orchardctl models routing-policy inspect --id <uuid>
+```
+
+Omitting `--routing-policy-id` explicitly selects canonical routing defaults;
+Orchard does not implicitly select a global policy. `disable` preserves an
+attached policy, while `revoke` deletes only the Tenant/Model access row.
+Initial routing policies do not accept pool-routing flags because scheduler pool
+enforcement is not yet implemented.
+
 ## Does not own
 
 - Controller business logic or persistence rules; see `../orchard_controller/`.

--- a/apps/orchard_cli/README.md
+++ b/apps/orchard_cli/README.md
@@ -98,11 +98,10 @@ machine-readable output.
 
 ## Tenant Model access
 
-Public Model discovery and inference are deny-by-default after the
-`tenant-model-grants` migration. The migration creates no grants, including for
-the legacy Tenant. During upgrade, stop or drain public inference, migrate,
-create any non-default routing policies, grant each approved Tenant/Model pair,
-verify positive and negative access, and only then expose the Controller.
+Public Model discovery and inference are deny-by-default, and the
+`tenant-model-grants` migration creates no grants. For the packaged upgrade
+rollout order and its verification steps, see
+[Tenant/Model access grant rollout](../../packaging/pkg/README.md#tenantmodel-access-grant-rollout).
 
 ```text
 orchardctl models access grant <model_id@version> --tenant <uuid-or-slug> [--routing-policy-id <uuid>]

--- a/apps/orchard_cli/lib/orchard_cli/commands/models.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/models.ex
@@ -10,6 +10,9 @@ defmodule OrchardCLI.Commands.Models do
 
   alias Orchard.Models
   alias Orchard.Models.Importer
+  alias OrchardCLI.Commands.Models.Access, as: AccessCommand
+  alias OrchardCLI.Commands.Models.Reference
+  alias OrchardCLI.Commands.Models.RoutingPolicy, as: RoutingPolicyCommand
   alias OrchardCLI.RepoRuntime
 
   @spec run([String.t()]) :: OrchardCLI.command_result()
@@ -33,6 +36,8 @@ defmodule OrchardCLI.Commands.Models do
   end
 
   def run(["delete" | rest]), do: run_delete(rest)
+  def run(["access" | rest]), do: AccessCommand.run(rest)
+  def run(["routing-policy" | rest]), do: RoutingPolicyCommand.run(rest)
 
   def run(_args) do
     {:error, group_usage(), 1}
@@ -103,7 +108,7 @@ defmodule OrchardCLI.Commands.Models do
   end
 
   defp run_delete([identity]) do
-    case parse_model_identity(identity) do
+    case Reference.parse_model_identity(identity) do
       {:ok, %{model_id: model_id, version: version}} ->
         RepoRuntime.run(fn -> do_run_delete(model_id, version, identity) end)
 
@@ -152,27 +157,9 @@ defmodule OrchardCLI.Commands.Models do
     {:error, "Error: delete failed for #{identity}: #{inspect(reason)}", 1}
   end
 
-  defp parse_model_identity(identity) when is_binary(identity) and identity != "" do
-    case :binary.matches(identity, "@") do
-      [] ->
-        :error
+  defp group_usage,
+    do: "Usage: orchardctl models <import|list|delete|access|routing-policy>"
 
-      matches ->
-        {pos, _len} = List.last(matches)
-        model_id = binary_part(identity, 0, pos)
-        version = binary_part(identity, pos + 1, byte_size(identity) - pos - 1)
-
-        if model_id == "" or version == "" do
-          :error
-        else
-          {:ok, %{model_id: model_id, version: version}}
-        end
-    end
-  end
-
-  defp parse_model_identity(_), do: :error
-
-  defp group_usage, do: "Usage: orchardctl models <import|list|delete>"
   defp import_usage, do: "Usage: orchardctl models import <path> [--activate]"
   defp delete_usage, do: "Usage: orchardctl models delete <model_id@version>"
 

--- a/apps/orchard_cli/lib/orchard_cli/commands/models/access.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/models/access.ex
@@ -1,0 +1,235 @@
+defmodule OrchardCLI.Commands.Models.Access do
+  @moduledoc false
+
+  alias Orchard.Models.Access, as: ModelAccess
+  alias OrchardCLI.Commands.Models.Reference
+  alias OrchardCLI.RepoRuntime
+
+  @spec run([String.t()]) :: OrchardCLI.command_result()
+  def run(["grant" | rest]), do: run_mutation(:grant, rest)
+  def run(["disable" | rest]), do: run_mutation(:disable, rest)
+  def run(["revoke" | rest]), do: run_mutation(:revoke, rest)
+  def run(["list" | rest]), do: run_list(rest)
+  def run(["inspect" | rest]), do: run_inspect(rest)
+  def run(_args), do: {:error, usage(), 1}
+
+  defp run_mutation(action, args) do
+    with {:ok, identity, opts} <- parse_identity_and_tenant(args, action) do
+      RepoRuntime.run(fn -> execute_mutation(action, identity, opts) end)
+    end
+  end
+
+  defp execute_mutation(action, identity, opts) do
+    with {:ok, tenant} <- Reference.resolve_tenant(opts[:tenant]),
+         {:ok, model} <- Reference.resolve_model(identity),
+         {:ok, policy_id} <- resolve_policy_id(opts[:routing_policy_id], action) do
+      action
+      |> mutate(tenant, model, policy_id)
+      |> render_mutation(action, tenant, model)
+    else
+      {:error, reason} -> render_reference_error(reason, identity, opts)
+    end
+  end
+
+  defp mutate(:grant, tenant, model, policy_id) do
+    ModelAccess.grant_model_access(tenant, model, policy_id,
+      actor_type: "operator",
+      surface: "orchardctl"
+    )
+  end
+
+  defp mutate(:disable, tenant, model, _policy_id) do
+    ModelAccess.disable_model_access(tenant, model,
+      actor_type: "operator",
+      surface: "orchardctl"
+    )
+  end
+
+  defp mutate(:revoke, tenant, model, _policy_id) do
+    ModelAccess.revoke_model_access(tenant, model,
+      actor_type: "operator",
+      surface: "orchardctl"
+    )
+  end
+
+  defp run_list(args) do
+    with {:ok, tenant_ref} <- parse_tenant_only(args, list_usage()) do
+      RepoRuntime.run(fn -> list_for_tenant(tenant_ref) end)
+    end
+  end
+
+  defp list_for_tenant(tenant_ref) do
+    with {:ok, tenant} <- Reference.resolve_tenant(tenant_ref),
+         {:ok, access_rows} <- ModelAccess.list_model_access(tenant) do
+      render_list(tenant, access_rows)
+    else
+      {:error, :tenant_not_found} -> tenant_not_found(tenant_ref)
+    end
+  end
+
+  defp run_inspect(args) do
+    with {:ok, identity, opts} <- parse_identity_and_tenant(args, :inspect) do
+      RepoRuntime.run(fn -> inspect_access(identity, opts[:tenant]) end)
+    end
+  end
+
+  defp inspect_access(identity, tenant_ref) do
+    with {:ok, tenant} <- Reference.resolve_tenant(tenant_ref),
+         {:ok, model} <- Reference.resolve_model(identity),
+         {:ok, access} <- ModelAccess.get_model_access(tenant, model) do
+      {:ok, render_access(access, tenant.slug)}
+    else
+      {:error, reason} ->
+        render_reference_error(reason, identity, tenant: tenant_ref)
+    end
+  end
+
+  defp parse_identity_and_tenant(args, action) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [tenant: :string, routing_policy_id: :string]
+      )
+
+    cond do
+      invalid != [] ->
+        {:error, "Error: invalid option\n#{mutation_usage(action)}", 1}
+
+      length(positional) != 1 ->
+        {:error, "Error: expected one model identity\n#{mutation_usage(action)}", 1}
+
+      is_nil(opts[:tenant]) ->
+        {:error, "Error: --tenant is required\n#{mutation_usage(action)}", 1}
+
+      action != :grant and opts[:routing_policy_id] ->
+        {:error, "Error: --routing-policy-id is only valid for grant\n#{mutation_usage(action)}",
+         1}
+
+      true ->
+        {:ok, hd(positional), opts}
+    end
+  end
+
+  defp parse_tenant_only(args, usage) do
+    {opts, positional, invalid} = OptionParser.parse(args, strict: [tenant: :string])
+
+    cond do
+      invalid != [] or positional != [] -> {:error, "Error: invalid arguments\n#{usage}", 1}
+      is_nil(opts[:tenant]) -> {:error, "Error: --tenant is required\n#{usage}", 1}
+      true -> {:ok, opts[:tenant]}
+    end
+  end
+
+  defp resolve_policy_id(nil, :grant), do: {:ok, nil}
+  defp resolve_policy_id(_policy_id, action) when action != :grant, do: {:ok, nil}
+
+  defp resolve_policy_id(policy_id, :grant) do
+    case Reference.resolve_policy(policy_id) do
+      {:ok, policy} -> {:ok, policy.id}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp render_mutation({:ok, result}, action, tenant, model) do
+    identity = model_identity(model)
+    routing = routing_label(result.access)
+    {:ok, mutation_message(action, result.outcome, identity, tenant.slug, routing)}
+  end
+
+  defp render_mutation({:error, reason}, _action, _tenant, _model) do
+    {:error, "Error: model access mutation failed: #{format_reason(reason)}", 1}
+  end
+
+  defp mutation_message(:grant, :created, identity, tenant, routing),
+    do: "Granted #{identity} to #{tenant} (routing=#{routing})"
+
+  defp mutation_message(:grant, :enabled, identity, tenant, routing),
+    do: "Enabled #{identity} for #{tenant} (routing=#{routing})"
+
+  defp mutation_message(:grant, :policy_changed, identity, tenant, routing),
+    do: "Updated #{identity} for #{tenant} (routing=#{routing})"
+
+  defp mutation_message(:grant, :unchanged, identity, tenant, routing),
+    do: "Already granted #{identity} to #{tenant} (routing=#{routing})"
+
+  defp mutation_message(:disable, :disabled, identity, tenant, _routing),
+    do: "Disabled #{identity} for #{tenant}"
+
+  defp mutation_message(:disable, :already_disabled, identity, tenant, _routing),
+    do: "Already disabled #{identity} for #{tenant}"
+
+  defp mutation_message(:disable, :not_granted, identity, tenant, _routing),
+    do: "No grant for #{identity} and #{tenant}"
+
+  defp mutation_message(:revoke, :revoked, identity, tenant, _routing),
+    do: "Revoked #{identity} from #{tenant}"
+
+  defp mutation_message(:revoke, :not_granted, identity, tenant, _routing),
+    do: "No grant for #{identity} and #{tenant}"
+
+  defp render_list(tenant, []), do: {:ok, "No model access records for #{tenant.slug}."}
+
+  defp render_list(tenant, access_rows) do
+    lines = Enum.map_join(access_rows, "\n", &render_access(&1, tenant.slug))
+    {:ok, lines}
+  end
+
+  defp render_access(access, tenant_slug) do
+    state = if access.enabled, do: "enabled", else: "disabled"
+
+    "#{model_identity(access.model)}  tenant=#{tenant_slug}  state=#{state}  routing=#{routing_label(access)}"
+  end
+
+  defp routing_label(nil), do: "defaults"
+  defp routing_label(%{routing_policy_id: nil}), do: "defaults"
+  defp routing_label(%{routing_policy_id: policy_id}), do: policy_id
+
+  defp model_identity(model), do: "#{model.model_id}@#{model.version}"
+
+  defp render_reference_error(:tenant_not_found, _identity, opts),
+    do: tenant_not_found(opts[:tenant])
+
+  defp render_reference_error(:invalid_model_identity, identity, _opts),
+    do: {:error, "Error: invalid model identity: #{identity}", 1}
+
+  defp render_reference_error(:model_not_found, identity, _opts),
+    do: {:error, "Error: model not found: #{identity}", 1}
+
+  defp render_reference_error(:routing_policy_not_found, _identity, opts),
+    do: {:error, "Error: routing policy not found: #{opts[:routing_policy_id]}", 1}
+
+  defp render_reference_error(reason, _identity, _opts),
+    do: {:error, "Error: #{format_reason(reason)}", 1}
+
+  defp tenant_not_found(reference), do: {:error, "Error: tenant not found: #{reference}", 1}
+  defp format_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_reason(reason), do: inspect(reason)
+
+  defp usage do
+    Enum.join(
+      [
+        mutation_usage(:grant),
+        mutation_usage(:disable),
+        mutation_usage(:revoke),
+        list_usage(),
+        mutation_usage(:inspect)
+      ],
+      "\n"
+    )
+  end
+
+  defp mutation_usage(:grant),
+    do:
+      "Usage: orchardctl models access grant <model_id@version> --tenant <uuid-or-slug> [--routing-policy-id <uuid>]"
+
+  defp mutation_usage(:disable),
+    do: "Usage: orchardctl models access disable <model_id@version> --tenant <uuid-or-slug>"
+
+  defp mutation_usage(:revoke),
+    do: "Usage: orchardctl models access revoke <model_id@version> --tenant <uuid-or-slug>"
+
+  defp mutation_usage(:inspect),
+    do: "Usage: orchardctl models access inspect <model_id@version> --tenant <uuid-or-slug>"
+
+  defp list_usage,
+    do: "Usage: orchardctl models access list --tenant <uuid-or-slug>"
+end

--- a/apps/orchard_cli/lib/orchard_cli/commands/models/reference.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/models/reference.ex
@@ -1,0 +1,63 @@
+defmodule OrchardCLI.Commands.Models.Reference do
+  @moduledoc false
+
+  alias Orchard.Governance
+  alias Orchard.Governance.Tenant
+  alias Orchard.Models
+  alias Orchard.Models.Access
+  alias Orchard.Repo
+
+  @spec resolve_tenant(String.t()) :: {:ok, Tenant.t()} | {:error, :tenant_not_found}
+  def resolve_tenant(reference) when is_binary(reference) do
+    case Ecto.UUID.cast(reference) do
+      {:ok, id} -> Governance.get_tenant(id)
+      :error -> fetch_tenant_by_slug(reference)
+    end
+  end
+
+  @spec resolve_model(String.t()) ::
+          {:ok, Orchard.Models.Model.t()} | {:error, :invalid_model_identity | :model_not_found}
+  def resolve_model(identity) do
+    with {:ok, %{model_id: model_id, version: version}} <- parse_model_identity(identity),
+         %Orchard.Models.Model{} = model <- Models.get_model_by_identity(model_id, version) do
+      {:ok, model}
+    else
+      nil -> {:error, :model_not_found}
+      :error -> {:error, :invalid_model_identity}
+    end
+  end
+
+  @spec resolve_policy(String.t()) ::
+          {:ok, Orchard.Models.RoutingPolicy.t()} | {:error, :routing_policy_not_found}
+  def resolve_policy(reference), do: Access.get_routing_policy(reference)
+
+  @spec parse_model_identity(String.t()) ::
+          {:ok, %{model_id: String.t(), version: String.t()}} | :error
+  def parse_model_identity(identity) when is_binary(identity) and identity != "" do
+    case :binary.matches(identity, "@") do
+      [] ->
+        :error
+
+      matches ->
+        split_model_identity(identity, List.last(matches))
+    end
+  end
+
+  def parse_model_identity(_identity), do: :error
+
+  defp split_model_identity(identity, {position, _length}) do
+    model_id = binary_part(identity, 0, position)
+    version = binary_part(identity, position + 1, byte_size(identity) - position - 1)
+
+    if model_id == "" or version == "",
+      do: :error,
+      else: {:ok, %{model_id: model_id, version: version}}
+  end
+
+  defp fetch_tenant_by_slug(slug) do
+    case Repo.get_by(Tenant, slug: slug) do
+      %Tenant{} = tenant -> {:ok, tenant}
+      nil -> {:error, :tenant_not_found}
+    end
+  end
+end

--- a/apps/orchard_cli/lib/orchard_cli/commands/models/routing_policy.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/models/routing_policy.ex
@@ -1,0 +1,186 @@
+defmodule OrchardCLI.Commands.Models.RoutingPolicy do
+  @moduledoc false
+
+  alias Orchard.Inference.AdmissionPolicy
+  alias Orchard.Models.Access
+  alias OrchardCLI.Commands.Models.Reference
+  alias OrchardCLI.RepoRuntime
+
+  @spec run([String.t()]) :: OrchardCLI.command_result()
+  def run(["create" | rest]), do: run_create(rest)
+  def run(["list" | rest]), do: run_list(rest)
+  def run(["inspect" | rest]), do: run_inspect(rest)
+  def run(_args), do: {:error, usage(), 1}
+
+  defp run_create(args) do
+    with {:ok, opts} <- parse_create(args) do
+      RepoRuntime.run(fn -> create_policy(opts) end)
+    end
+  end
+
+  defp create_policy(opts) do
+    with {:ok, tenant_id} <- resolve_scope(opts),
+         {:ok, residency} <- parse_residency(opts[:residency_preference]) do
+      defaults = AdmissionPolicy.default_routing_opts()
+
+      attrs = %{
+        tenant_id: tenant_id,
+        name: opts[:name],
+        allowed_pool_ids: [],
+        preferred_pool_ids: [],
+        residency_preference: residency,
+        max_cold_start_ms: opts[:max_cold_start_ms] || defaults[:max_cold_start_ms],
+        max_queue_wait_ms: opts[:max_queue_wait_ms] || defaults[:queue_wait_ms],
+        priority: opts[:priority] || 100
+      }
+
+      attrs
+      |> Access.create_routing_policy(actor_type: "operator", surface: "orchardctl")
+      |> render_create()
+    else
+      {:error, reason} -> render_error(reason, opts)
+    end
+  end
+
+  defp run_list(args) do
+    with {:ok, opts} <- parse_scope_only(args, list_usage()) do
+      RepoRuntime.run(fn -> list_policies(opts) end)
+    end
+  end
+
+  defp list_policies(opts) do
+    with {:ok, scope} <- resolve_list_scope(opts),
+         {:ok, policies} <- Access.list_routing_policies(scope) do
+      render_list(policies)
+    else
+      {:error, reason} -> render_error(reason, opts)
+    end
+  end
+
+  defp run_inspect(args) do
+    {opts, positional, invalid} = OptionParser.parse(args, strict: [id: :string])
+
+    if invalid == [] and positional == [] and is_binary(opts[:id]) do
+      RepoRuntime.run(fn -> inspect_policy(opts[:id]) end)
+    else
+      {:error, "Error: --id is required\n#{inspect_usage()}", 1}
+    end
+  end
+
+  defp inspect_policy(id) do
+    case Access.get_routing_policy(id) do
+      {:ok, policy} -> {:ok, render_policy(policy)}
+      {:error, :routing_policy_not_found} -> {:error, "Error: routing policy not found: #{id}", 1}
+    end
+  end
+
+  defp parse_create(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          tenant: :string,
+          global: :boolean,
+          name: :string,
+          residency_preference: :string,
+          max_cold_start_ms: :integer,
+          max_queue_wait_ms: :integer,
+          priority: :integer
+        ]
+      )
+
+    cond do
+      invalid != [] or positional != [] ->
+        {:error, "Error: invalid arguments\n#{create_usage()}", 1}
+
+      scope_count(opts) != 1 ->
+        {:error, "Error: choose exactly one of --tenant or --global\n#{create_usage()}", 1}
+
+      blank?(opts[:name]) ->
+        {:error, "Error: --name is required\n#{create_usage()}", 1}
+
+      blank?(opts[:residency_preference]) ->
+        {:error, "Error: --residency-preference is required\n#{create_usage()}", 1}
+
+      true ->
+        {:ok, opts}
+    end
+  end
+
+  defp parse_scope_only(args, usage) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args, strict: [tenant: :string, global: :boolean])
+
+    if invalid == [] and positional == [] and scope_count(opts) == 1,
+      do: {:ok, opts},
+      else: {:error, "Error: choose exactly one of --tenant or --global\n#{usage}", 1}
+  end
+
+  defp resolve_scope(opts) do
+    if opts[:global] do
+      {:ok, nil}
+    else
+      case Reference.resolve_tenant(opts[:tenant]) do
+        {:ok, tenant} -> {:ok, tenant.id}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp resolve_list_scope(opts) do
+    if opts[:global], do: {:ok, :global}, else: Reference.resolve_tenant(opts[:tenant])
+  end
+
+  defp parse_residency(value) do
+    case value do
+      "required_loaded" -> {:ok, :required_loaded}
+      "prefer_loaded" -> {:ok, :prefer_loaded}
+      "allow_cold_load" -> {:ok, :allow_cold_load}
+      _other -> {:error, :invalid_residency_preference}
+    end
+  end
+
+  defp render_create({:ok, policy}), do: {:ok, "Created #{render_policy(policy)}"}
+
+  defp render_create({:error, changeset}) do
+    {:error, "Error: routing policy creation failed: #{format_changeset(changeset)}", 1}
+  end
+
+  defp render_list([]), do: {:ok, "No routing policies."}
+  defp render_list(policies), do: {:ok, Enum.map_join(policies, "\n", &render_policy/1)}
+
+  defp render_policy(policy) do
+    scope = if policy.tenant_id, do: "tenant=#{policy.tenant_id}", else: "global"
+
+    "#{policy.id}  name=#{policy.name}  #{scope}  residency=#{policy.residency_preference}  cold_start_ms=#{policy.max_cold_start_ms}  queue_wait_ms=#{policy.max_queue_wait_ms}"
+  end
+
+  defp render_error(:tenant_not_found, opts),
+    do: {:error, "Error: tenant not found: #{opts[:tenant]}", 1}
+
+  defp render_error(:invalid_residency_preference, _opts),
+    do: {:error, "Error: invalid residency preference", 1}
+
+  defp format_changeset(%Ecto.Changeset{} = changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, _opts} -> message end)
+    |> Enum.map_join(", ", fn {field, messages} -> "#{field} #{Enum.join(messages, ", ")}" end)
+  end
+
+  defp scope_count(opts) do
+    Enum.count([opts[:tenant], opts[:global]], &present?/1)
+  end
+
+  defp present?(value), do: value not in [nil, false, ""]
+  defp blank?(value), do: not present?(value)
+
+  defp usage, do: Enum.join([create_usage(), list_usage(), inspect_usage()], "\n")
+
+  defp create_usage do
+    "Usage: orchardctl models routing-policy create (--tenant <uuid-or-slug> | --global) --name <name> --residency-preference <required_loaded|prefer_loaded|allow_cold_load> [--max-cold-start-ms <n>] [--max-queue-wait-ms <n>]"
+  end
+
+  defp list_usage,
+    do: "Usage: orchardctl models routing-policy list (--tenant <uuid-or-slug> | --global)"
+
+  defp inspect_usage,
+    do: "Usage: orchardctl models routing-policy inspect --id <uuid>"
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/models_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/models_test.exs
@@ -1,8 +1,13 @@
 defmodule OrchardCLI.Commands.ModelsTest do
   use ExUnit.Case, async: false
 
+  import Ecto.Query
+
   alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.Governance
+  alias Orchard.Governance.AuditLog
   alias Orchard.Models
+  alias Orchard.Models.{RoutingPolicy, TenantModelAccess}
   alias Orchard.Repo
   alias OrchardCLI.Commands.Models, as: ModelsCmd
 
@@ -109,7 +114,7 @@ defmodule OrchardCLI.Commands.ModelsTest do
   describe "group usage" do
     test "models without subcommand includes delete" do
       assert {:error, msg, 1} = ModelsCmd.run([])
-      assert msg =~ "<import|list|delete>"
+      assert msg =~ "<import|list|delete|access|routing-policy>"
     end
   end
 
@@ -164,5 +169,177 @@ defmodule OrchardCLI.Commands.ModelsTest do
       assert {:error, msg, 1} = ModelsCmd.run(["delete", "org/gone-model@v1"])
       assert msg =~ "model not found"
     end
+  end
+
+  describe "tenant Model access commands" do
+    test "command groups return focused lifecycle usage" do
+      assert {:error, access_usage, 1} = ModelsCmd.run(["access"])
+      assert access_usage =~ "models access grant"
+      assert access_usage =~ "models access inspect"
+
+      assert {:error, policy_usage, 1} = ModelsCmd.run(["routing-policy"])
+      assert policy_usage =~ "models routing-policy create"
+      assert policy_usage =~ "models routing-policy inspect"
+    end
+
+    test "SPEC.md §10.9 grants, inspects, disables, and revokes by Tenant slug" do
+      tenant = create_tenant!("cli-access")
+      model = create_model!(%{model_id: "org/access-model", version: "v1", state: :active})
+      identity = "#{model.model_id}@#{model.version}"
+
+      assert {:ok, message} =
+               ModelsCmd.run(["access", "grant", identity, "--tenant", tenant.slug])
+
+      assert message =~ "Granted #{identity}"
+      assert message =~ "routing=defaults"
+
+      assert {:ok, repeated} =
+               ModelsCmd.run(["access", "grant", identity, "--tenant", tenant.slug])
+
+      assert repeated =~ "Already granted"
+
+      assert {:ok, inspected} =
+               ModelsCmd.run(["access", "inspect", identity, "--tenant", tenant.id])
+
+      assert inspected =~ "state=enabled"
+      assert inspected =~ "routing=defaults"
+
+      assert {:ok, listed} = ModelsCmd.run(["access", "list", "--tenant", tenant.slug])
+      assert listed =~ identity
+
+      assert {:ok, disabled} =
+               ModelsCmd.run(["access", "disable", identity, "--tenant", tenant.slug])
+
+      assert disabled =~ "Disabled"
+
+      assert {:ok, already_disabled} =
+               ModelsCmd.run(["access", "disable", identity, "--tenant", tenant.slug])
+
+      assert already_disabled =~ "Already disabled"
+
+      assert {:ok, revoked} =
+               ModelsCmd.run(["access", "revoke", identity, "--tenant", tenant.slug])
+
+      assert revoked =~ "Revoked"
+
+      assert {:ok, not_granted} =
+               ModelsCmd.run(["access", "revoke", identity, "--tenant", tenant.slug])
+
+      assert not_granted =~ "No grant"
+      refute Repo.get_by(TenantModelAccess, tenant_id: tenant.id, model_id: model.id)
+
+      audits =
+        Repo.all(from(audit in AuditLog, where: audit.target_type == "tenant_model_access"))
+
+      assert length(audits) == 3
+      assert Enum.all?(audits, &(&1.payload["surface"] == "orchardctl"))
+    end
+
+    test "requires exact Tenant and Model identities" do
+      assert {:error, message, 1} =
+               ModelsCmd.run(["access", "grant", "missing@v1", "--tenant", "missing"])
+
+      assert message =~ "tenant not found"
+
+      assert {:error, usage, 1} = ModelsCmd.run(["access", "grant", "missing@v1"])
+      assert usage =~ "--tenant is required"
+    end
+  end
+
+  describe "routing policy commands" do
+    test "SPEC.md §10.9 creates Tenant and global policies and attaches one explicitly" do
+      tenant = create_tenant!("cli-policy")
+      model = create_model!(%{model_id: "org/policy-model", version: "v1", state: :active})
+
+      assert {:ok, created} =
+               ModelsCmd.run([
+                 "routing-policy",
+                 "create",
+                 "--tenant",
+                 tenant.slug,
+                 "--name",
+                 "loaded-only",
+                 "--residency-preference",
+                 "required_loaded",
+                 "--max-cold-start-ms",
+                 "0",
+                 "--max-queue-wait-ms",
+                 "800"
+               ])
+
+      policy = Repo.get_by!(RoutingPolicy, tenant_id: tenant.id, name: "loaded-only")
+      assert created =~ policy.id
+      assert created =~ "residency=required_loaded"
+
+      assert {:ok, grant} =
+               ModelsCmd.run([
+                 "access",
+                 "grant",
+                 "#{model.model_id}@#{model.version}",
+                 "--tenant",
+                 tenant.slug,
+                 "--routing-policy-id",
+                 policy.id
+               ])
+
+      assert grant =~ "routing=#{policy.id}"
+
+      assert {:ok, global_created} =
+               ModelsCmd.run([
+                 "routing-policy",
+                 "create",
+                 "--global",
+                 "--name",
+                 "shared-default",
+                 "--residency-preference",
+                 "allow_cold_load"
+               ])
+
+      assert global_created =~ "global"
+      assert {:ok, global_list} = ModelsCmd.run(["routing-policy", "list", "--global"])
+      assert global_list =~ "shared-default"
+      assert {:ok, inspected} = ModelsCmd.run(["routing-policy", "inspect", "--id", policy.id])
+      assert inspected =~ "loaded-only"
+    end
+
+    test "rejects another Tenant's policy without creating access" do
+      tenant = create_tenant!("cli-policy-target")
+      other = create_tenant!("cli-policy-owner")
+      model = create_model!(%{model_id: "org/scoped-policy-model", version: "v1"})
+
+      {:ok, _created} =
+        ModelsCmd.run([
+          "routing-policy",
+          "create",
+          "--tenant",
+          other.slug,
+          "--name",
+          "private",
+          "--residency-preference",
+          "prefer_loaded"
+        ])
+
+      policy = Repo.get_by!(RoutingPolicy, tenant_id: other.id, name: "private")
+
+      assert {:error, message, 1} =
+               ModelsCmd.run([
+                 "access",
+                 "grant",
+                 "#{model.model_id}@#{model.version}",
+                 "--tenant",
+                 tenant.slug,
+                 "--routing-policy-id",
+                 policy.id
+               ])
+
+      assert message =~ "routing_policy_scope_mismatch"
+      refute Repo.get_by(TenantModelAccess, tenant_id: tenant.id, model_id: model.id)
+    end
+  end
+
+  defp create_tenant!(prefix) do
+    suffix = System.unique_integer([:positive, :monotonic])
+    {:ok, tenant} = Governance.create_tenant(%{slug: "#{prefix}-#{suffix}", name: prefix})
+    tenant
   end
 end

--- a/apps/orchard_cli/test/orchard_cli_test.exs
+++ b/apps/orchard_cli/test/orchard_cli_test.exs
@@ -277,7 +277,7 @@ defmodule OrchardCLITest do
   test "Models.run/1 returns error tuple for missing subcommand" do
     assert {:error, message, 1} = Models.run([])
     assert message =~ "orchardctl models"
-    assert message =~ "<import|list|delete>"
+    assert message =~ "<import|list|delete|access|routing-policy>"
   end
 
   test "Models.run/1 returns error tuple for missing import path" do

--- a/apps/orchard_controller/lib/orchard/api/models_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/models_controller.ex
@@ -2,8 +2,8 @@ defmodule Orchard.API.ModelsController do
   @moduledoc """
   OpenAI-compatible model listing.
 
-  `GET /v1/models` returns all active catalog models in OpenAI list
-  format per SPEC.md §7.2.3.
+  `GET /v1/models` returns active catalog Models authorized for the
+  effective Tenant in OpenAI list format per SPEC.md §7.2.3.
   """
 
   use Phoenix.Controller, formats: [:json]
@@ -12,7 +12,7 @@ defmodule Orchard.API.ModelsController do
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
-    models = Models.list_active_models()
+    models = Models.list_active_models_for_tenant(conn.assigns.tenant_id)
     data = Enum.map(models, &to_openai_model/1)
     json(conn, %{object: "list", data: data})
   end

--- a/apps/orchard_controller/lib/orchard/console/playground.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground.ex
@@ -65,6 +65,9 @@ defmodule OrchardConsole.Playground do
   playground resolves to the seeded legacy Tenant. Deny-by-default Model access
   still applies: an operator must grant a Model to this Tenant with
   `orchardctl models access grant` before the playground can list or run it.
+
+  See `docs/decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md`
+  for the decision and its credential-sharing consequence.
   """
   @spec effective_tenant_id() :: Ecto.UUID.t()
   def effective_tenant_id, do: Governance.legacy_tenant_id()
@@ -232,10 +235,7 @@ defmodule OrchardConsole.Playground do
              )}
 
           nil ->
-            {:error,
-             unready_stream_error(
-               "Selected model is not granted to this console tenant. Grant it with orchardctl models access grant."
-             )}
+            {:error, unready_stream_error(unavailable_reason(model_value))}
         end
 
       {:error, _error} ->
@@ -245,6 +245,23 @@ defmodule OrchardConsole.Playground do
 
   defp ensure_model_inference_ready(_params) do
     {:error, unready_stream_error("Selected model is not inference-ready.")}
+  end
+
+  defp unavailable_reason(model_value) do
+    if catalog_active?(model_value) do
+      "Selected model is not granted to this console tenant. Grant it with orchardctl models access grant."
+    else
+      "Selected model is not an active catalog model. It may have been deactivated or deleted."
+    end
+  end
+
+  defp catalog_active?(model_value) do
+    Enum.any?(models_impl().list_active_models(), fn model ->
+      model_value(%{
+        model_id: safe_string(model.model_id),
+        version: safe_string(model.version)
+      }) == model_value
+    end)
   end
 
   defp unready_stream_error(message) do

--- a/apps/orchard_controller/lib/orchard/console/playground.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground.ex
@@ -26,6 +26,7 @@ defmodule OrchardConsole.Playground do
   `:finished` is always the last message, sent exactly once.
   """
 
+  alias Orchard.Governance
   alias Orchard.Inference.{ChatError, ChatOrchestrator}
   alias Orchard.InferenceEvent
   alias Orchard.Models
@@ -58,18 +59,31 @@ defmodule OrchardConsole.Playground do
   # ===========================================================================
 
   @doc """
-  Returns active models for the playground model picker with readiness facts.
+  Returns the Tenant the Console playground acts as.
 
-  Catalog-active models are always listed. Inference readiness is projected
-  from authoritative Runtime Endpoint loaded placements only. Missing or
-  unknown readiness facts fail closed as non-ready.
+  The console is an operator surface without per-Tenant credentials, so the
+  playground resolves to the seeded legacy Tenant. Deny-by-default Model access
+  still applies: an operator must grant a Model to this Tenant with
+  `orchardctl models access grant` before the playground can list or run it.
+  """
+  @spec effective_tenant_id() :: Ecto.UUID.t()
+  def effective_tenant_id, do: Governance.legacy_tenant_id()
+
+  @doc """
+  Returns the playground Tenant's authorized models with readiness facts.
+
+  Only catalog-active models with an enabled grant for `effective_tenant_id/0`
+  are listed. Inference readiness is projected from authoritative Runtime
+  Endpoint loaded placements only. Missing or unknown readiness facts fail
+  closed as non-ready.
   """
   @spec list_models() :: {:ok, [model_option()]} | {:error, map()}
   def list_models do
     readiness_index = runtime_readiness_index()
 
     models =
-      models_impl().list_active_models()
+      effective_tenant_id()
+      |> models_impl().list_active_models_for_tenant()
       |> Enum.map(fn model ->
         project_model_option(
           safe_string(model.model_id),
@@ -127,11 +141,15 @@ defmodule OrchardConsole.Playground do
   `ChatOrchestrator.execute/3` so the dispatcher cancels the inference
   if the LiveView process exits.
 
+  `caller_context` defaults `:tenant_id` to `effective_tenant_id/0` so
+  preparation enforces the same Tenant-model grants the picker lists.
+
   Returns `{:ok, pid}` immediately.
   """
   @spec start_stream(pid(), term(), map(), keyword()) :: {:ok, pid()}
   def start_stream(owner, run_ref, params, caller_context \\ []) do
     orchestrator = orchestrator_impl()
+    caller_context = Keyword.put_new(caller_context, :tenant_id, effective_tenant_id())
 
     Task.start(fn ->
       run_stream(orchestrator, owner, run_ref, params, caller_context)
@@ -214,7 +232,10 @@ defmodule OrchardConsole.Playground do
              )}
 
           nil ->
-            {:error, unready_stream_error("Selected model is not available in the catalog.")}
+            {:error,
+             unready_stream_error(
+               "Selected model is not granted to this console tenant. Grant it with orchardctl models access grant."
+             )}
         end
 
       {:error, _error} ->

--- a/apps/orchard_controller/lib/orchard/console/playground_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground_live.ex
@@ -88,7 +88,7 @@ defmodule OrchardConsole.PlaygroundLive do
         |> assign(
           models: [],
           models_status: :empty,
-          models_error: "No active models available.",
+          models_error: "No active models are granted to this console tenant.",
           selected_model: nil,
           can_submit: false
         )
@@ -804,7 +804,7 @@ defmodule OrchardConsole.PlaygroundLive do
               kind={:empty}
               layout={:compact}
               title={@models_error}
-              body="Download and import a model from Model Hub, then return here to send your first test message."
+              body="Import a model from Model Hub, then grant it to this console tenant with orchardctl models access grant, and return here to send your first test message."
             >
               <:action>
                 <.link

--- a/apps/orchard_controller/lib/orchard/governance/audit_writer.ex
+++ b/apps/orchard_controller/lib/orchard/governance/audit_writer.ex
@@ -72,6 +72,8 @@ defmodule Orchard.Governance.AuditWriter do
   defp action_domain("api_key." <> _rest), do: {:ok, "api_key"}
   defp action_domain("service_account." <> _rest), do: {:ok, "service_account"}
   defp action_domain("role_binding." <> _rest), do: {:ok, "role_binding"}
+  defp action_domain("routing_policy." <> _rest), do: {:ok, "routing_policy"}
+  defp action_domain("tenant_model_access." <> _rest), do: {:ok, "tenant_model_access"}
   defp action_domain("support_bundle." <> _rest), do: {:ok, "support_bundle"}
   defp action_domain("node_admission." <> _rest), do: {:ok, "node_admission"}
   defp action_domain("node_enrollment." <> _rest), do: {:ok, "node_admission"}

--- a/apps/orchard_controller/lib/orchard/governance/tenant.ex
+++ b/apps/orchard_controller/lib/orchard/governance/tenant.ex
@@ -8,6 +8,7 @@ defmodule Orchard.Governance.Tenant do
   import Ecto.Changeset
 
   alias Orchard.Governance.{ApiKey, AuditLog, ProvisioningBatch, ServiceAccount}
+  alias Orchard.Models.{RoutingPolicy, TenantModelAccess}
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -29,6 +30,8 @@ defmodule Orchard.Governance.Tenant do
     has_many(:audit_logs, AuditLog)
     has_many(:service_accounts, ServiceAccount)
     has_many(:provisioning_batches, ProvisioningBatch)
+    has_many(:model_access, TenantModelAccess)
+    has_many(:routing_policies, RoutingPolicy)
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/apps/orchard_controller/lib/orchard/inference/admission_policy.ex
+++ b/apps/orchard_controller/lib/orchard/inference/admission_policy.ex
@@ -54,6 +54,20 @@ defmodule Orchard.Inference.AdmissionPolicy do
   def default_queue_wait_ms, do: @default_queue_wait_ms
 
   @doc """
+  Returns the canonical routing values used when an access grant has no policy.
+  """
+  @spec default_routing_opts() :: resolve_opts()
+  def default_routing_opts do
+    [
+      routing_policy_id: nil,
+      allowed_pool_ids: [],
+      residency_preference: @default_residency_preference,
+      max_cold_start_ms: @default_max_cold_start_ms,
+      queue_wait_ms: @default_queue_wait_ms
+    ]
+  end
+
+  @doc """
   Returns a CanonicalRequest with authoritative admission and resolved_policy.
 
   Defaults come from SPEC routing_policies (`max_cold_start_ms`, `max_queue_wait_ms`)

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -86,7 +86,6 @@ defmodule Orchard.Inference.ChatError do
   def from_prepare_reason({:model_not_found, model_ref}),
     do: build(:model_not_found, detail: model_ref)
 
-  def from_prepare_reason({:error, :model_not_authorized}), do: build(:model_not_authorized, [])
   def from_prepare_reason(:model_not_authorized), do: build(:model_not_authorized, [])
 
   def from_prepare_reason({:context_overflow, detail}),

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -16,6 +16,7 @@ defmodule Orchard.Inference.ChatError do
           | :unsupported_parameter
           | :invalid_value
           | :model_not_found
+          | :model_not_authorized
           | :context_overflow
           | :tooling_not_supported
           | :tokenization_invalid_request
@@ -84,6 +85,9 @@ defmodule Orchard.Inference.ChatError do
 
   def from_prepare_reason({:model_not_found, model_ref}),
     do: build(:model_not_found, detail: model_ref)
+
+  def from_prepare_reason({:error, :model_not_authorized}), do: build(:model_not_authorized, [])
+  def from_prepare_reason(:model_not_authorized), do: build(:model_not_authorized, [])
 
   def from_prepare_reason({:context_overflow, detail}),
     do: build(:context_overflow, detail: detail)
@@ -180,6 +184,16 @@ defmodule Orchard.Inference.ChatError do
       type: "invalid_request_error",
       code: "model_not_found",
       message: "Model not found: #{model_ref}",
+      param: "model"
+    }
+  end
+
+  def api_mapping(%__MODULE__{kind: :model_not_authorized}) do
+    %{
+      status: :forbidden,
+      type: "invalid_request_error",
+      code: "model_not_authorized",
+      message: "Model not authorized for tenant",
       param: "model"
     }
   end

--- a/apps/orchard_controller/lib/orchard/inference/request_preparation.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_preparation.ex
@@ -2,8 +2,16 @@ defmodule Orchard.Inference.RequestPreparation do
   @moduledoc false
 
   alias Orchard.CanonicalRequest
-  alias Orchard.Inference.{ToolExecutionSemantics, ToolingValidation, ToolRegistryResolver}
+
+  alias Orchard.Inference.{
+    AdmissionPolicy,
+    ToolExecutionSemantics,
+    ToolingValidation,
+    ToolRegistryResolver
+  }
+
   alias Orchard.Models
+  alias Orchard.Models.Access
   alias Orchard.Models.ManifestParser
   alias Orchard.Tokenizer.Client, as: TokenizerClient
 
@@ -23,7 +31,8 @@ defmodule Orchard.Inference.RequestPreparation do
          {:ok, model} <- resolve_model(canonical),
          :ok <- enforce_tooling_support(canonical, model),
          {:ok, canonical} <- tokenize(canonical, model),
-         :ok <- enforce_context_window(canonical, model) do
+         :ok <- enforce_context_window(canonical, model),
+         {:ok, canonical} <- authorize_model(canonical, model) do
       {:ok, canonical, model}
     end
   end
@@ -158,6 +167,13 @@ defmodule Orchard.Inference.RequestPreparation do
         "request requires #{total} tokens (#{canonical.input_token_count} input + #{max_output} output) but model supports at most #{model.max_context_tokens}"}}
     else
       :ok
+    end
+  end
+
+  defp authorize_model(%CanonicalRequest{} = canonical, model) do
+    case Access.authorize(canonical.tenant_id, model.id) do
+      {:ok, routing_opts} -> {:ok, AdmissionPolicy.resolve(canonical, routing_opts)}
+      {:error, :model_not_authorized} = error -> error
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
@@ -16,7 +16,7 @@ defmodule Orchard.Metrics.Normalizer do
     quota_reason:
       ~w(requests_per_minute input_tokens_per_day output_tokens_per_day tenant_concurrency),
     audit_action:
-      ~w(tenant api_key service_account role_binding support_bundle node_admission node_lifecycle cluster),
+      ~w(tenant api_key service_account role_binding routing_policy tenant_model_access support_bundle node_admission node_lifecycle cluster),
     audit_outcome: ~w(succeeded failed denied)
   }
 

--- a/apps/orchard_controller/lib/orchard/models.ex
+++ b/apps/orchard_controller/lib/orchard/models.ex
@@ -7,7 +7,7 @@ defmodule Orchard.Models do
 
   alias Ecto.Changeset
   alias Orchard.Models.Importer
-  alias Orchard.Models.Model
+  alias Orchard.Models.{Model, TenantModelAccess}
   alias Orchard.Repo
   alias Orchard.Requests.Request
 
@@ -26,9 +26,27 @@ defmodule Orchard.Models do
     |> Repo.all()
   end
 
-  @spec list_active_models() :: [struct()]
+  @spec list_active_models() :: [Model.t()]
   def list_active_models do
     list_models(state: :active)
+  end
+
+  @doc """
+  Lists active catalog Models authorized for the effective Tenant.
+
+  SPEC.md §7.2.3 requires public discovery to omit disabled, revoked,
+  ungranted, inactive, and other-Tenant-only Models.
+  """
+  @spec list_active_models_for_tenant(Ecto.UUID.t()) :: [Model.t()]
+  def list_active_models_for_tenant(tenant_id) do
+    Model
+    |> join(:inner, [model], access in TenantModelAccess, on: access.model_id == model.id)
+    |> where(
+      [model, access],
+      model.state == :active and access.tenant_id == ^tenant_id and access.enabled
+    )
+    |> order_by([model], asc: model.inserted_at, asc: model.id)
+    |> Repo.all()
   end
 
   @spec get_model!(Ecto.UUID.t()) :: struct()

--- a/apps/orchard_controller/lib/orchard/models/access.ex
+++ b/apps/orchard_controller/lib/orchard/models/access.ex
@@ -1,0 +1,480 @@
+defmodule Orchard.Models.Access do
+  @moduledoc """
+  Tenant-scoped Model access and routing-policy lifecycle.
+
+  Access checks are deny-by-default and query Postgres on every operation.
+  Mutations and their audit records commit atomically.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Changeset
+  alias Orchard.Governance.{AuditLog, AuditWriter, Tenant}
+  alias Orchard.Inference.AdmissionPolicy
+  alias Orchard.Models.{Model, RoutingPolicy, TenantModelAccess}
+  alias Orchard.Repo
+  alias Orchard.SchemaSupport
+
+  @type mutation_outcome ::
+          :created
+          | :enabled
+          | :policy_changed
+          | :unchanged
+          | :disabled
+          | :already_disabled
+          | :revoked
+          | :not_granted
+
+  @type mutation_result :: %{
+          access: TenantModelAccess.t() | nil,
+          outcome: mutation_outcome()
+        }
+
+  @type routing_resolution :: keyword()
+
+  @spec create_routing_policy(map() | keyword(), keyword()) ::
+          {:ok, RoutingPolicy.t()} | {:error, Changeset.t()}
+  def create_routing_policy(attrs, opts \\ []) do
+    attrs = SchemaSupport.normalize_attrs(attrs)
+
+    AuditWriter.transaction(fn ->
+      with {:ok, policy} <- %RoutingPolicy{} |> RoutingPolicy.changeset(attrs) |> Repo.insert(),
+           {:ok, _audit_log} <- insert_routing_policy_audit(policy, opts) do
+        policy
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
+  @spec list_routing_policies(:global | Tenant.t() | Ecto.UUID.t()) ::
+          {:ok, [RoutingPolicy.t()]} | {:error, :tenant_not_found}
+  def list_routing_policies(:global) do
+    {:ok,
+     RoutingPolicy
+     |> where([policy], is_nil(policy.tenant_id))
+     |> order_by([policy], asc: policy.name, asc: policy.id)
+     |> Repo.all()}
+  end
+
+  def list_routing_policies(tenant_or_id) do
+    with {:ok, tenant} <- resolve_tenant(tenant_or_id) do
+      {:ok,
+       RoutingPolicy
+       |> where([policy], policy.tenant_id == ^tenant.id)
+       |> order_by([policy], asc: policy.name, asc: policy.id)
+       |> Repo.all()}
+    end
+  end
+
+  @spec get_routing_policy(Ecto.UUID.t()) ::
+          {:ok, RoutingPolicy.t()} | {:error, :routing_policy_not_found}
+  def get_routing_policy(id) do
+    with {:ok, id} <- normalize_uuid(id),
+         %RoutingPolicy{} = policy <- Repo.get(RoutingPolicy, id) do
+      {:ok, policy}
+    else
+      _reason -> {:error, :routing_policy_not_found}
+    end
+  end
+
+  @spec grant_model_access(
+          Tenant.t() | Ecto.UUID.t(),
+          Model.t() | Ecto.UUID.t(),
+          Ecto.UUID.t() | nil,
+          keyword()
+        ) ::
+          {:ok, mutation_result()}
+          | {:error,
+             Changeset.t()
+             | :tenant_not_found
+             | :model_not_found
+             | :routing_policy_not_found
+             | :routing_policy_scope_mismatch}
+  def grant_model_access(tenant_or_id, model_or_id, routing_policy_id \\ nil, opts \\ []) do
+    with {:ok, tenant_id} <- tenant_id(tenant_or_id),
+         {:ok, model_id} <- model_id(model_or_id) do
+      mutate_access(tenant_id, model_id, fn ->
+        grant_model_access_by_id(tenant_id, model_id, routing_policy_id, opts)
+      end)
+    end
+  end
+
+  @spec disable_model_access(
+          Tenant.t() | Ecto.UUID.t(),
+          Model.t() | Ecto.UUID.t(),
+          keyword()
+        ) ::
+          {:ok, mutation_result()}
+          | {:error, Changeset.t() | :tenant_not_found | :model_not_found}
+  def disable_model_access(tenant_or_id, model_or_id, opts \\ []) do
+    with {:ok, tenant_id} <- tenant_id(tenant_or_id),
+         {:ok, model_id} <- model_id(model_or_id) do
+      mutate_access(tenant_id, model_id, fn ->
+        disable_model_access_by_id(tenant_id, model_id, opts)
+      end)
+    end
+  end
+
+  @spec revoke_model_access(
+          Tenant.t() | Ecto.UUID.t(),
+          Model.t() | Ecto.UUID.t(),
+          keyword()
+        ) ::
+          {:ok, mutation_result()}
+          | {:error, Changeset.t() | :tenant_not_found | :model_not_found}
+  def revoke_model_access(tenant_or_id, model_or_id, opts \\ []) do
+    with {:ok, tenant_id} <- tenant_id(tenant_or_id),
+         {:ok, model_id} <- model_id(model_or_id) do
+      mutate_access(tenant_id, model_id, fn ->
+        revoke_model_access_by_id(tenant_id, model_id, opts)
+      end)
+    end
+  end
+
+  @spec list_model_access(Tenant.t() | Ecto.UUID.t()) ::
+          {:ok, [TenantModelAccess.t()]} | {:error, :tenant_not_found}
+  def list_model_access(tenant_or_id) do
+    with {:ok, tenant} <- resolve_tenant(tenant_or_id) do
+      {:ok,
+       TenantModelAccess
+       |> join(:inner, [access], model in assoc(access, :model))
+       |> where([access], access.tenant_id == ^tenant.id)
+       |> order_by([_access, model], asc: model.model_id, asc: model.version)
+       |> preload([_access, model], model: model)
+       |> preload(:routing_policy)
+       |> Repo.all()}
+    end
+  end
+
+  @spec get_model_access(Tenant.t() | Ecto.UUID.t(), Model.t() | Ecto.UUID.t()) ::
+          {:ok, TenantModelAccess.t()}
+          | {:error, :tenant_not_found | :model_not_found | :not_granted}
+  def get_model_access(tenant_or_id, model_or_id) do
+    with {:ok, tenant} <- resolve_tenant(tenant_or_id),
+         {:ok, model} <- resolve_model(model_or_id),
+         %TenantModelAccess{} = access <- fetch_access(tenant.id, model.id) do
+      {:ok, Repo.preload(access, [:model, :routing_policy])}
+    else
+      nil -> {:error, :not_granted}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec authorize(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, routing_resolution()} | {:error, :model_not_authorized}
+  def authorize(tenant_id, model_id) do
+    with {:ok, tenant_id} <- normalize_uuid(tenant_id),
+         {:ok, model_id} <- normalize_uuid(model_id),
+         %TenantModelAccess{enabled: true} = access <- fetch_access(tenant_id, model_id) do
+      access
+      |> Repo.preload(:routing_policy)
+      |> routing_resolution()
+      |> then(&{:ok, &1})
+    else
+      _reason -> {:error, :model_not_authorized}
+    end
+  end
+
+  defp grant_model_access_by_id(tenant_id, model_id, routing_policy_id, opts) do
+    with {:ok, tenant} <- fetch_tenant(tenant_id),
+         {:ok, model} <- fetch_model(model_id),
+         {:ok, policy} <- resolve_policy(routing_policy_id, tenant.id) do
+      grant_locked(tenant, model, policy, opts)
+    end
+  end
+
+  defp disable_model_access_by_id(tenant_id, model_id, opts) do
+    with {:ok, tenant} <- fetch_tenant(tenant_id),
+         {:ok, model} <- fetch_model(model_id) do
+      disable_locked(tenant, model, opts)
+    end
+  end
+
+  defp revoke_model_access_by_id(tenant_id, model_id, opts) do
+    with {:ok, tenant} <- fetch_tenant(tenant_id),
+         {:ok, model} <- fetch_model(model_id) do
+      revoke_locked(tenant, model, opts)
+    end
+  end
+
+  defp mutate_access(tenant_id, model_id, fun) do
+    AuditWriter.transaction(fn ->
+      lock_access_identity(tenant_id, model_id)
+
+      case fun.() do
+        {:ok, result} -> result
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
+  defp grant_locked(tenant, model, policy, opts) do
+    case lock_access(tenant.id, model.id) do
+      nil -> create_access(tenant, model, policy, opts)
+      access -> update_access(access, tenant, model, policy, opts)
+    end
+  end
+
+  defp create_access(tenant, model, policy, opts) do
+    attrs = %{
+      tenant_id: tenant.id,
+      model_id: model.id,
+      routing_policy_id: policy_id(policy),
+      enabled: true
+    }
+
+    with {:ok, access} <-
+           %TenantModelAccess{} |> TenantModelAccess.changeset(attrs) |> Repo.insert(),
+         {:ok, _audit_log} <-
+           insert_access_audit(access, "tenant_model_access.granted", nil, opts) do
+      {:ok, %{access: access, outcome: :created}}
+    end
+  end
+
+  defp update_access(access, tenant, model, policy, opts) do
+    target_policy_id = policy_id(policy)
+
+    cond do
+      access.enabled and access.routing_policy_id == target_policy_id ->
+        {:ok, %{access: access, outcome: :unchanged}}
+
+      not access.enabled ->
+        persist_access_change(
+          access,
+          tenant,
+          model,
+          target_policy_id,
+          :enabled,
+          "tenant_model_access.enabled",
+          opts
+        )
+
+      true ->
+        persist_access_change(
+          access,
+          tenant,
+          model,
+          target_policy_id,
+          :policy_changed,
+          "tenant_model_access.policy_changed",
+          opts
+        )
+    end
+  end
+
+  defp persist_access_change(access, tenant, model, policy_id, outcome, action, opts) do
+    previous_policy_id = access.routing_policy_id
+
+    with {:ok, updated} <-
+           access
+           |> TenantModelAccess.changeset(%{enabled: true, routing_policy_id: policy_id})
+           |> Repo.update(),
+         {:ok, _audit_log} <- insert_access_audit(updated, action, previous_policy_id, opts) do
+      {:ok, %{access: %{updated | tenant: tenant, model: model}, outcome: outcome}}
+    end
+  end
+
+  defp disable_locked(tenant, model, opts) do
+    case lock_access(tenant.id, model.id) do
+      nil ->
+        {:ok, %{access: nil, outcome: :not_granted}}
+
+      %TenantModelAccess{enabled: false} = access ->
+        {:ok, %{access: access, outcome: :already_disabled}}
+
+      access ->
+        with {:ok, disabled} <-
+               access |> TenantModelAccess.changeset(%{enabled: false}) |> Repo.update(),
+             {:ok, _audit_log} <-
+               insert_access_audit(
+                 disabled,
+                 "tenant_model_access.disabled",
+                 access.routing_policy_id,
+                 opts
+               ) do
+          {:ok, %{access: disabled, outcome: :disabled}}
+        end
+    end
+  end
+
+  defp revoke_locked(tenant, model, opts) do
+    case lock_access(tenant.id, model.id) do
+      nil ->
+        {:ok, %{access: nil, outcome: :not_granted}}
+
+      access ->
+        with {:ok, deleted} <- Repo.delete(access),
+             {:ok, _audit_log} <-
+               insert_access_audit(
+                 deleted,
+                 "tenant_model_access.revoked",
+                 access.routing_policy_id,
+                 opts
+               ) do
+          {:ok, %{access: deleted, outcome: :revoked}}
+        end
+    end
+  end
+
+  defp routing_resolution(%TenantModelAccess{routing_policy: nil}) do
+    AdmissionPolicy.default_routing_opts()
+  end
+
+  defp routing_resolution(%TenantModelAccess{routing_policy: %RoutingPolicy{} = policy}) do
+    [
+      routing_policy_id: policy.id,
+      allowed_pool_ids: policy.allowed_pool_ids,
+      residency_preference: policy.residency_preference,
+      max_cold_start_ms: policy.max_cold_start_ms,
+      queue_wait_ms: policy.max_queue_wait_ms
+    ]
+  end
+
+  defp resolve_policy(nil, _tenant_id), do: {:ok, nil}
+
+  defp resolve_policy(policy_id, tenant_id) do
+    with {:ok, policy} <- get_routing_policy(policy_id),
+         true <- is_nil(policy.tenant_id) or policy.tenant_id == tenant_id do
+      {:ok, policy}
+    else
+      false -> {:error, :routing_policy_scope_mismatch}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_tenant(%Tenant{} = tenant), do: fetch_tenant(tenant.id)
+
+  defp resolve_tenant(id) do
+    with {:ok, id} <- tenant_id(id), do: fetch_tenant(id)
+  end
+
+  defp fetch_tenant(id) do
+    case Repo.get(Tenant, id) do
+      %Tenant{} = tenant -> {:ok, tenant}
+      nil -> {:error, :tenant_not_found}
+    end
+  end
+
+  defp resolve_model(%Model{} = model), do: fetch_model(model.id)
+
+  defp resolve_model(id) do
+    with {:ok, id} <- model_id(id), do: fetch_model(id)
+  end
+
+  defp fetch_model(id) do
+    case Repo.get(Model, id) do
+      %Model{} = model -> {:ok, model}
+      nil -> {:error, :model_not_found}
+    end
+  end
+
+  defp tenant_id(%Tenant{id: id}), do: normalize_entity_id(id, :tenant_not_found)
+  defp tenant_id(id), do: normalize_entity_id(id, :tenant_not_found)
+  defp model_id(%Model{id: id}), do: normalize_entity_id(id, :model_not_found)
+  defp model_id(id), do: normalize_entity_id(id, :model_not_found)
+
+  defp normalize_entity_id(id, error) do
+    case normalize_uuid(id) do
+      {:ok, id} -> {:ok, id}
+      :error -> {:error, error}
+    end
+  end
+
+  defp normalize_uuid(id) when is_binary(id), do: Ecto.UUID.cast(id)
+  defp normalize_uuid(_id), do: :error
+
+  defp fetch_access(tenant_id, model_id) do
+    Repo.get_by(TenantModelAccess, tenant_id: tenant_id, model_id: model_id)
+  end
+
+  defp lock_access(tenant_id, model_id) do
+    TenantModelAccess
+    |> where([access], access.tenant_id == ^tenant_id and access.model_id == ^model_id)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+  end
+
+  defp lock_access_identity(tenant_id, model_id) do
+    Repo.query!("SELECT pg_advisory_xact_lock(hashtext($1))", [
+      "tenant_model_access:#{tenant_id}:#{model_id}"
+    ])
+
+    :ok
+  end
+
+  defp insert_routing_policy_audit(policy, opts) do
+    scope_attrs =
+      if is_nil(policy.tenant_id),
+        do: %{scope: "cluster", tenant_id: nil},
+        else: %{scope: "tenant", tenant_id: policy.tenant_id}
+
+    attrs =
+      Map.merge(scope_attrs, %{
+        api_key_id: nil,
+        actor_type: audit_actor_type(opts),
+        actor_id: audit_actor_id(opts),
+        action: "routing_policy.created",
+        target_type: "routing_policy",
+        target_id: policy.id,
+        occurred_at: utc_now(),
+        payload:
+          %{
+            "name" => policy.name,
+            "tenant_id" => policy.tenant_id,
+            "residency_preference" => Atom.to_string(policy.residency_preference),
+            "max_cold_start_ms" => policy.max_cold_start_ms,
+            "max_queue_wait_ms" => policy.max_queue_wait_ms
+          }
+          |> put_surface(opts)
+      })
+
+    %AuditLog{}
+    |> audit_log_impl().changeset(attrs)
+    |> AuditWriter.insert()
+  end
+
+  defp insert_access_audit(access, action, previous_policy_id, opts) do
+    %AuditLog{}
+    |> audit_log_impl().changeset(%{
+      scope: "tenant",
+      tenant_id: access.tenant_id,
+      api_key_id: nil,
+      actor_type: audit_actor_type(opts),
+      actor_id: audit_actor_id(opts),
+      action: action,
+      target_type: "tenant_model_access",
+      target_id: "#{access.tenant_id}:#{access.model_id}",
+      occurred_at: utc_now(),
+      payload:
+        %{
+          "tenant_id" => access.tenant_id,
+          "model_id" => access.model_id,
+          "previous_routing_policy_id" => previous_policy_id,
+          "routing_policy_id" => access.routing_policy_id,
+          "enabled" => access.enabled
+        }
+        |> put_surface(opts)
+    })
+    |> AuditWriter.insert()
+  end
+
+  defp policy_id(nil), do: nil
+  defp policy_id(%RoutingPolicy{id: id}), do: id
+
+  defp audit_actor_type(opts), do: opts |> Keyword.get(:actor_type, "operator") |> to_string()
+  defp audit_actor_id(opts), do: Keyword.get(opts, :actor_id)
+
+  defp put_surface(payload, opts) do
+    case Keyword.get(opts, :surface) do
+      nil -> payload
+      surface -> Map.put(payload, "surface", to_string(surface))
+    end
+  end
+
+  defp audit_log_impl do
+    Application.get_env(:orchard_controller, :governance_audit_log_impl, AuditLog)
+  end
+
+  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+end

--- a/apps/orchard_controller/lib/orchard/models/access.ex
+++ b/apps/orchard_controller/lib/orchard/models/access.ex
@@ -417,7 +417,7 @@ defmodule Orchard.Models.Access do
         action: "routing_policy.created",
         target_type: "routing_policy",
         target_id: policy.id,
-        occurred_at: utc_now(),
+        occurred_at: SchemaSupport.utc_now(),
         payload:
           %{
             "name" => policy.name,
@@ -445,7 +445,7 @@ defmodule Orchard.Models.Access do
       action: action,
       target_type: "tenant_model_access",
       target_id: "#{access.tenant_id}:#{access.model_id}",
-      occurred_at: utc_now(),
+      occurred_at: SchemaSupport.utc_now(),
       payload:
         %{
           "tenant_id" => access.tenant_id,
@@ -475,6 +475,4 @@ defmodule Orchard.Models.Access do
   defp audit_log_impl do
     Application.get_env(:orchard_controller, :governance_audit_log_impl, AuditLog)
   end
-
-  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
 end

--- a/apps/orchard_controller/lib/orchard/models/model.ex
+++ b/apps/orchard_controller/lib/orchard/models/model.ex
@@ -34,6 +34,7 @@ defmodule Orchard.Models.Model do
     field(:runtime_requirements, :map, default: %{})
 
     has_many(:requests, Orchard.Requests.Request)
+    has_many(:tenant_model_access, Orchard.Models.TenantModelAccess)
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/apps/orchard_controller/lib/orchard/models/routing_policy.ex
+++ b/apps/orchard_controller/lib/orchard/models/routing_policy.ex
@@ -1,0 +1,82 @@
+defmodule Orchard.Models.RoutingPolicy do
+  @moduledoc """
+  Persisted Tenant-scoped or global routing policy.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Orchard.Governance.Tenant
+  alias Orchard.Models.TenantModelAccess
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @residency_preferences [:required_loaded, :prefer_loaded, :allow_cold_load]
+
+  @type t :: %__MODULE__{}
+
+  schema "routing_policies" do
+    field(:name, :string)
+    field(:allowed_pool_ids, {:array, :binary_id}, default: [])
+    field(:preferred_pool_ids, {:array, :binary_id}, default: [])
+    field(:residency_preference, Ecto.Enum, values: @residency_preferences)
+    field(:max_cold_start_ms, :integer, default: 15_000)
+    field(:max_queue_wait_ms, :integer, default: 3_000)
+    field(:priority, :integer, default: 100)
+
+    belongs_to(:tenant, Tenant)
+    has_many(:model_access, TenantModelAccess)
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @spec residency_preferences() :: [atom()]
+  def residency_preferences, do: @residency_preferences
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(policy, attrs) do
+    policy
+    |> cast(attrs, [
+      :tenant_id,
+      :name,
+      :allowed_pool_ids,
+      :preferred_pool_ids,
+      :residency_preference,
+      :max_cold_start_ms,
+      :max_queue_wait_ms,
+      :priority
+    ])
+    |> validate_required([
+      :name,
+      :allowed_pool_ids,
+      :preferred_pool_ids,
+      :residency_preference,
+      :max_cold_start_ms,
+      :max_queue_wait_ms,
+      :priority
+    ])
+    |> update_change(:name, &String.trim/1)
+    |> validate_length(:name, min: 1)
+    |> validate_number(:max_cold_start_ms, greater_than_or_equal_to: 0)
+    |> validate_number(:max_queue_wait_ms, greater_than_or_equal_to: 0)
+    |> validate_number(:priority, greater_than_or_equal_to: 0)
+    |> validate_empty_pool_ids(:allowed_pool_ids)
+    |> validate_empty_pool_ids(:preferred_pool_ids)
+    |> foreign_key_constraint(:tenant_id)
+    |> unique_constraint([:tenant_id, :name], name: :idx_routing_policies_tenant_name)
+    |> unique_constraint(:name, name: :idx_routing_policies_global_name)
+    |> check_constraint(:tenant_id, name: :routing_policies_tenant_immutable)
+  end
+
+  defp validate_empty_pool_ids(changeset, field) do
+    case get_field(changeset, field) do
+      [] ->
+        changeset
+
+      _ ->
+        add_error(changeset, field, "must be empty until scheduler pool enforcement is available")
+    end
+  end
+end

--- a/apps/orchard_controller/lib/orchard/models/tenant_model_access.ex
+++ b/apps/orchard_controller/lib/orchard/models/tenant_model_access.ex
@@ -1,0 +1,42 @@
+defmodule Orchard.Models.TenantModelAccess do
+  @moduledoc """
+  Explicit Tenant authorization for a catalog Model.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Orchard.Governance.Tenant
+  alias Orchard.Models.{Model, RoutingPolicy}
+
+  @primary_key false
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{}
+
+  schema "tenant_model_access" do
+    belongs_to(:tenant, Tenant, primary_key: true)
+    belongs_to(:model, Model, primary_key: true)
+    belongs_to(:routing_policy, RoutingPolicy)
+
+    field(:enabled, :boolean, default: true)
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(access, attrs) do
+    access
+    |> cast(attrs, [:tenant_id, :model_id, :routing_policy_id, :enabled])
+    |> validate_required([:tenant_id, :model_id, :enabled])
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:model_id)
+    |> foreign_key_constraint(:routing_policy_id)
+    |> unique_constraint([:tenant_id, :model_id], name: :tenant_model_access_pkey)
+    |> check_constraint(:routing_policy_id,
+      name: :tenant_model_access_routing_policy_scope,
+      message: "must reference a global policy or one owned by the same tenant"
+    )
+  end
+end

--- a/apps/orchard_controller/priv/repo/migrations/20260819010000_tenant_model_access_foundation.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260819010000_tenant_model_access_foundation.exs
@@ -1,0 +1,161 @@
+defmodule Orchard.Repo.Migrations.TenantModelAccessFoundation do
+  use Ecto.Migration
+
+  def up do
+    create table(:routing_policies, primary_key: false) do
+      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:tenant_id, references(:tenants, type: :binary_id, on_delete: :nothing))
+      add(:name, :text, null: false)
+      add(:allowed_pool_ids, {:array, :binary_id}, null: false, default: fragment("'{}'::uuid[]"))
+
+      add(:preferred_pool_ids, {:array, :binary_id},
+        null: false,
+        default: fragment("'{}'::uuid[]")
+      )
+
+      add(:residency_preference, :text, null: false)
+      add(:max_cold_start_ms, :integer, null: false, default: 15_000)
+      add(:max_queue_wait_ms, :integer, null: false, default: 3_000)
+      add(:priority, :integer, null: false, default: 100)
+      add(:inserted_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+      add(:updated_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+    end
+
+    create(
+      unique_index(:routing_policies, [:tenant_id, :name],
+        where: "tenant_id IS NOT NULL",
+        name: :idx_routing_policies_tenant_name
+      )
+    )
+
+    create(
+      unique_index(:routing_policies, [:name],
+        where: "tenant_id IS NULL",
+        name: :idx_routing_policies_global_name
+      )
+    )
+
+    create(
+      constraint(:routing_policies, :routing_policies_name_not_blank,
+        check: "length(btrim(name)) > 0"
+      )
+    )
+
+    create(
+      constraint(:routing_policies, :routing_policies_residency_preference_closed,
+        check:
+          "residency_preference IN ('required_loaded', 'prefer_loaded', 'allow_cold_load')"
+      )
+    )
+
+    create(
+      constraint(:routing_policies, :routing_policies_budgets_non_negative,
+        check: "max_cold_start_ms >= 0 AND max_queue_wait_ms >= 0 AND priority >= 0"
+      )
+    )
+
+    create(
+      constraint(:routing_policies, :routing_policies_pool_constraints_deferred,
+        check: "cardinality(allowed_pool_ids) = 0 AND cardinality(preferred_pool_ids) = 0"
+      )
+    )
+
+    execute("""
+    CREATE FUNCTION orchard_reject_routing_policy_tenant_change()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id THEN
+        RAISE EXCEPTION USING
+          ERRCODE = '23514',
+          CONSTRAINT = 'routing_policies_tenant_immutable',
+          MESSAGE = 'routing policy tenant scope is immutable';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    execute("""
+    CREATE TRIGGER routing_policies_tenant_immutable
+    BEFORE UPDATE OF tenant_id ON routing_policies
+    FOR EACH ROW
+    EXECUTE FUNCTION orchard_reject_routing_policy_tenant_change()
+    """)
+
+    create table(:tenant_model_access, primary_key: false) do
+      add(:tenant_id,
+        references(:tenants, type: :binary_id, on_delete: :delete_all),
+        primary_key: true,
+        null: false
+      )
+
+      add(:model_id,
+        references(:models, type: :binary_id, on_delete: :delete_all),
+        primary_key: true,
+        null: false
+      )
+
+      add(:enabled, :boolean, null: false, default: true)
+
+      add(:routing_policy_id,
+        references(:routing_policies, type: :binary_id, on_delete: :nothing)
+      )
+
+      add(:inserted_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+      add(:updated_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+    end
+
+    create(index(:tenant_model_access, [:tenant_id, :enabled]))
+    create(index(:tenant_model_access, [:model_id]))
+    create(index(:tenant_model_access, [:routing_policy_id]))
+
+    execute("""
+    CREATE FUNCTION orchard_enforce_tenant_model_access_policy_scope()
+    RETURNS trigger AS $$
+    DECLARE
+      policy_tenant_id uuid;
+    BEGIN
+      IF NEW.routing_policy_id IS NULL THEN
+        RETURN NEW;
+      END IF;
+
+      SELECT tenant_id
+      INTO policy_tenant_id
+      FROM routing_policies
+      WHERE id = NEW.routing_policy_id
+      FOR KEY SHARE;
+
+      IF FOUND AND policy_tenant_id IS NOT NULL AND policy_tenant_id <> NEW.tenant_id THEN
+        RAISE EXCEPTION USING
+          ERRCODE = '23514',
+          CONSTRAINT = 'tenant_model_access_routing_policy_scope',
+          MESSAGE = 'routing policy must be global or owned by the access tenant';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """)
+
+    execute("""
+    CREATE TRIGGER tenant_model_access_routing_policy_scope
+    BEFORE INSERT OR UPDATE OF tenant_id, routing_policy_id ON tenant_model_access
+    FOR EACH ROW
+    EXECUTE FUNCTION orchard_enforce_tenant_model_access_policy_scope()
+    """)
+  end
+
+  def down do
+    execute(
+      "DROP TRIGGER IF EXISTS tenant_model_access_routing_policy_scope ON tenant_model_access"
+    )
+
+    execute("DROP FUNCTION IF EXISTS orchard_enforce_tenant_model_access_policy_scope()")
+    drop(table(:tenant_model_access))
+
+    execute("DROP TRIGGER IF EXISTS routing_policies_tenant_immutable ON routing_policies")
+    execute("DROP FUNCTION IF EXISTS orchard_reject_routing_policy_tenant_change()")
+    drop(table(:routing_policies))
+  end
+end

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -46,10 +46,12 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
   alias Orchard.Inference.ChatRequestNormalizer
   alias Orchard.Inference.QueueManager
   alias Orchard.InferenceEvent
+  alias Orchard.Models.Access, as: ModelAccess
   alias Orchard.Node
   alias Orchard.Node.ModelManager
+  alias Orchard.Repo
   alias Orchard.Requests
-  alias Orchard.Requests.Idempotency
+  alias Orchard.Requests.{Idempotency, Request}
 
   # When testing through Router.call/2 directly (not the Endpoint),
   # Plug.Parsers does not run, so body_params are not merged into params.
@@ -202,6 +204,33 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       assert body["error"]["param"] == "model"
     end
 
+    test "SPEC.md §5.2 returns exact 403 for an active ungranted Model before persistence" do
+      model = create_model!(%{state: :active})
+      %{token: token} = create_api_key_with_token!("chat-ungranted", grant_active?: false)
+      before_count = Repo.aggregate(Request, :count, :id)
+
+      conn =
+        post_chat(
+          %{
+            "model" => "#{model.model_id}@#{model.version}",
+            "messages" => [%{"role" => "user", "content" => "hello"}],
+            "max_tokens" => 1
+          },
+          token
+        )
+
+      assert conn.status == 403
+
+      assert Jason.decode!(conn.resp_body)["error"] == %{
+               "type" => "invalid_request_error",
+               "code" => "model_not_authorized",
+               "message" => "Model not authorized for tenant",
+               "param" => "model"
+             }
+
+      assert Repo.aggregate(Request, :count, :id) == before_count
+    end
+
     test "rejects unsupported parameter" do
       conn =
         post_chat(%{
@@ -249,6 +278,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
           prefill_workspace_bytes_per_token: 64,
           max_context_tokens: 131_072
         })
+
+      grant_active_models!(tenant)
 
       conn =
         post_chat(
@@ -341,7 +372,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
         )
       )
 
-      %{token: token} = create_api_key_with_token!("unsupported-version-score")
+      %{token: token, tenant: tenant} =
+        create_api_key_with_token!("unsupported-version-score")
 
       {:ok, _model} =
         Orchard.Models.create_model(%{
@@ -360,6 +392,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
           prefill_workspace_bytes_per_token: 64,
           max_context_tokens: 131_072
         })
+
+      grant_active_models!(tenant)
 
       conn =
         post_chat(
@@ -425,6 +459,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
           prefill_workspace_bytes_per_token: 64,
           max_context_tokens: 131_072
         })
+
+      grant_active_models!(tenant)
 
       params = %{
         "model" => "persist-non-stream-model@v1",
@@ -520,8 +556,11 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
          %{
            bundle: bundle
          } do
-      %{token: token_a} = create_api_key_with_token!("idempotency-tenant-a")
-      %{token: token_b} = create_api_key_with_token!("idempotency-tenant-b")
+      %{tenant: tenant_a, token: token_a} =
+        create_api_key_with_token!("idempotency-tenant-a")
+
+      %{tenant: tenant_b, token: token_b} =
+        create_api_key_with_token!("idempotency-tenant-b")
 
       {:ok, _model} =
         Orchard.Models.create_model(%{
@@ -540,6 +579,9 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
           prefill_workspace_bytes_per_token: 64,
           max_context_tokens: 131_072
         })
+
+      grant_active_models!(tenant_a)
+      grant_active_models!(tenant_b)
 
       params = %{
         "model" => "tenant-scope-model@v1",
@@ -682,7 +724,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
 
     @tag :db
     test "valid ref-backed request succeeds without API shape changes" do
-      %{token: token} = create_api_key_with_token!("chat-ref-success")
+      %{tenant: tenant, token: token} = create_api_key_with_token!("chat-ref-success")
       create_tool!("lookup_weather", "2026-04-10")
       executable = write_tokenizer_executable!()
       on_exit(fn -> File.rm(executable) end)
@@ -696,6 +738,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
           artifact_uri: "file://#{fixture_bundle_path()}",
           artifact_source_uri: "file://#{fixture_bundle_path()}"
         })
+
+      grant_active_models!(tenant)
 
       params = %{
         "model" => "#{model.model_id}@#{model.version}",
@@ -1117,7 +1161,9 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
 
   describe "POST /v1/chat/completions (streaming happy path)" do
     @tag :db
-    test "stream=true with valid model emits SSE chunks then [DONE]", %{bundle: bundle} do
+    test "SPEC.md §7.2.5 keeps one public ID across SSE chunks and persistence", %{
+      bundle: bundle
+    } do
       {:ok, _model} =
         Orchard.Models.create_model(%{
           model_id: "test-stream-model",
@@ -1155,6 +1201,11 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       # Should have data chunks followed by [DONE]
       data_events = Enum.filter(events, fn {type, _} -> type == :data end)
       done_events = Enum.filter(events, fn {type, _} -> type == :done end)
+
+      chunk_ids = Enum.map(data_events, fn {:data, chunk} -> Map.fetch!(chunk, "id") end)
+      assert [public_id] = Enum.uniq(chunk_ids)
+      assert String.starts_with?(public_id, "chatcmpl-")
+      assert %{public_id: ^public_id} = Requests.get_request_by_public_id(public_id)
 
       # At least: role chunk + content chunk(s) + finish chunk
       assert length(data_events) >= 3
@@ -1410,6 +1461,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
           max_context_tokens: 131_072
         })
 
+      grant_active_models!(tenant)
+
       conn =
         post_chat(
           %{
@@ -1477,6 +1530,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
           prefill_workspace_bytes_per_token: 64,
           max_context_tokens: 131_072
         })
+
+      grant_active_models!(tenant)
 
       params = %{
         "model" => "persist-model@v1",
@@ -1708,12 +1763,19 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     token
   end
 
-  defp create_api_key_with_token!(slug) do
+  defp grant_active_models!(tenant) do
+    Enum.each(Orchard.Models.list_active_models(), fn model ->
+      assert {:ok, _result} = ModelAccess.grant_model_access(tenant, model)
+    end)
+  end
+
+  defp create_api_key_with_token!(slug, opts \\ []) do
     {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
 
     {:ok, %{api_key: api_key, token: token}} =
       Governance.create_api_key(tenant.id, %{name: "Primary"})
 
+    if Keyword.get(opts, :grant_active?, true), do: grant_active_models!(tenant)
     %{tenant: tenant, api_key: api_key, token: token}
   end
 

--- a/apps/orchard_controller/test/orchard/api/models_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/models_controller_test.exs
@@ -1,62 +1,50 @@
 defmodule Orchard.API.ModelsControllerTest do
   use Orchard.ConnCase, async: false
 
+  import Orchard.TestSupport.ModelRequestFixtures
+
   alias Orchard.API.Router
   alias Orchard.Governance
-  alias Orchard.Models
+  alias Orchard.Models.Access
 
   describe "GET /v1/models" do
     @describetag :db
 
     test "SPEC.md §7.2.7 returns 401 when bearer auth is missing" do
-      conn =
-        build_conn(:get, "/v1/models")
-        |> put_req_header("accept", "application/json")
-        |> Router.call(Router.init([]))
+      conn = request_models(nil)
 
       assert conn.status == 401
       assert Jason.decode!(conn.resp_body)["error"]["type"] == "authentication_error"
     end
 
-    test "returns empty list when no models exist" do
-      conn =
-        build_conn(:get, "/v1/models")
-        |> put_req_header("accept", "application/json")
-        |> put_req_header("authorization", "Bearer #{default_api_token!()}")
-        |> Router.call(Router.init([]))
+    test "SPEC.md §7.2.3 returns empty list when the Tenant has no authorized active Models" do
+      %{token: token} = create_direct_token!("models-empty")
+      _ungranted = create_model!(%{state: :active})
 
+      conn = request_models(token)
       body = Jason.decode!(conn.resp_body)
+
       assert conn.status == 200
-      assert body["object"] == "list"
-      assert body["data"] == []
+      assert body == %{"object" => "list", "data" => []}
     end
 
-    test "returns OpenAI-shaped model objects for active models" do
-      {:ok, _model} =
-        Models.create_model(%{
+    test "SPEC.md §7.2.3 returns OpenAI-shaped objects only for active granted Models" do
+      %{tenant: tenant, token: token} = create_direct_token!("models-granted")
+
+      model =
+        create_model!(%{
           model_id: "llama-3.1-8b-instruct",
           version: "mlx-q4-v1",
           state: :active,
-          format: "mlx",
-          capabilities: ["chat"],
-          artifact_uri: "file:///models/llama-3.1-8b",
-          artifact_sha256: "abc123",
-          artifact_size_bytes: 1000,
-          resident_memory_bytes: 2000,
-          kv_cache_bytes_per_token: 32,
-          prefill_workspace_bytes_per_token: 64,
-          max_context_tokens: 8192,
-          tokenizer: %{"type" => "huggingface_tokenizer_json"},
-          runtime_requirements: %{"backend" => "mlx"}
+          artifact_uri: "file:///models/llama-3.1-8b"
         })
 
-      conn =
-        build_conn(:get, "/v1/models")
-        |> put_req_header("accept", "application/json")
-        |> put_req_header("authorization", "Bearer #{default_api_token!()}")
-        |> Router.call(Router.init([]))
+      assert {:ok, %{outcome: :created}} = Access.grant_model_access(tenant, model)
 
+      conn = request_models(token)
       body = Jason.decode!(conn.resp_body)
+
+      assert conn.status == 200
       assert body["object"] == "list"
       assert length(body["data"]) == 1
 
@@ -71,40 +59,85 @@ defmodule Orchard.API.ModelsControllerTest do
       refute Map.has_key?(model_obj, "artifact_sha256")
     end
 
-    test "excludes non-active models" do
-      {:ok, _} =
-        Models.create_model(%{
-          model_id: "retired-model",
-          version: "v1",
-          state: :retired,
-          format: "mlx",
-          capabilities: ["chat"],
-          artifact_uri: "file:///models/retired",
-          artifact_sha256: "def456",
-          artifact_size_bytes: 500,
-          resident_memory_bytes: 1000,
-          kv_cache_bytes_per_token: 16,
-          prefill_workspace_bytes_per_token: 32,
-          max_context_tokens: 4096,
-          tokenizer: %{"type" => "sentencepiece"},
-          runtime_requirements: %{"backend" => "mlx"}
-        })
+    test "SPEC.md §7.2.3 excludes inactive, disabled, revoked, ungranted, and other-Tenant Models" do
+      %{tenant: tenant, token: token} = create_direct_token!("models-scope-a")
+      %{tenant: other_tenant, token: other_token} = create_direct_token!("models-scope-b")
 
-      conn =
-        build_conn(:get, "/v1/models")
-        |> put_req_header("accept", "application/json")
-        |> put_req_header("authorization", "Bearer #{default_api_token!()}")
-        |> Router.call(Router.init([]))
+      visible = create_model!(%{state: :active})
+      inactive = create_model!(%{state: :retired})
+      disabled = create_model!(%{state: :active})
+      revoked = create_model!(%{state: :active})
+      _ungranted = create_model!(%{state: :active})
 
-      body = Jason.decode!(conn.resp_body)
-      assert body["data"] == []
+      assert {:ok, _result} = Access.grant_model_access(tenant, visible)
+      assert {:ok, _result} = Access.grant_model_access(tenant, inactive)
+      assert {:ok, _result} = Access.grant_model_access(tenant, disabled)
+      assert {:ok, _result} = Access.disable_model_access(tenant, disabled)
+      assert {:ok, _result} = Access.grant_model_access(tenant, revoked)
+      assert {:ok, _result} = Access.revoke_model_access(tenant, revoked)
+      assert {:ok, _result} = Access.grant_model_access(other_tenant, disabled)
+
+      assert model_ids(request_models(token)) == ["#{visible.model_id}@#{visible.version}"]
+
+      assert model_ids(request_models(other_token)) == [
+               "#{disabled.model_id}@#{disabled.version}"
+             ]
+    end
+
+    test "SPEC.md §5.2 uses the same effective Tenant for direct and Service Account credentials" do
+      %{tenant: tenant, token: direct_token} = create_direct_token!("models-principals")
+      service_token = create_service_account_token!(tenant)
+      model = create_model!(%{state: :active})
+
+      assert {:ok, _result} = Access.grant_model_access(tenant, model)
+
+      expected = ["#{model.model_id}@#{model.version}"]
+      assert model_ids(request_models(direct_token)) == expected
+      assert model_ids(request_models(service_token)) == expected
     end
   end
 
-  defp default_api_token! do
-    slug = "models-auth-#{System.unique_integer([:positive])}"
+  defp request_models(nil) do
+    build_conn(:get, "/v1/models")
+    |> put_req_header("accept", "application/json")
+    |> Router.call(Router.init([]))
+  end
+
+  defp request_models(token) do
+    build_conn(:get, "/v1/models")
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> Router.call(Router.init([]))
+  end
+
+  defp model_ids(conn) do
+    conn.resp_body
+    |> Jason.decode!()
+    |> Map.fetch!("data")
+    |> Enum.map(&Map.fetch!(&1, "id"))
+  end
+
+  defp create_direct_token!(prefix) do
+    slug = unique_slug(prefix)
     {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
     {:ok, %{token: token}} = Governance.create_api_key(tenant.id, %{name: "Primary"})
+    %{tenant: tenant, token: token}
+  end
+
+  defp create_service_account_token!(tenant) do
+    {:ok, api_client} =
+      Governance.upsert_api_client(tenant, %{
+        name: "models-client-#{System.unique_integer([:positive])}",
+        owner_contact: "owner@example.com"
+      })
+
+    {:ok, _role_binding} = Governance.ensure_inference_client_access(api_client, tenant)
+
+    {:ok, %{token: token}} =
+      Governance.create_api_client_api_token(api_client, %{name: "Primary"})
+
     token
   end
+
+  defp unique_slug(prefix), do: "#{prefix}-#{System.unique_integer([:positive, :monotonic])}"
 end

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -13,6 +13,7 @@ defmodule Orchard.API.ResponsesControllerTest do
   alias Orchard.Governance.Tenant
   alias Orchard.Inference.QueueManager
   alias Orchard.InferenceEvent
+  alias Orchard.Models.Access, as: ModelAccess
   alias Orchard.Node
   alias Orchard.Node.ModelManager
   alias Orchard.Repo
@@ -141,6 +142,33 @@ defmodule Orchard.API.ResponsesControllerTest do
     assert body["error"]["param"] == "model"
   end
 
+  test "SPEC.md §5.2 returns exact 403 for an active ungranted Model before persistence" do
+    model = create_model!(%{state: :active})
+    %{token: token} = create_api_key_with_token!("responses-ungranted", grant_active?: false)
+    before_count = Repo.aggregate(Request, :count, :id)
+
+    conn =
+      post_responses(
+        %{
+          "model" => "#{model.model_id}@#{model.version}",
+          "input" => "hello",
+          "max_output_tokens" => 1
+        },
+        token
+      )
+
+    assert conn.status == 403
+
+    assert Jason.decode!(conn.resp_body)["error"] == %{
+             "type" => "invalid_request_error",
+             "code" => "model_not_authorized",
+             "message" => "Model not authorized for tenant",
+             "param" => "model"
+           }
+
+    assert Repo.aggregate(Request, :count, :id) == before_count
+  end
+
   test "successful non-stream request returns response payload and persists responses endpoint",
        %{bundle: bundle} do
     %{token: token, tenant: tenant} = create_api_key_with_token!("responses-success")
@@ -167,6 +195,8 @@ defmodule Orchard.API.ResponsesControllerTest do
         prefill_workspace_bytes_per_token: 64,
         max_context_tokens: 131_072
       })
+
+    grant_active_models!(tenant)
 
     conn =
       post_responses(
@@ -323,7 +353,7 @@ defmodule Orchard.API.ResponsesControllerTest do
   end
 
   test "valid ref-backed request succeeds without API shape changes" do
-    %{token: token} = create_api_key_with_token!("responses-ref-success")
+    %{tenant: tenant, token: token} = create_api_key_with_token!("responses-ref-success")
     create_tool!("lookup_weather", "2026-04-10")
     executable = write_tokenizer_executable!()
     on_exit(fn -> File.rm(executable) end)
@@ -337,6 +367,8 @@ defmodule Orchard.API.ResponsesControllerTest do
         artifact_uri: "file://#{fixture_bundle_path()}",
         artifact_source_uri: "file://#{fixture_bundle_path()}"
       })
+
+    grant_active_models!(tenant)
 
     params = %{
       "model" => "#{model.model_id}@#{model.version}",
@@ -702,6 +734,8 @@ defmodule Orchard.API.ResponsesControllerTest do
         max_context_tokens: 131_072
       })
 
+    grant_active_models!(tenant)
+
     params = %{"model" => "responses-replay-model@v1", "input" => "hello"}
 
     conn_a = post_responses(params, token, [{"idempotency-key", "responses-replay"}])
@@ -788,12 +822,19 @@ defmodule Orchard.API.ResponsesControllerTest do
     token
   end
 
-  defp create_api_key_with_token!(slug) do
+  defp grant_active_models!(tenant) do
+    Enum.each(Orchard.Models.list_active_models(), fn model ->
+      assert {:ok, _result} = ModelAccess.grant_model_access(tenant, model)
+    end)
+  end
+
+  defp create_api_key_with_token!(slug, opts \\ []) do
     {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
 
     {:ok, %{api_key: api_key, token: token}} =
       Governance.create_api_key(tenant.id, %{name: "Primary"})
 
+    if Keyword.get(opts, :grant_active?, true), do: grant_active_models!(tenant)
     %{tenant: tenant, api_key: api_key, token: token}
   end
 
@@ -825,6 +866,8 @@ defmodule Orchard.API.ResponsesControllerTest do
         prefill_workspace_bytes_per_token: 64,
         max_context_tokens: 131_072
       })
+
+    grant_active_models!(tenant)
 
     conn =
       post_responses(
@@ -1322,7 +1365,7 @@ defmodule Orchard.API.ResponsesControllerTest do
   end
 
   test "post-start failure emits response.created then response.failed with no [DONE]" do
-    %{token: token} = create_api_key_with_token!("responses-stream-fail")
+    %{tenant: tenant, token: token} = create_api_key_with_token!("responses-stream-fail")
 
     # Model with a mismatched hash — will fail at dispatch/model-load
     _model =
@@ -1343,6 +1386,8 @@ defmodule Orchard.API.ResponsesControllerTest do
         prefill_workspace_bytes_per_token: 64,
         max_context_tokens: 131_072
       })
+
+    grant_active_models!(tenant)
 
     conn =
       post_responses(

--- a/apps/orchard_controller/test/orchard/api/safe_tokenization_lifecycle_test.exs
+++ b/apps/orchard_controller/test/orchard/api/safe_tokenization_lifecycle_test.exs
@@ -39,6 +39,7 @@ defmodule Orchard.API.SafeTokenizationLifecycleTest do
   alias Orchard.Node
   alias Orchard.Node.ModelManager
   alias Orchard.Requests
+  alias Orchard.TestSupport.ModelRequestFixtures
 
   @moduletag :db
   @moduletag :safe_tokenization_smoke
@@ -143,9 +144,12 @@ defmodule Orchard.API.SafeTokenizationLifecycleTest do
   end
 
   test "streaming lifecycle persists canonical_request without prompt_token_ids and stays term-equivalent across :off/:on" do
-    %{token: token} = create_api_key_with_token!("safe-tok-lifecycle-stream")
+    %{tenant: tenant, token: token} =
+      create_api_key_with_token!("safe-tok-lifecycle-stream")
+
     bundle = stage_safe_lifecycle_bundle!(@stream_model_id)
-    create_active_model!(bundle, @stream_model_id)
+    model = create_active_model!(bundle, @stream_model_id)
+    ModelRequestFixtures.grant_model_access!(tenant, model)
     capture_file = command_capture_file!()
     tokenizer_executable = write_lifecycle_tokenizer_executable!(capture_file)
 
@@ -176,9 +180,12 @@ defmodule Orchard.API.SafeTokenizationLifecycleTest do
   end
 
   test "non-streaming lifecycle persists canonical_request without prompt_token_ids and stays term-equivalent across :off/:on" do
-    %{token: token} = create_api_key_with_token!("safe-tok-lifecycle-nonstream")
+    %{tenant: tenant, token: token} =
+      create_api_key_with_token!("safe-tok-lifecycle-nonstream")
+
     bundle = stage_safe_lifecycle_bundle!(@nonstream_model_id)
-    create_active_model!(bundle, @nonstream_model_id)
+    model = create_active_model!(bundle, @nonstream_model_id)
+    ModelRequestFixtures.grant_model_access!(tenant, model)
     capture_file = command_capture_file!()
     tokenizer_executable = write_lifecycle_tokenizer_executable!(capture_file)
 

--- a/apps/orchard_controller/test/orchard/console/playground_access_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_access_test.exs
@@ -51,6 +51,19 @@ defmodule OrchardConsole.PlaygroundAccessTest do
     refute_receive {:prepare_called, _caller_context}, 100
   end
 
+  test "reports a non-active catalog Model as unavailable rather than ungranted" do
+    inactive = create_model!(%{state: :registered})
+
+    ref = make_ref()
+    {:ok, _pid} = Playground.start_stream(self(), ref, params_for(inactive))
+
+    assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+    assert error.code == "model_not_ready"
+    assert error.message =~ "not an active catalog model"
+    refute error.message =~ "orchardctl models access grant"
+    refute_receive {:prepare_called, _caller_context}, 100
+  end
+
   test "SPEC.md §5.2 lists and runs a Model granted to the console Tenant", %{model: model} do
     grant_model_access!(Playground.effective_tenant_id(), model)
 

--- a/apps/orchard_controller/test/orchard/console/playground_access_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_access_test.exs
@@ -1,0 +1,107 @@
+defmodule OrchardConsole.PlaygroundAccessTest do
+  use Orchard.DataCase, async: false
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  alias Orchard.Models.Access
+  alias OrchardConsole.Playground
+
+  setup do
+    previous = Application.get_env(:orchard_controller, :console, [])
+
+    console_config =
+      previous
+      |> Keyword.merge(
+        playground_orchestrator_impl: __MODULE__.StubOrchestrator,
+        playground_runtime_impl: __MODULE__.StubRuntime
+      )
+      |> Keyword.delete(:playground_models_impl)
+
+    Application.put_env(:orchard_controller, :console, console_config)
+
+    on_exit(fn ->
+      Application.put_env(:orchard_controller, :console, previous)
+      :persistent_term.erase({__MODULE__, :loaded})
+      :persistent_term.erase({__MODULE__, :test_pid})
+    end)
+
+    :persistent_term.put({__MODULE__, :test_pid}, self())
+
+    model = create_model!(%{state: :active})
+
+    :persistent_term.put({__MODULE__, :loaded}, [
+      %{model_id: model.model_id, version: model.version}
+    ])
+
+    %{model: model}
+  end
+
+  test "SPEC.md §7.2.3 hides active Models the console Tenant is not granted", %{model: model} do
+    assert {:ok, []} = Playground.list_models()
+
+    ref = make_ref()
+    {:ok, _pid} = Playground.start_stream(self(), ref, params_for(model))
+
+    assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+    assert error.phase == :prepare
+    assert error.code == "model_not_ready"
+    assert error.message =~ "orchardctl models access grant"
+
+    refute_receive {:playground, ^ref, :started, _}, 100
+    refute_receive {:prepare_called, _caller_context}, 100
+  end
+
+  test "SPEC.md §5.2 lists and runs a Model granted to the console Tenant", %{model: model} do
+    grant_model_access!(Playground.effective_tenant_id(), model)
+
+    assert {:ok, [option]} = Playground.list_models()
+    assert option.model_id == model.model_id
+    assert option.version == model.version
+    assert option.inference_ready == true
+
+    ref = make_ref()
+    {:ok, _pid} = Playground.start_stream(self(), ref, params_for(model))
+
+    assert_receive {:prepare_called, caller_context}, 1000
+    assert Keyword.get(caller_context, :tenant_id) == Playground.effective_tenant_id()
+
+    assert_receive {:playground, ^ref, :started, _}, 1000
+    assert_receive {:playground, ^ref, :finished, {:ok, _summary}}, 1000
+  end
+
+  test "SPEC.md §5.2 drops a Model from the picker once its grant is disabled", %{model: model} do
+    grant_model_access!(Playground.effective_tenant_id(), model)
+    assert {:ok, [_option]} = Playground.list_models()
+
+    assert {:ok, %{outcome: :disabled}} =
+             Access.disable_model_access(Playground.effective_tenant_id(), model)
+
+    assert {:ok, []} = Playground.list_models()
+  end
+
+  defp params_for(model) do
+    %{
+      "model" => "#{model.model_id}@#{model.version}",
+      "messages" => [%{"role" => "user", "content" => "hello"}]
+    }
+  end
+
+  defmodule StubRuntime do
+    def cluster_snapshot(_opts \\ []) do
+      loaded = :persistent_term.get({OrchardConsole.PlaygroundAccessTest, :loaded}, [])
+      [%{status: :ok, loaded_models: loaded}]
+    end
+  end
+
+  defmodule StubOrchestrator do
+    def prepare(_params, caller_context) do
+      test_pid = :persistent_term.get({OrchardConsole.PlaygroundAccessTest, :test_pid}, nil)
+
+      if test_pid, do: send(test_pid, {:prepare_called, caller_context})
+
+      {:ok, %{public_id: "chatcmpl-console"}, %{}}
+    end
+
+    def execute(canonical, _model, _opts), do: {:ok, canonical, []}
+  end
+end

--- a/apps/orchard_controller/test/orchard/console/playground_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_live_test.exs
@@ -65,9 +65,10 @@ defmodule OrchardConsole.PlaygroundLiveTest do
       stub_models([])
       {:ok, view, html} = live(conn, "/console/playground")
 
-      assert html =~ "No active models available."
+      assert html =~ "No active models are granted to this console tenant."
       assert html =~ "playground-models-empty"
-      assert html =~ "Download and import a model from Model Hub"
+      assert html =~ "Import a model from Model Hub"
+      assert html =~ "orchardctl models access grant"
       assert has_element?(view, ~s|#playground-browse-model-hub[href="/console/model-hub"]|)
       assert html =~ "Browse Model Hub"
     end
@@ -195,7 +196,7 @@ defmodule OrchardConsole.PlaygroundLiveTest do
 
       {:ok, view, html} = live(conn, "/console/playground")
 
-      assert html =~ "No active models available."
+      assert html =~ "No active models are granted to this console tenant."
       refute has_element?(view, "#playground-model-selected")
     end
 

--- a/apps/orchard_controller/test/orchard/console/playground_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_test.exs
@@ -135,6 +135,24 @@ defmodule OrchardConsole.PlaygroundTest do
       assert {:ok, []} = Playground.list_models()
     end
 
+    test "lists only models granted to the effective tenant" do
+      stub_models(%{
+        Playground.effective_tenant_id() => [%{model_id: "granted-model", version: "v1"}],
+        Ecto.UUID.generate() => [%{model_id: "other-tenant-model", version: "v1"}]
+      })
+
+      stub_runtime([%{status: :ok, loaded_models: []}])
+
+      assert {:ok, [%{model_id: "granted-model", version: "v1"}]} = Playground.list_models()
+    end
+
+    test "returns no models when the effective tenant has no grants" do
+      stub_models(%{Ecto.UUID.generate() => [%{model_id: "other-tenant-model", version: "v1"}]})
+      stub_runtime([%{status: :ok, loaded_models: []}])
+
+      assert {:ok, []} = Playground.list_models()
+    end
+
     test "normalizes non-binary identity fields defensively" do
       stub_models([%{model_id: nil, version: 42}])
       stub_runtime([%{status: :ok, loaded_models: []}])
@@ -285,6 +303,57 @@ defmodule OrchardConsole.PlaygroundTest do
       assert Keyword.get(opts, :caller) == owner
     end
 
+    test "refuses to run a model the effective tenant is not granted" do
+      stub_models(%{Ecto.UUID.generate() => [%{model_id: "test-model", version: "v1"}]})
+      ref = make_ref()
+
+      stub_orchestrator(
+        prepare: {:ok, fake_canonical(), %{}},
+        execute: {:ok, fake_canonical(), []},
+        capture_opts: true
+      )
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
+
+      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+      assert error.phase == :prepare
+      assert error.code == "model_not_ready"
+      assert error.message =~ "orchardctl models access grant"
+      refute_receive {:playground, ^ref, :started, _}, 100
+      refute_receive {:captured_opts, _}, 100
+    end
+
+    test "passes the effective tenant through the preparation caller context" do
+      ref = make_ref()
+
+      stub_orchestrator(
+        prepare: {:ok, fake_canonical(), %{}},
+        execute: {:ok, fake_canonical(), []},
+        capture_caller_context: true
+      )
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
+
+      assert_receive {:captured_caller_context, caller_context}, 1000
+      assert Keyword.get(caller_context, :tenant_id) == Playground.effective_tenant_id()
+    end
+
+    test "keeps an explicit caller tenant context" do
+      ref = make_ref()
+      tenant_id = Ecto.UUID.generate()
+
+      stub_orchestrator(
+        prepare: {:ok, fake_canonical(), %{}},
+        execute: {:ok, fake_canonical(), []},
+        capture_caller_context: true
+      )
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params(), tenant_id: tenant_id)
+
+      assert_receive {:captured_caller_context, caller_context}, 1000
+      assert Keyword.get(caller_context, :tenant_id) == tenant_id
+    end
+
     test "rescues unexpected task exceptions" do
       ref = make_ref()
       stub_orchestrator(prepare: :raise)
@@ -301,10 +370,16 @@ defmodule OrchardConsole.PlaygroundTest do
   # ===========================================================================
 
   defmodule StubModels do
-    def list_active_models do
+    def list_active_models_for_tenant(tenant_id) do
       case :persistent_term.get({OrchardConsole.PlaygroundTest, :models}, []) do
-        :raise -> raise "DB unavailable"
-        models when is_list(models) -> models
+        :raise ->
+          raise "DB unavailable"
+
+        models when is_list(models) ->
+          models
+
+        grants when is_map(grants) ->
+          Map.get(grants, tenant_id, [])
       end
     end
   end
@@ -320,8 +395,13 @@ defmodule OrchardConsole.PlaygroundTest do
   end
 
   defmodule StubOrchestrator do
-    def prepare(_params, _caller_context) do
+    def prepare(_params, caller_context) do
       config = :persistent_term.get({OrchardConsole.PlaygroundTest, :orchestrator}, [])
+      test_pid = :persistent_term.get({OrchardConsole.PlaygroundTest, :test_pid}, nil)
+
+      if config[:capture_caller_context] && test_pid do
+        send(test_pid, {:captured_caller_context, caller_context})
+      end
 
       case config[:prepare] do
         :raise -> raise "Prepare exploded"

--- a/apps/orchard_controller/test/orchard/console/playground_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_test.exs
@@ -20,6 +20,7 @@ defmodule OrchardConsole.PlaygroundTest do
     on_exit(fn ->
       Application.put_env(:orchard_controller, :console, previous)
       :persistent_term.erase({__MODULE__, :models})
+      :persistent_term.erase({__MODULE__, :catalog})
       :persistent_term.erase({__MODULE__, :runtime})
       :persistent_term.erase({__MODULE__, :orchestrator})
       :persistent_term.erase({__MODULE__, :test_pid})
@@ -323,6 +324,27 @@ defmodule OrchardConsole.PlaygroundTest do
       refute_receive {:captured_opts, _}, 100
     end
 
+    test "reports a model missing from the active catalog distinctly" do
+      stub_models(%{})
+      stub_catalog([])
+      ref = make_ref()
+
+      stub_orchestrator(
+        prepare: {:ok, fake_canonical(), %{}},
+        execute: {:ok, fake_canonical(), []},
+        capture_opts: true
+      )
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
+
+      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+      assert error.phase == :prepare
+      assert error.code == "model_not_ready"
+      assert error.message =~ "not an active catalog model"
+      refute error.message =~ "orchardctl models access grant"
+      refute_receive {:captured_opts, _}, 100
+    end
+
     test "passes the effective tenant through the preparation caller context" do
       ref = make_ref()
 
@@ -371,7 +393,7 @@ defmodule OrchardConsole.PlaygroundTest do
 
   defmodule StubModels do
     def list_active_models_for_tenant(tenant_id) do
-      case :persistent_term.get({OrchardConsole.PlaygroundTest, :models}, []) do
+      case stubbed_models() do
         :raise ->
           raise "DB unavailable"
 
@@ -381,6 +403,25 @@ defmodule OrchardConsole.PlaygroundTest do
         grants when is_map(grants) ->
           Map.get(grants, tenant_id, [])
       end
+    end
+
+    def list_active_models do
+      case :persistent_term.get({OrchardConsole.PlaygroundTest, :catalog}, :derive) do
+        :derive -> derived_catalog()
+        models when is_list(models) -> models
+      end
+    end
+
+    defp derived_catalog do
+      case stubbed_models() do
+        models when is_list(models) -> models
+        grants when is_map(grants) -> grants |> Map.values() |> List.flatten()
+        _other -> []
+      end
+    end
+
+    defp stubbed_models do
+      :persistent_term.get({OrchardConsole.PlaygroundTest, :models}, [])
     end
   end
 
@@ -438,6 +479,10 @@ defmodule OrchardConsole.PlaygroundTest do
 
   defp stub_models(data) do
     :persistent_term.put({__MODULE__, :models}, data)
+  end
+
+  defp stub_catalog(data) do
+    :persistent_term.put({__MODULE__, :catalog}, data)
   end
 
   defp stub_runtime(data) do

--- a/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
@@ -18,6 +18,21 @@ defmodule Orchard.Inference.ChatErrorTest do
            }
   end
 
+  test "SPEC.md §7.2.7 maps model authorization denial to the exact public 403" do
+    mapping =
+      :model_not_authorized
+      |> ChatError.from_prepare_reason()
+      |> ChatError.api_mapping()
+
+    assert mapping == %{
+             status: :forbidden,
+             type: "invalid_request_error",
+             code: "model_not_authorized",
+             message: "Model not authorized for tenant",
+             param: "model"
+           }
+  end
+
   test "prepare model_not_found mapping preserves current status and param" do
     mapping =
       {:model_not_found, "missing@v1"}

--- a/apps/orchard_controller/test/orchard/inference/chat_orchestrator_port_mode_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_orchestrator_port_mode_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Inference.ChatOrchestratorPortModeTest do
   import Orchard.TestSupport.ToolRegistryTestSupport,
     only: [with_inference_overrides: 2, write_tokenizer_executable!: 0]
 
+  alias Orchard.Governance
   alias Orchard.Inference.ChatOrchestrator
   alias Orchard.TestSupport.ModelRequestFixtures
 
@@ -15,6 +16,8 @@ defmodule Orchard.Inference.ChatOrchestratorPortModeTest do
 
     model =
       create_port_mode_model!("file://#{@fixture_bundle}")
+
+    ModelRequestFixtures.grant_model_access!(Governance.legacy_tenant_id(), model)
 
     params = %{
       "model" => "#{model.model_id}@#{model.version}",

--- a/apps/orchard_controller/test/orchard/inference/chat_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_orchestrator_test.exs
@@ -7,7 +7,9 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
   import Orchard.TestSupport.ToolRegistryTestSupport,
     only: [fixture_bundle_path: 0, with_inference_overrides: 2, write_tokenizer_executable!: 0]
 
+  alias Orchard.Governance
   alias Orchard.Inference.ChatOrchestrator
+  alias Orchard.Models.Access
   alias Orchard.TestSupport.ModelRequestFixtures
   alias Orchard.Tools
 
@@ -58,6 +60,7 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
         "messages" => [%{"role" => "user", "content" => "Hello"}]
       }
 
+      grant_legacy_access!(model)
       assert {:ok, canonical, _model} = ChatOrchestrator.prepare(params, [])
       assert canonical.sampling.max_output_tokens == nil
     end
@@ -77,6 +80,7 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
         "max_tokens" => 50
       }
 
+      grant_legacy_access!(model)
       assert {:ok, canonical, _model} = ChatOrchestrator.prepare(params, [])
       assert canonical.sampling.max_output_tokens == 50
     end
@@ -99,6 +103,7 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
       with_inference_overrides(
         [tokenizer_mode: :fake, tokenizer_client_impl: SegmentedTokenizerClient],
         fn ->
+          grant_legacy_access!(model)
           assert {:ok, canonical, _model} = ChatOrchestrator.prepare(params, [])
           assert canonical.rendered_prompt == "segmented prompt"
           assert canonical.input_token_count == 2
@@ -123,6 +128,7 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
         "messages" => [%{"role" => "user", "content" => content}]
       }
 
+      grant_legacy_access!(model)
       assert {:ok, _canonical, returned_model} = ChatOrchestrator.prepare(params, [])
       assert returned_model.max_context_tokens == nil
     end
@@ -192,6 +198,7 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
         "tool_choice" => "none"
       }
 
+      grant_legacy_access!(model)
       assert {:ok, canonical, prepared_model} = ChatOrchestrator.prepare(params, [])
       assert prepared_model.id == model.id
 
@@ -256,6 +263,7 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
       }
 
       with_inference_overrides([tokenizer_mode: :port, tokenizer_executable: executable], fn ->
+        grant_legacy_access!(model)
         assert {:ok, canonical, _prepared_model} = ChatOrchestrator.prepare(params, [])
 
         assert canonical.tooling.requested_tools == params["tools"]
@@ -308,6 +316,10 @@ defmodule Orchard.Inference.ChatOrchestratorTest do
                 "tool ref tool://lookup_weather@2026-04-10 was not found or is not active"}}} =
                ChatOrchestrator.prepare(params, [])
     end
+  end
+
+  defp grant_legacy_access!(model) do
+    assert {:ok, _result} = Access.grant_model_access(Governance.legacy_tenant_id(), model)
   end
 
   defp create_tool!(name, version, overrides \\ %{}) do

--- a/apps/orchard_controller/test/orchard/inference/request_preparation_access_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_preparation_access_test.exs
@@ -1,0 +1,121 @@
+defmodule Orchard.Inference.RequestPreparationAccessTest do
+  use Orchard.DataCase, async: false
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  alias Orchard.Governance
+  alias Orchard.Inference.ChatOrchestrator
+  alias Orchard.Models
+  alias Orchard.Models.Access
+
+  setup do
+    suffix = System.unique_integer([:positive, :monotonic])
+    {:ok, tenant} = Governance.create_tenant(%{slug: "prepare-access-#{suffix}", name: "Prepare"})
+    model = create_model!(%{state: :active, max_context_tokens: 8_192})
+
+    %{tenant: tenant, model: model}
+  end
+
+  test "SPEC.md §5.2 denies an active ungranted Model after tokenization", %{
+    tenant: tenant,
+    model: model
+  } do
+    assert {:error, :model_not_authorized} =
+             ChatOrchestrator.prepare(params_for(model, "hello"), tenant_id: tenant.id)
+  end
+
+  test "SPEC.md §5.2 authorized requests preserve the canonical default routing snapshot", %{
+    tenant: tenant,
+    model: model
+  } do
+    grant_model_access!(tenant, model)
+
+    assert {:ok, canonical, returned_model} =
+             ChatOrchestrator.prepare(params_for(model, "hello"), tenant_id: tenant.id)
+
+    assert returned_model.id == model.id
+    assert canonical.resolved_policy.routing_policy_id == nil
+    assert canonical.resolved_policy.allowed_pool_ids == []
+    assert canonical.resolved_policy.residency_preference == :allow_cold_load
+    assert canonical.admission.max_cold_start_ms == 15_000
+    assert canonical.admission.queue_wait_ms == 3_000
+  end
+
+  test "SPEC.md §5.2 snapshots explicit routing values before execution", %{
+    tenant: tenant,
+    model: model
+  } do
+    {:ok, policy} =
+      Access.create_routing_policy(%{
+        tenant_id: tenant.id,
+        name: "loaded-only",
+        allowed_pool_ids: [],
+        preferred_pool_ids: [],
+        residency_preference: :required_loaded,
+        max_cold_start_ms: 0,
+        max_queue_wait_ms: 900,
+        priority: 1
+      })
+
+    assert {:ok, _result} = Access.grant_model_access(tenant, model, policy.id)
+
+    assert {:ok, canonical, returned_model} =
+             ChatOrchestrator.prepare(params_for(model, "hello"), tenant_id: tenant.id)
+
+    assert returned_model.id == model.id
+    assert canonical.resolved_policy.routing_policy_id == policy.id
+    assert canonical.resolved_policy.allowed_pool_ids == []
+    assert canonical.resolved_policy.residency_preference == :required_loaded
+    assert canonical.admission.max_cold_start_ms == 0
+    assert canonical.admission.queue_wait_ms == 900
+  end
+
+  test "SPEC.md §5.2 disable affects new checks without mutating an authorized snapshot", %{
+    tenant: tenant,
+    model: model
+  } do
+    grant_model_access!(tenant, model)
+
+    assert {:ok, authorized, _returned_model} =
+             ChatOrchestrator.prepare(params_for(model, "hello"), tenant_id: tenant.id)
+
+    assert {:ok, %{outcome: :disabled}} = Access.disable_model_access(tenant, model)
+    assert Models.list_active_models_for_tenant(tenant.id) == []
+
+    assert {:error, :model_not_authorized} =
+             ChatOrchestrator.prepare(params_for(model, "hello"), tenant_id: tenant.id)
+
+    assert authorized.resolved_policy.routing_policy_id == nil
+    assert authorized.resolved_policy.residency_preference == :allow_cold_load
+    assert authorized.admission.max_cold_start_ms == 15_000
+  end
+
+  test "SPEC.md §5.2 context overflow precedes model authorization denial", %{
+    tenant: tenant,
+    model: model
+  } do
+    content = Enum.map_join(1..8_200, " ", &"word#{&1}")
+
+    assert {:error, {:context_overflow, _detail}} =
+             ChatOrchestrator.prepare(params_for(model, content), tenant_id: tenant.id)
+  end
+
+  test "SPEC.md §5.2 missing Model precedence remains model_not_found", %{tenant: tenant} do
+    params = %{
+      "model" => "missing/model@v1",
+      "messages" => [%{"role" => "user", "content" => "hello"}],
+      "max_tokens" => 1
+    }
+
+    assert {:error, {:model_not_found, _detail}} =
+             ChatOrchestrator.prepare(params, tenant_id: tenant.id)
+  end
+
+  defp params_for(model, content) do
+    %{
+      "model" => "#{model.model_id}@#{model.version}",
+      "messages" => [%{"role" => "user", "content" => content}],
+      "max_tokens" => 1
+    }
+  end
+end

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -1,5 +1,6 @@
 defmodule Orchard.InferenceTest do
   use ExUnit.Case, async: false
+  import Orchard.TestSupport.ModelRequestFixtures, only: [grant_model_access!: 2]
   import Orchard.TestSupport.RepoHelpers
 
   alias Orchard.CanonicalRequest
@@ -100,7 +101,7 @@ defmodule Orchard.InferenceTest do
 
     put_inference(tokenizer_mode: :port, tokenizer_client_impl: FakeTokenizer)
 
-    assert {:ok, _model} =
+    assert {:ok, model} =
              Models.create_model(%{
                model_id: "cache-authority-model",
                version: "v1",
@@ -118,6 +119,8 @@ defmodule Orchard.InferenceTest do
                tokenizer: %{"kind" => "huggingface_tokenizer_json", "path" => "tokenizer.json"},
                runtime_requirements: %{"adapter" => "mlx_lm"}
              })
+
+    grant_model_access!(Orchard.Governance.legacy_tenant_id(), model)
 
     assert {:ok, canonical, _model} =
              ChatOrchestrator.prepare(%{

--- a/apps/orchard_controller/test/orchard/models/access_test.exs
+++ b/apps/orchard_controller/test/orchard/models/access_test.exs
@@ -1,0 +1,282 @@
+defmodule Orchard.Models.AccessTest.InvalidAuditLog do
+  alias Orchard.Governance.AuditLog
+
+  def changeset(audit_log, attrs) do
+    attrs = attrs |> Map.new() |> Map.delete(:target_type)
+    AuditLog.changeset(audit_log, attrs)
+  end
+end
+
+defmodule Orchard.Models.AccessTest do
+  use Orchard.DataCase, async: false
+
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.Governance
+  alias Orchard.Governance.{AuditLog, Tenant}
+  alias Orchard.Models.{Access, RoutingPolicy, TenantModelAccess}
+
+  setup do
+    previous = Application.get_env(:orchard_controller, :governance_audit_log_impl)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:orchard_controller, :governance_audit_log_impl, previous)
+      else
+        Application.delete_env(:orchard_controller, :governance_audit_log_impl)
+      end
+    end)
+
+    tenant = create_tenant!("access-a")
+    model = create_model!(%{state: :active})
+
+    %{tenant: tenant, model: model}
+  end
+
+  describe "routing policies" do
+    test "SPEC.md §10.9 creates and lists Tenant and global policies with atomic audit", %{
+      tenant: tenant
+    } do
+      assert {:ok, tenant_policy} =
+               Access.create_routing_policy(policy_attrs(tenant.id, "tenant-policy"),
+                 surface: :orchardctl
+               )
+
+      assert {:ok, global_policy} =
+               Access.create_routing_policy(policy_attrs(nil, "global-policy"))
+
+      assert {:ok, [listed_tenant]} = Access.list_routing_policies(tenant)
+      assert listed_tenant.id == tenant_policy.id
+
+      assert {:ok, [listed_global]} = Access.list_routing_policies(:global)
+      assert listed_global.id == global_policy.id
+
+      tenant_audit = audit_for!("routing_policy.created", tenant_policy.id)
+      assert tenant_audit.scope == "tenant"
+      assert tenant_audit.tenant_id == tenant.id
+      assert tenant_audit.payload["surface"] == "orchardctl"
+
+      global_audit = audit_for!("routing_policy.created", global_policy.id)
+      assert global_audit.scope == "cluster"
+      assert global_audit.tenant_id == nil
+    end
+
+    test "SPEC.md §10.9 rolls back policy creation when audit insertion fails", %{tenant: tenant} do
+      Application.put_env(
+        :orchard_controller,
+        :governance_audit_log_impl,
+        Orchard.Models.AccessTest.InvalidAuditLog
+      )
+
+      assert {:error, %Ecto.Changeset{}} =
+               Access.create_routing_policy(policy_attrs(tenant.id, "rolled-back"))
+
+      refute Repo.get_by(RoutingPolicy, tenant_id: tenant.id, name: "rolled-back")
+    end
+  end
+
+  describe "model access lifecycle" do
+    test "SPEC.md §5.2 and §6.6 grants deny-by-default access with canonical defaults", %{
+      tenant: tenant,
+      model: model
+    } do
+      assert {:error, :model_not_authorized} = Access.authorize(tenant.id, model.id)
+
+      assert {:ok, %{outcome: :created, access: access}} =
+               Access.grant_model_access(tenant, model, nil, surface: :orchardctl)
+
+      assert access.enabled
+      assert access.routing_policy_id == nil
+      assert {:ok, resolution} = Access.authorize(tenant.id, model.id)
+
+      assert resolution == [
+               routing_policy_id: nil,
+               allowed_pool_ids: [],
+               residency_preference: :allow_cold_load,
+               max_cold_start_ms: 15_000,
+               queue_wait_ms: 3_000
+             ]
+
+      assert {:ok, %{outcome: :unchanged}} = Access.grant_model_access(tenant, model)
+      assert audit_count("tenant_model_access.granted", access_target(tenant, model)) == 1
+    end
+
+    test "SPEC.md §10.9 attaches same-Tenant and global policies but rejects cross-Tenant policy",
+         %{tenant: tenant, model: model} do
+      other_tenant = create_tenant!("access-b")
+      own_policy = create_policy!(tenant.id, "own")
+      other_policy = create_policy!(other_tenant.id, "other")
+      global_policy = create_policy!(nil, "global")
+
+      assert {:error, :routing_policy_scope_mismatch} =
+               Access.grant_model_access(tenant, model, other_policy.id)
+
+      refute Repo.get_by(TenantModelAccess, tenant_id: tenant.id, model_id: model.id)
+
+      assert {:ok, %{outcome: :created}} =
+               Access.grant_model_access(tenant, model, own_policy.id)
+
+      assert {:ok, own_resolution} = Access.authorize(tenant.id, model.id)
+      assert own_resolution[:routing_policy_id] == own_policy.id
+      assert own_resolution[:residency_preference] == :required_loaded
+      assert own_resolution[:max_cold_start_ms] == 0
+
+      assert {:ok, %{outcome: :policy_changed}} =
+               Access.grant_model_access(tenant, model, global_policy.id)
+
+      assert {:ok, global_resolution} = Access.authorize(tenant.id, model.id)
+      assert global_resolution[:routing_policy_id] == global_policy.id
+    end
+
+    test "SPEC.md §10.9 disable preserves policy, re-enable can clear it, and no-ops do not audit",
+         %{tenant: tenant, model: model} do
+      policy = create_policy!(tenant.id, "preserved")
+      assert {:ok, %{access: granted}} = Access.grant_model_access(tenant, model, policy.id)
+
+      assert {:ok, %{outcome: :disabled, access: disabled}} =
+               Access.disable_model_access(tenant, model)
+
+      refute disabled.enabled
+      assert disabled.routing_policy_id == policy.id
+      assert {:error, :model_not_authorized} = Access.authorize(tenant.id, model.id)
+
+      assert {:ok, %{outcome: :already_disabled}} = Access.disable_model_access(tenant, model)
+
+      target = access_target(tenant, model)
+      assert audit_count("tenant_model_access.disabled", target) == 1
+
+      assert {:ok, %{outcome: :enabled, access: enabled}} =
+               Access.grant_model_access(tenant, model)
+
+      assert enabled.enabled
+      assert enabled.routing_policy_id == nil
+      assert audit_count("tenant_model_access.enabled", target) == 1
+      assert granted.tenant_id == tenant.id
+    end
+
+    test "SPEC.md §10.9 revoke removes only access and repeated revoke is deterministic", %{
+      tenant: tenant,
+      model: model
+    } do
+      policy = create_policy!(tenant.id, "retained")
+      assert {:ok, %{outcome: :created}} = Access.grant_model_access(tenant, model, policy.id)
+
+      assert {:ok, %{outcome: :revoked}} = Access.revoke_model_access(tenant, model)
+      assert Repo.get(RoutingPolicy, policy.id)
+      refute Repo.get_by(TenantModelAccess, tenant_id: tenant.id, model_id: model.id)
+      assert {:error, :model_not_authorized} = Access.authorize(tenant.id, model.id)
+
+      assert {:ok, %{outcome: :not_granted}} = Access.revoke_model_access(tenant, model)
+      assert audit_count("tenant_model_access.revoked", access_target(tenant, model)) == 1
+    end
+
+    test "SPEC.md §5.2 isolates authorization and listing between Tenants", %{
+      tenant: tenant,
+      model: model
+    } do
+      other_tenant = create_tenant!("access-c")
+      assert {:ok, %{outcome: :created}} = Access.grant_model_access(tenant, model)
+
+      assert {:ok, _resolution} = Access.authorize(tenant.id, model.id)
+      assert {:error, :model_not_authorized} = Access.authorize(other_tenant.id, model.id)
+
+      assert {:ok, [listed]} = Access.list_model_access(tenant)
+      assert listed.model.id == model.id
+      assert {:ok, []} = Access.list_model_access(other_tenant)
+    end
+
+    test "SPEC.md §10.9 concurrent grants are idempotent and write one audit row", %{
+      tenant: tenant,
+      model: model
+    } do
+      parent = self()
+      start_ref = make_ref()
+
+      task = fn ->
+        Task.async(fn ->
+          Sandbox.allow(Repo, parent, self())
+          send(parent, {:grant_ready, self()})
+
+          receive do
+            ^start_ref -> Access.grant_model_access(tenant, model)
+          end
+        end)
+      end
+
+      task_one = task.()
+      task_two = task.()
+      assert_receive {:grant_ready, _pid}, 1_000
+      assert_receive {:grant_ready, _pid}, 1_000
+      send(task_one.pid, start_ref)
+      send(task_two.pid, start_ref)
+
+      results = [Task.await(task_one, 5_000), Task.await(task_two, 5_000)]
+      outcomes = Enum.map(results, fn {:ok, result} -> result.outcome end)
+      assert Enum.sort(outcomes) == [:created, :unchanged]
+
+      assert Repo.aggregate(
+               from(access in TenantModelAccess,
+                 where: access.tenant_id == ^tenant.id and access.model_id == ^model.id
+               ),
+               :count
+             ) == 1
+
+      assert audit_count("tenant_model_access.granted", access_target(tenant, model)) == 1
+    end
+
+    test "SPEC.md §10.9 rolls back grant state when audit insertion fails", %{
+      tenant: tenant,
+      model: model
+    } do
+      Application.put_env(
+        :orchard_controller,
+        :governance_audit_log_impl,
+        Orchard.Models.AccessTest.InvalidAuditLog
+      )
+
+      assert {:error, %Ecto.Changeset{}} = Access.grant_model_access(tenant, model)
+      refute Repo.get_by(TenantModelAccess, tenant_id: tenant.id, model_id: model.id)
+    end
+  end
+
+  defp create_tenant!(prefix) do
+    suffix = System.unique_integer([:positive, :monotonic])
+    {:ok, tenant} = Governance.create_tenant(%{slug: "#{prefix}-#{suffix}", name: prefix})
+    tenant
+  end
+
+  defp policy_attrs(tenant_id, name) do
+    %{
+      tenant_id: tenant_id,
+      name: name,
+      residency_preference: :required_loaded,
+      max_cold_start_ms: 0,
+      max_queue_wait_ms: 750,
+      priority: 10,
+      allowed_pool_ids: [],
+      preferred_pool_ids: []
+    }
+  end
+
+  defp create_policy!(tenant_id, name) do
+    {:ok, policy} = Access.create_routing_policy(policy_attrs(tenant_id, name))
+    policy
+  end
+
+  defp audit_for!(action, target_id) do
+    Repo.get_by!(AuditLog, action: action, target_id: target_id)
+  end
+
+  defp audit_count(action, target_id) do
+    Repo.aggregate(
+      from(audit in AuditLog,
+        where: audit.action == ^action and audit.target_id == ^target_id
+      ),
+      :count,
+      :id
+    )
+  end
+
+  defp access_target(%Tenant{id: tenant_id}, model), do: "#{tenant_id}:#{model.id}"
+end

--- a/apps/orchard_controller/test/orchard/repo/migrations/governance_db_foundation_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/governance_db_foundation_test.exs
@@ -20,6 +20,7 @@ defmodule Orchard.Repo.Migrations.GovernanceDbFoundationTest do
   end
 
   test "recreates governance tables and the legacy sentinel tenant across down/up" do
+    remove_later_dependent_schema()
     run_down_sql()
     refute table_exists?("tenants")
     refute table_exists?("api_keys")
@@ -54,6 +55,13 @@ defmodule Orchard.Repo.Migrations.GovernanceDbFoundationTest do
                Governance.legacy_tenant_name()
              ]
            ]
+  end
+
+  defp remove_later_dependent_schema do
+    # This test isolates an older migration. In real rollback order, later
+    # migrations remove these foreign-key dependants before governance tables.
+    Repo.query!("DROP TABLE IF EXISTS tenant_model_access")
+    Repo.query!("DROP TABLE IF EXISTS routing_policies")
   end
 
   defp run_up_sql do

--- a/apps/orchard_controller/test/orchard/repo/migrations/tenant_model_access_migration_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/tenant_model_access_migration_test.exs
@@ -1,0 +1,299 @@
+defmodule Orchard.Repo.Migrations.TenantModelAccessMigrationTest do
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.{Governance, Models, Repo}
+
+  setup do
+    :ok = Sandbox.checkout(Repo)
+
+    {:ok, tenant_a} = create_tenant("a")
+    {:ok, tenant_b} = create_tenant("b")
+    {:ok, model} = create_model()
+
+    %{model: model, tenant_a: tenant_a, tenant_b: tenant_b}
+  end
+
+  test "SPEC.md §10.9 makes Tenant and Model the unique access identity", context do
+    assert {:ok, _result} = insert_access(context.tenant_a.id, context.model.id, nil)
+
+    assert {:error, %Postgrex.Error{postgres: %{constraint: "tenant_model_access_pkey"}}} =
+             insert_access(context.tenant_a.id, context.model.id, nil)
+  end
+
+  test "SPEC.md §10.9 accepts same-Tenant and explicit global routing policies", context do
+    tenant_policy_id = insert_policy!(context.tenant_a.id, "tenant-policy")
+    global_policy_id = insert_policy!(nil, "global-policy")
+
+    assert {:ok, _result} =
+             insert_access(context.tenant_a.id, context.model.id, tenant_policy_id)
+
+    other_model = create_model!("global-policy-model")
+
+    assert {:ok, _result} =
+             insert_access(context.tenant_b.id, other_model.id, global_policy_id)
+  end
+
+  test "SPEC.md §10.9 rejects cross-Tenant routing policy attachment", context do
+    policy_id = insert_policy!(context.tenant_a.id, "tenant-a-only")
+
+    assert {:error,
+            %Postgrex.Error{
+              postgres: %{constraint: "tenant_model_access_routing_policy_scope"}
+            }} = insert_access(context.tenant_b.id, context.model.id, policy_id)
+  end
+
+  test "ADR 0021 keeps routing policy Tenant scope immutable", context do
+    policy_id = insert_policy!(context.tenant_a.id, "immutable-scope")
+
+    assert {:error, %Postgrex.Error{postgres: %{constraint: "routing_policies_tenant_immutable"}}} =
+             Repo.query("UPDATE routing_policies SET tenant_id = $1 WHERE id = $2", [
+               dump_uuid(context.tenant_b.id),
+               dump_uuid(policy_id)
+             ])
+  end
+
+  test "ADR 0021 rejects pool constraints before scheduler enforcement", context do
+    assert {:error,
+            %Postgrex.Error{
+              postgres: %{constraint: "routing_policies_pool_constraints_deferred"}
+            }} =
+             Repo.query(
+               """
+               INSERT INTO routing_policies (
+                 tenant_id,
+                 name,
+                 allowed_pool_ids,
+                 preferred_pool_ids,
+                 residency_preference,
+                 max_cold_start_ms,
+                 max_queue_wait_ms,
+                 priority,
+                 inserted_at,
+                 updated_at
+               )
+               VALUES ($1, 'invalid-pools', ARRAY[$2]::uuid[], '{}'::uuid[],
+                       'allow_cold_load', 15000, 3000, 100, NOW(), NOW())
+               """,
+               [dump_uuid(context.tenant_a.id), dump_uuid(Ecto.UUID.generate())]
+             )
+  end
+
+  test "ADR 0021 requires an explicit routing policy residency preference", context do
+    assert {:error, %Postgrex.Error{postgres: %{column: "residency_preference"}}} =
+             Repo.query(
+               """
+               INSERT INTO routing_policies (
+                 tenant_id,
+                 name,
+                 allowed_pool_ids,
+                 preferred_pool_ids,
+                 max_cold_start_ms,
+                 max_queue_wait_ms,
+                 priority,
+                 inserted_at,
+                 updated_at
+               )
+               VALUES ($1, 'missing-residency', '{}'::uuid[], '{}'::uuid[],
+                       15000, 3000, 100, NOW(), NOW())
+               """,
+               [dump_uuid(context.tenant_a.id)]
+             )
+  end
+
+  test "SPEC.md §10.9 rejects invalid routing policy budgets", context do
+    assert {:error,
+            %Postgrex.Error{postgres: %{constraint: "routing_policies_budgets_non_negative"}}} =
+             Repo.query(
+               """
+               INSERT INTO routing_policies (
+                 tenant_id,
+                 name,
+                 allowed_pool_ids,
+                 preferred_pool_ids,
+                 residency_preference,
+                 max_cold_start_ms,
+                 max_queue_wait_ms,
+                 priority,
+                 inserted_at,
+                 updated_at
+               )
+               VALUES ($1, 'negative-budget', '{}'::uuid[], '{}'::uuid[],
+                       'allow_cold_load', -1, 3000, 100, NOW(), NOW())
+               """,
+               [dump_uuid(context.tenant_a.id)]
+             )
+  end
+
+  test "SPEC.md §10.9 rejects invalid routing policy residency", context do
+    assert {:error,
+            %Postgrex.Error{
+              postgres: %{constraint: "routing_policies_residency_preference_closed"}
+            }} =
+             Repo.query(
+               """
+               INSERT INTO routing_policies (
+                 tenant_id,
+                 name,
+                 allowed_pool_ids,
+                 preferred_pool_ids,
+                 residency_preference,
+                 max_cold_start_ms,
+                 max_queue_wait_ms,
+                 priority,
+                 inserted_at,
+                 updated_at
+               )
+               VALUES ($1, 'invalid-residency', '{}'::uuid[], '{}'::uuid[],
+                       'anywhere', 15000, 3000, 100, NOW(), NOW())
+               """,
+               [dump_uuid(context.tenant_a.id)]
+             )
+  end
+
+  test "ADR 0021 restricts Tenant deletion while it owns a routing policy" do
+    tenant_id = insert_tenant!("policy-owner")
+    _policy_id = insert_policy!(tenant_id, "owned-policy")
+
+    assert {:error, %Postgrex.Error{postgres: %{constraint: "routing_policies_tenant_id_fkey"}}} =
+             Repo.query("DELETE FROM tenants WHERE id = $1", [dump_uuid(tenant_id)])
+  end
+
+  test "SPEC.md §10.9 cascades access when its Model is deleted", context do
+    assert {:ok, _result} = insert_access(context.tenant_a.id, context.model.id, nil)
+    assert access_count(context.tenant_a.id, context.model.id) == 1
+
+    assert {:ok, _model} = Repo.delete(context.model)
+    assert access_count(context.tenant_a.id, context.model.id) == 0
+  end
+
+  test "SPEC.md §10.9 restricts policy deletion while access references it", context do
+    policy_id = insert_policy!(context.tenant_a.id, "retained-policy")
+    assert {:ok, _result} = insert_access(context.tenant_a.id, context.model.id, policy_id)
+
+    assert {:error,
+            %Postgrex.Error{
+              postgres: %{constraint: "tenant_model_access_routing_policy_id_fkey"}
+            }} =
+             Repo.query("DELETE FROM routing_policies WHERE id = $1", [dump_uuid(policy_id)])
+  end
+
+  test "SPEC.md §10.9 cascades access when its Tenant is deleted", context do
+    tenant_id = insert_tenant!("cascade")
+
+    assert {:ok, _result} = insert_access(tenant_id, context.model.id, nil)
+    assert access_count(tenant_id, context.model.id) == 1
+
+    assert {:ok, %{num_rows: 1}} =
+             Repo.query("DELETE FROM tenants WHERE id = $1", [dump_uuid(tenant_id)])
+
+    assert access_count(tenant_id, context.model.id) == 0
+  end
+
+  defp create_tenant(suffix) do
+    Governance.create_tenant(%{
+      slug: "tenant-model-migration-#{suffix}-#{System.unique_integer([:positive])}",
+      name: "Tenant Model Migration #{suffix}"
+    })
+  end
+
+  defp create_model do
+    create_model("tenant-model-migration-#{System.unique_integer([:positive])}")
+  end
+
+  defp create_model!(model_id) do
+    {:ok, model} = create_model(model_id)
+    model
+  end
+
+  defp create_model(model_id) do
+    Models.create_model(%{
+      model_id: model_id,
+      version: "v1",
+      state: :active,
+      format: "mlx",
+      capabilities: ["chat"],
+      tokenizer: %{},
+      artifact_uri: "file:///tmp/#{model_id}",
+      artifact_sha256: String.duplicate("a", 64),
+      artifact_size_bytes: 1,
+      resident_memory_bytes: 1,
+      kv_cache_bytes_per_token: 1,
+      prefill_workspace_bytes_per_token: 1,
+      runtime_requirements: %{}
+    })
+  end
+
+  defp insert_tenant!(suffix) do
+    assert {:ok, %{rows: [[tenant_id]]}} =
+             Repo.query(
+               """
+               INSERT INTO tenants (slug, name, request_body_capture_mode, inserted_at, updated_at)
+               VALUES ($1, $2, 'metadata', NOW(), NOW())
+               RETURNING id
+               """,
+               [
+                 "tenant-model-raw-#{suffix}-#{System.unique_integer([:positive])}",
+                 "Tenant Model Raw #{suffix}"
+               ]
+             )
+
+    Ecto.UUID.load!(tenant_id)
+  end
+
+  defp insert_policy!(tenant_id, name) do
+    assert {:ok, %{rows: [[policy_id]]}} =
+             Repo.query(
+               """
+               INSERT INTO routing_policies (
+                 tenant_id,
+                 name,
+                 allowed_pool_ids,
+                 preferred_pool_ids,
+                 residency_preference,
+                 max_cold_start_ms,
+                 max_queue_wait_ms,
+                 priority,
+                 inserted_at,
+                 updated_at
+               )
+               VALUES ($1, $2, '{}'::uuid[], '{}'::uuid[],
+                       'allow_cold_load', 15000, 3000, 100, NOW(), NOW())
+               RETURNING id
+               """,
+               [dump_uuid(tenant_id), name]
+             )
+
+    Ecto.UUID.load!(policy_id)
+  end
+
+  defp insert_access(tenant_id, model_id, policy_id) do
+    Repo.query(
+      """
+      INSERT INTO tenant_model_access (
+        tenant_id,
+        model_id,
+        enabled,
+        routing_policy_id,
+        inserted_at,
+        updated_at
+      )
+      VALUES ($1, $2, true, $3, NOW(), NOW())
+      """,
+      [dump_uuid(tenant_id), dump_uuid(model_id), dump_uuid(policy_id)]
+    )
+  end
+
+  defp access_count(tenant_id, model_id) do
+    %{num_rows: count} =
+      Repo.query!(
+        "SELECT 1 FROM tenant_model_access WHERE tenant_id = $1 AND model_id = $2",
+        [dump_uuid(tenant_id), dump_uuid(model_id)]
+      )
+
+    count
+  end
+
+  defp dump_uuid(nil), do: nil
+  defp dump_uuid(value), do: Ecto.UUID.dump!(value)
+end

--- a/apps/orchard_controller/test/support/model_request_fixtures.ex
+++ b/apps/orchard_controller/test/support/model_request_fixtures.ex
@@ -16,7 +16,7 @@ defmodule Orchard.TestSupport.ModelRequestFixtures do
   """
 
   alias Orchard.Models
-  alias Orchard.Models.Importer
+  alias Orchard.Models.{Access, Importer}
   alias Orchard.Requests
 
   @doc """
@@ -61,6 +61,20 @@ defmodule Orchard.TestSupport.ModelRequestFixtures do
     case Models.create_model(attrs) do
       {:ok, model} -> model
       {:error, changeset} -> raise "create_model! failed: #{inspect(changeset.errors)}"
+    end
+  end
+
+  @doc """
+  Explicitly grants a Tenant access to a Model and returns the access row.
+
+  Accepts the same Tenant and Model identifiers as
+  `Orchard.Models.Access.grant_model_access/4`. Repeated calls are safe and
+  return the existing grant.
+  """
+  def grant_model_access!(tenant_or_id, model_or_id, routing_policy_id \\ nil) do
+    case Access.grant_model_access(tenant_or_id, model_or_id, routing_policy_id) do
+      {:ok, %{access: access}} -> access
+      {:error, reason} -> raise "grant_model_access! failed: #{inspect(reason)}"
     end
   end
 

--- a/docs/decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md
+++ b/docs/decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md
@@ -32,7 +32,11 @@ Authorization occurs at shared request preparation after Model validation, token
 Denial occurs before Request persistence, quota, queueing, scheduling, Node contact, Model loading, or inference execution.
 
 The first supported operator surface is local `orchardctl models` commands for policy create/list/inspect and access grant/disable/revoke/list/inspect.
-A partial Admin API or Console surface is not required for the first slice.
+A partial Admin API or Console management surface is not required for the first slice.
+
+The Console Playground is an inference consumer, not a management surface.
+It has no per-Tenant operator credential, so its effective Tenant is the seeded legacy Tenant.
+It lists and runs only Models with an enabled grant for that Tenant and receives no bypass and no automatic grant.
 
 Authorized Requests persist the resolved routing snapshot.
 A later disable, revoke, or policy mutation governs new checks and does not retroactively cancel an already authorized Request.
@@ -42,6 +46,9 @@ A later disable, revoke, or policy mutation governs new checks and does not retr
 Upgrading Controllers is intentionally fail-closed until operators create explicit grants.
 The rollout must stop or drain public inference, migrate, grant, verify positive and negative Tenant behavior, and only then expose the upgraded Controller.
 There is no temporary global-access feature flag.
+
+Because the Console Playground shares the seeded legacy Tenant, granting a Model so operators can use the Playground also authorizes every existing legacy-Tenant API credential for that Model on `/v1`.
+Operators who want Playground access separated from legacy API credentials must retire or re-scope those credentials; a Console-only grant scope requires a later Console identity decision.
 
 Application rollback to code that ignores grants reintroduces the access-control defect and is not security-preserving.
 Pool-routing enforcement requires a later contract and scheduler change before non-empty pool arrays can be accepted.

--- a/docs/decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md
+++ b/docs/decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md
@@ -1,0 +1,56 @@
+# ADR: Explicit Tenant-model grants and routing snapshots
+
+## Status
+
+Accepted.
+
+## Context
+
+`SPEC.md` requires active catalog state, an enabled Tenant grant, and routing resolution before a Model is visible or usable by a public inference caller.
+Current code resolves an effective Tenant but lists every active Model and accepts any active Model during shared request preparation.
+The apex schema permits Tenant-scoped and global routing policies and allows a grant to omit a policy, but it does not define an implicit global-policy selection order, migration backfill, or whether disable and revoke are identical.
+The scheduler does not yet enforce pool allowlists or preferences.
+
+## Decision
+
+Model access is deny-by-default and keyed only by effective Tenant plus catalog Model.
+Existing active Models, existing Tenants, and the legacy Tenant receive no automatic grants.
+
+An enabled access row authorizes new listing and inference checks.
+Disable preserves the row and its policy while denying access.
+Revoke deletes only the access row.
+Repeated desired-state operations are deterministic and do not create duplicate audits.
+
+A null routing-policy reference resolves directly to canonical `AdmissionPolicy` defaults.
+Orchard does not implicitly select a global policy by name, priority, creation order, or scope.
+An explicit policy must be global or owned by the same Tenant; the database enforces that boundary.
+
+The initial routing-policy surface requires empty pool allowlists and preferences because the scheduler cannot yet enforce them.
+No operator interface claims pool isolation before that enforcement exists.
+
+Authorization occurs at shared request preparation after Model validation, tokenization, and context-limit enforcement, preserving `SPEC.md` failure precedence.
+Denial occurs before Request persistence, quota, queueing, scheduling, Node contact, Model loading, or inference execution.
+
+The first supported operator surface is local `orchardctl models` commands for policy create/list/inspect and access grant/disable/revoke/list/inspect.
+A partial Admin API or Console surface is not required for the first slice.
+
+Authorized Requests persist the resolved routing snapshot.
+A later disable, revoke, or policy mutation governs new checks and does not retroactively cancel an already authorized Request.
+
+## Consequences
+
+Upgrading Controllers is intentionally fail-closed until operators create explicit grants.
+The rollout must stop or drain public inference, migrate, grant, verify positive and negative Tenant behavior, and only then expose the upgraded Controller.
+There is no temporary global-access feature flag.
+
+Application rollback to code that ignores grants reintroduces the access-control defect and is not security-preserving.
+Pool-routing enforcement requires a later contract and scheduler change before non-empty pool arrays can be accepted.
+
+State-changing policy and access operations require atomic append-only audit evidence without credentials, artifact paths, prompts, or responses.
+
+## SPEC.md impact
+
+No apex behavior is weakened.
+This decision implements and makes explicit the operational choices under `SPEC.md` §5.2, §6.6, §7.2, §10.9, and the persisted `routing_policies` and `tenant_model_access` relations.
+
+The associated OpenSpec change is `openspec/changes/tenant-model-grants/` and issue #219 owns implementation.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,4 +23,4 @@ Start from [`_template.md`](_template.md) when useful. Decisions already fixed b
 
 ## Decision index
 
-The current sequence ends with [ADR 0020: Portal User is a portal-scoped minting-gate identity](0020-portal-user-is-not-a-platform-principal.md).
+The current sequence ends with [ADR 0021: Explicit Tenant-model grants and routing snapshots](0021-explicit-tenant-model-grants-and-routing-snapshots.md).

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -523,7 +523,7 @@ Worker Unix domain sockets default to `/tmp/od-<hash>/ws`, outside the repo tree
 | GET | `/health/ready` | Status-only readiness probe (`{"status":"ok"}` or `{"status":"error"}`) |
 | GET | `/ops/v1/health` | Detailed readiness and observations; cluster Operator/admin Bearer token required |
 | GET | `/metrics` | Prometheus exposition on the same listener; cluster Operator/admin Bearer token required; `503` when valid exposition cannot be produced |
-| GET | `/v1/models` | List active models; Bearer token required |
+| GET | `/v1/models` | List active models granted to the calling Tenant; Bearer token required |
 | POST | `/v1/chat/completions` | Chat completion; stream + non-stream; Bearer token required |
 | POST | `/v1/responses` | Bounded Responses API subset; stream + non-stream; Bearer token required |
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -62,6 +62,12 @@ OrchardCLI.main(["models", "import", "/path/to/model-bundle", "--activate"])
 # 4. Create an Organization and direct API Token for /v1 API calls (in the running IEx session)
 OrchardCLI.main(["tenants", "create", "--slug", "dev", "--name", "Dev"])
 OrchardCLI.main(["api-keys", "create", "--tenant-id", "<tenant-id>", "--name", "dev"])
+
+# 5. Grant the Tenant explicit access to the Model (nothing is granted automatically)
+OrchardCLI.main(["models", "access", "grant", "<model_id>@<version>", "--tenant", "dev"])
+
+# 6. Grant the Console Playground Tenant as well (the Console runs as the seeded `legacy` Tenant)
+OrchardCLI.main(["models", "access", "grant", "<model_id>@<version>", "--tenant", "legacy"])
 ```
 
 `make dev` wraps `mise exec -- bin/dev`. `bin/dev` is the single low-level
@@ -74,7 +80,22 @@ gRPC server on `127.0.0.1:50071`.
 Copy the API Token printed by `api-keys create` into
 `ORCHARD_API_KEY` for the `curl` examples below.
 
+Model access is deny-by-default. Any Model without an enabled grant for the
+calling Tenant is omitted from `GET /v1/models` and rejected by
+`/v1/chat/completions` and `/v1/responses` with `403 model_not_authorized`.
+No Tenant — including the seeded `legacy` Tenant — receives an automatic grant,
+so step 5 is required before any `/v1` inference call succeeds. The Console
+Playground runs as the `legacy` Tenant and lists only Models granted to it, so
+step 6 is required before it can send a message. See
+`../apps/orchard_cli/README.md` for the full `orchardctl models access` and
+`orchardctl models routing-policy` surface.
+
 ## Phase 0 observability acceptance probe
+
+The probe posts to `/v1/responses` with a Tenant token, so the probe Model must
+already be granted to that token's Tenant with
+`orchardctl models access grant <model_id@version> --tenant <uuid-or-slug>`.
+An ungranted Model fails the probe with `403 model_not_authorized`.
 
 Copy `scripts/support/observability_probe.example.json` to a non-secret local
 configuration, set the two environment variables named by that file, and run:
@@ -779,8 +800,8 @@ Run this before the first Topology B / two-Mac BEAM smoke on macOS.
 
 1. Console Nodes should show the configured Runtime Endpoint targets with distinct display names and reachable status with distinct display names and reachable status.
 2. The BEAM smoke should include both the controller-side node-agent and the remote node-agent when validating local and remote reachability.
-3. `GET /v1/models` should return `200`.
-4. `POST /v1/chat/completions` should complete through the Console Playground or an equivalent API request.
+3. `GET /v1/models` should return `200` and list the Models granted to the calling Tenant.
+4. `POST /v1/chat/completions` should complete through the Console Playground or an equivalent API request, after the Model is granted to the calling Tenant (`legacy` for the Console Playground).
 5. Cluster summary should show the configured target count for the selected transport.
 6. Playground inference should attribute requests to specific nodes when the scheduler has multiple eligible targets.
 7. Killing the remote node-agent should transition its health to degraded or unreachable.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -86,9 +86,12 @@ calling Tenant is omitted from `GET /v1/models` and rejected by
 No Tenant — including the seeded `legacy` Tenant — receives an automatic grant,
 so step 5 is required before any `/v1` inference call succeeds. The Console
 Playground runs as the `legacy` Tenant and lists only Models granted to it, so
-step 6 is required before it can send a message. See
-`../apps/orchard_cli/README.md` for the full `orchardctl models access` and
-`orchardctl models routing-policy` surface.
+step 6 is required before it can send a message. Because the Console shares the
+`legacy` Tenant, that grant also authorizes any existing `legacy`-Tenant API
+credential for the same Model on `/v1`. See `../apps/orchard_cli/README.md` for
+the full `orchardctl models access` and `orchardctl models routing-policy`
+surface, and `decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md`
+for the decision record.
 
 ## Phase 0 observability acceptance probe
 

--- a/docs/operator-journey.md
+++ b/docs/operator-journey.md
@@ -132,9 +132,10 @@ After Console is reachable, the operator currently:
 2. Creates a tenant-direct API Token for bootstrap or manual use, or provisions an API Client and API Token for a named non-interactive principal.
 3. Stores the one-time API Token output securely.
 4. Imports and activates a Model Bundle.
-5. Verifies that the model source is reachable by the Node Agent that will load it.
-6. Confirms `/v1/models` lists the active model.
-7. Runs a small request through Playground or the Public Inference API.
+5. Grants the Model to each approved Organization with `orchardctl models access grant`; activation alone authorizes nothing, and the Console Playground needs the same grant for the seeded `legacy` Tenant.
+6. Verifies that the model source is reachable by the Node Agent that will load it.
+7. Confirms `/v1/models` lists the granted active model.
+8. Runs a small request through Playground or the Public Inference API.
 
 The current local-file import path is not controller-hosted model distribution.
 For a remote worker, the operator must pre-stage the same model at a usable path or use another worker-reachable source supported by the lower-level acquisition path.
@@ -170,6 +171,7 @@ Future implementation PRs should record sanitized timings against the measuremen
 | Static target missing or wrong | Console diagnostics and scheduler cannot reach the intended Node Agent. | Correct the Controller target list and restart or reconfigure the Controller. |
 | Endpoint observed but not trusted | Admission execution remains blocked and the endpoint is not schedulable. | Complete the future certificate-backed registration flow when implemented; observation alone is insufficient. |
 | Lost first-admin credential | Admin API access is unavailable. | Use local `orchardctl cluster init --force-new-admin --yes` break-glass recovery and audit the new credential. |
+| Model activated but not granted to the calling Organization | `/v1/models` omits the model and inference fails with `403 model_not_authorized`. | Grant the Tenant/Model pair with `orchardctl models access grant`; see [`../apps/orchard_cli/README.md`](../apps/orchard_cli/README.md). |
 | Controller-local model source on a remote worker | Model acquisition fails with an unavailable path or artifact. | Pre-stage the verified bundle on the worker or provide a worker-reachable source. |
 | Worker or Controller upgrade interrupts readiness | Service status, heartbeat, or requests become unavailable. | Follow the packaging runbook's service-level backup, preflight, update, and health checks, and use cordon, drain, and resume only where lifecycle-managed Nodes exist. |
 

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -19,7 +19,9 @@ Before opening the window:
 1. Controller and at least one healthy worker are up.
 2. End-to-end inference works from outside the box on the APIs offered to clients.
 3. One tenant exists, with per-user API clients/tokens where practical.
-4. At least one operator-chosen model is loaded on a schedulable node.
+4. At least one operator-chosen model is loaded on a schedulable node and
+   granted to the pilot tenant with `orchardctl models access grant`; model
+   access is deny-by-default and nothing is granted automatically.
 5. Operators can inspect requests, restart a node, and revoke a token.
 6. Clients have a short note covering allowed content, support hours, contact path, and stop authority.
 

--- a/openspec/changes/tenant-model-grants/design.md
+++ b/openspec/changes/tenant-model-grants/design.md
@@ -1,0 +1,174 @@
+# Design: tenant-scoped model grants and routing snapshots
+
+## Context
+
+Public authentication already resolves one effective `tenant_id` for both Tenant-direct and Service Account credentials. The authorization gap begins after that point:
+
+- `/v1/models` calls a global active-catalog query;
+- shared request preparation accepts any active catalog Model;
+- no tenant-model access or routing-policy relation exists;
+- no supported operator lifecycle can grant or revoke access; and
+- no exact `model_not_authorized` public error is emitted.
+
+`RequestPreparation` is the shared Chat Completions and Responses boundary. It completes before `RequestOrchestrator` creates a durable Request or reaches quota, queue, scheduler, Node, model-load, or inference execution paths.
+
+## Decisions
+
+### 1. Access is deny-by-default and keyed by effective Tenant
+
+An enabled `tenant_model_access` row for `(tenant_id, model_id)` authorizes a new listing or inference check. A missing or disabled row does not.
+
+Credential principal type, Service Account identity, Owner Contact, Team, API Key ownership form, and credential metadata do not create or widen model access. Both credential forms use the effective Tenant already assigned by `RequestContext`.
+
+Existing Models and Tenants receive no migration backfill. The legacy Tenant has no special implicit access.
+
+### 2. Disable and revoke are distinct
+
+- **Disable** sets `enabled=false` and preserves the attached policy for later review or re-enable.
+- **Revoke** deletes the access row and leaves the routing-policy row unchanged.
+- Repeated desired-state operations are deterministic and succeed without duplicate audit rows.
+
+A grant creates a missing row, re-enables a disabled row, or replaces/clears its explicit policy. Omitting a policy explicitly selects canonical defaults.
+
+### 3. Null policy means canonical defaults only
+
+A null `routing_policy_id` resolves directly to the defaults owned by `AdmissionPolicy`:
+
+- `routing_policy_id: nil`;
+- `allowed_pool_ids: []`;
+- `residency_preference: :allow_cold_load`;
+- `max_cold_start_ms: 15_000`; and
+- `queue_wait_ms: 3_000`.
+
+Orchard does not implicitly search global policies by name, priority, creation time, or any other order.
+
+### 4. Explicit policies are Tenant-scoped or global
+
+A grant may reference:
+
+- a policy owned by the same Tenant; or
+- a global policy whose `tenant_id` is null.
+
+A database integrity trigger rejects cross-Tenant policy attachment. Application validation provides a friendly error but is not the integrity boundary. Policy Tenant scope is immutable after creation.
+
+### 5. Pool constraints are not claimed before scheduler support
+
+The current scheduler consumes residency preference and cold-start budgets but does not enforce `allowed_pool_ids` or `preferred_pool_ids`.
+
+This slice persists the apex policy shape but requires both arrays to be empty. The CLI does not expose pool flags. A later scheduler change must remove that constraint only with its own contract, enforcement, and tests.
+
+Policy priority is stored as a constrained value for schema compatibility but is not used for implicit selection.
+
+### 6. Authorization preserves apex failure precedence
+
+Shared preparation performs:
+
+1. request validation and canonicalization;
+2. Model identity and active-state resolution;
+3. tool support validation;
+4. tokenization;
+5. context-limit enforcement;
+6. Tenant-model authorization and routing resolution; and
+7. return of the authorized canonical snapshot.
+
+This preserves `SPEC.md` §5.2. An unauthorized request may contact the tokenizer, but it cannot create a Request, reserve quota, enter a queue, schedule, contact a Node, load a Model, or execute inference.
+
+Missing or inactive Models remain `404 model_not_found`. An existing active Model without an enabled grant returns exact `403 model_not_authorized` with `param=model`.
+
+### 7. Routing is snapshotted into the canonical Request
+
+Authorization returns the resolved policy values. `AdmissionPolicy.resolve/2` applies them to the canonical Request before `RequestOrchestrator` persists it.
+
+The persisted snapshot, not a later mutable policy lookup, governs the accepted Request. Disable, revoke, or later policy changes apply to new authorization checks and do not cancel already authorized Requests.
+
+### 8. The first operator surface is local `orchardctl`
+
+The first slice extends the existing Repo-backed `orchardctl models` command group:
+
+```text
+orchardctl models access grant <model_id@version> --tenant <uuid-or-slug> [--routing-policy-id <uuid>]
+orchardctl models access disable <model_id@version> --tenant <uuid-or-slug>
+orchardctl models access revoke <model_id@version> --tenant <uuid-or-slug>
+orchardctl models access list --tenant <uuid-or-slug>
+orchardctl models access inspect <model_id@version> --tenant <uuid-or-slug>
+
+orchardctl models routing-policy create (--tenant <uuid-or-slug> | --global) --name <name> --residency-preference <value> [--max-cold-start-ms <n>] [--max-queue-wait-ms <n>]
+orchardctl models routing-policy list (--tenant <uuid-or-slug> | --global)
+orchardctl models routing-policy inspect --id <uuid>
+```
+
+The CLI validates Model and Tenant identities before reporting idempotent outcomes. Policy references are UUID-only to avoid ambiguous lookup.
+
+A partial Admin API or Console surface would expand authorization and compatibility scope without being required to close the public inference defect.
+
+### 9. State changes and audit evidence are atomic
+
+Grant, re-enable, policy replacement, disable, revoke, and policy creation use `AuditWriter.transaction/1`. Mutation and append-only audit either both commit or both roll back.
+
+No-op operations emit no duplicate audit. Payloads may include Tenant, Model, previous/new policy IDs, transition, and operator surface. They exclude credentials, artifact paths, prompts, responses, and raw model content.
+
+### 10. Public authorization is uncached
+
+Listing and authorization query Postgres for each operation. A committed disable or revoke therefore affects the next listing and new preparation check without an invalidation channel.
+
+## Persistence
+
+### `routing_policies`
+
+- UUID primary key.
+- Nullable Tenant FK; null denotes an explicitly shareable global policy.
+- Nonblank name.
+- Empty UUID arrays for allowed and preferred pools in this slice.
+- Closed residency preference.
+- Non-negative cold-start, queue-wait, and priority values.
+- Unique `(tenant_id, name)` for Tenant policies and unique global name for null-Tenant policies.
+- Immutable Tenant scope.
+
+### `tenant_model_access`
+
+- Composite primary key `(tenant_id, model_id)`.
+- Tenant and Model FKs with cascade delete.
+- `enabled` non-null, default true.
+- Nullable routing-policy FK with restrictive delete behavior.
+- Indexes for Tenant enabled listing, Model lookup, and policy references.
+- Database validation that an attached policy is global or belongs to the same Tenant.
+
+## Concurrency
+
+Mutation operations take a transaction-scoped Postgres advisory lock derived from the `(tenant_id, model_id)` identity before reading or writing the access row. This serializes both first creation and later state changes; the composite primary key remains the database backstop against duplicate grants.
+
+The final committed state governs later authorization checks. Already snapshotted Requests are not retroactively changed.
+
+## Migration and rollback
+
+Upgrade procedure:
+
+1. Stop or drain public inference traffic.
+2. Back up Postgres.
+3. Run the migration.
+4. Create explicit policies when defaults are insufficient.
+5. Grant approved Tenant/Model pairs.
+6. Verify positive listing/inference and negative cross-Tenant denial.
+7. Expose the upgraded Controller.
+
+The migration inserts no grants or policies. A schema rollback destroys grant/policy data. An application rollback to globally authorized behavior is a security regression and requires public inference to remain stopped.
+
+## Alternatives rejected
+
+- Automatic grants for every existing Tenant and active Model.
+- A legacy-Tenant bypass.
+- Authorization before mandatory tokenization/context validation.
+- Implicit global/default-policy selection.
+- Treating disable and revoke as aliases.
+- Exposing unenforced pool-routing flags.
+- Shipping only `/v1/models` filtering without inference enforcement.
+- Shipping inference enforcement without a supported operator lifecycle.
+
+## Risks
+
+- **Upgrade outage:** deny-by-default blocks traffic until explicit grants exist. Mitigate operationally; do not add a bypass.
+- **Rollback exposure:** old application code ignores grant tables. Treat rollback as security-sensitive.
+- **Policy scope race:** enforce at the database boundary.
+- **Test masking:** model creation fixtures must never grant implicitly.
+- **Partial enforcement:** Chat Completions and Responses must share the same preparation path and failure mapping.
+- **False routing claims:** keep pool arrays empty until scheduler enforcement is implemented.

--- a/openspec/changes/tenant-model-grants/design.md
+++ b/openspec/changes/tenant-model-grants/design.md
@@ -99,15 +99,25 @@ orchardctl models routing-policy inspect --id <uuid>
 
 The CLI validates Model and Tenant identities before reporting idempotent outcomes. Policy references are UUID-only to avoid ambiguous lookup.
 
-A partial Admin API or Console surface would expand authorization and compatibility scope without being required to close the public inference defect.
+A partial Admin API or Console grant-management surface would expand authorization and compatibility scope without being required to close the public inference defect.
 
-### 9. State changes and audit evidence are atomic
+### 9. The Console Playground consumes the same effective-Tenant decision
+
+The Console Playground is an inference consumer, not a grant-management surface. Console authentication is an operator gate with no per-Tenant credential, so the Playground resolves one effective Tenant: the seeded legacy Tenant.
+
+The Playground passes that Tenant through its preparation caller context and lists only active Models with an enabled grant for it. Both the picker and the pre-execution readiness gate therefore agree with the decision `RequestPreparation` enforces.
+
+Consequence: a grant created so operators can exercise a Model in the Playground equally authorizes every existing legacy-Tenant API credential for that Model on `/v1`. Separating those audiences requires a later Console identity decision, not a Playground bypass.
+
+The Playground distinguishes an absent or non-active catalog Model from an active but ungranted Model in its operator-facing readiness message. Both remain fail-closed and neither reveals another Tenant's grants.
+
+### 10. State changes and audit evidence are atomic
 
 Grant, re-enable, policy replacement, disable, revoke, and policy creation use `AuditWriter.transaction/1`. Mutation and append-only audit either both commit or both roll back.
 
 No-op operations emit no duplicate audit. Payloads may include Tenant, Model, previous/new policy IDs, transition, and operator surface. They exclude credentials, artifact paths, prompts, responses, and raw model content.
 
-### 10. Public authorization is uncached
+### 11. Public authorization is uncached
 
 Listing and authorization query Postgres for each operation. A committed disable or revoke therefore affects the next listing and new preparation check without an invalidation channel.
 
@@ -157,6 +167,7 @@ The migration inserts no grants or policies. A schema rollback destroys grant/po
 
 - Automatic grants for every existing Tenant and active Model.
 - A legacy-Tenant bypass.
+- A Console Playground exemption from Tenant-model grants.
 - Authorization before mandatory tokenization/context validation.
 - Implicit global/default-policy selection.
 - Treating disable and revoke as aliases.
@@ -172,3 +183,4 @@ The migration inserts no grants or policies. A schema rollback destroys grant/po
 - **Test masking:** model creation fixtures must never grant implicitly.
 - **Partial enforcement:** Chat Completions and Responses must share the same preparation path and failure mapping.
 - **False routing claims:** keep pool arrays empty until scheduler enforcement is implemented.
+- **Console surprise:** the Playground is fail-closed until the legacy Tenant is granted; document the grant step rather than exempting the Console.

--- a/openspec/changes/tenant-model-grants/proposal.md
+++ b/openspec/changes/tenant-model-grants/proposal.md
@@ -12,6 +12,7 @@ The effective Tenant is already resolved by public authentication. The missing p
 - Add supported local operator commands to create and inspect constrained routing policies and to grant, disable, revoke, list, and inspect tenant-model access.
 - Keep grant decisions keyed only by effective Tenant and catalog Model, regardless of direct or Service Account credential ownership.
 - Filter `GET /v1/models` to active Models with an enabled grant for the effective Tenant.
+- Resolve the Console Playground's effective Tenant to the seeded legacy Tenant and filter its model picker and runs to that Tenant's enabled grants.
 - Enforce model access in the shared Chat Completions and Responses preparation path after tokenization/context validation and before Request persistence or admission/execution side effects.
 - Return exact `403 model_not_authorized` for an existing active but ungranted or disabled Model.
 - Resolve a null grant policy to the existing canonical routing defaults; attach an explicit same-Tenant or global policy only by UUID.
@@ -25,7 +26,8 @@ The effective Tenant is already resolved by public authentication. The missing p
 - Cancelling already authorized or running Requests after a later revoke.
 - Implicit selection of a global routing policy by name, priority, or creation order.
 - Executing non-empty pool allowlists or preferences before scheduler support exists.
-- A partial Admin API or Console management surface in the first slice.
+- A partial Admin API or Console grant-management surface in the first slice.
+- A Console-only grant scope or per-operator Console Tenant identity.
 - Model import, activation, artifact distribution, placement, or scheduler redesign.
 
 ## SPEC.md impact
@@ -46,6 +48,8 @@ No `SPEC.md` behavior is relaxed. Authorization remains after mandatory tokeniza
 The migration creates no grants and no implicit default policy row. Operators must stop or drain public inference, migrate, explicitly create any desired policies and grants, verify positive and negative Tenant behavior, and only then expose the upgraded Controller.
 
 Rolling application code back to a version that ignores grants reintroduces the access-control defect and is not a security-preserving rollback.
+
+The Console Playground shares the seeded legacy Tenant, so operators must grant a Model to that Tenant before the Playground can list or run it, and that grant equally authorizes existing legacy-Tenant API credentials for the same Model.
 
 ## Delivery state
 

--- a/openspec/changes/tenant-model-grants/proposal.md
+++ b/openspec/changes/tenant-model-grants/proposal.md
@@ -1,0 +1,52 @@
+# Tenant-scoped model grants and routing snapshots (#219)
+
+## Why
+
+`SPEC.md` requires tenant-scoped model visibility and inference authorization, but Orchard currently exposes every active catalog model to every authenticated Tenant and accepts any active model during shared Chat Completions and Responses preparation.
+
+The effective Tenant is already resolved by public authentication. The missing persistence, operator lifecycle, filtered listing, and pre-admission enforcement are a direct access-control gap and block specification-compliant pilot approval under #196.
+
+## What changes
+
+- Add deny-by-default `routing_policies` and `tenant_model_access` persistence matching the apex contract.
+- Add supported local operator commands to create and inspect constrained routing policies and to grant, disable, revoke, list, and inspect tenant-model access.
+- Keep grant decisions keyed only by effective Tenant and catalog Model, regardless of direct or Service Account credential ownership.
+- Filter `GET /v1/models` to active Models with an enabled grant for the effective Tenant.
+- Enforce model access in the shared Chat Completions and Responses preparation path after tokenization/context validation and before Request persistence or admission/execution side effects.
+- Return exact `403 model_not_authorized` for an existing active but ungranted or disabled Model.
+- Resolve a null grant policy to the existing canonical routing defaults; attach an explicit same-Tenant or global policy only by UUID.
+- Persist the resolved routing policy snapshot on authorized Requests.
+- Audit state-changing grant, disable, revoke, and routing-policy operations without credentials, artifact paths, prompts, or responses.
+- Migrate without implicitly granting existing Tenants access to existing active Models.
+
+## Out of scope
+
+- Weakening `SPEC.md` or adding a pilot-only global authorization bypass.
+- Cancelling already authorized or running Requests after a later revoke.
+- Implicit selection of a global routing policy by name, priority, or creation order.
+- Executing non-empty pool allowlists or preferences before scheduler support exists.
+- A partial Admin API or Console management surface in the first slice.
+- Model import, activation, artifact distribution, placement, or scheduler redesign.
+
+## SPEC.md impact
+
+This change implements the existing apex requirements for:
+
+- §5.2 admission ordering and failure precedence;
+- §6.6 model publication and tenant visibility;
+- §7.2 effective-Tenant model listing and exact public errors;
+- §10.9 governance evidence;
+- persisted `routing_policies` and `tenant_model_access` relations; and
+- the canonical resolved routing snapshot used by Requests.
+
+No `SPEC.md` behavior is relaxed. Authorization remains after mandatory tokenization and context-limit enforcement, while denial remains before Request creation, quota, queueing, scheduling, node contact, model loading, or inference execution.
+
+## Rollout
+
+The migration creates no grants and no implicit default policy row. Operators must stop or drain public inference, migrate, explicitly create any desired policies and grants, verify positive and negative Tenant behavior, and only then expose the upgraded Controller.
+
+Rolling application code back to a version that ignores grants reintroduces the access-control defect and is not a security-preserving rollback.
+
+## Delivery state
+
+Issue #219 owns this contract and implementation. Issue #196 remains the pilot-approval owner.

--- a/openspec/changes/tenant-model-grants/specs/tenant-model-access/spec.md
+++ b/openspec/changes/tenant-model-grants/specs/tenant-model-access/spec.md
@@ -19,6 +19,13 @@ This implements `SPEC.md` §5.2, §6.6, and §7.2.3.
 - **WHEN** each credential lists Models or requests the same Model
 - **THEN** Orchard makes the same grant decision for both credentials
 
+#### Scenario: Console Playground resolves the seeded legacy Tenant
+- **GIVEN** the Console Playground has no per-Tenant credential
+- **WHEN** an operator loads the Playground Model picker or sends a Playground message
+- **THEN** Orchard resolves the effective Tenant to the seeded legacy Tenant
+- **AND** offers and authorizes only Models with an enabled grant for that Tenant
+- **AND** a Model granted for Playground use is equally authorized for API credentials scoped to that same Tenant
+
 ### Requirement: Tenant-model access has explicit lifecycle states
 An enabled access record SHALL authorize new listing and inference checks.
 A disabled access record SHALL preserve its routing-policy reference and SHALL NOT authorize.
@@ -96,6 +103,13 @@ This implements `SPEC.md` §7.2.3.
 - **GIVEN** an active Model is visible through an enabled grant
 - **WHEN** the grant is revoked and committed
 - **THEN** the next Model listing omits that Model
+
+#### Scenario: Console Playground reports why a Model cannot run
+- **GIVEN** an operator submits a Model that the Playground picker does not offer
+- **WHEN** the Model is active in the catalog but has no enabled grant for the Playground Tenant
+- **THEN** the Playground reports an ungranted-Model reason naming the operator grant command
+- **AND** when the Model is absent or not active in the catalog it reports an unavailable-Model reason instead
+- **AND** neither reason authorizes the run or discloses another Tenant's grants
 
 ### Requirement: Shared inference enforces Model access with exact precedence
 Chat Completions and Responses SHALL enforce Tenant-model access through their shared preparation boundary.

--- a/openspec/changes/tenant-model-grants/specs/tenant-model-access/spec.md
+++ b/openspec/changes/tenant-model-grants/specs/tenant-model-access/spec.md
@@ -1,0 +1,153 @@
+## ADDED Requirements
+
+### Requirement: Model access is deny-by-default for the effective Tenant
+Orchard SHALL authorize public Model listing and new inference only when the effective Tenant has an enabled access record for the active catalog Model.
+Tenant-direct and Service Account credentials that resolve to the same effective Tenant SHALL receive the same model-access decision.
+Principal metadata, credential ownership form, Owner Contact, and Team SHALL NOT create or widen model access.
+Existing Models and Tenants SHALL NOT receive automatic access during migration.
+This implements `SPEC.md` §5.2, §6.6, and §7.2.3.
+
+#### Scenario: Another Tenant's grant does not authorize the caller
+- **GIVEN** Tenant A has an enabled grant for an active Model
+- **AND** Tenant B has no enabled grant for that Model
+- **WHEN** a credential whose effective Tenant is Tenant B lists Models or requests inference with that Model
+- **THEN** Orchard does not use Tenant A's grant
+- **AND** Tenant B cannot list or infer with that Model
+
+#### Scenario: Service Account uses its owning effective Tenant
+- **GIVEN** a Tenant-direct credential and a Service Account credential resolve to the same effective Tenant
+- **WHEN** each credential lists Models or requests the same Model
+- **THEN** Orchard makes the same grant decision for both credentials
+
+### Requirement: Tenant-model access has explicit lifecycle states
+An enabled access record SHALL authorize new listing and inference checks.
+A disabled access record SHALL preserve its routing-policy reference and SHALL NOT authorize.
+A revoked access record SHALL be deleted and SHALL NOT delete its referenced routing policy.
+Repeated grant, enable, disable, and revoke operations SHALL converge on the requested durable state without duplicate audit records for no-op outcomes.
+This implements the `tenant_model_access` persistence and governance requirements in `SPEC.md` §10.9.
+
+#### Scenario: Disable preserves policy but denies access
+- **GIVEN** a Tenant has an enabled grant with an explicit routing policy
+- **WHEN** an operator disables the grant
+- **THEN** Orchard preserves the routing-policy reference
+- **AND** subsequent listing and new inference checks deny access
+
+#### Scenario: Revoke removes the grant only
+- **GIVEN** a Tenant grant references a routing policy
+- **WHEN** an operator revokes the grant
+- **THEN** Orchard deletes the access record
+- **AND** Orchard retains the routing policy
+- **AND** a repeated revoke reports an idempotent not-granted outcome
+
+### Requirement: Routing-policy attachment preserves Tenant scope
+Orchard SHALL permit a Tenant-model grant to reference only a routing policy owned by the same Tenant or a global routing policy whose Tenant is null.
+Orchard SHALL reject attachment of another Tenant's routing policy at the database integrity boundary.
+Routing-policy Tenant scope SHALL be immutable after creation.
+This implements the `routing_policies` and `tenant_model_access` integrity requirements in `SPEC.md` §10.9.
+
+#### Scenario: Cross-Tenant policy attachment is rejected
+- **GIVEN** a routing policy owned by Tenant A
+- **WHEN** an operator attempts to attach it to Tenant B's Model grant
+- **THEN** Orchard rejects the mutation
+- **AND** no access or audit mutation commits
+
+#### Scenario: Global policy attachment is explicit
+- **GIVEN** a routing policy whose Tenant is null
+- **WHEN** an operator attaches its UUID to a Tenant grant
+- **THEN** Orchard accepts the explicit global policy
+- **AND** Orchard does not select any other global policy implicitly
+
+### Requirement: Null routing policy resolves canonical defaults
+A grant with no routing-policy reference SHALL resolve directly to the canonical defaults owned by `AdmissionPolicy`.
+Orchard SHALL NOT select a policy implicitly by name, priority, creation order, or global scope.
+The resolved values SHALL enter the canonical Request snapshot before persistence.
+This implements `SPEC.md` §5.2 and §6.6 routing resolution.
+
+#### Scenario: Grant without policy uses defaults
+- **GIVEN** an enabled grant whose routing-policy reference is null
+- **WHEN** Orchard authorizes a new inference Request
+- **THEN** the canonical Request records no routing-policy ID
+- **AND** records empty allowed pool IDs
+- **AND** uses `allow_cold_load`, the canonical cold-start budget, and the canonical queue-wait budget
+
+### Requirement: Initial routing policies do not claim unenforced pool isolation
+Until scheduler pool enforcement is implemented, routing policies SHALL require empty allowed and preferred pool arrays.
+The initial operator surface SHALL NOT expose pool-routing flags.
+A non-empty pool array SHALL be rejected by persistence constraints.
+This implements the executable-routing boundary in `SPEC.md` §5.2 and the `routing_policies` shape in §10.9.
+
+#### Scenario: Non-empty pool constraint is rejected
+- **WHEN** a caller attempts to persist a routing policy with a non-empty allowed or preferred pool array
+- **THEN** Orchard rejects the policy
+- **AND** no audit mutation commits
+
+### Requirement: Public Model listing is Tenant-filtered
+`GET /v1/models` SHALL return only active catalog Models with an enabled grant for the effective Tenant.
+Disabled, revoked, ungranted, inactive, and other-Tenant-only Models SHALL be absent.
+Grant changes SHALL affect the next listing after commit.
+This implements `SPEC.md` §7.2.3.
+
+#### Scenario: Tenants receive different Model lists
+- **GIVEN** Tenant A and Tenant B have different enabled grants
+- **WHEN** each Tenant calls `GET /v1/models`
+- **THEN** each response contains only that Tenant's active authorized Models
+
+#### Scenario: Revocation removes Model from listing
+- **GIVEN** an active Model is visible through an enabled grant
+- **WHEN** the grant is revoked and committed
+- **THEN** the next Model listing omits that Model
+
+### Requirement: Shared inference enforces Model access with exact precedence
+Chat Completions and Responses SHALL enforce Tenant-model access through their shared preparation boundary.
+Model identity, active-state validation, tokenization, and context-limit enforcement SHALL precede access enforcement as required by `SPEC.md`.
+Access denial SHALL precede Request persistence, quota, queueing, scheduling, Node contact, model loading, and inference execution.
+A missing or inactive Model SHALL remain `404 model_not_found`.
+An existing active Model without an enabled grant SHALL return `403 model_not_authorized` with type `invalid_request_error`, message `Model not authorized for tenant`, and `param=model`.
+This implements `SPEC.md` §5.2 and §7.2.7.
+
+#### Scenario: Active ungranted Model returns exact forbidden error
+- **GIVEN** an active catalog Model without an enabled grant for the effective Tenant
+- **WHEN** the Tenant requests that Model through Chat Completions or Responses
+- **THEN** Orchard returns HTTP 403
+- **AND** error code is `model_not_authorized`
+- **AND** error type is `invalid_request_error`
+- **AND** error message is `Model not authorized for tenant`
+- **AND** error parameter is `model`
+- **AND** no Request or admission/execution side effect is created
+
+#### Scenario: Context failure precedes access denial
+- **GIVEN** an active Model is ungranted for the effective Tenant
+- **AND** the request exceeds the Model context limit
+- **WHEN** Orchard prepares the request
+- **THEN** Orchard returns the context-limit error required by `SPEC.md`
+- **AND** does not continue to access enforcement or Request persistence
+
+### Requirement: Access and routing mutations are audited atomically
+Routing-policy creation and state-changing grant, enable, policy replacement, disable, and revoke operations SHALL commit with append-only audit evidence or roll back together.
+No-op desired-state operations SHALL NOT emit duplicate audit records.
+Audit payloads MUST NOT contain credentials, artifact paths, prompts, responses, or raw Model content.
+This implements `SPEC.md` §10.9.
+
+#### Scenario: Audit failure rolls back a grant
+- **WHEN** a grant mutation succeeds but its required audit insertion fails
+- **THEN** Orchard rolls back the access mutation
+- **AND** no enabled grant becomes visible
+
+### Requirement: Local operator commands provide the first supported lifecycle
+The first implementation SHALL provide local `orchardctl models` commands to create, list, and inspect constrained routing policies and to grant, disable, revoke, list, and inspect Tenant-model access.
+Tenant references SHALL accept an exact UUID or slug.
+Model references SHALL use exact `<model_id>@<version>` identity.
+Policy references SHALL use UUIDs.
+The commands SHALL distinguish enabled, disabled, revoked/not-granted, default-policy, and explicit-policy outcomes.
+This implements the local operator command authority defined by `SPEC.md` and the §10.9 governance lifecycle.
+
+#### Scenario: Operator grants default access
+- **WHEN** an operator grants an exact Model to an exact Tenant without a routing-policy UUID
+- **THEN** Orchard creates or enables the access record
+- **AND** records a null policy reference
+- **AND** reports the canonical default routing outcome
+
+#### Scenario: Invalid identity does not create access
+- **WHEN** an operator supplies an unknown Tenant, Model, or policy identity
+- **THEN** the command exits with an error
+- **AND** no access or audit mutation commits

--- a/openspec/changes/tenant-model-grants/tasks.md
+++ b/openspec/changes/tenant-model-grants/tasks.md
@@ -1,0 +1,76 @@
+# Tasks: tenant-scoped model grants and routing snapshots
+
+## 1. Contract and review
+
+- [x] 1.1 Review `proposal.md`, `design.md`, and the tenant-model-access delta against the cited `SPEC.md` clauses.
+- [x] 1.2 Confirm the initial operator surface is local `orchardctl`, with no partial Admin API or Console requirement.
+- [x] 1.3 Confirm deny-by-default rollout with no automatic grant for existing Models, Tenants, or the legacy Tenant.
+- [x] 1.4 Confirm null policy means canonical defaults and never an implicit global lookup.
+- [x] 1.5 Confirm pool arrays remain empty until scheduler enforcement exists.
+- [x] 1.6 Validate the change strictly before production code begins.
+
+## 2. Persistence foundation
+
+- [x] 2.1 Add `routing_policies` with Tenant/global scope, closed residency preference, non-negative budgets/priority, empty pool-array constraints, indexes, and immutable Tenant scope.
+- [x] 2.2 Add `tenant_model_access` with composite identity, Tenant/Model cascade FKs, enabled state, restrictive policy FK, and indexes.
+- [x] 2.3 Enforce at the database boundary that an attached policy is global or belongs to the grant Tenant.
+- [x] 2.4 Add `RoutingPolicy` and `TenantModelAccess` Ecto schemas and associations.
+- [x] 2.5 Add migration tests for uniqueness, ranges, enum values, cascades, policy delete restriction, scope immutability, and cross-Tenant policy rejection.
+
+## 3. Access and routing domain
+
+- [x] 3.1 Add atomic audited routing-policy create/list/inspect operations.
+- [x] 3.2 Add deterministic grant, re-enable, policy replacement, disable, revoke, list, inspect, and authorize operations.
+- [x] 3.3 Serialize concurrent grant changes and converge safely after duplicate-create races.
+- [x] 3.4 Add one audit per actual state change and none for no-op outcomes.
+- [x] 3.5 Expose canonical default routing values from `AdmissionPolicy` without duplicating constants.
+- [x] 3.6 Add domain tests for lifecycle transitions, policy scopes, two-Tenant isolation, concurrency, audit atomicity, and default/explicit routing resolution.
+
+## 4. Public model listing
+
+- [x] 4.1 Add `Models.list_active_models_for_tenant/1` while preserving the trusted global catalog query.
+- [x] 4.2 Make `ModelsController` use the effective Tenant assigned by `RequestContext`.
+- [x] 4.3 Update controller documentation to describe active-and-authorized listing.
+- [x] 4.4 Test active granted, ungranted, disabled, revoked, inactive, cross-Tenant, direct-token, and Service Account listing behavior.
+
+## 5. Shared inference authorization
+
+- [x] 5.1 Enforce access in `RequestPreparation` after tokenization/context validation and before returning an executable canonical Request.
+- [x] 5.2 Apply the resolved routing snapshot through `AdmissionPolicy` before Request persistence.
+- [x] 5.3 Add exact `403 model_not_authorized` normalization and public mapping.
+- [x] 5.4 Preserve missing/inactive `404 model_not_found` precedence.
+- [x] 5.5 Test authorized and denied behavior for both Chat Completions and Responses.
+- [x] 5.6 Prove denial happens before Request persistence, quota, queue, scheduler, Node, model-load, or inference side effects.
+- [x] 5.7 Prove tokenizer/context failures precede authorization as required by `SPEC.md`.
+- [x] 5.8 Prove committed disable/revoke affects new listing and inference checks without cancelling already authorized Requests.
+
+## 6. Operator lifecycle
+
+- [x] 6.1 Add shared Model, Tenant UUID/slug, and policy UUID reference parsing.
+- [x] 6.2 Add `orchardctl models access grant|disable|revoke|list|inspect`.
+- [x] 6.3 Add `orchardctl models routing-policy create|list|inspect`.
+- [x] 6.4 Render deterministic mutation/no-op outcomes without credentials or artifact paths.
+- [x] 6.5 Test help, parsing, missing identities, scope failures, lifecycle distinctions, default/explicit policy output, and repeat operations.
+- [x] 6.6 Document deny-by-default rollout and command usage in the CLI/operator documentation.
+
+## 7. Fixture and regression migration
+
+- [x] 7.1 Add explicit grant helpers; do not make Model creation grant implicitly.
+- [x] 7.2 Update successful public API and direct preparation tests to create explicit grants.
+- [x] 7.3 Preserve global catalog tests that intentionally exercise trusted unscoped listing.
+- [x] 7.4 Preserve the existing streaming `chatcmpl-*` public-ID persistence regression.
+- [x] 7.5 Convert the existing two-Tenant idempotency test to grant both Tenants and add a separate one-Tenant-only denial test.
+- [x] 7.6 Search the whole test tree for active ungranted success fixtures and reconcile each explicitly.
+
+## 8. Validation and rollout
+
+- [x] 8.1 Run strict OpenSpec validation after every contract change.
+- [x] 8.2 Run focused migration, domain, listing, inference, error, and CLI tests during implementation.
+- [x] 8.3 Run `mise exec -- mix format`.
+- [x] 8.4 Run `mise exec -- mix compile --warnings-as-errors`.
+- [x] 8.5 Run `mise exec -- mix credo --strict`.
+- [x] 8.6 Run `mise exec -- mix dialyzer`.
+- [x] 8.7 Run `mise exec -- mix test`.
+- [x] 8.8 Run `mise exec -- mix test --cover`.
+- [x] 8.9 Review generated specifications for placeholders and accidental global-access language.
+- [x] 8.10 Document the stop/drain, migrate, grant, verify, and expose rollout procedure.

--- a/openspec/changes/tenant-model-grants/tasks.md
+++ b/openspec/changes/tenant-model-grants/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Contract and review
 
 - [x] 1.1 Review `proposal.md`, `design.md`, and the tenant-model-access delta against the cited `SPEC.md` clauses.
-- [x] 1.2 Confirm the initial operator surface is local `orchardctl`, with no partial Admin API or Console requirement.
+- [x] 1.2 Confirm the initial operator surface is local `orchardctl`, with no partial Admin API or Console grant-management requirement.
 - [x] 1.3 Confirm deny-by-default rollout with no automatic grant for existing Models, Tenants, or the legacy Tenant.
 - [x] 1.4 Confirm null policy means canonical defaults and never an implicit global lookup.
 - [x] 1.5 Confirm pool arrays remain empty until scheduler enforcement exists.
@@ -32,6 +32,8 @@
 - [x] 4.2 Make `ModelsController` use the effective Tenant assigned by `RequestContext`.
 - [x] 4.3 Update controller documentation to describe active-and-authorized listing.
 - [x] 4.4 Test active granted, ungranted, disabled, revoked, inactive, cross-Tenant, direct-token, and Service Account listing behavior.
+- [x] 4.5 Resolve the Console Playground effective Tenant and filter its Model picker, readiness gate, and preparation caller context to that Tenant's enabled grants.
+- [x] 4.6 Distinguish absent or non-active catalog Models from active ungranted Models in Playground readiness diagnostics, with regression coverage for both.
 
 ## 5. Shared inference authorization
 
@@ -52,6 +54,7 @@
 - [x] 6.4 Render deterministic mutation/no-op outcomes without credentials or artifact paths.
 - [x] 6.5 Test help, parsing, missing identities, scope failures, lifecycle distinctions, default/explicit policy output, and repeat operations.
 - [x] 6.6 Document deny-by-default rollout and command usage in the CLI/operator documentation.
+- [x] 6.7 Document the explicit grant step in local-development and observability-probe instructions, including the Console Playground Tenant.
 
 ## 7. Fixture and regression migration
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -154,7 +154,7 @@ Verification:
 - On the controller, authenticated `/ops/v1/health` should report PostgreSQL reachable and migrations current; public `/health/ready` reports status only.
 - On the controller, Runtime Endpoint target configuration should match each remote node-agent BEAM node name in `ORCHARD_RUNTIME_ENDPOINT_TARGETS`.
 - Stage the model on every worker before attempting inference; controller import and activation do not distribute the artifact.
-- After admin credentials, tenant/API access, model import, model activation, and worker model staging are configured, use `/v1/models` and a single chat completion request as the external-site API smoke test.
+- After admin credentials, tenant/API access, model import, model activation, the Tenant/Model access grant, and worker model staging are configured, use `/v1/models` and a single chat completion request as the external-site API smoke test.
 
 Worker model staging:
 
@@ -162,7 +162,7 @@ Worker model staging:
 - On the controller, the imported bundle is at `/Library/Application Support/Orchard/bundles/<model_id>/<version>`. `<model_id>` may contain a slash, so the layout is nested.
 - Copy that bundle directory to the identical absolute path on every worker Mac before the first request for the model, preserving directory structure and file contents.
 - On the first request, the node-agent copies the staged bundle into its own cache under `/Library/Application Support/Orchard/models`, verifies it against the recorded artifact digest, and fails closed on mismatch.
-- This repeats per model and per worker. A catalog-active but unstaged model still appears in `/v1/models` and is not blocked before dispatch, so a missed staging step surfaces only on the first request that the scheduler places on the unstaged worker.
+- This repeats per model and per worker. A granted, catalog-active but unstaged model still appears in `/v1/models` and is not blocked before dispatch, so a missed staging step surfaces only on the first request that the scheduler places on the unstaged worker.
 - How that failure is reported depends on whether the request streams, because the streaming response commits its HTTP status before the model load is attempted:
   - Non-streaming: HTTP `503` with error type `server_error` and code `source_not_found`.
   - Streaming: the response has already returned HTTP `200` and opened the event stream, so the failure arrives as an SSE `data: {"error":{...}}` event carrying the same `server_error` type and `source_not_found` code, and the stream then closes without a `[DONE]` line. Check the event payload, not just the HTTP status; a streaming smoke test that only asserts on `200` reads this failure as a success.
@@ -620,6 +620,12 @@ sudo chmod 600 '/Library/Application Support/Orchard/config/controller.env'
    ```bash
    sudo orchardctl migrate
    ```
+
+   The Tenant/Model access migration creates no grants, so an upgraded
+   controller denies every public inference request until an operator grants
+   each approved Organization/model pair. Follow the rollout order in
+   [Tenant Model access](../../apps/orchard_cli/README.md#tenant-model-access)
+   before re-exposing the controller.
 
 6. **Start services:**
    ```bash
@@ -1314,6 +1320,20 @@ Tenant-direct API Tokens remain supported for manual/bootstrap use and the token
 sudo orchardctl tenants create --slug default --name "Default"
 sudo orchardctl api-keys create --tenant-id <tenant-id> --name "Primary"
 ```
+
+Then grant the Organization access to each approved model. Model access is
+deny-by-default, and no Organization — including the seeded `legacy` Tenant that
+the Console Playground runs as — receives an automatic grant, so an imported and
+activated model stays invisible to `/v1/models` and unusable by
+`/v1/chat/completions` and `/v1/responses` until it is granted:
+
+```bash
+sudo orchardctl models access grant <model_id>@<version> --tenant default
+```
+
+See [Tenant Model access](../../apps/orchard_cli/README.md#tenant-model-access)
+for the full `orchardctl models access` and `orchardctl models routing-policy`
+surface.
 
 For internal developers, applications, coding agents, or automation clients, use bulk API Client provisioning instead:
 

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -621,11 +621,11 @@ sudo chmod 600 '/Library/Application Support/Orchard/config/controller.env'
    sudo orchardctl migrate
    ```
 
-   The Tenant/Model access migration creates no grants, so an upgraded
-   controller denies every public inference request until an operator grants
-   each approved Organization/model pair. Follow the rollout order in
-   [Tenant Model access](../../apps/orchard_cli/README.md#tenant-model-access)
-   before re-exposing the controller.
+   Releases that carry the Tenant/Model access migration need the extra
+   grant steps in
+   [Tenant/Model access grant rollout](#tenantmodel-access-grant-rollout)
+   between this step and step 6, because the migration leaves the controller
+   denying every public inference request.
 
 6. **Start services:**
    ```bash
@@ -638,6 +638,54 @@ sudo chmod 600 '/Library/Application Support/Orchard/config/controller.env'
    curl --cacert '/Library/Application Support/Orchard/config/tls/ca.crt' \
      https://localhost:8443/health/ready
    ```
+
+### Tenant/Model access grant rollout
+
+Releases carrying the Tenant/Model access migration make public Model discovery
+and inference deny-by-default. The migration inserts no grants and no routing
+policies, and no Organization is exempt — including the seeded `legacy` Tenant
+that the Console Playground runs as. An upgraded controller therefore omits
+every model from `/v1/models` and rejects every `/v1/chat/completions` and
+`/v1/responses` request with `403 model_not_authorized` until an operator grants
+each approved Organization/model pair.
+
+Interleave this order with the upgrade workflow above and do not re-expose the
+controller until the verification step passes:
+
+1. Stop or drain public inference traffic. The packaged install in upgrade-workflow
+   step 4 stops services and does not auto-restart them, so keep the controller
+   unexposed from that point on.
+2. Back up Postgres, as in upgrade-workflow step 2.
+3. Run the migration, as in upgrade-workflow step 5.
+4. Create explicit routing policies only where canonical `AdmissionPolicy`
+   defaults are insufficient:
+   ```bash
+   sudo orchardctl models routing-policy create --tenant <uuid-or-slug> \
+     --name <name> --residency-preference <required_loaded|prefer_loaded|allow_cold_load>
+   ```
+   Omitting `--routing-policy-id` on a grant selects those canonical defaults;
+   Orchard never implicitly selects a global policy.
+5. Grant every approved Organization/model pair:
+   ```bash
+   sudo orchardctl models access grant <model_id>@<version> \
+     --tenant <uuid-or-slug> [--routing-policy-id <uuid>]
+   ```
+6. Verify both directions before exposing the controller. Positive: a
+   credential of a granted Organization sees the model in `GET /v1/models` and
+   completes one chat completion request. Negative: a credential of an
+   Organization without that grant does not see the model in `GET /v1/models`
+   and receives `403 model_not_authorized` from `/v1/chat/completions` and
+   `/v1/responses`.
+7. Start services and expose the upgraded controller, as in upgrade-workflow
+   steps 6 and 7.
+
+Rollback is asymmetric. A schema rollback destroys grant and routing-policy
+data. Rolling the application back to globally authorized behavior is a
+security regression, so public inference must stay stopped on that path.
+
+See [Tenant Model access](../../apps/orchard_cli/README.md#tenant-model-access)
+for the full `orchardctl models access` and `orchardctl models routing-policy`
+command surface.
 
 ## Licensing v0
 


### PR DESCRIPTION
## Intent

Close the pilot-approval gap identified in issue #196 by implementing issue #219: explicit deny-by-default Tenant-to-Model grants, Tenant-filtered model discovery, shared inference authorization for Chat Completions and Responses, immutable routing snapshots, audited and concurrency-safe grant lifecycle operations, and an orchardctl-only operator surface. Existing Models, Tenants, and the legacy Tenant must receive no automatic grants; null routing policy must resolve to canonical AdmissionPolicy defaults rather than an implicit global lookup; pool arrays remain empty until scheduler enforcement exists. Include the OpenSpec change, ADR, rollout documentation, migration and regression coverage, while excluding transient investigation notes and unrelated local files.

## What Changed

- Added `routing_policies` and `tenant_model_access` tables plus `Orchard.Models.Access` as the lifecycle owner: grant/disable/revoke/inspect run under a per-Tenant/Model advisory lock, each mutation commits with its audit row, routing-policy scope and empty pool arrays are enforced by both changesets and DB constraints, and the migration creates no grants, so existing Tenants, Models, and the seeded legacy Tenant all start ungranted.
- Wired enforcement into the read and inference paths: `GET /v1/models` now lists only active Models with an enabled grant for the caller's Tenant, and a shared `RequestPreparation.authorize_model/2` step (after identity, tokenization, and context checks) backs both `/v1/chat/completions` and `/v1/responses`, returning 403 `model_not_authorized` and snapshotting the grant's routing values into `resolved_policy` — with a null policy resolving to `AdmissionPolicy.default_routing_opts/0` instead of an implicit global lookup.
- Exposed the operator surface only through `orchardctl models access grant|disable|revoke|list|inspect` and `orchardctl models routing-policy create|list` (no HTTP or Console admin path); made the Console Playground explicitly act as the legacy Tenant so its picker and readiness gate follow the same grants, and added ADR 0021, the `tenant-model-grants` OpenSpec change, and grant-rollout steps to the CLI, local-dev, and packaging docs.

## Risk Assessment

⚠️ Medium: Every prior warning is now resolved with durable decision records and real-Repo regression coverage, leaving only one narrow unrescued diagnostic query, but the branch as a whole still introduces fail-closed authorization on the public inference path that requires an explicit operator grant rollout for existing deployments.

## Testing

Ran the targeted suites for every changed surface (Access lifecycle, migration integrity, shared request preparation, Models/Chat/Responses controllers, Console Playground, orchardctl) — all passed with no test or source fixes needed — then proved the intent at product level on a live source-dev Controller: a database created at the pre-#219 schema and seeded with existing Tenants and active Models gained zero grants on migration; real curl transcripts show Tenant-filtered /v1/models, the exact 403 model_not_authorized body on both Chat Completions and Responses with no Request persisted, unchanged 404 precedence, and Service-Account/Tenant-direct parity; persisted canonical routing snapshots match the explicit policy when attached and AdmissionPolicy defaults with empty pools when not; Postgres itself rejects non-empty pool arrays, cross-Tenant policy attachment, and Tenant-scope mutation; 8 concurrent orchardctl grants converged on one access row and one audit row with no duplicate no-op audits and no credentials or prompts in payloads; and headless-Chrome screenshots capture the Playground's new ungranted empty state and the Tenant-filtered picker after the grant. The only intent detail I could not capture visually is the split ungranted-vs-inactive Playground diagnostic, which requires a Model with a loaded placement on a ready node that this host cannot provide — it is asserted on exact strings in playground_access_test.exs. Cleanup done: dev server and Chrome stopped, evidence databases dropped, tmp/ scratch removed, worktree clean at b44a39eb; gitignored node_modules/ and compiled priv/static/assets/ were intentionally left since make openspec and the Console need them and neither can be committed.

<details>
<summary>Evidence: Evidence bundle index (what each file proves)</summary>

```text
# Issue #219 — Tenant-to-Model grants: end-to-end evidence

Environment: source-dev Controller (`mix phx.server`, HTTP `127.0.0.1:4099`) against a
dedicated Postgres database that was created at the pre-#219 schema, seeded with
pre-existing Tenants and active Models, and only then migrated. Tokenizer ran in the
supported deterministic `:fake` mode (this host has no MLX model artifacts), so
tokenization succeeds and the grant decision is the next gate. API bearer secrets are
redacted from every transcript. No Node is admitted on this host, so an *authorized*
request correctly gets as far as scheduling and fails with `503 cluster_busy`.

| File | What it shows |
|---|---|
| `01-migration-no-automatic-grants.txt` | Migration applied to a DB that already had 3 Tenants (incl. `legacy`) and 2 active Models → 0 `tenant_model_access` rows, 0 `routing_policies` rows, no grant for any Tenant×Model pair |
| `02-api-deny-by-default.txt` | Post-upgrade `GET /v1/models` empty; `/v1/chat/completions` and `/v1/responses` both return exact `403 model_not_authorized` / `invalid_request_error` / `Model not authorized for tenant` / `param=model`; `legacy` Tenant gets no free pass; unknown Model still `404 model_not_found`; 0 Request rows persisted |
| `03-orchardctl-lifecycle.txt` | `orchardctl models access grant/inspect/list` and `models routing-policy create/list`, including idempotent repeat-grant output |
| `04-orchardctl-routing-policy-scope.txt` | Cross-Tenant policy attachment rejected (`routing_policy_scope_mismatch`); unknown Tenant/Model/policy identities never mutate |
| `05-tenant-filtered-discovery-and-inference.txt` | Two Tenants get two different `/v1/models` lists; cross-Tenant inference denied 403; authorized calls pass the gate and reach scheduling (503) |
| `07-routing-snapshot.txt` | Persisted `canonical_request.resolved_policy`: explicit global policy → its UUID + `prefer_loaded`; null-policy grant → `routing_policy_id: null`, empty `allowed_pool_ids`, `allow_cold_load` — identical to `AdmissionPolicy.default_routing_opts()` printed at the end |
| `08-disable-revoke-lifecycle.txt` | Disable keeps the row + policy reference but denies listing and inference; revoke deletes only the access row and keeps the routing policy; repeat operations are idempotent |
| `09-audit-evidence.txt` | Audit rows for every real `routing_policy.created` / `tenant_model_access.granted|disabled|revoked`, with payloads free of credentials, prompts, responses and artifact paths; repeated no-op operations wrote no duplicate rows |
| `10-console-playground-ungranted.png` | Console Playground as the seeded `legacy` Tenant with no grant: empty picker + new copy "No active models are granted to this console tenant." / "…grant it to this console tenant with orchardctl models access grant…" |
| `11-console-playground-granted.png` | Same page after `orchardctl models access grant … --tenant legacy`: picker offers the granted Model only (the second active-but-ungranted Model stays hidden) |
| `12-console-playground-grant-steps.txt` | The operator commands run between the two screenshots |
| `13-concurrency-safety.txt` | 8 independent `orchardctl` processes granting the same Tenant+Model converge on 1 access row and 1 audit row |
| `14-db-integrity-boundary.txt` | Postgres rejects non-empty pool arrays, cross-Tenant policy attachment, and any change to a routing policy's Tenant scope |
| `15-operator-surface-scope.txt` | No HTTP route, Console LiveView, or other module mutates grants — only `Orchard.Models.Access`, reached through `orchardctl` |
| `16-service-account-parity.txt` | A Service Account credential provisioned under `pilot-b` gets byte-identical listing and identical 403/503 decisions as the Tenant-direct credential |
| `17-doc-deliverables.txt` | ADR 0021, the OpenSpec change package, and the `docs/local-dev.md` rollout guidance shipped with the change; no transient investigation notes in the diff |
```
</details>
- Evidence: Console Playground as the legacy Tenant with no grant (new empty-state copy naming the orchardctl grant command) (local file: <code>/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/no-mistakes-evidence/01M0CK5MBG8KBTNZG7AMM9WQTQ/10-console-playground-ungranted.png</code>)
- Evidence: Console Playground after `orchardctl models access grant ... --tenant legacy` (picker offers only the granted Model) (local file: <code>/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/no-mistakes-evidence/01M0CK5MBG8KBTNZG7AMM9WQTQ/11-console-playground-granted.png</code>)
<details>
<summary>Evidence: Migration on a pre-existing database grants nothing</summary>

<code>### 4. Rollout assertion: existing Tenants (including legacy) and existing active Models receive NO automatic grants&#10;tenant_model_access_rows&#10;--------------------------&#10;0&#10;routing_policy_rows&#10;---------------------&#10;0&#10;tenant | model | has_grant&#10;---------+-----------------------------+-----------&#10;legacy | mlx-community/alpha-8b@main | f&#10;legacy | mlx-community/beta-3b@main | f&#10;pilot-a | mlx-community/alpha-8b@main | f&#10;pilot-a | mlx-community/beta-3b@main | f&#10;pilot-b | mlx-community/alpha-8b@main | f&#10;pilot-b | mlx-community/beta-3b@main | f</code>

```text
### 3. Apply the #219 migration to the pre-existing database
== Running 20260819010000 Orchard.Repo.Migrations.TenantModelAccessFoundation.up/0 forward
== Migrated 20260819010000 in 0.0s

### 4. Rollout assertion: existing Tenants (including legacy) and existing active Models receive NO automatic grants
 tenant_model_access_rows 
--------------------------
                        0
(1 row)

 routing_policy_rows 
---------------------
                   0
(1 row)

 tenant  |            model            | has_grant 
---------+-----------------------------+-----------
 legacy  | mlx-community/alpha-8b@main | f
 legacy  | mlx-community/beta-3b@main  | f
 pilot-a | mlx-community/alpha-8b@main | f
 pilot-a | mlx-community/beta-3b@main  | f
 pilot-b | mlx-community/alpha-8b@main | f
 pilot-b | mlx-community/beta-3b@main  | f
(6 rows)
```
</details>
<details>
<summary>Evidence: Deny-by-default over real HTTP: exact 403 on both endpoints, 404 precedence intact, no Request persisted</summary>

<code>$ curl -H &#34;Authorization: Bearer &lt;pilot-a key&gt;&#34; http://127.0.0.1:4099/v1/models&#10;HTTP 200&#10;{&#34;data&#34;: [], &#34;object&#34;: &#34;list&#34;}&#10;&#10;$ curl ... -X POST /v1/chat/completions -d {&#34;model&#34;:&#34;mlx-community/alpha-8b@main&#34;,...}&#10;HTTP 403&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;model_not_authorized&#34;, &#34;message&#34;: &#34;Model not authorized for tenant&#34;, &#34;type&#34;: &#34;invalid_request_error&#34;, &#34;param&#34;: &#34;model&#34;}}&#10;&#10;$ curl ... -X POST /v1/responses -d {&#34;model&#34;:&#34;mlx-community/alpha-8b@main&#34;,...}&#10;HTTP 403&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;model_not_authorized&#34;, &#34;message&#34;: &#34;Model not authorized for tenant&#34;, &#34;type&#34;: &#34;invalid_request_error&#34;, &#34;param&#34;: &#34;model&#34;}}&#10;&#10;$ curl -H &#34;Authorization: Bearer &lt;legacy key&gt;&#34; -X POST /v1/chat/completions # legacy Tenant gets no free pass&#10;HTTP 403&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;model_not_authorized&#34;, ...}}&#10;&#10;$ curl ... -X POST /v1/chat/completions -d {&#34;model&#34;:&#34;does-not-exist@main&#34;,...} # 404 precedence unchanged&#10;HTTP 404&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;model_not_found&#34;, &#34;message&#34;: &#34;Model not found: does-not-exist@main&#34;, &#34;type&#34;: &#34;invalid_request_error&#34;, &#34;param&#34;: &#34;model&#34;}}&#10;&#10;# No Request rows were created by the denied calls:&#10;0 request rows</code>

```text
Upgraded source-dev Controller at http://127.0.0.1:4099, DB = the database migrated in step 01.
Tokenizer runs in the supported deterministic :fake mode (this host has no MLX model artifacts),
so tokenization succeeds and the grant decision is the next gate. Bearer secrets are redacted.

=== A. Deny-by-default immediately after upgrade: zero grants exist ===

$ curl -H "Authorization: Bearer <pilot-a key>" http://127.0.0.1:4099/v1/models
HTTP 200
{
    "data": [],
    "object": "list"
}

$ curl -H "Authorization: Bearer <pilot-a key>" -X POST /v1/chat/completions -d {"model":"mlx-community/alpha-8b@main",...}
HTTP 403
{
    "error": {
        "code": "model_not_authorized",
        "message": "Model not authorized for tenant",
        "type": "invalid_request_error",
        "param": "model"
    }
}

$ curl -H "Authorization: Bearer <pilot-a key>" -X POST /v1/responses -d {"model":"mlx-community/alpha-8b@main",...}
HTTP 403
{
    "error": {
        "code": "model_not_authorized",
        "message": "Model not authorized for tenant",
        "type": "invalid_request_error",
        "param": "model"
    }
}

$ curl -H "Authorization: Bearer <legacy key>" -X POST /v1/chat/completions -d {"model":"mlx-community/alpha-8b@main",...}   # legacy Tenant gets no free pass
HTTP 403
{
    "error": {
        "code": "model_not_authorized",
        "message": "Model not authorized for tenant",
        "type": "invalid_request_error",
        "param": "model"
    }
}

$ curl ... -X POST /v1/chat/completions -d {"model":"does-not-exist@main",...}   # 404 precedence unchanged
HTTP 404
{
    "error": {
        "code": "model_not_found",
        "message": "Model not found: does-not-exist@main",
        "type": "invalid_request_error",
        "param": "model"
    }
}

# No Request rows were created by the denied calls:
0 request rows
```
</details>
<details>
<summary>Evidence: Tenant-filtered discovery and cross-Tenant isolation</summary>

<code>$ curl -H &#34;Authorization: Bearer &lt;pilot-a key&gt;&#34; /v1/models&#10;HTTP 200 {&#34;data&#34;:[{&#34;id&#34;:&#34;mlx-community/alpha-8b@main&#34;,...}],&#34;object&#34;:&#34;list&#34;}&#10;&#10;$ curl -H &#34;Authorization: Bearer &lt;pilot-b key&gt;&#34; /v1/models&#10;HTTP 200 {&#34;data&#34;:[{&#34;id&#34;:&#34;mlx-community/beta-3b@main&#34;,...}],&#34;object&#34;:&#34;list&#34;}&#10;&#10;$ curl -H &#34;Authorization: Bearer &lt;legacy key&gt;&#34; /v1/models # legacy still has no grants&#10;HTTP 200 {&#34;data&#34;:[],&#34;object&#34;:&#34;list&#34;}&#10;&#10;=== Cross-Tenant isolation: pilot-b asks for pilot-a&#39;s Model ===&#10;HTTP 403 {&#34;error&#34;:{&#34;code&#34;:&#34;model_not_authorized&#34;,...}}&#10;&#10;=== Authorized inference passes the access gate (no Node admitted on this host) ===&#10;pilot-a + alpha-8b -&gt; HTTP 503 cluster_busy&#10;pilot-b + beta-3b -&gt; HTTP 503 cluster_busy</code>

```text
=== C. Tenant-filtered discovery: pilot-a granted alpha-8b (defaults), pilot-b granted beta-3b (explicit policy) ===

$ curl -H "Authorization: Bearer <pilot-a key>" /v1/models
HTTP 200
{
    "data": [
        {
            "id": "mlx-community/alpha-8b@main",
            "created": 1787131721,
            "object": "model",
            "owned_by": "local"
        }
    ],
    "object": "list"
}

$ curl -H "Authorization: Bearer <pilot-b key>" /v1/models
HTTP 200
{
    "data": [
        {
            "id": "mlx-community/beta-3b@main",
            "created": 1787131721,
            "object": "model",
            "owned_by": "local"
        }
    ],
    "object": "list"
}

$ curl -H "Authorization: Bearer <legacy key>" /v1/models   # legacy Tenant still has no grants
HTTP 200
{
    "data": [],
    "object": "list"
}

=== D. Cross-Tenant isolation on inference: pilot-b asks for pilot-a's Model ===
$ curl -H "Authorization: Bearer <pilot-b key>" -X POST /v1/chat/completions -d {"model":"mlx-community/alpha-8b@main",...}
HTTP 403
{
    "error": {
        "code": "model_not_authorized",
        "message": "Model not authorized for tenant",
        "type": "invalid_request_error",
        "param": "model"
    }
}

=== E. Authorized inference passes the access gate (no Node is admitted on this host, so it fails later at dispatch) ===
$ curl -H "Authorization: Bearer <pilot-a key>" -X POST /v1/chat/completions -d {"model":"mlx-community/alpha-8b@main",...}
HTTP 503
{
    "error": {
        "code": "cluster_busy",
        "message": "Cluster is busy",
        "type": "server_error",
        "param": null
    }
}

$ curl -H "Authorization: Bearer <pilot-b key>" -X POST /v1/responses -d {"model":"mlx-community/beta-3b@main",...}
HTTP 503
{
    "error": {
        "code": "cluster_busy",
        "message": "Cluster is busy",
        "type": "server_error",
        "param": null
    }
}
```
</details>
<details>
<summary>Evidence: Persisted routing snapshot: explicit global policy vs null policy resolving to canonical defaults</summary>

<code>requested_model | mlx-community/alpha-8b@main (grant attaches the global policy)&#10;resolved_policy | { &#34;quota_id&#34;: null, &#34;allowed_pool_ids&#34;: [], &#34;routing_policy_id&#34;: &#34;c935f68e-3083-4efa-ad3b-cc5b96d12156&#34;, &#34;max_active_requests&#34;: null, &#34;residency_preference&#34;: &#34;prefer_loaded&#34; }&#10;&#10;requested_model | mlx-community/beta-3b@main (grant has no routing policy)&#10;resolved_policy | { &#34;quota_id&#34;: null, &#34;allowed_pool_ids&#34;: [], &#34;routing_policy_id&#34;: null, &#34;max_active_requests&#34;: null, &#34;residency_preference&#34;: &#34;allow_cold_load&#34; }&#10;&#10;# AdmissionPolicy.default_routing_opts() for comparison:&#10;[routing_policy_id: nil, allowed_pool_ids: [], residency_preference: :allow_cold_load, max_cold_start_ms: 15000, queue_wait_ms: 3000]</code>

```text
=== G. Explicit global routing policy vs null policy, snapshotted on the persisted Request ===
# Tenant pilot-c runs with request_body_capture_mode=full so the canonical Request snapshot is persisted.

$ orchardctl models routing-policy create --global --name shared-standard --residency-preference prefer_loaded --max-cold-start-ms 9000 --max-queue-wait-ms 1500
Created c935f68e-3083-4efa-ad3b-cc5b96d12156  name=shared-standard  global  residency=prefer_loaded  cold_start_ms=9000  queue_wait_ms=1500

$ orchardctl models access grant mlx-community/alpha-8b@main --tenant pilot-c --routing-policy-id c935f68e-3083-4efa-ad3b-cc5b96d12156
Granted mlx-community/alpha-8b@main to pilot-c (routing=c935f68e-3083-4efa-ad3b-cc5b96d12156)

$ orchardctl models access grant mlx-community/beta-3b@main --tenant pilot-c
Granted mlx-community/beta-3b@main to pilot-c (routing=defaults)

$ orchardctl models access list --tenant pilot-c
mlx-community/alpha-8b@main  tenant=pilot-c  state=enabled  routing=c935f68e-3083-4efa-ad3b-cc5b96d12156
mlx-community/beta-3b@main  tenant=pilot-c  state=enabled  routing=defaults

POST /v1/chat/completions model=mlx-community/alpha-8b@main -> HTTP 503
POST /v1/chat/completions model=mlx-community/beta-3b@main -> HTTP 503

# Persisted canonical Request routing snapshot for pilot-c:
-[ RECORD 1 ]---+-----------------------------------------------------------------
requested_model | mlx-community/alpha-8b@main
resolved_policy | {                                                               +
                |     "quota_id": null,                                           +
                |     "allowed_pool_ids": [                                       +
                |     ],                                                          +
                |     "routing_policy_id": "c935f68e-3083-4efa-ad3b-cc5b96d12156",+
                |     "max_active_requests": null,                                +
                |     "residency_preference": "prefer_loaded"                     +
                | }
-[ RECORD 2 ]---+-----------------------------------------------------------------
requested_model | mlx-community/beta-3b@main
resolved_policy | {                                                               +
                |     "quota_id": null,                                           +
                |     "allowed_pool_ids": [                                       +
                |     ],                                                          +
                |     "routing_policy_id": null,                                  +
                |     "max_active_requests": null,                                +
                |     "residency_preference": "allow_cold_load"                   +
                | }

# Canonical AdmissionPolicy defaults for comparison (null-policy grant must equal these):
$ orchardctl-side: Orchard.Inference.AdmissionPolicy.default_routing_opts()
Compiling 1 file (.ex)
[routing_policy_id: nil, allowed_pool_ids: [], residency_preference: :allow_cold_load, max_cold_start_ms: 15000, queue_wait_ms: 3000]
```
</details>
<details>
<summary>Evidence: orchardctl grant lifecycle and Tenant-scoped routing policy enforcement</summary>

<code>$ orchardctl models access grant mlx-community/alpha-8b@main --tenant pilot-a&#10;Granted mlx-community/alpha-8b@main to pilot-a (routing=defaults)&#10;$ orchardctl models access grant mlx-community/alpha-8b@main --tenant pilot-a&#10;Already granted mlx-community/alpha-8b@main to pilot-a (routing=defaults)&#10;$ orchardctl models access inspect mlx-community/alpha-8b@main --tenant pilot-a&#10;mlx-community/alpha-8b@main tenant=pilot-a state=enabled routing=defaults&#10;$ orchardctl models routing-policy create --tenant pilot-b --name pilot-b-fast --residency-preference required_loaded --max-cold-start-ms 250 --max-queue-wait-ms 750&#10;Created 521f1278-... name=pilot-b-fast tenant=d2f8b5f7-... residency=required_loaded cold_start_ms=250 queue_wait_ms=750&#10;&#10;# pilot-a may not borrow pilot-b&#39;s Tenant-scoped policy:&#10;Error: model access mutation failed: routing_policy_scope_mismatch&#10;# unknown identities never mutate:&#10;Error: tenant not found: no-such-tenant&#10;Error: model not found: no-such-model@main&#10;Error: routing policy not found: 00000000-0000-4000-8000-000000000000</code>

```text
=== B. orchardctl-only operator surface (source-dev wrapper over the same OrchardCLI dispatch) ===

$ orchardctl models list
Compiling 1 file (.ex)
mlx-community/alpha-8b@main  state=active  format=mlx
mlx-community/beta-3b@main  state=active  format=mlx

$ orchardctl models access list --tenant pilot-a
No model access records for pilot-a.

$ orchardctl models access grant mlx-community/alpha-8b@main --tenant pilot-a
Granted mlx-community/alpha-8b@main to pilot-a (routing=defaults)

$ orchardctl models access grant mlx-community/alpha-8b@main --tenant pilot-a
Already granted mlx-community/alpha-8b@main to pilot-a (routing=defaults)

$ orchardctl models access inspect mlx-community/alpha-8b@main --tenant pilot-a
mlx-community/alpha-8b@main  tenant=pilot-a  state=enabled  routing=defaults

$ orchardctl models routing-policy create --tenant pilot-b --name pilot-b-fast --residency-preference required_loaded --max-cold-start-ms 250 --max-queue-wait-ms 750
Created 521f1278-fe38-430f-8fd7-8c65c56b0ac4  name=pilot-b-fast  tenant=d2f8b5f7-1e9e-418a-ad73-406b6e779997  residency=required_loaded  cold_start_ms=250  queue_wait_ms=750

$ orchardctl models routing-policy list --tenant pilot-b
521f1278-fe38-430f-8fd7-8c65c56b0ac4  name=pilot-b-fast  tenant=d2f8b5f7-1e9e-418a-ad73-406b6e779997  residency=required_loaded  cold_start_ms=250  queue_wait_ms=750

$ orchardctl models routing-policy list --global
No routing policies.
```
</details>
<details>
<summary>Evidence: Disable keeps the policy reference but denies; revoke deletes only the access row</summary>

<code>$ orchardctl models access disable mlx-community/alpha-8b@main --tenant pilot-a&#10;Disabled mlx-community/alpha-8b@main for pilot-a&#10;$ orchardctl models access disable ... (again)&#10;Already disabled mlx-community/alpha-8b@main for pilot-a&#10;$ orchardctl models access inspect ...&#10;mlx-community/alpha-8b@main tenant=pilot-a state=disabled routing=defaults&#10;$ curl -H &#34;Authorization: Bearer &lt;pilot-a key&gt;&#34; /v1/models&#10;HTTP 200 {&#34;data&#34;:[],&#34;object&#34;:&#34;list&#34;}&#10;$ curl ... POST /v1/chat/completions {&#34;model&#34;:&#34;mlx-community/alpha-8b@main&#34;}&#10;HTTP 403 {&#34;error&#34;:{&#34;code&#34;:&#34;model_not_authorized&#34;,...}}&#10;&#10;$ orchardctl models access revoke mlx-community/alpha-8b@main --tenant pilot-a&#10;Revoked mlx-community/alpha-8b@main from pilot-a&#10;$ orchardctl models access revoke ... (again)&#10;No grant for mlx-community/alpha-8b@main and pilot-a&#10;# revoke deletes only the access row; the routing policy survives:&#10;tenant_model_access rows: 3&#10;routing_policies rows: 2</code>

```text
=== H. Disable then revoke: listing and new inference follow the durable state ===

$ orchardctl models access disable mlx-community/alpha-8b@main --tenant pilot-a
Disabled mlx-community/alpha-8b@main for pilot-a

$ orchardctl models access disable mlx-community/alpha-8b@main --tenant pilot-a
Already disabled mlx-community/alpha-8b@main for pilot-a

$ orchardctl models access inspect mlx-community/alpha-8b@main --tenant pilot-a
mlx-community/alpha-8b@main  tenant=pilot-a  state=disabled  routing=defaults

# disabled grant keeps its row and policy reference but denies:
pilot-a | mlx-community/alpha-8b@main | enabled=false | routing_policy_id=NULL
pilot-b | mlx-community/beta-3b@main | enabled=true | routing_policy_id=521f1278-fe38-430f-8fd7-8c65c56b0ac4
pilot-c | mlx-community/alpha-8b@main | enabled=true | routing_policy_id=c935f68e-3083-4efa-ad3b-cc5b96d12156
pilot-c | mlx-community/beta-3b@main | enabled=true | routing_policy_id=NULL

$ curl -H "Authorization: Bearer <pilot-a key>" /v1/models
HTTP 200  {"data":[],"object":"list"}
$ curl -H "Authorization: Bearer <pilot-a key>" -X POST /v1/chat/completions {"model":"mlx-community/alpha-8b@main"}
HTTP 403  {"error":{"code":"model_not_authorized","message":"Model not authorized for tenant","type":"invalid_request_error","param":"model"}}

$ orchardctl models access revoke mlx-community/alpha-8b@main --tenant pilot-a
Compiling 1 file (.ex)
Revoked mlx-community/alpha-8b@main from pilot-a

$ orchardctl models access revoke mlx-community/alpha-8b@main --tenant pilot-a
No grant for mlx-community/alpha-8b@main and pilot-a

$ orchardctl models access inspect mlx-community/alpha-8b@main --tenant pilot-a
Error: not_granted

# revoke deletes only the access row; the routing policy it referenced survives:
tenant_model_access rows: 3
routing_policies rows: 2

$ curl -H "Authorization: Bearer <pilot-a key>" /v1/models
HTTP 200  {"data":[],"object":"list"}
$ curl -H "Authorization: Bearer <pilot-a key>" -X POST /v1/chat/completions {"model":"mlx-community/alpha-8b@main"}
HTTP 403  {"error":{"code":"model_not_authorized","message":"Model not authorized for tenant","type":"invalid_request_error","param":"model"}}
```
</details>
<details>
<summary>Evidence: Audit evidence with no duplicate no-op rows and no sensitive payload content</summary>

<code>at | action | scope | tenant | actor_type | surface | target_type&#10;----------+------------------------------+---------+---------+------------+------------+---------------------&#10;09:33:16 | tenant_model_access.granted | tenant | pilot-a | operator | orchardctl | tenant_model_access&#10;09:33:18 | routing_policy.created | tenant | pilot-b | operator | orchardctl | routing_policy&#10;09:35:35 | routing_policy.created | cluster | - | operator | orchardctl | routing_policy&#10;09:36:14 | tenant_model_access.disabled | tenant | pilot-a | operator | orchardctl | tenant_model_access&#10;09:36:16 | tenant_model_access.revoked | tenant | pilot-a | operator | orchardctl | tenant_model_access&#10;&#10;# payload shape (no credentials, prompts, responses or artifact paths); api_key_id is NULL:&#10;{ &#34;enabled&#34;: true, &#34;surface&#34;: &#34;orchardctl&#34;, &#34;model_id&#34;: &#34;41a8a60d-...&#34;, &#34;tenant_id&#34;: &#34;d68527d8-...&#34;, &#34;routing_policy_id&#34;: null, &#34;previous_routing_policy_id&#34;: null }&#10;&#10;# grant/disable/revoke were each issued twice; audit rows per action:&#10;tenant_model_access.disabled | 1&#10;tenant_model_access.granted | 4 (pilot-a x1, pilot-b x1, pilot-c x2 - the repeat grant added none)&#10;tenant_model_access.revoked | 1</code>

```text
=== I. Append-only audit evidence for every state-changing grant / routing-policy operation ===
# The transcript above ran grant, disable and revoke TWICE each; only real state changes are audited.

    at    |            action            |  scope  | tenant  | actor_type |  surface   |     target_type     
----------+------------------------------+---------+---------+------------+------------+---------------------
 09:33:16 | tenant_model_access.granted  | tenant  | pilot-a | operator   | orchardctl | tenant_model_access
 09:33:18 | routing_policy.created       | tenant  | pilot-b | operator   | orchardctl | routing_policy
 09:33:29 | tenant_model_access.granted  | tenant  | pilot-b | operator   | orchardctl | tenant_model_access
 09:35:35 | routing_policy.created       | cluster | -       | operator   | orchardctl | routing_policy
 09:35:36 | tenant_model_access.granted  | tenant  | pilot-c | operator   | orchardctl | tenant_model_access
 09:35:37 | tenant_model_access.granted  | tenant  | pilot-c | operator   | orchardctl | tenant_model_access
 09:36:14 | tenant_model_access.disabled | tenant  | pilot-a | operator   | orchardctl | tenant_model_access
 09:36:16 | tenant_model_access.revoked  | tenant  | pilot-a | operator   | orchardctl | tenant_model_access
(8 rows)

# Full payloads (no credentials, no prompts, no responses, no artifact paths):
-[ RECORD 1 ]----------------------------------------------------------------
action     | tenant_model_access.granted
api_key_id | 
payload    | {                                                               +
           |     "enabled": true,                                            +
           |     "surface": "orchardctl",                                    +
           |     "model_id": "41a8a60d-a504-45d5-88aa-94d22930b80a",         +
           |     "tenant_id": "d68527d8-8efd-4383-92bc-182a5e75814a",        +
           |     "routing_policy_id": null,                                  +
           |     "previous_routing_policy_id": null                          +
           | }
-[ RECORD 2 ]----------------------------------------------------------------
action     | routing_policy.created
api_key_id | 
payload    | {                                                               +
           |     "name": "pilot-b-fast",                                     +
           |     "surface": "orchardctl",                                    +
           |     "tenant_id": "d2f8b5f7-1e9e-418a-ad73-406b6e779997",        +
           |     "max_cold_start_ms": 250,                                   +
           |     "max_queue_wait_ms": 750,                                   +
           |     "residency_preference": "required_loaded"                   +
           | }
-[ RECORD 3 ]----------------------------------------------------------------
action     | tenant_model_access.granted
api_key_id | 
payload    | {                                                               +
           |     "enabled": true,                                            +
           |     "surface": "orchardctl",                                    +
           |     "model_id": "ccada385-2ef1-4067-a43c-f302c4883a44",         +
           |     "tenant_id": "d2f8b5f7-1e9e-418a-ad73-406b6e779997",        +
           |     "routing_policy_id": "521f1278-fe38-430f-8fd7-8c65c56b0ac4",+
           |     "previous_routing_policy_id": null                          +
           | }
-[ RECORD 4 ]----------------------------------------------------------------
action     | routing_policy.created
api_key_id | 
payload    | {                                                               +
           |     "name": "shared-standard",                                  +
           |     "surface": "orchardctl",                                    +
           |     "tenant_id": null,                                          +
           |     "max_cold_start_ms": 9000,                                  +
           |     "max_queue_wait_ms": 1500,                                  +
           |     "residency_preference": "prefer_loaded"                     +
           | }
-[ RECORD 5 ]----------------------------------------------------------------
action     | tenant_model_access.granted
api_key_id | 
payload    | {                                                               +
           |     "enabled": true,                                            +
           |     "surface": "orchardctl",                                    +
           |     "model_id": "41a8a60d-a504-45d5-88aa-94d22930b80a",         +
           |     "tenant_id": "b5d3a2a9-045d-4716-a775-7d37b442fe00",        +
           |     "routing_policy_id": "c935f68e-3083-4efa-ad3b-cc5b96d12156",+
           |     "previous_routing_policy_id": null                          +
           | }
-[ RECORD 6 ]----------------------------------------------------------------
action     | tenant_model_access.granted
api_key_id | 
payload    | {                                                               +
           |     "enabled": true,                                            +
           |     "surface": "orchardctl",                                    +
           |     "model_id": "ccada385-2ef1-4067-a43c-f302c4883a44",         +
           |     "tenant_id": "b5d3a2a9-045d-4716-a775-7d37b442fe00",        +
           |     "routing_policy_id": null,                                  +
           |     "previous_routing_policy_id": null                          +
           | }
-[ RECORD 7 ]----------------------------------------------------------------
action     | tenant_model_access.disabled
api_key_id | 
payload    | {                                                               +
           |     "enabled": false,                                           +
           |     "surface": "orchardctl",                                    +
           |     "model_id": "41a8a60d-a504-45d5-88aa-94d22930b80a",         +
           |     "tenant_id": "d68527d8-8efd-4383-92bc-182a5e75814a",        +
           |     "routing_policy_id": null,                                  +
           |     "previous_routing_policy_id": null                          +
           | }
-[ RECORD 8 ]----------------------------------------------------------------
action     | tenant_model_access.revoked
api_key_id | 
payload    | {                                                               +
           |     "enabled": false,                                           +
           |     "surface": "orchardctl",                                    +
           |     "model_id": "41a8a60d-a504-45d5-88aa-94d22930b80a",         +
           |     "tenant_id": "d68527d8-8efd-4383-92bc-182a5e75814a",        +
           |     "routing_policy_id": null,                                  +
           |     "previous_routing_policy_id": null                          +
           | }

# No-op counter: grant/disable/revoke were each issued twice, audit rows per action:
            action            | audit_rows 
------------------------------+------------
 tenant_model_access.disabled |          1
 tenant_model_access.granted  |          4
 tenant_model_access.revoked  |          1
(3 rows)
```
</details>
<details>
<summary>Evidence: Concurrency safety across independent orchardctl processes</summary>

<code>$ for i in 1..8; do orchardctl models access grant mlx-community/alpha-8b@main --tenant pilot-b &amp; done; wait&#10;Granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)&#10;Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults) x7&#10;&#10;# Convergent durable state:&#10;access_rows&#10;-------------&#10;1&#10;action | audit_rows&#10;-----------------------------+------------&#10;tenant_model_access.granted | 1</code>

```text
=== K. Concurrency safety: 8 independent orchardctl OS processes grant the same Tenant+Model at once ===
# (build already warm, so these boot and hit Postgres concurrently)
$ for i in 1..8; do orchardctl models access grant mlx-community/alpha-8b@main --tenant pilot-b & done; wait
Granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)
Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)
Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)
Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)
Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)
Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)
Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)
Already granted mlx-community/alpha-8b@main to pilot-b (routing=defaults)

# Convergent durable state: exactly one access row and one audit row for that Tenant+Model:
 access_rows 
-------------
           1
(1 row)

           action            | audit_rows 
-----------------------------+------------
 tenant_model_access.granted |          1
(1 row)
```
</details>
<details>
<summary>Evidence: Database integrity boundary: empty pools, cross-Tenant rejection, immutable policy scope</summary>

<code>-- non-empty allowed_pool_ids is rejected by persistence, not just by app code&#10;ERROR: new row for relation &#34;routing_policies&#34; violates check constraint &#34;routing_policies_pool_constraints_deferred&#34;&#10;&#10;-- cross-Tenant routing policy attachment is rejected at the integrity boundary&#10;ERROR: routing policy must be global or owned by the access tenant&#10;&#10;-- routing policy Tenant scope cannot be changed after creation&#10;ERROR: routing policy tenant scope is immutable&#10;&#10;-- state unchanged after all three rejected mutations&#10;name | scope | allowed_pool_ids | preferred_pool_ids&#10;-----------------+----------+------------------+--------------------&#10;pilot-b-fast | d2f8b5f7 | {} | {}&#10;shared-standard | GLOBAL | {} | {}</code>

```text
=== L. Database integrity boundary: pool arrays stay empty, policy Tenant scope is immutable ===

-- non-empty allowed_pool_ids is rejected by persistence, not just by app code
ERROR:  new row for relation "routing_policies" violates check constraint "routing_policies_pool_constraints_deferred"
DETAIL:  Failing row contains (b3b9aebf-94bb-4caf-90a8-e06818542e79, null, illegal-pools, {11dbcec1-d6ac-4423-a2c9-8c23db76bdc4}, {}, prefer_loaded, 1000, 1000, 100, 2026-08-19 17:44:52.381026, 2026-08-19 17:44:52.381026).

-- cross-Tenant routing policy attachment is rejected at the integrity boundary
ERROR:  routing policy must be global or owned by the access tenant
CONTEXT:  PL/pgSQL function orchard_enforce_tenant_model_access_policy_scope() line 16 at RAISE

-- routing policy Tenant scope cannot be changed after creation
ERROR:  routing policy tenant scope is immutable
CONTEXT:  PL/pgSQL function orchard_reject_routing_policy_tenant_change() line 4 at RAISE

-- state is unchanged after all three rejected mutations
      name       |                scope                 | allowed_pool_ids | preferred_pool_ids 
-----------------+--------------------------------------+------------------+--------------------
 pilot-b-fast    | d2f8b5f7-1e9e-418a-ad73-406b6e779997 | {}               | {}
 shared-standard | GLOBAL                               | {}               | {}
(2 rows)
```
</details>
<details>
<summary>Evidence: Service Account credential parity with the Tenant-direct credential</summary>

<code>$ curl -H &#34;Authorization: Bearer &lt;pilot-b TENANT-DIRECT key&gt;&#34; /v1/models&#10;HTTP 200 {&#34;data&#34;:[{&#34;id&#34;:&#34;mlx-community/alpha-8b@main&#34;,...},{&#34;id&#34;:&#34;mlx-community/beta-3b@main&#34;,...}],&#34;object&#34;:&#34;list&#34;}&#10;$ curl -H &#34;Authorization: Bearer &lt;pilot-b SERVICE ACCOUNT key&gt;&#34; /v1/models&#10;HTTP 200 {&#34;data&#34;:[{&#34;id&#34;:&#34;mlx-community/alpha-8b@main&#34;,...},{&#34;id&#34;:&#34;mlx-community/beta-3b@main&#34;,...}],&#34;object&#34;:&#34;list&#34;}&#10;&#10;# after revoking alpha-8b from pilot-b, both credentials are denied identically:&#10;TENANT-DIRECT -&gt; HTTP 403 model_not_authorized&#10;SERVICE ACCOUNT -&gt; HTTP 403 model_not_authorized&#10;SERVICE ACCOUNT + still-granted beta-3b on /v1/responses -&gt; HTTP 503 cluster_busy</code>

```text
=== N. A Service Account credential gets the same decision as the Tenant-direct credential ===
# orchardctl api-clients bulk-provision created a Service Account key under Tenant pilot-b.
# pilot-b's grants: alpha-8b (defaults) and beta-3b (pilot-b-fast policy). It has no grant for anything else.

$ curl -H "Authorization: Bearer <pilot-b TENANT-DIRECT key>" /v1/models
HTTP 200  {"data":[{"id":"mlx-community/alpha-8b@main","created":1787131721,"object":"model","owned_by":"local"},{"id":"mlx-community/beta-3b@main","created":1787131721,"object":"model","owned_by":"local"}],"object":"list"}
$ curl -H "Authorization: Bearer <pilot-b SERVICE ACCOUNT key>" /v1/models
HTTP 200  {"data":[{"id":"mlx-community/alpha-8b@main","created":1787131721,"object":"model","owned_by":"local"},{"id":"mlx-community/beta-3b@main","created":1787131721,"object":"model","owned_by":"local"}],"object":"list"}

# and the same denial for a Model pilot-b is not granted (after revoking alpha-8b from pilot-b):
Compiling 1 file (.ex)
Revoked mlx-community/alpha-8b@main from pilot-b
$ curl -H "Authorization: Bearer <pilot-b TENANT-DIRECT key>" -X POST /v1/chat/completions {"model":"mlx-community/alpha-8b@main"}
HTTP 403  {"error":{"code":"model_not_authorized","message":"Model not authorized for tenant","type":"invalid_request_error","param":"model"}}
$ curl -H "Authorization: Bearer <pilot-b SERVICE ACCOUNT key>" -X POST /v1/chat/completions {"model":"mlx-community/alpha-8b@main"}
HTTP 403  {"error":{"code":"model_not_authorized","message":"Model not authorized for tenant","type":"invalid_request_error","param":"model"}}
$ curl -H "Authorization: Bearer <pilot-b SERVICE ACCOUNT key>" -X POST /v1/responses {"model":"mlx-community/beta-3b@main"}  # still granted
HTTP 503  {"error":{"code":"cluster_busy","message":"Cluster is busy","type":"server_error","param":null}}
```
</details>
<details>
<summary>Evidence: Operator surface is orchardctl-only (no HTTP or Console grant management)</summary>

<code># router grant/access routes:&#10;(none)&#10;# Console LiveViews referencing grant mutations:&#10;(none)&#10;# writers of tenant_model_access / routing_policies:&#10;apps/orchard_controller/lib/orchard/models/access.ex&#10;# probing plausible HTTP admin paths on the running Controller:&#10;/admin/v1/tenants/x/model-access -&gt; HTTP 404&#10;/admin/v1/model-access -&gt; HTTP 404&#10;/v1/model-access -&gt; HTTP 404&#10;/admin/v1/routing-policies -&gt; HTTP 404</code>

```text
=== M. Operator surface is orchardctl-only: no HTTP or Console grant-management surface ===

# router grant/access routes:
  (none)

# Console LiveViews referencing grant mutations:
  (none)

# writers of tenant_model_access / routing_policies outside Orchard.Models.Access:
  apps/orchard_controller/lib/orchard/models/access.ex

# probing plausible HTTP admin paths on the running Controller:
  /admin/v1/tenants/x/model-access           -> HTTP 404
  /admin/v1/model-access                     -> HTTP 404
  /v1/model-access                           -> HTTP 404
  /admin/v1/routing-policies                 -> HTTP 404
```
</details>
<details>
<summary>Evidence: Operator commands run between the two Console screenshots</summary>

<code>$ orchardctl models access list --tenant legacy&#10;No model access records for legacy.&#10;# -&gt; screenshot 10-console-playground-ungranted.png (picker empty, new empty-state copy)&#10;&#10;$ orchardctl models access grant mlx-community/alpha-8b@main --tenant legacy&#10;Granted mlx-community/alpha-8b@main to legacy (routing=defaults)&#10;$ orchardctl models access list --tenant legacy&#10;mlx-community/alpha-8b@main tenant=legacy state=enabled routing=defaults&#10;# -&gt; screenshot 11-console-playground-granted.png (picker now offers the granted Model)</code>

```text
=== J. Console Playground shares the seeded legacy Tenant and obeys the same grants ===

$ orchardctl models access list --tenant legacy
Compiling 1 file (.ex)
No model access records for legacy.

# -> screenshot 10-console-playground-ungranted.png (picker empty, new empty-state copy)

$ orchardctl models access grant mlx-community/alpha-8b@main --tenant legacy
Granted mlx-community/alpha-8b@main to legacy (routing=defaults)

$ orchardctl models access list --tenant legacy
mlx-community/alpha-8b@main  tenant=legacy  state=enabled  routing=defaults

# -> screenshot 11-console-playground-granted.png (picker now offers the granted Model)
```
</details>
<details>
<summary>Evidence: Documentation deliverables (ADR 0021, OpenSpec change, rollout guidance) and absence of transient files</summary>

<code>docs/decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md | 63 +++++++&#10;docs/local-dev.md | 28 +++-&#10;openspec/changes/tenant-model-grants/design.md | 186 +++++++&#10;openspec/changes/tenant-model-grants/proposal.md | 56 +++++&#10;openspec/changes/tenant-model-grants/specs/tenant-model-access/spec.md | 167 ++++++&#10;openspec/changes/tenant-model-grants/tasks.md | 79 +++++&#10;&#10;-- Transient/unrelated files in the change (expect none):&#10;(none)</code>

```text
=== O. Documentation deliverables shipped with the change ===
 ...it-tenant-model-grants-and-routing-snapshots.md |  63 +++++++
 docs/local-dev.md                                  |  28 +++-
 openspec/changes/tenant-model-grants/design.md     | 186 +++++++++++++++++++++
 openspec/changes/tenant-model-grants/proposal.md   |  56 +++++++
 .../specs/tenant-model-access/spec.md              | 167 ++++++++++++++++++
 openspec/changes/tenant-model-grants/tasks.md      |  79 +++++++++
 6 files changed, 577 insertions(+), 2 deletions(-)

-- ADR 0021 (title + status):
# ADR: Explicit Tenant-model grants and routing snapshots

## Status

Accepted.

## Context

`SPEC.md` requires active catalog state, an enabled Tenant grant, and routing resolution before a Model is visible or usable by a public inference caller.
Current code resolves an effective Tenant but lists every active Model and accepts any active Model during shared request preparation.
The apex schema permits Tenant-scoped and global routing policies and allows a grant to omit a policy, but it does not define an implicit global-policy selection order, migration backfill, or whether disable and revoke are identical.
The scheduler does not yet enforce pool allowlists or preferences.

-- Rollout guidance added to docs/local-dev.md:
  
  # 5. Grant the Tenant explicit access to the Model (nothing is granted automatically)
  OrchardCLI.main(["models", "access", "grant", "<model_id>@<version>", "--tenant", "dev"])
  
  # 6. Grant the Console Playground Tenant as well (the Console runs as the seeded `legacy` Tenant)
  OrchardCLI.main(["models", "access", "grant", "<model_id>@<version>", "--tenant", "legacy"])
  Model access is deny-by-default. Any Model without an enabled grant for the
  calling Tenant is omitted from `GET /v1/models` and rejected by
  `/v1/chat/completions` and `/v1/responses` with `403 model_not_authorized`.
  No Tenant — including the seeded `legacy` Tenant — receives an automatic grant,
  so step 5 is required before any `/v1` inference call succeeds. The Console
  Playground runs as the `legacy` Tenant and lists only Models granted to it, so
  step 6 is required before it can send a message. Because the Console shares the
  `legacy` Tenant, that grant also authorizes any existing `legacy`-Tenant API
  credential for the same Model on `/v1`. See `../apps/orchard_cli/README.md` for
  the full `orchardctl models access` and `orchardctl models routing-policy`
  surface, and `decisions/0021-explicit-tenant-model-grants-and-routing-snapshots.md`
  for the decision record.
  
  The probe posts to `/v1/responses` with a Tenant token, so the probe Model must
  already be granted to that token's Tenant with
  `orchardctl models access grant <model_id@version> --tenant <uuid-or-slug>`.
  An ungranted Model fails the probe with `403 model_not_authorized`.
  
  3. `GET /v1/models` should return `200` and list the Models granted to the calling Tenant.
  4. `POST /v1/chat/completions` should complete through the Console Playground or an equivalent API request, after the Model is granted to the calling Tenant (`legacy` for the Console Playground).

-- Transient/unrelated files in the change (expect none):
  (none)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

_... (3 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 1 info</summary>

🔧 Fix: make Console Playground tenant-aware under deny-by-default grants
3 infos still open:
- ℹ️ `apps/orchard_controller/lib/orchard/console/playground.ex:215` - start_stream/4 now honors an explicit caller_context :tenant_id (Keyword.put_new at line 152), but the pre-execution gate ensure_model_inference_ready/1 calls list_models/0, which is hardcoded to effective_tenant_id/0. So a caller passing a non-legacy tenant would be gated against the legacy Tenant&#39;s grants and then enforced against its own tenant at prepare. Not reachable today: playground_live.ex:394 uses start_stream/3, so both layers resolve to the legacy Tenant. Worth knowing that the new playground_test.exs &#34;keeps an explicit caller tenant context&#34; test only passes because StubModels ignores the tenant argument when the stub value is a list; with the real Models impl that model would not be listed for the explicit tenant and the run would be blocked before prepare. If the console ever gains per-Tenant identity, thread the caller tenant into the readiness lookup (e.g. list_models/1 with the LiveView passing effective_tenant_id/0) rather than adding a second tenant source.
- ℹ️ `apps/orchard_controller/lib/orchard/console/playground.ex:70` - &#34;The Console Playground acts as the seeded legacy Tenant&#34; is now a durable governance decision (it determines which Models a Console operator can see and run), but it is recorded only in this module&#39;s docstring and docs/local-dev.md. ADR 0021 and openspec/changes/tenant-model-grants/ (both owned by this branch) say only that &#34;a partial Admin API or Console surface is not required for the first slice&#34; and are silent on Console consumption. A consequence worth recording explicitly: because the Console shares the legacy Tenant, granting a Model so operators can use the Playground also authorizes any existing legacy-Tenant API credentials for that Model on /v1. Consider one line in ADR 0021 Consequences plus a Console scenario in the tenant-model-access delta; alternatively confirm the local-dev doc is the intended record.
- ℹ️ `apps/orchard_controller/lib/orchard/console/playground.ex:237` - The `nil` branch of ensure_model_inference_ready/1 previously reported &#34;Selected model is not available in the catalog&#34; and now reports &#34;Selected model is not granted to this console tenant&#34;. That branch is also taken when the submitted model genuinely is not in the catalog — retired or deleted between picker render and submit, or an arbitrary model string posted through the form — so an operator debugging a retired model now gets a grant hint instead of an accurate cause. Behavior is still fail-closed either way; only the diagnostic wording is affected. Consider covering both cases (&#34;not available to this console tenant — it may be inactive or not granted; grant it with orchardctl models access grant&#34;).

🔧 Fix: record Console tenant decision; split ungranted vs inactive diagnostics
1 info still open:
- ℹ️ `apps/orchard_controller/lib/orchard/console/playground.ex:258` - catalog_active?/1 issues a second, unprotected Repo query on the failure path. list_models/0 wraps its own query in `rescue _ -&gt; {:error, models_unavailable}` (line ~97), but this helper has no rescue, so a connection drop between the two calls escapes ensure_model_inference_ready/1 into run_stream/5&#39;s catch-all rescue (line 175) and reclassifies a clean `%{phase: :prepare, code: &#34;model_not_ready&#34;}` outcome as `%{phase: :execute, code: &#34;internal_error&#34;, message: &#34;Unexpected error: ...&#34;}` with the raw exception text. Narrow race (list_models/0 just succeeded) and security is unaffected — both branches of unavailable_reason/1 still deny — but a `rescue _ -&gt; false` keeps the previous clean failure mode. Secondary, lower-priority note: the membership test loads the entire active catalog via Enum.any?; if the seam is ever extended, a single get_model_by_identity/2 lookup would be an indexed check instead.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/models/access_test.exs apps/orchard_controller/test/orchard/repo/migrations/tenant_model_access_migration_test.exs apps/orchard_controller/test/orchard/inference/request_preparation_access_test.exs` (27 passed)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/api/models_controller_test.exs apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs apps/orchard_controller/test/orchard/api/responses_controller_test.exs apps/orchard_controller/test/orchard/inference/chat_error_test.exs` (104 passed)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/console/playground_access_test.exs apps/orchard_controller/test/orchard/console/playground_test.exs apps/orchard_controller/test/orchard/console/playground_live_test.exs` (73 passed)</code>
- <code>`mise exec -- mix test apps/orchard_cli/test/orchard_cli/commands/models_test.exs apps/orchard_cli/test/orchard_cli_test.exs` (54 passed)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/api/safe_tokenization_lifecycle_test.exs apps/orchard_controller/test/orchard/inference/chat_orchestrator_test.exs apps/orchard_controller/test/orchard/inference/chat_orchestrator_port_mode_test.exs apps/orchard_controller/test/orchard/inference_test.exs apps/orchard_controller/test/orchard/repo/migrations/governance_db_foundation_test.exs` (99 passed)</code>
- <code>Staged rollout: `MIX_ENV=dev PGDATABASE=orchard_grants_premigrate mix ecto.migrate --to 20260813010000`, seeded 3 Tenants + 2 active Models, then `mix ecto.migrate` and asserted `SELECT count(*) FROM tenant_model_access` = 0 and no grant for any Tenant x active-Model pair</code>
- <code>Live source-dev Controller: `PGDATABASE=orchard_grants_premigrate MIX_ENV=dev PORT=4099 mix phx.server` (tokenizer switched to the supported `:fake` mode over CDP-free `:rpc` since this host has no MLX artifacts)</code>
- <code>`curl -H &#39;Authorization: Bearer &lt;tenant key&gt;&#39; http://127.0.0.1:4099/v1/models` for pilot-a, pilot-b, legacy, and a Service Account key</code>
- <code>`curl -X POST http://127.0.0.1:4099/v1/chat/completions` and `curl -X POST http://127.0.0.1:4099/v1/responses` for ungranted, cross-Tenant, disabled, revoked, granted, and non-existent Models</code>
- <code>`psql -d orchard_grants_premigrate -c &#34;SELECT count(*) FROM requests&#34;` to confirm denied calls persist no Request row</code>
- <code>`orchardctl models access grant|inspect|list|disable|revoke` and `orchardctl models routing-policy create|list` including repeat/no-op invocations and unknown Tenant/Model/policy identities</code>
- <code>`orchardctl models access grant ... --routing-policy-id &lt;other tenant&#39;s policy&gt;` (rejected with routing_policy_scope_mismatch)</code>
- <code>8 concurrent `orchardctl models access grant` OS processes on the same Tenant+Model, then counted access rows and audit rows</code>
- <code>`psql` direct INSERT/UPDATE attempts against `routing_policies` (non-empty pool array), `tenant_model_access` (cross-Tenant policy), and routing-policy tenant_id mutation</code>
- <code>`psql -x -c &#34;SELECT jsonb_pretty(canonical_request-&gt;&#39;resolved_policy&#39;) FROM requests&#34;` for a full-capture Tenant, compared against `Orchard.Inference.AdmissionPolicy.default_routing_opts()`</code>
- <code>`psql` query of `audit_logs` for `routing_policy.*` and `tenant_model_access.*` actions, payloads, and per-action row counts</code>
- <code>`orchardctl api-clients bulk-provision --apply` to mint a Service Account credential under pilot-b, then compared its listing/inference decisions to the Tenant-direct key</code>
- <code>Headless Chrome (CDP `Page.captureScreenshot`) of `http://127.0.0.1:4099/console/playground` before and after `orchardctl models access grant ... --tenant legacy`</code>
- <code>Operator-surface scope check: grep of `apps/orchard_controller/lib/orchard/api/router.ex`, Console LiveViews, and all `TenantModelAccess.changeset`/`RoutingPolicy.changeset` writers, plus `curl -X POST` probes of plausible admin grant paths (all 404)</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `packaging/pkg/README.md:626` - Ownership split worth a follow-up, left as a pointer rather than a migration here: the operator rollout ordering for the fail-closed grants migration (stop/drain inference, migrate, create policies, grant pairs, verify positive and negative access, then re-expose) lives in apps/orchard_cli/README.md:99, an app orientation README, while packaging/pkg/README.md owns the packaged upgrade sequence. I kept the packaged upgrade step as a short consequence plus a link to that section instead of duplicating the ordering. A later change could move the operator rollout sequence into the packaging runbook and leave the CLI README owning only the command surface; doing it now would exceed this change&#39;s scope.

🔧 Fix: move tenant/model grant rollout into packaging runbook
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789725923&installation_model_id=428414&pr_number=224&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F224&signature=548202301ecf4debe8dbff7fbfdd5ab4bdd73127f1cd797c77867ea496128e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->