### PR TITLE
fix(portal): keep state feedback current

### DIFF
--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -70,6 +70,10 @@ defmodule Orchard.Governance do
   defdelegate create_portal_invite(tenant, attrs), to: PortalGovernance, as: :create_invite
   defdelegate copy_portal_invite(tenant, user), to: PortalGovernance, as: :copy_invite
 
+  @spec validate_portal_invite(String.t(), String.t()) ::
+          :ok | {:error, :invalid_invite | :https_required}
+  defdelegate validate_portal_invite(slug, token), to: PortalGovernance, as: :validate_invite
+
   defdelegate redeem_portal_invite(slug, token, password),
     to: PortalGovernance,
     as: :redeem_invite

--- a/apps/orchard_controller/lib/orchard/governance/portal_governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance/portal_governance.ex
@@ -60,6 +60,27 @@ defmodule Orchard.Governance.PortalGovernance do
     end
   end
 
+  @spec validate_invite(String.t(), String.t()) ::
+          :ok | {:error, :invalid_invite | :https_required}
+  def validate_invite(slug, token) do
+    current = now()
+
+    with :ok <- require_https() do
+      valid? =
+        PortalInviteToken
+        |> join(:inner, [invite], user in PortalUser, on: user.id == invite.portal_user_id)
+        |> join(:inner, [_invite, user], tenant in Tenant, on: tenant.id == user.tenant_id)
+        |> where([invite, user, tenant], invite.token_hash == ^digest(token))
+        |> where([_invite, _user, tenant], tenant.slug == ^normalize_slug(slug))
+        |> where([invite, user, _tenant], user.status == "invited")
+        |> where([invite, _user, _tenant], is_nil(invite.redeemed_at))
+        |> where([invite, _user, _tenant], invite.expires_at > ^current)
+        |> Repo.exists?()
+
+      if valid?, do: :ok, else: {:error, :invalid_invite}
+    end
+  end
+
   def disable_user(tenant_or_id, user_or_id) do
     with {:ok, tenant} <- tenant(tenant_or_id) do
       Repo.transaction(fn -> disable_user_transaction(tenant.id, id(user_or_id)) end)

--- a/apps/orchard_controller/lib/orchard/portal/keys_live.ex
+++ b/apps/orchard_controller/lib/orchard/portal/keys_live.ex
@@ -23,7 +23,9 @@ defmodule Orchard.Portal.KeysLive do
       |> assign(:generated_secret, nil)
       |> assign(:copy_status, :idle)
       |> assign(:stored_ack, false)
-      |> assign(:form_error, nil)
+      |> assign(:mint_error, nil)
+      |> assign(:revoke_error, nil)
+      |> assign(:focus_cap_status?, false)
       |> assign(:key_name, "")
       |> refresh_keys()
 
@@ -31,7 +33,7 @@ defmodule Orchard.Portal.KeysLive do
       Process.send_after(self(), :revalidate_portal_session, @revalidate_ms)
     end
 
-    {:ok, socket}
+    {:ok, socket, temporary_assigns: [focus_cap_status?: false]}
   end
 
   @impl true
@@ -42,13 +44,17 @@ defmodule Orchard.Portal.KeysLive do
       {:noreply,
        socket
        |> assign(:mint_open?, true)
-       |> assign(:form_error, nil)
+       |> assign(:mint_error, nil)
        |> assign(:key_name, "")}
     end
   end
 
   def handle_event("close_mint", _params, socket) do
-    {:noreply, assign(socket, :mint_open?, false)}
+    {:noreply,
+     socket
+     |> assign(:mint_open?, false)
+     |> assign(:mint_error, nil)
+     |> assign(:key_name, "")}
   end
 
   def handle_event("mint_key", %{"key" => %{"name" => name}}, socket) do
@@ -68,24 +74,29 @@ defmodule Orchard.Portal.KeysLive do
          |> assign(:generated_secret, result)
          |> assign(:copy_status, :idle)
          |> assign(:stored_ack, false)
-         |> assign(:form_error, nil)
+         |> assign(:mint_error, nil)
          |> refresh_keys()}
 
       {:error, :portal_key_limit_reached} ->
         {:noreply,
          socket
-         |> assign(:mint_open?, false)
-         |> assign(:form_error, "Portal cap reached — revoke a key to mint a new one.")
-         |> refresh_keys()}
+         |> assign(:key_name, name)
+         |> reconcile_key_limit()}
 
       {:error, :invalid_session} ->
         {:noreply, expire_session(socket)}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, :form_error, first_error(changeset))}
