### PR TITLE
feat(scheduler): add durable circuit-breaker authority

### DIFF
--- a/apps/orchard_controller/lib/orchard/api/ops/circuit_breaker_presenter.ex
+++ b/apps/orchard_controller/lib/orchard/api/ops/circuit_breaker_presenter.ex
@@ -1,0 +1,32 @@
+defmodule Orchard.API.Ops.CircuitBreakerPresenter do
+  @moduledoc """
+  Bounded Operator API projection for durable circuit-breaker state.
+  """
+
+  alias Orchard.CircuitBreakers.Decision
+
+  @spec breaker(Decision.t()) :: map()
+  def breaker(%Decision{} = decision) do
+    %{
+      object: "circuit_breaker",
+      kind: Atom.to_string(decision.kind),
+      node_id: decision.node_id,
+      model_id: decision.model_id,
+      state: Atom.to_string(decision.state),
+      contribution_count: decision.contribution_count,
+      opened_at: decision.opened_at,
+      suppressed_until: decision.suppressed_until,
+      last_cleared_at: decision.last_cleared_at,
+      generation: decision.generation
+    }
+  end
+
+  @spec clear_result(Decision.t()) :: map()
+  def clear_result(%Decision{} = decision) do
+    %{
+      result: if(decision.changed_state?, do: "cleared", else: "already_cleared"),
+      changed: decision.changed_state?,
+      breaker: breaker(decision)
+    }
+  end
+end

--- a/apps/orchard_controller/lib/orchard/api/ops/circuit_breakers_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/ops/circuit_breakers_controller.ex
@@ -1,0 +1,173 @@
+defmodule Orchard.API.Ops.CircuitBreakersController do
+  @moduledoc false
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Orchard.API.AdminErrorHelpers
+  alias Orchard.API.Ops.CircuitBreakerPresenter
+  alias Orchard.CircuitBreakers
+  alias Orchard.ControlPlane
+  alias Orchard.Governance
+
+  @spec show_node(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show_node(conn, %{"node_id" => node_id}) do
+    inspect_breaker(conn, {:node, node_id})
+  end
+
+  @spec show_placement(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show_placement(conn, %{"node_id" => node_id, "model_id" => model_id}) do
+    inspect_breaker(conn, {:placement, node_id, model_id})
+  end
+
+  @spec clear_node(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def clear_node(conn, %{"node_id" => node_id}) do
+    clear(conn, {:node, node_id})
+  end
+
+  @spec clear_placement(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def clear_placement(conn, %{"node_id" => node_id, "model_id" => model_id}) do
+    clear(conn, {:placement, node_id, model_id})
+  end
+
+  defp inspect_breaker(conn, target) do
+    result =
+      with :ok <- ControlPlane.authorize_write_path(:circuit_breaker_inspection) do
+        CircuitBreakers.inspect(target)
+      end
+
+    render_inspection(conn, result)
+  end
+
+  defp render_inspection(conn, {:ok, decision}) do
+    json(conn, CircuitBreakerPresenter.breaker(decision))
+  end
+
+  defp render_inspection(conn, {:error, reason}), do: send_error(conn, reason)
+
+  defp clear(conn, target) do
+    with {:ok, reason} <- clear_reason(conn),
+         {:ok, decision} <-
+           CircuitBreakers.clear(target,
+             reason: reason,
+             audit: &insert_clear_audit(&1, reason, conn)
+           ) do
+      json(conn, CircuitBreakerPresenter.clear_result(decision))
+    else
+      {:error, error} -> send_error(conn, error)
+    end
+  end
+
+  defp clear_reason(%Plug.Conn{body_params: %{"reason" => reason}}) when is_binary(reason) do
+    case String.trim(reason) do
+      "" -> {:error, :clear_reason_required}
+      normalized -> {:ok, normalized}
+    end
+  end
+
+  defp clear_reason(_conn), do: {:error, :clear_reason_required}
+
+  defp insert_clear_audit(decision, reason, conn) do
+    result = if decision.changed_state?, do: "cleared", else: "already_cleared"
+
+    Governance.insert_cluster_audit_log(%{
+      actor_type: "service_account",
+      actor_id: conn.assigns[:service_account_id] || conn.assigns[:principal_id],
+      action: clear_action(decision.kind),
+      target_type: clear_target_type(decision.kind),
+      target_id: clear_target_id(decision),
+      occurred_at: decision.decision_at,
+      payload: %{
+        "result" => result,
+        "changed" => decision.changed_state?,
+        "reason" => reason,
+        "previous_state" => Atom.to_string(decision.previous_state),
+        "resulting_generation" => decision.generation,
+        "node_id" => decision.node_id,
+        "model_id" => decision.model_id
+      }
+    })
+    |> case do
+      {:ok, _audit_log} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp clear_action(:node), do: "circuit_breaker.node.cleared"
+  defp clear_action(:placement), do: "circuit_breaker.placement.cleared"
+
+  defp clear_target_type(:node), do: "node_circuit_breaker"
+  defp clear_target_type(:placement), do: "placement_circuit_breaker"
+
+  defp clear_target_id(%{kind: :node, node_id: node_id}), do: node_id
+
+  defp clear_target_id(%{kind: :placement, node_id: node_id, model_id: model_id}) do
+    "#{node_id}:#{model_id}"
+  end
+
+  defp send_error(conn, :clear_reason_required) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :unprocessable_entity,
+      "circuit_breaker_clear_reason_required",
+      "A nonblank circuit-breaker clear reason is required."
+    )
+  end
+
+  defp send_error(conn, reason)
+       when reason in [:node_not_found, :model_not_found, :model_not_active] do
+    public_reason = if(reason == :node_not_found, do: :node_not_found, else: :model_not_found)
+
+    AdminErrorHelpers.send_error(
+      conn,
+      :not_found,
+      Atom.to_string(public_reason),
+      not_found_message(public_reason)
+    )
+  end
+
+  defp send_error(conn, reason)
+       when reason in [
+              :invalid_node_id,
+              :invalid_node_identity,
+              :invalid_model_id,
+              :invalid_model_identity,
+              :invalid_target
+            ] do
+    AdminErrorHelpers.send_error(
+      conn,
+      :unprocessable_entity,
+      "invalid_circuit_breaker_target",
+      "Circuit-breaker target identity is invalid."
+    )
+  end
+
+  defp send_error(conn, :controller_standby) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :service_unavailable,
+      "controller_standby",
+      "This controller is in standby mode."
+    )
+  end
+
+  defp send_error(conn, :controller_leadership_unproven) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :service_unavailable,
+      "controller_leadership_unproven",
+      "This controller has not proven local leadership."
+    )
+  end
+
+  defp send_error(conn, _reason) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :service_unavailable,
+      "circuit_breaker_unavailable",
+      "Circuit-breaker state is unavailable."
+    )
+  end
+
+  defp not_found_message(:node_not_found), do: "Node was not found."
+  defp not_found_message(:model_not_found), do: "Model was not found."
+end

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -87,6 +87,20 @@ defmodule Orchard.API.Router do
 
     get("/health", HealthController, :show)
     get("/scheduler/explanations/:request_id", SchedulerExplanationsController, :show)
+    get("/circuit-breakers/nodes/:node_id", CircuitBreakersController, :show_node)
+    post("/circuit-breakers/nodes/:node_id/clear", CircuitBreakersController, :clear_node)
+
+    get(
+      "/circuit-breakers/placements/:node_id/:model_id",
+      CircuitBreakersController,
+      :show_placement
+    )
+
+    post(
+      "/circuit-breakers/placements/:node_id/:model_id/clear",
+      CircuitBreakersController,
+      :clear_placement
+    )
   end
 
   scope "/admin/v1", Orchard.API.Admin do

--- a/apps/orchard_controller/lib/orchard/circuit_breakers.ex
+++ b/apps/orchard_controller/lib/orchard/circuit_breakers.ex
@@ -1,0 +1,673 @@
+defmodule Orchard.CircuitBreakers do
+  @moduledoc """
+  Persistent Node and placement circuit breakers defined by `SPEC.md` section 5.10.
+
+  Postgres owns failure identity, rolling-window evidence, serialization, clear
+  watermarks, and suppression deadlines. The optional `:now` value is a
+  deterministic decision-time seam; production callers omit it and use the
+  database clock.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL
+  alias Ecto.UUID
+  alias Orchard.CircuitBreakers.{Breaker, Decision, Failure}
+  alias Orchard.ControlPlane
+  alias Orchard.Governance.AuditWriter
+  alias Orchard.Models.Model
+  alias Orchard.Nodes.Node
+  alias Orchard.Repo
+
+  @node_classes ~w(pre_acceptance_unavailable worker_or_node_loss)
+  @placement_classes ~w(model_load_failure)
+
+  @ineligible_classes ~w(
+    capacity_rejection
+    runtime_failure
+    terminal_conformance
+    cancellation
+    deadline
+    controller_failure
+    occupancy_unresolved
+    identity_unresolved
+  )
+
+  @policies %{
+    node: %{window_seconds: 60, suppression_seconds: 300},
+    placement: %{window_seconds: 600, suppression_seconds: 900}
+  }
+
+  @type target :: {:node, Ecto.UUID.t()} | {:placement, Ecto.UUID.t(), Ecto.UUID.t()}
+  @type error ::
+          :invalid_failure_identity
+          | :invalid_node_identity
+          | :node_not_found
+          | :invalid_model_identity
+          | :model_not_found
+          | :model_not_active
+          | :invalid_failure_class
+          | :invalid_occurred_at
+          | :failure_target_mismatch
+          | :failure_identity_conflict
+          | :breaker_state_invalid
+          | :circuit_breaker_unavailable
+          | :controller_standby
+          | :controller_leadership_unproven
+          | term()
+
+  @doc """
+  Records one stable eligible failure exactly once and returns its durable decision.
+
+  Duplicate delivery with the same identity and payload is idempotent. Reuse of
+  the identity for a different failure fails closed.
+  """
+  @spec record_failure(map(), keyword()) ::
+          {:ok, Decision.t() | :not_eligible} | {:error, error()}
+  def record_failure(attrs, opts \\ [])
+
+  def record_failure(attrs, opts) when is_map(attrs) and is_list(opts) do
+    domain_call(fn ->
+      with :ok <- ControlPlane.authorize_write_path(:circuit_breaker),
+           {:ok, normalized} <- normalize_failure(attrs) do
+        record_normalized(normalized, opts)
+      end
+    end)
+  end
+
+  def record_failure(_attrs, _opts), do: {:error, :invalid_failure_identity}
+
+  defp record_normalized(:not_eligible, _opts), do: {:ok, :not_eligible}
+
+  defp record_normalized(failure, opts),
+    do: transact(fn -> record_eligible(failure, opts) end)
+
+  @doc """
+  Evaluates whether a canonical Node or placement is currently suppressed.
+
+  Expiry is lazy: a persisted open row whose deadline has passed is returned as
+  closed immediately, and the next authorized mutation persists the transition.
+  """
+  @spec evaluate(target(), keyword()) :: {:ok, Decision.t()} | {:error, error()}
+  def evaluate(target, opts \\ []) when is_list(opts) do
+    domain_call(fn -> evaluate_target(target, opts) end)
+  end
+
+  defp evaluate_target(target, opts) do
+    with {:ok, identity} <- normalize_target(target) do
+      transact(fn -> evaluate_locked(identity, opts) end)
+    end
+  end
+
+  @doc """
+  Evaluates several canonical targets from one coherent database decision point.
+
+  Target locks are acquired in canonical order so callers may supply targets in
+  any order without introducing lock-order inversions. Results preserve the
+  caller's input order.
+  """
+  @spec evaluate_many([target()], keyword()) :: {:ok, [Decision.t()]} | {:error, error()}
+  def evaluate_many(targets, opts \\ []) when is_list(targets) and is_list(opts) do
+    domain_call(fn -> evaluate_targets(targets, opts) end)
+  end
+
+  defp evaluate_targets(targets, opts) do
+    with {:ok, identities} <- normalize_targets(targets) do
+      transact(fn -> evaluate_many_locked(identities, opts) end)
+    end
+  end
+
+  @doc """
+  Inspects durable breaker history, including placements whose catalog Model was removed.
+  """
+  @spec inspect(target(), keyword()) :: {:ok, Decision.t()} | {:error, error()}
+  def inspect(target, opts \\ []) when is_list(opts) do
+    domain_call(fn -> inspect_target(target, opts) end)
+  end
+
+  defp inspect_target(target, opts) do
+    with {:ok, identity} <- normalize_target(target) do
+      transact(fn -> inspect_locked(identity, opts) end)
+    end
+  end
+
+  @doc """
+  Clears a breaker with a durable generation and time watermark.
+
+  An `:audit` callback, when supplied, runs with the post-clear decision inside
+  the same transaction. Any callback error rolls the clear back.
+  """
+  @spec clear(target(), keyword()) :: {:ok, Decision.t()} | {:error, error()}
+  def clear(target, opts \\ []) when is_list(opts) do
+    domain_call(fn -> clear_target(target, opts) end)
+  end
+
+  defp clear_target(target, opts) do
+    with :ok <- ControlPlane.authorize_write_path(:circuit_breaker_clear),
+         {:ok, identity} <- normalize_target(target) do
+      transact(fn -> clear_locked(identity, opts) end)
+    end
+  end
+
+  defp record_eligible(failure, opts) do
+    identity = failure_identity(failure)
+    lock_target(identity, opts)
+    lock_failure(failure.failure_id, opts)
+
+    case Repo.get(Failure, failure.failure_id) do
+      nil -> insert_failure(failure, opts)
+      existing -> duplicate_result(existing, failure, opts)
+    end
+  end
+
+  defp insert_failure(failure, opts) do
+    identity = failure_identity(failure)
+    now = decision_time(opts)
+
+    with :ok <- validate_occurrence(failure, now),
+         :ok <- validate_target(identity),
+         {:ok, breaker} <- get_or_create_breaker(identity),
+         {:ok, breaker} <- persist_expiry(breaker, now),
+         disposition = failure_disposition(breaker, failure),
+         {:ok, persisted_failure} <- persist_failure(failure, breaker, now, disposition),
+         {:ok, count} <- contribution_count(breaker, now),
+         {:ok, breaker, changed?} <- maybe_open(breaker, count, now),
+         transition = if(changed?, do: :opened, else: :none),
+         {:ok, _persisted_failure} <- mark_transition(persisted_failure, transition),
+         {:ok, decision} <-
+           decision(breaker, now, changed?, :recorded,
+             contribution_disposition: disposition,
+             transition: transition
+           ) do
+      %{decision | contribution_count: count}
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp duplicate_result(existing, failure, opts) do
+    if same_failure?(existing, failure) do
+      now = decision_time(opts)
+
+      with :ok <- validate_occurrence(failure, now),
+           {:ok, breaker} <- fetch_breaker_by_id(existing.breaker_id),
+           true <- breaker_matches_failure?(breaker, existing) || {:error, :breaker_state_invalid},
+           {:ok, result} <-
+             decision(breaker, now, false, :duplicate,
+               contribution_disposition: existing.disposition,
+               transition: existing.transition
+             ) do
+        result
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    else
+      Repo.rollback(:failure_identity_conflict)
+    end
+  end
+
+  defp clear_locked(identity, opts) do
+    lock_target(identity, opts)
+    now = decision_time(opts)
+
+    with :ok <- validate_target(identity),
+         {:ok, breaker} <- get_or_create_breaker(identity),
+         previous_state = effective_state(breaker, now),
+         {:ok, breaker} <- persist_expiry(breaker, now),
+         changed? = previous_state == :open,
+         {:ok, breaker} <- persist_clear(breaker, changed?, now),
+         {:ok, result} <- decision(breaker, now, changed?, nil, previous_state: previous_state),
+         :ok <- audit_clear(Keyword.get(opts, :audit), result) do
+      result
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp evaluate_locked(identity, opts) do
+    lock_target(identity, opts)
+    now = decision_time(opts)
+
+    case validate_target(identity) do
+      :ok -> evaluate_fetched(identity, now)
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp evaluate_many_locked(identities, opts) do
+    identities
+    |> Enum.uniq_by(&target_lock_key/1)
+    |> Enum.sort_by(&target_lock_key/1)
+    |> Enum.each(&lock_target(&1, opts))
+
+    now = decision_time(opts)
+
+    identities
+    |> Enum.reduce_while([], fn identity, decisions ->
+      case validate_target(identity) do
+        :ok -> {:cont, [evaluate_fetched(identity, now) | decisions]}
+        {:error, reason} -> {:halt, Repo.rollback(reason)}
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp evaluate_fetched(identity, now) do
+    case fetch_breaker(identity) do
+      nil -> empty_decision(identity, now)
+      breaker -> unwrap_or_rollback(decision(breaker, now, false, nil))
+    end
+  end
+
+  defp inspect_locked(identity, opts) do
+    lock_target(identity, opts)
+    now = decision_time(opts)
+
+    case validate_node(identity.node_id) do
+      :ok -> inspect_fetched(identity, now)
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp inspect_fetched(identity, now) do
+    case fetch_breaker(identity) do
+      nil -> inspect_empty(identity, now)
+      breaker -> unwrap_or_rollback(decision(breaker, now, false, nil))
+    end
+  end
+
+  defp inspect_empty(identity, now) do
+    case validate_model(identity.kind, identity.model_id) do
+      :ok -> empty_decision(identity, now)
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp audit_clear(nil, _decision), do: :ok
+  defp audit_clear(callback, decision) when is_function(callback, 1), do: callback.(decision)
+  defp audit_clear(_callback, _decision), do: {:error, :invalid_audit_callback}
+
+  defp persist_clear(breaker, false, _now), do: {:ok, breaker}
+
+  defp persist_clear(breaker, true, now) do
+    breaker
+    |> Ecto.Changeset.change(%{
+      state: :closed,
+      generation: breaker.generation + 1,
+      opened_at: nil,
+      suppressed_until: nil,
+      last_cleared_at: now
+    })
+    |> Repo.update()
+  end
+
+  defp persist_failure(failure, breaker, now, disposition) do
+    %Failure{}
+    |> Failure.changeset(%{
+      id: failure.failure_id,
+      breaker_id: breaker.id,
+      node_id: failure.node_id,
+      model_id: failure.model_id,
+      failure_class: failure.failure_class,
+      occurred_at: failure.occurred_at,
+      decision_at: now,
+      disposition: disposition,
+      transition: :none,
+      generation: breaker.generation
+    })
+    |> Repo.insert()
+  end
+
+  defp mark_transition(failure, transition) do
+    failure
+    |> Ecto.Changeset.change(transition: transition)
+    |> Repo.update()
+  end
+
+  defp failure_disposition(%Breaker{last_cleared_at: nil}, _failure), do: :contributed
+
+  defp failure_disposition(%Breaker{last_cleared_at: cleared_at}, failure) do
+    if DateTime.compare(failure.occurred_at, cleared_at) == :gt,
+      do: :contributed,
+      else: :fenced
+  end
+
+  defp contribution_count(breaker, now) do
+    cutoff = DateTime.add(now, -policy(breaker).window_seconds, :second)
+
+    count =
+      Failure
+      |> where([failure], failure.breaker_id == ^breaker.id)
+      |> where([failure], failure.generation == ^breaker.generation)
+      |> where([failure], failure.disposition == :contributed)
+      |> where([failure], failure.decision_at > ^cutoff)
+      |> where([failure], failure.decision_at <= ^now)
+      |> after_clear_watermark(breaker.last_cleared_at)
+      |> Repo.aggregate(:count)
+
+    {:ok, count}
+  end
+
+  defp after_clear_watermark(query, nil), do: query
+
+  defp after_clear_watermark(query, cleared_at),
+    do: where(query, [failure], failure.occurred_at > ^cleared_at)
+
+  defp maybe_open(%Breaker{state: :closed} = breaker, count, now) when count >= 3 do
+    suppression_until = DateTime.add(now, policy(breaker).suppression_seconds, :second)
+
+    breaker
+    |> Ecto.Changeset.change(%{
+      state: :open,
+      opened_at: now,
+      suppressed_until: suppression_until
+    })
+    |> Repo.update()
+    |> case do
+      {:ok, opened} -> {:ok, opened, true}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  defp maybe_open(breaker, _count, _now), do: {:ok, breaker, false}
+
+  defp persist_expiry(%Breaker{} = breaker, now) do
+    if breaker.state == :open and effective_state(breaker, now) == :closed do
+      breaker
+      |> Ecto.Changeset.change(state: :closed, opened_at: nil, suppressed_until: nil)
+      |> Repo.update()
+    else
+      {:ok, breaker}
+    end
+  end
+
+  defp decision(%Breaker{} = breaker, now, changed?, delivery, opts \\ []) do
+    with {:ok, count} <- contribution_count(breaker, now),
+         {:ok, state} <- validated_effective_state(breaker, now) do
+      {:ok,
+       %Decision{
+         id: breaker.id,
+         kind: breaker.kind,
+         node_id: breaker.node_id,
+         model_id: breaker.model_id,
+         state: state,
+         contribution_count: count,
+         opened_at: if(state == :open, do: breaker.opened_at),
+         suppressed_until: if(state == :open, do: breaker.suppressed_until),
+         last_cleared_at: breaker.last_cleared_at,
+         decision_at: now,
+         previous_state: Keyword.get(opts, :previous_state),
+         contribution_disposition: Keyword.get(opts, :contribution_disposition),
+         transition: Keyword.get(opts, :transition),
+         generation: breaker.generation,
+         delivery: delivery,
+         changed_state?: changed?
+       }}
+    end
+  end
+
+  defp empty_decision(identity, now) do
+    %Decision{
+      kind: identity.kind,
+      node_id: identity.node_id,
+      model_id: identity.model_id,
+      state: :closed,
+      contribution_count: 0,
+      decision_at: now,
+      transition: nil,
+      generation: 0
+    }
+  end
+
+  defp get_or_create_breaker(identity) do
+    case fetch_breaker(identity) do
+      nil ->
+        %Breaker{}
+        |> Breaker.create_changeset(%{
+          kind: identity.kind,
+          node_id: identity.node_id,
+          model_id: identity.model_id,
+          state: :closed,
+          generation: 0
+        })
+        |> Repo.insert()
+
+      breaker ->
+        {:ok, breaker}
+    end
+  end
+
+  defp fetch_breaker(%{kind: :node, node_id: node_id}),
+    do: Repo.get_by(Breaker, kind: :node, node_id: node_id)
+
+  defp fetch_breaker(%{kind: :placement, node_id: node_id, model_id: model_id}),
+    do: Repo.get_by(Breaker, kind: :placement, node_id: node_id, model_id: model_id)
+
+  defp fetch_breaker_by_id(id) do
+    case Repo.get(Breaker, id) do
+      nil -> {:error, :breaker_state_invalid}
+      breaker -> {:ok, breaker}
+    end
+  end
+
+  defp validate_target(%{node_id: node_id, kind: kind} = identity) do
+    with :ok <- validate_node(node_id) do
+      validate_model(kind, Map.get(identity, :model_id))
+    end
+  end
+
+  defp validate_node(node_id) do
+    case Repo.get(Node, node_id) do
+      nil -> {:error, :node_not_found}
+      %Node{} -> :ok
+    end
+  end
+
+  defp validate_model(:node, nil), do: :ok
+
+  defp validate_model(:placement, model_id) do
+    case Repo.get(Model, model_id) do
+      nil -> {:error, :model_not_found}
+      %Model{state: state} when state in [:active, :deprecated] -> :ok
+      %Model{} -> {:error, :model_not_active}
+    end
+  end
+
+  defp normalize_failure(attrs) do
+    failure_id = attr(attrs, :failure_id)
+    node_id = attr(attrs, :node_id)
+    model_id = attr(attrs, :model_id)
+    failure_class = normalize_class(attr(attrs, :failure_class))
+    occurred_at = attr(attrs, :occurred_at)
+
+    with {:ok, failure_id} <- cast_uuid(failure_id, :invalid_failure_identity),
+         {:ok, node_id} <- cast_uuid(node_id, :invalid_node_identity),
+         {:ok, occurred_at} <- cast_time(occurred_at),
+         {:ok, target} <- class_target(failure_class, model_id) do
+      case target do
+        :not_eligible ->
+          {:ok, :not_eligible}
+
+        {kind, model_id} ->
+          {:ok,
+           %{
+             failure_id: failure_id,
+             node_id: node_id,
+             model_id: model_id,
+             failure_class: failure_class,
+             occurred_at: occurred_at,
+             kind: kind
+           }}
+      end
+    end
+  end
+
+  defp class_target(class, model_id) when class in @node_classes do
+    if is_nil(model_id), do: {:ok, {:node, nil}}, else: {:error, :failure_target_mismatch}
+  end
+
+  defp class_target(class, model_id) when class in @placement_classes do
+    with {:ok, model_id} <- cast_uuid(model_id, :invalid_model_identity) do
+      {:ok, {:placement, model_id}}
+    end
+  end
+
+  defp class_target(class, _model_id) when class in @ineligible_classes,
+    do: {:ok, :not_eligible}
+
+  defp class_target(_class, _model_id), do: {:error, :invalid_failure_class}
+
+  defp normalize_target({:node, node_id}) do
+    with {:ok, node_id} <- cast_uuid(node_id, :invalid_node_identity) do
+      {:ok, %{kind: :node, node_id: node_id, model_id: nil}}
+    end
+  end
+
+  defp normalize_target({:placement, node_id, model_id}) do
+    with {:ok, node_id} <- cast_uuid(node_id, :invalid_node_identity),
+         {:ok, model_id} <- cast_uuid(model_id, :invalid_model_identity) do
+      {:ok, %{kind: :placement, node_id: node_id, model_id: model_id}}
+    end
+  end
+
+  defp normalize_target(_target), do: {:error, :invalid_node_identity}
+
+  defp normalize_targets(targets) do
+    Enum.reduce_while(targets, {:ok, []}, fn target, {:ok, identities} ->
+      case normalize_target(target) do
+        {:ok, identity} -> {:cont, {:ok, [identity | identities]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, identities} -> {:ok, Enum.reverse(identities)}
+      error -> error
+    end
+  end
+
+  defp failure_identity(%{kind: kind, node_id: node_id, model_id: model_id}),
+    do: %{kind: kind, node_id: node_id, model_id: model_id}
+
+  defp same_failure?(existing, failure) do
+    existing.node_id == failure.node_id and existing.model_id == failure.model_id and
+      existing.failure_class == failure.failure_class and
+      DateTime.compare(existing.occurred_at, failure.occurred_at) == :eq
+  end
+
+  defp breaker_matches_failure?(breaker, failure) do
+    breaker.node_id == failure.node_id and breaker.model_id == failure.model_id and
+      breaker.generation >= failure.generation
+  end
+
+  defp validate_occurrence(failure, now) do
+    if DateTime.compare(failure.occurred_at, now) == :gt,
+      do: {:error, :invalid_occurred_at},
+      else: :ok
+  end
+
+  defp validated_effective_state(%Breaker{state: state} = breaker, now)
+       when state in [:open, :closed],
+       do: {:ok, effective_state(breaker, now)}
+
+  defp validated_effective_state(_breaker, _now), do: {:error, :breaker_state_invalid}
+
+  defp effective_state(%Breaker{state: :open, suppressed_until: %DateTime{} = until}, now) do
+    if DateTime.compare(until, now) == :gt, do: :open, else: :closed
+  end
+
+  defp effective_state(%Breaker{state: :closed}, _now), do: :closed
+  defp effective_state(_breaker, _now), do: :closed
+
+  defp policy(%Breaker{kind: kind}), do: Map.fetch!(@policies, kind)
+
+  defp lock_failure(id, opts) do
+    advisory_lock("failure:" <> id)
+    notify_lock(opts, :failure)
+  end
+
+  defp lock_target(%{kind: kind, node_id: node_id, model_id: model_id}, opts) do
+    advisory_lock(Enum.join([kind, node_id, model_id], ":"))
+    notify_lock(opts, :target)
+  end
+
+  defp target_lock_key(%{kind: kind, node_id: node_id, model_id: model_id}),
+    do: Enum.join([kind, node_id, model_id], ":")
+
+  defp notify_lock(opts, lock_name) do
+    case Keyword.get(opts, :test_lock_observer) do
+      observer when is_function(observer, 1) -> observer.(lock_name)
+      _observer -> :ok
+    end
+  end
+
+  defp advisory_lock(key) do
+    SQL.query!(
+      Repo,
+      "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+      ["orchard:circuit-breaker:" <> key]
+    )
+
+    :ok
+  end
+
+  defp decision_time(opts) do
+    case Keyword.fetch(opts, :now) do
+      {:ok, %DateTime{} = now} ->
+        DateTime.truncate(now, :microsecond)
+
+      _ ->
+        %{rows: [[now]]} = SQL.query!(Repo, "SELECT clock_timestamp()", [])
+        DateTime.truncate(now, :microsecond)
+    end
+  end
+
+  defp transact(fun), do: AuditWriter.transaction(fun)
+
+  defp unwrap_or_rollback({:ok, value}), do: value
+  defp unwrap_or_rollback({:error, reason}), do: Repo.rollback(reason)
+
+  defp domain_call(fun) do
+    fun.()
+  rescue
+    _exception in [
+      DBConnection.ConnectionError,
+      DBConnection.OwnershipError,
+      Postgrex.Error
+    ] ->
+      {:error, :circuit_breaker_unavailable}
+  catch
+    :exit, reason ->
+      if database_exit?(reason),
+        do: {:error, :circuit_breaker_unavailable},
+        else: exit(reason)
+  end
+
+  defp database_exit?(%DBConnection.ConnectionError{}), do: true
+  defp database_exit?(%DBConnection.OwnershipError{}), do: true
+  defp database_exit?(%Postgrex.Error{}), do: true
+
+  defp database_exit?(reason) when is_tuple(reason) do
+    reason
+    |> Tuple.to_list()
+    |> Enum.any?(&database_exit?/1)
+  end
+
+  defp database_exit?(reason) when is_list(reason), do: Enum.any?(reason, &database_exit?/1)
+  defp database_exit?(_reason), do: false
+
+  defp cast_uuid(value, error) do
+    case UUID.cast(value) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, error}
+    end
+  end
+
+  defp cast_time(%DateTime{} = value), do: {:ok, DateTime.truncate(value, :microsecond)}
+  defp cast_time(_value), do: {:error, :invalid_occurred_at}
+
+  defp normalize_class(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_class(value) when is_binary(value), do: value
+  defp normalize_class(_value), do: nil
+
+  defp attr(attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+end

--- a/apps/orchard_controller/lib/orchard/circuit_breakers/breaker.ex
+++ b/apps/orchard_controller/lib/orchard/circuit_breakers/breaker.ex
@@ -1,0 +1,32 @@
+defmodule Orchard.CircuitBreakers.Breaker do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "circuit_breakers" do
+    field(:kind, Ecto.Enum, values: [:node, :placement])
+    field(:model_id, :binary_id)
+    field(:state, Ecto.Enum, values: [:closed, :open])
+    field(:generation, :integer, default: 0)
+    field(:opened_at, :utc_datetime_usec)
+    field(:suppressed_until, :utc_datetime_usec)
+    field(:last_cleared_at, :utc_datetime_usec)
+    belongs_to(:node, Orchard.Nodes.Node)
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @type t :: %__MODULE__{}
+
+  @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(breaker, attrs) do
+    breaker
+    |> cast(attrs, [:kind, :node_id, :model_id, :state, :generation])
+    |> validate_required([:kind, :node_id, :state, :generation])
+    |> check_constraint(:model_id, name: :circuit_breakers_identity_valid)
+  end
+end

--- a/apps/orchard_controller/lib/orchard/circuit_breakers/decision.ex
+++ b/apps/orchard_controller/lib/orchard/circuit_breakers/decision.ex
@@ -1,0 +1,44 @@
+defmodule Orchard.CircuitBreakers.Decision do
+  @moduledoc """
+  Durable circuit-breaker decision returned at the Controller domain boundary.
+  """
+
+  @enforce_keys [:kind, :node_id, :state, :contribution_count, :generation]
+  defstruct [
+    :id,
+    :kind,
+    :node_id,
+    :model_id,
+    :state,
+    :contribution_count,
+    :opened_at,
+    :suppressed_until,
+    :last_cleared_at,
+    :decision_at,
+    :previous_state,
+    :contribution_disposition,
+    :transition,
+    :generation,
+    :delivery,
+    changed_state?: false
+  ]
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t() | nil,
+          kind: :node | :placement,
+          node_id: Ecto.UUID.t(),
+          model_id: Ecto.UUID.t() | nil,
+          state: :open | :closed,
+          contribution_count: non_neg_integer(),
+          opened_at: DateTime.t() | nil,
+          suppressed_until: DateTime.t() | nil,
+          last_cleared_at: DateTime.t() | nil,
+          decision_at: DateTime.t() | nil,
+          previous_state: :open | :closed | nil,
+          contribution_disposition: :contributed | :fenced | nil,
+          transition: :opened | :none | nil,
+          generation: non_neg_integer(),
+          delivery: :recorded | :duplicate | nil,
+          changed_state?: boolean()
+        }
+end

--- a/apps/orchard_controller/lib/orchard/circuit_breakers/failure.ex
+++ b/apps/orchard_controller/lib/orchard/circuit_breakers/failure.ex
@@ -1,0 +1,55 @@
+defmodule Orchard.CircuitBreakers.Failure do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: false}
+  @foreign_key_type :binary_id
+
+  schema "circuit_breaker_failures" do
+    field(:node_id, :binary_id)
+    field(:model_id, :binary_id)
+    field(:failure_class, :string)
+    field(:occurred_at, :utc_datetime_usec)
+    field(:decision_at, :utc_datetime_usec)
+    field(:disposition, Ecto.Enum, values: [:contributed, :fenced])
+    field(:transition, Ecto.Enum, values: [:none, :opened])
+    field(:generation, :integer)
+    belongs_to(:breaker, Orchard.CircuitBreakers.Breaker)
+    field(:inserted_at, :utc_datetime_usec)
+  end
+
+  @type t :: %__MODULE__{}
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(failure, attrs) do
+    failure
+    |> cast(attrs, [
+      :id,
+      :breaker_id,
+      :node_id,
+      :model_id,
+      :failure_class,
+      :occurred_at,
+      :decision_at,
+      :disposition,
+      :transition,
+      :generation
+    ])
+    |> validate_required([
+      :id,
+      :breaker_id,
+      :node_id,
+      :failure_class,
+      :occurred_at,
+      :decision_at,
+      :disposition,
+      :transition,
+      :generation
+    ])
+    |> unique_constraint(:id, name: :circuit_breaker_failures_pkey)
+    |> check_constraint(:model_id, name: :circuit_breaker_failures_target_valid)
+  end
+end

--- a/apps/orchard_controller/lib/orchard/governance/audit_writer.ex
+++ b/apps/orchard_controller/lib/orchard/governance/audit_writer.ex
@@ -79,6 +79,7 @@ defmodule Orchard.Governance.AuditWriter do
   defp action_domain("node_enrollment." <> _rest), do: {:ok, "node_admission"}
   defp action_domain("node_trust." <> _rest), do: {:ok, "node_admission"}
   defp action_domain("node_lifecycle." <> _rest), do: {:ok, "node_lifecycle"}
+  defp action_domain("circuit_breaker." <> _rest), do: {:ok, "circuit_breaker"}
   defp action_domain("provisioning_batch." <> _rest), do: {:ok, "service_account"}
   defp action_domain("cluster" <> _rest), do: {:ok, "cluster"}
   defp action_domain(_action), do: :error

--- a/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
@@ -16,7 +16,7 @@ defmodule Orchard.Metrics.Normalizer do
     quota_reason:
       ~w(requests_per_minute input_tokens_per_day output_tokens_per_day tenant_concurrency),
     audit_action:
-      ~w(tenant api_key service_account role_binding routing_policy tenant_model_access support_bundle node_admission node_lifecycle cluster),
+      ~w(tenant api_key service_account role_binding routing_policy tenant_model_access support_bundle node_admission node_lifecycle circuit_breaker cluster),
     audit_outcome: ~w(succeeded failed denied)
   }
 

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -105,6 +105,11 @@ defmodule Orchard.Nodes do
   @snapshot_truncation_key "__orchard_snapshot_truncation__"
   @authenticated_observation_future_skew_ms 5_000
   @reserved_actor_provenance_keys ~w(actor_id actor_type)
+  @dispatch_database_errors [
+    DBConnection.ConnectionError,
+    DBConnection.OwnershipError,
+    Postgrex.Error
+  ]
 
   # -- Read APIs --
 
@@ -918,6 +923,43 @@ defmodule Orchard.Nodes do
     end
   rescue
     _ -> :noop
+  end
+
+  @doc """
+  Atomically records one actually-run transport failure against Node health and
+  the durable circuit-breaker ledger.
+
+  Unlike `record_transport_failure/3`, this seam requires the caller's stable,
+  durable failure identity and canonical Node identity. It is reserved for
+  actually-run attempt failures whose stable failure class is breaker-eligible.
+  Activation, discovery, and compatibility probes must continue to use
+  `record_transport_failure/3`, which remains health-only.
+
+  The target must resolve to the same Node as `failure.node_id`. A mismatch
+  fails before either health or breaker state is mutated. Re-delivery of the
+  same failure is idempotent: the breaker reports `:duplicate`, and the Node
+  transport watermark prevents a second health write.
+  """
+  @spec record_dispatch_transport_failure(keyword() | Target.t(), term(), map()) ::
+          {:ok, %{node: Node.t(), breaker: Orchard.CircuitBreakers.Decision.t()}}
+          | {:error, atom()}
+  def record_dispatch_transport_failure(target, reason, failure) do
+    cond do
+      not repo_available?() ->
+        {:error, :node_inventory_unavailable}
+
+      not transport_failure_reason?(reason) ->
+        {:error, :transport_failure_reason_not_eligible}
+
+      true ->
+        with {:ok, failure} <- normalize_dispatch_transport_failure(failure),
+             {:ok, target_lookup} <- target_lookup(target) do
+          record_dispatch_transport_failure_transaction(target_lookup, failure)
+        else
+          :error -> {:error, :transport_failure_target_invalid}
+          {:error, reason} -> {:error, reason}
+        end
+    end
   end
 
   @doc """
