### PR TITLE
fix(shared): support TokenDelta in the inference event domain and proto mapper

### DIFF
--- a/apps/orchard_node_agent/test/orchard/node/worker_runtime_adapter_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_runtime_adapter_test.exs
@@ -14,7 +14,9 @@ defmodule Orchard.Node.WorkerRuntimeAdapterTest do
     ScorePrefixCacheResponse
   }
 
+  alias Orchard.Cluster.V1.Completed, as: ProtoCompleted
   alias Orchard.Cluster.V1.OutputTextDelta, as: ProtoOutputTextDelta
+  alias Orchard.Cluster.V1.TokenDelta, as: ProtoTokenDelta
 
   alias Orchard.Node.Worker.V1.{
     LoadModelRequest,
@@ -26,7 +28,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapterTest do
   }
 
   alias Orchard.InferenceEvent, as: DomainInferenceEvent
-  alias Orchard.InferenceEvent.OutputTextDelta
+  alias Orchard.InferenceEvent.{Completed, OutputTextDelta, TokenDelta}
   alias Orchard.Node.WorkerRuntimeAdapter
 
   defmodule OpenUnavailableWorkerService do
@@ -70,6 +72,37 @@ defmodule Orchard.Node.WorkerRuntimeAdapterTest do
     use GRPC.Endpoint
 
     run(MidStreamUnavailableWorkerService)
+  end
+
+  defmodule TokenDeltaWorkerService do
+    use GRPC.Server, service: WorkerRuntimeService.Service
+
+    def get_status(%WorkerStatusRequest{}, _stream), do: %WorkerStatusResponse{ready: true}
+    def load_model(%LoadModelRequest{}, _stream), do: %Ack{ok: true}
+    def unload_model(_request, _stream), do: %Ack{ok: true}
+    def cancel(%CancelInferenceRequest{}, _stream), do: %Ack{ok: true}
+
+    def generate(%ExecuteInferenceRequest{}, stream) do
+      GRPC.Server.send_reply(
+        stream,
+        %InferenceEvent{
+          event: {:token_delta, %ProtoTokenDelta{token_ids: [17], logprobs: [-0.25]}}
+        }
+      )
+
+      GRPC.Server.send_reply(
+        stream,
+        %InferenceEvent{
+          event: {:completed, %ProtoCompleted{finish_reason: :FINISH_REASON_STOP, usage: nil}}
+        }
+      )
+    end
+  end
+
+  defmodule TokenDeltaEndpoint do
+    use GRPC.Endpoint
+
+    run(TokenDeltaWorkerService)
   end
 
   defmodule MemoryBudgetWorkerService do
@@ -584,6 +617,39 @@ defmodule Orchard.Node.WorkerRuntimeAdapterTest do
 
       assert_receive {:runtime_adapter_done, ^generation_ref, :worker_unavailable}, 1_000
       refute_receive {:runtime_adapter_event, ^generation_ref, _event}, 100