+        {:noreply,
+         socket
+         |> assign(:key_name, name)
+         |> assign(:mint_error, first_error(changeset))}
 
       {:error, _reason} ->
-        {:noreply, assign(socket, :form_error, "Could not mint that key.")}
+        {:noreply,
+         socket
+         |> assign(:key_name, name)
+         |> assign(:mint_error, "Could not mint that key.")}
     end
   end
 
@@ -123,7 +134,8 @@ defmodule Orchard.Portal.KeysLive do
     {:noreply,
      socket
      |> assign(:revoke_key, key)
-     |> assign(:revoke_confirmation, "")}
+     |> assign(:revoke_confirmation, "")
+     |> assign(:revoke_error, nil)}
   end
 
   def handle_event("update_revoke_confirmation", params, socket) do
@@ -132,7 +144,10 @@ defmodule Orchard.Portal.KeysLive do
   end
 
   def handle_event("close_revoke", _params, socket) do
-    {:noreply, assign(socket, :revoke_key, nil)}
+    {:noreply,
+     socket
+     |> assign(:revoke_key, nil)
+     |> assign(:revoke_error, nil)}
   end
 
   def handle_event("revoke_key", _params, socket) do
@@ -156,13 +171,14 @@ defmodule Orchard.Portal.KeysLive do
              socket
              |> assign(:revoke_key, nil)
              |> assign(:revoke_confirmation, "")
+             |> assign(:revoke_error, nil)
              |> refresh_keys()}
 
           {:error, :invalid_session} ->
             {:noreply, expire_session(socket)}
 
           {:error, _reason} ->
-            {:noreply, assign(socket, :form_error, "Could not revoke that key.")}
+            {:noreply, assign(socket, :revoke_error, "Could not revoke that key.")}
         end
     end
   end
@@ -208,10 +224,23 @@ defmodule Orchard.Portal.KeysLive do
         </div>
       </div>
 
-      <p :if={@active_portal_count >= 10} class="text-sm text-slate-400">
-        Portal cap reached — revoke a key to mint a new one.
+      <p
+        id="portal-key-cap-message"
+        class="text-sm text-slate-400"
+        role="status"
+        aria-atomic="true"
+        tabindex="-1"
+      >
+        <span
+          :if={@active_portal_count >= 10}
+          phx-mounted={
+            if @focus_cap_status?,
+              do: Phoenix.LiveView.JS.focus(to: "#portal-key-cap-message")
+          }
+        >
+          Portal cap reached — revoke a key to mint a new one.
+        </span>
       </p>
-      <p :if={@form_error} class="text-sm text-red-400">{@form_error}</p>
 
       <div
         :if={@keys == []}
@@ -295,8 +324,25 @@ defmodule Orchard.Portal.KeysLive do
           name="key[name]"
           placeholder="production-agent"
           required
-          class="mt-1 block w-full rounded-md border border-slate-600 bg-slate-900/60 px-3 py-2 text-sm text-slate-50 shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40"
+          value={@key_name}
+          aria-invalid={if @mint_error, do: "true"}
+          aria-describedby={if @mint_error, do: "portal-mint-error"}
+          class={[
+            "mt-1 block w-full rounded-md bg-slate-900/60 px-3 py-2 text-sm text-slate-50 shadow-inner focus-visible:outline-none focus-visible:ring-2",
+            if(@mint_error,
+              do: "border border-red-400 ring-1 ring-red-400/30 focus-visible:border-red-400 focus-visible:ring-red-400/40",
+              else: "border border-slate-600 focus-visible:ring-sky-400/40"
+            )
+          ]}
         />
+        <p
+          :if={@mint_error}
+          id="portal-mint-error"
+          role="alert"
+          class="mt-1 text-xs text-red-400"
+        >
+          {@mint_error}
+        </p>
         <p class="mt-2 text-sm text-slate-400">Name it after the app or agent that will hold it.</p>
         <div class="mt-6 flex justify-end gap-3">
           <button type="button" phx-click="close_mint" class="text-sm text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-700">Cancel</button>
@@ -416,6 +462,9 @@ defmodule Orchard.Portal.KeysLive do
           value={@revoke_confirmation}
           class="mt-4 block w-full rounded-md border border-slate-600 bg-slate-900/60 px-3 py-2 text-sm text-slate-50 shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-700"
         />