@@ -2723,6 +2765,116 @@ defmodule Orchard.Nodes do
     end
   end
 
+  defp record_dispatch_transport_failure_transaction(target_lookup, failure) do
+    normalize_dispatch_database_failure(fn ->
+      Repo.transaction(fn ->
+        validate_dispatch_transport_identity(target_lookup, failure.node_id)
+        record_dispatch_transport_breaker(target_lookup, failure)
+      end)
+      |> case do
+        {:ok, {node, breaker, true}} ->
+          clear_dispatch_capacity_sources(node.id)
+          {:ok, %{node: node, breaker: breaker}}
+
+        {:ok, {node, breaker, false}} ->
+          {:ok, %{node: node, breaker: breaker}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end)
+  end
+
+  defp normalize_dispatch_database_failure(fun) do
+    fun.()
+  rescue
+    _exception in @dispatch_database_errors ->
+      {:error, :circuit_breaker_unavailable}
+  catch
+    :exit, reason ->
+      if dispatch_database_exit?(reason),
+        do: {:error, :circuit_breaker_unavailable},
+        else: exit(reason)
+  end
+
+  defp dispatch_database_exit?(reason) when is_struct(reason),
+    do: reason.__struct__ in @dispatch_database_errors
+
+  defp dispatch_database_exit?(reason) when is_tuple(reason),
+    do: reason |> Tuple.to_list() |> Enum.any?(&dispatch_database_exit?/1)
+
+  defp dispatch_database_exit?(reason) when is_list(reason),
+    do: Enum.any?(reason, &dispatch_database_exit?/1)
+
+  defp dispatch_database_exit?(_reason), do: false
+
+  defp validate_dispatch_transport_identity(target_lookup, expected_node_id) do
+    case lookup_node_by_target_lookup(target_lookup) do
+      nil ->
+        Repo.rollback(:transport_failure_target_unknown)
+
+      %Node{id: node_id} when node_id != expected_node_id ->
+        Repo.rollback(:transport_failure_target_mismatch)
+
+      %Node{} ->
+        :ok
+    end
+  end
+
+  defp refetch_dispatch_transport_node(target_lookup, node_id) do
+    case fetch_node_for_transport_update({:node_id, node_id}) do
+      nil ->
+        Repo.rollback(:transport_failure_target_unknown)
+
+      %Node{} = node ->
+        validate_dispatch_transport_target(node, target_lookup)
+    end
+  end
+
+  defp validate_dispatch_transport_target(node, target_lookup) do
+    if dispatch_transport_target_match?(node, target_lookup),
+      do: node,
+      else: Repo.rollback(:transport_failure_target_mismatch)
+  end
+
+  defp dispatch_transport_target_match?(%Node{id: node_id}, {:node_id, node_id}), do: true
+
+  defp dispatch_transport_target_match?(node, {:connect_target, host, port}) do
+    (node.connect_host == host and node.connect_port == port) or
+      (is_nil(node.connect_host) and is_nil(node.connect_port) and
+         node.advertise_addr == host and node.rpc_port == port)
+  end
+
+  defp record_dispatch_transport_breaker(target_lookup, failure) do
+    case Orchard.CircuitBreakers.record_failure(failure) do
+      {:ok, :not_eligible} ->
+        Repo.rollback(:transport_failure_class_not_breaker_eligible)
+
+      {:ok, breaker} ->
+        node = refetch_dispatch_transport_node(target_lookup, failure.node_id)
+        {node, health_changed?} = apply_dispatch_transport_health(node, failure.occurred_at)
+        {node, breaker, health_changed?}
+
+      {:error, reason} ->
+        Repo.rollback(reason)
+    end
+  end
+
+  defp apply_dispatch_transport_health(node, occurred_at) do
+    case resolve_transport_failure_health(node, occurred_at) do
+      :noop ->
+        {node, false}
+
+      health ->
+        node =
+          node
+          |> Ecto.Changeset.change(demotion_changes(health, occurred_at, :transport_failure))
+          |> Repo.update!()
+
+        {node, true}
+    end
+  end
+
   defp fetch_node_for_transport_update({:connect_target, host, port}) do
     fetch_node_by_connect_target(host, port) ||
       fetch_legacy_node_by_advertise_target(host, port)
@@ -3282,4 +3434,24 @@ defmodule Orchard.Nodes do
   defp transport_failure_reason?(:authenticated_transport_failed), do: true
   defp transport_failure_reason?(:beam_peer_grant_authorization_unavailable), do: true
   defp transport_failure_reason?(_reason), do: false
+
+  defp normalize_dispatch_transport_failure(failure) when is_map(failure) do
+    with {:ok, failure_id} <- Ecto.UUID.cast(map_get(failure, :failure_id)),
+         {:ok, node_id} <- Ecto.UUID.cast(map_get(failure, :node_id)),
+         failure_class when is_binary(failure_class) or is_atom(failure_class) <-
+           map_get(failure, :failure_class),
+         %DateTime{} = occurred_at <- map_get(failure, :occurred_at) do
+      {:ok,
+       failure
+       |> Map.put(:failure_id, failure_id)
+       |> Map.put(:node_id, node_id)
+       |> Map.put(:failure_class, failure_class)
+       |> Map.put(:occurred_at, occurred_at)}
+    else
+      _invalid -> {:error, :transport_failure_identity_invalid}
+    end
+  end
+
+  defp normalize_dispatch_transport_failure(_failure),
+    do: {:error, :transport_failure_identity_invalid}
 end

--- a/apps/orchard_controller/lib/orchard/scheduler/circuit_breaker_eligibility.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/circuit_breaker_eligibility.ex
@@ -1,0 +1,161 @@
+defmodule Orchard.Scheduler.CircuitBreakerEligibility do
+  @moduledoc false
+
+  alias Orchard.CanonicalRequest.ModelRef
+  alias Orchard.CircuitBreakers
+  alias Orchard.DispatchCapacity.Evaluator.Input
+  alias Orchard.Models
+  alias Orchard.Models.Model
+
+  @type reason_code ::
+          :node_circuit_breaker_open
+          | :model_load_suppressed
+          | :runtime_identity_mismatch
+          | :dispatch_capacity_facts_unavailable
+
+  @type snapshot :: %{
+          model_id: Ecto.UUID.t(),
+          decisions: %{CircuitBreakers.target() => Orchard.CircuitBreakers.Decision.t() | map()}
+        }
+
+  @doc """
+  Reads the Node and load-required placement facts for a request candidate set atomically.
+  """
+  @spec snapshot([{Ecto.UUID.t(), boolean()}], ModelRef.t(), keyword()) ::
+          {:ok, snapshot()} | {:error, reason_code()}
+  def snapshot(candidates, %ModelRef{} = model_ref, opts \\ []) when is_list(candidates) do
+    with {:ok, model_id} <- resolve_model_id(model_ref, opts),
+         targets = snapshot_targets(candidates, model_id),
+         {:ok, decisions} <- evaluate_many(targets, opts),
+         true <- length(decisions) == length(targets) do
+      {:ok, %{model_id: model_id, decisions: Map.new(Enum.zip(targets, decisions))}}
+    else
+      {:error, reason} -> {:error, normalize_error(reason)}
+      _invalid -> {:error, :dispatch_capacity_facts_unavailable}
+    end
+  rescue
+    _error -> {:error, :dispatch_capacity_facts_unavailable}
+  catch
+    _kind, _reason -> {:error, :dispatch_capacity_facts_unavailable}
+  end
+
+  @spec apply(Input.t(), Ecto.UUID.t() | nil, ModelRef.t(), boolean(), keyword()) ::
+          {:ok, Input.t(), [reason_code()]} | {:error, reason_code()}
+  def apply(%Input{} = input, node_id, %ModelRef{} = model_ref, load_required?, opts \\ []) do
+    if production_managed?(input) do
+      apply_managed(input, node_id, model_ref, load_required?, opts)
+    else
+      {:ok, input, []}
+    end
+  end
+
+  @spec check_node(Ecto.UUID.t() | nil, keyword()) :: :ok | {:error, reason_code()}
+  def check_node(nil, _opts), do: :ok
+
+  def check_node(node_id, opts) do
+    case evaluate({:node, node_id}, opts) do
+      {:ok, %{state: :closed}} -> :ok
+      {:ok, %{state: :open}} -> {:error, :node_circuit_breaker_open}
+      {:error, reason} -> {:error, normalize_error(reason)}
+      _invalid -> {:error, :dispatch_capacity_facts_unavailable}
+    end
+  rescue
+    _error -> {:error, :dispatch_capacity_facts_unavailable}
+  catch
+    _kind, _reason -> {:error, :dispatch_capacity_facts_unavailable}
+  end
+
+  defp apply_managed(input, node_id, model_ref, load_required?, opts) do
+    with {:ok, snapshot} <- breaker_snapshot(node_id, model_ref, load_required?, opts),
+         {:ok, node_decision} <- Map.fetch(snapshot.decisions, {:node, node_id}),
+         {:ok, eligible?, reason_codes} <-
+           placement_decision(node_decision, node_id, snapshot, load_required?) do
+      {:ok, %{input | breaker_eligible?: eligible?}, reason_codes}
+    else
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  rescue
+    _error -> {:error, :dispatch_capacity_facts_unavailable}
+  catch
+    _kind, _reason -> {:error, :dispatch_capacity_facts_unavailable}
+  end
+
+  defp production_managed?(%Input{management_classification: {:ok, :production_managed}}),
+    do: true
+
+  defp production_managed?(_input), do: false
+
+  defp resolve_model_id(%ModelRef{model_id: model_id, version: version}, opts) do
+    models = Keyword.get(opts, :circuit_breaker_models, Models)
+
+    case models.get_model_by_identity(model_id, version) do
+      %Model{id: id, state: state} when state in [:active, :deprecated] and is_binary(id) ->
+        {:ok, id}
+
+      %Model{} ->
+        {:error, :model_not_active}
+
+      nil ->
+        {:error, :model_not_found}
+
+      _invalid ->
+        {:error, :invalid_model_identity}
+    end
+  end
+
+  defp evaluate(target, opts) do
+    evaluator = Keyword.get(opts, :circuit_breaker_evaluator, CircuitBreakers)
+    evaluator.evaluate(target)
+  end
+
+  defp evaluate_many(targets, opts) do
+    evaluator = Keyword.get(opts, :circuit_breaker_evaluator, CircuitBreakers)
+    evaluator.evaluate_many(targets)
+  end
+
+  defp breaker_snapshot(node_id, model_ref, load_required?, opts) do
+    case Keyword.fetch(opts, :circuit_breaker_snapshot) do
+      {:ok, {:ok, snapshot}} -> {:ok, snapshot}
+      {:ok, {:error, reason}} -> {:error, reason}
+      {:ok, _invalid} -> {:error, :breaker_state_invalid}
+      :error -> snapshot([{node_id, load_required?}], model_ref, opts)
+    end
+  end
+
+  defp snapshot_targets(candidates, model_id) do
+    candidates
+    |> Enum.flat_map(fn
+      {node_id, true} when is_binary(node_id) ->
+        [{:node, node_id}, {:placement, node_id, model_id}]
+
+      {node_id, false} when is_binary(node_id) ->
+        [{:node, node_id}]
+
+      _invalid ->
+        []
+    end)
+    |> Enum.uniq()
+  end
+
+  defp placement_decision(%{state: :open}, _node_id, _snapshot, _load_required?),
+    do: {:ok, false, [:node_circuit_breaker_open]}
+
+  defp placement_decision(%{state: :closed}, _node_id, _snapshot, false),
+    do: {:ok, true, []}
+
+  defp placement_decision(%{state: :closed}, node_id, snapshot, true) do
+    case Map.fetch(snapshot.decisions, {:placement, node_id, snapshot.model_id}) do
+      {:ok, %{state: :open}} -> {:ok, false, [:model_load_suppressed]}
+      {:ok, %{state: :closed}} -> {:ok, true, []}
+      _missing_or_invalid -> {:error, :breaker_state_invalid}
+    end
+  end
+
+  defp placement_decision(_invalid, _node_id, _snapshot, _load_required?),
+    do: {:error, :breaker_state_invalid}
+
+  defp normalize_error(reason) when reason in [:invalid_node_identity, :node_not_found],
+    do: :runtime_identity_mismatch
+
+  defp normalize_error(_reason), do: :dispatch_capacity_facts_unavailable
+end

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -46,6 +46,7 @@ defmodule Orchard.Scheduler.MultiNode do
   alias Orchard.Models
   alias Orchard.NodeHeartbeats
   alias Orchard.Nodes
+  alias Orchard.Scheduler.CircuitBreakerEligibility
   alias Orchard.Scheduler.MultiNode.CompatibilityProbeRunner
 
   alias Orchard.RuntimeEndpoint.{
@@ -194,12 +195,28 @@ defmodule Orchard.Scheduler.MultiNode do
   defp schedule_production_candidates(request, targets, active_targets, opts) do
     case production_candidate_snapshot(targets, active_targets, opts) do
       {:ok, snapshot} ->
-        candidates =
+        base_candidates =
           snapshot.candidates
           |> Enum.map(&snapshot_candidate(&1, request))
+
+        breaker_snapshot =
+          CircuitBreakerEligibility.snapshot(
+            Enum.map(base_candidates, &{&1.node_id, not &1.loaded_model?}),
+            request.model_ref,
+            opts
+          )
+
+        breaker_opts = Keyword.put(opts, :circuit_breaker_snapshot, breaker_snapshot)
+
+        candidates =
+          base_candidates
           |> Enum.map(fn candidate ->
             candidate
-            |> annotate_dispatch_capacity(opts, candidate.observation.observed_at)
+            |> annotate_dispatch_capacity(
+              request,
+              breaker_opts,
+              candidate.observation.observed_at
+            )
             |> annotate_residency_policy(request, opts)
           end)
 
@@ -258,7 +275,7 @@ defmodule Orchard.Scheduler.MultiNode do
           {:ok, {:candidate, candidate}} ->
             annotated =
               candidate
-              |> annotate_dispatch_capacity(opts, observed_at)
+              |> annotate_dispatch_capacity(request, opts, observed_at)
               |> annotate_residency_policy(request, opts)
 
             {[annotated | candidates], rejections}
@@ -732,11 +749,20 @@ defmodule Orchard.Scheduler.MultiNode do
   end
 
   defp ineligible_reason_codes(candidate) do
+    breaker_reason_codes = Map.get(candidate, :breaker_reason_codes, [])
+
     capacity_reason_codes =
       case Map.get(candidate, :dispatch_capacity_evaluation) do
-        %{eligible?: true} -> []
-        %{reason_codes: reason_codes} -> Enum.map(reason_codes, &Atom.to_string/1)
-        _missing -> ["dispatch_capacity_facts_unavailable"]
+        %{eligible?: true} ->
+          []
+
+        %{reason_codes: reason_codes} ->
+          reason_codes
+          |> Enum.reject(&(&1 == :circuit_breaker_open and breaker_reason_codes != []))
+          |> Enum.map(&Atom.to_string/1)
+
+        _missing ->
+          ["dispatch_capacity_facts_unavailable"]
       end
 
     residency_reason_codes = Map.get(candidate, :residency_reason_codes, [])
@@ -754,7 +780,12 @@ defmodule Orchard.Scheduler.MultiNode do
       ]
       |> Enum.reject(&is_nil/1)
 
-    Enum.uniq(capacity_reason_codes ++ residency_reason_codes ++ legacy_reason_codes)
+    Enum.uniq(
+      breaker_reason_codes ++
+        capacity_reason_codes ++
+        residency_reason_codes ++
+        legacy_reason_codes
+    )
   end
 
   defp rejection_reason(candidate, predicate, code) do
@@ -1012,25 +1043,34 @@ defmodule Orchard.Scheduler.MultiNode do
       :ok
   end
 
-  defp annotate_dispatch_capacity(candidate, opts, observed_at) do
+  defp annotate_dispatch_capacity(candidate, request, opts, observed_at) do
     placement_capacity =
       Map.get(candidate, :model_placement_capacity, placement_default(candidate, :acquisition))
 
-    case dispatch_capacity_input(candidate, placement_capacity, opts, observed_at) do
-      {:ok, input} ->
-        authority = Keyword.get(opts, :dispatch_capacity_authority, AllocationAuthority)
+    with {:ok, input} <- dispatch_capacity_input(candidate, placement_capacity, opts, observed_at),
+         {:ok, input, breaker_reason_codes} <-
+           CircuitBreakerEligibility.apply(
+             input,
+             candidate.node_id,
+             request.model_ref,
+             not candidate.loaded_model?,
+             opts
+           ) do
+      authority = Keyword.get(opts, :dispatch_capacity_authority, AllocationAuthority)
 
-        candidate
-        |> Map.put(:dispatch_capacity_input, input)
-        |> Map.put(
-          :dispatch_capacity_evaluation,
-          safe_evaluate_dispatch_capacity(authority, candidate.node_id, input)
-        )
-
-      {:error, _reason} ->
+      candidate
+      |> Map.put(:dispatch_capacity_input, input)
+      |> Map.put(:breaker_reason_codes, Enum.map(breaker_reason_codes, &Atom.to_string/1))
+      |> Map.put(
+        :dispatch_capacity_evaluation,
+        safe_evaluate_dispatch_capacity(authority, candidate.node_id, input)
+      )
+    else
+      {:error, reason} ->
         candidate
         |> Map.put(:dispatch_capacity_input, nil)
         |> Map.put(:dispatch_capacity_evaluation, nil)
+        |> Map.put(:breaker_reason_codes, [Atom.to_string(reason)])
     end
   end
 
@@ -1107,7 +1147,13 @@ defmodule Orchard.Scheduler.MultiNode do
 
     case {Keyword.has_key?(opts, :dispatch_capacity_input_provider), refresh_strategy} do
       {true, _strategy} ->
-        configured_dispatch_capacity_input_provider(candidate, placement_capacity, opts)
+        configured_dispatch_capacity_input_provider(
+          candidate,
+          request,
+          phase,
+          placement_capacity,
+          opts
+        )
 
       {false, :snapshot} ->
         snapshot_dispatch_capacity_input_provider(candidate, request, phase, opts)
@@ -1125,12 +1171,18 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp inline_status_dispatch_capacity_input_provider(
          candidate,
-         _request,
+         request,
          :acquisition,
          placement_capacity,
          opts
        ) do
-    configured_dispatch_capacity_input_provider(candidate, placement_capacity, opts)
+    configured_dispatch_capacity_input_provider(
+      candidate,
+      request,
+      :acquisition,
+      placement_capacity,
+      opts
+    )
   end
 
   defp inline_status_dispatch_capacity_input_provider(
@@ -1253,10 +1305,26 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp valid_matching_placement(_capacity, _model_ref), do: nil
 
-  defp configured_dispatch_capacity_input_provider(candidate, placement_capacity, opts) do
+  defp configured_dispatch_capacity_input_provider(
+         candidate,
+         request,
+         phase,
+         placement_capacity,
+         opts
+       ) do
     fn ->
-      case dispatch_capacity_input(candidate, placement_capacity, opts, DateTime.utc_now()) do
-        {:ok, input} -> input
+      with {:ok, input} <-
+             dispatch_capacity_input(candidate, placement_capacity, opts, DateTime.utc_now()),
+           {:ok, input, _reason_codes} <-
+             CircuitBreakerEligibility.apply(
+               input,
+               candidate.node_id,
+               request.model_ref,
+               phase == :acquisition and not candidate.loaded_model?,
+               opts
+             ) do
+        input
+      else
         {:error, _reason} -> nil
       end
     end
@@ -1287,6 +1355,14 @@ defmodule Orchard.Scheduler.MultiNode do
              refreshed_placement,
              opts,
              snapshot_candidate.observed_at
+           ),
+         {:ok, input, _reason_codes} <-
+           CircuitBreakerEligibility.apply(
+             input,
+             refreshed.node_id,
+             request.model_ref,
+             phase == :acquisition and not refreshed.loaded_model?,
+             opts
            ) do
       input
     else

--- a/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/single_node.ex
@@ -28,6 +28,7 @@ defmodule Orchard.Scheduler.SingleNode do
   alias Orchard.Inference
   alias Orchard.Nodes
   alias Orchard.RuntimeEndpoint.{GrpcCompatibilityMapper, ModelRef, Observation, Target}
+  alias Orchard.Scheduler.CircuitBreakerEligibility
 
   @type schedule_result ::
           {:ok, map()} | {:error, term()} | {:error, term(), map()}
@@ -94,7 +95,20 @@ defmodule Orchard.Scheduler.SingleNode do
           }
           |> put_target(target)
 
