### PR TITLE
feat(metrics): emit bounded attempt and retry metrics

### DIFF
--- a/apps/orchard_controller/lib/orchard/domain_metrics.ex
+++ b/apps/orchard_controller/lib/orchard/domain_metrics.ex
@@ -38,6 +38,25 @@ defmodule Orchard.DomainMetrics do
     emit(:output_tokens, output_tokens, %{tenant: tenant_id, model: model_id})
   end
 
+  @spec inference_attempt(1 | 2, atom() | String.t(), atom() | String.t(), number()) :: :ok
+  def inference_attempt(attempt, outcome, failure_class, duration_seconds) do
+    emit(:inference_attempts, 1, %{
+      attempt: attempt,
+      outcome: outcome,
+      failure_class: failure_class
+    })
+
+    emit(:inference_attempt_duration, duration_seconds, %{
+      attempt: attempt,
+      outcome: outcome
+    })
+  end
+
+  @spec inference_retry(atom() | String.t(), atom() | String.t()) :: :ok
+  def inference_retry(reason, result) do
+    emit(:inference_retries, 1, %{reason: reason, result: result})
+  end
+
   @spec scheduler_decision(term(), number()) :: :ok
   def scheduler_decision(result, duration_seconds) do
     emit(:scheduler_duration, duration_seconds, %{})

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -12,6 +12,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
   alias Orchard.Dispatch.{AttemptOutcome, RequestDispatcher}
   alias Orchard.DomainMetrics
   alias Orchard.Inference
+  alias Orchard.Metrics.{InferenceAttemptProjection, Status}
 
   alias Orchard.Inference.{
     AdmissionPolicy,
@@ -3084,6 +3085,40 @@ defmodule Orchard.Inference.RequestOrchestrator do
       request_duration_seconds(),
       terminal_output_tokens(attrs, db_request)
     )
+
+    emit_attempt_metrics(db_request)
+  end
+
+  defp emit_attempt_metrics(db_request) do
+    result =
+      db_request
+      |> Requests.list_request_step_events()
+      |> InferenceAttemptProjection.project()
+
+    case result do
+      {:ok, projection} -> emit_attempt_projection(projection)
+      {:error, reason} -> Status.degrade({:inference_attempt_projection, reason})
+    end
+  rescue
+    _exception -> Status.degrade({:inference_attempt_projection, :unavailable})
+  catch
+    _kind, _reason -> Status.degrade({:inference_attempt_projection, :unavailable})
+  end
+
+  defp emit_attempt_projection(projection) do
+    Enum.each(projection.attempts, fn attempt ->
+      DomainMetrics.inference_attempt(
+        attempt.attempt,
+        attempt.outcome,
+        attempt.failure_class,
+        attempt.duration_seconds
+      )
+    end)
+
+    case projection.retry do
+      %{reason: reason, result: result} -> DomainMetrics.inference_retry(reason, result)
+      nil -> :ok
+    end
   end
 
   defp terminal_model_id(_db_request, %CanonicalRequest{} = canonical),

--- a/apps/orchard_controller/lib/orchard/metrics/catalog.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/catalog.ex
@@ -42,6 +42,28 @@ defmodule Orchard.Metrics.Catalog do
       buckets: @request_buckets
     },
     %{
+      family: :inference_attempts,
+      name: "orchard_inference_attempts_total",
+      type: :counter,
+      labels: [:attempt, :outcome, :failure_class],
+      ceiling: 90
+    },
+    %{
+      family: :inference_attempt_duration,
+      name: "orchard_inference_attempt_duration_seconds",
+      type: :histogram,
+      labels: [:attempt, :outcome],
+      ceiling: 10,
+      buckets: @request_buckets
+    },
+    %{
+      family: :inference_retries,
+      name: "orchard_inference_retries_total",
+      type: :counter,
+      labels: [:reason, :result],
+      ceiling: 9
+    },
+    %{
       family: :input_tokens,
       name: "orchard_input_tokens_total",
       type: :counter,
@@ -165,7 +187,7 @@ defmodule Orchard.Metrics.Catalog do
     }
   ]
 
-  @worksheet_total 2_588
+  @worksheet_total 2_817
   @series_ceiling 5_000
 
   @spec descriptors() :: [map()]
@@ -179,7 +201,7 @@ defmodule Orchard.Metrics.Catalog do
     end
   end
 
-  @spec worksheet_total() :: 2_588
+  @spec worksheet_total() :: 2_817
   def worksheet_total, do: @worksheet_total
 
   @spec series_ceiling() :: 5_000

