### PR TITLE
fix(node-agent): gate worker shutdown signals on launch-time OS identity

### DIFF
--- a/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
@@ -117,7 +117,7 @@ defmodule Orchard.Node.RuntimeProcessReaper do
       model_ref: Map.get(meta, :model_ref),
       phase: Map.get(meta, :phase, :loading),
       os_pid: os_pid,
-      os_identity: lease_identity(meta, os_pid),
+      os_identity: lease_identity(meta),
       shutdown_timeout_ms: Map.get(meta, :shutdown_timeout_ms, 1_000),
       socket_path: Map.get(meta, :socket_path),
       term_deadline: nil,
@@ -210,8 +210,10 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   end
 
   defp resolve_term_deadline(%{term_deadline: nil} = lease) do
-    _ = WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM")
-    System.monotonic_time(:millisecond) + lease.shutdown_timeout_ms
+    case WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM") do
+      :ok -> System.monotonic_time(:millisecond) + lease.shutdown_timeout_ms
+      {:error, _reason} -> System.monotonic_time(:millisecond)
+    end
   end
 
   defp resolve_term_deadline(%{term_deadline: deadline}), do: deadline
@@ -226,15 +228,20 @@ defmodule Orchard.Node.RuntimeProcessReaper do
         _ = cleanup_socket(lease.socket_path)
 
         if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-          _ = WorkerProcessLifecycle.signal_owned_process(os_pid, lease.os_identity, "-TERM")
-          timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
+          case WorkerProcessLifecycle.signal_owned_process(os_pid, lease.os_identity, "-TERM") do
+            {:error, :identity_mismatch} ->
+              cleanup_lease(state, ref)
 
-          state
-          |> put_in([Access.key(:leases), ref, :timer_ref], timer_ref)
-          |> put_in(
-            [Access.key(:leases), ref, :term_deadline],
-            System.monotonic_time(:millisecond) + timeout
-          )
+            _signal_result ->
+              timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
+
+              state
+              |> put_in([Access.key(:leases), ref, :timer_ref], timer_ref)
+              |> put_in(
+                [Access.key(:leases), ref, :term_deadline],
+                System.monotonic_time(:millisecond) + timeout
+              )
+          end
         else
           cleanup_lease(state, ref)
         end
@@ -276,16 +283,10 @@ defmodule Orchard.Node.RuntimeProcessReaper do
 
   defp log_orphan_reap(_lease, _reason), do: :ok
 
-  defp lease_identity(meta, os_pid) do
+  defp lease_identity(meta) do
     case Map.get(meta, :os_identity) do
-      identity when is_binary(identity) ->
-        identity
-
-      _other ->
-        case WorkerProcessLifecycle.process_identity(os_pid) do
-          {:ok, identity} -> identity
-          {:error, :identity_unavailable} -> nil
-        end
+      identity when is_binary(identity) -> identity
+      _other -> nil
     end
   end
 

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
@@ -142,7 +142,7 @@ defmodule Orchard.Node.RuntimeProcessReaper do
 
       %{os_pid: os_pid} = _lease ->
         if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-          WorkerProcessLifecycle.kill_process_tree(os_pid)
+          _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
         end
 
         {:noreply, cleanup_lease(state, ref)}
@@ -163,7 +163,7 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   def terminate(_reason, state) do
     Enum.each(state.leases, fn {_ref, %{os_pid: os_pid}} ->
       if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-        WorkerProcessLifecycle.kill_process_tree(os_pid)
+        _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
       end
     end)
 
@@ -179,7 +179,7 @@ defmodule Orchard.Node.RuntimeProcessReaper do
         log_orphan_reap(lease, reason)
 
         if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-          WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+          _ = WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
           timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
           put_in(state.leases[ref][:timer_ref], timer_ref)
         else

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
@@ -17,10 +17,12 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   `WorkerProcess` does not trap exits, so on orderly `Application.stop/1` it dies
   without running its adapter unload; the reaper is therefore the only component
   that can remove the owned socket without depending on worker cooperation. The
-  shutdown sweep preserves each lease's remaining TERM grace before escalating,
-  bounded by `@sweep_budget_ms` so it always fits the supervisor shutdown budget,
-  and every signal is gated on the identity snapshot so a recycled PID belonging
-  to an unrelated process is never targeted.
+  shutdown sweep delivers TERM to every lease before it waits on any of them, so
+  a single shared `@sweep_budget_ms` grace window runs concurrently across leases
+  instead of being consumed by whichever lease the map happened to yield first.
+  The budget always fits the supervisor shutdown budget, and every signal is
+  gated on the identity snapshot so a recycled PID belonging to an unrelated
+  process is never targeted.
   """
 
   use GenServer
@@ -184,39 +186,55 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   def terminate(_reason, state) do
     sweep_deadline = System.monotonic_time(:millisecond) + @sweep_budget_ms
 
-    Enum.each(state.leases, fn {_ref, lease} -> sweep_lease(lease, sweep_deadline) end)
+    state.leases
+    |> Enum.map(fn {_ref, lease} -> signal_swept_lease(lease, sweep_deadline) end)
+    |> Enum.each(&await_swept_lease(&1, sweep_deadline))
 
     :ok
   end
 
-  defp sweep_lease(lease, sweep_deadline) do
-    _ = cleanup_socket(lease.socket_path)
+  defp signal_swept_lease(lease, sweep_deadline) do
+    _ = WorkerProcessLifecycle.remove_owned_socket(lease.socket_path)
 
-    if WorkerProcessLifecycle.os_process_alive?(lease.os_pid) do
-      grace_deadline = min(resolve_term_deadline(lease), sweep_deadline)
-      grace_ms = max(0, grace_deadline - System.monotonic_time(:millisecond))
-
-      case WorkerProcessLifecycle.await_exit(lease.os_pid, grace_ms) do
-        :ok ->
-          :ok
-
-        {:error, :timeout} ->
-          _ = WorkerProcessLifecycle.kill_owned_process_tree(lease.os_pid, lease.os_identity)
-          :ok
-      end
+    with true <- WorkerProcessLifecycle.os_process_alive?(lease.os_pid),
+         deadline when is_integer(deadline) <- resolve_term_deadline(lease) do
+      {lease, min(deadline, sweep_deadline)}
     else
-      :ok
+      _unsignalled -> :swept
     end
   end
 
-  defp resolve_term_deadline(%{term_deadline: nil} = lease) do
-    case WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM") do
-      :ok -> System.monotonic_time(:millisecond) + lease.shutdown_timeout_ms
-      {:error, _reason} -> System.monotonic_time(:millisecond)
-    end
+  defp await_swept_lease(:swept, _sweep_deadline), do: :ok
+
+  defp await_swept_lease({lease, grace_deadline}, sweep_deadline) do
+    _ =
+      WorkerProcessLifecycle.escalate_owned_exit(
+        lease.os_pid,
+        lease.os_identity,
+        grace_deadline,
+        sweep_deadline
+      )
+
+    :ok
   end
 
-  defp resolve_term_deadline(%{term_deadline: deadline}), do: deadline
+  defp resolve_term_deadline(%{term_deadline: deadline}) when is_integer(deadline), do: deadline
+
+  defp resolve_term_deadline(lease) do
+    signal_result =
+      WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM")
+
+    cond do
+      WorkerProcessLifecycle.custody_refused?(signal_result) ->
+        :custody_refused
+
+      signal_result == :ok ->
+        System.monotonic_time(:millisecond) + lease.shutdown_timeout_ms
+
+      true ->
+        System.monotonic_time(:millisecond)
+    end
+  end
 
   defp start_reaping(state, ref, reason) do
     case get_in(state.leases[ref]) do
@@ -225,7 +243,7 @@ defmodule Orchard.Node.RuntimeProcessReaper do
 
       %{os_pid: os_pid, shutdown_timeout_ms: timeout, timer_ref: nil} = lease ->
         log_orphan_reap(lease, reason)
-        _ = cleanup_socket(lease.socket_path)
+        _ = WorkerProcessLifecycle.remove_owned_socket(lease.socket_path)
 
         if WorkerProcessLifecycle.os_process_alive?(os_pid) do
           start_live_process_reaping(state, ref, lease, timeout)
@@ -239,19 +257,20 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   end
 
   defp start_live_process_reaping(state, ref, lease, timeout) do
-    case WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM") do
-      {:error, :identity_mismatch} ->
-        cleanup_lease(state, ref)
+    signal_result =
+      WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM")
 
-      _signal_result ->
-        timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
+    if WorkerProcessLifecycle.custody_refused?(signal_result) do
+      cleanup_lease(state, ref)
+    else
+      timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
 
-        state
-        |> put_in([Access.key(:leases), ref, :timer_ref], timer_ref)
-        |> put_in(
-          [Access.key(:leases), ref, :term_deadline],
-          System.monotonic_time(:millisecond) + timeout
-        )
+      state
+      |> put_in([Access.key(:leases), ref, :timer_ref], timer_ref)
+      |> put_in(
+        [Access.key(:leases), ref, :term_deadline],
+        System.monotonic_time(:millisecond) + timeout
+      )
     end
   end
 
@@ -292,12 +311,5 @@ defmodule Orchard.Node.RuntimeProcessReaper do
       identity when is_binary(identity) -> identity
       _other -> nil
     end
-  end
-
-  defp cleanup_socket(nil), do: :ok
-
-  defp cleanup_socket(socket_path) when is_binary(socket_path) do
-    _ = File.rm(socket_path)
-    :ok
   end
 end

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
@@ -12,6 +12,15 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   performs escalation even when the owning WorkerProcess is killed abruptly by
   its supervisor. Its own `terminate/2` sweeps any remaining leases on node
   shutdown.
+
+  A lease also carries the worker's socket path and an OS identity snapshot.
+  `WorkerProcess` does not trap exits, so on orderly `Application.stop/1` it dies
+  without running its adapter unload; the reaper is therefore the only component
+  that can remove the owned socket without depending on worker cooperation. The
+  shutdown sweep preserves each lease's remaining TERM grace before escalating,
+  bounded by `@sweep_budget_ms` so it always fits the supervisor shutdown budget,
+  and every signal is gated on the identity snapshot so a recycled PID belonging
+  to an unrelated process is never targeted.
   """
 
   use GenServer
@@ -22,6 +31,8 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   @type lease_ref :: reference()
 
   @type lease_meta :: %{
+          optional(:os_identity) => WorkerProcessLifecycle.custody_identity() | nil,
+          optional(:socket_path) => String.t() | nil,
           shutdown_timeout_ms: pos_integer(),
           model_ref: term(),
           phase: :loading | :loaded | :unloading
@@ -31,11 +42,18 @@ defmodule Orchard.Node.RuntimeProcessReaper do
           owner_pid: pid(),
           owner_monitor_ref: reference(),
           os_pid: pos_integer(),
+          os_identity: WorkerProcessLifecycle.custody_identity() | nil,
           model_ref: term(),
           phase: :loading | :loaded | :unloading,
           shutdown_timeout_ms: pos_integer(),
+          socket_path: String.t() | nil,
+          term_deadline: integer() | nil,
           timer_ref: reference() | nil
         }
+
+  # Kept below the 5_000ms child_spec shutdown budget so the sweep can never be
+  # cut short by a brutal kill from the supervisor.
+  @sweep_budget_ms 4_000
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -99,7 +117,10 @@ defmodule Orchard.Node.RuntimeProcessReaper do
       model_ref: Map.get(meta, :model_ref),
       phase: Map.get(meta, :phase, :loading),
       os_pid: os_pid,
+      os_identity: lease_identity(meta, os_pid),
       shutdown_timeout_ms: Map.get(meta, :shutdown_timeout_ms, 1_000),
+      socket_path: Map.get(meta, :socket_path),
+      term_deadline: nil,
       timer_ref: nil
     }
 
@@ -140,9 +161,9 @@ defmodule Orchard.Node.RuntimeProcessReaper do
       nil ->
         {:noreply, state}
 
-      %{os_pid: os_pid} = _lease ->
+      %{os_pid: os_pid, os_identity: os_identity} = _lease ->
         if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-          _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
+          _ = WorkerProcessLifecycle.kill_owned_process_tree(os_pid, os_identity)
         end
 
         {:noreply, cleanup_lease(state, ref)}
@@ -161,14 +182,39 @@ defmodule Orchard.Node.RuntimeProcessReaper do
 
   @impl true
   def terminate(_reason, state) do
-    Enum.each(state.leases, fn {_ref, %{os_pid: os_pid}} ->
-      if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-        _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
-      end
-    end)
+    sweep_deadline = System.monotonic_time(:millisecond) + @sweep_budget_ms
+
+    Enum.each(state.leases, fn {_ref, lease} -> sweep_lease(lease, sweep_deadline) end)
 
     :ok
   end
+
+  defp sweep_lease(lease, sweep_deadline) do
+    _ = cleanup_socket(lease.socket_path)
+
+    if WorkerProcessLifecycle.os_process_alive?(lease.os_pid) do
+      grace_deadline = min(resolve_term_deadline(lease), sweep_deadline)
+      grace_ms = max(0, grace_deadline - System.monotonic_time(:millisecond))
+
+      case WorkerProcessLifecycle.await_exit(lease.os_pid, grace_ms) do
+        :ok ->
+          :ok
+
+        {:error, :timeout} ->
+          _ = WorkerProcessLifecycle.kill_owned_process_tree(lease.os_pid, lease.os_identity)
+          :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  defp resolve_term_deadline(%{term_deadline: nil} = lease) do
+    _ = WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM")
+    System.monotonic_time(:millisecond) + lease.shutdown_timeout_ms
+  end
+
+  defp resolve_term_deadline(%{term_deadline: deadline}), do: deadline
 
   defp start_reaping(state, ref, reason) do
     case get_in(state.leases[ref]) do
@@ -177,11 +223,18 @@ defmodule Orchard.Node.RuntimeProcessReaper do
 
       %{os_pid: os_pid, shutdown_timeout_ms: timeout, timer_ref: nil} = lease ->
         log_orphan_reap(lease, reason)
+        _ = cleanup_socket(lease.socket_path)
 
         if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-          _ = WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+          _ = WorkerProcessLifecycle.signal_owned_process(os_pid, lease.os_identity, "-TERM")
           timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
-          put_in(state.leases[ref][:timer_ref], timer_ref)
+
+          state
+          |> put_in([Access.key(:leases), ref, :timer_ref], timer_ref)
+          |> put_in(
+            [Access.key(:leases), ref, :term_deadline],
+            System.monotonic_time(:millisecond) + timeout
+          )
         else
           cleanup_lease(state, ref)
         end
@@ -222,4 +275,24 @@ defmodule Orchard.Node.RuntimeProcessReaper do
   end
 
   defp log_orphan_reap(_lease, _reason), do: :ok
+
+  defp lease_identity(meta, os_pid) do
+    case Map.get(meta, :os_identity) do
+      identity when is_binary(identity) ->
+        identity
+
+      _other ->
+        case WorkerProcessLifecycle.process_identity(os_pid) do
+          {:ok, identity} -> identity
+          {:error, :identity_unavailable} -> nil
+        end
+    end
+  end
+
+  defp cleanup_socket(nil), do: :ok
+
+  defp cleanup_socket(socket_path) when is_binary(socket_path) do
+    _ = File.rm(socket_path)
+    :ok
+  end
 end

--- a/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex
@@ -228,26 +228,30 @@ defmodule Orchard.Node.RuntimeProcessReaper do
         _ = cleanup_socket(lease.socket_path)
 
         if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-          case WorkerProcessLifecycle.signal_owned_process(os_pid, lease.os_identity, "-TERM") do
-            {:error, :identity_mismatch} ->
-              cleanup_lease(state, ref)
-
-            _signal_result ->
-              timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
-
-              state
-              |> put_in([Access.key(:leases), ref, :timer_ref], timer_ref)
-              |> put_in(
-                [Access.key(:leases), ref, :term_deadline],
-                System.monotonic_time(:millisecond) + timeout
-              )
-          end
+          start_live_process_reaping(state, ref, lease, timeout)
         else
           cleanup_lease(state, ref)
         end
 
       _other ->
         state
+    end
+  end
+
+  defp start_live_process_reaping(state, ref, lease, timeout) do
+    case WorkerProcessLifecycle.signal_owned_process(lease.os_pid, lease.os_identity, "-TERM") do
+      {:error, :identity_mismatch} ->
+        cleanup_lease(state, ref)
+
+      _signal_result ->
+        timer_ref = Process.send_after(self(), {:escalate, ref}, timeout)
+
+        state
+        |> put_in([Access.key(:leases), ref, :timer_ref], timer_ref)
+        |> put_in(
+          [Access.key(:leases), ref, :term_deadline],
+          System.monotonic_time(:millisecond) + timeout
+        )
     end
   end
 

--- a/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
@@ -11,11 +11,12 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   captures an owner/start-time snapshot at launch, and the `*_owned_*` helpers
   refuse to signal a PID whose snapshot no longer matches.
 
-  Custody refusal has two distinct reasons. `:identity_mismatch` means the PID is
-  live but belongs to something else — the security-relevant case.
-  `:identity_unavailable` means no snapshot was captured, or the target has
-  already exited, which is the ordinary outcome of a shutdown race. Both refuse
-  to signal; only the former is logged as a warning.
+  Custody refusal has two distinct reasons and neither one signals.
+  `:identity_mismatch` means the PID is live but belongs to something else — the
+  security-relevant case, logged as a warning. `:identity_unavailable` covers
+  both a missing launch snapshot, warned because it leaves an owned child
+  unsignallable, and a target that has already exited, the ordinary outcome of a
+  shutdown race, logged at debug.
   """
 
   require Logger

--- a/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
@@ -7,6 +7,10 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   has already exited.
   """
 
+  require Logger
+
+  @type signal_result :: :ok | {:error, :signal_failed}
+
   @spec os_process_alive?(non_neg_integer()) :: boolean()
   def os_process_alive?(os_pid) when is_integer(os_pid) and os_pid > 0 do
     case System.cmd("kill", ["-0", Integer.to_string(os_pid)], stderr_to_stdout: true) do
@@ -17,15 +21,25 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
 
   def os_process_alive?(_), do: false
 
-  @spec send_signal(non_neg_integer(), String.t()) :: :ok
+  @spec send_signal(non_neg_integer(), String.t()) :: signal_result()
   def send_signal(os_pid, signal) when is_integer(os_pid) and os_pid > 0 do
-    _ = System.cmd("kill", [signal, Integer.to_string(os_pid)], stderr_to_stdout: true)
-    :ok
+    case System.cmd("kill", [signal, Integer.to_string(os_pid)], stderr_to_stdout: true) do
+      {_output, 0} ->
+        :ok
+
+      {_output, exit_status} ->
+        Logger.warning(
+          "worker signal failed os_pid=#{os_pid} signal=#{signal_name(signal)} " <>
+            "exit_status=#{exit_status}"
+        )
+
+        {:error, :signal_failed}
+    end
   end
 
-  def send_signal(_, _), do: :ok
+  def send_signal(_, _), do: {:error, :signal_failed}
 
-  @spec kill_process_tree(non_neg_integer() | nil) :: :ok
+  @spec kill_process_tree(non_neg_integer() | nil) :: signal_result()
   def kill_process_tree(os_pid) when is_integer(os_pid) and os_pid > 0 do
     {children_output, _} =
       System.cmd("pgrep", ["-P", Integer.to_string(os_pid)], stderr_to_stdout: true)
@@ -36,7 +50,7 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
     |> Enum.each(fn child_pid ->
       case Integer.parse(child_pid) do
         {child_pid_int, _} when child_pid_int > 0 ->
-          kill_process_tree(child_pid_int)
+          _ = kill_process_tree(child_pid_int)
 
         _other ->
           :ok
@@ -44,8 +58,11 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
     end)
 
     send_signal(os_pid, "-KILL")
-    :ok
   end
 
-  def kill_process_tree(_), do: :ok
+  def kill_process_tree(_), do: {:error, :signal_failed}
+
+  defp signal_name("-TERM"), do: "TERM"
+  defp signal_name("-KILL"), do: "KILL"
+  defp signal_name(_signal), do: "unknown"
 end

--- a/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
@@ -5,11 +5,20 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   These helpers intentionally avoid BEAM abstractions: they operate directly on
   Unix PIDs so cleanup can continue even when the process that opened the port
   has already exited.