-        authorize_schedule(schedule, request, target, node, opts)
+        case CircuitBreakerEligibility.check_node(node && node.id, opts) do
+          :ok ->
+            authorize_schedule(schedule, request, target, node, opts)
+
+          {:error, reason} ->
+            schedule_failure(
+              request,
+              target,
+              node,
+              :model_busy,
+              [Atom.to_string(reason)],
+              %{fact: "circuit_breaker_evaluation_failed"}
+            )
+        end
 
       {:error, :node_inventory_unavailable} ->
         schedule_failure(
@@ -169,26 +183,33 @@ defmodule Orchard.Scheduler.SingleNode do
     placement_capacity = model_placement_capacity_for(response, request.model_ref)
     schedule = Map.put(schedule, :selected_tier, selected_tier(response, request.model_ref))
 
-    case capacity_input(node, target, response, placement_capacity, opts) do
-      {:ok, input} ->
-        authorize_capacity_input(
-          schedule,
-          request,
-          target,
-          node,
-          response,
-          placement_capacity,
-          input,
-          opts
-        )
-
-      {:error, _reason} ->
+    with {:ok, input} <- capacity_input(node, target, response, placement_capacity, opts),
+         {:ok, input, breaker_reason_codes} <-
+           CircuitBreakerEligibility.apply(
+             input,
+             node && node.id,
+             request.model_ref,
+             Map.get(schedule, :selected_tier) != "loaded",
+             opts
+           ) do
+      authorize_capacity_input(
+        schedule,
+        request,
+        target,
+        node,
+        response,
+        placement_capacity,
+        input,
+        Keyword.put(opts, :breaker_reason_codes, breaker_reason_codes)
+      )
+    else
+      {:error, reason} ->
         schedule_failure(
           request,
           target,
           node,
           :model_busy,
-          ["dispatch_capacity_facts_unavailable"],
+          [Atom.to_string(normalize_capacity_reason(reason))],
           %{fact: "capacity_input_unavailable"}
         )
     end
@@ -241,14 +262,7 @@ defmodule Orchard.Scheduler.SingleNode do
 
       {:ok, authorized_schedule}
     else
-      reason_codes =
-        case result do
-          %{reason_codes: codes} when is_list(codes) and codes != [] ->
-            Enum.map(codes, &to_string/1)
-
-          _other ->
-            ["dispatch_capacity_facts_unavailable"]
-        end
+      reason_codes = unauthorized_reason_codes(result, opts)
 
       schedule_failure(
         request,
@@ -313,17 +327,42 @@ defmodule Orchard.Scheduler.SingleNode do
          opts
        ) do
     if Keyword.has_key?(opts, :dispatch_capacity_input_provider) do
-      configured_capacity_input_provider(node, target, response, placement_capacity, opts)
+      configured_capacity_input_provider(
+        request,
+        node,
+        target,
+        response,
+        placement_capacity,
+        phase,
+        opts
+      )
     else
       expected_node_id = if node, do: node.id, else: nil
       fn -> fresh_capacity_input(request, target, expected_node_id, phase, opts) end
     end
   end
 
-  defp configured_capacity_input_provider(node, target, response, placement_capacity, opts) do
+  defp configured_capacity_input_provider(
+         request,
+         node,
+         target,
+         response,
+         placement_capacity,
+         phase,
+         opts
+       ) do
     fn ->
-      case capacity_input(node, target, response, placement_capacity, opts) do
-        {:ok, refreshed_input} -> refreshed_input
+      with {:ok, input} <- capacity_input(node, target, response, placement_capacity, opts),
+           {:ok, input, _reason_codes} <-
+             CircuitBreakerEligibility.apply(
+               input,
+               node && node.id,
+               request.model_ref,
+               phase == :acquisition and selected_tier(response, request.model_ref) != "loaded",
+               opts
+             ) do
+        input
+      else
         {:error, _reason} -> nil
       end
     end
@@ -343,6 +382,14 @@ defmodule Orchard.Scheduler.SingleNode do
              response,
              placement_capacity,
              opts
+           ),
+         {:ok, input, _reason_codes} <-
+           CircuitBreakerEligibility.apply(
+             input,
+             expected_node_id,
+             request.model_ref,
+             phase == :acquisition and selected_tier(response, request.model_ref) != "loaded",
+             opts
            ) do
       input
     else
@@ -353,6 +400,29 @@ defmodule Orchard.Scheduler.SingleNode do
   defp capacity_identity_matches?(%Orchard.Nodes.Node{id: node_id}, node_id), do: true
   defp capacity_identity_matches?(nil, nil), do: true
   defp capacity_identity_matches?(_node, _expected_node_id), do: false
+
+  defp unauthorized_reason_codes(result, opts) do
+    breaker_reason_codes = Keyword.get(opts, :breaker_reason_codes, [])
+
+    capacity_reason_codes =
+      case result do
+        %{reason_codes: codes} when is_list(codes) and codes != [] ->
+          codes
+          |> Enum.reject(&(&1 == :circuit_breaker_open and breaker_reason_codes != []))
+          |> Enum.map(&to_string/1)
+
+        _other ->
+          ["dispatch_capacity_facts_unavailable"]
+      end
+
+    Enum.uniq(Enum.map(breaker_reason_codes, &to_string/1) ++ capacity_reason_codes)
+  end
+
+  defp normalize_capacity_reason(reason)
+       when reason in [:runtime_identity_mismatch, :dispatch_capacity_facts_unavailable],
+       do: reason
+
+  defp normalize_capacity_reason(_reason), do: :dispatch_capacity_facts_unavailable
 
   defp refreshed_placement_capacity(response, model_ref, :acquisition),
     do: model_placement_capacity_for(response, model_ref)

