### PR TITLE
feat(scheduler): add hard prior-node exclusion

### DIFF
--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -30,6 +30,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   alias Orchard.Governance
   alias Orchard.InferenceEvent
   alias Orchard.Nodes
+  alias Orchard.Nodes.ExclusionSet
   alias Orchard.Requests
 
   alias Orchard.Requests.{
@@ -88,7 +89,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
       when is_map(schedule) and is_list(exclude_node_ids) do
     with {:ok, selected_node_id} <- Ecto.UUID.cast(map_value(schedule, :node_id)),
          :ok <- validate_selected_target_identity(schedule, selected_node_id),
-         {:ok, excluded_node_ids} <- canonical_exclusion_set(exclude_node_ids),
+         {:ok, excluded_node_ids} <- ExclusionSet.canonicalize(exclude_node_ids),
          false <- MapSet.member?(excluded_node_ids, selected_node_id) do
       :ok
     else
@@ -984,15 +985,6 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp target_node_id(_target), do: :error
-
-  defp canonical_exclusion_set(node_ids) do
-    Enum.reduce_while(node_ids, {:ok, MapSet.new()}, fn node_id, {:ok, acc} ->
-      case Ecto.UUID.cast(node_id) do
-        {:ok, canonical} -> {:cont, {:ok, MapSet.put(acc, canonical)}}
-        :error -> {:halt, :error}
-      end
-    end)
-  end
 
   defp record_scheduler_decision(db_request, metadata) do
     case Requests.record_schedule(db_request, metadata) do

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -29,6 +29,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   alias Orchard.Governance
   alias Orchard.InferenceEvent
+  alias Orchard.Nodes
   alias Orchard.Requests
 
   alias Orchard.Requests.{
@@ -42,6 +43,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   }
 
   alias Orchard.Runtime.{MemoryBudget, PrefixCacheScore, PrefixCacheStatus}
+  alias Orchard.RuntimeEndpoint.Target
   alias Orchard.SentryContext
 
   @type event_handler ::
@@ -74,6 +76,23 @@ defmodule Orchard.Inference.RequestOrchestrator do
       end
     after
       restore_metrics_started_at(previous_started_at)
+    end
+  end
+
+  @doc false
+  @spec validate_scheduler_selection(map(), [Ecto.UUID.t()]) ::
+          :ok | {:error, {:dispatch_failed, :identity_unresolved}}
+  def validate_scheduler_selection(_schedule, []), do: :ok
+
+  def validate_scheduler_selection(schedule, exclude_node_ids)
+      when is_map(schedule) and is_list(exclude_node_ids) do
+    with {:ok, selected_node_id} <- Ecto.UUID.cast(map_value(schedule, :node_id)),
+         :ok <- validate_selected_target_identity(schedule, selected_node_id),
+         {:ok, excluded_node_ids} <- canonical_exclusion_set(exclude_node_ids),
+         false <- MapSet.member?(excluded_node_ids, selected_node_id) do
+      :ok
+    else
+      _identity_unresolved -> {:error, {:dispatch_failed, :identity_unresolved}}
     end
   end
 
@@ -848,19 +867,21 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp schedule_request(db_request, canonical) do
+    schedule_request(db_request, canonical, [])
+  end
+
+  defp schedule_request(db_request, canonical, exclude_node_ids) do
     if RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) <= 0 do
       {:error, {:dispatch_failed, :request_timeout}}
     else
-      schedule_live_request(db_request, canonical)
+      schedule_live_request(db_request, canonical, exclude_node_ids)
     end
   end
 
-  defp schedule_live_request(db_request, canonical) do
-    case call_scheduler(canonical) do
+  defp schedule_live_request(db_request, canonical, exclude_node_ids) do
+    case call_scheduler(canonical, exclude_node_ids) do
       {:ok, schedule} when is_map(schedule) ->
-        if RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) > 0,
-          do: {:ok, Map.put(schedule, :timeout_at, db_request.timeout_at)},
-          else: {:error, {:dispatch_failed, :request_timeout}}
+        accept_scheduler_selection(db_request, schedule, exclude_node_ids)
 
       {:error, reason, decision} when is_map(decision) ->
         persist_rejected_scheduler_decision(db_request, decision)
@@ -871,6 +892,16 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
       _other ->
         {:error, orchestration_crash(:scheduler, :invalid_return)}
+    end
+  end
+
+  defp accept_scheduler_selection(db_request, schedule, exclude_node_ids) do
+    with :ok <- validate_scheduler_selection(schedule, exclude_node_ids),
+         true <- RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) > 0 do
+      {:ok, Map.put(schedule, :timeout_at, db_request.timeout_at)}
+    else
+      false -> {:error, {:dispatch_failed, :request_timeout}}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -888,8 +919,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
     end
   end
 
-  defp call_scheduler(canonical) do
-    Inference.scheduler().schedule(canonical)
+  defp call_scheduler(canonical, exclude_node_ids) do
+    Inference.scheduler().schedule(canonical, exclude_node_ids: exclude_node_ids)
   rescue
     error ->
       log_warn("scheduler crashed: #{exception_name(error)}")
@@ -902,6 +933,65 @@ defmodule Orchard.Inference.RequestOrchestrator do
     _kind, _reason ->
       log_warn("scheduler threw")
       {:error, orchestration_crash(:scheduler, :throw)}
+  end
+
+  defp validate_selected_target_identity(schedule, selected_node_id) do
+    case map_value(schedule, :runtime_endpoint_target) do
+      nil ->
+        validate_legacy_target_identity(schedule, selected_node_id)
+
+      target ->
+        validate_runtime_endpoint_target_identity(target, selected_node_id)
+    end
+  end
+
+  defp validate_runtime_endpoint_target_identity(
+         %Target{transport: :grpc_compat} = target,
+         selected_node_id
+       ) do
+    with {:ok, ^selected_node_id} <- target_node_id(target),
+         {:ok, %Orchard.Nodes.Node{id: durable_node_id}} <- Nodes.lookup_by_target_result(target),
+         {:ok, ^selected_node_id} <- Ecto.UUID.cast(durable_node_id) do
+      :ok
+    else
+      _missing_or_conflicting -> :error
+    end
+  end
+
+  defp validate_runtime_endpoint_target_identity(target, selected_node_id) do
+    case target_node_id(target) do
+      {:ok, ^selected_node_id} -> :ok
+      _missing_or_conflicting -> :error
+    end
+  end
+
+  defp validate_legacy_target_identity(schedule, selected_node_id) do
+    with target when not is_nil(target) <- map_value(schedule, :runtime_client_target),
+         {:ok, %Orchard.Nodes.Node{id: node_id}} <- Nodes.lookup_by_target_result(target),
+         {:ok, ^selected_node_id} <- Ecto.UUID.cast(node_id) do
+      :ok
+    else
+      _missing_or_conflicting -> :error
+    end
+  end
+
+  defp target_node_id(%Target{node_id: node_id}), do: Ecto.UUID.cast(node_id)
+
+  defp target_node_id(target) when is_map(target) do
+    target
+    |> map_value(:node_id)
+    |> Ecto.UUID.cast()
+  end
+
+  defp target_node_id(_target), do: :error
+
+  defp canonical_exclusion_set(node_ids) do
+    Enum.reduce_while(node_ids, {:ok, MapSet.new()}, fn node_id, {:ok, acc} ->
+      case Ecto.UUID.cast(node_id) do
+        {:ok, canonical} -> {:cont, {:ok, MapSet.put(acc, canonical)}}
+        :error -> {:halt, :error}
+      end
+    end)
   end
 
   defp record_scheduler_decision(db_request, metadata) do