+
+  A PID alone is not proof of custody once the BEAM has relinquished the port:
+  the kernel is free to recycle it for an unrelated process. `process_identity/1`
+  captures an owner/start-time snapshot at launch, and the `*_owned_*` helpers
+  refuse to signal a PID whose snapshot no longer matches.
   """
 
   require Logger
 
+  @poll_interval_ms 25
+
   @type signal_result :: :ok | {:error, :signal_failed}
+  @type owned_signal_result :: signal_result() | {:error, :identity_mismatch}
+  @type custody_identity :: String.t()
 
   @spec os_process_alive?(non_neg_integer()) :: boolean()
   def os_process_alive?(os_pid) when is_integer(os_pid) and os_pid > 0 do
@@ -61,6 +70,97 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   end
 
   def kill_process_tree(_), do: {:error, :signal_failed}
+
+  @doc """
+  Captures the owner uid and process start time of `os_pid`.
+
+  The snapshot deliberately excludes argv: the dev worker wrapper `exec`s the
+  venv entrypoint, so argv changes under a stable PID. uid and start time do
+  survive `exec`, and a recycled PID cannot reproduce them because reusing a PID
+  requires wrapping the whole PID space — far longer than the one-second
+  resolution of `lstart`.
+  """
+  @spec process_identity(non_neg_integer() | nil) ::
+          {:ok, custody_identity()} | {:error, :identity_unavailable}
+  def process_identity(os_pid) when is_integer(os_pid) and os_pid > 0 do
+    args = ["-o", "uid=", "-o", "lstart=", "-p", Integer.to_string(os_pid)]
+
+    case System.cmd("ps", args, stderr_to_stdout: true) do
+      {output, 0} -> parse_process_identity(output)
+      {_output, _exit_status} -> {:error, :identity_unavailable}
+    end
+  end
+
+  def process_identity(_), do: {:error, :identity_unavailable}
+
+  @doc """
+  Sends `signal` to `os_pid` only while it still matches `identity`.
+
+  A `nil` identity means no snapshot was captured (for example when `ps` is
+  unavailable) and falls back to unguarded signalling.
+  """
+  @spec signal_owned_process(non_neg_integer(), custody_identity() | nil, String.t()) ::
+          owned_signal_result()
+  def signal_owned_process(os_pid, identity, signal) do
+    case confirm_custody(os_pid, identity) do
+      :ok -> send_signal(os_pid, signal)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Kills the process tree rooted at `os_pid` only while it still matches `identity`.
+  """
+  @spec kill_owned_process_tree(non_neg_integer() | nil, custody_identity() | nil) ::
+          owned_signal_result()
+  def kill_owned_process_tree(os_pid, identity) do
+    case confirm_custody(os_pid, identity) do
+      :ok -> kill_process_tree(os_pid)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Polls until `os_pid` has exited or `timeout_ms` elapses.
+  """
+  @spec await_exit(non_neg_integer(), non_neg_integer()) :: :ok | {:error, :timeout}
+  def await_exit(os_pid, timeout_ms) when is_integer(timeout_ms) and timeout_ms >= 0 do
+    await_exit_by_deadline(os_pid, System.monotonic_time(:millisecond) + timeout_ms)
+  end
+
+  defp await_exit_by_deadline(os_pid, deadline) do
+    cond do
+      not os_process_alive?(os_pid) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:error, :timeout}
+
+      true ->
+        Process.sleep(@poll_interval_ms)
+        await_exit_by_deadline(os_pid, deadline)
+    end
+  end
+
+  defp confirm_custody(_os_pid, nil), do: :ok
+
+  defp confirm_custody(os_pid, identity) when is_binary(identity) do
+    case process_identity(os_pid) do
+      {:ok, ^identity} ->
+        :ok
+
+      _other ->
+        Logger.warning("worker custody identity mismatch os_pid=#{os_pid}")
+        {:error, :identity_mismatch}
+    end
+  end
+
+  defp parse_process_identity(output) do
+    case output |> String.trim() |> String.replace(~r/\s+/, " ") do
+      "" -> {:error, :identity_unavailable}
+      identity -> {:ok, identity}
+    end
+  end
 
   defp signal_name("-TERM"), do: "TERM"
   defp signal_name("-KILL"), do: "KILL"

--- a/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
@@ -10,6 +10,12 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   the kernel is free to recycle it for an unrelated process. `process_identity/1`
   captures an owner/start-time snapshot at launch, and the `*_owned_*` helpers
   refuse to signal a PID whose snapshot no longer matches.
+
+  Custody refusal has two distinct reasons. `:identity_mismatch` means the PID is
+  live but belongs to something else — the security-relevant case.
+  `:identity_unavailable` means no snapshot was captured, or the target has
+  already exited, which is the ordinary outcome of a shutdown race. Both refuse
+  to signal; only the former is logged as a warning.
   """
 
   require Logger
@@ -17,7 +23,8 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   @poll_interval_ms 25
 
   @type signal_result :: :ok | {:error, :signal_failed}
-  @type owned_signal_result :: signal_result() | {:error, :identity_mismatch}
+  @type custody_refusal :: :identity_mismatch | :identity_unavailable
+  @type owned_signal_result :: signal_result() | {:error, custody_refusal()}
   @type custody_identity :: String.t()
 
   @spec os_process_alive?(non_neg_integer()) :: boolean()
@@ -121,14 +128,78 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   end
 
   @doc """
+  Reports whether a `*_owned_*` result was refused for custody reasons.
+
+  Callers use this instead of matching a single reason so a new refusal reason
+  can never silently re-arm signalling on an unproven PID.
+  """
+  @spec custody_refused?(term()) :: boolean()
+  def custody_refused?({:error, reason})
+      when reason in [:identity_mismatch, :identity_unavailable],
+      do: true
+
+  def custody_refused?(_result), do: false
+
+  @doc """
+  Waits for `os_pid` to exit by `term_deadline`, then escalates to a
+  custody-gated tree kill confirmed by `kill_deadline`.
+
+  Both arguments are absolute `System.monotonic_time(:millisecond)` values, so a
+  caller's shutdown budget is spent once across both phases rather than once per
+  phase.
+  """
+  @spec escalate_owned_exit(
+          non_neg_integer(),
+          custody_identity() | nil,
+          integer(),
+          integer()
+        ) :: :ok | {:error, :timeout} | {:error, custody_refusal()}
+  def escalate_owned_exit(os_pid, identity, term_deadline, kill_deadline) do
+    case await_exit_until(os_pid, term_deadline) do
+      :ok ->
+        :ok
+
+      {:error, :timeout} ->
+        kill_result = kill_owned_process_tree(os_pid, identity)
+
+        if custody_refused?(kill_result) do
+          kill_result
+        else
+          await_exit_until(os_pid, kill_deadline)
+        end
+    end
+  end
+
+  @doc """
+  Removes a worker-owned Unix socket path.
+
+  The reaper must be able to drop the socket even when the worker died without
+  running its own adapter unload, so a missing file is success.
+  """
+  @spec remove_owned_socket(Path.t() | nil) :: :ok | {:error, {:socket_cleanup_failed, term()}}
+  def remove_owned_socket(nil), do: :ok
+
+  def remove_owned_socket(socket_path) when is_binary(socket_path) do
+    case File.rm(socket_path) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, reason} -> {:error, {:socket_cleanup_failed, reason}}
+    end
+  end
+
+  @doc """
   Polls until `os_pid` has exited or `timeout_ms` elapses.
   """
   @spec await_exit(non_neg_integer(), non_neg_integer()) :: :ok | {:error, :timeout}
   def await_exit(os_pid, timeout_ms) when is_integer(timeout_ms) and timeout_ms >= 0 do
-    await_exit_by_deadline(os_pid, System.monotonic_time(:millisecond) + timeout_ms)
+    await_exit_until(os_pid, System.monotonic_time(:millisecond) + timeout_ms)
   end
 
-  defp await_exit_by_deadline(os_pid, deadline) do
+  @doc """
+  Polls until `os_pid` has exited or the absolute monotonic `deadline` passes.
+  """
+  @spec await_exit_until(non_neg_integer(), integer()) :: :ok | {:error, :timeout}
+  def await_exit_until(os_pid, deadline) when is_integer(deadline) do
     cond do
       not os_process_alive?(os_pid) ->
         :ok
@@ -138,13 +209,13 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
 
       true ->
         Process.sleep(@poll_interval_ms)
-        await_exit_by_deadline(os_pid, deadline)
+        await_exit_until(os_pid, deadline)
     end
   end
 
   defp confirm_custody(os_pid, nil) do
     Logger.warning("worker custody identity unavailable os_pid=#{os_pid}")
-    {:error, :identity_mismatch}
+    {:error, :identity_unavailable}
   end
 
   defp confirm_custody(os_pid, identity) when is_binary(identity) do
@@ -152,7 +223,11 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
       {:ok, ^identity} ->
         :ok
 
-      _other ->
+      {:error, :identity_unavailable} ->
+        Logger.debug("worker custody target already exited os_pid=#{os_pid}")
+        {:error, :identity_unavailable}
+
+      {:ok, _other_identity} ->
         Logger.warning("worker custody identity mismatch os_pid=#{os_pid}")
         {:error, :identity_mismatch}
     end

--- a/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex
@@ -96,8 +96,8 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
   @doc """
   Sends `signal` to `os_pid` only while it still matches `identity`.
 
-  A `nil` identity means no snapshot was captured (for example when `ps` is
-  unavailable) and falls back to unguarded signalling.
+  A missing identity fails closed because a numeric PID is not custody proof
+  after the BEAM Port has closed.
   """
   @spec signal_owned_process(non_neg_integer(), custody_identity() | nil, String.t()) ::
           owned_signal_result()
@@ -142,7 +142,10 @@ defmodule Orchard.Node.WorkerProcessLifecycle do
     end
   end
 
-  defp confirm_custody(_os_pid, nil), do: :ok
+  defp confirm_custody(os_pid, nil) do
+    Logger.warning("worker custody identity unavailable os_pid=#{os_pid}")
+    {:error, :identity_mismatch}
+  end
 
   defp confirm_custody(os_pid, identity) when is_binary(identity) do
     case process_identity(os_pid) do

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -57,6 +57,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
           log_path: String.t(),
           model_path: String.t(),
           model_ref: ModelRef.t(),
+          os_identity: WorkerProcessLifecycle.custody_identity() | nil,
           os_pid: non_neg_integer() | nil,
           port: port(),
           reaper_ref: reference() | nil,
@@ -342,7 +343,14 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     start_time = System.monotonic_time(:millisecond)
 
     unload_result = if skip_rpc?, do: :ok, else: unload_model_rpc(state.channel, state.model_ref)
-    stop_result = stop_runtime(state.port, state.os_pid, shutdown_timeout_ms)
+
+    stop_result =
+      stop_runtime(
+        state.port,
+        state.os_pid,
+        Map.get(state, :os_identity),
+        shutdown_timeout_ms
+      )
 
     cleanup_generation_tasks(state.generations)
     _ = disconnect_channel(state.channel)
@@ -462,6 +470,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
         memory_budget_overhead_bytes: memory_budget_overhead_bytes
       )
 
+    os_identity = capture_os_identity(os_pid)
+
     runtime_params = %{
       backend: backend,
       executable: executable,
@@ -469,6 +479,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       log_path: log_path,
       model_path: model_path,
       model_ref: model_ref,
+      os_identity: os_identity,
       shutdown_timeout_ms: shutdown_timeout_ms,
       socket_path: socket_path
     }
@@ -476,6 +487,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     reaper_meta = %{
       shutdown_timeout_ms: shutdown_timeout_ms,
       model_ref: model_ref,
+      os_identity: os_identity,
+      socket_path: socket_path,
       phase: :loading
     }
 