--- a/apps/orchard_controller/priv/repo/migrations/20260828010000_circuit_breaker_foundation.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260828010000_circuit_breaker_foundation.exs
@@ -1,0 +1,88 @@
+defmodule Orchard.Repo.Migrations.CircuitBreakerFoundation do
+  use Ecto.Migration
+
+  def change do
+    create table(:circuit_breakers, primary_key: false) do
+      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:kind, :text, null: false)
+      add(:node_id, references(:nodes, type: :binary_id, on_delete: :nothing), null: false)
+      add(:model_id, :binary_id)
+      add(:state, :text, null: false, default: "closed")
+      add(:generation, :bigint, null: false, default: 0)
+      add(:opened_at, :utc_datetime_usec)
+      add(:suppressed_until, :utc_datetime_usec)
+      add(:last_cleared_at, :utc_datetime_usec)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(
+      unique_index(:circuit_breakers, [:node_id],
+        where: "kind = 'node'",
+        name: :circuit_breakers_node_identity
+      )
+    )
+
+    create(
+      unique_index(:circuit_breakers, [:node_id, :model_id],
+        where: "kind = 'placement'",
+        name: :circuit_breakers_placement_identity
+      )
+    )
+
+    create(
+      constraint(:circuit_breakers, :circuit_breakers_identity_valid,
+        check:
+          "(kind = 'node' AND model_id IS NULL) OR " <>
+            "(kind = 'placement' AND model_id IS NOT NULL)"
+      )
+    )
+
+    create(
+      constraint(:circuit_breakers, :circuit_breakers_state_valid,
+        check:
+          "(state = 'closed' AND suppressed_until IS NULL) OR " <>
+            "(state = 'open' AND opened_at IS NOT NULL AND suppressed_until IS NOT NULL)"
+      )
+    )
+
+    create(
+      constraint(:circuit_breakers, :circuit_breakers_generation_non_negative,
+        check: "generation >= 0"
+      )
+    )
+
+    create table(:circuit_breaker_failures, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(
+        :breaker_id,
+        references(:circuit_breakers, type: :binary_id, on_delete: :nothing),
+        null: false
+      )
+
+      add(:node_id, :binary_id, null: false)
+      add(:model_id, :binary_id)
+      add(:failure_class, :text, null: false)
+      add(:occurred_at, :utc_datetime_usec, null: false)
+      add(:generation, :bigint, null: false)
+      add(:inserted_at, :utc_datetime_usec, null: false, default: fragment("NOW()"))
+    end
+
+    create(index(:circuit_breaker_failures, [:breaker_id, :generation, :occurred_at]))
+
+    create(
+      constraint(:circuit_breaker_failures, :circuit_breaker_failures_target_valid,
+        check:
+          "(failure_class IN ('pre_acceptance_unavailable', 'worker_or_node_loss') AND " <>
+            "model_id IS NULL) OR " <>
+            "(failure_class = 'model_load_failure' AND model_id IS NOT NULL)"
+      )
+    )
+
+    create(
+      constraint(:circuit_breaker_failures, :circuit_breaker_failures_generation_non_negative,
+        check: "generation >= 0"
+      )
+    )
+  end
+end

--- a/apps/orchard_controller/priv/repo/migrations/20260828010100_circuit_breaker_contribution_evidence.exs
+++ b/apps/orchard_controller/priv/repo/migrations/20260828010100_circuit_breaker_contribution_evidence.exs
@@ -1,0 +1,29 @@
+defmodule Orchard.Repo.Migrations.CircuitBreakerContributionEvidence do
+  use Ecto.Migration
+
+  def change do
+    alter table(:circuit_breaker_failures) do
+      add(:decision_at, :utc_datetime_usec, null: false)
+      add(:disposition, :text, null: false)
+      add(:transition, :text, null: false, default: "none")
+    end
+
+    create(
+      constraint(:circuit_breaker_failures, :circuit_breaker_failures_disposition_valid,
+        check: "disposition IN ('contributed', 'fenced')"
+      )
+    )
+
+    create(
+      constraint(:circuit_breaker_failures, :circuit_breaker_failures_transition_valid,
+        check: "transition IN ('none', 'opened')"
+      )
+    )
+
+    create(
+      index(:circuit_breaker_failures, [:breaker_id, :generation, :decision_at],
+        name: :circuit_breaker_failures_decision_window
+      )
+    )
+  end
+end

--- a/apps/orchard_controller/test/orchard/api/ops/circuit_breakers_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/circuit_breakers_controller_test.exs
@@ -1,0 +1,469 @@
+defmodule Orchard.API.Ops.CircuitBreakersControllerTest do
+  use Orchard.ConnCase, async: false
+
+  import Ecto.Query
+
+  alias Orchard.API.Router
+  alias Orchard.CircuitBreakers
+  alias Orchard.Governance
+  alias Orchard.Governance.AuditLog
+  alias Orchard.Governance.RoleBinding
+  alias Orchard.Models.Model
+  alias Orchard.Nodes.Node
+  alias Orchard.Repo
+
+  describe "GET /ops/v1/circuit-breakers/nodes/:node_id" do
+    @describetag :db
+
+    test "SPEC.md section 7.3 denies missing and tenant-direct credentials without state" do
+      node = insert_node!()
+      path = "/ops/v1/circuit-breakers/nodes/#{node.id}"
+
+      missing = operator_json(:get, path, nil)
+      assert missing.status == 401
+      assert get_resp_header(missing, "cache-control") == ["no-store"]
+      assert Jason.decode!(missing.resp_body)["error"]["code"] == "invalid_api_key"
+
+      tenant_token = tenant_token!("ops-breaker-tenant-denied")
+      tenant = operator_json(:get, path, tenant_token)
+      assert tenant.status == 403
+      assert get_resp_header(tenant, "cache-control") == ["no-store"]
+      assert Jason.decode!(tenant.resp_body)["error"]["code"] == "operator_required"
+    end
+
+    test "SPEC.md section 5.10 lets a cluster operator inspect a closed Node breaker" do
+      node = insert_node!()
+      token = operator_token!("ops-breaker-node-inspect")
+
+      conn = operator_json(:get, "/ops/v1/circuit-breakers/nodes/#{node.id}", token)
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "object" => "circuit_breaker",
+               "kind" => "node",
+               "node_id" => node.id,
+               "model_id" => nil,
+               "state" => "closed",
+               "contribution_count" => 0,
+               "opened_at" => nil,
+               "suppressed_until" => nil,
+               "last_cleared_at" => nil,
+               "generation" => 0
+             }
+    end
+
+    test "SPEC.md section 5.10 rejects inspection on a standby Controller without exposing state" do
+      node = insert_node!()
+      token = operator_token!("ops-breaker-node-standby-inspection")
+      configure_control_plane(role: :standby)
+
+      conn = operator_json(:get, "/ops/v1/circuit-breakers/nodes/#{node.id}", token)
+
+      assert conn.status == 503
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "error" => %{
+                 "code" => "controller_standby",
+                 "message" => "This controller is in standby mode."
+               }
+             }
+    end
+
+    test "SPEC.md section 5.10 fails inspection closed when Controller leadership is unproven" do
+      node = insert_node!()
+      token = operator_token!("ops-breaker-node-unproven-inspection")
+      configure_control_plane(role: :leader, this_controller_identity: "controller-a")
+
+      conn = operator_json(:get, "/ops/v1/circuit-breakers/nodes/#{node.id}", token)
+
+      assert conn.status == 503
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "error" => %{
+                 "code" => "controller_leadership_unproven",
+                 "message" => "This controller has not proven local leadership."
+               }
+             }
+    end
+
+    test "returns stable invalid and missing canonical identity errors" do
+      token = operator_token!("ops-breaker-node-errors")
+
+      invalid = operator_json(:get, "/ops/v1/circuit-breakers/nodes/not-a-uuid", token)
+      assert invalid.status == 422
+      assert Jason.decode!(invalid.resp_body)["error"]["code"] == "invalid_circuit_breaker_target"
+
+      missing =
+        operator_json(
+          :get,
+          "/ops/v1/circuit-breakers/nodes/#{Ecto.UUID.generate()}",
+          token
+        )
+
+      assert missing.status == 404
+      assert Jason.decode!(missing.resp_body)["error"]["code"] == "node_not_found"
+    end
+  end
+
+  describe "GET /ops/v1/circuit-breakers/placements/:node_id/:model_id" do
+    @describetag :db
+
+    test "lets a cluster admin inspect an open placement breaker" do
+      node = insert_node!()
+      model = insert_model!()
+      token = admin_token!("ops-breaker-placement-admin")
+      open_placement!(node.id, model.id)
+
+      conn =
+        operator_json(
+          :get,
+          "/ops/v1/circuit-breakers/placements/#{node.id}/#{model.id}",
+          token
+        )
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+
+      assert %{
+               "kind" => "placement",
+               "node_id" => node_id,
+               "model_id" => model_id,
+               "state" => "open",
+               "contribution_count" => 3,
+               "opened_at" => opened_at,
+               "suppressed_until" => suppressed_until
+             } = Jason.decode!(conn.resp_body)
+
+      assert node_id == node.id
+      assert model_id == model.id
+      assert is_binary(opened_at)
+      assert is_binary(suppressed_until)
+    end
+
+    test "rejects an unknown Model but preserves retained placement history after deletion" do
+      node = insert_node!()
+      model = insert_model!()
+      token = operator_token!("ops-breaker-placement-identity")
+
+      unknown =
+        operator_json(
+          :get,
+          "/ops/v1/circuit-breakers/placements/#{node.id}/#{Ecto.UUID.generate()}",
+          token
+        )
+
+      assert unknown.status == 404
+      assert Jason.decode!(unknown.resp_body)["error"]["code"] == "model_not_found"
+
+      open_placement!(node.id, model.id)
+      Repo.delete!(model)
+
+      retained =
+        operator_json(
+          :get,
+          "/ops/v1/circuit-breakers/placements/#{node.id}/#{model.id}",
+          token
+        )
+
+      assert retained.status == 200
+
+      assert %{"state" => "open", "model_id" => model_id} =
+               Jason.decode!(retained.resp_body)
+
+      assert model_id == model.id
+    end
+  end
+
+  describe "POST /ops/v1/circuit-breakers/placements/:node_id/:model_id/clear" do
+    @describetag :db
+
+    test "SPEC.md section 5.10 clears an open placement and audits a repeated no-op clear" do
+      node = insert_node!()
+      model = insert_model!()
+      token = operator_token!("ops-breaker-placement-clear")
+      open_placement!(node.id, model.id)
+
+      path = "/ops/v1/circuit-breakers/placements/#{node.id}/#{model.id}/clear"
+      first = operator_json(:post, path, token, %{"reason" => "load failures investigated"})
+
+      assert first.status == 200
+      assert get_resp_header(first, "cache-control") == ["no-store"]
+
+      assert %{
+               "result" => "cleared",
+               "changed" => true,
+               "breaker" => %{
+                 "kind" => "placement",
+                 "node_id" => node_id,
+                 "model_id" => model_id,
+                 "state" => "closed",
+                 "generation" => generation
+               }
+             } = Jason.decode!(first.resp_body)
+
+      assert node_id == node.id
+      assert model_id == model.id
+
+      second = operator_json(:post, path, token, %{"reason" => "confirm suppression clear"})
+
+      assert second.status == 200
+
+      assert %{
+               "result" => "already_cleared",
+               "changed" => false,
+               "breaker" => %{"generation" => ^generation}
+             } = Jason.decode!(second.resp_body)
+
+      audits =
+        AuditLog
+        |> where([audit], audit.action == "circuit_breaker.placement.cleared")
+        |> where([audit], audit.target_id == ^"#{node.id}:#{model.id}")
+        |> order_by([audit], asc: audit.occurred_at)
+        |> Repo.all()
+
+      assert Enum.map(audits, & &1.payload["changed"]) == [true, false]
+
+      assert Enum.map(audits, & &1.payload["reason"]) == [
+               "load failures investigated",
+               "confirm suppression clear"
+             ]
+
+      assert Enum.all?(audits, &(&1.scope == "cluster"))
+      assert Enum.all?(audits, &(&1.actor_type == "service_account"))
+      assert Enum.all?(audits, &is_binary(&1.actor_id))
+      assert Enum.all?(audits, &is_nil(&1.api_key_id))
+
+      assert [effective_audit, repeated_audit] = audits
+      assert DateTime.compare(repeated_audit.occurred_at, effective_audit.occurred_at) == :gt
+    end
+
+    test "requires a nonblank reason before attempting the clear" do
+      node = insert_node!()
+      model = insert_model!()
+      token = operator_token!("ops-breaker-placement-reason")
+
+      conn =
+        operator_json(
+          :post,
+          "/ops/v1/circuit-breakers/placements/#{node.id}/#{model.id}/clear",
+          token,
+          %{"reason" => "  "}
+        )
+
+      assert conn.status == 422
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "error" => %{
+                 "code" => "circuit_breaker_clear_reason_required",
+                 "message" => "A nonblank circuit-breaker clear reason is required."
+               }
+             }
+    end
+
+    test "clearing a closed breaker with contributions audits an idempotent no-op" do
+      node = insert_node!()
+      model = insert_model!()
+      token = operator_token!("ops-breaker-placement-closed-clear")
+      record_placement_failures!(node.id, model.id, 1)
+
+      conn =
+        operator_json(
+          :post,
+          "/ops/v1/circuit-breakers/placements/#{node.id}/#{model.id}/clear",
+          token,
+          %{"reason" => "discard isolated load failure"}
+        )
+
+      assert conn.status == 200
+
+      assert %{
+               "result" => "already_cleared",
+               "changed" => false,
+               "breaker" => %{"state" => "closed", "generation" => 0}
+             } = Jason.decode!(conn.resp_body)
+
+      audit =
+        Repo.get_by!(AuditLog,
+          action: "circuit_breaker.placement.cleared",
+          target_id: "#{node.id}:#{model.id}"
+        )
+
+      assert audit.payload["previous_state"] == "closed"
+      assert audit.payload["changed"] == false
+      assert audit.payload["resulting_generation"] == 0
+    end
+  end
+
+  describe "POST /ops/v1/circuit-breakers/nodes/:node_id/clear" do
+    @describetag :db
+
+    test "fails closed on a standby controller without appending audit evidence" do
+      node = insert_node!()
+      token = operator_token!("ops-breaker-node-standby")
+      previous = Application.get_env(:orchard_controller, :control_plane)
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:orchard_controller, :control_plane, previous),
+          else: Application.delete_env(:orchard_controller, :control_plane)
+      end)
+
+      Application.put_env(:orchard_controller, :control_plane, role: :standby)
+
+      conn =
+        operator_json(
+          :post,
+          "/ops/v1/circuit-breakers/nodes/#{node.id}/clear",
+          token,
+          %{"reason" => "operator investigation complete"}
+        )
+
+      assert conn.status == 503
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "controller_standby"
+
+      assert Repo.aggregate(
+               from(audit in AuditLog,
+                 where:
+                   audit.action == "circuit_breaker.node.cleared" and
+                     audit.target_id == ^node.id
+               ),
+               :count,
+               :id
+             ) == 0
+    end
+  end
+
+  defp operator_json(method, path, token, body \\ nil) do
+    conn =
+      build_conn(method, path, body)
+      |> put_req_header("accept", "application/json")
+
+    conn =
+      if token,
+        do: put_req_header(conn, "authorization", "Bearer #{token}"),
+        else: conn
+
+    Router.call(conn, Router.init([]))
+  end
+
+  defp configure_control_plane(config) do
+    previous = Application.get_env(:orchard_controller, :control_plane)
+    Application.put_env(:orchard_controller, :control_plane, config)
+
+    on_exit(fn ->
+      if is_nil(previous) do
+        Application.delete_env(:orchard_controller, :control_plane)
+      else
+        Application.put_env(:orchard_controller, :control_plane, previous)
+      end
+    end)
+  end
+
+  defp tenant_token!(slug) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+    {:ok, %{token: token}} = Governance.create_api_key(tenant, %{name: "Primary"})
+    token
+  end
+
+  defp operator_token!(slug) do
+    service_account_token!(slug, :operator)
+  end
+
+  defp admin_token!(slug) do
+    service_account_token!(slug, :admin)
+  end
+
+  defp service_account_token!(slug, role) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: String.capitalize(slug)})
+
+    {:ok, api_client} =
+      Governance.upsert_api_client(tenant, %{
+        name: "#{slug}-client",
+        owner_contact: "owner@example.com"
+      })
+
+    grant_cluster_role!(api_client, role)
+
+    {:ok, %{token: token}} =
+      Governance.create_api_client_api_token(api_client, %{name: "Primary"})
+
+    token
+  end
+
+  defp grant_cluster_role!(api_client, :admin) do
+    {:ok, _binding} = Governance.ensure_cluster_admin_access(api_client)
+  end
+
+  defp grant_cluster_role!(api_client, :operator) do
+    %RoleBinding{}
+    |> RoleBinding.changeset(%{
+      principal_type: :service_account,
+      principal_id: api_client.id,
+      role: :operator,
+      tenant_scope_id: nil
+    })
+    |> Repo.insert!()
+  end
+
+  defp insert_node! do
+    unique = System.unique_integer([:positive])
+
+    %Node{}
+    |> Node.changeset(%{
+      id: Ecto.UUID.generate(),
+      hostname: "ops-breaker-node-#{unique}.local",
+      display_name: "ops-breaker-node-#{unique}",
+      advertise_addr: "10.253.#{rem(div(unique, 254), 254)}.#{rem(unique, 254) + 1}",
+      rpc_port: 9444,
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      tool_readiness: %{}
+    })
+    |> Repo.insert!()
+  end
+
+  defp insert_model! do
+    unique = System.unique_integer([:positive])
+
+    %Model{}
+    |> Model.changeset(%{
+      model_id: "ops-breaker-model-#{unique}",
+      version: "main",
+      state: :active,
+      format: "mlx",
+      capabilities: ["text"],
+      tokenizer: %{"type" => "huggingface", "ref" => "test/tokenizer"},
+      artifact_uri: "file:///tmp/ops-breaker-model-#{unique}",
+      artifact_sha256: String.duplicate("a", 64),
+      artifact_size_bytes: 1,
+      resident_memory_bytes: 1,
+      kv_cache_bytes_per_token: 1,
+      prefill_workspace_bytes_per_token: 1,
+      runtime_requirements: %{}
+    })
+    |> Repo.insert!()
+  end
+
+  defp open_placement!(node_id, model_id) do
+    record_placement_failures!(node_id, model_id, 3)
+  end
+
+  defp record_placement_failures!(node_id, model_id, count) do
+    now = DateTime.utc_now()
+
+    for seconds_ago <- Enum.reverse(0..(count - 1)) do
+      assert {:ok, _decision} =
+               CircuitBreakers.record_failure(%{
+                 failure_id: Ecto.UUID.generate(),
+                 node_id: node_id,
+                 model_id: model_id,
+                 failure_class: "model_load_failure",
+                 occurred_at: DateTime.add(now, -seconds_ago, :second)
+               })
+    end
+  end
+end

