### PR TITLE
ci: add portable validation fan-out

### DIFF
--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -111,6 +111,8 @@ jobs:
 
       - name: Install portable dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes acl
           make setup-elixir
           mise exec -- uv sync --locked --directory native/orchard_tokenizer
           mise exec -- uv sync --locked --directory native/orchard_worker_mlx

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -13,78 +13,79 @@ concurrency:
   group: orchard-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  ORCHARD_TEST_NODE_AGENT_PORT: "50171"
+  PGHOST: localhost
+  PGPORT: "5432"
+  PGUSER: postgres
+  PGPASSWORD: postgres
+  PGDATABASE_TEST: orchard_test
+
 jobs:
-  # Detect whether the change touches anything beyond documentation. Runs on a
-  # cheap Linux runner so docs-only PRs never spin up the macOS runner. Do NOT
-  # use `paths-ignore` on the workflow trigger instead: a workflow skipped by
-  # path filtering leaves its required checks stuck in "Pending" and blocks
-  # merging (see GitHub docs, "Handling skipped but required checks").
   changes:
-    name: Detect changed paths
+    name: Classify required validation
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
     outputs:
-      # Pushes to main always run the full suite; PRs run it unless the diff
-      # is docs-only (docs/** and top-level *.md).
-      run_full: ${{ github.event_name != 'pull_request' || steps.filter.outputs.non_docs == 'true' }}
+      portable: ${{ steps.classify.outputs.portable }}
+      conformance: ${{ steps.classify.outputs.conformance }}
+      macos: ${{ steps.classify.outputs.macos }}
+      mlx: ${{ steps.classify.outputs.mlx }}
+      packaging: ${{ steps.classify.outputs.packaging }}
     steps:
-      - name: Detect non-docs changes
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          predicate-quantifier: some-with-excludes
-          filters: |
-            non_docs:
-              - '**'
-              - '!docs/**'
-              - '!*.md'
+          fetch-depth: 0
+          persist-credentials: false
 
-  required-validation:
-    name: Required Orchard validation
-    # Orchard is an Apple Silicon macOS-native product: the suite exercises
-    # macOS system binaries (BSD `date -j -f`, `/usr/bin/lockf`, launchctl) and
-    # BEAM TLS Distribution behavior that only pass on macOS. Run the required
-    # check on a pinned Apple Silicon runner.
-    runs-on: nscloud-macos-sequoia-stable-arm64-6x14
-    timeout-minutes: 60
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            printf '%s=true\n' portable conformance macos mlx packaging >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | scripts/ci/classify-required-validation-paths.sh \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Test validation fan-out and aggregate gate
+        run: |
+          scripts/ci/test-classify-required-validation-paths.sh
+          scripts/ci/test-required-validation-gate.sh
+
+  linux-portable:
+    name: Linux portable control-plane core
     needs: changes
-    if: needs.changes.outputs.run_full == 'true'
-    env:
-      ORCHARD_TEST_NODE_AGENT_PORT: "50171"
-      PGHOST: localhost
-      PGPORT: "5432"
-      PGUSER: postgres
-      PGPASSWORD: postgres
-      PGDATABASE_TEST: orchard_test
-
+    if: needs.changes.outputs.portable == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Provision deterministic Postgres
-        run: |
-          # macOS runners have no Docker service containers. Provision a fresh,
-          # reproducible Postgres 16 cluster with trust auth on a fixed port.
-          brew install postgresql@16
-          echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
-
-      - name: Start Postgres
-        run: |
-          pgdata="$RUNNER_TEMP/pgdata"
-          initdb --username="$PGUSER" --auth=trust --encoding=UTF8 --pgdata="$pgdata"
-          pg_ctl --pgdata="$pgdata" --log="$RUNNER_TEMP/postgres.log" \
-            --options="-p $PGPORT -k $RUNNER_TEMP" --wait start
-          for _ in $(seq 1 30); do
-            pg_isready --host="$PGHOST" --port="$PGPORT" --username="$PGUSER" && break
-            sleep 1
-          done
-          pg_isready --host="$PGHOST" --port="$PGPORT" --username="$PGUSER"
 
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -94,123 +95,241 @@ jobs:
       - name: Validate Product Version consistency
         run: make validate-product-version
 
-      - name: Install Elixir dependencies
-        run: make setup-elixir
+      - name: Install portable dependencies
+        run: |
+          make setup-elixir
+          mise exec -- uv sync --locked --directory native/orchard_tokenizer
+          mise exec -- uv sync --locked --directory native/orchard_worker_mlx
 
       - name: Prove portable compilation excludes Darwin helpers
         run: scripts/test-portable-core-compilation.sh
-
-      - name: Bootstrap native environments from lockfiles
-        run: |
-          mise exec -- uv sync --locked --directory native/orchard_tokenizer
-          mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx
-          mise exec -- native/orchard_worker_mlx/bin/orchard-worker-mlx --help >/dev/null
-
-      - name: Validate MLX-LM security baseline
-        run: |
-          mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx \
-            pytest
-
-      - name: Install OpenSpec dependencies
-        run: make setup-openspec
 
       - name: Prepare test database
         run: |
           MIX_ENV=test mise exec -- mix ecto.create
           MIX_ENV=test mise exec -- mix ecto.migrate
 
-      - name: Check formatting
-        run: mise exec -- mix format --check-formatted
+      - name: Run portable static gates
+        run: |
+          mise exec -- mix format --check-formatted
+          mise exec -- mix compile --warnings-as-errors
+          mise exec -- mix credo --strict
+          mise exec -- mix dialyzer
 
-      - name: Compile without warnings
-        run: mise exec -- mix compile --warnings-as-errors
+      - name: Run portable tests and coverage
+        run: scripts/test-linux-portable-core.sh
 
-      - name: Run Credo
-        run: mise exec -- mix credo --strict
-
-      - name: Cache Dialyzer PLTs
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+  provider-conformance:
+    name: Provider-neutral conformance
+    needs: changes
+    if: needs.changes.outputs.conformance == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          path: |
-            ~/.mix/dialyxir_erlang-*.plt
-            _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt
-            _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt.hash
-          key: orchard-dialyzer-plt-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mix.lock', 'mix.exs', 'apps/*/mix.exs') }}
+          persist-credentials: false
 
-      - name: Run Dialyzer
-        run: mise exec -- mix dialyzer
+      - name: Install pinned toolchain
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
 
-      - name: Test explicit macOS native-helper build
-        run: scripts/test-build-macos-native-helpers.sh
+      - name: Install Elixir dependencies
+        run: make setup-elixir
 
-      - name: Build macOS native helpers for Mix tests
-        run: make macos-native-test-helpers
+      - name: Prepare test database
+        run: |
+          MIX_ENV=test mise exec -- mix ecto.create
+          MIX_ENV=test mise exec -- mix ecto.migrate
 
-      - name: Run tests
-        run: mise exec -- mix test
+      - name: Run provider-neutral conformance tests
+        run: scripts/test-provider-neutral-conformance.sh
 
-      - name: Run coverage
-        run: mise exec -- mix test --cover
+  macos-host:
+    name: macOS host validation
+    needs: changes
+    if: needs.changes.outputs.macos == 'true'
+    runs-on: nscloud-macos-sequoia-stable-arm64-6x14
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - name: Test retained payload build contract
-        run: scripts/test-build-payload.sh
+      - name: Install pinned toolchain
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
 
-      - name: Test payload signing and closure contracts
-        run: scripts/test-payload-signing-contracts.sh
+      - name: Install Elixir dependencies
+        run: make setup-elixir
+
+      - name: Test explicit macOS native-helper boundary
+        run: |
+          scripts/test-portable-core-compilation.sh
+          scripts/test-build-macos-native-helpers.sh
+          make macos-native-test-helpers
+          mise exec -- mix test --only macos
+
+  mlx-validation:
+    name: MLX provider validation
+    needs: changes
+    if: needs.changes.outputs.mlx == 'true'
+    runs-on: nscloud-macos-sequoia-stable-arm64-6x14
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned toolchain
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+
+      - name: Bootstrap MLX environment from lockfile
+        run: |
+          mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx
+          mise exec -- native/orchard_worker_mlx/bin/orchard-worker-mlx --help >/dev/null
+
+      - name: Validate MLX-LM security baseline
+        run: >-
+          mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx
+          pytest
+
+  packaging-validation:
+    name: Orchard.app and DMG validation
+    needs: changes
+    if: needs.changes.outputs.packaging == 'true'
+    runs-on: nscloud-macos-sequoia-stable-arm64-6x14
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Provision deterministic Postgres
+        run: |
+          brew install postgresql@16
+          echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
+
+      - name: Start Postgres
+        run: |
+          pgdata="$RUNNER_TEMP/pgdata"
+          initdb --username="$PGUSER" --auth=trust --encoding=UTF8 --pgdata="$pgdata"
+          pg_ctl --pgdata="$pgdata" --log="$RUNNER_TEMP/postgres.log" \
+            --options="-p $PGPORT -k $RUNNER_TEMP" --wait start
+          pg_isready --host="$PGHOST" --port="$PGPORT" --username="$PGUSER"
+
+      - name: Install pinned toolchain
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+
+      - name: Install repository dependencies
+        run: make setup
+
+      - name: Prepare test database
+        run: |
+          MIX_ENV=test mise exec -- mix ecto.create
+          MIX_ENV=test mise exec -- mix ecto.migrate
+
+      - name: Test retained payload and signing contracts
+        run: |
+          scripts/test-build-payload.sh
+          scripts/test-payload-signing-contracts.sh
 
       - name: Test Orchard.app lifecycle and assembly
         run: |
+          xcrun swift-format lint --recursive packaging/app/Sources packaging/app/Tests
+          swift build --package-path packaging/app
           swift test --package-path packaging/app
+          swift test --package-path packaging/app --enable-code-coverage
           scripts/test-app-service-lifecycle.sh
           scripts/test-build-app.sh
           scripts/test-app-signing.sh
           scripts/test-build-dmg.sh
 
-      - name: Test payload orchardctl Controller runtime routing
-        run: scripts/test-payload-orchardctl-controller-runtime.sh
+      - name: Test packaged orchardctl
+        run: |
+          scripts/test-payload-orchardctl-controller-runtime.sh
+          scripts/test-payload-orchardctl-console-pty.sh
+          scripts/test-payload-orchardctl-controller-release.sh
 
-      - name: Test payload orchardctl PTY secret input
-        run: scripts/test-payload-orchardctl-console-pty.sh
+  openspec-validation:
+    name: OpenSpec validation
+    needs: changes
+    if: needs.changes.outputs.portable == 'true' || needs.changes.outputs.conformance == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - name: Test payload orchardctl assembled Controller release RPC
-        run: scripts/test-payload-orchardctl-controller-release.sh
+      - name: Install pinned toolchain
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+
+      - name: Install OpenSpec dependencies
+        run: make setup-openspec
 
       - name: Validate OpenSpec
         env:
           OPENSPEC_TELEMETRY: "0"
         run: mise exec -- npm run openspec -- validate --all --strict --no-interactive
 
-  # Aggregating gate: this job name ("Required Orchard validation gate") must
-  # be the required status check in branch protection, replacing
-  # "Required Orchard validation". It always runs (`if: always()`) and reports
-  # success when the heavy macOS job passed, or when it was legitimately
-  # skipped because the change is docs-only. This is the recommended pattern
-  # for keeping a required check green on docs-only PRs without leaving it
-  # stuck in "Pending".
   required-validation-gate:
     name: Required Orchard validation gate
+    needs:
+      - changes
+      - linux-portable
+      - provider-conformance
+      - macos-host
+      - mlx-validation
+      - packaging-validation
+      - openspec-validation
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [changes, required-validation]
-    if: always()
     steps:
-      - name: Evaluate validation result
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Evaluate required validation results
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          VALIDATION_RESULT: ${{ needs.required-validation.result }}
-          RUN_FULL: ${{ needs.changes.outputs.run_full }}
-        run: |
-          if [ "$CHANGES_RESULT" != "success" ]; then
-            echo "Path detection job did not succeed: $CHANGES_RESULT"
-            exit 1
-          fi
-          if [ "$VALIDATION_RESULT" = "success" ]; then
-            echo "Full validation passed."
-            exit 0
-          fi
-          if [ "$VALIDATION_RESULT" = "skipped" ] && [ "$RUN_FULL" != "true" ]; then
-            echo "Docs-only change: full validation legitimately skipped."
-            exit 0
-          fi
-          echo "Required validation result: $VALIDATION_RESULT"
-          exit 1
+          CONFORMANCE_REQUIRED: ${{ needs.changes.outputs.conformance }}
+          CONFORMANCE_RESULT: ${{ needs.provider-conformance.result }}
+          MACOS_REQUIRED: ${{ needs.changes.outputs.macos }}
+          MACOS_RESULT: ${{ needs.macos-host.result }}
+          MLX_REQUIRED: ${{ needs.changes.outputs.mlx }}
+          MLX_RESULT: ${{ needs.mlx-validation.result }}
+          OPENSPEC_REQUIRED: ${{ needs.changes.outputs.portable == 'true' || needs.changes.outputs.conformance == 'true' }}
+          OPENSPEC_RESULT: ${{ needs.openspec-validation.result }}
+          PACKAGING_REQUIRED: ${{ needs.changes.outputs.packaging }}
+          PACKAGING_RESULT: ${{ needs.packaging-validation.result }}
+          PORTABLE_REQUIRED: ${{ needs.changes.outputs.portable }}
+          PORTABLE_RESULT: ${{ needs.linux-portable.result }}
+        run: scripts/ci/evaluate-required-validation.sh

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -194,6 +194,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Provision deterministic Postgres
+        run: |
+          # macOS runners have no Docker service containers, so this lane
+          # provisions its own Postgres instead of using `services:`.
+          brew install postgresql@16
+          echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
+
+      - name: Start Postgres
+        run: |
+          pgdata="$RUNNER_TEMP/pgdata"
+          initdb --username="$PGUSER" --auth=trust --encoding=UTF8 --pgdata="$pgdata"
+          pg_ctl --pgdata="$pgdata" --log="$RUNNER_TEMP/postgres.log" \
+            --options="-p $PGPORT -k $RUNNER_TEMP" --wait start
+          pg_isready --host="$PGHOST" --port="$PGPORT" --username="$PGUSER"
+
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
@@ -201,6 +216,11 @@ jobs:
 
       - name: Install Elixir dependencies
         run: make setup-elixir
+
+      - name: Prepare test database
+        run: |
+          MIX_ENV=test mise exec -- mix ecto.create
+          MIX_ENV=test mise exec -- mix ecto.migrate
 
       - name: Test explicit macOS native-helper boundary
         run: |

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -22,6 +22,10 @@ env:
   PGDATABASE_TEST: orchard_test
 
 jobs:
+  # Lane selection lives in job-level `if:` conditions, never in workflow-level
+  # `paths-ignore`: a workflow skipped by path filtering leaves its required
+  # checks stuck in "Pending" and blocks merging (see GitHub docs, "Handling
+  # skipped but required checks").
   changes:
     name: Classify required validation
     runs-on: ubuntu-latest
@@ -245,6 +249,8 @@ jobs:
 
       - name: Provision deterministic Postgres
         run: |
+          # macOS runners have no Docker service containers, so this lane
+          # provisions its own Postgres instead of using `services:`.
           brew install postgresql@16
           echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
 
@@ -316,6 +322,9 @@ jobs:
           OPENSPEC_TELEMETRY: "0"
         run: mise exec -- npm run openspec -- validate --all --strict --no-interactive
 
+  # This job name is the required status check in branch protection. Renaming it
+  # silently drops the gate, so keep the name and add new lanes to `needs`
+  # plus the evaluator inputs instead.
   required-validation-gate:
     name: Required Orchard validation gate
     needs:

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -54,7 +54,7 @@ jobs:
             exit 0
           fi
 
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+          git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" \
             | scripts/ci/classify-required-validation-paths.sh \
             >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -44,17 +44,26 @@ jobs:
 
       - name: Classify changed paths
         id: classify
+        shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -o pipefail
+
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
             printf '%s=true\n' portable conformance macos mlx packaging >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" \
+          if ! changed_paths="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")"; then
+            printf 'Unable to diff %s..%s; refusing to classify validation lanes.\n' \
+              "$BASE_SHA" "$HEAD_SHA" >&2
+            exit 1
+          fi
+
+          printf '%s\n' "$changed_paths" \
             | scripts/ci/classify-required-validation-paths.sh \
             >> "$GITHUB_OUTPUT"
 
@@ -108,6 +117,15 @@ jobs:
         run: |
           MIX_ENV=test mise exec -- mix ecto.create
           MIX_ENV=test mise exec -- mix ecto.migrate
+
+      - name: Cache Dialyzer PLTs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.mix/dialyxir_erlang-*.plt
+            _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt
+            _build/dev/dialyxir_erlang-*_elixir-*_deps-dev.plt.hash
+          key: orchard-dialyzer-plt-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mix.lock', 'mix.exs', 'apps/*/mix.exs') }}
 
       - name: Run portable static gates
         run: |

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -222,6 +222,13 @@ jobs:
           MIX_ENV=test mise exec -- mix ecto.create
           MIX_ENV=test mise exec -- mix ecto.migrate
 
+      - name: Run portable helper transport tests on BSD stat
+        run: >-
+          mise exec -- mix test
+          apps/orchard_controller/test/orchard/tokenizer_client_test.exs
+          apps/orchard_controller/test/orchard/models/bundle_builder_test.exs
+          apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs
+
       - name: Test explicit macOS native-helper boundary
         run: |
           scripts/test-portable-core-compilation.sh

--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           scripts/ci/test-classify-required-validation-paths.sh
           scripts/ci/test-required-validation-gate.sh
+          scripts/ci/test-platform-test-routing.sh
 
   linux-portable:
     name: Linux portable control-plane core
@@ -302,7 +303,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.portable == 'true' || needs.changes.outputs.conformance == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -312,7 +313,7 @@ jobs:
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
-          cache: false
+          cache: true
 
       - name: Install OpenSpec dependencies
         run: make setup-openspec

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,11 +213,9 @@ Run these in order for Elixir/OTP changes from the umbrella root:
 6. `mise exec -- mix test`
 7. `mise exec -- mix test --cover`
 
-`make check-elixir` runs the same workflow, and on Darwin hosts `make test` and
-`make cover` stage the macOS test helpers themselves. Step 5 is required only
-before a bare `mix test` invocation: retained macOS terminal-custody and launchd
-lifecycle tests resolve their helpers from the `orchard_cli` application `priv`
-directory, and ordinary portable `mix compile` no longer emits them.
+`make check-elixir` runs the same workflow.
+On Darwin hosts, `make test` and `make cover` stage the macOS test helpers and run every test; on non-Darwin hosts they skip helper staging and exclude tests tagged `macos`.
+Step 5 is required only before a bare `mix test` invocation on Darwin: retained macOS terminal-custody and launchd lifecycle tests resolve their helpers from the `orchard_cli` application `priv` directory, and ordinary portable `mix compile` no longer emits them.
 
 Rules:
 
@@ -339,7 +337,7 @@ the "Source-dev BEAM Peer Grant tracer" section in `docs/local-dev.md`.
 When to bypass `bin/dev`:
 - `mise exec -- iex -S mix` — BEAM without HTTP server (one-off scripts, migrations)
 - `mise exec -- iex -S mix phx.server` — manual server start with custom env vars
-- `make test` - test suite (stages the macOS test helpers on Darwin hosts, then runs `mise exec -- mix test`; uses its own DB and defaults to port 50071 via `test.exs`; override with `ORCHARD_TEST_NODE_AGENT_PORT` when another worktree owns that port). Run `make macos-native-test-helpers` first when invoking `mise exec -- mix test` directly.
+- `make test` - test suite (stages the macOS test helpers and runs every test on Darwin; skips helper staging and excludes the `macos` tag on non-Darwin hosts; uses its own DB and defaults to port 50071 via `test.exs`; override with `ORCHARD_TEST_NODE_AGENT_PORT` when another worktree owns that port). Run `make macos-native-test-helpers` first when invoking `mise exec -- mix test` directly on Darwin.
 
 See `docs/local-dev.md` for full environment setup and configuration.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ Recommended targets:
 - `make format` — run Elixir formatter.
 - `make test` — run the default test suite.
 - `make cover` — run the default test suite with coverage.