@@ -488,6 +501,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
           {:error, reason} ->
             cleanup_failed_runtime(%{
               channel: nil,
+              os_identity: os_identity,
               os_pid: os_pid,
               port: port,
               reaper_ref: reaper_ref,
@@ -501,6 +515,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       {:error, reason} ->
         cleanup_failed_runtime(%{
           channel: nil,
+          os_identity: os_identity,
           os_pid: os_pid,
           port: port,
           reaper_ref: nil,
@@ -509,6 +524,13 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
         })
 
         {:error, reason}
+    end
+  end
+
+  defp capture_os_identity(os_pid) do
+    case WorkerProcessLifecycle.process_identity(os_pid) do
+      {:ok, identity} -> identity
+      {:error, :identity_unavailable} -> nil
     end
   end
 
@@ -524,6 +546,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
            log_path: params.log_path,
            model_path: params.model_path,
            model_ref: params.model_ref,
+           os_identity: params.os_identity,
            os_pid: os_pid,
            port: port,
            reaper_ref: reaper_ref,
@@ -534,6 +557,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       {:error, reason} ->
         cleanup_failed_runtime(%{
           channel: channel,
+          os_identity: params.os_identity,
           os_pid: os_pid,
           port: port,
           reaper_ref: reaper_ref,
@@ -1007,7 +1031,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     )
   end
 
-  defp stop_runtime(port, nil, timeout_ms) do
+  defp stop_runtime(port, nil, _os_identity, timeout_ms) do
     if port_open?(port) do
       case wait_for_port_exit(port, timeout_ms) do
         {:ok, _status} -> :ok
@@ -1018,33 +1042,48 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     end
   end
 
-  defp stop_runtime(port, os_pid, timeout_ms) do
+  defp stop_runtime(port, os_pid, os_identity, timeout_ms) do
     if port_open?(port) do
       stop_runtime_with_escalation(port, os_pid, timeout_ms)
     else
-      stop_closed_port_runtime(os_pid, timeout_ms)
+      stop_closed_port_runtime(os_pid, os_identity, timeout_ms)
     end
   end
 
-  defp stop_closed_port_runtime(os_pid, timeout_ms) do
+  # The BEAM has already relinquished custody of a closed port's child, so the
+  # recorded PID may have been recycled to an unrelated process. Every signal on
+  # this path is gated on the identity snapshot captured at launch.
+  defp stop_closed_port_runtime(os_pid, os_identity, timeout_ms) do
     if WorkerProcessLifecycle.os_process_alive?(os_pid) do
-      _ = WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
-
-      case wait_for_os_pid_exit(os_pid, timeout_ms) do
-        :ok -> :ok
-        {:error, :timeout} -> kill_closed_port_runtime(os_pid, timeout_ms)
-      end
+      terminate_closed_port_runtime(os_pid, os_identity, timeout_ms)
     else
       :ok
     end
   end
 
-  defp kill_closed_port_runtime(os_pid, timeout_ms) do
-    _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
+  defp terminate_closed_port_runtime(os_pid, os_identity, timeout_ms) do
+    case WorkerProcessLifecycle.signal_owned_process(os_pid, os_identity, "-TERM") do
+      {:error, :identity_mismatch} ->
+        :ok
 
-    case wait_for_os_pid_exit(os_pid, timeout_ms) do
-      :ok -> :ok
-      {:error, :timeout} -> {:error, :worker_shutdown_timeout}
+      _signal_result ->
+        case WorkerProcessLifecycle.await_exit(os_pid, timeout_ms) do
+          :ok -> :ok
+          {:error, :timeout} -> kill_closed_port_runtime(os_pid, os_identity, timeout_ms)
+        end
+    end
+  end
+
+  defp kill_closed_port_runtime(os_pid, os_identity, timeout_ms) do
+    case WorkerProcessLifecycle.kill_owned_process_tree(os_pid, os_identity) do
+      {:error, :identity_mismatch} ->
+        :ok
+
+      _kill_result ->
+        case WorkerProcessLifecycle.await_exit(os_pid, timeout_ms) do
+          :ok -> :ok
+          {:error, :timeout} -> {:error, :worker_shutdown_timeout}
+        end
     end
   end
 
@@ -1088,25 +1127,6 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     end
   end
 
-  defp wait_for_os_pid_exit(os_pid, timeout_ms) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_os_pid_exit(os_pid, deadline)
-  end
-
-  defp do_wait_for_os_pid_exit(os_pid, deadline) do
-    cond do
-      not WorkerProcessLifecycle.os_process_alive?(os_pid) ->
-        :ok
-
-      System.monotonic_time(:millisecond) >= deadline ->
-        {:error, :timeout}
-
-      true ->
-        Process.sleep(@poll_interval_ms)
-        do_wait_for_os_pid_exit(os_pid, deadline)
-    end
-  end
-
   defp port_open?(port) do
     not is_nil(Port.info(port))
   end
@@ -1125,6 +1145,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
 
   defp cleanup_failed_runtime(%{
          channel: channel,
+         os_identity: os_identity,
          os_pid: os_pid,
          port: port,
          reaper_ref: reaper_ref,
@@ -1132,7 +1153,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
          socket_path: socket_path
        }) do
     if is_reference(reaper_ref), do: RuntimeProcessReaper.reap(reaper_ref, :cleanup_failed)
-    _ = stop_runtime(port, os_pid, shutdown_timeout_ms)
+    _ = stop_runtime(port, os_pid, os_identity, shutdown_timeout_ms)
     _ = disconnect_channel(channel)
     _ = cleanup_socket(socket_path)
     if is_reference(reaper_ref), do: RuntimeProcessReaper.release(reaper_ref)

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -38,6 +38,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
 
   @poll_interval_ms 50
   @rpc_timeout_ms 1_000
+  # Slice of the shutdown budget reserved to confirm an uncatchable SIGKILL.
+  @kill_confirm_ms 250
   @default_generation_mode "batch"
   @default_max_concurrent_generations "auto"
   @default_auto_max_concurrent_generations 3
@@ -275,7 +277,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
            {:ok, resolved_executable} <- resolve_executable(executable),
            :ok <- ensure_socket_parent(socket_path),
            :ok <- ensure_log_parent(log_path),
-           :ok <- cleanup_socket(socket_path) do
+           :ok <- WorkerProcessLifecycle.remove_owned_socket(socket_path) do
         start_runtime(%{
           owner_pid: owner_pid,
           model_ref: model_ref,
@@ -354,7 +356,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
 
     cleanup_generation_tasks(state.generations)
     _ = disconnect_channel(state.channel)
-    socket_result = cleanup_socket(state.socket_path)
+    socket_result = WorkerProcessLifecycle.remove_owned_socket(state.socket_path)
 
     if is_reference(state[:reaper_ref]),
       do: RuntimeProcessReaper.release(state.reaper_ref)
@@ -489,7 +491,9 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       {:ok, os_identity} ->
         start_watched_runtime(Map.put(runtime_params, :os_identity, os_identity))
 
-      {:error, :identity_unavailable} = error ->
+      {:error, :identity_unavailable} ->
+        reason = launch_identity_failure_reason(port)
+
         cleanup_failed_runtime(%{
           channel: nil,
           os_identity: nil,
@@ -500,7 +504,26 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
           socket_path: socket_path
         })
 
-        error
+        {:error, reason}
+    end
+  end
+
+  # A worker that dies during launch is reaped before `ps` can snapshot it, so
+  # identity capture fails for a reason the operator cannot act on. The port's
+  # exit status names the actual failure and points at the worker log.
+  defp launch_identity_failure_reason(port) do
+    if port_open?(port) do
+      :identity_unavailable
+    else
+      drain_port_exit_reason(port)
+    end
+  end
+
+  defp drain_port_exit_reason(port) do
+    case poll_port(port) do
+      {:exit_status, status} -> {:worker_exited, status}
+      :ignore -> drain_port_exit_reason(port)
+      :none -> :identity_unavailable
     end
   end
 
@@ -627,14 +650,6 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     log_path
     |> Path.dirname()
     |> File.mkdir_p()
-  end
-
-  defp cleanup_socket(socket_path) do
-    case File.rm(socket_path) do
-      :ok -> :ok
-      {:error, :enoent} -> :ok
-      {:error, reason} -> {:error, {:socket_cleanup_failed, reason}}
-    end
   end
 
   # Public only so tests can validate worker process launch args without starting a port.
@@ -1075,29 +1090,31 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     end
   end
 
+  # TERM grace and post-KILL confirmation share the single `timeout_ms` budget so
+  # a TERM-resistant child cannot block the calling WorkerProcess for twice the
+  # configured shutdown timeout and orphan its `unload` call.
   defp terminate_closed_port_runtime(os_pid, os_identity, timeout_ms) do
-    case WorkerProcessLifecycle.signal_owned_process(os_pid, os_identity, "-TERM") do
-      {:error, :identity_mismatch} ->
-        :ok
+    kill_deadline = System.monotonic_time(:millisecond) + timeout_ms
+    term_deadline = kill_deadline - min(@kill_confirm_ms, div(timeout_ms, 2))
+    signal_result = WorkerProcessLifecycle.signal_owned_process(os_pid, os_identity, "-TERM")
 
-      _signal_result ->
-        case WorkerProcessLifecycle.await_exit(os_pid, timeout_ms) do
-          :ok -> :ok
-          {:error, :timeout} -> kill_closed_port_runtime(os_pid, os_identity, timeout_ms)
-        end
+    if WorkerProcessLifecycle.custody_refused?(signal_result) do
+      :ok
+    else
+      confirm_closed_port_exit(os_pid, os_identity, term_deadline, kill_deadline)
     end
   end
 
-  defp kill_closed_port_runtime(os_pid, os_identity, timeout_ms) do
-    case WorkerProcessLifecycle.kill_owned_process_tree(os_pid, os_identity) do
-      {:error, :identity_mismatch} ->
-        :ok
-
-      _kill_result ->
-        case WorkerProcessLifecycle.await_exit(os_pid, timeout_ms) do
-          :ok -> :ok
-          {:error, :timeout} -> {:error, :worker_shutdown_timeout}
-        end
+  defp confirm_closed_port_exit(os_pid, os_identity, term_deadline, kill_deadline) do
+    case WorkerProcessLifecycle.escalate_owned_exit(
+           os_pid,
+           os_identity,
+           term_deadline,
+           kill_deadline
+         ) do
+      :ok -> :ok
+      {:error, :timeout} -> {:error, :worker_shutdown_timeout}
+      {:error, _custody_refusal} -> :ok
     end
   end
 
@@ -1169,7 +1186,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     if is_reference(reaper_ref), do: RuntimeProcessReaper.reap(reaper_ref, :cleanup_failed)
     _ = stop_runtime(port, os_pid, os_identity, shutdown_timeout_ms)
     _ = disconnect_channel(channel)
-    _ = cleanup_socket(socket_path)
+    _ = WorkerProcessLifecycle.remove_owned_socket(socket_path)
     if is_reference(reaper_ref), do: RuntimeProcessReaper.release(reaper_ref)
     :ok
   end

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -1069,11 +1069,22 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   end
 
   defp wait_for_port_exit(port, timeout_ms) do
-    receive do
-      {^port, {:exit_status, status}} -> {:ok, status}
-      {^port, {:data, _data}} -> wait_for_port_exit(port, timeout_ms)
-    after
-      timeout_ms -> {:error, :timeout}
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_for_port_exit(port, deadline)
+  end
+
+  defp do_wait_for_port_exit(port, deadline) do
+    remaining_ms = deadline - System.monotonic_time(:millisecond)
+
+    if remaining_ms <= 0 do
+      {:error, :timeout}
+    else
+      receive do
+        {^port, {:exit_status, status}} -> {:ok, status}
+        {^port, {:data, _data}} -> do_wait_for_port_exit(port, deadline)
+      after
+        remaining_ms -> {:error, :timeout}
+      end
     end
   end
 

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -470,8 +470,6 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
         memory_budget_overhead_bytes: memory_budget_overhead_bytes
       )
 
-    os_identity = capture_os_identity(os_pid)
-
     runtime_params = %{
       backend: backend,
       executable: executable,
@@ -479,34 +477,57 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       log_path: log_path,
       model_path: model_path,
       model_ref: model_ref,
-      os_identity: os_identity,
+      os_pid: os_pid,
+      owner_pid: owner_pid,
+      port: port,
+      ready_timeout_ms: ready_timeout_ms,
       shutdown_timeout_ms: shutdown_timeout_ms,
       socket_path: socket_path
     }
 
+    case WorkerProcessLifecycle.process_identity(os_pid) do
+      {:ok, os_identity} ->
+        start_watched_runtime(Map.put(runtime_params, :os_identity, os_identity))
+
+      {:error, :identity_unavailable} = error ->
+        cleanup_failed_runtime(%{
+          channel: nil,
+          os_identity: nil,
+          os_pid: os_pid,
+          port: port,
+          reaper_ref: nil,
+          shutdown_timeout_ms: shutdown_timeout_ms,
+          socket_path: socket_path
+        })
+
+        error
+    end
+  end
+
+  defp start_watched_runtime(params) do
     reaper_meta = %{
-      shutdown_timeout_ms: shutdown_timeout_ms,
-      model_ref: model_ref,
-      os_identity: os_identity,
-      socket_path: socket_path,
+      shutdown_timeout_ms: params.shutdown_timeout_ms,
+      model_ref: params.model_ref,
+      os_identity: params.os_identity,
+      socket_path: params.socket_path,
       phase: :loading
     }
 
-    case RuntimeProcessReaper.watch(owner_pid, os_pid, reaper_meta) do
+    case RuntimeProcessReaper.watch(params.owner_pid, params.os_pid, reaper_meta) do
       {:ok, reaper_ref} ->
-        case wait_for_worker_ready(socket_path, port, ready_timeout_ms) do
+        case wait_for_worker_ready(params.socket_path, params.port, params.ready_timeout_ms) do
           {:ok, channel} ->
-            load_model_or_cleanup(channel, port, os_pid, reaper_ref, runtime_params)
+            load_model_or_cleanup(channel, params.port, params.os_pid, reaper_ref, params)
 
           {:error, reason} ->
             cleanup_failed_runtime(%{
               channel: nil,
-              os_identity: os_identity,
-              os_pid: os_pid,
-              port: port,
+              os_identity: params.os_identity,
+              os_pid: params.os_pid,
+              port: params.port,
               reaper_ref: reaper_ref,
-              shutdown_timeout_ms: shutdown_timeout_ms,
-              socket_path: socket_path
+              shutdown_timeout_ms: params.shutdown_timeout_ms,
+              socket_path: params.socket_path
             })
 
             {:error, reason}
@@ -515,22 +536,15 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       {:error, reason} ->
         cleanup_failed_runtime(%{
           channel: nil,
-          os_identity: os_identity,
-          os_pid: os_pid,
-          port: port,
+          os_identity: params.os_identity,
+          os_pid: params.os_pid,
+          port: params.port,
           reaper_ref: nil,
-          shutdown_timeout_ms: shutdown_timeout_ms,
-          socket_path: socket_path
+          shutdown_timeout_ms: params.shutdown_timeout_ms,
+          socket_path: params.socket_path
         })
 
         {:error, reason}
-    end
-  end
-
-  defp capture_os_identity(os_pid) do
-    case WorkerProcessLifecycle.process_identity(os_pid) do
-      {:ok, identity} -> identity
-      {:error, :identity_unavailable} -> nil
     end
   end
 

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -1022,7 +1022,29 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     if port_open?(port) do
       stop_runtime_with_escalation(port, os_pid, timeout_ms)
     else
+      stop_closed_port_runtime(os_pid, timeout_ms)
+    end
+  end
+
+  defp stop_closed_port_runtime(os_pid, timeout_ms) do
+    if WorkerProcessLifecycle.os_process_alive?(os_pid) do
+      _ = WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+
+      case wait_for_os_pid_exit(os_pid, timeout_ms) do
+        :ok -> :ok
+        {:error, :timeout} -> kill_closed_port_runtime(os_pid, timeout_ms)
+      end
+    else
       :ok
+    end
+  end
+
+  defp kill_closed_port_runtime(os_pid, timeout_ms) do
+    _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
+
+    case wait_for_os_pid_exit(os_pid, timeout_ms) do
+      :ok -> :ok
+      {:error, :timeout} -> {:error, :worker_shutdown_timeout}
     end
   end
 
@@ -1030,14 +1052,14 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   # The tree-kill is defense-in-depth against intermediate launchers
   # (e.g. `uv run`) that swallow signals without forwarding to children.
   defp stop_runtime_with_escalation(port, os_pid, timeout_ms) do
-    WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+    _ = WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
 
     case wait_for_port_exit(port, timeout_ms) do
       {:ok, _status} ->
         :ok
 
       {:error, :timeout} ->
-        WorkerProcessLifecycle.kill_process_tree(os_pid)
+        _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
 
         case wait_for_port_exit(port, timeout_ms) do
           {:ok, _status} -> :ok
@@ -1052,6 +1074,25 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       {^port, {:data, _data}} -> wait_for_port_exit(port, timeout_ms)
     after
       timeout_ms -> {:error, :timeout}
+    end
+  end
+
+  defp wait_for_os_pid_exit(os_pid, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_for_os_pid_exit(os_pid, deadline)
+  end
+
+  defp do_wait_for_os_pid_exit(os_pid, deadline) do
+    cond do
+      not WorkerProcessLifecycle.os_process_alive?(os_pid) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:error, :timeout}
+
+      true ->
+        Process.sleep(@poll_interval_ms)
+        do_wait_for_os_pid_exit(os_pid, deadline)
     end
   end
 

--- a/apps/orchard_node_agent/mix.exs
+++ b/apps/orchard_node_agent/mix.exs
@@ -11,6 +11,7 @@ defmodule OrchardNodeAgent.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
+      elixirc_paths: elixirc_paths(Mix.env()),
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       # M0 exception: this shell is intentionally shallow and the threshold will
@@ -19,6 +20,9 @@ defmodule OrchardNodeAgent.MixProject do
       deps: deps()
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_env), do: ["lib"]
 
   def application do
     [

--- a/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
@@ -15,6 +15,7 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
 
   @short_timeout_ms 200
   @stale_identity "0 Thu Jan 1 00:00:00 1970"
+  @sweep_grace_ms 1_000
 
   setup do
     # The node agent application starts the reaper under its supervisor.
@@ -303,6 +304,47 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
     assert event_logged?(marker_path, "term_ignored mode=resistant")
     CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
     refute File.exists?(socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  test "reaper termination signals every lease before it waits on any of them" do
+    root = unique_root("sweep-broadcast")
+    File.mkdir_p!(root)
+    private_reaper = start_private_reaper!()
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    children =
+      Enum.map(1..3, fn index ->
+        marker_path = Path.join(root, "events-#{index}.log")
+        {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+        %{marker_path: marker_path, os_pid: os_pid, port: port}
+      end)
+
+    on_exit(fn ->
+      Enum.each(children, &CustodyTestHelpers.stop_child(&1.port, &1.os_pid))
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+      File.rm_rf!(root)
+    end)
+
+    Enum.each(children, fn child ->
+      assert {:ok, _ref} = watch(child.os_pid, shutdown_timeout_ms: @sweep_grace_ms)
+    end)
+
+    sweep = Task.async(fn -> GenServer.stop(private_reaper, :shutdown) end)
+
+    # Every lease must record TERM well inside a single lease's grace window; a
+    # sweep that waits per lease only reaches the last one after N grace windows.
+    assert CustodyTestHelpers.wait_until(
+             fn ->
+               Enum.all?(children, &event_logged?(&1.marker_path, "term_ignored mode=resistant"))
+             end,
+             div(@sweep_grace_ms, 2)
+           ),
+           "expected the sweep to TERM every lease before awaiting any lease's exit"
+
+    assert :ok = Task.await(sweep, 5_000)
+
+    Enum.each(children, &CustodyTestHelpers.assert_os_pid_dead!(&1.os_pid, 2_000))
     assert WorkerProcessLifecycle.os_process_alive?(control_pid)
   end
 

--- a/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
@@ -47,7 +47,13 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
   end
 
   test "reaper kills the worker child when the owner process dies" do
-    {_port, os_pid} = start_sleeper_port!()
+    {port, os_pid} = start_sleeper_port!()
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
 
     owner_pid =
       spawn(fn ->
@@ -78,6 +84,8 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
              end,
              500
            )
+
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
   end
 
   test "watch returns an error when the reaper name is unavailable" do
@@ -136,9 +144,11 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
     marker_path = Path.join(root, "events.log")
     File.mkdir_p!(root)
     {port, os_pid} = CustodyTestHelpers.start_signal_child!(:cooperative, marker_path)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
 
     on_exit(fn ->
       CustodyTestHelpers.stop_child(port, os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
       File.rm_rf!(root)
     end)
 
@@ -151,6 +161,7 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
            )
 
     CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
     CustodyTestHelpers.assert_reaper_empty!(1_000)
   end
 
@@ -159,9 +170,11 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
     marker_path = Path.join(root, "events.log")
     File.mkdir_p!(root)
     {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
 
     on_exit(fn ->
       CustodyTestHelpers.stop_child(port, os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
       File.rm_rf!(root)
     end)
 
@@ -174,6 +187,7 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
            )
 
     CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
     CustodyTestHelpers.assert_reaper_empty!(1_000)
   end
 

--- a/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
@@ -9,6 +9,7 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
 
   use ExUnit.Case, async: false
 
+  alias Orchard.Node.CustodyTestHelpers
   alias Orchard.Node.RuntimeProcessReaper
   alias Orchard.Node.WorkerProcessLifecycle
 
@@ -128,6 +129,142 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
     assert WorkerProcessLifecycle.os_process_alive?(os_pid)
 
     WorkerProcessLifecycle.kill_process_tree(os_pid)
+  end
+
+  test "requested reap records cooperative TERM and clears lease custody" do
+    root = unique_root("cooperative")
+    marker_path = Path.join(root, "events.log")
+    File.mkdir_p!(root)
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:cooperative, marker_path)
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      File.rm_rf!(root)
+    end)
+
+    {:ok, ref} = watch(os_pid)
+    RuntimeProcessReaper.reap(ref, :custody_test)
+
+    assert CustodyTestHelpers.wait_until(
+             fn -> event_logged?(marker_path, "term_received mode=cooperative") end,
+             1_000
+           )
+
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
+  test "requested reap records resistant TERM before bounded KILL escalation" do
+    root = unique_root("resistant")
+    marker_path = Path.join(root, "events.log")
+    File.mkdir_p!(root)
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      File.rm_rf!(root)
+    end)
+
+    {:ok, ref} = watch(os_pid)
+    RuntimeProcessReaper.reap(ref, :custody_test)
+
+    assert CustodyTestHelpers.wait_until(
+             fn -> event_logged?(marker_path, "term_ignored mode=resistant") end,
+             1_000
+           )
+
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
+  test "release cancels a pending resistant-process escalation and clears monitors" do
+    root = unique_root("release")
+    marker_path = Path.join(root, "events.log")
+    File.mkdir_p!(root)
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      File.rm_rf!(root)
+    end)
+
+    {:ok, ref} = watch(os_pid)
+    RuntimeProcessReaper.reap(ref, :custody_test)
+
+    assert CustodyTestHelpers.wait_until(
+             fn ->
+               event_logged?(marker_path, "term_ignored mode=resistant") and
+                 match?(
+                   %{timer_ref: timer_ref} when is_reference(timer_ref),
+                   :sys.get_state(RuntimeProcessReaper).leases[ref]
+                 )
+             end,
+             1_000
+           )
+
+    RuntimeProcessReaper.release(ref)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+    Process.sleep(@short_timeout_ms + 100)
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+  end
+
+  test "reaper termination sweeps only its exact leased child" do
+    original_reaper = Process.whereis(RuntimeProcessReaper)
+    assert Process.unregister(RuntimeProcessReaper)
+
+    on_exit(fn ->
+      case Process.whereis(RuntimeProcessReaper) do
+        nil ->
+          Process.register(original_reaper, RuntimeProcessReaper)
+
+        ^original_reaper ->
+          :ok
+
+        other ->
+          GenServer.stop(other, :shutdown)
+          Process.register(original_reaper, RuntimeProcessReaper)
+      end
+    end)
+
+    assert {:ok, private_reaper} = RuntimeProcessReaper.start_link()
+    Process.unlink(private_reaper)
+    {leased_port, leased_pid} = CustodyTestHelpers.start_control_child!()
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(leased_port, leased_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
+
+    assert {:ok, _ref} = watch(leased_pid)
+    assert WorkerProcessLifecycle.os_process_alive?(leased_pid)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+
+    assert :ok = GenServer.stop(private_reaper, :shutdown)
+    CustodyTestHelpers.assert_os_pid_dead!(leased_pid, 2_000)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  defp watch(os_pid) do
+    RuntimeProcessReaper.watch(self(), os_pid, %{
+      shutdown_timeout_ms: @short_timeout_ms,
+      model_ref: nil,
+      phase: :loaded
+    })
+  end
+
+  defp unique_root(label) do
+    Path.join(
+      "/tmp",
+      "oc-reaper-#{label}-#{System.unique_integer([:positive, :monotonic])}"
+    )
+  end
+
+  defp event_logged?(marker_path, event) do
+    case File.read(marker_path) do
+      {:ok, contents} -> String.contains?(contents, event)
+      {:error, _reason} -> false
+    end
   end
 
   defp wait_until(fun, timeout_ms) do

--- a/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
@@ -65,10 +65,13 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
 
     assert WorkerProcessLifecycle.os_process_alive?(os_pid)
 
+    {:ok, os_identity} = WorkerProcessLifecycle.process_identity(os_pid)
+
     {:ok, _ref} =
       RuntimeProcessReaper.watch(owner_pid, os_pid, %{
         shutdown_timeout_ms: @short_timeout_ms,
         model_ref: nil,
+        os_identity: os_identity,
         phase: :loading
       })
 
@@ -122,10 +125,13 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
         end
       end)
 
+    {:ok, os_identity} = WorkerProcessLifecycle.process_identity(os_pid)
+
     {:ok, ref} =
       RuntimeProcessReaper.watch(owner_pid, os_pid, %{
         shutdown_timeout_ms: @short_timeout_ms,
         model_ref: nil,
+        os_identity: os_identity,
         phase: :loading
       })
 
@@ -324,6 +330,61 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
     assert WorkerProcessLifecycle.os_process_alive?(control_pid)
   end
 
+  test "owner-down reaping without launch identity cleans socket and lease without signaling" do
+    root = unique_root("owner-down-no-identity")
+    socket_path = Path.join(root, "worker.sock")
+    File.mkdir_p!(root)
+    File.write!(socket_path, "owned runtime artifact")
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    owner_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+      File.rm_rf!(root)
+    end)
+
+    assert {:ok, _ref} =
+             RuntimeProcessReaper.watch(owner_pid, control_pid, %{
+               shutdown_timeout_ms: @short_timeout_ms,
+               model_ref: nil,
+               os_identity: nil,
+               phase: :loaded,
+               socket_path: socket_path
+             })
+
+    Process.exit(owner_pid, :kill)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+
+    refute File.exists?(socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  test "shutdown sweep without launch identity cleans socket without signaling" do
+    root = unique_root("shutdown-no-identity")
+    socket_path = Path.join(root, "worker.sock")
+    File.mkdir_p!(root)
+    File.write!(socket_path, "owned runtime artifact")
+    private_reaper = start_private_reaper!()
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+      File.rm_rf!(root)
+    end)
+
+    assert {:ok, _ref} = watch(control_pid, os_identity: nil, socket_path: socket_path)
+    assert :ok = GenServer.stop(private_reaper, :shutdown)
+
+    refute File.exists?(socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
   defp start_private_reaper! do
     original_reaper = Process.whereis(RuntimeProcessReaper)
     assert Process.unregister(RuntimeProcessReaper)
@@ -348,9 +409,12 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
   end
 
   defp watch(os_pid, meta \\ []) do
+    {:ok, os_identity} = WorkerProcessLifecycle.process_identity(os_pid)
+
     base = %{
       shutdown_timeout_ms: @short_timeout_ms,
       model_ref: nil,
+      os_identity: os_identity,
       phase: :loaded
     }
 

--- a/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs
@@ -14,6 +14,7 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
   alias Orchard.Node.WorkerProcessLifecycle
 
   @short_timeout_ms 200
+  @stale_identity "0 Thu Jan 1 00:00:00 1970"
 
   setup do
     # The node agent application starts the reaper under its supervisor.
@@ -223,6 +224,107 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
   end
 
   test "reaper termination sweeps only its exact leased child" do
+    private_reaper = start_private_reaper!()
+    {leased_port, leased_pid} = CustodyTestHelpers.start_control_child!()
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(leased_port, leased_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
+
+    assert {:ok, _ref} = watch(leased_pid)
+    assert WorkerProcessLifecycle.os_process_alive?(leased_pid)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+
+    assert :ok = GenServer.stop(private_reaper, :shutdown)
+    CustodyTestHelpers.assert_os_pid_dead!(leased_pid, 2_000)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  test "reaper termination preserves the TERM grace and removes the owned socket" do
+    root = unique_root("sweep-grace")
+    marker_path = Path.join(root, "events.log")
+    socket_path = Path.join(root, "worker.sock")
+    File.mkdir_p!(root)
+    File.write!(socket_path, "owned runtime artifact")
+
+    private_reaper = start_private_reaper!()
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:cooperative, marker_path)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+      File.rm_rf!(root)
+    end)
+
+    assert {:ok, _ref} = watch(os_pid, socket_path: socket_path)
+    assert :ok = GenServer.stop(private_reaper, :shutdown)
+
+    # A cooperative child only writes this marker from its TERM trap, so the
+    # marker proves the sweep delivered TERM instead of an immediate KILL.
+    assert CustodyTestHelpers.wait_until(
+             fn -> event_logged?(marker_path, "term_received mode=cooperative") end,
+             500
+           )
+
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    refute File.exists?(socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  test "reaper termination escalates a TERM-resistant lease to bounded KILL" do
+    root = unique_root("sweep-kill")
+    marker_path = Path.join(root, "events.log")
+    socket_path = Path.join(root, "worker.sock")
+    File.mkdir_p!(root)
+    File.write!(socket_path, "owned runtime artifact")
+
+    private_reaper = start_private_reaper!()
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+      File.rm_rf!(root)
+    end)
+
+    assert {:ok, _ref} = watch(os_pid, socket_path: socket_path)
+    assert :ok = GenServer.stop(private_reaper, :shutdown)
+
+    assert event_logged?(marker_path, "term_ignored mode=resistant")
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    refute File.exists?(socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  test "reaper termination refuses to signal a lease whose PID identity changed" do
+    private_reaper = start_private_reaper!()
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(control_port, control_pid) end)
+
+    assert {:ok, _ref} = watch(control_pid, os_identity: @stale_identity)
+    assert :ok = GenServer.stop(private_reaper, :shutdown)
+
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  test "owner-down reaping refuses to signal a lease whose PID identity changed" do
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(control_port, control_pid) end)
+
+    {:ok, ref} = watch(control_pid, os_identity: @stale_identity)
+    RuntimeProcessReaper.reap(ref, :custody_test)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  defp start_private_reaper! do
     original_reaper = Process.whereis(RuntimeProcessReaper)
     assert Process.unregister(RuntimeProcessReaper)
 
@@ -242,29 +344,17 @@ defmodule Orchard.Node.RuntimeProcessReaperTest do
 
     assert {:ok, private_reaper} = RuntimeProcessReaper.start_link()
     Process.unlink(private_reaper)
-    {leased_port, leased_pid} = CustodyTestHelpers.start_control_child!()
-    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
-
-    on_exit(fn ->
-      CustodyTestHelpers.stop_child(leased_port, leased_pid)
-      CustodyTestHelpers.stop_child(control_port, control_pid)
-    end)
-
-    assert {:ok, _ref} = watch(leased_pid)
-    assert WorkerProcessLifecycle.os_process_alive?(leased_pid)
-    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
-
-    assert :ok = GenServer.stop(private_reaper, :shutdown)
-    CustodyTestHelpers.assert_os_pid_dead!(leased_pid, 2_000)
-    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+    private_reaper
   end
 
-  defp watch(os_pid) do
-    RuntimeProcessReaper.watch(self(), os_pid, %{
+  defp watch(os_pid, meta \\ []) do
+    base = %{
       shutdown_timeout_ms: @short_timeout_ms,
       model_ref: nil,
       phase: :loaded
-    })
+    }
+
+    RuntimeProcessReaper.watch(self(), os_pid, Map.merge(base, Map.new(meta)))
   end
 
   defp unique_root(label) do

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -122,6 +122,81 @@ defmodule Orchard.Node.WorkerCustodyTest do
     refute File.exists?(context.socket_path)
   end
 
+  test "SPEC.md §4.9 closed Port without launch identity does not signal a recorded PID",
+       context do
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(control_port, control_pid) end)
+
+    File.write!(context.socket_path, "owned runtime artifact")
+
+    state = %{
+      backend: "stub",
+      channel: nil,
+      executable: Path.expand("../../support/custody-signal-child", __DIR__),
+      generations: %{},
+      model_ref: context.model_ref,
+      os_identity: nil,
+      os_pid: control_pid,
+      port: exited_port!(),
+      reaper_ref: nil,
+      shutdown_timeout_ms: @shutdown_timeout_ms,
+      socket_path: context.socket_path
+    }
+
+    log =
+      capture_log(fn ->
+        assert :ok = WorkerRuntimeAdapter.unload_model(state, skip_rpc: true)
+      end)
+
+    assert log =~ "worker custody identity unavailable"
+    assert log =~ "os_pid=#{control_pid}"
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+    refute File.exists?(context.socket_path)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
+  test "SPEC.md §4.9 launch aborts before arming reaper when identity capture fails",
+       context do
+    fake_bin = Path.join(context.root, "fake-bin")
+    fake_ps = Path.join(fake_bin, "ps")
+    worker = Path.join(context.root, "identity-unavailable-worker")
+    File.mkdir_p!(fake_bin)
+    File.write!(fake_ps, "#!/bin/sh\nexit 1\n")
+    File.chmod!(fake_ps, 0o755)
+    File.write!(worker, "#!/bin/sh\ntrap 'exit 0' TERM\nwhile :; do sleep 1; done\n")
+    File.chmod!(worker, 0o755)
+    File.write!(context.socket_path, "owned runtime artifact")
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+    previous_path = System.fetch_env!("PATH")
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(control_port, control_pid) end)
+
+    result =
+      try do
+        System.put_env("PATH", fake_bin <> ":" <> previous_path)
+
+        WorkerRuntimeAdapter.load_model(context.model_ref,
+          backend: "stub",
+          executable: worker,
+          load_timeout_ms: 5_000,
+          log_path: context.log_path,
+          models_root: context.models_root,
+          owner: self(),
+          ready_timeout_ms: 5_000,
+          shutdown_timeout_ms: @shutdown_timeout_ms,
+          socket_path: context.socket_path
+        )
+      after
+        System.put_env("PATH", previous_path)
+      end
+
+    assert {:error, :identity_unavailable} = result
+    refute File.exists?(context.socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
   test "SPEC.md §4.9 noisy TERM-resistant shutdown reaches bounded KILL", context do
     marker_path = Path.join(context.root, "events.log")
 
@@ -135,10 +210,13 @@ defmodule Orchard.Node.WorkerCustodyTest do
       CustodyTestHelpers.stop_child(control_port, control_pid)
     end)
 