+        <p :if={@revoke_error} id="portal-revoke-error" role="alert" class="mt-1 text-xs text-red-400">
+          {@revoke_error}
+        </p>
         <div class="mt-6 flex justify-end gap-3">
           <button type="button" phx-click="close_revoke" class="text-sm text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-700">Cancel</button>
           <button
@@ -444,6 +493,22 @@ defmodule Orchard.Portal.KeysLive do
 
       {:error, _reason} ->
         assign(socket, :keys, [])
+    end
+  end
+
+  defp reconcile_key_limit(socket) do
+    socket = refresh_keys(socket)
+
+    if socket.assigns.active_portal_count >= 10 do
+      socket
+      |> assign(:mint_open?, false)
+      |> assign(:mint_error, nil)
+      |> assign(:key_name, "")
+      |> assign(:focus_cap_status?, true)
+    else
+      socket
+      |> assign(:mint_open?, true)
+      |> assign(:mint_error, "Key capacity changed. Review the current keys and try again.")
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/portal/session_controller.ex
+++ b/apps/orchard_controller/lib/orchard/portal/session_controller.ex
@@ -82,12 +82,26 @@ defmodule Orchard.Portal.SessionController do
 
   @spec invite(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def invite(conn, %{"organization_slug" => slug, "token" => token}) do
-    conn
-    |> assign(:page_title, "Set your password")
-    |> assign(:organization_slug, normalize_slug(slug))
-    |> assign(:invite_token, token)
-    |> assign(:invite_error, nil)
-    |> render(:invite)
+    slug = normalize_slug(slug)
+
+    case Governance.validate_portal_invite(slug, token) do
+      :ok ->
+        conn
+        |> assign(:page_title, "Set your password")
+        |> assign(:organization_slug, slug)
+        |> assign(:invite_token, token)
+        |> assign(:invite_error, nil)
+        |> render(:invite)
+
+      {:error, _reason} ->
+        conn
+        |> assign(:page_title, "Invite unavailable")
+        |> assign(:organization_slug, slug)
+        |> assign(:invite_token, nil)
+        |> assign(:invite_error, :invalid_invite)
+        |> put_status(:unprocessable_entity)
+        |> render(:invite)
+    end
   end
 
   @spec redeem(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/apps/orchard_controller/lib/orchard/portal/session_html/invite.html.heex
+++ b/apps/orchard_controller/lib/orchard/portal/session_html/invite.html.heex
@@ -1,9 +1,21 @@
 <div class="mx-auto max-w-md">
   <section class="rounded-lg border border-slate-700 bg-slate-800 p-6">
-    <h1 class="text-lg font-semibold text-slate-50">Set your password</h1>
-    <p class="mt-1 text-sm text-slate-300">Activate your named Portal User for {@organization_slug}.</p>
+    <h1 class="text-lg font-semibold text-slate-50">
+      {if @invite_token, do: "Set your password", else: "Invite unavailable"}
+    </h1>
+    <p :if={@invite_token} class="mt-1 text-sm text-slate-300">
+      Activate your named Portal User for {@organization_slug}.
+    </p>
+    <p
+      :if={!@invite_token}
+      id="portal-invite-error"
+      role="alert"
+      class="mt-2 text-sm text-red-400"
+    >
+      This invite is invalid, expired, or already used.
+    </p>
 
-    <form action={"/portal/#{@organization_slug}/invites/#{@invite_token}"} method="post" class="mt-6 space-y-4">
+    <form :if={@invite_token} action={"/portal/#{@organization_slug}/invites/#{@invite_token}"} method="post" class="mt-6 space-y-4">
       <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
       <div>
         <label for="invite-password" class="block text-sm font-medium text-slate-200">Password</label>
@@ -29,7 +41,9 @@
           class="mt-1 block w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
         />
       </div>
-      <p :if={@invite_error} class="text-sm text-red-400">This invite is invalid, expired, or already used.</p>
+      <p :if={@invite_error} id="portal-invite-error" role="alert" class="text-sm text-red-400">
+        This invite is invalid, expired, or already used.
+      </p>
       <button
         type="submit"
         class="w-full rounded-md bg-sky-500 px-3 py-2 text-sm font-medium text-slate-950 transition-colors hover:bg-sky-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"

--- a/apps/orchard_controller/test/orchard/portal/keys_live_test.exs
+++ b/apps/orchard_controller/test/orchard/portal/keys_live_test.exs
@@ -73,6 +73,200 @@ defmodule Orchard.Portal.KeysLiveTest do
     assert html =~ "orchard_kp_"
   end
 
+  test "mint validation stays inside the dialog and describes the key-name input", %{
+    conn: conn,
+    token: token
+  } do
+    {:ok, view, _html} = live(authed(conn, token), "/portal/portal-keys/keys")
+    view |> element("#portal-mint-button") |> render_click()
+
+    view
+    |> form("#portal-mint-modal form", key: %{name: "   "})
+    |> render_submit()
+
+    assert has_element?(view, "#portal-mint-modal #portal-mint-error", "can't be blank")
+
+    assert has_element?(
+             view,
+             ~s|#portal-key-name[aria-invalid="true"][aria-describedby="portal-mint-error"]|
+           )
+
+    refute has_element?(view, "#portal-keys #portal-mint-error")
+
+    view |> element("#portal-mint-modal button", "Cancel") |> render_click()
+    view |> element("#portal-mint-button") |> render_click()
+
+    refute has_element?(view, "#portal-mint-error")
+    assert has_element?(view, ~s|#portal-key-name[value=""]:not([aria-invalid])|)
+
+    view
+    |> form("#portal-mint-modal form", key: %{name: "corrected-key"})
+    |> render_submit()
+
+    assert has_element?(view, "#portal-secret-modal")
+    refute has_element?(view, "#portal-mint-error")
+  end
+
+  test "revoke failure stays inside its dialog and clears when the dialog closes", %{
+    conn: conn,
+    token: token
+  } do
+    {:ok, minted} =
+      Governance.create_portal_api_key(token, "portal-keys", %{name: "stale-revoke"})
+
+    {:ok, view, _html} = live(authed(conn, token), "/portal/portal-keys/keys")
+    view |> element("#portal-revoke-#{minted.api_key.id}") |> render_click()
+    Repo.delete!(minted.api_key)
+
+    view
+    |> form("#portal-revoke-modal form", confirmation: "stale-revoke")
+    |> render_change()
+
+    view |> form("#portal-revoke-modal form") |> render_submit()
+
+    assert has_element?(view, "#portal-revoke-modal #portal-revoke-error[role=alert]")
+    refute has_element?(view, "#portal-keys #portal-revoke-error")
+
+    view |> element("#portal-revoke-modal button", "Cancel") |> render_click()
+    refute has_element?(view, "#portal-revoke-error")
+  end
+
+  test "stale cap rejection renders once and successful revoke clears it", %{
+    conn: conn,
+    token: token
+  } do
+    Enum.each(1..9, fn index ->
+      assert {:ok, _key} =
+               Governance.create_portal_api_key(token, "portal-keys", %{
+                 name: "seed-#{index}"
+               })
+    end)
+
+    {:ok, view, _html} = live(authed(conn, token), "/portal/portal-keys/keys")
+
+    assert has_element?(
+             view,
+             "#portal-key-cap-message[role=status][aria-atomic=true][tabindex='-1']",
+             ""
+           )
+
+    refute has_element?(view, "#portal-key-cap-message", "Portal cap reached")
+    view |> element("#portal-mint-button") |> render_click()
+
+    assert {:ok, tenth} =
+             Governance.create_portal_api_key(token, "portal-keys", %{name: "concurrent-tenth"})
+
+    cap_html =
+      view
+      |> form("#portal-mint-modal form", key: %{name: "stale-eleventh"})
+      |> render_submit()
+
+    assert cap_html =~ "10 / 10"
+    assert cap_occurrences(cap_html) == 1
+    assert cap_html =~ "phx-mounted"
+    refute has_element?(view, "#portal-mint-modal")
+
+    view
+    |> element("#portal-revoke-#{tenth.api_key.id}")
+    |> render_click()
+
+    view
+    |> form("#portal-revoke-modal form", confirmation: "concurrent-tenth")
+    |> render_change()
+
+    revoked_html = view |> form("#portal-revoke-modal form") |> render_submit()
+
+    assert revoked_html =~ "9 / 10"
+    assert cap_occurrences(revoked_html) == 0
+    assert has_element?(view, "#portal-mint-button:not([disabled])")
+  end
+
+  test "successful tenth mint keeps focus ownership with the one-time-secret dialog", %{
+    conn: conn,
+    token: token
+  } do
+    Enum.each(1..9, fn index ->
+      assert {:ok, _key} =
+               Governance.create_portal_api_key(token, "portal-keys", %{
+                 name: "focus-seed-#{index}"
+               })
+    end)
+
+    {:ok, view, _html} = live(authed(conn, token), "/portal/portal-keys/keys")
+    view |> element("#portal-mint-button") |> render_click()
+
+    html =
+      view
+      |> form("#portal-mint-modal form", key: %{name: "focus-tenth"})
+      |> render_submit()
+
+    assert html =~ "10 / 10"
+    assert has_element?(view, "#portal-secret-modal[role=dialog][aria-modal=true]")
+    refute html =~ "phx-mounted"
+  end
+
+  test "cap rejection keeps retry feedback when capacity is relieved before refresh", %{
+    conn: conn,
+    token: token
+  } do
+    Enum.each(1..9, fn index ->
+      assert {:ok, _key} =
+               Governance.create_portal_api_key(token, "portal-keys", %{
+                 name: "race-seed-#{index}"
+               })
+    end)
+
+    {:ok, view, _html} = live(authed(conn, token), "/portal/portal-keys/keys")
+    view |> element("#portal-mint-button") |> render_click()
+
+    assert {:ok, tenth} =
+             Governance.create_portal_api_key(token, "portal-keys", %{name: "race-tenth"})
+
+    test_pid = self()
+
+    handler_id =
+      {__MODULE__, :relieve_cap_before_refresh, System.unique_integer([:positive])}
+
+    :telemetry.attach(
+      handler_id,
+      [:orchard, :repo, :query],
+      fn _event, _measurements, metadata, _config ->
+        if String.contains?(metadata.query, ~s|ORDER BY a0."inserted_at" DESC|) do
+          send(test_pid, {:listing_started, self()})
+
+          receive do
+            :capacity_relieved -> :ok
+          after
+            1_000 -> raise "timed out waiting for the capacity race"
+          end
+        end
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    submitter =
+      Task.async(fn ->
+        view
+        |> form("#portal-mint-modal form", key: %{name: "retry-me"})
+        |> render_submit()
+      end)
+
+    assert_receive {:listing_started, listing_pid}, 1_000
+
+    assert {:ok, _revoked} =
+             Governance.revoke_portal_api_key(token, "portal-keys", tenth.api_key.id)
+
+    send(listing_pid, :capacity_relieved)
+    html = Task.await(submitter)
+
+    assert html =~ "9 / 10"
+    assert has_element?(view, "#portal-mint-modal #portal-mint-error", "try again")
+    assert has_element?(view, ~s|#portal-key-name[value="retry-me"]|)
+    assert cap_occurrences(html) == 0
+  end
+
   test "reconnect after mint does not restore the plaintext token", %{
     conn: conn,
     token: token
@@ -169,4 +363,6 @@ defmodule Orchard.Portal.KeysLiveTest do
       _pid -> :ok
     end
   end
+
+  defp cap_occurrences(html), do: length(Regex.scan(~r/Portal cap reached/, html))
 end

--- a/apps/orchard_controller/test/orchard/portal/session_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/portal/session_controller_test.exs
@@ -57,8 +57,19 @@ defmodule Orchard.Portal.SessionControllerTest do
     {:ok, user} = Governance.create_portal_invite(tenant, %{email: "dev@example.com"})
     {:ok, invite} = Governance.copy_portal_invite(tenant, user)
 
+    unavailable =
+      conn |> https_conn() |> get("/portal/portal-route-other/invites/#{invite.token}")
+
+    assert {422, headers, body} = unusable_invite_get_signature(unavailable)
+    assert headers["content-type"] == ["text/html; charset=utf-8"]
+    assert headers["cache-control"] == ["no-store"]
+    assert body =~ "This invite is invalid, expired, or already used."
+
     page = conn |> https_conn() |> get("/portal/#{tenant.slug}/invites/#{invite.token}")
     assert html_response(page, 200) =~ "Set your password"
+    assert page.resp_body =~ ~s|id="invite-password"|
+    assert page.resp_body =~ ~s|id="invite-password-confirmation"|
+    assert page.resp_body =~ ~s|name="_csrf_token"|
     csrf_token = csrf_token(page)
 
     redeemed =
@@ -89,7 +100,7 @@ defmodule Orchard.Portal.SessionControllerTest do
     {:ok, user} = Governance.create_portal_invite(tenant, %{email: "dev@example.com"})
     {:ok, invite} = Governance.copy_portal_invite(tenant, user)
 
-    page = conn |> https_conn() |> get("/portal/portal-route-other/invites/#{invite.token}")
+    page = conn |> https_conn() |> get("/portal/#{tenant.slug}/invites/#{invite.token}")
 
     wrong_organization =
       post_form(page, "/portal/portal-route-other/invites/#{invite.token}", %{
@@ -136,6 +147,9 @@ defmodule Orchard.Portal.SessionControllerTest do
     {:ok, disabled} = Governance.copy_portal_invite(tenant, disabled_user)
     {:ok, _disabled_user} = Governance.disable_portal_user(tenant, disabled_user)
 
+    {:ok, other_tenant} =
+      Governance.create_tenant(%{slug: "portal-invalid-other", name: "Invalid Other"})
+
     {:ok, redeemed_user} =
       Governance.create_portal_invite(tenant, %{email: "redeemed@example.com"})
 
@@ -144,13 +158,35 @@ defmodule Orchard.Portal.SessionControllerTest do
     {:ok, _active_user} =
       Governance.redeem_portal_invite(tenant.slug, redeemed.token, @password)
 
-    responses = [
-      redeem_attempt(conn, tenant.slug, invalidated.token),
-      redeem_attempt(conn, tenant.slug, expired.token),
-      redeem_attempt(conn, tenant.slug, disabled.token),
-      redeem_attempt(conn, tenant.slug, redeemed.token),
-      redeem_attempt(conn, tenant.slug, "orchard_pi_unknown")
+    unusable_tokens = [
+      invalidated.token,
+      expired.token,
+      disabled.token,
+      redeemed.token,
+      "orchard_pi_unknown"
     ]
+
+    get_responses =
+      Enum.map(unusable_tokens, fn token ->
+        conn |> https_conn() |> get("/portal/#{tenant.slug}/invites/#{token}")
+      end) ++
+        [
+          conn
+          |> https_conn()
+          |> get("/portal/#{other_tenant.slug}/invites/#{replacement.token}")
+        ]
+
+    signatures = Enum.map(get_responses, &unusable_invite_get_signature/1)
+    assert length(Enum.uniq(signatures)) == 1
+
+    assert hd(signatures) ==
+             {422, unusable_invite_headers(hd(get_responses)),
+              normalize_unusable_invite_body(hd(get_responses).resp_body)}
+
+    valid_page =
+      conn |> https_conn() |> get("/portal/#{tenant.slug}/invites/#{replacement.token}")
+
+    responses = Enum.map(unusable_tokens, &redeem_attempt(valid_page, tenant.slug, &1))
 
     assert Enum.map(responses, &invalid_invite_response_signature/1)
            |> Enum.uniq() ==
@@ -264,11 +300,44 @@ defmodule Orchard.Portal.SessionControllerTest do
     }
   end
 
-  defp redeem_attempt(conn, slug, token) do
-    page = conn |> https_conn() |> get("/portal/#{slug}/invites/#{token}")
+  defp unusable_invite_get_signature(conn) do
+    {
+      conn.status,
+      unusable_invite_headers(conn),
+      normalize_unusable_invite_body(conn.resp_body)
+    }
+  end
 
-    post_form(page, "/portal/#{slug}/invites/#{token}", %{
-      "_csrf_token" => csrf_token(page),
+  defp unusable_invite_headers(conn) do
+    for name <- [
+          "cache-control",
+          "content-security-policy",
+          "content-type",
+          "referrer-policy",
+          "x-content-type-options",
+          "x-frame-options"
+        ],
+        into: %{} do
+      {name, get_resp_header(conn, name)}
+    end
+  end
+
+  defp normalize_unusable_invite_body(body) do
+    assert body =~ "This invite is invalid, expired, or already used."
+    refute body =~ ~s|id="invite-password"|
+    refute body =~ ~s|id="invite-password-confirmation"|
+    refute body =~ "<form"
+
+    Regex.replace(
+      ~r/name="csrf-token" content="[^"]+"/,
+      body,
+      ~s|name="csrf-token" content="CSRF"|
+    )
+  end
+
+  defp redeem_attempt(conn, slug, token) do
+    post_form(conn, "/portal/#{slug}/invites/#{token}", %{
+      "_csrf_token" => csrf_token(conn),
       "invite[password]" => @password,
       "invite[password_confirmation]" => @password
     })


### PR DESCRIPTION
## Context

Developer Portal feedback could become stale after revocation, repeat the key-cap message, render mint validation outside the active dialog, and show an actionable password form for an unusable invite.

This change fixes all four behaviors while preserving the Portal invitation and API-key contracts reconciled in #300.

## What changed

- Give mint and revoke failures separate dialog-owned state, clear each error at the relevant surface transition, and keep validation inside the open dialog with accessible error semantics.
- Derive the 10-key cap message from current key state, render it once, reconcile concurrent mint races, and focus its status region only when a mint is rejected because capacity changed.
- Keep a successful tenth mint focused on the one-time-secret flow instead of moving focus to the cap status.
- Validate invite usability before rendering the GET surface and return the same generic 422 alert with no password form for invalid, expired, already-used, deleted-user, and wrong-organization cases.
- Add LiveView and controller regressions for error ownership, clearing transitions, cap races, focus intent, generic invite-response equivalence, CSRF, and valid invite rendering.

## Scope and non-goals

- Preserves the 10-key ceiling and existing valid API keys.
- Preserves deletion-based invite invalidation, invited-only redemption, and indistinguishable invalid, expired, and already-used responses.
- Preserves existing CSRF behavior and authentication semantics.
- Does not change public inference APIs, redesign the Portal, or widen into #279 lifecycle work.

## Browser evidence

Verified through the real HTTPS Portal path behind Caddy in Chrome, with local screenshots and DOM assertions retained outside the repository:

- At 1440x763 and 1024x768, mint validation remains visible inside the active dialog without overflow or obscured content.
- The mint input reports one dialog-local alert with `aria-invalid="true"` and `aria-describedby="portal-mint-error"`.
- A two-tab 9-to-10 key race renders one cap message, closes the losing mint dialog, and focuses the `role="status"`, `aria-atomic="true"` cap region.
- A successful tenth mint leaves the one-time-secret dialog in control and does not move focus to the cap status.
- Revoking the tenth key returns the page to 9/10 and clears the cap message immediately.
- An unusable invite renders the generic alert with no form or password input.

No generated API-key secret was inspected or captured.

## Independent review

- RepoPrompt implementation review: GO, no P0/P1/P2 findings after race, response-equivalence, and focus findings were addressed.
- Oracle second opinion: GO.
- Final independent diff audit: GO, no P0/P1/P2 findings.

## Validation

- `env PGDATABASE_TEST=orchard_issue270_47e7_test ORCHARD_TEST_NODE_AGENT_PORT=50271 mise exec -- mix test apps/orchard_controller/test/orchard/portal/keys_live_test.exs apps/orchard_controller/test/orchard/portal/session_controller_test.exs`
  - 20 passed.
- `env PGDATABASE_TEST=orchard_issue270_47e7_test ORCHARD_TEST_NODE_AGENT_PORT=50271 make check-elixir`
  - Formatting passed.
  - Compilation with warnings as errors passed.
  - Credo strict passed across 739 files and 90 checks with no issues.
  - Dialyzer passed with 0 errors.
  - macOS native test helper staging passed.
  - Tests passed: shared 216; controller 3,596 with 5 skipped; node-agent 412; CLI 678 with 1 skipped and 10 excluded.
  - Coverage passed: shared 67.25%; controller 85.2%; node-agent 78.33%; CLI 76.40%.
- `git diff --check`
  - Passed.

## Risk Assessment

✅ **Low**

- The change is limited to Portal key/invite feedback and its regression tests.
- Invite redemption, authentication, API-key validity, inference APIs, and lifecycle semantics are unchanged.
- Concurrent key-cap handling is covered in LiveView tests and a real two-tab browser race.

## Checklist

- [x] Regression tests added for each reported defect.
- [x] Portal invitation and key contracts preserved.
- [x] Desktop browser, focus, and accessibility transitions verified.
- [x] Full repository Elixir gate and coverage passed.
- [x] No transient browser evidence or local goal artifacts committed.

Closes #270

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790490913&installation_model_id=428414&pr_number=303&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F303&signature=1598efdb489d91c20aa31259b1b85f2c80df6d491613af3e947b5ef65694c003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->