### PR TITLE
docs(openspec): define source-dev reverse-proxy transport

### DIFF
--- a/openspec/changes/source-dev-reverse-proxy-transport/.openspec.yaml
+++ b/openspec/changes/source-dev-reverse-proxy-transport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/source-dev-reverse-proxy-transport/design.md
+++ b/openspec/changes/source-dev-reverse-proxy-transport/design.md
@@ -1,0 +1,56 @@
+## Context
+
+Release Controllers parse `ORCHARD_TRANSPORT_MODE` and configure listener, public URL, origin, and trusted-proxy behavior in `config/runtime.exs`. Source development instead hard-codes a loopback HTTP Endpoint in `config/dev.exs`, leaving `Orchard.API.Transport` at `plain_http_localhost` regardless of an operator-managed HTTPS proxy.
+
+Readiness correctly consumes `Orchard.API.Transport.public_api_https_enabled?/0`; the defect is the missing source-dev deployment configuration, not the readiness evaluator. ADR 0016 forbids a second readiness truth or source-dev-only health override.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let source-dev Controllers declare the existing reverse-proxy topology through deployment configuration.
+- Keep release and source-dev reverse-proxy parsing and trusted-proxy validation aligned.
+- Preserve fail-closed forwarded-header handling and actionable boot errors.
+- Make readiness reflect the configured transport through its existing authority.
+
+**Non-Goals:**
+
+- Add source-dev direct HTTPS or certificate management.
+- Observe or probe the external proxy from the Controller.
+- Complete the broader `SPEC.md` §3.1 readiness aggregate.
+- Change packaged transport behavior, public health bodies, or Portal transport enforcement.
+
+## Decisions
+
+### Source dev supports reverse proxy but not direct HTTPS
+
+Source dev SHALL accept `plain_http_localhost` and `reverse_proxy`. The first remains the default. `direct_https` SHALL fail at configuration time with guidance that it is release-only.
+
+This gives the pilot a supported HTTPS termination path without making certificate custody, generated CA metadata, or Cowboy TLS listener setup part of source development. Supporting all release modes was rejected because it widens this issue into TLS lifecycle and source-dev certificate management.
+
+### Shared transport configuration owns common parsing
+
+A configuration helper SHALL own source-dev mode selection and the reverse-proxy values shared with release configuration: bind IP, backend port, public host and port, trusted proxy CIDRs, public HTTPS URL, and origin checks. Both environments SHALL consume that helper for reverse-proxy configuration.
+
+Duplicating the release parser in `config/dev.exs` was rejected because validation could drift. Moving the complete release TLS implementation was also rejected because only reverse-proxy behavior is shared.
+
+### Existing runtime transport remains readiness authority
+
+Source-dev configuration SHALL write the same `:orchard_controller, :transport_mode`, `:transport_degraded`, and Endpoint settings as the release path. `Orchard.API.Transport` and `TrustedForwardedHeaders` remain unchanged.
+
+A readiness-specific flag was rejected because it would violate ADR 0016 and could report ready without applying the network trust boundary.
+
+## Risks / Trade-offs
+
+- **A declared proxy may be absent or broken** → Readiness continues to assert configured HTTPS topology rather than perform an external network probe, matching the existing release contract; authenticated inference remains the end-to-end availability check.
+- **Source dev binds beyond loopback** → Non-loopback reverse-proxy binds require an explicit non-empty trusted-proxy allowlist, and forwarded headers remain stripped unless the peer and complete header set validate.
+- **Shared helper changes release configuration** → Preserve existing release defaults and cover release/source-dev parity with focused configuration tests.
+- **Direct HTTPS remains unavailable in source dev** → Operators needing direct certificate termination use a release build; source-dev operators terminate HTTPS in an external proxy.
+
+## Migration Plan
+
+No migration is required. Existing source-dev commands remain loopback HTTP by default. Operators opt in by setting the reverse-proxy environment variables before starting the Controller. Removing the opt-in restores the prior behavior.
+
+## Open Questions
+
+None.

