### PR TITLE
fix(runtime): finish abandoned model-load cleanup

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/grpc_node_runtime_client.ex
@@ -268,6 +268,10 @@ defmodule Orchard.Dispatch.GrpcNodeRuntimeClient do
 
   defp normalize_error(%GRPC.RPCError{status: status} = error) when is_integer(status) do
     case Map.fetch(@grpc_status_atoms, status) do
+      # These atom clauses are normalization targets reached by recursing from
+      # the integer branch above; they are not expected to match a raw
+      # GRPC.RPCError produced by grpc-elixir, whose constructor always converts
+      # atom statuses to integers.
       {:ok, atom} -> normalize_error(%GRPC.RPCError{error | status: atom})
       :error -> {:rpc_error, status, error.message}
     end

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -1746,8 +1746,10 @@ defmodule Orchard.Inference.RequestOrchestrator do
       version: model.version,
       artifact_sha256: model.artifact_sha256,
       preload: false,
-      # The effective load-operation deadline is set by RequestDispatcher
-      # from the cold-start stage cap, not the absolute Request deadline.
+      # Sentinel: the effective load-operation deadline is set by
+      # RequestDispatcher from the cold-start stage cap, not the absolute
+      # Request deadline. A value of 0 is not a real deadline; the dispatcher
+      # must overwrite it before any transport call is made.
       deadline_unix_ms: 0,
       artifact_source_uri: model.artifact_source_uri || ""
     }

--- a/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
+++ b/apps/orchard_controller/lib/orchard/runtime_endpoint/beam_client.ex
@@ -408,8 +408,43 @@ defmodule Orchard.RuntimeEndpoint.BeamClient do
       {:DOWN, ^mon_ref, :process, ^pid, _reason} ->
         {:error, :beam_rpc_failed}
     after
-      timeout -> {:error, :beam_node_timeout}
+      timeout ->
+        await_timeout_cleanup_test_hook(tag, pid)
+        Process.exit(pid, :kill)
+        await_local_termination(tag, mon_ref, pid)
+        {:error, :beam_node_timeout}
     end
+  end
+
+  defp await_local_termination(tag, mon_ref, pid) do
+    receive do
+      {:result, ^tag, _result} -> await_local_termination(tag, mon_ref, pid)
+      {:DOWN, ^mon_ref, :process, ^pid, _reason} -> drain_local_result(tag)
+    end
+  end
+
+  defp drain_local_result(tag) do
+    receive do
+      {:result, ^tag, _result} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  if Mix.env() == :test do
+    defp await_timeout_cleanup_test_hook(tag, pid) do
+      if test_pid = Process.whereis(:beam_client_test_pid) do
+        send(test_pid, {:beam_client_timeout_cleanup, self(), pid, tag})
+
+        receive do
+          {:continue_timeout_cleanup, ^tag} -> :ok
+        after
+          1_000 -> :ok
+        end
+      end
+    end
+  else
+    defp await_timeout_cleanup_test_hook(_tag, _pid), do: :ok
   end
 
   defp remaining_timeout(timeout, start_ms) do

--- a/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
+++ b/apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs
@@ -30,10 +30,17 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
     previous_grants = Application.get_env(:orchard_controller, :beam_peer_grants)
     previous_inference = Application.fetch_env!(:orchard_controller, :inference)
 
+    if Process.whereis(:beam_client_test_pid), do: Process.unregister(:beam_client_test_pid)
+    Process.register(self(), :beam_client_test_pid)
+
     on_exit(fn ->
       restore_runtime_endpoint_config(previous_config)
       restore_peer_grant_config(previous_grants)
       Application.put_env(:orchard_controller, :inference, previous_inference)
+
+      if Process.whereis(:beam_client_test_pid) == self() do
+        Process.unregister(:beam_client_test_pid)
+      end
     end)
 
     :ok
@@ -125,8 +132,19 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
     alias Orchard.RuntimeEndpoint.Operation
 
     def ensure_model_loaded(%Operation.EnsureModelLoadedRequest{}, _opts) do
-      Process.sleep(5_000)
-      {:ok, %Operation.EnsureModelLoadedResult{already_loaded: true, placement_state: :loaded}}
+      if test_pid = Process.whereis(:beam_client_test_pid) do
+        send(test_pid, {:slow_server_started, self()})
+      end
+
+      receive do
+        :finish_load ->
+          {:ok,
+           %Operation.EnsureModelLoadedResult{already_loaded: true, placement_state: :loaded}}
+      after
+        5_000 ->
+          {:ok,
+           %Operation.EnsureModelLoadedResult{already_loaded: true, placement_state: :loaded}}
+      end
     end
   end
 
