### PR TITLE
fix(node_agent): reap MLX worker OS children via RuntimeProcessReaper

### DIFF
--- a/apps/orchard_node_agent/lib/orchard/node/model_load_failure.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_load_failure.ex
@@ -249,6 +249,14 @@ defmodule Orchard.Node.ModelLoadFailure do
         "model runtime is unavailable on this node"
       )
 
+  def from_reason(:reaper_unavailable),
+    do:
+      new(
+        :MODEL_LOAD_FAILURE_CATEGORY_RUNTIME_UNAVAILABLE,
+        "reaper_unavailable",
+        "model runtime supervision is unavailable on this node"
+      )
+
   def from_reason({:worker_exited, _status}),
     do:
       new(

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
@@ -17,6 +17,7 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   use GenServer
 
   alias Orchard.Node.WorkerProcessLifecycle
+  require Logger
 
   @type lease_ref :: reference()
 
@@ -30,6 +31,8 @@ defmodule Orchard.Node.RuntimeProcessReaper do
           owner_pid: pid(),
           owner_monitor_ref: reference(),
           os_pid: pos_integer(),
+          model_ref: term(),
+          phase: :loading | :loaded | :unloading,
           shutdown_timeout_ms: pos_integer(),
           timer_ref: reference() | nil
         }
@@ -49,7 +52,15 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   @spec watch(pid(), pos_integer(), lease_meta()) :: {:ok, lease_ref()} | {:error, atom()}
   def watch(owner_pid, os_pid, meta)
       when is_pid(owner_pid) and is_integer(os_pid) and os_pid > 0 do
-    GenServer.call(__MODULE__, {:watch, owner_pid, os_pid, meta})
+    if Process.whereis(__MODULE__) do
+      try do
+        GenServer.call(__MODULE__, {:watch, owner_pid, os_pid, meta})
+      catch
+        :exit, _reason -> {:error, :reaper_unavailable}
+      end
+    else
+      {:error, :reaper_unavailable}
+    end
   end
 
   def watch(_, _, _), do: {:error, :invalid_lease}
@@ -60,8 +71,8 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   end
 
   @spec reap(lease_ref(), term()) :: :ok
-  def reap(ref, _reason) do
-    GenServer.cast(__MODULE__, {:reap, ref})
+  def reap(ref, reason) do
+    GenServer.cast(__MODULE__, {:reap, ref, reason})
   end
 
   @impl true