--- a/apps/orchard_controller/lib/orchard/metrics/inference_attempt_projection.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/inference_attempt_projection.ex
@@ -1,0 +1,142 @@
+defmodule Orchard.Metrics.InferenceAttemptProjection do
+  @moduledoc """
+  Projects bounded inference-attempt metrics from durable Request step evidence.
+  """
+
+  alias Orchard.Requests.{InferenceAttemptResult, RequestStepEvent}
+
+  @decline_decisions InferenceAttemptResult.attempt_one_retry_decisions() -- ["retried"]
+
+  @type attempt_observation :: %{
+          attempt: 1 | 2,
+          outcome: String.t(),
+          failure_class: String.t(),
+          duration_seconds: float()
+        }
+  @type retry_observation :: %{reason: String.t(), result: String.t()}
+  @type projection :: %{attempts: [attempt_observation()], retry: retry_observation() | nil}
+  @type projection_result :: {:ok, projection()} | {:error, :invalid_attempt_evidence}
+
+  @spec project([RequestStepEvent.t()]) :: projection_result()
+  def project(events) when is_list(events) do
+    case observation(events, 1) do
+      :absent -> project_without_attempt_one(events)
+      {:ok, attempt_one} -> project_with_attempt_one(events, attempt_one)
+      {:error, :invalid_attempt_evidence} = error -> error
+    end
+  end
+
+  def project(_events), do: {:error, :invalid_attempt_evidence}
+
+  defp observation(events, attempt) do
+    step_id = RequestStepEvent.inference_turn_step_id(1, attempt)
+    started_events = matching_events(events, step_id, "request_step.started")
+    terminal_events = matching_terminal_events(events, step_id)
+
+    case {started_events, terminal_events} do
+      {[], []} ->
+        :absent
+
+      {[%RequestStepEvent{} = started], [%RequestStepEvent{} = terminal]} ->
+        build_observation(started, terminal, attempt)
+
+      _invalid_or_ambiguous ->
+        {:error, :invalid_attempt_evidence}
+    end
+  end
+
+  defp build_observation(started, terminal, attempt) do
+    with true <- valid_order?(started, terminal),
+         {:ok, result} <-
+           InferenceAttemptResult.new(terminal.event_type, attempt, terminal.result),
+         {:ok, duration_seconds} <- duration_seconds(result) do
+      {:ok,
+       %{
+         attempt: attempt,
+         outcome: result["attempt_outcome"],
+         failure_class: Map.get(result, "failure_class", "none"),
+         duration_seconds: duration_seconds,
+         retry_decision: Map.get(result, "retry_decision"),
+         started_seq: started.seq,
+         terminal_seq: terminal.seq
+       }}
+    else
+      _invalid_or_ambiguous -> {:error, :invalid_attempt_evidence}
+    end
+  end
+
+  defp matching_events(events, step_id, event_type) do
+    Enum.filter(events, &matching_event?(&1, step_id, event_type))
+  end
+
+  defp matching_terminal_events(events, step_id) do
+    terminal_types = RequestStepEvent.terminal_step_event_types()
+    Enum.filter(events, &matching_event?(&1, step_id, terminal_types))
+  end
+
+  defp matching_event?(%RequestStepEvent{} = event, step_id, event_types) do
+    event.step_id == step_id and event.step_type == "inference_turn" and event.turn_index == 1 and
+      event.attempt in [1, 2] and event.event_type in List.wrap(event_types)
+  end
+
+  defp matching_event?(_event, _step_id, _event_types), do: false
+
+  defp valid_order?(%{seq: started_seq}, %{seq: terminal_seq}) do
+    is_integer(started_seq) and is_integer(terminal_seq) and started_seq < terminal_seq
+  end
+
+  defp duration_seconds(result) do
+    with {:ok, started_at, 0} <- DateTime.from_iso8601(result["started_at"]),
+         {:ok, ended_at, 0} <- DateTime.from_iso8601(result["ended_at"]) do
+      {:ok, DateTime.diff(ended_at, started_at, :microsecond) / 1_000_000}
+    end
+  end
+
+  defp project_without_attempt_one(events) do
+    case observation(events, 2) do
+      :absent -> {:ok, %{attempts: [], retry: nil}}
+      _attempt_two_evidence -> {:error, :invalid_attempt_evidence}
+    end
+  end
+
+  defp project_with_attempt_one(events, %{retry_decision: "retried"} = attempt_one) do
+    case observation(events, 2) do
+      {:ok, %{started_seq: started_seq} = attempt_two}
+      when attempt_one.terminal_seq < started_seq ->
+        {:ok, projection(attempt_one, attempt_two)}
+
+      _missing_invalid_or_reordered ->
+        {:error, :invalid_attempt_evidence}
+    end
+  end
+
+  defp project_with_attempt_one(events, attempt_one) do
+    case observation(events, 2) do
+      :absent -> {:ok, projection(attempt_one, nil)}
+      _unexpected_attempt_two -> {:error, :invalid_attempt_evidence}
+    end
+  end
+
+  defp projection(attempt_one, attempt_two) do
+    %{
+      attempts:
+        Enum.map(Enum.reject([attempt_one, attempt_two], &is_nil/1), &public_observation/1),
+      retry: retry_metric(attempt_one, attempt_two)
+    }
+  end
+
+  defp retry_metric(%{retry_decision: "retried"}, %{outcome: "completed"}),
+    do: %{reason: "retried", result: "succeeded"}
+
+  defp retry_metric(%{retry_decision: "retried"}, %{outcome: _outcome}),
+    do: %{reason: "retried", result: "failed"}
+
+  defp retry_metric(%{retry_decision: decision}, nil) when decision in @decline_decisions,
+    do: %{reason: decision, result: "declined"}
+
+  defp retry_metric(_attempt_one, _attempt_two), do: nil
+
+  defp public_observation(observation) do
+    Map.take(observation, [:attempt, :outcome, :failure_class, :duration_seconds])
+  end
+end

--- a/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
@@ -2,6 +2,7 @@ defmodule Orchard.Metrics.Normalizer do
   @moduledoc false
 
   alias Orchard.Metrics.Catalog
