### PR TITLE
fix(inference): attribute attempt failures to breakers

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -448,6 +448,15 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp attempt_failure(_result, _terminal, :completed), do: nil
 
   defp attempt_failure(
+         {:ok, _events, %AttemptEventDelivery{}},
+         %InferenceEvent{event: %InferenceEvent.Failed{code: code}},
+         _outcome
+       )
+       when code in ["node_unavailable", "node_timeout", "worker_unavailable", "worker_down"] do
+    InferenceAttemptFailure.normalize(%{category: :worker_or_node_loss, code: code})
+  end
+
+  defp attempt_failure(
          _result,
          %InferenceEvent{event: %InferenceEvent.Failed{code: code}},
          _outcome
@@ -524,6 +533,16 @@ defmodule Orchard.Dispatch.RequestDispatcher do
               :dispatch_capacity_quarantine_store_unavailable
             ],
        do: %{category: :capacity, code: reason}
+
+  defp failure_source(reason)
+       when reason in [
+              :node_acceptance_missing,
+              :node_unavailable,
+              :node_timeout,
+              :rpc_unavailable,
+              :unavailable
+            ],
+       do: %{category: :pre_acceptance, code: reason}
 
   defp failure_source(reason), do: %{category: :runtime, code: reason}
 
@@ -1190,11 +1209,11 @@ defmodule Orchard.Dispatch.RequestDispatcher do
   defp handle_dispatch_connect_failure(target, reason, metrics) do
     mark_transport_failure(target, reason)
 
-    error_metrics = finalize_metrics(metrics, {:error, {:model_load_failed, :node_unavailable}})
+    error_metrics = finalize_metrics(metrics, {:error, {:dispatch_failed, :node_unavailable}})
     put_dispatch_terminal_context(error_metrics, target)
-    emit_timing_log(error_metrics, {:error, {:model_load_failed, :node_unavailable}})
+    emit_timing_log(error_metrics, {:error, {:dispatch_failed, :node_unavailable}})
 
-    {:error, {:model_load_failed, ModelLoadFailure.from_transport_reason(:node_unavailable)}}
+    {:error, {:dispatch_failed, :node_unavailable}}
   end
 
   defp probe_and_resolve_node(

--- a/apps/orchard_controller/lib/orchard/inference/attempt_breaker_attribution.ex
+++ b/apps/orchard_controller/lib/orchard/inference/attempt_breaker_attribution.ex
@@ -1,0 +1,82 @@
+defmodule Orchard.Inference.AttemptBreakerAttribution do
+  @moduledoc """
+  Attributes one typed inference-attempt failure to its producing breaker target.
+
+  The failure identity is deterministic for one logical Request and attempt so
+  defensive redelivery remains idempotent at the durable breaker boundary.
+  """
+
+  alias Orchard.CircuitBreakers
+  alias Orchard.CircuitBreakers.Decision
+  alias Orchard.Dispatch.AttemptOutcome
+
+  @node_failure_classes ~w(pre_acceptance_unavailable worker_or_node_loss)
+  @placement_failure_classes ~w(model_load_failure)
+
+  @type record_error ::
+          :invalid_attempt_identity
+          | CircuitBreakers.error()
+          | Ecto.Changeset.t()
+
+  @spec record(Ecto.UUID.t(), 1 | 2, Ecto.UUID.t(), AttemptOutcome.t()) ::
+          {:ok, :not_eligible | Decision.t()} | {:error, record_error()}
+  def record(
+        request_id,
+        attempt,
+        model_id,
+        %AttemptOutcome{failure: %{"failure_class" => failure_class}} = outcome
+      ) do
+    case failure_target(failure_class, model_id) do
+      :not_eligible ->
+        {:ok, :not_eligible}
+
+      {:eligible, _target_model_id} when is_nil(outcome.node_id) ->
+        {:ok, :not_eligible}
+
+      {:eligible, target_model_id} ->
+        with {:ok, failure_id} <- failure_id(request_id, attempt) do
+          CircuitBreakers.record_failure(%{
+            failure_id: failure_id,
+            node_id: outcome.node_id,
+            model_id: target_model_id,
+            failure_class: failure_class,
+            occurred_at: outcome.ended_at
+          })
+        end
+    end
+  end
+
+  def record(_request_id, _attempt, _model_id, %AttemptOutcome{}),
+    do: {:ok, :not_eligible}
+
+  defp failure_target(failure_class, _model_id) when failure_class in @node_failure_classes,
+    do: {:eligible, nil}
+
+  defp failure_target(failure_class, model_id)
+       when failure_class in @placement_failure_classes,
+       do: {:eligible, model_id}
+
+  defp failure_target(_failure_class, _model_id), do: :not_eligible
+
+  defp failure_id(request_id, attempt) when attempt in [1, 2] do
+    case Ecto.UUID.cast(request_id) do
+      {:ok, request_id} ->
+        digest =
+          :crypto.hash(
+            :sha256,
+            "orchard:attempt-breaker-failure:v1:#{request_id}:#{attempt}"
+          )
+          |> Base.encode16(case: :lower)
+
+        <<a::binary-size(8), b::binary-size(4), c::binary-size(4), d::binary-size(4),
+          e::binary-size(12), _rest::binary>> = digest
+
+        {:ok, Enum.join([a, b, c, d, e], "-")}
+
+      :error ->
+        {:error, :invalid_attempt_identity}
+    end
+  end
+
+  defp failure_id(_request_id, _attempt), do: {:error, :invalid_attempt_identity}
+end

--- a/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
+++ b/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
@@ -151,6 +151,12 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
        }),
        do: code in @pre_acceptance_retryable_codes
 
