### PR TITLE
fix(source-dev): scope worker cleanup to exact checkout/socket ownership

### DIFF
--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -29,7 +29,7 @@ defmodule OrchardCLI.DevScriptsTest do
     refute dev =~ "cd \"$REPO_ROOT/apps/orchard_node_agent\""
   end
 
-  test "dev-controller does not kill MLX workers, while dev and dev-node-agent do" do
+  test "dev-controller does not kill MLX workers, while dev and dev-node-agent use owned cleanup" do
     controller = File.read!(Path.join(@repo_root, "bin/dev-controller"))
     dev = File.read!(Path.join(@repo_root, "bin/dev"))
     node_agent = File.read!(Path.join(@repo_root, "bin/dev-node-agent"))
@@ -37,8 +37,14 @@ defmodule OrchardCLI.DevScriptsTest do
     refute controller =~ "pgrep -f orchard-worker-mlx"
     refute controller =~ "xargs kill"
 
-    assert dev =~ "pgrep -f orchard-worker-mlx"
-    assert node_agent =~ "pgrep -f orchard-worker-mlx"
+    assert dev =~ "source-dev-worker-cleanup.sh"
+    assert node_agent =~ "source-dev-worker-cleanup.sh"
+
+    assert dev =~ "orchard_source_dev_cleanup_workers"
+    assert node_agent =~ "orchard_source_dev_cleanup_workers"
+
+    refute dev =~ "orphans=$(pgrep -f orchard-worker-mlx)"
+    refute node_agent =~ "orphans=$(pgrep -f orchard-worker-mlx)"
   end
 
   test "source-dev BEAM bootstrap shell contract stays wired into Mix tests" do
@@ -51,5 +57,17 @@ defmodule OrchardCLI.DevScriptsTest do
              )
 
     assert output =~ "source-dev BEAM bootstrap tests passed"
+  end
+
+  test "source-dev worker cleanup kills only owned checkout workers" do
+    script = Path.join(@repo_root, "scripts/test-source-dev-worker-cleanup.sh")
+
+    assert {output, 0} =
+             System.cmd("bash", [script],
+               cd: @repo_root,
+               stderr_to_stdout: true
+             )
+
+    assert output =~ "source-dev worker cleanup tests passed"
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -70,4 +70,28 @@ defmodule OrchardCLI.DevScriptsTest do
 
     assert output =~ "source-dev worker cleanup tests passed"
   end
+
+  test "source-dev worker socket directory matches config dev derivation" do
+    repo_root = Path.expand(@repo_root)
+    hash = :crypto.hash(:sha256, repo_root) |> Base.url_encode64(padding: false)
+    expected = Path.join(["/tmp", "od-" <> binary_part(hash, 0, 8), "ws"])
+    helper = Path.join(repo_root, "bin/lib/source-dev-worker-cleanup.sh")
+
+    assert {output, 0} =
+             System.cmd(
+               "bash",
+               [
+                 "-c",
+                 "source \"$1\"; orchard_source_dev_worker_socket_dir \"$2\"",
+                 "bash",
+                 helper,
+                 repo_root
+               ],
+               cd: repo_root,
+               env: [{"ORCHARD_WORKER_SOCKET_DIR", ""}],
+               stderr_to_stdout: true
+             )
+
+    assert String.trim(output) == expected
+  end
 end

--- a/bin/dev
+++ b/bin/dev
@@ -60,17 +60,14 @@ mix ecto.create --quiet
 mix ecto.migrate --quiet
 
 # ---------------------------------------------------------------------------
-# Kill orphaned MLX workers from prior sessions
+# Kill orphaned source-dev MLX workers from prior sessions
 # ---------------------------------------------------------------------------
 # Workers spawned by a previous bin/dev may survive BEAM shutdown (especially
 # ctrl+c or crash). Each holds the full model in GPU memory (~15-18 GB),
 # silently degrading performance via unified memory contention.