+  alias Orchard.Requests.{InferenceAttemptFailure, InferenceAttemptResult}
 
   @values %{
     http_endpoint: ~w(public_api operator_api admin_api console health metrics static unmatched),
@@ -64,6 +65,24 @@ defmodule Orchard.Metrics.Normalizer do
        when family in [:inference_requests, :inference_request_duration],
        do: bounded(:inference_status, value)
 
+  defp normalize_value(family, :attempt, value)
+       when family in [:inference_attempts, :inference_attempt_duration],
+       do: bounded_values(~w(1 2), value)
+
+  defp normalize_value(family, :outcome, value)
+       when family in [:inference_attempts, :inference_attempt_duration],
+       do: bounded_values(InferenceAttemptResult.attempt_outcomes(), value)
+
+  defp normalize_value(:inference_attempts, :failure_class, value) do
+    bounded_values(InferenceAttemptFailure.failure_classes() ++ ["none"], value)
+  end
+
+  defp normalize_value(:inference_retries, :reason, value),
+    do: bounded_values(InferenceAttemptResult.attempt_one_retry_decisions(), value)
+
+  defp normalize_value(:inference_retries, :result, value),
+    do: bounded_values(~w(succeeded failed declined), value)
+
   defp normalize_value(:scheduler_decisions, :result, value),
     do: bounded(:scheduler_result, value)
 
@@ -78,8 +97,12 @@ defmodule Orchard.Metrics.Normalizer do
   defp normalize_value(_family, _key, _value), do: :error
 
   defp bounded(kind, value) do
+    bounded_values(Map.fetch!(@values, kind), value)
+  end
+
+  defp bounded_values(values, value) do
     value = to_string(value)
-    if value in Map.fetch!(@values, kind), do: {:ok, value}, else: :error
+    if value in values, do: {:ok, value}, else: :error
   end
 
   defp method(value) do
@@ -98,5 +121,19 @@ defmodule Orchard.Metrics.Normalizer do
 
   defp valid_pair?(:scheduler_decisions, %{tier: "none"}), do: true
   defp valid_pair?(:scheduler_decisions, _labels), do: false
+
+  defp valid_pair?(:inference_attempts, %{outcome: "completed", failure_class: "none"}),
+    do: true
+
+  defp valid_pair?(:inference_attempts, %{outcome: outcome, failure_class: failure_class}),
+    do: outcome != "completed" and failure_class != "none"
+
+  defp valid_pair?(:inference_retries, %{reason: "retried", result: result}),
+    do: result in ~w(succeeded failed)
+
+  defp valid_pair?(:inference_retries, %{reason: reason, result: "declined"}),
+    do: reason != "retried"
+
+  defp valid_pair?(:inference_retries, _labels), do: false
   defp valid_pair?(_family, _labels), do: true
 end

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
@@ -56,6 +56,12 @@ defmodule Orchard.Requests.InferenceAttemptResult do
   @spec fields() :: [String.t()]
   def fields, do: @fields
 
+  @spec attempt_outcomes() :: [String.t()]
+  def attempt_outcomes, do: @attempt_outcomes
+
+  @spec attempt_one_retry_decisions() :: [String.t()]
+  def attempt_one_retry_decisions, do: @attempt_one_decisions
+
   @spec new(String.t(), 1 | 2, map()) :: {:ok, t()} | {:error, String.t()}
   def new(event_type, attempt, result) when is_map(result) do
     with :ok <- validate_attempt(attempt),

--- a/apps/orchard_controller/test/orchard/domain_metrics_test.exs
+++ b/apps/orchard_controller/test/orchard/domain_metrics_test.exs
@@ -12,6 +12,9 @@ defmodule Orchard.DomainMetricsTest do
       [
         :inference_requests,
         :inference_request_duration,
+        :inference_attempts,
+        :inference_attempt_duration,
+        :inference_retries,
         :input_tokens,
         :output_tokens,
         :decode_tokens_per_second,
@@ -88,6 +91,31 @@ defmodule Orchard.DomainMetricsTest do
     })
 
     assert_metric(:output_tokens, 0, %{tenant: "tenant-1", model: "model-1"})
+  end
+
+  test "SPEC.md §9.1 one terminal attempt emits one count and one duration observation" do
+    DomainMetrics.inference_attempt(2, :completed, :none, 1.25)
+
+    assert_metric(:inference_attempts, 1, %{
+      attempt: "2",
+      outcome: "completed",
+      failure_class: "none"
+    })
+
+    assert_metric(:inference_attempt_duration, 1.25, %{
+      attempt: "2",
+      outcome: "completed"
+    })
+
+    refute_receive {:metric, [:orchard, :metrics, :inference_attempts], _, _}
+    refute_receive {:metric, [:orchard, :metrics, :inference_attempt_duration], _, _}
+  end
+
+  test "SPEC.md §9.1 one finalized retry emits one bounded observation" do
+    DomainMetrics.inference_retry(:retried, :succeeded)
+
+    assert_metric(:inference_retries, 1, %{reason: "retried", result: "succeeded"})
+    refute_receive {:metric, [:orchard, :metrics, :inference_retries], _, _}
   end
 
   test "SPEC.md §9.1 scheduler decisions, duration, and rejection labels are exact" do

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -3281,6 +3281,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   test "SPEC.md sections 5.8 and 5.10 preserve worker-loss attribution when retry is refused", %{
     bundle: bundle
   } do
+    metric_ref = attach_terminal_metrics()
     target = [host: "10.0.0.3", port: 50_063]
     node = insert_runtime_node!(target)
 
@@ -3308,11 +3309,25 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     assert {:ok, decision} = CircuitBreakers.evaluate({:node, node.id})
     assert decision.contribution_count == 1
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempts], %{value: 1},
+                    %{attempt: "1", outcome: "failed", failure_class: "worker_or_node_loss"}}
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempt_duration],
+                    %{value: duration}, %{attempt: "1", outcome: "failed"}}
+
+    assert duration >= 0
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_retries], %{value: 1},
+                    %{reason: "not_retryable", result: "declined"}}
+
+    assert_logical_terminal_metrics_once(metric_ref, canonical, "failed", 0)
   end
 
   test "SPEC.md §5.8 retries a pre-commit failure once on a different Node under one Request", %{
     bundle: bundle
   } do