@@ -85,6 +96,8 @@ defmodule Orchard.Node.RuntimeProcessReaper do
     lease = %{
       owner_pid: owner_pid,
       owner_monitor_ref: monitor_ref,
+      model_ref: Map.get(meta, :model_ref),
+      phase: Map.get(meta, :phase, :loading),
       os_pid: os_pid,
       shutdown_timeout_ms: Map.get(meta, :shutdown_timeout_ms, 1_000),
       timer_ref: nil
@@ -103,12 +116,12 @@ defmodule Orchard.Node.RuntimeProcessReaper do
     {:noreply, cleanup_lease(state, ref)}
   end
 
-  def handle_cast({:reap, ref}, state) do
-    {:noreply, start_reaping(state, ref)}
+  def handle_cast({:reap, ref, reason}, state) do
+    {:noreply, start_reaping(state, ref, {:requested, reason})}
   end
 
   @impl true
-  def handle_info({:DOWN, monitor_ref, :process, _pid, _reason}, state) do
+  def handle_info({:DOWN, monitor_ref, :process, _pid, reason}, state) do
     {ref, owner_monitors} = Map.pop(state.owner_monitors, monitor_ref)
 
     state =
@@ -116,20 +129,23 @@ defmodule Orchard.Node.RuntimeProcessReaper do
         state
       else
         state = %{state | owner_monitors: owner_monitors}
-        start_reaping(state, ref)
+        start_reaping(state, ref, {:owner_down, reason})
       end
 
     {:noreply, state}
   end
 
   def handle_info({:escalate, ref}, state) do
-    case Map.pop(state.leases, ref) do
-      {nil, _} ->
+    case state.leases[ref] do
+      nil ->
         {:noreply, state}
 
-      {%{os_pid: os_pid}, leases} ->
-        WorkerProcessLifecycle.kill_process_tree(os_pid)
-        {:noreply, %{state | leases: leases}}
+      %{os_pid: os_pid} = _lease ->
+        if WorkerProcessLifecycle.os_process_alive?(os_pid) do
+          WorkerProcessLifecycle.kill_process_tree(os_pid)
+        end
+
+        {:noreply, cleanup_lease(state, ref)}
     end
   end
 
@@ -141,24 +157,34 @@ defmodule Orchard.Node.RuntimeProcessReaper do
     {:stop, reason, state}
   end
 
+  def handle_info(_message, state), do: {:noreply, state}
+
   @impl true
   def terminate(_reason, state) do
     Enum.each(state.leases, fn {_ref, %{os_pid: os_pid}} ->
-      WorkerProcessLifecycle.kill_process_tree(os_pid)
+      if WorkerProcessLifecycle.os_process_alive?(os_pid) do
+        WorkerProcessLifecycle.kill_process_tree(os_pid)
+      end
     end)
 
     :ok
   end
 
-  defp start_reaping(state, ref) do
+  defp start_reaping(state, ref, reason) do
     case get_in(state.leases[ref]) do
       nil ->
         state
 
-      %{os_pid: os_pid, shutdown_timeout_ms: timeout, timer_ref: nil} ->
-        WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
-        timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
-        put_in(state.leases[ref][:timer_ref], timer_ref)
+      %{os_pid: os_pid, shutdown_timeout_ms: timeout, timer_ref: nil} = lease ->
+        log_orphan_reap(lease, reason)
+
+        if WorkerProcessLifecycle.os_process_alive?(os_pid) do
+          WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+          timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
+          put_in(state.leases[ref][:timer_ref], timer_ref)
+        else
+          cleanup_lease(state, ref)
+        end
 
       _other ->
         state
@@ -182,4 +208,18 @@ defmodule Orchard.Node.RuntimeProcessReaper do
         %{state | leases: leases, owner_monitors: owner_monitors}
     end
   end
+
+  defp log_orphan_reap(lease, {:owner_down, reason}) do
+    Logger.warning(
+      "reaping orphaned worker process " <>
+        inspect(%{
+          model_ref: lease.model_ref,
+          os_pid: lease.os_pid,
+          owner_reason: reason,
+          phase: lease.phase
+        })
+    )
+  end
+
+  defp log_orphan_reap(_lease, _reason), do: :ok
 end

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
@@ -1,0 +1,185 @@
+defmodule Orchard.Node.RuntimeProcessReaper do
+  @moduledoc """
+  Guarantees that an OS-level worker subprocess is reaped when its owning
+  WorkerProcess dies.
+
+  The reaper owns `{owner_pid -> os_pid}` leases. A lease is registered as soon
+  as the port opens and before readiness polling starts, so a worker killed
+  during a long model load is still cleaned up.
+
+  Because the reaper is a separate, mailbox-light GenServer placed before
+  `WorkerSupervisor` in the `:rest_for_one` tree, it survives worker death and
+  performs escalation even when the owning WorkerProcess is killed abruptly by
+  its supervisor. Its own `terminate/2` sweeps any remaining leases on node
+  shutdown.
+  """
+
+  use GenServer
+
+  alias Orchard.Node.WorkerProcessLifecycle
+
+  @type lease_ref :: reference()
+
+  @type lease_meta :: %{
+          shutdown_timeout_ms: pos_integer(),
+          model_ref: term(),
+          phase: :loading | :loaded | :unloading
+        }
+
+  @type lease :: %{
+          owner_pid: pid(),
+          owner_monitor_ref: reference(),
+          os_pid: pos_integer(),
+          shutdown_timeout_ms: pos_integer(),
+          timer_ref: reference() | nil
+        }
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      shutdown: 5_000
+    }
+  end
+
+  @spec watch(pid(), pos_integer(), lease_meta()) :: {:ok, lease_ref()} | {:error, atom()}
+  def watch(owner_pid, os_pid, meta)
+      when is_pid(owner_pid) and is_integer(os_pid) and os_pid > 0 do
+    GenServer.call(__MODULE__, {:watch, owner_pid, os_pid, meta})
+  end
+
+  def watch(_, _, _), do: {:error, :invalid_lease}
+
+  @spec release(lease_ref()) :: :ok
+  def release(ref) do
+    GenServer.cast(__MODULE__, {:release, ref})
+  end
+
+  @spec reap(lease_ref(), term()) :: :ok
+  def reap(ref, _reason) do
+    GenServer.cast(__MODULE__, {:reap, ref})
+  end
+
+  @impl true
+  def init(_opts) do
+    # The reaper itself must be resilient to supervisor exit signals; it is never
+    # blocked on long-running work and only performs short OS calls.
+    Process.flag(:trap_exit, true)
+
+    {:ok,
+     %{
+       leases: %{},
+       owner_monitors: %{}
+     }}
+  end
+
+  @impl true
+  def handle_call({:watch, owner_pid, os_pid, meta}, _from, state) do
+    ref = make_ref()
+    monitor_ref = Process.monitor(owner_pid)
+
+    lease = %{
+      owner_pid: owner_pid,
+      owner_monitor_ref: monitor_ref,
+      os_pid: os_pid,
+      shutdown_timeout_ms: Map.get(meta, :shutdown_timeout_ms, 1_000),
+      timer_ref: nil
+    }
+
+    state =
+      state
+      |> put_in([Access.key(:leases), ref], lease)
+      |> put_in([Access.key(:owner_monitors), monitor_ref], ref)
+
+    {:reply, {:ok, ref}, state}
+  end
+
+  @impl true
+  def handle_cast({:release, ref}, state) do
+    {:noreply, cleanup_lease(state, ref)}
+  end
+
+  def handle_cast({:reap, ref}, state) do
+    {:noreply, start_reaping(state, ref)}
+  end
+
+  @impl true
+  def handle_info({:DOWN, monitor_ref, :process, _pid, _reason}, state) do
+    {ref, owner_monitors} = Map.pop(state.owner_monitors, monitor_ref)
+
+    state =
+      if is_nil(ref) do
+        state
+      else
+        state = %{state | owner_monitors: owner_monitors}
+        start_reaping(state, ref)
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_info({:escalate, ref}, state) do
+    case Map.pop(state.leases, ref) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {%{os_pid: os_pid}, leases} ->
+        WorkerProcessLifecycle.kill_process_tree(os_pid)
+        {:noreply, %{state | leases: leases}}
+    end
+  end
+
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:EXIT, _pid, reason}, state) do
+    {:stop, reason, state}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    Enum.each(state.leases, fn {_ref, %{os_pid: os_pid}} ->
+      WorkerProcessLifecycle.kill_process_tree(os_pid)
+    end)
+
+    :ok
+  end
+
+  defp start_reaping(state, ref) do
+    case get_in(state.leases[ref]) do
+      nil ->
+        state
+
+      %{os_pid: os_pid, shutdown_timeout_ms: timeout, timer_ref: nil} ->
+        WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+        timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
+        put_in(state.leases[ref][:timer_ref], timer_ref)
+
+      _other ->
+        state
+    end
+  end
+
+  defp cleanup_lease(state, ref) do
+    case Map.pop(state.leases, ref) do
+      {nil, _} ->
+        state
+
+      {lease, leases} ->
+        Process.demonitor(lease.owner_monitor_ref, [:flush])
+
+        owner_monitors = Map.delete(state.owner_monitors, lease.owner_monitor_ref)
+
+        if is_reference(lease.timer_ref) do
+          Process.cancel_timer(lease.timer_ref, info: false)
+        end
+
+        %{state | leases: leases, owner_monitors: owner_monitors}
+    end
+  end
+end

