### PR TITLE
feat(inference): run one alternate-Node attempt on the original Request

### DIFF
--- a/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
+++ b/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
@@ -9,24 +9,29 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
     @enforce_keys [
       :attempt,
       :output_committed,
-      :budget_remaining?,
-      :cancelled?,
+      :caller_status,
+      :deadline_status,
       :failure_class,
       :failure_code,
       :runtime_retryable,
-      :alternate_available?
+      :identity_resolution,
+      :execution_resolution,
+      :capacity_release_outcome
     ]
     defstruct @enforce_keys
 
     @type t :: %__MODULE__{
             attempt: 1 | 2,
             output_committed: boolean(),
-            budget_remaining?: boolean(),
-            cancelled?: boolean(),
+            caller_status: :live | :cancelled,
+            deadline_status: :remaining | :exhausted,
             failure_class: String.t(),
             failure_code: String.t(),
             runtime_retryable: boolean() | nil,
-            alternate_available?: boolean()
+            identity_resolution: :resolved | :unresolved,
+            execution_resolution: :not_started | :terminated | :unresolved,
+            capacity_release_outcome:
+              :released | :already_released | :not_applicable | :unresolved
           }
   end
 
@@ -45,9 +50,13 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
     :cancelled,
     :budget_exhausted,
     :taxonomy,
-    :alternate
+    :identity,
+    :execution,
+    :capacity_release
   ]
 
+  @type alternate_result :: :different_node | :no_candidate | :identity_unresolved
+  @type pre_schedule_result :: :eligible_for_alternate | {:declined, retry_decision_atom()}
   @type retry_decision_atom ::
           :retried
           | :not_retryable
@@ -63,12 +72,14 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
   @spec new(%{
           attempt: 1 | 2,
           output_committed: boolean(),
-          budget_remaining?: boolean(),
-          cancelled?: boolean(),
+          caller_status: :live | :cancelled,
+          deadline_status: :remaining | :exhausted,
           failure_class: String.t(),
           failure_code: String.t(),
           runtime_retryable: boolean() | nil,
-          alternate_available?: boolean()
+          identity_resolution: :resolved | :unresolved,
+          execution_resolution: :not_started | :terminated | :unresolved,
+          capacity_release_outcome: :released | :already_released | :not_applicable | :unresolved
         }) :: t()
   def new(attrs) when is_map(attrs) do
     if Map.has_key?(attrs, :raw_source_code) or Map.has_key?(attrs, "raw_source_code") do
@@ -78,62 +89,119 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
     build_boundary(attrs)
   end
 
-  @spec decide(t()) :: retry_decision_atom()
-  def decide(%Boundary{attempt: 2, cancelled?: true}), do: :cancelled
-  def decide(%Boundary{attempt: 2}), do: :retry_exhausted
+  @spec pre_schedule(t()) :: pre_schedule_result()
+  def pre_schedule(%Boundary{attempt: 2, caller_status: :cancelled}),
+    do: {:declined, :cancelled}
 
-  def decide(%Boundary{attempt: 1} = boundary) do
-    Enum.find_value(@attempt_one_gates, &gate_decision(&1, boundary))
+  def pre_schedule(%Boundary{attempt: 2}), do: {:declined, :retry_exhausted}
+
+  def pre_schedule(%Boundary{attempt: 1} = boundary),
+    do: Enum.find_value(@attempt_one_gates, :eligible_for_alternate, &gate_decision(&1, boundary))
+
+  @spec finalize_alternate(t(), alternate_result()) ::
+          :retried | :no_alternative_node | :identity_unresolved
+  def finalize_alternate(%Boundary{attempt: 1} = boundary, alternate_result)
+      when alternate_result in [:different_node, :no_candidate, :identity_unresolved] do
+    case pre_schedule(boundary) do
+      :eligible_for_alternate ->
+        alternate_decision(alternate_result)
+
+      {:declined, decision} ->
+        raise ArgumentError, "cannot finalize declined retry boundary: #{decision}"
+    end
   end
 
   defp build_boundary(%{
          attempt: attempt,
          output_committed: output_committed,
-         budget_remaining?: budget_remaining?,
-         cancelled?: cancelled?,
+         caller_status: caller_status,
+         deadline_status: deadline_status,
          failure_class: failure_class,
          failure_code: failure_code,
          runtime_retryable: runtime_retryable,
-         alternate_available?: alternate_available?
-       })
-       when attempt in [1, 2] and is_boolean(output_committed) and
-              is_boolean(budget_remaining?) and is_boolean(cancelled?) and
-              is_binary(failure_class) and is_binary(failure_code) and
-              (is_boolean(runtime_retryable) or is_nil(runtime_retryable)) and
-              is_boolean(alternate_available?) do
+         identity_resolution: identity_resolution,
+         execution_resolution: execution_resolution,
+         capacity_release_outcome: capacity_release_outcome
+       }) do
+    :ok = validate_request_facts(attempt, output_committed, caller_status, deadline_status)
+    :ok = validate_failure_facts(failure_class, failure_code, runtime_retryable)
+    :ok = validate_identity_fact(identity_resolution)
+    :ok = validate_occupancy_facts(execution_resolution, capacity_release_outcome)
+
     %Boundary{
       attempt: attempt,
       output_committed: output_committed,
-      budget_remaining?: budget_remaining?,
-      cancelled?: cancelled?,
+      caller_status: caller_status,
+      deadline_status: deadline_status,
       failure_class: failure_class,
       failure_code: failure_code,
       runtime_retryable: runtime_retryable,
-      alternate_available?: alternate_available?
+      identity_resolution: identity_resolution,
+      execution_resolution: execution_resolution,
+      capacity_release_outcome: capacity_release_outcome
     }
   end
 
+  defp validate_request_facts(attempt, output_committed, caller_status, deadline_status)
+       when attempt in [1, 2] and is_boolean(output_committed) and
+              caller_status in [:live, :cancelled] and
+              deadline_status in [:remaining, :exhausted],
+       do: :ok
+
+  defp validate_failure_facts(failure_class, failure_code, runtime_retryable)
+       when is_binary(failure_class) and is_binary(failure_code) and
+              (is_boolean(runtime_retryable) or is_nil(runtime_retryable)),
+       do: :ok
+
+  defp validate_identity_fact(identity_resolution)
+       when identity_resolution in [:resolved, :unresolved],
+       do: :ok
+
+  defp validate_occupancy_facts(execution_resolution, capacity_release_outcome)
+       when execution_resolution in [:not_started, :terminated, :unresolved] and
+              capacity_release_outcome in [
+                :released,
+                :already_released,
+                :not_applicable,
+                :unresolved
+              ],
+       do: :ok
+
   defp gate_decision(:output_committed, %Boundary{output_committed: true}),
-    do: :output_committed
+    do: {:declined, :output_committed}
 
-  defp gate_decision(:budget_exhausted, %Boundary{budget_remaining?: false}),
-    do: :budget_exhausted
+  defp gate_decision(:budget_exhausted, %Boundary{deadline_status: :exhausted}),
+    do: {:declined, :budget_exhausted}
 
-  defp gate_decision(:cancelled, %Boundary{cancelled?: true}), do: :cancelled
+  defp gate_decision(:cancelled, %Boundary{caller_status: :cancelled}),
+    do: {:declined, :cancelled}
+
   defp gate_decision(:taxonomy, boundary), do: taxonomy_verdict(boundary)
-  defp gate_decision(:alternate, %Boundary{alternate_available?: true}), do: :retried
-  defp gate_decision(:alternate, %Boundary{}), do: :no_alternative_node
+
+  defp gate_decision(:identity, %Boundary{identity_resolution: :unresolved}),
+    do: {:declined, :identity_unresolved}
+
+  defp gate_decision(:execution, %Boundary{execution_resolution: :unresolved}),
+    do: {:declined, :occupancy_unresolved}
+
+  defp gate_decision(:capacity_release, %Boundary{capacity_release_outcome: :unresolved}),
+    do: {:declined, :occupancy_unresolved}
+
   defp gate_decision(_gate, %Boundary{}), do: nil
 
   defp taxonomy_verdict(%Boundary{failure_class: "identity_unresolved"}),
-    do: :identity_unresolved
+    do: {:declined, :identity_unresolved}
 
   defp taxonomy_verdict(%Boundary{failure_class: "occupancy_unresolved"}),
-    do: :occupancy_unresolved
+    do: {:declined, :occupancy_unresolved}
 
   defp taxonomy_verdict(%Boundary{} = boundary) do
-    if retry_eligible?(boundary), do: nil, else: :not_retryable
+    if retry_eligible?(boundary), do: nil, else: {:declined, :not_retryable}
   end