-- `make macos-native-test-helpers` — stage macOS test helpers for direct `mix test` runs.
+- `make macos-native-test-helpers` — stage macOS test helpers for direct `mix test` runs (Darwin hosts only).
 - `make check-elixir` — run the full Elixir quality workflow.
 
 `make dev` must remain a foreground/blocking command equivalent to
@@ -213,11 +213,11 @@ Run these in order for Elixir/OTP changes from the umbrella root:
 6. `mise exec -- mix test`
 7. `mise exec -- mix test --cover`
 
-`make check-elixir` runs the same workflow, and `make test` and `make cover`
-stage the macOS test helpers themselves. Step 5 is required only before a bare
-`mix test` invocation: retained macOS terminal-custody and launchd lifecycle
-tests resolve their helpers from the `orchard_cli` application `priv` directory,
-and ordinary portable `mix compile` no longer emits them.
+`make check-elixir` runs the same workflow, and on Darwin hosts `make test` and
+`make cover` stage the macOS test helpers themselves. Step 5 is required only
+before a bare `mix test` invocation: retained macOS terminal-custody and launchd
+lifecycle tests resolve their helpers from the `orchard_cli` application `priv`
+directory, and ordinary portable `mix compile` no longer emits them.
 
 Rules:
 
@@ -339,7 +339,7 @@ the "Source-dev BEAM Peer Grant tracer" section in `docs/local-dev.md`.
 When to bypass `bin/dev`:
 - `mise exec -- iex -S mix` — BEAM without HTTP server (one-off scripts, migrations)
 - `mise exec -- iex -S mix phx.server` — manual server start with custom env vars
-- `make test` - test suite (stages the macOS test helpers, then runs `mise exec -- mix test`; uses its own DB and defaults to port 50071 via `test.exs`; override with `ORCHARD_TEST_NODE_AGENT_PORT` when another worktree owns that port). Run `make macos-native-test-helpers` first when invoking `mise exec -- mix test` directly.
+- `make test` - test suite (stages the macOS test helpers on Darwin hosts, then runs `mise exec -- mix test`; uses its own DB and defaults to port 50071 via `test.exs`; override with `ORCHARD_TEST_NODE_AGENT_PORT` when another worktree owns that port). Run `make macos-native-test-helpers` first when invoking `mise exec -- mix test` directly.
 
 See `docs/local-dev.md` for full environment setup and configuration.
 

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,14 @@ macos-native-helpers:
 macos-native-test-helpers:
 	scripts/build-macos-native-helpers.sh --output _build/test/lib/orchard_cli/priv --include-test-helper
 
-ifeq ($(shell uname -s),Darwin)
+HOST_OS ?= $(shell uname -s)
+
+ifeq ($(HOST_OS),Darwin)
 MACOS_TEST_HELPER_PREREQ := macos-native-test-helpers
+MIX_TEST_PLATFORM_ARGS :=
 else
 MACOS_TEST_HELPER_PREREQ :=
+MIX_TEST_PLATFORM_ARGS := --exclude macos
 endif
 
 format:
@@ -74,9 +78,9 @@ dialyzer:
 	mise exec -- mix dialyzer
 
 test: $(MACOS_TEST_HELPER_PREREQ)
-	mise exec -- mix test
+	mise exec -- mix test $(MIX_TEST_PLATFORM_ARGS)
 
 cover: $(MACOS_TEST_HELPER_PREREQ)
-	mise exec -- mix test --cover
+	mise exec -- mix test --cover $(MIX_TEST_PLATFORM_ARGS)
 
 check-elixir: format compile credo dialyzer test cover

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ macos-native-helpers:
 macos-native-test-helpers:
 	scripts/build-macos-native-helpers.sh --output _build/test/lib/orchard_cli/priv --include-test-helper
 
+ifeq ($(shell uname -s),Darwin)
+MACOS_TEST_HELPER_PREREQ := macos-native-test-helpers
+else
+MACOS_TEST_HELPER_PREREQ :=
+endif
+
 format:
 	mise exec -- mix format
 
@@ -67,10 +73,10 @@ credo:
 dialyzer:
 	mise exec -- mix dialyzer
 
-test: macos-native-test-helpers
+test: $(MACOS_TEST_HELPER_PREREQ)
 	mise exec -- mix test
 
-cover: macos-native-test-helpers
+cover: $(MACOS_TEST_HELPER_PREREQ)
 	mise exec -- mix test --cover
 
 check-elixir: format compile credo dialyzer test cover

--- a/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
@@ -7,6 +7,7 @@ defmodule OrchardCLI.Commands.Cluster do
   alias Orchard.ControlPlane
   alias Orchard.Governance.ClusterBootstrap
   alias OrchardCLI.Commands.GovernanceHelpers
+  alias OrchardCLI.PlatformACL
   alias OrchardCLI.RepoRuntime
 
   @cluster_status_object "cluster_management.cluster_status"
@@ -15,18 +16,6 @@ defmodule OrchardCLI.Commands.Cluster do
   @cluster_init_object "cluster_management.cluster_init"
   @cluster_init_contract_version "orchard.cluster_management.cluster_init.v2"
 
-  @acl_mutation_rights ~w(
-    add_file
-    add_subdirectory
-    append
-    chown
-    delete
-    delete_child
-    write
-    writeattr
-    writeextattr
-    writesecurity
-  )
   @private_directory_mode 0o700
   @secret_file_mode 0o600
   @descriptor_preflight_payload "orchard-cluster-init-write-preflight\n"
@@ -1366,7 +1355,7 @@ defmodule OrchardCLI.Commands.Cluster do
 
   defp protect_created_path(path, identity, type, mode, ops) do
     with :ok <- verify_path(path, identity, type, nil, ops),
-         :ok <- remove_extended_acl(path, ops),
+         :ok <- remove_extended_acl(path, type, ops),
          :ok <- verify_path(path, identity, type, nil, ops),
          :ok <- ops.chmod(path, mode),
          :ok <- verify_path(path, identity, type, mode, ops) do
@@ -1387,14 +1376,11 @@ defmodule OrchardCLI.Commands.Cluster do
     end
   end
 
-  defp remove_extended_acl(path, ops) do
-    if descriptor_ops?(ops, :remove_acl, 1) do
-      ops.remove_acl(path)
+  defp remove_extended_acl(path, type, ops) do
+    if descriptor_ops?(ops, :remove_acl, 2) do
+      ops.remove_acl(path, type)
     else
-      case System.cmd("/bin/chmod", ["-N", path], stderr_to_stdout: true) do
-        {_output, 0} -> :ok
-        {_output, _status} -> {:error, :acl_removal_failed}
-      end
+      PlatformACL.remove_extended(path, type)
     end
   end
 
@@ -1410,7 +1396,7 @@ defmodule OrchardCLI.Commands.Cluster do
 
   defp verify_parent_acl_safe(path, ops) do
     with {:ok, entries} <- acl_entries(path, ops),
-         false <- Enum.any?(entries, &acl_grants_mutation?/1) do
+         false <- Enum.any?(entries, &PlatformACL.grants_parent_mutation?/1) do
       :ok
     else
       true -> {:error, :output_parent_acl_unsafe}
@@ -1422,30 +1408,7 @@ defmodule OrchardCLI.Commands.Cluster do
     if descriptor_ops?(ops, :acl_entries, 1) do
       ops.acl_entries(path)
     else
-      case System.cmd("/bin/ls", ["-lde", path], stderr_to_stdout: true) do
-        {output, 0} ->
-          entries =
-            output
-            |> String.split("\n", trim: true)
-            |> Enum.filter(&Regex.match?(~r/^\s+\d+:\s/, &1))
-
-          {:ok, entries}
-
-        {_output, _status} ->
-          {:error, :acl_inspection_failed}
-      end
-    end
-  end
-
-  defp acl_grants_mutation?(entry) do
-    case String.split(entry, ~r/\s+allow\s+/, parts: 2) do
-      [_principal, rights] ->
-        rights
-        |> String.split([",", " "], trim: true)
-        |> Enum.any?(&(&1 in @acl_mutation_rights))
-
-      _other ->
-        false
+      PlatformACL.entries(path)
     end
   end
 

--- a/apps/orchard_cli/lib/orchard_cli/platform_acl.ex
+++ b/apps/orchard_cli/lib/orchard_cli/platform_acl.ex
@@ -184,7 +184,7 @@ defmodule OrchardCLI.PlatformACL do
             scope: :access,
             kind: :other,
             qualifier: nil,
-            disposition: String.to_existing_atom(disposition),
+            disposition: darwin_disposition(disposition),
             permissions: permissions
           }
 
@@ -229,7 +229,7 @@ defmodule OrchardCLI.PlatformACL do
         entry = %{
           platform: :linux,
           scope: linux_scope(default),
-          kind: String.to_existing_atom(kind),
+          kind: linux_kind(kind),
           qualifier: empty_to_nil(qualifier),
           permissions: permissions
         }
@@ -249,6 +249,14 @@ defmodule OrchardCLI.PlatformACL do
 
   defp linux_scope("default:"), do: :default
   defp linux_scope(""), do: :access
+
+  defp darwin_disposition("allow"), do: :allow
+  defp darwin_disposition("deny"), do: :deny
+
+  defp linux_kind("user"), do: :user
+  defp linux_kind("group"), do: :group
+  defp linux_kind("mask"), do: :mask
+  defp linux_kind("other"), do: :other
 
   defp accumulate_linux_entry(entry, %{base_kinds: base_kinds} = accumulator) do
     case linux_base_kind(entry) do

