### PR TITLE
fix(verify-orchard): harden source-dev proof workflows

### DIFF
--- a/.cursor/skills/verify-orchard/SKILL.md
+++ b/.cursor/skills/verify-orchard/SKILL.md
@@ -24,6 +24,8 @@ control-orchard meta
 
 **Ready when:** `GET http://127.0.0.1:${ORCHARD_VERIFY_PORT:-4000}/health/live` returns exactly `{"status":"ok"}`.
 
+`launch` detaches the BEAM into a new session so the helper can return without SIGHUP-killing the server. `stop` still targets only the recorded PID.
+
 Verification launch sets `ORCHARD_VERIFY_MODE=1`, which disables Phoenix code reload and asset watchers in `config/dev.exs` so health probes stay stable. It runs `mix assets.build` before boot. Launch checks the HTTP port is free before bootstrap, so an existing `make dev` is not disrupted by trust recovery.
 
 **Defaults:**
@@ -60,11 +62,11 @@ Pass criteria:
 3. `/health/live` body is `{"status":"ok"}`
 4. `/console` returns HTTP 200 and HTML containing `Orchard Console`
 
-`/health/ready` may be non-200 while runtime/worker subsystems are still warming — log it, but do not treat it alone as launch failure.
+`/health/ready` may be HTTP 503 with exactly `{"status":"error"}` on source-dev (`plain_http_localhost` fails the public HTTPS check). Log it; do not treat it alone as launch failure.
 
 ## Drive
 
-**Harness:** `cursor-ide-browser` MCP (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_take_screenshot`).
+**Harness:** `cursor-ide-browser` MCP (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_take_screenshot`). If that MCP is unavailable mid-run, the same URLs, sidebar labels, and wait conditions can be driven with another Chromium CDP session (for example `agent-browser open|snapshot|click|screenshot`) against `ORCHARD_VERIFY_BASE_URL`.
 
 **Conventions:**
 1. Run `control-orchard doctor` first.
@@ -136,7 +138,7 @@ If launch failed mid-boot, still run `control-orchard stop` to clear a partial P
 | Command | Purpose |
 |---------|---------|
 | `control-orchard bootstrap` | Ensure `tmp/dev/node-trust` exists; opt-in orphan recover via `ORCHARD_VERIFY_TRUST_RECOVER=1` |
-| `control-orchard launch` | Background source-dev with log + pid files |
+| `control-orchard launch` | Detach source-dev (new session) with log + pid files |
 | `control-orchard doctor` | Readiness gate before driving |
 | `control-orchard stop` | Stop the launched instance |
 | `control-orchard meta` | Print `BASE_URL`, pid, log, artifacts paths |

--- a/.cursor/skills/verify-orchard/SKILL.md
+++ b/.cursor/skills/verify-orchard/SKILL.md
@@ -38,6 +38,7 @@ Verification launch sets `ORCHARD_VERIFY_MODE=1`, which disables Phoenix code re
 - Do **not** launch if the user already has `make dev` on the same port — `control-orchard launch` refuses occupied ports.
 - Do **not** run two verification launches with the same `ORCHARD_VERIFY_STATE_DIR`.
 - Prefer a fresh `ORCHARD_VERIFY_RUN_ID` per proof run.
+- `control-orchard smoke-mlx` is an isolated CLI session. It does not need `launch`. If `launch` is already up, smoke rebinds the Elixir test gRPC port.
 - Inference/API proofs that mutate tenants or models share the dev DB; restore or use disposable slugs when mutating.
 
 **Teardown:**
@@ -119,9 +120,9 @@ ${ORCHARD_VERIFY_STATE_DIR}/artifacts/overview/
 ```
 
 **API / inference proofs** (optional, heavier setup):
-- Prepare a local Orchard bundle with `scripts/prepare-mlx-smoke-bundle.sh` and export `ORCHARD_MLX_SMOKE_MODEL_PATH` from `--print-path`. That helper is not a CI gate.
-- Import/activate a model and grant tenant access per `docs/local-dev.md` before Playground or `/v1/chat/completions` checks.
-- Never commit API tokens; pass via env (`ORCHARD_API_KEY`) only for the run.
+- `control-orchard prepare-bundle` wraps `scripts/prepare-mlx-smoke-bundle.sh` and records `ORCHARD_MLX_SMOKE_MODEL_PATH` in meta. Not a CI gate.
+- `control-orchard smoke-mlx` runs `scripts/smoke-mlx.sh` (Python worker + Elixir node-agent). Isolated CLI; does not require `launch`.
+- Playground and `/v1/chat/completions` still need import, tenant grants, and `ORCHARD_API_KEY` per `docs/local-dev.md`. Never commit API tokens.
 
 ## Cleanup
 
@@ -143,6 +144,8 @@ If launch failed mid-boot, still run `control-orchard stop` to clear a partial P
 | `control-orchard stop` | Stop the launched instance |
 | `control-orchard meta` | Print `BASE_URL`, pid, log, artifacts paths |
 | `control-orchard curl /health/live` | HTTP GET against verification base URL |
+| `control-orchard prepare-bundle` | Prepare pinned Qwen3 MLX bundle; record `ORCHARD_MLX_SMOKE_MODEL_PATH` |
+| `control-orchard smoke-mlx` | Run `scripts/smoke-mlx.sh` against that bundle |
 
 Script path: `.cursor/skills/verify-orchard/scripts/control-orchard.sh`
 

--- a/.cursor/skills/verify-orchard/features/README.md
+++ b/.cursor/skills/verify-orchard/features/README.md
@@ -37,7 +37,7 @@ Each feature file starts with an H1 title and one paragraph describing user-visi
 
 1. `Sub-features` — short IDs with one line each.
 2. `How to get to it (user POV)` — every user entry point.
-3. `Driving it with cursor-ide-browser` — starts with `Preconditions:` and pairs actions with observable results.
+3. `Driving it with cursor-ide-browser` or `Driving it with control-orchard` — starts with `Preconditions:` and pairs actions with observable results.
 4. `Gotchas` — traps that invalidate a run.
 
 ## Features
@@ -47,8 +47,9 @@ Each feature file starts with an H1 title and one paragraph describing user-visi
 - [Public health probes](./health-probes.md) — `/health/live` and `/health/ready` without auth.
 - [Models catalog](./models-catalog.md) — Models page catalog or explicit empty/error state.
 - [Settings page](./settings.md) — appearance notes, inference defaults, and debug snapshot.
+- [MLX smoke](./mlx-smoke.md) — pinned Qwen3 bundle plus Python/Elixir MLX smoke (opt-in, not a CI gate).
 
 ## Optional (heavy setup)
 
-- Playground chat and `/v1/chat/completions` require an imported model, tenant grants, and API token per `docs/local-dev.md`. Prepare the pinned Qwen3 bundle with `scripts/prepare-mlx-smoke-bundle.sh` and `ORCHARD_MLX_SMOKE_MODEL_PATH`; that script is not a CI gate. Add a feature file when import/grants/token are scripted for verification.
+- Playground chat and `/v1/chat/completions` still need `orchardctl models import`, tenant grants, and an API token per `docs/local-dev.md`. `control-orchard prepare-bundle` only prepares the local bundle; it does not import or grant.
 - Authenticated `GET /ops/v1/health` needs an operator/admin Bearer token. Do not treat a 401 here as a public-probe failure.

--- a/.cursor/skills/verify-orchard/features/README.md
+++ b/.cursor/skills/verify-orchard/features/README.md
@@ -19,7 +19,7 @@ This directory is the maintained source for verifying user-facing Orchard operat
 - Console dev auth is `:none` — no Basic Auth prompt locally.
 - Run browser actions through **cursor-ide-browser** MCP tools.
 - Run HTTP probes through `control-orchard curl` or `curl` against `ORCHARD_VERIFY_BASE_URL`.
-- LiveView pages may show a brief loading panel on first connect; wait for the page `<h1>` or a stable content card before proof.
+- LiveView first paint can include the page `<h1>` before connected data; wait for the feature file's settled-content signal (Overview **Last updated**, Models catalog/error card, Settings model options or error).
 - Do not remove proof artifacts during cleanup.
 
 ## Proof and skip reporting
@@ -46,8 +46,9 @@ Each feature file starts with an H1 title and one paragraph describing user-visi
 - [Console navigation](./console-navigation.md) — sidebar routes to major Console pages.
 - [Public health probes](./health-probes.md) — `/health/live` and `/health/ready` without auth.
 - [Models catalog](./models-catalog.md) — Models page catalog or explicit empty/error state.
-- [Settings page](./settings.md) — inference defaults and debug snapshot panel load.
+- [Settings page](./settings.md) — appearance notes, inference defaults, and debug snapshot.
 
 ## Optional (heavy setup)
 
 - Playground chat and `/v1/chat/completions` require an imported model, tenant grants, and API token per `docs/local-dev.md`. Prepare the pinned Qwen3 bundle with `scripts/prepare-mlx-smoke-bundle.sh` and `ORCHARD_MLX_SMOKE_MODEL_PATH`; that script is not a CI gate. Add a feature file when import/grants/token are scripted for verification.
+- Authenticated `GET /ops/v1/health` needs an operator/admin Bearer token. Do not treat a 401 here as a public-probe failure.

--- a/.cursor/skills/verify-orchard/features/console-navigation.md
+++ b/.cursor/skills/verify-orchard/features/console-navigation.md
@@ -19,13 +19,13 @@ Preconditions:
 - `control-orchard doctor` passes.
 - Browser is on any Console page (start at `/console` if needed).
 
-- **Nodes.** Click link `Nodes`. Run `browser_click` on the `Nodes` link from snapshot ref. Heading becomes `Nodes`; URL path is `/console/nodes`.
-- **Models.** Click link `Models`. Heading becomes `Models`; URL path is `/console/models`.
-- **Settings.** Click link `Settings`. Heading becomes `Settings`; URL path is `/console/settings`.
+- **Nodes.** Click link `Nodes`. Heading becomes `Nodes`; URL path is `/console/nodes`. Inner inventory may still hydrate; heading + `aria-current="page"` is enough for this sub-feature.
+- **Models.** Click link `Models`. Heading becomes `Models`; URL path is `/console/models`. Do **not** stop at the loading panel titled **Model Catalog**. Wait until `#models-catalog-card` or `#models-error-card` (`Models unavailable`).
+- **Settings.** Click link `Settings`. Heading becomes `Settings`; URL path is `/console/settings`. Wait until inference-defaults **Default model** options or `#settings-inference-defaults-error` appear — the Appearance card and empty form are already on the disconnected shell.
 - **Proof.** After each navigation, capture snapshot lines showing the new heading and `aria-current="page"` on the clicked nav item. Save combined snapshot to `${ARTIFACTS}/console-navigation/nav.aria.txt` and screenshot to `${ARTIFACTS}/console-navigation/nav.png`. Record visited paths in `proof.txt`.
 
 ## Gotchas
 