+
+  defp alternate_decision(:different_node), do: :retried
+  defp alternate_decision(:no_candidate), do: :no_alternative_node
+  defp alternate_decision(:identity_unresolved), do: :identity_unresolved
 
   defp retry_eligible?(%Boundary{
          failure_class: "runtime_failure",

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -16,6 +16,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   alias Orchard.Inference.{
     AdmissionPolicy,
     AttemptBreakerAttribution,
+    AttemptContext,
     AttemptRetryClassifier,
     CacheAffinity,
     CanonicalRequestSerializer,
@@ -646,7 +647,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          model,
          schedule,
          execution_opts,
-         step_context
+         %AttemptContext{} = context
        ) do
     case dispatch(
            db_request,
@@ -658,37 +659,35 @@ defmodule Orchard.Inference.RequestOrchestrator do
            Map.get(execution_opts, :queue_grant)
          ) do
       %AttemptOutcome{} = pending_outcome ->
-        outcome =
-          AttemptOutcome.select(
-            pending_outcome,
-            canonical.public_id,
-            execution_opts.event_handler
-          )
-
-        case record_attempt_breaker_failure(db_request, model, step_context, outcome) do
+        case record_attempt_breaker_failure(db_request, model, context, pending_outcome) do
           :ok ->
-            continue_selected_attempt(
+            continue_after_breaker(
               db_request,
               canonical,
-              outcome,
+              model,
               execution_opts,
-              step_context
+              context,
+              pending_outcome
             )
 
           {:error, reason} ->
-            {:error, reason, Map.put(step_context, :attempt_outcome, outcome)}
+            decision =
+              finished_attempt_decision(pending_outcome, db_request, context, execution_opts)
+
+            {:error, reason, terminal_evidence(context, pending_outcome, decision)}
         end
 
       {:error, reason} ->
         outcome = failed_dispatch_outcome(schedule)
-        {:error, reason, Map.put(step_context, :attempt_outcome, outcome)}
+        decision = finished_attempt_decision(outcome, db_request, context, execution_opts)
+        {:error, reason, terminal_evidence(context, outcome, decision)}
     end
   end
 
-  defp record_attempt_breaker_failure(db_request, model, step_context, outcome) do
+  defp record_attempt_breaker_failure(db_request, model, context, outcome) do
     case AttemptBreakerAttribution.record(
            db_request.id,
-           step_context.attempt,
+           context.attempt,
            Map.get(model, :id),
            outcome
          ) do
@@ -697,17 +696,446 @@ defmodule Orchard.Inference.RequestOrchestrator do
     end
   end
 
+  defp continue_after_breaker(
+         db_request,
+         canonical,
+         model,
+         execution_opts,
+         %AttemptContext{attempt: 1} = context,
+         %AttemptOutcome{attempt_outcome: attempt_outcome, delivery_state: :pending} =
+           pending_outcome
+       )
+       when attempt_outcome != :completed do
+    continue_attempt_one_after_breaker(
+      db_request,
+      canonical,
+      model,
+      execution_opts,
+      context,
+      pending_outcome
+    )
+  end
+
+  defp continue_after_breaker(
+         db_request,
+         canonical,
+         _model,
+         execution_opts,
+         %AttemptContext{} = context,
+         %AttemptOutcome{} = pending_outcome
+       ) do
+    selected = select_attempt_outcome(pending_outcome, canonical, execution_opts)
+    decision = finished_attempt_decision(selected, db_request, context, execution_opts)
+
+    continue_selected_attempt(
+      db_request,
+      canonical,
+      selected,
+      execution_opts,
+      context,
+      decision
+    )
+  end
+
+  defp continue_attempt_one_after_breaker(
+         db_request,
+         canonical,
+         model,
+         execution_opts,
+         %AttemptContext{} = context,
+         %AttemptOutcome{} = pending_outcome
+       ) do
+    boundary = retry_boundary(pending_outcome, db_request, context, execution_opts)
+
+    case AttemptRetryClassifier.pre_schedule(boundary) do
+      {:declined, decision} ->
+        decline_attempt_one(
+          db_request,
+          canonical,
+          pending_outcome,
+          execution_opts,
+          context,
+          decision
+        )
+
+      :eligible_for_alternate ->
+        case persist_attempt_one_state(db_request.id, pending_outcome) do
+          :ok ->
+            start_alternate_attempt(
+              db_request,
+              canonical,
+              model,
+              execution_opts,
+              context,
+              pending_outcome
+            )
+
+          {:error, reason} ->
+            {:error, {:attempt_one_state_transition_failed, reason},
+             terminal_evidence(context, pending_outcome, :not_retryable)}
+        end
+    end
+  end
+
+  defp persist_attempt_one_state(request_id, %AttemptOutcome{accepted: true}) do
+    case RequestServer.get_state(request_id) do
+      {:ok, :running} -> :ok
+      {:ok, _state} -> advance_fsm(request_id, :running)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp persist_attempt_one_state(request_id, %AttemptOutcome{accepted: false}) do
+    case RequestServer.get_state(request_id) do
+      {:ok, :dispatching} -> :ok
+      other -> {:error, {:unexpected_unaccepted_attempt_state, other}}
+    end
+  end
+
+  defp start_alternate_attempt(
+         db_request,
+         canonical,
+         model,
+         execution_opts,
+         %AttemptContext{} = context,
+         %AttemptOutcome{} = pending_outcome
+       ) do
+    with_live_retry_boundary(
+      db_request,
+      canonical,
+      pending_outcome,
+      execution_opts,
+      context,
+      fn _boundary ->
+        result =
+          schedule_alternate_request(canonical, [pending_outcome.node_id], db_request.timeout_at)
+
+        with_live_retry_boundary(
+          db_request,
+          canonical,
+          pending_outcome,
+          execution_opts,
+          context,
+          fn _post_schedule_boundary ->
+            handle_alternate_schedule_result(
+              result,
+              db_request,
+              canonical,
+              model,
+              execution_opts,
+              context,
+              pending_outcome
+            )
+          end
+        )
+      end
+    )
+  end
+
+  defp handle_alternate_schedule_result(
+         {:candidate, alternate_schedule, persistence_metadata},
+         db_request,
+         canonical,
+         model,
+         execution_opts,
+         context,
+         pending_outcome
+       ) do
+    case record_scheduler_decision(db_request, persistence_metadata) do
+      {:ok, _request} ->
+        run_retry_persist_probe()
+
+        with_live_retry_boundary(
+          db_request,
+          canonical,
+          pending_outcome,
+          execution_opts,
+          context,
+          fn boundary ->
+            persist_and_dispatch_alternate(
+              db_request,
+              canonical,
+              model,
+              alternate_schedule,
+              execution_opts,
+              context,
+              pending_outcome,
+              AttemptRetryClassifier.finalize_alternate(boundary, :different_node)
+            )
+          end
+        )
+
+      {:error, reason} ->
+        {:error, {:alternate_schedule_persist_failed, reason},
+         terminal_evidence(context, pending_outcome, :not_retryable)}
+    end
+  end
+
+  defp handle_alternate_schedule_result(
+         {:no_candidate, _reason, persistence_metadata},
+         db_request,
+         canonical,
+         _model,
+         execution_opts,
+         context,
+         pending_outcome
+       ) do
+    persist_alternate_rejection(db_request, persistence_metadata)
+
+    with_live_retry_boundary(
+      db_request,
+      canonical,
+      pending_outcome,
+      execution_opts,
+      context,
+      fn boundary ->
+        decline_attempt_one(
+          db_request,
+          canonical,
+          pending_outcome,
+          execution_opts,
+          context,
+          AttemptRetryClassifier.finalize_alternate(boundary, :no_candidate)
+        )
+      end
+    )
+  end
+
+  defp handle_alternate_schedule_result(
+         {:identity_unresolved, persistence_metadata},
+         db_request,
+         canonical,
+         _model,
+         execution_opts,
+         context,
+         pending_outcome
+       ) do
+    persist_alternate_rejection(db_request, persistence_metadata)
+
+    with_live_retry_boundary(
+      db_request,
+      canonical,
+      pending_outcome,
+      execution_opts,
+      context,
+      fn boundary ->
+        decline_attempt_one(
+          db_request,
+          canonical,
+          pending_outcome,
+          execution_opts,
+          context,
+          AttemptRetryClassifier.finalize_alternate(boundary, :identity_unresolved)
+        )
+      end
+    )
+  end
+
+  defp handle_alternate_schedule_result(
+         {:orchestration_error, reason},
+         _db_request,
+         _canonical,
+         _model,
+         _execution_opts,
+         context,
+         pending_outcome
+       ) do
+    {:error, reason, terminal_evidence(context, pending_outcome, :not_retryable)}
+  end
+
+  defp persist_alternate_rejection(db_request, metadata),
+    do: persist_rejected_scheduler_decision(db_request, metadata)
+
+  defp persist_and_dispatch_alternate(
+         db_request,
+         canonical,
+         model,
+         alternate_schedule,
+         execution_opts,
+         %AttemptContext{} = attempt_one_context,
+         %AttemptOutcome{} = pending_outcome,
+         :retried
+       ) do
+    attempt_two_context = inference_turn_step_context(canonical, 2, [pending_outcome.node_id])
+
+    case persist_retried_attempt_boundary(
+           db_request,
+           pending_outcome,
+           attempt_one_context,
+           attempt_two_context,
+           execution_opts
+         ) do
+      {:ok, {:attempt_two_started, persisted_attempt_two_context}} ->
+        dispatch_persisted_alternate(
+          db_request,
+          canonical,
+          model,
+          alternate_schedule,
+          execution_opts,
+          pending_outcome,
+          persisted_attempt_two_context
+        )
+
+      {:error, reason} ->
+        {:error, reason, terminal_evidence(attempt_one_context, pending_outcome, :not_retryable)}
+    end
+  end
+
+  defp dispatch_persisted_alternate(
+         db_request,
+         canonical,
+         model,
+         alternate_schedule,
+         execution_opts,
+         pending_outcome,
+         %AttemptContext{} = attempt_two_context
+       ) do
+    with :ok <- authorize_attempt_two_fsm(db_request.id),
+         {:ok, _discarded} <- AttemptOutcome.discard(pending_outcome) do
+      dispatch_alternate_if_live(
+        db_request,
+        canonical,
+        model,
+        alternate_schedule,
+        execution_opts,
+        attempt_two_context
+      )
+    else
+      {:error, reason} ->
+        terminalize_started_attempt_two_controller(
+          alternate_schedule,
+          attempt_two_context,
+          reason
+        )
+    end
+  end
+
+  defp authorize_attempt_two_fsm(request_id), do: RequestServer.start_attempt_two(request_id)
+
+  defp dispatch_alternate_if_live(
+         db_request,
+         canonical,
+         model,
+         alternate_schedule,
+         execution_opts,
+         attempt_two_context
+       ) do
+    snapshot = retry_gate_snapshot(execution_opts.caller, db_request.timeout_at, nil)
+
+    case snapshot do
+      %{caller_status: :cancelled} ->
+        terminalize_started_attempt_two(alternate_schedule, attempt_two_context, :cancelled)
+
+      %{deadline_status: :exhausted} ->
+        terminalize_started_attempt_two(
+          alternate_schedule,
+          attempt_two_context,
+          :budget_exhausted
+        )
+
+      _open ->
+        dispatch_started_inference_turn(
+          db_request,
+          canonical,
+          model,
+          alternate_schedule,
+          execution_opts,
+          attempt_two_context
+        )
+    end
+  end
+
+  defp decline_attempt_one(
+         _db_request,
+         _canonical,
+         %AttemptOutcome{attempt_outcome: attempt_outcome} = pending_outcome,
+         _execution_opts,
+         %AttemptContext{} = context,
+         :cancelled
+       )
+       when attempt_outcome != :cancelled do
+    _ = AttemptOutcome.discard(pending_outcome)
+    cancelled = cancel_attempt_outcome(pending_outcome)
+
+    {:error, {:dispatch_failed, :request_caller_disconnect},
+     terminal_evidence(context, cancelled, :cancelled)}
+  end
+
+  defp decline_attempt_one(
+         db_request,
+         canonical,
+         %AttemptOutcome{} = pending_outcome,
+         execution_opts,
+         %AttemptContext{} = context,
+         planned_decision
+       ) do
+    selected = select_attempt_outcome(pending_outcome, canonical, execution_opts)
+    decision = selected_decline_decision(selected, db_request, execution_opts, planned_decision)
+
+    continue_selected_attempt(
+      db_request,
+      canonical,
+      selected,
+      execution_opts,
+      context,
+      decision
+    )
+  end
+
+  defp cancel_attempt_outcome(%AttemptOutcome{} = outcome) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    attrs = %{
+      outcome
+      | attempt_outcome: :cancelled,
+        failure:
+          InferenceAttemptFailure.normalize(%{
+            category: :cancellation,
+            code: :request_caller_disconnect
+          }),
+        ended_at: now
+    }
+
+    {:ok, cancelled} = AttemptOutcome.new(Map.from_struct(attrs))
+    cancelled
+  end
+
+  defp selected_decline_decision(selected, db_request, execution_opts, planned_decision) do
+    boundary = retry_boundary(selected, db_request, 1, execution_opts)
+
+    case AttemptRetryClassifier.pre_schedule(boundary) do
+      {:declined, decision}
+      when decision in [:output_committed, :cancelled, :budget_exhausted] ->
+        decision
+
+      _other ->
+        planned_decision
+    end
+  end
+
+  defp select_attempt_outcome(
+         %AttemptOutcome{delivery_state: :pending} = outcome,
+         canonical,
+         execution_opts
+       ) do
+    AttemptOutcome.select(outcome, canonical.public_id, execution_opts.event_handler)
+  end
+
+  defp select_attempt_outcome(%AttemptOutcome{} = outcome, _canonical, _execution_opts),
+    do: outcome
+
   defp continue_selected_attempt(
          db_request,
          canonical,
          %AttemptOutcome{} = outcome,
          execution_opts,
-         step_context
+         %AttemptContext{} = context,
+         retry_decision
        ) do
     cond do
       outcome.delivery_state == :failed ->
         {:error, public_dispatch_reason(outcome),
-         Map.put(step_context, :attempt_outcome, outcome)}
+         terminal_evidence(context, outcome, retry_decision)}
 
       Enum.any?(outcome.events, &InferenceEvent.terminal?/1) ->
         finalize_started_inference_turn(
@@ -715,27 +1143,43 @@ defmodule Orchard.Inference.RequestOrchestrator do
           canonical,
           outcome,
           execution_opts,
-          step_context
+          context,
+          retry_decision
         )
 
       true ->
         {:error, public_dispatch_reason(outcome),
-         Map.put(step_context, :attempt_outcome, outcome)}
+         terminal_evidence(context, outcome, retry_decision)}
     end
   end
 
   defp failed_dispatch_outcome(schedule) do
+    started_attempt_outcome(
+      schedule,
+      :failed,
+      InferenceAttemptFailure.normalize(%{category: :controller, code: :orchestration_error}),
+      :unresolved,
+      :unresolved
+    )
+  end
+
+  defp started_attempt_outcome(
+         schedule,
+         attempt_outcome,
+         failure,
+         execution_resolution,
+         capacity_release_outcome
+       ) do
     now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
 
     attrs = %{
-      attempt_outcome: :failed,
+      attempt_outcome: attempt_outcome,
       node_id: trusted_node_id(schedule),
       accepted: false,
       events: [],
-      failure:
-        InferenceAttemptFailure.normalize(%{category: :controller, code: :orchestration_error}),
-      execution_resolution: :unresolved,
-      capacity_release_outcome: :unresolved,
+      failure: failure,
+      execution_resolution: execution_resolution,
+      capacity_release_outcome: capacity_release_outcome,
       started_at: now,
       ended_at: now,
       first_token_at: nil,
@@ -749,6 +1193,207 @@ defmodule Orchard.Inference.RequestOrchestrator do
     {:ok, outcome} = AttemptOutcome.new(attrs)
     outcome
   end
+
+  defp schedule_alternate_request(canonical, exclude_node_ids, timeout_at) do
+    case call_scheduler(canonical, exclude_node_ids) do
+      {:ok, schedule} when is_map(schedule) ->
+        classify_alternate_scheduler_selection(schedule, exclude_node_ids, timeout_at)
+
+      {:error, reason, decision} when is_map(decision) ->
+        {:no_candidate, reason, decision}
+
+      {:error, {:orchestration_crash, _details} = reason} ->
+        {:orchestration_error, reason}
+
+      {:error, reason} ->
+        {:orchestration_error, orchestration_crash(:scheduler, {:missing_decision, reason})}
+
+      other ->
+        {:orchestration_error, orchestration_crash(:scheduler, {:invalid_return, other})}
+    end
+  end
+
+  defp classify_alternate_scheduler_selection(schedule, exclude_node_ids, timeout_at) do
+    case validate_scheduler_selection(schedule, exclude_node_ids) do
+      :ok ->
+        accepted = Map.put(schedule, :timeout_at, timeout_at)
+        {:candidate, accepted, scheduler_persistence_metadata(accepted)}
+
+      {:error, {:dispatch_failed, :identity_unresolved}} ->
+        {:identity_unresolved, scheduler_persistence_metadata(schedule)}
+    end
+  end
+
+  defp persist_retried_attempt_boundary(
+         db_request,
+         %AttemptOutcome{} = attempt_one_outcome,
+         %AttemptContext{} = attempt_one_context,
+         %AttemptContext{} = attempt_two_context,
+         execution_opts
+       ) do
+    terminal_attrs = unsuccessful_attempt_terminal_attrs(attempt_one_outcome)
+
+    steps = [
+      terminal_inference_turn_step(
+        db_request,
+        attempt_one_outcome.events,
+        terminal_attrs,
+        attempt_one_context,
+        attempt_one_outcome,
+        :retried
+      ),
+      inference_turn_started_step(attempt_two_context)
+    ]
+
+    case execution_opts.step_event_appender.(db_request, steps) do
+      {:ok, _step_events} -> {:ok, {:attempt_two_started, attempt_two_context}}
+      {:error, reason} -> {:error, {:request_step_start_failed, reason}}
+    end
+  end
+
+  defp unsuccessful_attempt_terminal_attrs(%AttemptOutcome{events: events} = outcome) do
+    if Enum.any?(events, &InferenceEvent.terminal?/1) do
+      terminal_attrs_from_events(events)
+    else
+      outcome
+      |> public_dispatch_reason()
+      |> ChatError.from_execute_error()
+      |> ChatError.terminal_attrs()
+    end
+  end
+
+  defp terminalize_started_attempt_two(schedule, context, :cancelled) do
+    failure =
+      InferenceAttemptFailure.normalize(%{
+        category: :cancellation,
+        code: :request_caller_disconnect
+      })
+
+    outcome =
+      started_attempt_outcome(schedule, :cancelled, failure, :not_started, :not_applicable)
+
+    {:error, {:dispatch_failed, :request_caller_disconnect},
+     terminal_evidence(context, outcome, :cancelled)}
+  end
+
+  defp terminalize_started_attempt_two(schedule, context, :budget_exhausted) do
+    failure = InferenceAttemptFailure.normalize(%{category: :deadline, code: :request_timeout})
+
+    outcome =
+      started_attempt_outcome(schedule, :timed_out, failure, :not_started, :not_applicable)
+
+    {:error, {:dispatch_failed, :request_timeout},
+     terminal_evidence(context, outcome, :retry_exhausted)}
+  end
+
+  defp terminalize_started_attempt_two_controller(schedule, context, reason) do
+    failure =
+      InferenceAttemptFailure.normalize(%{category: :controller, code: :orchestration_error})
+
+    outcome = started_attempt_outcome(schedule, :failed, failure, :not_started, :not_applicable)
+
+    {:error, orchestration_crash(:attempt_two_start, reason),
+     terminal_evidence(context, outcome, :retry_exhausted)}
+  end
+
+  defp finished_attempt_decision(
+         %AttemptOutcome{attempt_outcome: :completed},
+         _db_request,
+         _context,
+         _execution_opts
+       ),
+       do: nil
+
+  defp finished_attempt_decision(outcome, db_request, context, execution_opts) do
+    boundary = retry_boundary(outcome, db_request, context, execution_opts)
+
+    case AttemptRetryClassifier.pre_schedule(boundary) do
+      {:declined, decision} -> decision
+      :eligible_for_alternate -> :not_retryable
+    end
+  end
+
+  defp with_live_retry_boundary(
+         db_request,
+         canonical,
+         pending_outcome,
+         execution_opts,
+         %AttemptContext{} = context,
+         on_eligible
+       )
+       when is_function(on_eligible, 1) do
+    boundary = retry_boundary(pending_outcome, db_request, context, execution_opts)
+
+    case AttemptRetryClassifier.pre_schedule(boundary) do
+      {:declined, decision} ->
+        decline_attempt_one(
+          db_request,
+          canonical,
+          pending_outcome,
+          execution_opts,
+          context,
+          decision
+        )
+
+      :eligible_for_alternate ->
+        on_eligible.(boundary)
+    end
+  end
+
+  defp run_retry_persist_probe do
+    case Process.get(:orchard_retry_persist_probe) do
+      fun when is_function(fun, 0) -> fun.()
+      _other -> :ok
+    end
+  end
+
+  defp retry_boundary(outcome, db_request, %AttemptContext{attempt: attempt}, execution_opts),
+    do: retry_boundary(outcome, db_request, attempt, execution_opts)
+
+  defp retry_boundary(outcome, db_request, attempt, execution_opts) do
+    snapshot = retry_gate_snapshot(execution_opts.caller, db_request.timeout_at, outcome)
+
+    %{
+      attempt: attempt,
+      output_committed: outcome.output_committed,
+      caller_status: snapshot.caller_status,
+      deadline_status: snapshot.deadline_status,
+      failure_class: Map.fetch!(outcome.failure, "failure_class"),
+      failure_code: Map.fetch!(outcome.failure, "failure_code"),
+      runtime_retryable: outcome.runtime_retryable,
+      identity_resolution: identity_resolution(outcome),
+      execution_resolution: outcome.execution_resolution,
+      capacity_release_outcome: outcome.capacity_release_outcome
+    }
+    |> AttemptRetryClassifier.new()
+  end
+
+  defp retry_gate_snapshot(caller, timeout_at, outcome) do
+    caller_status =
+      if match?(%AttemptOutcome{attempt_outcome: :cancelled}, outcome) or
+           not Process.alive?(caller) do
+        :cancelled
+      else
+        :live
+      end
+
+    deadline_status =
+      if RequestDeadline.remaining_ms(timeout_at, DateTime.utc_now()) > 0,
+        do: :remaining,
+        else: :exhausted
+
+    %{caller_status: caller_status, deadline_status: deadline_status}
+  end
+
+  defp identity_resolution(%AttemptOutcome{node_id: node_id}) do
+    if match?({:ok, _uuid}, Ecto.UUID.cast(node_id)), do: :resolved, else: :unresolved
+  end
+
+  defp terminal_evidence(%AttemptContext{attempt: 1} = context, outcome, decision),
+    do: {:attempt_one_declined, context, outcome, decision}
+
+  defp terminal_evidence(%AttemptContext{attempt: 2} = context, outcome, decision),
+    do: {:attempt_two_finished, context, outcome, decision}
 
   defp trusted_node_id(schedule) do
     case Map.get(schedule, :node_id) do
@@ -765,15 +1410,24 @@ defmodule Orchard.Inference.RequestOrchestrator do
          canonical,
          %AttemptOutcome{} = outcome,
          execution_opts,
-         step_context
+         %AttemptContext{} = context,
+         retry_decision
        ) do
-    case finalize(db_request, canonical, outcome, execution_opts, step_context) do
+    case finalize(
+           db_request,
+           canonical,
+           outcome,
+           execution_opts,
+           context,
+           retry_decision
+         ) do
       {:ok, _, _} = success ->
         success
 
       {:error, reason} ->
         failed_outcome = AttemptOutcome.fail_attempt(outcome)
-        {:error, reason, Map.put(step_context, :attempt_outcome, failed_outcome)}
+        decision = finished_attempt_decision(failed_outcome, db_request, context, execution_opts)
+        {:error, reason, terminal_evidence(context, failed_outcome, decision)}
     end
   end
 
@@ -1441,7 +2095,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
          canonical,
          %AttemptOutcome{events: events, first_token_at: first_token_at} = outcome,
          execution_opts,
-         step_context
+         %AttemptContext{} = context,
+         retry_decision
        ) do
     case build_terminal_attrs(
            canonical,
@@ -1455,8 +2110,9 @@ defmodule Orchard.Inference.RequestOrchestrator do
           canonical,
           events,
           terminal_attrs,
-          Map.put(step_context, :attempt_outcome, outcome),
-          execution_opts.step_event_appender,
+          context,
+          outcome,
+          retry_decision,
           execution_opts.terminal_persister
         )
 
@@ -1506,11 +2162,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
          canonical,
          events,
          terminal_attrs,
-         step_context,
-         _step_event_appender,
+         %AttemptContext{} = context,
+         %AttemptOutcome{} = outcome,
+         retry_decision,
          terminal_persister
        ) do
-    advance_fsm_best_effort(db_request.id, events, step_context[:attempt_outcome])
+    advance_fsm_best_effort(db_request.id, events, outcome)
 
     case terminal_persister.(
            db_request,
@@ -1520,7 +2177,9 @@ defmodule Orchard.Inference.RequestOrchestrator do
              canonical,
              events,
              terminal_attrs,
-             step_context
+             context,
+             outcome,
+             retry_decision
            )
          ) do
       {:ok, _updated} ->
@@ -1562,12 +2221,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
   defp advance_attempt_fsm_best_effort(
          request_id,
-         %{attempt_outcome: %AttemptOutcome{} = outcome}
+         {_owner, %AttemptContext{}, %AttemptOutcome{} = outcome, _decision}
        ) do
     advance_fsm_best_effort(request_id, outcome.events, outcome)
   end
 
-  defp advance_attempt_fsm_best_effort(_request_id, _step_context), do: :ok
+  defp advance_attempt_fsm_best_effort(_request_id, _terminal_evidence), do: :ok
 
   defp advance_fsm_best_effort(request_id, _events, %AttemptOutcome{} = outcome) do
     if outcome.accepted do
@@ -1576,14 +2235,6 @@ defmodule Orchard.Inference.RequestOrchestrator do
       if outcome.output_committed do
         try_advance(request_id, :streaming)
       end
-    end
-  end
-
-  defp advance_fsm_best_effort(request_id, events, nil) do
-    try_advance(request_id, :running)
-
-    if Enum.any?(events, &(InferenceEvent.kind(&1) == :output_text_delta)) do
-      try_advance(request_id, :streaming)
     end
   end
 
@@ -1655,14 +2306,17 @@ defmodule Orchard.Inference.RequestOrchestrator do
     |> ChatError.terminal_attrs()
   end
 
-  defp inference_turn_step_context(canonical) do
-    %{
-      turn_index: 1,
-      attempt: 1,
-      step_id: RequestStepEvent.inference_turn_step_id(1, 1),
-      model_id: canonical.model_ref.model_id,
-      model_version: canonical.model_ref.version
-    }
+  defp inference_turn_step_context(canonical, attempt \\ 1, excluded_node_ids \\ []) do
+    {:ok, context} =
+      AttemptContext.new(%{
+        turn_index: 1,
+        attempt: attempt,
+        excluded_node_ids: excluded_node_ids,
+        model_id: canonical.model_ref.model_id,
+        model_version: canonical.model_ref.version
+      })
+
+    context
   end
 
   defp persist_inference_turn_started(db_request, step_context, step_event_appender) do
@@ -1677,16 +2331,40 @@ defmodule Orchard.Inference.RequestOrchestrator do
          canonical,
          events,
          terminal_attrs,
-         step_context
+         %AttemptContext{} = context,
+         %AttemptOutcome{} = outcome,
+         retry_decision
        ) do
-    build_tool_call_proposed_steps(canonical, events, step_context) ++
-      [terminal_inference_turn_step(db_request, events, terminal_attrs, step_context)]
+    build_tool_call_proposed_steps(canonical, events, context) ++
+      [
+        terminal_inference_turn_step(
+          db_request,
+          events,
+          terminal_attrs,
+          context,
+          outcome,
+          retry_decision
+        )
+      ]
   end
 
   defp failure_terminal_steps(_db_request, _terminal_attrs, nil), do: []
 
-  defp failure_terminal_steps(db_request, terminal_attrs, step_context) do
-    [terminal_inference_turn_step(db_request, [], terminal_attrs, step_context)]
+  defp failure_terminal_steps(
+         db_request,
+         terminal_attrs,
+         {_owner, %AttemptContext{} = context, %AttemptOutcome{} = outcome, retry_decision}
+       ) do
+    [
+      terminal_inference_turn_step(
+        db_request,
+        [],
+        terminal_attrs,
+        context,
+        outcome,
+        retry_decision
+      )
+    ]
   end
 
   defp inference_turn_started_step(step_context) do
@@ -1704,15 +2382,22 @@ defmodule Orchard.Inference.RequestOrchestrator do
     }
   end
 
-  defp terminal_inference_turn_step(db_request, events, terminal_attrs, step_context) do
+  defp terminal_inference_turn_step(
+         db_request,
+         events,
+         terminal_attrs,
+         %AttemptContext{} = context,
+         %AttemptOutcome{} = outcome,
+         retry_decision
+       ) do
     event_type = RequestStepEvent.terminal_step_event_type!(terminal_attrs.state)
 
     %{
       event_type: event_type,
-      step_id: step_context.step_id,
+      step_id: context.step_id,
       step_type: "inference_turn",
-      turn_index: step_context.turn_index,
-      attempt: step_context.attempt,
+      turn_index: context.turn_index,
+      attempt: context.attempt,
       parent_step_id: nil,
       boundary: "post_observation",
       result:
@@ -1720,12 +2405,13 @@ defmodule Orchard.Inference.RequestOrchestrator do
           db_request,
           events,
           terminal_attrs,
-          Map.get(step_context, :attempt_outcome),
-          event_type,
-          step_context.attempt
+          context,
+          outcome,
+          retry_decision,
+          event_type
         ),
-      model_id: step_context.model_id,
-      model_version: step_context.model_version
+      model_id: context.model_id,
+      model_version: context.model_version
     }
   end
 
@@ -1775,26 +2461,21 @@ defmodule Orchard.Inference.RequestOrchestrator do
     }
   end
 
-  defp terminal_step_result(_db_request, events, terminal_attrs, nil, _event_type, _attempt) do
-    events
-    |> legacy_terminal_step_result(terminal_attrs)
-    |> maybe_put_result("error_code", Map.get(terminal_attrs, :error_code))
-  end
-
   defp terminal_step_result(
          db_request,
          events,
          terminal_attrs,
+         %AttemptContext{} = context,
          %AttemptOutcome{} = outcome,
-         event_type,
-         attempt
+         retry_decision,
+         event_type
        ) do
     result =
       outcome
-      |> attempt_result_fields(db_request, attempt)
+      |> attempt_result_fields(db_request, context, retry_decision)
       |> Map.merge(legacy_terminal_step_result(events, terminal_attrs))
 
-    {:ok, normalized} = InferenceAttemptResult.new(event_type, attempt, result)
+    {:ok, normalized} = InferenceAttemptResult.new(event_type, context.attempt, result)
     normalized
   end
 
@@ -1807,7 +2488,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
     |> maybe_put_result("http_status", Map.get(terminal_attrs, :http_status))
   end
 