+    assert {:ok, os_identity} = WorkerProcessLifecycle.process_identity(os_pid)
+
     assert {:ok, reaper_ref} =
              RuntimeProcessReaper.watch(self(), os_pid, %{
                shutdown_timeout_ms: @shutdown_timeout_ms,
                model_ref: context.model_ref,
+               os_identity: os_identity,
                phase: :loaded
              })
 
@@ -150,6 +228,7 @@ defmodule Orchard.Node.WorkerCustodyTest do
       executable: Path.expand("../../support/custody-signal-child", __DIR__),
       generations: %{},
       model_ref: context.model_ref,
+      os_identity: os_identity,
       os_pid: os_pid,
       port: port,
       reaper_ref: reaper_ref,

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Node.WorkerCustodyTest do
   alias Orchard.Cluster.V1.EnsureModelLoadedRequest
   alias Orchard.Cluster.V1.ModelRef
   alias Orchard.Node.CustodyTestHelpers
+  alias Orchard.Node.RuntimeProcessReaper
   alias Orchard.Node.WorkerProcess
   alias Orchard.Node.WorkerProcessLifecycle
   alias Orchard.Node.WorkerRuntimeAdapter
@@ -67,8 +68,12 @@ defmodule Orchard.Node.WorkerCustodyTest do
 
   test "SPEC.md §4.9 closed BEAM port still reaps its live recorded PID", context do
     state = load_stub_runtime!(context)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
 
