### PR TITLE
fix(console): harden Playground catalog diagnostic

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/playground.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground.ex
@@ -256,12 +256,17 @@ defmodule OrchardConsole.Playground do
   end
 
   defp catalog_active?(model_value) do
-    Enum.any?(models_impl().list_active_models(), fn model ->
-      model_value(%{
-        model_id: safe_string(model.model_id),
-        version: safe_string(model.version)
-      }) == model_value
-    end)
+    with [model_id, version] when model_id != "" and version != "" <-
+           String.split(model_value, "@", parts: 2),
+         %{state: :active} <- models_impl().get_model_by_identity(model_id, version) do
+      true
+    else
+      _ -> false
+    end
+  rescue
+    _ -> false
+  catch
+    _kind, _reason -> false
   end
 
   defp unready_stream_error(message) do

--- a/apps/orchard_controller/test/orchard/console/playground_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_test.exs
@@ -304,8 +304,9 @@ defmodule OrchardConsole.PlaygroundTest do
       assert Keyword.get(opts, :caller) == owner
     end
 
-    test "refuses to run a model the effective tenant is not granted" do
+    test "refuses to run an active model the effective tenant is not granted" do
       stub_models(%{Ecto.UUID.generate() => [%{model_id: "test-model", version: "v1"}]})
+      stub_catalog([%{model_id: "test-model", version: "v1", state: :active}])
       ref = make_ref()
 
       stub_orchestrator(
@@ -322,9 +323,10 @@ defmodule OrchardConsole.PlaygroundTest do
       assert error.message =~ "orchardctl models access grant"
       refute_receive {:playground, ^ref, :started, _}, 100
       refute_receive {:captured_opts, _}, 100
+      refute_receive :list_active_models_called, 100
     end
 
-    test "reports a model missing from the active catalog distinctly" do
+    test "reports a missing or deleted catalog model distinctly" do
       stub_models(%{})
       stub_catalog([])
       ref = make_ref()
@@ -343,6 +345,55 @@ defmodule OrchardConsole.PlaygroundTest do
       assert error.message =~ "not an active catalog model"
       refute error.message =~ "orchardctl models access grant"
       refute_receive {:captured_opts, _}, 100
+      refute_receive :list_active_models_called, 100
+    end
+
+    test "reports a non-active catalog model distinctly" do
+      stub_models(%{})
+      stub_catalog([%{model_id: "test-model", version: "v1", state: :deprecated}])
+      ref = make_ref()
+
+      stub_orchestrator(
+        prepare: {:ok, fake_canonical(), %{}},
+        execute: {:ok, fake_canonical(), []},
+        capture_opts: true
+      )
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
+
+      assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+      assert error.phase == :prepare
+      assert error.code == "model_not_ready"
+      assert error.message =~ "not an active catalog model"
+      refute error.message =~ "orchardctl models access grant"
+      refute_receive {:captured_opts, _}, 100
+      refute_receive :list_active_models_called, 100
+    end
+
+    test "fails closed when the targeted catalog lookup raises or exits" do
+      stub_models(%{})
+
+      Enum.each([:raise, :exit], fn failure ->
+        stub_catalog(failure)
+        ref = make_ref()
+
+        stub_orchestrator(
+          prepare: {:ok, fake_canonical(), %{}},
+          execute: {:ok, fake_canonical(), []},
+          capture_opts: true
+        )
+
+        {:ok, _pid} = Playground.start_stream(self(), ref, valid_params())
+
+        assert_receive {:playground, ^ref, :finished, {:error, error}}, 1000
+        assert error.phase == :prepare
+        assert error.code == "model_not_ready"
+        refute error.code == "internal_error"
+        assert error.message =~ "not an active catalog model"
+        refute_receive {:captured_opts, _}, 100
+      end)
+
+      refute_receive :list_active_models_called, 100
     end
 
     test "passes the effective tenant through the preparation caller context" do
@@ -405,20 +456,42 @@ defmodule OrchardConsole.PlaygroundTest do
       end
     end
 
-    def list_active_models do
+    def get_model_by_identity(model_id, version) do
       case :persistent_term.get({OrchardConsole.PlaygroundTest, :catalog}, :derive) do
-        :derive -> derived_catalog()
-        models when is_list(models) -> models
+        :raise -> raise "catalog lookup unavailable"
+        :exit -> exit(:catalog_lookup_unavailable)
+        :derive -> find_by_identity(derived_catalog(), model_id, version)
+        models when is_list(models) -> find_by_identity(models, model_id, version)
       end
+    end
+
+    def list_active_models do
+      send(
+        :persistent_term.get({OrchardConsole.PlaygroundTest, :test_pid}),
+        :list_active_models_called
+      )
+
+      raise "full catalog enumeration is forbidden"
+    end
+
+    defp find_by_identity(models, model_id, version) do
+      Enum.find(models, &(&1.model_id == model_id and &1.version == version))
     end
 
     defp derived_catalog do
       case stubbed_models() do
-        models when is_list(models) -> models
-        grants when is_map(grants) -> grants |> Map.values() |> List.flatten()
-        _other -> []
+        models when is_list(models) ->
+          Enum.map(models, &Map.put_new(&1, :state, :active))
+
+        grants when is_map(grants) ->
+          grants |> Map.values() |> List.flatten() |> derived_catalog()
+
+        _other ->
+          []
       end
     end
+
+    defp derived_catalog(models), do: Enum.map(models, &Map.put_new(&1, :state, :active))
 
     defp stubbed_models do
       :persistent_term.get({OrchardConsole.PlaygroundTest, :models}, [])


### PR DESCRIPTION
## Summary
- Use targeted `get_model_by_identity/2` lookup for Playground catalog diagnostics.
- Fail closed on lookup exceptions and exits.
- Add regression coverage proving the full catalog is not enumerated.

Closes #225

## Testing
- `mise exec -- mix format` — exit 0.
- `mise exec -- mix compile --warnings-as-errors` — exit 0.
- `mise exec -- mix credo --strict` — exit 0; 734 files, 0 issues.
- `mise exec -- mix dialyzer` — exit 0; 0 errors, 0 skipped, 0 unnecessary skips.
- `mise exec -- mix test apps/orchard_controller/test/orchard/console/playground_test.exs` — exit 0; 25 passed.
- `mise exec -- mix test apps/orchard_controller/test/orchard/console/playground_access_test.exs` — exit 0; 4 passed.
- `mise exec -- mix test` and `mise exec -- mix test --cover` were executed but exited 2 due unrelated environment-dependent uv/venv/PTY/packaged-wrapper failures: 4,943 passed, 67 failed, 5 skipped, 10 excluded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789892844&installation_model_id=428414&pr_number=236&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F236&signature=f77c2a1e388e55943e3a88322154a63a23bf06437e9047f9bfefad8ced658c75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->