-  defp attempt_result_fields(%AttemptOutcome{} = outcome, db_request, attempt) do
+  defp attempt_result_fields(
+         %AttemptOutcome{} = outcome,
+         _db_request,
+         %AttemptContext{} = context,
+         retry_decision
+       ) do
     base = %{
       "attempt_outcome" => Atom.to_string(outcome.attempt_outcome),
       "started_at" => outcome.started_at,
@@ -1816,7 +2502,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
       "output_committed" => outcome.output_committed,
       "execution_resolution" => Atom.to_string(outcome.execution_resolution),
       "capacity_release_outcome" => Atom.to_string(outcome.capacity_release_outcome),
-      "excluded_node_ids" => []
+      "excluded_node_ids" => context.excluded_node_ids
     }
 
     base
@@ -1825,43 +2511,26 @@ defmodule Orchard.Inference.RequestOrchestrator do
       commitment_kind_string(outcome.output_commitment_kind)
     )
     |> maybe_put_result("node_id", outcome.node_id)
-    |> put_attempt_failure(outcome, db_request, attempt)
+    |> put_attempt_failure(outcome, retry_decision)
   end
 
   defp put_attempt_failure(
          result,
          %AttemptOutcome{attempt_outcome: :completed},
-         _db_request,
-         _attempt
+         nil
        ),
        do: result
 
   defp put_attempt_failure(
          result,
          %AttemptOutcome{failure: failure} = outcome,
-         db_request,
-         attempt
-       ) do
-    retry_decision =
-      %{
-        attempt: attempt,
-        output_committed: outcome.output_committed,
-        budget_remaining?:
-          RequestDeadline.remaining_ms(db_request.timeout_at, DateTime.utc_now()) > 0,
-        cancelled?: outcome.attempt_outcome == :cancelled,
-        failure_class: Map.fetch!(failure, "failure_class"),
-        failure_code: Map.fetch!(failure, "failure_code"),
-        runtime_retryable: outcome.runtime_retryable,
-        alternate_available?: false
-      }
-      |> AttemptRetryClassifier.new()
-      |> AttemptRetryClassifier.decide()
-      |> Atom.to_string()
-
+         retry_decision
+       )
+       when is_atom(retry_decision) do
     result
     |> Map.merge(failure)
     |> maybe_put_result("runtime_retryable", outcome.runtime_retryable)
-    |> Map.put("retry_decision", retry_decision)
+    |> Map.put("retry_decision", Atom.to_string(retry_decision))
   end
 
   defp commitment_kind_string(nil), do: nil

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -665,6 +665,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
               db_request,
               canonical,
               model,
+              schedule,
               execution_opts,
               context,
               pending_outcome
@@ -700,6 +701,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          db_request,
          canonical,
          model,
+         schedule,
          execution_opts,
          %AttemptContext{attempt: 1} = context,
          %AttemptOutcome{attempt_outcome: attempt_outcome, delivery_state: :pending} =
@@ -710,6 +712,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
       db_request,
       canonical,
       model,
+      schedule,
       execution_opts,
       context,
       pending_outcome
@@ -720,6 +723,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          db_request,
          canonical,
          _model,
+         _schedule,
          execution_opts,
          %AttemptContext{} = context,
          %AttemptOutcome{} = pending_outcome
@@ -741,6 +745,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          db_request,
          canonical,
          model,
+         schedule,
          execution_opts,
          %AttemptContext{} = context,
          %AttemptOutcome{} = pending_outcome
@@ -759,21 +764,73 @@ defmodule Orchard.Inference.RequestOrchestrator do
         )
 
       :eligible_for_alternate ->
-        case persist_attempt_one_state(db_request.id, pending_outcome) do
-          :ok ->
-            start_alternate_attempt(
-              db_request,
-              canonical,
-              model,
-              execution_opts,
-              context,
-              pending_outcome
-            )
+        continue_eligible_attempt_one(
+          db_request,
+          canonical,
+          model,
+          schedule,
+          execution_opts,
+          context,
+          pending_outcome
+        )
+    end
+  end
 
-          {:error, reason} ->
-            {:error, {:attempt_one_state_transition_failed, reason},
-             terminal_evidence(context, pending_outcome, :not_retryable)}
-        end
+  defp continue_eligible_attempt_one(
+         db_request,
+         canonical,
+         model,
+         schedule,
+         execution_opts,
+         context,
+         pending_outcome
+       ) do
+    if unmanaged_compatibility_schedule?(schedule) do
+      decline_attempt_one(
+        db_request,
+        canonical,
+        pending_outcome,
+        execution_opts,
+        context,
+        :no_alternative_node
+      )
+    else
+      continue_schedulable_attempt_one(
+        db_request,
+        canonical,
+        model,
+        schedule,
+        execution_opts,
+        context,
+        pending_outcome
+      )
+    end
+  end
+
+  defp continue_schedulable_attempt_one(
+         db_request,
+         canonical,
+         model,
+         schedule,
+         execution_opts,
+         context,
+         pending_outcome
+       ) do
+    case persist_attempt_one_state(db_request.id, pending_outcome) do
+      :ok ->
+        start_alternate_attempt(
+          db_request,
+          canonical,
+          model,
+          schedule,
+          execution_opts,
+          context,
+          pending_outcome
+        )
+
+      {:error, reason} ->
+        {:error, {:attempt_one_state_transition_failed, reason},
+         terminal_evidence(context, pending_outcome, :not_retryable)}
     end
   end
 
@@ -796,6 +853,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          db_request,
          canonical,
          model,
+         attempt_one_schedule,
          execution_opts,
          %AttemptContext{} = context,
          %AttemptOutcome{} = pending_outcome
@@ -807,8 +865,16 @@ defmodule Orchard.Inference.RequestOrchestrator do
       execution_opts,
       context,
       fn _boundary ->
+        prefix_cache_score_budget_consumed =
+          prefix_cache_score_budget_consumed(attempt_one_schedule)
+
         result =
-          schedule_alternate_request(canonical, [pending_outcome.node_id], db_request.timeout_at)
+          schedule_alternate_request(
+            canonical,
+            [pending_outcome.node_id],
+            db_request.timeout_at,
+            prefix_cache_score_budget_consumed
+          )
 
         with_live_retry_boundary(
           db_request,
@@ -841,34 +907,27 @@ defmodule Orchard.Inference.RequestOrchestrator do
          context,
          pending_outcome
        ) do
-    case record_scheduler_decision(db_request, persistence_metadata) do
-      {:ok, _request} ->
-        run_retry_persist_probe()
+    run_retry_persist_probe()
 
-        with_live_retry_boundary(
+    with_live_retry_boundary(
+      db_request,
+      canonical,
+      pending_outcome,
+      execution_opts,
+      context,
+      fn boundary ->
+        persist_and_dispatch_alternate(
           db_request,
           canonical,
-          pending_outcome,
+          model,
+          {alternate_schedule, persistence_metadata},
           execution_opts,
           context,
-          fn boundary ->
-            persist_and_dispatch_alternate(
-              db_request,
-              canonical,
-              model,
-              alternate_schedule,
-              execution_opts,
-              context,
-              pending_outcome,
-              AttemptRetryClassifier.finalize_alternate(boundary, :different_node)
-            )
-          end
+          pending_outcome,
+          AttemptRetryClassifier.finalize_alternate(boundary, :different_node)
         )
-
-      {:error, reason} ->
-        {:error, {:alternate_schedule_persist_failed, reason},
-         terminal_evidence(context, pending_outcome, :not_retryable)}
-    end
+      end
+    )
   end
 
   defp handle_alternate_schedule_result(
@@ -950,7 +1009,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          db_request,
          canonical,
          model,
-         alternate_schedule,
+         {alternate_schedule, persistence_metadata},
          execution_opts,
          %AttemptContext{} = attempt_one_context,
          %AttemptOutcome{} = pending_outcome,
@@ -963,7 +1022,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
            pending_outcome,
            attempt_one_context,
            attempt_two_context,
-           execution_opts
+           persistence_metadata
          ) do
       {:ok, {:attempt_two_started, persisted_attempt_two_context}} ->
         dispatch_persisted_alternate(
@@ -990,17 +1049,17 @@ defmodule Orchard.Inference.RequestOrchestrator do
          pending_outcome,
          %AttemptContext{} = attempt_two_context
        ) do
-    with :ok <- authorize_attempt_two_fsm(db_request.id),
-         {:ok, _discarded} <- AttemptOutcome.discard(pending_outcome) do
-      dispatch_alternate_if_live(
-        db_request,
-        canonical,
-        model,
-        alternate_schedule,
-        execution_opts,
-        attempt_two_context
-      )
-    else
+    case AttemptOutcome.discard(pending_outcome) do
+      {:ok, _discarded} ->
+        dispatch_alternate_if_live(
+          db_request,
+          canonical,
+          model,
+          alternate_schedule,
+          execution_opts,
+          attempt_two_context
+        )
+
       {:error, reason} ->
         terminalize_started_attempt_two_controller(
           alternate_schedule,
@@ -1009,8 +1068,6 @@ defmodule Orchard.Inference.RequestOrchestrator do
         )
     end
   end
-
-  defp authorize_attempt_two_fsm(request_id), do: RequestServer.start_attempt_two(request_id)
 
   defp dispatch_alternate_if_live(
          db_request,
@@ -1194,8 +1251,13 @@ defmodule Orchard.Inference.RequestOrchestrator do
     outcome
   end
 
-  defp schedule_alternate_request(canonical, exclude_node_ids, timeout_at) do
-    case call_scheduler(canonical, exclude_node_ids) do
+  defp schedule_alternate_request(
+         canonical,
+         exclude_node_ids,
+         timeout_at,
+         prefix_cache_score_budget_consumed
+       ) do
+    case call_scheduler(canonical, exclude_node_ids, prefix_cache_score_budget_consumed) do
       {:ok, schedule} when is_map(schedule) ->
         classify_alternate_scheduler_selection(schedule, exclude_node_ids, timeout_at)
 
@@ -1229,7 +1291,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
          %AttemptOutcome{} = attempt_one_outcome,
          %AttemptContext{} = attempt_one_context,
          %AttemptContext{} = attempt_two_context,
-         execution_opts
+         persistence_metadata
        ) do
     terminal_attrs = unsuccessful_attempt_terminal_attrs(attempt_one_outcome)
 
@@ -1245,9 +1307,32 @@ defmodule Orchard.Inference.RequestOrchestrator do
       inference_turn_started_step(attempt_two_context)
     ]
 
-    case execution_opts.step_event_appender.(db_request, steps) do
-      {:ok, _step_events} -> {:ok, {:attempt_two_started, attempt_two_context}}
-      {:error, reason} -> {:error, {:request_step_start_failed, reason}}
+    case start_attempt_two_fsm(db_request.id, persistence_metadata, steps) do
+      :ok ->
+        run_retry_started_probe(db_request)
+        {:ok, {:attempt_two_started, attempt_two_context}}
+
+      {:error, reason} ->
+        {:error, {:request_step_start_failed, reason}}
+    end
+  end
+
+  defp start_attempt_two_fsm(request_id, persistence_metadata, steps) do
+    case RequestServer.start_attempt_two(request_id, persistence_metadata, steps) do
+      {:error, {:invalid_scheduler_explanation, reason}} ->
+        log_error(
+          "invalid scheduler explanation at attempt 2 start: #{inspect(reason)}; " <>
+            "persisting scheduler decision without explanation candidates"
+        )
+
+        RequestServer.start_attempt_two(
+          request_id,
+          drop_scheduler_explanation(persistence_metadata),
+          steps
+        )
+
+      result ->
+        result
     end
   end
 
@@ -1343,6 +1428,13 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp run_retry_persist_probe do
     case Process.get(:orchard_retry_persist_probe) do
       fun when is_function(fun, 0) -> fun.()
+      _other -> :ok
+    end
+  end
+
+  defp run_retry_started_probe(db_request) do
+    case Process.get(:orchard_retry_started_probe) do
+      fun when is_function(fun, 1) -> fun.(db_request)
       _other -> :ok
     end
   end
@@ -1610,7 +1702,24 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp call_scheduler(canonical, exclude_node_ids) do
-    Inference.scheduler().schedule(canonical, exclude_node_ids: exclude_node_ids)
+    call_scheduler(canonical, exclude_node_ids, 0)
+  end
+
+  defp call_scheduler(canonical, exclude_node_ids, prefix_cache_score_budget_consumed) do
+    opts = [exclude_node_ids: exclude_node_ids]
+
+    opts =
+      if prefix_cache_score_budget_consumed > 0 do
+        Keyword.put(
+          opts,
+          :prefix_cache_score_budget_consumed,
+          prefix_cache_score_budget_consumed
+        )
+      else
+        opts
+      end
+
+    Inference.scheduler().schedule(canonical, opts)
   rescue
     error ->
       log_warn("scheduler crashed: #{exception_name(error)}")
@@ -1835,6 +1944,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
   defp prefix_cache_metadata_key?("prefix_cache_fingerprint_match?"), do: true
   defp prefix_cache_metadata_key?(:prefix_cache_score), do: true
   defp prefix_cache_metadata_key?("prefix_cache_score"), do: true
+  defp prefix_cache_metadata_key?(:prefix_cache_score_budget_consumed), do: true
+  defp prefix_cache_metadata_key?("prefix_cache_score_budget_consumed"), do: true
 
   defp prefix_cache_metadata_key?(key) when is_atom(key) do
     key
@@ -1847,6 +1958,21 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp prefix_cache_metadata_key?(_key), do: false
+
+  defp prefix_cache_score_budget_consumed(schedule) do
+    case map_value(schedule, :prefix_cache_score_budget_consumed) do
+      consumed when is_integer(consumed) and consumed > 0 -> consumed
+      _other -> 0
+    end
+  end
+
+  defp unmanaged_compatibility_schedule?(schedule) do
+    case map_value(schedule, :dispatch_capacity_evaluation) do
+      %{authority_decision: :unmanaged_compatibility} -> true
+      %{"authority_decision" => "unmanaged_compatibility"} -> true
+      _other -> false
+    end
+  end
 
   defp strip_memory_admission_metadata(schedule) do
     Map.reject(schedule, fn {key, _value} -> memory_admission_metadata_key?(key) end)

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -269,6 +269,38 @@ defmodule Orchard.Requests do
     end
   end
 
+  @spec append_attempt_two_dispatch_transition(struct() | Ecto.UUID.t()) ::
+          {:ok, struct()}
+          | {:error,
+             Ecto.Changeset.t()
+             | :request_not_found
+             | :request_not_running
+             | :attempt_two_boundary_missing
+             | :attempt_two_dispatch_already_started}
+  def append_attempt_two_dispatch_transition(%Request{id: request_id}),
+    do: append_attempt_two_dispatch_transition(request_id)
+
+  def append_attempt_two_dispatch_transition(request_id) do
+    Repo.transaction(fn ->
+      with {:ok, request} <- lock_request(request_id),
+           :ok <- authorize_attempt_two_source_state(request.state),
+           :ok <- authorize_attempt_two_dispatch(request_id) do
+        insert_event_and_sync_state(request, request_id, %{
+          event_type: "state_transition",
+          state: :dispatching,
+          payload: %{
+            source: "automatic_attempt_retry",
+            attempt: 2,
+            to_state: "dispatching"
+          }
+        })
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> unwrap_transaction_result()
+  end
+
   defp insert_event_and_sync_state(request, request_id, attrs) do
     event_attrs =
       attrs
@@ -325,6 +357,70 @@ defmodule Orchard.Requests do
       end
     end)
     |> unwrap_transaction_result()
+  end
+
+  defp authorize_attempt_two_source_state(state) when state in [:running, :dispatching], do: :ok
+  defp authorize_attempt_two_source_state(_state), do: {:error, :request_not_running}
+
+  defp authorize_attempt_two_dispatch(request_id) do
+    events =
+      RequestEvent
+      |> where([event], event.request_id == ^request_id)
+      |> order_by([event], asc: event.seq)
+      |> Repo.all()
+
+    cond do
+      Enum.any?(events, &automatic_attempt_two_dispatch?/1) ->
+        {:error, :attempt_two_dispatch_already_started}
+
+      valid_attempt_two_boundary?(events) ->
+        :ok
+
+      true ->
+        {:error, :attempt_two_boundary_missing}
+    end
+  end
+
+  defp automatic_attempt_two_dispatch?(%RequestEvent{
+         event_type: "state_transition",
+         state: :dispatching,
+         payload: payload
+       }) do
+    payload["source"] == "automatic_attempt_retry" and payload["attempt"] == 2 and
+      payload["to_state"] == "dispatching"
+  end
+
+  defp automatic_attempt_two_dispatch?(%RequestEvent{}), do: false
+
+  defp valid_attempt_two_boundary?(events) do
+    step_events =
+      Enum.flat_map(events, fn event ->
+        case RequestStepEvent.from_request_event(event) do
+          {:ok, step_event} -> [step_event]
+          {:error, _reason} -> []
+        end
+      end)
+
+    attempt_one_terminals =
+      Enum.filter(step_events, fn step ->
+        step.attempt == 1 and
+          step.event_type in RequestStepEvent.terminal_step_event_types() and
+          step.result["retry_decision"] == "retried" and
+          step.result["output_committed"] == false
+      end)
+
+    attempt_two_starts =
+      Enum.filter(step_events, fn step ->
+        step.attempt == 2 and step.event_type == "request_step.started"
+      end)
+
+    case {attempt_one_terminals, attempt_two_starts} do
+      {[%RequestStepEvent{seq: terminal_seq}], [%RequestStepEvent{seq: started_seq}]} ->
+        started_seq == terminal_seq + 1
+
+      _other ->
+        false
+    end
   end
 
   defp sync_request_state(request, event_attrs, raw_attrs) do
@@ -511,17 +607,27 @@ defmodule Orchard.Requests do
   end
 
   defp persist_schedule(request, schedule, normalized_schedule) do
-    attrs = %{
-      scheduler_decision:
-        CapturePolicy.schedule_attrs(request.payload_capture_mode, normalized_schedule, %{
-          requested_model: request.requested_model
-        }),
-      node_id: Map.get(schedule, :node_id)
-    }
+    attrs =
+      %{
+        scheduler_decision:
+          CapturePolicy.schedule_attrs(request.payload_capture_mode, normalized_schedule, %{
+            requested_model: request.requested_model
+          })
+      }
+      |> maybe_put_schedule_node_id(schedule)
 
     request
     |> Request.schedule_changeset(attrs)
     |> Repo.update()