-    on_exit(fn -> CustodyTestHelpers.stop_child(state.port, state.os_pid) end)
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(state.port, state.os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
 
     Port.close(state.port)
     assert is_nil(Port.info(state.port))
@@ -78,6 +83,71 @@ defmodule Orchard.Node.WorkerCustodyTest do
 
     CustodyTestHelpers.assert_os_pid_dead!(state.os_pid, 2_000)
     refute File.exists?(state.socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
+  test "SPEC.md §4.9 noisy TERM-resistant shutdown reaches bounded KILL", context do
+    marker_path = Path.join(context.root, "events.log")
+
+    {port, os_pid} =
+      CustodyTestHelpers.start_signal_child!(:chatty_resistant, marker_path)
+
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
+
+    assert {:ok, reaper_ref} =
+             RuntimeProcessReaper.watch(self(), os_pid, %{
+               shutdown_timeout_ms: @shutdown_timeout_ms,
+               model_ref: context.model_ref,
+               phase: :loaded
+             })
+
+    File.write!(context.socket_path, "owned runtime artifact")
+
+    state = %{
+      backend: "stub",
+      channel: nil,
+      executable: Path.join(__DIR__, "../../../support/custody-signal-child"),
+      generations: %{},
+      model_ref: context.model_ref,
+      os_pid: os_pid,
+      port: port,
+      reaper_ref: reaper_ref,
+      shutdown_timeout_ms: @shutdown_timeout_ms,
+      socket_path: context.socket_path
+    }
+
+    task =
+      Task.async(fn ->
+        receive do
+          :unload -> WorkerRuntimeAdapter.unload_model(state, skip_rpc: true)
+        end
+      end)
+
+    assert true = Port.connect(port, task.pid)
+    send(task.pid, :unload)
+
+    result = Task.yield(task, 2_000) || Task.shutdown(task, :brutal_kill)
+    assert {:ok, :ok} = result
+
+    assert CustodyTestHelpers.wait_until(
+             fn ->
+               case File.read(marker_path) do
+                 {:ok, contents} -> String.contains?(contents, "term_ignored mode=resistant")
+                 {:error, _reason} -> false
+               end
+             end,
+             1_000
+           )
+
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    refute File.exists?(context.socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
     CustodyTestHelpers.assert_reaper_empty!(1_000)
   end
 

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -1,0 +1,160 @@
+defmodule Orchard.Node.WorkerCustodyTest do
+  use ExUnit.Case, async: false
+
+  alias Orchard.Cluster.V1.EnsureModelLoadedRequest
+  alias Orchard.Cluster.V1.ModelRef
+  alias Orchard.Node.CustodyTestHelpers
+  alias Orchard.Node.WorkerProcess
+  alias Orchard.Node.WorkerProcessLifecycle
+  alias Orchard.Node.WorkerRuntimeAdapter
+  alias Orchard.Node.WorkerSupervisor
+
+  @shutdown_timeout_ms 200
+
+  setup do
+    assert {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+
+    root =
+      Path.join(
+        "/tmp",
+        "oc-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    models_root = Path.join(root, "models")
+    model_ref = %ModelRef{model_id: "custody/test", version: "v1"}
+    File.mkdir_p!(Path.join([models_root, model_ref.model_id, model_ref.version]))
+
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    %{
+      log_path: Path.join(root, "worker.log"),
+      model_ref: model_ref,
+      models_root: models_root,
+      root: root,
+      socket_path: Path.join(root, "worker.sock")
+    }
+  end
+
+  test "SPEC.md §4.9 explicit unload reaps the exact stub runtime PID and socket", context do
+    state = load_stub_runtime!(context)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(state.port, state.os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
+
+    assert WorkerProcessLifecycle.os_process_alive?(state.os_pid)
+    assert File.exists?(state.socket_path)
+    assert :ok = WorkerRuntimeAdapter.unload_model(state, [])
+
+    CustodyTestHelpers.assert_os_pid_dead!(state.os_pid, 2_000)
+    refute File.exists?(state.socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+
+    assert CustodyTestHelpers.wait_until(
+             fn ->
+               case File.read(state.log_path) do
+                 {:ok, contents} -> String.contains?(contents, "worker stopping")
+                 {:error, _reason} -> false
+               end
+             end,
+             1_000
+           )
+  end
+
+  test "SPEC.md §4.9 closed BEAM port still reaps its live recorded PID", context do
+    state = load_stub_runtime!(context)
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(state.port, state.os_pid) end)
+
+    Port.close(state.port)
+    assert is_nil(Port.info(state.port))
+    assert WorkerProcessLifecycle.os_process_alive?(state.os_pid)
+
+    assert :ok = WorkerRuntimeAdapter.unload_model(state, skip_rpc: true)
+
+    CustodyTestHelpers.assert_os_pid_dead!(state.os_pid, 2_000)
+    refute File.exists?(state.socket_path)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
+  test "SPEC.md §4.9 Application.stop reaps the exact runtime PID and socket", context do
+    previous_runtime = Application.fetch_env!(:orchard_node_agent, :runtime)
+    stop_node_agent_app()
+
+    runtime =
+      Keyword.merge(previous_runtime,
+        fake_runtime?: false,
+        models_root: context.models_root,
+        runtime_adapter_impl: WorkerRuntimeAdapter,
+        worker_backend: "stub",
+        worker_executable: worker_executable(),
+        worker_log_dir: context.root,
+        worker_shutdown_timeout_ms: @shutdown_timeout_ms,
+        worker_socket_dir: context.root
+      )
+
+    Application.put_env(:orchard_node_agent, :runtime, runtime)
+
+    on_exit(fn ->
+      stop_node_agent_app()
+      Application.put_env(:orchard_node_agent, :runtime, previous_runtime)
+      assert {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
+    end)
+
+    assert {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
+    assert {:ok, worker_pid} = WorkerSupervisor.start_worker(context.model_ref, manager: self())
+
+    assert :loaded =
+             WorkerProcess.ensure_loaded(worker_pid, %EnsureModelLoadedRequest{},
+               load_timeout_ms: 5_000
+             )
+
+    %{adapter_state: state} = :sys.get_state(worker_pid)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(state.port, state.os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
+
+    assert WorkerProcessLifecycle.os_process_alive?(state.os_pid)
+    assert File.exists?(state.socket_path)
+    assert :ok = Application.stop(:orchard_node_agent)
+
+    CustodyTestHelpers.assert_os_pid_dead!(state.os_pid, 2_000)
+    refute File.exists?(state.socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  defp load_stub_runtime!(context) do
+    assert {:ok, state} =
+             WorkerRuntimeAdapter.load_model(context.model_ref,
+               backend: "stub",
+               executable: worker_executable(),
+               load_timeout_ms: 5_000,
+               log_path: context.log_path,
+               models_root: context.models_root,
+               owner: self(),
+               ready_timeout_ms: 5_000,
+               shutdown_timeout_ms: @shutdown_timeout_ms,
+               socket_path: context.socket_path
+             )
+
+    state
+  end
+
+  defp worker_executable do
+    Path.expand("../../../../../native/orchard_worker_mlx/bin/orchard-worker-mlx", __DIR__)
+  end
+
+  defp stop_node_agent_app do
+    case Application.stop(:orchard_node_agent) do
+      :ok -> :ok
+      {:error, {:not_started, :orchard_node_agent}} -> :ok
+    end
+  end
+end

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -1,6 +1,8 @@
 defmodule Orchard.Node.WorkerCustodyTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias Orchard.Cluster.V1.EnsureModelLoadedRequest
   alias Orchard.Cluster.V1.ModelRef
   alias Orchard.Node.CustodyTestHelpers
@@ -11,6 +13,7 @@ defmodule Orchard.Node.WorkerCustodyTest do
   alias Orchard.Node.WorkerSupervisor
 
   @shutdown_timeout_ms 200
+  @stale_identity "0 Thu Jan 1 00:00:00 1970"
 
   setup do
     assert {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
@@ -87,6 +90,38 @@ defmodule Orchard.Node.WorkerCustodyTest do
     CustodyTestHelpers.assert_reaper_empty!(1_000)
   end
 
+  test "SPEC.md §4.9 closed BEAM port refuses to signal a recycled PID", context do
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(control_port, control_pid) end)
+
+    File.write!(context.socket_path, "owned runtime artifact")
+
+    state = %{
+      backend: "stub",
+      channel: nil,
+      executable: Path.expand("../../support/custody-signal-child", __DIR__),
+      generations: %{},
+      model_ref: context.model_ref,
+      os_identity: @stale_identity,
+      os_pid: control_pid,
+      port: exited_port!(),
+      reaper_ref: nil,
+      shutdown_timeout_ms: @shutdown_timeout_ms,
+      socket_path: context.socket_path
+    }
+
+    log =
+      capture_log(fn ->
+        assert :ok = WorkerRuntimeAdapter.unload_model(state, skip_rpc: true)
+      end)
+
+    assert log =~ "worker custody identity mismatch"
+    assert log =~ "os_pid=#{control_pid}"
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+    refute File.exists?(context.socket_path)
+  end
+
   test "SPEC.md §4.9 noisy TERM-resistant shutdown reaches bounded KILL", context do
     marker_path = Path.join(context.root, "events.log")
 
@@ -112,7 +147,7 @@ defmodule Orchard.Node.WorkerCustodyTest do
     state = %{
       backend: "stub",
       channel: nil,
-      executable: Path.join(__DIR__, "../../../support/custody-signal-child"),
+      executable: Path.expand("../../support/custody-signal-child", __DIR__),
       generations: %{},
       model_ref: context.model_ref,
       os_pid: os_pid,
@@ -215,6 +250,18 @@ defmodule Orchard.Node.WorkerCustodyTest do
              )
 
     state
+  end
+
+  defp exited_port! do
+    true_executable = System.find_executable("true") || "/usr/bin/true"
+    port = Port.open({:spawn_executable, true_executable}, [:exit_status])
+
+    assert_receive {^port, {:exit_status, _status}}, 2_000
+
+    assert CustodyTestHelpers.wait_until(fn -> is_nil(Port.info(port)) end, 1_000),
+           "expected the fixture port to close after its program exited"
+
+    port
   end
 
   defp worker_executable do

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -15,6 +15,8 @@ defmodule Orchard.Node.WorkerCustodyTest do
   @shutdown_timeout_ms 200
   @stale_identity "0 Thu Jan 1 00:00:00 1970"
   @closed_port_budget_ms 600
+  @kill_confirm_reserve_ms 250
+  @escalation_slack_ms 150
 
   setup do
     assert {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
@@ -248,6 +250,8 @@ defmodule Orchard.Node.WorkerCustodyTest do
       CustodyTestHelpers.stop_child(control_port, control_pid)
     end)
 
+    escalation_overhead_ms = measure_escalation_overhead!(context)
+
     assert {:ok, os_identity} = WorkerProcessLifecycle.process_identity(os_pid)
     File.write!(context.socket_path, "owned runtime artifact")
 
@@ -273,8 +277,14 @@ defmodule Orchard.Node.WorkerCustodyTest do
     assert :ok = WorkerRuntimeAdapter.unload_model(state, skip_rpc: true)
     elapsed = System.monotonic_time(:millisecond) - started
 
-    assert elapsed < @closed_port_budget_ms,
-           "closed-Port unload spent #{elapsed}ms of a #{@closed_port_budget_ms}ms budget"
+    ceiling_ms =
+      @closed_port_budget_ms - @kill_confirm_reserve_ms + escalation_overhead_ms +
+        @escalation_slack_ms
+
+    assert elapsed <= ceiling_ms,
+           "closed-Port unload spent #{elapsed}ms; one #{@closed_port_budget_ms}ms budget " <>
+             "less its KILL-confirmation reserve allows #{ceiling_ms}ms " <>
+             "(measured escalation overhead #{escalation_overhead_ms}ms)"
 
     assert {:ok, marker} = File.read(marker_path)
     assert marker =~ "term_ignored mode=resistant"
@@ -398,6 +408,29 @@ defmodule Orchard.Node.WorkerCustodyTest do
     CustodyTestHelpers.assert_os_pid_dead!(state.os_pid, 2_000)
     refute File.exists?(state.socket_path)
     assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+  end
+
+  # Cost of one custody-gated escalation with no waiting left, so the closed-Port
+  # budget assertion tracks this machine's process-spawn cost instead of assuming it.
+  defp measure_escalation_overhead!(context) do
+    marker_path = Path.join(context.root, "baseline-events.log")
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(port, os_pid) end)
+
+    assert {:ok, identity} = WorkerProcessLifecycle.process_identity(os_pid)
+
+    started = System.monotonic_time(:millisecond)
+
+    assert :ok =
+             WorkerProcessLifecycle.escalate_owned_exit(
+               os_pid,
+               identity,
+               started,
+               started + 2_000
+             )
+
+    System.monotonic_time(:millisecond) - started
   end
 
   defp load_stub_runtime!(context) do

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -14,6 +14,7 @@ defmodule Orchard.Node.WorkerCustodyTest do
 
   @shutdown_timeout_ms 200
   @stale_identity "0 Thu Jan 1 00:00:00 1970"
+  @closed_port_budget_ms 600
 
   setup do
     assert {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
@@ -195,6 +196,91 @@ defmodule Orchard.Node.WorkerCustodyTest do
     refute File.exists?(context.socket_path)
     assert WorkerProcessLifecycle.os_process_alive?(control_pid)
     CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
+  test "SPEC.md §4.9 launch identity failure retains a deterministic worker exit status",
+       context do
+    fake_bin = Path.join(context.root, "slow-ps-bin")
+    fake_ps = Path.join(fake_bin, "ps")
+    worker = Path.join(context.root, "immediate-exit-worker")
+    File.mkdir_p!(fake_bin)
+    File.write!(fake_ps, "#!/bin/sh\nsleep 0.5\nexit 1\n")
+    File.chmod!(fake_ps, 0o755)
+    File.write!(worker, "#!/bin/sh\nexit 42\n")
+    File.chmod!(worker, 0o755)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+    previous_path = System.fetch_env!("PATH")
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(control_port, control_pid) end)
+
+    result =
+      try do
+        System.put_env("PATH", fake_bin <> ":" <> previous_path)
+
+        WorkerRuntimeAdapter.load_model(context.model_ref,
+          backend: "stub",
+          executable: worker,
+          load_timeout_ms: 5_000,
+          log_path: context.log_path,
+          models_root: context.models_root,
+          owner: self(),
+          ready_timeout_ms: 5_000,
+          shutdown_timeout_ms: @shutdown_timeout_ms,
+          socket_path: context.socket_path
+        )
+      after
+        System.put_env("PATH", previous_path)
+      end
+
+    assert {:error, {:worker_exited, 42}} = result
+    refute File.exists?(context.socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+  end
+
+  test "SPEC.md §4.9 closed BEAM port unload spends its shutdown budget once", context do
+    marker_path = Path.join(context.root, "events.log")
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+    {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      CustodyTestHelpers.stop_child(control_port, control_pid)
+    end)
+
+    assert {:ok, os_identity} = WorkerProcessLifecycle.process_identity(os_pid)
+    File.write!(context.socket_path, "owned runtime artifact")
+
+    Port.close(port)
+    assert is_nil(Port.info(port))
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+
+    state = %{
+      backend: "stub",
+      channel: nil,
+      executable: Path.expand("../../support/custody-signal-child", __DIR__),
+      generations: %{},
+      model_ref: context.model_ref,
+      os_identity: os_identity,
+      os_pid: os_pid,
+      port: port,
+      reaper_ref: nil,
+      shutdown_timeout_ms: @closed_port_budget_ms,
+      socket_path: context.socket_path
+    }
+
+    started = System.monotonic_time(:millisecond)
+    assert :ok = WorkerRuntimeAdapter.unload_model(state, skip_rpc: true)
+    elapsed = System.monotonic_time(:millisecond) - started
+
+    assert elapsed < @closed_port_budget_ms,
+           "closed-Port unload spent #{elapsed}ms of a #{@closed_port_budget_ms}ms budget"
+
+    assert {:ok, marker} = File.read(marker_path)
+    assert marker =~ "term_ignored mode=resistant"
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    refute File.exists?(context.socket_path)
+    assert WorkerProcessLifecycle.os_process_alive?(control_pid)
   end
 
   test "SPEC.md §4.9 noisy TERM-resistant shutdown reaches bounded KILL", context do

--- a/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
@@ -89,10 +89,10 @@ defmodule Orchard.Node.WorkerProcessLifecycleTest do
 
     log =
       capture_log(fn ->
-        assert {:error, :identity_mismatch} =
+        assert {:error, :identity_unavailable} =
                  WorkerProcessLifecycle.signal_owned_process(os_pid, nil, "-TERM")
 
-        assert {:error, :identity_mismatch} =
+        assert {:error, :identity_unavailable} =
                  WorkerProcessLifecycle.kill_owned_process_tree(os_pid, nil)
       end)
 
@@ -100,6 +100,97 @@ defmodule Orchard.Node.WorkerProcessLifecycleTest do
     assert log =~ "os_pid=#{os_pid}"
     assert WorkerProcessLifecycle.os_process_alive?(os_pid)
     assert {:error, :identity_unavailable} = WorkerProcessLifecycle.process_identity(@missing_pid)
+  end
+
+  test "custody refusal separates an already-exited target from a recycled PID" do
+    {port, os_pid} = CustodyTestHelpers.start_control_child!()
+
+    assert {:ok, identity} = WorkerProcessLifecycle.process_identity(os_pid)
+    CustodyTestHelpers.stop_child(port, os_pid)
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+
+    log =
+      capture_log(fn ->
+        assert {:error, :identity_unavailable} =
+                 WorkerProcessLifecycle.signal_owned_process(os_pid, identity, "-TERM")
+
+        assert {:error, :identity_unavailable} =
+                 WorkerProcessLifecycle.kill_owned_process_tree(os_pid, identity)
+      end)
+
+    refute log =~ "worker custody identity mismatch"
+
+    assert WorkerProcessLifecycle.custody_refused?({:error, :identity_unavailable})
+    assert WorkerProcessLifecycle.custody_refused?({:error, :identity_mismatch})
+    refute WorkerProcessLifecycle.custody_refused?({:error, :signal_failed})
+    refute WorkerProcessLifecycle.custody_refused?(:ok)
+  end
+
+  test "escalate_owned_exit spends no grace past an already-elapsed TERM deadline" do
+    root = Path.join("/tmp", "oc-escalate-#{System.unique_integer([:positive, :monotonic])}")
+    marker_path = Path.join(root, "events.log")
+    File.mkdir_p!(root)
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      File.rm_rf!(root)
+    end)
+
+    assert {:ok, identity} = WorkerProcessLifecycle.process_identity(os_pid)
+
+    started = System.monotonic_time(:millisecond)
+
+    assert :ok =
+             WorkerProcessLifecycle.escalate_owned_exit(
+               os_pid,
+               identity,
+               started,
+               started + 2_000
+             )
+
+    elapsed = System.monotonic_time(:millisecond) - started
+
+    assert elapsed < 500,
+           "expected an elapsed TERM deadline to escalate immediately, spent #{elapsed}ms"
+
+    refute WorkerProcessLifecycle.os_process_alive?(os_pid)
+  end
+
+  test "escalate_owned_exit refuses to kill a PID whose identity snapshot changed" do
+    {port, os_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(port, os_pid) end)
+
+    now = System.monotonic_time(:millisecond)
+
+    log =
+      capture_log(fn ->
+        assert {:error, :identity_mismatch} =
+                 WorkerProcessLifecycle.escalate_owned_exit(
+                   os_pid,
+                   @stale_identity,
+                   now,
+                   now + 500
+                 )
+      end)
+
+    assert log =~ "worker custody identity mismatch"
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+  end
+
+  test "remove_owned_socket drops an owned path and tolerates a missing one" do
+    root = Path.join("/tmp", "oc-socket-#{System.unique_integer([:positive, :monotonic])}")
+    socket_path = Path.join(root, "worker.sock")
+    File.mkdir_p!(root)
+    File.write!(socket_path, "owned runtime artifact")
+
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    assert :ok = WorkerProcessLifecycle.remove_owned_socket(socket_path)
+    refute File.exists?(socket_path)
+    assert :ok = WorkerProcessLifecycle.remove_owned_socket(socket_path)
+    assert :ok = WorkerProcessLifecycle.remove_owned_socket(nil)
   end
 
   test "await_exit reports a bounded timeout while the child is still alive" do

--- a/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
@@ -82,13 +82,23 @@ defmodule Orchard.Node.WorkerProcessLifecycleTest do
     CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
   end
 
-  test "custody-gated signals fall back to unguarded delivery without a snapshot" do
+  test "custody-gated signals fail closed without a launch identity" do
     {port, os_pid} = CustodyTestHelpers.start_control_child!()
 
     on_exit(fn -> CustodyTestHelpers.stop_child(port, os_pid) end)
 
-    assert :ok = WorkerProcessLifecycle.signal_owned_process(os_pid, nil, "-TERM")
-    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    log =
+      capture_log(fn ->
+        assert {:error, :identity_mismatch} =
+                 WorkerProcessLifecycle.signal_owned_process(os_pid, nil, "-TERM")
+
+        assert {:error, :identity_mismatch} =
+                 WorkerProcessLifecycle.kill_owned_process_tree(os_pid, nil)
+      end)
+
+    assert log =~ "worker custody identity unavailable"
+    assert log =~ "os_pid=#{os_pid}"
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
     assert {:error, :identity_unavailable} = WorkerProcessLifecycle.process_identity(@missing_pid)
   end
 

--- a/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
@@ -1,0 +1,71 @@
+defmodule Orchard.Node.WorkerProcessLifecycleTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Orchard.Node.CustodyTestHelpers
+  alias Orchard.Node.WorkerProcessLifecycle
+
+  test "TERM delivery succeeds for a live resistant child" do
+    root = Path.join("/tmp", "oc-signal-#{System.unique_integer([:positive, :monotonic])}")
+    marker_path = Path.join(root, "events.log")
+    File.mkdir_p!(root)
+    {port, os_pid} = CustodyTestHelpers.start_signal_child!(:resistant, marker_path)
+
+    on_exit(fn ->
+      CustodyTestHelpers.stop_child(port, os_pid)
+      File.rm_rf!(root)
+    end)
+
+    assert :ok = WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+
+    assert CustodyTestHelpers.wait_until(
+             fn ->
+               case File.read(marker_path) do
+                 {:ok, contents} -> String.contains?(contents, "term_ignored mode=resistant")
+                 {:error, _reason} -> false
+               end
+             end,
+             1_000
+           )
+
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+  end
+
+  test "signal command failures are observable with secret-safe stable fields" do
+    {port, os_pid} = CustodyTestHelpers.start_control_child!()
+    secret_signal = "-NOT-A-SIGNAL-/tmp/private/token-secret"
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(port, os_pid) end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, :signal_failed} =
+                 WorkerProcessLifecycle.send_signal(os_pid, secret_signal)
+      end)
+
+    assert log =~ "worker signal failed"
+    assert log =~ "os_pid=#{os_pid}"
+    assert log =~ "signal=unknown"
+    assert log =~ "exit_status="
+    refute log =~ secret_signal
+    refute log =~ "/tmp/private"
+    refute log =~ "token-secret"
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+  end
+
+  test "signaling a missing PID returns the stable failure reason" do
+    missing_pid = 2_147_483_647
+
+    log =
+      capture_log(fn ->
+        assert {:error, :signal_failed} =
+                 WorkerProcessLifecycle.send_signal(missing_pid, "-TERM")
+      end)
+
+    assert log =~ "worker signal failed"
+    assert log =~ "os_pid=#{missing_pid}"
+    assert log =~ "signal=TERM"
+    refute log =~ "No such process"
+  end
+end

--- a/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_process_lifecycle_test.exs
@@ -6,6 +6,9 @@ defmodule Orchard.Node.WorkerProcessLifecycleTest do
   alias Orchard.Node.CustodyTestHelpers
   alias Orchard.Node.WorkerProcessLifecycle
 
+  @missing_pid 2_147_483_647
+  @stale_identity "0 Thu Jan 1 00:00:00 1970"
+
   test "TERM delivery succeeds for a live resistant child" do
     root = Path.join("/tmp", "oc-signal-#{System.unique_integer([:positive, :monotonic])}")
     marker_path = Path.join(root, "events.log")
@@ -54,17 +57,62 @@ defmodule Orchard.Node.WorkerProcessLifecycleTest do
     assert WorkerProcessLifecycle.os_process_alive?(os_pid)
   end
 
-  test "signaling a missing PID returns the stable failure reason" do
-    missing_pid = 2_147_483_647
+  test "custody-gated signals refuse a PID whose identity snapshot no longer matches" do
+    {port, os_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(port, os_pid) end)
+
+    assert {:ok, identity} = WorkerProcessLifecycle.process_identity(os_pid)
+    assert {:ok, ^identity} = WorkerProcessLifecycle.process_identity(os_pid)
 
     log =
       capture_log(fn ->
+        assert {:error, :identity_mismatch} =
+                 WorkerProcessLifecycle.signal_owned_process(os_pid, @stale_identity, "-TERM")
+
+        assert {:error, :identity_mismatch} =
+                 WorkerProcessLifecycle.kill_owned_process_tree(os_pid, @stale_identity)
+      end)
+
+    assert log =~ "worker custody identity mismatch"
+    assert log =~ "os_pid=#{os_pid}"
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+
+    assert :ok = WorkerProcessLifecycle.signal_owned_process(os_pid, identity, "-TERM")
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+  end
+
+  test "custody-gated signals fall back to unguarded delivery without a snapshot" do
+    {port, os_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(port, os_pid) end)
+
+    assert :ok = WorkerProcessLifecycle.signal_owned_process(os_pid, nil, "-TERM")
+    CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
+    assert {:error, :identity_unavailable} = WorkerProcessLifecycle.process_identity(@missing_pid)
+  end
+
+  test "await_exit reports a bounded timeout while the child is still alive" do
+    {port, os_pid} = CustodyTestHelpers.start_control_child!()
+
+    on_exit(fn -> CustodyTestHelpers.stop_child(port, os_pid) end)
+
+    assert {:error, :timeout} = WorkerProcessLifecycle.await_exit(os_pid, 50)
+    assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+
+    assert :ok = WorkerProcessLifecycle.send_signal(os_pid, "-TERM")
+    assert :ok = WorkerProcessLifecycle.await_exit(os_pid, 2_000)
+  end
+
+  test "signaling a missing PID returns the stable failure reason" do
+    log =
+      capture_log(fn ->
         assert {:error, :signal_failed} =
-                 WorkerProcessLifecycle.send_signal(missing_pid, "-TERM")
+                 WorkerProcessLifecycle.send_signal(@missing_pid, "-TERM")
       end)
 
     assert log =~ "worker signal failed"
-    assert log =~ "os_pid=#{missing_pid}"
+    assert log =~ "os_pid=#{@missing_pid}"
     assert log =~ "signal=TERM"
     refute log =~ "No such process"
   end

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -29,6 +29,7 @@ defmodule OrchardNodeAgentTest do
   alias Orchard.ModelManifest.RuntimeRequirements
   alias Orchard.ModelManifest.Tokenizer
   alias Orchard.Node
+  alias Orchard.Node.CustodyTestHelpers
   alias Orchard.Node.ModelManager
   alias Orchard.Node.RuntimeEndpoint, as: NodeRuntimeEndpoint
   alias Orchard.Node.RuntimeServer
@@ -36,6 +37,7 @@ defmodule OrchardNodeAgentTest do
   alias Orchard.Node.SharedContract
   alias Orchard.Node.Status, as: NodeStatus
   alias Orchard.Node.Supervisor, as: NodeSupervisor
+  alias Orchard.Node.WorkerProcessLifecycle
   alias Orchard.Node.WorkerSupervisor
   alias Orchard.NodeAgent.Supervisor, as: NodeAgentSupervisor
   alias Orchard.RuntimeEndpoint.ModelRef, as: RuntimeModelRef
@@ -2461,6 +2463,12 @@ defmodule OrchardNodeAgentTest do
        %{bundle: bundle} do
     with_real_worker_runtime(fn ->
       socket_path = real_worker_socket_path()
+      custody_ref = make_ref()
+      {control_port, control_pid} = CustodyTestHelpers.start_control_child!()
+
+      on_exit(fn ->
+        CustodyTestHelpers.stop_child(control_port, control_pid)
+      end)
 
       refute File.exists?(socket_path)
 
@@ -2476,6 +2484,9 @@ defmodule OrchardNodeAgentTest do
                  )
 
         wait_until(fn -> File.exists?(socket_path) end)
+        os_pid = worker_os_pid()
+        assert WorkerProcessLifecycle.os_process_alive?(os_pid)
+        send(self(), {custody_ref, os_pid})
 
         request = execute_inference_request("req-r5-real-runtime")
         assert {:ok, event_stream} = NodeRuntimeStub.execute_inference(channel, request)
@@ -2519,8 +2530,12 @@ defmodule OrchardNodeAgentTest do
                  )
       end)
 
+      assert_receive {^custody_ref, os_pid}
       wait_until(fn -> worker_count() == 0 end)
+      CustodyTestHelpers.assert_os_pid_dead!(os_pid, 2_000)
       refute File.exists?(socket_path)
+      assert WorkerProcessLifecycle.os_process_alive?(control_pid)
+      CustodyTestHelpers.assert_reaper_empty!(1_000)
     end)
   end
 

--- a/apps/orchard_node_agent/test/support/custody-signal-child
+++ b/apps/orchard_node_agent/test/support/custody-signal-child
@@ -23,14 +23,20 @@ resist() {
 
 case "$mode" in
   cooperative) trap cooperate TERM ;;
-  resistant) trap resist TERM ;;
+  resistant | chatty_resistant) trap resist TERM ;;
   *) exit 64 ;;
 esac
 
 printf 'ready\n' > "${marker_path}.ready"
 
 while :; do
-  sleep 1 &
+  if [ "$mode" = "chatty_resistant" ]; then
+    printf 'runtime_output\n'
+    sleep 0.01 &
+  else
+    sleep 1 &
+  fi
+
   child_pid=$!
   wait "$child_pid" || true
 done

--- a/apps/orchard_node_agent/test/support/custody-signal-child
+++ b/apps/orchard_node_agent/test/support/custody-signal-child
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+mode=$1
+marker_path=$2
+child_pid=
+
+stop_child() {
+  if [ -n "$child_pid" ]; then
+    kill "$child_pid" 2>/dev/null || true
+  fi
+}
+
+cooperate() {
+  printf 'term_received mode=cooperative\n' >> "$marker_path"
+  stop_child
+  exit 0
+}
+
+resist() {
+  printf 'term_ignored mode=resistant\n' >> "$marker_path"
+}
+
+case "$mode" in
+  cooperative) trap cooperate TERM ;;
+  resistant) trap resist TERM ;;
+  *) exit 64 ;;
+esac
+
+printf 'ready\n' > "${marker_path}.ready"
+
+while :; do
+  sleep 1 &
+  child_pid=$!
+  wait "$child_pid" || true
+done

--- a/apps/orchard_node_agent/test/support/custody_test_helpers.ex
+++ b/apps/orchard_node_agent/test/support/custody_test_helpers.ex
@@ -38,15 +38,17 @@ defmodule Orchard.Node.CustodyTestHelpers do
     {port, os_pid}
   end
 
-  @spec start_signal_child!(:cooperative | :resistant, Path.t()) :: {port(), pos_integer()}
-  def start_signal_child!(mode, marker_path) when mode in [:cooperative, :resistant] do
+  @spec start_signal_child!(:chatty_resistant | :cooperative | :resistant, Path.t()) ::
+          {port(), pos_integer()}
+  def start_signal_child!(mode, marker_path)
+      when mode in [:chatty_resistant, :cooperative, :resistant] do
     shell = System.find_executable("sh") || "/bin/sh"
     fixture = Path.join(__DIR__, "custody-signal-child")
 
     port =
       Port.open(
         {:spawn_executable, shell},
-        [{:args, [fixture, Atom.to_string(mode), marker_path]}, :stderr_to_stdout]
+        [{:args, [fixture, Atom.to_string(mode), marker_path]}, :stderr_to_stdout, :exit_status]
       )
 
     os_pid = port |> Port.info() |> Keyword.fetch!(:os_pid)