--- a/apps/orchard_node_agent/lib/orchard/node/supervisor.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/supervisor.ex
@@ -9,7 +9,7 @@ defmodule Orchard.Node.Supervisor do
 
   use Supervisor
 
-  alias Orchard.Node.{Endpoint, ModelManager, RuntimeTLS, WorkerSupervisor}
+  alias Orchard.Node.{Endpoint, ModelManager, RuntimeProcessReaper, RuntimeTLS, WorkerSupervisor}
 
   @grpc_server_id Orchard.Node.GRPCServer
 
@@ -23,6 +23,7 @@ defmodule Orchard.Node.Supervisor do
       {GRPC.Client.Supervisor, []},
       ModelManager,
       {Task.Supervisor, name: Orchard.Node.ModelLoadTaskSupervisor},
+      RuntimeProcessReaper,
       WorkerSupervisor,
       {Task.Supervisor, name: Orchard.Node.RuntimeEndpointTaskSupervisor},
       Supervisor.child_spec({GRPC.Server.Supervisor, grpc_server_opts()}, id: @grpc_server_id)

--- a/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
@@ -1,0 +1,52 @@
+defmodule Orchard.Node.WorkerProcessLifecycle do
+  @moduledoc """
+  OS-level primitives for managing worker subprocesses.
+
+  These helpers intentionally avoid BEAM abstractions: they operate directly on
+  Unix PIDs so cleanup can continue even when the process that opened the port
+  has already exited.
+  """
+
+  @spec os_process_alive?(non_neg_integer()) :: boolean()
+  def os_process_alive?(os_pid) when is_integer(os_pid) and os_pid > 0 do
+    case System.cmd("kill", ["-0", Integer.to_string(os_pid)], stderr_to_stdout: true) do
+      {_, 0} -> true
+      {_, _} -> false
+    end
+  end
+
+  def os_process_alive?(_), do: false
+
+  @spec send_signal(non_neg_integer(), String.t()) :: :ok
+  def send_signal(os_pid, signal) when is_integer(os_pid) and os_pid > 0 do
+    _ = System.cmd("kill", [signal, Integer.to_string(os_pid)], stderr_to_stdout: true)
+    :ok
+  end
+
+  def send_signal(_, _), do: :ok
+
+  @spec kill_process_tree(non_neg_integer() | nil) :: :ok
+  def kill_process_tree(os_pid) when is_integer(os_pid) and os_pid > 0 do
+    {children_output, _} =
+      System.cmd("pgrep", ["-P", Integer.to_string(os_pid)], stderr_to_stdout: true)
+
+    children_output
+    |> String.trim()
+    |> String.split("\n", trim: true)
+    |> Enum.each(fn child_pid ->
+      case Integer.parse(child_pid) do
+        {child_pid_int, _} when child_pid_int > 0 ->
+          kill_process_tree(child_pid_int)
+          send_signal(child_pid_int, "-KILL")
+
+        _other ->
+          :ok
+      end
+    end)
+
+    send_signal(os_pid, "-KILL")
+    :ok
+  end
+
+  def kill_process_tree(_), do: :ok
+end