+    metric_ref = attach_terminal_metrics()
     nodes = configure_alternate_attempt_nodes!()
     put_alternate_attempt_scheduler_config()
 
@@ -3385,6 +3400,27 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert attempt_two_terminal["node_id"] == nodes.second.node_id
     assert attempt_two_terminal["excluded_node_ids"] == [nodes.first.node_id]
     refute Map.has_key?(attempt_two_terminal, "retry_decision")
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempts], %{value: 1},
+                    %{attempt: "1", outcome: "failed", failure_class: "worker_or_node_loss"}}
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempt_duration],
+                    %{value: attempt_one_duration}, %{attempt: "1", outcome: "failed"}}
+
+    assert attempt_one_duration >= 0
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempts], %{value: 1},
+                    %{attempt: "2", outcome: "completed", failure_class: "none"}}
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempt_duration],
+                    %{value: attempt_two_duration}, %{attempt: "2", outcome: "completed"}}
+
+    assert attempt_two_duration >= 0
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_retries], %{value: 1},
+                    %{reason: "retried", result: "succeeded"}}
+
+    assert_logical_terminal_metrics_once(metric_ref, canonical, "completed", 0)
 
     states = request_event_states(request)
     running_idx = Enum.find_index(states, &(&1 == :running))
@@ -3459,6 +3495,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   end
 
   test "SPEC.md §5.8 records retry_exhausted when attempt 2 fails", %{bundle: bundle} do
+    metric_ref = attach_terminal_metrics()
     nodes = configure_alternate_attempt_nodes!()
     put_alternate_attempt_scheduler_config()
 
@@ -3489,6 +3526,28 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert attempt_two["retry_decision"] == "retry_exhausted"
     assert attempt_two["excluded_node_ids"] == [nodes.first.node_id]
     assert attempt_two["node_id"] == nodes.second.node_id
+
+    for attempt <- ["1", "2"] do
+      assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempts], %{value: 1},
+                      %{
+                        attempt: ^attempt,
+                        outcome: "failed",
+                        failure_class: "worker_or_node_loss"
+                      }}
+
+      assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempt_duration],
+                      %{value: duration}, %{attempt: ^attempt, outcome: "failed"}}
+
+      assert duration >= 0
+    end
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_retries], %{value: 1},
+                    %{reason: "retried", result: "failed"}}
+
+    refute_receive {^metric_ref, [:orchard, :metrics, :inference_retries], _,
+                    %{reason: "retry_exhausted"}}
+
+    assert_logical_terminal_metrics_once(metric_ref, canonical, "failed", 0)
   end
 
   test "SPEC.md §5.8 dispatches attempt 2 from dispatching after a pre-acceptance failure", %{
@@ -3779,6 +3838,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   test "SPEC.md §5.8 terminalizes attempt 2 when its caller dies after durable start", %{
     bundle: bundle
   } do
+    metric_ref = attach_terminal_metrics()
     _nodes = configure_alternate_attempt_nodes!()
     put_alternate_attempt_scheduler_config()
     stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
@@ -3803,11 +3863,20 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     assert attempt_one["retry_decision"] == "retried"
     assert attempt_two["retry_decision"] == "cancelled"
+
+    assert_failed_retry_metrics_once(
+      metric_ref,
+      canonical,
+      "cancelled",
+      "cancellation",
+      "cancelled"
+    )
   end
 
   test "SPEC.md §5.8 terminalizes attempt 2 when its deadline lapses after durable start", %{
     bundle: bundle
   } do
+    metric_ref = attach_terminal_metrics()
     _nodes = configure_alternate_attempt_nodes!()
     put_alternate_attempt_scheduler_config()
     stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
@@ -3837,6 +3906,8 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     assert attempt_one["retry_decision"] == "retried"
     assert attempt_two["retry_decision"] == "retry_exhausted"
+
+    assert_failed_retry_metrics_once(metric_ref, canonical, "timed_out", "deadline", "timed_out")
   end
 
   test "SPEC.md §5.8 observes the original Request as in progress throughout attempt 2 start", %{
@@ -5605,6 +5676,95 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
 
     on_exit(fn -> :telemetry.detach(handler_id) end)
     ref
+  end
+
+  defp attach_terminal_metrics do
+    case Process.whereis(Orchard.Metrics.Supervisor) do
+      nil -> :ok
+      pid -> Supervisor.stop(pid)
+    end
+
+    start_supervised!(Orchard.Metrics.Supervisor)
+
+    owner = self()
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+
+    events =
+      ~w(inference_requests inference_request_duration inference_attempts inference_attempt_duration inference_retries input_tokens output_tokens)a
+      |> Enum.map(&[:orchard, :metrics, &1])
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event, measurements, metadata, _config ->
+          send(owner, {ref, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    ref
+  end
+
+  defp assert_logical_terminal_metrics_once(metric_ref, canonical, status, output_tokens) do
+    tenant = canonical.tenant_id
+    model = canonical.model_ref.model_id
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :input_tokens], %{value: _input_tokens},
+                    %{tenant: ^tenant, model: ^model}}
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_requests], %{value: 1},
+                    %{endpoint: _endpoint, tenant: ^tenant, model: ^model, status: ^status}}
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_request_duration],
+                    %{value: request_duration},
+                    %{tenant: ^tenant, model: ^model, status: ^status}}
+
+    assert request_duration >= 0
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :output_tokens], %{value: ^output_tokens},
+                    %{tenant: ^tenant, model: ^model}}
+
+    refute_receive {^metric_ref, _event, _measurements, _metadata}, 0
+  end
+
+  defp assert_failed_retry_metrics_once(
+         metric_ref,
+         canonical,
+         attempt_two_outcome,
+         attempt_two_failure_class,
+         logical_status
+       ) do
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempts], %{value: 1},
+                    %{attempt: "1", outcome: "failed", failure_class: "worker_or_node_loss"}}
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempt_duration],
+                    %{value: attempt_one_duration}, %{attempt: "1", outcome: "failed"}}
+
+    assert attempt_one_duration >= 0
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempts], %{value: 1},
+                    %{
+                      attempt: "2",
+                      outcome: ^attempt_two_outcome,
+                      failure_class: ^attempt_two_failure_class
+                    }}
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_attempt_duration],
+                    %{value: attempt_two_duration},
+                    %{attempt: "2", outcome: ^attempt_two_outcome}}
+
+    assert attempt_two_duration >= 0
+
+    assert_receive {^metric_ref, [:orchard, :metrics, :inference_retries], %{value: 1},
+                    %{reason: "retried", result: "failed"}}
+
+    refute_receive {^metric_ref, [:orchard, :metrics, :inference_retries], _,
+                    %{reason: "retry_exhausted"}}
+
+    assert_logical_terminal_metrics_once(metric_ref, canonical, logical_status, 0)
   end
 
   defp restore_runtime_events(nil),

