### PR TITLE
fix(source-dev): scope worker cleanup to exact checkout ownership

### DIFF
--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -29,7 +29,7 @@ defmodule OrchardCLI.DevScriptsTest do
     refute dev =~ "cd \"$REPO_ROOT/apps/orchard_node_agent\""
   end
 
-  test "dev-controller does not kill MLX workers, while dev and dev-node-agent do" do
+  test "dev-controller does not kill MLX workers, while dev and dev-node-agent use owned cleanup" do
     controller = File.read!(Path.join(@repo_root, "bin/dev-controller"))
     dev = File.read!(Path.join(@repo_root, "bin/dev"))
     node_agent = File.read!(Path.join(@repo_root, "bin/dev-node-agent"))
@@ -37,8 +37,14 @@ defmodule OrchardCLI.DevScriptsTest do
     refute controller =~ "pgrep -f orchard-worker-mlx"
     refute controller =~ "xargs kill"
 
-    assert dev =~ "pgrep -f orchard-worker-mlx"
-    assert node_agent =~ "pgrep -f orchard-worker-mlx"
+    assert dev =~ "source-dev-worker-cleanup.sh"
+    assert node_agent =~ "source-dev-worker-cleanup.sh"
+
+    assert dev =~ "orchard_source_dev_cleanup_workers"
+    assert node_agent =~ "orchard_source_dev_cleanup_workers"
+
+    refute dev =~ "orphans=$(pgrep -f orchard-worker-mlx)"
+    refute node_agent =~ "orphans=$(pgrep -f orchard-worker-mlx)"
   end
 
   test "source-dev BEAM bootstrap shell contract stays wired into Mix tests" do
@@ -51,5 +57,17 @@ defmodule OrchardCLI.DevScriptsTest do
              )
 
     assert output =~ "source-dev BEAM bootstrap tests passed"
+  end
+
+  test "source-dev worker cleanup kills only owned checkout workers" do
+    script = Path.join(@repo_root, "scripts/test-source-dev-worker-cleanup.sh")
+
+    assert {output, 0} =
+             System.cmd("bash", [script],
+               cd: @repo_root,
+               stderr_to_stdout: true
+             )
+
+    assert output =~ "source-dev worker cleanup tests passed"
   end
 end

--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -70,4 +70,28 @@ defmodule OrchardCLI.DevScriptsTest do
 
     assert output =~ "source-dev worker cleanup tests passed"
   end
+
+  test "source-dev worker socket directory matches config dev derivation" do
+    repo_root = Path.expand(@repo_root)
+    hash = :crypto.hash(:sha256, repo_root) |> Base.url_encode64(padding: false)
+    expected = Path.join(["/tmp", "od-" <> binary_part(hash, 0, 8), "ws"])
+    helper = Path.join(repo_root, "bin/lib/source-dev-worker-cleanup.sh")
+
+    assert {output, 0} =
+             System.cmd(
+               "bash",
+               [
+                 "-c",
+                 "source \"$1\"; orchard_source_dev_worker_socket_dir \"$2\"",
+                 "bash",
+                 helper,
+                 repo_root
+               ],
+               cd: repo_root,
+               env: [{"ORCHARD_WORKER_SOCKET_DIR", ""}],
+               stderr_to_stdout: true
+             )
+
+    assert String.trim(output) == expected
+  end
 end

--- a/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
@@ -243,6 +243,35 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert runtime[:worker_socket_dir] == "/tmp/orchard-worker-sockets"
   end
 