--- a/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
@@ -37,7 +37,6 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
       case Integer.parse(child_pid) do
         {child_pid_int, _} when child_pid_int > 0 ->
           kill_process_tree(child_pid_int)
-          send_signal(child_pid_int, "-KILL")
 
         _other ->
           :ok

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -486,20 +486,28 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
             load_model_or_cleanup(channel, port, os_pid, reaper_ref, runtime_params)
 
           {:error, reason} ->
-            cleanup_failed_runtime(
-              port,
-              os_pid,
-              nil,
-              socket_path,
-              shutdown_timeout_ms,
-              reaper_ref
-            )
+            cleanup_failed_runtime(%{
+              channel: nil,
+              os_pid: os_pid,
+              port: port,
+              reaper_ref: reaper_ref,
+              shutdown_timeout_ms: shutdown_timeout_ms,
+              socket_path: socket_path
+            })
 
             {:error, reason}
         end
 
       {:error, reason} ->
-        cleanup_failed_runtime(port, os_pid, nil, socket_path, shutdown_timeout_ms, nil)
+        cleanup_failed_runtime(%{
+          channel: nil,
+          os_pid: os_pid,
+          port: port,
+          reaper_ref: nil,
+          shutdown_timeout_ms: shutdown_timeout_ms,
+          socket_path: socket_path
+        })
+
         {:error, reason}
     end
   end
@@ -524,14 +532,14 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
          }}
 
       {:error, reason} ->
-        cleanup_failed_runtime(
-          port,
-          os_pid,
-          channel,
-          params.socket_path,
-          params.shutdown_timeout_ms,
-          reaper_ref
-        )
+        cleanup_failed_runtime(%{
+          channel: channel,
+          os_pid: os_pid,
+          port: port,
+          reaper_ref: reaper_ref,
+          shutdown_timeout_ms: params.shutdown_timeout_ms,
+          socket_path: params.socket_path
+        })
 
         {:error, reason}
     end