--- a/apps/orchard_controller/test/orchard/metrics/inference_attempt_projection_test.exs
+++ b/apps/orchard_controller/test/orchard/metrics/inference_attempt_projection_test.exs
@@ -1,0 +1,170 @@
+defmodule Orchard.Metrics.InferenceAttemptProjectionTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.Metrics.InferenceAttemptProjection
+  alias Orchard.Requests.RequestStepEvent
+
+  @node_1 "00000000-0000-4000-a000-000000000001"
+  @node_2 "00000000-0000-4000-a000-000000000002"
+
+  test "SPEC.md section 9.1 projects one completed started attempt without a retry" do
+    events = [started(1, 1), terminal(1, :completed, nil, 2)]
+
+    assert InferenceAttemptProjection.project(events) ==
+             {:ok,
+              %{
+                attempts: [
+                  %{
+                    attempt: 1,
+                    duration_seconds: 1.25,
+                    failure_class: "none",
+                    outcome: "completed"
+                  }
+                ],
+                retry: nil
+              }}
+  end
+
+  test "SPEC.md section 9.1 projects a successful logical retry once" do
+    events = [
+      started(1, 1),
+      terminal(1, :failed, "retried", 2),
+      started(2, 3),
+      terminal(2, :completed, nil, 4)
+    ]
+
+    assert {:ok,
+            %{
+              attempts: [
+                %{attempt: 1, outcome: "failed", failure_class: "runtime_failure"},
+                %{attempt: 2, outcome: "completed", failure_class: "none"}
+              ],
+              retry: %{reason: "retried", result: "succeeded"}
+            }} = InferenceAttemptProjection.project(events)
+  end
+
+  test "SPEC.md section 9.1 reports an exhausted attempt 2 as one failed logical retry" do
+    events = [
+      started(1, 1),
+      terminal(1, :failed, "retried", 2),
+      started(2, 3),
+      terminal(2, :failed, "retry_exhausted", 4)
+    ]
+
+    assert {:ok,
+            %{
+              attempts: [
+                %{attempt: 1, outcome: "failed"},
+                %{attempt: 2, outcome: "failed"}
+              ],
+              retry: %{reason: "retried", result: "failed"}
+            }} = InferenceAttemptProjection.project(events)
+  end
+
+  test "SPEC.md section 9.1 reports every attempt-1 decline reason only as declined" do
+    reasons =
+      ~w(not_retryable output_committed cancelled budget_exhausted identity_unresolved occupancy_unresolved no_alternative_node)
+
+    for reason <- reasons do
+      outcome = if reason == "cancelled", do: :cancelled, else: :failed
+
+      assert {:ok,
+              %{
+                attempts: [%{attempt: 1}],
+                retry: %{reason: ^reason, result: "declined"}
+              }} =
+               InferenceAttemptProjection.project([
+                 started(1, 1),
+                 terminal(1, outcome, reason, 2)
+               ])
+    end
+  end
+
+  test "ambiguous or orphaned evidence cannot duplicate attempt or retry metrics" do
+    duplicate_terminal = terminal(1, :failed, "not_retryable", 2)
+
+    assert {:error, :invalid_attempt_evidence} =
+             InferenceAttemptProjection.project([
+               started(1, 1),
+               duplicate_terminal,
+               duplicate_terminal
+             ])
+
+    assert {:error, :invalid_attempt_evidence} =
+             InferenceAttemptProjection.project([
+               started(2, 3),
+               terminal(2, :failed, "retry_exhausted", 4)
+             ])
+  end
+
+  defp started(attempt, seq) do
+    %RequestStepEvent{
+      event_type: "request_step.started",
+      step_id: RequestStepEvent.inference_turn_step_id(1, attempt),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: attempt,
+      boundary: "pre_side_effect",
+      result: %{},
+      seq: seq
+    }
+  end
+
+  defp terminal(attempt, outcome, retry_decision, seq) do
+    event_type = "request_step.#{outcome}"
+
+    %RequestStepEvent{
+      event_type: event_type,
+      step_id: RequestStepEvent.inference_turn_step_id(1, attempt),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: attempt,
+      boundary: "post_observation",
+      result: terminal_result(attempt, outcome, retry_decision),
+      seq: seq
+    }
+  end
+
+  defp terminal_result(attempt, :completed, nil) do
+    %{
+      "attempt_outcome" => "completed",
+      "started_at" => ~U[2026-08-12 10:00:00.000000Z],
+      "ended_at" => ~U[2026-08-12 10:00:01.250000Z],
+      "accepted" => true,
+      "output_committed" => false,
+      "execution_resolution" => "terminated",
+      "capacity_release_outcome" => "released",
+      "excluded_node_ids" => if(attempt == 1, do: [], else: [@node_1])
+    }
+  end
+
+  defp terminal_result(attempt, outcome, retry_decision) do
+    result = %{
+      "attempt_outcome" => Atom.to_string(outcome),
+      "started_at" => ~U[2026-08-12 10:00:00.000000Z],
+      "ended_at" => ~U[2026-08-12 10:00:01.250000Z],
+      "accepted" => true,
+      "output_committed" => false,
+      "execution_resolution" => "terminated",
+      "capacity_release_outcome" => "released",
+      "excluded_node_ids" => if(attempt == 1, do: [], else: [@node_1]),
+      "node_id" => if(attempt == 1, do: @node_1, else: @node_2),
+      "failure_class" => "runtime_failure",
+      "failure_code" => "runtime_unavailable",
+      "retry_decision" => retry_decision
+    }
+
+    case {outcome, retry_decision} do
+      {:cancelled, "cancelled"} ->
+        %{result | "failure_class" => "cancellation", "failure_code" => "request_cancelled"}
+
+      {_outcome, "output_committed"} ->
+        result
+        |> Map.put("output_committed", true)
+        |> Map.put("output_commitment_kind", "text")
+
+      _other ->
+        result
+    end
+  end
+end

