### PR TITLE
feat(verify): add project-local Orchard Console verification skill

### DIFF
--- a/.cursor/skills/verify-orchard/SKILL.md
+++ b/.cursor/skills/verify-orchard/SKILL.md
@@ -17,14 +17,14 @@ From the repo root:
 chmod +x .cursor/skills/verify-orchard/scripts/control-orchard.sh
 export ORCHARD_VERIFY_RUN_ID="orchard-$(date +%Y%m%d%H%M%S)-$$"
 export PATH="$PWD/.cursor/skills/verify-orchard/scripts:$PATH"
-control-orchard bootstrap   # idempotent; repairs missing tmp/dev/node-trust files
+control-orchard bootstrap   # creates missing node-trust; wipe/re-init only with ORCHARD_VERIFY_TRUST_RECOVER=1
 control-orchard launch
 control-orchard meta
 ```
 
 **Ready when:** `GET http://127.0.0.1:${ORCHARD_VERIFY_PORT:-4000}/health/live` returns exactly `{"status":"ok"}`.
 
-Verification launch sets `ORCHARD_VERIFY_MODE=1`, which disables Phoenix code reload and asset watchers in `config/dev.exs` so health probes stay stable. It runs `mix assets.build` before boot.
+Verification launch sets `ORCHARD_VERIFY_MODE=1`, which disables Phoenix code reload and asset watchers in `config/dev.exs` so health probes stay stable. It runs `mix assets.build` before boot. Launch checks the HTTP port is free before bootstrap, so an existing `make dev` is not disrupted by trust recovery.
 
 **Defaults:**
 - HTTP port `4000` (`ORCHARD_VERIFY_PORT` to override)
@@ -134,7 +134,7 @@ If launch failed mid-boot, still run `control-orchard stop` to clear a partial P
 
 | Command | Purpose |
 |---------|---------|
-| `control-orchard bootstrap` | Ensure `tmp/dev/node-trust` exists (orphan DB recovery) |
+| `control-orchard bootstrap` | Ensure `tmp/dev/node-trust` exists; opt-in orphan recover via `ORCHARD_VERIFY_TRUST_RECOVER=1` |
 | `control-orchard launch` | Background source-dev with log + pid files |
 | `control-orchard doctor` | Readiness gate before driving |
 | `control-orchard stop` | Stop the launched instance |

