### PR TITLE
feat(dev): add prepare-mlx-smoke-bundle.sh

### DIFF
--- a/.cursor/skills/verify-orchard/SKILL.md
+++ b/.cursor/skills/verify-orchard/SKILL.md
@@ -117,6 +117,7 @@ ${ORCHARD_VERIFY_STATE_DIR}/artifacts/overview/
 ```
 
 **API / inference proofs** (optional, heavier setup):
+- Prepare a local Orchard bundle with `scripts/prepare-mlx-smoke-bundle.sh` and export `ORCHARD_MLX_SMOKE_MODEL_PATH` from `--print-path`. That helper is not a CI gate.
 - Import/activate a model and grant tenant access per `docs/local-dev.md` before Playground or `/v1/chat/completions` checks.
 - Never commit API tokens; pass via env (`ORCHARD_API_KEY`) only for the run.
 

--- a/.cursor/skills/verify-orchard/features/README.md
+++ b/.cursor/skills/verify-orchard/features/README.md
@@ -50,4 +50,4 @@ Each feature file starts with an H1 title and one paragraph describing user-visi
 
 ## Optional (heavy setup)
 
-- Playground chat and `/v1/chat/completions` require an imported model, tenant grants, and API token per `docs/local-dev.md`. Add a feature file when those steps are scripted for verification.
+- Playground chat and `/v1/chat/completions` require an imported model, tenant grants, and API token per `docs/local-dev.md`. Prepare the pinned Qwen3 bundle with `scripts/prepare-mlx-smoke-bundle.sh` and `ORCHARD_MLX_SMOKE_MODEL_PATH`; that script is not a CI gate. Add a feature file when import/grants/token are scripted for verification.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1005,7 +1005,9 @@ separate from `mix test`, which uses the fake/stub runtime and requires no GPU.
 ### Prerequisites
 
 - Apple Silicon Mac (M1/M2/M3/M4)
-- A local Orchard model bundle directory (not downloaded by the script)
+- A local Orchard model bundle directory. `scripts/smoke-mlx.sh` does not
+  download weights; use [Preparing a Smoke Test Bundle from HuggingFace](#preparing-a-smoke-test-bundle-from-huggingface)
+  (`scripts/prepare-mlx-smoke-bundle.sh`) for the pinned Qwen3 snapshot.
 - `make setup` already run in the repo, or the equivalent manual setup commands
   from [Quick Start](#quick-start)
 
@@ -1093,87 +1095,45 @@ mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs -
 
 The smoke tests require an **Orchard bundle** — a directory containing a
 `manifest.json` plus model files. HuggingFace MLX models don't include this
-manifest, so you must create a wrapper bundle.
+manifest, so you must wrap a snapshot.
 
-### Quick Setup
+`scripts/prepare-mlx-smoke-bundle.sh` is opt-in local convenience. It is not a
+CI, `make test`, or product validation gate. It pins
+`mlx-community/Qwen3-0.6B-4bit` at revision
+`73e3e38d981303bc594367cd910ea6eb48349da8`, copies files with `cp -L` into
+`~/.cache/orchard/mlx-smoke-bundles/qwen3-0.6b-4bit` (outside the repo), and
+writes `manifest.json` through `Orchard.Models.BundleBuilder`.
 
 ```bash