--- a/apps/orchard_controller/test/orchard/circuit_breakers_test.exs
+++ b/apps/orchard_controller/test/orchard/circuit_breakers_test.exs
@@ -1,0 +1,844 @@
+defmodule Orchard.CircuitBreakersTest do
+  use Orchard.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.CircuitBreakers
+  alias Orchard.CircuitBreakers.Decision
+  alias Orchard.Models.Model
+  alias Orchard.Nodes.Node
+
+  @now ~U[2026-08-28 01:00:00.000000Z]
+
+  setup do
+    node = insert_node!()
+    model = insert_model!()
+    %{node: node, model: model}
+  end
+
+  describe "record_failure/2 and evaluate/2" do
+    test "opens a Node breaker on the third eligible dispatch failure in 60 seconds", %{
+      node: node
+    } do
+      for {seconds_ago, expected_count} <- [{59, 1}, {30, 2}] do
+        assert {:ok, decision} =
+                 CircuitBreakers.record_failure(
+                   failure(node.id, "worker_or_node_loss", seconds_ago),
+                   now: @now
+                 )
+
+        assert decision.kind == :node
+        assert decision.node_id == node.id
+        assert decision.state == :closed
+        assert decision.contribution_count == expected_count
+        refute decision.changed_state?
+      end
+
+      assert {:ok, opened} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "pre_acceptance_unavailable", 0),
+                 now: @now
+               )
+
+      assert opened.state == :open
+      assert opened.changed_state?
+      assert opened.opened_at == @now
+      assert opened.suppressed_until == ~U[2026-08-28 01:05:00.000000Z]
+
+      assert {:ok, evaluated} = CircuitBreakers.evaluate({:node, node.id}, now: @now)
+      assert evaluated.id == opened.id
+      assert evaluated.state == :open
+      assert evaluated.contribution_count == 3
+    end
+
+    test "opens a placement breaker from three decisions in ten minutes", %{
+      node: node,
+      model: model
+    } do
+      assert {:ok, :not_eligible} =
+               CircuitBreakers.record_failure(failure(node.id, "capacity_rejection", 0),
+                 now: @now
+               )
+
+      assert {:ok, first} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "model_load_failure", 601, %{model_id: model.id}),
+                 now: @now
+               )
+
+      assert first.kind == :placement
+      assert first.contribution_count == 1
+
+      assert {:ok, second} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "model_load_failure", 599, %{model_id: model.id}),
+                 now: @now
+               )
+
+      assert second.state == :closed
+
+      assert {:ok, opened} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "model_load_failure", 300, %{model_id: model.id}),
+                 now: @now
+               )
+
+      assert opened.state == :open
+      assert opened.contribution_count == 3
+      assert opened.suppressed_until == ~U[2026-08-28 01:15:00.000000Z]
+      assert opened.contribution_disposition == :contributed
+      assert opened.transition == :opened
+    end
+
+    test "uses a half-open rolling decision-time window", %{node: node} do
+      boundary = DateTime.add(@now, -60, :second)
+
+      assert {:ok, _outside} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "worker_or_node_loss", 120),
+                 now: boundary
+               )
+
+      for seconds_ago <- [1, 0] do
+        assert {:ok, decision} =
+                 CircuitBreakers.record_failure(
+                   failure(node.id, "worker_or_node_loss", seconds_ago),
+                   now: @now
+                 )
+
+        assert decision.state == :closed
+      end
+
+      assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id}, now: @now)
+      assert decision.contribution_count == 2
+      assert decision.state == :closed
+    end
+
+    test "makes identical global failure delivery idempotent and rejects conflicting reuse", %{
+      node: node
+    } do
+      attrs = failure(node.id, "worker_or_node_loss", 0)
+
+      assert {:ok, recorded} = CircuitBreakers.record_failure(attrs, now: @now)
+      assert recorded.delivery == :recorded
+      assert recorded.contribution_count == 1
+
+      assert {:ok, duplicate} = CircuitBreakers.record_failure(attrs, now: @now)
+      assert duplicate.delivery == :duplicate
+      assert duplicate.id == recorded.id
+      assert duplicate.contribution_count == 1
+
+      conflicting = %{attrs | failure_class: "pre_acceptance_unavailable"}
+
+      assert {:error, :failure_identity_conflict} =
+               CircuitBreakers.record_failure(conflicting, now: @now)
+    end
+
+    test "serializes concurrent contributions so one canonical breaker opens", %{node: node} do
+      failures = for _ <- 1..8, do: failure(node.id, "worker_or_node_loss", 0)
+      owner = self()
+
+      results =
+        failures
+        |> Task.async_stream(
+          fn attrs ->
+            Sandbox.allow(Repo, owner, self())
+            CircuitBreakers.record_failure(attrs, now: @now)
+          end,
+          max_concurrency: 8,
+          ordered: false,
+          timeout: 10_000
+        )
+        |> Enum.to_list()
+
+      assert Enum.all?(results, &match?({:ok, {:ok, %Decision{}}}, &1))
+      assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id}, now: @now)
+      assert decision.state == :open
+      assert decision.contribution_count == 8
+    end
+
+    test "uses the persisted deadline for lazy expiry", %{node: node} do
+      opened = open_node_breaker(node.id)
+
+      assert {:ok, expired} =
+               CircuitBreakers.evaluate({:node, node.id},
+                 now: DateTime.add(opened.suppressed_until, 1, :microsecond)
+               )
+
+      assert expired.id == opened.id
+      assert expired.state == :closed
+      assert expired.contribution_count == 0
+      assert is_nil(expired.suppressed_until)
+    end
+
+    test "rejects future-dated contribution evidence", %{node: node} do
+      assert {:error, :invalid_occurred_at} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "worker_or_node_loss", -1),
+                 now: @now
+               )
+    end
+
+    test "fences a delayed first delivery whose occurrence predates an Operator clear", %{
+      node: node
+    } do
+      open_node_breaker(node.id)
+
+      clear_time = DateTime.add(@now, 10, :second)
+      assert {:ok, cleared} = CircuitBreakers.clear({:node, node.id}, now: clear_time)
+      assert cleared.contribution_count == 0
+
+      assert {:ok, fenced} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "worker_or_node_loss", 1),
+                 now: DateTime.add(clear_time, 1, :second)
+               )
+
+      assert fenced.contribution_disposition == :fenced
+      assert fenced.transition == :none
+      assert fenced.contribution_count == 0
+      assert fenced.state == :closed
+    end
+  end
+
+  describe "clear/2" do
+    test "clearing a closed pre-threshold breaker is already cleared without fencing evidence", %{
+      node: node
+    } do
+      assert {:ok, recorded} =
+               CircuitBreakers.record_failure(failure(node.id, "worker_or_node_loss", 0),
+                 now: @now
+               )
+
+      assert recorded.state == :closed
+      assert recorded.contribution_count == 1
+
+      later = DateTime.add(@now, 10, :second)
+      assert {:ok, already_cleared} = CircuitBreakers.clear({:node, node.id}, now: later)
+
+      refute already_cleared.changed_state?
+      assert already_cleared.state == :closed
+      assert already_cleared.generation == 0
+      assert is_nil(already_cleared.last_cleared_at)
+      assert already_cleared.contribution_count == 1
+    end
+
+    test "advances the clear generation once, preserves identity, and audits repeated no-op clear",
+         %{
+           node: node
+         } do
+      opened = open_node_breaker(node.id)
+      test_pid = self()
+
+      audit = fn decision ->
+        send(test_pid, {:audited, decision})
+        :ok
+      end
+
+      assert {:ok, cleared} =
+               CircuitBreakers.clear({:node, node.id}, now: @now, audit: audit)
+
+      assert cleared.id == opened.id
+      assert cleared.state == :closed
+      assert cleared.changed_state?
+      assert cleared.contribution_count == 0
+      assert cleared.generation == 1
+      assert cleared.last_cleared_at == @now
+      assert cleared.decision_at == @now
+      assert cleared.previous_state == :open
+      assert_receive {:audited, ^cleared}
+
+      later = DateTime.add(@now, 30, :second)
+      assert {:ok, repeated} = CircuitBreakers.clear({:node, node.id}, now: later, audit: audit)
+      refute repeated.changed_state?
+      assert repeated.generation == 1
+      assert repeated.last_cleared_at == @now
+      assert repeated.decision_at == later
+      assert repeated.previous_state == :closed
+      assert_receive {:audited, ^repeated}
+    end
+
+    test "rolls a clear back when its atomic audit callback fails", %{node: node} do
+      opened = open_node_breaker(node.id)
+
+      assert {:error, :audit_failed} =
+               CircuitBreakers.clear({:node, node.id},
+                 now: @now,
+                 audit: fn _decision -> {:error, :audit_failed} end
+               )
+
+      assert {:ok, still_open} = CircuitBreakers.inspect({:node, node.id}, now: @now)
+      assert still_open.id == opened.id
+      assert still_open.state == :open
+      assert still_open.generation == 0
+    end
+
+    test "does not normalize unrelated programming errors from the transaction", %{node: node} do
+      open_node_breaker(node.id)
+
+      assert_raise Ecto.ChangeError, "programming defect", fn ->
+        CircuitBreakers.clear({:node, node.id},
+          now: @now,
+          audit: fn _decision -> raise Ecto.ChangeError, message: "programming defect" end
+        )
+      end
+    end
+
+    test "normalizes a database connection exit from the transaction", %{node: node} do
+      open_node_breaker(node.id)
+
+      connection_error = DBConnection.ConnectionError.exception(message: "connection closed")
+
+      assert {:error, :circuit_breaker_unavailable} =
+               CircuitBreakers.clear({:node, node.id},
+                 now: @now,
+                 audit: fn _decision -> exit(connection_error) end
+               )
+    end
+  end
+
+  describe "fail-closed identities and write authority" do
+    test "rejects malformed and unresolved canonical identities", %{node: node, model: model} do
+      assert {:error, :invalid_failure_identity} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "worker_or_node_loss", 0, %{failure_id: "not-a-uuid"}),
+                 now: @now
+               )
+
+      assert {:error, :node_not_found} =
+               CircuitBreakers.evaluate({:node, Ecto.UUID.generate()}, now: @now)
+
+      assert {:error, :model_not_active} =
+               model
+               |> Ecto.Changeset.change(state: :retired)
+               |> Repo.update!()
+               |> then(fn retired ->
+                 CircuitBreakers.evaluate({:placement, node.id, retired.id}, now: @now)
+               end)
+    end
+
+    test "accepts a deprecated placement Model while retired Models remain ineligible", %{
+      node: node,
+      model: model
+    } do
+      deprecated =
+        model
+        |> Ecto.Changeset.change(state: :deprecated)
+        |> Repo.update!()
+
+      assert {:ok, %Decision{state: :closed, model_id: model_id}} =
+               CircuitBreakers.evaluate({:placement, node.id, deprecated.id}, now: @now)
+
+      assert model_id == deprecated.id
+
+      retired =
+        deprecated
+        |> Ecto.Changeset.change(state: :retired)
+        |> Repo.update!()
+
+      assert {:error, :model_not_active} =
+               CircuitBreakers.evaluate({:placement, node.id, retired.id}, now: @now)
+    end
+
+    test "retains inspectable placement history after catalog Model deletion", %{
+      node: node,
+      model: model
+    } do
+      assert {:ok, recorded} =
+               CircuitBreakers.record_failure(
+                 failure(node.id, "model_load_failure", 0, %{model_id: model.id}),
+                 now: @now
+               )
+
+      Repo.delete!(model)
+
+      assert {:ok, retained} =
+               CircuitBreakers.inspect({:placement, node.id, model.id}, now: @now)
+
+      assert retained.id == recorded.id
+      assert retained.contribution_count == 1
+      assert retained.model_id == model.id
+
+      assert {:error, :model_not_found} =
+               CircuitBreakers.evaluate({:placement, node.id, model.id}, now: @now)
+    end
+
+    test "rejects an unknown placement Model when no retained breaker exists", %{node: node} do
+      assert {:error, :model_not_found} =
+               CircuitBreakers.inspect({:placement, node.id, Ecto.UUID.generate()}, now: @now)
+    end
+
+    test "standby Controllers cannot record or clear failures", %{node: node} do
+      previous = Application.get_env(:orchard_controller, :control_plane)
+      Application.put_env(:orchard_controller, :control_plane, role: :standby)
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:orchard_controller, :control_plane, previous),
+          else: Application.delete_env(:orchard_controller, :control_plane)
+      end)
+
+      assert {:error, :controller_standby} =
+               CircuitBreakers.record_failure(failure(node.id, "worker_or_node_loss", 0),
+                 now: @now
+               )
+
+      assert {:error, :controller_standby} =
+               CircuitBreakers.clear({:node, node.id}, now: @now)
+    end
+
+    test "a fresh Standby process reads durable state after role handoff while writes fail", %{
+      node: node
+    } do
+      opened = open_node_breaker(node.id)
+      previous = Application.get_env(:orchard_controller, :control_plane)
+      Application.put_env(:orchard_controller, :control_plane, role: :standby)
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:orchard_controller, :control_plane, previous),
+          else: Application.delete_env(:orchard_controller, :control_plane)
+      end)
+
+      read_task = Task.async(fn -> CircuitBreakers.evaluate({:node, node.id}, now: @now) end)
+
+      assert {:ok, {:ok, read_back}} =
+               Task.yield(read_task, 5_000)
+
+      assert read_back.id == opened.id
+      assert read_back.state == :open
+
+      assert {:error, :controller_standby} =
+               CircuitBreakers.record_failure(failure(node.id, "worker_or_node_loss", 0),
+                 now: @now
+               )
+    end
+  end
+
+  describe "serialized database decision time and coherent reads" do
+    test "batch evaluation preserves input order and one post-lock decision time", %{
+      node: node,
+      model: model
+    } do
+      open_node_breaker(node.id)
+
+      assert {:ok, [placement, node_decision]} =
+               CircuitBreakers.evaluate_many(
+                 [{:placement, node.id, model.id}, {:node, node.id}],
+                 now: @now
+               )
+
+      assert placement.kind == :placement
+      assert placement.model_id == model.id
+      assert placement.state == :closed
+      assert node_decision.kind == :node
+      assert node_decision.state == :open
+      assert placement.decision_at == node_decision.decision_at
+    end
+
+    test "concurrent reversed batch evaluations acquire targets in one deterministic order", %{
+      node: node,
+      model: model
+    } do
+      owner = self()
+      targets = [{:node, node.id}, {:placement, node.id, model.id}]
+
+      results =
+        [targets, Enum.reverse(targets)]
+        |> Task.async_stream(
+          fn ordered_targets ->
+            Sandbox.allow(Repo, owner, self())
+            CircuitBreakers.evaluate_many(ordered_targets, now: @now)
+          end,
+          max_concurrency: 2,
+          timeout: 5_000
+        )
+        |> Enum.to_list()
+
+      assert Enum.all?(results, fn
+               {:ok, {:ok, [%Decision{}, %Decision{}]}} -> true
+               _result -> false
+             end)
+    end
+
+    test "batch evaluation fails closed as one result when any identity is unresolved", %{
+      node: node
+    } do
+      assert {:error, :node_not_found} =
+               CircuitBreakers.evaluate_many(
+                 [{:node, node.id}, {:node, Ecto.UUID.generate()}],
+                 now: @now
+               )
+    end
+
+    test "a blocked recorder decides after the target lock and excludes the elapsed boundary" do
+      node = begin_unboxed_node!()
+      db_now = database_now()
+      seed_time = DateTime.add(db_now, -59, :second)
+
+      for _ <- 1..2 do
+        attrs = failure_at(node.id, "worker_or_node_loss", seed_time)
+
+        assert {:ok, %Decision{state: :closed}} =
+                 Sandbox.unboxed_run(Repo, fn ->
+                   CircuitBreakers.record_failure(attrs, now: seed_time)
+                 end)
+      end
+
+      {holder, release_ref} = hold_target_lock(node.id)
+      attrs = failure_at(node.id, "worker_or_node_loss", db_now)
+      parent = self()
+
+      recorder =
+        Task.async(fn ->
+          Sandbox.unboxed_run(Repo, fn ->
+            backend_pid = backend_pid()
+            send(parent, {:recorder_backend, backend_pid})
+            CircuitBreakers.record_failure(attrs)
+          end)
+        end)
+
+      assert_receive {:recorder_backend, recorder_backend}, 2_000
+      assert_backend_waiting_on_lock(recorder_backend)
+      Process.sleep(1_100)
+      send(holder.pid, release_ref)
+      assert {:ok, released_at} = Task.await(holder, 5_000)
+
+      assert {:ok, %Decision{} = result} = Task.await(recorder, 5_000)
+      assert DateTime.compare(result.decision_at, released_at) in [:eq, :gt]
+      assert result.contribution_count == 1
+      assert result.state == :closed
+      assert result.transition == :none
+    end
+
+    test "evaluation waits for an in-flight opening transition and reads the committed state" do
+      node = begin_unboxed_node!()
+
+      for seconds_ago <- [2, 1] do
+        assert {:ok, _decision} =
+                 Sandbox.unboxed_run(Repo, fn ->
+                   CircuitBreakers.record_failure(
+                     failure(node.id, "worker_or_node_loss", seconds_ago),
+                     now: @now
+                   )
+                 end)
+      end
+
+      {opener, release_ref} = paused_record(failure(node.id, "worker_or_node_loss", 0), @now)
+
+      reader = start_unboxed_reader({:node, node.id}, @now)
+      assert_receive {:reader_backend, reader_backend}, 2_000
+      assert_backend_waiting_on_lock(reader_backend)
+      send(opener.pid, release_ref)
+
+      assert {:ok, %Decision{state: :open}} = Task.await(opener, 5_000)
+      assert {:ok, %Decision{state: :open, contribution_count: 3}} = Task.await(reader, 5_000)
+    end
+
+    test "evaluation waits for an in-flight clear and reads one committed generation" do
+      node = begin_unboxed_node!()
+
+      opened =
+        Sandbox.unboxed_run(Repo, fn ->
+          for seconds_ago <- [2, 1] do
+            assert {:ok, _decision} =
+                     CircuitBreakers.record_failure(
+                       failure(node.id, "worker_or_node_loss", seconds_ago),
+                       now: @now
+                     )
+          end
+
+          assert {:ok, result} =
+                   CircuitBreakers.record_failure(
+                     failure(node.id, "worker_or_node_loss", 0),
+                     now: @now
+                   )
+
+          result
+        end)
+
+      {clearer, release_ref} = paused_clear(node.id, @now)
+      reader = start_unboxed_reader({:node, node.id}, @now)
+      assert_receive {:reader_backend, reader_backend}, 2_000
+      assert_backend_waiting_on_lock(reader_backend)
+      send(clearer.pid, release_ref)
+
+      assert {:ok, %Decision{state: :closed, generation: 1}} = Task.await(clearer, 5_000)
+
+      assert {:ok, %Decision{id: id, state: :closed, generation: 1, contribution_count: 0}} =
+               Task.await(reader, 5_000)
+
+      assert id == opened.id
+    end
+
+    test "database unavailability returns a stable error without partial clear or audit" do
+      node = begin_unboxed_node!()
+
+      Sandbox.unboxed_run(Repo, fn ->
+        for seconds_ago <- [2, 1, 0] do
+          assert {:ok, _decision} =
+                   CircuitBreakers.record_failure(
+                     failure(node.id, "worker_or_node_loss", seconds_ago),
+                     now: @now
+                   )
+        end
+      end)
+
+      test_pid = self()
+
+      audit = fn _decision ->
+        send(test_pid, :unexpected_audit)
+        :ok
+      end
+
+      assert {:error, :circuit_breaker_unavailable} =
+               CircuitBreakers.inspect({:node, node.id}, now: @now)
+
+      assert {:error, :circuit_breaker_unavailable} =
+               CircuitBreakers.clear({:node, node.id}, now: @now, audit: audit)
+
+      refute_receive :unexpected_audit
+
+      assert {:ok, %Decision{state: :open, generation: 0}} =
+               Sandbox.unboxed_run(Repo, fn ->
+                 CircuitBreakers.inspect({:node, node.id}, now: @now)
+               end)
+    end
+  end
+
+  defp open_node_breaker(node_id) do
+    for seconds_ago <- [2, 1] do
+      assert {:ok, _decision} =
+               CircuitBreakers.record_failure(
+                 failure(node_id, "worker_or_node_loss", seconds_ago),
+                 now: @now
+               )
+    end
+
+    assert {:ok, opened} =
+             CircuitBreakers.record_failure(
+               failure(node_id, "worker_or_node_loss", 0),
+               now: @now
+             )
+
+    opened
+  end
+
+  defp failure(node_id, failure_class, seconds_ago, overrides \\ %{}) do
+    Map.merge(
+      %{
+        failure_id: Ecto.UUID.generate(),
+        node_id: node_id,
+        failure_class: failure_class,
+        occurred_at: DateTime.add(@now, -seconds_ago, :second)
+      },
+      overrides
+    )
+  end
+
+  defp failure_at(node_id, failure_class, occurred_at) do
+    %{
+      failure_id: Ecto.UUID.generate(),
+      node_id: node_id,
+      failure_class: failure_class,
+      occurred_at: occurred_at
+    }
+  end
+
+  defp begin_unboxed_node! do
+    :ok = Sandbox.checkin(Repo)
+    node = Sandbox.unboxed_run(Repo, &insert_node!/0)
+
+    on_exit(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        Repo.query!("DELETE FROM circuit_breaker_failures WHERE node_id = $1", [
+          Ecto.UUID.dump!(node.id)
+        ])
+
+        Repo.query!("DELETE FROM circuit_breakers WHERE node_id = $1", [
+          Ecto.UUID.dump!(node.id)
+        ])
+
+        Repo.delete_all(from(candidate in Node, where: candidate.id == ^node.id))
+      end)
+    end)
+
+    node
+  end
+
+  defp hold_target_lock(node_id) do
+    parent = self()
+    release_ref = make_ref()
+
+    task =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          hold_target_lock_transaction(node_id, parent, release_ref)
+        end)
+      end)
+
+    assert_receive {:target_lock_held, _pid}, 2_000
+    {task, release_ref}
+  end
+
+  defp hold_target_lock_transaction(node_id, parent, release_ref) do
+    Repo.transaction(fn ->
+      advisory_target_lock(node_id)
+      send(parent, {:target_lock_held, self()})
+
+      receive do
+        ^release_ref -> database_now_direct()
+      after
+        5_000 -> raise "timed out waiting to release circuit-breaker target lock"
+      end
+    end)
+  end
+
+  defp paused_record(attrs, now) do
+    parent = self()
+    release_ref = make_ref()
+
+    task =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          CircuitBreakers.record_failure(attrs,
+            now: now,
+            test_lock_observer: pause_on_target(parent, release_ref)
+          )
+        end)
+      end)
+
+    assert_receive {:domain_target_lock_held, _pid}, 2_000
+    {task, release_ref}
+  end
+
+  defp paused_clear(node_id, now) do
+    parent = self()
+    release_ref = make_ref()
+
+    task =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          CircuitBreakers.clear({:node, node_id},
+            now: now,
+            test_lock_observer: pause_on_target(parent, release_ref)
+          )
+        end)
+      end)
+
+    assert_receive {:domain_target_lock_held, _pid}, 2_000
+    {task, release_ref}
+  end
+
+  defp pause_on_target(parent, release_ref) do
+    fn
+      :target ->
+        send(parent, {:domain_target_lock_held, self()})
+
+        receive do
+          ^release_ref -> :ok
+        after
+          5_000 -> raise "timed out waiting to release domain target lock"
+        end
+
+      :failure ->
+        :ok
+    end
+  end
+
+  defp start_unboxed_reader(target, now) do
+    parent = self()
+
+    Task.async(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        send(parent, {:reader_backend, backend_pid()})
+        CircuitBreakers.evaluate(target, now: now)
+      end)
+    end)
+  end
+
+  defp assert_backend_waiting_on_lock(backend_pid, attempts \\ 40)
+
+  defp assert_backend_waiting_on_lock(_backend_pid, 0),
+    do: flunk("backend did not wait on the circuit-breaker advisory lock")
+
+  defp assert_backend_waiting_on_lock(backend_pid, attempts) do
+    waiting? =
+      Sandbox.unboxed_run(Repo, fn ->
+        %{rows: rows} =
+          Repo.query!(
+            "SELECT 1 FROM pg_stat_activity WHERE pid = $1 AND wait_event_type = 'Lock'",
+            [backend_pid]
+          )
+
+        rows != []
+      end)
+
+    if waiting? do
+      :ok
+    else
+      Process.sleep(25)
+      assert_backend_waiting_on_lock(backend_pid, attempts - 1)
+    end
+  end
+
+  defp advisory_target_lock(node_id) do
+    Repo.query!(
+      "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+      ["orchard:circuit-breaker:node:#{node_id}:"]
+    )
+  end
+
+  defp database_now do
+    Sandbox.unboxed_run(Repo, &database_now_direct/0)
+  end
+
+  defp database_now_direct do
+    %{rows: [[now]]} = Repo.query!("SELECT clock_timestamp()")
+    DateTime.truncate(now, :microsecond)
+  end
+
+  defp backend_pid do
+    %{rows: [[pid]]} = Repo.query!("SELECT pg_backend_pid()")
+    pid
+  end
+
+  defp insert_node! do
+    unique = System.unique_integer([:positive])
+
+    %Node{}
+    |> Node.changeset(%{
+      id: Ecto.UUID.generate(),
+      hostname: "breaker-node-#{unique}.local",
+      display_name: "breaker-node-#{unique}",
+      advertise_addr: "10.254.#{rem(div(unique, 254), 254)}.#{rem(unique, 254) + 1}",
+      rpc_port: 9444,
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      tool_readiness: %{}
+    })
+    |> Repo.insert!()
+  end
+
+  defp insert_model! do
+    unique = System.unique_integer([:positive])
+
+    %Model{}
+    |> Model.changeset(%{
+      model_id: "breaker-model-#{unique}",
+      version: "main",
+      state: :active,
+      format: "mlx",
+      capabilities: ["text"],
+      tokenizer: %{"type" => "huggingface", "ref" => "test/tokenizer"},
+      artifact_uri: "file:///tmp/breaker-model-#{unique}",
+      artifact_sha256: String.duplicate("a", 64),
+      artifact_size_bytes: 1,
+      resident_memory_bytes: 1,
+      kv_cache_bytes_per_token: 1,
+      prefill_workspace_bytes_per_token: 1,
+      runtime_requirements: %{}
+    })
+    |> Repo.insert!()
+  end
+end

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -815,6 +815,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
   alias Orchard.CanonicalRequest
   alias Orchard.CanonicalRequest.ModelRef
+  alias Orchard.CircuitBreakers
   alias Orchard.Cluster.V1.{EnsureModelLoadedRequest, ExecuteInferenceRequest}
   alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.DispatchCapacity.AllocationAuthority
@@ -824,6 +825,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
   alias Orchard.Inference
   alias Orchard.Inference.QueueManager
   alias Orchard.InferenceEvent
+  alias Orchard.Models.Model
   alias Orchard.NodeHeartbeats.CandidateSnapshot
   alias Orchard.NodeHeartbeats.CandidateSnapshot.Candidate
   alias Orchard.Nodes.{AdmissionDecision, Node}
@@ -876,6 +878,8 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
   @expiring_request_timeout_ms 250
 
   setup do
+    insert_canonical_model!()
+
     previous_inference = Application.fetch_env!(:orchard_controller, :inference)
     @client.configure(self())
     @gate_client.configure(self())
@@ -2184,6 +2188,46 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     assert AllocationAuthority.claim_count(authority, node.id) == 0
   end
 
+  test "SPEC 5.10 SingleNode acquisition applies placement suppression only when refreshed status requires load" do
+    authority = start_supervised!({AllocationAuthority, name: nil})
+    target = SingleNode.target()
+    now = DateTime.utc_now()
+    node = insert_admitted_node!(target, now)
+    model = Repo.get_by!(Model, model_id: "test/model", version: "v1")
+    cold_status = production_status(node, target, [])
+
+    @production_fresh_status_client.configure(self(), cold_status, cold_status)
+
+    assert {:ok, schedule} =
+             SingleNode.default_schedule(
+               canonical_request(),
+               target,
+               status_client: @production_fresh_status_client,
+               dispatch_capacity_authority: authority
+             )
+
+    open_placement_breaker!(node.id, model.id)
+
+    loaded_status =
+      node
+      |> production_status(target, [%{model_id: "test/model", version: "v1"}])
+      |> Map.put(:runtime_model_placements, [
+        %{
+          model_ref: %{model_id: "test/model", version: "v1"},
+          active_request_count: 0,
+          max_concurrency: 2
+        }
+      ])
+
+    @production_fresh_status_client.configure(self(), loaded_status, loaded_status)
+    loaded_input = schedule.dispatch_capacity_acquisition_input_provider.()
+    assert loaded_input.breaker_eligible?
+
+    @production_fresh_status_client.configure(self(), cold_status, cold_status)
+    cold_input = schedule.dispatch_capacity_acquisition_input_provider.()
+    refute cold_input.breaker_eligible?
+  end
+
   test "SPEC 5.9 SingleNode target remap cannot move a queued claim to another Node" do
     authority = start_supervised!({AllocationAuthority, name: nil})
     target = SingleNode.target()
@@ -3463,6 +3507,44 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       model_ref: %ModelRef{model_id: "test/model", version: "v1"},
       rendered_prompt: "hello orchard"
     })
+  end
+
+  defp insert_canonical_model! do
+    %Model{}
+    |> Model.changeset(%{
+      model_id: "test/model",
+      version: "v1",
+      state: :active,
+      format: "mlx",
+      capabilities: ["text"],
+      tokenizer: %{"type" => "huggingface", "ref" => "test/tokenizer"},
+      artifact_uri: "file:///tmp/request-dispatcher-claim-test-model",
+      artifact_sha256: String.duplicate("a", 64),
+      artifact_size_bytes: 1,
+      resident_memory_bytes: 1,
+      kv_cache_bytes_per_token: 1,
+      prefill_workspace_bytes_per_token: 1,
+      runtime_requirements: %{}
+    })
+    |> Repo.insert!()
+  end
+
+  defp open_placement_breaker!(node_id, model_id) do
+    now = DateTime.utc_now()
+
+    for offset <- [2, 1, 0] do
+      assert {:ok, _decision} =
+               CircuitBreakers.record_failure(
+                 %{
+                   failure_id: Ecto.UUID.generate(),
+                   node_id: node_id,
+                   model_id: model_id,
+                   failure_class: "model_load_failure",
+                   occurred_at: DateTime.add(now, -offset, :second)
+                 },
+                 now: now
+               )
+    end
   end
 
   defp put_inference(overrides) do

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/scheduler_authorization_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/scheduler_authorization_test.exs
@@ -7,6 +7,7 @@ defmodule Orchard.DispatchCapacity.SchedulerAuthorizationTest do
   alias Orchard.DispatchCapacity.AllocationAuthority
   alias Orchard.DispatchCapacity.Evaluator.Input
   alias Orchard.DispatchCapacity.Policy
+  alias Orchard.Models
   alias Orchard.NodeHeartbeats
   alias Orchard.Nodes.{AdmissionDecision, Node}
   alias Orchard.RuntimeEndpoint.Target
@@ -22,6 +23,8 @@ defmodule Orchard.DispatchCapacity.SchedulerAuthorizationTest do
   end
 
   setup do
+    ensure_model!()
+
     previous_inference = Application.fetch_env!(:orchard_controller, :inference)
 
     previous_artifact_provider =
@@ -348,6 +351,28 @@ defmodule Orchard.DispatchCapacity.SchedulerAuthorizationTest do
       model_ref: %ModelRef{model_id: "test/model", version: "v1"},
       rendered_prompt: "hello"
     })