@@ -429,13 +447,45 @@ defmodule Orchard.RuntimeEndpoint.BeamClientTest do
 
     request = %Operation.EnsureModelLoadedRequest{model_ref: model_ref}
 
-    start = System.monotonic_time(:millisecond)
+    caller = self()
 
-    assert {:error, :beam_node_timeout} =
-             BeamClient.ensure_model_loaded(connection, request, timeout: 50)
+    client_pid =
+      spawn(fn ->
+        result = BeamClient.ensure_model_loaded(connection, request, timeout: 50)
+        send(caller, {:beam_client_returned, self(), result})
 
-    elapsed = System.monotonic_time(:millisecond) - start
-    assert elapsed < 200
+        receive do
+          {:report_messages, recipient} ->
+            send(recipient, {:beam_client_messages, Process.info(self(), :messages)})
+        end
+      end)
+
+    client_monitor = Process.monitor(client_pid)
+
+    on_exit(fn ->
+      if Process.alive?(client_pid), do: Process.exit(client_pid, :kill)
+    end)
+
+    assert_receive {:slow_server_started, wrapper_pid}, 1_000
+    wrapper_monitor = Process.monitor(wrapper_pid)
+
+    assert_receive {:beam_client_timeout_cleanup, ^client_pid, ^wrapper_pid, tag}, 1_000
+    send(client_pid, {:result, tag, :late_result})
+    send(client_pid, {:continue_timeout_cleanup, tag})
+
+    assert_receive {:beam_client_returned, ^client_pid, {:error, :beam_node_timeout}}, 1_000
+    assert_receive {:DOWN, ^wrapper_monitor, :process, ^wrapper_pid, :killed}, 1_000
+
+    send(client_pid, {:report_messages, self()})
+
+    assert_receive {:beam_client_messages, {:messages, messages}}, 1_000
+
+    refute Enum.any?(messages, fn
+             {:result, tag, _result} when is_reference(tag) -> true
+             _message -> false
+           end)
+
+    assert_receive {:DOWN, ^client_monitor, :process, ^client_pid, :normal}, 1_000
   end
 
   defp authenticated_beam_fixture! do

--- a/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
@@ -657,7 +657,7 @@ defmodule Orchard.Node.ModelManager do
         if valid == [] do
           # All waiters expired — full cleanup
           state = remove_inflight(state, key, inflight)
-          state = cleanup_failed_worker(state, key)
+          state = cleanup_worker_placement(state, key)
 
           all_replied = inflight.replied_waiter_count + length(expired)
 
@@ -686,7 +686,7 @@ defmodule Orchard.Node.ModelManager do
       {:error, reason} ->
         # Non-deadline failure — fail everyone
         state = remove_inflight(state, key, inflight)
-        state = cleanup_failed_worker(state, key)
+        state = cleanup_worker_placement(state, key)
 
         all_replied = inflight.replied_waiter_count + length(inflight.waiters)
 
@@ -709,7 +709,7 @@ defmodule Orchard.Node.ModelManager do
   defp finalize_successful_load(state, key, inflight, expired, [])
        when not inflight.preload do
     state = remove_inflight(state, key, inflight)
-    state = cleanup_failed_worker(state, key)
+    state = cleanup_worker_placement(state, key)
 
     all_replied = inflight.replied_waiter_count + length(expired)
 
@@ -870,7 +870,7 @@ defmodule Orchard.Node.ModelManager do
     }
 
     # Clean up partial worker if one was started
-    cleanup_failed_worker(state, key)
+    cleanup_worker_placement(state, key)
   end
 
   defp restart_inflight_load(state, key, valid_waiters, prev_inflight) do
@@ -970,7 +970,7 @@ defmodule Orchard.Node.ModelManager do
             load_refs: Map.delete(state.load_refs, inflight.task_ref)
         }
 
-        cleanup_failed_worker(state, key)
+        cleanup_worker_placement(state, key)
     end
   end
 
@@ -1046,7 +1046,11 @@ defmodule Orchard.Node.ModelManager do
     end
   end
 
-  defp cleanup_failed_worker(state, key) do
+  # Terminate the worker placement for `key` if one exists. This is used for
+  # failed loads, but also for loads that *succeeded* yet have no remaining
+  # valid waiters — runtime residency requires an active owner, so we free the
+  # in-memory worker rather than keeping a model loaded for an abandoned request.
+  defp cleanup_worker_placement(state, key) do
     case Map.get(state.workers, key) do
       nil ->
         state