--- a/apps/orchard_node_agent/test/support/custody_test_helpers.ex
+++ b/apps/orchard_node_agent/test/support/custody_test_helpers.ex
@@ -1,0 +1,89 @@
+defmodule Orchard.Node.CustodyTestHelpers do
+  @moduledoc false
+
+  import ExUnit.Assertions
+
+  alias Orchard.Node.RuntimeProcessReaper
+  alias Orchard.Node.WorkerProcessLifecycle
+
+  @poll_interval_ms 10
+
+  @spec assert_os_pid_dead!(pos_integer(), pos_integer()) :: :ok
+  def assert_os_pid_dead!(os_pid, timeout_ms) do
+    assert wait_until(fn -> not WorkerProcessLifecycle.os_process_alive?(os_pid) end, timeout_ms),
+           "expected OS process #{os_pid} to be dead within #{timeout_ms}ms"
+
+    :ok
+  end
+
+  @spec assert_reaper_empty!(pos_integer()) :: :ok
+  def assert_reaper_empty!(timeout_ms) do
+    assert wait_until(
+             fn ->
+               state = :sys.get_state(RuntimeProcessReaper)
+               state.leases == %{} and state.owner_monitors == %{}
+             end,
+             timeout_ms
+           ),
+           "expected runtime process reaper leases and owner monitors to be empty"
+
+    :ok
+  end
+
+  @spec start_control_child!() :: {port(), pos_integer()}
+  def start_control_child! do
+    sleep = System.find_executable("sleep") || "/bin/sleep"
+    port = Port.open({:spawn_executable, sleep}, args: ["3600"])
+    os_pid = port |> Port.info() |> Keyword.fetch!(:os_pid)
+    {port, os_pid}
+  end
+
+  @spec start_signal_child!(:cooperative | :resistant, Path.t()) :: {port(), pos_integer()}
+  def start_signal_child!(mode, marker_path) when mode in [:cooperative, :resistant] do
+    shell = System.find_executable("sh") || "/bin/sh"
+    fixture = Path.join(__DIR__, "custody-signal-child")
+
+    port =
+      Port.open(
+        {:spawn_executable, shell},
+        [{:args, [fixture, Atom.to_string(mode), marker_path]}, :stderr_to_stdout]
+      )
+
+    os_pid = port |> Port.info() |> Keyword.fetch!(:os_pid)
+
+    assert wait_until(fn -> File.exists?(marker_path <> ".ready") end, 1_000),
+           "expected custody signal fixture to become ready"
+
+    {port, os_pid}
+  end
+
+  @spec stop_child(port(), pos_integer()) :: :ok
+  def stop_child(port, os_pid) do
+    if WorkerProcessLifecycle.os_process_alive?(os_pid) do
+      _ = WorkerProcessLifecycle.kill_process_tree(os_pid)
+      _ = wait_until(fn -> not WorkerProcessLifecycle.os_process_alive?(os_pid) end, 1_000)
+    end
+
+    if Port.info(port), do: Port.close(port)
+    :ok
+  end
+
+  @spec wait_until((-> as_boolean(term())), non_neg_integer()) :: boolean()
+  def wait_until(fun, timeout_ms) when is_function(fun, 0) and timeout_ms >= 0 do
+    do_wait_until(fun, System.monotonic_time(:millisecond) + timeout_ms)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(@poll_interval_ms)
+        do_wait_until(fun, deadline)
+    end
+  end
+end

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -950,6 +950,42 @@ mise exec -- mix credo --strict
 mise exec -- mix dialyzer
 ```
 
+## Node Agent Shutdown Custody Smoke
+
+`scripts/smoke-node-agent-shutdown-custody.sh` proves that an orderly foreground
+`bin/dev-node-agent` shutdown cannot leave its owned runtime child or worker
+socket behind while unrelated processes survive. It uses the stub worker backend
+and a synthetic bundle, so it needs no real model weights and no GPU.
+
+### Prerequisites
+
+- `mise` and `nc` on `PATH`
+- The MLX worker virtualenv built once via `make setup` (or
+  `mise exec -- uv sync --directory native/orchard_worker_mlx`), so both
+  `native/orchard_worker_mlx/bin/orchard-worker-mlx` and
+  `native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx` are executable
+- A free listen port — the smoke defaults to `50091` and refuses to start when
+  the port is already bound
+- No pre-existing `tmp/dev/models/issue-286-shutdown-custody` directory; the
+  smoke creates and removes its own bundle
+
+### Running the Smoke Script
+
+```bash
+mise exec -- ./scripts/smoke-node-agent-shutdown-custody.sh
+
+# When 50091 is already taken (for example by another worktree)
+ORCHARD_SHUTDOWN_CUSTODY_PORT=50191 mise exec -- ./scripts/smoke-node-agent-shutdown-custody.sh
+```
+
+The script starts `bin/dev-node-agent` in the foreground, loads the synthetic
+bundle over gRPC, records the exact worker PID and socket path, starts an
+unrelated control child, sends `SIGTERM` to the node agent, and then asserts that
+the node agent exited within its bound, the exact worker PID is dead, the worker
+socket is gone, and the control child survived. It prints a single `PASS`/`FAIL`
+summary and removes its temporary state; record the result in the pull request or
+issue rather than committing evidence files.
+
 ## Apple Silicon MLX Smoke Tests
 
 Opt-in smoke tests verify real MLX inference on Apple Silicon hardware. These are

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -982,9 +982,12 @@ The script starts `bin/dev-node-agent` in the foreground, loads the synthetic
 bundle over gRPC, records the exact worker PID and socket path, starts an
 unrelated control child, sends `SIGTERM` to the node agent, and then asserts that
 the node agent exited within its bound, the exact worker PID is dead, the worker
-socket is gone, and the control child survived. It prints a single `PASS`/`FAIL`
-summary and removes its temporary state; record the result in the pull request or
-issue rather than committing evidence files.
+socket is gone, and the control child survived. It also asserts that its own
+`EXIT` cleanup refuses to signal a recorded PID whose launch identity no longer
+matches, so a stale worker, BEAM, or control PID cannot kill an unrelated
+process. It prints a single `PASS`/`FAIL` summary and removes its temporary
+state; record the result in the pull request or issue rather than committing
+evidence files.
 
 ## Apple Silicon MLX Smoke Tests
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -961,7 +961,7 @@ and a synthetic bundle, so it needs no real model weights and no GPU.
 
 - `mise` and `nc` on `PATH`
 - The MLX worker virtualenv built once via `make setup` (or
-  `mise exec -- uv sync --directory native/orchard_worker_mlx`), so both
+  `mise exec -- uv sync --locked --directory native/orchard_worker_mlx`), so both
   `native/orchard_worker_mlx/bin/orchard-worker-mlx` and
   `native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx` are executable
 - A free listen port — the smoke defaults to `50091` and refuses to start when

--- a/scripts/smoke-node-agent-shutdown-custody.sh
+++ b/scripts/smoke-node-agent-shutdown-custody.sh
@@ -4,22 +4,48 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 STATE_ROOT=""
 BEAM_PID=""
+BEAM_IDENTITY=""
 WORKER_PID=""
+WORKER_IDENTITY=""
 CONTROL_PID=""
+CONTROL_IDENTITY=""
 SOCKET_PATH=""
 BUNDLE_ROOT="$REPO_ROOT/tmp/dev/models/issue-286-shutdown-custody"
 BUNDLE_OWNED=false
 PORT="${ORCHARD_SHUTDOWN_CUSTODY_PORT:-50091}"
 
+process_identity() {
+  local pid="$1"
+  local identity
+
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  identity="$(ps -o uid= -o lstart= -p "$pid" 2>/dev/null)" || return 1
+  identity="$(printf '%s\n' "$identity" | awk '{$1=$1; print}')"
+  [[ -n "$identity" ]] || return 1
+  printf '%s\n' "$identity"
+}
+
+cleanup_owned_pid() {
+  local pid="$1"
+  local expected_identity="$2"
+  local current_identity
+
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 0
+  [[ -n "$expected_identity" ]] || return 0
+  kill -0 "$pid" 2>/dev/null || return 0
+  current_identity="$(process_identity "$pid")" || return 0
+  [[ "$current_identity" == "$expected_identity" ]] || return 0
+
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
 cleanup() {
   trap - EXIT INT TERM
 
-  for pid in "$WORKER_PID" "$BEAM_PID" "$CONTROL_PID"; do
-    if [[ "$pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$pid" 2>/dev/null; then
-      kill -KILL "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
-    fi
-  done
+  cleanup_owned_pid "$WORKER_PID" "$WORKER_IDENTITY"
+  cleanup_owned_pid "$BEAM_PID" "$BEAM_IDENTITY"
+  cleanup_owned_pid "$CONTROL_PID" "$CONTROL_IDENTITY"
 
   exec 9>&- 2>/dev/null || true
   [[ -n "$STATE_ROOT" ]] && rm -rf -- "$STATE_ROOT" >/dev/null 2>&1
@@ -71,6 +97,22 @@ wait_for_death() {
   ! kill -0 "$pid" 2>/dev/null
 }
 
+assert_exit_cleanup_rejects_stale_pid() {
+  (
+    STATE_ROOT=""
+    BUNDLE_OWNED=false
+    WORKER_PID="$CONTROL_PID"
+    WORKER_IDENTITY="stale-worker-identity"
+    BEAM_PID="$CONTROL_PID"
+    BEAM_IDENTITY="stale-beam-identity"
+    CONTROL_IDENTITY="stale-control-identity"
+    trap cleanup EXIT
+  )
+
+  kill -0 "$CONTROL_PID" 2>/dev/null ||
+    fail "EXIT cleanup signaled a stale or mismatched recorded PID"
+}
+
 trap cleanup EXIT
 trap 'cleanup; exit 130' INT TERM
 
@@ -110,6 +152,7 @@ export ORCHARD_SHUTDOWN_CUSTODY_REAL_WORKER="$REAL_WORKER"
 cd "$REPO_ROOT"
 mise exec -- bin/dev-node-agent <&9 >"$STATE_ROOT/node-agent.log" 2>&1 &
 BEAM_PID=$!
+BEAM_IDENTITY="$(process_identity "$BEAM_PID")" || fail "BEAM launch identity unavailable"
 
 wait_for_port || fail "launcher readiness timeout"
 
@@ -126,11 +169,14 @@ SOCKET_PATH="$(cat "$STATE_ROOT/worker.socket")"
 
 [[ "$WORKER_PID" =~ ^[1-9][0-9]*$ ]] || fail "invalid worker identity"
 kill -0 "$WORKER_PID" 2>/dev/null || fail "exact worker not running"
+WORKER_IDENTITY="$(process_identity "$WORKER_PID")" || fail "worker launch identity unavailable"
 [[ -S "$SOCKET_PATH" ]] || fail "exact worker socket unavailable"
 
 sleep 3600 &
 CONTROL_PID=$!
+CONTROL_IDENTITY="$(process_identity "$CONTROL_PID")" || fail "control launch identity unavailable"
 kill -0 "$CONTROL_PID" 2>/dev/null || fail "control child unavailable"
+assert_exit_cleanup_rejects_stale_pid
 
 kill -TERM "$BEAM_PID" 2>/dev/null || fail "foreground termination failed"
 wait_for_death "$BEAM_PID" 30 || fail "foreground shutdown timeout"
@@ -145,4 +191,5 @@ printf '%s\n' \
   "  beam: exited on SIGTERM (bounded)" \
   "  worker child: exact pid dead" \
   "  worker socket: removed" \
-  "  control child: survived"
+  "  control child: survived" \
+  "  EXIT cleanup: stale and mismatched PIDs rejected"

--- a/scripts/smoke-node-agent-shutdown-custody.sh
+++ b/scripts/smoke-node-agent-shutdown-custody.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STATE_ROOT=""
+BEAM_PID=""
+WORKER_PID=""
+CONTROL_PID=""
+SOCKET_PATH=""
+BUNDLE_ROOT="$REPO_ROOT/tmp/dev/models/issue-286-shutdown-custody"
+BUNDLE_OWNED=false
+PORT="${ORCHARD_SHUTDOWN_CUSTODY_PORT:-50091}"
+
+cleanup() {
+  trap - EXIT INT TERM
+
+  for pid in "$WORKER_PID" "$BEAM_PID" "$CONTROL_PID"; do
+    if [[ "$pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+
+  exec 9>&- 2>/dev/null || true
+  [[ -n "$STATE_ROOT" ]] && rm -rf -- "$STATE_ROOT" >/dev/null 2>&1
+  [[ "$BUNDLE_OWNED" == "true" ]] && rm -rf -- "$BUNDLE_ROOT" >/dev/null 2>&1
+}
+
+fail() {
+  printf '%s\n' \
+    "shutdown-custody smoke: FAIL" \
+    "  reason: $1"
+  exit 1
+}
+
+wait_for_port() {
+  local deadline=$((SECONDS + 120))
+
+  while ((SECONDS < deadline)); do
+    kill -0 "$BEAM_PID" 2>/dev/null || return 1
+    nc -z 127.0.0.1 "$PORT" >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_file() {
+  local path="$1"
+  local deadline=$((SECONDS + 30))
+
+  while ((SECONDS < deadline)); do
+    [[ -s "$path" ]] && return 0
+    kill -0 "$BEAM_PID" 2>/dev/null || return 1
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_death() {
+  local pid="$1"
+  local timeout="$2"
+  local deadline=$((SECONDS + timeout))
+
+  while ((SECONDS < deadline)); do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 1
+  done
+
+  ! kill -0 "$pid" 2>/dev/null
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT TERM
+
+command -v mise >/dev/null 2>&1 || fail "mise unavailable"
+command -v nc >/dev/null 2>&1 || fail "nc unavailable"
+[[ "$PORT" =~ ^[1-9][0-9]*$ ]] || fail "invalid listen port"
+((PORT <= 65535)) || fail "invalid listen port"
+nc -z 127.0.0.1 "$PORT" >/dev/null 2>&1 && fail "listen port unavailable"
+[[ ! -e "$BUNDLE_ROOT" ]] || fail "issue bundle path already exists"
+
+REAL_WORKER="$REPO_ROOT/native/orchard_worker_mlx/bin/orchard-worker-mlx"
+EFFECTIVE_WORKER="$REPO_ROOT/native/orchard_worker_mlx/.venv/bin/orchard-worker-mlx"
+SMOKE_WORKER="$REPO_ROOT/scripts/support/shutdown-custody-worker"
+LOADER="$REPO_ROOT/scripts/support/shutdown_custody_load.exs"
+
+[[ -x "$REAL_WORKER" && -x "$EFFECTIVE_WORKER" && -x "$SMOKE_WORKER" ]] ||
+  fail "worker fixture unavailable"
+[[ -f "$LOADER" ]] || fail "loader unavailable"
+
+STATE_ROOT="$(mktemp -d "/tmp/orchard-286.XXXXXX" 2>/dev/null)" ||
+  fail "temporary directory unavailable"
+mkdir -p -- "$STATE_ROOT/socket" >/dev/null 2>&1 || fail "temporary directory unavailable"
+mkfifo "$STATE_ROOT/stdin" >/dev/null 2>&1 || fail "stdin fixture unavailable"
+exec 9<>"$STATE_ROOT/stdin" 2>/dev/null || fail "stdin fixture unavailable"
+
+export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc
+export ORCHARD_NODE_AGENT_LISTEN_HOST=127.0.0.1
+export ORCHARD_NODE_AGENT_LISTEN_PORT="$PORT"
+export ORCHARD_RUNTIME_CLIENT_PORT="$PORT"
+export ORCHARD_WORKER_BACKEND=stub
+export ORCHARD_WORKER_SOCKET_DIR="$STATE_ROOT/socket"
+export ORCHARD_WORKER_EXECUTABLE="$SMOKE_WORKER"
+export ORCHARD_WORKER_EFFECTIVE_EXECUTABLE="$EFFECTIVE_WORKER"
+export ORCHARD_SHUTDOWN_CUSTODY_STATE_DIR="$STATE_ROOT"
+export ORCHARD_SHUTDOWN_CUSTODY_REAL_WORKER="$REAL_WORKER"
+
+cd "$REPO_ROOT"
+mise exec -- bin/dev-node-agent <&9 >"$STATE_ROOT/node-agent.log" 2>&1 &
+BEAM_PID=$!
+
+wait_for_port || fail "launcher readiness timeout"
+
+BUNDLE_OWNED=true
+(
+  cd "$REPO_ROOT/apps/orchard_node_agent" &&
+    mise exec -- mix run --no-start "$LOADER"
+) >"$STATE_ROOT/loader.log" 2>&1 || fail "fixture load failed"
+
+wait_for_file "$STATE_ROOT/worker.pid" || fail "worker identity unavailable"
+wait_for_file "$STATE_ROOT/worker.socket" || fail "worker socket identity unavailable"
+WORKER_PID="$(cat "$STATE_ROOT/worker.pid")"
+SOCKET_PATH="$(cat "$STATE_ROOT/worker.socket")"
+
+[[ "$WORKER_PID" =~ ^[1-9][0-9]*$ ]] || fail "invalid worker identity"
+kill -0 "$WORKER_PID" 2>/dev/null || fail "exact worker not running"
+[[ -S "$SOCKET_PATH" ]] || fail "exact worker socket unavailable"
+
+sleep 3600 &
+CONTROL_PID=$!
+kill -0 "$CONTROL_PID" 2>/dev/null || fail "control child unavailable"
+
+kill -TERM "$BEAM_PID" 2>/dev/null || fail "foreground termination failed"
+wait_for_death "$BEAM_PID" 30 || fail "foreground shutdown timeout"
+wait "$BEAM_PID" 2>/dev/null || true
+
+wait_for_death "$WORKER_PID" 10 || fail "exact worker survived"
+[[ ! -e "$SOCKET_PATH" ]] || fail "exact worker socket survived"
+kill -0 "$CONTROL_PID" 2>/dev/null || fail "control child did not survive"
+
+printf '%s\n' \
+  "shutdown-custody smoke: PASS" \
+  "  beam: exited on SIGTERM (bounded)" \
+  "  worker child: exact pid dead" \
+  "  worker socket: removed" \
+  "  control child: survived"

--- a/scripts/support/shutdown-custody-worker
+++ b/scripts/support/shutdown-custody-worker
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir="${ORCHARD_SHUTDOWN_CUSTODY_STATE_DIR:?missing smoke state directory}"
+real_worker="${ORCHARD_SHUTDOWN_CUSTODY_REAL_WORKER:?missing real worker executable}"
+socket_path=""
+args=("$@")
+
+while (($# > 0)); do
+  case "$1" in
+    --socket-path)
+      (($# >= 2)) || exit 64
+      socket_path="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$socket_path" ]] || exit 64
+mkdir -p -- "$state_dir"
+printf '%s\n' "$$" >"$state_dir/worker.pid.tmp"
+printf '%s\n' "$socket_path" >"$state_dir/worker.socket.tmp"
+mv -- "$state_dir/worker.pid.tmp" "$state_dir/worker.pid"
+mv -- "$state_dir/worker.socket.tmp" "$state_dir/worker.socket"
+
+exec "$real_worker" "${args[@]}"

--- a/scripts/support/shutdown_custody_load.exs
+++ b/scripts/support/shutdown_custody_load.exs
@@ -1,0 +1,37 @@
+alias Orchard.ArtifactBundle
+alias Orchard.Cluster.V1.EnsureModelLoadedRequest
+alias Orchard.Cluster.V1.EnsureModelLoadedResponse
+alias Orchard.Cluster.V1.NodeRuntimeService.Stub, as: NodeRuntimeStub
+
+repo_root = Path.expand("../..", __DIR__)
+model_id = "issue-286-shutdown-custody"
+version = "v1"
+bundle_path = Path.join([repo_root, "tmp", "dev", "models", model_id, version])
+
+File.rm_rf!(bundle_path)
+File.mkdir_p!(Path.join(bundle_path, "weights"))
+File.write!(Path.join(bundle_path, "config.json"), ~s({"model_type":"test"}))
+File.write!(Path.join(bundle_path, "tokenizer.json"), ~s({"version":"1.0"}))
+File.write!(Path.join(bundle_path, "weights/model.safetensors"), "fake-weights-data")
+{:ok, artifact_sha256} = ArtifactBundle.tree_sha256(bundle_path)
+
+{:ok, _apps} = Application.ensure_all_started(:grpc)
+port = System.fetch_env!("ORCHARD_NODE_AGENT_LISTEN_PORT")
+{:ok, channel} = GRPC.Stub.connect("127.0.0.1:" <> port)
+
+request = %EnsureModelLoadedRequest{
+  node_id: "node-local",
+  model_id: model_id,
+  version: version,
+  artifact_sha256: artifact_sha256,
+  preload: true,
+  deadline_unix_ms: System.system_time(:millisecond) + 30_000
+}
+
+result = NodeRuntimeStub.ensure_model_loaded(channel, request, timeout: 30_000)
+_ = GRPC.Stub.disconnect(channel)
+
+case result do
+  {:ok, %EnsureModelLoadedResponse{placement_state: :PLACEMENT_STATE_LOADED}} -> :ok
+  other -> raise "shutdown custody load failed: #{inspect(other)}"
+end


### PR DESCRIPTION
## Intent

Address PR #290 strict process-custody review blockers without broadening issue #286: require a launch-time OS identity that still matches before any TERM or KILL after BEAM Port custody ends; fail closed when identity capture is unavailable; abort launch while the Port remains owned rather than arming PID-only reaper cleanup; ensure missing or mismatched identity still permits owned socket and lease/monitor cleanup without signaling; harden the source-dev shutdown smoke EXIT trap so stale or mismatched recorded worker, BEAM, and control PIDs cannot kill unrelated processes; preserve the existing shutdown-custody acceptance proof and unrelated-control guarantees; add regression coverage for closed-Port unload, reaper owner-down/shutdown, launch identity unavailability, and stale smoke cleanup; keep raw process evidence out of the repository; update the existing PR rather than opening a new one.

## What Changed

- `WorkerProcessLifecycle` now snapshots a worker's uid/start-time identity at launch and gates every TERM/KILL on it, failing closed when the snapshot is missing (`:identity_unavailable`) or no longer matches a recycled PID (`:identity_mismatch`); refused signalling still permits owned socket removal and lease/monitor cleanup, and the new `escalate_owned_exit/4` spends one absolute deadline across the TERM grace and the post-KILL confirmation instead of one budget per phase.
- `WorkerRuntimeAdapter` aborts launch while the Port is still owned — reporting the port's exit status when the worker died during startup — rather than arming a PID-only reaper lease, and routes closed-port unload through the custody-gated escalation; `RuntimeProcessReaper` leases now carry the identity plus socket path, and its shutdown sweep broadcasts TERM to all leases before awaiting them against one shared 4s budget that stays under the supervisor's shutdown window.
- Adds `scripts/smoke-node-agent-shutdown-custody.sh` (foreground shutdown proof with an identity-checked EXIT trap so stale recorded worker/BEAM/control PIDs cannot kill unrelated processes) with prerequisites and usage documented in `docs/local-dev.md`, plus regression coverage for closed-Port unload, reaper owner-down and shutdown sweeps, launch identity unavailability, fail-closed signalling, and stale-PID smoke cleanup.

## Risk Assessment

✅ Low: This round is a test-only recalibration that I verified arithmetically on both sides — the fixed implementation lands ~125ms under the new ceiling while the pre-fix double-timeout exceeds it by a spawn-cost-independent margin — and with every round-1 and round-2 source finding already closed, no substantiated defect remains in the branch.

## Testing

Ran the targeted custody regression suites (35 tests green: worker_process_lifecycle, runtime_process_reaper, worker_custody, plus the modified real-worker unload integration test), then proved the intent at product level by running the committed source-dev shutdown-custody smoke end-to-end three times — all PASS — and wrapping one run in a read-only observer that captured the real operator-visible surface: the exact launch-recorded worker PID and its owned Unix socket alive alongside the node-agent BEAM, then a polled timeline showing both gone after SIGTERM while the unrelated control child stayed alive. I separately exercised the hardened EXIT-trap guard by sourcing `process_identity`/`cleanup_owned_pid` verbatim from the committed smoke and running them against real bystander processes (8/8: identity-matched PIDs still reaped, while mismatched, stale, absent, different-process, and malformed PID 0/-1/non-numeric inputs were all refused). Finally I mutation-checked four custody guarantees in lib/ — fail-open on missing identity, ignored mismatch, pre-fix double budget spend, and arming a PID-only reaper instead of aborting launch — and each was caught by exactly the tests claiming to guard it, with the budget assertion proving tight (539ms ceiling against a measured 39ms overhead). This change has no UI surface (OS process custody in the node agent plus a bash smoke script), so no screenshots or rendered artifacts apply; the equivalent end-user evidence is the process/socket state transcript. Source was restored after every mutation and the worktree ends byte-identical to the target commit with no smoke bundle or temp state left behind. Everything passed; no actionable findings.

<details>
<summary>Evidence: Observed shutdown-custody smoke — real PIDs, owned socket, and state timeline across SIGTERM</summary>

<code>=== BEFORE node-agent SIGTERM — steady state, synthetic bundle loaded over gRPC ===&#10;node-agent BEAM (pid 31521):&#10;31521 31506 /Users/luqman/.local/share/mise/installs/erlang/29.0.2/erts-17.0.2/bin/beam.smp -- -root ...&#10;&#10;owned worker child — exact PID recorded at launch (31635):&#10;31635 31606 501 .../native/orchard_worker_mlx/.venv/bin/python /U&#10;&#10;owned worker socket:&#10;srwxr-xr-x@ 1 luqman wheel 0 Aug 26 11:42 /private/tmp/orchard-286.LAOyRf/socket/orchard-worker-11cf5d65c0b475a7.sock&#10;&#10;=== TIMELINE across the shutdown (100ms poll, rows printed on state change) ===&#10;t beam worker_pid socket control_child&#10;+0ms yes yes present not-started&#10;+1000ms no no absent yes&#10;+2000ms no no absent no&#10;&#10;control child resolved by observer: 31727 (seen=yes)&#10;The control child is the last thing to go: it dies only in the smoke&#39;s own&#10;identity-matched EXIT trap, after the node agent and its owned worker are gone.&#10;&#10;smoke temporary state dir: removed — no raw process evidence left behind&#10;&#10;=== smoke script verdict ===&#10;shutdown-custody smoke: PASS&#10;beam: exited on SIGTERM (bounded)&#10;worker child: exact pid dead&#10;worker socket: removed&#10;control child: survived&#10;EXIT cleanup: stale and mismatched PIDs rejected&#10;smoke_exit_status=0</code>

```text
=== BEFORE node-agent SIGTERM — steady state, synthetic bundle loaded over gRPC ===
node-agent BEAM (pid 31521):
31521 31506 /Users/luqman/.local/share/mise/installs/erlang/29.0.2/erts-17.0.2/bin/beam.smp -- -root /Users/luqman/.local/share/mise/install