+  end
+
+  defp ensure_model! do
+    Models.get_model_by_identity("test/model", "v1") ||
+      case Models.create_model(%{
+             model_id: "test/model",
+             version: "v1",
+             state: :active,
+             format: "mlx",
+             capabilities: ["text"],
+             tokenizer: %{"type" => "huggingface", "ref" => "test/tokenizer"},
+             artifact_uri: "file:///tmp/dispatch-capacity-test-model",
+             artifact_sha256: String.duplicate("a", 64),
+             artifact_size_bytes: 1,
+             resident_memory_bytes: 1,
+             kv_cache_bytes_per_token: 1,
+             prefill_workspace_bytes_per_token: 1,
+             runtime_requirements: %{}
+           }) do
+        {:ok, model} -> model
+        {:error, changeset} -> raise "failed to create test model: #{inspect(changeset.errors)}"
+      end
   end
 
   defp enforcing_input(ceiling) do

--- a/apps/orchard_controller/test/orchard/governance/audit_writer_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/audit_writer_test.exs
@@ -23,6 +23,7 @@ defmodule Orchard.Governance.AuditWriterTest do
     {"node_enrollment.issued", "node_admission", "succeeded"},
     {"node_trust.initialized", "node_admission", "succeeded"},
     {"node_lifecycle.cordoned", "node_lifecycle", "succeeded"},
+    {"circuit_breaker.node.cleared", "circuit_breaker", "succeeded"},
     {"provisioning_batch.failed", "service_account", "failed"},
     {"cluster_admin_bootstrap.minted", "cluster", "succeeded"}
   ]

--- a/apps/orchard_controller/test/orchard/nodes_circuit_breaker_transport_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_circuit_breaker_transport_test.exs
@@ -1,0 +1,290 @@
+defmodule Orchard.NodesCircuitBreakerTransportTest do
+  use Orchard.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.CircuitBreakers
+  alias Orchard.Nodes
+  alias Orchard.Nodes.Node
+  alias Orchard.RuntimeEndpoint.Target
+
+  test "SPEC.md §5.10 actually-run transport failure updates health and contributes once" do
+    occurred_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    node = insert_node!(occurred_at)
+    target = target(node)
+
+    failure = %{
+      failure_id: Ecto.UUID.generate(),
+      node_id: node.id,
+      failure_class: "worker_or_node_loss",
+      occurred_at: occurred_at
+    }
+
+    assert {:ok, %{node: marked, breaker: recorded}} =
+             Nodes.record_dispatch_transport_failure(target, :node_timeout, failure)
+
+    assert marked.health == :degraded
+    assert marked.last_transport_failure_at == occurred_at
+    assert recorded.delivery == :recorded
+    assert recorded.contribution_count == 1
+
+    assert {:ok, %{node: duplicate_node, breaker: duplicate}} =
+             Nodes.record_dispatch_transport_failure(target, :node_timeout, failure)
+
+    assert duplicate_node.health == :degraded
+    assert duplicate_node.last_transport_failure_at == occurred_at
+    assert duplicate_node.updated_at == marked.updated_at
+    assert duplicate.delivery == :duplicate
+    assert duplicate.contribution_count == 1
+
+    assert {:ok, evaluated} =
+             CircuitBreakers.evaluate({:node, node.id},
+               now: DateTime.add(occurred_at, 1, :second)
+             )
+
+    assert evaluated.contribution_count == 1
+  end
+
+  test "activation and discovery transport failures remain health-only" do
+    occurred_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    node = insert_node!(occurred_at)
+
+    assert {:ok, marked} =
+             Nodes.record_transport_failure(target(node), :node_timeout, occurred_at)
+
+    assert marked.health == :degraded
+    assert marked.last_transport_failure_at == occurred_at
+
+    assert {:ok, evaluated} =
+             CircuitBreakers.evaluate({:node, node.id},
+               now: DateTime.add(occurred_at, 1, :second)
+             )
+
+    assert evaluated.state == :closed
+    assert evaluated.contribution_count == 0
+  end
+
+  test "concurrent duplicate delivery locks canonical Node health and contributes once" do
+    occurred_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    node = insert_node!(occurred_at)
+    target = target(node)
+    owner = self()
+
+    failure = %{
+      failure_id: Ecto.UUID.generate(),
+      node_id: node.id,
+      failure_class: "worker_or_node_loss",
+      occurred_at: occurred_at
+    }
+
+    results =
+      1..2
+      |> Task.async_stream(
+        fn _delivery ->
+          Sandbox.allow(Repo, owner, self())
+          Nodes.record_dispatch_transport_failure(target, :node_timeout, failure)
+        end,
+        max_concurrency: 2,
+        timeout: 10_000
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+
+    assert Enum.all?(results, &match?({:ok, %{node: %Node{health: :degraded}}}, &1))
+
+    assert results
+           |> Enum.map(fn {:ok, %{breaker: breaker}} -> breaker.delivery end)
+           |> Enum.sort() == [:duplicate, :recorded]
+
+    persisted = Repo.get!(Node, node.id)
+    assert persisted.health == :degraded
+    assert persisted.last_transport_failure_at == occurred_at
+
+    assert {:ok, evaluated} =
+             CircuitBreakers.evaluate({:node, node.id},
+               now: DateTime.add(occurred_at, 1, :second)
+             )
+
+    assert evaluated.contribution_count == 1
+  end
+
+  test "combined recording shares target-before-Node lock order with direct delivery" do
+    occurred_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    node = begin_unboxed_node!(occurred_at)
+    target = target(node)
+    owner = self()
+    release_ref = make_ref()
+
+    failure = %{
+      failure_id: Ecto.UUID.generate(),
+      node_id: node.id,
+      failure_class: "worker_or_node_loss",
+      occurred_at: occurred_at
+    }
+
+    direct =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          CircuitBreakers.record_failure(failure,
+            test_lock_observer: fn
+              :target ->
+                send(owner, {:direct_target_locked, self()})
+
+                receive do
+                  {:release_target, ^release_ref} -> :ok
+                end
+
+              _lock ->
+                :ok
+            end
+          )
+        end)
+      end)
+
+    assert_receive {:direct_target_locked, direct_pid}, 1_000
+
+    combined =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Nodes.record_dispatch_transport_failure(target, :node_timeout, failure)
+        end)
+      end)
+
+    assert Task.yield(combined, 50) == nil
+    send(direct_pid, {:release_target, release_ref})
+
+    assert {:ok, %{delivery: :recorded}} = Task.await(direct, 5_000)
+
+    assert {:ok, %{node: %Node{health: :degraded}, breaker: %{delivery: :duplicate}}} =
+             Task.await(combined, 5_000)
+
+    assert {:ok, evaluated} =
+             Sandbox.unboxed_run(Repo, fn ->
+               CircuitBreakers.evaluate({:node, node.id},
+                 now: DateTime.add(occurred_at, 1, :second)
+               )
+             end)
+
+    assert evaluated.contribution_count == 1
+  end
+
+  test "canonical target mismatch fails before health or breaker mutation" do
+    occurred_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    node = insert_node!(occurred_at)
+
+    failure = %{
+      failure_id: Ecto.UUID.generate(),
+      node_id: Ecto.UUID.generate(),
+      failure_class: "worker_or_node_loss",
+      occurred_at: occurred_at
+    }
+
+    assert {:error, :transport_failure_target_mismatch} =
+             Nodes.record_dispatch_transport_failure(target(node), :node_timeout, failure)
+
+    unchanged = Repo.get!(Node, node.id)
+    assert unchanged.health == :healthy
+    assert unchanged.last_transport_failure_at == nil
+
+    assert {:ok, evaluated} = CircuitBreakers.evaluate({:node, node.id}, now: occurred_at)
+    assert evaluated.contribution_count == 0
+  end
+
+  test "outer transaction checkout failure returns a stable error without mutation" do
+    occurred_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    node = begin_unboxed_node!(occurred_at)
+
+    failure = %{
+      failure_id: Ecto.UUID.generate(),
+      node_id: node.id,
+      failure_class: "worker_or_node_loss",
+      occurred_at: occurred_at
+    }
+
+    assert {:error, :circuit_breaker_unavailable} =
+             Nodes.record_dispatch_transport_failure(target(node), :node_timeout, failure)
+
+    unchanged = Sandbox.unboxed_run(Repo, fn -> Repo.get!(Node, node.id) end)
+    assert unchanged.health == :healthy
+    assert unchanged.last_transport_failure_at == nil
+
+    assert {:ok, evaluated} =
+             Sandbox.unboxed_run(Repo, fn ->
+               CircuitBreakers.evaluate({:node, node.id}, now: occurred_at)
+             end)
+
+    assert evaluated.contribution_count == 0
+  end
+
+  test "operator clear does not change transport health or lifecycle" do
+    occurred_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    node = insert_node!(occurred_at)
+
+    failure = %{
+      failure_id: Ecto.UUID.generate(),
+      node_id: node.id,
+      failure_class: "worker_or_node_loss",
+      occurred_at: occurred_at
+    }
+
+    assert {:ok, %{node: marked}} =
+             Nodes.record_dispatch_transport_failure(target(node), :node_timeout, failure)
+
+    assert {:ok, _cleared} =
+             CircuitBreakers.clear({:node, node.id},
+               now: DateTime.add(occurred_at, 1, :second)
+             )
+
+    unchanged = Repo.get!(Node, node.id)
+    assert unchanged.state == marked.state
+    assert unchanged.health == marked.health
+    assert unchanged.last_transport_failure_at == marked.last_transport_failure_at
+  end
+
+  defp insert_node!(occurred_at) do
+    node_id = Ecto.UUID.generate()
+
+    %Node{}
+    |> Node.changeset(%{
+      id: node_id,
+      hostname: "transport-breaker-#{node_id}.local",
+      display_name: "transport-breaker-#{node_id}",
+      advertise_addr: "10.252.0.1",
+      rpc_port: 9444,
+      state: :active,
+      health: :healthy,
+      last_heartbeat_at: DateTime.add(occurred_at, -1, :second),
+      capabilities: %{},
+      tool_readiness: %{}
+    })
+    |> Repo.insert!()
+  end
+
+  defp begin_unboxed_node!(occurred_at) do
+    :ok = Sandbox.checkin(Repo)
+    node = Sandbox.unboxed_run(Repo, fn -> insert_node!(occurred_at) end)
+
+    on_exit(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        Repo.query!("DELETE FROM circuit_breaker_failures WHERE node_id = $1", [
+          Ecto.UUID.dump!(node.id)
+        ])
+
+        Repo.query!("DELETE FROM circuit_breakers WHERE node_id = $1", [
+          Ecto.UUID.dump!(node.id)
+        ])
+
+        Repo.delete_all(from(candidate in Node, where: candidate.id == ^node.id))
+      end)
+    end)
+
+    node
+  end
+
+  defp target(node) do
+    Target.grpc_compat(
+      host: node.advertise_addr,
+      port: node.rpc_port,
+      source: :node_inventory,
+      trusted: true
+    )
+  end
+end

--- a/apps/orchard_controller/test/orchard/repo/migrations/circuit_breaker_foundation_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/circuit_breaker_foundation_test.exs
@@ -1,0 +1,127 @@
+defmodule Orchard.Repo.Migrations.CircuitBreakerFoundationTest do
+  @moduledoc """
+  Executes the real circuit-breaker migrations in an isolated Postgres schema.
+  """
+
+  use Orchard.DataCase, async: false
+
+  alias Ecto.Migration.Runner
+  alias Orchard.Repo
+  alias Orchard.Repo.Migrations.CircuitBreakerContributionEvidence
+  alias Orchard.Repo.Migrations.CircuitBreakerFoundation
+
+  @migration_dir Path.expand("../../../../priv/repo/migrations", __DIR__)
+  Code.require_file(Path.join(@migration_dir, "20260828010000_circuit_breaker_foundation.exs"))
+
+  Code.require_file(
+    Path.join(@migration_dir, "20260828010100_circuit_breaker_contribution_evidence.exs")
+  )
+
+  test "the actual migrations run up, down, and up with their durable constraints" do
+    prefix = "circuit_breaker_migration_#{System.unique_integer([:positive])}"
+    Repo.query!("CREATE SCHEMA #{prefix}")
+    Repo.query!("CREATE TABLE #{prefix}.nodes (id uuid PRIMARY KEY)")
+
+    run(CircuitBreakerFoundation, :up, prefix)
+    run(CircuitBreakerContributionEvidence, :up, prefix)
+    assert_contract(prefix)
+
+    run(CircuitBreakerContributionEvidence, :down, prefix)
+    run(CircuitBreakerFoundation, :down, prefix)
+    refute table_exists?(prefix, "circuit_breakers")
+    refute table_exists?(prefix, "circuit_breaker_failures")
+    assert table_exists?(prefix, "nodes")
+
+    run(CircuitBreakerFoundation, :up, prefix)
+    run(CircuitBreakerContributionEvidence, :up, prefix)
+    assert_contract(prefix)
+  end
+
+  defp run(module, direction, prefix) do
+    runner_direction = if direction == :up, do: :forward, else: :backward
+
+    Runner.run(
+      Repo,
+      Repo.config(),
+      0,
+      module,
+      runner_direction,
+      :change,
+      direction,
+      prefix: prefix,
+      log: false
+    )
+  end
+
+  defp assert_contract(prefix) do
+    assert table_exists?(prefix, "circuit_breakers")
+    assert table_exists?(prefix, "circuit_breaker_failures")
+    assert column_exists?(prefix, "circuit_breaker_failures", "decision_at")
+    assert column_exists?(prefix, "circuit_breaker_failures", "disposition")
+    assert column_exists?(prefix, "circuit_breaker_failures", "transition")
+    assert index_exists?(prefix, "circuit_breakers_node_identity")
+    assert index_exists?(prefix, "circuit_breakers_placement_identity")
+    assert index_exists?(prefix, "circuit_breaker_failures_decision_window")
+    assert constraint_exists?(prefix, "circuit_breakers", "circuit_breakers_identity_valid")
+
+    assert constraint_exists?(
+             prefix,
+             "circuit_breaker_failures",
+             "circuit_breaker_failures_disposition_valid"
+           )
+
+    node_id = Ecto.UUID.generate()
+    Repo.query!("INSERT INTO #{prefix}.nodes (id) VALUES ($1)", [Ecto.UUID.dump!(node_id)])
+
+    Repo.query!("""
+    INSERT INTO #{prefix}.circuit_breakers (kind, node_id, state, inserted_at, updated_at)
+    VALUES ('node', '#{node_id}', 'closed', NOW(), NOW())
+    """)
+  end
+
+  defp table_exists?(prefix, table) do
+    %{num_rows: count} =
+      Repo.query!(
+        "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2",
+        [prefix, table]
+      )
+
+    count > 0
+  end
+
+  defp column_exists?(prefix, table, column) do
+    %{num_rows: count} =
+      Repo.query!(
+        "SELECT 1 FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3",
+        [prefix, table, column]
+      )
+
+    count > 0
+  end
+
+  defp index_exists?(prefix, index) do
+    %{num_rows: count} =
+      Repo.query!("SELECT 1 FROM pg_indexes WHERE schemaname = $1 AND indexname = $2", [
+        prefix,
+        index
+      ])
+
+    count > 0
+  end
+
+  defp constraint_exists?(prefix, table, constraint) do
+    %{num_rows: count} =
+      Repo.query!(
+        """
+        SELECT 1
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = $1 AND t.relname = $2 AND c.conname = $3
+        """,
+        [prefix, table, constraint]
+      )
+
+    count > 0
+  end
+end

--- a/apps/orchard_controller/test/orchard/repo/migrations/node_inventory_foundation_test.exs
+++ b/apps/orchard_controller/test/orchard/repo/migrations/node_inventory_foundation_test.exs
@@ -123,6 +123,8 @@ defmodule Orchard.Repo.Migrations.NodeInventoryFoundationTest do
   end
 
   defp run_down_sql do
+    Repo.query!("DROP TABLE IF EXISTS circuit_breaker_failures")
+    Repo.query!("DROP TABLE IF EXISTS circuit_breakers")
     Repo.query!("DROP TABLE IF EXISTS node_heartbeats")
     Repo.query!("DROP TABLE IF EXISTS node_runtime_capacity_evidence")
     Repo.query!("DROP TABLE IF EXISTS node_dispatch_capacity_policies")

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -6,6 +6,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
 
   alias Orchard.CanonicalRequest
   alias Orchard.CanonicalRequest.ModelRef
+  alias Orchard.CircuitBreakers
   alias Orchard.Cluster.V1.ScorePrefixCacheResponse
   alias Orchard.ClusterManagement.SchedulerExplanation
   alias Orchard.DispatchCapacity
@@ -29,6 +30,25 @@ defmodule Orchard.Scheduler.MultiNodeTest do
 
   alias Orchard.Scheduler.MultiNode
   alias Orchard.Scheduler.MultiNode.CompatibilityProbeRunner
+
+  defmodule SnapshotBreakerEvaluator do
+    @moduledoc false
+
+    def evaluate_many(targets) do
+      send(Process.get({__MODULE__, :owner}), {:breaker_snapshot, targets})
+      {:ok, Enum.map(targets, &decision/1)}
+    end
+
+    def evaluate(target) do
+      send(Process.get({__MODULE__, :owner}), {:breaker_single_read, target})
+      {:error, :unexpected_single_read}
+    end
+
+    defp decision({:node, node_id}), do: %{target: {:node, node_id}, state: :closed}
+
+    defp decision({:placement, node_id, model_id}),
+      do: %{target: {:placement, node_id, model_id}, state: :closed}
+  end
 
   # -- Stub Status Client --
 
@@ -251,6 +271,8 @@ defmodule Orchard.Scheduler.MultiNodeTest do
   # -- Helpers --
 
   defp canonical_request(model_id \\ "test-model", version \\ "v1", overrides \\ []) do
+    ensure_scheduler_model!(model_id, version)
+
     attrs = %{
       internal_id: "int_#{System.unique_integer([:positive])}",
       public_id: "pub_#{System.unique_integer([:positive])}",
@@ -273,6 +295,31 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       end
 
     CanonicalRequest.new(attrs)
+  end
+
+  defp ensure_scheduler_model!(model_id, version) do
+    Models.get_model_by_identity(model_id, version) ||
+      case Models.create_model(%{
+             model_id: model_id,
+             version: version,
+             state: :active,
+             format: "mlx",
+             capabilities: ["text"],
+             tokenizer: %{"type" => "huggingface", "ref" => "test/tokenizer"},
+             artifact_uri: "file:///tmp/scheduler-model-#{model_id}-#{version}",
+             artifact_sha256: String.duplicate("a", 64),
+             artifact_size_bytes: 1,
+             resident_memory_bytes: 1,
+             kv_cache_bytes_per_token: 1,
+             prefill_workspace_bytes_per_token: 1,
+             runtime_requirements: %{}
+           }) do
+        {:ok, model} ->
+          model
+
+        {:error, changeset} ->
+          raise "failed to create scheduler model: #{inspect(changeset.errors)}"
+      end
   end
 
   defp queue_admission_request(public_id, model_id \\ "test-model", version \\ "v1") do
@@ -795,6 +842,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     do: Application.delete_env(:orchard_controller, key)
 
   setup do
+    Process.put({SnapshotBreakerEvaluator, :owner}, self())
     previous_inference = Application.fetch_env!(:orchard_controller, :inference)
     previous_stub_client = Application.fetch_env(:orchard_controller, StubClient)
 
@@ -850,6 +898,250 @@ defmodule Orchard.Scheduler.MultiNodeTest do
   end
 
   describe "production candidate snapshots" do
+    test "SPEC.md sections 5.10 and 6.2 schedules a deprecated catalog Model" do
+      model = insert_breaker_model!(:deprecated)
+      node = insert_node!(%{advertise_addr: "10.0.0.90", rpc_port: 50_090})
+      target = Target.grpc_compat(host: "10.0.0.90", port: 50_090, node_id: node.id)
+      observed_at = node.last_heartbeat_at
+      snapshot = production_snapshot([production_snapshot_candidate(node, target)], observed_at)
+
+      persist_snapshot_capacity_evidence!(snapshot)
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(model.model_id, model.version),
+                 observed_at: observed_at,
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      assert schedule.node_id == node.id
+    end
+
+    test "SPEC.md sections 5.10 and 6.2 fail closed for retired and missing Models" do
+      retired = insert_breaker_model!(:retired)
+
+      model_refs = [
+        {retired.model_id, retired.version, false},
+        {"missing-breaker-model-#{System.unique_integer([:positive])}", "v1", true}
+      ]
+
+      model_refs
+      |> Enum.with_index()
+      |> Enum.each(fn {{model_id, version, delete_after_build?}, index} ->
+        node =
+          insert_node!(%{
+            advertise_addr: "10.0.1.#{index + 1}",
+            rpc_port: 50_101 + index
+          })
+
+        target =
+          Target.grpc_compat(host: node.advertise_addr, port: node.rpc_port, node_id: node.id)
+
+        observed_at = node.last_heartbeat_at
+        snapshot = production_snapshot([production_snapshot_candidate(node, target)], observed_at)
+        request = canonical_request(model_id, version)
+
+        if delete_after_build? do
+          model_id
+          |> Models.get_model_by_identity(version)
+          |> Orchard.Repo.delete!()
+        end
+
+        persist_snapshot_capacity_evidence!(snapshot)
+
+        assert {:error, :cluster_busy, decision} =
+                 MultiNode.schedule(request,
+                   observed_at: observed_at,
+                   active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                   production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                     {:ok, snapshot}
+                   end
+                 )
+
+        assert hd(hd(decision.rejected_candidates).reason_codes) ==
+                 "dispatch_capacity_facts_unavailable"
+      end)
+    end
+
+    test "SPEC.md section 5.10 reads a request candidate set in one breaker snapshot" do
+      model = insert_breaker_model!()
+      node_a = insert_node!(%{advertise_addr: "10.0.0.95", rpc_port: 50_095})
+      node_b = insert_node!(%{advertise_addr: "10.0.0.96", rpc_port: 50_096})
+      target_a = Target.grpc_compat(host: "10.0.0.95", port: 50_095, node_id: node_a.id)
+      target_b = Target.grpc_compat(host: "10.0.0.96", port: 50_096, node_id: node_b.id)
+      observed_at = node_a.last_heartbeat_at
+
+      snapshot =
+        production_snapshot(
+          [
+            production_snapshot_candidate(node_a, target_a),
+            production_snapshot_candidate(node_b, target_b)
+          ],
+          observed_at
+        )
+
+      persist_snapshot_capacity_evidence!(snapshot)
+
+      assert {:ok, _schedule} =
+               MultiNode.schedule(canonical_request(model.model_id, model.version),
+                 observed_at: observed_at,
+                 circuit_breaker_evaluator: SnapshotBreakerEvaluator,
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target_a, target_b]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      expected_targets = [
+        {:node, node_a.id},
+        {:placement, node_a.id, model.id},
+        {:node, node_b.id},
+        {:placement, node_b.id, model.id}
+      ]
+
+      assert_received {:breaker_snapshot, ^expected_targets}
+      refute_received {:breaker_snapshot, _targets}
+      refute_received {:breaker_single_read, _target}
+    end
+
+    test "SPEC.md §5.10 excludes a Node with an open durable breaker before ranking" do
+      model = insert_breaker_model!()
+      node = insert_node!(%{advertise_addr: "10.0.0.91", rpc_port: 50_091})
+      target = Target.grpc_compat(host: "10.0.0.91", port: 50_091, node_id: node.id)
+      observed_at = node.last_heartbeat_at
+      snapshot = production_snapshot([production_snapshot_candidate(node, target)], observed_at)
+
+      persist_snapshot_capacity_evidence!(snapshot)
+      open_node_breaker!(node.id, observed_at)
+
+      assert {:error, :cluster_busy, decision} =
+               MultiNode.schedule(canonical_request(model.model_id, model.version),
+                 observed_at: observed_at,
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      assert [rejected] = decision.rejected_candidates
+      assert rejected.node_id == node.id
+      assert hd(rejected.reason_codes) == "node_circuit_breaker_open"
+      assert decision.scored_candidates == []
+    end
+
+    test "SPEC.md §5.10 placement suppression blocks load but preserves loaded dispatch" do
+      model = insert_breaker_model!()
+      node = insert_node!(%{advertise_addr: "10.0.0.92", rpc_port: 50_092})
+      target = Target.grpc_compat(host: "10.0.0.92", port: 50_092, node_id: node.id)
+      observed_at = node.last_heartbeat_at
+      cold_candidate = production_snapshot_candidate(node, target)
+      cold_snapshot = production_snapshot([cold_candidate], observed_at)
+
+      open_placement_breaker!(node.id, model.id, observed_at)
+      persist_snapshot_capacity_evidence!(cold_snapshot)
+
+      schedule_opts = [
+        observed_at: observed_at,
+        active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+        production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+          {:ok, cold_snapshot}
+        end
+      ]
+
+      assert {:error, :cluster_busy, decision} =
+               MultiNode.schedule(
+                 canonical_request(model.model_id, model.version),
+                 schedule_opts
+               )
+
+      assert hd(hd(decision.rejected_candidates).reason_codes) == "model_load_suppressed"
+
+      loaded_placement =
+        Placement.new(%{
+          model_ref: %{model_id: model.model_id, version: model.version},
+          state: :loaded,
+          capacity: %{active_request_count: 0, max_concurrency: 4, status: :available}
+        })
+
+      loaded_snapshot =
+        production_snapshot(
+          [production_snapshot_candidate(node, target, placements: [loaded_placement])],
+          observed_at
+        )
+
+      persist_snapshot_capacity_evidence!(loaded_snapshot)
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(model.model_id, model.version),
+                 observed_at: observed_at,
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, loaded_snapshot}
+                 end
+               )
+
+      assert schedule.selected_tier == "loaded"
+      assert schedule.node_id == node.id
+    end
+
+    test "SPEC.md §5.10 re-reads a Node breaker at acquisition and final revalidation" do
+      model = insert_breaker_model!()
+      node = insert_node!(%{advertise_addr: "10.0.0.93", rpc_port: 50_093})
+      target = Target.grpc_compat(host: "10.0.0.93", port: 50_093, node_id: node.id)
+      observed_at = node.last_heartbeat_at
+      snapshot = production_snapshot([production_snapshot_candidate(node, target)], observed_at)
+
+      persist_snapshot_capacity_evidence!(snapshot)
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(model.model_id, model.version),
+                 observed_at: observed_at,
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      open_node_breaker!(node.id, DateTime.utc_now())
+
+      acquisition = schedule.dispatch_capacity_acquisition_input_provider.()
+      revalidation = schedule.dispatch_capacity_input_provider.()
+
+      refute acquisition.breaker_eligible?
+      refute revalidation.breaker_eligible?
+      assert :circuit_breaker_open in Evaluator.evaluate(acquisition).reason_codes
+      assert :circuit_breaker_open in Evaluator.evaluate(revalidation).reason_codes
+    end
+
+    test "SPEC.md §5.10 a placement opening after selection blocks load but not post-load dispatch" do
+      model = insert_breaker_model!()
+      node = insert_node!(%{advertise_addr: "10.0.0.94", rpc_port: 50_094})
+      target = Target.grpc_compat(host: "10.0.0.94", port: 50_094, node_id: node.id)
+      observed_at = node.last_heartbeat_at
+      snapshot = production_snapshot([production_snapshot_candidate(node, target)], observed_at)
+
+      persist_snapshot_capacity_evidence!(snapshot)
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(canonical_request(model.model_id, model.version),
+                 observed_at: observed_at,
+                 active_runtime_endpoint_targets_provider: fn -> {:ok, [target]} end,
+                 production_candidate_snapshot_provider: fn _effective, _active, _opts ->
+                   {:ok, snapshot}
+                 end
+               )
+
+      open_placement_breaker!(node.id, model.id, DateTime.utc_now())
+
+      acquisition = schedule.dispatch_capacity_acquisition_input_provider.()
+      revalidation = schedule.dispatch_capacity_input_provider.()
+
+      refute acquisition.breaker_eligible?
+      assert revalidation.breaker_eligible?
+    end
+
     test "ADR 0017 production scheduling uses the snapshot without inline status probing" do
       node = insert_node!(%{advertise_addr: "10.0.0.1", rpc_port: 50_061})
       target = Target.grpc_compat(host: "10.0.0.1", port: 50_061, node_id: node.id)