-- All sidebar items are enabled in dev; none should show `aria-disabled="true"`.
-- Wide pages (Models) may take a moment to exit the loading panel — wait for `Model Catalog` title or an explicit error card.
-- Settings triggers connected fetches; wait past the initial shell before proof.
+- All eight sidebar items are enabled (Overview, Nodes, Playground, Models, Model Hub, Organizations, Requests, Settings); none should show `aria-disabled="true"`. This feature only proves Nodes, Models, and Settings.
+- Direct URLs under `/console/...` are valid page proofs but do not replace the click path for this feature.
+- Settings **Advanced** / **Runtime / config snapshot** starts collapsed; expanding it is optional for nav proof.

--- a/.cursor/skills/verify-orchard/features/health-probes.md
+++ b/.cursor/skills/verify-orchard/features/health-probes.md
@@ -1,11 +1,11 @@
 # Public health probes
 
-Orchard exposes unauthenticated liveness and readiness HTTP probes used by operators and load balancers.
+Orchard exposes unauthenticated liveness and readiness HTTP probes used by operators and load balancers. Public bodies are status-only JSON.
 
 ## Sub-features
 
 - `health-live` — `/health/live` returns the public liveness JSON.
-- `health-ready` — `/health/ready` returns readiness status (success or structured not-ready).
+- `health-ready` — `/health/ready` returns public readiness status (`ok` or `error`).
 
 ## How to get to it (user POV)
 
@@ -19,11 +19,12 @@ Preconditions:
 - `control-orchard doctor` passes (includes live probe).
 
 - **Live probe.** Run `control-orchard curl /health/live`. Exit code 0; body exactly `{"status":"ok"}`.
-- **Ready probe.** Run `control-orchard curl /health/ready` and capture HTTP status + body (e.g. `curl -sS -D - -o body.json "${BASE_URL}/health/ready"`). Save headers/body under `${ARTIFACTS}/health-probes/`.
-- **Proof.** Write `proof.txt` listing both URLs, status codes, and bodies. Live must match spec; ready documents actual state without treating warm-up degradation as launch failure.
+- **Ready probe.** Run `curl -sS -D - -o body.json "${BASE_URL}/health/ready"` (or `control-orchard curl /health/ready` for the body). Capture HTTP status + body under `${ARTIFACTS}/health-probes/`. Expect HTTP **200** `{"status":"ok"}` or HTTP **503** `{"status":"error"}` — no extra keys.
+- **Proof.** Write `proof.txt` listing both URLs, status codes, and bodies. Live must match spec. Ready documents actual state; source-dev `plain_http_localhost` commonly stays 503 even after Postgres is up.
 
 ## Gotchas
 
-- `/health/live` only asserts the HTTP stack is up; `/health/ready` checks Postgres, migrations, and controller readiness.
-- Ready may fail briefly while migrations or runtime subsystems initialize — retry with backoff before failing the feature.
+- `/health/live` only asserts the HTTP stack is up. `/health/ready` uses the staged M0 predicate (Postgres reachable, migrations current, public API HTTPS enabled, a constant boot flag) but **strips** checks from the public body.
+- Source-dev defaults to plain HTTP localhost, so ready is often 503 `{"status":"error"}` for the HTTPS check — that is expected, not a launch failure.
+- Authenticated operator diagnostics live at `GET /ops/v1/health` (Bearer operator/admin token). Do not fold that into this public feature.
 - These endpoints are public; do not attach API tokens in URLs or commit probe secrets.

--- a/.cursor/skills/verify-orchard/features/mlx-smoke.md
+++ b/.cursor/skills/verify-orchard/features/mlx-smoke.md
@@ -1,0 +1,36 @@
+# MLX smoke
+
+The pinned Qwen3 MLX snapshot can be wrapped as an Orchard bundle and exercised with the opt-in Apple Silicon smoke tests. This is not a CI gate.
+
+## Sub-features
+
+- `prepare-bundle` — pinned Qwen3 bundle exists with `manifest.json` and `ORCHARD_MLX_SMOKE_MODEL_PATH` is exported.
+- `python-smoke` — worker pytest `mlx_backend_real` passes against that bundle.
+- `elixir-smoke` — node-agent `mix test --only mlx_smoke` passes against that bundle.
+
+## How to get to it (user POV)
+
+- Prepare the bundle: `mise exec -- ./scripts/prepare-mlx-smoke-bundle.sh` then `eval "$(mise exec -- ./scripts/prepare-mlx-smoke-bundle.sh --print-path)"`.
+- Run smoke: `mise exec -- ./scripts/smoke-mlx.sh`.
+- Verification wrappers: `control-orchard prepare-bundle` then `control-orchard smoke-mlx`.
+
+## Driving it with control-orchard
+
+Preconditions:
+
+- Apple Silicon macOS (`Darwin` `arm64`).
+- `make setup` (or equivalent) already run.
+- Do not treat a missing Hugging Face download as a product failure — report `verified-unreachable` with the attempted command.
+
+- **Prepare bundle.** Run `control-orchard prepare-bundle`. Exit 0. stdout includes `export ORCHARD_MLX_SMOKE_MODEL_PATH=...` and `control-orchard meta` shows the same path. The directory contains `manifest.json`. A cache hit (already prepared) is valid proof.
+- **Run smoke.** Run `control-orchard smoke-mlx`. Exit 0. Log ends with `Python smoke: PASS`, `Elixir smoke: PASS`, and `Overall: PASS`.
+- **Proof.** Save `${ARTIFACTS}/mlx-smoke/smoke.log` (created by the helper) and `proof.txt` with feature id `mlx-smoke`, the bundle path, and the summary lines. Do not commit the bundle or the log.
+
+## Gotchas
+
+- Not a CI, `make test`, or product validation gate. Skip on non-arm64 hosts.
+- The helper refuses destinations inside the git checkout. Default cache is `~/.cache/orchard/mlx-smoke-bundles/qwen3-0.6b-4bit` (~335 MB).
+- First prepare may download from Hugging Face; `--print-path` fails until a successful prepare. Use `--from-snapshot DIR` when air-gapped.
+- `smoke-mlx` is an isolated CLI session. It does not need `control-orchard launch`. If a verification source-dev instance is already up, the helper binds Elixir smoke to a free `ORCHARD_TEST_NODE_AGENT_PORT` so it does not steal `:50071`.
+- Qwen3 thinking mode can consume a short generation budget. The Elixir smoke uses a tiny `max_output_tokens`; Chat Completions checks should use non-thinking if added later.
+- Playground and `/v1/chat/completions` still need `orchardctl models import`, tenant grants, and an API token. This feature only proves the worker/node-agent smoke path.

