### PR TITLE
docs: define Orchard platform portability contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,12 @@
 # Contributing to Orchard
 
-Orchard is a sovereign on-prem LLM orchestration platform for Apple Silicon
-macOS. This repository is the collaborator-facing source of truth.
+Orchard is a sovereign on-prem LLM orchestration platform with a portable
+Elixir control-plane core and a currently supported Apple Silicon macOS
+platform profile.
+The accepted next platform target is a Linux Controller with external Postgres
+and Apple Silicon macOS Nodes, but that profile is not supported until the
+Milestone 8 acceptance gates in `SPEC.md` pass.
+This repository is the collaborator-facing source of truth.
 
 ## Source Of Truth
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,13 @@
 # Orchard v2 - Technical Specification
 
-This document is a normative implementation spec for Orchard, a sovereign on-prem LLM orchestration platform optimized for **1–4 Apple Silicon macOS nodes**. It is intended for a coding agent that will build the system incrementally. “MUST”, “SHALL”, and “MUST NOT” are mandatory requirements. “SHOULD” is a strong recommendation.
+This document is the normative implementation spec for Orchard, a sovereign on-prem LLM orchestration platform with a portable control plane and an existing **1–4 Apple Silicon macOS** deployment profile.
+It is intended for a coding agent that will build the system incrementally.
+“MUST”, “SHALL”, and “MUST NOT” are mandatory requirements.
+“SHOULD” is a strong recommendation.
+
+The macOS all-in-one and split-role profiles are the currently supported product profiles.
+The first accepted platform-expansion target is a Linux Controller Host with operator-provided external Postgres dispatching to admitted macOS Apple Silicon Nodes using the MLX runtime provider.
+That Linux Controller profile SHALL NOT be represented as supported until the Milestone 8 acceptance contract passes.
 
 Unless otherwise noted, implementation-facing names in this spec use the Orchard namespace: `Orchard.*` for Elixir modules, `orchard_*` for OTP apps and repositories, `orchard-*` for binaries/daemons, `orchardctl` for the CLI, and `com.orchard.*` for bundle identifiers, launchd labels, and similar platform identifiers. This naming policy does not apply to OpenAI-compatible wire protocol fields, endpoints, event names, or error envelopes, which SHALL remain unchanged for compatibility.
 
@@ -12,7 +19,7 @@ The platform exposes **OpenAI-compatible** inference APIs. Internally, it SHALL 
 
 ### 1.1 Target topology
 
-Supported deployment modes:
+Current supported deployment modes:
 
 1. **All-in-one single node**
 
@@ -37,11 +44,25 @@ Supported deployment modes:
    * active/standby coordination via Postgres advisory lock
    * requires external VIP, reverse proxy, or operator-managed endpoint failover
 
+Accepted platform-expansion target:
+
+4. **Linux Controller + macOS inference Nodes**
+
+   * 1 Linux Controller Host runs the portable control plane
+   * Postgres is operator-provided and external
+   * 1–3 admitted Apple Silicon macOS Nodes run Node Agents and MLX Worker Runtimes
+   * the Linux Controller Host is not a schedulable Node unless it separately satisfies Node admission and capability requirements
+   * final Linux distribution format, host manager, managed Postgres, and Linux accelerator Nodes remain deferred
+   * support SHALL NOT be declared before Milestone 8 acceptance completes
+
 ### 1.2 Core design rules
 
 * No Kubernetes.
 * No active/active controller mode in v1.
 * All durable state SHALL live in Postgres.
+* `orchard_shared`, `orchard_controller`, `orchard_node_agent`, and portable `orchard_cli` code SHALL depend only on portable contracts for platform-neutral behavior.
+* Platform host adapters, runtime-provider implementations, platform packaging, and vendor SDKs SHALL depend inward on portable contracts and MUST NOT become unconditional compile dependencies of the portable umbrella.
+* A Controller Host and a schedulable Node are distinct roles.
 * Controller runtime execution SHALL use the Runtime Endpoint Interface.
 * Runtime Endpoint semantics are transport-independent.
 * The gRPC/protobuf `NodeRuntimeService` remains the compatibility transport and a candidate protocol for future non-BEAM adapters.
@@ -74,6 +95,7 @@ Supported deployment modes:
                                     |
                      +--------------v----------------+
                      |  Controller (Elixir/OTP)      |
+                     |  macOS now; Linux target     |
                      |  - Public Inference API       |
                      |  - Operator API               |
                      |  - Admin API                  |
@@ -113,13 +135,34 @@ Supported deployment modes:
                                  +---------------------+
 ```
 
-### 1.4 macOS-specific platform assumptions
+### 1.4 Platform profiles and portable assumptions
 
-The system SHALL be packaged as a native macOS product using **launchd** for system daemons and agents. Managed local Postgres mode SHALL use Apple Silicon-compatible local containerization, with Apple’s Containerization project or the open-source `container` implementation as the supported local runtime path. Apple documents launchd as the system service manager for daemons/agents, and its Containerization project as a macOS Linux-container runtime built on Apple Silicon virtualization. ([Apple Support][2])
+Platform profiles bind portable Orchard roles to supported host lifecycle, paths, credential storage, packaging, and runtime payloads.
+Profile-specific requirements MUST NOT be treated as requirements of every Controller Host or Node.
+
+The current macOS profile SHALL remain a native macOS product using **launchd** for system daemons and agents.
+Managed local Postgres mode SHALL remain macOS-profile behavior using Apple Silicon-compatible local containerization, with Apple’s Containerization project or the open-source `container` implementation as the supported local runtime path.
+Apple documents launchd as the system service manager for daemons and agents, and its Containerization project as a macOS Linux-container runtime built on Apple Silicon virtualization. ([Apple Support][2])
+
+The accepted Linux Controller target SHALL use operator-provided external Postgres and SHALL NOT require a local Node Agent, accelerator runtime, Apple tooling, launchd, Keychain, DMG, PKG, or Orchard.app.
+Its final distribution format and host manager remain deferred.
+No Linux support claim follows from portable compilation alone.
 
 ### 1.5 First-class runtime
 
-The required v1 worker runtime is **MLX-based**. The default adapter SHALL target **MLX-LM**. Additional compatible runtimes may be added later via a runtime adapter interface. MLX is specifically built for Apple Silicon, and MLX-LM provides text generation on Apple Silicon. ([GitHub][3])
+The required v1 macOS worker runtime is **MLX-based**.
+The default macOS runtime provider SHALL target **MLX-LM**.
+MLX is specifically built for Apple Silicon, and MLX-LM provides text generation on Apple Silicon. ([GitHub][3])
+
+Orchard SHALL distinguish these concepts:
+
+* **artifact format**: the model artifact representation, such as GGUF or SafeTensors
+* **runtime provider**: the Worker Runtime implementation, such as MLX-LM or a future provider
+* **acceleration implementation**: the execution technology, such as Metal, CUDA, ROCm, or CPU
+* **device resource**: a versioned device identity, topology, memory domain, and allocatable capacity
+
+Portable policy and scheduling MUST NOT infer one concept from another or use operating-system and provider names as capability proof.
+Additional runtime providers require provider-neutral conformance and applicable real-hardware acceptance before entering a supported profile.
 
 ### 1.6 Non-goals for v1
 
@@ -143,7 +186,7 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 
 | Component           | Process type         | Responsibility                                               |
 | ------------------- | -------------------- | ------------------------------------------------------------ |
-| `orchard-controller`    | launchd LaunchDaemon | Main control plane daemon                                    |
+| `orchard-controller`    | OTP release; launchd in macOS profile | Main control plane daemon                     |
 | `Orchard.API`           | OTP app              | HTTP API surface: `/v1`, `/ops/v1`, `/admin/v1`              |
 | `Orchard.Auth`          | OTP app              | API key auth, service account auth, RBAC                     |
 | `Orchard.Admission`     | OTP app              | validation, tenant policy, quotas, idempotency               |
@@ -159,7 +202,7 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 
 | Component               | Process type         | Responsibility                                   |
 | ----------------------- | -------------------- | ------------------------------------------------ |
-| `orchard-node-agent`        | launchd LaunchDaemon | Node control endpoint                            |
+| `orchard-node-agent`        | OTP release; launchd in macOS profile | Node control endpoint             |
 | `Orchard.Node.Register`      | OTP app              | join, cert renewal, heartbeat                    |
 | `Orchard.Node.Models`        | OTP app              | artifact cache, verification, load/unload        |
 | `Orchard.Node.Workers`       | OTP app              | worker supervisor, crash recovery                |
@@ -171,7 +214,7 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 
 | Component               | Packaging                    | Responsibility                                             |
 | ----------------------- | ---------------------------- | ---------------------------------------------------------- |
-| Tray/menu bar app       | `.app` + LaunchAgent         | local status, onboarding, logs, support bundle entry point |
+| Tray/menu bar app       | macOS `.app` + LaunchAgent   | local status, onboarding, logs, support bundle entry point |
 | `orchardctl` CLI            | binary                       | admin/operator automation, bootstrap, diagnostics          |
 | Orchard Console         | controller LiveView          | local/operator UI for runtime status, node inventory and admission review, action previews, requests, Organizations, API Tokens, and API Clients |
 | Developer Portal        | controller LiveView          | Invite-only, Organization-scoped self-service mint, list, and revoke of a Portal User's tenant-direct API Keys |
@@ -188,10 +231,11 @@ The implementation SHOULD use an umbrella repository with separate Elixir releas
   /orchard_node_agent    # node agent release
   /orchard_cli           # CLI
 /native
-  /orchard_worker_mlx    # python runtime adapter
+  /orchard_worker_mlx    # macOS MLX runtime-provider implementation
   /orchard_tokenizer     # tokenizer/render helper
 /proto
   cluster/v1/*.proto
+  orchard/worker/v1/*.proto  # target provider-neutral Worker Runtime ownership
 /packaging
   dmg/
   pkg/
@@ -205,6 +249,9 @@ The implementation SHOULD use an umbrella repository with separate Elixir releas
 * Controller MAY run on a node that also runs a node agent.
 * Worker runtimes SHALL be subprocesses supervised by node agent, not permanent launchd services.
 * Tokenization/rendering helper MAY be a bundled native or Python helper, but the controller API layer remains Elixir/OTP.
+* Controller-owned durable operations SHALL execute inside the active Controller through authenticated, authorized, leader-aware, and audited domain operations.
+* Portable CLI code SHALL own client interaction and presentation, not direct Repo authority or host lifecycle mechanics.
+* Host lifecycle actors SHALL remain external to the managed Node Agent instance and SHALL preserve the platform-neutral exclusion, fencing, observation, and provisional-launch contract.
 
 ---
 
@@ -699,7 +746,13 @@ Rules:
 
 ### 4.1 Node identity model
 
-A node is an explicitly managed resource representing one macOS Apple Silicon machine.
+A Controller Host is a host that runs a Controller instance and participates in durable orchestration and, when configured, Active/Standby leadership.
+A Controller Host is not schedulable unless an admitted Node Agent on that host separately satisfies the Node contract.
+
+A Node is an explicitly managed resource representing an admitted host that runs a Node Agent and advertises authenticated, versioned runtime-provider and device-resource capabilities.
+A Node is not defined solely by operating system or processor vendor.
+The current supported Nodes are Apple Silicon macOS hosts under the macOS profile.
+Future Node profiles require separate host lifecycle, runtime-provider, packaging, trust, and real-hardware acceptance.
 
 A node record SHALL include:
 
@@ -708,7 +761,8 @@ A node record SHALL include:
 * advertise address
 * canonical production BEAM node name after validated private IPv4 inventory exists
 * pool membership
-* chip/memory/runtime capabilities
+* platform and architecture observations
+* distinct runtime-provider, acceleration, device-resource, and memory-domain capabilities
 * trust material reference
 * lifecycle state
 * current health
@@ -1225,13 +1279,16 @@ Node agent SHALL:
 * expose the current gRPC Runtime Endpoint compatibility service
 * download/verify model artifacts
 * manage worker subprocess lifecycle
+* obtain host-observed device inventory and health through a capability-provider contract distinct from runtime-provider evidence
 * report immediate state changes
 * collect diagnostics
 * cancel orphaned requests when controller session disappears
 
 ### 4.10 Local worker contract
 
-Node agent SHALL own worker lifecycle. Local workers SHOULD speak gRPC over Unix domain sockets, with this minimal internal contract:
+Node agent SHALL own Worker Runtime subprocess lifecycle, model loading, execution, cancellation, capacity observation, diagnostics, and cleanup.
+The Worker Runtime protocol source, version policy, generated bindings, and conformance fixtures SHALL have provider-neutral ownership outside any runtime-provider implementation.
+Local workers SHOULD speak gRPC over Unix domain sockets, with this minimal internal contract:
 
 * `LoadModel`
 * `UnloadModel`
@@ -1240,6 +1297,9 @@ Node agent SHALL own worker lifecycle. Local workers SHOULD speak gRPC over Unix
 * `Status`
 
 This local API is internal-only and not part of the public compatibility contract.
+Before capability evidence authorizes work, a Worker Runtime provider SHALL report its protocol version, provider identity and version, supported artifact formats, runtime features, acceleration implementations, device bindings, memory semantics, concurrency, and cache capabilities.
+Unknown, malformed, absent, stale, or incompatible required evidence MUST NOT prove capability eligibility.
+Existing MLX-owned protocol source and hand-maintained bindings remain migration inputs until the provider-neutral ownership change is implemented and accepted.
 
 ---
 
@@ -1364,6 +1424,14 @@ Configured base lane capacity remains separate. Neither it nor a live capacity s
 
 ### 5.5 Eligibility filter
 
+The heterogeneous scheduling target SHALL match model artifact requirements to fresh authenticated runtime-provider capabilities, acceleration capabilities, device resources, memory domains, and Controller policy.
+Scheduling MUST NOT authorize work solely from operating-system names, `worker_backend` strings, transport type, or inferred provider defaults.
+Missing, malformed, stale, conflicting, unauthenticated, or version-incompatible evidence required by an accepted capability contract SHALL fail closed with stable provider-neutral explanations.
+
+This target does not change current production eligibility in this contract-only change.
+Normalized capability evidence SHALL be introduced additively and compared diagnostically before a separately reviewed behavior change makes it authoritative.
+Until that cutover, omitted new fields MUST NOT create a new rejection path beyond the current eligibility contract below.
+
 For each production MultiNode scheduling attempt, the candidate universe SHALL be the exact intersection of the effective normalized targets returned by `Inference.runtime_endpoint_targets/0`, the certificate-backed active inventory returned by `Nodes.active_runtime_endpoint_targets/0`, and the latest accepted scheduler-fresh `node_heartbeats` rows whose Node and normalized target identities match. A fresh row does not admit an unconfigured, inactive, untrusted, address-only, removed, reconfigured, or identity-mismatched target.
 
 The scheduler SHALL obtain one immutable request-scoped Postgres snapshot with one statement or equivalent read-transaction semantics, deterministically selecting the latest accepted row per intersected target by descending `observed_at` and then descending row identity. Per-Node observation times may differ; both `nodes.last_heartbeat_at` and the selected row's `observed_at` SHALL satisfy `node_freshness_threshold_ms` at query time. Controller or scheduler restart requires no production candidate-cache hydration; the next attempt reads Postgres.
@@ -1444,6 +1512,10 @@ Tier selection rule:
 * else consider Tier 2
 
 ### 5.7 Scoring formula
+
+The heterogeneous scheduling target SHALL represent memory as versioned device resources and explicit memory domains such as unified memory, discrete device memory, and system memory.
+Provider-specific working-set, VRAM, or host-memory fields MAY feed adapter normalization but MUST NOT become the portable scheduling vocabulary.
+Any change from the current observe-only memory-ranking behavior to capability eligibility or enforcement requires a separately reviewed behavior change.
 
 Within a tier, compute:
 
@@ -1724,6 +1796,13 @@ State meanings:
 * `failed`: most recent placement transition failed
 
 ### 6.4 Model bundle format
+
+The target model contract SHALL represent artifact format independently from compatible runtime providers, acceleration implementations, and device-resource requirements.
+An artifact MAY declare more than one compatible provider or acceleration requirement set.
+Portable model policy MUST NOT rewrite artifact format as a runtime-provider name.
+
+The current `format`, `adapter`, `min_agent_capability`, MLX manifest values, database constraints, and accepted model bundles remain valid migration inputs.
+They SHALL NOT be removed, reinterpreted, or made non-authoritative until additive replacements, backward decoding, data migration, and scheduler cutover pass separate review and acceptance.
 
 Offline-importable model bundle SHALL be a tarball or directory with manifest:
 
@@ -2755,6 +2834,15 @@ Degraded `plain_http_localhost` SHALL return `404` for every portal route.
 
 ### 7.5 Runtime Endpoint and Internal Worker Interfaces
 
+Runtime Endpoint semantics SHALL remain independent of Controller Host and Node operating systems.
+Runtime Endpoint Observations SHALL evolve additively to distinguish host capability-provider evidence from runtime-provider evidence and to carry normalized platform, architecture, provider, acceleration, device-resource, memory-domain, health, availability, freshness, and capability-version facts.
+Host hardware presence MUST NOT prove runtime initialization.
+Runtime readiness MUST NOT fabricate host device inventory.
+Unknown, malformed, stale, unauthenticated, or version-incompatible evidence MUST NOT prove a capability requirement.
+
+Existing observations that omit additive heterogeneous capability fields SHALL remain decodable.
+Their omission SHALL remain non-authoritative for new capability requirements and SHALL NOT change current scheduling behavior until the separately reviewed authoritative cutover.
+
 Controller runtime execution SHALL use the Runtime Endpoint Interface.
 Runtime Endpoint semantics are transport-independent.
 The gRPC/protobuf `NodeRuntimeService` remains the gRPC Compatibility Adapter and a candidate protocol for future non-BEAM adapters.
@@ -2953,6 +3041,10 @@ service NodeRuntimeService {
 ```
 
 #### 7.5.2a Worker-side service (node-agent ↔ worker)