--- a/apps/orchard_controller/test/orchard/metrics/metrics_test.exs
+++ b/apps/orchard_controller/test/orchard/metrics/metrics_test.exs
@@ -83,13 +83,16 @@ defmodule Orchard.MetricsTest do
   test "SPEC.md §9.1 descriptor catalog and immutable histogram buckets are exact" do
     descriptors = Catalog.descriptors()
 
-    assert length(descriptors) == 21
+    assert length(descriptors) == 24
 
     assert Enum.map(descriptors, & &1.name) == [
              "orchard_http_requests_total",
              "orchard_http_request_duration_seconds",
              "orchard_inference_requests_total",
              "orchard_inference_request_duration_seconds",
+             "orchard_inference_attempts_total",
+             "orchard_inference_attempt_duration_seconds",
+             "orchard_inference_retries_total",
              "orchard_input_tokens_total",
              "orchard_output_tokens_total",
              "orchard_decode_tokens_per_second",
@@ -115,6 +118,9 @@ defmodule Orchard.MetricsTest do
     assert descriptor!(:inference_request_duration).buckets ==
              [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120]
 
+    assert descriptor!(:inference_attempt_duration).buckets ==
+             [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120]
+
     assert descriptor!(:decode_tokens_per_second).buckets == [1, 2, 5, 10, 20, 40, 80, 120]
 
     assert descriptor!(:scheduler_duration).buckets ==
@@ -122,19 +128,23 @@ defmodule Orchard.MetricsTest do
 
     assert descriptor!(:model_load_duration).buckets ==
              [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120]
+
+    assert Enum.uniq_by(descriptors, & &1.family) == descriptors
+    assert Enum.uniq_by(descriptors, & &1.name) == descriptors
+    assert Enum.uniq_by(descriptors, &Catalog.event_name(&1.family)) == descriptors
   end
 
-  test "SPEC.md §9.1 worksheet is exactly 2,588 below the 5,000 ceiling" do
+  test "SPEC.md §9.1 worksheet includes bounded attempt and retry families" do
     calculated =
       Enum.reduce(Catalog.descriptors(), 0, fn descriptor, total ->
         cost = if descriptor.type == :histogram, do: length(descriptor.buckets) + 3, else: 1
         total + descriptor.ceiling * cost
       end)
 
-    assert calculated == 2_588
-    assert Catalog.worksheet_total() == 2_588
+    assert calculated == 2_817
+    assert Catalog.worksheet_total() == 2_817
     assert Catalog.series_ceiling() == 5_000
-    assert Catalog.series_ceiling() - calculated == 2_412
+    assert Catalog.series_ceiling() - calculated == 2_183
   end
 
   test "bounded normalization rejects unknown categorical values and preserves identifiers" do
@@ -150,6 +160,67 @@ defmodule Orchard.MetricsTest do
 
     assert {:error, :invalid_labels} =
              Normalizer.normalize(:quota_rejections, %{tenant: "t1", reason: "arbitrary"})
+  end
+
+  test "SPEC.md §9.1 attempt and retry labels accept only closed legal combinations" do
+    failure_classes =
+      ~w(
+        pre_acceptance_unavailable model_load_failure worker_or_node_loss runtime_failure
+        terminal_conformance capacity_rejection cancellation deadline controller_failure
+        occupancy_unresolved identity_unresolved
+      )
+
+    for attempt <- [1, 2] do
+      assert {:ok, %{attempt: attempt_label, outcome: "completed", failure_class: "none"}} =
+               Normalizer.normalize(:inference_attempts, %{
+                 attempt: attempt,
+                 outcome: :completed,
+                 failure_class: :none
+               })
+
+      assert attempt_label == Integer.to_string(attempt)
+
+      for outcome <- ~w(failed cancelled timed_out interrupted),
+          failure_class <- failure_classes do
+        assert {:ok, _labels} =
+                 Normalizer.normalize(:inference_attempts, %{
+                   attempt: attempt,
+                   outcome: outcome,
+                   failure_class: failure_class
+                 })
+      end
+    end
+
+    legal_retry_pairs = [
+      {:retried, :succeeded},
+      {:retried, :failed},
+      {:not_retryable, :declined},
+      {:output_committed, :declined},
+      {:cancelled, :declined},
+      {:budget_exhausted, :declined},
+      {:identity_unresolved, :declined},
+      {:occupancy_unresolved, :declined},
+      {:no_alternative_node, :declined}
+    ]
+
+    for {reason, result} <- legal_retry_pairs do
+      assert {:ok, _labels} =
+               Normalizer.normalize(:inference_retries, %{reason: reason, result: result})
+    end
+
+    invalid_labels = [
+      {:inference_attempts, %{attempt: 3, outcome: :failed, failure_class: :runtime_failure}},
+      {:inference_attempts, %{attempt: 1, outcome: :completed, failure_class: :runtime_failure}},
+      {:inference_attempts, %{attempt: 1, outcome: :failed, failure_class: :none}},
+      {:inference_retries, %{reason: :retried, result: :declined}},
+      {:inference_retries, %{reason: :no_alternative_node, result: :succeeded}},
+      {:inference_retries, %{reason: :retry_exhausted, result: :failed}},
+      {:inference_retries, %{reason: :retried, result: :succeeded, request_id: "req-1"}}
+    ]
+
+    for {family, labels} <- invalid_labels do
+      assert {:error, :invalid_labels} = Normalizer.normalize(family, labels)
+    end
   end
 
   test "series admission charges complete histogram cost and fails closed at identifier ceiling" do
@@ -350,6 +421,41 @@ defmodule Orchard.MetricsTest do
 
     assert exposition =~
              ~s(orchard_http_request_duration_seconds_count{endpoint="health",status="success"} 1)
+  end
+
+  test "SPEC.md §9.1 attempt and retry exposition uses only bounded labels" do
+    assert :ok =
+             SeriesAdmission.emit(:inference_attempts, 1, %{
+               attempt: 2,
+               outcome: :completed,
+               failure_class: :none
+             })
+
+    assert :ok =
+             SeriesAdmission.emit(:inference_attempt_duration, 1.25, %{
+               attempt: 2,
+               outcome: :completed
+             })
+
+    assert :ok =
+             SeriesAdmission.emit(:inference_retries, 1, %{
+               reason: :retried,
+               result: :succeeded
+             })
+
+    assert {:ok, exposition} = Renderer.render()
+
+    assert exposition =~
+             ~s(orchard_inference_attempts_total{attempt="2",failure_class="none",outcome="completed"} 1)
+
+    assert exposition =~
+             ~s(orchard_inference_attempt_duration_seconds_bucket{attempt="2",outcome="completed",le="2.5"} 1)
+
+    assert exposition =~
+             ~s(orchard_inference_attempt_duration_seconds_count{attempt="2",outcome="completed"} 1)
+
+    assert exposition =~
+             ~s(orchard_inference_retries_total{reason="retried",result="succeeded"} 1)
   end
 
   test "combined renderer returns core plus gauge exposition and fails closed when degraded" do

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
@@ -6,6 +6,19 @@ defmodule Orchard.Requests.InferenceAttemptResultTest do
   @node_1 "00000000-0000-4000-a000-000000000001"
   @node_2 "00000000-0000-4000-a000-000000000002"
 
+  test "SPEC.md §9.1 exposes the durable attempt and attempt-1 retry vocabularies" do
+    assert InferenceAttemptResult.attempt_outcomes() ==
+             ~w(completed failed cancelled timed_out interrupted)
+
+    assert InferenceAttemptResult.attempt_one_retry_decisions() ==
+             ~w(
+               retried not_retryable output_committed cancelled budget_exhausted
+               identity_unresolved occupancy_unresolved no_alternative_node
+             )
+
+    refute "retry_exhausted" in InferenceAttemptResult.attempt_one_retry_decisions()
+  end
+
   test "valid attempt 1 and attempt 2 terminal evidence normalize to JSON-safe maps" do
     assert {:ok, attempt_1} =
              InferenceAttemptResult.new(

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -75,10 +75,10 @@
 
 ## 9. Attempt and retry metrics
 
-- [ ] 9.1 Emit attempt count and duration metrics with closed labels
-- [ ] 9.2 Finalize the retry counter once per logical Request using only valid reason/result combinations
-- [ ] 9.3 Prove logical admission, quota, token, outcome, and duration metrics remain once per Request
-- [ ] 9.4 Prove metric labels exclude high-cardinality identifiers
+- [x] 9.1 Emit attempt count and duration metrics with closed labels
+- [x] 9.2 Finalize the retry counter once per logical Request using only valid reason/result combinations
+- [x] 9.3 Prove logical admission, quota, token, outcome, and duration metrics remain once per Request
+- [x] 9.4 Prove metric labels exclude high-cardinality identifiers
 
 ## 10. End-to-end acceptance
 


### PR DESCRIPTION
## Summary

Orchard now exports bounded Prometheus counters and duration histograms for each physical inference attempt, plus a bounded logical retry counter, while preserving the existing once-per-Request metrics.

This continues the automatic retry sequence after #169, #170, and #171.
It completes the metrics slice in parent #121.
Exporter-safe terminal-reason work remains deliberately deferred to #173.

## Key decisions

- Extend Orchard's existing metric catalog and registry with `orchard_inference_attempts_total`, `orchard_inference_attempt_duration_seconds`, and `orchard_inference_retries_total`.
- Project attempt and retry metrics from durable `RequestStepEvent` evidence only after successful logical Request terminalization.
- Fail closed on incomplete, reordered, orphaned, or duplicate attempt evidence, and degrade `Metrics.Status` with bounded reasons instead of exporting misleading series.
- Keep labels on explicit closed vocabularies. The new series exclude Request IDs, Node IDs, target addresses, claim tokens, raw messages, and arbitrary runtime codes.
- Keep admission, quota, token, public outcome, Request duration, and other logical Request metrics on their existing once-only path.
- Use the existing Request duration buckets for physical-attempt duration histograms.

## Risk Assessment

**Medium.** This changes the Request terminal telemetry path and the registered Prometheus surface.

- Blast radius is limited to controller-side metric registration and post-terminalization emission.
- Durable Request state and public Request outcomes are unchanged.
- Invalid attempt evidence suppresses only the new attempt/retry series and records bounded telemetry degradation.
- Prometheus registration uniqueness, reporter restart behavior, and label-cardinality ceilings have direct tests.
- A process crash after durable terminal persistence but before telemetry emission remains the existing best-effort metrics window. Removing it requires a persistent metrics outbox or reconciliation design outside #172.

## Validation

- `ORCHARD_TEST_NODE_AGENT_PORT=51272 mise exec -- mix test apps/orchard_controller/test/orchard/metrics/metrics_test.exs apps/orchard_controller/test/orchard/domain_metrics_test.exs apps/orchard_controller/test/orchard/metrics/inference_attempt_projection_test.exs apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs` - 158 passed in 30.9s.
- `mise exec -- mix format` - passed in 0.455s.
- `mise exec -- mix compile --warnings-as-errors` - passed in about 41.6s, including a fresh dependency build.
- `mise exec -- mix credo --strict` - 745 files, 90 checks, 0 issues in 19.18s.
- `mise exec -- mix dialyzer` - 0 errors and 0 skips in 67.17s, including PLT work.
- `make macos-native-test-helpers` - passed in 0.932s.
- `ORCHARD_TEST_NODE_AGENT_PORT=51272 mise exec -- mix test` - 4,968 passed, 6 skipped, and 10 integration-tagged tests excluded; aggregate suite time 410.3s.
- `ORCHARD_TEST_NODE_AGENT_PORT=51272 mise exec -- mix test --cover` - 4,968 passed, 6 skipped, and 10 integration-tagged tests excluded; aggregate suite time 400.3s. Coverage: shared 67.25%, controller 85.4%, node agent 78.30%, CLI 76.40%, and the new projection module 90.6%.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate automatic-attempt-retry --type change --strict --no-interactive` - passed in 1.227s.
- `git diff --check` - passed.

Independent RepoPrompt review found no remaining blocker or important findings after the malformed-evidence and terminal-path coverage changes.

## SPEC and OpenSpec impact

`SPEC.md` is unchanged because it already specifies the required bounded attempt and retry telemetry contract.

The existing `automatic-attempt-retry` OpenSpec package remains subordinate to `SPEC.md`.
This PR completes tasks 9.1 through 9.4 only.
The 10.x terminal-reason work remains unchecked as the breadcrumb for #173.

## Non-goals

- Dashboards and alerts
- Circuit-breaker policy changes
- Terminal-reason taxonomy or metrics from #173
- Retry behavior beyond the landed one-alternate-Node policy
- A broader observability redesign or persistent metrics outbox

Fixes #172
Related: #121


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Orchard adds bounded Prometheus telemetry for physical inference attempts and logical retries, projected from durable request-step evidence after terminalization.
- Registers attempt counters, attempt-duration histograms, and retry counters with bounded labels and cardinality ceilings.
- Validates attempt evidence before projection and degrades telemetry status when evidence is malformed or unavailable.
- Extends terminal orchestration and tests to emit the new metrics without changing existing once-per-request metrics.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The new metrics are emitted only after successful terminalization, projected from validated durable evidence, bounded through the existing normalization and admission layers, and suppressed with an explicit degradation state when evidence cannot be trusted.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/metrics/inference_attempt_projection.ex | Adds fail-closed projection of bounded attempt and retry observations from durable step-event pairs. |
| apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex | Hooks projection and emission into successful terminalization while preserving best-effort telemetry behavior. |
| apps/orchard_controller/lib/orchard/metrics/normalizer.ex | Adds closed-vocabulary normalization and valid label-pair checks for the new metric families. |
| apps/orchard_controller/lib/orchard/metrics/catalog.ex | Registers the three new metric families and updates the cardinality worksheet. |
| apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex | Exposes existing bounded attempt outcomes and attempt-one retry decisions for reuse by telemetry validation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant O as RequestOrchestrator
    participant DB as Durable Request Events
    participant P as Attempt Projection
    participant M as Metrics Registry
    O->>DB: Persist logical terminal state and step events
    DB-->>O: Terminalization succeeds
    O->>M: Emit existing request metrics once
    O->>DB: Read durable step evidence
    O->>P: Project attempts and retry
    alt Evidence is valid
        P-->>O: Bounded attempt/retry observations
        O->>M: Emit attempt counters and durations
        O->>M: Emit logical retry counter
    else Evidence is invalid or unavailable
        P-->>O: Projection error
        O->>M: Record bounded degradation status
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(metrics): emit bounded attempt and ..."](https://github.com/kapitan-ai/orchard/commit/cacf41c48eef7c9ac74222177438118b8dab3b45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58166272)</sub>

<!-- /greptile_comment -->