--- a/.cursor/skills/verify-orchard/features/models-catalog.md
+++ b/.cursor/skills/verify-orchard/features/models-catalog.md
@@ -4,7 +4,7 @@ The Models page lists the full model catalog with lifecycle actions. On a fresh 
 
 ## Sub-features
 
-- `models-load` — Models page exits loading and shows catalog or explicit empty state.
+- `models-load` — Models page exits loading and shows catalog or explicit empty/error state.
 - `models-shell` — Console shell with Models nav active.
 
 ## How to get to it (user POV)
@@ -19,10 +19,12 @@ Preconditions:
 - `control-orchard doctor` passes.
 
 - **Open models.** Navigate or click **Models**. URL `/console/models`; heading `Models`.
-- **Wait for catalog.** Wait until `#models-catalog-card`, `#models-loading-card`, or `#models-error-card` is present — loading alone is insufficient for final proof.
-- **Proof.** Snapshot should include `Model Catalog` title or the explicit unavailable/error message. Save `${ARTIFACTS}/models-catalog/models.aria.txt`, screenshot `${ARTIFACTS}/models-catalog/models.png`, and `proof.txt` noting empty vs populated catalog.
+- **Wait for catalog.** Ignore `#models-loading-card` (its title is also **Model Catalog**). Final proof requires `#models-catalog-card` or `#models-error-card`.
+- **Proof.** Catalog: `h3` **Model Catalog** plus either table rows or `#models-empty-state` (`No models imported yet.`). Error: **Models unavailable**. Save `${ARTIFACTS}/models-catalog/models.aria.txt`, screenshot `${ARTIFACTS}/models-catalog/models.png`, and `proof.txt` noting empty vs populated catalog.
 
 ## Gotchas
 
+- Loading and success both say **Model Catalog**; that string alone is not settled-catalog proof.
+- Overview also has a **Model Catalog** card — require `/console/models` plus `#models-catalog-card` or `#models-error-card`.
 - Lifecycle action buttons (activate/deprecate/retire/delete) mutate DB state — read-only verification should not click them unless cleanup is planned.
 - Imported models from manual dev sessions appear in the shared `orchard_dev` database; empty vs non-empty depends on local DB state, not the proof harness.

--- a/.cursor/skills/verify-orchard/features/overview.md
+++ b/.cursor/skills/verify-orchard/features/overview.md
@@ -1,12 +1,12 @@
 # Console overview
 
-The Console overview is the operator landing page at `/console`. It shows system readiness, runtime snapshot cards, request counts, and the model catalog summary once LiveView connects.
+The Console overview is the operator landing page at `/console`. After LiveView connects it shows Quickstart, System Status, readiness checks, a runtime snapshot, request counts, and a model catalog summary.
 
 ## Sub-features
 
 - `overview-load` — page renders with Console shell and Overview heading.
 - `overview-nav-active` — sidebar marks Overview as the current page.
-- `overview-readiness` — readiness section renders (pass or fail states are both valid proof).
+- `overview-readiness` — readiness section renders (OK, Blocked, Unknown, or unavailable are all valid proof).
 
 ## How to get to it (user POV)
 
@@ -23,11 +23,12 @@ Preconditions:
 - **Open overview.** Navigate to `{BASE_URL}/console`. Run `browser_navigate` with the verification base URL + `/console`. The document title or main heading includes `Overview`.
 - **Confirm shell.** Run `browser_snapshot`. Snapshot includes `aria-label="Console navigation"`, link name `Overview`, and `#console-sidebar`.
 - **Confirm active nav.** Snapshot shows the Overview link with `aria-current="page"`.
-- **Wait for content.** If a loading panel appears (`Loading` / quickstart hydrating), wait and snapshot again until readiness cards, quickstart, or explicit empty/runtime states render.
+- **Wait for connected data.** The first paint is already a full dashboard (Quickstart hydrating, System Status with `—` metrics, Readiness rows, compact in-card loaders). Do not treat that as done. Wait until **Last updated** replaces **Waiting for first live update** / **Connecting to live controller…**, and Runtime Snapshot is no longer **Loading runtime snapshot.** (a table, **No loaded models.**, or **Runtime unavailable.** are all success).
 - **Proof.** Run `browser_snapshot` → save to `${ARTIFACTS}/overview/overview.aria.txt`. Run `browser_take_screenshot` → save to `${ARTIFACTS}/overview/overview.png`. Write `${ARTIFACTS}/overview/proof.txt` with feature id `overview`, entry `GET /console`, and timestamp.
 
 ## Gotchas
 
-- Disconnected first render shows loading copy only; do not screenshot until connected content appears.
-- Runtime cards may show unavailable/degraded states on a fresh dev boot without an imported model — that is still valid proof if the page heading and nav are correct.
+- Disconnected HTTP GET already includes the Overview `h1`, sidebar, and `#overview-readiness`. Waiting only for those can snapshot pre-connect placeholders.
+- Quickstart may stay on **Loading your quickstart state…** until the `OverviewQuickstart` JS hook runs; connected proof is **Last updated** plus a settled Runtime Snapshot, not the checklist alone.
+- Runtime cards may show unavailable/degraded states on source-dev (for example **Degraded** with 3/4 checks when public HTTPS is off) — that is still valid proof if the heading and nav are correct.
 - Do not use packaged BEAM on port 4000; verification expects source-dev from `control-orchard launch`.

--- a/.cursor/skills/verify-orchard/features/settings.md
+++ b/.cursor/skills/verify-orchard/features/settings.md
@@ -1,11 +1,11 @@
 # Settings page
 
-Settings exposes Console inference defaults and an advanced debug snapshot for operators.
+Settings exposes Console appearance notes, inference defaults, and an advanced debug snapshot for operators.
 
 ## Sub-features
 
-- `settings-load` — Settings page renders with heading and form regions.
-- `settings-connected` — connected mount completes (defaults or explicit error state).
+- `settings-load` — Settings page renders with heading and the Appearance, Inference Defaults, and Advanced cards.
+- `settings-connected` — connected mount completes (defaults loaded or explicit error; debug snapshot leaves Loading).
 
 ## How to get to it (user POV)
 
@@ -19,10 +19,11 @@ Preconditions:
 - `control-orchard doctor` passes.
 
 - **Open settings.** Navigate to `/console/settings` or click **Settings**. Heading `Settings`; nav item Settings has `aria-current="page"`.