@@ -6132,6 +6424,60 @@ defmodule Orchard.Scheduler.MultiNodeTest do
     else
       Process.sleep(20)
       wait_until(fun, attempts - 1)
+    end
+  end
+
+  defp insert_breaker_model!(state \\ :active) do
+    unique = System.unique_integer([:positive])
+
+    {:ok, model} =
+      Models.create_model(%{
+        model_id: "scheduler-breaker-model-#{unique}",
+        version: "v1",
+        state: state,
+        format: "mlx",
+        capabilities: ["text"],
+        tokenizer: %{"type" => "huggingface", "ref" => "test/tokenizer"},
+        artifact_uri: "file:///tmp/scheduler-breaker-model-#{unique}",
+        artifact_sha256: String.duplicate("a", 64),
+        artifact_size_bytes: 1,
+        resident_memory_bytes: 1,
+        kv_cache_bytes_per_token: 1,
+        prefill_workspace_bytes_per_token: 1,
+        runtime_requirements: %{}
+      })
+
+    model
+  end
+
+  defp open_node_breaker!(node_id, now) do
+    for offset <- [2, 1, 0] do
+      assert {:ok, _decision} =
+               CircuitBreakers.record_failure(
+                 %{
+                   failure_id: Ecto.UUID.generate(),
+                   node_id: node_id,
+                   failure_class: "worker_or_node_loss",
+                   occurred_at: DateTime.add(now, -offset, :second)
+                 },
+                 now: now
+               )
+    end
+  end
+
+  defp open_placement_breaker!(node_id, model_id, now) do
+    for offset <- [2, 1, 0] do
+      assert {:ok, _decision} =
+               CircuitBreakers.record_failure(
+                 %{
+                   failure_id: Ecto.UUID.generate(),
+                   node_id: node_id,
+                   model_id: model_id,
+                   failure_class: "model_load_failure",
+                   occurred_at: DateTime.add(now, -offset, :second)
+                 },
+                 now: now
+               )
     end
   end
 

--- a/apps/orchard_controller/test/orchard/scheduler/single_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/single_node_test.exs
@@ -3,6 +3,7 @@ defmodule Orchard.Scheduler.SingleNodeTest do
 
   alias Orchard.CanonicalRequest
   alias Orchard.CanonicalRequest.ModelRef
+  alias Orchard.CircuitBreakers
   alias Orchard.DispatchCapacity.Evaluator
   alias Orchard.RuntimeEndpoint.Target
   alias Orchard.Scheduler.SingleNode
@@ -34,9 +35,67 @@ defmodule Orchard.Scheduler.SingleNodeTest do
     def disconnect(_channel), do: :ok
   end
 
+  defmodule CountingClient do
+    @moduledoc false
+
+    def connect(target) do
+      send(Process.get({__MODULE__, :owner}), {:single_node_connect, target})
+      {:ok, target}
+    end
+
+    def status(channel, _opts) do
+      send(Process.get({__MODULE__, :owner}), {:single_node_status, channel})
+      {:ok, %{active_request_count: 0, max_concurrency: 1}}
+    end
+
+    def disconnect(_channel), do: :ok
+  end
+
+  defmodule UnavailableBreakerEvaluator do
+    @moduledoc false
+
+    def evaluate(_target), do: {:error, :breaker_state_invalid}
+  end
+
   setup do
     Process.delete(:single_node_status)
+    Process.put({CountingClient, :owner}, self())
     :ok
+  end
+
+  test "SPEC.md §5.10 rejects an open canonical Node before status probing" do
+    node = insert_breaker_node!()
+    open_node_breaker!(node.id)
+
+    assert {:error, :model_busy, decision} =
+             SingleNode.default_schedule(
+               canonical_request("single-node-open-breaker"),
+               SingleNode.target(),
+               status_client: CountingClient,
+               node_resolver: fn _target -> {:ok, node} end
+             )
+
+    assert hd(hd(decision.rejected_candidates).reason_codes) == "node_circuit_breaker_open"
+    refute_received {:single_node_connect, _target}
+    refute_received {:single_node_status, _channel}
+  end
+
+  test "SPEC.md §5.10 fails closed distinctly when durable breaker state is unavailable" do
+    node = insert_breaker_node!()
+
+    assert {:error, :model_busy, decision} =
+             SingleNode.default_schedule(
+               canonical_request("single-node-breaker-read-failure"),
+               SingleNode.target(),
+               status_client: CountingClient,
+               node_resolver: fn _target -> {:ok, node} end,
+               circuit_breaker_evaluator: UnavailableBreakerEvaluator
+             )
+
+    assert hd(hd(decision.rejected_candidates).reason_codes) ==
+             "dispatch_capacity_facts_unavailable"
+
+    refute_received {:single_node_connect, _target}
   end
 
   test "SPEC.md §5.5 bounds loaded placement capacity by unmanaged aggregate fallback" do
@@ -470,16 +529,14 @@ defmodule Orchard.Scheduler.SingleNodeTest do
   end
 
   test "issue #128 probe failure returns model_busy with stable explanation" do
-    node_id = Ecto.UUID.generate()
+    node = insert_breaker_node!()
 
     assert {:error, :model_busy, decision} =
              SingleNode.default_schedule(
                canonical_request("single-explained-probe-failure"),
                SingleNode.target(),
                status_client: StubClient,
-               node_resolver: fn _target ->
-                 {:ok, %Orchard.Nodes.Node{id: node_id, health: :healthy, state: :active}}
-               end
+               node_resolver: fn _target -> {:ok, node} end
              )
 
     assert decision.strategy == :single_node
@@ -487,7 +544,7 @@ defmodule Orchard.Scheduler.SingleNodeTest do
 
     codes = hd(decision.rejected_candidates).reason_codes
     assert "transport_unreachable" in codes
-    assert hd(decision.rejected_candidates).node_id == node_id
+    assert hd(decision.rejected_candidates).node_id == node.id
   end
 
   defp canonical_request(model_id) do
@@ -513,5 +570,40 @@ defmodule Orchard.Scheduler.SingleNodeTest do
     {pid, monitor} = spawn_monitor(fn -> :ok end)
     assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}
     pid
+  end
+
+  defp insert_breaker_node! do
+    unique = System.unique_integer([:positive])
+
+    %Orchard.Nodes.Node{}
+    |> Orchard.Nodes.Node.changeset(%{
+      id: Ecto.UUID.generate(),
+      hostname: "single-breaker-node-#{unique}.local",
+      display_name: "single-breaker-node-#{unique}",
+      advertise_addr: "10.253.0.#{rem(unique, 254) + 1}",
+      rpc_port: 9444,
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      tool_readiness: %{}
+    })
+    |> Repo.insert!()
+  end
+
+  defp open_node_breaker!(node_id) do
+    now = DateTime.utc_now()
+
+    for offset <- [2, 1, 0] do
+      assert {:ok, _decision} =
+               CircuitBreakers.record_failure(
+                 %{
+                   failure_id: Ecto.UUID.generate(),
+                   node_id: node_id,
+                   failure_class: "worker_or_node_loss",
+                   occurred_at: DateTime.add(now, -offset, :second)
+                 },
+                 now: now
+               )
+    end
   end
 end

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -56,6 +56,7 @@
 
 ## 7. Breaker attribution prerequisite
 
+- [x] 7.0 Implement the durable Node and placement breaker foundation separately through #296 and `node-placement-circuit-breaker-foundation`
 - [ ] 7.1 Attribute each actual breaker-eligible failure to its producing Node or placement using the `SPEC.md` §5.10 eligible failure-class mapping, excluding `capacity_rejection`
 - [ ] 7.2 Make attempt 1 breaker effects durable and visible before alternate scheduling
 - [ ] 7.3 Prove retry decisions and declined retries add no breaker events

--- a/openspec/changes/node-placement-circuit-breaker-foundation/design.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/design.md
@@ -1,0 +1,130 @@
+# Design: Node and placement circuit-breaker foundation
+
+## Context
+
+The scheduler already has stable reason codes and dispatch-capacity evaluation accepts breaker-related input, while Node transport handling already updates health.
+Those adjacent seams do not establish durable breaker identity, counting, concurrency, recovery, or Operator control.
+This design adds one Postgres authority without coupling breaker state to lifecycle or health.
+
+## Goals
+
+- Make one actual eligible failure contribute at most once to exactly one canonical breaker.
+- Make threshold, expiry, and clear decisions deterministic under concurrency and Controller replacement.
+- Keep scheduler behavior explainable and fail closed without inventing false breaker state.
+- Preserve the exact `SPEC.md` §5.10 policy and the boundary with future retry attribution.
+
+## Decisions
+
+### Postgres owns identity, time, and serialization
+
+Node breakers use canonical `node_id` identity.
+Placement breakers use canonical `(node_id, model_id)` identity, where `model_id` is the durable catalog identity rather than a runtime alias or target address.
+The Node identity retains a restrictive foreign key because Node removal is a lifecycle state rather than row deletion.
+The stored model UUID is validated against the catalog when a placement breaker is first addressed but intentionally has no database foreign key to `models.id`.
+Catalog retirement may delete a model row, and breaker history must survive that deletion.
+Re-import creates a new model UUID and therefore cannot inherit suppression from the retired placement.
+Unresolved or conflicting identity refuses recording and scheduling authority rather than guessing a target.
+
+Breaker state and its contribution rows live in Postgres.
+Recording or clearing locks the canonical breaker row in a transaction, assigns a database-authoritative `decision_time`, and persists the contribution, transition, and audit evidence atomically.
+The state row retains breaker kind, canonical target identity, generation, state, suppression deadline, last transition time, and clear watermark.
+Each contribution retains its globally idempotent failure identity, breaker identity, generation, closed failure class, source `occurred_at` evidence, database decision time, and resulting transition.
+No request content, target credential, prompt, response, or raw diagnostic belongs in either record.
+
+### Rolling windows use a half-open lower boundary
+
+For a decision at database time `decision_time`, eligible contributions are those in `(decision_time - window, decision_time]` in the current generation.
+The contribution decision time is assigned by the database when the failure is first accepted.
+`occurred_at` remains evidence about the source failure and does not let a delayed or caller-clock timestamp move a contribution into the authoritative rolling window.
+
+The Node breaker opens on the third accepted `pre_acceptance_unavailable` or `worker_or_node_loss` contribution in 60 seconds and sets `suppressed_until` to five minutes after the opening decision time.
+The placement breaker opens on the third accepted `model_load_failure` contribution for one canonical placement in 10 minutes and sets `suppressed_until` to 15 minutes after the opening decision time.
+An unsuccessful outcome contributes to at most one breaker.
+Ineligible classes are durably rejected from contribution and cannot affect the state.
+
+Duplicate delivery is identified by the failure identity before counting.
+Re-recording it returns the already-recorded result and neither increments the window nor extends suppression.
+Concurrent first deliveries serialize on the breaker row, so exactly one transaction observes and persists the threshold crossing.
+
+### Expiry is evaluated at each authoritative decision
+
+Suppression is active only while `decision_time < suppressed_until`.
+At `decision_time >= suppressed_until`, the state deterministically evaluates as expired before the current read or recording decision.
+Expiry does not bypass lifecycle, health, trust, policy, memory, placement, or capacity gates.
+An expired breaker does not require process-local timers or cache hydration, so restart and Active/Standby changes read the same result from Postgres.
+
+Accepted failures while a breaker is open may remain evidence, but they do not extend `suppressed_until` or create another opening transition.
+The configured suppression duration always begins at the threshold-crossing transition.
+
+### Clear starts a fenced generation
+
+An explicit clear locks the breaker row, increments its generation, records the database clear decision time as the clear watermark, removes active suppression, and appends audit evidence in one transaction.
+Repeated clear of the already-cleared generation is an idempotent no-op with a stable result and no lifecycle or health mutation.
+
+Contributions are tagged with the current generation.
+A delayed delivery whose durable source `occurred_at` is at or before the clear watermark is recorded as fenced evidence and cannot contribute in the new generation.
+This generation and watermark fence prevents a failure produced before clear from reopening the breaker merely because delivery happened later.
+A failure occurring after the watermark may contribute once in the new generation using its database acceptance time for the rolling window.
+
+### Scheduler reads one durable breaker view
+
+Candidate construction and final dispatch revalidation read breaker facts from the same request-scoped Postgres decision context used for authoritative scheduler inputs, or an equivalent transactionally coherent read.
+No caller-supplied default can claim breaker eligibility.
+
+An active Node breaker removes that Node before tiering, ranking, scoring, prefix-cache scoring, or dispatch and explains the rejection with `node_circuit_breaker_open`.
+An active placement breaker does not suppress a separately valid already-loaded placement.
+It suppresses only a candidate path that requires cold or warm loading and explains that decision with `model_load_suppressed`.
+`placement_suppressed` remains the broader placement-lifecycle reason and is not reused for this breaker.
+
+If required breaker identity, persistence, or read authority is unavailable, scheduling and final revalidation fail closed with the applicable existing identity or unavailable-facts code.
+They do not emit `node_circuit_breaker_open` or `model_load_suppressed` unless durable state proves that breaker is active.
+
+### Operator commands use Controller authority
+
+Inspection and clear operations execute in the active Controller through the existing cluster-scoped Operator-or-admin service-account boundary.
+Tenant-direct credentials and public inference credentials remain unauthorized.
+The fixed routes are:
+
+- `GET /ops/v1/circuit-breakers/nodes/:node_id`
+- `POST /ops/v1/circuit-breakers/nodes/:node_id/clear`
+- `GET /ops/v1/circuit-breakers/placements/:node_id/:model_id`
+- `POST /ops/v1/circuit-breakers/placements/:node_id/:model_id/clear`
+
+Inspection returns bounded canonical identity, state, generation, window evidence, suppression deadline, last transition, and expiry evaluation without exposing request content.
+Successful inspection uses `Cache-Control: no-store` and a bounded `circuit_breaker` object containing kind, canonical identities, state, current contribution count, opening and suppression times, last clear time, and generation.
+The absence of a breaker row for an existing canonical target is an authoritative closed breaker with zero contributions and generation zero, not an unavailable read.
+Clear requires a JSON body with a non-empty `reason`.
+It returns `cleared` or `already_cleared` plus the resulting bounded breaker object, and an already inactive breaker does not increment its generation again.
+The authoritative mutation and audit event persist atomically with actor, action, target, time, reason, previous state, and resulting generation.
+Malformed identity or reason, missing canonical targets, unavailable authority, and unauthorized credentials retain distinct validation, not-found, service-unavailable, and authentication or authorization failures.
+An effective clear uses audit action `circuit_breaker.node.cleared` or `circuit_breaker.placement.cleared` at cluster scope.
+
+### Transport health and breaker ownership remain separate
+
+Runtime Endpoint liveness and status probes remain health-only observations and never create breaker contributions.
+`Nodes.record_transport_failure/3` retains its health and queue-source behavior but is not an independent breaker counter.
+The actual dispatch or execution failure outcome is the sole breaker contribution source, using its durable failure identity so health handling and repeated delivery cannot double-count it.
+Health and breaker facts remain separate scheduler gates, and loss of either authority fails closed without translating one state into the other.
+
+### Retry attribution remains downstream
+
+This foundation exposes an idempotent public recording seam for a typed actual failure and a durable read seam for scheduling.
+Issue #170 will connect individual attempt outcomes to that recording seam and must make attempt 1 effects durable before alternate scheduling.
+This change does not introduce attempt identity policy, prior-Node exclusion, retry decisions, or attempt orchestration.
+
+## Migration and compatibility
+
+The expand migration creates empty breaker authority without synthesizing historical failures from Node health, request history, placement lifecycle, or transport observations.
+Existing Nodes and placements therefore begin closed until new eligible failures are recorded.
+All schema constraints, unique failure identity enforcement, the restrictive Node foreign key, and the validated non-FK model UUID contract are established before scheduler consumers require the new authority.
+The implementation must not use a process-local fallback during rollout or restart.
+
+## Rejected alternatives
+
+- Process-local counters were rejected because they lose state across restart and split authority across Controllers.
+- `occurred_at`-based rolling windows were rejected because delivery order and caller clocks could change threshold outcomes.
+- Resetting rows in place without a generation and watermark was rejected because delayed pre-clear delivery could reopen a cleared breaker.
+- Reusing Node health or placement lifecycle as breaker state was rejected because those gates have different causes, recovery, and Operator semantics.
+- Suppressing already-loaded placements was rejected because `SPEC.md` limits the placement breaker effect to cold or warm load.
+- Treating unavailable facts as an open breaker was rejected because fail-closed unavailability and a proven breaker transition require different stable explanations.
+- Adding a foreign key from placement breaker history to `models.id` was rejected because restrict would block catalog deletion while cascade or nullification would destroy canonical history.

--- a/openspec/changes/node-placement-circuit-breaker-foundation/proposal.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/proposal.md
@@ -1,0 +1,38 @@
+# Node and placement circuit-breaker foundation (#296)
+
+## Why
+
+`SPEC.md` §5.10 already requires durable Node and `(node, model)` placement circuit breakers, but Orchard has no authoritative persistent state machine that records eligible failures, drives scheduler suppression, survives Controller changes, or supports Operator inspection and clearing.
+The closed failure taxonomy prerequisite from #168 has landed, so this foundation can consume that vocabulary without widening it.
+The separate automatic-attempt-retry change still needs this foundation before #170 can attribute failures from individual attempts.
+
+## What changes
+
+- Persist canonical Node and placement breaker identities, idempotent failure contributions, current generation, suppression state, and transition evidence in Postgres.
+- Serialize recording and clearing so threshold crossings, duplicate delivery, expiry, and explicit clear remain deterministic across concurrent Controllers, restart, and Active/Standby changes.
+- Apply the exact `SPEC.md` §5.10 failure classes, thresholds, rolling windows, and suppression durations using database-authoritative decision time.
+- Make scheduler and dispatch-capacity decisions consume durable breaker facts and fail closed when required identity or state cannot be established.
+- Suppress an open Node before ranking or dispatch, and suppress only cold or warm loading for an open placement breaker while preserving a separately valid already-loaded placement.
+- Add authenticated Operator inspection and idempotent clear operations through Controller-owned authority with durable audit evidence.
+- Keep Runtime Endpoint transport probes health-only and give actual failure outcomes one idempotent breaker-recording path.
+
+## Out of scope
+
+- Attempt attribution from #170.
+- Hard prior-Node exclusion from #169.
+- Attempt 2 orchestration from #171.
+- Retry metrics from #172 or end-to-end retry proof from #173.
+- New failure classes, reason codes, thresholds, windows, durations, or retry-specific breakers.
+- Treating breaker state as Node health, Node lifecycle, or placement lifecycle.
+- Metrics or alerting for breaker transitions.
+
+## SPEC.md impact
+
+This change implements the existing contract in `SPEC.md` §5.10 and integrates it with the scheduler eligibility contract in §5.5, the stable explanation vocabulary in §7.3.5, the Operator boundary in §7.3, audit requirements in §10, and Postgres-backed Active/Standby ownership in §3.3.
+It does not change the apex policy.
+
+## Relationship to automatic attempt retry
+
+The `automatic-attempt-retry` package continues to own per-attempt attribution and retry sequencing.
+Its task ledger records this separately implemented foundation as complete while leaving #169 through #173 work uncompleted.
+No retry decision, declined retry, transport probe, or synthetic scheduler outcome contributes a breaker failure.