+  defp retry_eligible?(%Boundary{
+         failure_class: "worker_or_node_loss",
+         runtime_retryable: false
+       }),
+       do: false
+
   defp retry_eligible?(%Boundary{failure_class: "worker_or_node_loss"}), do: true
   defp retry_eligible?(%Boundary{}), do: false
 end

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -658,15 +658,15 @@ defmodule Orchard.Inference.RequestOrchestrator do
            Map.get(execution_opts, :queue_grant)
          ) do
       %AttemptOutcome{} = pending_outcome ->
-        case record_attempt_breaker_failure(db_request, model, step_context, pending_outcome) do
-          :ok ->
-            outcome =
-              AttemptOutcome.select(
-                pending_outcome,
-                canonical.public_id,
-                execution_opts.event_handler
-              )
+        outcome =
+          AttemptOutcome.select(
+            pending_outcome,
+            canonical.public_id,
+            execution_opts.event_handler
+          )
 
+        case record_attempt_breaker_failure(db_request, model, step_context, outcome) do
+          :ok ->
             continue_selected_attempt(
               db_request,
               canonical,
@@ -676,7 +676,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
             )
 
           {:error, reason} ->
-            {:error, reason, Map.put(step_context, :attempt_outcome, pending_outcome)}
+            {:error, reason, Map.put(step_context, :attempt_outcome, outcome)}
         end
 
       {:error, reason} ->

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -15,6 +15,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   alias Orchard.Inference.{
     AdmissionPolicy,
+    AttemptBreakerAttribution,
     AttemptRetryClassifier,
     CacheAffinity,
     CanonicalRequestSerializer,
@@ -637,20 +638,16 @@ defmodule Orchard.Inference.RequestOrchestrator do
            Map.get(execution_opts, :queue_grant)
          ) do
       %AttemptOutcome{} = pending_outcome ->
-        outcome =
-          AttemptOutcome.select(
-            pending_outcome,
-            canonical.public_id,
-            execution_opts.event_handler
-          )
+        case record_attempt_breaker_failure(db_request, model, step_context, pending_outcome) do
+          :ok ->
+            outcome =
+              AttemptOutcome.select(
+                pending_outcome,
+                canonical.public_id,
+                execution_opts.event_handler
+              )
 