--- a/openspec/changes/source-dev-reverse-proxy-transport/proposal.md
+++ b/openspec/changes/source-dev-reverse-proxy-transport/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Source-development Controllers cannot declare the HTTPS reverse-proxy topology already supported by Orchard, so the shared readiness evaluator reports `public_api_https_enabled` as false even when an operator has placed a valid HTTPS proxy in front of the source checkout. This blocks the internal source-dev pilot from using readiness honestly and forces unsupported runtime configuration overrides.
+
+## What Changes
+
+- Allow a source-dev Controller to select `reverse_proxy` through the existing `ORCHARD_TRANSPORT_MODE` environment variable.
+- Preserve `plain_http_localhost` as the source-dev default.
+- Apply the existing bind-address, trusted-proxy, forwarded-header, public URL, and origin validation to source-dev reverse-proxy mode.
+- Reject `direct_https` in source dev; direct certificate and HTTPS listener ownership remains release-only.
+- Keep `Orchard.API.Transport` as the single readiness authority without adding a readiness override or source-dev-only health shim.
+- Document and test the supported source-dev reverse-proxy deployment path.
+
+No SPEC.md behavior impact. The change makes source development realize the existing reverse-proxy transport contract in `SPEC.md` §10.7 without changing public health semantics or the staged readiness predicate.
+
+## Capabilities
+
+### New Capabilities
+
+- `source-dev-controller-transport`: Defines supported source-dev Controller transport selection and reverse-proxy validation.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Source-dev and release runtime configuration for Controller transport parsing and trusted-proxy validation.
+- Source-dev Endpoint listener, public URL, origin, and forwarded-header configuration.
+- Readiness configuration regression tests and source-development operator documentation.
+- No API, persistence, dependency, packaged transport, or public health response changes.

--- a/openspec/changes/source-dev-reverse-proxy-transport/specs/source-dev-controller-transport/spec.md
+++ b/openspec/changes/source-dev-reverse-proxy-transport/specs/source-dev-controller-transport/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Source Development Has Explicit Transport Selection
+
+A source-dev Controller SHALL consume `ORCHARD_TRANSPORT_MODE` as its deployment transport declaration. An unset value SHALL select `plain_http_localhost`; the only additional supported source-dev value SHALL be `reverse_proxy`. This realizes the existing transport contract in `SPEC.md` §10.7 without changing readiness semantics.
+
+#### Scenario: Default source development remains loopback HTTP
+
+- **WHEN** a source-dev Controller starts without `ORCHARD_TRANSPORT_MODE`
+- **THEN** it binds the local HTTP listener and reports transport mode `plain_http_localhost` as degraded for public HTTPS readiness
+
+#### Scenario: Unsupported source-dev mode fails closed
+
+- **WHEN** a source-dev Controller starts with `ORCHARD_TRANSPORT_MODE=direct_https` or any unknown value
+- **THEN** configuration fails with an actionable error before the Endpoint starts
+
+### Requirement: Source-Dev Reverse Proxy Uses the Shared Trust Contract
+
+A source-dev Controller in `reverse_proxy` mode SHALL use the same backend listener, public HTTPS URL, origin, trusted-proxy CIDR, and forwarded-header validation contract as a release Controller. A non-loopback backend bind MUST require an explicit non-empty `ORCHARD_TRUSTED_PROXIES` allowlist.
+
+#### Scenario: Loopback reverse proxy uses bounded defaults
+
+- **WHEN** a source-dev Controller selects `reverse_proxy` without overriding its backend bind or trusted proxies
+- **THEN** it binds the HTTP backend to loopback, trusts only loopback proxy CIDRs, and publishes an HTTPS public URL and origin
+
+#### Scenario: Non-loopback reverse proxy requires explicit trust
+
+- **WHEN** a source-dev Controller selects `reverse_proxy` with a non-loopback backend bind and no explicit trusted-proxy allowlist
+- **THEN** configuration fails before the Endpoint starts
+
+#### Scenario: Untrusted forwarded headers are rejected
+
+- **WHEN** a source-dev reverse-proxy request arrives from outside the configured trusted-proxy CIDRs or carries an invalid forwarded-header set
+- **THEN** Orchard strips the forwarded headers rather than rewriting request scheme, host, port, or client address
+
+### Requirement: Readiness Uses Configured Transport Without an Override
+
+Source development SHALL configure the existing `Orchard.API.Transport` authority. It MUST NOT add a source-dev readiness flag, health-route exception, or proxy-reachability assertion.
+
+#### Scenario: Reverse-proxy declaration satisfies the HTTPS readiness check
+
+- **WHEN** a source-dev Controller starts with a valid `reverse_proxy` configuration
+- **THEN** `public_api_https_enabled` evaluates true through `Orchard.API.Transport`
+
+#### Scenario: Plain HTTP remains degraded
+
+- **WHEN** a source-dev Controller uses the default `plain_http_localhost` mode
+- **THEN** `public_api_https_enabled` evaluates false through the same authority