--- a/openspec/changes/node-placement-circuit-breaker-foundation/specs/circuit-breakers/spec.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/specs/circuit-breakers/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Durable canonical breaker authority
+
+Orchard SHALL persist Node breakers by canonical `node_id` and placement breakers by canonical `(node_id, model_id)` in Postgres.
+Node breaker identity SHALL retain referential integrity to Node inventory.
+Placement breaker `model_id` SHALL be a validated catalog UUID without a database foreign key to the deletable model row, so retired-model history survives and a re-imported model with a new UUID does not inherit suppression.
+It SHALL persist a globally idempotent failure identity, breaker kind, canonical target identity, generation, closed failure class, source occurrence evidence, database decision time, current state, suppression deadline, and resulting transition without request content or secrets.
+Recording and clearing MUST serialize on canonical breaker identity so concurrent Controllers cannot lose a contribution or produce inconsistent transitions.
+This requirement implements `SPEC.md` §5.10 under the Postgres and Active/Standby authority in §3.3.
+
+#### Scenario: Duplicate failure delivery crosses Controllers
+
+- **WHEN** two Controller processes deliver the same eligible failure identity for one canonical breaker
+- **THEN** exactly one contribution affects the rolling window
+- **AND** both callers observe the same durable resulting transition
+
+#### Scenario: Identity cannot be proven
+
+- **WHEN** the producing Node or model cannot be resolved to canonical durable identity
+- **THEN** Orchard refuses the contribution without attributing it elsewhere
+- **AND** the failure does not change any breaker
+
+#### Scenario: Retired model is re-imported
+
+- **WHEN** a catalog model is deleted after placement breaker evidence exists and equivalent model content is later imported under a new UUID
+- **THEN** the historical breaker evidence retains the retired model UUID
+- **AND** the new placement does not inherit the retired placement's suppression
+
+### Requirement: Exact rolling-window transitions
+
+Each record or read decision SHALL use database-authoritative `decision_time`.
+The applicable rolling window SHALL include current-generation contributions in `(decision_time - window, decision_time]` and SHALL use source `occurred_at` only as evidence and clear-fence input.
+The Node breaker SHALL open on the third eligible contribution in 60 seconds and suppress for five minutes.
+The placement breaker SHALL open on the third eligible contribution for one placement in 10 minutes and suppress cold or warm loading for 15 minutes.
+Suppression SHALL expire when `decision_time >= suppressed_until`, and recording while open MUST NOT extend the original suppression deadline.
+Eligibility and durations remain those fixed by `SPEC.md` §5.10.
+
+#### Scenario: Contribution lies exactly on the lower boundary
+
+- **WHEN** an earlier contribution decision time equals `decision_time - window`
+- **THEN** that contribution is outside the rolling window
+- **AND** a contribution later than that boundary is inside it
+
+#### Scenario: Decision reaches the suppression deadline
+
+- **WHEN** database decision time equals or exceeds `suppressed_until`
+- **THEN** the breaker evaluates as expired
+- **AND** every other scheduling eligibility gate remains independently required
+
+### Requirement: Closed failure eligibility and target isolation
+
+The Node breaker SHALL count only `pre_acceptance_unavailable` and `worker_or_node_loss`.
+The placement breaker SHALL count only `model_load_failure`.
+Every other closed failure class, including ordinary `capacity_rejection`, MUST NOT contribute, and one unsuccessful outcome MUST affect at most one breaker.
+Node and placement identities SHALL isolate their windows and transitions.
+This requirement implements `SPEC.md` §5.10 without adding retry-specific policy.
+
+#### Scenario: Busy Node rejects capacity
+
+- **WHEN** an attempt produces `capacity_rejection`
+- **THEN** neither Node nor placement breaker receives a contribution
+
+#### Scenario: One placement reaches its threshold
+
+- **WHEN** one `(node_id, model_id)` receives three eligible load failures in its window
+- **THEN** only that placement breaker opens
+- **AND** other models on that Node and the same model on other Nodes remain unaffected
+
+### Requirement: Generation-fenced Operator clear
+
+An authenticated clear SHALL atomically increment the breaker generation, record the database clear decision time as a watermark, remove active suppression, and append audit evidence.
+A delayed delivery with source `occurred_at` at or before the clear watermark MUST NOT contribute in the new generation.
+Repeated clear of an already-cleared generation SHALL be idempotent.
+Clear MUST NOT mutate Node lifecycle, Node health, placement lifecycle, or historical evidence.
+This requirement implements the Operator clear contract in `SPEC.md` §5.10 and the audit boundary in §10.
+
+#### Scenario: Old failure arrives after clear
+
+- **WHEN** an eligible failure occurred before the clear watermark but is delivered after clear
+- **THEN** Orchard retains bounded fenced evidence without counting it in the new generation
+- **AND** the breaker remains cleared
+
+#### Scenario: Clear is repeated
+
+- **WHEN** the same effective clear is submitted again
+- **THEN** Orchard returns an idempotent no-op result
+- **AND** it does not change health, lifecycle, or the current generation again
+
+### Requirement: Actual failures own breaker contributions
+
+Runtime Endpoint transport and status probes SHALL remain health-only and MUST NOT create breaker contributions.
+The actual typed dispatch or execution failure outcome SHALL be the sole contribution source and SHALL use its durable failure identity for idempotency.
+Health state and breaker state SHALL remain independent scheduler gates.
+This requirement preserves the Node health behavior adjacent to `SPEC.md` §5.10 without duplicate counting.
+
+#### Scenario: Transport failure is health-relevant and breaker-eligible
+
+- **WHEN** one actual dispatch failure also causes Node health handling and is delivered repeatedly
+- **THEN** health handling may update the Node through its existing authority
+- **AND** the actual failure contributes to the Node breaker at most once
+
+#### Scenario: Liveness probe fails
+
+- **WHEN** a transport probe marks or confirms a Node health condition without an actual attempt failure
+- **THEN** no breaker contribution is created

--- a/openspec/changes/node-placement-circuit-breaker-foundation/specs/dispatch-capacity/spec.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/specs/dispatch-capacity/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Breaker facts are authoritative capacity inputs
+
+Shared dispatch-capacity evaluation SHALL consume normalized durable breaker facts for the canonical Node and requested placement.
+A consumer MUST NOT authorize work from a caller-supplied breaker default or infer breaker state from health, lifecycle, telemetry, or placement status.
+Missing, malformed, mismatched, or unreadable required breaker facts SHALL produce an ineligible fail-closed decision without claiming a breaker transition.
+This requirement refines `SPEC.md` §4.6.2, §5.5, and §5.10.
+
+#### Scenario: Caller omits breaker authority
+
+- **WHEN** a production consumer cannot assemble durable current breaker facts for the canonical candidate
+- **THEN** shared evaluation returns no dispatch authority
+- **AND** it does not substitute a permissive default
+
+#### Scenario: Health and breaker disagree
+
+- **WHEN** Node health is eligible but durable Node breaker state is actively suppressed
+- **THEN** shared evaluation remains ineligible because the breaker gate fails
+- **AND** it does not rewrite Node health

--- a/openspec/changes/node-placement-circuit-breaker-foundation/specs/operator-command-authority/spec.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/specs/operator-command-authority/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Controller owns breaker inspection and clear
+
+Breaker inspection and clear operations SHALL execute in the active Controller through the cluster-scoped Operator-or-admin service-account boundary and the shared Controller-owned domain authority.
+Node inspection and clear SHALL use `GET /ops/v1/circuit-breakers/nodes/:node_id` and `POST /ops/v1/circuit-breakers/nodes/:node_id/clear`.
+Placement inspection and clear SHALL use `GET /ops/v1/circuit-breakers/placements/:node_id/:model_id` and `POST /ops/v1/circuit-breakers/placements/:node_id/:model_id/clear`.
+Inspection SHALL return `Cache-Control: no-store` and bounded canonical state and transition evidence.
+Clear SHALL require a JSON body with non-empty `reason`, SHALL return `cleared` or `already_cleared` with resulting bounded state, and SHALL persist an effective mutation and audit evidence atomically.
+An already inactive breaker MUST NOT increment generation again.
+Tenant-direct credentials and public inference credentials MUST fail closed.
+This requirement implements `SPEC.md` §5.10, §7.3, and §10 under the portable command authority contract.
+
+#### Scenario: Authorized Operator clears a placement breaker
+
+- **WHEN** a service-account principal with cluster-scoped `operator` or `admin` authority posts a non-empty reason to `/ops/v1/circuit-breakers/placements/:node_id/:model_id/clear`
+- **THEN** the active Controller performs the generation-fenced clear
+- **AND** the resulting state and audit evidence commit atomically
+
+#### Scenario: Operator inspects a Node without a breaker row
+
+- **WHEN** an authorized principal gets `/ops/v1/circuit-breakers/nodes/:node_id` for an existing Node with no breaker row
+- **THEN** Orchard returns the bounded Node breaker object with `Cache-Control: no-store`
+- **AND** it represents the breaker as closed with zero contributions and generation zero
+
+#### Scenario: Tenant credential attempts inspection
+
+- **WHEN** a tenant-direct or public inference credential requests breaker inspection or clear
+- **THEN** Orchard denies the request without revealing breaker state

--- a/openspec/changes/node-placement-circuit-breaker-foundation/specs/scheduler/spec.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/specs/scheduler/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Durable circuit-breaker eligibility gates
+
+Production candidate construction and final dispatch revalidation SHALL consume database-authoritative breaker facts for canonical Node and placement identities.
+An active Node breaker SHALL reject the Node before tiering, ranking, scoring, prefix-cache scoring, or dispatch with `node_circuit_breaker_open`.
+An active placement breaker SHALL reject only a cold or warm loading path with `model_load_suppressed`; a separately valid already-loaded placement remains dispatchable.
+`placement_suppressed` SHALL remain the broader placement-lifecycle reason.
+This requirement implements `SPEC.md` §5.5, §5.10, and §7.3.5.
+
+#### Scenario: Node breaker is open
+
+- **WHEN** durable current breaker state proves a candidate Node is suppressed
+- **THEN** the scheduler rejects it before ranking with `node_circuit_breaker_open`
+
+#### Scenario: Placement breaker is open and model is already loaded
+
+- **WHEN** durable current breaker state suppresses loading for a placement but current trusted facts prove the requested model is already loaded and every other gate passes
+- **THEN** the placement breaker does not reject dispatch
+
+#### Scenario: Placement breaker is open and loading is required
+
+- **WHEN** a candidate requires cold or warm loading on a durably suppressed placement
+- **THEN** the scheduler rejects that load path with `model_load_suppressed`
+
+### Requirement: Breaker authority failures fail closed distinctly
+
+If scheduler or final-revalidation code cannot resolve required canonical breaker identity, read durable state, or establish a coherent breaker decision, it SHALL fail closed with the applicable existing identity or unavailable-facts reason.
+It MUST NOT emit `node_circuit_breaker_open` or `model_load_suppressed` unless durable state proves that breaker is active.
+This requirement refines the fail-closed scheduler behavior in `SPEC.md` §5.5 and §7.3.5.
+
+#### Scenario: Breaker read fails
+
+- **WHEN** the scheduler cannot read the required durable breaker facts
+- **THEN** the candidate is not authorized for dispatch
+- **AND** its explanation reports unavailable authority rather than falsely claiming a breaker is open

--- a/openspec/changes/node-placement-circuit-breaker-foundation/tasks.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/tasks.md
@@ -1,0 +1,45 @@
+## 1. Contract and persistence
+
+- [x] 1.1 Create a separate OpenSpec package subordinate to `SPEC.md` §5.10
+- [x] 1.2 Fix canonical identity, database decision time, half-open windows, expiry, clear fencing, and transport ownership in the design
+- [x] 1.3 Add the expand migration, schemas, constraints, restrictive Node foreign key, validated non-FK model UUID, and globally idempotent failure identity
+- [x] 1.4 Prove migration rollback and do not synthesize contributions from historical health or request data
+
+## 2. Durable breaker recording
+
+- [x] 2.1 Add one public idempotent recording seam for typed actual failures
+- [x] 2.2 Enforce the closed §5.10 failure-class mapping and one-breaker maximum
+- [x] 2.3 Serialize concurrent recording and persist transition evidence atomically
+- [x] 2.4 Implement exact Node and placement rolling windows, thresholds, and suppression durations
+- [x] 2.5 Fence late pre-clear delivery by generation and watermark
+- [x] 2.6 Cover duplicate delivery, boundary times, concurrent threshold crossings, and target isolation
+
+## 3. Scheduler and dispatch capacity
+
+- [x] 3.1 Read database-authoritative breaker facts in candidate construction and final revalidation
+- [x] 3.2 Remove open Nodes before tiering, ranking, scoring, or dispatch with `node_circuit_breaker_open`
+- [x] 3.3 Suppress only cold or warm placement loading with `model_load_suppressed`
+- [x] 3.4 Preserve valid already-loaded dispatch and broader `placement_suppressed` lifecycle semantics
+- [x] 3.5 Fail closed on unavailable read or identity authority without falsely reporting an open breaker
+- [x] 3.6 Cover scheduler explanation, expiry, restart, and Active/Standby behavior
+
+## 4. Operator authority and audit
+
+- [x] 4.1 Add bounded Node and placement breaker inspection through authenticated Operator API routes
+- [x] 4.2 Add idempotent clear operations with required reason and Controller-owned authorization
+- [x] 4.3 Persist clear and transition audit evidence atomically
+- [x] 4.4 Prove unauthorized credentials fail closed and clear does not mutate health or lifecycle
+
+## 5. Transport-health ownership
+
+- [x] 5.1 Keep transport probes and `Nodes.record_transport_failure/3` health-only
+- [x] 5.2 Route each actual eligible failure through the sole idempotent breaker recorder
+- [x] 5.3 Cover one transport failure updating health and contributing at most once without contradictory eligibility
+
+## 6. Validation and handoff
+
+- [x] 6.1 Run focused persistence, concurrency, window, scheduler, transport, and Operator API tests
+- [x] 6.2 Run the complete applicable Elixir workflow and coverage from `AGENTS.md`
+- [x] 6.3 Validate this change strictly and validate all OpenSpec specs strictly
+- [x] 6.4 Reconcile independent design and Oracle review findings against `SPEC.md` and the final code
+- [ ] 6.5 Record exact local and hosted validation evidence in the pull request without merging it

--- a/openspec/changes/node-placement-circuit-breaker-foundation/tasks.md
+++ b/openspec/changes/node-placement-circuit-breaker-foundation/tasks.md
@@ -42,4 +42,4 @@
 - [x] 6.2 Run the complete applicable Elixir workflow and coverage from `AGENTS.md`
 - [x] 6.3 Validate this change strictly and validate all OpenSpec specs strictly
 - [x] 6.4 Reconcile independent design and Oracle review findings against `SPEC.md` and the final code
-- [ ] 6.5 Record exact local and hosted validation evidence in the pull request without merging it
+- [x] 6.5 Record exact local and hosted validation evidence in the pull request without merging it


### PR DESCRIPTION
## Summary

Implements the durable Node and `(node, model)` placement circuit-breaker foundation required by `SPEC.md` section 5.10.

- Persists canonical breaker identity, rolling-window contributions, state generations, suppression deadlines, and idempotent failure delivery.
- Enforces deterministic lock ordering and coherent batch evaluation for concurrent recorder, scheduler, expiry, and Operator clear paths.
- Applies fail-closed breaker eligibility at scheduler snapshot, acquisition, and final dispatch revalidation.
- Adds authenticated Active-Controller Operator inspection and reason-required clear commands with durable audit evidence.
- Integrates the existing Node transport-health owner without double-counting request-attempt failures.
- Adds a dedicated OpenSpec change and records the satisfied relationship to the landed automatic-attempt-retry foundation dependency.

Closes #296.

## Contract

- Node breaker: 3 eligible failures in 60 seconds, open for 5 minutes.
- Placement breaker: 3 eligible failures in 10 minutes, open for 15 minutes.
- The Node breaker counts only `pre_acceptance_unavailable` and `worker_or_node_loss`; the placement breaker counts only `model_load_failure`.
- Suppression uses stable `node_circuit_breaker_open` and `model_load_suppressed` scheduler reason codes.
- Missing or unreadable breaker authority fails closed. Expired suppression closes transactionally before admission.
- Clear commands advance a live breaker generation, remove prior-window influence, require a non-empty reason, and always emit an audit event. A closed pre-threshold target returns `already_cleared` without inventing a generation or watermark.

## Migration and API surface

- Adds `circuit_breakers` for durable target state and `circuit_breaker_failures` for deduplicated rolling-window evidence.
- Uses canonical Node UUID and placement `(Node UUID, model UUID)` identity with foreign keys and uniqueness constraints.
- Adds:
  - `GET /ops/v1/circuit-breakers/nodes/:node_id`
  - `POST /ops/v1/circuit-breakers/nodes/:node_id/clear`
  - `GET /ops/v1/circuit-breakers/placements/:node_id/:model_id`
  - `POST /ops/v1/circuit-breakers/placements/:node_id/:model_id/clear`

## Scope

This branch starts directly from current `origin/main` after #168 landed in #299. It is independent of #169 and does not implement #170 attempt attribution, #169 prior-Node exclusion, #171 retry orchestration, #172 metrics, or #173 retry E2E coverage.

## Risk Assessment

⚠️ **High**

- Adds two durable Postgres tables and new scheduler admission authority on every candidate path.
- Concurrency mistakes could over-count failures, shorten suppression, or admit a suppressed target.
- Fail-closed database behavior can intentionally reduce availability when breaker authority is unreadable.

Mitigations:

- Uniform advisory-lock, failure-row, Node/FK lock ordering and transactional state transitions.
- Idempotency uniqueness plus concurrent-delivery and clear/record race coverage.
- Fresh atomic Node and placement evaluation at acquisition and final dispatch authorization.
- Restart, Active/Standby, migration, expiry, database-outage, Operator authorization, and audit tests.
- Independent RepoPrompt and Oracle reviews both returned GO after all material findings were reconciled.

## TDD evidence

- Persistence slices progressed from missing authority/table failures to node threshold green, then future-evidence rejection, disposition/clear semantics, migration/restart, and concurrency coverage.
- Scheduler regressions first demonstrated deprecated-model and incoherent-snapshot failures, then passed with coherent batch evaluation and fresh revalidation.
- Operator standby tests first demonstrated mutation/inspection on Standby, then passed with Active-Controller gating.
- Transport regression first exposed the outer transaction checkout leak, then passed with narrow database-failure normalization and no Node/breaker mutation.

## Validation

- `mise exec -- mix format` - passed
- `mise exec -- mix compile --warnings-as-errors` - passed
- `mise exec -- mix credo --strict` - passed, 739 files, 16,425 mods/funs, no issues
- `mise exec -- mix dialyzer` - passed, 0 errors, 0 skips
- `make macos-native-test-helpers` - passed
- Focused circuit-breaker/migration/concurrency/API/scheduler/dispatch-capacity suite - 314 passed
- `ORCHARD_TEST_NODE_AGENT_PORT=50241 mise exec -- mix test` - passed:
  - `orchard_shared`: 216 passed
  - `orchard_controller`: 3,591 passed, 5 skipped
  - `orchard_node_agent`: 412 passed
  - `orchard_cli`: 678 passed, 1 skipped, 10 excluded
- `ORCHARD_TEST_NODE_AGENT_PORT=50241 mise exec -- mix test --cover` - passed with the same test counts:
  - `orchard_shared`: 67.25%
  - `orchard_controller`: 85.2% overall; `Orchard.CircuitBreakers` 90.5%; Operator controller 87.2%
  - `orchard_node_agent`: 78.33%
  - `orchard_cli`: 76.40%
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate node-placement-circuit-breaker-foundation --type change --strict --no-interactive` - passed
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` - 32 passed, 0 failed
- `git diff --check` - passed

## Review

- RepoPrompt final pair review: GO, no material blockers; focused review validation 33 passed.
- Oracle final second opinion: GO, no remaining material blockers against `SPEC.md` section 5.10 or #296.

## Hosted validation

Implementation head `f3d429517739fdc464261d87b168fd0c0f830328` completed [Orchard CI run 33140538568](https://github.com/kapitan-ai/orchard/actions/runs/33140538568) successfully:

- [Required Orchard validation gate](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98753306554) - passed
- [Orchard.app and DMG validation](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98750215742) - passed
- [macOS host validation](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98750215731) - passed
- [MLX provider validation](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98750215557) - passed
- [Provider-neutral conformance](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98750215627) - passed
- [OpenSpec validation](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98750215637) - passed
- [Linux portable control-plane core](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98750215610) - passed
- [Classify required validation](https://github.com/kapitan-ai/orchard/actions/runs/33140538568/job/98750184363) - passed
- [Devin Review](https://app.devin.ai/review/kapitan-ai/orchard/pull/302) - passed; three threads were resolved with contract-backed explanations and no code change

Final ledger-only head `93a533e18589e45179f456579ad21b93336b9b09` completed [Orchard CI run 33141878719](https://github.com/kapitan-ai/orchard/actions/runs/33141878719) successfully:

- [Required Orchard validation gate](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98757000595) - passed
- [MLX provider validation](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98754313574) - passed
- [Orchard.app and DMG validation](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98754313618) - passed
- [macOS host validation](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98754313548) - passed
- [Provider-neutral conformance](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98754313576) - passed
- [Linux portable control-plane core](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98754313546) - passed
- [OpenSpec validation](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98754313601) - passed
- [Classify required validation](https://github.com/kapitan-ai/orchard/actions/runs/33141878719/job/98754287816) - passed
- Devin Review - passed; [code]smith - skipped

## Checklist

- [x] Exact `SPEC.md` thresholds, windows, durations, eligible classes, and reason codes preserved
- [x] OpenSpec change validates strictly
- [x] Full local Orchard gate and coverage pass
- [x] Independent RepoPrompt and Oracle findings reconciled
- [x] Hosted required checks pass on the final PR head