-        cond do
-          outcome.delivery_state == :failed ->
-            {:error, public_dispatch_reason(outcome),
-             Map.put(step_context, :attempt_outcome, outcome)}
-
-          Enum.any?(outcome.events, &InferenceEvent.terminal?/1) ->
-            finalize_started_inference_turn(
+            continue_selected_attempt(
               db_request,
               canonical,
               outcome,
@@ -658,14 +655,52 @@ defmodule Orchard.Inference.RequestOrchestrator do
               step_context
             )
 
-          true ->
-            {:error, public_dispatch_reason(outcome),
-             Map.put(step_context, :attempt_outcome, outcome)}
+          {:error, reason} ->
+            {:error, reason, Map.put(step_context, :attempt_outcome, pending_outcome)}
         end
 
       {:error, reason} ->
         outcome = failed_dispatch_outcome(schedule)
         {:error, reason, Map.put(step_context, :attempt_outcome, outcome)}
+    end
+  end
+
+  defp record_attempt_breaker_failure(db_request, model, step_context, outcome) do
+    case AttemptBreakerAttribution.record(
+           db_request.id,
+           step_context.attempt,
+           Map.get(model, :id),
+           outcome
+         ) do
+      {:ok, _decision} -> :ok
+      {:error, reason} -> {:error, {:breaker_attribution_failed, reason}}
+    end
+  end
+
+  defp continue_selected_attempt(
+         db_request,
+         canonical,
+         %AttemptOutcome{} = outcome,
+         execution_opts,
+         step_context
+       ) do
+    cond do
+      outcome.delivery_state == :failed ->
+        {:error, public_dispatch_reason(outcome),
+         Map.put(step_context, :attempt_outcome, outcome)}
+
+      Enum.any?(outcome.events, &InferenceEvent.terminal?/1) ->
+        finalize_started_inference_turn(
+          db_request,
+          canonical,
+          outcome,
+          execution_opts,
+          step_context
+        )
+
+      true ->
+        {:error, public_dispatch_reason(outcome),
+         Map.put(step_context, :attempt_outcome, outcome)}
     end
   end
 
@@ -1162,6 +1197,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
          }
        }) do
     {:model_load_failed, ModelLoadFailure.from_model_load_code(failure_code)}
+  end
+
+  defp public_dispatch_reason(%AttemptOutcome{
+         failure: %{"failure_class" => "pre_acceptance_unavailable"}
+       }) do
+    {:model_load_failed, ModelLoadFailure.from_model_load_code("runtime_unavailable")}
   end
 
   defp public_dispatch_reason(%AttemptOutcome{

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -51,6 +51,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
   alias Orchard.Models.RoutingPolicy
   alias Orchard.Node
   alias Orchard.Node.ModelManager
+  alias Orchard.Nodes.Node, as: InventoryNode
   alias Orchard.Repo
   alias Orchard.Requests
   alias Orchard.Requests.{Idempotency, Request}
@@ -1654,6 +1655,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     test "non-streaming model load failure returns mapped HTTP status and error envelope", %{
       bundle: bundle
     } do
+      insert_runtime_inventory_node!()
+
       # Create a model in DB but don't stage cache, and give a source URI
       # pointing to a nonexistent path so model acquisition fails.
       {:ok, _model} =
@@ -1708,6 +1711,8 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     test "streaming model load failure emits SSE error with mapped code and no [DONE]", %{
       bundle: bundle
     } do
+      insert_runtime_inventory_node!()
+
       {:ok, _model} =
         Orchard.Models.create_model(%{
           model_id: "fail-stream-model",
@@ -1810,6 +1815,24 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
   end
 
   defp refute_struct_artifacts!(_value), do: :ok
+
+  defp insert_runtime_inventory_node! do
+    target = Orchard.Inference.runtime_client_target()
+
+    %InventoryNode{}
+    |> InventoryNode.changeset(%{
+      id: Node.node_id(),
+      hostname: "chat-controller-runtime.local",
+      display_name: "chat-controller-runtime",
+      advertise_addr: Keyword.fetch!(target, :host),
+      rpc_port: Keyword.fetch!(target, :port),
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      tool_readiness: %{}
+    })
+    |> Repo.insert!()
+  end
 
   defp stub_chat_orchestrator(config) do
     Application.put_env(

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -977,9 +977,8 @@ defmodule Orchard.Dispatch.DispatchTest do
                delivery_state: :pending,
                delivered_event_count: 0,
                failure: %{
-                 "failure_class" => "model_load_failure",
-                 "failure_code" => "runtime_unavailable",
-                 "raw_source_code" => "node_unavailable"
+                 "failure_class" => "pre_acceptance_unavailable",
+                 "failure_code" => "node_unavailable"
                }
              } =
                RequestDispatcher.dispatch(schedule, execute, model_load)

--- a/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/probe_compatibility_test.exs
@@ -602,9 +602,8 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
                attempt_outcome: :failed,
                accepted: false,
                failure: %{
-                 "failure_class" => "model_load_failure",
-                 "failure_code" => "runtime_unavailable",
-                 "raw_source_code" => "node_unavailable"
+                 "failure_class" => "pre_acceptance_unavailable",
+                 "failure_code" => "node_unavailable"
                }
              } =
                RequestDispatcher.dispatch(schedule, ctx.execute, ctx.model_load,
@@ -666,7 +665,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
                attempt_outcome: :failed,
                accepted: false,
                failure: %{
-                 "failure_class" => "runtime_failure",
+                 "failure_class" => "pre_acceptance_unavailable",
                  "failure_code" => "node_timeout"
                }
              } =
@@ -847,9 +846,8 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
                attempt_outcome: :failed,
                accepted: false,
                failure: %{
-                 "failure_class" => "model_load_failure",
-                 "failure_code" => "runtime_unavailable",
-                 "raw_source_code" => "node_unavailable"
+                 "failure_class" => "pre_acceptance_unavailable",
+                 "failure_code" => "node_unavailable"
                }
              } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
@@ -874,9 +872,8 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
                attempt_outcome: :failed,
                accepted: false,
                failure: %{
-                 "failure_class" => "model_load_failure",
-                 "failure_code" => "runtime_unavailable",
-                 "raw_source_code" => "node_unavailable"
+                 "failure_class" => "pre_acceptance_unavailable",
+                 "failure_code" => "node_unavailable"
                }
              } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
@@ -908,9 +905,8 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
                attempt_outcome: :failed,
                accepted: false,
                failure: %{
-                 "failure_class" => "model_load_failure",
-                 "failure_code" => "runtime_unavailable",
-                 "raw_source_code" => "node_unavailable"
+                 "failure_class" => "pre_acceptance_unavailable",
+                 "failure_code" => "node_unavailable"
                }
              } =
                RequestDispatcher.dispatch(ctx.schedule, ctx.execute, ctx.model_load,
@@ -956,7 +952,7 @@ defmodule Orchard.Dispatch.ProbeCompatibilityTest do
                attempt_outcome: :failed,
                accepted: false,
                failure: %{
-                 "failure_class" => "runtime_failure",
+                 "failure_class" => "pre_acceptance_unavailable",
                  "failure_code" => "node_timeout"
                }
              } =

