### PR TITLE
fix(api): accept SSE-only streaming requests

### DIFF
--- a/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
+++ b/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
@@ -1,0 +1,76 @@
+defmodule Orchard.API.InferenceAccepts do
+  @moduledoc false
+
+  import Plug.Conn
+
+  alias Orchard.API.ErrorHelpers
+  alias Plug.Conn.Utils
+
+  @json "application/json"
+  @event_stream "text/event-stream"
+
+  @spec init(keyword()) :: keyword()
+  def init(opts), do: opts
+
+  @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    if acceptable?(conn) do
+      put_private(conn, :phoenix_format, "json")
+    else
+      conn
+      |> ErrorHelpers.send_error(
+        :not_acceptable,
+        "No acceptable response media type was requested",
+        "invalid_request_error",
+        code: "not_acceptable"
+      )
+      |> halt()
+    end
+  end
+
+  defp acceptable?(conn) do
+    accepted_types = if streaming?(conn), do: [@json, @event_stream], else: [@json]
+
+    case get_req_header(conn, "accept") do
+      [] -> true
+      headers -> Enum.any?(headers, &header_accepts?(&1, accepted_types))
+    end
+  end
+
+  defp streaming?(%Plug.Conn{body_params: %{"stream" => true}}), do: true
+  defp streaming?(_conn), do: false
+
+  defp header_accepts?(header, accepted_types) do
+    header
+    |> Utils.list()
+    |> Enum.any?(&media_range_accepts?(&1, accepted_types))
+  end
+
+  defp media_range_accepts?(media_range, accepted_types) do
+    case Utils.media_type(media_range) do
+      {:ok, type, subtype, params} ->
+        positive_quality?(params) and
+          Enum.any?(accepted_types, &matches_media_range?(&1, type, subtype))
+
+      :error ->
+        false
+    end
+  end
+
+  defp positive_quality?(%{"q" => quality}) do
+    case Float.parse(quality) do
+      {value, _rest} -> value > 0
+      :error -> true
+    end
+  end
+
+  defp positive_quality?(_params), do: true
+
+  defp matches_media_range?(media_type, "*", "*"), do: media_type in [@json, @event_stream]
+
+  defp matches_media_range?(media_type, type, "*") do
+    String.starts_with?(media_type, type <> "/")
+  end
+
+  defp matches_media_range?(media_type, type, subtype), do: media_type == type <> "/" <> subtype
+end

--- a/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
+++ b/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
@@ -1,6 +1,8 @@
 defmodule Orchard.API.InferenceAccepts do
   @moduledoc false
 
+  @behaviour Plug
+
   import Plug.Conn
 
   alias Orchard.API.ErrorHelpers
@@ -9,9 +11,11 @@ defmodule Orchard.API.InferenceAccepts do
   @json "application/json"
   @event_stream "text/event-stream"
 
+  @impl Plug
   @spec init(keyword()) :: keyword()
   def init(opts), do: opts
 
+  @impl Plug
   @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
   def call(conn, _opts) do
     if acceptable?(conn) do
@@ -66,7 +70,7 @@ defmodule Orchard.API.InferenceAccepts do
 
   defp positive_quality?(_params), do: true
 
-  defp matches_media_range?(media_type, "*", "*"), do: media_type in [@json, @event_stream]
+  defp matches_media_range?(_media_type, "*", "*"), do: true
 
   defp matches_media_range?(media_type, type, "*") do
     String.starts_with?(media_type, type <> "/")

--- a/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
+++ b/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
@@ -63,7 +63,7 @@ defmodule Orchard.API.InferenceAccepts do
 
   defp positive_quality?(%{"q" => quality}) do
     case Float.parse(quality) do
-      {value, ""} -> value > 0
+      {value, ""} -> value > 0 and value <= 1
       _invalid -> false
     end
   end

--- a/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
+++ b/apps/orchard_controller/lib/orchard/api/inference_accepts.ex
@@ -63,8 +63,8 @@ defmodule Orchard.API.InferenceAccepts do
 
   defp positive_quality?(%{"q" => quality}) do
     case Float.parse(quality) do
-      {value, _rest} -> value > 0
-      :error -> true
+      {value, ""} -> value > 0
+      _invalid -> false
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -10,9 +10,12 @@ defmodule Orchard.API.Router do
   end
 
   pipeline :authenticated_api do
-    plug(:accepts, ["json"])
     plug(Orchard.API.RequestContext)
     plug(Orchard.API.LicensePlug)