+  test "dev.exs treats an empty worker socket override as unset" do
+    runtime =
+      read_dev_config!(%{"ORCHARD_WORKER_SOCKET_DIR" => ""})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert String.starts_with?(runtime[:worker_socket_dir], "/tmp/od-")
+  end
+
+  test "dev.exs resolves relative worker paths from the repository root" do
+    runtime =
+      read_dev_config!(%{
+        "ORCHARD_WORKER_SOCKET_DIR" => "tmp/worker-sockets",
+        "ORCHARD_WORKER_EXECUTABLE" => "native/worker"
+      })
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    repo_root = Path.expand("../../../../..", __DIR__)
+    assert runtime[:worker_socket_dir] == Path.join(repo_root, "tmp/worker-sockets")
+    assert runtime[:worker_executable] == Path.join(repo_root, "native/worker")
+  end
+
+  test "dev.exs rejects worker paths containing whitespace" do
+    assert_raise RuntimeError, ~r/must not contain whitespace or control characters/, fn ->
+      read_dev_config!(%{"ORCHARD_WORKER_SOCKET_DIR" => "/tmp/worker sockets"})
+    end
+  end
+
   test "dev.exs explicit generation mode overrides stub backend default" do
     runtime =
       read_dev_config!(%{

--- a/bin/dev
+++ b/bin/dev
@@ -60,17 +60,14 @@ mix ecto.create --quiet
 mix ecto.migrate --quiet
 
 # ---------------------------------------------------------------------------
-# Kill orphaned MLX workers from prior sessions
+# Kill orphaned source-dev MLX workers from prior sessions
 # ---------------------------------------------------------------------------
 # Workers spawned by a previous bin/dev may survive BEAM shutdown (especially
 # ctrl+c or crash). Each holds the full model in GPU memory (~15-18 GB),
 # silently degrading performance via unified memory contention.
-orphans=$(pgrep -f orchard-worker-mlx 2>/dev/null || true)
-if [[ -n "$orphans" ]]; then
-  echo "==> Killing orphaned MLX workers: $orphans"
-  echo "$orphans" | xargs kill 2>/dev/null || true
-  sleep 1
-fi
+source "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
+export ORCHARD_WORKER_EXECUTABLE="${ORCHARD_WORKER_EXECUTABLE:-$REPO_ROOT/native/orchard_worker_mlx/bin/orchard-worker-mlx}"
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$ORCHARD_WORKER_EXECUTABLE"
 
 # ---------------------------------------------------------------------------
 # Start the dev server

--- a/bin/dev
+++ b/bin/dev
@@ -66,8 +66,11 @@ mix ecto.migrate --quiet
 # ctrl+c or crash). Each holds the full model in GPU memory (~15-18 GB),
 # silently degrading performance via unified memory contention.
 source "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
-export ORCHARD_WORKER_EXECUTABLE="${ORCHARD_WORKER_EXECUTABLE:-$REPO_ROOT/native/orchard_worker_mlx/bin/orchard-worker-mlx}"
-orchard_source_dev_cleanup_workers "$REPO_ROOT" "$ORCHARD_WORKER_EXECUTABLE"
+orchard_source_dev_configure_worker_runtime "$REPO_ROOT"
+orchard_source_dev_cleanup_workers \
+  "$REPO_ROOT" \
+  "$ORCHARD_WORKER_EXECUTABLE" \
+  "$ORCHARD_WORKER_EFFECTIVE_EXECUTABLE"
 
 # ---------------------------------------------------------------------------
 # Start the dev server

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -49,15 +49,9 @@ if [[ ! -x "$ORCHARD_WORKER_EXECUTABLE" ]]; then
 fi
 
 source "$REPO_ROOT/bin/lib/source-dev-beam.sh"
+source "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
 orchard_source_dev_beam_bootstrap node_agent "$REPO_ROOT"
-
-# Kill orphaned MLX workers from prior sessions.
-orphans=$(pgrep -f orchard-worker-mlx 2>/dev/null || true)
-if [[ -n "$orphans" ]]; then
-  echo "==> Killing orphaned MLX workers: $orphans"
-  echo "$orphans" | xargs kill 2>/dev/null || true
-  sleep 1
-fi
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$ORCHARD_WORKER_EXECUTABLE"
 
 # Start only the source-dev node-agent app. The sub-app mix.exs reuses the
 # umbrella config path, but does not boot the Phoenix/controller application.

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -42,16 +42,14 @@ fi
 export ORCHARD_NODE_AGENT_LISTEN_PORT="$resolved_port"
 export ORCHARD_RUNTIME_CLIENT_PORT="$resolved_port"
 export ORCHARD_NODE_AGENT_LISTEN_HOST="${ORCHARD_NODE_AGENT_LISTEN_HOST:-127.0.0.1}"
-export ORCHARD_WORKER_EXECUTABLE="${ORCHARD_WORKER_EXECUTABLE:-$REPO_ROOT/native/orchard_worker_mlx/bin/orchard-worker-mlx}"
-
-if [[ ! -x "$ORCHARD_WORKER_EXECUTABLE" ]]; then
-  echo "warning: ORCHARD_WORKER_EXECUTABLE is not executable: $ORCHARD_WORKER_EXECUTABLE" >&2
-fi
-
 source "$REPO_ROOT/bin/lib/source-dev-beam.sh"
 source "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
+orchard_source_dev_configure_worker_runtime "$REPO_ROOT"
 orchard_source_dev_beam_bootstrap node_agent "$REPO_ROOT"
-orchard_source_dev_cleanup_workers "$REPO_ROOT" "$ORCHARD_WORKER_EXECUTABLE"
+orchard_source_dev_cleanup_workers \
+  "$REPO_ROOT" \
+  "$ORCHARD_WORKER_EXECUTABLE" \
+  "$ORCHARD_WORKER_EFFECTIVE_EXECUTABLE"
 
 # Start only the source-dev node-agent app. The sub-app mix.exs reuses the
 # umbrella config path, but does not boot the Phoenix/controller application.

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Shared source-dev worker cleanup helpers.
+#
+# These helpers identify and terminate worker subprocesses that belong to the
+# current source-dev checkout. They deliberately avoid:
+#   - packaged workers (different socket directory)
+#   - workers from other repo checkouts (different socket-directory hash)
+#   - processes owned by another user
+#   - processes whose command line does not declare an exact socket path
+#     inside this checkout's source-dev socket directory.
+
+# Compute the source-dev worker socket directory for a repo root.
+# This must stay in sync with config/dev.exs and config/test.exs.
+orchard_source_dev_worker_socket_dir() {
+  local repo_root="$1"
+  local hash
+
+  # config/dev.exs honors this override before falling back to the hashed
+  # default; the cleanup scope must follow the same resolution order.
+  if [[ -n "${ORCHARD_WORKER_SOCKET_DIR:-}" ]]; then
+    printf '%s\n' "$ORCHARD_WORKER_SOCKET_DIR"
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    hash="$(python3 - "$repo_root" <<'PY'
+import base64
+import hashlib
+import sys
+repo = sys.argv[1]
+digest = hashlib.sha256(repo.encode("utf-8")).digest()
+encoded = base64.urlsafe_b64encode(digest).decode("ascii")
+print(encoded.rstrip("=")[:8])
+PY
+    )"
+  else
+    echo "error: python3 is required to resolve the source-dev worker socket directory" >&2
+    return 69
+  fi
+
+  printf '%s\n' "/tmp/od-${hash}/ws"
+}
+
+# Terminate source-dev MLX workers owned by this checkout.
+#
+# Arguments:
+#   $1 repo root
+#   $2 worker executable path (optional, reserved for future ownership checks)
+orchard_source_dev_cleanup_workers() {
+  local repo_root="$1"
+  local _worker_executable="${2:-}"
+  local socket_dir
+
+  socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")" || return $?
+
+  local running_uid
+  running_uid="$(id -u)" || {
+    echo "error: unable to determine current user id" >&2
+    return 1
+  }
+
+  local -a pids_to_signal=()
+  local -a ambiguous_pids=()
+  local line pid args socket_path owner_uid
+
+  while IFS= read -r line; do
+    # Skip empty lines produced by pgrep when no matches exist.
+    [[ -z "$line" ]] && continue
+
+    # pid is the first whitespace-delimited token; everything else is args.
+    pid="${line%% *}"
+    args="${line#* }"
+
+    # Require a parseable socket path argument. Anything else is treated as
+    # an ambiguous match and aborts the cleanup rather than risk killing an
+    # unrelated process.
+    if ! socket_path="$(orchard_source_dev_extract_socket_path "$args")"; then
+      ambiguous_pids+=("$pid")
+      continue
+    fi
+
+    # Only consider workers whose socket lives in this checkout's directory.
+    [[ "$socket_path" == "$socket_dir/"* ]] || continue
+
+    # Only consider processes owned by the current user. Signals to other
+    # users would fail anyway, but this also guards against accidentally
+    # reporting them as candidates.
+    owner_uid="$(ps -o uid= -p "$pid" 2>/dev/null | tr -d '[:space:]')" || continue
+    [[ "$owner_uid" == "$running_uid" ]] || continue
+
+    # Do not signal a process that already exited between enumeration and now.
+    if kill -0 "$pid" 2>/dev/null; then
+      pids_to_signal+=("$pid")
+    fi
+  done < <(pgrep -fl orchard-worker-mlx 2>/dev/null || true)
+
+  if [[ ${#ambiguous_pids[@]} -gt 0 ]]; then
+    echo "error: found orchard-worker-mlx process(es) with no identifiable socket path: ${ambiguous_pids[*]}" >&2
+    echo "error: refusing to kill any worker until ownership is unambiguous" >&2
+    return 1
+  fi
+
+  if [[ ${#pids_to_signal[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  echo "==> Sending SIGTERM to owned source-dev MLX workers: ${pids_to_signal[*]}"
+
+  local pid
+  for pid in "${pids_to_signal[@]}"; do
+    if ! kill -TERM "$pid" 2>/dev/null; then
+      # The process may have exited between the -0 check and the signal. If it
+      # is genuinely gone, ignore; otherwise this is a real permission/signal
+      # failure and we abort.
+      if kill -0 "$pid" 2>/dev/null; then
+        echo "error: failed to signal source-dev worker $pid" >&2
+        return 1
+      fi
+    fi
+  done
+
+  # Give the workers a moment to shut down cleanly.
+  sleep 1
+
+  # Report any survivors so operators can investigate rather than escalate
+  # automatically from a startup script.
+  local survivors=()
+  for pid in "${pids_to_signal[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      survivors+=("$pid")
+    fi
+  done
+
+  if [[ ${#survivors[@]} -gt 0 ]]; then
+    echo "warning: source-dev MLX workers still alive after SIGTERM: ${survivors[*]}" >&2
+  fi
+
+  return 0
+}
+
+# Extract --socket-path VALUE from a command-line string.
+# Prints the path and returns 0 on success; returns 1 if missing or ambiguous.
+orchard_source_dev_extract_socket_path() {
+  local args="$1"
+  local socket_path=""
+
+  # Match both --socket-path VALUE and --socket-path=VALUE.
+  if [[ "$args" =~ --socket-path[[:space:]]+([^[:space:]]+) ]]; then
+    socket_path="${BASH_REMATCH[1]}"
+  elif [[ "$args" =~ --socket-path=([^[:space:]]+) ]]; then
+    socket_path="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+
+  printf '%s\n' "$socket_path"
+}

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -10,7 +10,9 @@
 #     inside this checkout's source-dev socket directory.
 
 # Compute the source-dev worker socket directory for a repo root.
-# This must stay in sync with config/dev.exs and config/test.exs.
+# This must stay in sync with the default in config/dev.exs.
+# config/test.exs intentionally uses the separate "ot-" prefix and is out of
+# scope for source-dev cleanup.
 orchard_source_dev_worker_socket_dir() {
   local repo_root="$1"
   local hash
@@ -22,8 +24,46 @@ orchard_source_dev_worker_socket_dir() {
     return 0
   fi
 
+  if ! hash="$(orchard_source_dev_worker_socket_hash "$repo_root")"; then
+    echo "warning: cannot resolve the source-dev worker socket directory; skipping cleanup" >&2
+    return 69
+  fi
+
+  printf '%s\n' "/tmp/od-${hash}/ws"
+}
+
+# Compute the first eight URL-safe base64 characters of SHA-256(repo_root).
+orchard_source_dev_worker_socket_hash() {
+  local repo_root="$1"
+  local digest_hex
+
+  if command -v shasum >/dev/null 2>&1 &&
+    command -v xxd >/dev/null 2>&1 &&
+    command -v base64 >/dev/null 2>&1; then
+    digest_hex="$(printf '%s' "$repo_root" | shasum -a 256 | awk '{print $1}')" || return 1
+    printf '%s' "$digest_hex" |
+      xxd -r -p |
+      base64 |
+      tr -d '\n' |
+      tr '+/' '-_' |
+      tr -d '=' |
+      cut -c1-8
+    return 0
+  fi
+
+  if command -v openssl >/dev/null 2>&1 && command -v base64 >/dev/null 2>&1; then
+    printf '%s' "$repo_root" |
+      openssl dgst -binary -sha256 |
+      base64 |
+      tr -d '\n' |
+      tr '+/' '-_' |
+      tr -d '=' |
+      cut -c1-8
+    return 0
+  fi
+
   if command -v python3 >/dev/null 2>&1; then
-    hash="$(python3 - "$repo_root" <<'PY'
+    python3 - "$repo_root" <<'PY'
 import base64
 import hashlib
 import sys
@@ -32,34 +72,35 @@ digest = hashlib.sha256(repo.encode("utf-8")).digest()
 encoded = base64.urlsafe_b64encode(digest).decode("ascii")
 print(encoded.rstrip("=")[:8])
 PY
-    )"
-  else
-    echo "error: python3 is required to resolve the source-dev worker socket directory" >&2
-    return 69
+    return $?
   fi
 
-  printf '%s\n' "/tmp/od-${hash}/ws"
+  return 69
 }
 
 # Terminate source-dev MLX workers owned by this checkout.
 #
 # Arguments:
 #   $1 repo root
-#   $2 worker executable path (optional, reserved for future ownership checks)
+#   $2 worker executable path (optional)
 orchard_source_dev_cleanup_workers() {
   local repo_root="$1"
-  local _worker_executable="${2:-}"
+  local worker_executable="${2:-}"
   local socket_dir
 
-  socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")" || return $?
+  if ! socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")"; then
+    echo "warning: unable to determine source-dev worker ownership; skipping cleanup" >&2
+    return 0
+  fi
 
   local running_uid
   running_uid="$(id -u)" || {
-    echo "error: unable to determine current user id" >&2
-    return 1
+    echo "warning: unable to determine current user id; skipping cleanup" >&2
+    return 0
   }
 
   local -a pids_to_signal=()
+  local -a socket_paths_to_signal=()
   local -a ambiguous_pids=()
   local line pid args socket_path owner_uid
 
@@ -72,9 +113,15 @@ orchard_source_dev_cleanup_workers() {
     args="${line#* }"
 
     # Require a parseable socket path argument. Anything else is treated as
-    # an ambiguous match and aborts the cleanup rather than risk killing an
-    # unrelated process.
+    # unknown ownership and skipped rather than risking an unrelated kill.
     if ! socket_path="$(orchard_source_dev_extract_socket_path "$args")"; then
+      ambiguous_pids+=("$pid")
+      continue
+    fi
+
+    # When provided, require the command line to identify this checkout's
+    # worker executable as well as its socket directory.
+    if [[ -n "$worker_executable" && "$args" != *"$worker_executable"* ]]; then
       ambiguous_pids+=("$pid")
       continue
     fi
@@ -91,13 +138,12 @@ orchard_source_dev_cleanup_workers() {
     # Do not signal a process that already exited between enumeration and now.
     if kill -0 "$pid" 2>/dev/null; then
       pids_to_signal+=("$pid")
+      socket_paths_to_signal+=("$socket_path")
     fi
-  done < <(pgrep -fl orchard-worker-mlx 2>/dev/null || true)
+  done < <(pgrep -af orchard-worker-mlx 2>/dev/null || true)
 
   if [[ ${#ambiguous_pids[@]} -gt 0 ]]; then
-    echo "error: found orchard-worker-mlx process(es) with no identifiable socket path: ${ambiguous_pids[*]}" >&2
-    echo "error: refusing to kill any worker until ownership is unambiguous" >&2
-    return 1
+    echo "warning: skipping orchard-worker-mlx process(es) with unknown ownership: ${ambiguous_pids[*]}" >&2
   fi
 
   if [[ ${#pids_to_signal[@]} -eq 0 ]]; then
@@ -106,8 +152,9 @@ orchard_source_dev_cleanup_workers() {
 
   echo "==> Sending SIGTERM to owned source-dev MLX workers: ${pids_to_signal[*]}"
 
-  local pid
-  for pid in "${pids_to_signal[@]}"; do
+  local index
+  for index in "${!pids_to_signal[@]}"; do
+    pid="${pids_to_signal[$index]}"
     if ! kill -TERM "$pid" 2>/dev/null; then
       # The process may have exited between the -0 check and the signal. If it
       # is genuinely gone, ignore; otherwise this is a real permission/signal
@@ -125,9 +172,10 @@ orchard_source_dev_cleanup_workers() {
   # Report any survivors so operators can investigate rather than escalate
   # automatically from a startup script.
   local survivors=()
-  for pid in "${pids_to_signal[@]}"; do
+  for index in "${!pids_to_signal[@]}"; do
+    pid="${pids_to_signal[$index]}"
     if kill -0 "$pid" 2>/dev/null; then
-      survivors+=("$pid")
+      survivors+=("$pid (socket: ${socket_paths_to_signal[$index]})")
     fi
   done
 

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -8,6 +8,91 @@
 #   - processes owned by another user
 #   - processes whose command line does not declare an exact socket path
 #     inside this checkout's source-dev socket directory.
+#
+# Ambiguous executable or socket ownership leaves a worker resident rather
+# than risking termination of an unrelated process.
+
+orchard_source_dev_reject_unsafe_path() {
+  local label="$1"
+  local value="$2"
+
+  if [[ "$value" =~ [[:space:][:cntrl:]] ]]; then
+    echo "error: $label must not contain whitespace or control characters: $value" >&2
+    return 64
+  fi
+}
+
+orchard_source_dev_resolve_executable() {
+  local repo_root="$1"
+  local executable="$2"
+  local require_executable="${3:-true}"
+  local resolved canonical
+
+  orchard_source_dev_reject_unsafe_path "worker executable" "$executable" || return
+
+  if [[ "$executable" == */* ]]; then
+    if [[ "$executable" == /* ]]; then
+      resolved="$executable"
+    else
+      resolved="$repo_root/$executable"
+    fi
+  else
+    resolved="$(command -v -- "$executable")" || return 1
+  fi
+
+  canonical="$(orchard_source_dev_canonical_existing_path "$resolved")" || return 1
+  [[ -f "$canonical" ]] || return 1
+  if [[ "$require_executable" == "true" ]]; then
+    [[ -x "$canonical" ]] || return 1
+  fi
+
+  printf '%s\n' "$canonical"
+}
+
+# Normalize source-dev worker paths once, before cleanup and Mix startup.
+# The exported values are consumed unchanged by config/dev.exs.
+orchard_source_dev_configure_worker_runtime() {
+  local repo_root="$1"
+  local socket_dir worker_executable effective_executable default_wrapper
+
+  if socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")"; then
+    orchard_source_dev_reject_unsafe_path "ORCHARD_WORKER_SOCKET_DIR" "$socket_dir" || return
+    [[ "$socket_dir" == /* ]] || socket_dir="$repo_root/$socket_dir"
+    mkdir -p -- "$socket_dir" || return
+    socket_dir="$(orchard_source_dev_canonical_directory "$socket_dir")" || return
+  else
+    socket_dir=""
+  fi
+
+  worker_executable="${ORCHARD_WORKER_EXECUTABLE:-$repo_root/native/orchard_worker_mlx/bin/orchard-worker-mlx}"
+  worker_executable="$(orchard_source_dev_resolve_executable "$repo_root" "$worker_executable")" || {
+    echo "error: unable to resolve ORCHARD_WORKER_EXECUTABLE" >&2
+    return 64
+  }
+
+  effective_executable="${ORCHARD_WORKER_EFFECTIVE_EXECUTABLE:-}"
+  default_wrapper="$repo_root/native/orchard_worker_mlx/bin/orchard-worker-mlx"
+  default_wrapper="$(orchard_source_dev_canonical_existing_path "$default_wrapper")" || true
+  if [[ -z "$effective_executable" && "$worker_executable" == "$default_wrapper" ]]; then
+    effective_executable="$repo_root/native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx"
+    if [[ ! -e "$effective_executable" ]]; then
+      echo "warning: MLX worker environment is not built; effective-executable cleanup is disabled" >&2
+      effective_executable=""
+    fi
+  elif [[ -z "$effective_executable" ]]; then
+    effective_executable="$worker_executable"
+  fi
+  if [[ -n "$effective_executable" ]]; then
+    effective_executable="$(orchard_source_dev_resolve_executable "$repo_root" "$effective_executable" false)" || {
+      echo "error: unable to resolve ORCHARD_WORKER_EFFECTIVE_EXECUTABLE" >&2
+      return 64
+    }
+  fi
+
+  export ORCHARD_WORKER_SOCKET_DIR="$socket_dir"
+  export ORCHARD_WORKER_EXECUTABLE="$worker_executable"
+  export ORCHARD_WORKER_EFFECTIVE_EXECUTABLE="$effective_executable"
+}
 
 # Compute the source-dev worker socket directory for a repo root.
 # This must stay in sync with the default in config/dev.exs.
@@ -78,20 +163,98 @@ PY
   return 69
 }
 
+# List matching workers as "pid full argv". The ps format is supported by both
+# BSD/macOS and Linux; avoid pgrep flags whose full-argv behavior is not
+# portable across those platforms.
+orchard_source_dev_worker_processes() {
+  local line pid args
+
+  while IFS= read -r line; do
+    read -r pid args <<< "$line"
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    [[ "$args" == *orchard-worker-mlx* ]] || continue
+    [[ "$pid" != "$$" ]] || continue
+    printf '%s %s\n' "$pid" "$args"
+  done < <(ps -ww -A -o pid= -o args= 2>/dev/null || true)
+}
+
+orchard_source_dev_process_identity() {
+  local pid="$1"
+
+  ps -ww -o uid= -o lstart= -o args= -p "$pid" 2>/dev/null
+}
+
+orchard_source_dev_canonical_existing_path() {
+  local path="$1"
+  local directory basename
+
+  directory="$(dirname -- "$path")" || return 1
+  basename="$(basename -- "$path")" || return 1
+
+  (
+    cd -P -- "$directory" 2>/dev/null || exit 1
+    printf '%s/%s\n' "$PWD" "$basename"
+  )
+}
+
+orchard_source_dev_canonical_directory() {
+  local directory="$1"
+
+  (
+    cd -P -- "$directory" 2>/dev/null || exit 1
+    printf '%s\n' "$PWD"
+  )
+}
+
+orchard_source_dev_args_include_executable() {
+  local args="$1"
+  shift
+
+  local -a tokens=()
+  local -a launch_tokens=()
+  local token canonical_token expected interpreter
+  read -r -a tokens <<< "$args"
+  [[ ${#tokens[@]} -gt 0 ]] || return 1
+
+  launch_tokens+=("${tokens[0]}")
+  interpreter="$(basename -- "${tokens[0]}")"
+  if [[ ${#tokens[@]} -gt 1 && "$interpreter" =~ ^(ba|z|k)?sh$|^python([0-9.]*)?$ ]]; then
+    launch_tokens+=("${tokens[1]}")
+  fi
+
+  for token in "${launch_tokens[@]}"; do
+    [[ "$token" == */* ]] || continue
+    canonical_token="$(orchard_source_dev_canonical_existing_path "$token")" || continue
+
+    for expected in "$@"; do
+      [[ "$canonical_token" == "$expected" ]] && return 0
+    done
+  done
+
+  return 1
+}
+
 # Terminate source-dev MLX workers owned by this checkout.
 #
 # Arguments:
 #   $1 repo root
 #   $2 worker executable path (optional)
+#   $3 effective executable path after a wrapper exec (optional)
 orchard_source_dev_cleanup_workers() {
   local repo_root="$1"
   local worker_executable="${2:-}"
-  local socket_dir
+  local configured_effective_executable="${3:-}"
+  local socket_dir canonical_socket_dir
 
   if ! socket_dir="$(orchard_source_dev_worker_socket_dir "$repo_root")"; then
     echo "warning: unable to determine source-dev worker ownership; skipping cleanup" >&2
     return 0
   fi
+
+  canonical_socket_dir="$(orchard_source_dev_canonical_directory "$socket_dir")" || {
+    echo "warning: unable to resolve source-dev worker socket directory; skipping cleanup" >&2
+    return 0
+  }
 
   local running_uid
   running_uid="$(id -u)" || {
@@ -101,11 +264,31 @@ orchard_source_dev_cleanup_workers() {
 
   local -a pids_to_signal=()
   local -a socket_paths_to_signal=()
+  local -a process_identities_to_signal=()
   local -a ambiguous_pids=()
-  local line pid args socket_path owner_uid
+  local -a different_executable_pids=()
+  local line pid args socket_path socket_parent owner_uid process_identity
+  local identity_weekday identity_month identity_day identity_time identity_year identity_args
+  local canonical_worker_executable effective_worker_executable
+
+  canonical_worker_executable=""
+  effective_worker_executable=""
+  if [[ -n "$worker_executable" ]]; then
+    canonical_worker_executable="$(orchard_source_dev_canonical_existing_path "$worker_executable")" || {
+      echo "warning: unable to resolve configured worker executable; skipping cleanup" >&2
+      return 0
+    }
+
+    if [[ -n "$configured_effective_executable" ]]; then
+      effective_worker_executable="$(orchard_source_dev_canonical_existing_path "$configured_effective_executable")" || {
+        echo "warning: unable to resolve effective worker executable; skipping cleanup" >&2
+        return 0
+      }
+    fi
+  fi
 
   while IFS= read -r line; do
-    # Skip empty lines produced by pgrep when no matches exist.
+    # Skip empty lines produced by ps when no matches exist.
     [[ -z "$line" ]] && continue
 
     # pid is the first whitespace-delimited token; everything else is args.
@@ -119,52 +302,116 @@ orchard_source_dev_cleanup_workers() {
       continue
     fi
 
-    # When provided, require the command line to identify this checkout's
-    # worker executable as well as its socket directory.
-    if [[ -n "$worker_executable" && "$args" != *"$worker_executable"* ]]; then
+    socket_parent="$(dirname -- "$socket_path")" || {
       ambiguous_pids+=("$pid")
       continue
+    }
+    socket_parent="$(orchard_source_dev_canonical_directory "$socket_parent")" || {
+      ambiguous_pids+=("$pid")
+      continue
+    }
+
+    # Compare canonical parent directories so lexical traversal cannot turn an
+    # out-of-scope socket into an owned candidate.
+    [[ "$socket_parent" == "$canonical_socket_dir" ]] || continue
+
+    # When provided, require the command line to identify this checkout's
+    # worker executable as well as its socket directory.
+    if [[ -n "$worker_executable" ]]; then
+      if ! orchard_source_dev_args_include_executable \
+        "$args" \
+        "$canonical_worker_executable" \
+        "$effective_worker_executable"; then
+        different_executable_pids+=("$pid")
+        continue
+      fi
     fi
 
-    # Only consider workers whose socket lives in this checkout's directory.
-    [[ "$socket_path" == "$socket_dir/"* ]] || continue
-
-    # Only consider processes owned by the current user. Signals to other
-    # users would fail anyway, but this also guards against accidentally
-    # reporting them as candidates.
-    owner_uid="$(ps -o uid= -p "$pid" 2>/dev/null | tr -d '[:space:]')" || continue
-    [[ "$owner_uid" == "$running_uid" ]] || continue
-
-    # Do not signal a process that already exited between enumeration and now.
+    # Capture one identity snapshot, then re-run every ownership predicate
+    # against its argv. This prevents a replacement process from inheriting a
+    # candidate PID between enumeration and baseline capture.
     if kill -0 "$pid" 2>/dev/null; then
+      process_identity="$(orchard_source_dev_process_identity "$pid")" || continue
+      [[ -n "$process_identity" ]] || continue
+
+      read -r \
+        owner_uid \
+        identity_weekday \
+        identity_month \
+        identity_day \
+        identity_time \
+        identity_year \
+        identity_args <<< "$process_identity"
+      [[ "$owner_uid" == "$running_uid" && -n "$identity_args" ]] || continue
+
+      if ! socket_path="$(orchard_source_dev_extract_socket_path "$identity_args")"; then
+        ambiguous_pids+=("$pid")
+        continue
+      fi
+      socket_parent="$(dirname -- "$socket_path")" || continue
+      socket_parent="$(orchard_source_dev_canonical_directory "$socket_parent")" || continue
+      [[ "$socket_parent" == "$canonical_socket_dir" ]] || continue
+
+      if [[ -n "$worker_executable" ]] &&
+        ! orchard_source_dev_args_include_executable \
+          "$identity_args" \
+          "$canonical_worker_executable" \
+          "$effective_worker_executable"; then
+        different_executable_pids+=("$pid")
+        continue
+      fi
+
       pids_to_signal+=("$pid")
       socket_paths_to_signal+=("$socket_path")
+      process_identities_to_signal+=("$process_identity")
     fi
-  done < <(pgrep -af orchard-worker-mlx 2>/dev/null || true)
+  done < <(orchard_source_dev_worker_processes)
 
   if [[ ${#ambiguous_pids[@]} -gt 0 ]]; then
-    echo "warning: skipping orchard-worker-mlx process(es) with unknown ownership: ${ambiguous_pids[*]}" >&2
+    echo "warning: skipping orchard-worker-mlx process(es) without a parseable --socket-path: ${ambiguous_pids[*]}" >&2
+  fi
+
+  if [[ ${#different_executable_pids[@]} -gt 0 ]]; then
+    echo "warning: skipping in-scope orchard-worker-mlx process(es) with a different executable: ${different_executable_pids[*]}" >&2
   fi
 
   if [[ ${#pids_to_signal[@]} -eq 0 ]]; then
     return 0
   fi
 
-  echo "==> Sending SIGTERM to owned source-dev MLX workers: ${pids_to_signal[*]}"
-
-  local index
+  local -a signalled_pids=()
+  local -a signalled_socket_paths=()
+  local -a signalled_identities=()
+  local -a changed_identity_pids=()
+  local current_identity index
   for index in "${!pids_to_signal[@]}"; do
     pid="${pids_to_signal[$index]}"
+
+    echo "==> Revalidating owned source-dev MLX worker before SIGTERM: $pid"
+    current_identity="$(orchard_source_dev_process_identity "$pid")" || continue
+    if [[ "$current_identity" != "${process_identities_to_signal[$index]}" ]]; then
+      changed_identity_pids+=("$pid")
+      continue
+    fi
+
     if ! kill -TERM "$pid" 2>/dev/null; then
-      # The process may have exited between the -0 check and the signal. If it
-      # is genuinely gone, ignore; otherwise this is a real permission/signal
-      # failure and we abort.
       if kill -0 "$pid" 2>/dev/null; then
         echo "error: failed to signal source-dev worker $pid" >&2
         return 1
       fi
+      continue
     fi
+
+    signalled_pids+=("$pid")
+    signalled_socket_paths+=("${socket_paths_to_signal[$index]}")
+    signalled_identities+=("$current_identity")
   done
+
+  if [[ ${#changed_identity_pids[@]} -gt 0 ]]; then
+    echo "warning: skipping source-dev worker process(es) whose identity changed before signalling: ${changed_identity_pids[*]}" >&2
+  fi
+
+  [[ ${#signalled_pids[@]} -gt 0 ]] || return 0
 
   # Give the workers a moment to shut down cleanly.
   sleep 1
@@ -172,10 +419,11 @@ orchard_source_dev_cleanup_workers() {
   # Report any survivors so operators can investigate rather than escalate
   # automatically from a startup script.
   local survivors=()
-  for index in "${!pids_to_signal[@]}"; do
-    pid="${pids_to_signal[$index]}"
-    if kill -0 "$pid" 2>/dev/null; then
-      survivors+=("$pid (socket: ${socket_paths_to_signal[$index]})")
+  for index in "${!signalled_pids[@]}"; do
+    pid="${signalled_pids[$index]}"
+    current_identity="$(orchard_source_dev_process_identity "$pid")" || continue
+    if [[ "$current_identity" == "${signalled_identities[$index]}" ]]; then
+      survivors+=("$pid (socket: ${signalled_socket_paths[$index]})")
     fi
   done
 
@@ -191,15 +439,34 @@ orchard_source_dev_cleanup_workers() {
 orchard_source_dev_extract_socket_path() {
   local args="$1"
   local socket_path=""
+  local -a tokens=()
+  local token expect_value=0 count=0
 
-  # Match both --socket-path VALUE and --socket-path=VALUE.
-  if [[ "$args" =~ --socket-path[[:space:]]+([^[:space:]]+) ]]; then
-    socket_path="${BASH_REMATCH[1]}"
-  elif [[ "$args" =~ --socket-path=([^[:space:]]+) ]]; then
-    socket_path="${BASH_REMATCH[1]}"
-  else
-    return 1
-  fi
+  # ps exposes argv as a whitespace-delimited string on supported platforms.
+  # Reject repeated or malformed forms because accepting the first value could
+  # disagree with the worker parser, which accepts the last repeated option.
+  read -r -a tokens <<< "$args"
+  for token in "${tokens[@]}"; do
+    if [[ "$expect_value" -eq 1 ]]; then
+      socket_path="$token"
+      expect_value=0
+      count=$((count + 1))
+      continue
+    fi
+
+    case "$token" in
+      --socket-path)
+        expect_value=1
+        ;;
+      --socket-path=*)
+        socket_path="${token#--socket-path=}"
+        [[ -n "$socket_path" ]] || return 1
+        count=$((count + 1))
+        ;;
+    esac
+  done
+
+  [[ "$expect_value" -eq 0 && "$count" -eq 1 ]] || return 1
 
   printf '%s\n' "$socket_path"
 }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -53,6 +53,20 @@ env_optional_string = fn env_name ->
   end
 end
 
+env_source_dev_path = fn env_name ->
+  case env_optional_string.(env_name) do
+    nil ->
+      nil
+
+    value ->
+      if String.match?(value, ~r/[[:space:][:cntrl:]]/u) do
+        raise "environment variable #{env_name} must not contain whitespace or control characters"
+      end
+
+      Path.expand(value, repo_root)
+  end
+end
+
 env_tokenizer_safe_mode = fn env_name, default ->
   case System.get_env(env_name) || default do
     value when value in [:off, "off"] ->
@@ -409,8 +423,10 @@ worker_socket_dir_hash =
 # Python gRPC rejects Unix socket paths above roughly 103 bytes on macOS.
 # Keep source-dev worker sockets under a short, worktree-specific root.
 worker_socket_dir =
-  System.get_env("ORCHARD_WORKER_SOCKET_DIR") ||
-    Path.join(["/tmp", "od-" <> worker_socket_dir_hash, "ws"])
+  case env_source_dev_path.("ORCHARD_WORKER_SOCKET_DIR") do
+    nil -> Path.join(["/tmp", "od-" <> worker_socket_dir_hash, "ws"])
+    path -> path
+  end
 
 worker_backend =
   env_optional_string.("ORCHARD_WORKER_BACKEND") ||
@@ -561,7 +577,7 @@ config :orchard_node_agent,
       node_identity_root: dev_node_identity_root,
       listen_address: [host: dev_node_agent_listen_host, port: dev_runtime_port],
       worker_executable:
-        System.get_env("ORCHARD_WORKER_EXECUTABLE") ||
+        env_source_dev_path.("ORCHARD_WORKER_EXECUTABLE") ||
           Path.join([repo_root, "native", "orchard_worker_mlx", "bin", "orchard-worker-mlx"]),
       worker_socket_dir: worker_socket_dir,
       worker_backend: worker_backend,

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -477,13 +477,23 @@ assert_fails_with 'ORCHARD_RUNTIME_ENDPOINT_TRANSPORT must be grpc|beam' "$TMP_R
   run_helper controller "$TMP_ROOT/repo-g" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=http
 
 ENTRYPOINT_REPO="$TMP_ROOT/entrypoint-repo"
-mkdir -p "$ENTRYPOINT_REPO/bin/lib" "$ENTRYPOINT_REPO/apps/orchard_controller" "$ENTRYPOINT_REPO/apps/orchard_node_agent"
+mkdir -p \
+  "$ENTRYPOINT_REPO/bin/lib" \
+  "$ENTRYPOINT_REPO/apps/orchard_controller" \
+  "$ENTRYPOINT_REPO/apps/orchard_node_agent" \
+  "$ENTRYPOINT_REPO/native/orchard_worker_mlx/bin" \
+  "$ENTRYPOINT_REPO/native/orchard_worker_mlx/.venv/bin"
 cp "$REPO_ROOT/bin/dev" "$ENTRYPOINT_REPO/bin/dev"
 cp "$REPO_ROOT/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-controller"
 cp "$REPO_ROOT/bin/dev-node-agent" "$ENTRYPOINT_REPO/bin/dev-node-agent"
 cp "$HELPER" "$ENTRYPOINT_REPO/bin/lib/source-dev-beam.sh"
 cp "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh" "$ENTRYPOINT_REPO/bin/lib/source-dev-worker-cleanup.sh"
 chmod +x "$ENTRYPOINT_REPO/bin/dev" "$ENTRYPOINT_REPO/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-node-agent"
+: > "$ENTRYPOINT_REPO/native/orchard_worker_mlx/bin/orchard-worker-mlx"
+: > "$ENTRYPOINT_REPO/native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx"
+chmod +x \
+  "$ENTRYPOINT_REPO/native/orchard_worker_mlx/bin/orchard-worker-mlx" \
+  "$ENTRYPOINT_REPO/native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx"
 : > "$ENTRYPOINT_REPO/mix.exs"
 
 # H: all-in-one bin/dev rejects explicit BEAM mode before running Mix.
@@ -568,7 +578,22 @@ assert_grep '-S mix run --no-halt' "$TMP_ROOT/j-node-iex.log"
 assert_no_grep '--name' "$TMP_ROOT/j-node-iex.log"
 assert_no_grep '--erl' "$TMP_ROOT/j-node-iex.log"
 
-# K: peer-grant commands reject every legacy or compatibility authorization input.
+# K: source-dev entrypoints still boot before the optional MLX venv is built.
+rm -rf "$ENTRYPOINT_REPO/native/orchard_worker_mlx/.venv"
+: > "$TMP_ROOT/k-dev-mix.log"
+assert_succeeds "$TMP_ROOT/k-dev.out" \
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/k-dev-mix.log" IEX_ARG_LOG="$TMP_ROOT/k-dev-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc "$ENTRYPOINT_REPO/bin/dev"
+assert_grep 'mix called: ecto.create --quiet' "$TMP_ROOT/k-dev-mix.log"
+assert_grep '-S mix phx.server' "$TMP_ROOT/k-dev-iex.log"
+assert_grep 'MLX worker environment is not built; effective-executable cleanup is disabled' "$TMP_ROOT/k-dev.out"
+
+: > "$TMP_ROOT/k-node-mix.log"
+assert_succeeds "$TMP_ROOT/k-node.out" \
+  env -i PATH="$TOOLS_I:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$TMP_ROOT/home" MIX_CALL_LOG="$TMP_ROOT/k-node-mix.log" IEX_ARG_LOG="$TMP_ROOT/k-node-iex.log" ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc "$ENTRYPOINT_REPO/bin/dev-node-agent"
+assert_grep '-S mix run --no-halt' "$TMP_ROOT/k-node-iex.log"
+assert_grep 'MLX worker environment is not built; effective-executable cleanup is disabled' "$TMP_ROOT/k-node.out"
+
+# L: peer-grant commands reject every legacy or compatibility authorization input.
 assert_fails_with 'ORCHARD_BEAM_COOKIE_FILE is forbidden for peer-grant Distribution' \
   "$TMP_ROOT/k-cookie.out" \
   env ORCHARD_BEAM_COOKIE_FILE="$STRICT_COOKIE" \

--- a/scripts/test-source-dev-beam-bootstrap.sh
+++ b/scripts/test-source-dev-beam-bootstrap.sh
@@ -482,6 +482,7 @@ cp "$REPO_ROOT/bin/dev" "$ENTRYPOINT_REPO/bin/dev"
 cp "$REPO_ROOT/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-controller"
 cp "$REPO_ROOT/bin/dev-node-agent" "$ENTRYPOINT_REPO/bin/dev-node-agent"
 cp "$HELPER" "$ENTRYPOINT_REPO/bin/lib/source-dev-beam.sh"
+cp "$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh" "$ENTRYPOINT_REPO/bin/lib/source-dev-worker-cleanup.sh"
 chmod +x "$ENTRYPOINT_REPO/bin/dev" "$ENTRYPOINT_REPO/bin/dev-controller" "$ENTRYPOINT_REPO/bin/dev-node-agent"
 : > "$ENTRYPOINT_REPO/mix.exs"
 

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -2,8 +2,8 @@
 # Focused tests for the source-dev worker cleanup helper.
 #
 # Verifies that the helper kills only workers whose socket path lives in this
-# checkout's source-dev socket directory and leaves foreign / out-of-tree workers
-# alone.
+# checkout's source-dev socket directory, skips ambiguous workers, and leaves
+# foreign / out-of-tree workers alone.
 
 set -euo pipefail
 
@@ -62,6 +62,15 @@ while :; do sleep 0.2; done
 SCRIPT
 chmod +x "$FAKE_WORKER"
 
+FAKE_AMBIGUOUS="$TMP_ROOT/orchard-worker-mlx-ambiguous"
+cat > "$FAKE_AMBIGUOUS" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'exit 0' TERM
+while :; do sleep 0.2; done
+SCRIPT
+chmod +x "$FAKE_AMBIGUOUS"
+
 socket_owned="$SOCKET_DIR/owned.sock"
 socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
 
@@ -73,6 +82,8 @@ socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
 owned_pid=$!
 "$FAKE_WORKER" --socket-path "$socket_foreign" &
 foreign_pid=$!
+"$FAKE_AMBIGUOUS" &
+ambiguous_pid=$!
 
 # Give the background jobs a moment to establish their command lines.
 sleep 0.2
@@ -80,9 +91,15 @@ sleep 0.2
 # Verify both are alive before cleanup.
 kill -0 "$owned_pid" 2>/dev/null || fail "owned worker was not running before cleanup"
 kill -0 "$foreign_pid" 2>/dev/null || fail "foreign worker was not running before cleanup"
+kill -0 "$ambiguous_pid" 2>/dev/null || fail "ambiguous worker was not running before cleanup"
 
 # Run the cleanup helper.
-orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER"
+cleanup_output="$(orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" 2>&1)"
+printf '%s\n' "$cleanup_output"
+[[ "$cleanup_output" == *"warning: skipping orchard-worker-mlx process(es) with unknown ownership"* ]] ||
+  fail "ambiguous worker warning was not emitted"
+[[ "$cleanup_output" == *"$ambiguous_pid"* ]] ||
+  fail "ambiguous worker warning did not name its pid"
 
 # Reap the owned worker first: it is a child of this shell, so until wait(2)
 # collects it the zombie still answers kill -0.
@@ -98,8 +115,16 @@ if ! kill -0 "$foreign_pid" 2>/dev/null; then
   fail "foreign worker was incorrectly killed by cleanup"
 fi
 
-# Clean up the foreign worker.
+# The ambiguous worker should still be alive and the helper should have
+# returned success despite not being able to establish ownership.
+if ! kill -0 "$ambiguous_pid" 2>/dev/null; then
+  fail "ambiguous worker was incorrectly killed by cleanup"
+fi
+
+# Clean up the foreign and ambiguous workers.
 kill -TERM "$foreign_pid" 2>/dev/null || true
 wait "$foreign_pid" 2>/dev/null || true
+kill -TERM "$ambiguous_pid" 2>/dev/null || true
+wait "$ambiguous_pid" 2>/dev/null || true
 
 echo "source-dev worker cleanup tests passed"

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -11,7 +11,72 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HELPER="$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
 TMP_ROOT="$(mktemp -d)"
 
+owned_pid=""
+foreign_pid=""
+other_pid=""
+ambiguous_pid=""
+wrapper_pid=""
+traversal_pid=""
+duplicate_pid=""
+resistant_pid=""
+race_pid=""
+override_pid=""
+long_argv_pid=""
+path_pid=""
+unrelated_arg_pid=""
+relative_socket_dir=""
+baseline_pid=""
+default_effective_pid=""
+
 cleanup() {
+  local pid
+  local socket_path
+  local active_jobs
+
+  active_jobs=" $(jobs -pr | tr '\n' ' ') "
+
+  for pid in \
+    "$owned_pid" \
+    "$foreign_pid" \
+    "$other_pid" \
+    "$ambiguous_pid" \
+    "$wrapper_pid" \
+    "$traversal_pid" \
+    "$duplicate_pid" \
+    "$resistant_pid" \
+    "$race_pid" \
+    "$override_pid" \
+    "$long_argv_pid" \
+    "$path_pid" \
+    "$unrelated_arg_pid" \
+    "$baseline_pid" \
+    "$default_effective_pid"; do
+    [[ -n "$pid" ]] || continue
+    [[ "$active_jobs" == *" $pid "* ]] || continue
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+
+  for socket_path in \
+    "${socket_owned:-}" \
+    "${socket_other:-}" \
+    "${socket_wrapper:-}" \
+    "${socket_duplicate_owned:-}" \
+    "${socket_resistant:-}" \
+    "${socket_race:-}" \
+    "${socket_long_argv:-}" \
+    "${socket_path_resolved:-}" \
+    "${socket_traversal:-}" \
+    "${socket_baseline:-}" \
+    "${socket_default_effective:-}"; do
+    [[ -n "$socket_path" ]] || continue
+    rm -f -- "$socket_path"
+  done
+
+  if [[ -n "$relative_socket_dir" ]]; then
+    rm -rf -- "$REPO_ROOT/$relative_socket_dir"
+  fi
+
   rm -rf "$TMP_ROOT"
 }
 trap cleanup EXIT
@@ -19,6 +84,14 @@ trap cleanup EXIT
 fail() {
   echo "FAIL: $1" >&2
   exit 1
+}
+
+process_is_running() {
+  local pid="$1"
+  local state
+
+  state="$(ps -o stat= -p "$pid" 2>/dev/null | tr -d '[:space:]')"
+  [[ -n "$state" && "$state" != Z* ]]
 }
 
 # shellcheck source=../bin/lib/source-dev-worker-cleanup.sh
@@ -62,6 +135,10 @@ while :; do sleep 0.2; done
 SCRIPT
 chmod +x "$FAKE_WORKER"
 
+FAKE_OTHER="$TMP_ROOT/orchard-worker-mlx-other"
+cp "$FAKE_WORKER" "$FAKE_OTHER"
+chmod +x "$FAKE_OTHER"
+
 FAKE_AMBIGUOUS="$TMP_ROOT/orchard-worker-mlx-ambiguous"
 cat > "$FAKE_AMBIGUOUS" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -71,19 +148,72 @@ while :; do sleep 0.2; done
 SCRIPT
 chmod +x "$FAKE_AMBIGUOUS"
 
-socket_owned="$SOCKET_DIR/owned.sock"
+FAKE_SOURCE_PACKAGE="$TMP_ROOT/native/orchard_worker_mlx"
+FAKE_WRAPPER="$FAKE_SOURCE_PACKAGE/bin/orchard-worker-mlx"
+FAKE_VENV_ENTRY="$FAKE_SOURCE_PACKAGE/.venv/bin/orchard-worker-mlx"
+mkdir -p "$(dirname "$FAKE_WRAPPER")" "$(dirname "$FAKE_VENV_ENTRY")"
+cp "$FAKE_WORKER" "$FAKE_VENV_ENTRY"
+cat > "$FAKE_WRAPPER" <<SCRIPT
+#!/usr/bin/env bash
+exec "$FAKE_VENV_ENTRY" "\$@"
+SCRIPT
+chmod +x "$FAKE_WRAPPER" "$FAKE_VENV_ENTRY"
+
+FAKE_RESISTANT="$TMP_ROOT/orchard-worker-mlx-resistant"
+cat > "$FAKE_RESISTANT" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+socket_path=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --socket-path)
+      socket_path="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+[[ -n "$socket_path" ]] || exit 1
+mkdir -p "$(dirname "$socket_path")"
+touch "$socket_path"
+trap ':' TERM
+while :; do read -r -t 1 _ || true; done
+SCRIPT
+chmod +x "$FAKE_RESISTANT"
+
+socket_owned="$SOCKET_DIR/owned-$$.sock"
 socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
+socket_other="$SOCKET_DIR/other-$$.sock"
+socket_wrapper="$SOCKET_DIR/wrapper-$$.sock"
+socket_traversal="$SOCKET_DIR/../../foreign-traversal-$$.sock"
+socket_duplicate_owned="$SOCKET_DIR/duplicate-owned-$$.sock"
+socket_duplicate_foreign="$FOREIGN_SOCKET_DIR/duplicate-foreign.sock"
+socket_resistant="$SOCKET_DIR/resistant-$$.sock"
+socket_race="$SOCKET_DIR/race-$$.sock"
+socket_long_argv="$SOCKET_DIR/long-argv-$$.sock"
 
 # Start a worker that belongs to this checkout and one that belongs elsewhere.
 # Note: capturing the pid via command substitution ($(cmd & echo $!)) would
 # hang — the background child inherits the substitution's stdout pipe and the
 # read blocks until the child exits.
-"$FAKE_WORKER" --socket-path "$socket_owned" &
+bash "$FAKE_WORKER" --socket-path "$socket_owned" &
 owned_pid=$!
-"$FAKE_WORKER" --socket-path "$socket_foreign" &
+bash "$FAKE_WORKER" --socket-path "$socket_foreign" &
 foreign_pid=$!
-"$FAKE_AMBIGUOUS" &
+bash "$FAKE_OTHER" --socket-path "$socket_other" &
+other_pid=$!
+bash "$FAKE_AMBIGUOUS" &
 ambiguous_pid=$!
+bash "$FAKE_VENV_ENTRY" --socket-path "$socket_wrapper" &
+wrapper_pid=$!
+bash "$FAKE_WORKER" --socket-path "$socket_traversal" &
+traversal_pid=$!
+bash "$FAKE_WORKER" \
+  --socket-path "$socket_duplicate_owned" \
+  --socket-path "$socket_duplicate_foreign" &
+duplicate_pid=$!
 
 # Give the background jobs a moment to establish their command lines.
 sleep 0.2
@@ -91,28 +221,63 @@ sleep 0.2
 # Verify both are alive before cleanup.
 kill -0 "$owned_pid" 2>/dev/null || fail "owned worker was not running before cleanup"
 kill -0 "$foreign_pid" 2>/dev/null || fail "foreign worker was not running before cleanup"
+kill -0 "$other_pid" 2>/dev/null || fail "different-executable worker was not running before cleanup"
 kill -0 "$ambiguous_pid" 2>/dev/null || fail "ambiguous worker was not running before cleanup"
+kill -0 "$wrapper_pid" 2>/dev/null || fail "exec-wrapped worker was not running before cleanup"
+kill -0 "$traversal_pid" 2>/dev/null || fail "traversal worker was not running before cleanup"
+kill -0 "$duplicate_pid" 2>/dev/null || fail "duplicate-socket worker was not running before cleanup"
+
+# Confirm the cleanup enumeration exposes the full argv for a known worker.
+enumeration_output="$(orchard_source_dev_worker_processes)"
+[[ "$enumeration_output" == *"$owned_pid"* ]] || fail "worker enumeration omitted the known pid"
+[[ "$enumeration_output" == *"$FAKE_WORKER"* ]] ||
+  fail "worker enumeration omitted the known executable path"
+[[ "$enumeration_output" == *"--socket-path $socket_owned"* ]] ||
+  fail "worker enumeration omitted the known socket argument"
 
 # Run the cleanup helper.
 cleanup_output="$(orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" 2>&1)"
 printf '%s\n' "$cleanup_output"
-[[ "$cleanup_output" == *"warning: skipping orchard-worker-mlx process(es) with unknown ownership"* ]] ||
+[[ "$cleanup_output" == *"warning: skipping orchard-worker-mlx process(es) without a parseable --socket-path"* ]] ||
   fail "ambiguous worker warning was not emitted"
 [[ "$cleanup_output" == *"$ambiguous_pid"* ]] ||
   fail "ambiguous worker warning did not name its pid"
+[[ "$cleanup_output" == *"warning: skipping in-scope orchard-worker-mlx process(es) with a different executable"* ]] ||
+  fail "different-executable worker warning was not emitted"
+[[ "$cleanup_output" == *"$other_pid"* ]] ||
+  fail "different-executable worker warning did not name its pid"
+[[ "$cleanup_output" != *"$foreign_pid"* ]] ||
+  fail "out-of-scope worker was incorrectly reported"
 
 # Reap the owned worker first: it is a child of this shell, so until wait(2)
 # collects it the zombie still answers kill -0.
 wait "$owned_pid" 2>/dev/null || true
+owned_pid=""
 
 # The owned worker should be gone.
 if kill -0 "$owned_pid" 2>/dev/null; then
   fail "owned source-dev worker survived cleanup"
 fi
 
+process_is_running "$wrapper_pid" || fail "exec-wrapped worker was killed for a different executable"
+orchard_source_dev_cleanup_workers \
+  "$REPO_ROOT" \
+  "$FAKE_WRAPPER" \
+  "$FAKE_VENV_ENTRY" >/dev/null 2>&1
+
+if process_is_running "$wrapper_pid"; then
+  fail "exec-wrapped source-dev worker survived cleanup"
+fi
+wait "$wrapper_pid" 2>/dev/null || true
+wrapper_pid=""
+
 # The foreign worker should still be alive.
 if ! kill -0 "$foreign_pid" 2>/dev/null; then
   fail "foreign worker was incorrectly killed by cleanup"
+fi
+
+if ! kill -0 "$other_pid" 2>/dev/null; then
+  fail "different-executable worker was incorrectly killed by cleanup"
 fi
 
 # The ambiguous worker should still be alive and the helper should have
@@ -121,10 +286,243 @@ if ! kill -0 "$ambiguous_pid" 2>/dev/null; then
   fail "ambiguous worker was incorrectly killed by cleanup"
 fi
 
+if ! process_is_running "$traversal_pid"; then
+  fail "path-traversal worker was incorrectly killed by cleanup"
+fi
+
+if ! process_is_running "$duplicate_pid"; then
+  fail "duplicate-socket worker was incorrectly killed by cleanup"
+fi
+
+# Carrying the expected executable as an unrelated argument must not establish
+# ownership. Only argv0, or argv1 after a recognized interpreter, is valid.
+bash "$FAKE_OTHER" "$FAKE_WORKER" --socket-path "$socket_other" &
+unrelated_arg_pid=$!
+sleep 0.2
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" >/dev/null 2>&1
+process_is_running "$unrelated_arg_pid" || fail "unrelated executable argument established ownership"
+kill -TERM "$unrelated_arg_pid" 2>/dev/null || true
+wait "$unrelated_arg_pid" 2>/dev/null || true
+unrelated_arg_pid=""
+
+bash "$FAKE_RESISTANT" --socket-path "$socket_resistant" &
+resistant_pid=$!
+sleep 0.2
+
+resistant_cleanup_output="$(
+  orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_RESISTANT" 2>&1
+)" || fail "cleanup failed while a confirmed owned worker survived SIGTERM"
+[[ "$resistant_cleanup_output" == *"warning: source-dev MLX workers still alive after SIGTERM"* ]] ||
+  fail "cleanup did not warn about the confirmed owned worker that survived SIGTERM"
+
+kill -0 "$resistant_pid" 2>/dev/null || fail "TERM-resistant fixture exited unexpectedly"
+
 # Clean up the foreign and ambiguous workers.
 kill -TERM "$foreign_pid" 2>/dev/null || true
 wait "$foreign_pid" 2>/dev/null || true
+foreign_pid=""
+kill -TERM "$other_pid" 2>/dev/null || true
+wait "$other_pid" 2>/dev/null || true
+other_pid=""
 kill -TERM "$ambiguous_pid" 2>/dev/null || true
 wait "$ambiguous_pid" 2>/dev/null || true
+ambiguous_pid=""
+kill -TERM "$traversal_pid" 2>/dev/null || true
+wait "$traversal_pid" 2>/dev/null || true
+traversal_pid=""
+kill -TERM "$duplicate_pid" 2>/dev/null || true
+wait "$duplicate_pid" 2>/dev/null || true
+duplicate_pid=""
+kill -KILL "$resistant_pid" 2>/dev/null || true
+wait "$resistant_pid" 2>/dev/null || true
+resistant_pid=""
+
+override_socket_dir="$TMP_ROOT/override-ws"
+mkdir -p "$override_socket_dir"
+bash "$FAKE_WORKER" --socket-path "$override_socket_dir/owned.sock" &
+override_pid=$!
+sleep 0.2
+ORCHARD_WORKER_SOCKET_DIR="$override_socket_dir/" \
+  orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" >/dev/null 2>&1
+wait "$override_pid" 2>/dev/null || true
+override_pid=""
+process_is_running "$override_pid" && fail "trailing-slash socket override missed an owned worker"
+
+relative_socket_dir="tmp/source-dev-worker-cleanup-$$"
+export ORCHARD_WORKER_SOCKET_DIR="$relative_socket_dir"
+export ORCHARD_WORKER_EXECUTABLE="$FAKE_WORKER"
+export ORCHARD_WORKER_EFFECTIVE_EXECUTABLE="$FAKE_WORKER"
+orchard_source_dev_configure_worker_runtime "$REPO_ROOT"
+[[ "$ORCHARD_WORKER_SOCKET_DIR" == "$REPO_ROOT/$relative_socket_dir" ]] ||
+  fail "relative socket override was not normalized from the repo root"
+
+export ORCHARD_WORKER_SOCKET_DIR=""
+orchard_source_dev_configure_worker_runtime "$REPO_ROOT"
+canonical_default_socket_dir="$(orchard_source_dev_canonical_directory "$SOCKET_DIR")"
+[[ "$ORCHARD_WORKER_SOCKET_DIR" == "$canonical_default_socket_dir" ]] ||
+  fail "empty socket override did not select the hashed default"
+
+hashless_startup_log="$TMP_ROOT/hashless-startup.log"
+if ! bash -c '
+  set -euo pipefail
+  source "$1"
+  orchard_source_dev_worker_socket_hash() { return 69; }
+  unset ORCHARD_WORKER_SOCKET_DIR
+  export ORCHARD_WORKER_EXECUTABLE="$3"
+  export ORCHARD_WORKER_EFFECTIVE_EXECUTABLE="$3"
+  orchard_source_dev_configure_worker_runtime "$2"
+  orchard_source_dev_cleanup_workers \
+    "$2" \
+    "$ORCHARD_WORKER_EXECUTABLE" \
+    "$ORCHARD_WORKER_EFFECTIVE_EXECUTABLE"
+  printf "startup-continued\n"
+' bash "$HELPER" "$REPO_ROOT" "$FAKE_WORKER" >"$hashless_startup_log" 2>&1; then
+  fail "source-dev startup aborted when socket hashing was unavailable"
+fi
+hashless_startup_output="$(cat "$hashless_startup_log")"
+[[ "$hashless_startup_output" == *"cannot resolve the source-dev worker socket directory; skipping cleanup"* ]] ||
+  fail "hashless source-dev startup did not explain that cleanup was skipped"
+[[ "$hashless_startup_output" == *"startup-continued"* ]] ||
+  fail "hashless source-dev startup did not continue after cleanup was skipped"
+
+if ORCHARD_WORKER_SOCKET_DIR="$TMP_ROOT/socket dir" \
+  ORCHARD_WORKER_EXECUTABLE="$FAKE_WORKER" \
+  orchard_source_dev_configure_worker_runtime "$REPO_ROOT" >/dev/null 2>&1; then
+  fail "whitespace socket override was accepted"
+fi
+
+if ORCHARD_WORKER_SOCKET_DIR="$SOCKET_DIR" \
+  ORCHARD_WORKER_EXECUTABLE="$TMP_ROOT/missing-worker" \
+  orchard_source_dev_configure_worker_runtime "$REPO_ROOT" >/dev/null 2>&1; then
+  fail "missing explicit worker executable was accepted"
+fi
+
+NONEXEC_WORKER="$TMP_ROOT/non-executable-worker"
+: > "$NONEXEC_WORKER"
+chmod 600 "$NONEXEC_WORKER"
+if ORCHARD_WORKER_SOCKET_DIR="$SOCKET_DIR" \
+  ORCHARD_WORKER_EXECUTABLE="$NONEXEC_WORKER" \
+  orchard_source_dev_configure_worker_runtime "$REPO_ROOT" >/dev/null 2>&1; then
+  fail "non-executable explicit worker executable was accepted"
+fi
+
+if ORCHARD_WORKER_SOCKET_DIR="$SOCKET_DIR" \
+  ORCHARD_WORKER_EXECUTABLE="$FAKE_WORKER" \
+  ORCHARD_WORKER_EFFECTIVE_EXECUTABLE="$TMP_ROOT/missing-effective-worker" \
+  orchard_source_dev_configure_worker_runtime "$REPO_ROOT" >/dev/null 2>&1; then
+  fail "missing explicit effective worker executable was accepted"
+fi
+
+DEFAULT_REPO="$TMP_ROOT/default-repo"
+DEFAULT_WRAPPER="$DEFAULT_REPO/native/orchard_worker_mlx/bin/orchard-worker-mlx"
+DEFAULT_EFFECTIVE="$DEFAULT_REPO/native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx"
+mkdir -p "$(dirname "$DEFAULT_WRAPPER")" "$(dirname "$DEFAULT_EFFECTIVE")"
+cp "$FAKE_WORKER" "$DEFAULT_WRAPPER"
+cp "$FAKE_WORKER" "$DEFAULT_EFFECTIVE"
+chmod +x "$DEFAULT_WRAPPER" "$DEFAULT_EFFECTIVE"
+default_socket_dir="$TMP_ROOT/default-ws"
+mkdir -p "$default_socket_dir"
+socket_default_effective="$default_socket_dir/non-executable-effective.sock"
+bash "$DEFAULT_EFFECTIVE" --socket-path "$socket_default_effective" &
+default_effective_pid=$!
+sleep 0.2
+chmod 600 "$DEFAULT_EFFECTIVE"
+unset ORCHARD_WORKER_EXECUTABLE ORCHARD_WORKER_EFFECTIVE_EXECUTABLE
+export ORCHARD_WORKER_SOCKET_DIR="$default_socket_dir"
+orchard_source_dev_configure_worker_runtime "$DEFAULT_REPO"
+canonical_default_effective="$(orchard_source_dev_canonical_existing_path "$DEFAULT_EFFECTIVE")"
+[[ "$ORCHARD_WORKER_EFFECTIVE_EXECUTABLE" == "$canonical_default_effective" ]] ||
+  fail "existing default effective worker lost its cleanup identity after an execute-bit change"
+orchard_source_dev_cleanup_workers \
+  "$DEFAULT_REPO" \
+  "$ORCHARD_WORKER_EXECUTABLE" \
+  "$ORCHARD_WORKER_EFFECTIVE_EXECUTABLE" >/dev/null 2>&1
+wait "$default_effective_pid" 2>/dev/null || true
+default_effective_pid=""
+
+original_path="$PATH"
+export PATH="$TMP_ROOT:$PATH"
+export ORCHARD_WORKER_SOCKET_DIR="$SOCKET_DIR"
+export ORCHARD_WORKER_EXECUTABLE="orchard-worker-mlx"
+export ORCHARD_WORKER_EFFECTIVE_EXECUTABLE=""
+orchard_source_dev_configure_worker_runtime "$REPO_ROOT"
+export PATH="$original_path"
+canonical_fake_worker="$(orchard_source_dev_canonical_existing_path "$FAKE_WORKER")"
+[[ "$ORCHARD_WORKER_EXECUTABLE" == "$canonical_fake_worker" ]] ||
+  fail "bare worker executable was not resolved through PATH"
+socket_path_resolved="$SOCKET_DIR/path-resolved-$$.sock"
+bash "$FAKE_WORKER" --socket-path "$socket_path_resolved" &
+path_pid=$!
+sleep 0.2
+orchard_source_dev_cleanup_workers \
+  "$REPO_ROOT" \
+  "$ORCHARD_WORKER_EXECUTABLE" \
+  "$ORCHARD_WORKER_EFFECTIVE_EXECUTABLE" >/dev/null 2>&1
+wait "$path_pid" 2>/dev/null || true
+path_pid=""
+process_is_running "$path_pid" && fail "PATH-resolved worker survived cleanup"
+
+export ORCHARD_WORKER_SOCKET_DIR="$SOCKET_DIR"
+export ORCHARD_WORKER_EXECUTABLE="native/orchard_worker_mlx/bin/orchard-worker-mlx"
+export ORCHARD_WORKER_EFFECTIVE_EXECUTABLE=""
+orchard_source_dev_configure_worker_runtime "$REPO_ROOT"
+[[ "$ORCHARD_WORKER_EXECUTABLE" == "$REPO_ROOT/native/orchard_worker_mlx/bin/orchard-worker-mlx" ]] ||
+  fail "relative default wrapper was not normalized"
+[[ "$ORCHARD_WORKER_EFFECTIVE_EXECUTABLE" == "$REPO_ROOT/native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx" ]] ||
+  fail "relative default wrapper did not resolve its effective entrypoint"
+
+printf -v long_padding '%*s' 300 ''
+long_padding="${long_padding// /x}"
+bash "$FAKE_WORKER" --padding "$long_padding" --socket-path "$socket_long_argv" &
+long_argv_pid=$!
+sleep 0.2
+long_enumeration="$(orchard_source_dev_worker_processes)"
+[[ "$long_enumeration" == *"$socket_long_argv"* ]] || fail "wide process enumeration truncated worker argv"
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" >/dev/null 2>&1
+wait "$long_argv_pid" 2>/dev/null || true
+long_argv_pid=""
+process_is_running "$long_argv_pid" && fail "long-argv worker survived cleanup"
+
+socket_baseline="$SOCKET_DIR/baseline-$$.sock"
+bash "$FAKE_WORKER" --socket-path "$socket_baseline" &
+baseline_pid=$!
+sleep 0.2
+identity_marker="$TMP_ROOT/race-identity-read"
+
+orchard_source_dev_process_identity() {
+  local pid="$1"
+
+  if [[ "$pid" == "$baseline_pid" ]]; then
+    printf '%s\n' "$(id -u) Fri Aug 21 09:00:00 2026 bash $FAKE_OTHER --socket-path $socket_foreign"
+    return 0
+  fi
+
+  if [[ "$pid" == "$race_pid" ]]; then
+    if [[ -e "$identity_marker" ]]; then
+      printf '%s\n' "changed process identity"
+      return 0
+    fi
+    touch "$identity_marker"
+  fi
+
+  ps -ww -o uid= -o lstart= -o args= -p "$pid" 2>/dev/null
+}
+
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" >/dev/null 2>&1
+process_is_running "$baseline_pid" || fail "replacement before baseline capture was signalled"
+kill -TERM "$baseline_pid" 2>/dev/null || true
+wait "$baseline_pid" 2>/dev/null || true
+baseline_pid=""
+
+bash "$FAKE_WORKER" --socket-path "$socket_race" &
+race_pid=$!
+sleep 0.2
+
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" >/dev/null 2>&1
+[[ -e "$identity_marker" ]] || fail "cleanup did not capture process identity"
+process_is_running "$race_pid" || fail "worker with changed process identity was signalled"
+kill -TERM "$race_pid" 2>/dev/null || true
+wait "$race_pid" 2>/dev/null || true
+race_pid=""
 
 echo "source-dev worker cleanup tests passed"

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Focused tests for the source-dev worker cleanup helper.
+#
+# Verifies that the helper kills only workers whose socket path lives in this
+# checkout's source-dev socket directory and leaves foreign / out-of-tree workers
+# alone.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/bin/lib/source-dev-worker-cleanup.sh"
+TMP_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# shellcheck source=../bin/lib/source-dev-worker-cleanup.sh
+source "$HELPER"
+
+SOCKET_DIR="$(orchard_source_dev_worker_socket_dir "$REPO_ROOT")"
+FOREIGN_SOCKET_DIR="$TMP_ROOT/foreign-ws"
+mkdir -p "$SOCKET_DIR" "$FOREIGN_SOCKET_DIR"
+
+# A fake orchard-worker-mlx process that idles until SIGTERM. We use a wrapper
+# script so the command line contains the substring "orchard-worker-mlx" and a
+# --socket-path argument.
+FAKE_WORKER="$TMP_ROOT/orchard-worker-mlx"
+cat > "$FAKE_WORKER" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+socket_path=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --socket-path)
+      socket_path="$2"
+      shift 2
+      ;;
+    --socket-path=*)
+      socket_path="${1#*=}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+[[ -n "$socket_path" ]] || exit 1
+# Touch the socket file so the cleanup helper sees an owned socket path.
+mkdir -p "$(dirname "$socket_path")"
+touch "$socket_path"
+# Stay alive with the original argv intact: exec would replace the command
+# line, hiding this process from pgrep -f matching. Exit promptly on TERM.
+trap 'exit 0' TERM
+while :; do sleep 0.2; done
+SCRIPT
+chmod +x "$FAKE_WORKER"
+
+socket_owned="$SOCKET_DIR/owned.sock"
+socket_foreign="$FOREIGN_SOCKET_DIR/foreign.sock"
+
+# Start a worker that belongs to this checkout and one that belongs elsewhere.
+# Note: capturing the pid via command substitution ($(cmd & echo $!)) would
+# hang — the background child inherits the substitution's stdout pipe and the
+# read blocks until the child exits.
+"$FAKE_WORKER" --socket-path "$socket_owned" &
+owned_pid=$!
+"$FAKE_WORKER" --socket-path "$socket_foreign" &
+foreign_pid=$!
+
+# Give the background jobs a moment to establish their command lines.
+sleep 0.2
+
+# Verify both are alive before cleanup.
+kill -0 "$owned_pid" 2>/dev/null || fail "owned worker was not running before cleanup"
+kill -0 "$foreign_pid" 2>/dev/null || fail "foreign worker was not running before cleanup"
+
+# Run the cleanup helper.
+orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER"
+
+# Reap the owned worker first: it is a child of this shell, so until wait(2)
+# collects it the zombie still answers kill -0.
+wait "$owned_pid" 2>/dev/null || true
+
+# The owned worker should be gone.
+if kill -0 "$owned_pid" 2>/dev/null; then
+  fail "owned source-dev worker survived cleanup"
+fi
+
+# The foreign worker should still be alive.
+if ! kill -0 "$foreign_pid" 2>/dev/null; then
+  fail "foreign worker was incorrectly killed by cleanup"
+fi
+
+# Clean up the foreign worker.
+kill -TERM "$foreign_pid" 2>/dev/null || true
+wait "$foreign_pid" 2>/dev/null || true
+
+echo "source-dev worker cleanup tests passed"


### PR DESCRIPTION
## Context

This replaces closed PR #229 on current `main`.
It preserves only the three source-dev cleanup commits from that stack and avoids reintroducing the already-merged #221 history.

The result scopes orphaned MLX worker cleanup to the current checkout, current UID, exact socket directory, and normalized executable identity.

## What changed

- Added a shared source-dev worker cleanup helper used by `bin/dev` and `bin/dev-node-agent`.
- Normalized socket and executable overrides before cleanup and Mix startup.
- Matched only recognized worker launch positions, including the default wrapper's effective virtualenv entrypoint.
- Revalidated UID, start time, argv, socket ownership, and executable ownership before signalling.
- Treated ambiguous ownership as a safe skip and reported confirmed SIGTERM survivors as startup errors.
- Added shell and Mix regressions for checkout isolation, traversal, duplicate arguments, wrapper transitions, PATH and relative overrides, PID reuse, long argv, survivor handling, and fixture cleanup.

## Verification

- `bash -n bin/lib/source-dev-worker-cleanup.sh bin/dev bin/dev-node-agent scripts/test-source-dev-worker-cleanup.sh scripts/test-source-dev-beam-bootstrap.sh`
- `mise exec -- bash scripts/test-source-dev-worker-cleanup.sh` - passed five consecutive stress runs
- `mise exec -- bash scripts/test-source-dev-beam-bootstrap.sh` - passed
- `mise exec -- mix test apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs` - 31 passed
- `mise exec -- mix format` - passed
- `mise exec -- mix compile --warnings-as-errors` - passed
- `mise exec -- mix credo --strict` - passed with no issues
- `mise exec -- mix dialyzer` - passed with zero errors
- `mise exec -- mix test` - passed: 310 shared, 3,524 controller with 5 skipped, 400 node-agent, 779 CLI with 10 excluded
- `mise exec -- mix test --cover` - passed and generated coverage reports
- RepoPrompt review of the final committed diff - GO, with no correctness or process-signal safety blockers

## Risk Assessment

⚠️ **Medium**

- The changed path sends signals to local worker processes, so incorrect ownership checks could affect another development process.
- Cleanup now fails closed: ambiguous identity, malformed argv, unsafe overrides, or PID reuse causes a skip instead of a signal.
- Scope is limited to source-development entrypoints. Packaged runtime and production lifecycle behavior are unchanged.
- There are no database migrations or API compatibility changes.

Closes #220

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789869225&installation_model_id=428414&pr_number=234&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F234&signature=19620fe51e3cc808c722856e04caa0ef393e79f19aaea28e91ddef0c6e85ce76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->