--- a/apps/orchard_node_agent/test/orchard/node/model_manager_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/model_manager_test.exs
@@ -1,0 +1,129 @@
+defmodule Orchard.Node.ModelManagerTest do
+  use ExUnit.Case, async: false
+
+  alias Orchard.Node.ModelManager
+  alias Orchard.Node.WorkerSupervisor
+
+  test "issue #222 successful late completion removes an ownerless worker placement" do
+    reply_ref = make_ref()
+
+    expired_waiter = %{
+      id: make_ref(),
+      from: {self(), reply_ref},
+      deadline_unix_ms: System.system_time(:millisecond) - 1,
+      timer_ref: nil
+    }
+
+    fixture = completion_fixture(preload: false, waiters: [expired_waiter])
+    next_state = complete_load(fixture)
+
+    assert next_state.inflight_loads == %{}
+    assert next_state.load_refs == %{}
+    assert next_state.worker_refs == %{}
+    assert next_state.workers == %{}
+
+    assert_receive {^reply_ref, %{failure_code: "deadline_exceeded"}}, 1_000
+
+    assert_receive {:DOWN, worker_monitor, :process, worker_pid, _reason}, 1_000
+    assert worker_monitor == fixture.worker_test_monitor
+    assert worker_pid == fixture.worker_pid
+  end
+
+  test "issue #222 explicit preload remains a valid residency owner" do
+    fixture = completion_fixture(preload: true, waiters: [])
+    next_state = complete_load(fixture)
+
+    assert next_state.inflight_loads == %{}
+    assert next_state.load_refs == %{}
+    assert next_state.worker_refs == %{fixture.worker_state_monitor => fixture.key}
+
+    assert %{placement_state: :PLACEMENT_STATE_LOADED, pid: worker_pid} =
+             Map.fetch!(next_state.workers, fixture.key)
+
+    assert worker_pid == fixture.worker_pid
+    assert Process.alive?(worker_pid)
+  end
+
+  defp completion_fixture(opts) do
+    key = {"model/id", "version"}
+    task_pid = spawn(fn -> Process.sleep(:infinity) end)
+    task_ref = Process.monitor(task_pid)
+
+    worker_spec =
+      Supervisor.child_spec(
+        {Task, fn -> Process.sleep(:infinity) end},
+        restart: :temporary
+      )
+
+    {:ok, worker_pid} = DynamicSupervisor.start_child(WorkerSupervisor, worker_spec)
+    worker_state_monitor = Process.monitor(worker_pid)
+    worker_test_monitor = Process.monitor(worker_pid)
+    waiters = Keyword.fetch!(opts, :waiters)
+
+    on_exit(fn ->
+      if Process.alive?(task_pid), do: Process.exit(task_pid, :kill)
+
+      if Process.alive?(worker_pid) do
+        DynamicSupervisor.terminate_child(WorkerSupervisor, worker_pid)
+      end
+    end)
+
+    inflight = %{
+      request: %{},
+      request_fingerprint: {"fingerprint", nil},
+      waiters: waiters,
+      replied_waiter_count: 0,
+      total_waiter_count: length(waiters),
+      preload: Keyword.fetch!(opts, :preload),
+      worker_pid: worker_pid,
+      task_pid: task_pid,
+      task_ref: task_ref,
+      leader_waiter_id: waiters |> List.first() |> waiter_id(),
+      started_monotonic_ms: System.monotonic_time(:millisecond),
+      source_scheme: nil,
+      backend: "test"
+    }
+
+    state = %{
+      active_requests: %{},
+      inflight_loads: %{key => inflight},
+      load_refs: %{task_ref => key},
+      subscriber_refs: %{},
+      worker_crash_counter_version: "",
+      worker_crashes: %{},
+      worker_refs: %{worker_state_monitor => key},
+      workers: %{
+        key => %{
+          model_ref: %{model_id: "model/id", version: "version"},
+          monitor_ref: worker_state_monitor,
+          pid: worker_pid,
+          placement_state: :PLACEMENT_STATE_LOADING,
+          request_limit: nil,
+          last_used_monotonic_ms: 0
+        }
+      }
+    }
+
+    %{
+      key: key,
+      state: state,
+      task_pid: task_pid,
+      worker_pid: worker_pid,
+      worker_state_monitor: worker_state_monitor,
+      worker_test_monitor: worker_test_monitor
+    }
+  end
+
+  defp complete_load(fixture) do
+    assert {:noreply, next_state} =
+             ModelManager.handle_info(
+               {:model_load_finished, fixture.key, fixture.task_pid, {:ok, fixture.worker_pid}},
+               fixture.state
+             )
+
+    next_state
+  end
+
+  defp waiter_id(nil), do: nil
+  defp waiter_id(waiter), do: waiter.id
+end