--- a/apps/orchard_cli/lib/orchard_cli/platform_acl.ex
+++ b/apps/orchard_cli/lib/orchard_cli/platform_acl.ex
@@ -1,0 +1,285 @@
+defmodule OrchardCLI.PlatformACL do
+  @moduledoc false
+
+  @type acl_entry :: %{
+          required(:scope) => :access | :default,
+          required(:kind) => :user | :group | :mask | :other,
+          required(:qualifier) => String.t() | nil,
+          required(:permissions) => String.t(),
+          optional(:disposition) => :allow | :deny,
+          optional(:platform) => :darwin | :linux
+        }
+  @type path_type :: :regular | :directory
+
+  @darwin_mutation_rights ~w(
+    add_file
+    add_subdirectory
+    append
+    chown
+    delete
+    delete_child
+    write
+    writeattr
+    writeextattr
+    writesecurity
+  )
+  @darwin_acl_tokens MapSet.new(~w(
+                         add_file
+                         add_subdirectory
+                         append
+                         chown
+                         delete
+                         delete_child
+                         directory_inherit
+                         execute
+                         file_inherit
+                         limit_inherit
+                         list
+                         only_inherit
+                         read
+                         readattr
+                         readextattr
+                         readsecurity
+                         search
+                         write
+                         writeattr
+                         writeextattr
+                         writesecurity
+                       ))
+  @linux_base_kinds MapSet.new([:user, :group, :other])
+
+  @spec remove_extended(String.t(), path_type(), keyword()) ::
+          :ok | {:error, :acl_removal_failed}
+  def remove_extended(path, type, opts \\ []) do
+    case removal_command(platform(opts), path, type) do
+      {:ok, command, args} -> run(command, args, opts, :acl_removal_failed)
+      :error -> {:error, :acl_removal_failed}
+    end
+  end
+
+  @spec entries(String.t(), keyword()) :: {:ok, [acl_entry()]} | {:error, :acl_inspection_failed}
+  def entries(path, opts \\ []) do
+    with {:ok, command, args} <- inspection_command(platform(opts), path),
+         {:ok, output} <- run_for_output(command, args, opts),
+         {:ok, entries} <- parse_entries(platform(opts), output) do
+      {:ok, entries}
+    else
+      _error -> {:error, :acl_inspection_failed}
+    end
+  end
+
+  @spec grants_parent_mutation?(acl_entry()) :: boolean()
+  def grants_parent_mutation?(%{
+        platform: :darwin,
+        disposition: :allow,
+        permissions: permissions
+      }) do
+    permissions
+    |> darwin_permission_tokens()
+    |> Enum.any?(&(&1 in @darwin_mutation_rights))
+  end
+
+  def grants_parent_mutation?(%{
+        platform: :linux,
+        scope: :access,
+        kind: kind,
+        qualifier: qualifier,
+        permissions: permissions
+      })
+      when kind in [:user, :group] and is_binary(qualifier) do
+    String.contains?(permissions, "w")
+  end
+
+  def grants_parent_mutation?(_entry), do: false
+
+  defp removal_command(:darwin, path, type) when type in [:regular, :directory] do
+    {:ok, "/bin/chmod", ["-N", path]}
+  end
+
+  defp removal_command(:linux, path, :regular) do
+    {:ok, "/usr/bin/setfacl", ["-b", "--", path]}
+  end
+
+  defp removal_command(:linux, path, :directory) do
+    {:ok, "/usr/bin/setfacl", ["-b", "-k", "--", path]}
+  end
+
+  defp removal_command(_platform, _path, _type), do: :error
+
+  defp inspection_command(:darwin, path), do: {:ok, "/bin/ls", ["-lde", path]}
+
+  defp inspection_command(:linux, path) do
+    {:ok, "/usr/bin/getfacl", ["-c", "-p", "--", path]}
+  end
+
+  defp inspection_command(_platform, _path), do: :error
+
+  defp run(command, args, opts, error_reason) do
+    case invoke_runner(command, args, opts) do
+      {_output, 0} -> :ok
+      {_output, _status} -> {:error, error_reason}
+      :runner_error -> {:error, error_reason}
+    end
+  end
+
+  defp run_for_output(command, args, opts) do
+    case invoke_runner(command, args, opts) do
+      {output, 0} -> {:ok, output}
+      {_output, _status} -> :error
+      :runner_error -> :error
+    end
+  end
+
+  defp invoke_runner(command, args, opts) do
+    runner = Keyword.get(opts, :runner, &System.cmd/3)
+    command_opts = [env: [{"LC_ALL", "C"}], stderr_to_stdout: true]
+
+    runner.(command, args, command_opts)
+  rescue
+    _error in [ArgumentError, ErlangError] -> :runner_error
+  end
+
+  defp parse_entries(:darwin, output), do: parse_darwin_entries(output)
+  defp parse_entries(:linux, output), do: parse_linux_entries(output)
+  defp parse_entries(_platform, _output), do: :error
+
+  defp parse_darwin_entries(output) do
+    case String.split(output, "\n", trim: true) do
+      [header | acl_lines] ->
+        with {:ok, marker} <- darwin_header_acl_marker(header),
+             {:ok, _next_ordinal, entries} <-
+               Enum.reduce_while(acl_lines, {:ok, 0, []}, &parse_darwin_entry/2),
+             :ok <- validate_darwin_acl_marker(marker, entries) do
+          {:ok, Enum.reverse(entries)}
+        else
+          _error -> :error
+        end
+
+      [] ->
+        :error
+    end
+  end
+
+  defp darwin_header_acl_marker(header) do
+    case Regex.run(
+           ~r/^[bcdlpsw-][rwxStTs-]{9}([+@]?)\s+\d+\s+\S+\s+\S+\s+\d+\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{2}:\d{2}|\d{4})\s+.+$/,
+           header
+         ) do
+      [_header, marker] -> {:ok, marker}
+      _other -> :error
+    end
+  end
+
+  defp validate_darwin_acl_marker("", []), do: :ok
+  defp validate_darwin_acl_marker("+", [_entry | _entries]), do: :ok
+  defp validate_darwin_acl_marker("@", _entries), do: :ok
+  defp validate_darwin_acl_marker(_marker, _entries), do: :error
+
+  defp parse_darwin_entry(line, {:ok, next_ordinal, entries}) do
+    case Regex.run(~r/^\s+(\d+):\s+.+\s+(allow|deny)\s+(.+)$/, line) do
+      [_line, ordinal, disposition, permissions] ->
+        if String.to_integer(ordinal) == next_ordinal and valid_darwin_permissions?(permissions) do
+          entry = %{
+            platform: :darwin,
+            scope: :access,
+            kind: :other,
+            qualifier: nil,
+            disposition: String.to_existing_atom(disposition),
+            permissions: permissions
+          }
+
+          {:cont, {:ok, next_ordinal + 1, [entry | entries]}}
+        else
+          {:halt, :error}
+        end
+
+      _other ->
+        {:halt, :error}
+    end
+  end
+
+  defp valid_darwin_permissions?(permissions) do
+    tokens = darwin_permission_tokens(permissions)
+
+    tokens != [] and
+      Enum.all?(tokens, &(&1 != "" and MapSet.member?(@darwin_acl_tokens, &1)))
+  end
+
+  defp darwin_permission_tokens(permissions) do
+    permissions
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.flat_map(&String.split(&1, ",", trim: false))
+  end
+
+  defp parse_linux_entries(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.reduce_while({:ok, %{base_kinds: MapSet.new(), entries: []}}, &parse_linux_line/2)
+    |> complete_linux_entries()
+  end
+
+  defp parse_linux_line("#" <> _comment, accumulator), do: {:cont, accumulator}
+
+  defp parse_linux_line(line, {:ok, accumulator}) do
+    case Regex.run(
+           ~r/^(default:)?(user|group|mask|other):([^:]*):([rwx-]{3})(?:\s+#effective:[rwx-]{3})?$/,
+           line
+         ) do
+      [_line, default, kind, qualifier, permissions] ->
+        entry = %{
+          platform: :linux,
+          scope: linux_scope(default),
+          kind: String.to_existing_atom(kind),
+          qualifier: empty_to_nil(qualifier),
+          permissions: permissions
+        }
+
+        accumulate_linux_entry(entry, accumulator)
+
+      _other ->
+        {:halt, :error}
+    end
+  end
+
+  defp complete_linux_entries({:ok, %{base_kinds: @linux_base_kinds, entries: entries}}) do
+    {:ok, Enum.reverse(entries)}
+  end
+
+  defp complete_linux_entries(_incomplete), do: :error
+
+  defp linux_scope("default:"), do: :default
+  defp linux_scope(""), do: :access
+
+  defp accumulate_linux_entry(entry, %{base_kinds: base_kinds} = accumulator) do
+    case linux_base_kind(entry) do
+      nil ->
+        {:cont, {:ok, %{accumulator | entries: [entry | accumulator.entries]}}}
+
+      kind ->
+        if MapSet.member?(base_kinds, kind) do
+          {:halt, :error}
+        else
+          {:cont, {:ok, %{accumulator | base_kinds: MapSet.put(base_kinds, kind)}}}
+        end
+    end
+  end
+
+  defp linux_base_kind(%{scope: :access, kind: kind, qualifier: nil})
+       when kind in [:user, :group, :other],
+       do: kind
+
+  defp linux_base_kind(_entry), do: nil
+
+  defp empty_to_nil(""), do: nil
+  defp empty_to_nil(value), do: value
+
+  defp platform(opts), do: Keyword.get_lazy(opts, :platform, &host_platform/0)
+
+  defp host_platform do
+    case :os.type() do
+      {:unix, :darwin} -> :darwin
+      {:unix, :linux} -> :linux
+      _other -> :unsupported
+    end
+  end
+end

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -8,6 +8,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
   alias Orchard.Governance.{ApiKey, AuditLog, RoleBinding, ServiceAccount}
   alias Orchard.Repo
   alias OrchardCLI.Commands.Cluster, as: ClusterCmd
+  alias OrchardCLI.PlatformACL
 
   defmodule ConfigurableFileOps do
     @descriptor_preflight_payload "orchard-cluster-init-write-preflight\n"
@@ -457,13 +458,13 @@ defmodule OrchardCLI.Commands.ClusterTest do
       end
     end
 
-    def remove_acl(path) do
+    def remove_acl(path, type) do
       if staging_protection_target?(path, :cluster_file_ops_fail_staging_acl_removal) do
         Process.put(:cluster_file_ops_unprotected_staging_dir, path)
         maybe_replace_unprotected_staging(path)
         {:error, :acl_removal_failed}
       else
-        strip_acl(path)
+        PlatformACL.remove_extended(path, type)
       end
     end
 
@@ -472,18 +473,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
         Process.put(:cluster_file_ops_retained_output_parent_probe_path, path)
         {:error, :acl_inspection_failed}
       else
-        case System.cmd("/bin/ls", ["-lde", path], stderr_to_stdout: true) do
-          {output, 0} ->
-            entries =
-              output
-              |> String.split("\n", trim: true)
-              |> Enum.filter(&Regex.match?(~r/^\s+\d+:\s/, &1))
-
-            {:ok, entries}
-
-          {_output, _status} ->
-            {:error, :acl_inspection_failed}
-        end
+        PlatformACL.entries(path)
       end
     end
 
@@ -509,13 +499,6 @@ defmodule OrchardCLI.Commands.ClusterTest do
 
     defp staging_protection_target?(path, key) do
       Process.get(key) == true and path == Process.get(:cluster_file_ops_staging_dir)
-    end
-
-    defp strip_acl(path) do
-      case System.cmd("/bin/chmod", ["-N", path], stderr_to_stdout: true) do
-        {_output, 0} -> :ok
-        {_output, _status} -> {:error, :acl_removal_failed}
-      end
     end
 
     def sync_directory(_path) do

--- a/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
@@ -792,6 +792,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
       assert token_occurrences(File.read!(output_path), token) == 1
     end
 
+    @tag :macos
     test "SPEC.md §7.4.4 public init strips inherited non-owner read ACL before minting",
          %{tmp_dir: tmp_dir} do
       output_path = Path.join(tmp_dir, "acl-protected-admin.json")
@@ -823,6 +824,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
       refute log =~ "orchard_sk_"
     end
 
+    @tag :macos
     test "SPEC.md §7.4.4 public init rejects a parent ACL granting non-owner mutation",
          %{tmp_dir: tmp_dir} do
       assert_public_init_rejects_parent_acl(
@@ -832,6 +834,7 @@ defmodule OrchardCLI.Commands.ClusterTest do
       )
     end
 
+    @tag :macos
     test "SPEC.md §7.4.4 public init rejects a parent ACL granting non-owner ownership control",
          %{tmp_dir: tmp_dir} do
       assert_public_init_rejects_parent_acl(

--- a/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
@@ -2,6 +2,7 @@ defmodule OrchardCLI.Commands.ConsolePTYTest do
   use ExUnit.Case, async: false
 
   @moduletag :capture_log
+  @moduletag :macos
   # Paced-paste scenarios drive a real PTY for tens of seconds once macOS timer
   # coalescing stretches their sleep intervals, well past the 60s ExUnit default.
   @moduletag timeout: 180_000

--- a/apps/orchard_cli/test/orchard_cli/commands/status_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/status_test.exs
@@ -411,6 +411,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     refute banner =~ "127.0.0.1:4101/console"
   end
 
+  @tag :macos
   test "packaged fallback uses direct HTTPS when ORCHARD_TRANSPORT_MODE selects it" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_port = System.get_env("ORCHARD_API_HTTPS_PORT")
@@ -442,6 +443,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert banner =~ "Console: https://orchard.example.internal:9443/console"
   end
 
+  @tag :macos
   test "direct HTTPS packaged fallback passes configured external CA to request" do
     ca_path =
       Path.join(System.tmp_dir!(), "orchard-status-ca-#{System.unique_integer([:positive])}.crt")
@@ -477,6 +479,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert Keyword.get(opts, :ca_certfile) == ca_path
   end
 
+  @tag :macos
   test "packaged fallback uses HTTPS for legacy shims when transport mode is unset" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_disabled = System.get_env("ORCHARD_TLS_DISABLED")
@@ -618,6 +621,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert message =~ "ORCHARD_TRUSTED_PROXIES contains invalid CIDR"
   end
 
+  @tag :macos
   test "packaged fallback brackets IPv6 public display host" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_host = System.get_env("ORCHARD_PUBLIC_HOST")
@@ -668,6 +672,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert message =~ "invalid ORCHARD_API_BIND_IP: not-an-ip"
   end
 
+  @tag :macos
   test "packaged fallback does not auto-use generated-local CA with explicit operator certs" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_cert = System.get_env("ORCHARD_TLS_CERTFILE")
@@ -725,6 +730,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert Keyword.get(opts, :ca_certfile) == nil
   end
 
+  @tag :macos
   test "packaged fallback allows explicit default cert paths with external CA despite generated-local metadata" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_cert = System.get_env("ORCHARD_TLS_CERTFILE")
@@ -771,6 +777,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert {:ok, _banner} = Status.run([], runtime)
   end
 
+  @tag :macos
   test "packaged fallback allows explicit cert CA override despite generated-local metadata" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_cert = System.get_env("ORCHARD_TLS_CERTFILE")
@@ -820,6 +827,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert {:ok, _banner} = Status.run([], runtime)
   end
 
+  @tag :macos
   test "packaged fallback rejects missing generated-local default CA in direct_https" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     support_root = System.get_env("ORCHARD_SUPPORT_ROOT")
@@ -893,6 +901,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert message =~ "ORCHARD_TLS_CACERTFILE cannot override generated-local CA publication"
   end
 
+  @tag :macos
   test "packaged fallback rejects malformed explicit CA in direct_https" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_ca = System.get_env("ORCHARD_TLS_CACERTFILE")
@@ -923,6 +932,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     assert message =~ "TLS CA certificate file is malformed"
   end
 
+  @tag :macos
   test "packaged fallback rejects missing explicit CA in direct_https" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_ca = System.get_env("ORCHARD_TLS_CACERTFILE")
@@ -1006,6 +1016,7 @@ defmodule OrchardCLI.Commands.StatusTest do
     end
   end
 
+  @tag :macos
   test "packaged fallback rejects malformed legacy transport envs" do
     original_mode = System.get_env("ORCHARD_TRANSPORT_MODE")
     original_disabled = System.get_env("ORCHARD_TLS_DISABLED")

--- a/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/dev_scripts_test.exs
@@ -63,7 +63,7 @@ defmodule OrchardCLI.DevScriptsTest do
     script = Path.join(@repo_root, "scripts/test-source-dev-worker-cleanup.sh")
 
     assert {output, 0} =
-             System.cmd("bash", [script],
+             System.cmd("/bin/bash", [script],
                cd: @repo_root,
                stderr_to_stdout: true
              )

--- a/apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs
@@ -1,6 +1,8 @@
 defmodule OrchardCLI.LifecycleNativeTest do
   use ExUnit.Case, async: false
 
+  @moduletag :macos
+
   alias OrchardCLI.LifecycleNative
   alias OrchardCLI.TestTemp
 

--- a/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
@@ -1,6 +1,8 @@
 defmodule OrchardCLI.PackagingWrapperTest do
   use ExUnit.Case, async: true
 
+  @moduletag :macos
+
   @repo_root Path.expand("../../../..", __DIR__)
   @orchardctl Path.join(@repo_root, "packaging/payload/bin/orchardctl")
 

--- a/apps/orchard_cli/test/orchard_cli/payload_wrapper_script_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/payload_wrapper_script_test.exs
@@ -8,6 +8,8 @@ defmodule OrchardCLI.PayloadWrapperScriptTest do
 
   use ExUnit.Case, async: true
 
+  @moduletag :macos
+
   @repo_root Path.expand("../../../..", __DIR__)
   @controller_wrapper Path.join(@repo_root, "packaging/payload/bin/orchard-controller")
   @node_agent_wrapper Path.join(@repo_root, "packaging/payload/bin/orchard-node-agent")

--- a/apps/orchard_cli/test/orchard_cli/platform_acl_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/platform_acl_test.exs
@@ -1,0 +1,220 @@
+defmodule OrchardCLI.PlatformACLTest do
+  use ExUnit.Case, async: true
+
+  alias OrchardCLI.PlatformACL
+  alias OrchardCLI.TestTemp
+
+  test "Darwin ACL removal preserves the established absolute command contract" do
+    runner = recording_runner({"", 0})
+
+    assert :ok =
+             PlatformACL.remove_extended("/tmp/path with spaces", :directory,
+               platform: :darwin,
+               runner: runner
+             )
+
+    assert_receive {:command, "/bin/chmod", ["-N", "/tmp/path with spaces"], command_opts}
+    assert command_opts[:env] == [{"LC_ALL", "C"}]
+    assert command_opts[:stderr_to_stdout]
+  end
+
+  test "Darwin inspection accepts a valid header and complete numbered ACL entries" do
+    assert {:ok, []} =
+             darwin_entries("-rw-------  1 orchard  staff  6 Aug 26 20:00 /tmp/secret\n")
+
+    assert {:ok, []} =
+             darwin_entries("-rw-------@ 1 orchard  staff  6 Aug 26 20:00 /tmp/secret\n")
+
+    output = """
+    drwx------@ 3 orchard  staff  96 Aug 26 20:00 /tmp/parent
+     0: group:everyone deny delete
+    """
+
+    assert {:ok, [entry]} = darwin_entries(output)
+    assert entry.platform == :darwin
+    assert entry.disposition == :deny
+    assert entry.permissions == "delete"
+  end
+
+  test "Darwin inspection fails closed on empty, malformed, truncated, or inconsistent output" do
+    invalid_outputs = [
+      "",
+      "arbitrary successful output\n",
+      "drwx------@ 3 \n",
+      "drwx------@ 3 arbitrary\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0:\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow , \n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow read,\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow read,,search\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow add_fil\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow unknown_right\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 1: group:everyone allow read\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow read\n 2: group:everyone allow search\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow read\n 0: group:everyone allow search\n",
+      "drwx------+ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow read\n 2: group:everyone allow search\n 1: group:everyone allow execute\n",
+      "drwx------ 3 orchard staff 96 Aug 26 20:00 /tmp/parent\n 0: group:everyone allow write\n"
+    ]
+
+    for output <- invalid_outputs do
+      assert {:error, :acl_inspection_failed} = darwin_entries(output)
+    end
+  end
+
+  test "Linux ACL removal clears access ACLs from files and access plus default ACLs from directories" do
+    runner = recording_runner({"", 0})
+
+    assert :ok =
+             PlatformACL.remove_extended("/tmp/-file", :regular,
+               platform: :linux,
+               runner: runner
+             )
+
+    assert_receive {:command, "/usr/bin/setfacl", ["-b", "--", "/tmp/-file"], _opts}
+
+    assert :ok =
+             PlatformACL.remove_extended("/tmp/directory", :directory,
+               platform: :linux,
+               runner: runner
+             )
+
+    assert_receive {:command, "/usr/bin/setfacl", ["-b", "-k", "--", "/tmp/directory"], _opts}
+  end
+
+  test "Linux inspection ignores mode-derived base entries" do
+    output = """
+    user::rw-
+    group::r--
+    other::---
+    """
+
+    assert {:ok, []} = linux_entries(output)
+  end
+
+  test "Linux inspection retains named entries, masks, and default entries" do
+    output = """
+    user::rwx
+    user:1001:r--
+    group::r-x
+    group:operators:rwx #effective:r-x
+    mask::r-x
+    other::---
+    default:user::rwx
+    default:user:1002:r--
+    default:group::r-x
+    default:mask::r-x
+    default:other::---
+    """
+
+    assert {:ok, entries} = linux_entries(output)
+    assert length(entries) == 8
+    assert Enum.any?(entries, &match?(%{scope: :access, kind: :user, qualifier: "1001"}, &1))
+    assert Enum.any?(entries, &match?(%{scope: :access, kind: :mask}, &1))
+    assert Enum.count(entries, &(&1.scope == :default)) == 5
+  end
+
+  test "parent mutation uses declared named access permissions and ignores effective and default permissions" do
+    output = """
+    user::rwx
+    user:reader:r--
+    user:writer:rwx #effective:r-x
+    group::r-x
+    group:auditors:r-x
+    mask::r-x
+    other::---
+    default:user:future-writer:rwx
+    """
+
+    assert {:ok, entries} = linux_entries(output)
+
+    reader = Enum.find(entries, &(&1.qualifier == "reader"))
+    writer = Enum.find(entries, &(&1.qualifier == "writer"))
+    default_writer = Enum.find(entries, &(&1.scope == :default))
+
+    refute PlatformACL.grants_parent_mutation?(reader)
+    assert PlatformACL.grants_parent_mutation?(writer)
+    refute PlatformACL.grants_parent_mutation?(default_writer)
+  end
+
+  test "inspection fails closed on malformed output, unsupported platforms, and partial command failures" do
+    assert {:error, :acl_inspection_failed} = linux_entries("user::rwx\nunexpected acl line\n")
+
+    assert {:error, :acl_inspection_failed} =
+             PlatformACL.entries("/tmp/path",
+               platform: :freebsd,
+               runner: recording_runner({"", 0})
+             )
+
+    assert {:error, :acl_inspection_failed} =
+             PlatformACL.entries("/tmp/path",
+               platform: :linux,
+               runner: recording_runner({"user:1001:rwx\n", 1})
+             )
+  end
+
+  test "Linux inspection requires one complete base access ACL" do
+    invalid_outputs = [
+      "",
+      "# comments alone are not an ACL\n",
+      "user::rwx\ngroup::r-x\n",
+      "user::rwx\nuser::rwx\ngroup::r-x\nother::---\n",
+      "user::rwx\ngroup::r-x\nother::--\n"
+    ]
+
+    for output <- invalid_outputs do
+      assert {:error, :acl_inspection_failed} = linux_entries(output)
+    end
+  end
+
+  @tag skip:
+         if(:os.type() == {:unix, :linux},
+           do: false,
+           else: "Linux ACL integration contract"
+         )
+  test "hosted Linux exercises real access and default ACL cleanup" do
+    run = TestTemp.create_run!(prefix: "orchard-platform-acl")
+    on_exit(fn -> TestTemp.cleanup!(run) end)
+
+    file = TestTemp.path(run, "file with spaces")
+    directory = TestTemp.path(run, "directory")
+    File.write!(file, "secret")
+    File.mkdir!(directory)
+
+    assert {"", 0} = System.cmd("/usr/bin/setfacl", ["-m", "u:65534:rw", "--", file])
+
+    assert {"", 0} =
+             System.cmd("/usr/bin/setfacl", ["-m", "u:65534:rwx,d:u:65534:rwx", "--", directory])
+
+    assert {:ok, [_named_file_entry, _mask]} = PlatformACL.entries(file)
+    assert {:ok, directory_entries} = PlatformACL.entries(directory)
+    assert Enum.any?(directory_entries, &(&1.scope == :default))
+
+    assert :ok = PlatformACL.remove_extended(file, :regular)
+    assert :ok = PlatformACL.remove_extended(directory, :directory)
+    assert {:ok, []} = PlatformACL.entries(file)
+    assert {:ok, []} = PlatformACL.entries(directory)
+  end
+
+  defp linux_entries(output) do
+    PlatformACL.entries("/tmp/path with spaces",
+      platform: :linux,
+      runner: recording_runner({output, 0})
+    )
+  end
+
+  defp darwin_entries(output) do
+    PlatformACL.entries("/tmp/path with spaces",
+      platform: :darwin,
+      runner: recording_runner({output, 0})
+    )
+  end
+
+  defp recording_runner(result) do
+    test_pid = self()
+
+    fn command, args, opts ->
+      send(test_pid, {:command, command, args, opts})
+      result
+    end
+  end
+end

--- a/apps/orchard_controller/test/application_test.exs
+++ b/apps/orchard_controller/test/application_test.exs
@@ -177,7 +177,7 @@ defmodule OrchardApplicationTest do
     assert {:ok, _apps} = Application.ensure_all_started(:orchard_controller)
 
     bootstrap = Process.whereis(Orchard.Metrics.Bootstrap)
-    generation = Process.whereis(Orchard.Metrics.Supervisor)
+    generation = metrics_generation()
     ledger = Process.whereis(CardinalityLedger)
     assert is_pid(generation)
     assert is_pid(ledger)

--- a/apps/orchard_controller/test/orchard/backfill_resident_memory_task_test.exs
+++ b/apps/orchard_controller/test/orchard/backfill_resident_memory_task_test.exs
@@ -106,9 +106,16 @@ defmodule Mix.Tasks.Orchard.Backfill.ResidentMemoryTest do
       :orchard_controller,
       Repo,
       Keyword.merge(Application.fetch_env!(:orchard_controller, Repo),
-        hostname: 123,
+        hostname: "127.0.0.1",
+        port: 1,
+        connect_timeout: 100,
+        backoff_min: 100,
+        backoff_max: 100,
         pool: DBConnection.ConnectionPool,
-        pool_size: 1
+        pool_count: 1,
+        pool_size: 1,
+        queue_interval: 10,
+        queue_target: 10
       )
     )
 
@@ -117,9 +124,14 @@ defmodule Mix.Tasks.Orchard.Backfill.ResidentMemoryTest do
     assert_raise Mix.Error,
                  ~r/resident_memory_bytes backfill failed to start: \{:db_unreachable,/,
                  fn ->
-                   capture_io(fn ->
-                     Mix.Task.run("orchard.backfill.resident_memory", [])
-                   end)
+                   RepoManager.run_bounded_failure_probe(
+                     fn ->
+                       capture_io(fn ->
+                         Mix.Task.run("orchard.backfill.resident_memory", [])
+                       end)
+                     end,
+                     2_000
+                   )
                  end
   end
 

--- a/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
+++ b/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
@@ -907,6 +907,7 @@ defmodule Orchard.BeamPeerGrantsTest do
     assert Enum.sort(certificate.extended_key_usages) == [:client_auth, :server_auth]
   end
 
+  @tag :macos
   test "SPEC.md §7.5.0 Node retrieves and stores a grant over a real mTLS control stream", %{
     root: root,
     trust_root: trust_root,

--- a/apps/orchard_controller/test/orchard/models/bundle_builder_test.exs
+++ b/apps/orchard_controller/test/orchard/models/bundle_builder_test.exs
@@ -1345,7 +1345,7 @@ defmodule Orchard.Models.BundleBuilderTest do
     [ -f "$request" ] || exit 22
     [ ! -L "$request" ] || exit 23
 
-    mode=$(stat -f '%Lp' "$selected" 2>/dev/null || stat -c '%a' "$selected" 2>/dev/null || echo unknown)
+    mode=$(stat -c '%a' "$selected" 2>/dev/null || stat -f '%Lp' "$selected" 2>/dev/null || echo unknown)
     [ "$mode" = "700" ] || exit 24
 
     payload=$(cat)

--- a/apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs
+++ b/apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs
@@ -619,7 +619,7 @@ defmodule Orchard.Models.SafeTokenizationPreflightTest do
       exit 43
     fi
 
-    mode=$(stat -f %Lp "$transport_dir" 2>/dev/null || stat -c %a "$transport_dir" 2>/dev/null || printf unknown)
+    mode=$(stat -c '%a' "$transport_dir" 2>/dev/null || stat -f '%Lp' "$transport_dir" 2>/dev/null || printf unknown)
 
     if [ "$mode" != "700" ]; then
       exit 44

--- a/apps/orchard_controller/test/orchard/release_test.exs
+++ b/apps/orchard_controller/test/orchard/release_test.exs
@@ -104,15 +104,26 @@ defmodule Orchard.ReleaseTest do
       :orchard_controller,
       Repo,
       Keyword.merge(Application.fetch_env!(:orchard_controller, Repo),
-        hostname: 123,
+        hostname: "127.0.0.1",
+        port: 1,
+        connect_timeout: 100,
+        backoff_min: 100,
+        backoff_max: 100,
         pool: DBConnection.ConnectionPool,
-        pool_size: 1
+        pool_count: 1,
+        pool_size: 1,
+        queue_interval: 10,
+        queue_target: 10
       )
     )
 
     :ok = RepoManager.stop_repo()
 
-    assert {:error, {:db_unreachable, _message}} = Release.backfill_resident_memory()
+    assert {:error, {:db_unreachable, _message}} =
+             RepoManager.run_bounded_failure_probe(
+               fn -> Release.backfill_resident_memory() end,
+               2_000
+             )
   end
 
   test "SPEC 13.7 DB helpers fail closed when DB checks are disabled" do

--- a/apps/orchard_controller/test/orchard/repo_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/repo_manager_test.exs
@@ -1,0 +1,38 @@
+defmodule Orchard.TestSupport.RepoManagerTest do
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.Repo
+  alias Orchard.TestSupport.RepoManager
+
+  setup do
+    previous_repo_config = Application.fetch_env!(:orchard_controller, Repo)
+
+    on_exit(fn ->
+      :ok = RepoManager.stop_repo()
+      Application.put_env(:orchard_controller, Repo, previous_repo_config)
+      :ok = RepoManager.ensure_repo_started()
+    end)
+
+    %{previous_repo_config: previous_repo_config}
+  end
+
+  test "ensure_repo_started replaces a running non-sandbox repo", %{
+    previous_repo_config: previous_repo_config
+  } do
+    :ok = RepoManager.stop_repo()
+
+    Application.put_env(
+      :orchard_controller,
+      Repo,
+      Keyword.put(previous_repo_config, :pool, DBConnection.ConnectionPool)
+    )
+
+    {:ok, non_sandbox_repo} = Repo.start_link()
+    Application.put_env(:orchard_controller, Repo, previous_repo_config)
+
+    assert :ok = RepoManager.ensure_repo_started()
+    refute Process.alive?(non_sandbox_repo)
+    assert :ok = Sandbox.mode(Repo, :manual)
+  end
+end

--- a/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
+++ b/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
@@ -2717,7 +2717,7 @@ defmodule Orchard.Tokenizer.ClientTest do
       exit 43
     fi
 
-    dir_mode=$(stat -f '%Lp' "$request_dir" 2>/dev/null || stat -c '%a' "$request_dir")
+    dir_mode=$(stat -c '%a' "$request_dir" 2>/dev/null || stat -f '%Lp' "$request_dir")
 
     if [ "$dir_mode" != "700" ]; then
       printf 'unexpected directory mode %s\n' "$dir_mode" > "#{probe_file}"

--- a/apps/orchard_controller/test/support/repo_manager.ex
+++ b/apps/orchard_controller/test/support/repo_manager.ex
@@ -18,6 +18,40 @@ defmodule Orchard.TestSupport.RepoManager do
     GenServer.call(__MODULE__, :stop_repo, 30_000)
   end
 
+  @spec run_bounded_failure_probe((-> result), pos_integer()) :: result when result: var
+  def run_bounded_failure_probe(fun, timeout_ms)
+      when is_function(fun, 0) and is_integer(timeout_ms) and timeout_ms > 0 do
+    {:ok, supervisor} = Task.Supervisor.start_link()
+
+    task =
+      Task.Supervisor.async_nolink(supervisor, fn ->
+        try do
+          {:returned, fun.()}
+        rescue
+          error in Mix.Error -> {:raised, error, __STACKTRACE__}
+        end
+      end)
+
+    try do
+      case Task.yield(task, timeout_ms) do
+        {:ok, {:returned, result}} ->
+          result
+
+        {:ok, {:raised, error, stacktrace}} ->
+          reraise error, stacktrace
+
+        {:exit, reason} ->
+          raise "repo failure probe exited: #{inspect(reason)}"
+
+        nil ->
+          Task.shutdown(task, :brutal_kill)
+          raise "repo failure probe exceeded #{timeout_ms}ms"
+      end
+    after
+      Supervisor.stop(supervisor)
+    end
+  end
+
   @impl true
   def init(:ok) do
     {:ok, %{}, {:continue, :ensure_repo_started}}

--- a/apps/orchard_controller/test/support/repo_manager.ex
+++ b/apps/orchard_controller/test/support/repo_manager.ex
@@ -39,6 +39,17 @@ defmodule Orchard.TestSupport.RepoManager do
   end
 
   defp ensure_repo_started(state) do
+    state = start_repo_if_needed(state)
+
+    try do
+      Sandbox.mode(Repo, :manual)
+      state
+    rescue
+      error in RuntimeError -> recover_non_sandbox_repo(error, __STACKTRACE__, state)
+    end
+  end
+
+  defp start_repo_if_needed(state) do
     case Process.whereis(Repo) do
       nil ->
         {:ok, _pid} = Repo.start_link()
@@ -47,8 +58,21 @@ defmodule Orchard.TestSupport.RepoManager do
         :ok
     end
 
-    Sandbox.mode(Repo, :manual)
     state
+  end
+
+  defp recover_non_sandbox_repo(error, stacktrace, state) do
+    if String.starts_with?(error.message, "cannot invoke sandbox operation with pool ") do
+      state
+      |> stop_repo()
+      |> start_repo_if_needed()
+      |> then(fn restarted_state ->
+        :ok = Sandbox.mode(Repo, :manual)
+        restarted_state
+      end)
+    else
+      reraise error, stacktrace
+    end
   end
 
   defp stop_repo(state) do

--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -1,6 +1,8 @@
 defmodule Orchard.Node.BeamPeerGrantStoreTest do
   use ExUnit.Case, async: true
 
+  @moduletag :macos
+
   import Bitwise, only: [band: 2]
 
   alias Orchard.Cluster.V1.{RetrieveBeamPeerGrantRequest, RetrieveBeamPeerGrantResponse}

--- a/apps/orchard_shared/test/orchard/runtime_endpoint/distribution_expiry_guard_test.exs
+++ b/apps/orchard_shared/test/orchard/runtime_endpoint/distribution_expiry_guard_test.exs
@@ -137,7 +137,7 @@ defmodule Orchard.RuntimeEndpoint.DistributionExpiryGuardTest do
                hard_stop: fn -> send(test_pid, :independent_hard_stop) end
              )
 
-    assert_receive :application_stopped
+    assert_receive :application_stopped, 500
     GenServer.stop(pid)
     assert_receive :independent_hard_stop, 500
   end

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -163,6 +163,33 @@ PY
   return 69
 }
 
+# Return success when argv launches an orchard-worker-mlx executable directly
+# or through a supported interpreter. Later arguments are not executable
+# identity: agent prompts and diagnostics may legitimately mention the worker
+# name without launching one.
+orchard_source_dev_args_launch_worker() {
+  local args="$1"
+  local -a tokens=()
+  local -a launch_tokens=()
+  local token executable interpreter
+
+  read -r -a tokens <<< "$args"
+  [[ ${#tokens[@]} -gt 0 ]] || return 1
+
+  launch_tokens+=("${tokens[0]}")
+  interpreter="${tokens[0]##*/}"
+  if [[ ${#tokens[@]} -gt 1 && "$interpreter" =~ ^(ba|z|k)?sh$|^python([0-9.]*)?$ ]]; then
+    launch_tokens+=("${tokens[1]}")
+  fi
+
+  for token in "${launch_tokens[@]}"; do
+    executable="${token##*/}"
+    [[ "$executable" == orchard-worker-mlx* ]] && return 0
+  done
+
+  return 1
+}
+
 # List matching workers as "pid full argv". The ps format is supported by both
 # BSD/macOS and Linux; avoid pgrep flags whose full-argv behavior is not
 # portable across those platforms.
@@ -172,7 +199,7 @@ orchard_source_dev_worker_processes() {
   while IFS= read -r line; do
     read -r pid args <<< "$line"
     [[ "$pid" =~ ^[0-9]+$ ]] || continue
-    [[ "$args" == *orchard-worker-mlx* ]] || continue
+    orchard_source_dev_args_launch_worker "$args" || continue
     [[ "$pid" != "$$" ]] || continue
     printf '%s %s\n' "$pid" "$args"
   done < <(ps -ww -A -o pid= -o args= 2>/dev/null || true)

--- a/bin/lib/source-dev-worker-cleanup.sh
+++ b/bin/lib/source-dev-worker-cleanup.sh
@@ -163,33 +163,6 @@ PY
   return 69
 }
 
-# Return success when argv launches an orchard-worker-mlx executable directly
-# or through a supported interpreter. Later arguments are not executable
-# identity: agent prompts and diagnostics may legitimately mention the worker
-# name without launching one.
-orchard_source_dev_args_launch_worker() {
-  local args="$1"
-  local -a tokens=()
-  local -a launch_tokens=()
-  local token executable interpreter
-
-  read -r -a tokens <<< "$args"
-  [[ ${#tokens[@]} -gt 0 ]] || return 1
-
-  launch_tokens+=("${tokens[0]}")
-  interpreter="${tokens[0]##*/}"
-  if [[ ${#tokens[@]} -gt 1 && "$interpreter" =~ ^(ba|z|k)?sh$|^python([0-9.]*)?$ ]]; then
-    launch_tokens+=("${tokens[1]}")
-  fi
-
-  for token in "${launch_tokens[@]}"; do
-    executable="${token##*/}"
-    [[ "$executable" == orchard-worker-mlx* ]] && return 0
-  done
-
-  return 1
-}
-
 # List matching workers as "pid full argv". The ps format is supported by both
 # BSD/macOS and Linux; avoid pgrep flags whose full-argv behavior is not
 # portable across those platforms.
@@ -199,7 +172,7 @@ orchard_source_dev_worker_processes() {
   while IFS= read -r line; do
     read -r pid args <<< "$line"
     [[ "$pid" =~ ^[0-9]+$ ]] || continue
-    orchard_source_dev_args_launch_worker "$args" || continue
+    [[ "$args" == *orchard-worker-mlx* ]] || continue
     [[ "$pid" != "$$" ]] || continue
     printf '%s %s\n' "$pid" "$args"
   done < <(ps -ww -A -o pid= -o args= 2>/dev/null || true)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -635,8 +635,8 @@ make cover
 git diff --check
 ```
 
-`make test` and `make cover` stage the retained macOS test helpers before Mix
-runs; the scoped Console run above needs no helper staging.
+On Darwin, `make test` and `make cover` stage the retained macOS test helpers before Mix runs.
+On non-Darwin hosts, those targets exclude tests tagged `macos`; the scoped Console run above needs no helper staging.
 
 Repo-wide gates that fail outside the touched scope must be recorded as
 explicit baseline blockers, not silently accepted.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -935,10 +935,10 @@ The tracer and its supporting flows are validated by
 
 ## Testing
 
-`make test` and `make cover` stage the retained macOS native helpers into
-`_build/test/lib/orchard_cli/priv` before running Mix, because ordinary portable
-`mix compile` no longer emits them. Invoke `mix test` directly only after
-`make macos-native-test-helpers`.
+On Darwin hosts, `make test` and `make cover` stage the retained macOS native
+helpers into `_build/test/lib/orchard_cli/priv` before running Mix, because
+ordinary portable `mix compile` no longer emits them. Invoke `mix test` directly
+only after `make macos-native-test-helpers`.
 
 ```bash
 # Full test suite (uses fake runtime, no GPU needed)

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -935,10 +935,9 @@ The tracer and its supporting flows are validated by
 
 ## Testing
 
-On Darwin hosts, `make test` and `make cover` stage the retained macOS native
-helpers into `_build/test/lib/orchard_cli/priv` before running Mix, because
-ordinary portable `mix compile` no longer emits them. Invoke `mix test` directly
-only after `make macos-native-test-helpers`.
+On Darwin hosts, `make test` and `make cover` stage the retained macOS native helpers into `_build/test/lib/orchard_cli/priv` before running every test, because ordinary portable `mix compile` no longer emits them.
+On non-Darwin hosts, the same Make targets skip helper staging and exclude tests tagged `macos`.
+Invoke `mix test` directly on Darwin only after `make macos-native-test-helpers`.
 
 ```bash
 # Full test suite (uses fake runtime, no GPU needed)
@@ -950,7 +949,7 @@ ORCHARD_TEST_NODE_AGENT_PORT=50171 make test
 # With coverage
 make cover
 
-# Direct Mix invocation, once the macOS test helpers are staged
+# Direct Mix invocation on Darwin, once the macOS test helpers are staged
 make macos-native-test-helpers
 mise exec -- mix test apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -59,7 +59,7 @@ the Python interpreter version that `uv` is allowed to use.
 For macOS host-artifact validation, Apple's C toolchain is required outside mise, the same way the Swift and signing tools are.
 Ordinary `mix compile` does not build Orchard's Darwin helpers, but compiling third-party NIF dependencies such as `argon2_elixir` still needs a working host C compiler.
 Run `make macos-native-helpers` when source development needs the retained terminal-custody or launchd lifecycle helpers in the development CLI application.
-On Darwin hosts the `make test`, `make cover`, and `make check-elixir` workflows stage test helpers automatically; on Linux they skip staging because the helpers are Darwin-only, and the Linux portable lane excludes the retained `macos` tag instead.
+On Darwin hosts the `make test`, `make cover`, and `make check-elixir` workflows stage test helpers automatically and run every test; on non-Darwin hosts they skip staging and exclude the retained `macos` tag.
 Run `make macos-native-test-helpers` first only when invoking `mix test` directly for retained macOS paths.
 The explicit builder owns sources under `packaging/macos/native_helpers` and stages binaries into the selected `orchard_cli` application `priv` directory.
 Payload assembly invokes the same builder before producing the packaged CLI release.
@@ -112,9 +112,8 @@ make test
 make cover
 ```
 
-The last two steps use the Make wrappers because they stage the retained macOS
-test helpers before Mix runs. Substitute `mise exec -- mix test` and
-`mise exec -- mix test --cover` only after `make macos-native-test-helpers`.
+The last two steps use the Make wrappers because they stage the retained macOS test helpers before Mix runs on Darwin and exclude macOS-only tests on non-Darwin hosts.
+Substitute `mise exec -- mix test` and `mise exec -- mix test --cover` on Darwin only after `make macos-native-test-helpers`.
 
 Portable-boundary and macOS native-helper proofs:
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -11,13 +11,13 @@ shell-specific runtime versions when working in this repo.
 ## Platform scope
 
 The documented complete development and validation workflow currently runs on the supported Apple Silicon macOS platform profile.
-The accepted Linux Controller profile is a Milestone 8 target and does not yet have a supported bootstrap, packaging, or validation lane.
+The accepted Linux Controller profile is a Milestone 8 target and does not yet have a supported bootstrap, packaging, or deployment path; required CI does run a Linux portable Orchard control-plane core validation lane, which is validation coverage rather than Linux Controller profile support.
 Portable tools such as mise, Erlang, Elixir, Node.js, npm, and Postgres remain part of that target.
 Ordinary portable Orchard control-plane core compilation no longer invokes `xcrun` or builds Orchard's own Darwin helpers; Apple's C toolchain is a build prerequisite for explicit macOS host-artifact builds and validation.
 Dependency compilation on the current macOS profile still requires a working host C compiler for third-party NIFs such as `argon2_elixir`.
 Swift, DMG assembly, Developer ID signing, notarization, stapling, launchd, and Keychain steps apply to the macOS native distribution profile, and MLX steps apply to the macOS MLX Node runtime profile.
 
-The target validation design moves broad portable Orchard control-plane core compilation, static analysis, tests, coverage, tokenizer validation, and provider-neutral conformance to Linux.
+Required validation runs broad portable Orchard control-plane core compilation, static analysis, tests, coverage, tokenizer validation, and provider-neutral conformance on Linux.
 Separate macOS lanes prove host lifecycle, Orchard.app/DMG behavior, and MLX runtime behavior.
 Credential-free signing-contract validation may run in normal CI, while Developer ID signing, notarization, stapling, and publication remain credentialed release-only operations.
 
@@ -58,7 +58,7 @@ the Python interpreter version that `uv` is allowed to use.
 For macOS host-artifact validation, Apple's C toolchain is required outside mise, the same way the Swift and signing tools are.
 Ordinary `mix compile` does not build Orchard's Darwin helpers, but compiling third-party NIF dependencies such as `argon2_elixir` still needs a working host C compiler.
 Run `make macos-native-helpers` when source development needs the retained terminal-custody or launchd lifecycle helpers in the development CLI application.
-The `make test`, `make cover`, and `make check-elixir` workflows stage test helpers automatically.
+On Darwin hosts the `make test`, `make cover`, and `make check-elixir` workflows stage test helpers automatically; on Linux they skip staging because the retained macOS tags are excluded there.
 Run `make macos-native-test-helpers` first only when invoking `mix test` directly for retained macOS paths.
 The explicit builder owns sources under `packaging/macos/native_helpers` and stages binaries into the selected `orchard_cli` application `priv` directory.
 Payload assembly invokes the same builder before producing the packaged CLI release.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -19,6 +19,7 @@ Swift, DMG assembly, Developer ID signing, notarization, stapling, launchd, and 
 
 Required validation runs broad portable Orchard control-plane core compilation, static analysis, tests, coverage, tokenizer validation, and provider-neutral conformance on Linux.
 Separate macOS lanes prove host lifecycle, Orchard.app/DMG behavior, and MLX runtime behavior.
+`scripts/ci/classify-required-validation-paths.sh` selects which lanes a pull request runs from its changed paths, unknown paths select every lane, and `scripts/ci/evaluate-required-validation.sh` backs the single required `Required Orchard validation gate` check by demanding success from every selected lane and `skipped` from every unselected one.
 Credential-free signing-contract validation may run in normal CI, while Developer ID signing, notarization, stapling, and publication remain credentialed release-only operations.
 
 ## Required Toolchain
@@ -58,7 +59,7 @@ the Python interpreter version that `uv` is allowed to use.
 For macOS host-artifact validation, Apple's C toolchain is required outside mise, the same way the Swift and signing tools are.
 Ordinary `mix compile` does not build Orchard's Darwin helpers, but compiling third-party NIF dependencies such as `argon2_elixir` still needs a working host C compiler.
 Run `make macos-native-helpers` when source development needs the retained terminal-custody or launchd lifecycle helpers in the development CLI application.
-On Darwin hosts the `make test`, `make cover`, and `make check-elixir` workflows stage test helpers automatically; on Linux they skip staging because the retained macOS tags are excluded there.
+On Darwin hosts the `make test`, `make cover`, and `make check-elixir` workflows stage test helpers automatically; on Linux they skip staging because the helpers are Darwin-only, and the Linux portable lane excludes the retained `macos` tag instead.
 Run `make macos-native-test-helpers` first only when invoking `mix test` directly for retained macOS paths.
 The explicit builder owns sources under `packaging/macos/native_helpers` and stages binaries into the selected `orchard_cli` application `priv` directory.
 Payload assembly invokes the same builder before producing the packaged CLI release.
@@ -125,6 +126,19 @@ scripts/test-build-macos-native-helpers.sh
 The first forces a first-party umbrella recompile behind an `xcrun` tripwire and rejects any newly emitted or changed Orchard Darwin helper artifact.
 The second exercises the explicit helper builder and proves a production-only build excludes the test-only terminal helper.
 Run both when changing umbrella compile configuration, the retained helper sources, or the helper builder.
+
+Required CI lane proofs:
+
+```bash
+scripts/test-linux-portable-core.sh
+scripts/test-provider-neutral-conformance.sh
+scripts/ci/test-classify-required-validation-paths.sh
+scripts/ci/test-required-validation-gate.sh
+```
+
+`scripts/test-linux-portable-core.sh` runs the Linux portable lane's tests, coverage, tokenizer checks, and non-accelerator Worker Runtime checks; it excludes the `integration`, `macos`, `mlx_smoke`, and `mlx_benchmark` tags and refuses to run on Darwin.
+`scripts/test-provider-neutral-conformance.sh` runs the focused Worker Runtime, Runtime Endpoint, capability, lifecycle-invariant, and scheduler contract tests against the prepared test database.
+The two `scripts/ci/test-*` proofs are the trigger matrix and fail-closed aggregate tests; run them on any host when changing the classifier, the evaluator, or `.github/workflows/required-validation.yml`.
 
 Native validation:
 

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -56,7 +56,8 @@ Combining both lanes was rejected because focused provider-neutral failures woul
 
 ### Retained platform evidence stays explicit
 
-The macOS host lane SHALL compile the retained Darwin helpers through the explicit builder and run tests tagged `macos`.
+The macOS host lane SHALL provision a deterministic test Postgres, compile the retained Darwin helpers through the explicit builder, and run tests tagged `macos`.
+Darwin-only integration cases that transitively invoke macOS host commands such as `lockf` SHALL carry the same tag as their owning modules.
 The MLX lane SHALL install the accelerator extra and run the real provider package tests on Apple Silicon.
 The packaging lane SHALL retain payload, signing-contract, Swift application, lifecycle, assembled app, DMG, and packaged CLI validation.
 

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -38,6 +38,7 @@ Retained macOS test fixtures SHALL select each macOS host or packaged PTY lane t
 First-party umbrella application source outside `test/` SHALL also select packaging validation because payload assembly and the packaged CLI lanes build `MIX_ENV=prod` releases from those trees.
 Unknown paths SHALL fail safe by selecting every lane.
 An empty changed-path set SHALL fail classification rather than emit an all-inapplicable decision, so a failed or unresolvable pull-request diff cannot green the required gate with no validation.
+Packaging-owned Markdown SHALL be classified before ordinary documentation, and unrecognized nested Markdown SHALL fail safe rather than inherit the top-level documentation exemption.
 Ordinary documentation MAY select no heavy lane.
 Pull-request diffs SHALL disable rename detection so both the removed source path and added destination path enter classification.
 
@@ -46,6 +47,7 @@ Using only workflow-native directory filters was rejected because the dependency
 ### Linux portable and provider-neutral evidence are separate
 
 The Linux portable lane SHALL run the portable compile tripwire, format check, warnings-as-errors compilation, Credo, Dialyzer, portable Mix tests and coverage, tokenizer formatting, lint, tests, and coverage.
+Its repository-owned entrypoint SHALL reject every host whose kernel name is not `Linux`.
 It SHALL install the Worker Runtime base environment without the MLX extra so stub-backed tests can run without importing accelerator implementations.
 It SHALL run focused Worker Runtime stub formatting, lint, tests, and coverage from that base environment.
 
@@ -57,6 +59,7 @@ Combining both lanes was rejected because focused provider-neutral failures woul
 ### Retained platform evidence stays explicit
 
 The macOS host lane SHALL provision a deterministic test Postgres, compile the retained Darwin helpers through the explicit builder, and run tests tagged `macos`.
+It SHALL also run the focused portable helper-transport suites so their GNU-first, BSD-fallback permission probes are exercised under BSD `stat`.
 Darwin-only integration cases that transitively invoke macOS host commands such as `lockf` SHALL carry the same tag as their owning modules.
 Files that mix portable and case-level `macos` tests SHALL fan out to both portable and macOS host lanes when changed.
 The MLX lane SHALL install the accelerator extra and run the real provider package tests on Apple Silicon.

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -33,6 +33,8 @@ The classifier SHALL emit independent portable, conformance, macOS, MLX, and pac
 Pushes to `main` SHALL run every lane.
 
 Shared contracts, proto source, root configuration, root toolchain, release composition, accepted OpenSpec material, `SPEC.md`, and workflow changes SHALL fan out to every lane.
+Native package source, lockfile, metadata, or entrypoint changes SHALL also select packaging validation because payload assembly installs non-editable package trees in a separate environment.
+Retained macOS test fixtures SHALL select each macOS host or packaged PTY lane that consumes them.
 Unknown paths SHALL fail safe by selecting every lane.
 Ordinary documentation MAY select no heavy lane.
 Pull-request diffs SHALL disable rename detection so both the removed source path and added destination path enter classification.

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -74,7 +74,7 @@ Inline workflow conditionals were rejected because they are difficult to exercis
 ## Risks / Trade-offs
 
 - **A dependency edge is omitted** - unknown paths and normative shared surfaces select every lane, while matrix tests lock the known classifications.
-- **A macOS-only test is silently lost** - retained Darwin test modules carry the `macos` tag and the macOS host lane runs that tag explicitly.
+- **A macOS-only test is silently lost** - retained Darwin-only test modules and cases carry the `macos` tag and the macOS host lane runs that tag explicitly.
 - **Linux accidentally imports MLX** - the portable lane installs only the base Worker Runtime environment and never selects the `mlx` extra.
 - **Conditional jobs make branch protection ambiguous** - the unchanged aggregate gate requires exact success or skipped states for every lane.
 

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The existing required workflow has one path detector, one monolithic Apple Silicon validation job, and one required aggregate gate.
+The accepted portability-validation specification requires Linux portable evidence without allowing fake or portable tests to substitute for platform-specific acceptance.
+It also requires dependency-aware fan-out rather than a simple documentation versus code split.
+
+The prerequisite issue #287 moves retained Darwin helper compilation behind an explicit macOS-owned boundary.
+The Linux lane can therefore compile the umbrella with an `xcrun` tripwire and reject any Darwin helper artifact.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prove the portable Orchard control-plane core on Linux with no Apple or accelerator toolchain.
+- Exercise provider-neutral contracts with fake or stub implementations on Linux.
+- Retain explicit macOS host, MLX, application, DMG, and signing-contract evidence.
+- Make validation fan-out and aggregate behavior executable and locally testable.
+- Preserve the required branch-protection check name.
+
+**Non-Goals:**
+
+- Define or support a Linux Platform or Distribution Profile.
+- Add Linux Nodes, CUDA, ROCm, or accelerator discovery.
+- Replace Apple Silicon MLX validation with stub-worker tests.
+- Change branch protection, release credentials, notarization, or publication.
+
+## Decisions
+
+### A repository-owned classifier controls fan-out
+
+Changed paths SHALL be passed to `scripts/ci/classify-required-validation-paths.sh` on pull requests.
+The classifier SHALL emit independent portable, conformance, macOS, MLX, and packaging decisions.
+Pushes to `main` SHALL run every lane.
+
+Shared contracts, proto source, root configuration, root toolchain, release composition, accepted OpenSpec material, `SPEC.md`, and workflow changes SHALL fan out to every lane.
+Unknown paths SHALL fail safe by selecting every lane.
+Ordinary documentation MAY select no heavy lane.
+
+Using only workflow-native directory filters was rejected because the dependency rules would be harder to test locally and unknown paths could silently miss consumers.
+
+### Linux portable and provider-neutral evidence are separate
+
+The Linux portable lane SHALL run the portable compile tripwire, format check, warnings-as-errors compilation, Credo, Dialyzer, portable Mix tests and coverage, tokenizer formatting, lint, tests, and coverage.
+It SHALL install the Worker Runtime base environment without the MLX extra so stub-backed tests can run without importing accelerator implementations.
+
+The provider-neutral lane SHALL run focused contract tests over Worker Runtime mapping, Runtime Endpoints, capability evaluation, lifecycle command invariants, and scheduling.
+It SHALL remain separately named so its success is not represented as Linux host support or real-hardware acceptance.
+
+Combining both lanes was rejected because focused provider-neutral failures would be harder to identify and retry.
+
+### Retained platform evidence stays explicit
+
+The macOS host lane SHALL compile the retained Darwin helpers through the explicit builder and run tests tagged `macos`.
+The MLX lane SHALL install the accelerator extra and run the real provider package tests on Apple Silicon.
+The packaging lane SHALL retain payload, signing-contract, Swift application, lifecycle, assembled app, DMG, and packaged CLI validation.
+
+Moving these checks to Linux or replacing them with stubs was rejected because it would erase the distinction between portable evidence and platform acceptance.
+
+### One tested evaluator owns the aggregate result
+
+The `Required Orchard validation gate` SHALL run after every conditional lane.
+It SHALL require `success` for every selected lane and `skipped` for every unselected lane.
+Changed-path classification failure, a failed or skipped selected lane, or an unexpectedly executed unselected lane SHALL fail the aggregate.
+
+The evaluator SHALL live in a repository-owned script with deliberate success and failure tests.
+Inline workflow conditionals were rejected because they are difficult to exercise before pushing and can accidentally accept an ambiguous result.
+
+## Risks / Trade-offs
+
+- **A dependency edge is omitted** - unknown paths and normative shared surfaces select every lane, while matrix tests lock the known classifications.
+- **A macOS-only test is silently lost** - retained Darwin test modules carry the `macos` tag and the macOS host lane runs that tag explicitly.
+- **Linux accidentally imports MLX** - the portable lane installs only the base Worker Runtime environment and never selects the `mlx` extra.
+- **Conditional jobs make branch protection ambiguous** - the unchanged aggregate gate requires exact success or skipped states for every lane.
+
+## Migration Plan
+
+The workflow change takes effect when this stacked pull request merges after issue #287.
+No persisted state, operator migration, branch-protection update, or release credential is required.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -35,6 +35,7 @@ Pushes to `main` SHALL run every lane.
 Shared contracts, proto source, root configuration, root toolchain, release composition, accepted OpenSpec material, `SPEC.md`, and workflow changes SHALL fan out to every lane.
 Unknown paths SHALL fail safe by selecting every lane.
 Ordinary documentation MAY select no heavy lane.
+Pull-request diffs SHALL disable rename detection so both the removed source path and added destination path enter classification.
 
 Using only workflow-native directory filters was rejected because the dependency rules would be harder to test locally and unknown paths could silently miss consumers.
 
@@ -42,6 +43,7 @@ Using only workflow-native directory filters was rejected because the dependency
 
 The Linux portable lane SHALL run the portable compile tripwire, format check, warnings-as-errors compilation, Credo, Dialyzer, portable Mix tests and coverage, tokenizer formatting, lint, tests, and coverage.
 It SHALL install the Worker Runtime base environment without the MLX extra so stub-backed tests can run without importing accelerator implementations.
+It SHALL run focused Worker Runtime stub formatting, lint, tests, and coverage from that base environment.
 
 The provider-neutral lane SHALL run focused contract tests over Worker Runtime mapping, Runtime Endpoints, capability evaluation, lifecycle command invariants, and scheduling.
 It SHALL remain separately named so its success is not represented as Linux host support or real-hardware acceptance.

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -58,6 +58,7 @@ Combining both lanes was rejected because focused provider-neutral failures woul
 
 The macOS host lane SHALL provision a deterministic test Postgres, compile the retained Darwin helpers through the explicit builder, and run tests tagged `macos`.
 Darwin-only integration cases that transitively invoke macOS host commands such as `lockf` SHALL carry the same tag as their owning modules.
+Files that mix portable and case-level `macos` tests SHALL fan out to both portable and macOS host lanes when changed.
 The MLX lane SHALL install the accelerator extra and run the real provider package tests on Apple Silicon.
 The packaging lane SHALL retain payload, signing-contract, Swift application, lifecycle, assembled app, DMG, and packaged CLI validation.
 

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -50,6 +50,8 @@ The Linux portable lane SHALL run the portable compile tripwire, format check, w
 Its repository-owned entrypoint SHALL reject every host whose kernel name is not `Linux`.
 It SHALL install the Worker Runtime base environment without the MLX extra so stub-backed tests can run without importing accelerator implementations.
 It SHALL run focused Worker Runtime stub formatting, lint, tests, and coverage from that base environment.
+It SHALL provision standard Linux ACL tooling and execute the portable `cluster init` safety surface against GNU `getfacl` and `setfacl` rather than excluding the behavior from Linux validation.
+The ACL seam SHALL retain Darwin `chmod -N` and `ls -lde` behavior, remove Linux access ACLs plus directory default ACLs, ignore only mode-derived base entries, and fail closed on unsupported hosts, tool failures, or malformed inspection output.
 
 The provider-neutral lane SHALL run focused contract tests over Worker Runtime mapping, Runtime Endpoints, capability evaluation, lifecycle command invariants, and scheduling.
 It SHALL remain separately named so its success is not represented as Linux host support or real-hardware acceptance.
@@ -61,6 +63,7 @@ Combining both lanes was rejected because focused provider-neutral failures woul
 The macOS host lane SHALL provision a deterministic test Postgres, compile the retained Darwin helpers through the explicit builder, and run tests tagged `macos`.
 It SHALL also run the focused portable helper-transport suites so their GNU-first, BSD-fallback permission probes are exercised under BSD `stat`.
 Darwin-only integration cases that transitively invoke macOS host commands such as `lockf` SHALL carry the same tag as their owning modules.
+Test modules that exclusively exercise the staged macOS application payload SHALL carry a module-level `macos` tag and remain covered by the macOS and packaging lanes.
 Files that mix portable and case-level `macos` tests SHALL fan out to both portable and macOS host lanes when changed.
 The MLX lane SHALL install the accelerator extra and run the real provider package tests on Apple Silicon.
 The packaging lane SHALL retain payload, signing-contract, Swift application, lifecycle, assembled app, DMG, and packaged CLI validation.

--- a/openspec/changes/add-portable-validation-fanout/design.md
+++ b/openspec/changes/add-portable-validation-fanout/design.md
@@ -35,7 +35,9 @@ Pushes to `main` SHALL run every lane.
 Shared contracts, proto source, root configuration, root toolchain, release composition, accepted OpenSpec material, `SPEC.md`, and workflow changes SHALL fan out to every lane.
 Native package source, lockfile, metadata, or entrypoint changes SHALL also select packaging validation because payload assembly installs non-editable package trees in a separate environment.
 Retained macOS test fixtures SHALL select each macOS host or packaged PTY lane that consumes them.
+First-party umbrella application source outside `test/` SHALL also select packaging validation because payload assembly and the packaged CLI lanes build `MIX_ENV=prod` releases from those trees.
 Unknown paths SHALL fail safe by selecting every lane.
+An empty changed-path set SHALL fail classification rather than emit an all-inapplicable decision, so a failed or unresolvable pull-request diff cannot green the required gate with no validation.
 Ordinary documentation MAY select no heavy lane.
 Pull-request diffs SHALL disable rename detection so both the removed source path and added destination path enter classification.
 

--- a/openspec/changes/add-portable-validation-fanout/proposal.md
+++ b/openspec/changes/add-portable-validation-fanout/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The required Orchard workflow currently concentrates portable, provider-neutral, macOS host, MLX, application, and DMG validation in one Apple Silicon job.
+That structure cannot prove the accepted Linux portability contract, and it makes Controller-only changes pay for unrelated platform lanes.
+
+Issue #287 establishes the prerequisite compile boundary by removing Darwin native-helper compilation from the portable Orchard control-plane core.
+This dependent change makes the accepted portability-validation contract executable in required CI.
+
+## What Changes
+
+- Add a required Linux lane for portable compilation, static analysis, tests, coverage, tokenizer validation, and the non-accelerator Worker Runtime environment.
+- Add a Linux provider-neutral conformance lane over Worker Runtime, Runtime Endpoint, capability, host-lifecycle invariant, and scheduler contracts.
+- Keep macOS host-native, MLX, Orchard.app, DMG, and credential-free signing evidence in separate applicable lanes.
+- Add an executable changed-path classifier with matrix tests for dependency fan-out.
+- Preserve the `Required Orchard validation gate` name while making it aggregate every applicable lane.
+- Add deliberate aggregate-gate tests for failed required lanes, skipped required lanes, and incorrectly executed inapplicable lanes.
+
+No `SPEC.md` change is required.
+This change implements `SPEC.md` §§1.2 and 1.4 plus the accepted `portability-validation` and `platform-profiles` specifications.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `portability-validation`: Defines the executable dependency classifier, conditional required lanes, and aggregate gate behavior.
+
+## Impact
+
+- Portable and provider-neutral changes gain required Linux evidence.
+- Controller-only portable changes can skip unrelated Apple-only lanes when the classifier proves that those dependencies are unaffected.
+- Normative, shared-interface, root-toolchain, root-configuration, release-composition, and workflow changes fan out to all lanes.
+- This change makes no Linux Platform Profile, distribution, host-lifecycle, Node, or accelerator support claim.

--- a/openspec/changes/add-portable-validation-fanout/specs/portability-validation/spec.md
+++ b/openspec/changes/add-portable-validation-fanout/specs/portability-validation/spec.md
@@ -61,3 +61,14 @@ The aggregate decision SHALL be implemented by a repository-owned evaluator with
 
 - **WHEN** a lane classified as inapplicable reports success, failure, or cancellation instead of skipped
 - **THEN** the required aggregate gate fails closed
+
+### Requirement: Default Test Commands Respect Host Boundaries
+
+The repository-owned default test and coverage commands SHALL stage retained Darwin test helpers and run macOS-tagged tests on Darwin hosts.
+On non-Darwin hosts, those commands MUST NOT invoke the Darwin helper builder and MUST exclude tests tagged `macos`.
+
+#### Scenario: Contributor runs default tests on Linux
+
+- **WHEN** a contributor runs the repository-owned default test or coverage command on Linux
+- **THEN** the command runs the portable test surface without invoking Darwin tooling
+- **AND** retained macOS-only test cases remain assigned to the macOS host lane

--- a/openspec/changes/add-portable-validation-fanout/specs/portability-validation/spec.md
+++ b/openspec/changes/add-portable-validation-fanout/specs/portability-validation/spec.md
@@ -6,7 +6,9 @@ Validation selection SHALL follow owned dependency edges and contract fan-out ra
 The repository SHALL own an executable classifier that emits independent portable, provider-neutral conformance, macOS host, MLX provider, and packaging decisions from changed paths.
 Changes to shared contracts, proto source, root configuration, toolchain, release composition, normative product contracts, accepted OpenSpec contracts, or the required workflow SHALL trigger every consuming lane needed to prove compatibility.
 Documentation-only optimization MUST NOT classify a normative `SPEC.md` or OpenSpec contract change as ordinary prose that skips applicable validation.
+First-party umbrella application source that the packaged release composes MUST select the packaging lane.
 Unknown paths MUST select every lane rather than risk missing a dependency edge.
+An empty changed-path set MUST fail classification rather than emit an all-inapplicable decision.
 
 #### Scenario: Worker protocol changes
 
@@ -16,9 +18,21 @@ Unknown paths MUST select every lane rather than risk missing a dependency edge.
 
 #### Scenario: Controller-only portable change
 
-- **WHEN** a change modifies only portable Controller behavior
+- **WHEN** a change modifies only portable Controller source
+- **THEN** the Linux portable, provider-neutral conformance, and packaging lanes run because the packaged release builds that source
+- **AND** unrelated macOS host and MLX provider lanes are explicitly inapplicable
+
+#### Scenario: Portable application test-only change
+
+- **WHEN** a change modifies only portable first-party application test source
 - **THEN** the Linux portable and provider-neutral conformance lanes run
 - **AND** unrelated macOS host, MLX provider, and packaging lanes are explicitly inapplicable
+
+#### Scenario: Changed paths cannot be resolved
+
+- **WHEN** classification receives no changed paths
+- **THEN** classification fails
+- **AND** the required aggregate gate fails instead of reporting that every lane was legitimately inapplicable
 
 #### Scenario: Ordinary documentation changes
 

--- a/openspec/changes/add-portable-validation-fanout/specs/portability-validation/spec.md
+++ b/openspec/changes/add-portable-validation-fanout/specs/portability-validation/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Validation Triggers Follow Dependencies
+
+Validation selection SHALL follow owned dependency edges and contract fan-out rather than directory names alone.
+The repository SHALL own an executable classifier that emits independent portable, provider-neutral conformance, macOS host, MLX provider, and packaging decisions from changed paths.
+Changes to shared contracts, proto source, root configuration, toolchain, release composition, normative product contracts, accepted OpenSpec contracts, or the required workflow SHALL trigger every consuming lane needed to prove compatibility.
+Documentation-only optimization MUST NOT classify a normative `SPEC.md` or OpenSpec contract change as ordinary prose that skips applicable validation.
+Unknown paths MUST select every lane rather than risk missing a dependency edge.
+
+#### Scenario: Worker protocol changes
+
+- **WHEN** the provider-neutral Worker Runtime protocol changes
+- **THEN** portable binding and conformance lanes run
+- **AND** every supported runtime-provider acceptance lane runs
+
+#### Scenario: Controller-only portable change
+
+- **WHEN** a change modifies only portable Controller behavior
+- **THEN** the Linux portable and provider-neutral conformance lanes run
+- **AND** unrelated macOS host, MLX provider, and packaging lanes are explicitly inapplicable
+
+#### Scenario: Ordinary documentation changes
+
+- **WHEN** a change modifies only non-normative documentation
+- **THEN** heavy validation lanes may be explicitly inapplicable
+- **AND** the required aggregate gate still evaluates their skipped results
+
+### Requirement: Required Gate Aggregates Conditional Lanes
+
+The required repository gate named `Required Orchard validation gate` SHALL fail when any applicable portable, conformance, platform, or packaging lane fails and SHALL succeed only when every applicable lane passes and every inapplicable lane is explicitly skipped under the dependency rules.
+Changed-path classification failure, a skipped applicable lane, or an executed inapplicable lane MUST fail the aggregate.
+The aggregate decision SHALL be implemented by a repository-owned evaluator with deliberate success and failure tests.
+
+#### Scenario: Controller-only portable change
+
+- **WHEN** dependency classification proves that no platform implementation or packaging contract is affected
+- **THEN** the required gate omits expensive platform lanes
+- **AND** it still requires the Linux portable and applicable conformance lanes
+
+#### Scenario: Applicable lane fails or skips
+
+- **WHEN** any lane selected by dependency classification fails or is skipped
+- **THEN** the required aggregate gate fails
+
+#### Scenario: Inapplicable lane does not skip
+
+- **WHEN** a lane classified as inapplicable reports success, failure, or cancellation instead of skipped
+- **THEN** the required aggregate gate fails closed

--- a/openspec/changes/add-portable-validation-fanout/tasks.md
+++ b/openspec/changes/add-portable-validation-fanout/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Dependency Fan-Out
 
 - [x] 1.1 Add a repository-owned classifier for portable, conformance, macOS, MLX, and packaging lanes.
-- [x] 1.2 Add trigger-matrix tests for portable-only, provider, macOS-native, packaging, normative, shared-protocol, root-toolchain, workflow, source renames, and ordinary documentation changes.
+- [x] 1.2 Add trigger-matrix tests for portable-only, provider, native package, macOS-native fixture, packaging, normative, shared-protocol, root-toolchain, workflow, source rename, and ordinary documentation changes.
 
 ## 2. Required Validation Lanes
 

--- a/openspec/changes/add-portable-validation-fanout/tasks.md
+++ b/openspec/changes/add-portable-validation-fanout/tasks.md
@@ -1,0 +1,24 @@
+## 1. Dependency Fan-Out
+
+- [x] 1.1 Add a repository-owned classifier for portable, conformance, macOS, MLX, and packaging lanes.
+- [x] 1.2 Add trigger-matrix tests for portable-only, provider, macOS-native, packaging, normative, shared-protocol, root-toolchain, workflow, and ordinary documentation changes.
+
+## 2. Required Validation Lanes
+
+- [x] 2.1 Add Linux portable compilation, static analysis, tests, coverage, tokenizer, and non-accelerator Worker Runtime setup.
+- [x] 2.2 Add focused provider-neutral conformance on Linux.
+- [x] 2.3 Retain explicit macOS host-native, Apple Silicon MLX, Orchard.app, DMG, signing-contract, and packaged CLI evidence.
+- [x] 2.4 Tag retained Darwin-only test modules and run them explicitly in the macOS host lane.
+
+## 3. Aggregate Gate
+
+- [x] 3.1 Preserve the `Required Orchard validation gate` check name.
+- [x] 3.2 Add a repository-owned aggregate evaluator that requires exact success or skipped results.
+- [x] 3.3 Add deliberate success and failure proofs for aggregate behavior.
+
+## 4. Validation
+
+- [x] 4.1 Run strict focused and repository-wide OpenSpec validation and inspect the prose for placeholders.
+- [x] 4.2 Run local trigger, aggregate, portable compile, provider-neutral, Elixir, and applicable macOS validation.
+- [ ] 4.3 Run the exact Linux, provider-neutral, macOS, MLX, packaging, and aggregate lanes in hosted CI.
+- [ ] 4.4 Run exact-head RepoPrompt review and the repository required review gate.

--- a/openspec/changes/add-portable-validation-fanout/tasks.md
+++ b/openspec/changes/add-portable-validation-fanout/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Dependency Fan-Out
 
 - [x] 1.1 Add a repository-owned classifier for portable, conformance, macOS, MLX, and packaging lanes.
-- [x] 1.2 Add trigger-matrix tests for portable-only, provider, macOS-native, packaging, normative, shared-protocol, root-toolchain, workflow, and ordinary documentation changes.
+- [x] 1.2 Add trigger-matrix tests for portable-only, provider, macOS-native, packaging, normative, shared-protocol, root-toolchain, workflow, source renames, and ordinary documentation changes.
 
 ## 2. Required Validation Lanes
 

--- a/openspec/changes/add-portable-validation-fanout/tasks.md
+++ b/openspec/changes/add-portable-validation-fanout/tasks.md
@@ -8,7 +8,7 @@
 - [x] 2.1 Add Linux portable compilation, static analysis, tests, coverage, tokenizer, and non-accelerator Worker Runtime setup.
 - [x] 2.2 Add focused provider-neutral conformance on Linux.
 - [x] 2.3 Retain explicit macOS host-native, Apple Silicon MLX, Orchard.app, DMG, signing-contract, and packaged CLI evidence.
-- [x] 2.4 Tag retained Darwin-only test modules and run them explicitly in the macOS host lane.
+- [x] 2.4 Tag retained Darwin-only test modules and cases and run them explicitly in the macOS host lane.
 
 ## 3. Aggregate Gate
 

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -71,6 +71,9 @@ while IFS= read -r path; do
     apps/orchard_cli/test/support/console_pty_process.ex|apps/orchard_cli/test/support/flock_holder.swift|apps/orchard_cli/test/test_helper.exs|apps/orchard_node_agent/test/test_helper.exs)
       enable_portable_macos_tests
       ;;
+    apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs|apps/orchard_cli/test/orchard_cli/commands/status_test.exs|apps/orchard_controller/test/orchard/beam_peer_grants_test.exs)
+      enable_portable_macos_tests
+      ;;
     native/orchard_worker_mlx/pyproject.toml|native/orchard_worker_mlx/uv.lock|native/orchard_worker_mlx/bin/*|native/orchard_worker_mlx/proto/*|native/orchard_worker_mlx/src/*)
       portable=true
       conformance=true

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -23,6 +23,12 @@ enable_macos_consumers() {
   packaging=true
 }
 
+enable_portable_macos_tests() {
+  portable=true
+  conformance=true
+  macos=true
+}
+
 while IFS= read -r path; do
   [[ -n "$path" ]] || continue
 
@@ -42,11 +48,30 @@ while IFS= read -r path; do
     apps/orchard_cli/lib/orchard_cli/lifecycle_native.ex|apps/orchard_cli/lib/orchard_cli/lifecycle_system.ex|apps/orchard_cli/lib/orchard_cli/secret_tty.ex|apps/orchard_cli/lib/orchard_cli/commands/console.ex|apps/orchard_cli/lib/orchard_cli/commands/node_agent_stop.ex|apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs|apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs|apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex|apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs)
       enable_macos_consumers
       ;;
+    apps/orchard_cli/test/support/console_pty_harness.c|apps/orchard_cli/test/support/orchardctl_delayed_term_fixture.c)
+      macos=true
+      packaging=true
+      ;;
+    apps/orchard_cli/test/support/console_pty_process.ex|apps/orchard_cli/test/support/flock_holder.swift|apps/orchard_cli/test/test_helper.exs|apps/orchard_node_agent/test/test_helper.exs)
+      enable_portable_macos_tests
+      ;;
+    native/orchard_worker_mlx/pyproject.toml|native/orchard_worker_mlx/uv.lock|native/orchard_worker_mlx/bin/*|native/orchard_worker_mlx/proto/*|native/orchard_worker_mlx/src/*)
+      portable=true
+      conformance=true
+      macos=true
+      mlx=true
+      packaging=true
+      ;;
     native/orchard_worker_mlx/*)
       portable=true
       conformance=true
       macos=true
       mlx=true
+      ;;
+    native/orchard_tokenizer/pyproject.toml|native/orchard_tokenizer/uv.lock|native/orchard_tokenizer/bin/*|native/orchard_tokenizer/src/*)
+      portable=true
+      conformance=true
+      packaging=true
       ;;
     native/orchard_tokenizer/*)
       portable=true

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -39,6 +39,18 @@ while IFS= read -r path; do
     docs/decisions/*|docs/architecture.md|docs/tooling.md|docs/process.md)
       enable_all
       ;;
+    native/orchard_worker_mlx/README.md)
+      portable=true
+      conformance=true
+      macos=true
+      mlx=true
+      packaging=true
+      ;;
+    native/orchard_tokenizer/README.md)
+      portable=true
+      conformance=true
+      packaging=true
+      ;;
     docs/*|*.md)
       ;;
     packaging/*|scripts/build-app.sh|scripts/build-dmg.sh|scripts/build-payload.sh|scripts/sign-app.sh|scripts/test-app-*|scripts/test-build-app.sh|scripts/test-build-dmg.sh|scripts/test-build-payload.sh|scripts/test-payload-*)

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -37,6 +37,10 @@ while IFS= read -r path; do
   saw_path=true
 
   case "$path" in
+    apps/orchard_shared/test/*)
+      portable=true
+      conformance=true
+      ;;
     SPEC.md|AGENTS.md|mix.exs|mix.lock|mise.toml|Makefile|package.json|package-lock.json|config/*|rel/*|proto/*|openspec/*|.github/workflows/*|apps/orchard_shared/*)
       enable_all
       ;;
@@ -59,7 +63,12 @@ while IFS= read -r path; do
       macos=true
       packaging=true
       ;;
-    docs/*|README.md|CONTRIBUTING.md|CONTEXT-MAP.md|CLAUDE.md)
+    docs/*)
+      if [[ "$path" != docs/*.md || "$path" == docs/*/* ]]; then
+        enable_all
+      fi
+      ;;
+    README.md|CONTRIBUTING.md|CONTEXT-MAP.md|CLAUDE.md)
       ;;
     apps/orchard_cli/lib/orchard_cli/lifecycle_native.ex|apps/orchard_cli/lib/orchard_cli/lifecycle_system.ex|apps/orchard_cli/lib/orchard_cli/secret_tty.ex|apps/orchard_cli/lib/orchard_cli/commands/console.ex|apps/orchard_cli/lib/orchard_cli/commands/node_agent_stop.ex|apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs|apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs|apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex|apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs)
       enable_macos_consumers
@@ -68,11 +77,18 @@ while IFS= read -r path; do
       macos=true
       packaging=true
       ;;
+    apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs|apps/orchard_cli/test/orchard_cli/payload_wrapper_script_test.exs)
+      macos=true
+      packaging=true
+      ;;
     apps/orchard_cli/test/support/console_pty_process.ex|apps/orchard_cli/test/support/flock_holder.swift|apps/orchard_cli/test/test_helper.exs|apps/orchard_node_agent/test/test_helper.exs)
       enable_portable_macos_tests
       ;;
     apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs|apps/orchard_cli/test/orchard_cli/commands/status_test.exs|apps/orchard_controller/test/orchard/beam_peer_grants_test.exs|apps/orchard_controller/test/orchard/tokenizer_client_test.exs|apps/orchard_controller/test/orchard/models/bundle_builder_test.exs|apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs)
       enable_portable_macos_tests
+      ;;
+    apps/orchard_cli/lib/orchard_cli/platform_acl.ex|apps/orchard_cli/lib/orchard_cli/commands/cluster.ex)
+      enable_macos_consumers
       ;;
     native/orchard_worker_mlx/pyproject.toml|native/orchard_worker_mlx/uv.lock|native/orchard_worker_mlx/bin/*|native/orchard_worker_mlx/proto/*|native/orchard_worker_mlx/src/*)
       portable=true
@@ -86,6 +102,7 @@ while IFS= read -r path; do
       conformance=true
       macos=true
       mlx=true
+      packaging=true
       ;;
     native/orchard_tokenizer/pyproject.toml|native/orchard_tokenizer/uv.lock|native/orchard_tokenizer/bin/*|native/orchard_tokenizer/src/*)
       portable=true
@@ -95,6 +112,7 @@ while IFS= read -r path; do
     native/orchard_tokenizer/*)
       portable=true
       conformance=true
+      packaging=true
       ;;
     apps/orchard_controller/test/*|apps/orchard_node_agent/test/*|apps/orchard_cli/test/*)
       portable=true

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+portable=false
+conformance=false
+macos=false
+mlx=false
+packaging=false
+
+enable_all() {
+  portable=true
+  conformance=true
+  macos=true
+  mlx=true
+  packaging=true
+}
+
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+
+  case "$path" in
+    SPEC.md|AGENTS.md|mix.exs|mix.lock|mise.toml|Makefile|package.json|package-lock.json|config/*|rel/*|proto/*|openspec/*|.github/workflows/*|apps/orchard_shared/*)
+      enable_all
+      ;;
+    docs/decisions/*|docs/architecture.md|docs/tooling.md|docs/process.md)
+      enable_all
+      ;;
+    docs/*|*.md)
+      ;;
+    packaging/*|scripts/build-app.sh|scripts/build-dmg.sh|scripts/build-payload.sh|scripts/sign-app.sh|scripts/test-app-*|scripts/test-build-app.sh|scripts/test-build-dmg.sh|scripts/test-build-payload.sh|scripts/test-payload-*)
+      macos=true
+      packaging=true
+      ;;
+    native/orchard_worker_mlx/*)
+      conformance=true
+      macos=true
+      mlx=true
+      ;;
+    native/orchard_tokenizer/*)
+      portable=true
+      conformance=true
+      ;;
+    apps/orchard_controller/*|apps/orchard_node_agent/*|apps/orchard_cli/*)
+      portable=true
+      conformance=true
+      ;;
+    scripts/ci/*|scripts/test-linux-portable-core.sh|scripts/test-provider-neutral-conformance.sh)
+      enable_all
+      ;;
+    *)
+      enable_all
+      ;;
+  esac
+done
+
+printf 'portable=%s\n' "$portable"
+printf 'conformance=%s\n' "$conformance"
+printf 'macos=%s\n' "$macos"
+printf 'mlx=%s\n' "$mlx"
+printf 'packaging=%s\n' "$packaging"

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -29,8 +29,12 @@ enable_portable_macos_tests() {
   macos=true
 }
 
+saw_path=false
+
 while IFS= read -r path; do
   [[ -n "$path" ]] || continue
+
+  saw_path=true
 
   case "$path" in
     SPEC.md|AGENTS.md|mix.exs|mix.lock|mise.toml|Makefile|package.json|package-lock.json|config/*|rel/*|proto/*|openspec/*|.github/workflows/*|apps/orchard_shared/*)
@@ -89,9 +93,14 @@ while IFS= read -r path; do
       portable=true
       conformance=true
       ;;
+    apps/orchard_controller/test/*|apps/orchard_node_agent/test/*|apps/orchard_cli/test/*)
+      portable=true
+      conformance=true
+      ;;
     apps/orchard_controller/*|apps/orchard_node_agent/*|apps/orchard_cli/*)
       portable=true
       conformance=true
+      packaging=true
       ;;
     scripts/ci/*|scripts/test-linux-portable-core.sh|scripts/test-provider-neutral-conformance.sh)
       enable_all
@@ -101,6 +110,11 @@ while IFS= read -r path; do
       ;;
   esac
 done
+
+if [[ "$saw_path" != "true" ]]; then
+  printf 'classify-required-validation-paths: no changed paths on stdin\n' >&2
+  exit 1
+fi
 
 printf 'portable=%s\n' "$portable"
 printf 'conformance=%s\n' "$conformance"

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -16,6 +16,13 @@ enable_all() {
   packaging=true
 }
 
+enable_macos_consumers() {
+  portable=true
+  conformance=true
+  macos=true
+  packaging=true
+}
+
 while IFS= read -r path; do
   [[ -n "$path" ]] || continue
 
@@ -32,7 +39,11 @@ while IFS= read -r path; do
       macos=true
       packaging=true
       ;;
+    apps/orchard_cli/lib/orchard_cli/lifecycle_native.ex|apps/orchard_cli/lib/orchard_cli/lifecycle_system.ex|apps/orchard_cli/lib/orchard_cli/secret_tty.ex|apps/orchard_cli/lib/orchard_cli/commands/console.ex|apps/orchard_cli/lib/orchard_cli/commands/node_agent_stop.ex|apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs|apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs|apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex|apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs)
+      enable_macos_consumers
+      ;;
     native/orchard_worker_mlx/*)
+      portable=true
       conformance=true
       macos=true
       mlx=true

--- a/scripts/ci/classify-required-validation-paths.sh
+++ b/scripts/ci/classify-required-validation-paths.sh
@@ -55,11 +55,11 @@ while IFS= read -r path; do
       conformance=true
       packaging=true
       ;;
-    docs/*|*.md)
-      ;;
     packaging/*|scripts/build-app.sh|scripts/build-dmg.sh|scripts/build-payload.sh|scripts/sign-app.sh|scripts/test-app-*|scripts/test-build-app.sh|scripts/test-build-dmg.sh|scripts/test-build-payload.sh|scripts/test-payload-*)
       macos=true
       packaging=true
+      ;;
+    docs/*|README.md|CONTRIBUTING.md|CONTEXT-MAP.md|CLAUDE.md)
       ;;
     apps/orchard_cli/lib/orchard_cli/lifecycle_native.ex|apps/orchard_cli/lib/orchard_cli/lifecycle_system.ex|apps/orchard_cli/lib/orchard_cli/secret_tty.ex|apps/orchard_cli/lib/orchard_cli/commands/console.ex|apps/orchard_cli/lib/orchard_cli/commands/node_agent_stop.ex|apps/orchard_cli/test/orchard_cli/lifecycle_native_test.exs|apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs|apps/orchard_node_agent/lib/orchard/node/beam_peer_grant_store.ex|apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs)
       enable_macos_consumers
@@ -71,7 +71,7 @@ while IFS= read -r path; do
     apps/orchard_cli/test/support/console_pty_process.ex|apps/orchard_cli/test/support/flock_holder.swift|apps/orchard_cli/test/test_helper.exs|apps/orchard_node_agent/test/test_helper.exs)
       enable_portable_macos_tests
       ;;
-    apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs|apps/orchard_cli/test/orchard_cli/commands/status_test.exs|apps/orchard_controller/test/orchard/beam_peer_grants_test.exs)
+    apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs|apps/orchard_cli/test/orchard_cli/commands/status_test.exs|apps/orchard_controller/test/orchard/beam_peer_grants_test.exs|apps/orchard_controller/test/orchard/tokenizer_client_test.exs|apps/orchard_controller/test/orchard/models/bundle_builder_test.exs|apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs)
       enable_portable_macos_tests
       ;;
     native/orchard_worker_mlx/pyproject.toml|native/orchard_worker_mlx/uv.lock|native/orchard_worker_mlx/bin/*|native/orchard_worker_mlx/proto/*|native/orchard_worker_mlx/src/*)

--- a/scripts/ci/evaluate-required-validation.sh
+++ b/scripts/ci/evaluate-required-validation.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_result() {
+  local label="$1"
+  local required="$2"
+  local result="$3"
+
+  if [[ "$required" == "true" && "$result" != "success" ]]; then
+    printf '%s was required but finished with result: %s\n' "$label" "$result" >&2
+    return 1
+  fi
+
+  if [[ "$required" != "true" && "$result" != "skipped" ]]; then
+    printf '%s was not required but finished with result: %s\n' "$label" "$result" >&2
+    return 1
+  fi
+}
+
+if [[ "${CHANGES_RESULT:?}" != "success" ]]; then
+  printf 'Changed-path classification finished with result: %s\n' "$CHANGES_RESULT" >&2
+  exit 1
+fi
+
+require_result "Linux portable-core validation" "${PORTABLE_REQUIRED:?}" "${PORTABLE_RESULT:?}"
+require_result "Provider-neutral conformance" "${CONFORMANCE_REQUIRED:?}" "${CONFORMANCE_RESULT:?}"
+require_result "macOS host validation" "${MACOS_REQUIRED:?}" "${MACOS_RESULT:?}"
+require_result "MLX validation" "${MLX_REQUIRED:?}" "${MLX_RESULT:?}"
+require_result "Packaging validation" "${PACKAGING_REQUIRED:?}" "${PACKAGING_RESULT:?}"
+require_result "OpenSpec validation" "${OPENSPEC_REQUIRED:?}" "${OPENSPEC_RESULT:?}"
+
+printf 'All applicable Orchard validation lanes passed and all other lanes were skipped.\n'

--- a/scripts/ci/evaluate-required-validation.sh
+++ b/scripts/ci/evaluate-required-validation.sh
@@ -2,6 +2,20 @@
 
 set -euo pipefail
 
+validate_required() {
+  local label="$1"
+  local required="$2"
+
+  case "$required" in
+    true|false)
+      ;;
+    *)
+      printf '%s requirement must be true or false, got: %s\n' "$label" "$required" >&2
+      return 1
+      ;;
+  esac
+}
+
 require_result() {
   local label="$1"
   local required="$2"
@@ -22,6 +36,13 @@ if [[ "${CHANGES_RESULT:?}" != "success" ]]; then
   printf 'Changed-path classification finished with result: %s\n' "$CHANGES_RESULT" >&2
   exit 1
 fi
+
+validate_required "Linux portable-core validation" "${PORTABLE_REQUIRED:?}"
+validate_required "Provider-neutral conformance" "${CONFORMANCE_REQUIRED:?}"
+validate_required "macOS host validation" "${MACOS_REQUIRED:?}"
+validate_required "MLX validation" "${MLX_REQUIRED:?}"
+validate_required "Packaging validation" "${PACKAGING_REQUIRED:?}"
+validate_required "OpenSpec validation" "${OPENSPEC_REQUIRED:?}"
 
 require_result "Linux portable-core validation" "${PORTABLE_REQUIRED:?}" "${PORTABLE_RESULT:?}"
 require_result "Provider-neutral conformance" "${CONFORMANCE_REQUIRED:?}" "${CONFORMANCE_RESULT:?}"

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -26,16 +26,16 @@ assert_case controller-only \
   'portable=true conformance=true macos=false mlx=false packaging=false ' \
   apps/orchard_controller/lib/orchard/api/router.ex
 assert_case tokenizer \
-  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  'portable=true conformance=true macos=false mlx=false packaging=true ' \
   native/orchard_tokenizer/src/orchard_tokenizer/cli.py
 assert_case macos-packaging \
   'portable=false conformance=false macos=true mlx=false packaging=true ' \
   packaging/app/Sources/OrchardApp/main.swift
 assert_case mlx-provider \
-  'portable=true conformance=true macos=true mlx=true packaging=false ' \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
   native/orchard_worker_mlx/src/orchard_worker_mlx/runtime.py
 assert_case worker-protocol \
-  'portable=true conformance=true macos=true mlx=true packaging=false ' \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
   native/orchard_worker_mlx/proto/orchard/worker/v1/worker_runtime.proto
 assert_case retained-macos-helper-consumer \
   'portable=true conformance=true macos=true mlx=false packaging=true ' \
@@ -43,6 +43,12 @@ assert_case retained-macos-helper-consumer \
 assert_case retained-macos-test \
   'portable=true conformance=true macos=true mlx=false packaging=true ' \
   apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
+assert_case macos-pty-support \
+  'portable=false conformance=false macos=true mlx=false packaging=true ' \
+  apps/orchard_cli/test/support/console_pty_harness.c
+assert_case macos-test-helper \
+  'portable=true conformance=true macos=true mlx=false packaging=false ' \
+  apps/orchard_cli/test/test_helper.exs
 assert_case source-to-doc-rename \
   'portable=true conformance=true macos=false mlx=false packaging=false ' \
   apps/orchard_controller/lib/orchard/api/router.ex docs/router.md

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -50,6 +50,9 @@ assert_case tokenizer \
 assert_case macos-packaging \
   'portable=false conformance=false macos=true mlx=false packaging=true ' \
   packaging/app/Sources/OrchardApp/main.swift
+assert_case packaging-contract-readme \
+  'portable=false conformance=false macos=true mlx=false packaging=true ' \
+  packaging/dmg/README.md
 assert_case mlx-provider \
   'portable=true conformance=true macos=true mlx=true packaging=true ' \
   native/orchard_worker_mlx/src/orchard_worker_mlx/runtime.py
@@ -77,6 +80,15 @@ assert_case case-tagged-macos-status-test \
 assert_case case-tagged-macos-peer-grant-test \
   'portable=true conformance=true macos=true mlx=false packaging=false ' \
   apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
+assert_case bsd-stat-tokenizer-transport-test \
+  'portable=true conformance=true macos=true mlx=false packaging=false ' \
+  apps/orchard_controller/test/orchard/tokenizer_client_test.exs
+assert_case bsd-stat-catalog-transport-test \
+  'portable=true conformance=true macos=true mlx=false packaging=false ' \
+  apps/orchard_controller/test/orchard/models/bundle_builder_test.exs
+assert_case bsd-stat-preflight-transport-test \
+  'portable=true conformance=true macos=true mlx=false packaging=false ' \
+  apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs
 assert_case macos-pty-support \
   'portable=false conformance=false macos=true mlx=false packaging=true ' \
   apps/orchard_cli/test/support/console_pty_harness.c

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -93,6 +93,13 @@ assert_case workflow \
   'portable=true conformance=true macos=true mlx=true packaging=true ' \
   .github/workflows/required-validation.yml
 
+assert_case unclassified-new-surface \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  Dockerfile
+assert_case unclassified-path-overrides-docs-only \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  docs/local-dev.md Dockerfile
+
 assert_rejects empty-diff ''
 assert_rejects blank-line-only-diff $'\n\n'
 

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CLASSIFIER="$REPO_ROOT/scripts/ci/classify-required-validation-paths.sh"
+
+assert_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local actual
+
+  actual="$(printf '%s\n' "$@" | "$CLASSIFIER" | tr '\n' ' ')"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'classification case failed: %s\nexpected: %s\nactual:   %s\n' \
+      "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_case ordinary-docs \
+  'portable=false conformance=false macos=false mlx=false packaging=false ' \
+  docs/local-dev.md README.md
+assert_case controller-only \
+  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  apps/orchard_controller/lib/orchard/api/router.ex
+assert_case tokenizer \
+  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  native/orchard_tokenizer/src/orchard_tokenizer/cli.py
+assert_case macos-packaging \
+  'portable=false conformance=false macos=true mlx=false packaging=true ' \
+  packaging/app/Sources/OrchardApp/main.swift
+assert_case mlx-provider \
+  'portable=false conformance=true macos=true mlx=true packaging=false ' \
+  native/orchard_worker_mlx/src/orchard_worker_mlx/runtime.py
+assert_case normative-contract \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  SPEC.md
+assert_case shared-protocol \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  proto/orchard_cluster.proto
+assert_case accepted-openspec \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  openspec/specs/portability-validation/spec.md
+assert_case root-toolchain \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  mise.toml
+assert_case workflow \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  .github/workflows/required-validation.yml
+
+printf 'required validation path-classification tests passed\n'

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -37,6 +37,12 @@ assert_case mlx-provider \
 assert_case worker-protocol \
   'portable=true conformance=true macos=true mlx=true packaging=true ' \
   native/orchard_worker_mlx/proto/orchard/worker/v1/worker_runtime.proto
+assert_case worker-package-readme \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  native/orchard_worker_mlx/README.md
+assert_case tokenizer-package-readme \
+  'portable=true conformance=true macos=false mlx=false packaging=true ' \
+  native/orchard_tokenizer/README.md
 assert_case retained-macos-helper-consumer \
   'portable=true conformance=true macos=true mlx=false packaging=true ' \
   apps/orchard_cli/lib/orchard_cli/secret_tty.ex

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -19,12 +19,31 @@ assert_case() {
   fi
 }
 
+assert_rejects() {
+  local name="$1"
+  local input="$2"
+  local status=0
+
+  printf '%s' "$input" | "$CLASSIFIER" >/dev/null 2>&1 || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    printf 'classification case failed: %s\nexpected a non-zero exit, got 0\n' \
+      "$name" >&2
+    exit 1
+  fi
+}
+
 assert_case ordinary-docs \
   'portable=false conformance=false macos=false mlx=false packaging=false ' \
   docs/local-dev.md README.md
 assert_case controller-only \
-  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  'portable=true conformance=true macos=false mlx=false packaging=true ' \
   apps/orchard_controller/lib/orchard/api/router.ex
+assert_case controller-release-boot \
+  'portable=true conformance=true macos=false mlx=false packaging=true ' \
+  apps/orchard_controller/lib/orchard/application.ex
+assert_case app-test-only \
+  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  apps/orchard_controller/test/orchard/api/router_test.exs
 assert_case tokenizer \
   'portable=true conformance=true macos=false mlx=false packaging=true ' \
   native/orchard_tokenizer/src/orchard_tokenizer/cli.py
@@ -56,7 +75,7 @@ assert_case macos-test-helper \
   'portable=true conformance=true macos=true mlx=false packaging=false ' \
   apps/orchard_cli/test/test_helper.exs
 assert_case source-to-doc-rename \
-  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  'portable=true conformance=true macos=false mlx=false packaging=true ' \
   apps/orchard_controller/lib/orchard/api/router.ex docs/router.md
 assert_case normative-contract \
   'portable=true conformance=true macos=true mlx=true packaging=true ' \
@@ -73,5 +92,8 @@ assert_case root-toolchain \
 assert_case workflow \
   'portable=true conformance=true macos=true mlx=true packaging=true ' \
   .github/workflows/required-validation.yml
+
+assert_rejects empty-diff ''
+assert_rejects blank-line-only-diff $'\n\n'
 
 printf 'required validation path-classification tests passed\n'

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -68,6 +68,15 @@ assert_case retained-macos-helper-consumer \
 assert_case retained-macos-test \
   'portable=true conformance=true macos=true mlx=false packaging=true ' \
   apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
+assert_case case-tagged-macos-cluster-test \
+  'portable=true conformance=true macos=true mlx=false packaging=false ' \
+  apps/orchard_cli/test/orchard_cli/commands/cluster_test.exs
+assert_case case-tagged-macos-status-test \
+  'portable=true conformance=true macos=true mlx=false packaging=false ' \
+  apps/orchard_cli/test/orchard_cli/commands/status_test.exs
+assert_case case-tagged-macos-peer-grant-test \
+  'portable=true conformance=true macos=true mlx=false packaging=false ' \
+  apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
 assert_case macos-pty-support \
   'portable=false conformance=false macos=true mlx=false packaging=true ' \
   apps/orchard_cli/test/support/console_pty_harness.c

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -32,8 +32,20 @@ assert_case macos-packaging \
   'portable=false conformance=false macos=true mlx=false packaging=true ' \
   packaging/app/Sources/OrchardApp/main.swift
 assert_case mlx-provider \
-  'portable=false conformance=true macos=true mlx=true packaging=false ' \
+  'portable=true conformance=true macos=true mlx=true packaging=false ' \
   native/orchard_worker_mlx/src/orchard_worker_mlx/runtime.py
+assert_case worker-protocol \
+  'portable=true conformance=true macos=true mlx=true packaging=false ' \
+  native/orchard_worker_mlx/proto/orchard/worker/v1/worker_runtime.proto
+assert_case retained-macos-helper-consumer \
+  'portable=true conformance=true macos=true mlx=false packaging=true ' \
+  apps/orchard_cli/lib/orchard_cli/secret_tty.ex
+assert_case retained-macos-test \
+  'portable=true conformance=true macos=true mlx=false packaging=true ' \
+  apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs
+assert_case source-to-doc-rename \
+  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  apps/orchard_controller/lib/orchard/api/router.ex docs/router.md
 assert_case normative-contract \
   'portable=true conformance=true macos=true mlx=true packaging=true ' \
   SPEC.md

--- a/scripts/ci/test-classify-required-validation-paths.sh
+++ b/scripts/ci/test-classify-required-validation-paths.sh
@@ -35,6 +35,15 @@ assert_rejects() {
 assert_case ordinary-docs \
   'portable=false conformance=false macos=false mlx=false packaging=false ' \
   docs/local-dev.md README.md
+assert_case unknown-nested-doc \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  docs/new-area/contract.md
+assert_case unknown-nested-doc-support \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  docs/new-area/check.sh
+assert_case unknown-top-level-doc-support \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  docs/check.sh
 assert_case controller-only \
   'portable=true conformance=true macos=false mlx=false packaging=true ' \
   apps/orchard_controller/lib/orchard/api/router.ex
@@ -65,6 +74,12 @@ assert_case worker-package-readme \
 assert_case tokenizer-package-readme \
   'portable=true conformance=true macos=false mlx=false packaging=true ' \
   native/orchard_tokenizer/README.md
+assert_case worker-unknown-package-metadata \
+  'portable=true conformance=true macos=true mlx=true packaging=true ' \
+  native/orchard_worker_mlx/MANIFEST.in
+assert_case tokenizer-unknown-package-metadata \
+  'portable=true conformance=true macos=false mlx=false packaging=true ' \
+  native/orchard_tokenizer/MANIFEST.in
 assert_case retained-macos-helper-consumer \
   'portable=true conformance=true macos=true mlx=false packaging=true ' \
   apps/orchard_cli/lib/orchard_cli/secret_tty.ex
@@ -89,9 +104,24 @@ assert_case bsd-stat-catalog-transport-test \
 assert_case bsd-stat-preflight-transport-test \
   'portable=true conformance=true macos=true mlx=false packaging=false ' \
   apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs
+assert_case portable-shared-test \
+  'portable=true conformance=true macos=false mlx=false packaging=false ' \
+  apps/orchard_shared/test/orchard/runtime_endpoint/target_test.exs
 assert_case macos-pty-support \
   'portable=false conformance=false macos=true mlx=false packaging=true ' \
   apps/orchard_cli/test/support/console_pty_harness.c
+assert_case macos-payload-wrapper-test \
+  'portable=false conformance=false macos=true mlx=false packaging=true ' \
+  apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs
+assert_case macos-payload-script-test \
+  'portable=false conformance=false macos=true mlx=false packaging=true ' \
+  apps/orchard_cli/test/orchard_cli/payload_wrapper_script_test.exs
+assert_case portable-platform-acl \
+  'portable=true conformance=true macos=true mlx=false packaging=true ' \
+  apps/orchard_cli/lib/orchard_cli/platform_acl.ex
+assert_case portable-cluster-init \
+  'portable=true conformance=true macos=true mlx=false packaging=true ' \
+  apps/orchard_cli/lib/orchard_cli/commands/cluster.ex
 assert_case macos-test-helper \
   'portable=true conformance=true macos=true mlx=false packaging=false ' \
   apps/orchard_cli/test/test_helper.exs

--- a/scripts/ci/test-platform-test-routing.sh
+++ b/scripts/ci/test-platform-test-routing.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOW="$ROOT/.github/workflows/required-validation.yml"
 PEER_GRANT_TEST="$ROOT/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs"
+PORTABLE_HELPER_FIXTURES=(
+  "$ROOT/apps/orchard_controller/test/orchard/tokenizer_client_test.exs"
+  "$ROOT/apps/orchard_controller/test/orchard/models/bundle_builder_test.exs"
+  "$ROOT/apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs"
+)
 
 fail() {
   printf 'platform test routing failed: %s\n' "$1" >&2
@@ -61,6 +66,12 @@ grep -Fq 'mix test --cover --exclude macos' <<<"$linux_cover_plan" ||
 peer_grant_case="$(grep -B 2 -F 'Node retrieves and stores a grant over a real mTLS control stream' "$PEER_GRANT_TEST")"
 grep -Fq '@tag :macos' <<<"$peer_grant_case" ||
   fail 'Darwin lockf-backed peer-grant case was not tagged for macOS routing'
+
+for fixture in "${PORTABLE_HELPER_FIXTURES[@]}"; do
+  stat_probe="$(grep -F 'stat -c' "$fixture" | grep -F 'stat -f' | head -n 1)"
+  [[ "$stat_probe" == *"stat -c '%a'"*"stat -f '%Lp'"* ]] ||
+    fail "portable helper fixture did not probe GNU stat before BSD stat: $fixture"
+done
 
 macos_host_job="$(
   awk '

--- a/scripts/ci/test-platform-test-routing.sh
+++ b/scripts/ci/test-platform-test-routing.sh
@@ -3,10 +3,33 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/required-validation.yml"
+PEER_GRANT_TEST="$ROOT/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs"
 
 fail() {
   printf 'platform test routing failed: %s\n' "$1" >&2
   exit 1
+}
+
+line_number() {
+  local content="$1"
+  local pattern="$2"
+
+  awk -v pattern="$pattern" 'index($0, pattern) { print NR; exit }' <<<"$content"
+}
+
+assert_precedes() {
+  local content="$1"
+  local before="$2"
+  local after="$3"
+  local before_line
+  local after_line
+
+  before_line="$(line_number "$content" "$before")"
+  after_line="$(line_number "$content" "$after")"
+
+  [[ -n "$before_line" && -n "$after_line" && "$before_line" -lt "$after_line" ]] ||
+    fail "expected '$before' before '$after'"
 }
 
 darwin_test_plan="$(make --no-print-directory -n -C "$ROOT" HOST_OS=Darwin test)"
@@ -34,5 +57,22 @@ grep -Fq 'mix test --exclude macos' <<<"$linux_test_plan" ||
   fail 'Linux test plan did not exclude macOS-tagged tests'
 grep -Fq 'mix test --cover --exclude macos' <<<"$linux_cover_plan" ||
   fail 'Linux coverage plan did not exclude macOS-tagged tests'
+
+peer_grant_case="$(grep -B 2 -F 'Node retrieves and stores a grant over a real mTLS control stream' "$PEER_GRANT_TEST")"
+grep -Fq '@tag :macos' <<<"$peer_grant_case" ||
+  fail 'Darwin lockf-backed peer-grant case was not tagged for macOS routing'
+
+macos_host_job="$(
+  awk '
+    /^  macos-host:/ { capture = 1 }
+    capture && /^  [a-zA-Z0-9_-]+:/ && $0 !~ /^  macos-host:/ { exit }
+    capture { print }
+  ' "$WORKFLOW"
+)"
+
+assert_precedes "$macos_host_job" 'brew install postgresql@16' 'mise exec -- mix test --only macos'
+assert_precedes "$macos_host_job" 'pg_isready' 'mise exec -- mix test --only macos'
+assert_precedes "$macos_host_job" 'MIX_ENV=test mise exec -- mix ecto.create' 'mise exec -- mix test --only macos'
+assert_precedes "$macos_host_job" 'MIX_ENV=test mise exec -- mix ecto.migrate' 'mise exec -- mix test --only macos'
 
 printf 'platform test-routing tests passed\n'

--- a/scripts/ci/test-platform-test-routing.sh
+++ b/scripts/ci/test-platform-test-routing.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOW="$ROOT/.github/workflows/required-validation.yml"
 PEER_GRANT_TEST="$ROOT/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs"
+LINUX_PORTABLE_TEST="$ROOT/scripts/test-linux-portable-core.sh"
 PORTABLE_HELPER_FIXTURES=(
   "$ROOT/apps/orchard_controller/test/orchard/tokenizer_client_test.exs"
   "$ROOT/apps/orchard_controller/test/orchard/models/bundle_builder_test.exs"
@@ -85,5 +86,23 @@ assert_precedes "$macos_host_job" 'brew install postgresql@16' 'mise exec -- mix
 assert_precedes "$macos_host_job" 'pg_isready' 'mise exec -- mix test --only macos'
 assert_precedes "$macos_host_job" 'MIX_ENV=test mise exec -- mix ecto.create' 'mise exec -- mix test --only macos'
 assert_precedes "$macos_host_job" 'MIX_ENV=test mise exec -- mix ecto.migrate' 'mise exec -- mix test --only macos'
+assert_precedes "$macos_host_job" 'Run portable helper transport tests on BSD stat' 'mise exec -- mix test --only macos'
+
+host_stub_dir="$(mktemp -d)"
+host_stub_marker="$host_stub_dir/mise-called"
+trap 'rm -rf "$host_stub_dir"' EXIT
+
+printf '#!/bin/sh\nprintf "FreeBSD\\n"\n' >"$host_stub_dir/uname"
+printf '#!/bin/sh\ntouch "$ORCHARD_TEST_MISE_MARKER"\nexit 99\n' >"$host_stub_dir/mise"
+chmod +x "$host_stub_dir/uname" "$host_stub_dir/mise"
+
+host_guard_status=0
+ORCHARD_TEST_MISE_MARKER="$host_stub_marker" PATH="$host_stub_dir:$PATH" \
+  "$LINUX_PORTABLE_TEST" >/dev/null 2>&1 || host_guard_status=$?
+
+[[ "$host_guard_status" -eq 69 ]] ||
+  fail "Linux portable test accepted FreeBSD host (status $host_guard_status)"
+[[ ! -e "$host_stub_marker" ]] ||
+  fail 'Linux portable test invoked mise on FreeBSD host'
 
 printf 'platform test-routing tests passed\n'

--- a/scripts/ci/test-platform-test-routing.sh
+++ b/scripts/ci/test-platform-test-routing.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() {
+  printf 'platform test routing failed: %s\n' "$1" >&2
+  exit 1
+}
+
+darwin_test_plan="$(make --no-print-directory -n -C "$ROOT" HOST_OS=Darwin test)"
+linux_test_plan="$(make --no-print-directory -n -C "$ROOT" HOST_OS=Linux test)"
+darwin_cover_plan="$(make --no-print-directory -n -C "$ROOT" HOST_OS=Darwin cover)"
+linux_cover_plan="$(make --no-print-directory -n -C "$ROOT" HOST_OS=Linux cover)"
+
+grep -Fq 'build-macos-native-helpers.sh' <<<"$darwin_test_plan" ||
+  fail 'Darwin test plan did not stage macOS native helpers'
+grep -Fq 'build-macos-native-helpers.sh' <<<"$darwin_cover_plan" ||
+  fail 'Darwin coverage plan did not stage macOS native helpers'
+grep -Fq 'mix test' <<<"$darwin_test_plan" || fail 'Darwin test plan did not run Mix tests'
+grep -Fq 'mix test --cover' <<<"$darwin_cover_plan" ||
+  fail 'Darwin coverage plan did not run Mix coverage'
+grep -Fq -- '--exclude macos' <<<"$darwin_test_plan" &&
+  fail 'Darwin test plan excluded macOS-tagged tests'
+grep -Fq -- '--exclude macos' <<<"$darwin_cover_plan" &&
+  fail 'Darwin coverage plan excluded macOS-tagged tests'
+
+grep -Fq 'build-macos-native-helpers.sh' <<<"$linux_test_plan" &&
+  fail 'Linux test plan attempted to stage Darwin helpers'
+grep -Fq 'build-macos-native-helpers.sh' <<<"$linux_cover_plan" &&
+  fail 'Linux coverage plan attempted to stage Darwin helpers'
+grep -Fq 'mix test --exclude macos' <<<"$linux_test_plan" ||
+  fail 'Linux test plan did not exclude macOS-tagged tests'
+grep -Fq 'mix test --cover --exclude macos' <<<"$linux_cover_plan" ||
+  fail 'Linux coverage plan did not exclude macOS-tagged tests'
+
+printf 'platform test-routing tests passed\n'

--- a/scripts/ci/test-required-validation-gate.sh
+++ b/scripts/ci/test-required-validation-gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+EVALUATOR="$REPO_ROOT/scripts/ci/evaluate-required-validation.sh"
+
+run_case() {
+  local expected="$1"
+  local name="$2"
+  shift 2
+
+  if env "$@" "$EVALUATOR" >/dev/null 2>&1; then
+    actual=pass
+  else
+    actual=fail
+  fi
+
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'required-gate case failed: %s (expected %s, got %s)\n' \
+      "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+COMMON=(
+  CHANGES_RESULT=success
+  PORTABLE_REQUIRED=true PORTABLE_RESULT=success
+  CONFORMANCE_REQUIRED=true CONFORMANCE_RESULT=success
+  MACOS_REQUIRED=false MACOS_RESULT=skipped
+  MLX_REQUIRED=false MLX_RESULT=skipped
+  PACKAGING_REQUIRED=false PACKAGING_RESULT=skipped
+  OPENSPEC_REQUIRED=true OPENSPEC_RESULT=success
+)
+
+run_case pass applicable-lanes-pass "${COMMON[@]}"
+run_case fail required-lane-fails "${COMMON[@]}" PORTABLE_RESULT=failure
+run_case fail required-lane-skips "${COMMON[@]}" CONFORMANCE_RESULT=skipped
+run_case fail inapplicable-lane-runs "${COMMON[@]}" MACOS_RESULT=success
+run_case fail classifier-fails "${COMMON[@]}" CHANGES_RESULT=failure
+
+run_case pass all-lanes-skipped \
+  CHANGES_RESULT=success \
+  PORTABLE_REQUIRED=false PORTABLE_RESULT=skipped \
+  CONFORMANCE_REQUIRED=false CONFORMANCE_RESULT=skipped \
+  MACOS_REQUIRED=false MACOS_RESULT=skipped \
+  MLX_REQUIRED=false MLX_RESULT=skipped \
+  PACKAGING_REQUIRED=false PACKAGING_RESULT=skipped \
+  OPENSPEC_REQUIRED=false OPENSPEC_RESULT=skipped
+
+printf 'required validation aggregate-gate tests passed\n'

--- a/scripts/ci/test-required-validation-gate.sh
+++ b/scripts/ci/test-required-validation-gate.sh
@@ -38,6 +38,8 @@ run_case fail required-lane-fails "${COMMON[@]}" PORTABLE_RESULT=failure
 run_case fail required-lane-skips "${COMMON[@]}" CONFORMANCE_RESULT=skipped
 run_case fail inapplicable-lane-runs "${COMMON[@]}" MACOS_RESULT=success
 run_case fail classifier-fails "${COMMON[@]}" CHANGES_RESULT=failure
+run_case fail empty-requirement "${COMMON[@]}" PORTABLE_REQUIRED=
+run_case fail malformed-requirement "${COMMON[@]}" CONFORMANCE_REQUIRED=maybe
 
 run_case pass all-lanes-skipped \
   CHANGES_RESULT=success \

--- a/scripts/test-linux-portable-core.sh
+++ b/scripts/test-linux-portable-core.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
+if [[ "$(uname -s)" != "Linux" ]]; then
   printf 'test-linux-portable-core: Linux host required\n' >&2
   exit 69
 fi

--- a/scripts/test-linux-portable-core.sh
+++ b/scripts/test-linux-portable-core.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  printf 'test-linux-portable-core: Linux host required\n' >&2
+  exit 69
+fi
+
+EXCLUDES=(
+  --exclude integration
+  --exclude macos
+  --exclude mlx_smoke
+  --exclude mlx_benchmark
+  --exclude safe_tokenization_smoke
+)
+
+mise exec -- mix test "${EXCLUDES[@]}"
+mise exec -- mix test --cover "${EXCLUDES[@]}"
+
+mise exec -- uv run --locked --directory native/orchard_tokenizer ruff format --check
+mise exec -- uv run --locked --directory native/orchard_tokenizer ruff check
+mise exec -- uv run --locked --directory native/orchard_tokenizer pytest
+mise exec -- uv run --locked --directory native/orchard_tokenizer pytest --cov

--- a/scripts/test-linux-portable-core.sh
+++ b/scripts/test-linux-portable-core.sh
@@ -22,3 +22,10 @@ mise exec -- uv run --locked --directory native/orchard_tokenizer ruff format --
 mise exec -- uv run --locked --directory native/orchard_tokenizer ruff check
 mise exec -- uv run --locked --directory native/orchard_tokenizer pytest
 mise exec -- uv run --locked --directory native/orchard_tokenizer pytest --cov
+
+mise exec -- uv run --locked --directory native/orchard_worker_mlx ruff format --check
+mise exec -- uv run --locked --directory native/orchard_worker_mlx ruff check
+mise exec -- uv run --locked --directory native/orchard_worker_mlx \
+  pytest tests/test_backends.py tests/test_service.py
+mise exec -- uv run --locked --directory native/orchard_worker_mlx \
+  pytest --cov=orchard_worker_mlx tests/test_backends.py tests/test_service.py

--- a/scripts/test-linux-portable-core.sh
+++ b/scripts/test-linux-portable-core.sh
@@ -12,7 +12,6 @@ EXCLUDES=(
   --exclude macos
   --exclude mlx_smoke
   --exclude mlx_benchmark
-  --exclude safe_tokenization_smoke
 )
 
 mise exec -- mix test "${EXCLUDES[@]}"

--- a/scripts/test-provider-neutral-conformance.sh
+++ b/scripts/test-provider-neutral-conformance.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+mise exec -- mix test \
+  apps/orchard_shared/test/orchard/runtime_endpoint/domain_test.exs \
+  apps/orchard_shared/test/orchard/runtime_endpoint/grpc_mapping_test.exs \
+  apps/orchard_node_agent/test/orchard/node/runtime_endpoint_mapper_test.exs \
+  apps/orchard_node_agent/test/orchard/node/tool_capability_catalog_test.exs \
+  apps/orchard_node_agent/test/orchard/node/worker_runtime_adapter_test.exs \
+  apps/orchard_controller/test/orchard/runtime_endpoint/grpc_compatibility_mapper_test.exs \
+  apps/orchard_controller/test/orchard/dispatch/dispatch_capability_gate_test.exs \
+  apps/orchard_controller/test/orchard/dispatch_capacity/evaluator_test.exs \
+  apps/orchard_controller/test/orchard/scheduler/single_node_test.exs \
+  apps/orchard_cli/test/orchard_cli/lifecycle_system_test.exs \
+  apps/orchard_cli/test/orchard_cli/commands/lifecycle_support_test.exs

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -139,10 +139,6 @@ FAKE_OTHER="$TMP_ROOT/orchard-worker-mlx-other"
 cp "$FAKE_WORKER" "$FAKE_OTHER"
 chmod +x "$FAKE_OTHER"
 
-FAKE_UNRELATED="$TMP_ROOT/unrelated-command"
-cp "$FAKE_WORKER" "$FAKE_UNRELATED"
-chmod +x "$FAKE_UNRELATED"
-
 FAKE_AMBIGUOUS="$TMP_ROOT/orchard-worker-mlx-ambiguous"
 cat > "$FAKE_AMBIGUOUS" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -300,12 +296,9 @@ fi
 
 # Carrying the expected executable as an unrelated argument must not establish
 # ownership. Only argv0, or argv1 after a recognized interpreter, is valid.
-bash "$FAKE_UNRELATED" "$FAKE_WORKER" --socket-path "$socket_other" &
+bash "$FAKE_OTHER" "$FAKE_WORKER" --socket-path "$socket_other" &
 unrelated_arg_pid=$!
 sleep 0.2
-unrelated_enumeration="$(orchard_source_dev_worker_processes)"
-[[ "$unrelated_enumeration" != *"$unrelated_arg_pid "* ]] ||
-  fail "worker enumeration matched an unrelated executable argument"
 orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" >/dev/null 2>&1
 process_is_running "$unrelated_arg_pid" || fail "unrelated executable argument established ownership"
 kill -TERM "$unrelated_arg_pid" 2>/dev/null || true

--- a/scripts/test-source-dev-worker-cleanup.sh
+++ b/scripts/test-source-dev-worker-cleanup.sh
@@ -139,6 +139,10 @@ FAKE_OTHER="$TMP_ROOT/orchard-worker-mlx-other"
 cp "$FAKE_WORKER" "$FAKE_OTHER"
 chmod +x "$FAKE_OTHER"
 
+FAKE_UNRELATED="$TMP_ROOT/unrelated-command"
+cp "$FAKE_WORKER" "$FAKE_UNRELATED"
+chmod +x "$FAKE_UNRELATED"
+
 FAKE_AMBIGUOUS="$TMP_ROOT/orchard-worker-mlx-ambiguous"
 cat > "$FAKE_AMBIGUOUS" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -296,9 +300,12 @@ fi
 
 # Carrying the expected executable as an unrelated argument must not establish
 # ownership. Only argv0, or argv1 after a recognized interpreter, is valid.
-bash "$FAKE_OTHER" "$FAKE_WORKER" --socket-path "$socket_other" &
+bash "$FAKE_UNRELATED" "$FAKE_WORKER" --socket-path "$socket_other" &
 unrelated_arg_pid=$!
 sleep 0.2
+unrelated_enumeration="$(orchard_source_dev_worker_processes)"
+[[ "$unrelated_enumeration" != *"$unrelated_arg_pid "* ]] ||
+  fail "worker enumeration matched an unrelated executable argument"
 orchard_source_dev_cleanup_workers "$REPO_ROOT" "$FAKE_WORKER" >/dev/null 2>&1
 process_is_running "$unrelated_arg_pid" || fail "unrelated executable argument established ownership"
 kill -TERM "$unrelated_arg_pid" 2>/dev/null || true


### PR DESCRIPTION
## Intent

Implement Orchard issue #288 on top of #292 by making Linux validation of the portable Orchard control-plane core a required CI signal while retaining separate macOS host, MLX provider, packaging, OpenSpec, and provider-neutral conformance evidence.
This PR does not claim a supported Linux Platform Profile or change `SPEC.md` behavior.

## Stack

Depends on #292, which implements #287 by removing Darwin native-helper builds from portable umbrella compilation.
Base: `najibninaba/issue-287-portable-helper-boundary` at `74a9614092f1580fb3eb55e15a2a17ee7dba971b`.
Head: `08ee1467cfe9947e37eebfba1820ec2227e9b9fa`.
The PR base remains unchanged.

## What Changed

- Split required validation into explicit Linux portable-core, provider-neutral conformance, macOS host, MLX provider, packaging, and OpenSpec lanes while preserving the required gate name.
- Added a repository-owned changed-path classifier with fail-closed defaults, rename-safe diff handling, and regression tests for every lane family.
- Added a Linux portable-core script that runs compilation, static analysis, umbrella tests and coverage, tokenizer validation, and the Worker stub backend without installing the MLX provider extra.
- Added real Linux ACL removal and inspection through `setfacl` and `getfacl`, with strict parsing and explicit fixed-token mappings.
- Added a focused provider-neutral conformance script covering supported, unknown, malformed, stale, and unsupported-version runtime observations.
- Tagged retained Darwin-only helper consumers with `:macos` so Linux excludes them while macOS continues to exercise them explicitly.
- Added the strict OpenSpec change `add-portable-validation-fanout` without changing the apex product contract.

## Risk Assessment

**Medium.**

- Blast radius: required-check routing, Linux dependency setup, provider conformance coverage, and Apple-specific validation routing.
- Main risk: an incomplete classifier rule could skip relevant evidence, or an over-broad rule could add unnecessary runner cost.
- ACL parsing risk is constrained by fixed Darwin and Linux token mappings and fail-closed output validation.
- Mitigations: normative, workflow, shared, protocol, and unknown paths fan out conservatively; rename source and destination paths are classified; aggregate inputs fail closed; the complete local Elixir gate passed.

## Validation

Focused validation:

- `make macos-native-test-helpers` - passed.
- `mise exec -- mix test apps/orchard_cli/test/orchard_cli/platform_acl_test.exs` - 9 passed, 1 skipped.
- `git diff --check` - passed.
- The hosted startup-race test passed 100 repeated seeded runs before the final review.

Complete Elixir gate:

- `make check-elixir` - passed.
- Format and compile with warnings as errors passed.
- Credo strict checked 723 files with zero findings.
- Dialyzer completed with zero errors.
- Tests passed: Shared 216; Controller 3,522 with 5 skipped; Node Agent 412; CLI 678 with 1 skipped and 10 excluded.
- Coverage passed: Shared 67.25%; Controller 85.1%; Node Agent 78.33%; CLI 76.40%.

Additional evidence:

- `scripts/ci/test-classify-required-validation-paths.sh` - passed.
- `scripts/ci/test-required-validation-gate.sh` - passed.
- `scripts/test-portable-core-compilation.sh` - passed with no Darwin helper invocation or emission.
- `scripts/test-provider-neutral-conformance.sh` - 141 tests passed.
- Focused and repository-wide strict OpenSpec validation passed.
- RepoPrompt review of the full #288 stack returned GO with no material correctness, security, CI-routing, scope, or spec-traceability blockers.

## Owner Gate

GitHub Actions did not create a fresh Orchard CI run immediately for `08ee1467` after the prior Actions outage left run [32983810140](https://github.com/kapitan-ai/orchard/actions/runs/32983810140) stuck before job creation.
Do not merge #293 until a fresh `Required Orchard validation gate` for the current head appears and passes.

Closes #288

Related: #266


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the previous monolithic macOS validation job with path-classified Linux portable-core, provider-conformance, macOS host, MLX, packaging, and OpenSpec lanes while retaining one required aggregate gate.
- Adds a fail-closed changed-path classifier and aggregate result evaluator with regression tests.
- Adds Linux portable-core and provider-neutral conformance scripts.
- Routes Darwin-dependent tests through explicit `macos` tags and platform-aware Make targets.
- Extracts portable ACL handling for Darwin and Linux cluster initialization.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/required-validation.yml | Splits required validation into independently selected lanes and feeds every lane result into the always-running aggregate gate. |
| scripts/ci/classify-required-validation-paths.sh | Classifies changed paths into validation families with all-lane fallback behavior and empty-input rejection. |
| scripts/ci/evaluate-required-validation.sh | Validates classifier values and requires selected jobs to succeed while requiring unselected jobs to be skipped. |
| scripts/test-linux-portable-core.sh | Defines the Linux-only portable compilation, static-analysis, test, coverage, tokenizer, and Worker-stub validation boundary. |
| scripts/test-provider-neutral-conformance.sh | Runs focused runtime-observation conformance tests across shared, controller, node-agent, and CLI applications. |
| Makefile | Makes default tests platform-aware by staging native helpers on Darwin and excluding macOS-tagged tests elsewhere. |
| apps/orchard_cli/lib/orchard_cli/platform_acl.ex | Encapsulates Darwin and Linux ACL inspection, mutation detection, and extended-ACL removal. |
| apps/orchard_cli/lib/orchard_cli/commands/cluster.ex | Delegates cluster-init ACL operations to the portable platform abstraction while retaining parent-mode and path-identity checks. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Pull request or push] --> B[Classify changed paths]
  B --> C{Selected lanes}
  C --> D[Linux portable core]
  C --> E[Provider-neutral conformance]
  C --> F[macOS host]
  C --> G[MLX provider]
  C --> H[Packaging]
  C --> I[OpenSpec]
  D --> J[Required validation gate]
  E --> J
  F --> J
  G --> J
  H --> J
  I --> J
  B --> J
  J --> K{All required lanes succeeded?}
  K -->|Yes| L[Required check passes]
  K -->|No| M[Required check fails]
```
</details>

<sub>Reviews (12): Last reviewed commit: ["fix(cli): map parsed ACL tokens explicit..."](https://github.com/kapitan-ai/orchard/commit/08ee1467cfe9947e37eebfba1820ec2227e9b9fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56974391)</sub>

<!-- /greptile_comment -->