--- a/apps/orchard_controller/lib/orchard/nodes/exclusion_set.ex
+++ b/apps/orchard_controller/lib/orchard/nodes/exclusion_set.ex
@@ -1,0 +1,19 @@
+defmodule Orchard.Nodes.ExclusionSet do
+  @moduledoc """
+  Canonical durable Node identities excluded from a scheduler decision.
+  """
+
+  @type t :: MapSet.t(Ecto.UUID.t())
+
+  @spec canonicalize(term()) :: {:ok, t()} | :error
+  def canonicalize(node_ids) when is_list(node_ids) do
+    Enum.reduce_while(node_ids, {:ok, MapSet.new()}, fn node_id, {:ok, exclusions} ->
+      case Ecto.UUID.cast(node_id) do
+        {:ok, canonical} -> {:cont, {:ok, MapSet.put(exclusions, canonical)}}
+        :error -> {:halt, :error}
+      end
+    end)
+  end
+
+  def canonicalize(_node_ids), do: :error
+end

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -707,9 +707,7 @@ defmodule Orchard.Scheduler.MultiNode do
   defp canonical_node_id_set(_node_ids), do: :error
 
   defp filter_prior_nodes({:ok, excluded_node_ids}, candidates) do
-    if MapSet.size(excluded_node_ids) == 0,
-      do: {candidates, []},
-      else: partition_prior_nodes(candidates, excluded_node_ids)
+    partition_prior_nodes(candidates, excluded_node_ids)
   end
 
   defp filter_prior_nodes(:error, candidates) do

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -75,7 +75,6 @@ defmodule Orchard.Scheduler.MultiNode do
   heartbeat snapshot, ranks candidates, and returns a dispatch-compatible schedule map.
   The existing inline-probe path remains only for confirmed-empty trusted inventory.
   """
-  @impl true
   def schedule(%CanonicalRequest{} = request) do
     schedule(request, [])
   end
@@ -84,12 +83,15 @@ defmodule Orchard.Scheduler.MultiNode do
   Schedule with injectable options for testing.
 
   Options:
+  - `:exclude_node_ids` - durable Node UUIDs removed before capacity
+    annotation, tiering, ranking, and scoring
   - `:status_client` - module implementing the Runtime Endpoint client callbacks
     (default: `Inference.runtime_endpoint_client/0`)
   - `:status_timeout_ms` - timeout for each status probe (default: #{@default_status_timeout_ms})
   - `:observed_at` - explicit deterministic observation/snapshot boundary for tests
   - `:compatibility_probe_runner` - internal compatibility-wave runner
   """
+  @impl true
   def schedule(%CanonicalRequest{} = request, opts) when is_list(opts) do
     started_at = System.monotonic_time()
     result = do_schedule(request, opts)
@@ -194,16 +196,23 @@ defmodule Orchard.Scheduler.MultiNode do
   defp schedule_production_candidates(request, targets, active_targets, opts) do
     case production_candidate_snapshot(targets, active_targets, opts) do
       {:ok, snapshot} ->
-        candidates =
+        {candidates, exclusion_rejections} =
           snapshot.candidates
           |> Enum.map(&snapshot_candidate(&1, request))
+          |> exclude_prior_nodes(opts)
+
+        candidates =
+          candidates
           |> Enum.map(fn candidate ->
             candidate
+            |> enrich_candidate(request)
             |> annotate_dispatch_capacity(opts, candidate.observation.observed_at)
             |> annotate_residency_policy(request, opts)
           end)
 
-        source_rejections = Enum.map(snapshot.rejections, &snapshot_rejection/1)
+        source_rejections =
+          exclusion_rejections ++ snapshot_rejections(snapshot.rejections, opts)
+
         available_candidates = Enum.filter(candidates, &schedule_eligible?/1)
 
         if available_candidates == [] do
@@ -256,12 +265,7 @@ defmodule Orchard.Scheduler.MultiNode do
       |> Enum.reduce({[], []}, fn {target, result}, {candidates, rejections} ->
         case result do
           {:ok, {:candidate, candidate}} ->
-            annotated =
-              candidate
-              |> annotate_dispatch_capacity(opts, observed_at)
-              |> annotate_residency_policy(request, opts)
-
-            {[annotated | candidates], rejections}
+            {[candidate | candidates], rejections}
 
           {:ok, {:rejected, rejection}} ->
             {candidates, [rejection | rejections]}
@@ -285,8 +289,20 @@ defmodule Orchard.Scheduler.MultiNode do
         end
       end)
 
-    candidates = Enum.reverse(candidates)
-    source_rejections = Enum.reverse(source_rejections)
+    {candidates, exclusion_rejections} =
+      candidates
+      |> Enum.reverse()
+      |> exclude_prior_nodes(opts)
+
+    candidates =
+      Enum.map(candidates, fn candidate ->
+        candidate
+        |> enrich_candidate(request)
+        |> annotate_dispatch_capacity(opts, observed_at)
+        |> annotate_residency_policy(request, opts)
+      end)
+
+    source_rejections = exclusion_rejections ++ Enum.reverse(source_rejections)
     available_candidates = Enum.filter(candidates, &schedule_eligible?/1)
 
     if available_candidates == [] do
@@ -618,6 +634,185 @@ defmodule Orchard.Scheduler.MultiNode do
     )
   end
 