--- a/openspec/changes/source-dev-reverse-proxy-transport/tasks.md
+++ b/openspec/changes/source-dev-reverse-proxy-transport/tasks.md
@@ -1,0 +1,15 @@
+## 1. Shared Transport Configuration
+
+- [ ] 1.1 Extract shared reverse-proxy mode, listener, public URL, origin, and trusted-proxy parsing without changing release behavior.
+- [ ] 1.2 Configure source development to accept the default `plain_http_localhost` and opt-in `reverse_proxy` modes while rejecting `direct_https` and unknown values.
+
+## 2. Contract Coverage and Documentation
+
+- [ ] 2.1 Add regression tests for source-dev defaults, valid reverse-proxy configuration, readiness authority, invalid modes, and non-loopback trusted-proxy enforcement.
+- [ ] 2.2 Document the supported source-dev reverse-proxy environment and operator verification path in `docs/local-dev.md`.
+
+## 3. Validation
+
+- [x] 3.1 Run strict validation for `source-dev-reverse-proxy-transport` and review all change artifacts for placeholder prose.
+- [ ] 3.2 Run the applicable Elixir format, compile, Credo, Dialyzer, test, and coverage workflow from the umbrella root.
+- [ ] 3.3 After future sync or archive, run repository-wide strict OpenSpec validation and review generated main-spec prose for placeholders.


### PR DESCRIPTION
## Context

Issue #237 needs a supported source-development HTTPS topology without adding a second readiness truth. This first stack layer fixes the contract before the runtime implementation in #264.

The design keeps `plain_http_localhost` as the source-dev default, permits an operator-managed `reverse_proxy`, and leaves `direct_https` release-only. Release and source dev share the same listener, public URL, origin, and trusted-proxy rules. `Orchard.API.Transport` remains the only readiness authority.

## What changed

- Added a narrow OpenSpec proposal, design, capability spec, and task ledger for source-dev Controller transport.
- Defined fail-closed mode selection and non-loopback trusted-proxy requirements.
- Explicitly excluded certificate custody, direct Cowboy HTTPS, proxy reachability probing, and readiness shims.
- Recorded that `SPEC.md` is unchanged because this realizes the existing section 10.7 transport contract.

## Validation

- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate source-dev-reverse-proxy-transport --type change --strict --no-interactive` - passed.
- Placeholder-prose review - passed with no placeholders found.

## Risk Assessment

🟢 **Low**

- This layer changes only OpenSpec artifacts and has no runtime effect.
- The implementation and regression coverage are isolated in the next stack layer, #264.
- No API, persistence, dependency, packaging, or public health response changes are introduced here.

## Related

Related: #237

Amp-Thread-ID: https://ampcode.com/threads/T-01a02cb9-993b-77cb-a633-7673802f1c16
Co-authored-by: Amp <amp@ampcode.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790054776&installation_model_id=428414&pr_number=263&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F263&signature=aa11537e9d71ea85d0aa1a5a501a8861a6de80ef677f8e8cbc952826e6a9c5f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR defines the source-development reverse-proxy transport contract without changing executable behavior.
- Keeps loopback HTTP as the source-development default and makes reverse proxy an explicit opt-in.
- Requires source development and release builds to share listener, public URL, origin, and trusted-proxy validation.
- Preserves `Orchard.API.Transport` as the sole readiness authority and excludes source-development direct HTTPS.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge with no concrete defects or independently actionable non-blocking issues identified.

The proposed requirements align with the existing reverse-proxy defaults, forwarded-header behavior, and single readiness authority while intentionally deferring runtime implementation to the next stack layer.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openspec/changes/source-dev-reverse-proxy-transport/design.md | Defines the source-development topology, shared configuration ownership, readiness authority, exclusions, and operational trade-offs. |
| openspec/changes/source-dev-reverse-proxy-transport/specs/source-dev-controller-transport/spec.md | Adds explicit mode-selection, trusted-proxy, forwarded-header, and readiness requirements with concrete scenarios. |
| openspec/changes/source-dev-reverse-proxy-transport/proposal.md | Explains the source-development readiness gap and scopes the proposed contract without runtime or public API changes. |
| openspec/changes/source-dev-reverse-proxy-transport/tasks.md | Tracks the future shared-configuration implementation, regression tests, operator documentation, and validation work. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Source-dev Controller starts] --> B{ORCHARD_TRANSPORT_MODE}
    B -->|unset or plain_http_localhost| C[Loopback HTTP listener]
    C --> D[Transport reports degraded public HTTPS readiness]
    B -->|reverse_proxy| E[Load shared listener, public URL, origin, and proxy trust configuration]
    E --> F{Configuration valid?}
    F -->|No| G[Fail before Endpoint starts]
    F -->|Yes| H[HTTP backend behind operator-managed HTTPS proxy]
    H --> I[Orchard.API.Transport reports public HTTPS enabled]
    B -->|direct_https or unknown| G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(openspec): define source-dev revers..."](https://github.com/kapitan-ai/orchard/commit/af766d1835f4af1d9f5f519b0c504e4361a9870f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55963637)</sub>

<!-- /greptile_comment -->