+  end
+
+  defp maybe_put_schedule_node_id(attrs, schedule) do
+    node_id = Map.get(schedule, :node_id, Map.get(schedule, "node_id"))
+
+    case Ecto.UUID.cast(node_id) do
+      {:ok, uuid} -> Map.put(attrs, :node_id, uuid)
+      :error -> attrs
+    end
   end
 
   @doc """
@@ -813,4 +919,6 @@ defmodule Orchard.Requests do
 
   defp unwrap_transaction_result({:error, {:request_changeset, changeset}}),
     do: {:error, changeset}
+
+  defp unwrap_transaction_result({:error, reason}), do: {:error, reason}
 end

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -269,36 +269,78 @@ defmodule Orchard.Requests do
     end
   end
 
-  @spec append_attempt_two_dispatch_transition(struct() | Ecto.UUID.t()) ::
-          {:ok, struct()}
+  @spec start_attempt_two(
+          struct() | Ecto.UUID.t(),
+          map(),
+          [RequestStepEvent.t() | map()]
+        ) ::
+          {:ok,
+           %{
+             request: Request.t(),
+             step_events: [RequestStepEvent.t()],
+             transition_event: struct()
+           }}
           | {:error,
              Ecto.Changeset.t()
              | :request_not_found
              | :request_not_running
-             | :attempt_two_boundary_missing
-             | :attempt_two_dispatch_already_started}
-  def append_attempt_two_dispatch_transition(%Request{id: request_id}),
-    do: append_attempt_two_dispatch_transition(request_id)
+             | :invalid_attempt_two_boundary
+             | :attempt_two_dispatch_already_started
+             | {:invalid_scheduler_explanation, term()}
+             | {:invalid_step_event, pos_integer(), String.t()}}
+  def start_attempt_two(%Request{id: request_id}, schedule, step_events),
+    do: start_attempt_two(request_id, schedule, step_events)
 
-  def append_attempt_two_dispatch_transition(request_id) do
-    Repo.transaction(fn ->
-      with {:ok, request} <- lock_request(request_id),
-           :ok <- authorize_attempt_two_source_state(request.state),
-           :ok <- authorize_attempt_two_dispatch(request_id) do
-        insert_event_and_sync_state(request, request_id, %{
-          event_type: "state_transition",
-          state: :dispatching,
-          payload: %{
-            source: "automatic_attempt_retry",
-            attempt: 2,
-            to_state: "dispatching"
-          }
-        })
-      else
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
-    |> unwrap_transaction_result()
+  def start_attempt_two(request_id, schedule, step_events) do
+    with {:ok, normalized_schedule} <- normalize_schedule(schedule),
+         {:ok, normalized_step_events} <- normalize_request_step_events(step_events) do
+      Repo.transaction(fn ->
+        start_attempt_two_transaction(
+          request_id,
+          schedule,
+          normalized_schedule,
+          normalized_step_events
+        )
+      end)
+      |> unwrap_transaction_result()
+    end
+  end
+
+  defp start_attempt_two_transaction(
+         request_id,
+         schedule,
+         normalized_schedule,
+         normalized_step_events
+       ) do
+    with {:ok, request} <- lock_request(request_id),
+         :ok <- authorize_attempt_two_source_state(request.state),
+         :ok <- authorize_attempt_two_start(request_id, normalized_step_events),
+         {:ok, updated_request} <- persist_schedule(request, schedule, normalized_schedule),
+         {:ok, persisted_step_events} <-
+           insert_request_step_events(updated_request, normalized_step_events),
+         {:ok, transition_event} <-
+           insert_attempt_two_dispatch_transition(updated_request, request_id) do
+      {:ok,
+       %{
+         request: updated_request,
+         step_events: persisted_step_events,
+         transition_event: transition_event
+       }}
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp insert_attempt_two_dispatch_transition(request, request_id) do
+    insert_event_and_sync_state(request, request_id, %{
+      event_type: "state_transition",
+      state: :dispatching,
+      payload: %{
+        source: "automatic_attempt_retry",
+        attempt: 2,
+        to_state: "dispatching"
+      }
+    })
   end
 
   defp insert_event_and_sync_state(request, request_id, attrs) do
@@ -362,7 +404,7 @@ defmodule Orchard.Requests do
   defp authorize_attempt_two_source_state(state) when state in [:running, :dispatching], do: :ok
   defp authorize_attempt_two_source_state(_state), do: {:error, :request_not_running}
 
-  defp authorize_attempt_two_dispatch(request_id) do
+  defp authorize_attempt_two_start(request_id, proposed_steps) do
     events =
       RequestEvent
       |> where([event], event.request_id == ^request_id)
@@ -373,11 +415,14 @@ defmodule Orchard.Requests do
       Enum.any?(events, &automatic_attempt_two_dispatch?/1) ->
         {:error, :attempt_two_dispatch_already_started}
 
-      valid_attempt_two_boundary?(events) ->
+      existing_attempt_two_start?(events) ->
+        {:error, :attempt_two_dispatch_already_started}
+
+      valid_attempt_two_boundary?(proposed_steps) ->
         :ok
 
       true ->
-        {:error, :attempt_two_boundary_missing}
+        {:error, :invalid_attempt_two_boundary}
     end
   end
 
@@ -392,36 +437,26 @@ defmodule Orchard.Requests do
 
   defp automatic_attempt_two_dispatch?(%RequestEvent{}), do: false
 
-  defp valid_attempt_two_boundary?(events) do
-    step_events =
-      Enum.flat_map(events, fn event ->
-        case RequestStepEvent.from_request_event(event) do
-          {:ok, step_event} -> [step_event]
-          {:error, _reason} -> []
-        end
-      end)
-
-    attempt_one_terminals =
-      Enum.filter(step_events, fn step ->
-        step.attempt == 1 and
-          step.event_type in RequestStepEvent.terminal_step_event_types() and
-          step.result["retry_decision"] == "retried" and
-          step.result["output_committed"] == false
-      end)
-
-    attempt_two_starts =
-      Enum.filter(step_events, fn step ->
-        step.attempt == 2 and step.event_type == "request_step.started"
-      end)
-
-    case {attempt_one_terminals, attempt_two_starts} do
-      {[%RequestStepEvent{seq: terminal_seq}], [%RequestStepEvent{seq: started_seq}]} ->
-        started_seq == terminal_seq + 1
-
-      _other ->
-        false
-    end
+  defp existing_attempt_two_start?(events) do
+    Enum.any?(events, fn event ->
+      case RequestStepEvent.from_request_event(event) do
+        {:ok, %RequestStepEvent{attempt: 2, event_type: "request_step.started"}} -> true
+        _other -> false
+      end
+    end)
   end
+
+  defp valid_attempt_two_boundary?([
+         %RequestStepEvent{
+           attempt: 1,
+           event_type: terminal_event_type,
+           result: %{"retry_decision" => "retried", "output_committed" => false}
+         },
+         %RequestStepEvent{attempt: 2, event_type: "request_step.started"}
+       ]),
+       do: terminal_event_type in RequestStepEvent.terminal_step_event_types()
+
+  defp valid_attempt_two_boundary?(_step_events), do: false
 
   defp sync_request_state(request, event_attrs, raw_attrs) do
     new_state = Map.get(event_attrs, "state") || Map.get(raw_attrs, :state)

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -481,10 +481,31 @@ defmodule Orchard.Requests.CapturePolicy do
       |> put_enum_value(payload, "step_type", @step_types)
       |> put_step_identity(payload)
       |> maybe_put_sanitized_result(payload)
+      |> maybe_put_automatic_retry_transition(payload, event_type)
     end
   end
 
   defp sanitize_event_payload(_payload, _event_type), do: %{}
+
+  defp maybe_put_automatic_retry_transition(
+         sanitized,
+         payload,
+         "state_transition"
+       ) do
+    if fetch_value(payload, :source) == "automatic_attempt_retry" and
+         fetch_value(payload, :attempt) == 2 and
+         fetch_value(payload, :to_state) == "dispatching" do
+      Map.merge(sanitized, %{
+        "source" => "automatic_attempt_retry",
+        "attempt" => 2,
+        "to_state" => "dispatching"
+      })
+    else
+      sanitized
+    end
+  end
+
+  defp maybe_put_automatic_retry_transition(sanitized, _payload, _event_type), do: sanitized
 
   defp sanitize_step_event_payload(payload, event_type) do
     sanitized =

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
@@ -92,7 +92,7 @@ defmodule Orchard.Requests.InferenceAttemptResult do
          :ok <- validate_acceptance_resolution(normalized),
          :ok <- validate_outcome_fields(attempt, normalized),
          :ok <- validate_outcome_failure_consistency(normalized),
-         :ok <- validate_retry_consistency(normalized) do
+         :ok <- validate_retry_consistency(attempt, normalized) do
       validate_node_evidence(attempt, normalized)
     end
   end
@@ -282,12 +282,14 @@ defmodule Orchard.Requests.InferenceAttemptResult do
 
   defp validate_outcome_failure_consistency(_result), do: :ok
 
-  defp validate_retry_consistency(%{
+  defp validate_retry_consistency(1, %{
          "output_committed" => true,
          "retry_decision" => decision
        })
        when decision != "output_committed",
        do: {:error, "committed output requires output_committed retry decision"}
+
+  defp validate_retry_consistency(_attempt, result), do: validate_retry_consistency(result)
 
   defp validate_retry_consistency(%{
          "attempt_outcome" => "cancelled",
@@ -329,20 +331,6 @@ defmodule Orchard.Requests.InferenceAttemptResult do
        })
        when outcome != "cancelled" or failure_class != "cancellation",
        do: {:error, "cancelled retry decision requires a cancelled attempt"}
-
-  defp validate_retry_consistency(%{
-         "retry_decision" => "identity_unresolved",
-         "failure_class" => failure_class
-       })
-       when failure_class != "identity_unresolved",
-       do: {:error, "identity_unresolved retry decision requires matching failure class"}
-
-  defp validate_retry_consistency(%{
-         "retry_decision" => "occupancy_unresolved",
-         "failure_class" => failure_class
-       })
-       when failure_class != "occupancy_unresolved",
-       do: {:error, "occupancy_unresolved retry decision requires matching failure class"}
 
   defp validate_retry_consistency(_result), do: :ok
 

--- a/apps/orchard_controller/lib/orchard/requests/request_server.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request_server.ex
@@ -12,6 +12,9 @@ defmodule Orchard.Requests.RequestServer do
       received → validated → admitted → queued → scheduled
         → dispatching → running → streaming → completed
 
+      bounded Automatic Attempt Retry edge through `start_attempt_two/1`:
+        running → dispatching
+
       failure exits (from any non-terminal state):
         → failed | cancelled | timed_out | interrupted
 
@@ -109,6 +112,24 @@ defmodule Orchard.Requests.RequestServer do
   end
 
   @doc """
+  Starts the sole durable attempt-two dispatch transition.
+  """
+  @spec start_attempt_two(String.t()) :: :ok | {:error, term()}
+  def start_attempt_two(request_id) do
+    case lookup(request_id) do
+      {:ok, pid} -> call_start_attempt_two(pid)
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp call_start_attempt_two(pid) do
+    :gen_statem.call(pid, :start_attempt_two)
+  catch
+    :exit, {:noproc, _details} -> {:error, :not_found}
+    :exit, {:normal, _details} -> {:error, :not_found}
+  end
+
+  @doc """
   Returns the current FSM state for a request.
   """
   @spec get_state(String.t()) :: {:ok, atom()} | {:error, :not_found}
@@ -140,6 +161,21 @@ defmodule Orchard.Requests.RequestServer do
   @impl true
   def handle_event({:call, from}, :get_state, state, _data) do
     {:keep_state_and_data, [{:reply, from, state}]}
+  end
+
+  def handle_event({:call, from}, :start_attempt_two, state, data)
+      when state in [:running, :dispatching] do
+    case Requests.append_attempt_two_dispatch_transition(data.request_id) do
+      {:ok, _event} ->
+        {:next_state, :dispatching, data, [{:reply, from, :ok}]}
+
+      {:error, _reason} = error ->
+        {:keep_state_and_data, [{:reply, from, error}]}
+    end
+  end
+
+  def handle_event({:call, from}, :start_attempt_two, state, _data) do
+    {:keep_state_and_data, [{:reply, from, {:error, {:invalid_transition, state, :dispatching}}}]}
   end
 
   def handle_event({:call, from}, {:transition, new_state, payload}, current_state, data) do

--- a/apps/orchard_controller/lib/orchard/requests/request_server.ex
+++ b/apps/orchard_controller/lib/orchard/requests/request_server.ex
@@ -12,7 +12,7 @@ defmodule Orchard.Requests.RequestServer do
       received → validated → admitted → queued → scheduled
         → dispatching → running → streaming → completed
 
-      bounded Automatic Attempt Retry edge through `start_attempt_two/1`:
+      bounded Automatic Attempt Retry edge through `start_attempt_two/3`:
         running → dispatching
 
       failure exits (from any non-terminal state):
@@ -112,18 +112,19 @@ defmodule Orchard.Requests.RequestServer do
   end
 
   @doc """