owned worker child — exact PID recorded at launch (31635):
31635 31606   501 /Users/luqman/.no-mistakes/worktrees/e9257108f400/01M0XZQJ4FCKV50JG3FPWB5767/native/orchard_worker_mlx/.venv/bin/python /U

owned worker socket:
srwxr-xr-x@ 1 luqman  wheel  0 Aug 26 11:42 /private/tmp/orchard-286.LAOyRf/socket/orchard-worker-11cf5d65c0b475a7.sock

=== TIMELINE across the shutdown (100ms poll, rows printed on state change) ===
t        beam        worker_pid    socket    control_child 
+0ms     yes         yes           present   not-started   
+1000ms  no          no            absent    yes           
+2000ms  no          no            absent    no            

control child resolved by observer: 31727 (seen=yes)
The control child is the last thing to go: it dies only in the smoke's own
identity-matched EXIT trap, after the node agent and its owned worker are gone.

smoke temporary state dir: removed — no raw process evidence left behind

=== smoke script verdict ===
shutdown-custody smoke: PASS
  beam: exited on SIGTERM (bounded)
  worker child: exact pid dead
  worker socket: removed
  control child: survived
  EXIT cleanup: stale and mismatched PIDs rejected
smoke_exit_status=0
```
</details>
<details>
<summary>Evidence: Hardened EXIT-trap guard vs. real bystander processes (committed guard functions, sourced verbatim)</summary>

<code>guard functions sourced verbatim from the committed smoke script:&#10;scripts/smoke-node-agent-shutdown-custody.sh :: 1:process_identity() {&#10;scripts/smoke-node-agent-shutdown-custody.sh :: 11:cleanup_owned_pid() {&#10;&#10;=== cleanup_owned_pid: hardened EXIT trap vs. real live bystander processes ===&#10;PASS MATCHING launch identity -&gt; genuine cleanup still reaps the PID bystander=dead&#10;PASS MISMATCHED identity (recycled PID) -&gt; bystander untouched bystander=alive&#10;PASS stale/garbage recorded identity -&gt; bystander untouched bystander=alive&#10;PASS identity never captured -&gt; fails closed, bystander untouched bystander=alive&#10;PASS identity of a DIFFERENT process (earlier start) -&gt; untouched bystander=alive&#10;PASS recorded PID 0 rejected -&gt; no self/process-group signalling bystander=alive&#10;PASS recorded PID -1 rejected -&gt; no kill(-1) blast radius bystander=alive&#10;PASS non-numeric recorded PID rejected bystander=alive&#10;&#10;guard cases: 8 passed, 0 failed</code>

```text
guard functions sourced verbatim from the committed smoke script:
  scripts/smoke-node-agent-shutdown-custody.sh :: 1:process_identity() {
  scripts/smoke-node-agent-shutdown-custody.sh :: 11:cleanup_owned_pid() {

=== cleanup_owned_pid: hardened EXIT trap vs. real live bystander processes ===
  PASS  MATCHING launch identity -> genuine cleanup still reaps the PID bystander=dead
  PASS  MISMATCHED identity (recycled PID) -> bystander untouched  bystander=alive
  PASS  stale/garbage recorded identity -> bystander untouched     bystander=alive
  PASS  identity never captured -> fails closed, bystander untouched bystander=alive
  PASS  identity of a DIFFERENT process (earlier start) -> untouched bystander=alive
  PASS  recorded PID 0 rejected -> no self/process-group signalling bystander=alive
  PASS  recorded PID -1 rejected -> no kill(-1) blast radius       bystander=alive
  PASS  non-numeric recorded PID rejected                          bystander=alive

guard cases: 8 passed, 0 failed
```
</details>
<details>
<summary>Evidence: Mutation checks — each custody guarantee broken in lib/ is caught by its regression test</summary>

<code>M1 missing launch identity fails OPEN (signals an unproven PID)&#10;result: Result: 0/4 passed, 30 excluded Failed: 4 tests&#10;failing: 1) test custody-gated signals fail closed without a launch identity&#10;failing: 2) test owner-down reaping without launch identity cleans socket and lease without signaling&#10;verdict: CAUGHT (tests failed as required)&#10;&#10;M2 identity MISMATCH ignored (signals a recycled PID)&#10;result: Result: 0/4 passed, 30 excluded Failed: 4 tests&#10;failing: 1) test custody-gated signals refuse a PID whose identity snapshot no longer matches&#10;failing: 2) test reaper termination refuses to signal a lease whose PID identity changed&#10;verdict: CAUGHT (tests failed as required)&#10;&#10;M3 closed-Port shutdown spends TWO full budgets (pre-fix escalation)&#10;result: Result: 0/1 passed, 8 excluded Failed: 1 test&#10;failing: 1) test SPEC.md §4.9 closed BEAM port unload spends its shutdown budget once&#10;verdict: CAUGHT (tests failed as required)&#10;&#10;M4 launch ARMS a PID-only reaper instead of aborting while Port is owned&#10;result: Result: 0/1 passed, 8 excluded Failed: 1 test&#10;failing: 1) test SPEC.md §4.9 launch aborts before arming reaper when identity capture fails&#10;verdict: CAUGHT (tests failed as required)&#10;&#10;source restored:&#10;(clean)</code>

```text
=== Mutation checks: does the new coverage actually hold the line? ===
Each case breaks ONE custody guarantee in lib/, runs only the tests that
claim to guard it, and expects them to FAIL. Source restored after each.

M1  missing launch identity fails OPEN (signals an unproven PID)
    tests run: test/orchard/node/worker_process_lifecycle_test.exs:85 test/orchard/node/worker_custody_test.exs:128 test/orchard/node/runtime_process_reaper_test.exs:375 test/orchard/node/runtime_process_reaper_test.exs:410
    result:    Result: 0/4 passed, 30 excluded Failed: 4 tests
    failing:   1) test custody-gated signals fail closed without a launch identity (Orchard.Node.WorkerProcessLifecycleTest)
    failing:   2) test owner-down reaping without launch identity cleans socket and lease without signaling (Orchard.Node.RuntimeProcessReaperTest)
    verdict:   CAUGHT (tests failed as required)

M2  identity MISMATCH ignored (signals a recycled PID)
    tests run: test/orchard/node/worker_process_lifecycle_test.exs:60 test/orchard/node/worker_custody_test.exs:96 test/orchard/node/runtime_process_reaper_test.exs:351 test/orchard/node/runtime_process_reaper_test.exs:363
    result:    Result: 0/4 passed, 30 excluded Failed: 4 tests
    failing:   1) test custody-gated signals refuse a PID whose identity snapshot no longer matches (Orchard.Node.WorkerProcessLifecycleTest)
    failing:   2) test reaper termination refuses to signal a lease whose PID identity changed (Orchard.Node.RuntimeProcessReaperTest)
    verdict:   CAUGHT (tests failed as required)

M3  closed-Port shutdown spends TWO full budgets (pre-fix escalation)
    tests run: test/orchard/node/worker_custody_test.exs:243
    result:    Result: 0/1 passed, 8 excluded Failed: 1 test
    failing:   1) test SPEC.md §4.9 closed BEAM port unload spends its shutdown budget once (Orchard.Node.WorkerCustodyTest)
    verdict:   CAUGHT (tests failed as required)

M4  launch ARMS a PID-only reaper instead of aborting while Port is owned
    tests run: test/orchard/node/worker_custody_test.exs:162
    result:    Result: 0/1 passed, 8 excluded Failed: 1 test
    failing:   1) test SPEC.md §4.9 launch aborts before arming reaper when identity capture fails (Orchard.Node.WorkerCustodyTest)
    verdict:   CAUGHT (tests failed as required)

source restored:
  (clean)
```
</details>
<details>
<summary>Evidence: Targeted regression suite result (restored source)</summary>

<code>Including tags: [location: &#34;test/orchard/node/worker_process_lifecycle_test.exs&#34;, location: &#34;test/orchard/node/runtime_process_reaper_test.exs&#34;, location: &#34;test/orchard/node/worker_custody_test.exs&#34;, location: {&#34;test/orchard_node_agent_test.exs&#34;, 2461}]&#10;&#10;11:49:22.044 [warning] worker custody identity mismatch os_pid=33677&#10;11:49:22.772 [warning] worker custody identity unavailable os_pid=33758&#10;11:49:22.504 [warning] reaping orphaned worker process %{os_pid: 33742, phase: :loading, owner_reason: :killed}&#10;&#10;Finished in 11.2 seconds (0.00s async, 11.2s sync)&#10;Result: 35 passed, 106 excluded</code>

```text
 169 │     |> Plug.Conn.put_resp_header("location", cdn_url)
 193 │     |> Plug.Conn.put_resp_header("content-length", to_string(byte_size(content)))
 194 │     |> Plug.Conn.put_resp_header("etag", "\"#{hash_content(content)}\"")
 204 │     |> Plug.Conn.put_resp_header("content-length", to_string(byte_size(body)))
 231 │         |> Plug.Conn.put_resp_header("content-length", to_string(byte_size(body)))
==> orchard_node_agent
Running ExUnit with seed: 462040, max_cases: 36
Excluding tags: [:test]
Including tags: [location: "test/orchard/node/worker_process_lifecycle_test.exs", location: "test/orchard/node/runtime_process_reaper_test.exs", location: "test/orchard/node/worker_custody_test.exs", location: {"test/orchard_node_agent_test.exs", 2461}]
............11:49:22.044 [warning] worker custody identity mismatch os_pid=33677
..11:49:22.125 [warning] worker custody identity mismatch os_pid=33701
...11:49:22.504 [warning] reaping orphaned worker process %{os_pid: 33742, phase: :loading, model_ref: nil, owner_reason: :killed}
.11:49:22.770 [warning] reaping orphaned worker process %{os_pid: 33758, phase: :loaded, model_ref: nil, owner_reason: :killed}
11:49:22.772 [warning] worker custody identity unavailable os_pid=33758
.....11:49:25.195 [warning] worker signal failed os_pid=33861 signal=KILL exit_status=1
.11:49:25.312 [warning] worker custody identity unavailable os_pid=33938
...11:49:27.984 [warning] reaping orphaned worker process %{os_pid: 33989, phase: :loading, model_ref: %Orchard.Cluster.V1.ModelRef{model_id: "custody/test", version: "v1", __unknown_fields__: [], __protobuf__: true}, owner_reason: :shutdown}
...../tmp/oc-19/identity-unavailable-worker: line 3: 34056 Killed: 9               sleep 1
11:49:31.100 [warning] worker signal failed os_pid=34054 signal=KILL exit_status=1
...
Finished in 11.2 seconds (0.00s async, 11.2s sync)
Result: 35 passed, 106 excluded
```
</details>
<details>
<summary>Evidence: Observer harness used to capture the smoke transcript (read-only wrapper around the committed script)</summary>

```text
#!/usr/bin/env bash
# Read-only observer around the committed shutdown-custody smoke.
# Narrates what an operator sees across an orderly foreground node-agent
# shutdown: the owned worker child, its owned socket, and an unrelated
# sibling process that must survive.
set -uo pipefail

REPO_ROOT="$1"; PORT="$2"; LOG="$3"

alive() { kill -0 "${1:-0}" 2>/dev/null && echo yes || echo no; }