--- a/apps/orchard_controller/test/orchard/inference/attempt_breaker_attribution_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/attempt_breaker_attribution_test.exs
@@ -1,0 +1,167 @@
+defmodule Orchard.Inference.AttemptBreakerAttributionTest do
+  use Orchard.DataCase, async: false
+
+  alias Orchard.Dispatch.AttemptOutcome
+  alias Orchard.Inference.AttemptBreakerAttribution
+  alias Orchard.Models.Model
+  alias Orchard.Nodes.Node
+
+  describe "record/4" do
+    test "attributes an eligible Node failure exactly once to its producing attempt" do
+      node = insert_node!()
+      model = insert_model!()
+      request_id = Ecto.UUID.generate()
+      outcome = failed_outcome(node.id, "worker_or_node_loss")
+
+      assert {:ok, recorded} =
+               AttemptBreakerAttribution.record(request_id, 1, model.id, outcome)
+
+      assert recorded.kind == :node
+      assert recorded.node_id == node.id
+      assert recorded.delivery == :recorded
+      assert recorded.contribution_count == 1
+
+      assert {:ok, duplicate} =
+               AttemptBreakerAttribution.record(request_id, 1, model.id, outcome)
+
+      assert duplicate.delivery == :duplicate
+      assert duplicate.id == recorded.id
+      assert duplicate.contribution_count == 1
+    end
+
+    test "attributes a model-load failure to the producing placement" do
+      node = insert_node!()
+      model = insert_model!()
+
+      assert {:ok, recorded} =
+               AttemptBreakerAttribution.record(
+                 Ecto.UUID.generate(),
+                 1,
+                 model.id,
+                 failed_outcome(node.id, "model_load_failure")
+               )
+
+      assert recorded.kind == :placement
+      assert recorded.node_id == node.id
+      assert recorded.model_id == model.id
+      assert recorded.contribution_count == 1
+    end
+
+    test "does not turn post-start capacity scarcity into breaker evidence" do
+      assert {:ok, :not_eligible} =
+               AttemptBreakerAttribution.record(
+                 Ecto.UUID.generate(),
+                 1,
+                 Ecto.UUID.generate(),
+                 failed_outcome(nil, "capacity_rejection")
+               )
+    end
+
+    test "keeps separate attempts attributed to their producing Nodes" do
+      first_node = insert_node!()
+      second_node = insert_node!()
+      model = insert_model!()
+      request_id = Ecto.UUID.generate()
+
+      assert {:ok, first} =
+               AttemptBreakerAttribution.record(
+                 request_id,
+                 1,
+                 model.id,
+                 failed_outcome(first_node.id, "pre_acceptance_unavailable")
+               )
+
+      assert {:ok, second} =
+               AttemptBreakerAttribution.record(
+                 request_id,
+                 2,
+                 model.id,
+                 failed_outcome(second_node.id, "worker_or_node_loss")
+               )
+
+      assert first.node_id == first_node.id
+      assert first.contribution_count == 1
+      assert second.node_id == second_node.id
+      assert second.contribution_count == 1
+    end
+
+    test "does not attribute an eligible class without a persistent Node identity" do
+      model = insert_model!()
+
+      assert {:ok, :not_eligible} =
+               AttemptBreakerAttribution.record(
+                 Ecto.UUID.generate(),
+                 1,
+                 model.id,
+                 failed_outcome(nil, "model_load_failure")
+               )
+
+      assert Orchard.Repo.aggregate(Orchard.CircuitBreakers.Failure, :count, :id) == 0
+    end
+  end
+
+  defp failed_outcome(node_id, failure_class) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    {:ok, outcome} =
+      AttemptOutcome.new(%{
+        attempt_outcome: :failed,
+        node_id: node_id,
+        accepted: failure_class != "pre_acceptance_unavailable",
+        events: [],
+        failure: %{"failure_class" => failure_class, "failure_code" => "internal_error"},
+        execution_resolution: :terminated,
+        capacity_release_outcome: :released,
+        started_at: DateTime.add(now, -1, :second),
+        ended_at: now,
+        first_token_at: nil,
+        output_committed: false,
+        output_commitment_kind: nil,
+        delivery_state: :selected,
+        delivered_event_count: 0,
+        runtime_retryable: true
+      })
+
+    outcome
+  end
+
+  defp insert_node! do
+    unique = System.unique_integer([:positive])
+
+    %Node{}
+    |> Node.changeset(%{
+      id: Ecto.UUID.generate(),
+      hostname: "attempt-breaker-node-#{unique}.local",
+      display_name: "attempt-breaker-node-#{unique}",
+      advertise_addr: "10.253.#{rem(div(unique, 254), 254)}.#{rem(unique, 254) + 1}",
+      rpc_port: 9444,
+      state: :active,
+      health: :healthy,
+      capabilities: %{},
+      tool_readiness: %{}
+    })
+    |> Repo.insert!()
+  end
+
+  defp insert_model! do
+    unique = System.unique_integer([:positive])
+
+    %Model{}
+    |> Model.changeset(%{
+      model_id: "attempt-breaker-model-#{unique}",
+      version: "main",
+      state: :active,
+      format: "mlx",
+      capabilities: ["text"],
+      tokenizer: %{"type" => "huggingface", "ref" => "test/tokenizer"},
+      artifact_uri: "file:///tmp/attempt-breaker-model-#{unique}",
+      artifact_sha256: String.duplicate("a", 64),
+      artifact_size_bytes: 1,
+      resident_memory_bytes: 1,
+      kv_cache_bytes_per_token: 1,
+      prefill_workspace_bytes_per_token: 1,
+      runtime_requirements: %{}
+    })
+    |> Repo.insert!()
+  end
+end