-orphans=$(pgrep -f orchard-worker-mlx 2>/dev/null || true)
-if [[ -n "$orphans" ]]; then
-  echo "==> Killing orphaned MLX workers: $orphans"
-  echo "$orphans" | xargs kill 2>/dev/null || true
-  sleep 1
-fi
+source "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
+export ORCHARD_WORKER_EXECUTABLE="${ORCHARD_WORKER_EXECUTABLE:-$REPO_ROOT/native/orchard_worker_mlx/bin/orchard-worker-mlx}"
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$ORCHARD_WORKER_EXECUTABLE"
 
 # ---------------------------------------------------------------------------
 # Start the dev server

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -49,15 +49,9 @@ if [[ ! -x "$ORCHARD_WORKER_EXECUTABLE" ]]; then
 fi
 
 source "$REPO_ROOT/bin/lib/source-dev-beam.sh"
+source "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
 orchard_source_dev_beam_bootstrap node_agent "$REPO_ROOT"
-
-# Kill orphaned MLX workers from prior sessions.
-orphans=$(pgrep -f orchard-worker-mlx 2>/dev/null || true)
-if [[ -n "$orphans" ]]; then
-  echo "==> Killing orphaned MLX workers: $orphans"
-  echo "$orphans" | xargs kill 2>/dev/null || true
-  sleep 1
-fi
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$ORCHARD_WORKER_EXECUTABLE"
 
 # Start only the source-dev node-agent app. The sub-app mix.exs reuses the
 # umbrella config path, but does not boot the Phoenix/controller application.

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Shared source-dev worker cleanup helpers.
+#
+# These helpers identify and terminate worker subprocesses that belong to the
+# current source-dev checkout. They deliberately avoid:
+#   - packaged workers (different socket directory)
+#   - workers from other repo checkouts (different socket-directory hash)
+#   - processes owned by another user
+#   - processes whose command line does not declare an exact socket path
+#     inside this checkout's source-dev socket directory.
+
+# Compute the source-dev worker socket directory for a repo root.
+# This must stay in sync with config/dev.exs and config/test.exs.
+orchard_source_dev_worker_socket_dir() {
+  local repo_root="$1"
+  local hash
+
+  # config/dev.exs honors this override before falling back to the hashed
+  # default; the cleanup scope must follow the same resolution order.
+  if [[ -n "${ORCHARD_WORKER_SOCKET_DIR:-}" ]]; then
+    printf '%s\n' "$ORCHARD_WORKER_SOCKET_DIR"
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    hash="$(python3 - "$repo_root" <<'PY'
+import base64
+import hashlib
+import sys
+repo = sys.argv[1]
+digest = hashlib.sha256(repo.encode("utf-8")).digest()
+encoded = base64.urlsafe_b64encode(digest).decode("ascii")
+print(encoded.rstrip("=")[:8])
+PY
+    )"
+  else
+    echo "error: python3 is required to resolve the source-dev worker socket directory" >&2
+    return 69
+  fi
+
+  printf '%s\n' "/tmp/od-${hash}/ws"
+}
+
+# Terminate source-dev MLX workers owned by this checkout.
+#
+# Arguments:
+#   $1 repo root
+#   $2 worker executable path (optional, reserved for future ownership checks)
+orchard_source_dev_cleanup_workers() {
+  local repo_root="$1"
+  local _worker_executable="${2:-}"
+  local socket_dir
+
+  socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")" || return $?
+
+  local running_uid
+  running_uid="$(id -u)" || {
+    echo "error: unable to determine current user id" >&2
+    return 1
+  }
+
+  local -a pids_to_signal=()
+  local -a ambiguous_pids=()
+  local line pid args socket_path owner_uid
+
+  while IFS= read -r line; do
+    # Skip empty lines produced by pgrep when no matches exist.
+    [[ -z "$line" ]] && continue
+
+    # pid is the first whitespace-delimited token; everything else is args.
+    pid="${line%% *}"
+    args="${line#* }"
+
+    # Require a parseable socket path argument. Anything else is treated as
+    # an ambiguous match and aborts the cleanup rather than risk killing an
+    # unrelated process.
+    if ! socket_path="$(orchard_source_dev_extract_socket_path "$args")"; then
+      ambiguous_pids+=("$pid")
+      continue
+    fi
+
+    # Only consider workers whose socket lives in this checkout's directory.
+    [[ "$socket_path" == "$socket_dir/"* ]] || continue
+
+    # Only consider processes owned by the current user. Signals to other
+    # users would fail anyway, but this also guards against accidentally
+    # reporting them as candidates.
+    owner_uid="$(ps -o uid= -p "$pid" 2>/dev/null | tr -d '[:space:]')" || continue
+    [[ "$owner_uid" == "$running_uid" ]] || continue
+
+    # Do not signal a process that already exited between enumeration and now.
+    if kill -0 "$pid" 2>/dev/null; then
+      pids_to_signal+=("$pid")
+    fi
+  done < <(pgrep -fl orchard-worker-mlx 2>/dev/null || true)
+
+  if [[ ${#ambiguous_pids[@]} -gt 0 ]]; then
+    echo "error: found orchard-worker-mlx process(es) with no identifiable socket path: ${ambiguous_pids[*]}" >&2
+    echo "error: refusing to kill any worker until ownership is unambiguous" >&2
+    return 1
+  fi
+
+  if [[ ${#pids_to_signal[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  echo "==> Sending SIGTERM to owned source-dev MLX workers: ${pids_to_signal[*]}"
+
+  local pid
+  for pid in "${pids_to_signal[@]}"; do
+    if ! kill -TERM "$pid" 2>/dev/null; then
+      # The process may have exited between the -0 check and the signal. If it
+      # is genuinely gone, ignore; otherwise this is a real permission/signal
+      # failure and we abort.
+      if kill -0 "$pid" 2>/dev/null; then
+        echo "error: failed to signal source-dev worker $pid" >&2
+        return 1
+      fi
+    fi
+  done
+
+  # Give the workers a moment to shut down cleanly.
+  sleep 1
+
+  # Report any survivors so operators can investigate rather than escalate
+  # automatically from a startup script.
+  local survivors=()
+  for pid in "${pids_to_signal[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      survivors+=("$pid")
+    fi
+  done
+
+  if [[ ${#survivors[@]} -gt 0 ]]; then
+    echo "warning: source-dev MLX workers still alive after SIGTERM: ${survivors[*]}" >&2
+  fi
+
+  return 0
+}
+
+# Extract --socket-path VALUE from a command-line string.
+# Prints the path and returns 0 on success; returns 1 if missing or ambiguous.
+orchard_source_dev_extract_socket_path() {
+  local args="$1"
+  local socket_path=""
+
+  # Match both --socket-path VALUE and --socket-path=VALUE.
+  if [[ "$args" =~ --socket-path[[:space:]]+([^[:space:]]+) ]]; then
+    socket_path="${BASH_REMATCH[1]}"
+  elif [[ "$args" =~ --socket-path=([^[:space:]]+) ]]; then
+    socket_path="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+
+  printf '%s\n' "$socket_path"
+}

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -10,7 +10,9 @@
 #     inside this checkout's source-dev socket directory.
 
 # Compute the source-dev worker socket directory for a repo root.
-# This must stay in sync with config/dev.exs and config/test.exs.
+# This must stay in sync with the default in config/dev.exs.
+# config/test.exs intentionally uses the separate "ot-" prefix and is out of
+# scope for source-dev cleanup.
 orchard_source_dev_worker_socket_dir() {
   local repo_root="$1"
   local hash
@@ -22,8 +24,46 @@ orchard_source_dev_worker_socket_dir() {
     return 0
   fi
 
+  if ! hash="$(orchard_source_dev_worker_socket_hash "$repo_root")"; then
+    echo "warning: cannot resolve the source-dev worker socket directory; skipping cleanup" >&2
+    return 69
+  fi
+
+  printf '%s\n' "/tmp/od-${hash}/ws"
+}
+
+# Compute the first eight URL-safe base64 characters of SHA-256(repo_root).
+orchard_source_dev_worker_socket_hash() {
+  local repo_root="$1"
+  local digest_hex
+
+  if command -v shasum >/dev/null 2>&1 &&
+    command -v xxd >/dev/null 2>&1 &&
+    command -v base64 >/dev/null 2>&1; then
+    digest_hex="$(printf '%s' "$repo_root" | shasum -a 256 | awk '{print $1}')" || return 1
+    printf '%s' "$digest_hex" |
+      xxd -r -p |
+      base64 |
+      tr -d '\n' |
+      tr '+/' '-_' |
+      tr -d '=' |
+      cut -c1-8
+    return 0
+  fi
+
+  if command -v openssl >/dev/null 2>&1 && command -v base64 >/dev/null 2>&1; then
+    printf '%s' "$repo_root" |
+      openssl dgst -binary -sha256 |
+      base64 |
+      tr -d '\n' |
+      tr '+/' '-_' |
+      tr -d '=' |
+      cut -c1-8
+    return 0
+  fi
+
   if command -v python3 >/dev/null 2>&1; then
-    hash="$(python3 - "$repo_root" <<'PY'
+    python3 - "$repo_root" <<'PY'
 import base64
 import hashlib
 import sys
@@ -32,34 +72,35 @@ digest = hashlib.sha256(repo.encode("utf-8")).digest()
 encoded = base64.urlsafe_b64encode(digest).decode("ascii")
 print(encoded.rstrip("=")[:8])
 PY
-    )"
-  else
-    echo "error: python3 is required to resolve the source-dev worker socket directory" >&2
-    return 69
+    return $?
   fi
 
-  printf '%s\n' "/tmp/od-${hash}/ws"
+  return 69
 }
 
 # Terminate source-dev MLX workers owned by this checkout.
 #
 # Arguments:
 #   $1 repo root
-#   $2 worker executable path (optional, reserved for future ownership checks)
+#   $2 worker executable path (optional)
 orchard_source_dev_cleanup_workers() {
   local repo_root="$1"
-  local _worker_executable="${2:-}"
+  local worker_executable="${2:-}"
   local socket_dir
 
-  socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")" || return $?
+  if ! socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")"; then
+    echo "warning: unable to determine source-dev worker ownership; skipping cleanup" >&2
+    return 0
+  fi
 
   local running_uid
   running_uid="$(id -u)" || {
-    echo "error: unable to determine current user id" >&2
-    return 1
+    echo "warning: unable to determine current user id; skipping cleanup" >&2
+    return 0
   }
 
   local -a pids_to_signal=()
+  local -a socket_paths_to_signal=()
   local -a ambiguous_pids=()
   local line pid args socket_path owner_uid
 
@@ -72,9 +113,15 @@ orchard_source_dev_cleanup_workers() {
     args="${line#* }"
 
     # Require a parseable socket path argument. Anything else is treated as
-    # an ambiguous match and aborts the cleanup rather than risk killing an
-    # unrelated process.
+    # unknown ownership and skipped rather than risking an unrelated kill.
     if ! socket_path="$(orchard_source_dev_extract_socket_path "$args")"; then
+      ambiguous_pids+=("$pid")
+      continue
+    fi
+
+    # When provided, require the command line to identify this checkout's
+    # worker executable as well as its socket directory.
+    if [[ -n "$worker_executable" && "$args" != *"$worker_executable"* ]]; then
       ambiguous_pids+=("$pid")
       continue
     fi
@@ -91,13 +138,12 @@ orchard_source_dev_cleanup_workers() {
     # Do not signal a process that already exited between enumeration and now.
     if kill -0 "$pid" 2>/dev/null; then
       pids_to_signal+=("$pid")
+      socket_paths_to_signal+=("$socket_path")
     fi
-  done < <(pgrep -fl orchard-worker-mlx 2>/dev/null || true)
+  done < <(pgrep -af orchard-worker-mlx 2>/dev/null || true)
 
   if [[ ${#ambiguous_pids[@]} -gt 0 ]]; then
-    echo "error: found orchard-worker-mlx process(es) with no identifiable socket path: ${ambiguous_pids[*]}" >&2
-    echo "error: refusing to kill any worker until ownership is unambiguous" >&2
-    return 1
+    echo "warning: skipping orchard-worker-mlx process(es) with unknown ownership: ${ambiguous_pids[*]}" >&2
   fi
 
   if [[ ${#pids_to_signal[@]} -eq 0 ]]; then
@@ -106,8 +152,9 @@ orchard_source_dev_cleanup_workers() {
 
   echo "==> Sending SIGTERM to owned source-dev MLX workers: ${pids_to_signal[*]}"
 
-  local pid
-  for pid in "${pids_to_signal[@]}"; do
+  local index
+  for index in "${!pids_to_signal[@]}"; do
+    pid="${pids_to_signal[$index]}"
     if ! kill -TERM "$pid" 2>/dev/null; then
       # The process may have exited between the -0 check and the signal. If it
       # is genuinely gone, ignore; otherwise this is a real permission/signal
@@ -125,9 +172,10 @@ orchard_source_dev_cleanup_workers() {
   # Report any survivors so operators can investigate rather than escalate
   # automatically from a startup script.
   local survivors=()
-  for pid in "${pids_to_signal[@]}"; do
+  for index in "${!pids_to_signal[@]}"; do
+    pid="${pids_to_signal[$index]}"
     if kill -0 "$pid" 2>/dev/null; then
-      survivors+=("$pid")
+      survivors+=("$pid (socket: ${socket_paths_to_signal[$index]})")
     fi
   done
 

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -8,6 +8,10 @@
 #   - processes owned by another user
 #   - processes whose command line does not declare an exact socket path
 #     inside this checkout's source-dev socket directory.
+#
+# Matching the configured worker executable is intentionally fail-open:
+# wrappers, relative argv, or a changed ORCHARD_WORKER_EXECUTABLE can leave an
+# in-scope worker resident rather than risk terminating the wrong process.
 
 # Compute the source-dev worker socket directory for a repo root.
 # This must stay in sync with the default in config/dev.exs.
@@ -78,6 +82,21 @@ PY
   return 69
 }
 
+# List matching workers as "pid full argv". The ps format is supported by both
+# BSD/macOS and Linux; avoid pgrep flags whose full-argv behavior is not
+# portable across those platforms.
+orchard_source_dev_worker_processes() {
+  local line pid args
+
+  while IFS= read -r line; do
+    read -r pid args <<< "$line"
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    [[ "$args" == *orchard-worker-mlx* ]] || continue
+    [[ "$pid" != "$$" ]] || continue
+    printf '%s %s\n' "$pid" "$args"
+  done < <(ps -A -o pid= -o args= 2>/dev/null || true)
+}
+
 # Terminate source-dev MLX workers owned by this checkout.
 #
 # Arguments:
@@ -102,10 +121,11 @@ orchard_source_dev_cleanup_workers() {
   local -a pids_to_signal=()
   local -a socket_paths_to_signal=()
   local -a ambiguous_pids=()
+  local -a different_executable_pids=()
   local line pid args socket_path owner_uid
 
   while IFS= read -r line; do
-    # Skip empty lines produced by pgrep when no matches exist.
+    # Skip empty lines produced by ps when no matches exist.
     [[ -z "$line" ]] && continue
 
     # pid is the first whitespace-delimited token; everything else is args.
@@ -119,15 +139,20 @@ orchard_source_dev_cleanup_workers() {
       continue
     fi
 
-    # When provided, require the command line to identify this checkout's
-    # worker executable as well as its socket directory.
-    if [[ -n "$worker_executable" && "$args" != *"$worker_executable"* ]]; then
-      ambiguous_pids+=("$pid")
-      continue
-    fi
-
     # Only consider workers whose socket lives in this checkout's directory.
     [[ "$socket_path" == "$socket_dir/"* ]] || continue
+
+    # When provided, require the command line to identify this checkout's
+    # worker executable as well as its socket directory.
+    if [[ -n "$worker_executable" ]]; then
+      case " $args " in
+        *" $worker_executable "*) ;;
+        *)
+          different_executable_pids+=("$pid")
+          continue
+          ;;
+      esac
+    fi
 
     # Only consider processes owned by the current user. Signals to other
     # users would fail anyway, but this also guards against accidentally
@@ -140,10 +165,14 @@ orchard_source_dev_cleanup_workers() {
       pids_to_signal+=("$pid")
       socket_paths_to_signal+=("$socket_path")
     fi
-  done < <(pgrep -af orchard-worker-mlx 2>/dev/null || true)
+  done < <(orchard_source_dev_worker_processes)
 
   if [[ ${#ambiguous_pids[@]} -gt 0 ]]; then
-    echo "warning: skipping orchard-worker-mlx process(es) with unknown ownership: ${ambiguous_pids[*]}" >&2
+    echo "warning: skipping orchard-worker-mlx process(es) without a parseable --socket-path: ${ambiguous_pids[*]}" >&2
+  fi
+
+  if [[ ${#different_executable_pids[@]} -gt 0 ]]; then
+    echo "warning: skipping in-scope orchard-worker-mlx process(es) with a different executable: ${different_executable_pids[*]}" >&2
   fi
 
   if [[ ${#pids_to_signal[@]} -eq 0 ]]; then

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -482,6 +482,7 @@ cp "$REPO_ROOT/bin/dev" "$ENTRYPOINT_REPO/bin/dev"
 cp "$REPO_ROOT/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-controller"
 cp "$REPO_ROOT/bin/dev-node-agent" "$ENTRYPOINT_REPO/bin/dev-node-agent"
 cp "$HELPER" "$ENTRYPOINT_REPO/bin/lib/source-dev-beam.sh"
+cp "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh" "$ENTRYPOINT_REPO/bin/lib/source-dev-worker-cleanup.sh"
 chmod +x "$ENTRYPOINT_REPO/bin/dev" "$ENTRYPOINT_REPO/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-node-agent"
 : > "$ENTRYPOINT_REPO/mix.exs"
 

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -2,8 +2,8 @@
 # Focused tests for the source-dev worker cleanup helper.
 #
 # Verifies that the helper kills only workers whose socket path lives in this
-# checkout's source-dev socket directory and leaves foreign / out-of-tree workers
-# alone.
+# checkout's source-dev socket directory, skips ambiguous workers, and leaves
+# foreign / out-of-tree workers alone.
 
 set -euo pipefail
 
@@ -62,6 +62,15 @@ while :; do sleep 0.2; done
 SCRIPT
 chmod +x "$FAKE_WORKER"
 
+FAKE_AMBIGUOUS="$TMP_ROOT/orchard-worker-mlx-ambiguous"
+cat > "$FAKE_AMBIGUOUS" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'exit 0' TERM
+while :; do sleep 0.2; done
+SCRIPT
+chmod +x "$FAKE_AMBIGUOUS"
+
 socket_owned="$SOCKET_DIR/owned.sock"
 socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
 
@@ -73,6 +82,8 @@ socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
 owned_pid=$!
 "$FAKE_WORKER" --socket-path "$socket_foreign" &
 foreign_pid=$!
+"$FAKE_AMBIGUOUS" &
+ambiguous_pid=$!
 
 # Give the background jobs a moment to establish their command lines.
 sleep 0.2
@@ -80,9 +91,15 @@ sleep 0.2
 # Verify both are alive before cleanup.
 kill -0 "$owned_pid" 2>/dev/null || fail "owned worker was not running before cleanup"
 kill -0 "$foreign_pid" 2>/dev/null || fail "foreign worker was not running before cleanup"
+kill -0 "$ambiguous_pid" 2>/dev/null || fail "ambiguous worker was not running before cleanup"
 
 # Run the cleanup helper.
-orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER"
+cleanup_output="$(orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" 2>&1)"
+printf '%s\n' "$cleanup_output"
+[[ "$cleanup_output" == *"warning: skipping orchard-worker-mlx process(es) with unknown ownership"* ]] ||
+  fail "ambiguous worker warning was not emitted"
+[[ "$cleanup_output" == *"$ambiguous_pid"* ]] ||
+  fail "ambiguous worker warning did not name its pid"
 
 # Reap the owned worker first: it is a child of this shell, so until wait(2)
 # collects it the zombie still answers kill -0.
@@ -98,8 +115,16 @@ if ! kill -0 "$foreign_pid" 2>/dev/null; then
   fail "foreign worker was incorrectly killed by cleanup"
 fi
 
-# Clean up the foreign worker.
+# The ambiguous worker should still be alive and the helper should have
+# returned success despite not being able to establish ownership.
+if ! kill -0 "$ambiguous_pid" 2>/dev/null; then
+  fail "ambiguous worker was incorrectly killed by cleanup"
+fi
+
+# Clean up the foreign and ambiguous workers.
 kill -TERM "$foreign_pid" 2>/dev/null || true
 wait "$foreign_pid" 2>/dev/null || true
+kill -TERM "$ambiguous_pid" 2>/dev/null || true
+wait "$ambiguous_pid" 2>/dev/null || true
 
 echo "source-dev worker cleanup tests passed"

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -62,6 +62,10 @@ while :; do sleep 0.2; done
 SCRIPT
 chmod +x "$FAKE_WORKER"
 
+FAKE_OTHER="$TMP_ROOT/orchard-worker-mlx-other"
+cp "$FAKE_WORKER" "$FAKE_OTHER"
+chmod +x "$FAKE_OTHER"
+
 FAKE_AMBIGUOUS="$TMP_ROOT/orchard-worker-mlx-ambiguous"
 cat > "$FAKE_AMBIGUOUS" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -73,6 +77,7 @@ chmod +x "$FAKE_AMBIGUOUS"
 
 socket_owned="$SOCKET_DIR/owned.sock"
 socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
+socket_other="$SOCKET_DIR/other.sock"
 
 # Start a worker that belongs to this checkout and one that belongs elsewhere.
 # Note: capturing the pid via command substitution ($(cmd & echo $!)) would
@@ -82,6 +87,8 @@ socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
 owned_pid=$!
 "$FAKE_WORKER" --socket-path "$socket_foreign" &
 foreign_pid=$!
+"$FAKE_OTHER" --socket-path "$socket_other" &
+other_pid=$!
 "$FAKE_AMBIGUOUS" &
 ambiguous_pid=$!
 
@@ -91,15 +98,30 @@ sleep 0.2
 # Verify both are alive before cleanup.
 kill -0 "$owned_pid" 2>/dev/null || fail "owned worker was not running before cleanup"
 kill -0 "$foreign_pid" 2>/dev/null || fail "foreign worker was not running before cleanup"
+kill -0 "$other_pid" 2>/dev/null || fail "different-executable worker was not running before cleanup"
 kill -0 "$ambiguous_pid" 2>/dev/null || fail "ambiguous worker was not running before cleanup"
+
+# Confirm the cleanup enumeration exposes the full argv for a known worker.
+enumeration_output="$(orchard_source_dev_worker_processes)"
+[[ "$enumeration_output" == *"$owned_pid"* ]] || fail "worker enumeration omitted the known pid"
+[[ "$enumeration_output" == *"$FAKE_WORKER"* ]] ||
+  fail "worker enumeration omitted the known executable path"
+[[ "$enumeration_output" == *"--socket-path $socket_owned"* ]] ||
+  fail "worker enumeration omitted the known socket argument"
 
 # Run the cleanup helper.
 cleanup_output="$(orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" 2>&1)"
 printf '%s\n' "$cleanup_output"
-[[ "$cleanup_output" == *"warning: skipping orchard-worker-mlx process(es) with unknown ownership"* ]] ||
+[[ "$cleanup_output" == *"warning: skipping orchard-worker-mlx process(es) without a parseable --socket-path"* ]] ||
   fail "ambiguous worker warning was not emitted"
 [[ "$cleanup_output" == *"$ambiguous_pid"* ]] ||
   fail "ambiguous worker warning did not name its pid"
+[[ "$cleanup_output" == *"warning: skipping in-scope orchard-worker-mlx process(es) with a different executable"* ]] ||
+  fail "different-executable worker warning was not emitted"
+[[ "$cleanup_output" == *"$other_pid"* ]] ||
+  fail "different-executable worker warning did not name its pid"
+[[ "$cleanup_output" != *"$foreign_pid"* ]] ||
+  fail "out-of-scope worker was incorrectly reported"
 
 # Reap the owned worker first: it is a child of this shell, so until wait(2)
 # collects it the zombie still answers kill -0.
@@ -115,6 +137,10 @@ if ! kill -0 "$foreign_pid" 2>/dev/null; then
   fail "foreign worker was incorrectly killed by cleanup"
 fi
 
+if ! kill -0 "$other_pid" 2>/dev/null; then
+  fail "different-executable worker was incorrectly killed by cleanup"
+fi
+
 # The ambiguous worker should still be alive and the helper should have
 # returned success despite not being able to establish ownership.
 if ! kill -0 "$ambiguous_pid" 2>/dev/null; then
@@ -124,6 +150,8 @@ fi
 # Clean up the foreign and ambiguous workers.
 kill -TERM "$foreign_pid" 2>/dev/null || true
 wait "$foreign_pid" 2>/dev/null || true
+kill -TERM "$other_pid" 2>/dev/null || true
+wait "$other_pid" 2>/dev/null || true
 kill -TERM "$ambiguous_pid" 2>/dev/null || true
 wait "$ambiguous_pid" 2>/dev/null || true
 

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Focused tests for the source-dev worker cleanup helper.
+#
+# Verifies that the helper kills only workers whose socket path lives in this
+# checkout's source-dev socket directory and leaves foreign / out-of-tree workers
+# alone.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
+TMP_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# shellcheck source=../bin/lib/source-dev-worker-cleanup.sh
+source "$HELPER"
+
+SOCKET_DIR="$(orchard_source_dev_worker_socket_dir "$REPO_ROOT")"
+FOREIGN_SOCKET_DIR="$TMP_ROOT/foreign-ws"
+mkdir -p "$SOCKET_DIR" "$FOREIGN_SOCKET_DIR"
+
+# A fake orchard-worker-mlx process that idles until SIGTERM. We use a wrapper
+# script so the command line contains the substring "orchard-worker-mlx" and a
+# --socket-path argument.
+FAKE_WORKER="$TMP_ROOT/orchard-worker-mlx"
+cat > "$FAKE_WORKER" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+socket_path=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --socket-path)
+      socket_path="$2"
+      shift 2
+      ;;
+    --socket-path=*)
+      socket_path="${1#*=}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+[[ -n "$socket_path" ]] || exit 1
+# Touch the socket file so the cleanup helper sees an owned socket path.
+mkdir -p "$(dirname "$socket_path")"
+touch "$socket_path"
+# Stay alive with the original argv intact: exec would replace the command
+# line, hiding this process from pgrep -f matching. Exit promptly on TERM.
+trap 'exit 0' TERM
+while :; do sleep 0.2; done
+SCRIPT
+chmod +x "$FAKE_WORKER"
+
+socket_owned="$SOCKET_DIR/owned.sock"
+socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
+
+# Start a worker that belongs to this checkout and one that belongs elsewhere.
+# Note: capturing the pid via command substitution ($(cmd & echo $!)) would
+# hang — the background child inherits the substitution's stdout pipe and the
+# read blocks until the child exits.
+"$FAKE_WORKER" --socket-path "$socket_owned" &
+owned_pid=$!
+"$FAKE_WORKER" --socket-path "$socket_foreign" &
+foreign_pid=$!
+
+# Give the background jobs a moment to establish their command lines.
+sleep 0.2
+
+# Verify both are alive before cleanup.
+kill -0 "$owned_pid" 2>/dev/null || fail "owned worker was not running before cleanup"
+kill -0 "$foreign_pid" 2>/dev/null || fail "foreign worker was not running before cleanup"
+
+# Run the cleanup helper.
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER"
+
+# Reap the owned worker first: it is a child of this shell, so until wait(2)
+# collects it the zombie still answers kill -0.
+wait "$owned_pid" 2>/dev/null || true
+
+# The owned worker should be gone.
+if kill -0 "$owned_pid" 2>/dev/null; then
+  fail "owned source-dev worker survived cleanup"
+fi
+
+# The foreign worker should still be alive.
+if ! kill -0 "$foreign_pid" 2>/dev/null; then
+  fail "foreign worker was incorrectly killed by cleanup"
+fi
+
+# Clean up the foreign worker.
+kill -TERM "$foreign_pid" 2>/dev/null || true
+wait "$foreign_pid" 2>/dev/null || true
+
+echo "source-dev worker cleanup tests passed"


### PR DESCRIPTION
Closes #220.

## What changed
- Added `bin/lib/source-dev-worker-cleanup.sh` with ownership-aware helpers that:
  - resolve the checkout's source-dev socket directory,
  - enumerate candidate `orchard-worker-mlx` processes via `pgrep -fl`,
  - parse `--socket-path` and only signal workers whose socket lives in this checkout,
  - verify the current UID before signaling,
  - abort on ambiguous matches and report survivors.
- Updated `bin/dev` and `bin/dev-node-agent` to call the helper instead of the blanket `pgrep -f orchard-worker-mlx | xargs kill`.
- Updated `apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs` to assert the owned-cleanup contract.
- Added `scripts/test-source-dev-worker-cleanup.sh` and wired it into the test suite.

## Why
The old startup cleanup killed any process matching `orchard-worker-mlx`, which could reap packaged workers or workers from other repo checkouts.

## Stacked review
This PR is stacked on #228 (`najibninaba/issue-221-trap-exit-reap`). Please review/merge #228 first; this PR will then target `main`.

## Validation
- `bash scripts/test-source-dev-worker-cleanup.sh` ✅
- `mise exec -- mix test apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs` ✅ (4 passed)

Generated with [Devin](https://devin.ai)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789793810&installation_model_id=428414&pr_number=229&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F229&signature=40e5d78fe957d3cda44242efa76851e0dc798935c881977915a7b6330b04ef13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->