+
+The Worker Runtime Interface is provider-neutral even while MLX is the required v1 macOS implementation.
+Its protocol source, generated bindings, version policy, and conformance fixtures SHALL be owned outside any runtime-provider implementation after the ownership migration is accepted.
+Every supported provider SHALL pass provider-neutral negotiation, health, load, unload, generation, streaming, cancellation, capacity, failure-normalization, and version-skew conformance, plus applicable real-hardware acceptance.
 
 The Worker Runtime Interface remains Node Agent-local.
 The Controller communicates with the Runtime Endpoint, not directly with Worker Runtime subprocesses.
@@ -4604,7 +4696,7 @@ Forwarded headers SHALL be trusted only in `reverse_proxy` mode and only from co
 Secrets SHALL be stored:
 
 * in Postgres only as hashes, never plaintext
-* private keys SHOULD be stored in macOS Keychain or protected filesystem paths
+* private keys SHOULD be stored in the platform profile's approved credential store or protected filesystem paths; macOS Keychain remains the macOS-profile store
 * bootstrap tokens stored only as hash
 * Portal User passwords stored only as a password hash, never plaintext
 * Portal Invite tokens stored only as a hash, with plaintext shown only in the newly issued URL
@@ -4689,6 +4781,14 @@ The purge verification SHALL explicitly enumerate every content-bearing Request 
 ---
 
 ## 11. Packaging and Deployment
+
+Distribution requirements are scoped by platform profile.
+DMG, PKG, Orchard.app, launchd, Keychain, Apple signing, notarization, and stapling requirements in this section SHALL remain mandatory for the macOS profile and MUST NOT be imposed on portable Controller compilation or the Linux Controller target.
+Generic Product Version, provenance, trust, secret-free artifact, role, rollback, retained-state, and protocol compatibility requirements remain shared where applicable.
+
+The accepted Linux Controller target uses operator-provided external Postgres and contains only portable compatible applications and assets.
+Its final distribution format, host manager, paths, service integration, and publication contract remain deferred to a separate change.
+No Linux distribution is supported by this contract-only amendment.
 
 The macOS-native packaging model SHALL use:
 
@@ -4900,6 +5000,9 @@ PKG `postinstall` SHALL NOT generate, procure, or trust production TLS certifica
 
 ### 11.5 Managed Database Mode
 
+Managed Database Mode in this section is a macOS-profile capability.
+It is not part of the first Linux Controller target.
+
 Managed DB mode SHALL:
 
 * run Postgres in a local container runtime on Apple Silicon
@@ -4915,6 +5018,8 @@ Implementation choice:
 Apple’s Containerization project is a Swift package for Linux containers on macOS using Apple Silicon virtualization, and `container` is its CLI implementation. ([Apple Open Source][9])
 
 ### 11.6 External Database Mode
+
+External Database Mode is the required database mode for the accepted Linux Controller target and remains supported for the macOS profile.
 
 External DB mode SHALL support:
 
@@ -4945,6 +5050,9 @@ Offline install flow:
 
 ### 11.8 Tray/menu bar app
 
+The Tray/Menu Bar App is a macOS-profile component.
+The first Linux Controller target is headless and does not require a desktop equivalent.
+
 Tray app SHALL provide:
 
 * local daemon status
@@ -4956,6 +5064,17 @@ Tray app SHALL provide:
 * version/build info
 
 ### 11.9 CLI
+
+The target portable CLI SHALL own argument parsing, client authentication, confirmation presentation, and output formatting.
+Normal Controller-state operations SHALL execute inside the active Controller through authenticated, authorized, leader-aware, and audited Controller-owned domain operations shared with Console clients.
+The portable CLI MUST NOT require direct Ecto Repo access, Controller application modules, launchd, Darwin native helpers, or local Controller release evaluation for normal operator operations after their command-family migrations are accepted.
+
+Host-local service management, process fencing, environment materialization, local trust-store mutation, terminal custody, and support collection SHALL belong to platform host tooling.
+Mixed commands SHALL separate Controller-owned and host-local operations.
+A narrow locally authenticated Controller bootstrap or recovery channel MAY remain only for operations that cannot yet use ordinary administrator credentials, and it SHALL invoke the same Controller-owned domain operations rather than become a general direct-Repo fallback.
+
+The existing local Controller-runtime CLI authority below remains the implemented migration baseline.
+It SHALL be replaced command family by command family only through separately reviewed security-led changes with explicit authentication, authorization, audit, leader, idempotency, confirmation, secret-output, and degraded-Controller contracts.
 
 Required commands:
 
@@ -5400,9 +5519,40 @@ Acceptance:
 * schema migration ownership is exclusive
 * interrupted requests reconcile correctly after controller handover
 
+### Milestone 8 - Platform portability and Linux Controller profile
+
+This is a vNext platform-expansion milestone.
+It does not rewrite completed macOS acceptance in Milestones 0–7.
+
+Deliver:
+
+* portable umbrella dependency boundaries with no unconditional Apple or accelerator toolchain requirement
+* Darwin host artifacts outside portable CLI compilation
+* required Linux portable and provider-neutral conformance validation
+* Controller release authority independent from CLI implementation
+* provider-neutral Worker Runtime protocol ownership and generated bindings
+* additive normalized artifact, runtime-provider, acceleration, device-resource, memory-domain, and failure contracts
+* separate host capability-provider and runtime-provider evidence
+* macOS managed lifecycle behind a host adapter that preserves ADR 0018
+* security-led migration of normal CLI command families to Controller-owned operations
+* Linux Controller release profile with operator-provided external Postgres
+
+Acceptance:
+
+* portable applications compile, lint, test, and produce coverage in the required Linux portability lane without Xcode, launchd, MLX, CUDA, or Darwin native-helper compilation
+* macOS all-in-one, split-role, Orchard.app, DMG, PKG, launchd, managed handover, retained-state, signing, notarization, air-gap, and MLX acceptance remain green
+* the Controller release does not load CLI implementation to obtain Controller authority
+* the portable CLI does not require direct Repo authority or Darwin native compilation for normal Controller-state operations
+* Worker Runtime contracts have provider-neutral ownership, generated bindings, version negotiation, drift checks, and conformance coverage
+* Linux Controller with external Postgres and an admitted macOS MLX Node passes trust, Runtime Endpoint observation, scheduling, streaming, cancellation, restart, and failure acceptance
+* production BEAM admission for the Linux Controller profile satisfies ADR 0012 provenance, identity, host-control, network, and mixed-platform acceptance gates
+* `SPEC.md`, decisions, OpenSpec specs, tests, documentation, and implementation agree before the Linux Controller profile is declared supported
+
 ---
 
-This spec defines the v1 platform contract. The coding agent should implement it in milestone order, preserving wire compatibility and state-machine behavior exactly as written where fields, states, and transitions are explicitly defined.
+This spec defines the supported v1 macOS platform contract and the accepted vNext platform-expansion target.
+The coding agent should implement it in milestone order, preserving wire compatibility and state-machine behavior exactly as written where fields, states, and transitions are explicitly defined.
+Architecture acceptance does not declare an unimplemented platform profile supported.
 
 [1]: https://developers.openai.com/api/docs/guides/migrate-to-responses/ "https://developers.openai.com/api/docs/guides/migrate-to-responses/"
 [2]: https://support.apple.com/guide/terminal/script-management-with-launchd-apdc6c1077b-5d5d-4d35-9c19-60f2397b2369/mac "https://support.apple.com/guide/terminal/script-management-with-launchd-apdc6c1077b-5d5d-4d35-9c19-60f2397b2369/mac"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,10 +55,32 @@ product/system/build contract.
 When this guide and `SPEC.md` disagree, treat the branch as blocked until the
 conflict is reconciled. `SPEC.md` wins until explicitly updated.
 