--- a/.cursor/skills/verify-orchard/SKILL.md
+++ b/.cursor/skills/verify-orchard/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: verify-orchard
+description: Drive Orchard source-dev locally — Console LiveView, public health probes, and optional /v1 API checks. Use when proving UI, readiness, or operator-console behavior after a change.
+---
+
+# verify-orchard
+
+Orchard is an Elixir/OTP inference platform. The primary user-facing surface for operators is the **Console** (Phoenix LiveView at `/console`). Secondary surfaces: public health endpoints (`/health/live`, `/health/ready`), authenticated ops health (`/ops/v1/health`), and the OpenAI-compatible `/v1/*` API.
+
+This skill launches **source-dev** (`mise exec -- bin/dev`), drives the Console with the **cursor-ide-browser** MCP tools, and captures proof artifacts under a disposable run directory.
+
+## Launch
+
+From the repo root:
+
+```bash
+chmod +x .cursor/skills/verify-orchard/scripts/control-orchard.sh
+export ORCHARD_VERIFY_RUN_ID="orchard-$(date +%Y%m%d%H%M%S)-$$"
+export PATH="$PWD/.cursor/skills/verify-orchard/scripts:$PATH"
+control-orchard bootstrap   # idempotent; repairs missing tmp/dev/node-trust files
+control-orchard launch
+control-orchard meta
+```
+
+**Ready when:** `GET http://127.0.0.1:${ORCHARD_VERIFY_PORT:-4000}/health/live` returns exactly `{"status":"ok"}`.
+
+Verification launch sets `ORCHARD_VERIFY_MODE=1`, which disables Phoenix code reload and asset watchers in `config/dev.exs` so health probes stay stable. It runs `mix assets.build` before boot.
+
+**Defaults:**
+- HTTP port `4000` (`ORCHARD_VERIFY_PORT` to override)
+- Shared dev database `orchard_dev` (same as `make dev`)
+- Console auth `:none` in `config/dev.exs` (no Basic Auth locally)
+- gRPC node-agent port `50071`
+
+**Isolation rules:**
+- Do **not** launch if the user already has `make dev` on the same port — `control-orchard launch` refuses occupied ports.
+- Do **not** run two verification launches with the same `ORCHARD_VERIFY_STATE_DIR`.
+- Prefer a fresh `ORCHARD_VERIFY_RUN_ID` per proof run.
+- Inference/API proofs that mutate tenants or models share the dev DB; restore or use disposable slugs when mutating.
+
+**Teardown:**
+
+```bash
+control-orchard stop
+```
+
+Only stops the PID recorded by `launch`. Never `pkill mix` or `pkill beam`.
+
+## Doctor
+
+Run before every drive when anything looks off:
+
+```bash
+control-orchard doctor
+```
+
+Pass criteria:
+1. PID file exists and process is alive
+2. Port listener matches that PID
+3. `/health/live` body is `{"status":"ok"}`
+4. `/console` returns HTTP 200 and HTML containing `Orchard Console`
+
+`/health/ready` may be non-200 while runtime/worker subsystems are still warming — log it, but do not treat it alone as launch failure.
+
+## Drive
+
+**Harness:** `cursor-ide-browser` MCP (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_take_screenshot`).
+
+**Conventions:**
+1. Run `control-orchard doctor` first.
+2. Read `.cursor/skills/verify-orchard/features/README.md`, then the feature file for the scenario.
+3. Prefer stable handles: sidebar link text (`Overview`, `Nodes`, …), page `<h1>` titles, `aria-label="Console navigation"`, element IDs such as `#console-sidebar` and `#console-app`.
+4. After navigation, wait for LiveView connected render (page heading visible; loading panels replaced by content or explicit empty states).
+5. HTTP-only probes use `control-orchard curl /health/live` or plain `curl` against `ORCHARD_VERIFY_BASE_URL` from `control-orchard meta`.
+
+**Console entry URL:** `{ORCHARD_VERIFY_BASE_URL}/console` (dev: `http://127.0.0.1:4000/console`).
+
+**Browser workflow example (Overview):**
+
+```
+browser_navigate → http://127.0.0.1:4000/console
+browser_snapshot → confirm heading "Overview" and nav link "Overview" has aria-current
+browser_take_screenshot → save to artifacts path
+```
+
+Sidebar routes (all under `/console`):
+
+| Label | Path |
+|-------|------|
+| Overview | `/console` |
+| Nodes | `/console/nodes` |
+| Playground | `/console/playground` |
+| Models | `/console/models` |
+| Model Hub | `/console/model-hub` |
+| Organizations | `/console/tenants` |
+| Requests | `/console/requests` |
+| Settings | `/console/settings` |
+
+## Evidence
+
+Artifacts live under `${ORCHARD_VERIFY_STATE_DIR}/artifacts/` (created by the agent; survives `control-orchard stop`).
+
+**Proof standards:**
+- Exercise the real operator path (Console navigation, public health URLs) — not test-only plugs or direct Repo calls.
+- Capture **action + resulting state** (snapshot after navigation, not only the initial screen).
+- For HTTP probes, save status code and body.
+- For UI proofs, save an ARIA snapshot **and** a screenshot showing the Console chrome (sidebar + page title).
+- Record feature id and entry point in a one-line `proof.txt` beside artifacts.
+
+Example layout:
+
+```
+${ORCHARD_VERIFY_STATE_DIR}/artifacts/overview/
+  proof.txt
+  overview.aria.txt
+  overview.png
+```
+
+**API / inference proofs** (optional, heavier setup):
+- Import/activate a model and grant tenant access per `docs/local-dev.md` before Playground or `/v1/chat/completions` checks.
+- Never commit API tokens; pass via env (`ORCHARD_API_KEY`) only for the run.
+
+## Cleanup
+
+```bash
+control-orchard stop
+```
+
+Removes the verification BEAM process only. Keeps `${ORCHARD_VERIFY_STATE_DIR}/artifacts/` intact.
+
+If launch failed mid-boot, still run `control-orchard stop` to clear a partial PID file.
+
+## Helpers
+
+| Command | Purpose |
+|---------|---------|
+| `control-orchard bootstrap` | Ensure `tmp/dev/node-trust` exists (orphan DB recovery) |
+| `control-orchard launch` | Background source-dev with log + pid files |
+| `control-orchard doctor` | Readiness gate before driving |
+| `control-orchard stop` | Stop the launched instance |
+| `control-orchard meta` | Print `BASE_URL`, pid, log, artifacts paths |
+| `control-orchard curl /health/live` | HTTP GET against verification base URL |
+
+Script path: `.cursor/skills/verify-orchard/scripts/control-orchard.sh`
+
+## Maintenance
+
+When routes, nav labels, health contracts, or dev startup change, update the feature map and re-run one proof. Use `/maintain-verification-skill` for the maintenance workflow.

--- a/.cursor/skills/verify-orchard/features/README.md
+++ b/.cursor/skills/verify-orchard/features/README.md
@@ -6,7 +6,7 @@ This directory is the maintained source for verifying user-facing Orchard operat
 
 - PostgreSQL accepting connections on `${PGHOST:-localhost}:${PGPORT:-5432}` with dev credentials (`PGUSER`/`PGPASSWORD`, default `postgres`/`postgres`).
 - Repo dependencies installed (`make setup` once).
-- Run `control-orchard bootstrap` before first launch if `tmp/dev/node-trust/current` is missing (repairs orphaned DB trust without local files).
+- Run `control-orchard bootstrap` before first launch if `tmp/dev/node-trust/current` is missing. Orphan DB wipe needs `ORCHARD_VERIFY_TRUST_RECOVER=1`.
 - Launch with `control-orchard launch` and confirm `control-orchard doctor` passes.
 - Set a disposable run id: `export ORCHARD_VERIFY_RUN_ID="orchard-$(date +%Y%m%d%H%M%S)-$$"`.
 - Put `.cursor/skills/verify-orchard/scripts` on `PATH`.

--- a/.cursor/skills/verify-orchard/features/README.md
+++ b/.cursor/skills/verify-orchard/features/README.md
@@ -1,0 +1,53 @@
+# Orchard verification map
+
+This directory is the maintained source for verifying user-facing Orchard operator behavior. Read this index before driving the app, then open the matching feature file.
+
+## Baseline preconditions
+
+- PostgreSQL accepting connections on `${PGHOST:-localhost}:${PGPORT:-5432}` with dev credentials (`PGUSER`/`PGPASSWORD`, default `postgres`/`postgres`).
+- Repo dependencies installed (`make setup` once).
+- Run `control-orchard bootstrap` before first launch if `tmp/dev/node-trust/current` is missing (repairs orphaned DB trust without local files).
+- Launch with `control-orchard launch` and confirm `control-orchard doctor` passes.
+- Set a disposable run id: `export ORCHARD_VERIFY_RUN_ID="orchard-$(date +%Y%m%d%H%M%S)-$$"`.
+- Put `.cursor/skills/verify-orchard/scripts` on `PATH`.
+- Never drive a Console instance that was not started by the current verification run on the recorded port.
+
+## Driving conventions
+
+- Start every recipe from the baseline unless its preconditions say otherwise.
+- Prefer sidebar link labels and page headings over CSS selectors or DOM position.
+- Console dev auth is `:none` — no Basic Auth prompt locally.
+- Run browser actions through **cursor-ide-browser** MCP tools.
+- Run HTTP probes through `control-orchard curl` or `curl` against `ORCHARD_VERIFY_BASE_URL`.
+- LiveView pages may show a brief loading panel on first connect; wait for the page `<h1>` or a stable content card before proof.
+- Do not remove proof artifacts during cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the initial screen.
+- UI proof includes an ARIA snapshot and a screenshot with Console sidebar visible.
+- HTTP proof includes status code and response body.
+- Record the feature ID and entry point in `proof.txt` beside artifacts.
+- Report unreachable paths with the attempted command and the unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing user-visible behavior. It then uses exactly four H2 sections in this order:
+
+1. `Sub-features` — short IDs with one line each.
+2. `How to get to it (user POV)` — every user entry point.
+3. `Driving it with cursor-ide-browser` — starts with `Preconditions:` and pairs actions with observable results.
+4. `Gotchas` — traps that invalidate a run.
+
+## Features
+
+- [Console overview](./overview.md) — landing page readiness, quickstart shell, sidebar chrome.
+- [Console navigation](./console-navigation.md) — sidebar routes to major Console pages.
+- [Public health probes](./health-probes.md) — `/health/live` and `/health/ready` without auth.
+- [Models catalog](./models-catalog.md) — Models page catalog or explicit empty/error state.
+- [Settings page](./settings.md) — inference defaults and debug snapshot panel load.
+
+## Optional (heavy setup)
+
+- Playground chat and `/v1/chat/completions` require an imported model, tenant grants, and API token per `docs/local-dev.md`. Add a feature file when those steps are scripted for verification.

--- a/.cursor/skills/verify-orchard/features/console-navigation.md
+++ b/.cursor/skills/verify-orchard/features/console-navigation.md
@@ -1,0 +1,31 @@
+# Console navigation
+
+Operators move between Console areas using the left sidebar. Each enabled item navigates to a distinct LiveView route under `/console`.
+
+## Sub-features
+
+- `nav-nodes` — Nodes page loads.
+- `nav-models` — Models page loads.
+- `nav-settings` — Settings page loads.
+
+## How to get to it (user POV)
+
+- From any Console page, click a sidebar label: **Nodes**, **Models**, **Settings**, etc.
+
+## Driving it with cursor-ide-browser
+
+Preconditions:
+
+- `control-orchard doctor` passes.
+- Browser is on any Console page (start at `/console` if needed).
+
+- **Nodes.** Click link `Nodes`. Run `browser_click` on the `Nodes` link from snapshot ref. Heading becomes `Nodes`; URL path is `/console/nodes`.
+- **Models.** Click link `Models`. Heading becomes `Models`; URL path is `/console/models`.
+- **Settings.** Click link `Settings`. Heading becomes `Settings`; URL path is `/console/settings`.
+- **Proof.** After each navigation, capture snapshot lines showing the new heading and `aria-current="page"` on the clicked nav item. Save combined snapshot to `${ARTIFACTS}/console-navigation/nav.aria.txt` and screenshot to `${ARTIFACTS}/console-navigation/nav.png`. Record visited paths in `proof.txt`.
+
+## Gotchas
+
+- All sidebar items are enabled in dev; none should show `aria-disabled="true"`.
+- Wide pages (Models) may take a moment to exit the loading panel — wait for `Model Catalog` title or an explicit error card.
+- Settings triggers connected fetches; wait past the initial shell before proof.

--- a/.cursor/skills/verify-orchard/features/health-probes.md
+++ b/.cursor/skills/verify-orchard/features/health-probes.md
@@ -1,0 +1,29 @@
+# Public health probes
+
+Orchard exposes unauthenticated liveness and readiness HTTP probes used by operators and load balancers.
+
+## Sub-features
+
+- `health-live` — `/health/live` returns the public liveness JSON.
+- `health-ready` — `/health/ready` returns readiness status (success or structured not-ready).
+
+## How to get to it (user POV)
+
+- HTTP GET `http://127.0.0.1:4000/health/live`
+- HTTP GET `http://127.0.0.1:4000/health/ready`
+
+## Driving it with control-orchard
+
+Preconditions:
+
+- `control-orchard doctor` passes (includes live probe).
+
+- **Live probe.** Run `control-orchard curl /health/live`. Exit code 0; body exactly `{"status":"ok"}`.
+- **Ready probe.** Run `control-orchard curl /health/ready` and capture HTTP status + body (e.g. `curl -sS -D - -o body.json "${BASE_URL}/health/ready"`). Save headers/body under `${ARTIFACTS}/health-probes/`.
+- **Proof.** Write `proof.txt` listing both URLs, status codes, and bodies. Live must match spec; ready documents actual state without treating warm-up degradation as launch failure.
+
+## Gotchas
+
+- `/health/live` only asserts the HTTP stack is up; `/health/ready` checks Postgres, migrations, and controller readiness.
+- Ready may fail briefly while migrations or runtime subsystems initialize — retry with backoff before failing the feature.
+- These endpoints are public; do not attach API tokens in URLs or commit probe secrets.

--- a/.cursor/skills/verify-orchard/features/models-catalog.md
+++ b/.cursor/skills/verify-orchard/features/models-catalog.md
@@ -1,0 +1,28 @@
+# Models catalog
+
+The Models page lists the full model catalog with lifecycle actions. On a fresh dev database it may show an empty catalog or a loading then empty state.
+
+## Sub-features
+
+- `models-load` — Models page exits loading and shows catalog or explicit empty state.
+- `models-shell` — Console shell with Models nav active.
+
+## How to get to it (user POV)
+
+- Click **Models** in the Console sidebar.
+- Navigate directly to `/console/models`.
+
+## Driving it with cursor-ide-browser
+
+Preconditions:
+
+- `control-orchard doctor` passes.
+
+- **Open models.** Navigate or click **Models**. URL `/console/models`; heading `Models`.
+- **Wait for catalog.** Wait until `#models-catalog-card`, `#models-loading-card`, or `#models-error-card` is present — loading alone is insufficient for final proof.
+- **Proof.** Snapshot should include `Model Catalog` title or the explicit unavailable/error message. Save `${ARTIFACTS}/models-catalog/models.aria.txt`, screenshot `${ARTIFACTS}/models-catalog/models.png`, and `proof.txt` noting empty vs populated catalog.
+
+## Gotchas
+
+- Lifecycle action buttons (activate/deprecate/retire/delete) mutate DB state — read-only verification should not click them unless cleanup is planned.
+- Imported models from manual dev sessions appear in the shared `orchard_dev` database; empty vs non-empty depends on local DB state, not the proof harness.

--- a/.cursor/skills/verify-orchard/features/overview.md
+++ b/.cursor/skills/verify-orchard/features/overview.md
@@ -1,0 +1,33 @@
+# Console overview
+
+The Console overview is the operator landing page at `/console`. It shows system readiness, runtime snapshot cards, request counts, and the model catalog summary once LiveView connects.
+
+## Sub-features
+
+- `overview-load` — page renders with Console shell and Overview heading.
+- `overview-nav-active` — sidebar marks Overview as the current page.
+- `overview-readiness` — readiness section renders (pass or fail states are both valid proof).
+
+## How to get to it (user POV)
+
+- Open `http://127.0.0.1:4000/console` in a browser (or the verification port from `control-orchard meta`).
+- Click **Overview** in the sidebar when another Console page is active.
+
+## Driving it with cursor-ide-browser
+
+Preconditions:
+
+- `control-orchard doctor` passes.
+- No other verification run owns the same port.
+
+- **Open overview.** Navigate to `{BASE_URL}/console`. Run `browser_navigate` with the verification base URL + `/console`. The document title or main heading includes `Overview`.
+- **Confirm shell.** Run `browser_snapshot`. Snapshot includes `aria-label="Console navigation"`, link name `Overview`, and `#console-sidebar`.
+- **Confirm active nav.** Snapshot shows the Overview link with `aria-current="page"`.
+- **Wait for content.** If a loading panel appears (`Loading` / quickstart hydrating), wait and snapshot again until readiness cards, quickstart, or explicit empty/runtime states render.
+- **Proof.** Run `browser_snapshot` → save to `${ARTIFACTS}/overview/overview.aria.txt`. Run `browser_take_screenshot` → save to `${ARTIFACTS}/overview/overview.png`. Write `${ARTIFACTS}/overview/proof.txt` with feature id `overview`, entry `GET /console`, and timestamp.
+
+## Gotchas
+
+- Disconnected first render shows loading copy only; do not screenshot until connected content appears.
+- Runtime cards may show unavailable/degraded states on a fresh dev boot without an imported model — that is still valid proof if the page heading and nav are correct.
+- Do not use packaged BEAM on port 4000; verification expects source-dev from `control-orchard launch`.

--- a/.cursor/skills/verify-orchard/features/settings.md
+++ b/.cursor/skills/verify-orchard/features/settings.md
@@ -1,0 +1,28 @@
+# Settings page
+
+Settings exposes Console inference defaults and an advanced debug snapshot for operators.
+
+## Sub-features
+
+- `settings-load` — Settings page renders with heading and form regions.
+- `settings-connected` — connected mount completes (defaults or explicit error state).
+
+## How to get to it (user POV)
+
+- Click **Settings** in the Console sidebar.
+- Navigate directly to `/console/settings`.
+
+## Driving it with cursor-ide-browser
+
+Preconditions:
+
+- `control-orchard doctor` passes.
+
+- **Open settings.** Navigate to `/console/settings` or click **Settings**. Heading `Settings`; nav item Settings has `aria-current="page"`.
+- **Wait for connected data.** Page may fetch inference defaults and debug snapshot after connect — wait until form fields or an explicit error/unavailable message appears (not merely the static shell).
+- **Proof.** Snapshot includes `Settings` heading and inference defaults section labels. Save `${ARTIFACTS}/settings/settings.aria.txt`, screenshot `${ARTIFACTS}/settings/settings.png`, and `proof.txt`.
+
+## Gotchas
+
+- Saving inference defaults mutates DB — read-only verification must not submit the form unless rollback is planned.
+- Debug snapshot refresh is async; a single snapshot after a short wait is enough for proof.

--- a/.cursor/skills/verify-orchard/scripts/control-orchard
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard
@@ -1,0 +1,1 @@
+control-orchard.sh

--- a/.cursor/skills/verify-orchard/scripts/control-orchard.sh
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# control-orchard — launch, doctor, and stop Orchard source-dev for verification runs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+RUN_ID="${ORCHARD_VERIFY_RUN_ID:-$(date +%Y%m%d%H%M%S)-$$}"
+STATE_DIR="${ORCHARD_VERIFY_STATE_DIR:-/tmp/orchard-verify-${RUN_ID}}"
+PID_FILE="${STATE_DIR}/dev.pid"
+LOG_FILE="${STATE_DIR}/dev.log"
+META_FILE="${STATE_DIR}/meta.env"
+PORT="${ORCHARD_VERIFY_PORT:-4000}"
+BASE_URL="http://127.0.0.1:${PORT}"
+READY_TIMEOUT_SEC="${ORCHARD_VERIFY_READY_TIMEOUT_SEC:-300}"
+
+mkdir -p "$STATE_DIR"
+
+write_meta() {
+  cat >"$META_FILE" <<EOF
+ORCHARD_VERIFY_RUN_ID=${RUN_ID}
+ORCHARD_VERIFY_STATE_DIR=${STATE_DIR}
+ORCHARD_VERIFY_PORT=${PORT}
+ORCHARD_VERIFY_BASE_URL=${BASE_URL}
+ORCHARD_VERIFY_PID_FILE=${PID_FILE}
+ORCHARD_VERIFY_LOG_FILE=${LOG_FILE}
+ORCHARD_VERIFY_ARTIFACTS_DIR=${STATE_DIR}/artifacts
+EOF
+}
+
+usage() {
+  cat <<EOF
+Usage: control-orchard <command>
+
+Commands:
+  bootstrap Ensure dev node-trust files exist (recovers orphaned DB state)
+  launch    Start source-dev in the background (mise exec -- bin/dev)
+  doctor    Read-only health check for the verification instance
+  stop      Stop the instance started by launch (PID file only)
+  meta      Print state paths for the current run
+  curl      curl wrapper against the verification base URL
+
+Environment:
+  ORCHARD_VERIFY_PORT          HTTP port (default: 4000)
+  ORCHARD_VERIFY_RUN_ID        Stable run id for state dir naming
+  ORCHARD_VERIFY_STATE_DIR     Override state directory
+  ORCHARD_VERIFY_READY_TIMEOUT_SEC  Launch wait timeout (default: 180)
+EOF
+}
+
+port_owner_pid() {
+  lsof -ti "tcp:${PORT}" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
+}
+
+require_repo() {
+  [[ -f "${REPO_ROOT}/mix.exs" ]] || {
+    echo "error: repo root not found at ${REPO_ROOT}" >&2
+    exit 1
+  }
+}
+
+cmd_bootstrap() {
+  require_repo
+  local trust_root="${ORCHARD_NODE_TRUST_ROOT:-${REPO_ROOT}/tmp/dev/node-trust}"
+
+  if [[ -e "${trust_root}/current" ]]; then
+    echo "==> Node trust files present at ${trust_root}/current"
+    return 0
+  fi
+
+  echo "==> Bootstrapping dev node trust at ${trust_root}"
+
+  (
+    cd "$REPO_ROOT"
+    export MIX_ENV=dev
+    mise exec -- mix run --no-start -e '
+      Application.ensure_all_started(:logger)
+      Application.load(:orchard_controller)
+
+      init = fn ->
+        Ecto.Migrator.with_repo(Orchard.Repo, fn _repo ->
+          case Orchard.NodeTrust.initialize(actor_id: "verify-orchard") do
+            {:ok, _} -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+        end)
+        |> case do
+          {:ok, :ok, _} -> :ok
+          {:ok, {:error, reason}, _} -> {:error, reason}
+          other -> {:error, other}
+        end
+      end
+
+      recover = fn ->
+        Ecto.Migrator.with_repo(Orchard.Repo, fn repo ->
+          Ecto.Adapters.SQL.query!(repo, "DELETE FROM controller_instances")
+          Ecto.Adapters.SQL.query!(repo, "DELETE FROM node_trust_authorities")
+          Ecto.Adapters.SQL.query!(repo, "DELETE FROM cluster_identities")
+          :recovered
+        end)
+      end
+
+      case init.() do
+        :ok ->
+          IO.puts("==> Node trust initialized")
+
+        {:error, _} ->
+          IO.puts("==> Trust init failed; recovering orphaned DB trust without local files")
+          {:ok, _, _} = recover.()
+
+          case init.() do
+            :ok -> IO.puts("==> Node trust initialized after orphan recovery")
+            other -> IO.inspect(other); System.halt(1)
+          end
+      end
+    '
+  )
+}
+
+cmd_launch() {
+  require_repo
+  cmd_bootstrap
+  write_meta
+
+  if [[ -f "$PID_FILE" ]]; then
+    existing_pid="$(cat "$PID_FILE")"
+    if kill -0 "$existing_pid" 2>/dev/null; then
+      echo "error: verification instance already running (pid ${existing_pid})" >&2
+      echo "error: run 'control-orchard stop' first" >&2
+      exit 1
+    fi
+  fi
+
+  foreign_pid="$(port_owner_pid)"
+  if [[ -n "$foreign_pid" ]]; then
+    echo "error: port ${PORT} is already in use by pid ${foreign_pid}" >&2
+    echo "error: stop that server or set ORCHARD_VERIFY_PORT to a free port" >&2
+    exit 1
+  fi
+
+  if ! pg_isready -h "${PGHOST:-localhost}" -p "${PGPORT:-5432}" >/dev/null 2>&1; then
+    echo "error: PostgreSQL is not accepting connections on ${PGHOST:-localhost}:${PGPORT:-5432}" >&2
+    exit 1
+  fi
+
+  echo "==> Ensuring dev database..."
+  (
+    cd "$REPO_ROOT"
+    export MIX_ENV=dev
+    mise exec -- mix ecto.create --quiet
+    mise exec -- mix ecto.migrate --quiet
+  )
+
+  echo "==> Compiling dev apps (foreground)..."
+  (
+    cd "$REPO_ROOT"
+    export MIX_ENV=dev
+    mise exec -- mix compile
+    mise exec -- mix assets.build
+  )
+
+  echo "==> Launching Orchard source-dev on ${BASE_URL}"
+  echo "    state: ${STATE_DIR}"
+  echo "    log:   ${LOG_FILE}"
+
+  (
+    cd "$REPO_ROOT"
+    export MIX_ENV=dev
+    export ORCHARD_VERIFY_MODE=1
+    export PORT="$PORT"
+    export ORCHARD_SOURCE_DEV_ROLE=all_in_one
+    export ORCHARD_NODE_AGENT_LISTEN_PORT=50071
+    export ORCHARD_RUNTIME_CLIENT_PORT=50071
+    exec mise exec -- mix phx.server
+  ) >"$LOG_FILE" 2>&1 &
+
+  pid=$!
+  echo "$pid" >"$PID_FILE"
+
+  deadline=$((SECONDS + READY_TIMEOUT_SEC))
+  while (( SECONDS < deadline )); do
+    if curl -sf "${BASE_URL}/health/live" >/dev/null 2>&1; then
+      echo "==> Ready (${BASE_URL}/health/live)"
+      echo "    pid: ${pid}"
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "error: dev server exited before becoming ready; see ${LOG_FILE}" >&2
+      tail -n 40 "$LOG_FILE" >&2 || true
+      exit 1
+    fi
+    sleep 2
+  done
+
+  echo "error: timed out waiting for ${BASE_URL}/health/live" >&2
+  tail -n 40 "$LOG_FILE" >&2 || true
+  exit 1
+}
+
+cmd_doctor() {
+  [[ -f "$META_FILE" ]] || write_meta
+
+  # shellcheck disable=SC1090
+  source "$META_FILE"
+
+  echo "==> Doctor for ${BASE_URL}"
+
+  if [[ ! -f "$PID_FILE" ]]; then
+    echo "FAIL: no pid file at ${PID_FILE} (was launch run?)"
+    exit 1
+  fi
+
+  pid="$(cat "$PID_FILE")"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "FAIL: pid ${pid} is not running"
+    exit 1
+  fi
+
+  owner="$(port_owner_pid)"
+  if [[ "$owner" != "$pid" ]]; then
+    echo "FAIL: port ${PORT} listener pid ${owner:-none} != verification pid ${pid}"
+    exit 1
+  fi
+
+  live_body="$(curl -sf "${BASE_URL}/health/live")" || {
+    echo "FAIL: GET /health/live unreachable"
+    exit 1
+  }
+  if [[ "$live_body" != '{"status":"ok"}' ]]; then
+    echo "FAIL: unexpected /health/live body: ${live_body}"
+    exit 1
+  fi
+
+  ready_code="$(curl -s -o /tmp/orchard-verify-ready.$$ -w '%{http_code}' "${BASE_URL}/health/ready")"
+  ready_body="$(cat /tmp/orchard-verify-ready.$$)"
+  rm -f /tmp/orchard-verify-ready.$$
+  echo "OK: /health/live"
+  echo "INFO: /health/ready -> HTTP ${ready_code} ${ready_body}"
+
+  console_code="$(curl -s -o /tmp/orchard-verify-console.$$ -w '%{http_code}' "${BASE_URL}/console")"
+  console_body="$(cat /tmp/orchard-verify-console.$$)"
+  rm -f /tmp/orchard-verify-console.$$
+  if [[ "$console_code" != "200" ]]; then
+    echo "FAIL: GET /console -> HTTP ${console_code}"
+    exit 1
+  fi
+  if ! grep -q "Orchard Console" <<<"$console_body"; then
+    echo "FAIL: /console body missing 'Orchard Console'"
+    exit 1
+  fi
+
+  echo "OK: /console loads (dev auth: none)"
+  echo "OK: verification instance healthy (pid ${pid}, port ${PORT})"
+}
+
+cmd_stop() {
+  [[ -f "$META_FILE" ]] && source "$META_FILE"
+
+  if [[ ! -f "$PID_FILE" ]]; then
+    echo "==> No pid file; nothing to stop"
+    return 0
+  fi
+
+  pid="$(cat "$PID_FILE")"
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "==> Stopping verification dev server (pid ${pid})"
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 30); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "==> Sending SIGTERM did not exit; sending SIGKILL"
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  else
+    echo "==> pid ${pid} already stopped"
+  fi
+
+  rm -f "$PID_FILE"
+  echo "==> Stopped"
+}
+
+cmd_meta() {
+  write_meta
+  cat "$META_FILE"
+}
+
+cmd_curl() {
+  [[ -f "$META_FILE" ]] && source "$META_FILE"
+  curl -sS "${BASE_URL}$*"
+}
+
+main() {
+  cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    launch) cmd_launch "$@" ;;
+    bootstrap) cmd_bootstrap "$@" ;;
+    doctor) cmd_doctor "$@" ;;
+    stop) cmd_stop "$@" ;;
+    meta) cmd_meta "$@" ;;
+    curl)
+      if (($# == 0)); then
+        echo "error: control-orchard curl expects a path such as /health/live" >&2
+        exit 1
+      fi
+      cmd_curl "$@"
+      ;;
+    -h | --help | help | "") usage ;;
+    *)
+      echo "error: unknown command: ${cmd}" >&2
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/.cursor/skills/verify-orchard/scripts/control-orchard.sh
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard.sh
@@ -34,8 +34,8 @@ usage() {
 Usage: control-orchard <command>
 
 Commands:
-  bootstrap Ensure dev node-trust files exist (recovers orphaned DB state)
-  launch    Start source-dev in the background (mise exec -- bin/dev)
+  bootstrap Ensure tmp/dev/node-trust exists (opt-in orphan recover)
+  launch    Start source-dev in the background (mix phx.server)
   doctor    Read-only health check for the verification instance
   stop      Stop the instance started by launch (PID file only)
   meta      Print state paths for the current run
@@ -45,7 +45,9 @@ Environment:
   ORCHARD_VERIFY_PORT          HTTP port (default: 4000)
   ORCHARD_VERIFY_RUN_ID        Stable run id for state dir naming
   ORCHARD_VERIFY_STATE_DIR     Override state directory
-  ORCHARD_VERIFY_READY_TIMEOUT_SEC  Launch wait timeout (default: 180)
+  ORCHARD_VERIFY_READY_TIMEOUT_SEC  Launch wait timeout (default: 300)
+  ORCHARD_VERIFY_TRUST_RECOVER      Set to 1 to allow wiping orphaned DB trust
+                                    when local node-trust files are missing
 EOF
 }
 