--- a/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
@@ -58,12 +58,29 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
     for runtime_retryable <- [nil, false, true],
         {failure_class, failure_code} <- [
           {"model_load_failure", "load_timeout"},
-          {"pre_acceptance_unavailable", "rpc_unavailable"},
-          {"worker_or_node_loss", "worker_down"}
+          {"pre_acceptance_unavailable", "rpc_unavailable"}
         ] do
       assert decide(%{
                failure_class: failure_class,
                failure_code: failure_code,
+               runtime_retryable: runtime_retryable,
+               alternate_available?: true
+             }) == :retried
+    end
+  end
+
+  test "SPEC.md §5.8 honors explicit runtime retry refusal for worker or node loss" do
+    assert decide(%{
+             failure_class: "worker_or_node_loss",
+             failure_code: "worker_down",
+             runtime_retryable: false,
+             alternate_available?: true
+           }) == :not_retryable
+
+    for runtime_retryable <- [nil, true] do
+      assert decide(%{
+               failure_class: "worker_or_node_loss",
+               failure_code: "worker_down",
                runtime_retryable: runtime_retryable,
                alternate_available?: true
              }) == :retried

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -2945,6 +2945,38 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert decision.contribution_count == 1
   end
 
+  test "SPEC.md sections 5.8 and 5.10 preserve worker-loss attribution when retry is refused", %{
+    bundle: bundle
+  } do
+    target = [host: "10.0.0.3", port: 50_063]
+    node = insert_runtime_node!(target)
+
+    put_auto_runtime_endpoint_scheduler_config([target])
+    stub_runtime_status(target, runtime_status(node.id, target))
+
+    stub_runtime_events([
+      InferenceEvent.failed("worker_down", "worker exited", false)
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-worker-loss-no-retry")
+    canonical = canonical_request("request-orchestrator-worker-loss-no-retry", stream?: false)
+
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+
+    terminal_result =
+      Requests.list_request_step_events(request) |> List.last() |> Map.fetch!(:result)
+
+    assert terminal_result["failure_class"] == "worker_or_node_loss"
+    assert terminal_result["failure_code"] == "worker_down"
+    assert terminal_result["runtime_retryable"] == false
+    assert terminal_result["retry_decision"] == "not_retryable"
+
+    assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id})
+    assert decision.contribution_count == 1
+  end
+
   test "execute/3 aborts before dispatch side effects when request_step.started persistence fails",
        %{bundle: bundle} do
     put_capturing_runtime_adapter_config()

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -484,6 +484,10 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler do
   alias Orchard.DispatchCapacity.{ConformanceFixture, Evaluator}
   alias Orchard.Inference
 