+  end
+
+  pipeline :inference_api do
+    plug(Orchard.API.InferenceAccepts)
   end
 
   pipeline :admin_api do
@@ -69,9 +72,13 @@ defmodule Orchard.API.Router do
   end
 
   scope "/v1", Orchard.API do
-    pipe_through(:authenticated_api)
-
+    pipe_through([:api, :authenticated_api])
     get("/models", ModelsController, :index)
+  end
+
+  scope "/v1", Orchard.API do
+    pipe_through([:inference_api, :authenticated_api])
+
     post("/chat/completions", ChatCompletionsController, :create)
     post("/responses", ResponsesController, :create)
   end

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -76,6 +76,14 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     |> Router.call(Router.init([]))
   end
 
+  defp post_chat_endpoint(params, token, accept) do
+    build_conn()
+    |> put_req_header("accept", accept)
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> post("/v1/chat/completions", params)
+  end
+
   # Parse SSE response body into a list of parsed events.
   # Returns [{:data, decoded_map}, {:done, nil}, {:error, decoded_map}]
   defp parse_sse_body(body) do
@@ -258,6 +266,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     end
 
     @tag :db
+    @tag :live
     test "successful metadata-capture request returns JSON without retaining the response", %{
       bundle: bundle
     } do
@@ -284,12 +293,13 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       grant_active_models!(tenant)
 
       conn =