-- **Wait for connected data.** Page may fetch inference defaults and debug snapshot after connect — wait until form fields or an explicit error/unavailable message appears (not merely the static shell).
-- **Proof.** Snapshot includes `Settings` heading and inference defaults section labels. Save `${ARTIFACTS}/settings/settings.aria.txt`, screenshot `${ARTIFACTS}/settings/settings.png`, and `proof.txt`.
+- **Wait for connected data.** The Inference Defaults form (`#settings-inference-defaults-form`) is already on the disconnected shell — form fields alone are not proof. Wait until **Default model** has real options (or **No default model** plus loaded options) **or** `#settings-inference-defaults-error` / `#settings-default-models-error` appears. The Advanced **Runtime / config snapshot** disclosure starts collapsed; inner Worker state is optional after expand.
+- **Proof.** Snapshot includes `Settings` heading, **Appearance**, **Inference Defaults** labels, and **Advanced**. Save `${ARTIFACTS}/settings/settings.aria.txt`, screenshot `${ARTIFACTS}/settings/settings.png`, and `proof.txt`.
 
 ## Gotchas
 
-- Saving inference defaults mutates DB — read-only verification must not submit the form unless rollback is planned.
-- Debug snapshot refresh is async; a single snapshot after a short wait is enough for proof.
+- Saving inference defaults mutates DB — read-only verification must not submit **Save defaults** unless rollback is planned.
+- **Refresh now** on the debug snapshot is read-only but async; do not require a second refresh for proof.
+- Expanding **Runtime / config snapshot** is optional; a11y snapshots often hide closed `<details>` content.

--- a/.cursor/skills/verify-orchard/features/settings.md
+++ b/.cursor/skills/verify-orchard/features/settings.md
@@ -19,11 +19,11 @@ Preconditions:
 - `control-orchard doctor` passes.
 
 - **Open settings.** Navigate to `/console/settings` or click **Settings**. Heading `Settings`; nav item Settings has `aria-current="page"`.
-- **Wait for connected data.** The Inference Defaults form (`#settings-inference-defaults-form`) is already on the disconnected shell — form fields alone are not proof. Wait until **Default model** has real options (or **No default model** plus loaded options) **or** `#settings-inference-defaults-error` / `#settings-default-models-error` appears. The Advanced **Runtime / config snapshot** disclosure starts collapsed; inner Worker state is optional after expand.
+- **Wait for connected data.** The Inference Defaults form (`#settings-inference-defaults-form`) is already on the disconnected shell — form fields alone are not proof. Expand **Runtime / config snapshot** and wait until its badge is no longer **Loading**; a worker state or **Unavailable** is settled proof even when the successfully loaded model list is empty. `#settings-inference-defaults-error` / `#settings-default-models-error` is also explicit settled proof.
 - **Proof.** Snapshot includes `Settings` heading, **Appearance**, **Inference Defaults** labels, and **Advanced**. Save `${ARTIFACTS}/settings/settings.aria.txt`, screenshot `${ARTIFACTS}/settings/settings.png`, and `proof.txt`.
 
 ## Gotchas
 
 - Saving inference defaults mutates DB — read-only verification must not submit **Save defaults** unless rollback is planned.
 - **Refresh now** on the debug snapshot is read-only but async; do not require a second refresh for proof.
-- Expanding **Runtime / config snapshot** is optional; a11y snapshots often hide closed `<details>` content.
+- A11y snapshots often hide closed `<details>` content, so expand **Runtime / config snapshot** before checking its badge.

--- a/.cursor/skills/verify-orchard/scripts/control-orchard.sh
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard.sh
@@ -27,6 +27,36 @@ preserved_bundle_path() {
   fi
 }
 