@@ -63,6 +65,7 @@ require_repo() {
 cmd_bootstrap() {
   require_repo
   local trust_root="${ORCHARD_NODE_TRUST_ROOT:-${REPO_ROOT}/tmp/dev/node-trust}"
+  local allow_recover="${ORCHARD_VERIFY_TRUST_RECOVER:-0}"
 
   if [[ -e "${trust_root}/current" ]]; then
     echo "==> Node trust files present at ${trust_root}/current"
@@ -74,9 +77,12 @@ cmd_bootstrap() {
   (
     cd "$REPO_ROOT"
     export MIX_ENV=dev
+    export ORCHARD_VERIFY_TRUST_RECOVER="$allow_recover"
     mise exec -- mix run --no-start -e '
       Application.ensure_all_started(:logger)
       Application.load(:orchard_controller)
+
+      allow_recover? = System.get_env("ORCHARD_VERIFY_TRUST_RECOVER") == "1"
 
       init = fn ->
         Ecto.Migrator.with_repo(Orchard.Repo, fn _repo ->
@@ -105,14 +111,26 @@ cmd_bootstrap() {
         :ok ->
           IO.puts("==> Node trust initialized")
 
-        {:error, _} ->
-          IO.puts("==> Trust init failed; recovering orphaned DB trust without local files")
+        {:error, :not_found} when allow_recover? ->
+          IO.puts("==> Orphaned DB trust (local files missing); recovering with ORCHARD_VERIFY_TRUST_RECOVER=1")
           {:ok, _, _} = recover.()
 
           case init.() do
             :ok -> IO.puts("==> Node trust initialized after orphan recovery")
             other -> IO.inspect(other); System.halt(1)
           end
+
+        {:error, :not_found} ->
+          IO.puts(:stderr, """
+          error: orchard_dev has cluster trust rows but #{System.get_env("ORCHARD_NODE_TRUST_ROOT") || "tmp/dev/node-trust"} has no current files.
+          Refusing to delete shared DB trust by default (this would disrupt an existing make dev session).
+          Restore the missing node-trust files, or re-run with ORCHARD_VERIFY_TRUST_RECOVER=1 only if you intend to wipe and re-init local trust.
+          """)
+          System.halt(1)
+
+        {:error, reason} ->
+          IO.puts(:stderr, "error: node trust init failed: #{inspect(reason)}")
+          System.halt(1)
       end
     '
   )
@@ -120,7 +138,6 @@ cmd_bootstrap() {
 
 cmd_launch() {
   require_repo
-  cmd_bootstrap
   write_meta
 
   if [[ -f "$PID_FILE" ]]; then
@@ -143,6 +160,8 @@ cmd_launch() {
     echo "error: PostgreSQL is not accepting connections on ${PGHOST:-localhost}:${PGPORT:-5432}" >&2
     exit 1
   fi
+
+  cmd_bootstrap
 
   echo "==> Ensuring dev database..."
   (

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -599,21 +599,31 @@ config :orchard_controller, :console,
   username: nil,
   password: nil
 
+verify_mode? = System.get_env("ORCHARD_VERIFY_MODE") == "1"
+
 config :orchard_controller, Orchard.API.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: String.to_integer(System.get_env("PORT") || "4000")],
   check_origin: false,
   cors_origins: [],
-  code_reloader: true,
+  code_reloader: not verify_mode?,
   debug_errors: true,
   secret_key_base: String.duplicate("dev-secret-", 8),
-  watchers: [
-    esbuild: {Esbuild, :install_and_run, [:orchard, ~w(--sourcemap=inline --watch)]},
-    tailwind: {Tailwind, :install_and_run, [:orchard, ~w(--watch)]}
-  ],
-  live_reload: [
-    patterns: [
-      ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
-      ~r"lib/orchard/console/.*(ex)$",
-      ~r"lib/orchard/console/.*(heex)$"
-    ]
-  ]
+  watchers:
+    if(verify_mode?,
+      do: [],
+      else: [
+        esbuild: {Esbuild, :install_and_run, [:orchard, ~w(--sourcemap=inline --watch)]},
+        tailwind: {Tailwind, :install_and_run, [:orchard, ~w(--watch)]}
+      ]
+    ),
+  live_reload:
+    if(verify_mode?,
+      do: [],
+      else: [
+        patterns: [
+          ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
+          ~r"lib/orchard/console/.*(ex)$",
+          ~r"lib/orchard/console/.*(heex)$"
+        ]
+      ]
+    )


### PR DESCRIPTION
## Why

Agents need a scripted way to drive source-dev Orchard the way an operator does, then keep proof. Without that, Console and health checks stay as ad-hoc curl or "trust the LiveView tests".

This adds `verify-orchard` under `.cursor/skills/`, with a `control-orchard` helper and a small feature map for Overview, navigation, health probes, Models, and Settings.

## Scope

- Adds `.cursor/skills/verify-orchard/SKILL.md` and `features/` recipes.
- Adds `control-orchard` / `control-orchard.sh`: bootstrap node trust, launch, doctor, stop, meta, curl.
- Changes `config/dev.exs` so `ORCHARD_VERIFY_MODE=1` turns off Phoenix code reload and asset watchers. Verification launch sets that env var and runs `mix assets.build` before `mix phx.server`.

Out of scope: Playground / `/v1` inference proofs (they need model import and tenant grants), and packaged BEAM installs.

## Tradeoffs

- Verification boots `mix phx.server`, not interactive `bin/dev` / IEx. Same Mix env, better for background PID control.
- `bootstrap` can clear orphaned `cluster_identities` / `node_trust_*` rows when DB trust exists but `tmp/dev/node-trust` files do not. That is local-dev recovery only.
- Browser MCP from this environment could not reach `127.0.0.1`, so the first proof used HTTP capture against `/health/live` and `/console`. Feature recipes still prefer cursor-ide-browser when the browser shares the host.

## Blast Radius

- Touches agent workflow and local `config/dev.exs` only when `ORCHARD_VERIFY_MODE=1`.
- Normal `make dev` is unchanged.
- Shares the `orchard_dev` database with source-dev. Do not launch on a port that already has `make dev`.

## Verification

- `control-orchard bootstrap`: recovered missing `tmp/dev/node-trust` against orphaned DB trust.
- `control-orchard launch` + `control-orchard doctor`: `/health/live` returned `{"status":"ok"}`; `/console` returned 200 with `Orchard Console`.
- Overview proof: wrote artifacts under the run state dir (`health-live.json`, `console.html`, `proof.txt`); artifacts remained after `control-orchard stop`.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790385139&installation_model_id=428414&pr_number=297&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F297&signature=e46a34a59ba75531d169dc013228fa33d1af2ff9c94454808991b0f9cf910966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a project-local verification skill for launching and exercising Orchard Console workflows while retaining proof artifacts.
- Adds feature recipes for Console navigation, health probes, Models, Settings, and Overview.
- Adds a lifecycle helper for trust bootstrap, launch, diagnostics, metadata, HTTP requests, and shutdown.
- Adds an opt-in verification mode that disables development reloaders and asset watchers.
- Fixes the previously reported trust-recovery path by requiring explicit recovery opt-in and checking port ownership before bootstrap during launch.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .cursor/skills/verify-orchard/scripts/control-orchard.sh | Adds the verification lifecycle helper and now limits destructive trust recovery to the explicit orphan-recovery mode after launch checks port availability. |
| config/dev.exs | Disables code reloading, asset watchers, and live reload only when verification mode is enabled. |
| .cursor/skills/verify-orchard/SKILL.md | Documents the source-development verification workflow, isolation rules, evidence requirements, and explicit trust-recovery behavior. |
| .cursor/skills/verify-orchard/features/README.md | Defines the verification feature contract and links the operator-facing scenarios. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[control-orchard launch] --> B{PID already active?}
    B -- Yes --> X[Abort]
    B -- No --> C{HTTP port occupied?}
    C -- Yes --> X
    C -- No --> D{PostgreSQL ready?}
    D -- No --> X
    D -- Yes --> E[Bootstrap node trust]
    E --> F{Trust files present or initialized?}
    F -- No, orphaned DB trust --> G{Recovery explicitly enabled?}
    G -- No --> X
    G -- Yes --> H[Clear orphaned trust rows and reinitialize]
    F -- Yes --> I[Migrate and build assets]
    H --> I
    I --> J[Start Phoenix in verification mode]
    J --> K[Poll liveness endpoint]
    K --> L[Run doctor and verification recipes]
    L --> M[Capture proof artifacts]
    M --> N[Stop recorded PID]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(verify): gate orphan trust recovery ..."](https://github.com/kapitan-ai/orchard/commit/e15b4cb19e136b85d473fb94c46f15982de94353) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57331701)</sub>

<!-- /greptile_comment -->