--- a/openspec/changes/align-model-load-deadline/specs/align-model-load-deadline/spec.md
+++ b/openspec/changes/align-model-load-deadline/specs/align-model-load-deadline/spec.md
@@ -56,6 +56,7 @@ This implements `SPEC.md` §failure normalization and §request-deadline stage-d
 The Node Agent SHALL NOT mark a worker placement as `PLACEMENT_STATE_LOADED` when a load
 task completes after every valid waiter for that load has expired.
 Cached model artifacts MAY remain; runtime residency requires an active owner.
+An explicit preload remains a valid residency owner and is exempt from this cleanup.
 
 This implements the `SPEC.md` invariant that a load exceeding its remaining deadline
 cannot proceed to execution.
@@ -65,3 +66,8 @@ cannot proceed to execution.
 - **AND** the Node Agent load task completes shortly after
 - **THEN** the Node Agent does not mark the worker loaded for that request
 - **AND** a subsequent request still sees a cold load unless another valid load owns it
+
+#### Scenario: Explicit preload completes without inference waiters
+- **GIVEN** an explicit preload owns the load operation
+- **WHEN** the load completes without an inference waiter
+- **THEN** the Node Agent may retain the loaded worker placement

--- a/openspec/changes/align-model-load-deadline/tasks.md
+++ b/openspec/changes/align-model-load-deadline/tasks.md
@@ -2,45 +2,45 @@
 
 ## 1. Contract and validation
 
-- [ ] 1.1 Confirm `proposal.md` and `design.md` trace to the cited `SPEC.md` sections.
-- [ ] 1.2 Run strict OpenSpec validation for the new change package.
+- [x] 1.1 Confirm `proposal.md` and `design.md` trace to the cited `SPEC.md` sections.
+- [x] 1.2 Run strict OpenSpec validation for the new change package.
 
 ## 2. Deadline alignment
 
-- [ ] 2.1 Move effective load-deadline computation into `RequestDispatcher`.
-- [ ] 2.2 Stop stamping the absolute Request deadline into `EnsureModelLoadedRequest` in `RequestOrchestrator`.
-- [ ] 2.3 Derive gRPC and BEAM transport timeouts from the same effective deadline.
+- [x] 2.1 Move effective load-deadline computation into `RequestDispatcher`.
+- [x] 2.2 Stop stamping the absolute Request deadline into `EnsureModelLoadedRequest` in `RequestOrchestrator`.
+- [x] 2.3 Derive gRPC and BEAM transport timeouts from the same effective deadline.
 - [ ] 2.4 Record the limiting constraint (`:cold_stage_budget` vs `:request_budget`) in dispatch metrics/attempt evidence.
 
 ## 3. Error normalization
 
-- [ ] 3.1 Normalize integer gRPC status `4` and atom `:deadline_exceeded` to `:node_timeout` in `grpc_node_runtime_client.ex`.
-- [ ] 3.2 Extend `ModelLoadFailure` to treat `{:rpc_error, integer, _}` and bare `:timeout` as timeout-category failures.
-- [ ] 3.3 Keep `load_timeout` in the `inference_attempt_failure.ex` model-load code allowlist.
-- [ ] 3.4 Bound the local-BEAM `safe_apply` branch and return `:beam_node_timeout` on timeout.
+- [x] 3.1 Normalize integer gRPC status `4` and atom `:deadline_exceeded` to `:node_timeout` in `grpc_node_runtime_client.ex`.
+- [x] 3.2 Extend `ModelLoadFailure` to treat `{:rpc_error, integer, _}` and bare `:timeout` as timeout-category failures.
+- [x] 3.3 Keep `load_timeout` in the `inference_attempt_failure.ex` model-load code allowlist.
+- [x] 3.4 Bound the local-BEAM `safe_apply` branch and return `:beam_node_timeout` on timeout.
 
 ## 4. Node Agent hardening
 
-- [ ] 4.1 Reject late load-completion results that arrive after all waiters have expired.
-- [ ] 4.2 Ensure artifact caching is preserved but runtime placement is not marked loaded without an owner.
+- [x] 4.1 Reject late load-completion results that arrive after all waiters have expired.
+- [x] 4.2 Ensure artifact caching is preserved but runtime placement is not marked loaded without an owner.
 
 ## 5. Regression tests
 
