### PR TITLE
docs(portal): reconcile invitation lifecycle contract

### DIFF
--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -1,11 +1,13 @@
 defmodule OrchardConsole.TenantDetailLiveTest do
   use Orchard.ConnCase, async: false
 
+  import Ecto.Query
   import Phoenix.LiveViewTest
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance
   alias Orchard.Governance.AuditLog
+  alias Orchard.Governance.PortalInviteToken
   alias Orchard.Repo
 
   @moduletag :live
@@ -397,6 +399,38 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "Invited"
       assert {:ok, [user]} = Governance.list_portal_users(tenant)
       assert user.email == "dev@example.com"
+    end
+
+    test "invite form creates an invited Portal User without issuing a token or URL", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      created =
+        view
+        |> form("#tenant-portal-invite-form", portal_invite: %{email: "dev@example.com"})
+        |> render_submit()
+
+      assert created =~ "Invited"
+      refute created =~ "tenant-portal-invite-url-card"
+      refute created =~ "/portal/#{tenant.slug}/invites/"
+      assert {:ok, [user]} = Governance.list_portal_users(tenant)
+      assert user.status == "invited"
+
+      assert Repo.aggregate(
+               from(row in PortalInviteToken, where: row.portal_user_id == ^user.id),
+               :count
+             ) == 0
+
+      issued = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
+      assert issued =~ "tenant-portal-invite-url-card"
+      assert issued =~ "/portal/#{tenant.slug}/invites/orchard_pi_"
+
+      assert Repo.aggregate(
+               from(row in PortalInviteToken, where: row.portal_user_id == ^user.id),
+               :count
+             ) == 1
     end
 
     test "Copy invite reissues a transient URL and disable leaves owned keys alone", %{

--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -1,13 +1,11 @@
 defmodule OrchardConsole.TenantDetailLiveTest do
   use Orchard.ConnCase, async: false
 
-  import Ecto.Query
   import Phoenix.LiveViewTest
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance
   alias Orchard.Governance.AuditLog
-  alias Orchard.Governance.PortalInviteToken
   alias Orchard.Repo
 
   @moduletag :live
@@ -399,38 +397,6 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "Invited"
       assert {:ok, [user]} = Governance.list_portal_users(tenant)
       assert user.email == "dev@example.com"
-    end
-
-    test "invite form creates an invited Portal User without issuing a token or URL", %{
-      conn: conn,
-      tenant: tenant
-    } do
-      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
-
-      created =
-        view
-        |> form("#tenant-portal-invite-form", portal_invite: %{email: "dev@example.com"})
-        |> render_submit()
-
-      assert created =~ "Invited"
-      refute created =~ "tenant-portal-invite-url-card"
-      refute created =~ "/portal/#{tenant.slug}/invites/"
-      assert {:ok, [user]} = Governance.list_portal_users(tenant)
-      assert user.status == "invited"
-
-      assert Repo.aggregate(
-               from(row in PortalInviteToken, where: row.portal_user_id == ^user.id),
-               :count
-             ) == 0
-
-      issued = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
-      assert issued =~ "tenant-portal-invite-url-card"
-      assert issued =~ "/portal/#{tenant.slug}/invites/orchard_pi_"
-
-      assert Repo.aggregate(
-               from(row in PortalInviteToken, where: row.portal_user_id == ^user.id),
-               :count
-             ) == 1
     end
 
     test "Copy invite reissues a transient URL and disable leaves owned keys alone", %{

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -521,7 +521,9 @@ When raw decision debug JSON is shown, apply the same key-based unsafe-key deny-
 
 The Organization detail surface manages Portal Users through three stacked Console cards.
 The first card is the Portal User invite form, with an email field and a navy primary **Invite** action.
-The second card is a transient sibling that appears only after an invite is issued or reissued and shows the Portal Invite URL once with its expiry and a navy **Copy invite** action.
+Submitting **Invite** creates the Portal User in `invited` status without issuing a token or showing a Portal Invite URL.
+The operator then uses **Copy invite** on that invited Portal User to issue the first token.
+The second card is a transient sibling that appears only after the first or a later **Copy invite** action succeeds and shows the Portal Invite URL once with a navy **Copy invite URL** action.
 The show-once card is not a flash, modal, or recoverable secret store.
 Disabling the Portal User the shown URL belongs to dismisses the card, because disablement invalidates that invite.
 Disabling any other Portal User leaves the card in place.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -297,8 +297,9 @@ A Portal User is not a Public Inference principal, Operator, Service Account, or
 _Avoid_: User account, Portal Developer, Tenant Admin, Owner Contact, Service Account
 
 **Portal Invite**:
-A single-use expiring token the operator can recopy from Console while the Portal User is invited.
-Each copy replaces the unused token.
+A single-use expiring token the operator issues and reissues with Copy invite from Console while the Portal User is invited.
+Creating the Portal User issues no token and shows no invite URL.
+Each Copy invite replaces any previous unused token.
 Orchard stores only the hash.
 _Avoid_: Persisted plaintext invite URL, magic link email, SMTP invite, Owner Contact
 

--- a/docs/operator-journey.md
+++ b/docs/operator-journey.md
@@ -208,12 +208,13 @@ It is not a claim about the current build.
 
 ### Target Developer Portal Access
 
-1. The operator opens the Organization in Console and invites a Portal User by email.
-2. Console shows the newly issued Portal Invite URL once, and the operator delivers it to that developer through an out-of-band channel.
-3. While the Portal User remains invited, **Copy invite** reissues the invite with a fresh hashed token and extended expiry, invalidates the previous unused token, and shows the replacement URL once for copying.
-4. The developer redeems the Portal Invite, chooses a password, and signs in to the Organization-scoped Developer Portal.
-5. When access must end, the operator disables that Portal User, which atomically invalidates every outstanding invite, ends only that user's portal sessions, and does not automatically revoke minted API Keys.
-6. The operator reviews that Portal User's portal-minted keys in Console and may revoke selected keys by displayed prefix when key access must also end.
+1. The operator opens the Organization in Console and creates a Portal User in `invited` status by email.
+2. Console shows the invited Portal User without issuing a token or displaying a Portal Invite URL.
+3. The operator selects **Copy invite** to issue the first single-use token, and Console shows the Portal Invite URL once for out-of-band delivery.
+4. While the Portal User remains invited, each later **Copy invite** action deletes the previous unused invite row, issues a fresh hash-only token with an extended expiry, and shows the replacement URL once.
+5. The developer redeems the Portal Invite, chooses a password, and signs in to the Organization-scoped Developer Portal.
+6. When access must end, the operator disables that Portal User, which atomically deletes every outstanding invite, ends only that user's portal sessions, and does not automatically revoke minted API Keys.
+7. The operator separately reviews Organization API Keys in Console and deliberately revokes known keys when key access must also end.
 
 ### Target Controller-Only Journey
 

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/design.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/design.md
@@ -1,0 +1,55 @@
+## Context
+
+PR #284 reconciled the apex Portal contract with shipped delete-based invite invalidation, Organization-bound invited-only redemption, and the canonical POST route.
+PR #291 later synchronized the accepted Developer Portal capability and removed the prior password-replacement claim.
+The remaining live ambiguity is the boundary between creating a Portal User and issuing the first Portal Invite.
+The original 2026-08-14 OpenSpec package still records earlier password-replacement and invalidation-state intent, but it is an archived historical artifact rather than current product truth.
+
+## Decisions
+
+### Portal User Creation And Portal Invite Issuance Stay Separate
+
+The **Invite** form creates a Portal User in `invited` status.
+It does not mint or store a Portal Invite token and does not return or display a Portal Invite URL.
+The first **Copy invite** action issues the initial Portal Invite.
+Each later **Copy invite** action uses the same issuance path to replace the prior unused invite.
+
+### Deletion Is The Only Invite Invalidation Record
+
+Each Copy invite action deletes any prior invite row before storing one replacement hash-only row.
+Portal User disablement deletes every outstanding unused invite row in the same transaction as the status and session changes.
+Orchard retains no invite invalidation tombstone, revocation record, or separate invite-state column.
+Redeemed state remains the `redeemed_at` value on the single stored invite row and does not authorize active-user recovery.
+
+### The Canonical Redemption Route Remains The Shipped Route
+
+Invite redemption uses `POST /portal/:organization_slug/invites/:token`.
+The route Organization and the Portal User's current `invited` status are rechecked before mutation.
+This reconciliation introduces no compatibility route and no route-independent redemption seam.
+
+### Historical OpenSpec Packages Are Not Rewritten
+
+The archived 2026-08-14 package remains unchanged because it records the intent reviewed at that time.
+Current truth comes from `SPEC.md`, the accepted capability spec, the later PR #284 archive, and shipped behavior.
+This package records the present reconciliation without attributing later decisions to the earlier package's reviewers.
+
+### Owner-Gated Future Slices Remain Undefined
+
+Active-user recovery, audit vocabulary, and neutral key-attribution labels require separate owner decisions.
+This change records them only as non-goals and does not create requirements, scenarios, labels, or implementation tasks for them.
+Issue #270 remains independent.
+
+## Alternatives Rejected
+
+- Updating `SPEC.md` was rejected because the apex contract is already complete and correct.
+- Rewriting the archived 2026-08-14 package was rejected because it would obscure the decision chronology.
+- Adding `invalidated_at`, retained history, or a separate invite-state column was rejected because it conflicts with the current apex contract.
+- Treating **Copy invite** as active-user recovery was rejected because current redemption is invited-only and recovery semantics remain owner-gated.
+- Defining audit vocabulary or key-attribution labels was rejected because no authoritative decision currently fixes those contracts.
+
+## Validation And Archive Plan
+
+The active change is validated strictly before archive.
+The accepted capability spec is synchronized directly because this package reconciles behavior that is already accepted and shipped.
+After review, archive this package with `--skip-specs` so the synchronized accepted spec is not applied twice.
+Then validate all active changes and accepted specs strictly and inspect the accepted capability for placeholder prose.

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/design.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/design.md
@@ -21,6 +21,13 @@ Portal User disablement deletes every outstanding unused invite row in the same 
 Orchard retains no invite invalidation tombstone, revocation record, or separate invite-state column.
 Redeemed state remains the `redeemed_at` value on the single stored invite row and does not authorize active-user recovery.
 
+### Every Copy Invite Action Ends Standing Sessions
+
+`copy_invite_transaction/4` deletes the Portal User's sessions on every Copy invite action, including the initial issuance.
+The accepted session-termination sentence previously named only invite reissue, which under-named the shipped behavior once the first Copy invite became the initial issuance path.
+The reconciled sentence names initial invite issuance alongside reissue, redemption, and disablement.
+This is a naming correction to already-shipped behavior and requires no product code, migration, or test change.
+
 ### The Canonical Redemption Route Remains The Shipped Route
 
 Invite redemption uses `POST /portal/:organization_slug/invites/:token`.

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/proposal.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`SPEC.md` and shipped Portal behavior already agree that creating a Portal User and issuing a Portal Invite are separate actions.
+The accepted Developer Portal capability and operator-facing documentation do not state that boundary consistently, which can make Portal User creation read as immediate token issuance.
+The accepted capability also needs to name deletion as the invalidation mechanism, the absence of retained invalidation history, and the canonical redemption POST route already fixed by `SPEC.md` and PR #284.
+
+## What Changes
+
+- Clarify that creating a Portal User persists only an identity in `invited` status and issues no token or URL.
+- Clarify that the first **Copy invite** action issues the initial Portal Invite and later actions reissue it through the same path.
+- State that issuance deletes any previous invite row, stores at most one hash-only row, and retains no invalidation or revocation history.
+- Name `POST /portal/:organization_slug/invites/:token` as the canonical Organization-bound redemption route.
+- Reconcile the Console design guidance and operator journey with the shipped Create then Copy sequence.
+- Preserve the earlier archived Developer Portal package as historical context rather than rewriting its original decision record.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `developer-api-key-portal`: Clarifies the already-shipped boundary between Portal User creation, first invite issuance, later reissue, deletion-based invalidation, and invited-only route-bound redemption.
+
+## Impact
+
+- `SPEC.md` impact: none.
+- Product behavior impact: none.
+- Implementation impact: none.
+- Persistence impact: none.
+- Documentation impact: the accepted capability spec, Console design guidance, and operator journey use one Create then Copy contract.
+- Historical impact: the archived 2026-08-14 Developer Portal package remains unchanged as a record of earlier intent, while current accepted truth remains in `SPEC.md`, accepted specs, and this reconciliation.
+
+## Non-Goals
+
+- This change does not add product code, migrations, tests, or Console behavior.
+- This change does not reintroduce `invalidated_at`, a separate invite-state column, or durable invite invalidation history.
+- Active-user recovery semantics remain owner-gated and are not defined here.
+- Audit actor, action, and outcome vocabulary remains owner-gated and is not defined here.
+- Neutral Console key-attribution labels remain owner-gated and are not defined here.
+- Issue #270 remains an independent Developer Portal feedback workstream.

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/proposal.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/proposal.md
@@ -25,7 +25,7 @@ The accepted capability also needs to name deletion as the invalidation mechanis
 - Product behavior impact: none.
 - Implementation impact: none.
 - Persistence impact: none.
-- Documentation impact: the accepted capability spec, Console design guidance, and operator journey use one Create then Copy contract.
+- Documentation impact: the accepted capability spec, Console design guidance, operator journey, and glossary Portal Invite entry use one Create then Copy contract.
 - Historical impact: the archived 2026-08-14 Developer Portal package remains unchanged as a record of earlier intent, while current accepted truth remains in `SPEC.md`, accepted specs, and this reconciliation.
 
 ## Non-Goals

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/proposal.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/proposal.md
@@ -3,6 +3,7 @@
 `SPEC.md` and shipped Portal behavior already agree that creating a Portal User and issuing a Portal Invite are separate actions.
 The accepted Developer Portal capability and operator-facing documentation do not state that boundary consistently, which can make Portal User creation read as immediate token issuance.
 The accepted capability also needs to name deletion as the invalidation mechanism, the absence of retained invalidation history, and the canonical redemption POST route already fixed by `SPEC.md` and PR #284.
+The accepted session-termination sentence also names only invite reissue, while shipped `copy_invite_transaction/4` ends standing sessions on the initial issuance too.
 
 ## What Changes
 
@@ -10,6 +11,7 @@ The accepted capability also needs to name deletion as the invalidation mechanis
 - Clarify that the first **Copy invite** action issues the initial Portal Invite and later actions reissue it through the same path.
 - State that issuance deletes any previous invite row, stores at most one hash-only row, and retains no invalidation or revocation history.
 - Name `POST /portal/:organization_slug/invites/:token` as the canonical Organization-bound redemption route.
+- State that initial invite issuance, not only reissue, ends that Portal User's standing sessions.
 - Reconcile the Console design guidance and operator journey with the shipped Create then Copy sequence.
 - Preserve the earlier archived Developer Portal package as historical context rather than rewriting its original decision record.
 
@@ -17,7 +19,7 @@ The accepted capability also needs to name deletion as the invalidation mechanis
 
 ### Modified Capabilities
 
-- `developer-api-key-portal`: Clarifies the already-shipped boundary between Portal User creation, first invite issuance, later reissue, deletion-based invalidation, and invited-only route-bound redemption.
+- `developer-api-key-portal`: Clarifies the already-shipped boundary between Portal User creation, first invite issuance, later reissue, deletion-based invalidation, invited-only route-bound redemption, and session termination on every issuance.
 
 ## Impact
 
@@ -25,7 +27,7 @@ The accepted capability also needs to name deletion as the invalidation mechanis
 - Product behavior impact: none.
 - Implementation impact: none.
 - Persistence impact: none.
-- Documentation impact: the accepted capability spec, Console design guidance, operator journey, and glossary Portal Invite entry use one Create then Copy contract.
+- Documentation impact: the accepted capability spec, Console design guidance, operator journey, and glossary Portal Invite entry use one Create then Copy contract, and the accepted session-termination sentence names initial issuance.
 - Historical impact: the archived 2026-08-14 Developer Portal package remains unchanged as a record of earlier intent, while current accepted truth remains in `SPEC.md`, accepted specs, and this reconciliation.
 
 ## Non-Goals

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/specs/developer-api-key-portal/spec.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/specs/developer-api-key-portal/spec.md
@@ -1,0 +1,89 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: Copy Invite Reissues A Hash-Only Token`
+- TO: `### Requirement: Copy Invite Issues Or Reissues A Hash-Only Token`
+
+## MODIFIED Requirements
+
+### Requirement: Portal Users Are Operator-Invited Named Identities
+
+A Portal User SHALL belong to exactly one Organization and use email as an identifier unique by normalized value within that Organization.
+An operator SHALL create Portal User accounts.
+Creating a Portal User SHALL persist only the Portal User in `invited` status.
+Creation SHALL NOT mint or store a Portal Invite token and SHALL NOT return or display a Portal Invite URL.
+The Developer Portal SHALL NOT offer public signup, self-registration, or shared Organization password authentication.
+SMTP SHALL NOT be required.
+This refines `SPEC.md` §7.4a and §8.
+
+#### Scenario: Public signup is unavailable
+
+- **WHEN** an unauthenticated caller visits any Developer Portal route
+- **THEN** Orchard SHALL offer only invite redemption or email-plus-password login
+- **AND** Orchard SHALL NOT create a Portal User without an operator creating that Portal User in `invited` status
+
+#### Scenario: Portal User creation does not issue an invite token
+
+- **WHEN** an operator creates a Portal User
+- **THEN** Orchard SHALL persist the Portal User in `invited` status
+- **AND** Orchard SHALL NOT create a Portal Invite row
+- **AND** Console SHALL NOT return or display a Portal Invite URL
+
+#### Scenario: Same email can identify users in different Organizations
+
+- **WHEN** two Organizations invite the same normalized email
+- **THEN** each Organization MAY have its own Portal User for that email
+- **AND** each Portal User SHALL remain scoped to its own Organization
+
+### Requirement: Copy Invite Issues Or Reissues A Hash-Only Token
+
+Console SHALL provide Copy invite for a Portal User in `invited` status.
+The first Copy invite action after Portal User creation SHALL issue the initial Portal Invite.
+Each Copy invite action SHALL mint a fresh single-use token, delete any previous invite row for that Portal User, extend expiry from the action time, and persist only the new token hash.
+A Portal User SHALL have at most one stored invite row at a time.
+Deleting the stored row SHALL be the invite invalidation mechanism, and Orchard SHALL NOT retain invite invalidation or revocation history.
+Orchard SHALL NOT persist the plaintext token or invite URL.
+The operator SHALL deliver the URL out of band without an SMTP dependency.
+Invite redemption SHALL be bound to the Organization identified by the route and SHALL activate only a Portal User who is currently `invited` in that Organization.
+Invite redemption SHALL use the canonical `POST /portal/:organization_slug/invites/:token` route.
+Wrong-Organization, disabled-user, invalidated, expired, redeemed, and unknown-token redemption failures SHALL use one generic external response and SHALL make no persisted mutation.
+This refines `SPEC.md` §7.4a, §8, §10.8, and §10.9.
+
+#### Scenario: First Copy invite issues the initial token
+
+- **WHEN** an operator uses Copy invite for an invited Portal User with no stored invite
+- **THEN** Orchard SHALL return the newly issued plaintext URL only for that Copy invite action
+- **AND** durable storage SHALL contain exactly one hash-only invite row for that Portal User
+
+#### Scenario: Recopy deletes and replaces the previous invite
+
+- **WHEN** an operator uses Copy invite twice for the same invited Portal User
+- **THEN** the second action SHALL return a newly issued plaintext URL
+- **AND** Orchard SHALL extend the invite expiry
+- **AND** the first unused token SHALL no longer redeem
+- **AND** durable storage SHALL contain exactly one invite row with only the replacement token hash
+- **AND** Orchard SHALL retain no invalidation tombstone or revocation history for the deleted row
+
+#### Scenario: Valid invite is redeemed once
+
+- **WHEN** an invited Portal User submits a valid unexpired invite token and a valid new password through `POST /portal/:organization_slug/invites/:token`
+- **THEN** Orchard SHALL store only the password hash
+- **AND** Orchard SHALL mark the invite redeemed and activate the Portal User
+- **AND** Orchard SHALL create no session from a second redemption attempt with the same token
+
+#### Scenario: Disable invalidates an outstanding invite
+
+- **WHEN** an operator disables an invited Portal User with an outstanding invite
+- **THEN** the Portal User SHALL remain disabled
+- **AND** the outstanding invite SHALL be invalid when disablement commits
+
+#### Scenario: Wrong Organization does not consume an invite
+
+- **WHEN** a caller submits one Organization's valid invite through another Organization's route
+- **THEN** Orchard SHALL return the generic invalid-invite response
+- **AND** the invite SHALL remain redeemable through its owning Organization's route
+
+#### Scenario: Ineligible redemption is generic and mutation-free
+
+- **WHEN** a caller submits an invite for a disabled Portal User, an invalidated invite, an expired invite, a redeemed invite, or an unknown token
+- **THEN** every submission SHALL receive the same generic invalid-invite response contract
+- **AND** Orchard SHALL NOT persist a mutation

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/specs/developer-api-key-portal/spec.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/specs/developer-api-key-portal/spec.md
@@ -87,3 +87,24 @@ This refines `SPEC.md` §7.4a, §8, §10.8, and §10.9.
 - **WHEN** a caller submits an invite for a disabled Portal User, an invalidated invite, an expired invite, a redeemed invite, or an unknown token
 - **THEN** every submission SHALL receive the same generic invalid-invite response contract
 - **AND** Orchard SHALL NOT persist a mutation
+
+### Requirement: Portal Sessions Belong To One Portal User
+
+Every Developer Portal session SHALL belong to one `portal_user_id` and that Portal User's Organization.
+Initial invite issuance, invite reissue, invite redemption, and Portal User disablement SHALL end that Portal User's standing sessions.
+Portal User disablement SHALL invalidate every outstanding invite in the same transaction that changes the user's status and ends the user's sessions.
+Disabling a Portal User SHALL NOT automatically revoke owned API Keys.
+This refines `SPEC.md` §7.4a and §8.
+
+#### Scenario: Disable ends sessions without revoking keys
+
+- **WHEN** an operator disables one Portal User who has a standing session and active owned keys
+- **THEN** only that Portal User's sessions SHALL fail revalidation
+- **AND** other Portal Users' sessions SHALL remain valid
+- **AND** the disabled Portal User's keys SHALL remain valid Bearer credentials until explicitly revoked
+
+#### Scenario: Disable an invited Portal User
+
+- **WHEN** an operator disables an invited Portal User with an outstanding invite
+- **THEN** the Portal User SHALL remain disabled
+- **AND** every outstanding invite for that Portal User SHALL be invalid immediately when disablement commits

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/tasks.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Clarify that Portal User creation persists only an invited identity and issues no token or URL.
 - [x] 1.2 Clarify that the first Copy invite action issues the initial token and later actions reissue through the same path.
 - [x] 1.3 Record one-row deletion-based invalidation, no retained invalidation history, invited-only redemption, and the canonical POST route.
+- [x] 1.4 Name initial invite issuance in the session-termination sentence so it matches shipped Copy invite behavior.
 
 ## 2. Durable documentation
 

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/tasks.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/tasks.md
@@ -1,0 +1,21 @@
+## 1. Accepted capability
+
+- [x] 1.1 Clarify that Portal User creation persists only an invited identity and issues no token or URL.
+- [x] 1.2 Clarify that the first Copy invite action issues the initial token and later actions reissue through the same path.
+- [x] 1.3 Record one-row deletion-based invalidation, no retained invalidation history, invited-only redemption, and the canonical POST route.
+
+## 2. Durable documentation
+
+- [x] 2.1 Reconcile `docs/DESIGN.md` with the Create then Copy Console sequence.
+- [x] 2.2 Reconcile `docs/operator-journey.md` with first issuance, later reissue, and deliberate separate key revocation.
+- [x] 2.3 Leave `SPEC.md`, the glossary, ADR 0020, and the archived 2026-08-14 package unchanged.
+- [x] 2.4 Record active-user recovery, audit vocabulary, and neutral key-attribution labels only as owner-gated non-goals.
+- [x] 2.5 Keep issue #270 independent.
+
+## 3. Validation And Review
+
+- [x] 3.1 Run `git diff --check`.
+- [x] 3.2 Run strict targeted OpenSpec validation for this change.
+- [x] 3.3 Run a read-only RepoPrompt reconciliation review and resolve blocker and important findings.
+- [x] 3.4 Archive this completed change with `--skip-specs` after the accepted capability is synchronized.
+- [x] 3.5 Run strict all-spec OpenSpec validation and review the accepted capability for placeholder prose.

--- a/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/tasks.md
+++ b/openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract/tasks.md
@@ -8,7 +8,7 @@
 
 - [x] 2.1 Reconcile `docs/DESIGN.md` with the Create then Copy Console sequence.
 - [x] 2.2 Reconcile `docs/operator-journey.md` with first issuance, later reissue, and deliberate separate key revocation.
-- [x] 2.3 Leave `SPEC.md`, the glossary, ADR 0020, and the archived 2026-08-14 package unchanged.
+- [x] 2.3 Leave `SPEC.md`, ADR 0020, and the archived 2026-08-14 package unchanged, and align the glossary Portal Invite entry with Create then Copy.
 - [x] 2.4 Record active-user recovery, audit vocabulary, and neutral key-attribution labels only as owner-gated non-goals.
 - [x] 2.5 Keep issue #270 independent.
 

--- a/openspec/specs/developer-api-key-portal/spec.md
+++ b/openspec/specs/developer-api-key-portal/spec.md
@@ -137,7 +137,7 @@ This refines `SPEC.md` §7.4a.
 ### Requirement: Portal Sessions Belong To One Portal User
 
 Every Developer Portal session SHALL belong to one `portal_user_id` and that Portal User's Organization.
-Invite reissue, invite redemption, and Portal User disablement SHALL end that Portal User's standing sessions.
+Initial invite issuance, invite reissue, invite redemption, and Portal User disablement SHALL end that Portal User's standing sessions.
 Portal User disablement SHALL invalidate every outstanding invite in the same transaction that changes the user's status and ends the user's sessions.
 Disabling a Portal User SHALL NOT automatically revoke owned API Keys.
 This refines `SPEC.md` §7.4a and §8.

--- a/openspec/specs/developer-api-key-portal/spec.md
+++ b/openspec/specs/developer-api-key-portal/spec.md
@@ -35,6 +35,8 @@ This refines `SPEC.md` §2.3, §7.1, and §7.4a.
 
 A Portal User SHALL belong to exactly one Organization and use email as an identifier unique by normalized value within that Organization.
 An operator SHALL create Portal User accounts.
+Creating a Portal User SHALL persist only the Portal User in `invited` status.
+Creation SHALL NOT mint or store a Portal Invite token and SHALL NOT return or display a Portal Invite URL.
 The Developer Portal SHALL NOT offer public signup, self-registration, or shared Organization password authentication.
 SMTP SHALL NOT be required.
 This refines `SPEC.md` §7.4a and §8.
@@ -43,7 +45,14 @@ This refines `SPEC.md` §7.4a and §8.
 
 - **WHEN** an unauthenticated caller visits any Developer Portal route
 - **THEN** Orchard SHALL offer only invite redemption or email-plus-password login
-- **AND** Orchard SHALL NOT create a Portal User without an operator-created invitation
+- **AND** Orchard SHALL NOT create a Portal User without an operator creating that Portal User in `invited` status
+
+#### Scenario: Portal User creation does not issue an invite token
+
+- **WHEN** an operator creates a Portal User
+- **THEN** Orchard SHALL persist the Portal User in `invited` status
+- **AND** Orchard SHALL NOT create a Portal Invite row
+- **AND** Console SHALL NOT return or display a Portal Invite URL
 
 #### Scenario: Same email can identify users in different Organizations
 
@@ -51,27 +60,38 @@ This refines `SPEC.md` §7.4a and §8.
 - **THEN** each Organization MAY have its own Portal User for that email
 - **AND** each Portal User SHALL remain scoped to its own Organization
 
-### Requirement: Copy Invite Reissues A Hash-Only Token
+### Requirement: Copy Invite Issues Or Reissues A Hash-Only Token
 
 Console SHALL provide Copy invite for a Portal User in `invited` status.
-Each Copy invite action SHALL mint a fresh single-use token, extend expiry from reissue, invalidate all prior unused tokens for that Portal User, and persist only the new token hash.
+The first Copy invite action after Portal User creation SHALL issue the initial Portal Invite.
+Each Copy invite action SHALL mint a fresh single-use token, delete any previous invite row for that Portal User, extend expiry from the action time, and persist only the new token hash.
+A Portal User SHALL have at most one stored invite row at a time.
+Deleting the stored row SHALL be the invite invalidation mechanism, and Orchard SHALL NOT retain invite invalidation or revocation history.
 Orchard SHALL NOT persist the plaintext token or invite URL.
 The operator SHALL deliver the URL out of band without an SMTP dependency.
 Invite redemption SHALL be bound to the Organization identified by the route and SHALL activate only a Portal User who is currently `invited` in that Organization.
+Invite redemption SHALL use the canonical `POST /portal/:organization_slug/invites/:token` route.
 Wrong-Organization, disabled-user, invalidated, expired, redeemed, and unknown-token redemption failures SHALL use one generic external response and SHALL make no persisted mutation.
 This refines `SPEC.md` §7.4a, §8, §10.8, and §10.9.
 
-#### Scenario: Recopy invalidates the previous invite
+#### Scenario: First Copy invite issues the initial token
+
+- **WHEN** an operator uses Copy invite for an invited Portal User with no stored invite
+- **THEN** Orchard SHALL return the newly issued plaintext URL only for that Copy invite action
+- **AND** durable storage SHALL contain exactly one hash-only invite row for that Portal User
+
+#### Scenario: Recopy deletes and replaces the previous invite
 
 - **WHEN** an operator uses Copy invite twice for the same invited Portal User
 - **THEN** the second action SHALL return a newly issued plaintext URL
 - **AND** Orchard SHALL extend the invite expiry
 - **AND** the first unused token SHALL no longer redeem
-- **AND** durable storage SHALL contain only token hashes
+- **AND** durable storage SHALL contain exactly one invite row with only the replacement token hash
+- **AND** Orchard SHALL retain no invalidation tombstone or revocation history for the deleted row
 
 #### Scenario: Valid invite is redeemed once
 
-- **WHEN** an invited Portal User submits a valid unexpired invite token and a valid new password
+- **WHEN** an invited Portal User submits a valid unexpired invite token and a valid new password through `POST /portal/:organization_slug/invites/:token`
 - **THEN** Orchard SHALL store only the password hash
 - **AND** Orchard SHALL mark the invite redeemed and activate the Portal User
 - **AND** Orchard SHALL create no session from a second redemption attempt with the same token


### PR DESCRIPTION
## Context

Lower-authority Portal documentation and the accepted OpenSpec capability did not describe the shipped invitation flow consistently after PR #284.
They could still be read as immediate invite issuance, retained invalidation state, or a route other than the canonical POST redemption endpoint.

This reconciles the current contract with `SPEC.md` and shipped behavior without changing the product.
It is the first contract-reconciliation slice after PR #284 and the later accepted-spec sync in PR #291.
Product follow-ups remain separate owner decisions.

## What changed

- Creating a Portal User now unambiguously creates only an `invited` identity, with no token or URL.
- The first **Copy invite** action issues the token, and later Copy actions delete and replace the previous unused invite row.
- The accepted contract now states the one-row hash-only model, deletion-based invalidation, no retained invalidation history, invited-only redemption, and the canonical `POST /portal/:organization_slug/invites/:token` route.
- Session wording now covers initial invite issuance as well as reissue, redemption, and disablement.
- Console design guidance, the operator journey, and the Portal Invite glossary entry now use the same Create then Copy sequence.
- A focused archived OpenSpec package records the reconciliation while preserving the earlier 2026-08-14 package as historical context.

## Scope and non-goals

This PR does not change `SPEC.md`, ADRs, product code, migrations, tests, or runtime behavior.

It does not add `invalidated_at`, a separate invite-state column, or durable invite invalidation history.
Active-user recovery, audit actor/action/outcome vocabulary, and neutral key-attribution labels remain owner-gated.

## Related

- Related: #279
- Related: #270, which remains an independent workstream.

## Validation

- `git diff --check origin/main...HEAD` - passed.
- `env OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate reconcile-portal-invite-issuance-contract --type change --strict --no-interactive` - passed against the final change delta.
- `env OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` - passed, 31 of 31.
- `rg -n 'Purpose TBD|TBD' openspec/specs/developer-api-key-portal/spec.md openspec/changes/archive/2026-08-27-reconcile-portal-invite-issuance-contract` - no matches.
- RepoPrompt final reconciliation review - Go, with no blocker or important findings.
- No Mistakes - passed source review, focused Portal validation, documentation review, and lint.
- The No Mistakes test stage exercised the shipped Create then Copy journey and successful redemption through the canonical POST route.

The full Elixir quality workflow was not rerun because the final diff contains no Elixir or product-code changes.

## Risk Assessment

✅ **Low**

- Blast radius is limited to contributor-facing contract documentation, accepted OpenSpec truth, and operator guidance.
- There is no runtime, schema, migration, compatibility, or test change.
- Strict targeted and all-spec validation, RepoPrompt review, and No Mistakes reduce the risk of documenting behavior that the product does not ship.
- The earlier archived package remains unchanged, and unresolved recovery, audit, and key-label contracts remain explicitly deferred.

## Checklist

- [x] I checked whether this changes `SPEC.md` behavior.
- [x] I updated docs, tests, or decisions that the change affects.
- [x] I ran relevant validation and recorded outcomes.
- [x] I did not commit active goal packages or private local artifacts.
- [x] I did not introduce dependencies on private workbench or session context.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790433344&installation_model_id=428414&pr_number=300&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F300&signature=a277f2ccb0e23c2957b28c44a010a1606f05a6c804c97d2c84594a52ae50b31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->