descendant_matching() {  # $1 root pid, $2 argv substring
  local root="$1" queue=("$1") cur kids k
  while ((${#queue[@]})); do
    cur="${queue[0]}"; queue=("${queue[@]:1}")
    kids="$(pgrep -P "$cur" 2>/dev/null)" || kids=""
    for k in $kids; do
      case "$(ps -ww -o args= -p "$k" 2>/dev/null)" in *"$2"*) printf '%s\n' "$k"; return 0 ;; esac
      queue+=("$k")
    done
  done
  return 1
}

cd "$REPO_ROOT"
ORCHARD_SHUTDOWN_CUSTODY_PORT="$PORT" mise exec -- ./scripts/smoke-node-agent-shutdown-custody.sh >"$LOG" 2>&1 &
SMOKE_PID=$!

# Resolve the bash process actually running the smoke script (not the `mise
# exec` wrapper), so its direct children -- the BEAM launcher and the unrelated
# control child -- are one cheap pgrep away during the tight shutdown window.
script_pid=""
for _ in $(seq 1 200); do
  for cand in $(pgrep -f 'smoke-node-agent-shutdown-custody.sh' 2>/dev/null); do
    cargs="$(ps -ww -o args= -p "$cand" 2>/dev/null)"
    [[ "$cargs" == *mise* ]] && continue
    [[ "$cargs" == *observe-shutdown-custody* ]] && continue
    script_pid="$cand"; break
  done
  [[ -n "$script_pid" ]] && break
  sleep 0.25
done
[[ -n "$script_pid" ]] || script_pid="$SMOKE_PID"

state_dir=""; deadline=$((SECONDS + 420))
while ((SECONDS < deadline)); do
  kill -0 "$SMOKE_PID" 2>/dev/null || break
  for d in /tmp/orchard-286.*; do
    [[ -s "$d/worker.pid" && -s "$d/worker.socket" ]] && { state_dir="$d"; break; }
  done
  [[ -n "$state_dir" ]] && break
  sleep 0.25
done
[[ -n "$state_dir" ]] || { echo "observer: never saw a recorded worker identity"; wait "$SMOKE_PID"; exit 1; }

worker_pid="$(cat "$state_dir/worker.pid")"
socket_path="$(cat "$state_dir/worker.socket")"
beam_pid="$(descendant_matching "$script_pid" 'beam.smp')" || beam_pid=""

echo "=== BEFORE node-agent SIGTERM — steady state, synthetic bundle loaded over gRPC ==="
echo "node-agent BEAM (pid ${beam_pid:-unresolved}):"
ps -ww -o pid=,ppid=,args= -p "${beam_pid:-0}" 2>/dev/null | cut -c1-140
echo
echo "owned worker child — exact PID recorded at launch ($worker_pid):"
ps -ww -o pid=,ppid=,uid=,args= -p "$worker_pid" 2>/dev/null | cut -c1-140
echo
echo "owned worker socket:"
ls -l "$socket_path" 2>&1
echo
echo "=== TIMELINE across the shutdown (100ms poll, rows printed on state change) ==="
printf '%-8s %-11s %-13s %-9s %-14s\n' "t" "beam" "worker_pid" "socket" "control_child"
start_ms=$(($(date +%s) * 1000))
prev=""; control_pid=""; control_seen=no
while kill -0 "$SMOKE_PID" 2>/dev/null; do
  if [[ -z "$control_pid" ]]; then
    for c in $(pgrep -P "$script_pid" 2>/dev/null); do
      case "$(ps -ww -o args= -p "$c" 2>/dev/null)" in
        *"sleep 3600"*) control_pid="$c"; control_seen=yes; break ;;
      esac
    done
  fi
  row="$(printf '%-11s %-13s %-9s %-14s' \
    "$(alive "$beam_pid")" "$(alive "$worker_pid")" \
    "$([[ -e "$socket_path" ]] && echo present || echo absent)" \
    "$([[ -n "$control_pid" ]] && alive "$control_pid" || echo "not-started")")"
  if [[ "$row" != "$prev" ]]; then
    printf '%-8s %s\n' "+$(( $(date +%s) * 1000 - start_ms ))ms" "$row"
    prev="$row"
  fi
  sleep 0.1
done
wait "$SMOKE_PID"; smoke_status=$?
printf '%-8s %s\n' "+$(( $(date +%s) * 1000 - start_ms ))ms" \
  "$(printf '%-11s %-13s %-9s %-14s' "$(alive "$beam_pid")" "$(alive "$worker_pid")" \
     "$([[ -e "$socket_path" ]] && echo present || echo absent)" \
     "$([[ -n "$control_pid" ]] && alive "$control_pid" || echo "not-started")")"
echo
echo "control child resolved by observer: ${control_pid:-none} (seen=$control_seen)"
echo "The control child is the last thing to go: it dies only in the smoke's own"
echo "identity-matched EXIT trap, after the node agent and its owned worker are gone."
echo
echo "smoke temporary state dir: $([[ -e "$state_dir" ]] && echo "STILL PRESENT $state_dir" || echo "removed — no raw process evidence left behind")"
echo
echo "=== smoke script verdict ==="
cat "$LOG"
echo "smoke_exit_status=$smoke_status"
exit "$smoke_status"
```
</details>
<details>
<summary>Evidence: EXIT-trap guard harness (sources the committed guard functions verbatim)</summary>

```text
#!/usr/bin/env bash
# Exercises the COMMITTED EXIT-trap guard from
# scripts/smoke-node-agent-shutdown-custody.sh against real live processes.
# The guard functions are extracted verbatim from the committed script and
# sourced, so this proves the shipped code, not a re-implementation.
set -uo pipefail

SCRIPT="$1/scripts/smoke-node-agent-shutdown-custody.sh"
extracted="$(mktemp)"
sed -n '/^process_identity() {/,/^}/p' "$SCRIPT"  >"$extracted"
sed -n '/^cleanup_owned_pid() {/,/^}/p' "$SCRIPT" >>"$extracted"
echo "guard functions sourced verbatim from the committed smoke script:"
grep -n '^[a-z_]*() {' "$extracted" | sed 's/^/  scripts\/smoke-node-agent-shutdown-custody.sh :: /'
echo
# shellcheck disable=SC1090
source "$extracted"

pass=0; fail=0; VICTIM=""; OTHER=""
spawn() { sleep 300 >/dev/null 2>&1 & VICTIM=$!; }
spawn_other() { sleep 300 >/dev/null 2>&1 & OTHER=$!; }
check() { # $1 label, $2 expectation alive|dead
  local state; kill -0 "$VICTIM" 2>/dev/null && state=alive || state=dead
  if [[ "$state" == "$2" ]]; then printf '  PASS  %-58s bystander=%s\n' "$1" "$state"; pass=$((pass+1))
  else printf '  FAIL  %-58s bystander=%s expected=%s\n' "$1" "$state" "$2"; fail=$((fail+1)); fi
  kill -KILL "$VICTIM" 2>/dev/null; wait "$VICTIM" 2>/dev/null
}

echo "=== cleanup_owned_pid: hardened EXIT trap vs. real live bystander processes ==="

spawn; cleanup_owned_pid "$VICTIM" "$(process_identity "$VICTIM")"
check "MATCHING launch identity -> genuine cleanup still reaps the PID" dead

spawn; cleanup_owned_pid "$VICTIM" "501 Wed Jan  1 00:00:00 2020"
check "MISMATCHED identity (recycled PID) -> bystander untouched" alive

spawn; cleanup_owned_pid "$VICTIM" "stale-worker-identity"
check "stale/garbage recorded identity -> bystander untouched" alive

spawn; cleanup_owned_pid "$VICTIM" ""
check "identity never captured -> fails closed, bystander untouched" alive

# `process_identity` is uid + `lstart`, and `lstart` has one-second resolution,
# so the identity of a *different* process must be captured at least a second
# apart to be distinguishable. That boundary is the documented tradeoff in
# Orchard.Node.WorkerProcessLifecycle: a recycled PID cannot collide without
# wrapping the whole PID space inside one second.
spawn_other; command sleep 1.5; spawn
cleanup_owned_pid "$VICTIM" "$(process_identity "$OTHER")"
check "identity of a DIFFERENT process (earlier start) -> untouched" alive
kill -KILL "$OTHER" 2>/dev/null; wait "$OTHER" 2>/dev/null

spawn; cleanup_owned_pid "0" "$(process_identity "$VICTIM")"
check "recorded PID 0 rejected -> no self/process-group signalling" alive

spawn; cleanup_owned_pid "-1" "$(process_identity "$VICTIM")"
check "recorded PID -1 rejected -> no kill(-1) blast radius" alive

spawn; cleanup_owned_pid "not-a-pid" "$(process_identity "$VICTIM")"
check "non-numeric recorded PID rejected" alive

rm -f "$extracted"
echo
echo "guard cases: $pass passed, $fail failed"
[[ "$fail" -eq 0 ]]
```
</details>
<details>
<summary>Evidence: Plain smoke run transcript</summary>

<code>$ ORCHARD_SHUTDOWN_CUSTODY_PORT=50191 mise exec -- ./scripts/smoke-node-agent-shutdown-custody.sh&#10;shutdown-custody smoke: PASS&#10;beam: exited on SIGTERM (bounded)&#10;worker child: exact pid dead&#10;worker socket: removed&#10;control child: survived&#10;EXIT cleanup: stale and mismatched PIDs rejected&#10;exit_status=0</code>

```text
$ ORCHARD_SHUTDOWN_CUSTODY_PORT=50191 mise exec -- ./scripts/smoke-node-agent-shutdown-custody.sh
shutdown-custody smoke: PASS
  beam: exited on SIGTERM (bounded)
  worker child: exact pid dead
  worker socket: removed
  control child: survived
  EXIT cleanup: stale and mismatched PIDs rejected
exit_status=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex:187` - The shutdown sweep serializes each lease&#39;s TERM grace against one shared 4s budget, so the moduledoc&#39;s &#34;preserves each lease&#39;s remaining TERM grace&#34; claim only holds for the first few leases. `terminate/2` iterates `state.leases` with `Enum.each` (arbitrary map order) and `sweep_lease/2` blocks in `await_exit` per lease; once `sweep_deadline` passes, `grace_deadline = min(term_deadline, sweep_deadline)` yields `grace_ms = 0`, so remaining leases get TERM (via `resolve_term_deadline`) followed immediately by `kill_owned_process_tree`. Failure: a node with 5+ loaded models (default `max_loaded_models: 0` = unlimited, see apps/orchard_node_agent/lib/orchard/node.ex:99) and the default `worker_shutdown_timeout_ms: 1000` exhausts the 4000ms budget on the first four leases; models 5..N are SIGKILLed with zero graceful window. The same occurs for a single lease whenever an operator sets ORCHARD_WORKER_SHUTDOWN_TIMEOUT_MS above 4000 — the sweep silently caps the configured grace. Fix at the shared boundary: signal TERM to every lease first, then await all of them against one deadline, and escalate only the survivors.
- ℹ️ `apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex:1084` - `terminate_closed_port_runtime/3` spends the full `timeout_ms` twice: once as TERM grace, then again in `kill_closed_port_runtime/3` waiting after an uncatchable SIGKILL. This blocks the calling WorkerProcess inside `handle_call({:unload, opts})`, which callers reach through `WorkerProcess.unload/2`&#39;s default 5000ms `GenServer.call` (apps/orchard_node_agent/lib/orchard/node/worker_process.ex:51). Failure: with ORCHARD_WORKER_SHUTDOWN_TIMEOUT_MS=3000 and a closed port whose recorded child is still alive and TERM-resistant, the adapter blocks ~6s, the ModelManager&#39;s `safe_worker_call` catches the exit and reports `{:error, :worker_unavailable}` / &#34;unload failed&#34; even though the worker was in fact killed, while the WorkerProcess stays blocked on the orphaned call. This path previously returned `:ok` immediately, so the timeout is newly reachable. Bound both phases with a single deadline (the post-KILL confirmation does not need the full grace).
- ℹ️ `apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex:492` - `process_identity/1` runs immediately after `Port.open`, so a worker that exits during startup is already reaped by `erl_child_setup` when `ps` runs, making it return `{:error, :identity_unavailable}`. `start_runtime/1` then aborts with that atom and `emit_runtime_exception` records `reason: :identity_unavailable`. Failure: `orchard-worker-mlx` exits 127 because the venv was never built; the operator sees `identity_unavailable` instead of `{:worker_exited, 127}` — the error that `wait_for_worker_ready` would have produced before this change and the one that points at the worker log. Fail-closed abort is correct per the intent; only the reported reason regresses. Check the port for a pending `{:exit_status, status}` in the `:identity_unavailable` branch and prefer `{:worker_exited, status}` when present.
- ℹ️ `apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex:155` - `confirm_custody/2` collapses &#34;identity genuinely differs (recycled PID)&#34; and &#34;process no longer exists&#34; into one `Logger.warning(&#34;worker custody identity mismatch&#34;)` plus one `{:error, :identity_mismatch}` atom, even though `process_identity/1` already distinguishes them via `{:error, :identity_unavailable}`. Failure: in `sweep_lease/2` (runtime_process_reaper.ex:199-204) `await_exit` returns `{:error, :timeout}` when the child is alive at the final 25ms poll; if it exits microseconds later, `kill_owned_process_tree` logs &#34;worker custody identity mismatch os_pid=N&#34; during a completely normal shutdown. The same race exists at worker_runtime_adapter.ex:1092. Operators cannot tell a refused kill on a recycled PID — the security-relevant case this PR exists for — from a benign exit. Match on `{:error, :identity_unavailable}` separately and log that case below warning level.
- ℹ️ `apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex:1078` - The custody-gated TERM -&gt; await -&gt; KILL escalation now exists twice with subtly different budgets: `terminate_closed_port_runtime/3` + `kill_closed_port_runtime/3` here, and `sweep_lease/2` + `resolve_term_deadline/1` at runtime_process_reaper.ex:192-219. `cleanup_socket/1` is likewise duplicated (worker_runtime_adapter.ex:632 and runtime_process_reaper.ex:297) with different return contracts. The two escalations already disagree on deadline handling, which is the root of the two timing findings above. Extracting one `WorkerProcessLifecycle` helper that takes an absolute deadline would fix both timing gaps at a single boundary and keep the two custody paths from drifting further.

🔧 Fix: share one absolute deadline across custody shutdown escalation
2 issues (1 warning, 1 info) still open:
- ⚠️ `apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs:276` - `assert elapsed &lt; @closed_port_budget_ms` (600ms) leaves too little slack for the OS work the production code does *outside* any deadline. With `@closed_port_budget_ms = 600`, `terminate_closed_port_runtime` sets `term_deadline = now + 350` (600 - min(250, 300)), so only 250ms remains for: the `await_exit_until` overshoot (one `Process.sleep(25)` + one `kill -0` past the deadline), then `confirm_custody`&#39;s `ps`, then `kill_process_tree`&#39;s `pgrep` on the root, `pgrep` on the `sleep` child, `kill -KILL` child, `kill -KILL` root, then 1-2 confirmation `kill -0` calls. That is ~7-8 `System.cmd` spawns; at ~30ms each under CI contention the total reaches ~640ms and the assertion fails even though the code behaved correctly. `escalate_owned_exit/4` bounds only the *waiting*, never the escalation syscalls, so the test asserts a stronger property than the implementation guarantees. Raise `@closed_port_budget_ms` (e.g. 1_500) so the fixed 250ms reserve plus spawn overhead is a small fraction of the budget — the pre-fix double-spend would still land near 2x and stay clearly distinguishable. The same class of tightness applies more mildly at runtime_process_reaper_test.exs:341, where `div(@sweep_grace_ms, 2)` gives phase 1 only 500ms to complete 9 spawns across 3 leases.
- ℹ️ `apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex:1124` - `stop_runtime/4`&#39;s two branches now have asymmetric budgets: the closed-port branch is bounded once by `timeout_ms` via the shared deadline, while `stop_runtime_with_escalation/3` still calls `wait_for_port_exit(port, timeout_ms)` twice and can spend 2x. With ORCHARD_WORKER_SHUTDOWN_TIMEOUT_MS=3000 and a TERM-resistant worker whose port is still open, `handle_call({:unload, opts})` blocks ~6s past `WorkerProcess.unload/2`&#39;s default 5000ms `GenServer.call`, so `safe_worker_call` reports `{:error, :worker_unavailable}` on a worker that was in fact killed. I confirmed this shape is pre-existing at base f20da13e (worker_runtime_adapter.ex:1032-1047 there) and the user&#39;s fix instruction scoped the single-deadline change to &#34;closed-port TERM/KILL&#34; only, so this is out of the authorized issue #286 scope — recording the asymmetry as a known tradeoff, not an oversight. If it is ever addressed, `escalate_owned_exit/4`&#39;s absolute-deadline shape is the boundary to reuse.

🔧 Fix: calibrate closed-port budget assertion against measured spawn cost
1 info still open:
- ℹ️ `apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs:341` - The sweep-broadcast test gives phase 1 a fixed `div(@sweep_grace_ms, 2)` = 500ms to deliver TERM to all three leases. Phase 1 does 3 leases x 3 `System.cmd` spawns (`kill -0`, `ps`, `kill -TERM`) = 9 spawns plus each resistant shell&#39;s trap write, so it needs roughly &lt;=50ms per spawn. This is the same class of tightness as the closed-port assertion but materially milder: it is a `wait_until` poll that succeeds the instant the last marker lands, needs no headroom for work after the condition holds, and 500ms for 9 spawns is about 2x more tolerant than the 250ms-for-8-spawns the closed-port test allowed before this commit. Recording it only for the record: the round-2 fix instruction explicitly scoped this round to &#34;only the flaky closed-port budget regression&#34;, so this was deliberately left alone and is not a merge concern. If it ever does flake, the same `measure_escalation_overhead!` calibration pattern introduced at worker_custody_test.exs:415 applies directly.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test test/orchard/node/worker_process_lifecycle_test.exs test/orchard/node/runtime_process_reaper_test.exs test/orchard/node/worker_custody_test.exs test/orchard_node_agent_test.exs:2461` (from apps/orchard_node_agent) — 35 passed, covering closed-Port unload, reaper owner-down/shutdown sweep, launch identity unavailability, fail-closed signalling, and shared shutdown deadline</code>
- <code>`ORCHARD_SHUTDOWN_CUSTODY_PORT=50191 mise exec -- ./scripts/smoke-node-agent-shutdown-custody.sh` — ran end-to-end 3x, PASS each time (beam exited bounded on SIGTERM, exact worker PID dead, owned socket removed, unrelated control child survived, stale/mismatched EXIT-trap PIDs rejected)</code>
- <code>Read-only observer around the real smoke capturing operator-visible state: `ps` of the node-agent BEAM and the exact launch-recorded worker PID, `ls -l` of the owned Unix socket, and a 100ms-polled timeline across the SIGTERM showing owned worker+socket disappearing while the unrelated control child stayed alive</code>
- <code>Extracted `process_identity` and `cleanup_owned_pid` verbatim from `scripts/smoke-node-agent-shutdown-custody.sh`, sourced them, and exercised them against real live bystander processes — 8/8 cases: matching identity reaps; mismatched, stale/garbage, absent, and different-process identities leave the bystander untouched; recorded PID `0`, `-1`, and non-numeric rejected before any signal</code>
- <code>Mutation check M1 — made `confirm_custody(os_pid, nil)` fail open; `worker_process_lifecycle_test.exs:85`, `worker_custody_test.exs:128`, `runtime_process_reaper_test.exs:375,410` all failed (0/4 passed) as required</code>
- <code>Mutation check M2 — made the identity-mismatch branch return `:ok`; `worker_process_lifecycle_test.exs:60`, `worker_custody_test.exs:96`, `runtime_process_reaper_test.exs:351,363` all failed (0/4 passed) as required</code>
- <code>Mutation check M3 — restored the pre-fix two-full-budget escalation in `terminate_closed_port_runtime`; `worker_custody_test.exs:243` failed (elapsed exceeded the 539ms ceiling derived from a measured 39ms escalation overhead)</code>
- <code>Mutation check M4 — armed a PID-only reaper instead of aborting launch on identity-capture failure; `worker_custody_test.exs:162` failed as required</code>
- <code>Probed `ps -o uid= -o lstart=` resolution to confirm the one-second `lstart` granularity documented in `worker_process_lifecycle.ex:83` (same-second processes share a snapshot; &gt;1s apart differ)</code>
- <code>`git status --porcelain` and `git diff --stat a841e4bf` after all mutation runs — both empty, confirming source restored and no test artifacts, smoke bundle (`tmp/dev/models/issue-286-shutdown-custody`), or `/tmp/orchard-286.*` state left behind</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CHANGELOG.md` - No CHANGELOG entry was added for this fix. Judgment call: CHANGELOG.md is maintained in dedicated weekly docs PRs (`docs: add CHANGELOG.md section for week ending 2026-08-23` #275, `docs: add dated weekly changelog section for 2026-08-21` #244) and is grouped by the date a change landed on `main`, not per feature PR. No repo instruction requires a per-PR entry, so adding one here would have contradicted the established convention. If the shutdown-custody fix should appear in the user-facing changelog, it belongs in the next weekly section under &#39;Bug fixes&#39; with a link to PR #290.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR strengthens orderly Node Agent shutdown by preserving runtime custody after worker ownership transitions.
- Captures and validates OS process identity before post-Port signaling.
- Moves socket cleanup and bounded TERM-to-KILL escalation into the runtime reaper.
- Adds deterministic lifecycle tests, support fixtures, and a documented foreground shutdown smoke.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_node_agent/lib/orchard/node/runtime_process_reaper.ex | Reaper leases now preserve socket and identity custody while applying a shared bounded shutdown sweep. |
| apps/orchard_node_agent/lib/orchard/node/worker_process_lifecycle.ex | Process signaling now fails closed when launch identity is absent or no longer matches the live PID. |
| apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex | Runtime launch captures process identity and propagates it through closed-Port and failed-launch cleanup. |
| scripts/smoke-node-agent-shutdown-custody.sh | The shutdown smoke records process identities and revalidates them before EXIT-trap cleanup signals any retained PID. |
| apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs | Adds focused coverage for unload, closed-Port custody, missing identities, escalation, and application shutdown. |
| apps/orchard_node_agent/test/orchard/node/runtime_process_reaper_test.exs | Adds deterministic coverage for socket removal, grace preservation, bounded escalation, and custody refusal. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Launch worker] --> B[Capture PID identity]
    B -->|Captured| C[Register reaper lease]
    B -->|Unavailable| D[Abort launch and clean artifacts]
    C --> E{Shutdown path}
    E -->|Port remains open| F[Signal BEAM-owned child]
    E -->|Port closed or owner exited| G[Revalidate PID identity]
    G -->|Match| H[TERM and bounded wait]
    G -->|Missing or mismatch| I[Refuse signaling]
    H -->|Still alive| J[Identity-gated tree KILL]
    C --> K[Remove owned socket]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["no-mistakes(document): document smoke st..."](https://github.com/kapitan-ai/orchard/commit/457e18a999c9f890fdd7ea3efac316d0bf9820ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56907359)</sub>

<!-- /greptile_comment -->


Closes #286