+  @scheduled_node_id "00000000-0000-4000-a000-000000000001"
+
+  def scheduled_node_id, do: @scheduled_node_id
+
   def schedule(%CanonicalRequest{} = request) do
     capacity_input = ConformanceFixture.input()
 
@@ -494,7 +498,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler do
        runtime_client_target: [host: "127.0.0.1", port: 1],
        request_timeout_ms: Inference.request_timeout_ms(),
        model_load_timeout_ms: 2_000,
-       node_id: "00000000-0000-4000-a000-000000000001",
+       node_id: @scheduled_node_id,
        dispatch_capacity_input: capacity_input,
        dispatch_capacity_evaluation: Evaluator.evaluate(capacity_input),
        dispatch_capacity_acquisition_input_provider: fn -> capacity_input end,
@@ -899,10 +903,12 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheUnavailableScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient
+  alias Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler
 
   alias Orchard.API.Ops.SchedulerExplanationPresenter
   alias Orchard.ArtifactBundle
   alias Orchard.CanonicalRequest
+  alias Orchard.CircuitBreakers
   alias Orchard.DispatchCapacity
   alias Orchard.DispatchCapacity.Policy
   alias Orchard.Governance
@@ -2714,10 +2720,22 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert terminal_result["attempt_outcome"] == "failed"
     assert terminal_result["accepted"] == false
     assert terminal_result["execution_resolution"] == "not_started"
-    assert terminal_result["failure_class"] == "model_load_failure"
-    assert terminal_result["failure_code"] == "runtime_unavailable"
+    assert terminal_result["failure_class"] == "pre_acceptance_unavailable"
+    assert terminal_result["failure_code"] == "node_unavailable"
     assert terminal_result["retry_decision"] == "no_alternative_node"
     refute Enum.any?(step_events, &(&1.attempt == 2))
+
+    assert {:ok, node_breaker} =
+             CircuitBreakers.evaluate({:node, StubUnreachableScheduler.scheduled_node_id()})
+
+    assert node_breaker.contribution_count == 1
+
+    assert {:ok, placement_breaker} =
+             CircuitBreakers.evaluate(
+               {:placement, StubUnreachableScheduler.scheduled_node_id(), model.id}
+             )
+
+    assert placement_breaker.contribution_count == 0
   end
 
   test "execute/3 persists inference-turn started and completed request_step events around dispatch",
@@ -2861,6 +2879,70 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert terminal_result["failure_code"] == "load_timeout"
     assert terminal_result["retry_decision"] == "no_alternative_node"
     refute Map.has_key?(terminal_result, "runtime_retryable")