+## Platform profiles and support status
+
+Orchard's Controller, Node Agent, CLI, and shared OTP applications form a
+portable core whose inward dependencies must remain independent of launchd,
+Keychain, MLX, Apple frameworks, and fixed macOS filesystem layouts.
+Platform integrations belong behind explicit host capability, lifecycle,
+packaging, and runtime-provider boundaries.
+
+The supported v1 profile remains Apple Silicon macOS for Controller and Node
+roles, including the existing all-in-one and multi-Mac topologies.
+The accepted next target is a headless Linux Controller using external Postgres
+with Apple Silicon macOS MLX Nodes.
+That target is an architecture commitment, not a current support claim, and it
+becomes supported only after Milestone 8 build, conformance, packaging,
+upgrade, rollback, security, and mixed-platform acceptance passes.
+
+A Controller Host is the machine that runs a Controller release.
+It is not a schedulable Node unless a separately enrolled and admitted Node
+Agent also runs there.
+
 ## System at a glance
 
-Orchard is an on-prem LLM orchestration platform for 1–4 Apple Silicon Macs.
-The target topology is:
+Orchard's current supported topology spans one to four Apple Silicon Macs.
+Its accepted platform-expansion target permits the Controller Host to run
+headlessly on Linux while inference Nodes remain Apple Silicon Macs.
+The logical topology is:
 
 ```text
 Public clients
@@ -119,7 +141,7 @@ The gRPC/mTLS path remains available for enrollment, certificate lifecycle, Peer
 | `apps/orchard_cli/` | `orchardctl` CLI: operator/admin automation for source dev and packaged installs. |
 | `apps/orchard_shared/` | Shared generated proto modules, Runtime Endpoint domain structs, helpers, licensing/build metadata. |
 | `native/orchard_tokenizer/` | Python helper for prompt rendering, exact token counts, and safe-tokenization support. |
-| `native/orchard_worker_mlx/` | Python MLX worker runtime package and node-agent ↔ worker proto. |
+| `native/orchard_worker_mlx/` | Current Python MLX Worker Runtime provider and current node-agent to worker protocol implementation; the accepted target moves the provider-neutral contract and generated bindings into neutral ownership. |
 | `proto/cluster/v1/` | Controller ↔ node-agent proto source: the current gRPC runtime-operations compatibility transport, the certificate-authenticated BEAM Peer Grant delivery control service, and future-adapter contracts. |
 | `packaging/` | `Orchard.app` DMG with app-owned service lifecycle, PKG, launchd, signing/build runbooks. |
 | `docs/` | Contributor-facing orientation, tooling, process, design, and durable decisions subordinate to `SPEC.md`. |

--- a/docs/decisions/0001-runtime-endpoints-beam-first.md
+++ b/docs/decisions/0001-runtime-endpoints-beam-first.md
@@ -68,6 +68,15 @@ The Node Agent may continue to use a local worker protocol for Python/MLX subpro
 The BEAM-first decision applies to first-party Controller-to-Node Agent communication.
 It does not remove the local process/protocol boundary between the Node Agent and non-BEAM Worker Runtimes.
 
+## Platform portability scope
+
+ADR 0023 makes Controller Host and Node platform profiles explicit, and ADR 0026 makes normalized capability evidence independent of transport and operating system.
+This decision remains transport-independent and applies to admitted first-party Runtime Endpoints across supported profiles.
+
+The accepted Linux Controller target does not gain production BEAM admission from architecture approval or Linux compilation alone.
+Production use requires ADR 0012 build provenance, certificate, Peer Grant, trusted-name, network, host-control, and mixed-platform acceptance gates to pass for that profile.
+The existing macOS source-dev and production evidence remains valid only for the scope it actually proved.
+
 ## Consequences
 
 This removes gRPC/protobuf as the durable Controller-to-Node Agent domain abstraction for first-party Elixir services.

--- a/docs/decisions/0003-observed-runtime-endpoints-are-admission-candidates.md
+++ b/docs/decisions/0003-observed-runtime-endpoints-are-admission-candidates.md
@@ -9,3 +9,9 @@ This preserves the distinction between live runtime observation and durable clus
 Rejected node admission is persisted as a Node Admission Decision, not as `decommissioning`.
 Re-admission after rejection requires current trusted registration state plus either an explicit admin clear action or a new registration and trust event recorded in audit.
 The trade-off is an extra admission-candidate persistence path before implementation can simplify observed nodes into inventory rows, but the boundary is hard to reverse once operators and support bundles rely on it.
+
+## Platform portability scope
+
+ADR 0023 removes the definition of a Node as only an Apple Silicon macOS machine, but it does not weaken this admission boundary.
+An observation from any platform or runtime provider remains untrusted candidate evidence until it reconciles to durable Node identity, trust, admission, lifecycle, capability, and policy state.
+Platform, provider, device, or transport metadata MUST NOT make an observed endpoint schedulable by itself.

--- a/docs/decisions/0006-local-orchardctl-node-admission-authority.md
+++ b/docs/decisions/0006-local-orchardctl-node-admission-authority.md
@@ -17,3 +17,12 @@ That boundary must not silently expand to remote or tenant-scoped execution.
 If a future remote CLI transport delegates to Admin API, it must preserve the shared admission contract and use the ADR 0004 token boundary.
 
 SPEC.md impact: `SPEC.md` §11.9 records the local node-admission and node-lifecycle CLI authority boundary.
+
+## Platform portability scope
+
+ADR 0024 refines this decision for the portable CLI target.
+The current local Controller-runtime path remains the migration baseline, not the permanent authority model for normal operator operations.
+
+Each migrated command family SHALL execute through Controller-owned authenticated, authorized, leader-aware, and audited domain operations shared by Console and CLI clients.
+The local boundary MAY remain only for a narrow bootstrap or recovery operation that cannot yet use ordinary administrator credentials.
+No command migration may weaken the action preview, confirmation, revalidation, audit, or secret-output contract established here.

--- a/docs/decisions/0011-first-admin-cluster-init.md
+++ b/docs/decisions/0011-first-admin-cluster-init.md
@@ -35,6 +35,15 @@ Alternatives rejected:
 
 Prior art: kubeadm mints local-file cluster-admin authority at `kubeadm init` and keeps bootstrap tokens strictly node-join material; k3s uses a server-local node token; Nomad's one-shot `acl bootstrap` demonstrates the one-shot guard plus guarded reset; Vault's `operator init` root token comes with use-for-setup-then-revoke hardening guidance, which this decision adopts as output guidance.
 
+## Platform portability scope
+
+ADR 0024 retains `orchardctl cluster init` as a narrow Controller-owned bootstrap operation because ordinary remote administrator credentials do not exist yet.
+It SHALL invoke the same Controller-owned bootstrap domain operation used by any future supported bootstrap presentation.
+It MUST NOT justify a general direct-Repo fallback for normal portable CLI commands.
+
+The final Linux host-tooling and local-authentication shape remains deferred to the Linux Controller release change.
+The existing one-shot guard, leader gate, audit, protected secret publication, and credential-only scope remain mandatory on every supported Controller profile.
+
 ## Consequences
 
 The Admin API becomes operator-usable on fresh installs through a documented local ritual, and the offline flow in §11.7 becomes fully executable.

--- a/docs/decisions/0012-scoped-beam-peer-grants.md
+++ b/docs/decisions/0012-scoped-beam-peer-grants.md
@@ -124,6 +124,14 @@ A second PKI would duplicate identity, renewal, revocation, and recovery surface
 A custom carrier would add a large security-critical handshake and compatibility surface without turning distributed Erlang into a method-level authorization system.
 The selected model keeps stock OTP TLS distribution and makes Orchard's additional authorization explicit.
 
+## Platform portability scope
+
+ADR 0023 accepts a Linux Controller as the first platform-expansion target, but this decision does not yet admit that profile to production BEAM Distribution.
+Before support is declared, the Linux Controller release must prove immutable build provenance, exact release identity, protected certificate and Peer Grant custody, trusted BEAM names, network restriction, host controls, and mixed Linux Controller/macOS Node acceptance.
+
+The first Linux Controller target remains a Controller Host and is not a schedulable Node unless a separately admitted local Node Agent satisfies the complete Node contract.
+No shared cookie, certificate-only authorization, provider identifier, or successful transport probe may substitute for the scoped Peer Grant and durable admission requirements.
+
 ## Consequences
 
 Production BEAM gains exact pair-scoped authorization, per-pair rotation, revocation, Active/Standby isolation, deterministic recovery, and visible failure without weakening Node Certificate identity.

--- a/docs/decisions/0013-controller-dispatch-capacity-authority.md
+++ b/docs/decisions/0013-controller-dispatch-capacity-authority.md
@@ -83,6 +83,14 @@ Independent per-placement ceilings without an aggregate bound are rejected becau
 Persisting only the Effective Dispatch Limit is rejected because it erases the two independent authority inputs.
 The term `Admitted Capacity` is rejected because it conflates Node Admission, Request Admission, policy, runtime enforcement, and remaining headroom.
 
+## Platform portability scope
+
+ADR 0026 introduces separate host capability-provider and runtime-provider evidence, but neither evidence source supersedes Controller Dispatch Capacity Authority.
+Normalized provider and device facts may become additional fail-closed eligibility inputs only through a separately reviewed behavior change.
+They MUST NOT bypass the Controller Dispatch Ceiling, Runtime Concurrency Enforcement Limit, allocation accounting, freshness, trust, lifecycle, health, management-class, or acceptance-gate requirements in this decision.
+
+Before authoritative cutover, additive heterogeneous capability evidence remains diagnostic and omitted new fields do not create a new production rejection path beyond the current contract.
+
 ## Consequences
 
 Node Admission and operator policy changes become auditable capacity-authority writes.

--- a/docs/decisions/0018-managed-node-agent-handover.md
+++ b/docs/decisions/0018-managed-node-agent-handover.md
@@ -65,6 +65,16 @@ An external installer wrapper is not required for correctness.
 Automatic Node Agent restart after uncertain state is not introduced.
 Support for blind or manual same-root launch during uncertainty is not introduced.
 
+## Platform portability scope
+
+ADR 0023 scopes the exact launchd and Darwin mechanics in this decision to the current macOS profile.
+ADR 0023 does not weaken any exclusion, suppression, exact-instance, evidence, provisional-launch, owner-death, rollback, or zero-overlap invariant defined here.
+
+A later managed-host lifecycle interface SHALL preserve these portable safety outcomes while hiding platform service-manager and process-identity vocabulary from callers.
+The macOS adapter must continue to satisfy this complete decision.
+A future Linux adapter requires its own host-manager mechanics and conformance evidence and MUST NOT claim parity by replacing `launchctl` commands with `systemctl` commands mechanically.
+No Linux Node lifecycle support is accepted by this contract-only scope amendment.
+
 ## Consequences
 
 Managed Node Agent updates incur a bounded per-node interruption during the active handover.

--- a/docs/decisions/0023-platform-profiles-and-portable-core.md
+++ b/docs/decisions/0023-platform-profiles-and-portable-core.md
@@ -1,0 +1,50 @@
+# ADR: Platform profiles refine Orchard's portable core
+
+## Status
+
+Accepted on 2026-08-23 under issues #266 and #267.
+
+## Context
+
+`SPEC.md` historically defines Orchard as one Apple Silicon macOS product with launchd, Apple packaging, and MLX requirements applied to the whole umbrella.
+The current repository already has useful portable boundaries, but `orchard_cli` unconditionally compiles Darwin helpers, macOS defaults reach portable configuration, and release composition mixes platform-specific payloads with portable applications.
+
+Orchard needs a path to Linux Controller Hosts and later Linux accelerator Nodes without weakening the accepted macOS product or scattering operating-system conditionals through portable code.
+Portable compilation alone is not sufficient evidence for supported deployment.
+
+## Decision
+
+Define a portable Orchard core and bind it to supported platform profiles.
+
+The portable core consists of `orchard_shared`, `orchard_controller`, `orchard_node_agent`, and portable `orchard_cli` behavior.
+These applications SHALL depend on portable contracts for platform-neutral behavior.
+Platform host adapters, runtime-provider implementations, platform packaging, and vendor SDKs SHALL depend inward on those contracts and MUST NOT become unconditional compile dependencies of the portable umbrella.
+
+Keep `orchard_node_agent` as the portable Node orchestration core.
+Do not extract an `orchard_node_core` application unless a later concrete dependency or supervision constraint requires it.
+
+Treat Controller Hosts and schedulable Nodes as distinct roles.
+A Controller Host does not become schedulable unless an admitted Node Agent on that host separately satisfies the Node trust, lifecycle, health, capability, and capacity contracts.
+
+The current supported platform profile remains Apple Silicon macOS.
+It preserves the all-in-one and split-role topologies, launchd, Orchard.app, DMG, PKG, managed handover, signing, notarization, air-gap, retained-state, managed Postgres, and MLX guarantees already accepted by `SPEC.md`.
+
+The first accepted platform-expansion target is a Linux Controller Host with operator-provided external Postgres dispatching to admitted macOS Apple Silicon Nodes using the MLX runtime provider.
+The Linux Controller profile is headless and does not require a local Node Agent or accelerator runtime.
+It SHALL NOT be declared supported until its release, trust, transport, scheduling, streaming, cancellation, restart, failure, provenance, and mixed-platform acceptance passes.
+
+Final Linux packaging, host management, managed Postgres, Linux Node lifecycle, Linux accelerator discovery, and CUDA or ROCm runtime support remain deferred.
+
+## Consequences
+
+The repository gains an enforceable dependency direction and a sequence for proving portability before adding another accelerator stack.
+Mac-specific operational guarantees remain visible instead of being reduced to a lowest-common-denominator abstraction.
+CI and release composition must later separate portable validation from platform acceptance and publication.
+Every new platform or runtime profile requires explicit contracts and acceptance evidence.
+
+The architecture contract may be accepted before implementation, but support status cannot.
+The vNext milestone carries the support gate and preserves completed v1 macOS acceptance as historical truth.
+
+## SPEC.md impact
+
+Update required in the document preamble, §§1.1–1.5, 2, 4.1, 11, and 14.

--- a/docs/decisions/0024-controller-owned-operator-authority.md
+++ b/docs/decisions/0024-controller-owned-operator-authority.md
@@ -1,0 +1,47 @@
+# ADR: Controller-owned operations are the durable operator authority
+
+## Status
+
+Accepted on 2026-08-23 under issues #266 and #267.
+This decision refines ADRs 0006 and 0011.
+
+## Context
+
+The current CLI mixes four responsibilities: portable client interaction, direct Controller and Repo authority, protected terminal custody, and macOS host lifecycle behavior.
+The Controller release also loads CLI implementation to obtain a narrow local command handler.
+
+Direct Repo operations prevent a portable remote CLI, duplicate authority across Console and CLI paths, and make transport, authorization, audit, leadership, confirmation, and secret-output behavior harder to keep coherent.
+Moving commands to a network API without defining those security contracts would expand the remotely reachable management surface unsafely.
+
+## Decision
+
+An operation that authoritatively reads or mutates Controller-owned durable state SHALL execute inside the active Controller through authenticated, authorized, leader-aware, and audited Controller-owned domain operations.
+Console and CLI clients SHALL invoke the same domain authority.
+
+The portable CLI SHALL own argument parsing, client authentication, confirmation presentation, and output formatting.
+After the applicable command-family migration, it MUST NOT require direct Ecto Repo access, Controller application modules, launchd, Darwin native helpers, or local Controller release evaluation for normal operator operations.
+The Controller release MUST NOT load CLI implementation to obtain Controller authority after the local-handler migration.
+
+Service-manager control, managed process fencing, environment materialization, local trust-store mutation, terminal custody, and host support collection belong to platform host tooling.
+Mixed commands SHALL separate Controller-owned and host-local operations rather than grant one process both implicit authorities.
+
+Retain a narrow locally authenticated Controller bootstrap or recovery channel only for operations that cannot yet use ordinary administrator credentials.
+That channel SHALL invoke the same Controller-owned domain operations and MUST NOT become a general direct-Repo fallback.
+`orchardctl cluster init` remains such a bootstrap operation under ADR 0011 unless a later accepted decision replaces it.
+
+Migrate command families incrementally.
+Before each migration, define its authentication, authorization scope, leader behavior, audit record, idempotency, confirmation and consequence acknowledgement, secret return semantics, and degraded-Controller behavior.
+Current local Controller-runtime behavior remains the migration baseline until each replacement passes parity and failure-path acceptance.
+
+## Consequences
+
+Console and CLI converge on one Controller authority and one audit policy.
+The CLI can become a portable remote client, and the Controller release can stop depending on CLI implementation.
+Host lifecycle and terminal custody can move to platform-specific tooling without polluting the portable client.
+
+The remotely reachable operator surface grows as command families migrate.
+Each migration therefore requires security-led review and cannot be implemented as a mechanical HTTP wrapper around existing command modules.
+
+## SPEC.md impact
+
+Update required in §§2.5, 7.3, 7.4, and 11.9.

--- a/docs/decisions/0025-provider-neutral-worker-runtime-contract.md
+++ b/docs/decisions/0025-provider-neutral-worker-runtime-contract.md
@@ -1,0 +1,48 @@
+# ADR: Worker Runtime contracts have provider-neutral ownership
+
+## Status
+
+Accepted on 2026-08-23 under issues #266 and #267.
+
+## Context
+
+The Node Agent already supervises Worker Runtime subprocesses through a local gRPC and Unix-domain-socket boundary.
+That boundary is the correct seam for multiple runtime providers.
+
+The MLX package currently owns the protobuf source, the Elixir binding is hand-maintained, and MLX vocabulary has leaked into durable model, failure, capability, memory, and UI contracts.
+Allowing each provider to own or fork the protocol would make version negotiation, generated bindings, conformance, and Node Agent mapping drift across implementations.
+
+## Decision
+
+Keep the Node Agent-to-worker subprocess boundary.
+The Node Agent continues to own subprocess supervision, model loading, execution, streaming, cancellation, active allocation, diagnostics, failure handling, and cleanup.
+The Controller communicates through the Runtime Endpoint and MUST NOT manage provider subprocesses directly.
+
+Move Worker Runtime protocol source, version policy, generated bindings, and conformance fixtures to a provider-neutral repository boundary.
+The MLX worker becomes one implementation of that contract and no longer owns it.
+Independent ownership does not require a new publishable package or OTP application.
+
+Generate every supported language binding from one normative source.
+Required validation SHALL fail when committed generated bindings drift from that source.
+The ownership migration SHALL preserve existing wire numbers and semantics.
+
+Add capability negotiation versionably and additively.
+A provider SHALL report protocol version, provider identity and version, supported artifact formats, runtime features, acceleration implementations, device-resource bindings, memory semantics, concurrency, and cache capabilities before those facts authorize work.
+Unknown, malformed, absent, stale, or incompatible required evidence MUST NOT be treated as affirmative compatibility.
+
+Provider-specific codes and fields MAY remain bounded diagnostic evidence during migration.
+They MUST NOT become portable scheduler policy or new durable public categories without an explicit contract change.
+Existing workers and bindings remain decodable through a documented compatibility window.
+
+## Consequences
+
+New providers can implement one stable local contract without joining the Controller transport or BEAM trust boundary.
+Generated bindings and conformance fixtures reduce silent wire drift.
+The Node Agent owns the mapping from provider protocol evidence into Orchard's portable domain.
+
+The migration requires reproducible generation, compatibility fixtures, additive decoding, and coordinated packaging changes.
+Real-hardware acceptance remains required in addition to provider-neutral conformance.
+
+## SPEC.md impact
+
+Update required in §§1.5, 2.4, 4.9, 4.10, 7.5, and 12.2.

--- a/docs/decisions/0026-separate-capability-and-runtime-providers.md
+++ b/docs/decisions/0026-separate-capability-and-runtime-providers.md
@@ -1,0 +1,48 @@
+# ADR: Host capability and runtime providers are separate authorities
+
+## Status
+
+Accepted on 2026-08-23 under issues #266 and #267.
+
+## Context
+
+The current MLX worker discovers Apple device and working-set facts while also reporting runtime readiness and execution capacity.
+Durable Controller contracts use overlapping `mlx`, `worker_backend`, working-set, artifact-format, and scheduler vocabulary.
+
+Hardware presence does not prove that a runtime can initialize or execute a particular model.
+Runtime readiness does not prove complete host inventory, driver health, topology, or allocatable resources.
+Keeping both authorities inside one provider also duplicates discovery when a host supports multiple providers or devices.
+
+## Decision
+
+Define a host capability provider and a runtime provider as separate authorities.
+
+The host capability provider reports host-observed device inventory, stable device identity, topology, architecture, acceleration availability, memory domains, driver readiness, changing health, observation time, and bounded diagnostics.
+The runtime provider reports protocol and provider identity, supported artifact formats and features, model compatibility, runtime initialization and health, device bindings, active allocation, concurrency, cache capabilities, and execution capacity.
+
+Neither authority proves the other.
+Dispatch eligibility requires compatible fresh authenticated evidence from both authorities plus current Controller trust, lifecycle, health, capacity, and policy gates.
+
+Orchard SHALL distinguish artifact format, runtime provider, acceleration implementation, device resource, and memory domain.
+Portable policy and scheduling MUST NOT branch on operating-system names or provider identifiers as substitutes for capability evidence.
+
+Introduce normalized evidence additively.
+Absent, malformed, stale, conflicting, unauthenticated, or version-incompatible required evidence cannot prove eligibility.
+Before normalized evidence becomes authoritative, compare decisions diagnostically and preserve current scheduling behavior.
+The authoritative cutover requires a separately reviewed behavior change and stable provider-neutral explanations.
+
+Current MLX fields and model records remain valid migration inputs.
+Provider-specific working-set or failure fields MAY feed normalization or bounded diagnostics until their documented compatibility window ends.
+
+## Consequences
+
+Orchard can represent multiple devices, memory domains, and runtime providers without encoding Apple or MLX assumptions in portable scheduling.
+Device inventory can exist before a worker starts, while runtime initialization remains provider-owned.
+Scheduler decisions become more explicit and explainable across heterogeneous Nodes.
+
+The Node Agent must aggregate and authenticate two evidence sources and handle disagreement, freshness, and version skew.
+Capability normalization touches Runtime Endpoints, persistence, diagnostics, model contracts, Console and CLI presentation, and scheduling, so implementation must remain additive until cutover.
+
+## SPEC.md impact
+
+Update required in §§1.5, 4.1, 4.6.1, 5.5, 5.7, 6.4, 7.5, 8.2, and 10.10.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,4 +23,4 @@ Start from [`_template.md`](_template.md) when useful. Decisions already fixed b
 
 ## Decision index
 
-The current sequence ends with [ADR 0021: Explicit Tenant-model grants and routing snapshots](0021-explicit-tenant-model-grants-and-routing-snapshots.md).
+The current sequence ends with [ADR 0026: Separate capability and runtime providers](0026-separate-capability-and-runtime-providers.md).

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -1,14 +1,20 @@
 # Orchard Glossary
 
-Orchard is a sovereign on-prem LLM orchestration platform for Apple Silicon macOS. This glossary defines Orchard's shared language; `SPEC.md` remains the normative build contract for behavior, interfaces, states, and milestones.
+Orchard is a sovereign on-prem LLM orchestration platform with a portable control-plane core and a currently supported Apple Silicon macOS platform profile.
+This glossary defines Orchard's shared language; `SPEC.md` remains the normative build contract for behavior, interfaces, states, and milestones.
 
 ## Language
 
 ### Product Truth
 
 **Orchard**:
-A sovereign on-prem LLM orchestration platform for one to four Apple Silicon macOS machines.
+A sovereign on-prem LLM orchestration platform whose supported v1 profile spans one to four Apple Silicon macOS machines and whose accepted next target permits a Linux Controller Host with Apple Silicon macOS Nodes.
 _Avoid_: Kapitan Orchard, cloud LLM platform
+
+**Platform Profile**:
+A named combination of supported operating systems, roles, persistence mode, host lifecycle, packaging, runtime providers, and acceptance evidence.
+An accepted target profile is not supported until its explicit milestone acceptance gates pass.
+_Avoid_: architecture aspiration, operating-system detection, support claim without acceptance
 
 **Normative Build Contract**:
 The top-level product and system contract that governs Orchard behavior and resolves conflicts between docs, tests, and implementation.
@@ -36,6 +42,11 @@ _Avoid_: Release, sprint
 The central control-plane service that owns public APIs, governance, admission, scheduling, dispatch, request state, and stream relay.
 _Avoid_: Worker, node agent
 
+**Controller Host**:
+The machine that runs a Controller release.
+A Controller Host is not a schedulable Node unless a separately enrolled and admitted Node Agent also runs there.
+_Avoid_: Node, Active Leader, Controller process
+
 **Node Agent**:
 The first-party node-local Orchard service that owns local runtime execution, model cache, worker supervision, diagnostics, status, and cleanup.
 _Avoid_: Controller agent, worker runtime
@@ -54,6 +65,26 @@ _Avoid_: Worker Runtime, transport protocol, durable cluster truth, managed Mac
 **Worker Runtime**:
 The local model execution process supervised by the Node Agent.
 _Avoid_: Public API server, permanent launchd service
+
+**Runtime Provider**:
+A Node-local implementation that satisfies the provider-neutral Worker Runtime Interface for a runtime family such as MLX-LM.
+_Avoid_: model artifact format, acceleration implementation, device resource
+
+**Acceleration Implementation**:
+A hardware or software execution backend used by a Runtime Provider, such as Apple Metal through MLX.
+_Avoid_: Runtime Provider, device resource, model format
+
+**Device Resource**:
+A normalized schedulable compute device exposed by a Host Capability Provider.
+_Avoid_: Runtime Provider, operating-system name, memory domain
+
+**Memory Domain**:
+A normalized memory pool associated with one or more Device Resources, including unified or discrete memory arrangements.
+_Avoid_: raw host memory metric, device resource, runtime concurrency
+
+**Host Capability Provider**:
+A platform-specific adapter that reports normalized operating-system, architecture, device, acceleration, memory-domain, lifecycle, and secret-store capabilities without defining runtime execution semantics.
+_Avoid_: Runtime Provider, Worker Runtime, scheduler policy
 
 **MLX Worker**:
 Orchard's Apple Silicon native Worker Runtime path for MLX and MLX-LM inference.
@@ -171,7 +202,7 @@ It remains an explicit mTLS compatibility, diagnostics, external-provider, recov
 _Avoid_: Runtime Endpoint Interface, Worker Runtime Interface, first-party BEAM mesh
 
 **Worker Runtime Interface**:
-The Node Agent-local execution process contract for loading models, generating output, reporting local worker status, and handling cancellation.
+The provider-neutral, versioned Node Agent-local execution process contract for readiness, model loading and unloading, inference streaming, cancellation, health, diagnostics, and normalized failures.
 _Avoid_: Runtime Endpoint Interface, Public Inference API, provider API
 
 **Node Lifecycle Interface**:
@@ -425,7 +456,8 @@ _Avoid_: Arbitrary remote compute
 ### Nodes and Models
 
 **Node**:
-A managed Apple Silicon macOS machine represented in Orchard's cluster inventory.
+A managed machine represented in Orchard's cluster inventory and running an enrolled first-party Node Agent.
+The supported v1 Node profile is Apple Silicon macOS; Linux Node support is deferred and requires a separately accepted profile.
 _Avoid_: Server when cluster role matters
 
 **Runtime Endpoint Admission Candidate**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -7,6 +7,15 @@ single-node; multi-node source-dev testing is supported via env vars
 Read [`architecture.md`](architecture.md) first if you need repo/runtime boundary
 orientation, and [`tooling.md`](tooling.md) for pinned tool versions.
 
+## Supported development profile
+
+The supported source-development profile is currently Apple Silicon macOS.
+The accepted Linux Controller profile is a Milestone 8 target, not an
+operational setup described by this guide.
+Existing Homebrew, launchd, Keychain, Xcode, Unix-socket, and MLX instructions
+remain the macOS implementation baseline and migration inputs rather than
+portable Controller requirements.
+
 ## Prerequisites
 
 | Dependency | Version | Notes |

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -8,6 +8,16 @@ tools that affect build output, warnings, generated code, Python environments,
 and packaging behavior. Do not rely on global Homebrew, system, uv-managed, or
 shell-specific runtime versions when working in this repo.
 
+## Platform scope
+
+The documented complete development and validation workflow currently targets
+the supported Apple Silicon macOS profile.
+The accepted Linux Controller profile is a Milestone 8 target and does not yet
+have a supported bootstrap, packaging, or validation lane.
+Portable tools such as mise, Erlang, Elixir, Node.js, npm, and Postgres remain
+part of that target, while Xcode, Swift, signing, launchd, Keychain, and MLX
+steps apply only to the macOS profile or its macOS Node artifacts.
+
 ## Required Toolchain
 
 Run these commands from the repo root:
@@ -42,12 +52,14 @@ The mise environment also sets:
 `uv` remains the package and virtualenv manager for `native/**`. `mise` owns
 the Python interpreter version that `uv` is allowed to use.
 
-Apple's C toolchain is also required and is outside mise, the same way the
+For the current macOS profile, Apple's C toolchain is also required and is outside mise, the same way the
 Swift and signing tools are. Compiling `apps/orchard_cli` builds the
 `orchard-secret-tty` terminal helper from `apps/orchard_cli/c_src` through
 `elixir_make`, so `mix compile`, `mix test`, and package builds need the host
 Xcode Command Line Tools for `xcrun clang`. Install them with
 `xcode-select --install` if `xcrun clang --version` fails.
+This native helper dependency is a documented portability migration input and
+must not be interpreted as part of the accepted portable CLI contract.
 
 ## Standard Commands
 

--- a/openspec/changes/establish-platform-portability-contract/.openspec.yaml
+++ b/openspec/changes/establish-platform-portability-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/establish-platform-portability-contract/design.md
+++ b/openspec/changes/establish-platform-portability-contract/design.md
@@ -1,0 +1,144 @@
+## Context
+
+Orchard currently presents one macOS-native product profile as the system-wide architecture. The four OTP applications are mostly portable, but `orchard_cli` unconditionally compiles Darwin C helpers, the Controller release loads CLI code to execute Controller-authoritative commands, configuration defaults encode macOS paths and MLX, and the MLX package owns the otherwise reusable Worker Runtime protobuf contract. Root umbrella validation therefore requires Apple tooling even for Controller-only work.
+
+The target product must preserve the existing Mac all-in-one, DMG/PKG, launchd, signing, air-gap, and managed Node Agent handover guarantees while adding Linux Controller Hosts and, later, Linux accelerator Nodes. Postgres remains durable truth, the Controller continues to schedule Runtime Endpoints, and the Node Agent continues to own worker subprocesses.
+
+The first mixed-platform deployment target is a Linux Controller with operator-provided external Postgres dispatching to existing macOS Apple Silicon Nodes using the MLX runtime provider.
+It becomes a supported profile only after portable control-plane, trust, transport, capability, release, and mixed-platform acceptance evidence passes.
+This ordering proves the required seams before CUDA or Linux Node lifecycle work begins.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define portable core modules and enforce inward-only dependency direction.
+- Preserve `orchard_node_agent` as the portable Node orchestration core.
+- Separate host lifecycle, hardware capability discovery, runtime execution, and packaging responsibilities.
+- Make Worker Runtime contracts provider-neutral, versioned, generated, and independently owned.
+- Move durable Controller authority behind authenticated Controller-owned operations used by Console and CLI.
+- Normalize artifact, runtime, acceleration, device, memory, and failure vocabulary for heterogeneous scheduling.
+- Establish Linux portability and provider conformance as required validation, with real platform acceptance retained.
+- Reconcile `SPEC.md`, decisions, OpenSpec capabilities, documentation, tests, and implementation before behavior changes land.
+- Define the target architecture without claiming that unimplemented Linux behavior is currently supported.
+
+**Non-Goals:**
+
+- Implement CUDA, ROCm, Linux accelerator discovery, or GPU driver management.
+- Select final Linux packaging, service manager, desktop UI, or managed Postgres behavior.
+- Replace BEAM Runtime Endpoints, Postgres durable truth, or the worker subprocess boundary.
+- Introduce Kubernetes, runtime downloads, a backend gallery, or a plugin marketplace.
+- Weaken macOS lifecycle, signing, notarization, rollback, retained-state, trust, or air-gap guarantees.
+
+## Decisions
+
+### 1. Platform profiles refine product support
+
+The portable product contract describes Controller Hosts, schedulable Nodes, Node Agents, Runtime Endpoints, and runtime providers independently. Platform profiles then bind those roles to host lifecycle, paths, credential stores, packaging, and runtime payloads.
+
+The macOS profile preserves all current behavior. The first Linux profile supports a Controller Host with external Postgres and no requirement to be a schedulable inference Node. A mixed cluster may contain that Linux Controller and macOS MLX Nodes.
+
+**Alternative considered:** Replace the macOS product definition with a generic lowest-common-denominator contract. Rejected because it would obscure or weaken accepted Mac-specific operational guarantees.
+
+### 2. Keep the existing portable OTP applications
+
+`orchard_shared`, `orchard_controller`, `orchard_node_agent`, and `orchard_cli` remain the portable umbrella applications. `orchard_node_agent` gains injected host-process, capability-provider, and runtime-provider seams rather than being split into a new core application.
+
+Platform host artifacts containing Darwin or future Linux native code must not become unconditional children of the portable umbrella. They are built and assembled only by their platform lanes.
+
+**Alternative considered:** Extract `orchard_node_core`. Rejected because the current Node Agent has portable dependencies and already owns the correct supervision and worker boundary; extraction would add churn without removing a platform dependency.
+
+### 3. Host lifecycle remains external to the managed Node Agent
+
+A deep managed-host lifecycle interface hides service-manager and process-identity vocabulary. Its normative operations establish crash-released exclusion, observe start policy/service/process state independently, fence an exact instance to a proven stopped state, and launch one provisional authorized instance. Portable orchestration owns lifecycle state-machine decisions; adapters own platform mechanics and opaque non-reusable process identities.
+
+The macOS adapter preserves launchd suppression, exact Darwin process identity, handover evidence, and one-shot acceptance. A Linux adapter must later prove equivalent invariants rather than translate `launchctl` calls mechanically.
+
+**Alternative considered:** Move lifecycle into the Node Agent. Rejected because the actor being fenced, replaced, or stopped cannot independently own the exclusion and liveness proof required by managed handover.
+
+### 4. Capability discovery and runtime execution are separate authorities
+
+A capability provider reports host-observed device inventory, topology, memory domains, driver readiness, availability, and changing health. A runtime provider reports what its engine can initialize and use, model compatibility, runtime health, active allocation, and execution capacity. Dispatch eligibility requires compatible evidence from both authorities plus current Controller policy.
+
+This prevents one worker process from defining all Node hardware facts and supports multiple runtime providers or devices on one host.
+
+**Alternative considered:** Keep discovery entirely inside each worker. Rejected because hardware inventory would remain unavailable before worker startup, duplicate across providers, and conflate device health with runtime initialization.
+
+### 5. Worker Runtime contract ownership is provider-neutral
+
+Worker Runtime proto source, generated bindings, version rules, and conformance fixtures move to a provider-neutral repository location. The Node Agent maps the contract to its internal domain. MLX remains one implementation and no longer owns the protocol.
+
+The existing operation set remains the compatibility baseline. Additive versioned capability negotiation identifies protocol version, provider identity/version, supported artifact formats and runtime features, acceleration implementations, device resources, memory semantics, concurrency, and cache features. Existing fields remain decodable during migration but cease to be authoritative where normalized replacements exist.
+
+All supported bindings are generated from one source with a drift check.
+
+**Alternative considered:** Create a new publishable package immediately. Rejected unless generation or artifact distribution later demonstrates a need; independent ownership does not require another OTP application.
+
+### 6. Domain vocabulary separates four concepts
+
+Orchard distinguishes:
+
+- artifact format, such as GGUF or SafeTensors;
+- runtime provider, such as MLX-LM or a future vLLM provider;
+- acceleration implementation, such as Metal, CUDA, ROCm, or CPU;
+- device resource, including identity, topology, memory domain, and allocatable capacity.
+
+Scheduler and policy code consume normalized capabilities and resource requirements, never operating-system or provider-name conditionals. Provider-specific details may appear only in bounded diagnostics and profile configuration.
+
+### 7. Controller owns durable operator authority
+
+Operations that authoritatively read or mutate Controller-owned durable state execute inside the active Controller through authenticated, authorized, audited operations. Console and CLI use the same Controller-owned domain operations. The CLI owns argument parsing, client interaction, confirmation presentation, and output formatting; it does not own Ecto Repo authority.
+
+A narrow Controller-owned local bootstrap/recovery channel may invoke the same domain operations when normal remote credentials do not yet exist. Host-local service, lifecycle, environment, trust-store, and support collection operations belong to platform host tooling.
+
+**Alternative considered:** Preserve direct Repo CLI operations on co-resident hosts. Rejected because it prevents a remote portable CLI, duplicates authority, bypasses one transport/audit policy, and keeps the Controller release coupled to CLI implementation.
+
+### 8. Portability is enforced by layered CI
+
+Required Linux validation compiles and tests portable applications without Xcode, MLX, CUDA, launchd, or platform native helpers. Provider-neutral fake worker, capability, lifecycle, and scheduler conformance runs without accelerator hardware. Real macOS host, Apple Silicon MLX, Swift app, packaging, and publication lanes remain separate. Future Linux host and CUDA lanes are additive.
+
+Triggers follow dependency ownership: shared contracts, proto, root configuration, toolchain, and release composition fan out to all consumers. Path filters may optimize only after ownership is clean and must not allow normative contract changes to skip applicable validation.
+
+### 9. Contract acceptance and implementation acceptance are separate
+
+This change establishes the normative target, ownership boundaries, migration order, and acceptance conditions.
+It does not make Linux Controller support, a portable CLI, provider-neutral capability scheduling, or host adapters operational by itself.
+
+Each implementation slice requires a linked child issue and a separate OpenSpec change when it changes behavior or architecture.
+The Linux Controller profile becomes supported only after its release, trust, transport, scheduling, streaming, cancellation, restart, and failure acceptance passes with an admitted macOS MLX Node.
+
+**Alternative considered:** Keep one 69-task OpenSpec change active through every implementation slice. Rejected because it would make contract review, behavior review, dependency ownership, and archival too coarse, and it would overlap active lifecycle, scheduling, and release-governance changes.
+
+## Risks / Trade-offs
+
+- **[Risk] The first Linux-green build exposes previously hidden assumptions.** → Introduce the lane after native eviction, characterize failures as portability gaps, and do not weaken the lane with broad skips.
+- **[Risk] Moving CLI authority expands the remotely reachable operator surface.** → Migrate command families incrementally through explicit authorization, audit, leader, idempotency, confirmation, and secret-output contracts; retain a narrow local bootstrap channel.
+- **[Risk] Capability normalization changes scheduling behavior.** → Add normalized evidence additively, compare decisions in diagnostics, then make it authoritative in a separate behavior slice with failure-path tests.
+- **[Risk] Protocol version skew creates silent false eligibility.** → Treat absent, unknown, malformed, or stale capability evidence as unknown and fail closed for requirements it must prove.
+- **[Risk] A new host adapter recreates umbrella contamination.** → Keep platform native artifacts outside unconditional portable compilation and validate the dependency rule in CI.
+- **[Risk] General lifecycle vocabulary loses forensic detail.** → Persist normalized normative outcomes plus bounded platform-tagged evidence; translate legacy macOS records read-side without rewriting history.
+- **[Risk] Mixed-platform BEAM operation expands the trust matrix.** → Require explicit build provenance, identity, transport, and mixed-platform acceptance before production admission; do not infer support from Linux compilation alone.
+
+## Follow-up Delivery Plan
+
+1. Amend `SPEC.md` with platform profiles, portable invariants, heterogeneous terminology, first Linux topology, and a new platform-expansion milestone; add or amend decisions before implementation.
+2. Evict Darwin helpers from `orchard_cli`'s unconditional compiler path while preserving macOS host behavior and tests.
+3. Add the required Linux portable and provider-neutral conformance lanes.
+4. Move the packaged local command handler into `orchard_controller`, update the wrapper, and remove `orchard_cli` from the Controller release without changing command semantics.
+5. Relocate Worker Runtime protocol ownership and generate both Elixir and Python bindings without wire changes.
+6. Add capability negotiation, normalized resources, generic failure categories, and compatibility decoding; make eligibility authoritative only in its reviewed behavior slice.
+7. Introduce the capability-provider seam and conformance implementations while preserving MLX runtime behavior.
+8. Put existing managed macOS lifecycle behavior behind the host-lifecycle interface and migrate evidence additively.
+9. Move Controller-authoritative CLI command families to authenticated Controller operations incrementally.
+10. Add and accept the Linux Controller release profile and mixed Linux Controller/macOS MLX Node evidence. Linux Node and CUDA work follow separate changes.
+
+The implementation steps above are follow-up changes under umbrella issue #266, not tasks in this contract-only change.
+Each slice preserves a rollback path to the prior macOS behavior until its replacement passes equivalent Mac acceptance.
+Additive schemas and protocol fields remain backward-decodable through the documented compatibility window.
+
+## Open Questions
+
+- Which Linux Controller distribution format and host manager should become supported after source/release portability is proven?
+- Should Linux managed Postgres remain deferred beyond the first external-Postgres profile?
+- Which command family should be the first authenticated CLI-to-Controller authority migration slice?
+- When should deprecated MLX-named durable error and memory fields be removed after normalized replacements become authoritative?

--- a/openspec/changes/establish-platform-portability-contract/proposal.md
+++ b/openspec/changes/establish-platform-portability-contract/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Orchard's current product contract and build ownership make macOS, launchd, Xcode tooling, and MLX assumptions apply to the entire umbrella even though the Controller, shared domain, CLI client behavior, and Node Agent orchestration core are structurally portable.
+Orchard needs an explicit platform-portability contract now so Linux Controller support and future Linux accelerator runtimes can be added without weakening the existing macOS all-in-one product or repeating platform conditionals throughout portable code.
+
+This contract change amends `SPEC.md`: Apple Silicon macOS with MLX becomes the current supported platform profile rather than the definition of every Controller Host and Node.
+Linux Controller with external Postgres plus existing macOS MLX Nodes becomes the first accepted mixed-platform target, but support is not declared until its later implementation and acceptance milestone passes.
+
+## What Changes
+
+- Define portable Orchard core responsibilities and inward-only dependency rules for `orchard_shared`, `orchard_controller`, `orchard_node_agent`, and the remote-capable `orchard_cli` client.
+- Define platform profiles that preserve macOS all-in-one operation while adding Linux Controller Hosts and heterogeneous schedulable Nodes.
+- Separate artifact format, runtime provider, acceleration implementation, and device-resource capability vocabulary.
+- Establish provider-neutral, versioned Worker Runtime contract ownership outside the MLX implementation while preserving the Node Agent-owned subprocess boundary.
+- Establish separate host-lifecycle and capability-provider interfaces so launchd/Darwin, future Linux host management, Apple hardware discovery, and future NVIDIA/AMD discovery remain outside portable core modules.
+- Move Controller-state authority behind Controller-owned authenticated operations shared by Console and CLI clients; retain only a narrow Controller-owned local bootstrap/recovery channel.
+- Establish the target contract that removes direct Controller Repo authority and Darwin native helper compilation from the portable CLI; host-local lifecycle operations become platform-host tooling after separately reviewed migrations.
+- Require a Linux portability validation lane for portable code, provider-neutral conformance validation, and separate platform acceptance and packaging lanes.
+- Preserve macOS app, DMG, PKG, launchd, managed Node Agent handover, signing, notarization, air-gap, and operator-state-retention guarantees within the macOS profile.
+- Defer CUDA implementation, Linux GPU driver management, final Linux Node packaging, final Linux Controller packaging, managed Linux Postgres, and remotely downloadable runtime catalogs.
+- Keep native relocation, CI restructuring, protocol and schema changes, CLI migrations, and Linux release implementation outside this contract-only change.
+
+## Capabilities
+
+### New Capabilities
+
+- `platform-profiles`: Defines portable Orchard roles, supported host/node profiles, dependency direction, Mac all-in-one preservation, and the first Linux Controller mixed-platform topology.
+- `host-lifecycle-adapters`: Defines platform-neutral managed-host lifecycle invariants and the adapter seam for macOS launchd and future Linux host implementations.
+- `worker-runtime-providers`: Defines provider-neutral Worker Runtime contract ownership, protocol versioning, normalized runtime/device vocabulary, capability negotiation, and provider conformance.
+- `operator-command-authority`: Defines Controller-owned operator authority, portable CLI client responsibilities, host-local operation ownership, and the narrow local bootstrap/recovery channel.
+- `portability-validation`: Defines Linux portable validation, provider conformance, platform acceptance, packaging lanes, and dependency-aware trigger requirements.
+
+### Modified Capabilities
+
+- `runtime-endpoints`: Runtime Endpoint Observations and Node Agent status gain normalized platform, runtime-provider, device-resource, and capability-version evidence without changing the Controller-to-Node Runtime Endpoint boundary.
+- `scheduler`: Production eligibility and placement must consume normalized artifact/runtime/device capabilities rather than backend or operating-system strings.
+- `packaging-deployment`: The existing DMG/PKG/launchd requirements become explicitly macOS-profile requirements while generic, secret-free distribution and role compatibility remain cross-profile invariants.
+
+## Impact
+
+- Normative changes to `SPEC.md` platform assumptions, topology, Node identity/capabilities, runtime requirements, scheduling eligibility, packaging/deployment, lifecycle, security storage examples, milestone acceptance, and implementation roadmap.
+- New decision records for platform profiles, CLI/Controller authority, Worker Runtime contract ownership, and capability-provider separation; scoped amendments to existing macOS, runtime, trust, and managed-handover decisions.
+- Follow-up refactoring across root release composition, CLI dependencies and native compilation, Controller command execution, Node Agent adapter injection, worker protobuf ownership/generation, model/runtime vocabulary, configuration defaults, and Console labels.
+- Follow-up CI changes from one Apple Silicon validation job to Linux portable and conformance gates plus macOS host, MLX, Swift, packaging, and publication lanes; future CUDA/Linux host lanes remain additive.
+- Existing public inference APIs, Postgres durable truth, Runtime Endpoint transport semantics, Mac all-in-one behavior, and current macOS distribution guarantees remain in scope and must not regress.
+- This change itself modifies contracts and documentation only; it does not declare the Linux profile supported or change application, schema, runtime, packaging, or CI behavior.

--- a/openspec/changes/establish-platform-portability-contract/specs/host-lifecycle-adapters/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/host-lifecycle-adapters/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Lifecycle Authority Is External To The Managed Process
+Managed Node Agent exclusion, fencing, replacement, and launch authorization SHALL be owned by a host lifecycle actor that remains independent of the Node Agent instance being managed.
+The managed Node Agent MUST NOT be the sole authority that proves its own termination or replacement safety.
+This requirement generalizes `SPEC.md` §§11.2 and 11.4 while preserving ADR 0018.
+
+#### Scenario: Managed Node Agent must be replaced
+- **WHEN** an authorized update or stop operation replaces or terminates a Node Agent
+- **THEN** an external host lifecycle actor retains exclusion and verifies the exact managed instance outcome
+- **AND** owner or managed-process death cannot create overlapping accepted instances
+
+### Requirement: Platform-Neutral Managed Host Lifecycle
+The managed-host lifecycle interface SHALL provide crash-released exclusion, independent observation of durable start policy, host-manager state, and managed-process state, exact-instance fencing to proven stopped state, and one provisional authorized launch.
+Callers MUST NOT need launchd, systemd, container, shell-command, or platform process-identity vocabulary to use the interface correctly.
+Unknown, multiple, unstable, or unverifiable process state SHALL fail closed.
+This requirement generalizes the invariants in `SPEC.md` §11.4.
+
+#### Scenario: Host manager reports inactive
+- **WHEN** a host adapter reports that its managed unit is inactive but cannot prove the captured process instance absent or exited
+- **THEN** the lifecycle interface does not report a coherent stopped state
+
+#### Scenario: Provisional child is launched
+- **WHEN** a lifecycle owner authorizes exactly one start attempt under retained exclusion
+- **THEN** the adapter returns a non-reusable child identity
+- **AND** the child cannot serve until portable lifecycle state records atomic acceptance
+
+### Requirement: Platform Evidence Preserves Portable Outcomes
+Lifecycle evidence SHALL record normalized exclusion, activation, process-observation, fence, and launch outcomes plus optional bounded platform-tagged diagnostic detail.
+Portable lifecycle code MUST NOT branch on platform diagnostic detail.
+Existing macOS lifecycle evidence SHALL remain readable and MUST NOT be rewritten solely to adopt the normalized schema.
+This requirement changes `SPEC.md` §11.4 evidence vocabulary without weakening its retention or safety rules.
+
+#### Scenario: Legacy macOS evidence is inspected
+- **WHEN** Orchard reads an existing launchd-named lifecycle evidence record
+- **THEN** it translates the record to normalized read semantics
+- **AND** it preserves the original durable record unchanged
+
+### Requirement: Platform Native Artifacts Are Isolated
+Host adapters that require native platform code SHALL be built and validated only in compatible platform lanes and MUST NOT be unconditional compile dependencies of the portable umbrella.
+
+#### Scenario: Linux portable compile excludes Darwin helper
+- **WHEN** the portable umbrella compiles on Linux
+- **THEN** Darwin lifecycle and terminal-custody sources are not compiled
+- **AND** their absence does not remove platform-neutral Controller, Node Agent, Shared, or CLI modules

--- a/openspec/changes/establish-platform-portability-contract/specs/operator-command-authority/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/operator-command-authority/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Controller Owns Durable Operator Operations
+An operator operation that authoritatively reads or mutates Controller-owned durable state SHALL execute inside the active Controller through authenticated, authorized, leader-aware, and audited Controller-owned domain operations.
+Console and CLI clients SHALL invoke the same domain authority rather than implement separate Repo mutation paths.
+This requirement changes the local CLI authority described around `SPEC.md` §§7.3, 7.4, 11.4, and 11.9 while preserving ADR 0006's Controller-runtime authority.
+
+#### Scenario: Remote CLI admits a Node
+- **WHEN** an authorized operator invokes Node admission from a portable CLI on another host
+- **THEN** the active Controller executes the admission operation under the same policy and audit contract used by the Console
+
+### Requirement: Portable CLI Is A Client
+The portable CLI SHALL own argument parsing, client authentication, confirmation presentation, and output formatting.
+It MUST NOT require direct Ecto Repo access, Controller application modules, launchd, Darwin native helpers, or local Controller release evaluation for normal operator operations.
+The Controller release MUST NOT load the CLI implementation to obtain Controller authority.
+
+#### Scenario: CLI runs on Linux
+- **WHEN** an operator runs the portable CLI in the Linux portability acceptance environment
+- **THEN** Controller-state commands execute through the authenticated Controller interface
+- **AND** the CLI does not require local database configuration or Apple tooling
+
+### Requirement: Host-Local Operations Belong To Host Tooling
+Service-manager control, managed process fencing, host environment materialization, local trust-store mutation, terminal custody, and host support collection SHALL execute through platform host tooling under the applicable host-lifecycle and privilege contract.
+Mixed commands SHALL separate Controller-owned and host-local operations rather than granting one process both implicit authorities.
+
+#### Scenario: Operator stops a local managed Node Agent
+- **WHEN** an authorized operator requests a host-local managed stop
+- **THEN** platform host tooling executes the lifecycle protocol
+- **AND** the portable CLI does not emulate the host adapter with operating-system conditionals
+
+### Requirement: Narrow Local Bootstrap And Recovery Channel
+Any local Controller-owned bootstrap or recovery channel SHALL be limited to operations that cannot yet use ordinary remote administrator credentials.
+If provided, the channel SHALL invoke the same Controller-owned domain operations, SHALL be locally authenticated and bounded, and MUST NOT become a general direct-Repo fallback.
+
+#### Scenario: First administrator does not yet exist
+- **WHEN** an approved bootstrap operation must create initial Controller authority before remote administrator credentials exist
+- **THEN** the local channel invokes the Controller-owned bootstrap domain operation
+- **AND** subsequent normal operator commands use the authenticated Controller interface

--- a/openspec/changes/establish-platform-portability-contract/specs/packaging-deployment/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/packaging-deployment/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Distribution Requirements Are Platform Profile Scoped
+DMG, PKG, Orchard.app, launchd, Keychain, Apple signing, notarization, and stapling requirements SHALL apply to the macOS distribution profile and SHALL remain release gates for that profile.
+Portable Controller compilation and the Linux Controller profile MUST NOT require those Apple distribution tools.
+Generic secret-free artifact, Product Version, trust, role, rollback, retained-state, and protocol compatibility invariants SHALL remain shared where applicable across profiles.
+This requirement refines `SPEC.md` §11 without changing existing macOS distribution acceptance.
+
+#### Scenario: macOS release is produced
+- **WHEN** Orchard produces a supported macOS distribution
+- **THEN** the existing app, DMG, PKG, launchd, signing, notarization, and retained-state requirements remain applicable
+
+#### Scenario: Linux Controller is compiled and validated
+- **WHEN** Orchard compiles or validates the portable Linux Controller profile
+- **THEN** the workflow does not require Apple packaging or publication tools
+- **AND** it still enforces generic version, trust, secret-free artifact, and protocol compatibility contracts
+
+### Requirement: Platform Runtime Payloads Are Selected Explicitly
+A platform distribution SHALL contain only runtime providers and native host artifacts compatible with its declared profile.
+The macOS all-in-one profile SHALL retain its current Controller, Node Agent, MLX, tokenizer, host lifecycle, and role-selected payload behavior until a separately accepted packaging change supersedes it.
+
+#### Scenario: Mac all-in-one artifact is assembled
+- **WHEN** the existing macOS all-in-one profile is built during this portability migration
+- **THEN** it continues to contain the accepted Mac-compatible role payloads
+- **AND** no future Linux or CUDA payload is required for acceptance

--- a/openspec/changes/establish-platform-portability-contract/specs/platform-profiles/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/platform-profiles/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Portable Core Dependency Contract
+`orchard_shared`, `orchard_controller`, `orchard_node_agent`, and the portable `orchard_cli` SHALL compile and run their platform-neutral tests on Linux validation hosts without Xcode, `xcrun`, launchd, MLX, CUDA, or platform-native helper compilation.
+Portable core modules MUST NOT depend on host adapters, runtime-provider implementations, platform packaging, or vendor SDKs.
+Platform and provider implementations SHALL depend inward on portable contracts.
+This requirement changes the product-wide macOS assumption in `SPEC.md` §§1.4, 2, and 14.
+
+#### Scenario: Controller-only Linux development
+- **WHEN** a contributor compiles and tests the portable Orchard core in the Linux portability validation lane
+- **THEN** the workflow does not require Apple or accelerator toolchains
+- **AND** no platform-native host artifact is compiled as an unconditional umbrella child
+
+### Requirement: Platform Profiles And Support Gates
+Orchard SHALL define platform profiles that bind portable roles to host lifecycle, paths, credential storage, packaging, runtime payloads, and support acceptance evidence.
+The macOS profile SHALL preserve the existing all-in-one Controller, Node Agent, MLX worker, app, DMG, PKG, launchd, and retained-state behavior.
+The first accepted Linux target SHALL be a Controller Host using operator-provided external Postgres and dispatching to admitted macOS MLX Nodes.
+The Linux Controller profile MUST NOT be represented as supported until its Milestone 8 acceptance gates pass.
+This requirement changes `SPEC.md` §§1.1, 1.4, 1.5, 4.1, 11, and 14.
+
+#### Scenario: Mixed Linux Controller and Mac Node cluster
+- **WHEN** the Linux Controller target undergoes mixed-platform acceptance with an admitted macOS MLX Node through an authenticated Runtime Endpoint
+- **THEN** the Controller may schedule compatible work to that Node under the same durable policy and trust requirements as a macOS Controller
+- **AND** the Linux Controller is not required to provide a local accelerator runtime
+
+#### Scenario: Existing Mac all-in-one deployment
+- **WHEN** Orchard runs under the macOS all-in-one profile
+- **THEN** the accepted Mac lifecycle, inference, packaging, signing, and retained-state guarantees remain applicable
+
+### Requirement: Controller Hosts And Schedulable Nodes Are Distinct
+Orchard SHALL model a Controller Host independently from a schedulable Node.
+A Node SHALL represent an admitted host running a Node Agent and advertising versioned runtime and device capabilities; it MUST NOT be defined solely as an Apple Silicon Mac.
+A Controller Host SHALL NOT become schedulable unless it also satisfies the Node admission and capability contract.
+This requirement changes `SPEC.md` §§1.1 and 4.1.
+
+#### Scenario: Linux Controller has no Node Agent
+- **WHEN** a Linux Controller Host runs without an admitted local Node Agent
+- **THEN** it participates in Controller leadership and durable orchestration
+- **AND** the scheduler does not create a local inference candidate for that host
+
+### Requirement: Heterogeneous Runtime Vocabulary
+Orchard SHALL represent artifact format, runtime provider, acceleration implementation, and device resource as distinct concepts.
+Portable policy and scheduling MUST NOT infer one concept from another or branch on an operating-system name.
+This requirement changes `SPEC.md` §§1.5, 4.1, 5.5, 6.4, and 8.2.
+
+#### Scenario: One artifact supports multiple providers
+- **WHEN** a model artifact is compatible with more than one runtime provider or acceleration implementation
+- **THEN** Orchard records and evaluates each compatibility independently
+- **AND** the artifact format is not rewritten as a provider name

--- a/openspec/changes/establish-platform-portability-contract/specs/portability-validation/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/portability-validation/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Required Linux Portable Validation
+Every non-documentation product change that can affect portable Orchard code SHALL run required Linux validation for portable application compilation, static analysis, tests, and coverage without Apple or accelerator toolchains.
+The lane SHALL include the portable tokenizer workflow and Worker Runtime stubs that do not import accelerator implementations.
+
+#### Scenario: Controller source changes
+- **WHEN** a change modifies portable Controller behavior
+- **THEN** required validation runs on Linux
+- **AND** the validation does not provision Xcode, launchd, MLX, or CUDA
+
+### Requirement: Provider-Neutral Conformance Validation
+Orchard SHALL validate Worker Runtime, capability-provider, host-lifecycle invariant, Runtime Endpoint mapping, and scheduler capability contracts with fake or stub implementations that require no accelerator hardware.
+Passing conformance MUST NOT be represented as real-hardware acceptance.
+
+#### Scenario: Capability schema changes
+- **WHEN** a change modifies normalized capability or resource semantics
+- **THEN** provider-neutral conformance validates success, unknown, malformed, stale, and version-skew paths
+
+### Requirement: Platform Acceptance Remains Separate
+macOS host lifecycle, Apple Silicon MLX, Swift app, macOS packaging, and credentialed publication SHALL remain separate applicable lanes.
+Future Linux host and CUDA acceptance SHALL be added as separate lanes when those profiles are proposed.
+Fake or Linux portable validation MUST NOT replace real platform acceptance for platform-specific behavior.
+
+#### Scenario: MLX provider behavior changes
+- **WHEN** a change modifies the MLX runtime implementation or its provider mapping
+- **THEN** provider-neutral conformance runs
+- **AND** the Apple Silicon MLX acceptance lane runs
+
+### Requirement: Validation Triggers Follow Dependencies
+Validation selection SHALL follow owned dependency edges and contract fan-out rather than directory names alone.
+Changes to shared contracts, proto source, root configuration, toolchain, release composition, normative product contracts, or a portable interface SHALL trigger every consuming lane needed to prove compatibility.
+Documentation-only optimization MUST NOT classify a normative `SPEC.md` or OpenSpec contract change as ordinary prose that skips applicable validation.
+
+#### Scenario: Worker protocol changes
+- **WHEN** the provider-neutral Worker Runtime protocol changes
+- **THEN** portable binding and conformance lanes run
+- **AND** every supported runtime-provider acceptance lane runs
+
+### Requirement: Required Gate Aggregates Conditional Lanes
+The required repository gate SHALL fail when any applicable portable, conformance, platform, or packaging lane fails and SHALL succeed when every applicable lane passes or is explicitly inapplicable under the dependency rules.
+
+#### Scenario: Controller-only portable change
+- **WHEN** dependency classification proves that no platform implementation or packaging contract is affected
+- **THEN** the required gate may omit expensive platform lanes
+- **AND** it still requires the Linux portable and applicable conformance lanes

--- a/openspec/changes/establish-platform-portability-contract/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/runtime-endpoints/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Heterogeneous Runtime Capability Observations
+Runtime Endpoint Observations SHALL carry normalized platform, architecture, runtime-provider, capability-version, acceleration, device-resource, memory-domain, runtime-health, and availability evidence required for heterogeneous scheduling.
+The evidence SHALL remain transport-independent and MUST NOT make provider or operating-system strings implicit policy.
+Unknown, malformed, stale, unauthenticated, or version-incompatible required evidence MUST NOT prove capability eligibility.
+This requirement refines `SPEC.md` §§4.1, 4.6.1, and 7.5.
+
+#### Scenario: Mac MLX Node is observed by Linux Controller
+- **WHEN** a Linux Controller receives an authenticated Runtime Endpoint Observation from an admitted macOS MLX Node
+- **THEN** it records normalized platform, provider, device, memory, health, and capacity evidence
+- **AND** transport or host differences do not change Runtime Endpoint semantics
+
+#### Scenario: Older Node Agent omits additive capabilities
+- **WHEN** an older Node Agent returns an observation without newly additive capability fields
+- **THEN** the Controller decodes the observation without crashing
+- **AND** absent evidence does not affirm compatibility for a requirement it must prove
+
+### Requirement: Node And Worker Capability Evidence Remain Distinct
+Runtime Endpoint Observations SHALL distinguish Node capability-provider evidence from runtime-provider evidence.
+Node hardware health MUST NOT by itself prove runtime initialization, and runtime readiness MUST NOT fabricate host device inventory.
+
+#### Scenario: Device exists but runtime cannot initialize
+- **WHEN** a capability provider reports a healthy device and the selected runtime provider reports initialization unavailable
+- **THEN** the Runtime Endpoint Observation preserves both facts
+- **AND** the endpoint does not claim executable capacity from device presence alone

--- a/openspec/changes/establish-platform-portability-contract/specs/scheduler/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/scheduler/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Normalized Runtime And Device Eligibility
+Production scheduling SHALL match model artifact requirements to fresh authenticated runtime-provider capabilities, acceleration capabilities, device resources, memory domains, and Controller policy.
+Scheduling MUST NOT authorize work solely from operating-system names, `worker_backend` strings, transport type, or inferred provider defaults.
+Missing, malformed, stale, conflicting, or version-incompatible required capability evidence SHALL fail closed with stable provider-neutral explanation reasons.
+This requirement refines `SPEC.md` §§5.5, 5.7, 5.9, and 7.3.5.
+
+#### Scenario: Artifact supports MLX and future CUDA providers
+- **WHEN** an artifact declares compatibility with multiple runtime-provider requirement sets
+- **THEN** the scheduler evaluates each candidate against its normalized provider and device evidence
+- **AND** it does not rewrite artifact format as `mlx` or `cuda`
+
+#### Scenario: Provider string exists without capabilities
+- **WHEN** an observation contains a provider identifier but omits required format, feature, device, or memory capability evidence
+- **THEN** the scheduler rejects that capability match
+- **AND** it does not infer eligibility from the provider identifier
+
+### Requirement: Memory Eligibility Uses Memory Domains
+Scheduler memory eligibility and ranking SHALL use normalized resource identities and memory domains such as unified, device, and system memory with fresh capacity and headroom evidence.
+Provider-specific working-set or VRAM fields MAY feed adapter normalization but MUST NOT be required by portable scheduling.
+
+#### Scenario: Unified-memory and discrete-GPU candidates are compared
+- **WHEN** compatible candidates report normalized unified-memory and device-memory resources
+- **THEN** each candidate is evaluated against the model requirement applicable to its memory domain
+- **AND** portable scheduling does not assume that all accelerators share Apple unified-memory semantics

--- a/openspec/changes/establish-platform-portability-contract/specs/worker-runtime-providers/spec.md
+++ b/openspec/changes/establish-platform-portability-contract/specs/worker-runtime-providers/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Provider-Neutral Worker Runtime Contract Ownership
+The Worker Runtime protocol source, version policy, generated bindings, and conformance fixtures SHALL be owned outside any runtime-provider implementation.
+Supported language bindings SHALL be generated from one normative source, and validation SHALL fail when committed generated bindings drift.
+This requirement refines `SPEC.md` §§4.9, 4.10, and 7.5.2a.
+
+#### Scenario: MLX provider evolves
+- **WHEN** the MLX runtime provider changes its implementation without changing Worker Runtime semantics
+- **THEN** the provider does not redefine or privately fork the Worker Runtime contract
+
+### Requirement: Versioned Runtime Capability Negotiation
+A Worker Runtime provider SHALL report protocol version, provider identity and version, supported artifact formats, runtime features, acceleration implementations, device-resource bindings, memory semantics, concurrency, and cache capabilities before those facts authorize work.
+Unknown, malformed, incompatible, or absent required capability evidence MUST NOT be treated as affirmative compatibility.
+This requirement changes the MLX-default assumptions in `SPEC.md` §§1.5, 4.6.1, 5.5, and 7.5.2a.
+
+#### Scenario: New Node Agent contacts an older worker
+- **WHEN** an older worker omits additive capability negotiation fields
+- **THEN** the Node Agent decodes the response without crashing
+- **AND** it does not claim capabilities the worker did not prove
+
+### Requirement: Normalized Runtime Resources And Failures
+Worker Runtime contracts SHALL express device resources and memory through normalized identities, memory domains, capacity, reservation, allocation, and observation freshness.
+Portable durable failure state SHALL use provider-neutral categories, while bounded provider-specific codes MAY be retained as diagnostics.
+Provider-specific codes MUST NOT become scheduler policy or new durable public categories without an explicit contract change.
+This requirement changes `SPEC.md` §§4.6.1, 5.7, 7.5.2a, and 10.10.
+
+#### Scenario: MLX reports unified memory
+- **WHEN** an MLX worker reports Apple unified-memory capacity and headroom
+- **THEN** the Node Agent maps it to a normalized unified memory resource
+- **AND** portable scheduling does not require an Apple working-set field name
+
+#### Scenario: Provider cannot initialize
+- **WHEN** a runtime provider reports a provider-specific initialization failure
+- **THEN** Orchard records the provider-neutral runtime-unavailable category required by policy
+- **AND** any provider-specific detail remains bounded diagnostic evidence
+
+### Requirement: Node Agent Owns Worker Processes
+The Node Agent SHALL continue to supervise Worker Runtime subprocesses, model loading, execution, cancellation, active allocation, diagnostics, and cleanup.
+The Controller MUST communicate through the Node Agent Runtime Endpoint rather than directly managing runtime-provider processes.
+
+#### Scenario: Runtime provider crashes
+- **WHEN** a Worker Runtime provider process crashes during local operation
+- **THEN** the Node Agent applies the portable worker supervision and failure contract
+- **AND** the Controller observes the result through Runtime Endpoint semantics
+
+### Requirement: Runtime Provider Conformance
+Every supported runtime provider SHALL pass the same provider-neutral conformance scenarios for negotiation, health, load, unload, generation, streaming, cancellation, capacity, failure normalization, and version skew.
+Hardware-specific acceptance SHALL supplement and MUST NOT replace provider-neutral conformance.
+
+#### Scenario: Provider is proposed for support
+- **WHEN** a runtime provider is added to a supported platform profile
+- **THEN** it passes provider-neutral conformance
+- **AND** it passes the applicable real-hardware acceptance lane

--- a/openspec/changes/establish-platform-portability-contract/tasks.md
+++ b/openspec/changes/establish-platform-portability-contract/tasks.md
@@ -1,0 +1,29 @@
+## 1. Reconcile The Normative Contract
+
+- [x] 1.1 Amend `SPEC.md` to define portable invariants, platform profiles, Controller Hosts versus schedulable Nodes, heterogeneous runtime vocabulary, the first Linux Controller/macOS MLX Node target, and a vNext platform-expansion milestone without rewriting completed Mac acceptance or claiming unimplemented support.
+- [x] 1.2 Add a platform-profiles decision record covering dependency direction, Mac all-in-one preservation, the Linux Controller target with external Postgres, the support acceptance gate, and deferred Linux Node packaging and runtime choices.
+- [x] 1.3 Add a decision record that assigns durable operator authority to Controller-owned authenticated operations, portable client behavior to the CLI, and lifecycle authority to platform host tooling.
+- [x] 1.4 Add a decision record for provider-neutral Worker Runtime contract ownership, generated bindings, version negotiation, and compatibility policy.
+- [x] 1.5 Add a decision record separating host capability providers from runtime providers and defining normalized device and memory-domain vocabulary.
+- [x] 1.6 Amend decisions 0001, 0003, 0006, 0011, 0012, 0013, and 0018 only where platform scope or mixed-platform acceptance changes, preserving their security, transport, scheduling, release, and lifecycle invariants.
+- [x] 1.7 Reconcile architecture, tooling, local-development, packaging, glossary, and contributor documentation with the accepted profile, support status, and ownership terms.
+- [x] 1.8 Run strict validation for this change and the complete OpenSpec corpus, then review the resulting main and delta specs for incomplete or contradictory prose.
+- [ ] 1.9 Obtain collaborator review of the contract and decisions before any implementation child change begins.
+
+## Follow-up Delivery Boundaries
+
+Implementation is outside this contract-only change.
+Umbrella issue #266 owns the dependency map, and issue #267 owns this contract reconciliation.
+After contract acceptance, create focused native child issues and separate OpenSpec changes as applicable for:
+
+1. Darwin native-helper eviction from portable CLI compilation.
+2. Dependency-aware Linux portability and provider-neutral conformance validation.
+3. Controller release decoupling from CLI implementation.
+4. Provider-neutral Worker Runtime protocol ownership and generated bindings.
+5. Additive normalized runtime, acceleration, device, memory-domain, and failure contracts.
+6. Capability-provider implementations and conformance.
+7. Managed host-lifecycle adapters that preserve ADR 0018.
+8. Incremental CLI command-family migration to Controller-owned authority.
+9. Linux Controller release and mixed-platform acceptance.
+
+Do not represent these follow-up boundaries as completed tasks in this change.

--- a/packaging/pkg/README.md
+++ b/packaging/pkg/README.md
@@ -5,6 +5,12 @@ Do not layer app-owned service mutations over a host with the `com.orchard.pkg` 
 The app lifecycle refuses that takeover and keeps the PKG's role selection, launchd labels, wrapper sources, and installed-path policy aligned through `packaging/service-lifecycle.json` and contract tests.
 See `packaging/dmg/README.md` for the app-owned path.
 
+This runbook describes the supported Apple Silicon macOS packaging profile.
+The accepted Linux Controller profile is a Milestone 8 target with separate
+headless host lifecycle and packaging acceptance still required.
+Nothing in this runbook establishes Linux support or makes launchd, Keychain,
+PKG paths, or Apple signing part of the portable Controller contract.
+
 Current packaged installs use a universal PKG payload with role selection for
 `all`, `controller`, and `node-agent` hosts. Controller-bearing installs require
 an **external PostgreSQL** server today; managed Postgres is not available in


### PR DESCRIPTION
## Context

Issue #266 accepted platform profiles and a portable-core direction for Orchard.
This PR turns that owner decision into a focused contract that collaborators can review before any portability implementation begins.

The supported v1 profile remains Apple Silicon macOS.
The first accepted expansion target is a headless Linux Controller with external Postgres and admitted macOS MLX Nodes, but it is not a supported profile until the new Milestone 8 acceptance gates pass.

## What changed

- Added the focused `establish-platform-portability-contract` OpenSpec change with eight completed contract tasks and a separate collaborator-review gate.
- Updated `SPEC.md` with portable dependency rules, platform profiles, Controller Host and Node separation, normalized runtime and device vocabulary, provider-neutral Worker Runtime ownership, and Milestone 8 acceptance.
- Added ADRs for platform profiles, Controller-owned operator authority, provider-neutral Worker Runtime contracts, and separate host capability and runtime providers.
- Narrowly amended existing transport, admission, CLI, bootstrap, Peer Grant, dispatch-capacity, and managed-handover ADRs to preserve their current invariants across future profiles.
- Reconciled architecture, contributor, tooling, local-development, packaging, decision-index, and glossary documentation.

## Intentionally out of scope

- Application, schema, runtime, protocol, scheduler, packaging, or CI behavior changes
- Linux release or packaging implementation
- Darwin helper relocation or CLI command migration
- Linux Node, CUDA, ROCm, or GPU discovery support

## Validation

Passed:

```text
OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate establish-platform-portability-contract --type change --strict --no-interactive
OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive
git diff --cached --check
```

The full OpenSpec corpus passed with 25 items and 0 failures.
I also reviewed the main and delta specs for placeholder prose and corrected scenarios that prematurely described the Linux target as supported.

## Risk Assessment

✅ **Low**

- The change is limited to normative contracts and documentation.
- It does not change application, persistence, runtime, packaging, public API, or CI behavior.
- Existing macOS acceptance and active security, lifecycle, transport, scheduling, and release-governance invariants remain explicit.
- The main residual risk is architectural ambiguity in a broad future migration, which is why implementation remains split into later child issues and separately reviewed changes.

Part of #266.
Closes #267.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790063621&installation_model_id=428414&pr_number=268&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F268&signature=6296aac609e5f44b93b19a4fb127f2742529453767105a7a6b3d4fd8ffec1d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR establishes Orchard’s portability contract while retaining Apple Silicon macOS as the sole supported v1 profile.

- Defines a future Linux Controller profile using external Postgres and admitted macOS MLX Nodes, gated by Milestone 8 acceptance.
- Separates portable core, platform lifecycle, capability discovery, runtime-provider, packaging, and operator-authority responsibilities.
- Adds provider-neutral runtime and device vocabulary, validation requirements, ADRs, and OpenSpec capabilities.
- Preserves existing macOS packaging, security, transport, scheduling, lifecycle, and release guarantees.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because its documentation and normative contracts consistently preserve current macOS support while gating the future Linux Controller profile on explicit acceptance.

No concrete contradiction, unsupported support claim, authority-path break, or prematurely completed implementation gate remains in the accepted review findings.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| SPEC.md | Establishes the normative platform-profile, portable-core, authority, runtime-provider, capability, and Milestone 8 acceptance contracts without declaring Linux support. |
| openspec/changes/establish-platform-portability-contract/design.md | Defines the portability architecture, migration boundaries, rejected alternatives, risks, and follow-up delivery plan. |
| openspec/changes/establish-platform-portability-contract/specs/platform-profiles/spec.md | Specifies portable dependency direction, profile support gates, distinct Controller and Node roles, and heterogeneous runtime vocabulary. |
| openspec/changes/establish-platform-portability-contract/specs/operator-command-authority/spec.md | Assigns durable operations to Controller-owned authority while preserving bounded local bootstrap and host-local tooling responsibilities. |
| openspec/changes/establish-platform-portability-contract/specs/portability-validation/spec.md | Defines future Linux portability, provider-neutral conformance, platform-specific acceptance, and dependency-aware validation gates. |
| openspec/changes/establish-platform-portability-contract/specs/worker-runtime-providers/spec.md | Establishes provider-neutral protocol ownership, capability negotiation, normalized resources and failures, and conformance requirements. |
| docs/decisions/0023-platform-profiles-and-portable-core.md | Records the durable decision to preserve the supported macOS profile while accepting a gated Linux Controller expansion target. |
| docs/decisions/0024-controller-owned-operator-authority.md | Records the target operator-authority boundary and incremental migration from local CLI implementation authority. |
| docs/decisions/0025-provider-neutral-worker-runtime-contract.md | Records neutral ownership and compatibility expectations for Worker Runtime contracts. |
| docs/decisions/0026-separate-capability-and-runtime-providers.md | Separates host-observed device authority from runtime initialization and execution authority. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[Public and Operator Clients] --> Controller[Portable Controller Core]
  CLI[Portable orchardctl Client] --> Controller
  Controller --> DB[(External or Profile-Managed Postgres)]
  Controller --> RE[Runtime Endpoint Interface]
  RE --> Node[Admitted Node Agent]
  Node --> CP[Host Capability Provider]
  Node --> RP[Worker Runtime Provider]
  Node --> HA[Host Lifecycle Adapter]
  RP --> MLX[macOS MLX Runtime]
  PP[Platform Profile] --> Controller
  PP --> Node
  PP --> HA
  PP --> RP
  M8[Milestone 8 Acceptance] -. gates support .-> PP
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: define platform portability contra..."](https://github.com/kapitan-ai/orchard/commit/d3eca022d753165cf8312f203f25c4ee4ba56d57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55974500)</sub>

<!-- /greptile_comment -->