-        post_chat(
+        post_chat_endpoint(
           %{
             "model" => "persist-non-stream-model@v1",
             "messages" => [%{"role" => "user", "content" => "hello"}]
           },
-          token
+          token,
+          "application/json"
         )
 
       assert conn.status == 200
@@ -1186,80 +1196,86 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
   end
 
   describe "POST /v1/chat/completions (streaming happy path)" do
-    @tag :db
-    test "SPEC.md §7.2.5 keeps one public ID across SSE chunks and persistence", %{
-      bundle: bundle
-    } do
-      {:ok, _model} =
-        Orchard.Models.create_model(%{
-          model_id: "test-stream-model",
-          version: "v1",
-          display_name: "Test Stream Model",
-          artifact_uri: "file:///tmp/test-stream-model",
-          artifact_sha256: bundle.hash,
-          state: :active,
-          format: "mlx",
-          backend: "mlx",
-          capabilities: ["chat"],
-          artifact_size_bytes: 1024,
-          resident_memory_bytes: 2048,
-          kv_cache_bytes_per_token: 128,
-          prefill_workspace_bytes_per_token: 64,
-          max_context_tokens: 131_072
-        })
+    for accept <- ["text/event-stream", "application/json"] do
+      @tag :db
+      @tag :live
+      test "SPEC.md §7.2.5 keeps one public ID across SSE chunks and persistence with Accept: #{accept}",
+           %{bundle: bundle} do
+        {:ok, _model} =
+          Orchard.Models.create_model(%{
+            model_id: "test-stream-model",
+            version: "v1",
+            display_name: "Test Stream Model",
+            artifact_uri: "file:///tmp/test-stream-model",
+            artifact_sha256: bundle.hash,
+            state: :active,
+            format: "mlx",
+            backend: "mlx",
+            capabilities: ["chat"],
+            artifact_size_bytes: 1024,
+            resident_memory_bytes: 2048,
+            kv_cache_bytes_per_token: 128,
+            prefill_workspace_bytes_per_token: 64,
+            max_context_tokens: 131_072
+          })
 
-      conn =
-        post_chat(%{
-          "model" => "test-stream-model@v1",
-          "messages" => [%{"role" => "user", "content" => "hello"}],
-          "stream" => true
-        })
+        conn =
+          post_chat_endpoint(
+            %{
+              "model" => "test-stream-model@v1",
+              "messages" => [%{"role" => "user", "content" => "hello"}],
+              "stream" => true
+            },
+            default_api_token!(),
+            unquote(accept)
+          )
 
-      # SSE started (chunked 200)
-      assert conn.status == 200
+        # SSE started (chunked 200)
+        assert conn.status == 200
 
-      assert get_resp_header(conn, "content-type")
-             |> Enum.any?(&String.contains?(&1, "text/event-stream"))
+        assert get_resp_header(conn, "content-type")
+               |> Enum.any?(&String.contains?(&1, "text/event-stream"))
 
-      # Parse SSE body
-      events = parse_sse_body(conn.resp_body)
+        # Parse SSE body
+        events = parse_sse_body(conn.resp_body)
 
-      # Should have data chunks followed by [DONE]
-      data_events = Enum.filter(events, fn {type, _} -> type == :data end)
-      done_events = Enum.filter(events, fn {type, _} -> type == :done end)
+        # Should have data chunks followed by [DONE]
+        data_events = Enum.filter(events, fn {type, _} -> type == :data end)
+        done_events = Enum.filter(events, fn {type, _} -> type == :done end)
 
-      chunk_ids = Enum.map(data_events, fn {:data, chunk} -> Map.fetch!(chunk, "id") end)
-      assert [public_id] = Enum.uniq(chunk_ids)
-      assert String.starts_with?(public_id, "chatcmpl-")
-      assert %{public_id: ^public_id} = Requests.get_request_by_public_id(public_id)
+        chunk_ids = Enum.map(data_events, fn {:data, chunk} -> Map.fetch!(chunk, "id") end)
+        assert [public_id] = Enum.uniq(chunk_ids)
+        assert String.starts_with?(public_id, "chatcmpl-")
+        assert %{public_id: ^public_id} = Requests.get_request_by_public_id(public_id)
 
-      # At least: role chunk + content chunk(s) + finish chunk
-      assert length(data_events) >= 3
+        # At least: role chunk + content chunk(s) + finish chunk
+        assert length(data_events) >= 3
 
-      # First chunk should be the role marker
-      {:data, first_chunk} = List.first(data_events)
-      assert first_chunk["object"] == "chat.completion.chunk"
-      assert first_chunk["model"] == "test-stream-model@v1"
-      [first_choice] = first_chunk["choices"]
-      assert first_choice["delta"]["role"] == "assistant"
+        # First chunk should be the role marker
+        {:data, first_chunk} = List.first(data_events)
+        assert first_chunk["object"] == "chat.completion.chunk"
+        assert first_chunk["model"] == "test-stream-model@v1"
+        [first_choice] = first_chunk["choices"]
+        assert first_choice["delta"]["role"] == "assistant"
 
-      # Last data chunk should have a finish_reason
-      {:data, last_chunk} = List.last(data_events)
-      [last_choice] = last_chunk["choices"]
-      assert last_choice["finish_reason"] != nil
+        # Last data chunk should have a finish_reason
+        {:data, last_chunk} = List.last(data_events)
+        [last_choice] = last_chunk["choices"]
+        assert last_choice["finish_reason"] != nil
 
-      # Stream ends with [DONE]
-      assert done_events == [{:done, nil}]
+        # Stream ends with [DONE]
+        assert done_events == [{:done, nil}]
 
-      # No error events
-      error_events = Enum.filter(events, fn {type, _} -> type == :error end)
-      assert error_events == []
+        # No error events
+        error_events = Enum.filter(events, fn {type, _} -> type == :error end)
+        assert error_events == []
 
-      request = Requests.get_request_by_public_id(first_chunk["id"])
-      assert_text_commitment!(request)
+        request = Requests.get_request_by_public_id(first_chunk["id"])
+        assert_text_commitment!(request)
 
-      assert Sentry.Context.get_all().extra == %{}
-      assert Sentry.Context.get_all().breadcrumbs == []
+        assert Sentry.Context.get_all().extra == %{}
+        assert Sentry.Context.get_all().breadcrumbs == []
+      end
     end
   end
 

--- a/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
+++ b/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
@@ -141,6 +141,36 @@ defmodule Orchard.API.EndpointRegressionTest do
       end
     end
 
+    test "inference Accept wildcards and zero quality remain stream-aware", %{conn: conn} do
+      token = create_api_token!("inference-accept-ranges")
+
+      for {path, base_params} <- [
+            {"/v1/chat/completions",
+             %{
+               "model" => "nonexistent@v1",
+               "messages" => [%{"role" => "user", "content" => "hello"}]
+             }},
+            {"/v1/responses", %{"model" => "nonexistent@v1", "input" => "hello"}}
+          ],
+          {accept, stream?, expected_status} <- [
+            {"*/*", false, 404},
+            {"text/*", true, 404},
+            {"text/*", false, 406},
+            {"application/json;q=0", false, 406}
+          ] do
+        params = if stream?, do: Map.put(base_params, "stream", true), else: base_params
+
+        response =
+          conn
+          |> put_req_header("accept", accept)
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Bearer #{token}")
+          |> post(path, params)
+
+        assert response.status == expected_status
+      end
+    end
+
     test "authenticated form-urlencoded API input remains invalid", %{conn: conn} do
       {:ok, tenant} =
         Orchard.Governance.create_tenant(%{

--- a/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
+++ b/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
@@ -171,6 +171,32 @@ defmodule Orchard.API.EndpointRegressionTest do
       end
     end
 
+    test "streaming inference rejects malformed Accept quality values", %{conn: conn} do
+      token = create_api_token!("malformed-inference-accept-quality")
+
+      for {path, params} <- [
+            {"/v1/chat/completions",
+             %{
+               "model" => "nonexistent@v1",
+               "messages" => [%{"role" => "user", "content" => "hello"}],
+               "stream" => true
+             }},
+            {"/v1/responses",
+             %{"model" => "nonexistent@v1", "input" => "hello", "stream" => true}}
+          ],
+          quality <- ["bogus", "0.5junk"] do
+        response =
+          conn
+          |> put_req_header("accept", "text/event-stream;q=#{quality}")
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Bearer #{token}")
+          |> post(path, params)
+
+        assert response.status == 406
+        assert Jason.decode!(response.resp_body)["error"]["code"] == "not_acceptable"
+      end
+    end
+
     test "authenticated form-urlencoded API input remains invalid", %{conn: conn} do
       {:ok, tenant} =
         Orchard.Governance.create_tenant(%{

--- a/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
+++ b/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
@@ -171,7 +171,7 @@ defmodule Orchard.API.EndpointRegressionTest do
       end
     end
 
-    test "streaming inference rejects malformed Accept quality values", %{conn: conn} do
+    test "streaming inference rejects invalid Accept quality values", %{conn: conn} do
       token = create_api_token!("malformed-inference-accept-quality")
 
       for {path, params} <- [
@@ -184,7 +184,7 @@ defmodule Orchard.API.EndpointRegressionTest do
             {"/v1/responses",
              %{"model" => "nonexistent@v1", "input" => "hello", "stream" => true}}
           ],
-          quality <- ["bogus", "0.5junk"] do
+          quality <- ["bogus", "0.5junk", "2"] do
         response =
           conn
           |> put_req_header("accept", "text/event-stream;q=#{quality}")

--- a/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
+++ b/apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
@@ -44,6 +44,103 @@ defmodule Orchard.API.EndpointRegressionTest do
       assert Jason.decode!(conn.resp_body)["error"]["type"] == "authentication_error"
     end
 
+    test "streaming chat request accepts text/event-stream through the endpoint", %{conn: conn} do
+      token = create_api_token!("streaming-chat-accept")
+
+      conn =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/v1/chat/completions", %{
+          "model" => "nonexistent@v1",
+          "messages" => [%{"role" => "user", "content" => "hello"}],
+          "stream" => true
+        })
+
+      assert conn.status == 404
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "model_not_found"
+    end
+
+    test "streaming responses request accepts text/event-stream through the endpoint", %{
+      conn: conn
+    } do
+      token = create_api_token!("streaming-responses-accept")
+
+      conn =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/v1/responses", %{
+          "model" => "nonexistent@v1",
+          "input" => "hello",
+          "stream" => true
+        })
+
+      assert conn.status == 404
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "model_not_found"
+    end
+
+    test "inference endpoints return an OpenAI 406 for unsupported Accept media types", %{
+      conn: conn
+    } do
+      token = create_api_token!("unsupported-inference-accept")
+
+      for {path, params} <- [
+            {"/v1/chat/completions",
+             %{
+               "model" => "nonexistent@v1",
+               "messages" => [%{"role" => "user", "content" => "hello"}],
+               "stream" => true
+             }},
+            {"/v1/responses",
+             %{"model" => "nonexistent@v1", "input" => "hello", "stream" => true}}
+          ] do
+        response =
+          conn
+          |> put_req_header("accept", "application/xml")
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Bearer #{token}")
+          |> post(path, params)
+
+        assert response.status == 406
+        assert get_resp_header(response, "content-type") |> hd() =~ "application/json"
+
+        assert Jason.decode!(response.resp_body)["error"] == %{
+                 "message" => "No acceptable response media type was requested",
+                 "type" => "invalid_request_error",
+                 "param" => nil,
+                 "code" => "not_acceptable"
+               }
+      end
+    end
+
+    test "non-streaming inference rejects text/event-stream without a JSON alternative", %{
+      conn: conn
+    } do
+      token = create_api_token!("non-streaming-event-stream-accept")
+
+      for {path, params} <- [
+            {"/v1/chat/completions",
+             %{
+               "model" => "nonexistent@v1",
+               "messages" => [%{"role" => "user", "content" => "hello"}]
+             }},
+            {"/v1/responses", %{"model" => "nonexistent@v1", "input" => "hello"}}
+          ] do
+        response =
+          conn
+          |> put_req_header("accept", "text/event-stream")
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Bearer #{token}")
+          |> post(path, params)
+
+        assert response.status == 406
+        assert Jason.decode!(response.resp_body)["error"]["code"] == "not_acceptable"
+      end
+    end
+
     test "authenticated form-urlencoded API input remains invalid", %{conn: conn} do
       {:ok, tenant} =
         Orchard.Governance.create_tenant(%{
@@ -103,5 +200,18 @@ defmodule Orchard.API.EndpointRegressionTest do
       assert conn.status == 200
       assert get_resp_header(conn, "content-type") |> hd() =~ "text/html"
     end
+  end
+
+  defp create_api_token!(slug) do
+    {:ok, tenant} =
+      Orchard.Governance.create_tenant(%{
+        slug: "#{slug}-#{System.unique_integer([:positive])}",
+        name: slug
+      })
+
+    {:ok, %{token: token}} =
+      Orchard.Governance.create_api_key(tenant.id, %{name: "#{slug} key"})
+
+    token
   end
 end

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -41,6 +41,14 @@ defmodule Orchard.API.ResponsesControllerTest do
     |> Router.call(Router.init([]))
   end
 
+  defp post_responses_endpoint(params, token, accept) do
+    build_conn()
+    |> put_req_header("accept", accept)
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> post("/v1/responses", params)
+  end
+
   setup do
     previous_orchestrator =
       Application.get_env(:orchard_controller, :api_responses_orchestrator_impl)
@@ -171,6 +179,7 @@ defmodule Orchard.API.ResponsesControllerTest do
     assert Repo.aggregate(Request, :count, :id) == before_count
   end
 
+  @tag :live
   test "successful non-stream request returns response payload and persists responses endpoint",
        %{bundle: bundle} do
     %{token: token, tenant: tenant} = create_api_key_with_token!("responses-success")
@@ -201,7 +210,7 @@ defmodule Orchard.API.ResponsesControllerTest do
     grant_active_models!(tenant)
 
     conn =
-      post_responses(
+      post_responses_endpoint(
         %{
           "model" => "responses-success-model@v1",
           "instructions" => "Be helpful",
@@ -215,7 +224,8 @@ defmodule Orchard.API.ResponsesControllerTest do
           "metadata" => %{"trace" => "abc"},
           "store" => false
         },
-        token
+        token,
+        "application/json"
       )
 
     assert conn.status == 200
@@ -862,136 +872,142 @@ defmodule Orchard.API.ResponsesControllerTest do
 
   # -- Streaming tests -------------------------------------------------------
 
-  test "successful stream emits typed events in correct order", %{bundle: bundle} do
-    %{token: token, tenant: tenant} =
-      create_api_key_with_token!("responses-stream-success")
+  for accept <- ["text/event-stream", "application/json"] do
+    @tag :live
+    test "successful stream emits typed events in correct order with Accept: #{accept}", %{
+      bundle: bundle
+    } do
+      %{token: token, tenant: tenant} =
+        create_api_key_with_token!("responses-stream-success")
 
-    tenant
-    |> Tenant.changeset(%{request_body_capture_mode: :full})
-    |> Repo.update!()
+      tenant
+      |> Tenant.changeset(%{request_body_capture_mode: :full})
+      |> Repo.update!()
 
-    model =
-      create_model!(%{
-        model_id: "responses-stream-model",
-        version: "v1",
-        display_name: "Responses Stream Model",
-        artifact_uri: "file:///tmp/responses-stream-model",
-        artifact_sha256: bundle.hash,
-        artifact_source_uri: "file:///tmp/responses-stream-model",
-        state: :active,
-        format: "mlx",
-        backend: "mlx",
-        capabilities: ["chat"],
-        artifact_size_bytes: 1024,
-        resident_memory_bytes: 2048,
-        kv_cache_bytes_per_token: 128,
-        prefill_workspace_bytes_per_token: 64,
-        max_context_tokens: 131_072
-      })
+      model =
+        create_model!(%{
+          model_id: "responses-stream-model",
+          version: "v1",
+          display_name: "Responses Stream Model",
+          artifact_uri: "file:///tmp/responses-stream-model",
+          artifact_sha256: bundle.hash,
+          artifact_source_uri: "file:///tmp/responses-stream-model",
+          state: :active,
+          format: "mlx",
+          backend: "mlx",
+          capabilities: ["chat"],
+          artifact_size_bytes: 1024,
+          resident_memory_bytes: 2048,
+          kv_cache_bytes_per_token: 128,
+          prefill_workspace_bytes_per_token: 64,
+          max_context_tokens: 131_072
+        })
 
-    grant_active_models!(tenant)
+      grant_active_models!(tenant)
 
-    {:ok, policy} =
-      %RoutingPolicy{}
-      |> RoutingPolicy.changeset(%{
-        tenant_id: tenant.id,
-        name: "responses-cold-deadline",
-        residency_preference: :allow_cold_load,
-        max_cold_start_ms: 180_000,
-        max_queue_wait_ms: 3_000
-      })
-      |> Repo.insert()
+      {:ok, policy} =
+        %RoutingPolicy{}
+        |> RoutingPolicy.changeset(%{
+          tenant_id: tenant.id,
+          name: "responses-cold-deadline",
+          residency_preference: :allow_cold_load,
+          max_cold_start_ms: 180_000,
+          max_queue_wait_ms: 3_000
+        })
+        |> Repo.insert()
 
-    assert {:ok, _result} = ModelAccess.grant_model_access(tenant, model, policy.id)
+      assert {:ok, _result} = ModelAccess.grant_model_access(tenant, model, policy.id)
 
-    conn =
-      post_responses(
-        %{
-          "model" => "responses-stream-model@v1",
-          "input" => "hello",
-          "stream" => true,
-          "metadata" => %{"trace" => "stream-test"}
-        },
-        token
-      )
+      conn =
+        post_responses_endpoint(
+          %{
+            "model" => "responses-stream-model@v1",
+            "input" => "hello",
+            "stream" => true,
+            "metadata" => %{"trace" => "stream-test"}
+          },
+          token,
+          unquote(accept)
+        )
 
-    assert conn.status == 200
-    assert resp_header(conn, "content-type") == ["text/event-stream"]
+      assert conn.status == 200
+      assert resp_header(conn, "content-type") == ["text/event-stream"]
 
-    events = parse_typed_sse_events(conn)
+      events = parse_typed_sse_events(conn)
 
-    # Must start with response.created
-    assert hd(events).type == "response.created"
-    created = hd(events)
-    assert created.data["response"]["status"] == "in_progress"
-    assert created.data["response"]["model"] == "responses-stream-model@v1"
-    assert created.data["response"]["metadata"] == %{"trace" => "stream-test"}
+      # Must start with response.created
+      assert hd(events).type == "response.created"
+      created = hd(events)
+      assert created.data["response"]["status"] == "in_progress"
+      assert created.data["response"]["model"] == "responses-stream-model@v1"
+      assert created.data["response"]["metadata"] == %{"trace" => "stream-test"}
 
-    # Must contain at least one response.output_text.delta
-    delta_events = Enum.filter(events, &(&1.type == "response.output_text.delta"))
-    [first_delta | _rest] = delta_events
-    assert is_binary(first_delta.data["delta"])
-    assert first_delta.data["output_index"] == 0
-    assert first_delta.data["content_index"] == 0
+      # Must contain at least one response.output_text.delta
+      delta_events = Enum.filter(events, &(&1.type == "response.output_text.delta"))
+      [first_delta | _rest] = delta_events
+      assert is_binary(first_delta.data["delta"])
+      assert first_delta.data["output_index"] == 0
+      assert first_delta.data["content_index"] == 0
 
-    # Must contain exactly one response.output_text.done
-    done_events = Enum.filter(events, &(&1.type == "response.output_text.done"))
-    assert length(done_events) == 1
-    done = hd(done_events)
-    assert is_binary(done.data["text"])
+      # Must contain exactly one response.output_text.done
+      done_events = Enum.filter(events, &(&1.type == "response.output_text.done"))
+      assert length(done_events) == 1
+      done = hd(done_events)
+      assert is_binary(done.data["text"])
 
-    # output_text.done must appear after all deltas and before terminal
-    delta_indices =
-      Enum.with_index(events)
-      |> Enum.filter(fn {e, _} -> e.type == "response.output_text.delta" end)
-      |> Enum.map(fn {_, i} -> i end)
+      # output_text.done must appear after all deltas and before terminal
+      delta_indices =
+        Enum.with_index(events)
+        |> Enum.filter(fn {e, _} -> e.type == "response.output_text.delta" end)
+        |> Enum.map(fn {_, i} -> i end)
 
-    [{_, done_index}] =
-      Enum.with_index(events)
-      |> Enum.filter(fn {e, _} -> e.type == "response.output_text.done" end)
+      [{_, done_index}] =
+        Enum.with_index(events)
+        |> Enum.filter(fn {e, _} -> e.type == "response.output_text.done" end)
 
-    terminal_index = length(events) - 1
-    assert Enum.all?(delta_indices, &(&1 < done_index))
-    assert done_index < terminal_index
+      terminal_index = length(events) - 1
+      assert Enum.all?(delta_indices, &(&1 < done_index))
+      assert done_index < terminal_index
 
-    # Must end with response.completed (terminal)
-    terminal = List.last(events)
-    assert terminal.type == "response.completed"
-    assert terminal.data["response"]["status"] == "completed"
-    assert terminal.data["response"]["output_text"] != nil
-    # Completed terminal's output_text must match concatenated deltas
-    concatenated = Enum.map_join(delta_events, "", & &1.data["delta"])
-    assert terminal.data["response"]["output_text"] == concatenated
+      # Must end with response.completed (terminal)
+      terminal = List.last(events)
+      assert terminal.type == "response.completed"
+      assert terminal.data["response"]["status"] == "completed"
+      assert terminal.data["response"]["output_text"] != nil
+      # Completed terminal's output_text must match concatenated deltas
+      concatenated = Enum.map_join(delta_events, "", & &1.data["delta"])
+      assert terminal.data["response"]["output_text"] == concatenated
 
-    # No [DONE] in stream
-    body = collect_chunked_body(conn)
-    refute String.contains?(body, "[DONE]")
+      # No [DONE] in stream
+      body = collect_chunked_body(conn)
+      refute String.contains?(body, "[DONE]")
 
-    # Request persisted with endpoint = :responses and stream = true
-    [request] = Repo.all(Request)
-    assert request.endpoint == :responses
-    assert request.stream == true
+      # Request persisted with endpoint = :responses and stream = true
+      [request] = Repo.all(Request)
+      assert request.endpoint == :responses
+      assert request.stream == true
 
-    persisted_timeout_ms =
-      DateTime.diff(request.timeout_at, request.inserted_at, :millisecond)
+      persisted_timeout_ms =
+        DateTime.diff(request.timeout_at, request.inserted_at, :millisecond)
 
-    configured_timeout_ms = Orchard.Inference.request_timeout_ms() + 3_000 + 180_000
+      configured_timeout_ms = Orchard.Inference.request_timeout_ms() + 3_000 + 180_000
 
-    assert persisted_timeout_ms in (configured_timeout_ms - 1_000)..configured_timeout_ms
+      assert persisted_timeout_ms in (configured_timeout_ms - 1_000)..configured_timeout_ms
 
-    # first_token_at must be persisted for successful streaming requests
-    response_id = terminal.data["response"]["id"]
-    request = Requests.get_request_by_public_id(response_id)
-    assert_text_commitment!(request)
-    assert request.payload_capture_mode == :full
-    assert request.canonical_request["stream"] == true
-    assert request.response_payload == terminal.data["response"]
+      # first_token_at must be persisted for successful streaming requests
+      response_id = terminal.data["response"]["id"]
+      request = Requests.get_request_by_public_id(response_id)
+      assert_text_commitment!(request)
+      assert request.payload_capture_mode == :full
+      assert request.canonical_request["stream"] == true
+      assert request.response_payload == terminal.data["response"]
 
-    request_events = Requests.list_request_events(request)
-    refute Enum.any?(request_events, &(&1.event_type == "response.output_text.delta"))
+      request_events = Requests.list_request_events(request)
+      refute Enum.any?(request_events, &(&1.event_type == "response.output_text.delta"))
 
-    assert Sentry.Context.get_all().extra == %{}
-    assert Sentry.Context.get_all().breadcrumbs == []
+      assert Sentry.Context.get_all().extra == %{}
+      assert Sentry.Context.get_all().breadcrumbs == []
+    end
   end
 
   test "streaming empty-string text delta still emits output_text.done before terminal" do


### PR DESCRIPTION
## Context

Streaming requests to the OpenAI-compatible inference endpoints were rejected with HTTP 406 when clients sent only `Accept: text/event-stream`.
The shared authenticated API pipeline accepted only JSON before request intent was inspected.

This PR makes content negotiation stream-aware for the two inference routes while preserving JSON behavior, terminal stream behavior, and fail-closed rejection for unsupported media types.

Closes #257.

## What changed

- Added an inference-specific Accept plug for `POST /v1/chat/completions` and `POST /v1/responses`.
- Accepts `text/event-stream` only when the parsed request has `stream: true`.
- Continues to accept `application/json` for streaming and non-streaming requests.
- Keeps `GET /v1/models` and the remaining authenticated API routes on their existing JSON-only pipeline.
- Returns an OpenAI-shaped JSON 406 response for unsupported media ranges.
- Added public Endpoint regression coverage for exact media types, wildcards, and zero-quality ranges.
- Parameterized the successful streaming tests across both relevant Accept variants while retaining their existing terminal assertions.

## Contract impact

`SPEC.md` is unchanged.
This is a narrow compatibility correction within the existing OpenAI HTTP and SSE contract.
It does not change endpoint schemas, stream event shapes, terminal semantics, persistence, scheduling, or runtime behavior.

Official OpenAI SDK source and documentation were checked for compatibility context.
The Python Responses API documents SSE streaming, and the Node SDK permits explicit Accept overrides.
The implementation therefore accepts both JSON and SSE without expanding the public contract further.

## Review findings addressed

- RepoPrompt found that static SSE acceptance would also allow SSE-only non-stream requests and that framework 406 responses would not use Orchard's OpenAI error envelope.
- RepoPrompt also found missing successful public-boundary JSON coverage.
- No Mistakes identified missing wildcard and `q=0` coverage, a tautological wildcard guard, and missing Plug callback annotations.
- All findings were addressed and the final RepoPrompt re-review reported no blocker or important findings.

## Validation

Passed on the final commit:

```text
mise exec -- mix format
mise exec -- mix compile --warnings-as-errors
mise exec -- mix credo --strict
mise exec -- mix dialyzer
mise exec -- mix test apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs
mise exec -- mix test
mise exec -- mix test --cover
```

Results:

- Focused Endpoint regression suite: 12 passed.
- Full umbrella suite: 5,055 passed, 5 skipped, 10 excluded.
- Full umbrella coverage suite: passed. Orchard CLI total coverage remained 75.73%.
- Credo: 736 files, 90 checks, no issues.
- Dialyzer: 0 errors.

One unrelated SQL sandbox ownership failure occurred in `OrchardCLI.Commands.NodeJoinTest` during an earlier full-suite run.
The exact test passed in isolation, and the complete suite then passed on two subsequent runs, including the final run above.

## Residual limitations

- Content negotiation uses the parsed `stream` boolean and intentionally does not accept SSE-only media types for malformed or non-stream requests.
- Pre-stream errors remain JSON, matching the existing endpoint behavior.
- No OpenSpec change was added because this fixes conformance with the existing contract rather than introducing behavior or architecture.

## Risk Assessment

✅ **Low**

- The blast radius is limited to Accept negotiation for two inference POST routes.
- Unsupported media types and SSE-only non-stream requests remain fail-closed with HTTP 406.
- Existing JSON success paths and both streaming terminal protocols are covered through the public Endpoint boundary.
- There are no schema, migration, dependency, packaging, scheduler, persistence, or runtime changes.
- The only observed residual signal is an unrelated non-reproducing SQL sandbox test flake; the final full test and coverage gates passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790078735&installation_model_id=428414&pr_number=274&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F274&signature=799374c0e78e61c2648432f8eef5f3d9f58324f4e5c88dcbdaf4eac91cbb7bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Accept negotiation stream-aware for the two OpenAI-compatible inference endpoints while retaining JSON-only negotiation elsewhere.
- Adds an inference-specific negotiation plug that accepts SSE only for requests parsed with `stream: true`.
- Returns OpenAI-shaped JSON errors for unsupported media ranges.
- Adds endpoint and streaming regression coverage for JSON, SSE, wildcards, and invalid or zero-quality ranges.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/api/inference_accepts.ex | Implements stream-aware media-range negotiation with strict, bounded quality parsing; both previously reported quality-validation defects are fixed. |
| apps/orchard_controller/lib/orchard/api/router.ex | Applies the new negotiation pipeline only to chat completions and responses while preserving the existing API pipeline for models. |
| apps/orchard_controller/test/orchard/api/endpoint_regression_test.exs | Covers successful SSE negotiation, JSON behavior, unsupported types, wildcards, zero quality, malformed quality, and out-of-range quality through the public endpoint boundary. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address PR review feedback (#274)"](https://github.com/kapitan-ai/orchard/commit/e77ffa95784120bc96565ff351ca589aebe5f8b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56000656)</sub>

<!-- /greptile_comment -->