+  end
+
+  test "SPEC.md section 5.10 records attempt breaker effects before terminal orchestration", %{
+    bundle: bundle
+  } do
+    target = [host: "10.0.0.2", port: 50_062]
+    node = insert_runtime_node!(target)
+
+    put_auto_runtime_endpoint_scheduler_config([target])
+    stub_runtime_status(target, runtime_status(node.id, target))
+    Process.put({StubRuntimeEndpointClient, :ensure_model_loaded_result}, {:error, :node_timeout})
+
+    model = create_active_model!(bundle, "request-orchestrator-breaker-ordering")
+    canonical = canonical_request("request-orchestrator-breaker-ordering", stream?: false)
+    owner = self()
+
+    terminal_persister = fn request, terminal_attrs, step_events ->
+      send(
+        owner,
+        {:breaker_before_terminal, CircuitBreakers.evaluate({:placement, node.id, model.id})}
+      )
+
+      Requests.mark_terminal_with_step_events(request, terminal_attrs, step_events)
+    end
+
+    assert {:error, {:model_load_failed, %ModelLoadFailure{category: :timeout}}} =
+             RequestOrchestrator.execute(canonical, model, terminal_persister: terminal_persister)
+
+    assert_receive {:breaker_before_terminal, {:ok, decision}}
+    assert decision.kind == :placement
+    assert decision.node_id == node.id
+    assert decision.model_id == model.id
+    assert decision.contribution_count == 1
+  end
+
+  test "SPEC.md section 5.10 attributes worker loss once without counting the retry decision", %{
+    bundle: bundle
+  } do
+    target = [host: "10.0.0.3", port: 50_063]
+    node = insert_runtime_node!(target)
+
+    put_auto_runtime_endpoint_scheduler_config([target])
+    stub_runtime_status(target, runtime_status(node.id, target))
+
+    stub_runtime_events([
+      InferenceEvent.failed("worker_down", "worker exited", true)
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-worker-loss-breaker")
+    canonical = canonical_request("request-orchestrator-worker-loss-breaker", stream?: false)
+
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+
+    terminal_result =
+      Requests.list_request_step_events(request) |> List.last() |> Map.fetch!(:result)
+
+    assert terminal_result["failure_class"] == "worker_or_node_loss"
+    assert terminal_result["failure_code"] == "worker_down"
+    assert terminal_result["retry_decision"] == "no_alternative_node"
+
+    assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id})
+    assert decision.contribution_count == 1
   end
 
   test "execute/3 aborts before dispatch side effects when request_step.started persistence fails",
@@ -4055,6 +4137,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   end
 
   defp put_unreachable_scheduler_config do
+    ensure_unreachable_scheduler_node!()
+
     inference =
       Application.fetch_env!(:orchard_controller, :inference)
       |> Keyword.merge(
@@ -4063,6 +4147,30 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       )
 
     Application.put_env(:orchard_controller, :inference, inference)
+  end
+
+  defp ensure_unreachable_scheduler_node! do
+    node_id = StubUnreachableScheduler.scheduled_node_id()
+
+    case Repo.get(InventoryNode, node_id) do
+      nil ->
+        %InventoryNode{}
+        |> InventoryNode.changeset(%{
+          id: node_id,
+          hostname: "unreachable-scheduler.local",
+          display_name: "unreachable-scheduler",
+          advertise_addr: "127.0.0.1",
+          rpc_port: 1,
+          state: :active,
+          health: :healthy,
+          capabilities: %{},
+          tool_readiness: %{}
+        })
+        |> Repo.insert!()
+
+      %InventoryNode{} = node ->
+        node
+    end
   end
 
   defp put_function_clause_scheduler_config do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -2733,6 +2733,35 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     refute Map.has_key?(terminal_result, "runtime_retryable")
   end
 