-  Starts the sole durable attempt-two dispatch transition.
+  Atomically starts the sole durable attempt-two boundary.
   """
-  @spec start_attempt_two(String.t()) :: :ok | {:error, term()}
-  def start_attempt_two(request_id) do
+  @spec start_attempt_two(String.t(), map(), [Orchard.Requests.RequestStepEvent.t() | map()]) ::
+          :ok | {:error, term()}
+  def start_attempt_two(request_id, schedule, step_events) do
     case lookup(request_id) do
-      {:ok, pid} -> call_start_attempt_two(pid)
+      {:ok, pid} -> call_start_attempt_two(pid, schedule, step_events)
       :error -> {:error, :not_found}
     end
   end
 
-  defp call_start_attempt_two(pid) do
-    :gen_statem.call(pid, :start_attempt_two)
+  defp call_start_attempt_two(pid, schedule, step_events) do
+    :gen_statem.call(pid, {:start_attempt_two, schedule, step_events})
   catch
     :exit, {:noproc, _details} -> {:error, :not_found}
     :exit, {:normal, _details} -> {:error, :not_found}
@@ -163,10 +164,10 @@ defmodule Orchard.Requests.RequestServer do
     {:keep_state_and_data, [{:reply, from, state}]}
   end
 
-  def handle_event({:call, from}, :start_attempt_two, state, data)
+  def handle_event({:call, from}, {:start_attempt_two, schedule, step_events}, state, data)
       when state in [:running, :dispatching] do
-    case Requests.append_attempt_two_dispatch_transition(data.request_id) do
-      {:ok, _event} ->
+    case Requests.start_attempt_two(data.request_id, schedule, step_events) do
+      {:ok, _boundary} ->
         {:next_state, :dispatching, data, [{:reply, from, :ok}]}
 
       {:error, _reason} = error ->
@@ -174,7 +175,12 @@ defmodule Orchard.Requests.RequestServer do
     end
   end
 
-  def handle_event({:call, from}, :start_attempt_two, state, _data) do
+  def handle_event(
+        {:call, from},
+        {:start_attempt_two, _schedule, _step_events},
+        state,
+        _data
+      ) do
     {:keep_state_and_data, [{:reply, from, {:error, {:invalid_transition, state, :dispatching}}}]}
   end
 

--- a/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
+++ b/apps/orchard_controller/lib/orchard/scheduler/multi_node.ex
@@ -87,6 +87,8 @@ defmodule Orchard.Scheduler.MultiNode do
   Options:
   - `:exclude_node_ids` - durable Node UUIDs removed before capacity
     annotation, tiering, ranking, and scoring
+  - `:prefix_cache_score_budget_consumed` - number of score candidates already
+    consumed by an earlier attempt of the same logical Request
   - `:status_client` - module implementing the Runtime Endpoint client callbacks
     (default: `Inference.runtime_endpoint_client/0`)
   - `:status_timeout_ms` - timeout for each status probe (default: #{@default_status_timeout_ms})
@@ -376,14 +378,15 @@ defmodule Orchard.Scheduler.MultiNode do
 
     ranked = rank_candidates(annotated_candidates, ranking_opts)
 
-    {selected, selected_score} =
+    {selected, selected_score, score_budget_consumed} =
       select_candidate_with_prefix_cache_score(
         request,
         ranked,
         client,
         cache_affinity_config,
         prefix_cache_scoring_enabled?,
-        ranking_opts
+        ranking_opts,
+        Keyword.get(opts, :prefix_cache_score_budget_consumed, 0)
       )
 
     selected_tier = if(selected.loaded_model?, do: "loaded", else: "cold")
@@ -424,6 +427,7 @@ defmodule Orchard.Scheduler.MultiNode do
       |> maybe_put_prefix_cache_status(Map.get(selected, :prefix_cache_status))
       |> maybe_put_prefix_cache_fingerprint_match(selected, live_fingerprint_match_enabled?)
       |> maybe_put_prefix_cache_score(selected_score)
+      |> maybe_put_prefix_cache_score_budget_consumed(score_budget_consumed)
       |> maybe_put_memory_admission(selected, memory_admission_enabled?)
       |> Map.merge(
         scheduler_explanation(
@@ -1789,15 +1793,23 @@ defmodule Orchard.Scheduler.MultiNode do
 
   defp maybe_put_prefix_cache_score(map, score), do: Map.put(map, :prefix_cache_score, score)
 
+  defp maybe_put_prefix_cache_score_budget_consumed(map, 0), do: map
+
+  defp maybe_put_prefix_cache_score_budget_consumed(map, consumed),
+    do: Map.put(map, :prefix_cache_score_budget_consumed, consumed)
+
   defp select_candidate_with_prefix_cache_score(
          request,
          ranked,
          client,
          cache_affinity_config,
          prefix_cache_scoring_enabled?,
-         ranking_opts
+         ranking_opts,
+         score_budget_consumed
        ) do
     selected = hd(ranked)
+
+    score_budget = prefix_cache_score_budget(score_budget_consumed)
 
     scoring_context =
       prefix_cache_scoring_context(
@@ -1807,7 +1819,8 @@ defmodule Orchard.Scheduler.MultiNode do
         Keyword.get(ranking_opts, :live_fingerprint_match?, false)
       )
 
-    selected_score = score_prefix_cache_candidate(request, selected, client, scoring_context)
+    {selected_score, score_budget} =
+      score_prefix_cache_candidate(request, selected, client, scoring_context, score_budget)
 
     maybe_reselect_prefix_cache_candidate(
       request,
@@ -1815,9 +1828,22 @@ defmodule Orchard.Scheduler.MultiNode do
       client,
       scoring_context,
       selected_score,
-      ranking_opts
+      ranking_opts,
+      score_budget
     )
   end
+
+  defp prefix_cache_score_budget(consumed) when is_integer(consumed) and consumed >= 0 do
+    maximum =
+      if Inference.prefix_cache_scoring_ranking_active?(),
+        do: Inference.prefix_cache_scoring_max_ranking_candidates(),
+        else: 1
+
+    consumed = min(consumed, maximum)
+    %{consumed: consumed, remaining: max(maximum - consumed, 0)}
+  end
+
+  defp prefix_cache_score_budget(_consumed), do: prefix_cache_score_budget(0)
 
   defp prefix_cache_scoring_context(
          _request,
@@ -1845,9 +1871,21 @@ defmodule Orchard.Scheduler.MultiNode do
     end
   end
 
-  defp score_prefix_cache_candidate(_request, _candidate, _client, nil), do: nil
+  defp score_prefix_cache_candidate(_request, _candidate, _client, nil, score_budget),
+    do: {nil, score_budget}
 
-  defp score_prefix_cache_candidate(request, candidate, client, scoring_context) do
+  defp score_prefix_cache_candidate(
+         _request,
+         _candidate,
+         _client,
+         _scoring_context,
+         %{
+           remaining: 0
+         } = score_budget
+       ),
+       do: {nil, score_budget}
+
+  defp score_prefix_cache_candidate(request, candidate, client, scoring_context, score_budget) do
     timeout_ms = scoring_context.timeout_ms
 
     response =
@@ -1860,7 +1898,10 @@ defmodule Orchard.Scheduler.MultiNode do
       }
       |> score_prefix_cache_response(client, candidate.target, timeout_ms)
 
-    PrefixCacheScore.normalize_for_scheduler(response)
+    normalized = PrefixCacheScore.normalize_for_scheduler(response)
+
+    {normalized,
+     %{score_budget | consumed: score_budget.consumed + 1, remaining: score_budget.remaining - 1}}
   end
 
   defp maybe_reselect_prefix_cache_candidate(
@@ -1869,9 +1910,10 @@ defmodule Orchard.Scheduler.MultiNode do
          _client,
          _scoring_context,
          nil,
-         _ranking_opts
+         _ranking_opts,
+         score_budget
        ),
-       do: {hd(ranked), nil}
+       do: {hd(ranked), nil, score_budget.consumed}
 
   defp maybe_reselect_prefix_cache_candidate(
          request,
@@ -1879,7 +1921,8 @@ defmodule Orchard.Scheduler.MultiNode do
          client,
          scoring_context,
          selected_score,
-         ranking_opts
+         ranking_opts,
+         score_budget
        ) do
     if Inference.prefix_cache_scoring_ranking_active?() do
       maybe_reselect_tied_candidate(
@@ -1888,10 +1931,11 @@ defmodule Orchard.Scheduler.MultiNode do
         client,
         scoring_context,
         selected_score,
-        ranking_opts
+        ranking_opts,
+        score_budget
       )
     else
-      {hd(ranked), selected_score}
+      {hd(ranked), selected_score, score_budget.consumed}
     end
   end
 
@@ -1901,21 +1945,28 @@ defmodule Orchard.Scheduler.MultiNode do
          client,
          scoring_context,
          selected_score,
-         ranking_opts
+         ranking_opts,
+         score_budget
        ) do
     case leading_tie_group(ranked, ranking_opts) do
       [incumbent, challenger] ->
-        challenger_score =
-          score_prefix_cache_candidate(request, challenger, client, scoring_context)
+        {challenger_score, score_budget} =
+          score_prefix_cache_candidate(
+            request,
+            challenger,
+            client,
+            scoring_context,
+            score_budget
+          )
 
         if prefix_cache_score_promotes?(selected_score, challenger_score) do
-          {challenger, challenger_score}
+          {challenger, challenger_score, score_budget.consumed}
         else
-          {incumbent, selected_score}
+          {incumbent, selected_score, score_budget.consumed}
         end
 
       _no_two_candidate_tie ->
-        {hd(ranked), selected_score}
+        {hd(ranked), selected_score, score_budget.consumed}
     end
   end
 

--- a/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
@@ -10,7 +10,7 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
   @model_load_codes ~w(acquisition_failed runtime_unavailable resource_exhausted load_timeout)
   @pre_acceptance_codes ~w(node_unavailable node_timeout runtime_unavailable rpc_unavailable)
 
-  test "SPEC.md §5.8 classifies every retry-eligible failure row through the alternate gate" do
+  test "SPEC.md §5.8 classifies every retry-eligible failure before alternate scheduling" do
     cases =
       Enum.map(@runtime_codes, &{"runtime_failure", &1, true}) ++
         Enum.map(@model_load_codes, &{"model_load_failure", &1, nil}) ++
@@ -18,39 +18,39 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
         [{"worker_or_node_loss", "worker_down", nil}]
 
     for {failure_class, failure_code, runtime_retryable} <- cases do
-      assert decide(%{
-               failure_class: failure_class,
-               failure_code: failure_code,
-               runtime_retryable: runtime_retryable,
-               alternate_available?: true
-             }) == :retried
+      boundary =
+        boundary(%{
+          failure_class: failure_class,
+          failure_code: failure_code,
+          runtime_retryable: runtime_retryable
+        })
 
-      assert decide(%{
-               failure_class: failure_class,
-               failure_code: failure_code,
-               runtime_retryable: runtime_retryable,
-               alternate_available?: false
-             }) == :no_alternative_node
+      assert AttemptRetryClassifier.pre_schedule(boundary) == :eligible_for_alternate
+      assert AttemptRetryClassifier.finalize_alternate(boundary, :different_node) == :retried
+
+      assert AttemptRetryClassifier.finalize_alternate(boundary, :no_candidate) ==
+               :no_alternative_node
+
+      assert AttemptRetryClassifier.finalize_alternate(boundary, :identity_unresolved) ==
+               :identity_unresolved
     end
   end
 
   test "SPEC.md §5.8 requires both the runtime retry flag and an allowlisted transient code" do
     for failure_code <- @runtime_codes, runtime_retryable <- [nil, false] do
-      assert decide(%{
+      assert classify(%{
                failure_class: "runtime_failure",
                failure_code: failure_code,
-               runtime_retryable: runtime_retryable,
-               alternate_available?: true
-             }) == :not_retryable
+               runtime_retryable: runtime_retryable
+             }) == {:declined, :not_retryable}
     end
 
     for runtime_retryable <- [nil, false, true] do
-      assert decide(%{
+      assert classify(%{
                failure_class: "runtime_failure",
                failure_code: "model_invalid",
-               runtime_retryable: runtime_retryable,
-               alternate_available?: true
-             }) == :not_retryable
+               runtime_retryable: runtime_retryable
+             }) == {:declined, :not_retryable}
     end
   end
 
@@ -60,30 +60,27 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
           {"model_load_failure", "load_timeout"},
           {"pre_acceptance_unavailable", "rpc_unavailable"}
         ] do
-      assert decide(%{
+      assert classify(%{
                failure_class: failure_class,
                failure_code: failure_code,
-               runtime_retryable: runtime_retryable,
-               alternate_available?: true
-             }) == :retried
+               runtime_retryable: runtime_retryable
+             }) == :eligible_for_alternate
     end
   end
 
   test "SPEC.md §5.8 honors explicit runtime retry refusal for worker or node loss" do
-    assert decide(%{
+    assert classify(%{
              failure_class: "worker_or_node_loss",
              failure_code: "worker_down",
-             runtime_retryable: false,
-             alternate_available?: true
-           }) == :not_retryable
+             runtime_retryable: false
+           }) == {:declined, :not_retryable}
 
     for runtime_retryable <- [nil, true] do
-      assert decide(%{
+      assert classify(%{
                failure_class: "worker_or_node_loss",
                failure_code: "worker_down",
-               runtime_retryable: runtime_retryable,
-               alternate_available?: true
-             }) == :retried
+               runtime_retryable: runtime_retryable
+             }) == :eligible_for_alternate
     end
   end
 
@@ -102,59 +99,94 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
     ]
 
     for {failure_class, failure_code} <- cases do
-      assert decide(%{
+      assert classify(%{
                failure_class: failure_class,
                failure_code: failure_code,
-               runtime_retryable: true,
-               alternate_available?: true
-             }) == :not_retryable
+               runtime_retryable: true
+             }) == {:declined, :not_retryable}
     end
   end
 
   test "SPEC.md §5.8 preserves named unresolved failure classes" do
-    assert decide(%{failure_class: "identity_unresolved"}) == :identity_unresolved
-    assert decide(%{failure_class: "occupancy_unresolved"}) == :occupancy_unresolved
+    assert classify(%{failure_class: "identity_unresolved"}) ==
+             {:declined, :identity_unresolved}
+
+    assert classify(%{failure_class: "occupancy_unresolved"}) ==
+             {:declined, :occupancy_unresolved}
   end
 
   test "SPEC.md §5.8 applies attempt 1 decline gates in order" do
     eligible = %{
       failure_class: "worker_or_node_loss",
       failure_code: "worker_down",
-      runtime_retryable: true,
-      alternate_available?: true
+      runtime_retryable: true
     }
 
-    assert decide(
+    assert classify(
              Map.merge(eligible, %{
                output_committed: true,
-               budget_remaining?: false,
-               cancelled?: true
+               caller_status: :cancelled,
+               deadline_status: :exhausted
              })
            ) ==
-             :output_committed
+             {:declined, :output_committed}
 
-    assert decide(Map.merge(eligible, %{budget_remaining?: false, cancelled?: true})) ==
-             :cancelled
+    assert classify(
+             Map.merge(eligible, %{caller_status: :cancelled, deadline_status: :exhausted})
+           ) ==
+             {:declined, :cancelled}
 
-    assert decide(Map.put(eligible, :budget_remaining?, false)) == :budget_exhausted
+    assert classify(Map.put(eligible, :deadline_status, :exhausted)) ==
+             {:declined, :budget_exhausted}
 
-    assert decide(Map.put(eligible, :cancelled?, true)) == :cancelled
+    assert classify(Map.put(eligible, :caller_status, :cancelled)) == {:declined, :cancelled}
 
-    assert decide(%{
+    assert classify(%{
              failure_class: "identity_unresolved",
              failure_code: "internal_error",
              runtime_retryable: nil,
-             alternate_available?: true,
-             cancelled?: true
-           }) == :cancelled
+             caller_status: :cancelled
+           }) == {:declined, :cancelled}
+  end
+
+  test "SPEC.md §5.8 uses exact identity, execution, and release evidence" do
+    eligible = %{
+      failure_class: "worker_or_node_loss",
+      failure_code: "worker_down",
+      runtime_retryable: true
+    }
+
+    assert classify(Map.put(eligible, :identity_resolution, :unresolved)) ==
+             {:declined, :identity_unresolved}
+
+    assert classify(Map.put(eligible, :execution_resolution, :unresolved)) ==
+             {:declined, :occupancy_unresolved}
+
+    assert classify(Map.put(eligible, :capacity_release_outcome, :unresolved)) ==
+             {:declined, :occupancy_unresolved}
+
+    assert classify(
+             Map.merge(eligible, %{
+               identity_resolution: :unresolved,
+               execution_resolution: :unresolved,
+               capacity_release_outcome: :unresolved
+             })
+           ) == {:declined, :identity_unresolved}
+
+    assert classify(%{
+             failure_class: "terminal_conformance",
+             failure_code: "runtime_endpoint_terminal_invalid",
+             runtime_retryable: true,
+             execution_resolution: :unresolved
+           }) == {:declined, :not_retryable}
   end
 
   test "SPEC.md §7.2.7 bounds attempt 2 to cancellation or retry exhaustion" do
-    assert decide(%{attempt: 2, cancelled?: true}) == :cancelled
-    assert decide(%{attempt: 2, cancelled?: false}) == :retry_exhausted
+    assert classify(%{attempt: 2, caller_status: :cancelled}) == {:declined, :cancelled}
+    assert classify(%{attempt: 2, caller_status: :live}) == {:declined, :retry_exhausted}
   end
 
-  test "classifier rejects raw source codes and crashes on incomplete or mistyped facts" do
+  test "constructor requires every exact fact and rejects raw source codes" do
     assert_raise ArgumentError, fn ->
       base_facts()
       |> Map.put(:raw_source_code, "upstream-free-text")
@@ -170,31 +202,32 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
     assert_raise FunctionClauseError, fn ->
       # Dynamic dispatch avoids a compile-time type warning for this intentional invalid input.
       # credo:disable-for-next-line Credo.Check.Refactor.Apply
-      apply(AttemptRetryClassifier, :new, [Map.delete(base_facts(), :failure_code)])
+      apply(AttemptRetryClassifier, :new, [Map.delete(base_facts(), :capacity_release_outcome)])
     end
 
     assert_raise FunctionClauseError, fn ->
-      AttemptRetryClassifier.new(Map.put(base_facts(), :attempt, 3))
+      # credo:disable-for-next-line Credo.Check.Refactor.Apply
+      apply(AttemptRetryClassifier, :new, [Map.put(base_facts(), :identity_resolution, true)])
     end
   end
 
-  defp decide(overrides) do
-    base_facts()
-    |> Map.merge(overrides)
-    |> AttemptRetryClassifier.new()
-    |> AttemptRetryClassifier.decide()
-  end
+  defp classify(overrides), do: overrides |> boundary() |> AttemptRetryClassifier.pre_schedule()
+
+  defp boundary(overrides),
+    do: base_facts() |> Map.merge(overrides) |> AttemptRetryClassifier.new()
 
   defp base_facts do
     %{
       attempt: 1,
       output_committed: false,
-      budget_remaining?: true,
-      cancelled?: false,
+      caller_status: :live,
+      deadline_status: :remaining,
       failure_class: "runtime_failure",
       failure_code: "runtime_unavailable",
       runtime_retryable: true,
-      alternate_available?: false
+      identity_resolution: :resolved,
+      execution_resolution: :terminated,
+      capacity_release_outcome: :released
     }
   end
 end

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -120,6 +120,54 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubAlternateNodeScheduler d
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheBudgetScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.RequestOrchestratorTest.StubAlternateNodeScheduler
+
+  def schedule(%CanonicalRequest{} = request, opts) do
+    with {:ok, schedule} <- StubAlternateNodeScheduler.schedule(request, opts) do
+      if Keyword.get(opts, :exclude_node_ids, []) == [] do
+        {:ok, Map.put(schedule, :prefix_cache_score_budget_consumed, 1)}
+      else
+        {:ok, schedule}
+      end
+    end
+  end
+end
+
+defmodule Orchard.Inference.RequestOrchestratorTest.StubUnmanagedCompatibilityScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.DispatchCapacity.Evaluator
+  alias Orchard.Inference.RequestOrchestratorTest.StubAlternateNodeScheduler
+
+  def schedule(%CanonicalRequest{} = request, opts) do
+    send(Process.whereis(:request_orchestrator_test_pid), {:compatibility_probe_wave, opts})
+    nodes = Process.get(:orchard_alternate_attempt_nodes)
+
+    schedule = StubAlternateNodeScheduler.schedule_for(request, nodes.first)
+    {:ok, classify_unmanaged_compatibility(schedule)}
+  end
+
+  defp classify_unmanaged_compatibility(schedule) do
+    capacity_input = %{
+      schedule.dispatch_capacity_input
+      | management_classification: {:ok, :unmanaged_compatibility}
+    }
+
+    %{
+      schedule
+      | dispatch_capacity_input: capacity_input,
+        dispatch_capacity_evaluation: Evaluator.evaluate(capacity_input),
+        dispatch_capacity_acquisition_input_provider: fn -> capacity_input end,
+        dispatch_capacity_input_provider: fn -> capacity_input end
+    }
+  end
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.StubSameNodeRetryScheduler do
   @behaviour Orchard.Scheduler.SingleNode
 
@@ -1058,10 +1106,12 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryTierOnlyScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMemoryUnavailableScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler
+  alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheBudgetScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheUnavailableScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient
   alias Orchard.Inference.RequestOrchestratorTest.StubSameNodeRetryScheduler
+  alias Orchard.Inference.RequestOrchestratorTest.StubUnmanagedCompatibilityScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler
 
   alias Orchard.API.Ops.SchedulerExplanationPresenter
@@ -3286,33 +3336,12 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
       :ok
     end
 
-    step_event_appender = fn request, step_events ->
-      if Enum.any?(step_events, &(&1.attempt == 2)) do
-        assert_receive {:runtime_execute_called, ^public_id}
-        refute_receive {:runtime_execute_called, ^public_id}, 0
-
-        assert Enum.map(Requests.list_request_step_events(request), &{&1.event_type, &1.attempt}) ==
-                 [
-                   {"request_step.started", 1}
-                 ]
-
-        {:ok, persisted} = Requests.append_request_step_events(request, step_events)
-        [attempt_one_terminal, attempt_two_started] = persisted
-        assert attempt_two_started.seq == attempt_one_terminal.seq + 1
-        {:ok, persisted}
-      else
-        Requests.append_request_step_events(request, step_events)
-      end
-    end
-
     assert {:ok, ^canonical, events} =
-             RequestOrchestrator.execute(canonical, model,
-               event_handler: handler,
-               step_event_appender: step_event_appender
-             )
+             RequestOrchestrator.execute(canonical, model, event_handler: handler)
 
     assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted, :completed]
     refute_received {:delivered, :failed}
+    assert_receive {:runtime_execute_called, ^public_id}
     assert_receive {:runtime_execute_called, ^public_id}
     refute_receive {:runtime_execute_called, ^public_id}, 0
 
@@ -3325,6 +3354,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request.state == :completed
+    assert request.node_id == nodes.second.node_id
     assert length(Orchard.Repo.all(Orchard.Requests.Request)) == 1
 
     step_events = Requests.list_request_step_events(request)
@@ -3337,6 +3367,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
            ]
 
     [_, attempt_one_terminal, _, attempt_two_terminal] = Enum.map(step_events, & &1.result)
+    [_, persisted_attempt_one, persisted_attempt_two, _] = step_events
+    assert persisted_attempt_two.seq == persisted_attempt_one.seq + 1
 
     assert attempt_one_terminal["retry_decision"] == "retried"
     assert attempt_one_terminal["node_id"] == nodes.first.node_id
@@ -3359,6 +3391,71 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert is_integer(running_idx)
     later_states = Enum.drop(states, running_idx + 1)
     assert :dispatching in later_states
+  end
+
+  test "SPEC.md §§5.5 and 5.9 do not probe compatibility again after attempt 1", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config(StubUnmanagedCompatibilityScheduler)
+
+    stub_runtime_events([
+      InferenceEvent.failed("worker_down", "worker exited", true)
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-compatibility-no-retry")
+
+    canonical =
+      canonical_request("request-orchestrator-compatibility-no-retry", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted, :failed]
+
+    assert_receive {:compatibility_probe_wave, [exclude_node_ids: []]}
+    refute_receive {:compatibility_probe_wave, _alternate_opts}, 0
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    [started, terminal] = Requests.list_request_step_events(request)
+
+    assert started.attempt == 1
+    assert terminal.attempt == 1
+    assert terminal.result["retry_decision"] == "no_alternative_node"
+  end
+
+  test "SPEC.md §7.5.3 carries attempt 1 prefix-cache score consumption into attempt 2", %{
+    bundle: bundle
+  } do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config(StubPrefixCacheBudgetScheduler)
+
+    stub_runtime_event_queue([
+      [InferenceEvent.failed("worker_down", "worker exited", true)],
+      [
+        InferenceEvent.completed(
+          :finish_reason_stop,
+          %InferenceEvent.Usage{input_tokens: 1, output_tokens: 0, total_tokens: 1}
+        )
+      ]
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-prefix-cache-retry-budget")
+
+    canonical =
+      canonical_request("request-orchestrator-prefix-cache-retry-budget", stream?: false)
+
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+    assert_receive {:scheduler_opts, [exclude_node_ids: []]}
+
+    assert_receive {:scheduler_opts,
+                    [
+                      prefix_cache_score_budget_consumed: 1,
+                      exclude_node_ids: [excluded_node_id]
+                    ]}
+
+    assert excluded_node_id == nodes.first.node_id
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    refute Map.has_key?(request.scheduler_decision, "prefix_cache_score_budget_consumed")
   end
 
   test "SPEC.md §5.8 records retry_exhausted when attempt 2 fails", %{bundle: bundle} do
@@ -3572,83 +3669,6 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end
   end
 
-  test "SPEC.md §5.8 does not dispatch attempt 2 when the atomic start boundary fails", %{
-    bundle: bundle
-  } do
-    _nodes = configure_alternate_attempt_nodes!()
-    put_alternate_attempt_scheduler_config()
-
-    stub_runtime_event_queue([
-      [InferenceEvent.failed("worker_down", "worker exited", true)],
-      [InferenceEvent.completed(:finish_reason_stop, nil)]
-    ])
-
-    model = create_active_model!(bundle, "request-orchestrator-alternate-persist-fail")
-    canonical = canonical_request("request-orchestrator-alternate-persist-fail", stream?: false)
-
-    step_event_appender = fn request, step_events ->
-      if Enum.any?(step_events, &(&1.attempt == 2)) do
-        {:error, :request_not_found}
-      else
-        Requests.append_request_step_events(request, step_events)
-      end
-    end
-
-    assert {:error, {:request_step_start_failed, :request_not_found}} =
-             RequestOrchestrator.execute(canonical, model,
-               step_event_appender: step_event_appender
-             )
-
-    request = Requests.get_request_by_public_id(canonical.public_id)
-    assert request.state == :failed
-    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
-  end
-
-  test "SPEC.md §5.8 terminalizes attempt 2 when the durable retry FSM edge fails", %{
-    bundle: bundle
-  } do
-    _nodes = configure_alternate_attempt_nodes!()
-    put_alternate_attempt_scheduler_config()
-    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
-
-    model = create_active_model!(bundle, "request-orchestrator-attempt-two-fsm-fail")
-    canonical = canonical_request("request-orchestrator-attempt-two-fsm-fail", stream?: false)
-    public_id = canonical.public_id
-
-    step_event_appender = fn request, step_events ->
-      result = Requests.append_request_step_events(request, step_events)
-
-      if Enum.any?(step_events, &(&1.attempt == 2)) do
-        assert_receive {:runtime_execute_called, ^public_id}
-        [{pid, _}] = Registry.lookup(Orchard.Requests.Registry, request.id)
-        assert :ok = DynamicSupervisor.terminate_child(Orchard.Requests.Supervisor, pid)
-      end
-
-      result
-    end
-
-    assert {:error, {:orchestration_crash, %{phase: :attempt_two_start}}} =
-             RequestOrchestrator.execute(canonical, model,
-               step_event_appender: step_event_appender
-             )
-
-    refute_receive {:runtime_execute_called, ^public_id}, 0
-    request = Requests.get_request_by_public_id(canonical.public_id)
-    step_events = Requests.list_request_step_events(request)
-
-    assert Enum.map(step_events, &{&1.event_type, &1.attempt}) == [
-             {"request_step.started", 1},
-             {"request_step.failed", 1},
-             {"request_step.started", 2},
-             {"request_step.failed", 2}
-           ]
-
-    attempt_two = List.last(step_events).result
-    assert attempt_two["failure_class"] == "controller_failure"
-    assert attempt_two["failure_code"] == "orchestration_error"
-    assert attempt_two["retry_decision"] == "retry_exhausted"
-  end
-
   test "SPEC.md §5.8 records cancellation when the caller dies after alternate scheduling", %{
     bundle: bundle
   } do
@@ -3693,7 +3713,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request.state == :cancelled
-    assert request.node_id == nodes.second.node_id
+    assert request.node_id == nodes.first.node_id
     refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
 
     assert List.last(Requests.list_request_step_events(request)).result["retry_decision"] ==
@@ -3721,7 +3741,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     request = Requests.get_request_by_public_id(canonical.public_id)
     assert request.state == :failed
     assert request.error_code == "worker_down"
-    assert request.node_id == nodes.second.node_id
+    assert request.node_id == nodes.first.node_id
     refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
 
     assert List.last(Requests.list_request_step_events(request)).result["retry_decision"] ==
@@ -3768,21 +3788,10 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical = canonical_request("request-orchestrator-started-alternate-cancel", stream?: false)
     public_id = canonical.public_id
 
-    step_event_appender = fn request, step_events ->
-      result = Requests.append_request_step_events(request, step_events)
-
-      if Enum.any?(step_events, &(&1.attempt == 2)) do
-        Process.exit(caller, :kill)
-      end
-
-      result
-    end
+    Process.put(:orchard_retry_started_probe, fn _request -> Process.exit(caller, :kill) end)
 
     assert {:error, {:dispatch_failed, :request_caller_disconnect}} =
-             RequestOrchestrator.execute(canonical, model,
-               caller: caller,
-               step_event_appender: step_event_appender
-             )
+             RequestOrchestrator.execute(canonical, model, caller: caller)
 
     assert_receive {:runtime_execute_called, ^public_id}
     refute_receive {:runtime_execute_called, ^public_id}, 0
@@ -3813,20 +3822,10 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     public_id = canonical.public_id
 
-    step_event_appender = fn request, step_events ->
-      result = Requests.append_request_step_events(request, step_events)
-
-      if Enum.any?(step_events, &(&1.attempt == 2)) do
-        Process.sleep(80)
-      end
-
-      result
-    end
+    Process.put(:orchard_retry_started_probe, fn _request -> Process.sleep(80) end)
 
     assert {:error, {:dispatch_failed, :request_timeout}} =
-             RequestOrchestrator.execute(canonical, model,
-               step_event_appender: step_event_appender
-             )
+             RequestOrchestrator.execute(canonical, model)
 
     assert_receive {:runtime_execute_called, ^public_id}
     refute_receive {:runtime_execute_called, ^public_id}, 0
@@ -3865,31 +3864,22 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     owner = self()
 
-    step_event_appender = fn request, step_events ->
-      result = Requests.append_request_step_events(request, step_events)
-
-      if Enum.any?(step_events, &(&1.attempt == 2 and &1.event_type == "request_step.started")) do
-        duplicate =
-          canonical_request("request-orchestrator-alternate-idem",
-            tenant_id: tenant_id,
-            public_id: "req_alternate_duplicate"
-          )
-
-        send(
-          owner,
-          {:duplicate_during_attempt_two,
-           RequestOrchestrator.execute(duplicate, model, idempotency: idempotency)}
+    Process.put(:orchard_retry_started_probe, fn _request ->
+      duplicate =
+        canonical_request("request-orchestrator-alternate-idem",
+          tenant_id: tenant_id,
+          public_id: "req_alternate_duplicate"
         )
-      end
 
-      result
-    end
+      send(
+        owner,
+        {:duplicate_during_attempt_two,
+         RequestOrchestrator.execute(duplicate, model, idempotency: idempotency)}
+      )
+    end)
 
     assert {:ok, ^canonical, _events} =
-             RequestOrchestrator.execute(canonical, model,
-               idempotency: idempotency,
-               step_event_appender: step_event_appender
-             )
+             RequestOrchestrator.execute(canonical, model, idempotency: idempotency)
 
     assert_receive {:duplicate_during_attempt_two,
                     {:error, {:idempotency_conflict, :request_in_progress}}}

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -33,6 +33,126 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubMultiNodeScheduler do
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.StubAlternateNodeScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.CircuitBreakers
+  alias Orchard.DispatchCapacity.{ConformanceFixture, Evaluator}
+  alias Orchard.Inference
+
+  def schedule(%CanonicalRequest{} = request), do: schedule(request, [])
+
+  def schedule(%CanonicalRequest{} = request, opts) do
+    send(Process.whereis(:request_orchestrator_test_pid), {:scheduler_opts, opts})
+
+    if Keyword.get(opts, :exclude_node_ids, []) != [] do
+      [excluded_node_id] = Keyword.fetch!(opts, :exclude_node_ids)
+
+      send(
+        Process.whereis(:request_orchestrator_test_pid),
+        {:attempt_two_breaker_decision, CircuitBreakers.evaluate({:node, excluded_node_id})}
+      )
+
+      send(
+        Process.whereis(:request_orchestrator_test_pid),
+        {:attempt_two_schedule_started, request.internal_id}
+      )
+
+      case Process.get(:orchard_alternate_schedule_sleep_ms) do
+        sleep_ms when is_integer(sleep_ms) and sleep_ms > 0 -> Process.sleep(sleep_ms)
+        _other -> :ok
+      end
+
+      case Process.get(:orchard_retry_caller) do
+        pid when is_pid(pid) -> Process.exit(pid, :kill)
+        _other -> :ok
+      end
+    end
+
+    case selected_alternate_node(Keyword.get(opts, :exclude_node_ids, [])) do
+      {:ok, node} -> {:ok, schedule_for(request, node)}
+      :error -> {:error, :cluster_busy}
+    end
+  end
+
+  def schedule_for(request, node) do
+    capacity_input = ConformanceFixture.input()
+
+    %{
+      strategy: :multi_node,
+      request_id: request.public_id,
+      runtime_client_target: node.target,
+      request_timeout_ms: Inference.request_timeout_ms(),
+      model_load_timeout_ms: Inference.model_load_timeout_ms(),
+      node_id: node.node_id,
+      candidate_count: 2,
+      selected_tier: :loaded,
+      dispatch_capacity_input: capacity_input,
+      dispatch_capacity_evaluation: Evaluator.evaluate(capacity_input),
+      dispatch_capacity_acquisition_input_provider: fn -> capacity_input end,
+      dispatch_capacity_input_provider: fn -> capacity_input end
+    }
+  end
+
+  defp selected_alternate_node(excluded_node_ids) do
+    nodes = Process.get(:orchard_alternate_attempt_nodes)
+
+    cond do
+      is_nil(nodes) ->
+        :error
+
+      not excluded?(nodes.first.node_id, excluded_node_ids) ->
+        {:ok, nodes.first}
+
+      not excluded?(nodes.second.node_id, excluded_node_ids) ->
+        {:ok, nodes.second}
+
+      true ->
+        :error
+    end
+  end
+
+  defp excluded?(node_id, excluded_node_ids) do
+    Enum.any?(excluded_node_ids, fn excluded ->
+      match?({{:ok, id}, {:ok, id}}, {Ecto.UUID.cast(node_id), Ecto.UUID.cast(excluded)})
+    end)
+  end
+end
+
+defmodule Orchard.Inference.RequestOrchestratorTest.StubSameNodeRetryScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.RequestOrchestratorTest.StubAlternateNodeScheduler
+
+  def schedule(%CanonicalRequest{} = request, opts) do
+    send(Process.whereis(:request_orchestrator_test_pid), {:scheduler_opts, opts})
+    nodes = Process.get(:orchard_alternate_attempt_nodes)
+    {:ok, StubAlternateNodeScheduler.schedule_for(request, nodes.first)}
+  end
+end
+
+defmodule Orchard.Inference.RequestOrchestratorTest.StubAlternateResultScheduler do
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.RequestOrchestratorTest.StubAlternateNodeScheduler
+
+  def schedule(%CanonicalRequest{} = request, opts) do
+    case Keyword.get(opts, :exclude_node_ids, []) do
+      [] ->
+        StubAlternateNodeScheduler.schedule(request, opts)
+
+      [_excluded_node_id] ->
+        case Process.get(:orchard_alternate_scheduler_result) do
+          :raise -> raise "alternate scheduler failed"
+          result -> result
+        end
+    end
+  end
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.DelayedScheduler do
   @behaviour Orchard.Scheduler.SingleNode
 
@@ -552,7 +672,11 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient do
   end
 
   def ensure_model_loaded(channel, %Operation.EnsureModelLoadedRequest{} = request, _opts) do
-    case Process.get({__MODULE__, :ensure_model_loaded_result}) do
+    address = channel.address
+    key = {Keyword.fetch!(address, :host), Keyword.fetch!(address, :port)}
+
+    case Process.get({__MODULE__, {:ensure_model_loaded_result, key}}) ||
+           Process.get({__MODULE__, :ensure_model_loaded_result}) do
       {:error, _reason} = result ->
         result
 
@@ -608,11 +732,11 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient do
     owner = Keyword.fetch!(opts, :owner)
     stream_ref = make_ref()
 
-    events =
-      Process.get(
-        {__MODULE__, :execute_events},
-        [InferenceEvent.completed(:finish_reason_stop, %InferenceEvent.Usage{})]
-      )
+    if test_pid = Process.whereis(:request_orchestrator_test_pid) do
+      send(test_pid, {:runtime_execute_called, request.request_id})
+    end
+
+    events = next_execute_events()
 
     send(
       owner,
@@ -626,6 +750,20 @@ defmodule Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient do
     send(owner, {:runtime_endpoint_done, stream_ref, :ok})
 
     {:ok, stream_ref}
+  end
+
+  defp next_execute_events do
+    case Process.get({__MODULE__, :execute_events_queue}) do
+      [next | rest] ->
+        Process.put({__MODULE__, :execute_events_queue}, rest)
+        next
+
+      _empty ->
+        Process.get(
+          {__MODULE__, :execute_events},
+          [InferenceEvent.completed(:finish_reason_stop, %InferenceEvent.Usage{})]
+        )
+    end
   end
 
   def cancel_inference(_channel, %Operation.CancelRequest{}, _opts), do: :ok
@@ -832,11 +970,26 @@ defmodule Orchard.Inference.RequestOrchestratorTest.RecordingQueueManager do
 
   alias Orchard.Inference.QueueManager
 
-  def acquire(request), do: QueueManager.acquire(request)
+  def acquire(request) do
+    if pid = Process.whereis(:request_orchestrator_test_pid) do
+      send(pid, {:recording_queue_acquire, request.request_id})
+    end
+
+    QueueManager.acquire(request)
+  end
+
   def await(ticket), do: QueueManager.await(ticket)
   def abandon(ticket), do: QueueManager.abandon(ticket)
   def release(grant), do: QueueManager.release(grant)
-  def requeue(grant, request, opts \\ []), do: QueueManager.requeue(grant, request, opts)
+
+  def requeue(grant, request, opts \\ []) do
+    if pid = Process.whereis(:request_orchestrator_test_pid) do
+      send(pid, {:recording_queue_requeue, request.request_id})
+    end
+
+    QueueManager.requeue(grant, request, opts)
+  end
+
   def mark_capacity_source_observed(grant), do: QueueManager.mark_capacity_source_observed(grant)
 
   def mark_grant_node(grant, node_id, opts \\ []) do
@@ -896,6 +1049,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   import Orchard.TestSupport.QueueAdmissionAPI,
     only: [assert_queue_metadata: 2, assert_queue_metadata: 3]
 
+  alias Orchard.Inference.RequestOrchestratorTest.StubAlternateNodeScheduler
+  alias Orchard.Inference.RequestOrchestratorTest.StubAlternateResultScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubCacheAffinityScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubLiveCapacityScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubMalformedExplanationScheduler
@@ -906,6 +1061,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubPrefixCacheUnavailableScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubRuntimeEndpointClient
+  alias Orchard.Inference.RequestOrchestratorTest.StubSameNodeRetryScheduler
   alias Orchard.Inference.RequestOrchestratorTest.StubUnreachableScheduler
 
   alias Orchard.API.Ops.SchedulerExplanationPresenter
@@ -2733,7 +2889,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     refute Map.has_key?(terminal_result, "runtime_retryable")
   end
 
-  test "SPEC.md sections 5.10 and 7.2.7 delivery cancellation does not count worker loss",
+  test "SPEC.md §§5.8 and 5.10 records frozen worker loss before delivery cancellation",
        %{bundle: bundle} do
     target = [host: "10.0.0.4", port: 50_064]
     node = insert_runtime_node!(target)
@@ -2759,7 +2915,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert terminal_result["retry_decision"] == "cancelled"
 
     assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id})
-    assert decision.contribution_count == 0
+    assert decision.contribution_count == 1
   end
 
   test "SPEC.md §§5.8 and 7.2.7 caller cancellation wins when the deadline lapses during delivery",
@@ -2849,7 +3005,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert terminal_result["execution_resolution"] == "not_started"
     assert terminal_result["failure_class"] == "pre_acceptance_unavailable"
     assert terminal_result["failure_code"] == "node_unavailable"
-    assert terminal_result["retry_decision"] == "no_alternative_node"
+    assert terminal_result["retry_decision"] == "identity_unresolved"
     refute Enum.any?(step_events, &(&1.attempt == 2))
 
     assert {:ok, node_breaker} =
@@ -3102,6 +3258,643 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id})
     assert decision.contribution_count == 1
+  end
+
+  test "SPEC.md §5.8 retries a pre-commit failure once on a different Node under one Request", %{
+    bundle: bundle
+  } do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+
+    stub_runtime_event_queue([
+      [InferenceEvent.failed("worker_down", "worker exited", true)],
+      [
+        InferenceEvent.completed(
+          :finish_reason_stop,
+          %InferenceEvent.Usage{input_tokens: 1, output_tokens: 0, total_tokens: 1}
+        )
+      ]
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-alternate-success")
+    canonical = canonical_request("request-orchestrator-alternate-success", stream?: false)
+    owner = self()
+    public_id = canonical.public_id
+
+    handler = fn _request_id, event ->
+      send(owner, {:delivered, InferenceEvent.kind(event)})
+      :ok
+    end
+
+    step_event_appender = fn request, step_events ->
+      if Enum.any?(step_events, &(&1.attempt == 2)) do
+        assert_receive {:runtime_execute_called, ^public_id}
+        refute_receive {:runtime_execute_called, ^public_id}, 0
+
+        assert Enum.map(Requests.list_request_step_events(request), &{&1.event_type, &1.attempt}) ==
+                 [
+                   {"request_step.started", 1}
+                 ]
+
+        {:ok, persisted} = Requests.append_request_step_events(request, step_events)
+        [attempt_one_terminal, attempt_two_started] = persisted
+        assert attempt_two_started.seq == attempt_one_terminal.seq + 1
+        {:ok, persisted}
+      else
+        Requests.append_request_step_events(request, step_events)
+      end
+    end
+
+    assert {:ok, ^canonical, events} =
+             RequestOrchestrator.execute(canonical, model,
+               event_handler: handler,
+               step_event_appender: step_event_appender
+             )
+
+    assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted, :completed]
+    refute_received {:delivered, :failed}
+    assert_receive {:runtime_execute_called, ^public_id}
+    refute_receive {:runtime_execute_called, ^public_id}, 0
+
+    assert_receive {:scheduler_opts, [exclude_node_ids: []]}
+    assert_receive {:scheduler_opts, [exclude_node_ids: [excluded_node_id]]}
+    assert excluded_node_id == nodes.first.node_id
+    assert_receive {:attempt_two_breaker_decision, {:ok, breaker_decision}}
+    assert breaker_decision.contribution_count == 1
+    assert_receive {:attempt_two_schedule_started, _canonical_request_id}
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :completed
+    assert length(Orchard.Repo.all(Orchard.Requests.Request)) == 1
+
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, &{&1.event_type, &1.attempt, &1.step_id}) == [
+             {"request_step.started", 1, "inference_turn:t1:a1"},
+             {"request_step.failed", 1, "inference_turn:t1:a1"},
+             {"request_step.started", 2, "inference_turn:t1:a2"},
+             {"request_step.completed", 2, "inference_turn:t1:a2"}
+           ]
+
+    [_, attempt_one_terminal, _, attempt_two_terminal] = Enum.map(step_events, & &1.result)
+
+    assert attempt_one_terminal["retry_decision"] == "retried"
+    assert attempt_one_terminal["node_id"] == nodes.first.node_id
+    assert attempt_one_terminal["excluded_node_ids"] == []
+    assert attempt_one_terminal["execution_resolution"] != "unresolved"
+
+    assert attempt_one_terminal["capacity_release_outcome"] in [
+             "released",
+             "already_released",
+             "not_applicable"
+           ]
+
+    assert attempt_two_terminal["attempt_outcome"] == "completed"
+    assert attempt_two_terminal["node_id"] == nodes.second.node_id
+    assert attempt_two_terminal["excluded_node_ids"] == [nodes.first.node_id]
+    refute Map.has_key?(attempt_two_terminal, "retry_decision")
+
+    states = request_event_states(request)
+    running_idx = Enum.find_index(states, &(&1 == :running))
+    assert is_integer(running_idx)
+    later_states = Enum.drop(states, running_idx + 1)
+    assert :dispatching in later_states
+  end
+
+  test "SPEC.md §5.8 records retry_exhausted when attempt 2 fails", %{bundle: bundle} do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+
+    stub_runtime_event_queue([
+      [InferenceEvent.failed("worker_down", "worker exited", true)],
+      [InferenceEvent.failed("worker_down", "second worker exited", true)]
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-alternate-exhausted")
+    canonical = canonical_request("request-orchestrator-alternate-exhausted", stream?: false)
+
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :failed
+
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, &{&1.event_type, &1.attempt}) == [
+             {"request_step.started", 1},
+             {"request_step.failed", 1},
+             {"request_step.started", 2},
+             {"request_step.failed", 2}
+           ]
+
+    [_, attempt_one, _, attempt_two] = Enum.map(step_events, & &1.result)
+    assert attempt_one["retry_decision"] == "retried"
+    assert attempt_two["retry_decision"] == "retry_exhausted"
+    assert attempt_two["excluded_node_ids"] == [nodes.first.node_id]
+    assert attempt_two["node_id"] == nodes.second.node_id
+  end
+
+  test "SPEC.md §5.8 dispatches attempt 2 from dispatching after a pre-acceptance failure", %{
+    bundle: bundle
+  } do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+
+    first_key =
+      {Keyword.fetch!(nodes.first.target, :host), Keyword.fetch!(nodes.first.target, :port)}
+
+    Process.put(
+      {StubRuntimeEndpointClient, {:ensure_model_loaded_result, first_key}},
+      {:error, :node_timeout}
+    )
+
+    stub_runtime_events([InferenceEvent.completed(:finish_reason_stop, nil)])
+
+    model = create_active_model!(bundle, "request-orchestrator-pre-acceptance-retry")
+    canonical = canonical_request("request-orchestrator-pre-acceptance-retry", stream?: false)
+    public_id = canonical.public_id
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert Enum.map(events, &InferenceEvent.kind/1) == [:accepted, :completed]
+    assert_receive {:runtime_execute_called, ^public_id}
+    refute_receive {:runtime_execute_called, ^public_id}, 0
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :completed
+
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, &{&1.event_type, &1.attempt}) == [
+             {"request_step.started", 1},
+             {"request_step.failed", 1},
+             {"request_step.started", 2},
+             {"request_step.completed", 2}
+           ]
+
+    [_, attempt_one, _, attempt_two] = Enum.map(step_events, & &1.result)
+    assert attempt_one["accepted"] == false
+    assert attempt_one["retry_decision"] == "retried"
+    assert attempt_one["failure_class"] == "model_load_failure"
+    assert attempt_one["failure_code"] == "load_timeout"
+    assert attempt_one["node_id"] == nodes.first.node_id
+    refute Map.has_key?(attempt_two, "retry_decision")
+    assert attempt_two["node_id"] == nodes.second.node_id
+
+    states = request_event_states(request)
+    assert Enum.count(states, &(&1 == :running)) == 1
+
+    assert Enum.any?(Requests.list_request_events(request), fn event ->
+             event.event_type == "state_transition" and event.state == :dispatching and
+               event.payload["source"] == "automatic_attempt_retry" and
+               event.payload["attempt"] == 2
+           end)
+  end
+
+  test "SPEC.md §5.8 records retry_exhausted when committed attempt 2 fails", %{bundle: bundle} do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+
+    stub_runtime_event_queue([
+      [InferenceEvent.failed("worker_down", "worker exited", true)],
+      [
+        InferenceEvent.output_text_delta("hello"),
+        InferenceEvent.failed("worker_down", "second worker exited", true)
+      ]
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-committed-attempt-two")
+    canonical = canonical_request("request-orchestrator-committed-attempt-two", stream?: true)
+
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :failed
+
+    [_, _attempt_one, _, attempt_two] =
+      request |> Requests.list_request_step_events() |> Enum.map(& &1.result)
+
+    assert attempt_two["output_committed"]
+    assert attempt_two["retry_decision"] == "retry_exhausted"
+    assert attempt_two["node_id"] == nodes.second.node_id
+  end
+
+  test "SPEC.md §5.8 reuses one queue grant without requeueing attempt 2", %{bundle: bundle} do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    put_queue_admission_config(enabled: true, capacity: 1, max_wait_ms: 1_000)
+    put_recording_queue_manager()
+
+    stub_runtime_event_queue([
+      [InferenceEvent.failed("worker_down", "worker exited", true)],
+      [InferenceEvent.completed(:finish_reason_stop, nil)]
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-alternate-one-grant")
+    canonical = canonical_request("request-orchestrator-alternate-one-grant", stream?: false)
+
+    assert {:ok, ^canonical, _events} = RequestOrchestrator.execute(canonical, model)
+    assert_receive {:recording_queue_acquire, request_id}
+    assert {:ok, _request_uuid} = Ecto.UUID.cast(request_id)
+    refute_receive {:recording_queue_acquire, ^request_id}, 0
+    refute_receive {:recording_queue_requeue, ^request_id}, 0
+  end
+
+  test "SPEC.md §5.8 classifies a same-Node alternate as identity_unresolved", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config(StubSameNodeRetryScheduler)
+
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    model = create_active_model!(bundle, "request-orchestrator-no-alternative")
+    canonical = canonical_request("request-orchestrator-no-alternative", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert match?(%{event: %InferenceEvent.Failed{code: "worker_down"}}, List.last(events))
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :failed
+    assert request.error_code == "worker_down"
+
+    step_events = Requests.list_request_step_events(request)
+    refute Enum.any?(step_events, &(&1.attempt == 2))
+    assert List.last(step_events).result["retry_decision"] == "identity_unresolved"
+  end
+
+  test "SPEC.md §5.8 preserves attempt 1's public failure for a coherent no-candidate result", %{
+    bundle: bundle
+  } do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config(StubAlternateResultScheduler)
+
+    Process.put(:orchard_alternate_scheduler_result, {
+      :error,
+      :cluster_busy,
+      %{strategy: :multi_node, candidate_count: 0, request_id: "alternate-no-candidate"}
+    })
+
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+    model = create_active_model!(bundle, "request-orchestrator-coherent-no-alternative")
+    canonical = canonical_request("request-orchestrator-coherent-no-alternative", stream?: false)
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert match?(%{event: %InferenceEvent.Failed{code: "worker_down"}}, List.last(events))
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.node_id == nodes.first.node_id
+    step_events = Requests.list_request_step_events(request)
+    refute Enum.any?(step_events, &(&1.attempt == 2))
+    assert List.last(step_events).result["retry_decision"] == "no_alternative_node"
+  end
+
+  test "SPEC.md §5.8 exposes alternate scheduler faults as orchestration failures", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config(StubAlternateResultScheduler)
+
+    for {suffix, result} <- [{"raise", :raise}, {"invalid", :invalid_return}] do
+      Process.put(:orchard_alternate_scheduler_result, result)
+      stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+      model = create_active_model!(bundle, "request-orchestrator-alternate-fault-#{suffix}")
+
+      canonical =
+        canonical_request("request-orchestrator-alternate-fault-#{suffix}", stream?: false)
+
+      assert {:error, {:orchestration_crash, %{phase: :scheduler}}} =
+               RequestOrchestrator.execute(canonical, model)
+
+      request = Requests.get_request_by_public_id(canonical.public_id)
+      step_events = Requests.list_request_step_events(request)
+      refute Enum.any?(step_events, &(&1.attempt == 2))
+      assert List.last(step_events).result["retry_decision"] == "not_retryable"
+    end
+  end
+
+  test "SPEC.md §5.8 does not dispatch attempt 2 when the atomic start boundary fails", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+
+    stub_runtime_event_queue([
+      [InferenceEvent.failed("worker_down", "worker exited", true)],
+      [InferenceEvent.completed(:finish_reason_stop, nil)]
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-alternate-persist-fail")
+    canonical = canonical_request("request-orchestrator-alternate-persist-fail", stream?: false)
+
+    step_event_appender = fn request, step_events ->
+      if Enum.any?(step_events, &(&1.attempt == 2)) do
+        {:error, :request_not_found}
+      else
+        Requests.append_request_step_events(request, step_events)
+      end
+    end
+
+    assert {:error, {:request_step_start_failed, :request_not_found}} =
+             RequestOrchestrator.execute(canonical, model,
+               step_event_appender: step_event_appender
+             )
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :failed
+    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
+  end
+
+  test "SPEC.md §5.8 terminalizes attempt 2 when the durable retry FSM edge fails", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    model = create_active_model!(bundle, "request-orchestrator-attempt-two-fsm-fail")
+    canonical = canonical_request("request-orchestrator-attempt-two-fsm-fail", stream?: false)
+    public_id = canonical.public_id
+
+    step_event_appender = fn request, step_events ->
+      result = Requests.append_request_step_events(request, step_events)
+
+      if Enum.any?(step_events, &(&1.attempt == 2)) do
+        assert_receive {:runtime_execute_called, ^public_id}
+        [{pid, _}] = Registry.lookup(Orchard.Requests.Registry, request.id)
+        assert :ok = DynamicSupervisor.terminate_child(Orchard.Requests.Supervisor, pid)
+      end
+
+      result
+    end
+
+    assert {:error, {:orchestration_crash, %{phase: :attempt_two_start}}} =
+             RequestOrchestrator.execute(canonical, model,
+               step_event_appender: step_event_appender
+             )
+
+    refute_receive {:runtime_execute_called, ^public_id}, 0
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, &{&1.event_type, &1.attempt}) == [
+             {"request_step.started", 1},
+             {"request_step.failed", 1},
+             {"request_step.started", 2},
+             {"request_step.failed", 2}
+           ]
+
+    attempt_two = List.last(step_events).result
+    assert attempt_two["failure_class"] == "controller_failure"
+    assert attempt_two["failure_code"] == "orchestration_error"
+    assert attempt_two["retry_decision"] == "retry_exhausted"
+  end
+
+  test "SPEC.md §5.8 records cancellation when the caller dies after alternate scheduling", %{
+    bundle: bundle
+  } do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    caller = spawn(fn -> Process.sleep(60_000) end)
+    Process.put(:orchard_retry_caller, caller)
+
+    model = create_active_model!(bundle, "request-orchestrator-alternate-cancel")
+    canonical = canonical_request("request-orchestrator-alternate-cancel", stream?: false)
+
+    assert {:error, {:dispatch_failed, :request_caller_disconnect}} =
+             RequestOrchestrator.execute(canonical, model, caller: caller)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :cancelled
+    assert request.node_id == nodes.first.node_id
+    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
+
+    assert List.last(Requests.list_request_step_events(request)).result["retry_decision"] ==
+             "cancelled"
+  end
+
+  test "SPEC.md §5.8 records cancellation when the caller dies during candidate persistence", %{
+    bundle: bundle
+  } do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    caller = spawn(fn -> Process.sleep(60_000) end)
+
+    Process.put(:orchard_retry_persist_probe, fn -> Process.exit(caller, :kill) end)
+
+    model = create_active_model!(bundle, "request-orchestrator-persist-cancel")
+    canonical = canonical_request("request-orchestrator-persist-cancel", stream?: false)
+
+    assert {:error, {:dispatch_failed, :request_caller_disconnect}} =
+             RequestOrchestrator.execute(canonical, model, caller: caller)
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :cancelled
+    assert request.node_id == nodes.second.node_id
+    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
+
+    assert List.last(Requests.list_request_step_events(request)).result["retry_decision"] ==
+             "cancelled"
+  end
+
+  test "SPEC.md §5.8 records budget_exhausted when the deadline lapses during candidate persistence",
+       %{bundle: bundle} do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    Process.put(:orchard_retry_persist_probe, fn -> Process.sleep(80) end)
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    model = create_active_model!(bundle, "request-orchestrator-persist-budget")
+
+    canonical =
+      canonical_request("request-orchestrator-persist-budget",
+        stream?: false,
+        admission: %{timeout_ms: 40}
+      )
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert match?(%{event: %InferenceEvent.Failed{code: "worker_down"}}, List.last(events))
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :failed
+    assert request.error_code == "worker_down"
+    assert request.node_id == nodes.second.node_id
+    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
+
+    assert List.last(Requests.list_request_step_events(request)).result["retry_decision"] ==
+             "budget_exhausted"
+  end
+
+  test "SPEC.md §5.8 records budget_exhausted when the deadline lapses after alternate scheduling",
+       %{bundle: bundle} do
+    nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    Process.put(:orchard_alternate_schedule_sleep_ms, 80)
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    model = create_active_model!(bundle, "request-orchestrator-alternate-budget")
+
+    canonical =
+      canonical_request("request-orchestrator-alternate-budget",
+        stream?: false,
+        admission: %{timeout_ms: 40}
+      )
+
+    assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
+    assert match?(%{event: %InferenceEvent.Failed{code: "worker_down"}}, List.last(events))
+
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :failed
+    assert request.error_code == "worker_down"
+    assert request.node_id == nodes.first.node_id
+    refute Enum.any?(Requests.list_request_step_events(request), &(&1.attempt == 2))
+
+    assert List.last(Requests.list_request_step_events(request)).result["retry_decision"] ==
+             "budget_exhausted"
+  end
+
+  test "SPEC.md §5.8 terminalizes attempt 2 when its caller dies after durable start", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    caller = spawn(fn -> Process.sleep(60_000) end)
+    model = create_active_model!(bundle, "request-orchestrator-started-alternate-cancel")
+    canonical = canonical_request("request-orchestrator-started-alternate-cancel", stream?: false)
+    public_id = canonical.public_id
+
+    step_event_appender = fn request, step_events ->
+      result = Requests.append_request_step_events(request, step_events)
+
+      if Enum.any?(step_events, &(&1.attempt == 2)) do
+        Process.exit(caller, :kill)
+      end
+
+      result
+    end
+
+    assert {:error, {:dispatch_failed, :request_caller_disconnect}} =
+             RequestOrchestrator.execute(canonical, model,
+               caller: caller,
+               step_event_appender: step_event_appender
+             )
+
+    assert_receive {:runtime_execute_called, ^public_id}
+    refute_receive {:runtime_execute_called, ^public_id}, 0
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :cancelled
+
+    [_, attempt_one, _, attempt_two] =
+      request |> Requests.list_request_step_events() |> Enum.map(& &1.result)
+
+    assert attempt_one["retry_decision"] == "retried"
+    assert attempt_two["retry_decision"] == "cancelled"
+  end
+
+  test "SPEC.md §5.8 terminalizes attempt 2 when its deadline lapses after durable start", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+    stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
+
+    model = create_active_model!(bundle, "request-orchestrator-started-alternate-timeout")
+
+    canonical =
+      canonical_request("request-orchestrator-started-alternate-timeout",
+        stream?: false,
+        admission: %{timeout_ms: 60}
+      )
+
+    public_id = canonical.public_id
+
+    step_event_appender = fn request, step_events ->
+      result = Requests.append_request_step_events(request, step_events)
+
+      if Enum.any?(step_events, &(&1.attempt == 2)) do
+        Process.sleep(80)
+      end
+
+      result
+    end
+
+    assert {:error, {:dispatch_failed, :request_timeout}} =
+             RequestOrchestrator.execute(canonical, model,
+               step_event_appender: step_event_appender
+             )
+
+    assert_receive {:runtime_execute_called, ^public_id}
+    refute_receive {:runtime_execute_called, ^public_id}, 0
+    request = Requests.get_request_by_public_id(canonical.public_id)
+    assert request.state == :timed_out
+
+    [_, attempt_one, _, attempt_two] =
+      request |> Requests.list_request_step_events() |> Enum.map(& &1.result)
+
+    assert attempt_one["retry_decision"] == "retried"
+    assert attempt_two["retry_decision"] == "retry_exhausted"
+  end
+
+  test "SPEC.md §5.8 observes the original Request as in progress throughout attempt 2 start", %{
+    bundle: bundle
+  } do
+    _nodes = configure_alternate_attempt_nodes!()
+    put_alternate_attempt_scheduler_config()
+
+    stub_runtime_event_queue([
+      [InferenceEvent.failed("worker_down", "worker exited", true)],
+      [InferenceEvent.completed(:finish_reason_stop, nil)]
+    ])
+
+    model = create_active_model!(bundle, "request-orchestrator-alternate-idem")
+    tenant_id = Process.get(:request_orchestrator_full_capture_tenant_id)
+    key = "req-orch-alternate-in-progress"
+    params = %{"model" => "request-orchestrator-alternate-idem@v1"}
+    {:ok, idempotency} = Idempotency.build_context(tenant_id, key, params)
+
+    canonical =
+      canonical_request("request-orchestrator-alternate-idem",
+        tenant_id: tenant_id,
+        public_id: "req_alternate_in_progress"
+      )
+
+    owner = self()
+
+    step_event_appender = fn request, step_events ->
+      result = Requests.append_request_step_events(request, step_events)
+
+      if Enum.any?(step_events, &(&1.attempt == 2 and &1.event_type == "request_step.started")) do
+        duplicate =
+          canonical_request("request-orchestrator-alternate-idem",
+            tenant_id: tenant_id,
+            public_id: "req_alternate_duplicate"
+          )
+
+        send(
+          owner,
+          {:duplicate_during_attempt_two,
+           RequestOrchestrator.execute(duplicate, model, idempotency: idempotency)}
+        )
+      end
+
+      result
+    end
+
+    assert {:ok, ^canonical, _events} =
+             RequestOrchestrator.execute(canonical, model,
+               idempotency: idempotency,
+               step_event_appender: step_event_appender
+             )
+
+    assert_receive {:duplicate_during_attempt_two,
+                    {:error, {:idempotency_conflict, :request_in_progress}}}
+
+    assert length(Orchard.Repo.all(Orchard.Requests.Request)) == 1
   end
 
   test "execute/3 aborts before dispatch side effects when request_step.started persistence fails",
@@ -4262,6 +5055,43 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
   defp stub_runtime_events(events) do
     Process.put({StubRuntimeEndpointClient, :execute_events}, events)
+  end
+
+  defp stub_runtime_event_queue(event_lists) when is_list(event_lists) do
+    Process.put({StubRuntimeEndpointClient, :execute_events_queue}, event_lists)
+  end
+
+  defp configure_alternate_attempt_nodes! do
+    first_target = [host: "10.0.10.1", port: 51_001]
+    second_target = [host: "10.0.10.2", port: 51_002]
+    first_node = insert_runtime_node!(first_target)
+    second_node = insert_runtime_node!(second_target)
+
+    stub_runtime_status(first_target, runtime_status(first_node.id, first_target))
+    stub_runtime_status(second_target, runtime_status(second_node.id, second_target))
+
+    nodes = %{
+      first: %{node_id: first_node.id, target: first_target, node: first_node},
+      second: %{node_id: second_node.id, target: second_target, node: second_node}
+    }
+
+    Process.put(:orchard_alternate_attempt_nodes, nodes)
+    nodes
+  end
+
+  defp put_alternate_attempt_scheduler_config(scheduler \\ StubAlternateNodeScheduler) do
+    nodes = Process.get(:orchard_alternate_attempt_nodes)
+
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.merge(
+        runtime_client_targets: [nodes.first.target, nodes.second.target],
+        runtime_endpoint_targets: [],
+        runtime_endpoint_client_impl: StubRuntimeEndpointClient,
+        scheduler_impl: scheduler
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
   end
 
   defp runtime_status(node_id, target) do

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
@@ -233,6 +233,52 @@ defmodule Orchard.Requests.InferenceAttemptResultTest do
                  "retry_decision" => "retry_exhausted"
                })
              )
+
+    assert {:ok, _result} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               2,
+               failed_result(%{
+                 "accepted" => true,
+                 "output_committed" => true,
+                 "output_commitment_kind" => "text",
+                 "execution_resolution" => "terminated",
+                 "capacity_release_outcome" => "released",
+                 "node_id" => @node_2,
+                 "excluded_node_ids" => [@node_1],
+                 "retry_decision" => "retry_exhausted"
+               })
+             )
+  end
+
+  test "retry resolution preserves the attempt's producing failure evidence" do
+    assert {:ok, identity_unresolved} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{
+                 "failure_class" => "worker_or_node_loss",
+                 "failure_code" => "worker_down",
+                 "retry_decision" => "identity_unresolved"
+               })
+             )
+
+    assert identity_unresolved["failure_class"] == "worker_or_node_loss"
+
+    assert {:ok, occupancy_unresolved} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               1,
+               failed_result(%{
+                 "failure_class" => "pre_acceptance_unavailable",
+                 "failure_code" => "runtime_unavailable",
+                 "execution_resolution" => "unresolved",
+                 "capacity_release_outcome" => "unresolved",
+                 "retry_decision" => "occupancy_unresolved"
+               })
+             )
+
+    assert occupancy_unresolved["failure_class"] == "pre_acceptance_unavailable"
   end
 
   test "event outcome and attempt 2 exclusions fail closed" do

--- a/apps/orchard_controller/test/orchard/requests/request_server_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/request_server_test.exs
@@ -138,71 +138,126 @@ defmodule Orchard.Requests.RequestServerTest do
                RequestServer.transition(request.id, :dispatching)
     end
 
-    test "attempt two transition requires the durable consecutive attempt pair" do
+    test "attempt two transition requires the consecutive attempt pair" do
       request = running_request!()
+      node_id = Ecto.UUID.generate()
 
-      assert {:error, :attempt_two_boundary_missing} =
-               RequestServer.start_attempt_two(request.id)
+      assert {:error, :invalid_attempt_two_boundary} =
+               RequestServer.start_attempt_two(
+                 request.id,
+                 attempt_two_schedule(node_id),
+                 [attempt_one_retried_step(node_id)]
+               )
 
       assert {:ok, :running} = RequestServer.get_state(request.id)
     end
 
-    test "attempt two transition is authorized once by the durable attempt pair" do
+    test "attempt two transition atomically persists the schedule, steps, and retry edge" do
       request = running_request!()
       node_id = Ecto.UUID.generate()
+      steps = attempt_two_boundary(node_id)
 
-      assert {:ok, _events} = append_attempt_two_boundary(request, node_id)
+      assert :ok =
+               RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), steps)
 
-      assert :ok = RequestServer.start_attempt_two(request.id)
       assert {:ok, :dispatching} = RequestServer.get_state(request.id)
+
+      updated = Requests.get_request!(request.id)
+      assert updated.node_id == node_id
+      assert updated.scheduler_decision["node_id"] == node_id
+
+      [attempt_one_terminal, attempt_two_started] = Requests.list_request_step_events(request)
+      assert attempt_two_started.seq == attempt_one_terminal.seq + 1
+
+      assert List.last(Requests.list_request_events(request)).payload == %{
+               "attempt" => 2,
+               "source" => "automatic_attempt_retry",
+               "to_state" => "dispatching"
+             }
 
       assert :ok = RequestServer.transition(request.id, :running)
 
       assert {:error, :attempt_two_dispatch_already_started} =
-               RequestServer.start_attempt_two(request.id)
+               RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), steps)
     end
 
     test "attempt two start from dispatching stays dispatching" do
       request = dispatching_request!()
       node_id = Ecto.UUID.generate()
+      steps = attempt_two_boundary(node_id)
 
-      assert {:ok, _events} = append_attempt_two_boundary(request, node_id)
-      assert :ok = RequestServer.start_attempt_two(request.id)
+      assert :ok =
+               RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), steps)
+
       assert {:ok, :dispatching} = RequestServer.get_state(request.id)
 
       assert {:error, :attempt_two_dispatch_already_started} =
-               RequestServer.start_attempt_two(request.id)
+               RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), steps)
     end
 
-    test "attempt two transition rejects nonconsecutive and duplicate starts" do
+    test "failed attempt two boundary persists none of the schedule, steps, or retry edge" do
       request = running_request!()
-      node_id = Ecto.UUID.generate()
+      attempt_one_node_id = Ecto.UUID.generate()
+      alternate_node_id = Ecto.UUID.generate()
+      {:ok, _request} = Requests.assign_node(request, attempt_one_node_id)
+      events_before = Requests.list_request_events(request)
 
-      assert {:ok, _events} =
-               Requests.append_request_step_events(request, [attempt_one_retried_step(node_id)])
+      invalid_steps = [
+        attempt_one_retried_step(attempt_one_node_id),
+        attempt_two_started_step(attempt_one_node_id),
+        attempt_two_started_step(attempt_one_node_id)
+      ]
 
-      assert {:ok, _event} =
-               Requests.append_request_event(request, %{
-                 event_type: "state_transition",
-                 state: :running,
-                 payload: %{source: "test_gap", to_state: "running"}
-               })
+      assert {:error, :invalid_attempt_two_boundary} =
+               RequestServer.start_attempt_two(
+                 request.id,
+                 attempt_two_schedule(alternate_node_id),
+                 invalid_steps
+               )
 
-      assert {:ok, _events} =
-               Requests.append_request_step_events(request, [
-                 attempt_two_started_step(node_id),
-                 attempt_two_started_step(node_id)
-               ])
+      unchanged = Requests.get_request!(request.id)
+      assert unchanged.node_id == attempt_one_node_id
+      assert unchanged.scheduler_decision == nil
+      assert unchanged.state == :running
+      assert Requests.list_request_events(request) == events_before
+      assert {:ok, :running} = RequestServer.get_state(request.id)
+    end
 
-      assert {:error, :attempt_two_boundary_missing} =
-               RequestServer.start_attempt_two(request.id)
+    test "transaction rollback removes every durable attempt two boundary write" do
+      request = running_request!()
+      attempt_one_node_id = Ecto.UUID.generate()
+      alternate_node_id = Ecto.UUID.generate()
+      {:ok, _request} = Requests.assign_node(request, attempt_one_node_id)
+      events_before = Requests.list_request_events(request)
+
+      assert {:error, :forced_failure} =
+               Orchard.Repo.transaction(fn ->
+                 assert {:ok, _boundary} =
+                          Requests.start_attempt_two(
+                            request,
+                            attempt_two_schedule(alternate_node_id),
+                            attempt_two_boundary(attempt_one_node_id)
+                          )
+
+                 Orchard.Repo.rollback(:forced_failure)
+               end)
+
+      unchanged = Requests.get_request!(request.id)
+      assert unchanged.node_id == attempt_one_node_id
+      assert unchanged.scheduler_decision == nil
+      assert unchanged.state == :running
+      assert Requests.list_request_events(request) == events_before
+      assert {:ok, :running} = RequestServer.get_state(request.id)
     end
 
     test "durable prior edge remains one-shot after RequestServer restart" do
       request = running_request!()
       node_id = Ecto.UUID.generate()
-      assert {:ok, _events} = append_attempt_two_boundary(request, node_id)
-      assert :ok = RequestServer.start_attempt_two(request.id)
+      steps = attempt_two_boundary(node_id)
+
+      assert :ok =
+               RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), steps)
+
       assert :ok = RequestServer.transition(request.id, :running)
       [{pid, _}] = Registry.lookup(Orchard.Requests.Registry, request.id)
       assert :ok = DynamicSupervisor.terminate_child(Orchard.Requests.Supervisor, pid)
@@ -215,21 +270,18 @@ defmodule Orchard.Requests.RequestServerTest do
                )
 
       assert {:error, :attempt_two_dispatch_already_started} =
-               RequestServer.start_attempt_two(request.id)
+               RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), steps)
     end
 
     test "declined attempt one evidence never authorizes the retry edge" do
       request = running_request!()
       node_id = Ecto.UUID.generate()
 
-      assert {:ok, _events} =
-               Requests.append_request_step_events(request, [
+      assert {:error, :invalid_attempt_two_boundary} =
+               RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), [
                  attempt_one_retried_step(node_id, "no_alternative_node"),
                  attempt_two_started_step(node_id)
                ])
-
-      assert {:error, :attempt_two_boundary_missing} =
-               RequestServer.start_attempt_two(request.id)
     end
 
     test "rejects transitions from terminal states" do
@@ -283,11 +335,19 @@ defmodule Orchard.Requests.RequestServerTest do
     request
   end
 
-  defp append_attempt_two_boundary(request, node_id) do
-    Requests.append_request_step_events(request, [
+  defp attempt_two_boundary(node_id) do
+    [
       attempt_one_retried_step(node_id),
       attempt_two_started_step(node_id)
-    ])
+    ]
+  end
+
+  defp attempt_two_schedule(node_id) do
+    %{
+      strategy: :multi_node,
+      request_id: "attempt-two-boundary",
+      node_id: node_id
+    }
   end
 
   defp attempt_one_retried_step(node_id, retry_decision \\ "retried") do

--- a/apps/orchard_controller/test/orchard/requests/request_server_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/request_server_test.exs
@@ -4,7 +4,7 @@ defmodule Orchard.Requests.RequestServerTest do
   @moduletag :db
 
   alias Orchard.Requests
-  alias Orchard.Requests.RequestServer
+  alias Orchard.Requests.{RequestServer, RequestStepEvent}
 
   @request_attrs %{
     public_id: "chatcmpl-test-1",
@@ -125,6 +125,113 @@ defmodule Orchard.Requests.RequestServerTest do
       assert {:error, :not_found} = RequestServer.get_state(request.id)
     end
 
+    test "generic running to dispatching remains invalid" do
+      request = create_request!()
+      {:ok, _} = RequestServer.start(request_id: request.id, public_id: request.public_id)
+
+      assert :ok = RequestServer.transition(request.id, :validated)
+      assert :ok = RequestServer.transition(request.id, :scheduled)
+      assert :ok = RequestServer.transition(request.id, :dispatching)
+      assert :ok = RequestServer.transition(request.id, :running)
+
+      assert {:error, {:invalid_transition, :running, :dispatching}} =
+               RequestServer.transition(request.id, :dispatching)
+    end
+
+    test "attempt two transition requires the durable consecutive attempt pair" do
+      request = running_request!()
+
+      assert {:error, :attempt_two_boundary_missing} =
+               RequestServer.start_attempt_two(request.id)
+
+      assert {:ok, :running} = RequestServer.get_state(request.id)
+    end
+
+    test "attempt two transition is authorized once by the durable attempt pair" do
+      request = running_request!()
+      node_id = Ecto.UUID.generate()
+
+      assert {:ok, _events} = append_attempt_two_boundary(request, node_id)
+
+      assert :ok = RequestServer.start_attempt_two(request.id)
+      assert {:ok, :dispatching} = RequestServer.get_state(request.id)
+
+      assert :ok = RequestServer.transition(request.id, :running)
+
+      assert {:error, :attempt_two_dispatch_already_started} =
+               RequestServer.start_attempt_two(request.id)
+    end
+
+    test "attempt two start from dispatching stays dispatching" do
+      request = dispatching_request!()
+      node_id = Ecto.UUID.generate()
+
+      assert {:ok, _events} = append_attempt_two_boundary(request, node_id)
+      assert :ok = RequestServer.start_attempt_two(request.id)
+      assert {:ok, :dispatching} = RequestServer.get_state(request.id)
+
+      assert {:error, :attempt_two_dispatch_already_started} =
+               RequestServer.start_attempt_two(request.id)
+    end
+
+    test "attempt two transition rejects nonconsecutive and duplicate starts" do
+      request = running_request!()
+      node_id = Ecto.UUID.generate()
+
+      assert {:ok, _events} =
+               Requests.append_request_step_events(request, [attempt_one_retried_step(node_id)])
+
+      assert {:ok, _event} =
+               Requests.append_request_event(request, %{
+                 event_type: "state_transition",
+                 state: :running,
+                 payload: %{source: "test_gap", to_state: "running"}
+               })
+
+      assert {:ok, _events} =
+               Requests.append_request_step_events(request, [
+                 attempt_two_started_step(node_id),
+                 attempt_two_started_step(node_id)
+               ])
+
+      assert {:error, :attempt_two_boundary_missing} =
+               RequestServer.start_attempt_two(request.id)
+    end
+
+    test "durable prior edge remains one-shot after RequestServer restart" do
+      request = running_request!()
+      node_id = Ecto.UUID.generate()
+      assert {:ok, _events} = append_attempt_two_boundary(request, node_id)
+      assert :ok = RequestServer.start_attempt_two(request.id)
+      assert :ok = RequestServer.transition(request.id, :running)
+      [{pid, _}] = Registry.lookup(Orchard.Requests.Registry, request.id)
+      assert :ok = DynamicSupervisor.terminate_child(Orchard.Requests.Supervisor, pid)
+
+      assert {:ok, _pid} =
+               RequestServer.start(
+                 request_id: request.id,
+                 public_id: request.public_id,
+                 initial_state: :running
+               )
+
+      assert {:error, :attempt_two_dispatch_already_started} =
+               RequestServer.start_attempt_two(request.id)
+    end
+
+    test "declined attempt one evidence never authorizes the retry edge" do
+      request = running_request!()
+      node_id = Ecto.UUID.generate()
+
+      assert {:ok, _events} =
+               Requests.append_request_step_events(request, [
+                 attempt_one_retried_step(node_id, "no_alternative_node"),
+                 attempt_two_started_step(node_id)
+               ])
+
+      assert {:error, :attempt_two_boundary_missing} =
+               RequestServer.start_attempt_two(request.id)
+    end
+
     test "rejects transitions from terminal states" do
       request = create_request!()
       {:ok, _} = RequestServer.start(request_id: request.id, public_id: request.public_id)
@@ -159,5 +266,66 @@ defmodule Orchard.Requests.RequestServerTest do
     test "returns not_found for unknown request" do
       assert {:error, :not_found} = RequestServer.transition(Ecto.UUID.generate(), :validated)
     end
+  end
+
+  defp running_request! do
+    request = dispatching_request!()
+    :ok = RequestServer.transition(request.id, :running)
+    request
+  end
+
+  defp dispatching_request! do
+    request = create_request!()
+    {:ok, _pid} = RequestServer.start(request_id: request.id, public_id: request.public_id)
+    :ok = RequestServer.transition(request.id, :validated)
+    :ok = RequestServer.transition(request.id, :scheduled)
+    :ok = RequestServer.transition(request.id, :dispatching)
+    request
+  end
+
+  defp append_attempt_two_boundary(request, node_id) do
+    Requests.append_request_step_events(request, [
+      attempt_one_retried_step(node_id),
+      attempt_two_started_step(node_id)
+    ])
+  end
+
+  defp attempt_one_retried_step(node_id, retry_decision \\ "retried") do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    RequestStepEvent.new!(%{
+      event_type: "request_step.failed",
+      step_id: RequestStepEvent.inference_turn_step_id(1, 1),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: 1,
+      boundary: "post_observation",
+      result: %{
+        "attempt_outcome" => "failed",
+        "started_at" => now,
+        "ended_at" => now,
+        "accepted" => true,
+        "output_committed" => false,
+        "execution_resolution" => "terminated",
+        "capacity_release_outcome" => "released",
+        "excluded_node_ids" => [],
+        "node_id" => node_id,
+        "failure_class" => "worker_or_node_loss",
+        "failure_code" => "worker_down",
+        "retry_decision" => retry_decision
+      }
+    })
+  end
+
+  defp attempt_two_started_step(excluded_node_id) do
+    RequestStepEvent.new!(%{
+      event_type: "request_step.started",
+      step_id: RequestStepEvent.inference_turn_step_id(1, 2),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: 2,
+      boundary: "pre_side_effect",
+      result: %{"excluded_node_ids" => [excluded_node_id]}
+    })
   end
 end

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -1230,8 +1230,14 @@ defmodule Orchard.RequestsTest do
       assert Repo.get!(Orchard.Requests.Request, request.id).scheduler_decision == nil
     end
 
-    test "preserves nil node_id when schedule has no node" do
-      request = create_request!(%{public_id: "req_schedule_3"})
+    test "omits invalid or absent node_id updates and preserves the producing Node" do
+      producing_node_id = Ecto.UUID.generate()
+
+      request =
+        create_request!(%{
+          public_id: "req_schedule_3",
+          node_id: producing_node_id
+        })
 
       schedule = %{
         strategy: :single_node,
@@ -1243,7 +1249,22 @@ defmodule Orchard.RequestsTest do
       }
 
       assert {:ok, updated} = Requests.record_schedule(request, schedule)
-      assert updated.node_id == nil
+      assert updated.node_id == producing_node_id
+
+      assert {:ok, updated} =
+               Requests.record_schedule(updated, Map.put(schedule, "node_id", "not-a-uuid"))
+
+      assert updated.node_id == producing_node_id
+
+      alternate_node_id = Ecto.UUID.generate()
+
+      assert {:ok, updated} =
+               Requests.record_schedule(
+                 updated,
+                 schedule |> Map.delete(:node_id) |> Map.put("node_id", alternate_node_id)
+               )
+
+      assert updated.node_id == alternate_node_id
     end
 
     test "returns error for unknown request" do

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -4376,6 +4376,28 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       assert [{{"10.0.0.1", 50_061}, _incumbent}] = score_calls()
     end
 
+    test "SPEC.md §7.5.3 observe-only retry preserves base order after score budget is consumed" do
+      put_inference(
+        cache_affinity: [enabled: true, live_fingerprint_match_enabled: true],
+        prefix_cache_scoring: [enabled: true, timeout_ms: 123]
+      )
+
+      {id_a, id_b} = insert_ordered_nodes!()
+      request = stub_tied_cold_nodes(id_a, id_b)
+      stub_score("10.0.0.1", 50_061, ok_resident_score())
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(request,
+                 status_client: StubClient,
+                 prefix_cache_score_budget_consumed: 1
+               )
+
+      assert schedule.node_id == id_a
+      assert schedule.prefix_cache_score_budget_consumed == 1
+      refute Map.has_key?(schedule, :prefix_cache_score)
+      assert score_calls() == []
+    end
+
     test "tie-only scoring promotes authoritative resident challenger over non-resident incumbent" do
       put_inference(
         cache_affinity: [
@@ -4454,6 +4476,38 @@ defmodule Orchard.Scheduler.MultiNodeTest do
 
       assert [{{"10.0.0.1", 50_061}, _incumbent}, {{"10.0.0.2", 50_062}, _challenger}] =
                score_calls()
+    end
+
+    test "SPEC.md §7.5.3 tie-only retry scores only within the remaining Request budget" do
+      put_tie_only_scoring_config()
+
+      {id_a, id_b} = insert_ordered_nodes!()
+      request = stub_tied_cold_nodes(id_a, id_b)
+      stub_score("10.0.0.1", 50_061, ok_non_resident_score())
+      stub_score("10.0.0.2", 50_062, ok_resident_score())
+
+      assert {:ok, schedule} =
+               MultiNode.schedule(request,
+                 status_client: StubClient,
+                 prefix_cache_score_budget_consumed: 1
+               )
+
+      assert schedule.node_id == id_a
+      assert schedule.prefix_cache_score_budget_consumed == 2
+      assert [{{"10.0.0.1", 50_061}, _incumbent}] = score_calls()
+
+      reset_score_calls()
+
+      assert {:ok, exhausted_schedule} =
+               MultiNode.schedule(request,
+                 status_client: StubClient,
+                 prefix_cache_score_budget_consumed: 2
+               )
+
+      assert exhausted_schedule.node_id == id_a
+      assert exhausted_schedule.prefix_cache_score_budget_consumed == 2
+      refute Map.has_key?(exhausted_schedule, :prefix_cache_score)
+      assert score_calls() == []
     end
 
     test "tie-only scoring preserves base order when incumbent score is non-ok" do

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -64,14 +64,14 @@
 
 ## 8. Bounded orchestrator retry
 
-- [ ] 8.1 Run attempt 1 and at most one attempt 2 under one logical Request
-- [ ] 8.2 Preserve one admission, queue grant, quota reservation, idempotency scope, capture snapshot, and deadline
-- [ ] 8.3 Require resolved execution and affirmative release before alternate scheduling or acquisition
-- [ ] 8.4 Run the fresh alternate decision only after attempt 1 breaker effects are durable
-- [ ] 8.5 Atomically append attempt 1 terminal evidence and attempt 2 started evidence before dispatch
-- [ ] 8.6 Recheck cancellation and deadline at every retry boundary
-- [ ] 8.7 Preserve attempt 1's public failure when no alternative exists
-- [ ] 8.8 Prevent every post-start failure from queue re-entry
+- [x] 8.1 Run attempt 1 and at most one attempt 2 under one logical Request
+- [x] 8.2 Preserve one admission, queue grant, quota reservation, idempotency scope, capture snapshot, and deadline
+- [x] 8.3 Require resolved execution and affirmative release before alternate scheduling or acquisition
+- [x] 8.4 Run the fresh alternate decision only after attempt 1 breaker effects are durable
+- [x] 8.5 Atomically append attempt 1 terminal evidence and attempt 2 started evidence before dispatch
+- [x] 8.6 Recheck cancellation and deadline at every retry boundary
+- [x] 8.7 Preserve attempt 1's public failure when no alternative exists
+- [x] 8.8 Prevent every post-start failure from queue re-entry
 
 ## 9. Attempt and retry metrics
 


### PR DESCRIPTION
## Summary

A retryable attempt 1 Node failure can now run one attempt 2 on a different Node under the original Request.
The retry preserves the original admission, queue grant, quota reservation, idempotency scope, capture snapshot, and absolute deadline.

This implements GitHub issue #171 and the bounded alternate-Node retry contract in OpenSpec `automatic-attempt-retry` section 8.

## Behavior and boundaries

- `AttemptRetryClassifier` makes the retry decision from closed attempt, commitment, caller, deadline, taxonomy, identity, execution, and capacity-release evidence.
- Alternate scheduling excludes the prior Node before capacity annotation, ranking, and prefix-cache scoring.
- A Request that used unmanaged inline compatibility scheduling cannot start a second compatibility probe wave. It keeps attempt 1's public failure with `no_alternative_node`.
- Prefix-cache scoring carries the consumed candidate count from attempt 1, so attempt 2 can use only the logical Request's remaining score budget and otherwise ranks fail-open.
- After the final pre-persist caller and deadline gate, `RequestServer.start_attempt_two/3` and `Requests.start_attempt_two/3` atomically persist the alternate Node selection, attempt 1 `retried`, attempt 2 `started`, and the retry-only `dispatching` transition. Dispatch happens only after that durable boundary and a final caller and deadline check.
- Attempt 2 records `retry_exhausted` on failure, including when output is already committed. Attempt 1 still requires `output_committed` for committed output.
- Restricted capture retains only the allowed retry transition fields: `source=automatic_attempt_retry`, `attempt=2`, and `to_state=dispatching`.

Out of scope: more than two attempts, same-Node retry, restart recovery, durable capacity permits, operator or cohort retry, metrics follow-up, and issues #172 and #173.

## Tradeoffs

The retry boundary uses explicit closed evidence instead of occupancy booleans or fail-open map defaults. This makes illegal retry states unrepresentable at the cost of more required fields at the orchestrator boundary.

The attempt-two start is one database transaction. A failure in schedule persistence, attempt-event persistence, or transition persistence rolls back the whole boundary before dispatch.

## Risk Assessment

✅ **Medium**

- Blast radius is limited to inference scheduling and durable Request transitions after a retryable attempt 1 failure.
- Caller, deadline, identity, prior-Node exclusion, unmanaged compatibility, and one-shot gates fail closed.
- No schema migration is included. Generic `running -> dispatching` remains invalid outside this retry-only path.
- Residual work for restart recovery, durable capacity permits, metrics, and broader acceptance coverage remains outside this PR.

## Verification

- `make check-elixir` passed on final head `ee0f70cf`.
  - Controller: 3,652 passed, 5 skipped; 85.3% coverage.
  - Node agent: 412 passed; 78.33% coverage.
  - CLI: 678 passed, 1 skipped, 10 excluded; 76.40% coverage.
  - Shared: 216 passed.
- The hosted Required Orchard validation gate passed on `ee0f70cf`.
- All hosted PR checks are green. CI was babysat through the final head.

Closes #171.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790518306&installation_model_id=428414&pr_number=305&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F305&signature=6cbaedf3d4163ccd7bcc53fd071e1706486f2d23161dfa3401519267b6f53280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