+  defp snapshot_rejections(rejections, opts) do
+    opts
+    |> Keyword.get(:exclude_node_ids, [])
+    |> canonical_node_id_set()
+    |> map_snapshot_rejections(rejections)
+  end
+
+  defp map_snapshot_rejections({:ok, excluded_node_ids}, rejections) do
+    Enum.map(rejections, &snapshot_rejection_for_exclusions(&1, excluded_node_ids))
+  end
+
+  defp map_snapshot_rejections(:error, rejections),
+    do: Enum.map(rejections, &snapshot_rejection/1)
+
+  defp snapshot_rejection_for_exclusions(rejection, excluded_node_ids) do
+    case verified_snapshot_rejection_node_id(rejection) do
+      {:ok, node_id} ->
+        maybe_excluded_snapshot_rejection(rejection, excluded_node_ids, node_id)
+
+      :error ->
+        snapshot_rejection(rejection)
+    end
+  end
+
+  defp maybe_excluded_snapshot_rejection(rejection, excluded_node_ids, node_id) do
+    if MapSet.member?(excluded_node_ids, node_id) do
+      rejection
+      |> Map.from_struct()
+      |> Map.put(:candidate_source, "monitor_snapshot")
+      |> candidate_rejection(
+        "previous_attempt_node_excluded",
+        "prior_node_identity_matched"
+      )
+    else
+      snapshot_rejection(rejection)
+    end
+  end
+
+  defp verified_snapshot_rejection_node_id(%{
+         node_id: node_id,
+         target: %Target{node_id: target_node_id}
+       }) do
+    with {:ok, canonical} <- Ecto.UUID.cast(node_id),
+         {:ok, ^canonical} <- Ecto.UUID.cast(target_node_id) do
+      {:ok, canonical}
+    else
+      _error -> :error
+    end
+  end
+
+  defp verified_snapshot_rejection_node_id(_rejection), do: :error
+
+  defp exclude_prior_nodes(candidates, opts) do
+    opts
+    |> Keyword.get(:exclude_node_ids, [])
+    |> canonical_node_id_set()
+    |> filter_prior_nodes(candidates)
+  end
+
+  defp canonical_node_id_set([]), do: {:ok, MapSet.new()}
+
+  defp canonical_node_id_set(node_ids) when is_list(node_ids) do
+    Enum.reduce_while(node_ids, {:ok, MapSet.new()}, fn node_id, {:ok, acc} ->
+      case Ecto.UUID.cast(node_id) do
+        {:ok, canonical} -> {:cont, {:ok, MapSet.put(acc, canonical)}}
+        :error -> {:halt, :error}
+      end
+    end)
+  end
+
+  defp canonical_node_id_set(_node_ids), do: :error
+
+  defp filter_prior_nodes({:ok, excluded_node_ids}, candidates) do
+    if MapSet.size(excluded_node_ids) == 0,
+      do: {candidates, []},
+      else: partition_prior_nodes(candidates, excluded_node_ids)
+  end
+
+  defp filter_prior_nodes(:error, candidates) do
+    rejections =
+      Enum.map(candidates, fn candidate ->
+        candidate_rejection(
+          candidate,
+          "runtime_identity_mismatch",
+          "invalid_exclusion_set"
+        )
+      end)
+
+    {[], rejections}
+  end
+
+  defp partition_prior_nodes(candidates, excluded_node_ids) do
+    {remaining, rejections} =
+      Enum.reduce(candidates, {[], []}, fn candidate, acc ->
+        partition_prior_node(candidate, excluded_node_ids, acc)
+      end)
+
+    {Enum.reverse(remaining), Enum.reverse(rejections)}
+  end
+
+  defp partition_prior_node(candidate, excluded_node_ids, {remaining, rejections}) do
+    case verified_candidate_node_id(candidate) do
+      {:ok, node_id} ->
+        partition_verified_node(
+          candidate,
+          excluded_node_ids,
+          node_id,
+          remaining,
+          rejections
+        )
+
+      :error ->
+        {remaining,
+         [
+           candidate_rejection(
+             candidate,
+             "runtime_identity_mismatch",
+             "durable_node_identity_conflict"
+           )
+           | rejections
+         ]}
+    end
+  end
+
+  defp partition_verified_node(candidate, excluded_node_ids, node_id, remaining, rejections) do
+    if MapSet.member?(excluded_node_ids, node_id) do
+      {remaining,
+       [
+         candidate_rejection(
+           candidate,
+           "previous_attempt_node_excluded",
+           "prior_node_identity_matched"
+         )
+         | rejections
+       ]}
+    else
+      {[candidate | remaining], rejections}
+    end
+  end
+
+  defp verified_candidate_node_id(%{
+         candidate_source: "monitor_snapshot",
+         node_id: node_id,
+         target: %Target{node_id: target_node_id}
+       }) do
+    with {:ok, canonical} <- Ecto.UUID.cast(node_id),
+         {:ok, ^canonical} <- Ecto.UUID.cast(target_node_id) do
+      {:ok, canonical}
+    else
+      _error -> :error
+    end
+  end
+
+  defp verified_candidate_node_id(%{
+         candidate_source: "bounded_compatibility_probe",
+         node_id: node_id,
+         target: %Target{node_id: target_node_id},
+         observation: %Observation{} = observation
+       }) do
+    with {:ok, canonical} <- Ecto.UUID.cast(node_id),
+         ^canonical <- BeamIdentity.metadata_node_id(observation),
+         true <- is_nil(target_node_id) or Ecto.UUID.cast(target_node_id) == {:ok, canonical} do
+      {:ok, canonical}
+    else
+      _error -> :error
+    end
+  end
+
+  defp verified_candidate_node_id(_candidate), do: :error
+
+  defp candidate_rejection(candidate, reason_code, fact) do
+    candidate
+    |> Map.put(:diagnostics, %{fact: fact})
+    |> explanation_candidate(%{
+      eligible: false,
+      reason_codes: [reason_code]
+    })
+  end
+
   defp compatibility_rejection(target, node_id, reason_code, fact) do
     explanation_candidate(
       %{
@@ -869,7 +1064,7 @@ defmodule Orchard.Scheduler.MultiNode do
   defp candidate_tier(%{loaded_model?: true}), do: "loaded"
   defp candidate_tier(_candidate), do: "cold"
 
-  defp snapshot_candidate(snapshot_candidate, request) do
+  defp snapshot_candidate(snapshot_candidate, _request) do
     observation =
       Observation.new(%{
         endpoint_id: snapshot_candidate.target.id,
@@ -885,25 +1080,31 @@ defmodule Orchard.Scheduler.MultiNode do
         supports_prompt_token_ids: snapshot_candidate.supports_prompt_token_ids
       })
 
-    loaded_model? = model_loaded?(observation, request)
-
     %{
       node_id: snapshot_candidate.node.id,
       target: snapshot_candidate.target,
       node: snapshot_candidate.node,
       observation: observation,
       availability: snapshot_candidate.availability,
-      loaded_model?: loaded_model?,
       active_request_count: snapshot_candidate.active_request_count,
       max_concurrency: snapshot_candidate.max_concurrency,
       supports_prompt_token_ids: snapshot_candidate.supports_prompt_token_ids,
       candidate_source: "monitor_snapshot"
     }
+  end
+
+  defp enrich_candidate(candidate, request) do
+    loaded_model? = model_loaded?(candidate.observation, request)
+
+    candidate
+    |> Map.put(:loaded_model?, loaded_model?)
     |> maybe_put_model_placement_capacity(
-      model_placement_capacity_for(observation, request.model_ref, loaded_model?)
+      model_placement_capacity_for(candidate.observation, request.model_ref, loaded_model?)
     )
-    |> maybe_put_prefix_cache_status(prefix_cache_status_for(observation, request.model_ref))
-    |> maybe_put_memory_budget(memory_budget_for(observation, request.model_ref))
+    |> maybe_put_prefix_cache_status(
+      prefix_cache_status_for(candidate.observation, request.model_ref)
+    )
+    |> maybe_put_memory_budget(memory_budget_for(candidate.observation, request.model_ref))
   end
 
   defp probe_target(target, client, timeout, observed_at, request) do
@@ -944,7 +1145,7 @@ defmodule Orchard.Scheduler.MultiNode do
     end
   end
 
-  defp resolve_probe_observation(target, observation, request) do
+  defp resolve_probe_observation(target, observation, _request) do
     case BeamIdentity.resolve_candidate_node_id(target, observation) do
       :missing ->
         {:rejected,
@@ -967,7 +1168,6 @@ defmodule Orchard.Scheduler.MultiNode do
       {:ok, node_id} ->
         target = schedule_target(target, node_id)
         {:ok, capacity_management_class} = Authorization.classify_unmanaged_target(target)
-        loaded_model? = model_loaded?(observation, request)
 
         {:candidate,
          %{
@@ -976,18 +1176,12 @@ defmodule Orchard.Scheduler.MultiNode do
            node: %{id: node_id, health: compatibility_health(observation)},
            observation: observation,
            availability: observation.availability,
-           loaded_model?: loaded_model?,
            active_request_count: observation.aggregate_active_request_count,
            max_concurrency: node_max_concurrency(observation),
            supports_prompt_token_ids: observation.supports_prompt_token_ids,
            capacity_management_class: capacity_management_class,
            candidate_source: "bounded_compatibility_probe"
-         }
-         |> maybe_put_model_placement_capacity(
-           model_placement_capacity_for(observation, request.model_ref, loaded_model?)
-         )
-         |> maybe_put_prefix_cache_status(prefix_cache_status_for(observation, request.model_ref))
-         |> maybe_put_memory_budget(memory_budget_for(observation, request.model_ref))}
+         }}
     end
   end
 
@@ -1274,7 +1468,10 @@ defmodule Orchard.Scheduler.MultiNode do
            production_candidate_snapshot(effective_targets, active_targets, opts),
          {:ok, snapshot_candidate} <-
            matching_snapshot_candidate(snapshot.candidates, candidate),
-         refreshed = snapshot_candidate(snapshot_candidate, request),
+         refreshed =
+           snapshot_candidate
+           |> snapshot_candidate(request)
+           |> enrich_candidate(request),
          refreshed_placement <-
            Map.get(
              refreshed,

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -46,6 +46,7 @@ defmodule Orchard.Scheduler.MultiNode do
   alias Orchard.Models
   alias Orchard.NodeHeartbeats
   alias Orchard.Nodes
+  alias Orchard.Nodes.ExclusionSet
   alias Orchard.Scheduler.CircuitBreakerEligibility
   alias Orchard.Scheduler.MultiNode.CompatibilityProbeRunner
 
@@ -652,7 +653,7 @@ defmodule Orchard.Scheduler.MultiNode do
   defp snapshot_rejections(rejections, opts) do
     opts
     |> Keyword.get(:exclude_node_ids, [])
-    |> canonical_node_id_set()
+    |> ExclusionSet.canonicalize()
     |> map_snapshot_rejections(rejections)
   end
 
@@ -704,22 +705,9 @@ defmodule Orchard.Scheduler.MultiNode do
   defp exclude_prior_nodes(candidates, opts) do
     opts
     |> Keyword.get(:exclude_node_ids, [])
-    |> canonical_node_id_set()
+    |> ExclusionSet.canonicalize()
     |> filter_prior_nodes(candidates)
   end
-
-  defp canonical_node_id_set([]), do: {:ok, MapSet.new()}
-
-  defp canonical_node_id_set(node_ids) when is_list(node_ids) do
-    Enum.reduce_while(node_ids, {:ok, MapSet.new()}, fn node_id, {:ok, acc} ->
-      case Ecto.UUID.cast(node_id) do
-        {:ok, canonical} -> {:cont, {:ok, MapSet.put(acc, canonical)}}
-        :error -> {:halt, :error}
-      end
-    end)
-  end
-
-  defp canonical_node_id_set(_node_ids), do: :error
 
   defp filter_prior_nodes({:ok, excluded_node_ids}, candidates) do
     partition_prior_nodes(candidates, excluded_node_ids)

--- a/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
@@ -32,15 +32,19 @@ defmodule Orchard.Scheduler.SingleNode do
   @type schedule_result ::
           {:ok, map()} | {:error, term()} | {:error, term(), map()}
 
-  @callback schedule(CanonicalRequest.t()) :: schedule_result()
+  @callback schedule(CanonicalRequest.t(), keyword()) :: schedule_result()
 
   @default_status_timeout_ms 2_000
 
   def schedule(%CanonicalRequest{} = request) do
+    schedule(request, [])
+  end
+
+  def schedule(%CanonicalRequest{} = request, opts) when is_list(opts) do
     case Inference.configured_scheduler_impl() do
-      nil -> default_schedule(request)
-      __MODULE__ -> default_schedule(request)
-      module -> module.schedule(request)
+      nil -> default_schedule(request, target(), opts)
+      __MODULE__ -> default_schedule(request, target(), opts)
+      module -> module.schedule(request, opts)
     end
   end
 
@@ -58,6 +62,8 @@ defmodule Orchard.Scheduler.SingleNode do
   The 3-arity version accepts test seams for live status probing.
 
   Options:
+  - `:exclude_node_ids` - durable Node UUIDs that are ineligible for this
+    scheduler decision
   - `:probe_status?` - set to `false` to skip live capacity probing
   - `:status_client` - module implementing `connect/1`, `status/2`, and
     `disconnect/1`. Defaults to `GrpcNodeRuntimeClient` for address-style
@@ -83,18 +89,31 @@ defmodule Orchard.Scheduler.SingleNode do
   defp do_default_schedule(request, target, opts) do
     case resolve_node(target, opts) do
       {:ok, node} ->
-        schedule =
-          %{
-            strategy: :single_node,
-            request_id: request.public_id,
-            request_timeout_ms: Inference.request_timeout_ms(),
-            model_load_timeout_ms: model_load_timeout_ms(request),
-            node_id: node && node.id,
-            selected_tier: "cold"
-          }
-          |> put_target(target)
+        case validate_node_exclusion(node, target, opts) do
+          :ok ->
+            schedule =
+              %{
+                strategy: :single_node,
+                request_id: request.public_id,
+                request_timeout_ms: Inference.request_timeout_ms(),
+                model_load_timeout_ms: model_load_timeout_ms(request),
+                node_id: node && node.id,
+                selected_tier: "cold"
+              }
+              |> put_target(target)
 
-        authorize_schedule(schedule, request, target, node, opts)
+            authorize_schedule(schedule, request, target, node, opts)
+
+          {:error, reason_code, fact} ->
+            schedule_failure(
+              request,
+              target,
+              node,
+              :model_busy,
+              [reason_code],
+              %{fact: fact}
+            )
+        end
 
       {:error, :node_inventory_unavailable} ->
         schedule_failure(
@@ -130,6 +149,57 @@ defmodule Orchard.Scheduler.SingleNode do
   catch
     _kind, _reason -> {:error, :node_inventory_unavailable}
   end
+
+  defp validate_node_exclusion(node, target, opts) do
+    case Keyword.get(opts, :exclude_node_ids, []) do
+      [] ->
+        :ok
+
+      exclude_node_ids ->
+        with {:ok, exclusions} <- canonical_exclusion_set(exclude_node_ids),
+             {:ok, node_id} <- resolved_node_id(node),
+             :ok <- validate_target_node_id(target, node_id),
+             false <- MapSet.member?(exclusions, node_id) do
+          :ok
+        else
+          true ->
+            {:error, "previous_attempt_node_excluded", "prior_node_identity_matched"}
+
+          _missing_or_conflicting ->
+            {:error, "runtime_identity_mismatch", "durable_node_identity_unresolved"}
+        end
+    end
+  end
+
+  defp canonical_exclusion_set(node_ids) when is_list(node_ids) do
+    Enum.reduce_while(node_ids, {:ok, MapSet.new()}, fn node_id, {:ok, acc} ->
+      case Ecto.UUID.cast(node_id) do
+        {:ok, canonical} -> {:cont, {:ok, MapSet.put(acc, canonical)}}
+        :error -> {:halt, :error}
+      end
+    end)
+  end
+
+  defp canonical_exclusion_set(_node_ids), do: :error
+
+  defp resolved_node_id(%Orchard.Nodes.Node{id: node_id}), do: Ecto.UUID.cast(node_id)
+  defp resolved_node_id(_node), do: :error
+
+  defp validate_target_node_id(target, node_id) do
+    case asserted_target_node_id(target) do
+      nil -> :ok
+      target_node_id -> if Ecto.UUID.cast(target_node_id) == {:ok, node_id}, do: :ok, else: :error
+    end
+  end
+
+  defp asserted_target_node_id(%Target{node_id: node_id}), do: node_id
+  defp asserted_target_node_id(target) when is_list(target), do: Keyword.get(target, :node_id)
+
+  defp asserted_target_node_id(target) when is_map(target) do
+    Map.get(target, :node_id) || Map.get(target, "node_id")
+  end
+
+  defp asserted_target_node_id(_target), do: nil
 
   defp authorize_schedule(schedule, request, target, node, opts) do
     opts = Keyword.put(opts, :canonical_request, request)

--- a/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
@@ -27,6 +27,7 @@ defmodule Orchard.Scheduler.SingleNode do
   alias Orchard.DomainMetrics
   alias Orchard.Inference
   alias Orchard.Nodes
+  alias Orchard.Nodes.ExclusionSet
   alias Orchard.RuntimeEndpoint.{GrpcCompatibilityMapper, ModelRef, Observation, Target}
   alias Orchard.Scheduler.CircuitBreakerEligibility
 
@@ -174,7 +175,7 @@ defmodule Orchard.Scheduler.SingleNode do
         :ok
 
       exclude_node_ids ->
-        with {:ok, exclusions} <- canonical_exclusion_set(exclude_node_ids),
+        with {:ok, exclusions} <- ExclusionSet.canonicalize(exclude_node_ids),
              {:ok, node_id} <- resolved_node_id(node),
              :ok <- validate_target_node_id(target, node_id),
              false <- MapSet.member?(exclusions, node_id) do
@@ -188,17 +189,6 @@ defmodule Orchard.Scheduler.SingleNode do
         end
     end
   end
-
-  defp canonical_exclusion_set(node_ids) when is_list(node_ids) do
-    Enum.reduce_while(node_ids, {:ok, MapSet.new()}, fn node_id, {:ok, acc} ->
-      case Ecto.UUID.cast(node_id) do
-        {:ok, canonical} -> {:cont, {:ok, MapSet.put(acc, canonical)}}
-        :error -> {:halt, :error}
-      end
-    end)
-  end
-
-  defp canonical_exclusion_set(_node_ids), do: :error
 
   defp resolved_node_id(%Orchard.Nodes.Node{id: node_id}), do: Ecto.UUID.cast(node_id)
   defp resolved_node_id(_node), do: :error

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -5,7 +5,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest.UnsupportedVersionScoreSched
   alias Orchard.Inference
   alias Orchard.TestSupport.DispatchCapacityFixtures
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     schedule =
       DispatchCapacityFixtures.authorize_unmanaged_schedule(%{
         strategy: :multi_node,

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -9,7 +9,10 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler do
 
   def scheduled_node_id, do: @scheduled_node_id
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request), do: schedule(request, [])
+
+  def schedule(%CanonicalRequest{} = request, opts) do
+    send(Process.whereis(:request_orchestrator_test_pid), {:scheduler_opts, opts})
     capacity_input = ConformanceFixture.input()
 
     {:ok,
@@ -37,7 +40,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.DelayedScheduler do
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
   @impl true
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     Process.sleep(50)
     StubMultiNodeScheduler.schedule(request)
   end
@@ -49,7 +52,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMalformedExplanationSche
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.merge(schedule, %{
@@ -70,7 +73,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubRejectedExplanationSched
 
   alias Orchard.CanonicalRequest
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     {:error, :cluster_busy,
      %{
        strategy: :multi_node,
@@ -126,7 +129,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMalformedRejectedExplana
 
   alias Orchard.CanonicalRequest
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     {:error, :cluster_busy,
      %{
        strategy: :multi_node,
@@ -148,7 +151,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubBareFailureScheduler do
 
   alias Orchard.CanonicalRequest
 
-  def schedule(%CanonicalRequest{}), do: {:error, :no_active_nodes}
+  def schedule(%CanonicalRequest{}, _opts), do: {:error, :no_active_nodes}
 end
 
 defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointTargetScheduler do
@@ -159,7 +162,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointTargetSch
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
   alias Orchard.RuntimeEndpoint.Target
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       runtime_target = Inference.runtime_client_target()
 
@@ -188,7 +191,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubCacheAffinityScheduler d
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.merge(schedule, %{
@@ -210,7 +213,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScheduler do
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.merge(schedule, %{
@@ -247,7 +250,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMemoryScheduler do
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.merge(schedule, %{
@@ -280,7 +283,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMemoryUnavailableSchedul
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.merge(schedule, %{
@@ -307,7 +310,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMemoryTierOnlyScheduler 
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.merge(schedule, %{
@@ -324,7 +327,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheUnavailableSc
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.put(schedule, :prefix_cache_status, %{
@@ -346,7 +349,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScoreSchedule
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        schedule
@@ -383,7 +386,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubPromotedPrefixCacheScore
 
   def promoted_node_id, do: @promoted_node_id
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     capacity_input = ConformanceFixture.input()
 
     {:ok,
@@ -461,7 +464,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScoreUnavaila
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     with {:ok, schedule} <- StubMultiNodeScheduler.schedule(request) do
       {:ok,
        Map.put(schedule, :prefix_cache_score, %{
@@ -484,7 +487,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler do
   alias Orchard.DispatchCapacity.{ConformanceFixture, Evaluator}
   alias Orchard.Inference
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     capacity_input = ConformanceFixture.input()
 
     {:ok,
@@ -508,7 +511,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubFunctionClauseScheduler 
 
   alias Orchard.CanonicalRequest
 
-  def schedule(%CanonicalRequest{}) do
+  def schedule(%CanonicalRequest{}, _opts) do
     raise FunctionClauseError, module: __MODULE__, function: :schedule, arity: 1
   end
 end
@@ -635,7 +638,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubLiveCapacityScheduler do
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
 
-  def schedule(%CanonicalRequest{} = request) do
+  def schedule(%CanonicalRequest{} = request, _opts) do
     owner = Application.fetch_env!(:orchard_controller, :request_orchestrator_live_capacity_owner)
     send(owner, {:live_capacity_schedule_attempt, self(), request.public_id})
 
@@ -919,6 +922,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.Requests
   alias Orchard.Requests.Idempotency
   alias Orchard.Requests.RequestServer
+  alias Orchard.RuntimeEndpoint.Target
   alias Orchard.TestSupport.TerminalCardinality
 
   setup :setup_sentry_context
@@ -1059,6 +1063,100 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request.endpoint == :responses
     assert request.canonical_request["endpoint"] == "responses"
+  end
+
+  test "SPEC.md §5.8 attempt 1 schedules with an empty prior-Node exclusion set", %{
+    bundle: bundle
+  } do
+    put_multi_node_scheduler_config()
+    model = create_active_model!(bundle, "request-orchestrator-initial-exclusions")
+    canonical = canonical_request("request-orchestrator-initial-exclusions", stream?: false)
+
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+    assert_receive {:scheduler_opts, [exclude_node_ids: []]}
+  end
+
+  test "ADR 0019 orchestrator defense rejects a scheduler-selected excluded Node" do
+    node_id = Ecto.UUID.generate()
+
+    schedule = %{
+      node_id: node_id,
+      runtime_endpoint_target:
+        Target.grpc_compat(host: "10.0.0.41", port: 50_061, node_id: node_id)
+    }
+
+    assert {:error, {:dispatch_failed, :identity_unresolved}} =
+             RequestOrchestrator.validate_scheduler_selection(schedule, [String.upcase(node_id)])
+  end
+
+  test "ADR 0019 orchestrator defense re-resolves legacy target identity" do
+    target = [host: "10.0.0.43", port: 50_061]
+    excluded_node = insert_runtime_node!(target)
+
+    schedule = %{
+      node_id: Ecto.UUID.generate(),
+      runtime_client_target: target
+    }
+
+    assert {:error, {:dispatch_failed, :identity_unresolved}} =
+             RequestOrchestrator.validate_scheduler_selection(schedule, [excluded_node.id])
+  end
+
+  test "ADR 0019 orchestrator defense re-resolves gRPC target identity by address" do
+    target = [host: "10.0.0.45", port: 50_061]
+    excluded_node = insert_runtime_node!(target)
+    asserted_node_id = Ecto.UUID.generate()
+
+    schedule = %{
+      node_id: asserted_node_id,
+      runtime_endpoint_target:
+        Target.grpc_compat(
+          host: Keyword.fetch!(target, :host),
+          port: Keyword.fetch!(target, :port),
+          node_id: asserted_node_id
+        )
+    }
+
+    assert {:error, {:dispatch_failed, :identity_unresolved}} =
+             RequestOrchestrator.validate_scheduler_selection(schedule, [excluded_node.id])
+  end
+
+  test "ADR 0019 orchestrator defense fails closed on missing or conflicting selected identity" do
+    selected_node_id = Ecto.UUID.generate()
+    conflicting_node_id = Ecto.UUID.generate()
+    exclusions = [Ecto.UUID.generate()]
+
+    schedules = [
+      %{node_id: nil},
+      %{
+        node_id: selected_node_id,
+        runtime_endpoint_target:
+          Target.grpc_compat(
+            host: "10.0.0.42",
+            port: 50_061,
+            node_id: conflicting_node_id
+          )
+      }
+    ]
+
+    for schedule <- schedules do
+      assert {:error, {:dispatch_failed, :identity_unresolved}} =
+               RequestOrchestrator.validate_scheduler_selection(schedule, exclusions)
+    end
+
+    assert {:error, {:dispatch_failed, :identity_unresolved}} =
+             RequestOrchestrator.validate_scheduler_selection(
+               %{
+                 node_id: selected_node_id,
+                 runtime_endpoint_target:
+                   Target.grpc_compat(
+                     host: "10.0.0.44",
+                     port: 50_061,
+                     node_id: selected_node_id
+                   )
+               },
+               ["not-a-node-uuid"]
+             )
   end
 
   test "Sentry controller enrichment records request lifecycle breadcrumbs and public request extra",

--- a/apps/orchard_controller/test/orchard/inference_test.exs
+++ b/apps/orchard_controller/test/orchard/inference_test.exs
@@ -28,7 +28,7 @@ defmodule Orchard.InferenceTest do
   defmodule FakeScheduler do
     @behaviour Orchard.Scheduler.SingleNode
 
-    def schedule(%CanonicalRequest{} = request) do
+    def schedule(%CanonicalRequest{} = request, _opts) do
       {:ok, %{scheduled_public_id: request.public_id, scheduler: :fake}}
     end
   end

--- a/apps/orchard_controller/test/orchard/nodes/exclusion_set_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes/exclusion_set_test.exs
@@ -1,0 +1,23 @@
+defmodule Orchard.Nodes.ExclusionSetTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Nodes.ExclusionSet
+
+  test "ADR 0019 canonicalizes valid Node UUID exclusions into a set" do
+    node_id = Ecto.UUID.generate()
+
+    assert {:ok, exclusions} =
+             ExclusionSet.canonicalize([node_id, String.upcase(node_id)])
+
+    assert exclusions == MapSet.new([node_id])
+  end
+
+  test "ADR 0019 preserves attempt-1 compatibility with an empty exclusion set" do
+    assert ExclusionSet.canonicalize([]) == {:ok, MapSet.new()}
+  end
+
+  test "ADR 0019 fails closed for malformed Node UUID exclusions" do
+    assert ExclusionSet.canonicalize(["not-a-uuid"]) == :error
+    assert ExclusionSet.canonicalize(:not_a_list) == :error
+  end
+end

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -850,6 +850,132 @@ defmodule Orchard.Scheduler.MultiNodeTest do
   end
 
   describe "production candidate snapshots" do
+    test "SPEC.md §5.5 and ADR 0019 exclude the prior Node before tiering and prefix scoring" do
+      prior_node = insert_node!(%{advertise_addr: "10.0.0.31", rpc_port: 50_061})
+      alternate_node = insert_node!(%{advertise_addr: "10.0.0.32", rpc_port: 50_062})
+
+      prior_target =
+        Target.grpc_compat(host: "10.0.0.31", port: 50_061, node_id: prior_node.id)
+
+      alternate_target =
+        Target.grpc_compat(host: "10.0.0.32", port: 50_062, node_id: alternate_node.id)
+
+      observed_at = prior_node.last_heartbeat_at
+
+      loaded_placement =
+        Placement.new(%{
+          model_ref: %{model_id: "test-model", version: "v1"},
+          state: :loaded,
+          capacity: %{active_request_count: 0, max_concurrency: 4, status: :available}
+        })
+
+      snapshot =
+        production_snapshot(
+          [
+            production_snapshot_candidate(prior_node, prior_target,
+              observed_at: observed_at,
+              placements: [loaded_placement]
+            ),
+            production_snapshot_candidate(alternate_node, alternate_target,
+              observed_at: observed_at
+            )
+          ],
+          observed_at
+        )
+
+      persist_snapshot_capacity_evidence!(snapshot)
+      put_tie_only_scoring_config()
+      put_inference(runtime_endpoint_targets: [prior_target, alternate_target])
+      stub_score("10.0.0.31", 50_061, ok_resident_score())
+      stub_score("10.0.0.32", 50_062, ok_non_resident_score())
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(),
+                 status_client: StubClient,
+                 observed_at: observed_at,
+                 exclude_node_ids: [String.upcase(prior_node.id)],
+                 active_runtime_endpoint_targets_provider: fn ->
+                   {:ok, [prior_target, alternate_target]}
+                 end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      assert schedule.node_id == alternate_node.id
+
+      assert Enum.any?(schedule.rejected_candidates, fn rejected ->
+               rejected.node_id == prior_node.id and
+                 rejected.reason_codes == ["previous_attempt_node_excluded"]
+             end)
+
+      refute Enum.any?(score_calls(), fn {{host, port}, _request} ->
+               host == "10.0.0.31" and port == 50_061
+             end)
+    end
+
+    test "SPEC.md §5.5 fails closed before exclusion when snapshot identities conflict" do
+      node = insert_node!(%{advertise_addr: "10.0.0.33", rpc_port: 50_063})
+      conflicting_id = Ecto.UUID.generate()
+      target = Target.grpc_compat(host: "10.0.0.33", port: 50_063, node_id: conflicting_id)
+      observed_at = node.last_heartbeat_at
+
+      snapshot =
+        production_snapshot(
+          [production_snapshot_candidate(node, target, observed_at: observed_at)],
+          observed_at
+        )
+
+      persist_snapshot_capacity_evidence!(snapshot)
+      put_inference(runtime_endpoint_targets: [target])
+
+      assert {:error, :cluster_busy, decision} =
+               MultiNode.schedule(canonical_request(),
+                 observed_at: observed_at,
+                 exclude_node_ids: [Ecto.UUID.generate()],
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      assert [rejected] = decision.rejected_candidates
+      assert rejected.node_id == node.id
+      assert rejected.reason_codes == ["runtime_identity_mismatch"]
+    end
+
+    test "SPEC.md §7.3.5 reports an excluded snapshot rejection with the hard-filter reason" do
+      node = insert_node!(%{advertise_addr: "10.0.0.34", rpc_port: 50_064})
+      target = Target.grpc_compat(host: "10.0.0.34", port: 50_064, node_id: node.id)
+      observed_at = node.last_heartbeat_at
+
+      rejection = %Rejection{
+        target: target,
+        node_id: node.id,
+        observed_at: observed_at,
+        reason_codes: ["node_observation_stale"],
+        diagnostics: %{fact: "heartbeat_observation_stale"},
+        candidate_source: "monitor_snapshot"
+      }
+
+      snapshot = production_snapshot([], observed_at, [rejection])
+      put_inference(runtime_endpoint_targets: [target])
+
+      assert {:error, :cluster_busy, decision} =
+               MultiNode.schedule(canonical_request(),
+                 observed_at: observed_at,
+                 exclude_node_ids: [node.id],
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      assert [rejected] = decision.rejected_candidates
+      assert rejected.node_id == node.id
+      assert rejected.reason_codes == ["previous_attempt_node_excluded"]
+    end
+
     test "ADR 0017 production scheduling uses the snapshot without inline status probing" do
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
       target = Target.grpc_compat(host: "10.0.0.1", port: 50_061, node_id: node.id)
@@ -1469,6 +1595,51 @@ defmodule Orchard.Scheduler.MultiNodeTest do
 
       assert Enum.map(schedule.rejected_candidates, & &1.target_ref) == [
                "grpc_compat:10.44.0.43:50073"
+             ]
+    end
+
+    test "SPEC.md §5.5 excludes every compatibility address for the same prior Node" do
+      node_id = "00000000-0000-4000-a000-0000000000ef"
+
+      targets = [
+        [host: "10.44.0.51", port: 50_071],
+        [host: "10.44.0.52", port: 50_072]
+      ]
+
+      stub_probe(
+        "10.44.0.51",
+        50_071,
+        make_status(node_id, host: "10.44.0.51", port: 50_071)
+      )
+
+      stub_probe(
+        "10.44.0.52",
+        50_072,
+        make_status(node_id, host: "10.44.0.52", port: 50_072)
+      )
+
+      put_inference(
+        allow_static_runtime_target_fallback: true,
+        runtime_endpoint_targets: [],
+        runtime_client_targets: targets
+      )
+
+      assert {:error, :cluster_busy, decision} =
+               MultiNode.schedule(canonical_request(),
+                 status_client: StubClient,
+                 exclude_node_ids: [node_id],
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, []} end,
+                 runtime_endpoint_targets_provider: fn {:ok, []} -> targets end
+               )
+
+      assert Enum.map(decision.rejected_candidates, & &1.target_ref) == [
+               "grpc_compat:10.44.0.51:50071",
+               "grpc_compat:10.44.0.52:50072"
+             ]
+
+      assert Enum.map(decision.rejected_candidates, & &1.reason_codes) == [
+               ["previous_attempt_node_excluded"],
+               ["previous_attempt_node_excluded"]
              ]
     end
 

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -1598,6 +1598,52 @@ defmodule Orchard.Scheduler.MultiNodeTest do
              ]
     end
 
+    test "SPEC.md §5.5 verifies compatibility identity before scoring with empty exclusions" do
+      configured_node_id = "00000000-0000-4000-a000-0000000000ad"
+      reported_node_id = "00000000-0000-4000-a000-0000000000ae"
+
+      target =
+        Target.grpc_compat(
+          host: "10.44.0.50",
+          port: 50_070,
+          node_id: configured_node_id
+        )
+
+      put_inference(
+        allow_static_runtime_target_fallback: true,
+        runtime_endpoint_targets: [],
+        runtime_client_targets: [[host: "10.44.0.50", port: 50_070]],
+        cache_affinity: [enabled: true, live_fingerprint_match_enabled: true],
+        prefix_cache_scoring: [enabled: true, timeout_ms: 120]
+      )
+
+      stub_probe(
+        target,
+        make_status(reported_node_id,
+          host: "10.44.0.50",
+          port: 50_070,
+          runtime_prefix_cache_statuses: [
+            prefix_cache_status("test-model", "v1", %{prefix_cache_fingerprints: []})
+          ]
+        )
+      )
+
+      stub_score("10.44.0.50", 50_070, ok_resident_score())
+
+      assert {:error, :cluster_busy, decision} =
+               MultiNode.schedule(canonical_request(),
+                 status_client: StubClient,
+                 exclude_node_ids: [],
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, []} end,
+                 runtime_endpoint_targets_provider: fn {:ok, []} -> [target] end
+               )
+
+      assert [rejected] = decision.rejected_candidates
+      assert rejected.node_id == configured_node_id
+      assert rejected.reason_codes == ["runtime_identity_mismatch"]
+      assert score_calls() == []
+    end
+
     test "SPEC.md §5.5 excludes every compatibility address for the same prior Node" do
       node_id = "00000000-0000-4000-a000-0000000000ef"
 

--- a/apps/orchard_controller/test/orchard/scheduler/single_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/single_node_test.exs
@@ -39,6 +39,88 @@ defmodule Orchard.Scheduler.SingleNodeTest do
     :ok
   end
 
+  test "SPEC.md §5.5 and ADR 0019 exclude the prior Node before probing" do
+    node_id = Ecto.UUID.generate()
+    target = Target.grpc_compat(host: "10.0.0.8", port: 50_061, node_id: node_id)
+
+    assert {:error, :model_busy, decision} =
+             SingleNode.default_schedule(
+               canonical_request("single-prior-node-exclusion"),
+               target,
+               status_client: RuntimeEndpointStubClient,
+               exclude_node_ids: [node_id],
+               node_resolver: fn _target ->
+                 {:ok, %Orchard.Nodes.Node{id: node_id, health: :healthy, state: :active}}
+               end
+             )
+
+    assert [rejected] = decision.rejected_candidates
+    assert rejected.node_id == node_id
+    assert rejected.reason_codes == ["previous_attempt_node_excluded"]
+    refute_received {:runtime_endpoint_connect, _target}
+  end
+
+  test "SPEC.md §5.5 fails closed when exclusions are present and durable identity is missing" do
+    target = Target.grpc_compat(host: "10.0.0.9", port: 50_061)
+
+    assert {:error, :model_busy, decision} =
+             SingleNode.default_schedule(
+               canonical_request("single-missing-durable-identity"),
+               target,
+               status_client: RuntimeEndpointStubClient,
+               exclude_node_ids: [Ecto.UUID.generate()],
+               node_resolver: fn _target -> {:ok, nil} end
+             )
+
+    assert [rejected] = decision.rejected_candidates
+    assert rejected.node_id == nil
+    assert rejected.reason_codes == ["runtime_identity_mismatch"]
+    refute_received {:runtime_endpoint_connect, _target}
+  end
+
+  test "SPEC.md §5.5 fails closed on conflicting durable identity before exclusion comparison" do
+    resolved_node_id = Ecto.UUID.generate()
+    target_node_id = Ecto.UUID.generate()
+    target = Target.grpc_compat(host: "10.0.0.10", port: 50_061, node_id: target_node_id)
+
+    assert {:error, :model_busy, decision} =
+             SingleNode.default_schedule(
+               canonical_request("single-conflicting-durable-identity"),
+               target,
+               status_client: RuntimeEndpointStubClient,
+               exclude_node_ids: [Ecto.UUID.generate()],
+               node_resolver: fn _target ->
+                 {:ok,
+                  %Orchard.Nodes.Node{id: resolved_node_id, health: :healthy, state: :active}}
+               end
+             )
+
+    assert [rejected] = decision.rejected_candidates
+    assert rejected.node_id == resolved_node_id
+    assert rejected.reason_codes == ["runtime_identity_mismatch"]
+    refute_received {:runtime_endpoint_connect, _target}
+  end
+
+  test "ADR 0019 compares SingleNode exclusions as canonical UUIDs" do
+    node_id = Ecto.UUID.generate()
+    target = Target.grpc_compat(host: "10.0.0.11", port: 50_061)
+
+    assert {:error, :model_busy, decision} =
+             SingleNode.default_schedule(
+               canonical_request("single-canonical-exclusion"),
+               target,
+               status_client: RuntimeEndpointStubClient,
+               exclude_node_ids: [String.upcase(node_id)],
+               node_resolver: fn _target ->
+                 {:ok, %Orchard.Nodes.Node{id: node_id, health: :healthy, state: :active}}
+               end
+             )
+
+    assert [rejected] = decision.rejected_candidates
+    assert rejected.reason_codes == ["previous_attempt_node_excluded"]
+    refute_received {:runtime_endpoint_connect, _target}
+  end
+
   test "SPEC.md §5.5 bounds loaded placement capacity by unmanaged aggregate fallback" do
     Process.put(:single_node_status, %{
       runtime_model_placements: [

--- a/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
+++ b/apps/orchard_shared/lib/orchard/cluster_management/reason_codes.ex
@@ -14,6 +14,7 @@ defmodule Orchard.ClusterManagement.ReasonCodes do
     transport_unreachable
     runtime_not_ready
     runtime_identity_mismatch
+    previous_attempt_node_excluded
     version_incompatible
     pool_not_allowed
     model_format_unsupported

--- a/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
+++ b/apps/orchard_shared/test/orchard/cluster_management/contract_test.exs
@@ -13,6 +13,7 @@ defmodule Orchard.ClusterManagement.ContractTest do
 
   test "reason-code vocabularies expose accepted fixed codes" do
     assert "node_not_active" in ReasonCodes.scheduler_rejection_codes()
+    assert "previous_attempt_node_excluded" in ReasonCodes.scheduler_rejection_codes()
     assert "lower_tier_not_considered" in ReasonCodes.scheduler_skip_codes()
     assert "node_not_pending_admission" in ReasonCodes.action_blocker_codes()
     assert "drain_not_running" in ReasonCodes.action_blocker_codes()

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -46,11 +46,11 @@
 
 ## 6. Hard prior-Node exclusion
 
-- [ ] 6.1 Extend scheduler contracts with hard `exclude_node_ids`
-- [ ] 6.2 Filter excluded Node identities before tiering, ranking, scoring, and prefix-cache scoring
-- [ ] 6.3 Record the `SPEC.md` §7.3.5 rejection reason code `previous_attempt_node_excluded` in scheduler explanations
-- [ ] 6.4 Make admitted single-target scheduling fail when its Node is excluded
-- [ ] 6.5 Recheck the selected Node in the orchestrator before dispatch
+- [x] 6.1 Extend scheduler contracts with hard `exclude_node_ids`
+- [x] 6.2 Filter excluded Node identities before tiering, ranking, scoring, and prefix-cache scoring
+- [x] 6.3 Record the `SPEC.md` §7.3.5 rejection reason code `previous_attempt_node_excluded` in scheduler explanations
+- [x] 6.4 Make admitted single-target scheduling fail when its Node is excluded
+- [x] 6.5 Recheck the selected Node in the orchestrator before dispatch
 - [ ] 6.6 Keep the §7.5.3 `ScorePrefixCache` caps per logical Request so attempt 2 uses only their unconsumed remainder and otherwise ranks fail-open
 - [ ] 6.7 Prove alternate scheduling runs no second compatibility status-probe wave and records `no_alternative_node` on that branch
 


### PR DESCRIPTION
## Summary

This closes the hard prior-Node scheduler exclusion slice for #169.
Schedulers now accept a canonical Node exclusion set, reject prior Nodes before eligibility and scoring work, explain that rejection with `previous_attempt_node_excluded`, and defend the same identity boundary again before dispatch.

This PR establishes the exclusion seam needed by automatic attempt retry in the portable Orchard control-plane core.
It does not start attempt 2.

## Contract and behavior

- `Orchard.Nodes.ExclusionSet` is the shared authority for canonical durable Node UUID exclusion sets across the production schedulers and the orchestrator defense.
- Attempt 1 preserves existing behavior by scheduling with `exclude_node_ids: []`.
- Multi-Node scheduling verifies durable identity and filters excluded candidates before enrichment, capacity annotation, cache affinity, tiering, ranking, scoring, and prefix-cache scoring.
- Single-Node scheduling rejects an admitted target when its resolved durable Node identity is excluded.
- Missing, malformed, or conflicting durable identity fails closed with `runtime_identity_mismatch`.
- Excluded candidates use the fixed scheduler explanation reason `previous_attempt_node_excluded`.
- The orchestrator rechecks selected Node identity before dispatch, including typed gRPC targets through durable address resolution and legacy address targets.
- Scheduler test doubles implement the two-argument callback and verify the initial empty exclusion set.

OpenSpec tasks 6.1 through 6.5 are complete.

## Scope boundaries

Retry orchestration, capacity release, queue re-entry, task 6.6 prefix-score budget accounting, task 6.7 compatibility probe reuse, #170 breaker attribution, and #171 attempt-2 behavior remain out of scope.
#296's circuit-breaker foundation is now on `main`.
This PR composes with that existing authority by applying prior-Node exclusion before circuit-breaker eligibility, but it does not implement or own breaker behavior.

## Risk Assessment

✅ **Medium**

- The blast radius covers production scheduler selection, scheduler explanations, scheduler test doubles, and the final orchestrator dispatch boundary.
- Exclusion is fail-closed for malformed, missing, or conflicting durable Node identity.
- Attempt-1 compatibility is preserved by the explicit empty exclusion set.
- The exclusion and circuit-breaker filters remain separate authorities with deterministic ordering.
- No database schema, migration, packaging, dependency, capacity-release, retry-loop, or breaker-attribution behavior changes.
- The non-empty path is covered through public scheduler seams and the pre-dispatch defense, but a real attempt-2 integration flow remains intentionally unavailable until #171.

## Verification

Latest clean review-fix gate:

```sh
mise exec -- mix format
mise exec -- mix compile --warnings-as-errors
mise exec -- mix credo --strict
mise exec -- mix dialyzer
make macos-native-test-helpers
mise exec -- mix test
mise exec -- mix test --cover
```

- Formatting, warnings-as-errors compilation, and macOS helper staging passed.
- Strict Credo checked 741 files with 90 checks and zero findings.
- Dialyzer completed with zero errors.
- Full tests passed: 216 Shared; 3,608 Controller with 5 skipped; 412 Node Agent; 678 CLI with 1 skipped and 10 excluded.
- The first coverage run hit one transient 50 ms timing failure in the MultiNode queue-capacity test.
- Exact reproduction passed:

```sh
mise exec -- mix test apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs:6142
```

Outcome: 1 test passed with 153 excluded.

- The exact coverage command then passed on rerun: Shared 67.25%; Controller 85.2%; Node Agent 78.33%; CLI 76.38%.

Strict OpenSpec validation:

```sh
OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate automatic-attempt-retry --type change --strict --no-interactive
```

Outcome: `Change 'automatic-attempt-retry' is valid`.

Hosted validation on head `2633c49ab30a31be446b65f6f7dfa4425fb4b2e6` is green: Required Orchard validation gate, Linux portable control-plane core, Provider-neutral conformance, macOS host validation, MLX provider validation, Orchard.app and DMG validation, OpenSpec validation, and Devin Review.

Independent RepoPrompt implementation review and Oracle second opinion both concluded GO with no blocking findings after the typed gRPC durable-address defense was added.

## PR Checklist

- [x] I checked the `SPEC.md` behavior change.
- [x] I reconciled the affected specification, ADR 0019, OpenSpec change, implementation, and tests.
- [x] I ran the relevant validation and recorded the exact outcomes.
- [x] I did not commit active goal packages or private local artifacts.
- [x] I did not introduce dependencies on private workbench or session context.

Closes #169

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790480275&installation_model_id=428414&pr_number=301&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F301&signature=3b5e7c3b3ddfb804302a1f06fe5e5ab5f68e3d585f6fee2063127d1c6f5537de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