+  test "SPEC.md sections 5.10 and 7.2.7 delivery cancellation does not count worker loss",
+       %{bundle: bundle} do
+    target = [host: "10.0.0.4", port: 50_064]
+    node = insert_runtime_node!(target)
+
+    put_auto_runtime_endpoint_scheduler_config([target])
+    stub_runtime_status(target, runtime_status(node.id, target))
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    model = create_active_model!(bundle, "request-orchestrator-worker-loss-cancel")
+    canonical = canonical_request("request-orchestrator-worker-loss-cancel", stream?: true)
+    handler = fn _request_id, _event -> :cancel end
+
+    assert {:error, {:dispatch_failed, :request_caller_disconnect}} =
+             RequestOrchestrator.execute(canonical, model, event_handler: handler)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+
+    terminal_result =
+      Requests.list_request_step_events(request) |> List.last() |> Map.fetch!(:result)
+
+    assert terminal_result["attempt_outcome"] == "cancelled"
+    assert terminal_result["failure_class"] == "cancellation"
+    assert terminal_result["retry_decision"] == "cancelled"
+
+    assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id})
+    assert decision.contribution_count == 0
+  end
+
   test "SPEC.md §§5.8 and 7.2.7 caller cancellation wins when the deadline lapses during delivery",
        %{bundle: bundle} do
     put_capturing_runtime_adapter_config()

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -57,10 +57,10 @@
 ## 7. Breaker attribution prerequisite
 
 - [x] 7.0 Implement the durable Node and placement breaker foundation separately through #296 and `node-placement-circuit-breaker-foundation`
-- [ ] 7.1 Attribute each actual breaker-eligible failure to its producing Node or placement using the `SPEC.md` §5.10 eligible failure-class mapping, excluding `capacity_rejection`
-- [ ] 7.2 Make attempt 1 breaker effects durable and visible before alternate scheduling
-- [ ] 7.3 Prove retry decisions and declined retries add no breaker events
-- [ ] 7.4 Preserve existing breaker thresholds, windows, suppression durations, and Operator clear behavior
+- [x] 7.1 Attribute each actual breaker-eligible failure to its producing Node or placement using the `SPEC.md` §5.10 eligible failure-class mapping, excluding `capacity_rejection`
+- [x] 7.2 Make attempt 1 breaker effects durable and visible before alternate scheduling
+- [x] 7.3 Prove retry decisions and declined retries add no breaker events
+- [x] 7.4 Preserve existing breaker thresholds, windows, suppression durations, and Operator clear behavior
 
 ## 8. Bounded orchestrator retry
 


### PR DESCRIPTION
## Summary

Each breaker-eligible inference attempt now contributes exactly once to the existing breaker for the Node or Node and Model placement that produced the failure.
Attribution uses the post-delivery selected outcome, then the breaker write completes before Orchard evaluates retry or terminal orchestration.

This is the breaker-attribution prerequisite for automatic attempt retry after the durable breaker foundation in #296.
Bounded orchestrator retry remains follow-on work.

## Design decisions

- Derive a stable breaker failure identity from the Request ID and attempt number so defensive redelivery is idempotent.
- Attribute pre-acceptance unavailability and worker or Node loss to the Node breaker.
- Attribute model-load failures to the Node and Model placement breaker.
- Use the final selected outcome so event-delivery cancellation does not contribute stale worker-loss evidence.
- Honor explicit runtime non-retryable outcomes for worker or Node loss while retaining their breaker attribution.
- Keep failures without a persistent Node identity non-attributable.
- Preserve the existing public model-load error mapping for compatibility.
- Fail closed when an attributable breaker mutation cannot become durable.

## Risk Assessment

⚠️ **Medium**

- The change affects failure handling in the Controller dispatch path, including failure taxonomy used by retry classification.
- Breaker policy, thresholds, suppression windows, Operator clear behavior, and database schema are unchanged.
- Attribution is fail closed, and durable breaker state is recorded before downstream retry or terminal decisions.
- Regression coverage includes exact-once delivery, Node and placement targeting, ordering, delivery cancellation, declined retry behavior, public API compatibility, and unmanaged identity handling.

## Validation

- `make check-elixir`
  - Formatting, warning-free compilation, Credo strict, Dialyzer, macOS helper staging, full tests, and coverage passed.
  - 4,929 tests passed across the umbrella, with 6 skipped and 10 CLI integration tests excluded by the standard gate.
  - Coverage: Shared 67.25%, Controller 85.2%, Node Agent 78.33%, CLI 76.40%.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate automatic-attempt-retry --type change --strict --no-interactive`
  - Passed.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
  - 32 passed, 0 failed.

## PR Checklist

- [x] I checked whether this changes `SPEC.md` behavior.
- [x] I updated docs, tests, or decisions that the change affects.
- [x] I ran relevant validation and recorded outcomes.
- [x] I did not commit active goal packages or private local artifacts.
- [x] I did not introduce dependencies on private workbench or session context.

Closes #170

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790494958&installation_model_id=428414&pr_number=304&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F304&signature=aa81bdd56d4be1192a51a7bc6837cb83098d31d8b613cbc990e01ee4bc6d13ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