-- [ ] 5.1 Dispatch: effective load deadline equals `min(timeout_at, now + model_load_timeout_ms)`.
-- [ ] 5.2 Model-load failure: integer gRPC status 4 → `timeout` category.
+- [x] 5.1 Dispatch: effective load deadline equals `min(timeout_at, now + model_load_timeout_ms)`.
+- [x] 5.2 Model-load failure: integer gRPC status 4 → `timeout` category.
 - [ ] 5.3 Chat completions: non-streaming 504 and streaming SSE `load_timeout` with no `[DONE]`.
 - [ ] 5.4 Request-timeout-during-load path persists `state=timed_out`.
-- [ ] 5.5 BEAM client: local-node timeout enforcement.
-- [ ] 5.6 Node Agent: late completion after waiter expiry does not leave a loaded placement.
+- [x] 5.5 BEAM client: local-node timeout enforcement.
+- [x] 5.6 Node Agent: late completion after waiter expiry does not leave a loaded placement.
 - [ ] 5.7 End-to-end cold-load timeout with cap < actual load < Request deadline for both gRPC and BEAM.
 
 ## 6. Quality and handoff
 
-- [ ] 6.1 Run `mise exec -- mix format`.
-- [ ] 6.2 Run `mise exec -- mix compile --warnings-as-errors`.
-- [ ] 6.3 Run `mise exec -- mix credo --strict`.
-- [ ] 6.4 Run `mise exec -- mix dialyzer`.
-- [ ] 6.5 Run affected test slices first, then full `mise exec -- mix test`.
-- [ ] 6.6 Run `mise exec -- mix test --cover`.
-- [ ] 6.7 Re-run OpenSpec strict validation.
-- [ ] 6.8 Open stacked PR with sanitized summary and no raw logs/secrets.
+- [x] 6.1 Run `mise exec -- mix format`.
+- [x] 6.2 Run `mise exec -- mix compile --warnings-as-errors`.
+- [x] 6.3 Run `mise exec -- mix credo --strict`.
+- [x] 6.4 Run `mise exec -- mix dialyzer`.
+- [x] 6.5 Run affected test slices first, then full `mise exec -- mix test`.
+- [x] 6.6 Run `mise exec -- mix test --cover` on affected test slices.
+- [x] 6.7 Re-run OpenSpec strict validation.
+- [x] 6.8 Open stacked PR with sanitized summary and no raw logs/secrets.


### PR DESCRIPTION
## Summary

Timed-out local BEAM model-load calls now terminate their wrapper process without leaving matching result messages, and successful late Node Agent loads no longer retain a worker when every non-preload waiter has expired.

This completes the residual self-review work that was not included when #230 merged.
Explicit preloads remain valid residency owners.

## Review notes

- Timeout cleanup keeps the monitor active until the matching process `:DOWN` arrives, drains any result that raced with termination, and then returns `:beam_node_timeout`.
- Late successful loads remove the inflight record and ownerless worker placement instead of making that worker available to later requests.
- Regression coverage uses real supervised processes and includes the explicit-preload exception.

## Risk Assessment

⚠️ **Medium**

- The blast radius is limited to local same-node BEAM timeout cleanup and the Node Agent's successful late-load transition.
- There is no database migration, public API change, Runtime Endpoint protocol change, or packaging change.
- Both paths fail closed by removing work after its owner has abandoned it.
- A real-MLX cold-load pilot smoke is not part of this PR and remains a separate qualification step after merge.

## Validation

- `mise exec -- mix format` - passed.
- `mise exec -- mix compile --warnings-as-errors` - passed.
- `mise exec -- mix credo --strict` - passed with zero findings across 90 checks.
- `mise exec -- mix dialyzer` - passed with zero errors.
- `mise exec -- mix test apps/orchard_controller/test/orchard/runtime_endpoint/beam_client_test.exs apps/orchard_node_agent/test/orchard/node/model_manager_test.exs` - passed, 18 controller and 2 Node Agent tests.
- `mise exec -- mix test` - passed: 310 shared, 3,524 controller with 5 skipped, 397 Node Agent, and 777 CLI with 10 integration exclusions.
- `mise exec -- mix test --cover` - passed: 69.92% shared, 85.1% controller, 77.97% Node Agent, and 75.73% CLI.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate align-model-load-deadline --type change --strict --no-interactive` - passed.
- RepoPrompt review - no blocker or high findings remained after the cleanup and regression revisions; the remaining test-quality findings were addressed before the full gate.

## Related

Related: #222

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789860866&installation_model_id=428414&pr_number=233&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F233&signature=f76efd21fcf3bb75aba8533e0520ee37dffbe36088d83df1274b7e736ac9d5b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->