+pinned_python() {
+  (
+    cd "$REPO_ROOT"
+    mise exec -- python "$@"
+  )
+}
+
+ensure_launch_pid_slot() {
+  if [[ ! -f "$PID_FILE" ]]; then
+    return 0
+  fi
+
+  local existing_pid
+  existing_pid="$(cat "$PID_FILE")"
+  if kill -0 "$existing_pid" 2>/dev/null; then
+    echo "error: verification instance already running (pid ${existing_pid})" >&2
+    echo "error: run 'control-orchard stop' first" >&2
+    return 1
+  fi
+
+  rm -f "$PID_FILE"
+}
+
+load_meta_preserving_bundle_path() {
+  local bundle_path
+  bundle_path="$(preserved_bundle_path)"
+  [[ -f "$META_FILE" ]] && source "$META_FILE"
+  ORCHARD_MLX_SMOKE_MODEL_PATH="$bundle_path"
+}
+
 write_meta() {
   local bundle_path
   bundle_path="$(preserved_bundle_path)"
@@ -156,14 +186,7 @@ cmd_launch() {
   require_repo
   write_meta
 
-  if [[ -f "$PID_FILE" ]]; then
-    existing_pid="$(cat "$PID_FILE")"
-    if kill -0 "$existing_pid" 2>/dev/null; then
-      echo "error: verification instance already running (pid ${existing_pid})" >&2
-      echo "error: run 'control-orchard stop' first" >&2
-      exit 1
-    fi
-  fi
+  ensure_launch_pid_slot || exit 1
 
   foreign_pid="$(port_owner_pid)"
   if [[ -n "$foreign_pid" ]]; then
@@ -201,12 +224,7 @@ cmd_launch() {
 
   # Detach into a new session so the BEAM survives this helper returning
   # (agent shells send SIGHUP to the launch process group when the command ends).
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "error: python3 is required to detach the verification server" >&2
-    exit 1
-  fi
-
-  python3 - "$REPO_ROOT" "$LOG_FILE" "$PID_FILE" "$PORT" <<'PY'
+  pinned_python - "$REPO_ROOT" "$LOG_FILE" "$PID_FILE" "$PORT" <<'PY'
 import os
 import sys
 import time
@@ -383,7 +401,7 @@ require_apple_silicon() {
 }
 
 free_tcp_port() {
-  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+  pinned_python -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
 }
 
 cmd_prepare_bundle() {
@@ -416,7 +434,7 @@ cmd_prepare_bundle() {
 cmd_smoke_mlx() {
   require_repo
   require_apple_silicon
-  [[ -f "$META_FILE" ]] && source "$META_FILE"
+  load_meta_preserving_bundle_path
   if [[ -z "${ORCHARD_MLX_SMOKE_MODEL_PATH:-}" || ! -f "${ORCHARD_MLX_SMOKE_MODEL_PATH}/manifest.json" ]]; then
     cmd_prepare_bundle
     source "$META_FILE"
@@ -469,4 +487,6 @@ main() {
   esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.cursor/skills/verify-orchard/scripts/control-orchard.sh
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard.sh
@@ -17,7 +17,19 @@ READY_TIMEOUT_SEC="${ORCHARD_VERIFY_READY_TIMEOUT_SEC:-300}"
 
 mkdir -p "$STATE_DIR"
 
+preserved_bundle_path() {
+  if [[ -n "${ORCHARD_MLX_SMOKE_MODEL_PATH:-}" ]]; then
+    printf '%s' "$ORCHARD_MLX_SMOKE_MODEL_PATH"
+    return
+  fi
+  if [[ -f "$META_FILE" ]]; then
+    sed -n 's/^ORCHARD_MLX_SMOKE_MODEL_PATH=//p' "$META_FILE" | tail -n 1
+  fi
+}
+
 write_meta() {
+  local bundle_path
+  bundle_path="$(preserved_bundle_path)"
   cat >"$META_FILE" <<EOF
 ORCHARD_VERIFY_RUN_ID=${RUN_ID}
 ORCHARD_VERIFY_STATE_DIR=${STATE_DIR}
@@ -26,6 +38,7 @@ ORCHARD_VERIFY_BASE_URL=${BASE_URL}
 ORCHARD_VERIFY_PID_FILE=${PID_FILE}
 ORCHARD_VERIFY_LOG_FILE=${LOG_FILE}
 ORCHARD_VERIFY_ARTIFACTS_DIR=${STATE_DIR}/artifacts
+ORCHARD_MLX_SMOKE_MODEL_PATH=${bundle_path}
 EOF
 }
 
@@ -34,12 +47,14 @@ usage() {
 Usage: control-orchard <command>
 
 Commands:
-  bootstrap Ensure tmp/dev/node-trust exists (opt-in orphan recover)
-  launch    Start source-dev in the background (mix phx.server)
-  doctor    Read-only health check for the verification instance
-  stop      Stop the instance started by launch (PID file only)
-  meta      Print state paths for the current run
-  curl      curl wrapper against the verification base URL
+  bootstrap       Ensure tmp/dev/node-trust exists (opt-in orphan recover)
+  launch          Start source-dev in the background (mix phx.server)
+  doctor          Read-only health check for the verification instance
+  stop            Stop the instance started by launch (PID file only)
+  meta            Print state paths for the current run
+  curl            curl wrapper against the verification base URL
+  prepare-bundle  Prepare the pinned Qwen3 MLX smoke bundle (not a CI gate)
+  smoke-mlx       Run scripts/smoke-mlx.sh against that bundle
 
 Environment:
   ORCHARD_VERIFY_PORT          HTTP port (default: 4000)
@@ -48,6 +63,7 @@ Environment:
   ORCHARD_VERIFY_READY_TIMEOUT_SEC  Launch wait timeout (default: 300)
   ORCHARD_VERIFY_TRUST_RECOVER      Set to 1 to allow wiping orphaned DB trust
                                     when local node-trust files are missing
+  ORCHARD_MLX_SMOKE_MODEL_PATH      Absolute Orchard bundle dir (set by prepare-bundle)
 EOF
 }
 
@@ -359,6 +375,73 @@ cmd_curl() {
   curl -sS "${BASE_URL}$*"
 }
 
+require_apple_silicon() {
+  if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+    echo "error: MLX smoke requires Apple Silicon macOS (detected $(uname -s) $(uname -m))" >&2
+    exit 1
+  fi
+}
+
+free_tcp_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+
+cmd_prepare_bundle() {
+  require_repo
+  write_meta
+  local prepare="${REPO_ROOT}/scripts/prepare-mlx-smoke-bundle.sh"
+  [[ -f "$prepare" ]] || {
+    echo "error: missing ${prepare}" >&2
+    exit 1
+  }
+
+  echo "==> Preparing pinned Qwen3 MLX smoke bundle (not a CI gate)"
+  local out
+  out="$(
+    cd "$REPO_ROOT"
+    mise exec -- ./scripts/prepare-mlx-smoke-bundle.sh "$@"
+  )"
+  printf '%s\n' "$out"
+  local export_line
+  export_line="$(printf '%s\n' "$out" | grep '^export ORCHARD_MLX_SMOKE_MODEL_PATH=' | tail -n 1 || true)"
+  if [[ -z "$export_line" ]]; then
+    echo "error: prepare-mlx-smoke-bundle.sh did not print export ORCHARD_MLX_SMOKE_MODEL_PATH=..." >&2
+    exit 1
+  fi
+  eval "$export_line"
+  write_meta
+  echo "==> Bundle ready: ${ORCHARD_MLX_SMOKE_MODEL_PATH}"
+}
+
+cmd_smoke_mlx() {
+  require_repo
+  require_apple_silicon
+  [[ -f "$META_FILE" ]] && source "$META_FILE"
+  if [[ -z "${ORCHARD_MLX_SMOKE_MODEL_PATH:-}" || ! -f "${ORCHARD_MLX_SMOKE_MODEL_PATH}/manifest.json" ]]; then
+    cmd_prepare_bundle
+    source "$META_FILE"
+  fi
+
+  if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+    ORCHARD_TEST_NODE_AGENT_PORT="$(free_tcp_port)"
+    export ORCHARD_TEST_NODE_AGENT_PORT
+    echo "==> Verification instance is running; Elixir smoke will use ORCHARD_TEST_NODE_AGENT_PORT=${ORCHARD_TEST_NODE_AGENT_PORT}"
+  fi
+
+  local art="${STATE_DIR}/artifacts/mlx-smoke"
+  mkdir -p "$art"
+  echo "==> Running scripts/smoke-mlx.sh"
+  echo "    bundle: ${ORCHARD_MLX_SMOKE_MODEL_PATH}"
+  (
+    cd "$REPO_ROOT"
+    export ORCHARD_MLX_SMOKE_MODEL_PATH
+    if [[ -n "${ORCHARD_TEST_NODE_AGENT_PORT:-}" ]]; then
+      export ORCHARD_TEST_NODE_AGENT_PORT
+    fi
+    mise exec -- ./scripts/smoke-mlx.sh
+  ) | tee "${art}/smoke.log"
+}
+
 main() {
   cmd="${1:-}"
   shift || true
@@ -368,6 +451,8 @@ main() {
     doctor) cmd_doctor "$@" ;;
     stop) cmd_stop "$@" ;;
     meta) cmd_meta "$@" ;;
+    prepare-bundle) cmd_prepare_bundle "$@" ;;
+    smoke-mlx) cmd_smoke_mlx "$@" ;;
     curl)
       if (($# == 0)); then
         echo "error: control-orchard curl expects a path such as /health/live" >&2

--- a/.cursor/skills/verify-orchard/scripts/control-orchard.sh
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard.sh
@@ -10,14 +10,115 @@ RUN_ID="${ORCHARD_VERIFY_RUN_ID:-$(date +%Y%m%d%H%M%S)-$$}"
 STATE_DIR="${ORCHARD_VERIFY_STATE_DIR:-/tmp/orchard-verify-${RUN_ID}}"
 PID_FILE="${STATE_DIR}/dev.pid"
 LOG_FILE="${STATE_DIR}/dev.log"
-META_FILE="${STATE_DIR}/meta.env"
+META_FILE="${STATE_DIR}/meta.json"
+LEGACY_META_FILE="${STATE_DIR}/meta.env"
 PORT="${ORCHARD_VERIFY_PORT:-4000}"
 BASE_URL="http://127.0.0.1:${PORT}"
 READY_TIMEOUT_SEC="${ORCHARD_VERIFY_READY_TIMEOUT_SEC:-300}"
 
 mkdir -p "$STATE_DIR"
 
+pinned_python() {
+  (
+    cd "$REPO_ROOT"
+    mise exec -- python "$@"
+  )
+}
+
+reject_legacy_meta() {
+  if [[ -e "$LEGACY_META_FILE" ]]; then
+    echo "error: legacy metadata at ${LEGACY_META_FILE} is rejected; remove the state directory and start a new verification run" >&2
+    return 1
+  fi
+}
+
+load_meta() {
+  reject_legacy_meta || return 1
+  if [[ ! -f "$META_FILE" ]]; then
+    echo "error: metadata not found at ${META_FILE}" >&2
+    return 1
+  fi
+
+  local values_file
+  values_file="$(mktemp "${STATE_DIR}/.meta-values.XXXXXX")"
+  if ! pinned_python - "$META_FILE" "$STATE_DIR" >"$values_file" <<'PY'
+import json
+import pathlib
+import sys
+
+meta_path = pathlib.Path(sys.argv[1])
+expected_state_dir = sys.argv[2]
+
+try:
+    with meta_path.open(encoding="utf-8") as handle:
+        metadata = json.load(handle)
+except (OSError, UnicodeError, json.JSONDecodeError) as error:
+    raise SystemExit(f"error: invalid verification metadata: {error}")
+
+expected_keys = {
+    "ORCHARD_MLX_SMOKE_MODEL_PATH",
+    "ORCHARD_VERIFY_ARTIFACTS_DIR",
+    "ORCHARD_VERIFY_BASE_URL",
+    "ORCHARD_VERIFY_LOG_FILE",
+    "ORCHARD_VERIFY_PID_FILE",
+    "ORCHARD_VERIFY_PORT",
+    "ORCHARD_VERIFY_RUN_ID",
+    "ORCHARD_VERIFY_STATE_DIR",
+    "format_version",
+}
+if not isinstance(metadata, dict) or set(metadata) != expected_keys:
+    raise SystemExit("error: invalid verification metadata schema")
+if metadata["format_version"] != 1:
+    raise SystemExit("error: unsupported verification metadata format")
+if not isinstance(metadata["ORCHARD_VERIFY_RUN_ID"], str) or not metadata["ORCHARD_VERIFY_RUN_ID"]:
+    raise SystemExit("error: invalid verification run id")
+if metadata["ORCHARD_VERIFY_STATE_DIR"] != expected_state_dir:
+    raise SystemExit("error: verification metadata state directory mismatch")
+if not isinstance(metadata["ORCHARD_VERIFY_PORT"], int) or isinstance(metadata["ORCHARD_VERIFY_PORT"], bool):
+    raise SystemExit("error: invalid verification port")
+if not 1 <= metadata["ORCHARD_VERIFY_PORT"] <= 65535:
+    raise SystemExit("error: invalid verification port")
+if not isinstance(metadata["ORCHARD_MLX_SMOKE_MODEL_PATH"], str):
+    raise SystemExit("error: invalid MLX smoke model path")
+
+derived_values = {
+    "ORCHARD_VERIFY_ARTIFACTS_DIR": str(pathlib.Path(expected_state_dir) / "artifacts"),
+    "ORCHARD_VERIFY_BASE_URL": f"http://127.0.0.1:{metadata['ORCHARD_VERIFY_PORT']}",
+    "ORCHARD_VERIFY_LOG_FILE": str(pathlib.Path(expected_state_dir) / "dev.log"),
+    "ORCHARD_VERIFY_PID_FILE": str(pathlib.Path(expected_state_dir) / "dev.pid"),
+}
+for key, expected_value in derived_values.items():
+    if metadata[key] != expected_value:
+        raise SystemExit(f"error: verification metadata {key} mismatch")
+
+values = (
+    metadata["ORCHARD_VERIFY_RUN_ID"],
+    metadata["ORCHARD_VERIFY_STATE_DIR"],
+    str(metadata["ORCHARD_VERIFY_PORT"]),
+    metadata["ORCHARD_MLX_SMOKE_MODEL_PATH"],
+)
+sys.stdout.buffer.write(b"".join(value.encode() + b"\0" for value in values))
+PY
+  then
+    rm -f "$values_file"
+    return 1
+  fi
+
+  exec 9<"$values_file"
+  IFS= read -r -d '' RUN_ID <&9
+  IFS= read -r -d '' STATE_DIR <&9
+  IFS= read -r -d '' PORT <&9
+  IFS= read -r -d '' ORCHARD_MLX_SMOKE_MODEL_PATH <&9
+  exec 9<&-
+  rm -f "$values_file"
+
+  PID_FILE="${STATE_DIR}/dev.pid"
+  LOG_FILE="${STATE_DIR}/dev.log"
+  BASE_URL="http://127.0.0.1:${PORT}"
+}
+
 preserved_bundle_path() {
+  reject_legacy_meta || return 1
   if [[ -n "${ORCHARD_MLX_SMOKE_MODEL_PATH:-}" ]]; then
     printf '%s' "$ORCHARD_MLX_SMOKE_MODEL_PATH"
     return
@@ -25,18 +126,10 @@ preserved_bundle_path() {
   if [[ -f "$META_FILE" ]]; then
     (
       unset ORCHARD_MLX_SMOKE_MODEL_PATH
-      # shellcheck disable=SC1090
-      source "$META_FILE"
+      load_meta
       printf '%s' "${ORCHARD_MLX_SMOKE_MODEL_PATH:-}"
     )
   fi
-}
-
-pinned_python() {
-  (
-    cd "$REPO_ROOT"
-    mise exec -- python "$@"
-  )
 }
 
 ensure_launch_pid_slot() {
@@ -57,24 +150,43 @@ ensure_launch_pid_slot() {
 
 load_meta_preserving_bundle_path() {
   local bundle_path
-  bundle_path="$(preserved_bundle_path)"
-  [[ -f "$META_FILE" ]] && source "$META_FILE"
+  if ! bundle_path="$(preserved_bundle_path)"; then
+    return 1
+  fi
+  [[ -f "$META_FILE" ]] && load_meta
   ORCHARD_MLX_SMOKE_MODEL_PATH="$bundle_path"
 }
 
 write_meta() {
   local bundle_path
-  bundle_path="$(preserved_bundle_path)"
-  {
-    printf 'ORCHARD_VERIFY_RUN_ID=%q\n' "$RUN_ID"
-    printf 'ORCHARD_VERIFY_STATE_DIR=%q\n' "$STATE_DIR"
-    printf 'ORCHARD_VERIFY_PORT=%q\n' "$PORT"
-    printf 'ORCHARD_VERIFY_BASE_URL=%q\n' "$BASE_URL"
-    printf 'ORCHARD_VERIFY_PID_FILE=%q\n' "$PID_FILE"
-    printf 'ORCHARD_VERIFY_LOG_FILE=%q\n' "$LOG_FILE"
-    printf 'ORCHARD_VERIFY_ARTIFACTS_DIR=%q\n' "${STATE_DIR}/artifacts"
-    printf 'ORCHARD_MLX_SMOKE_MODEL_PATH=%q\n' "$bundle_path"
-  } >"$META_FILE"
+  if ! bundle_path="$(preserved_bundle_path)"; then
+    return 1
+  fi
+  pinned_python - "$META_FILE" "$RUN_ID" "$STATE_DIR" "$PORT" "$bundle_path" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+meta_path = pathlib.Path(sys.argv[1])
+metadata = {
+    "ORCHARD_MLX_SMOKE_MODEL_PATH": sys.argv[5],
+    "ORCHARD_VERIFY_ARTIFACTS_DIR": str(pathlib.Path(sys.argv[3]) / "artifacts"),
+    "ORCHARD_VERIFY_BASE_URL": f"http://127.0.0.1:{int(sys.argv[4])}",
+    "ORCHARD_VERIFY_LOG_FILE": str(pathlib.Path(sys.argv[3]) / "dev.log"),
+    "ORCHARD_VERIFY_PID_FILE": str(pathlib.Path(sys.argv[3]) / "dev.pid"),
+    "ORCHARD_VERIFY_PORT": int(sys.argv[4]),
+    "ORCHARD_VERIFY_RUN_ID": sys.argv[2],
+    "ORCHARD_VERIFY_STATE_DIR": sys.argv[3],
+    "format_version": 1,
+}
+temporary_path = meta_path.with_name(f".{meta_path.name}.{os.getpid()}.tmp")
+with temporary_path.open("w", encoding="utf-8") as handle:
+    json.dump(metadata, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+os.chmod(temporary_path, 0o600)
+temporary_path.replace(meta_path)
+PY
 }
 
 usage() {
@@ -306,9 +418,7 @@ PY
 
 cmd_doctor() {
   [[ -f "$META_FILE" ]] || write_meta
-
-  # shellcheck disable=SC1090
-  source "$META_FILE"
+  load_meta
 
   echo "==> Doctor for ${BASE_URL}"
 
@@ -361,7 +471,8 @@ cmd_doctor() {
 }
 
 cmd_stop() {
-  [[ -f "$META_FILE" ]] && source "$META_FILE"
+  reject_legacy_meta
+  [[ -f "$META_FILE" ]] && load_meta
 
   if [[ ! -f "$PID_FILE" ]]; then
     echo "==> No pid file; nothing to stop"
@@ -394,7 +505,8 @@ cmd_meta() {
 }
 
 cmd_curl() {
-  [[ -f "$META_FILE" ]] && source "$META_FILE"
+  reject_legacy_meta
+  [[ -f "$META_FILE" ]] && load_meta
   curl -sS "${BASE_URL}$*"
 }
 
@@ -442,7 +554,7 @@ cmd_smoke_mlx() {
   load_meta_preserving_bundle_path
   if [[ -z "${ORCHARD_MLX_SMOKE_MODEL_PATH:-}" || ! -f "${ORCHARD_MLX_SMOKE_MODEL_PATH}/manifest.json" ]]; then
     cmd_prepare_bundle
-    source "$META_FILE"
+    load_meta
   fi
 
   if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then

--- a/.cursor/skills/verify-orchard/scripts/control-orchard.sh
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard.sh
@@ -183,19 +183,67 @@ cmd_launch() {
   echo "    state: ${STATE_DIR}"
   echo "    log:   ${LOG_FILE}"
 
-  (
-    cd "$REPO_ROOT"
-    export MIX_ENV=dev
-    export ORCHARD_VERIFY_MODE=1
-    export PORT="$PORT"
-    export ORCHARD_SOURCE_DEV_ROLE=all_in_one
-    export ORCHARD_NODE_AGENT_LISTEN_PORT=50071
-    export ORCHARD_RUNTIME_CLIENT_PORT=50071
-    exec mise exec -- mix phx.server
-  ) >"$LOG_FILE" 2>&1 &
+  # Detach into a new session so the BEAM survives this helper returning
+  # (agent shells send SIGHUP to the launch process group when the command ends).
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "error: python3 is required to detach the verification server" >&2
+    exit 1
+  fi
 
-  pid=$!
-  echo "$pid" >"$PID_FILE"
+  python3 - "$REPO_ROOT" "$LOG_FILE" "$PID_FILE" "$PORT" <<'PY'
+import os
+import sys
+import time
+
+repo, log_path, pid_path, port = sys.argv[1:5]
+env_update = {
+    "MIX_ENV": "dev",
+    "ORCHARD_VERIFY_MODE": "1",
+    "PORT": port,
+    "ORCHARD_SOURCE_DEV_ROLE": "all_in_one",
+    "ORCHARD_NODE_AGENT_LISTEN_PORT": "50071",
+    "ORCHARD_RUNTIME_CLIENT_PORT": "50071",
+}
+
+pid = os.fork()
+if pid > 0:
+    for _ in range(100):
+        try:
+            with open(pid_path, encoding="utf-8") as handle:
+                child = int(handle.read().strip())
+            os.kill(child, 0)
+            os._exit(0)
+        except (OSError, ValueError):
+            time.sleep(0.05)
+    sys.stderr.write("error: detached server did not record a live pid\n")
+    os._exit(1)
+
+os.setsid()
+pid = os.fork()
+if pid > 0:
+    os._exit(0)
+
+os.chdir(repo)
+os.environ.update(env_update)
+devnull = os.open(os.devnull, os.O_RDONLY)
+log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+os.dup2(devnull, 0)
+os.dup2(log_fd, 1)
+os.dup2(log_fd, 2)
+if devnull > 2:
+    os.close(devnull)
+if log_fd > 2:
+    os.close(log_fd)
+
+child = os.fork()
+if child == 0:
+    os.execvp("mise", ["mise", "exec", "--", "mix", "phx.server"])
+with open(pid_path, "w", encoding="utf-8") as handle:
+    handle.write(f"{child}\n")
+os._exit(0)
+PY
+
+  pid="$(cat "$PID_FILE")"
 
   deadline=$((SECONDS + READY_TIMEOUT_SEC))
   while (( SECONDS < deadline )); do

--- a/.cursor/skills/verify-orchard/scripts/control-orchard.sh
+++ b/.cursor/skills/verify-orchard/scripts/control-orchard.sh
@@ -23,7 +23,12 @@ preserved_bundle_path() {
     return
   fi
   if [[ -f "$META_FILE" ]]; then
-    sed -n 's/^ORCHARD_MLX_SMOKE_MODEL_PATH=//p' "$META_FILE" | tail -n 1
+    (
+      unset ORCHARD_MLX_SMOKE_MODEL_PATH
+      # shellcheck disable=SC1090
+      source "$META_FILE"
+      printf '%s' "${ORCHARD_MLX_SMOKE_MODEL_PATH:-}"
+    )
   fi
 }
 
@@ -60,16 +65,16 @@ load_meta_preserving_bundle_path() {
 write_meta() {
   local bundle_path
   bundle_path="$(preserved_bundle_path)"
-  cat >"$META_FILE" <<EOF
-ORCHARD_VERIFY_RUN_ID=${RUN_ID}
-ORCHARD_VERIFY_STATE_DIR=${STATE_DIR}
-ORCHARD_VERIFY_PORT=${PORT}
-ORCHARD_VERIFY_BASE_URL=${BASE_URL}
-ORCHARD_VERIFY_PID_FILE=${PID_FILE}
-ORCHARD_VERIFY_LOG_FILE=${LOG_FILE}
-ORCHARD_VERIFY_ARTIFACTS_DIR=${STATE_DIR}/artifacts
-ORCHARD_MLX_SMOKE_MODEL_PATH=${bundle_path}
-EOF
+  {
+    printf 'ORCHARD_VERIFY_RUN_ID=%q\n' "$RUN_ID"
+    printf 'ORCHARD_VERIFY_STATE_DIR=%q\n' "$STATE_DIR"
+    printf 'ORCHARD_VERIFY_PORT=%q\n' "$PORT"
+    printf 'ORCHARD_VERIFY_BASE_URL=%q\n' "$BASE_URL"
+    printf 'ORCHARD_VERIFY_PID_FILE=%q\n' "$PID_FILE"
+    printf 'ORCHARD_VERIFY_LOG_FILE=%q\n' "$LOG_FILE"
+    printf 'ORCHARD_VERIFY_ARTIFACTS_DIR=%q\n' "${STATE_DIR}/artifacts"
+    printf 'ORCHARD_MLX_SMOKE_MODEL_PATH=%q\n' "$bundle_path"
+  } >"$META_FILE"
 }
 
 usage() {

--- a/scripts/test-verify-orchard-control.sh
+++ b/scripts/test-verify-orchard-control.sh
@@ -39,7 +39,11 @@ load_meta_preserving_bundle_path
 [[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" == "$TMP_ROOT/operator-bundle" ]] ||
   fail "stored bundle path was not loaded"
 
-printf '%s\n' 'ORCHARD_MLX_SMOKE_MODEL_PATH=' >"$META_FILE"
+[[ "$META_FILE" == "$ORCHARD_VERIFY_STATE_DIR/meta.json" ]] ||
+  fail "metadata file is not data-only JSON"
+
+ORCHARD_MLX_SMOKE_MODEL_PATH=""
+write_meta
 ORCHARD_MLX_SMOKE_MODEL_PATH="$TMP_ROOT/operator-override"
 load_meta_preserving_bundle_path
 [[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" == "$TMP_ROOT/operator-override" ]] ||
@@ -54,6 +58,24 @@ load_meta_preserving_bundle_path
 [[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" == "$hostile_bundle" ]] ||
   fail "shell-sensitive bundle path did not round trip through meta"
 [[ ! -e "$sentinel" ]] || fail "bundle path executed as shell code"
+
+rm -f "$META_FILE"
+legacy_sentinel="$TMP_ROOT/legacy-meta-executed"
+printf '%s\n' "ORCHARD_MLX_SMOKE_MODEL_PATH=\$(touch '$legacy_sentinel')" >"$LEGACY_META_FILE"
+
+for command in doctor stop meta "curl /health/live"; do
+  if "$CONTROL" $command >"$TMP_ROOT/legacy.stdout" 2>"$TMP_ROOT/legacy.stderr"; then
+    fail "$command accepted legacy executable metadata"
+  fi
+  grep -q 'legacy metadata.*rejected' "$TMP_ROOT/legacy.stderr" ||
+    fail "$command did not explain legacy metadata rejection"
+done
+
+if load_meta_preserving_bundle_path >/dev/null 2>"$TMP_ROOT/legacy.stderr"; then
+  fail "smoke metadata loader accepted legacy executable metadata"
+fi
+[[ ! -e "$legacy_sentinel" ]] || fail "legacy metadata executed as shell code"
+rm -f "$LEGACY_META_FILE"
 
 python_version="$(pinned_python -c 'import sys; print(sys.version_info[:2])')"
 [[ "$python_version" == "(3, 11)" ]] || fail "pinned Python 3.11 was not used"

--- a/scripts/test-verify-orchard-control.sh
+++ b/scripts/test-verify-orchard-control.sh
@@ -45,6 +45,16 @@ load_meta_preserving_bundle_path
 [[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" == "$TMP_ROOT/operator-override" ]] ||
   fail "operator bundle path was overwritten by empty meta"
 
+sentinel="$TMP_ROOT/meta-executed"
+hostile_bundle="$TMP_ROOT/bundle with spaces;\$(touch $sentinel)"
+ORCHARD_MLX_SMOKE_MODEL_PATH="$hostile_bundle"
+write_meta
+unset ORCHARD_MLX_SMOKE_MODEL_PATH
+load_meta_preserving_bundle_path
+[[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" == "$hostile_bundle" ]] ||
+  fail "shell-sensitive bundle path did not round trip through meta"
+[[ ! -e "$sentinel" ]] || fail "bundle path executed as shell code"
+
 python_version="$(pinned_python -c 'import sys; print(sys.version_info[:2])')"
 [[ "$python_version" == "(3, 11)" ]] || fail "pinned Python 3.11 was not used"
 

--- a/scripts/test-verify-orchard-control.sh
+++ b/scripts/test-verify-orchard-control.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONTROL="$REPO_ROOT/.cursor/skills/verify-orchard/scripts/control-orchard.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/orchard-verify-control-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf 'test-verify-orchard-control: %s\n' "$1" >&2
+  exit 1
+}
+
+export ORCHARD_VERIFY_RUN_ID=test
+export ORCHARD_VERIFY_STATE_DIR="$TMP_ROOT/state"
+export ORCHARD_MLX_SMOKE_MODEL_PATH="$TMP_ROOT/operator-bundle"
+
+# shellcheck source=../.cursor/skills/verify-orchard/scripts/control-orchard.sh
+source "$CONTROL"
+
+printf '%s\n' 99999999 >"$PID_FILE"
+ensure_launch_pid_slot
+[[ ! -e "$PID_FILE" ]] || fail "stale pid file was not removed"
+
+printf '%s\n' "$$" >"$PID_FILE"
+if ensure_launch_pid_slot >/dev/null 2>&1; then
+  fail "live pid should prevent launch"
+fi
+[[ -f "$PID_FILE" ]] || fail "live pid file should be retained"
+rm -f "$PID_FILE"
+
+write_meta
+unset ORCHARD_MLX_SMOKE_MODEL_PATH
+load_meta_preserving_bundle_path
+[[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" == "$TMP_ROOT/operator-bundle" ]] ||
+  fail "stored bundle path was not loaded"
+
+printf '%s\n' 'ORCHARD_MLX_SMOKE_MODEL_PATH=' >"$META_FILE"
+ORCHARD_MLX_SMOKE_MODEL_PATH="$TMP_ROOT/operator-override"
+load_meta_preserving_bundle_path
+[[ "$ORCHARD_MLX_SMOKE_MODEL_PATH" == "$TMP_ROOT/operator-override" ]] ||
+  fail "operator bundle path was overwritten by empty meta"
+
+python_version="$(pinned_python -c 'import sys; print(sys.version_info[:2])')"
+[[ "$python_version" == "(3, 11)" ]] || fail "pinned Python 3.11 was not used"
+
+if grep -q 'python3' "$CONTROL"; then
+  fail "control helper still bypasses the pinned Python interpreter"
+fi
+
+printf 'test-verify-orchard-control: PASS\n'


### PR DESCRIPTION
## Summary

This hardens Orchard's source-dev verification workflow so proof runs survive the invoking shell, wait for connected application state, support an opt-in Apple Silicon MLX smoke, and never execute persisted run metadata.

## Key decisions

- `control-orchard launch` now detaches source-dev into a new session with the mise-pinned Python interpreter, records the actual server PID, clears stale PID files, and preserves PID-scoped doctor and stop behavior.
- Console verification waits for feature-specific settled signals instead of accepting disconnected LiveView shells or loading titles.
  Public readiness proof now accepts only the status-only `200 {"status":"ok"}` or `503 {"status":"error"}` contract.
- `control-orchard prepare-bundle` and `control-orchard smoke-mlx` expose the existing Qwen3 bundle and Python/Elixir smoke flow as an optional Apple Silicon check.
  The helper preserves an operator-selected bundle and uses an isolated Elixir test port when source-dev already owns the default port.
- Verification state is now versioned, data-only `meta.json` with an exact schema, derived-path validation, atomic replacement, and owner-only permissions.
  Every command rejects legacy `meta.env` state before reading it, so old executable metadata fails closed and must be replaced by a new verification run.

## Risk Assessment

✅ **Medium**

- The blast radius is limited to the local `verify-orchard` agent workflow and its focused regression script.
- Process custody changes affect launch, doctor, and stop semantics, but retain PID and listener ownership checks.
- Metadata handling is deliberately fail-closed.
  Existing `meta.env` run directories are incompatible and must be removed instead of migrated or sourced.
- The MLX path remains opt-in and is not a CI, `make test`, or product-release gate.

## Test plan

- [x] `mise exec -- ./scripts/test-verify-orchard-control.sh` passes on the current head, covering stale and live PID behavior, pinned Python, bundle preservation, shell-sensitive JSON round trips, and non-execution plus rejection of legacy metadata.
- [x] `make check-elixir` completed twice, including compilation, strict Credo, Dialyzer, tests, and coverage.
- [x] Manual `control-orchard launch` then `control-orchard doctor` survived helper return with the recorded PID matching the listener and `/health/live` returning `{"status":"ok"}`.
- [x] A live browser drive covered all five mapped features and waited through Overview, Models, and Settings connected-state transitions.
- [x] Current-head GitHub validation passes, including the Required Orchard validation gate, Linux portable control-plane core, macOS host, MLX provider, OpenSpec, provider-neutral conformance, and Orchard.app/DMG jobs.

## PR checklist

- [x] I checked whether this changes `SPEC.md` behavior.
  It changes local verification workflow behavior, not the Orchard product contract.
- [x] I updated the verification docs and added focused regression coverage.
- [x] I ran relevant validation and recorded outcomes above.
- [x] I did not commit active goal packages or private local artifacts.
- [x] I did not introduce dependencies on private workbench or session context.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kapitan-ai/codesmith/orchard/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790550693&installation_model_id=428414&pr_number=306&repository=kapitan-ai%2Forchard&return_to=https%3A%2F%2Fgithub.com%2Fkapitan-ai%2Forchard%2Fpull%2F306&signature=1a415c10801a37c83737b5d37b3aa89c7094001c12734aee34acd9bd5603444e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kapitan-ai/orchard/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the verification launcher survive its invoking shell and replaces executable metadata with validated, data-only JSON. It also updates feature-driving guidance to wait for connected UI state and documents the optional MLX smoke workflow.
- Launches source-dev in a detached session while retaining PID-based doctor and stop behavior.
- Rejects legacy `meta.env` state and validates versioned `meta.json` before loading values.
- Adds regression coverage for PID handling, metadata round-tripping, shell-sensitive paths, and legacy-state rejection.
- Corrects settled-content signals for Overview, Models, Settings, and public readiness probes.
- Adds wrappers and documentation for preparing and running the Apple Silicon MLX smoke test.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .cursor/skills/verify-orchard/scripts/control-orchard.sh | Introduces detached launch handling, validated JSON metadata with fail-closed legacy rejection, and MLX smoke helpers; the previously reported metadata execution paths are addressed. |
| scripts/test-verify-orchard-control.sh | Adds regression coverage confirming stale/live PID handling, safe metadata round-tripping, and rejection of executable legacy metadata. |
| .cursor/skills/verify-orchard/features/overview.md | Replaces first-paint checks with connected-data and settled-runtime signals. |
| .cursor/skills/verify-orchard/features/settings.md | Clarifies that disconnected form fields are insufficient and requires a settled debug snapshot or explicit error. |
| .cursor/skills/verify-orchard/features/models-catalog.md | Prevents the loading card’s shared title from being mistaken for a settled model catalog. |
| .cursor/skills/verify-orchard/features/health-probes.md | Documents the public readiness endpoint’s status-only 200/503 response contract. |
| .cursor/skills/verify-orchard/features/mlx-smoke.md | Documents the opt-in Apple Silicon bundle preparation and Python/Elixir smoke workflow. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: use data-only verification metadata..."](https://github.com/kapitan-ai/orchard/commit/4cfa7f7e17d5a81ae063e427d5d3f3f777285ffc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58101244)</sub>

<!-- /greptile_comment -->