+
+      cleaned_state = WorkerRuntimeAdapter.finish_generation(adapter_state, generation_ref, [])
+      refute Map.has_key?(cleaned_state.generations, generation_ref)
+    end)
+  end
+
+  test "start_generation maps token deltas and continues streaming to completed" do
+    with_worker_runtime_server(TokenDeltaEndpoint, fn channel ->
+      state = adapter_stream_state(channel)
+      request = execute_request("req-token-delta")
+
+      {:ok, generation_ref, adapter_state} =
+        WorkerRuntimeAdapter.start_generation(state, request, owner: self())
+
+      assert_receive {
+                       :runtime_adapter_event,
+                       ^generation_ref,
+                       %DomainInferenceEvent{
+                         event: %TokenDelta{token_ids: [17], logprobs: [-0.25]}
+                       }
+                     },
+                     1_000
+
+      assert_receive {
+                       :runtime_adapter_event,
+                       ^generation_ref,
+                       %DomainInferenceEvent{
+                         event: %Completed{finish_reason: :finish_reason_stop, usage: nil}
+                       }
+                     },
+                     1_000
+
+      refute_receive {:runtime_adapter_done, ^generation_ref, _reason}, 100
 
       cleaned_state = WorkerRuntimeAdapter.finish_generation(adapter_state, generation_ref, [])
       refute Map.has_key?(cleaned_state.generations, generation_ref)

--- a/apps/orchard_shared/lib/orchard/cluster/v1/inference_event_mapper.ex
+++ b/apps/orchard_shared/lib/orchard/cluster/v1/inference_event_mapper.ex
@@ -10,6 +10,7 @@ defmodule Orchard.Cluster.V1.InferenceEventMapper do
     Failed,
     OutputTextDelta,
     Progress,
+    TokenDelta,
     ToolCallDelta,
     Usage,
     UsageUpdate
@@ -30,6 +31,12 @@ defmodule Orchard.Cluster.V1.InferenceEventMapper do
 
   def to_proto(%InferenceEvent{event: %OutputTextDelta{delta: delta}}) do
     %V1.InferenceEvent{event: {:output_text_delta, %V1.OutputTextDelta{delta: delta}}}
+  end
+
+  def to_proto(%InferenceEvent{event: %TokenDelta{token_ids: token_ids, logprobs: logprobs}}) do
+    %V1.InferenceEvent{
+      event: {:token_delta, %V1.TokenDelta{token_ids: token_ids, logprobs: logprobs}}
+    }
   end
 
   def to_proto(%InferenceEvent{
@@ -81,6 +88,12 @@ defmodule Orchard.Cluster.V1.InferenceEventMapper do
         event: {:output_text_delta, %V1.OutputTextDelta{delta: delta}}
       }) do
     safe_build(:output_text_delta, fn -> InferenceEvent.output_text_delta(delta) end)
+  end
+
+  def from_proto(%V1.InferenceEvent{
+        event: {:token_delta, %V1.TokenDelta{token_ids: token_ids, logprobs: logprobs}}
+      }) do
+    safe_build(:token_delta, fn -> InferenceEvent.token_delta(token_ids, logprobs) end)
   end
 
   def from_proto(%V1.InferenceEvent{

--- a/apps/orchard_shared/lib/orchard/inference_event.ex
+++ b/apps/orchard_shared/lib/orchard/inference_event.ex
@@ -33,6 +33,18 @@ defmodule Orchard.InferenceEvent do
     @type t :: %__MODULE__{delta: String.t()}
   end
 
+  defmodule TokenDelta do
+    @moduledoc false
+
+    @enforce_keys [:token_ids]
+    defstruct token_ids: [], logprobs: []
+
+    @type t :: %__MODULE__{
+            token_ids: nonempty_list(non_neg_integer()),
+            logprobs: [float()]
+          }
+  end
+
   defmodule ToolCallDelta do
     @moduledoc false
 
@@ -88,6 +100,7 @@ defmodule Orchard.InferenceEvent do
     Failed,
     OutputTextDelta,
     Progress,
+    TokenDelta,
     ToolCallDelta,
     Usage,
     UsageUpdate
@@ -99,6 +112,7 @@ defmodule Orchard.InferenceEvent do
   @type payload ::
           Accepted.t()
           | OutputTextDelta.t()
+          | TokenDelta.t()
           | ToolCallDelta.t()
           | UsageUpdate.t()
           | Completed.t()
@@ -126,6 +140,19 @@ defmodule Orchard.InferenceEvent do
   def output_text_delta(delta) do
     raise ArgumentError,
           "#{inspect(__MODULE__)} delta must be a binary, got: #{inspect(delta)}"
+  end
+
+  @spec token_delta(nonempty_list(non_neg_integer())) :: t()
+  def token_delta(token_ids), do: token_delta(token_ids, [])
+
+  @spec token_delta(nonempty_list(non_neg_integer()), [float()]) :: t()
+  def token_delta(token_ids, logprobs) do
+    if valid_token_ids?(token_ids) and valid_logprobs?(token_ids, logprobs) do
+      %__MODULE__{event: %TokenDelta{token_ids: token_ids, logprobs: logprobs}}
+    else
+      raise ArgumentError,
+            "#{inspect(__MODULE__)} token_delta expects a non-empty list of uint32 token IDs and an empty or aligned list of float logprobs, got: #{inspect({token_ids, logprobs})}"
+    end
   end
 
   @spec tool_call_delta(String.t(), String.t()) :: t()
@@ -193,6 +220,7 @@ defmodule Orchard.InferenceEvent do
   @spec kind(t()) :: atom()
   def kind(%__MODULE__{event: %Accepted{}}), do: :accepted
   def kind(%__MODULE__{event: %OutputTextDelta{}}), do: :output_text_delta
+  def kind(%__MODULE__{event: %TokenDelta{}}), do: :token_delta
   def kind(%__MODULE__{event: %ToolCallDelta{}}), do: :tool_call_delta
   def kind(%__MODULE__{event: %UsageUpdate{}}), do: :usage
   def kind(%__MODULE__{event: %Completed{}}), do: :completed
@@ -203,6 +231,21 @@ defmodule Orchard.InferenceEvent do
   def terminal?(%__MODULE__{event: %Completed{}}), do: true
   def terminal?(%__MODULE__{event: %Failed{}}), do: true
   def terminal?(%__MODULE__{}), do: false
+
+  defp valid_token_ids?(token_ids) when is_list(token_ids) and token_ids != [] do
+    Enum.all?(token_ids, fn token_id ->
+      is_integer(token_id) and token_id >= 0 and token_id <= 4_294_967_295
+    end)
+  end
+
+  defp valid_token_ids?(_token_ids), do: false
+
+  defp valid_logprobs?(token_ids, logprobs) when is_list(logprobs) do
+    Enum.all?(logprobs, &is_float/1) and
+      (logprobs == [] or length(logprobs) == length(token_ids))
+  end
+
+  defp valid_logprobs?(_token_ids, _logprobs), do: false
 
   defp validate_finish_reason!(finish_reason)
        when finish_reason in [

--- a/apps/orchard_shared/test/shared_domain_types_test.exs
+++ b/apps/orchard_shared/test/shared_domain_types_test.exs
@@ -14,7 +14,7 @@ defmodule OrchardSharedDomainTypesTest do
 
   alias Orchard.Cluster.V1.{InferenceEventMapper, ModelManifestMapper}
   alias Orchard.InferenceEvent
-  alias Orchard.InferenceEvent.Usage
+  alias Orchard.InferenceEvent.{TokenDelta, Usage}
   alias Orchard.ModelManifest
   alias Orchard.ModelManifest.{ChatTemplate, RuntimeRequirements, Tokenizer}
 
@@ -194,6 +194,56 @@ defmodule OrchardSharedDomainTypesTest do
       InferenceEvent.usage_update(%Usage{input_tokens: 12, output_tokens: 8, total_tokens: 20})
 
     assert InferenceEvent.kind(usage_event) == :usage
+  end
+
+  test "token delta constructors classify and round-trip empty and populated logprobs" do
+    empty_logprobs_event = InferenceEvent.token_delta([0, 4_294_967_295])
+
+    assert %InferenceEvent{event: %TokenDelta{token_ids: [0, 4_294_967_295], logprobs: []}} =
+             empty_logprobs_event
+
+    assert InferenceEvent.kind(empty_logprobs_event) == :token_delta
+    refute InferenceEvent.terminal?(empty_logprobs_event)
+
+    assert {:ok, ^empty_logprobs_event} =
+             empty_logprobs_event
+             |> InferenceEventMapper.to_proto()
+             |> InferenceEventMapper.from_proto()
+
+    populated_logprobs_event = InferenceEvent.token_delta([17, 42], [-0.25, -1.5])
+
+    assert %InferenceEvent{event: %TokenDelta{token_ids: [17, 42], logprobs: [-0.25, -1.5]}} =
+             populated_logprobs_event
+
+    assert {:ok, ^populated_logprobs_event} =
+             populated_logprobs_event
+             |> InferenceEventMapper.to_proto()
+             |> InferenceEventMapper.from_proto()
+  end
+
+  test "token delta constructors and mapper reject malformed values and alignment" do
+    for {token_ids, logprobs} <- [
+          {[], []},
+          {[-1], []},
+          {[4_294_967_296], []},
+          {[1.0], []},
+          {:not_a_list, []},
+          {[1], :not_a_list},
+          {[1], [0]},
+          {[1, 2], [-0.5]}
+        ] do
+      assert_raise ArgumentError, fn -> InferenceEvent.token_delta(token_ids, logprobs) end
+
+      assert {:error, {:invalid_payload, :token_delta, :invalid_scalar_values}} =
+               InferenceEventMapper.from_proto(%Orchard.Cluster.V1.InferenceEvent{
+                 event:
+                   {:token_delta,
+                    %Orchard.Cluster.V1.TokenDelta{
+                      token_ids: token_ids,
+                      logprobs: logprobs
+                    }}
+               })
+    end
   end
 
   test "inference event mapper handles tool-call finish reason bidirectionally" do


### PR DESCRIPTION
## Summary
- Adds `Orchard.InferenceEvent.TokenDelta` with validated `token_delta/1` and `token_delta/2` constructors.
- Completes bidirectional `V1.TokenDelta` mapping in `InferenceEventMapper` through the existing `safe_build/2` error vocabulary.
- Adds shared regression tests for construction, classification, round trips, malformed inputs, and logprob alignment.
- Adds a node-agent bridge test proving a protobuf `TokenDelta` crosses the mapper and streaming continues to `Completed`.

No proto, generated protobuf, native worker, ADR, or OpenSpec changes were needed.

## Validation
Run from the umbrella root:

1. `mise exec -- mix format` - passed
2. `mise exec -- mix compile --warnings-as-errors` - passed
3. `mise exec -- mix credo --strict` - passed (16,644 functions, no issues)
4. `mise exec -- mix dialyzer` - passed (0 errors)
5. `mise exec -- mix test` - passed:
   - Shared: 310 passed
   - Controller: 3,519 passed, 5 skipped
   - Node agent: 392 passed
   - CLI: 777 passed, 10 excluded
6. `mise exec -- mix test --cover` - passed

## Notes
- #221 is already merged to `main`, so this PR targets `main` directly.
- The implementation was planned with RepoPrompt CE (`context_builder`, `oracle_send`, `Investigate`, and `Orchestrate` workflows) and executed by an RP engineer agent in a worktree; the final commit was cherry-picked onto `origin/main` for a clean history.

Generated with [Devin](https://devin.ai)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789820128&installation_model_id=428414&pr_number=232&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F232&signature=f4547cfe2175876cf673368a0646baf92d434eb68ccc28bfe20a79cceed6a902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->