@@ -1063,7 +1071,14 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     end)
   end
 
-  defp cleanup_failed_runtime(port, os_pid, channel, socket_path, shutdown_timeout_ms, reaper_ref) do
+  defp cleanup_failed_runtime(%{
+         channel: channel,
+         os_pid: os_pid,
+         port: port,
+         reaper_ref: reaper_ref,
+         shutdown_timeout_ms: shutdown_timeout_ms,
+         socket_path: socket_path
+       }) do
     if is_reference(reaper_ref), do: RuntimeProcessReaper.reap(reaper_ref, :cleanup_failed)
     _ = stop_runtime(port, os_pid, shutdown_timeout_ms)
     _ = disconnect_channel(channel)

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -32,6 +32,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     WorkerStatusRequest
   }
 
+  alias Orchard.Node.RuntimeProcessReaper
+  alias Orchard.Node.WorkerProcessLifecycle
   alias Orchard.PathUtils
 
   @poll_interval_ms 50
@@ -57,6 +59,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
           model_ref: ModelRef.t(),
           os_pid: non_neg_integer() | nil,
           port: port(),
+          reaper_ref: reference() | nil,
           shutdown_timeout_ms: pos_integer(),
           socket_path: String.t()
         }
@@ -264,6 +267,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     emit_runtime_start([:orchard, :node, :worker_runtime, :load, :start], load_meta)
     start_time = System.monotonic_time(:millisecond)
 
+    owner_pid = Keyword.get(opts, :owner, self())
+
     result =
       with {:ok, resolved_model_path} <- resolve_model_path(model_ref, models_root),
            {:ok, resolved_executable} <- resolve_executable(executable),