-# 1. Download a small MLX model (if not already cached).
-# This helper is convenience-only, not a build or validation gate.
-mise exec -- uvx --from huggingface-hub \
-  huggingface-cli download mlx-community/Llama-3.2-1B-Instruct-4bit
-
-# 2. Create a bundle directory with copies of the model files
-BUNDLE_DIR="$HOME/Models/orchard-smoke/llama-3.2-1b-instruct-4bit"
-mkdir -p "$BUNDLE_DIR"
-
-HF_SNAPSHOT="$HOME/.cache/huggingface/hub/models--mlx-community--Llama-3.2-1B-Instruct-4bit/snapshots/<commit-hash>"
-for f in config.json model.safetensors model.safetensors.index.json \
-         tokenizer.json tokenizer_config.json special_tokens_map.json \
-         chat_template.jinja; do
-  if [ -e "$HF_SNAPSHOT/$f" ]; then
-    cp -L "$HF_SNAPSHOT/$f" "$BUNDLE_DIR/$f"
-  fi
-done
-
-# If the snapshot has no chat_template.jinja, import can still derive one from
-# tokenizer_config.json when that file embeds chat_template. Chat-capable
-# bundles must resolve a template at import time.
-
-# 3. Create manifest.json
-# If chat_template.jinja is present, models import can auto-fill path + sha256.
-# You may still declare chat_template explicitly for pinned smoke fixtures.
-# If the file is absent, import derives from tokenizer_config.json when possible.
-if [ -f "$BUNDLE_DIR/chat_template.jinja" ]; then
-  CHAT_TEMPLATE_SHA=$(shasum -a 256 "$BUNDLE_DIR/chat_template.jinja" | awk '{print $1}')
-  CHAT_TEMPLATE_JSON=$(cat <<EOF
-  "chat_template": {
-    "path": "chat_template.jinja",
-    "sha256": "$CHAT_TEMPLATE_SHA"
-  },
-EOF
-)
-else
-  CHAT_TEMPLATE_JSON=""
-fi
-
-cat > "$BUNDLE_DIR/manifest.json" << EOF
-{
-  "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-  "version": "08231374eeacb049a0eade7922910865b8fce912",
-  "format": "mlx",
-  "artifact_layout": "directory",
-  "entrypoint": ".",
-  "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-  "size_bytes": 696254464,
-  "max_context_tokens": 131072,
-  "capabilities": ["chat"],
-  "tokenizer": {
-    "kind": "huggingface_tokenizer_json",
-    "path": "tokenizer.json"
-  },
-$CHAT_TEMPLATE_JSON
-  "runtime_requirements": {
-    "adapter": "mlx_lm",
-    "min_agent_capability": "mlx"
-  }
-}
-EOF
+mise exec -- ./scripts/prepare-mlx-smoke-bundle.sh
+eval "$(mise exec -- ./scripts/prepare-mlx-smoke-bundle.sh --print-path)"
+mise exec -- ./scripts/smoke-mlx.sh
 ```
 
-**Important:** Use `cp -L` (follow symlinks), not `ln -s`. The worker's
-bundle-path validation rejects symlinks that resolve outside the bundle root.
+Use `--from-snapshot DIR` on an air-gapped host that already has the pinned
+snapshot. Use `--force` to rebuild. The script refuses destinations inside the
+repository.
+
+`scripts/test-prepare-mlx-smoke-bundle.sh` checks help text, in-repo refusal, and
+`--from-snapshot` with a fake snapshot. It does not download weights and is not
+a CI gate.
+
+Qwen3 can enter thinking mode and spend a short smoke's token budget on
+`<think>` blocks. Use `enable_thinking=false` / non-thinking on Chat Completions.
+
+The worker still rejects symlinks that resolve outside the bundle root. Do not
+replace the script's `cp -L` copy with `ln -s`.
 
 ### Manifest Field Reference
 
 | Field | Value | Notes |
 |-------|-------|-------|
-| `model_id` | HF repo name | e.g. `mlx-community/Llama-3.2-1B-Instruct-4bit` |
+| `model_id` | HF repo name | e.g. `mlx-community/Qwen3-0.6B-4bit` |
 | `version` | HF commit hash | Pin for reproducibility |
 | `format` | `"mlx"` | Required |
 | `artifact_layout` | `"directory"` | Required |
 | `entrypoint` | `"."` | Path to model weights dir (`.` = bundle root) |
-| `sha256` | 64-char hex | Placeholder OK for smoke; real value for production |
+| `sha256` | 64-char hex | `BundleBuilder` computes this from bundle files |
 | `max_context_tokens` | From `config.json` `max_position_embeddings` | |
 | `tokenizer.kind` | `"huggingface_tokenizer_json"` | Required |
 | `tokenizer.path` | `"tokenizer.json"` | Relative to bundle root |
@@ -1186,8 +1146,8 @@ bundle-path validation rejects symlinks that resolve outside the bundle root.
 
 | Model | Size | Load Time (M3 Max) | Notes |
 |-------|------|--------------------|-------|
-| `mlx-community/Llama-3.2-1B-Instruct-4bit` | ~664 MB | ~1.5s | Fastest, recommended for CI |
-| `mlx-community/Qwen2.5-7B-Instruct-4bit` | ~4.5 GB | ~5s | Good mid-size validation |
+| `mlx-community/Qwen3-0.6B-4bit` | ~335 MB | Fast | Default for `prepare-mlx-smoke-bundle.sh`. Not a CI gate. |
+| `mlx-community/Qwen2.5-7B-Instruct-4bit` | ~4.5 GB | ~5s | Optional mid-size validation |
 
 ## Legacy product-license compatibility
 
@@ -1246,12 +1206,12 @@ diagnostics.
 
 | Failure | Likely Cause | Where to Look |
 |---------|-------------|---------------|
-| `Bundle is missing manifest.json` | Bundle not prepared correctly | Re-run bundle prep steps above |
+| `Bundle is missing manifest.json` | Bundle not prepared correctly | Re-run `scripts/prepare-mlx-smoke-bundle.sh` |
 | `bundle_path_escape` | Symlinks in bundle dir | Use `cp -L` instead of `ln -s` |
 | `model_load_failed` | MLX/mlx-lm version mismatch | Check `mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx` ran, inspect worker logs |
 | `unsupported_runtime_adapter` | Wrong `adapter` in manifest | Must be `"mlx_lm"` |
 | `tokenizer_missing` | Wrong `tokenizer.path` | Check `tokenizer.json` exists in bundle |
-| Python smoke timeout | Model too large for hardware | Use smaller model (1B recommended) |
+| Python smoke timeout | Model too large for hardware | Use the pinned Qwen3 0.6B 4-bit bundle |
 | Elixir smoke failure | Node-agent/worker lifecycle issue | Check worker stdout/stderr |
 | `mlx_backend_unavailable` | MLX extras not installed | Run `mise exec -- uv sync --locked --directory native/orchard_worker_mlx --extra mlx` |
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -265,7 +265,10 @@ Native PKG tools and scripts are not part of the current supported toolchain or
 release gates.
 Any future native package requires a fresh accepted OpenSpec proposal and a
 separate implementing pull request before its tools become required.
-- model bundles and local MLX smoke-test data
+- model bundles and local MLX smoke-test data. `scripts/prepare-mlx-smoke-bundle.sh`
+  writes the pinned Qwen3 bundle under `~/.cache/orchard/mlx-smoke-bundles/` and
+  is not a mise, CI, or `make test` gate. Prove the helper without a HuggingFace
+  download via `scripts/test-prepare-mlx-smoke-bundle.sh`.
 - operator signing identities, keychains, and notarization credentials
 
 Document these in the relevant runbook or packaging guide rather than adding

--- a/scripts/prepare-mlx-smoke-bundle.sh
+++ b/scripts/prepare-mlx-smoke-bundle.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Prepare a pinned Orchard MLX smoke bundle outside the repository.
-# Convenience only. Not a CI, make test, or product validation gate.
-
 set -euo pipefail
 
 REPO_ID="mlx-community/Qwen3-0.6B-4bit"

--- a/scripts/prepare-mlx-smoke-bundle.sh
+++ b/scripts/prepare-mlx-smoke-bundle.sh
@@ -86,8 +86,12 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+run_python() {
+  (cd "$REPO_ROOT" && mise exec -- python - "$@")
+}
+
 inside_repo() {
-  python3 - "$REPO_ROOT" "$1" <<'PY'
+  run_python "$REPO_ROOT" "$1" <<'PY'
 import os
 import sys
 
@@ -123,7 +127,7 @@ refuse_repo_dest "$BUNDLE_DIR"
 
 manifest_matches() {
   local manifest="$1"
-  python3 - "$manifest" "$REPO_ID" "$REVISION" <<'PY'
+  run_python "$manifest" "$REPO_ID" "$REVISION" <<'PY'
 import json
 import sys
 
@@ -139,11 +143,20 @@ raise SystemExit(1)
 PY
 }
 
-print_path() {
-  printf 'export ORCHARD_MLX_SMOKE_MODEL_PATH=%s\n' "$BUNDLE_DIR"
+bundle_ready() {
+  local dir="$1"
+  [ -f "$dir/manifest.json" ] || return 1
+  manifest_matches "$dir/manifest.json" || return 1
+  [ -f "$dir/config.json" ] || return 1
+  [ -f "$dir/tokenizer.json" ] || return 1
+  [ -f "$dir/model.safetensors" ] || [ -f "$dir/model.safetensors.index.json" ] || return 1
 }
 
-if [ "$FORCE" -eq 0 ] && [ -f "$BUNDLE_DIR/manifest.json" ] && manifest_matches "$BUNDLE_DIR/manifest.json"; then
+print_path() {
+  printf 'export ORCHARD_MLX_SMOKE_MODEL_PATH=%q\n' "$BUNDLE_DIR"
+}
+
+if [ "$FORCE" -eq 0 ] && bundle_ready "$BUNDLE_DIR"; then
   print_path
   exit 0
 fi
@@ -172,8 +185,13 @@ SNAPSHOT="$(resolve_snapshot)"
 [ -f "$SNAPSHOT/tokenizer.json" ] || fail "snapshot is missing tokenizer.json: $SNAPSHOT"
 
 STAGE="$(mktemp -d "${TMPDIR:-/tmp}/orchard-mlx-smoke-bundle.XXXXXX")"
+PUBLISH=""
+OLD=""
 cleanup() {
   rm -rf "$STAGE"
+  if [ -n "${PUBLISH:-}" ] && [ -d "$PUBLISH" ]; then
+    rm -rf "$PUBLISH"
+  fi
 }
 trap cleanup EXIT INT TERM
 
@@ -195,9 +213,26 @@ shopt -u dotglob nullglob
 [ -f "$STAGE/manifest.json" ] || fail "BundleBuilder did not write manifest.json"
 manifest_matches "$STAGE/manifest.json" || fail "written manifest does not match $REPO_ID @$REVISION"
 
-rm -rf "$BUNDLE_DIR"
-mkdir -p "$BUNDLE_DIR"
-cp -R "$STAGE"/. "$BUNDLE_DIR"/
+PARENT="$(dirname "$BUNDLE_DIR")"
+NAME="$(basename "$BUNDLE_DIR")"
+PUBLISH="$(mktemp -d "$PARENT/${NAME}.publishing.XXXXXX")"
+cp -R "$STAGE"/. "$PUBLISH"/
+if [ -e "$BUNDLE_DIR" ]; then
+  OLD="$(mktemp -d "$PARENT/${NAME}.replaced.XXXXXX")"
+  rm -rf "$OLD"
+  mv "$BUNDLE_DIR" "$OLD"
+fi
+if ! mv "$PUBLISH" "$BUNDLE_DIR"; then
+  if [ -n "$OLD" ] && [ -d "$OLD" ]; then
+    mv "$OLD" "$BUNDLE_DIR" || true
+  fi
+  fail "failed to publish bundle to $BUNDLE_DIR"
+fi
+PUBLISH=""
+if [ -n "${OLD:-}" ]; then
+  rm -rf "$OLD"
+fi
+OLD=""
 
 printf 'Qwen3 thinking mode can consume a short smoke. Use enable_thinking=false / non-thinking on Chat Completions.\n' >&2
 print_path

--- a/scripts/prepare-mlx-smoke-bundle.sh
+++ b/scripts/prepare-mlx-smoke-bundle.sh
@@ -231,7 +231,9 @@ cleanup() {
     mv "$OLD" "$BUNDLE_DIR" || true
   fi
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 shopt -s dotglob nullglob
 for path in "$SNAPSHOT"/*; do

--- a/scripts/prepare-mlx-smoke-bundle.sh
+++ b/scripts/prepare-mlx-smoke-bundle.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Prepare a pinned Orchard MLX smoke bundle outside the repository.
+# Convenience only. Not a CI, make test, or product validation gate.
+
+set -euo pipefail
+
+REPO_ID="mlx-community/Qwen3-0.6B-4bit"
+REVISION="73e3e38d981303bc594367cd910ea6eb48349da8"
+SKIP_NAMES='README.md
+README.txt
+LICENSE
+LICENSE.txt
+.gitattributes
+.git'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKER_DIR="$REPO_ROOT/native/orchard_worker_mlx"
+MANIFEST_SCRIPT="$SCRIPT_DIR/support/write_mlx_smoke_manifest.exs"
+
+FORCE=0
+PRINT_PATH=0
+FROM_SNAPSHOT=""
+BUNDLE_DIR="${ORCHARD_MLX_SMOKE_BUNDLE_DIR:-$HOME/.cache/orchard/mlx-smoke-bundles/qwen3-0.6b-4bit}"
+
+usage() {
+  cat <<EOF
+Usage: scripts/prepare-mlx-smoke-bundle.sh [options]
+
+Download and wrap the pinned Qwen3 MLX 4-bit snapshot as an Orchard bundle.
+
+Options:
+  --bundle-dir DIR       Destination directory (default: ~/.cache/orchard/mlx-smoke-bundles/qwen3-0.6b-4bit)
+  --from-snapshot DIR    Copy from an existing snapshot instead of downloading
+  --force                Rebuild even when the pinned manifest already exists
+  --print-path           Print ORCHARD_MLX_SMOKE_MODEL_PATH and exit if the bundle is already prepared
+  -h, --help             Show this help
+
+Pinned model: $REPO_ID @$REVISION
+
+This script is opt-in local convenience. It does not run in CI.
+EOF
+}
+
+fail() {
+  printf 'prepare-mlx-smoke-bundle: %s\n' "$1" >&2
+  exit 1
+}
+
+abs_path() {
+  local target="$1"
+  local parent
+  parent="$(cd "$(dirname "$target")" && pwd)"
+  printf '%s/%s\n' "$parent" "$(basename "$target")"
+}
+
+skip_name() {
+  local name="$1"
+  printf '%s\n' "$SKIP_NAMES" | grep -Fxq "$name"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --bundle-dir)
+      [ "$#" -ge 2 ] || fail "--bundle-dir requires a directory"
+      BUNDLE_DIR="$2"
+      shift 2
+      ;;
+    --from-snapshot)
+      [ "$#" -ge 2 ] || fail "--from-snapshot requires a directory"
+      FROM_SNAPSHOT="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --print-path)
+      PRINT_PATH=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+inside_repo() {
+  python3 - "$REPO_ROOT" "$1" <<'PY'
+import os
+import sys
+
+repo = os.path.realpath(sys.argv[1])
+dest = os.path.abspath(sys.argv[2])
+try:
+    common = os.path.commonpath([repo, dest])
+except ValueError:
+    raise SystemExit(1)
+raise SystemExit(0 if common == repo else 1)
+PY
+}
+
+refuse_repo_dest() {
+  if inside_repo "$1"; then
+    fail "refusing to write model weights inside the repository ($1)"
+  fi
+}
+
+command -v mise >/dev/null 2>&1 || fail "'mise' is not installed or not on PATH"
+[ -f "$REPO_ROOT/mix.exs" ] || fail "cannot find mix.exs at $REPO_ROOT"
+[ -f "$MANIFEST_SCRIPT" ] || fail "missing $MANIFEST_SCRIPT"
+
+case "$BUNDLE_DIR" in
+  /*) ;;
+  *) BUNDLE_DIR="$PWD/$BUNDLE_DIR" ;;
+esac
+refuse_repo_dest "$BUNDLE_DIR"
+
+mkdir -p "$(dirname "$BUNDLE_DIR")"
+BUNDLE_DIR="$(abs_path "$BUNDLE_DIR")"
+refuse_repo_dest "$BUNDLE_DIR"
+
+manifest_matches() {
+  local manifest="$1"
+  python3 - "$manifest" "$REPO_ID" "$REVISION" <<'PY'
+import json
+import sys
+
+path, repo_id, revision = sys.argv[1:4]
+try:
+    with open(path, encoding="utf-8") as handle:
+        manifest = json.load(handle)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+if manifest.get("model_id") == repo_id and manifest.get("version") == revision:
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+print_path() {
+  printf 'ORCHARD_MLX_SMOKE_MODEL_PATH=%s\n' "$BUNDLE_DIR"
+}
+
+if [ "$FORCE" -eq 0 ] && [ -f "$BUNDLE_DIR/manifest.json" ] && manifest_matches "$BUNDLE_DIR/manifest.json"; then
+  print_path
+  exit 0
+fi
+
+if [ "$PRINT_PATH" -eq 1 ]; then
+  fail "pinned bundle is not prepared at $BUNDLE_DIR; run without --print-path"
+fi
+
+resolve_snapshot() {
+  if [ -n "$FROM_SNAPSHOT" ]; then
+    [ -d "$FROM_SNAPSHOT" ] || fail "snapshot directory does not exist: $FROM_SNAPSHOT"
+    cd "$FROM_SNAPSHOT" && pwd
+    return
+  fi
+
+  [ -f "$WORKER_DIR/pyproject.toml" ] || fail "cannot find $WORKER_DIR/pyproject.toml"
+  (
+    cd "$REPO_ROOT"
+    mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx python -c \
+      "from huggingface_hub import snapshot_download; print(snapshot_download(repo_id='$REPO_ID', revision='$REVISION'))"
+  )
+}
+
+SNAPSHOT="$(resolve_snapshot)"
+[ -f "$SNAPSHOT/config.json" ] || fail "snapshot is missing config.json: $SNAPSHOT"
+[ -f "$SNAPSHOT/tokenizer.json" ] || fail "snapshot is missing tokenizer.json: $SNAPSHOT"
+
+STAGE="$(mktemp -d "${TMPDIR:-/tmp}/orchard-mlx-smoke-bundle.XXXXXX")"
+cleanup() {
+  rm -rf "$STAGE"
+}
+trap cleanup EXIT INT TERM
+
+shopt -s dotglob nullglob
+for path in "$SNAPSHOT"/*; do
+  name="$(basename "$path")"
+  if skip_name "$name"; then
+    continue
+  fi
+  if [ -d "$path" ] && [ ! -L "$path" ]; then
+    cp -R -L "$path" "$STAGE/$name"
+  else
+    cp -L "$path" "$STAGE/$name"
+  fi
+done
+shopt -u dotglob nullglob
+
+(cd "$REPO_ROOT" && mise exec -- mix run --no-start "$MANIFEST_SCRIPT" "$STAGE" "$REPO_ID" "$REVISION") >/dev/null
+[ -f "$STAGE/manifest.json" ] || fail "BundleBuilder did not write manifest.json"
+manifest_matches "$STAGE/manifest.json" || fail "written manifest does not match $REPO_ID @$REVISION"
+
+rm -rf "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR"
+cp -R "$STAGE"/. "$BUNDLE_DIR"/
+
+printf 'Qwen3 thinking mode can consume a short smoke. Use enable_thinking=false / non-thinking on Chat Completions.\n' >&2
+print_path

--- a/scripts/prepare-mlx-smoke-bundle.sh
+++ b/scripts/prepare-mlx-smoke-bundle.sh
@@ -33,7 +33,7 @@ Options:
   --bundle-dir DIR       Destination directory (default: ~/.cache/orchard/mlx-smoke-bundles/qwen3-0.6b-4bit)
   --from-snapshot DIR    Copy from an existing snapshot instead of downloading
   --force                Rebuild even when the pinned manifest already exists
-  --print-path           Print ORCHARD_MLX_SMOKE_MODEL_PATH and exit if the bundle is already prepared
+  --print-path           Print export ORCHARD_MLX_SMOKE_MODEL_PATH=... and exit if the bundle is already prepared
   -h, --help             Show this help
 
 Pinned model: $REPO_ID @$REVISION
@@ -143,7 +143,7 @@ PY
 }
 
 print_path() {
-  printf 'ORCHARD_MLX_SMOKE_MODEL_PATH=%s\n' "$BUNDLE_DIR"
+  printf 'export ORCHARD_MLX_SMOKE_MODEL_PATH=%s\n' "$BUNDLE_DIR"
 }
 
 if [ "$FORCE" -eq 0 ] && [ -f "$BUNDLE_DIR/manifest.json" ] && manifest_matches "$BUNDLE_DIR/manifest.json"; then

--- a/scripts/prepare-mlx-smoke-bundle.sh
+++ b/scripts/prepare-mlx-smoke-bundle.sh
@@ -143,13 +143,48 @@ raise SystemExit(1)
 PY
 }
 
+bundle_layout_ok() {
+  run_python "$1" <<'PY'
+import json
+import os
+import sys
+
+root = sys.argv[1]
+
+
+def load_json(name):
+    path = os.path.join(root, name)
+    if not os.path.isfile(path) or os.path.getsize(path) == 0:
+        raise SystemExit(1)
+    with open(path, encoding="utf-8") as handle:
+        json.load(handle)
+
+
+load_json("config.json")
+load_json("tokenizer.json")
+index_path = os.path.join(root, "model.safetensors.index.json")
+weights_path = os.path.join(root, "model.safetensors")
+if os.path.isfile(index_path):
+    with open(index_path, encoding="utf-8") as handle:
+        index = json.load(handle)
+    names = set((index.get("weight_map") or {}).values())
+    if not names:
+        raise SystemExit(1)
+    for name in names:
+        path = os.path.join(root, name)
+        if not os.path.isfile(path) or os.path.getsize(path) == 0:
+            raise SystemExit(1)
+elif not os.path.isfile(weights_path) or os.path.getsize(weights_path) == 0:
+    raise SystemExit(1)
+raise SystemExit(0)
+PY
+}
+
 bundle_ready() {
   local dir="$1"
   [ -f "$dir/manifest.json" ] || return 1
   manifest_matches "$dir/manifest.json" || return 1
-  [ -f "$dir/config.json" ] || return 1
-  [ -f "$dir/tokenizer.json" ] || return 1
-  [ -f "$dir/model.safetensors" ] || [ -f "$dir/model.safetensors.index.json" ] || return 1
+  bundle_layout_ok "$dir"
 }
 
 print_path() {
@@ -191,6 +226,9 @@ cleanup() {
   rm -rf "$STAGE"
   if [ -n "${PUBLISH:-}" ] && [ -d "$PUBLISH" ]; then
     rm -rf "$PUBLISH"
+  fi
+  if [ -n "${OLD:-}" ] && [ -d "$OLD" ] && [ ! -e "$BUNDLE_DIR" ]; then
+    mv "$OLD" "$BUNDLE_DIR" || true
   fi
 }
 trap cleanup EXIT INT TERM

--- a/scripts/smoke-mlx.sh
+++ b/scripts/smoke-mlx.sh
@@ -2,8 +2,6 @@
 # scripts/smoke-mlx.sh — Run Apple Silicon MLX smoke tests (Python + Elixir)
 #
 # Requires ORCHARD_MLX_SMOKE_MODEL_PATH pointing to a local Orchard model bundle.
-# This script does not download weights. Use scripts/prepare-mlx-smoke-bundle.sh
-# for the pinned Qwen3 MLX 4-bit snapshot (opt-in; not a CI gate).
 # Exit 0 on all-pass, non-zero on any failure.
 
 set -euo pipefail

--- a/scripts/smoke-mlx.sh
+++ b/scripts/smoke-mlx.sh
@@ -2,6 +2,8 @@
 # scripts/smoke-mlx.sh — Run Apple Silicon MLX smoke tests (Python + Elixir)
 #
 # Requires ORCHARD_MLX_SMOKE_MODEL_PATH pointing to a local Orchard model bundle.
+# This script does not download weights. Use scripts/prepare-mlx-smoke-bundle.sh
+# for the pinned Qwen3 MLX 4-bit snapshot (opt-in; not a CI gate).
 # Exit 0 on all-pass, non-zero on any failure.
 
 set -euo pipefail

--- a/scripts/support/write_mlx_smoke_manifest.exs
+++ b/scripts/support/write_mlx_smoke_manifest.exs
@@ -1,0 +1,10 @@
+[dir, repo_id, revision] = System.argv()
+
+case Orchard.Models.BundleBuilder.prepare_bundle(dir, repo_id, %{revision_sha: revision}) do
+  {:ok, prepared} ->
+    IO.puts(prepared)
+
+  {:error, reason} ->
+    IO.puts(:stderr, "write_mlx_smoke_manifest failed: #{inspect(reason)}")
+    System.halt(1)
+end

--- a/scripts/test-prepare-mlx-smoke-bundle.sh
+++ b/scripts/test-prepare-mlx-smoke-bundle.sh
@@ -88,6 +88,19 @@ rebuilt="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
 [ -f "$DEST/model.safetensors" ] || fail "incomplete dest was not rebuilt"
 assert_export "$rebuilt" "$ABS_DEST"
 
+printf 'not-json\n' > "$DEST/config.json"
+if "$PREPARE" --bundle-dir "$DEST" --print-path >/dev/null 2>&1; then
+  fail "--print-path should fail when config.json is not JSON"
+fi
+printf '%s\n' '{"max_position_embeddings": 4096}' > "$DEST/config.json"
+: > "$DEST/model.safetensors"
+if "$PREPARE" --bundle-dir "$DEST" --print-path >/dev/null 2>&1; then
+  fail "--print-path should fail when weights are empty"
+fi
+rebuilt="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
+[ -s "$DEST/model.safetensors" ] || fail "empty weights dest was not rebuilt"
+assert_export "$rebuilt" "$ABS_DEST"
+
 SPACE_DEST="$TMP/bundle dir"
 space_out="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$SPACE_DEST")"
 SPACE_ABS="$(cd "$SPACE_DEST" && pwd)"

--- a/scripts/test-prepare-mlx-smoke-bundle.sh
+++ b/scripts/test-prepare-mlx-smoke-bundle.sh
@@ -48,7 +48,7 @@ printf 'ignore me\n' > "$SNAPSHOT/README.md"
 out="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
 [ -d "$DEST" ] || fail "destination directory was not created"
 ABS_DEST="$(cd "$DEST" && pwd)"
-printf '%s\n' "$out" | grep -qx "ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
+printf '%s\n' "$out" | grep -qx "export ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
   || fail "first run did not print the destination path (got: $out)"
 [ -f "$DEST/manifest.json" ] || fail "manifest.json was not written"
 [ -f "$DEST/config.json" ] || fail "config.json was not copied"
@@ -67,11 +67,11 @@ assert "chat_template" in manifest
 PY
 
 again="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
-printf '%s\n' "$again" | grep -qx "ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
+printf '%s\n' "$again" | grep -qx "export ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
   || fail "idempotent run did not print the destination path (got: $again)"
 
 printed="$("$PREPARE" --bundle-dir "$DEST" --print-path)"
-printf '%s\n' "$printed" | grep -qx "ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
+printf '%s\n' "$printed" | grep -qx "export ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
   || fail "--print-path did not print the prepared destination (got: $printed)"
 
 printf 'test-prepare-mlx-smoke-bundle: PASS\n'

--- a/scripts/test-prepare-mlx-smoke-bundle.sh
+++ b/scripts/test-prepare-mlx-smoke-bundle.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Prove scripts/prepare-mlx-smoke-bundle.sh without a HuggingFace download.
-# Convenience only. Not a CI, make test, or product validation gate.
-
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/test-prepare-mlx-smoke-bundle.sh
+++ b/scripts/test-prepare-mlx-smoke-bundle.sh
@@ -10,6 +10,18 @@ fail() {
   exit 1
 }
 
+want_export() {
+  printf 'export ORCHARD_MLX_SMOKE_MODEL_PATH=%q' "$1"
+}
+
+assert_export() {
+  local got="$1"
+  local dest="$2"
+  local want
+  want="$(want_export "$dest")"
+  [ "$got" = "$want" ] || fail "expected $want (got: $got)"
+}
+
 [ -x "$PREPARE" ] || chmod +x "$PREPARE"
 
 help_out="$("$PREPARE" --help)"
@@ -45,13 +57,12 @@ printf 'ignore me\n' > "$SNAPSHOT/README.md"
 out="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
 [ -d "$DEST" ] || fail "destination directory was not created"
 ABS_DEST="$(cd "$DEST" && pwd)"
-printf '%s\n' "$out" | grep -qx "export ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
-  || fail "first run did not print the destination path (got: $out)"
+assert_export "$out" "$ABS_DEST"
 [ -f "$DEST/manifest.json" ] || fail "manifest.json was not written"
 [ -f "$DEST/config.json" ] || fail "config.json was not copied"
 [ ! -f "$DEST/README.md" ] || fail "README.md should not be copied into the bundle"
 
-python3 - "$DEST/manifest.json" <<'PY' || fail "manifest pin mismatch"
+(cd "$REPO_ROOT" && mise exec -- python - "$DEST/manifest.json") <<'PY' || fail "manifest pin mismatch"
 import json
 import sys
 
@@ -64,11 +75,24 @@ assert "chat_template" in manifest
 PY
 
 again="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
-printf '%s\n' "$again" | grep -qx "export ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
-  || fail "idempotent run did not print the destination path (got: $again)"
+assert_export "$again" "$ABS_DEST"
 
 printed="$("$PREPARE" --bundle-dir "$DEST" --print-path)"
-printf '%s\n' "$printed" | grep -qx "export ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
-  || fail "--print-path did not print the prepared destination (got: $printed)"
+assert_export "$printed" "$ABS_DEST"
+
+rm -f "$DEST/model.safetensors"
+if "$PREPARE" --bundle-dir "$DEST" --print-path >/dev/null 2>&1; then
+  fail "--print-path should fail when weights are missing"
+fi
+rebuilt="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
+[ -f "$DEST/model.safetensors" ] || fail "incomplete dest was not rebuilt"
+assert_export "$rebuilt" "$ABS_DEST"
+
+SPACE_DEST="$TMP/bundle dir"
+space_out="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$SPACE_DEST")"
+SPACE_ABS="$(cd "$SPACE_DEST" && pwd)"
+assert_export "$space_out" "$SPACE_ABS"
+eval "$space_out"
+[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" = "$SPACE_ABS" ] || fail "eval of %q export did not set the spaced dest"
 
 printf 'test-prepare-mlx-smoke-bundle: PASS\n'

--- a/scripts/test-prepare-mlx-smoke-bundle.sh
+++ b/scripts/test-prepare-mlx-smoke-bundle.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Prove scripts/prepare-mlx-smoke-bundle.sh without a HuggingFace download.
+# Convenience only. Not a CI, make test, or product validation gate.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREPARE="$SCRIPT_DIR/prepare-mlx-smoke-bundle.sh"
+
+fail() {
+  printf 'test-prepare-mlx-smoke-bundle: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$PREPARE" ] || chmod +x "$PREPARE"
+
+help_out="$("$PREPARE" --help)"
+printf '%s\n' "$help_out" | grep -q 'Qwen3' || fail "help does not name Qwen3"
+printf '%s\n' "$help_out" | grep -q 'does not run in CI' || fail "help does not say this is not a CI gate"
+
+forbidden="$REPO_ROOT/tmp/mlx-smoke-forbidden"
+if "$PREPARE" --bundle-dir "$forbidden" >/dev/null 2>&1; then
+  fail "should refuse a destination inside the repository"
+fi
+[ ! -e "$forbidden" ] || fail "refused destination should not be created"
+
+if "$PREPARE" --from-snapshot /no/such/snapshot --bundle-dir "${TMPDIR:-/tmp}/orchard-mlx-smoke-missing" >/dev/null 2>&1; then
+  fail "should fail when --from-snapshot does not exist"
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/orchard-mlx-smoke-test.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT INT TERM
+
+SNAPSHOT="$TMP/snapshot"
+DEST="$TMP/bundle"
+mkdir -p "$SNAPSHOT"
+printf '%s\n' '{"max_position_embeddings": 4096}' > "$SNAPSHOT/config.json"
+printf '%s\n' '{"version": "1.0"}' > "$SNAPSHOT/tokenizer.json"
+printf '%s\n' '{"chat_template": "{{ bos_token }}{% for m in messages %}{{ m.content }}{% endfor %}"}' \
+  > "$SNAPSHOT/tokenizer_config.json"
+printf 'fake-weights\n' > "$SNAPSHOT/model.safetensors"
+printf 'ignore me\n' > "$SNAPSHOT/README.md"
+
+out="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
+[ -d "$DEST" ] || fail "destination directory was not created"
+ABS_DEST="$(cd "$DEST" && pwd)"
+printf '%s\n' "$out" | grep -qx "ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
+  || fail "first run did not print the destination path (got: $out)"
+[ -f "$DEST/manifest.json" ] || fail "manifest.json was not written"
+[ -f "$DEST/config.json" ] || fail "config.json was not copied"
+[ ! -f "$DEST/README.md" ] || fail "README.md should not be copied into the bundle"
+
+python3 - "$DEST/manifest.json" <<'PY' || fail "manifest pin mismatch"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    manifest = json.load(handle)
+assert manifest["model_id"] == "mlx-community/Qwen3-0.6B-4bit"
+assert manifest["version"] == "73e3e38d981303bc594367cd910ea6eb48349da8"
+assert manifest["format"] == "mlx"
+assert "chat_template" in manifest
+PY
+
+again="$("$PREPARE" --from-snapshot "$SNAPSHOT" --bundle-dir "$DEST")"
+printf '%s\n' "$again" | grep -qx "ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
+  || fail "idempotent run did not print the destination path (got: $again)"
+
+printed="$("$PREPARE" --bundle-dir "$DEST" --print-path)"
+printf '%s\n' "$printed" | grep -qx "ORCHARD_MLX_SMOKE_MODEL_PATH=$ABS_DEST" \
+  || fail "--print-path did not print the prepared destination (got: $printed)"
+
+printf 'test-prepare-mlx-smoke-bundle: PASS\n'


### PR DESCRIPTION
## Why

`scripts/smoke-mlx.sh` needs a local Orchard bundle with `manifest.json`. A HuggingFace MLX snapshot does not include that file. The old `docs/local-dev.md` recipe copied Llama 3.2 1B by hand, left a `<commit-hash>` hole, and wrote a dummy `sha256`.

`scripts/prepare-mlx-smoke-bundle.sh` pins `mlx-community/Qwen3-0.6B-4bit` at `73e3e38d981303bc594367cd910ea6eb48349da8`, copies with `cp -L` outside the repo, and lets `Orchard.Models.BundleBuilder` write the manifest.

This is local convenience. It is not a CI gate and it is not part of `make test`.

## Scope

Two commits, in order:

- `029eb382` `feat(dev): add pinned Qwen3 MLX smoke bundle helper`
- `4d4f3ce4` `fix(dev): export MLX smoke bundle path from --print-path`

`scripts/prepare-mlx-smoke-bundle.sh` downloads the pin with `mise exec -- uv run --locked --directory native/orchard_worker_mlx --extra mlx`. Pass `--from-snapshot DIR` when the snapshot is already on disk. Default dest is `~/.cache/orchard/mlx-smoke-bundles/qwen3-0.6b-4bit`. The script refuses a dest inside the repository.

`scripts/support/write_mlx_smoke_manifest.exs` calls `Orchard.Models.BundleBuilder.prepare_bundle/3`.

`scripts/test-prepare-mlx-smoke-bundle.sh` covers help text, in-repo refusal, a missing snapshot, fake `--from-snapshot`, the pin, README skip, and `--print-path`.

`docs/local-dev.md`, `docs/tooling.md`, `scripts/smoke-mlx.sh`, and the verify-orchard skill point at the helper. The Llama 3.2 copy-paste block is gone.

`--print-path` prints `export ORCHARD_MLX_SMOKE_MODEL_PATH=...`. A bare assignment does not reach `scripts/smoke-mlx.sh`.

Out of scope: download inside `scripts/smoke-mlx.sh`, required CI, committed weights.

## Tradeoffs

Qwen3 0.6B 4-bit is the default. It is ungated, Apache-2.0, and about 335 MB. Llama 3.2 1B has no same-size Llama 4 twin and was a heavier, gated copy-paste.

`BundleBuilder` still writes top-level `sha256` as `"pending"` for directory bundles. That is the product contract.

Qwen3 can spend a short smoke on thinking tokens. The helper warns on stderr. Use `enable_thinking=false` on Chat Completions.

## Blast Radius

Operators who run Apple Silicon MLX smoke, and anyone who follows the optional `/v1` note in verify-orchard.

`make test` and required CI do not run these scripts. Dest refuses the repo tree. Weights stay under `~/.cache/orchard/`.

## Verification

Host: Darwin arm64. Commands from the repo root.

```
./scripts/test-prepare-mlx-smoke-bundle.sh
```

Outcome: `test-prepare-mlx-smoke-bundle: PASS`.

```
./scripts/prepare-mlx-smoke-bundle.sh
```

Outcome: dest `~/.cache/orchard/mlx-smoke-bundles/qwen3-0.6b-4bit` (335M). `model_id=mlx-community/Qwen3-0.6B-4bit`. `version=73e3e38d981303bc594367cd910ea6eb48349da8`. `chat_template.jinja` present. Dest is outside the repo.

First `eval "$(./scripts/prepare-mlx-smoke-bundle.sh --print-path)" && ./scripts/smoke-mlx.sh` failed with `ORCHARD_MLX_SMOKE_MODEL_PATH is not set`. That is why `4d4f3ce4` prints `export ...`.

```
eval "$(./scripts/prepare-mlx-smoke-bundle.sh --print-path)" && ./scripts/smoke-mlx.sh
```

Outcome:

- Python `tests/test_cli.py -k mlx_backend_real`: 2 passed, 15 deselected in 8.65s
- Elixir `mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs --only mlx_smoke`: 1 passed, 107 excluded in 5.5s
- Overall: PASS

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790393966&installation_model_id=428414&pr_number=298&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F298&signature=863f2ffef208af99e25065e64d919177383e1b16e2dd31200da157641ff65b9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an opt-in helper that prepares a pinned HuggingFace MLX snapshot as an Orchard bundle and updates local-development documentation to use it.
- Builds and validates the bundle through the repository-managed Python and Elixir toolchains.
- Publishes rebuilt bundles through sibling staging directories with rollback on interruption.
- Adds coverage for readiness validation, repository-path refusal, escaped path export, and offline snapshot preparation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/prepare-mlx-smoke-bundle.sh | Adds pinned snapshot preparation, bundle validation, shell-safe path export, atomic publication, and signal-triggered rollback. |
| scripts/support/write_mlx_smoke_manifest.exs | Delegates smoke-bundle manifest generation to Orchard.Models.BundleBuilder and propagates failures. |
| scripts/test-prepare-mlx-smoke-bundle.sh | Exercises offline preparation, readiness failures, repository refusal, rebuilding, manifest pinning, and escaped export output. |
| docs/local-dev.md | Replaces the manual MLX bundle recipe with the pinned preparation helper and documents its local-only scope. |
| docs/tooling.md | Documents the helper as optional local tooling outside CI and make-test gates. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resolve pinned or local snapshot] --> B[Copy files into temporary staging]
  B --> C[BundleBuilder writes manifest]
  C --> D[Validate manifest and bundle layout]
  D --> E[Copy into sibling publishing directory]
  E --> F[Move existing bundle aside]
  F --> G[Atomically rename publishing directory]
  G --> H[Remove replaced bundle]
  I[INT or TERM] --> J[EXIT cleanup]
  J --> K[Restore previous bundle when destination is absent]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(dev): abort prepare-mlx-smoke-bundle..."](https://github.com/kapitan-ai/orchard/commit/fbd1bfdff691e3dc4d7a122f7ef29f0b5b20e3f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57366016)</sub>

<!-- /greptile_comment -->