@@ -271,6 +276,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
            :ok <- ensure_log_parent(log_path),
            :ok <- cleanup_socket(socket_path) do
         start_runtime(%{
+          owner_pid: owner_pid,
           model_ref: model_ref,
           model_path: resolved_model_path,
           executable: resolved_executable,
@@ -341,6 +347,9 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     cleanup_generation_tasks(state.generations)
     _ = disconnect_channel(state.channel)
     socket_result = cleanup_socket(state.socket_path)
+
+    if is_reference(state[:reaper_ref]),
+      do: RuntimeProcessReaper.release(state.reaper_ref)
 
     final_result = pick_unload_result(unload_result, stop_result, socket_result)
     duration_ms = System.monotonic_time(:millisecond) - start_time
@@ -422,6 +431,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   end
 
   defp start_runtime(%{
+         owner_pid: owner_pid,
          model_ref: model_ref,
          model_path: model_path,
          executable: executable,
@@ -452,32 +462,77 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
         memory_budget_overhead_bytes: memory_budget_overhead_bytes
       )
 
-    case wait_for_worker_ready(socket_path, port, ready_timeout_ms) do
-      {:ok, channel} ->
-        case load_model_rpc(channel, model_ref, model_path, load_timeout_ms) do
-          :ok ->
-            {:ok,
-             %{
-               backend: backend,
-               channel: channel,
-               executable: executable,
-               generations: %{},
-               log_path: log_path,
-               model_path: model_path,
-               model_ref: model_ref,
-               os_pid: os_pid,
-               port: port,
-               shutdown_timeout_ms: shutdown_timeout_ms,
-               socket_path: socket_path
-             }}
+    runtime_params = %{
+      backend: backend,
+      executable: executable,
+      load_timeout_ms: load_timeout_ms,
+      log_path: log_path,
+      model_path: model_path,
+      model_ref: model_ref,
+      shutdown_timeout_ms: shutdown_timeout_ms,
+      socket_path: socket_path
+    }
+
+    reaper_meta = %{
+      shutdown_timeout_ms: shutdown_timeout_ms,
+      model_ref: model_ref,
+      phase: :loading
+    }
+
+    case RuntimeProcessReaper.watch(owner_pid, os_pid, reaper_meta) do
+      {:ok, reaper_ref} ->
+        case wait_for_worker_ready(socket_path, port, ready_timeout_ms) do
+          {:ok, channel} ->
+            load_model_or_cleanup(channel, port, os_pid, reaper_ref, runtime_params)
 
           {:error, reason} ->
-            cleanup_failed_runtime(port, os_pid, channel, socket_path, shutdown_timeout_ms)
+            cleanup_failed_runtime(
+              port,
+              os_pid,
+              nil,
+              socket_path,
+              shutdown_timeout_ms,
+              reaper_ref
+            )
+
             {:error, reason}
         end
 
       {:error, reason} ->
-        cleanup_failed_runtime(port, os_pid, nil, socket_path, shutdown_timeout_ms)
+        cleanup_failed_runtime(port, os_pid, nil, socket_path, shutdown_timeout_ms, nil)
+        {:error, reason}
+    end
+  end
+
+  defp load_model_or_cleanup(channel, port, os_pid, reaper_ref, params) do
+    case load_model_rpc(channel, params.model_ref, params.model_path, params.load_timeout_ms) do
+      :ok ->
+        {:ok,
+         %{
+           backend: params.backend,
+           channel: channel,
+           executable: params.executable,
+           generations: %{},
+           log_path: params.log_path,
+           model_path: params.model_path,
+           model_ref: params.model_ref,
+           os_pid: os_pid,
+           port: port,
+           reaper_ref: reaper_ref,
+           shutdown_timeout_ms: params.shutdown_timeout_ms,
+           socket_path: params.socket_path
+         }}
+
+      {:error, reason} ->
+        cleanup_failed_runtime(
+          port,
+          os_pid,
+          channel,
+          params.socket_path,
+          params.shutdown_timeout_ms,
+          reaper_ref
+        )
+
         {:error, reason}
     end
   end
@@ -967,14 +1022,14 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   # The tree-kill is defense-in-depth against intermediate launchers
   # (e.g. `uv run`) that swallow signals without forwarding to children.
   defp stop_runtime_with_escalation(port, os_pid, timeout_ms) do
-    send_signal(os_pid, "-TERM")
+    WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
 
     case wait_for_port_exit(port, timeout_ms) do
       {:ok, _status} ->
         :ok
 
       {:error, :timeout} ->
-        kill_process_tree(os_pid)
+        WorkerProcessLifecycle.kill_process_tree(os_pid)
 
         case wait_for_port_exit(port, timeout_ms) do
           {:ok, _status} -> :ok
@@ -992,35 +1047,6 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     end
   end
 
-  defp send_signal(os_pid, signal) when is_integer(os_pid) and os_pid >= 0 do
-    case System.cmd("kill", [signal, Integer.to_string(os_pid)], stderr_to_stdout: true) do
-      {_output, 0} -> :ok
-      {_output, _exit_status} -> :ok
-    end
-  end
-
-  # Recursively kill a process tree bottom-up (children first, then parent)
-  # using SIGKILL. This guards against intermediate launcher processes
-  # (e.g. `uv run`) that may not forward signals to their children.
-  defp kill_process_tree(os_pid) when is_integer(os_pid) and os_pid >= 0 do
-    {children_output, _} =
-      System.cmd("pgrep", ["-P", Integer.to_string(os_pid)], stderr_to_stdout: true)
-
-    children_output
-    |> String.trim()
-    |> String.split("\n", trim: true)
-    |> Enum.each(fn child_pid_str ->
-      case Integer.parse(child_pid_str) do
-        {child_pid, _} -> kill_process_tree(child_pid)
-        :error -> :ok
-      end
-    end)
-
-    send_signal(os_pid, "-KILL")
-  end
-
-  defp kill_process_tree(_), do: :ok
-
   defp port_open?(port) do
     not is_nil(Port.info(port))
   end
@@ -1037,10 +1063,12 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     end)
   end
 
-  defp cleanup_failed_runtime(port, os_pid, channel, socket_path, shutdown_timeout_ms) do
+  defp cleanup_failed_runtime(port, os_pid, channel, socket_path, shutdown_timeout_ms, reaper_ref) do
+    if is_reference(reaper_ref), do: RuntimeProcessReaper.reap(reaper_ref, :cleanup_failed)
     _ = stop_runtime(port, os_pid, shutdown_timeout_ms)
     _ = disconnect_channel(channel)
     _ = cleanup_socket(socket_path)
+    if is_reference(reaper_ref), do: RuntimeProcessReaper.release(reaper_ref)
     :ok
   end
 

--- a/apps/orchard_node_agent/test/orchard/node/model_load_failure_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/model_load_failure_test.exs
@@ -162,6 +162,12 @@ defmodule Orchard.Node.ModelLoadFailureTest do
     assert f.code == "worker_unavailable"
   end
 
+  test "reaper_unavailable -> RUNTIME_UNAVAILABLE" do
+    f = ModelLoadFailure.from_reason(:reaper_unavailable)
+    assert f.category == :MODEL_LOAD_FAILURE_CATEGORY_RUNTIME_UNAVAILABLE
+    assert f.code == "reaper_unavailable"
+  end
+
   test "worker_exited -> RUNTIME_UNAVAILABLE" do
     f = ModelLoadFailure.from_reason({:worker_exited, 1})
     assert f.category == :MODEL_LOAD_FAILURE_CATEGORY_RUNTIME_UNAVAILABLE

--- a/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
@@ -1,0 +1,104 @@
+defmodule Orchard.Node.RuntimeProcessReaperTest do
+  @moduledoc """
+  Unit tests for the runtime process reaper.
+
+  The reaper must kill the OS-level worker child when its owning WorkerProcess
+  dies, even if the WorkerProcess was blocked in a long-running load and never
+  ran terminate/2.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Orchard.Node.RuntimeProcessReaper
+  alias Orchard.Node.WorkerProcessLifecycle
+
+  @short_timeout_ms 200
+
+  setup do
+    # The node agent application starts the reaper under its supervisor.
+    assert Process.whereis(RuntimeProcessReaper),
+           "RuntimeProcessReaper must be running (start the orchard_node_agent app)"
+
+    :ok
+  end
+
+  defp start_sleeper_port! do
+    sleep = System.find_executable("sleep") || "/bin/sleep"
+    port = Port.open({:spawn_executable, sleep}, args: ["3600"])
+    os_pid = port |> Port.info() |> Keyword.fetch!(:os_pid)
+    {port, os_pid}
+  end
+
+  defp wait_until_dead(os_pid, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+
+    cond do
+      not WorkerProcessLifecycle.os_process_alive?(os_pid) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("expected OS process #{os_pid} to be dead within #{timeout_ms}ms")
+
+      true ->
+        Process.sleep(10)
+        wait_until_dead(os_pid, max(0, deadline - System.monotonic_time(:millisecond)))
+    end
+  end
+
+  test "reaper kills the worker child when the owner process dies" do
+    {_port, os_pid} = start_sleeper_port!()
+
+    owner_pid =
+      spawn(fn ->
+        receive do
+          :die -> :ok
+        end
+      end)
+
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+
+    {:ok, ref} =
+      RuntimeProcessReaper.watch(owner_pid, os_pid, %{
+        shutdown_timeout_ms: @short_timeout_ms,
+        model_ref: nil,
+        phase: :loading
+      })
+
+    Process.exit(owner_pid, :kill)
+
+    # The reaper should SIGTERM immediately and SIGKILL after the timeout.
+    assert wait_until_dead(os_pid, 2_000) == :ok
+
+    # The lease should have been removed after escalation.
+    RuntimeProcessReaper.reap(ref, :test_cleanup)
+    RuntimeProcessReaper.release(ref)
+  end
+
+  test "release prevents the reaper from killing a still-alive owner" do
+    {_port, os_pid} = start_sleeper_port!()
+
+    owner_pid =
+      spawn(fn ->
+        receive do
+          :die -> :ok
+        end
+      end)
+
+    {:ok, ref} =
+      RuntimeProcessReaper.watch(owner_pid, os_pid, %{
+        shutdown_timeout_ms: @short_timeout_ms,
+        model_ref: nil,
+        phase: :loading
+      })
+
+    RuntimeProcessReaper.release(ref)
+
+    # Killing the owner after release should not kill the unrelated sleeper.
+    Process.exit(owner_pid, :kill)
+    Process.sleep(50)
+
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+
+    WorkerProcessLifecycle.kill_process_tree(os_pid)
+  end
+end

--- a/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
@@ -57,7 +57,7 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
 
     assert WorkerProcessLifecycle.os_process_alive?(os_pid)
 
-    {:ok, ref} =
+    {:ok, _ref} =
       RuntimeProcessReaper.watch(owner_pid, os_pid, %{
         shutdown_timeout_ms: @short_timeout_ms,
         model_ref: nil,
@@ -70,8 +70,36 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
     assert wait_until_dead(os_pid, 2_000) == :ok
 
     # The lease should have been removed after escalation.
-    RuntimeProcessReaper.reap(ref, :test_cleanup)
-    RuntimeProcessReaper.release(ref)
+    assert wait_until(
+             fn ->
+               state = :sys.get_state(RuntimeProcessReaper)
+               state.leases == %{} and state.owner_monitors == %{}
+             end,
+             500
+           )
+  end
+
+  test "watch returns an error when the reaper name is unavailable" do
+    reaper_pid = Process.whereis(RuntimeProcessReaper)
+    assert is_pid(reaper_pid)
+    assert Process.unregister(RuntimeProcessReaper)
+
+    on_exit(fn -> Process.register(reaper_pid, RuntimeProcessReaper) end)
+
+    owner_pid = self()
+
+    assert RuntimeProcessReaper.watch(owner_pid, 1, %{
+             shutdown_timeout_ms: @short_timeout_ms,
+             model_ref: nil,
+             phase: :loading
+           }) == {:error, :reaper_unavailable}
+  end
+
+  test "stray messages do not stop the reaper" do
+    reaper_pid = Process.whereis(RuntimeProcessReaper)
+    send(reaper_pid, :unexpected_message)
+    Process.sleep(20)
+    assert Process.alive?(reaper_pid)
   end
 
   test "release prevents the reaper from killing a still-alive owner" do
@@ -100,5 +128,21 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
     assert WorkerProcessLifecycle.os_process_alive?(os_pid)
 
     WorkerProcessLifecycle.kill_process_tree(os_pid)
+  end
+
+  defp wait_until(fun, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+
+    cond do
+      fun.() ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(10)
+        wait_until(fun, max(0, deadline - System.monotonic_time(:millisecond)))
+    end
   end
 end


### PR DESCRIPTION
Closes #221.

## What changed
- Added `Orchard.Node.RuntimeProcessReaper`, a supervised GenServer that owns `{owner_pid -> os_pid}` leases.
- Registered the lease as soon as the worker port opens in `WorkerRuntimeAdapter.start_runtime/1`, before readiness polling, so a worker killed during a long model load is still reaped.
- Placed the reaper before `WorkerSupervisor` in the `:rest_for_one` supervision tree so it outlives workers on shutdown.
- Extracted shared OS kill helpers into `Orchard.Node.WorkerProcessLifecycle`.
- Reverted the `Process.flag(:trap_exit, true)` / `{:EXIT, ...}` handler attempt in `WorkerProcess`; `terminate/2` remains best-effort for explicit stops.

## Why
Normal BEAM/supervisor shutdown and cancellation during `load_model` left the Python MLX subprocess alive because `WorkerProcess.terminate/2` is not guaranteed. Trapping exits in `WorkerProcess` fixed idle shutdown but broke `ModelManager.reset/0` and `unload_model/1`, which call `DynamicSupervisor.terminate_child/2` while the worker is blocked in `load_model`.

## Validation
- `mise exec -- mix format` ✅
- `mise exec -- mix compile --warnings-as-errors` ✅
- `mise exec -- mix credo --strict` ✅
- `mise exec -- mix dialyzer` ✅
- `mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs` ✅ (108 passed)
- `mise exec -- mix test apps/orchard_node_agent/test/orchard/node/worker_process_test.exs apps/orchard_node_agent/test/orchard/node/worker_runtime_adapter_test.exs apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs` ✅ (48 passed)

Generated with [Devin](https://devin.ai)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789793803&installation_model_id=428414&pr_number=228&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F228&signature=ec7da1b8966ec33b16d4af2bced5c9a5c410c5e70faebf2aa3815d0c7d92f986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->