### PR TITLE
fix(inference): prove bounded retry across both APIs

### DIFF
--- a/apps/orchard_controller/lib/orchard/inference/output_commitment.ex
+++ b/apps/orchard_controller/lib/orchard/inference/output_commitment.ex
@@ -28,6 +28,16 @@ defmodule Orchard.Inference.OutputCommitment do
 
   def observe(%__MODULE__{} = commitment, %InferenceEvent{}), do: commitment
 
+  @spec observe_structured_output(t(), String.t()) :: t()
+  def observe_structured_output(%__MODULE__{kind: kind} = commitment, _delta)
+      when not is_nil(kind),
+      do: commitment
+
+  def observe_structured_output(%__MODULE__{} = commitment, ""), do: commitment
+
+  def observe_structured_output(%__MODULE__{} = commitment, delta) when is_binary(delta),
+    do: %__MODULE__{commitment | kind: :structured_output}
+
   @spec committed?(t()) :: boolean()
   def committed?(%__MODULE__{kind: nil}), do: false
   def committed?(%__MODULE__{}), do: true

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -1578,6 +1578,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
       sampling_params: CanonicalRequestSerializer.sampling_params(canonical.sampling),
       response_format: %{"type" => Atom.to_string(canonical.response_format.type)},
       input_tokens: canonical.input_token_count,
+      reserved_output_tokens: effective_max_output_tokens(canonical.sampling),
       timeout_at:
         RequestDeadline.timeout_at(
           canonical.admission.timeout_ms,

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -539,7 +539,10 @@ defmodule Orchard.Requests do
   end
 
   defp apply_terminal_update(%Request{} = request, attrs) do
-    attrs = CapturePolicy.terminal_attrs(request.payload_capture_mode, attrs)
+    attrs =
+      request.payload_capture_mode
+      |> CapturePolicy.terminal_attrs(attrs)
+      |> Map.put(:reserved_output_tokens, 0)
 
     # Allow idempotent terminal updates: if the row is already in a terminal
     # state (set by append_request_event's atomic state sync), still apply

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -1834,7 +1834,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
 
       assert_in_delta DateTime.diff(request.timeout_at, request.inserted_at, :millisecond),
                       Orchard.Inference.request_timeout_ms() + 3_000 + 180_000,
-                      1
+                      25
 
       # Terminal state after successful completion
       assert request.state in [:completed, :streaming]

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -37,6 +37,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
 
   import Orchard.TestSupport.ModelRequestFixtures
   import Orchard.TestSupport.QueueAdmissionAPI
+  import Orchard.TestSupport.RetryAPI
   import Orchard.TestSupport.ToolRegistryTestSupport
 
   alias Orchard.API.Router
@@ -77,11 +78,15 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
     |> Router.call(Router.init([]))
   end
 
-  defp post_chat_endpoint(params, token, accept) do
-    build_conn()
-    |> put_req_header("accept", accept)
-    |> put_req_header("content-type", "application/json")
-    |> put_req_header("authorization", "Bearer #{token}")
+  defp post_chat_endpoint(params, token, accept, headers \\ []) do
+    conn =
+      build_conn()
+      |> put_req_header("accept", accept)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer #{token}")
+
+    headers
+    |> Enum.reduce(conn, fn {name, value}, acc -> put_req_header(acc, name, value) end)
     |> post("/v1/chat/completions", params)
   end
 
@@ -128,6 +133,7 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       Application.put_env(:orchard_controller, :inference, previous_inference)
       Application.put_env(:orchard_node_agent, :runtime, previous_runtime)
       QueueManager.reset()
+      clear()
       clear_chat_stub_config()
       Enum.each(bundle.cache_paths, &File.rm_rf/1)
       File.rm_rf(bundle.source_path)
@@ -1194,6 +1200,253 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
 
       refute get_resp_header(conn, "content-type")
              |> Enum.any?(&String.contains?(&1, "text/event-stream"))
+    end
+  end
+
+  describe "POST /v1/chat/completions bounded automatic retry" do
+    @tag :live
+    test "SPEC.md M4 retries one uncommitted attempt across JSON and SSE", %{bundle: bundle} do
+      create_queue_model!(bundle, "chat-bounded-retry")
+      %{token: token, tenant: tenant} = create_api_key_with_token!("chat-bounded-retry")
+      grant_active_models!(tenant)
+
+      for stream? <- [false, true] do
+        idempotency_key = "chat-bounded-retry-#{stream?}"
+
+        nodes = configure_retry_nodes!(successful_retry_events())
+
+        Process.put(:orchard_retry_started_probe, fn request ->
+          send(self(), {:retry_api_reservation_at_attempt_two, request.reserved_output_tokens})
+        end)
+
+        conn =
+          post_chat_endpoint(
+            %{
+              "model" => "chat-bounded-retry@v1",
+              "messages" => [%{"role" => "user", "content" => "hello"}],
+              "max_tokens" => 7,
+              "stream" => stream?
+            },
+            token,
+            if(stream?, do: "text/event-stream", else: "application/json"),
+            [{"idempotency-key", idempotency_key}]
+          )
+
+        assert conn.status == 200
+
+        public_id =
+          if stream? do
+            events = parse_sse_body(conn.resp_body)
+            data_events = for {:data, event} <- events, do: event
+            assert Enum.filter(events, &match?({:done, nil}, &1)) == [{:done, nil}]
+            assert Enum.filter(events, &match?({:error, _}, &1)) == []
+
+            assert Enum.map(data_events, fn event ->
+                     get_in(event, ["choices", Access.at(0), "delta", "content"])
+                   end) == ["", "attempt-two-only", nil]
+
+            assert Enum.map_join(data_events, "", fn event ->
+                     get_in(event, ["choices", Access.at(0), "delta", "content"]) || ""
+                   end) ==
+                     "attempt-two-only"
+
+            refute conn.resp_body =~ "attempt-one-only"
+            hd(data_events)["id"]
+          else
+            body = Jason.decode!(conn.resp_body)
+
+            assert get_in(body, ["choices", Access.at(0), "message", "content"]) ==
+                     "attempt-two-only"
+
+            refute conn.resp_body =~ "attempt-one-only"
+            body["id"]
+          end
+
+        request = Requests.get_request_by_public_id(public_id)
+        assert request.stream == stream?
+        assert_receive {:retry_api_reservation_at_attempt_two, 7}
+        assert request.reserved_output_tokens == 0
+        assert_logical_identity!(request, idempotency_key, :metadata)
+        assert_successful_retry!(request, nodes)
+      end
+    end
+
+    @tag :live
+    test "SPEC.md M4 exposes attempt 2 failure without a third Chat attempt", %{bundle: bundle} do
+      create_queue_model!(bundle, "chat-bounded-retry-failure")
+      %{token: token, tenant: tenant} = create_api_key_with_token!("chat-bounded-retry-failure")
+      grant_active_models!(tenant)
+
+      for stream? <- [false, true] do
+        nodes = configure_retry_nodes!(exhausted_retry_events())
+
+        conn =
+          post_chat_endpoint(
+            %{
+              "model" => "chat-bounded-retry-failure@v1",
+              "messages" => [%{"role" => "user", "content" => "hello"}],
+              "stream" => stream?
+            },
+            token,
+            if(stream?, do: "text/event-stream", else: "application/json")
+          )
+
+        if stream? do
+          assert conn.status == 200
+          events = parse_sse_body(conn.resp_body)
+          assert [{:error, error}] = Enum.filter(events, &match?({:error, _}, &1))
+          assert error["error"]["code"] == "runtime_unavailable"
+          assert Enum.filter(events, &match?({:done, nil}, &1)) == []
+        else
+          assert conn.status == 500
+          assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+        end
+
+        request = latest_request!("chat-bounded-retry-failure@v1", stream?)
+        assert request.reserved_output_tokens == 0
+        assert_failed_retry!(request, nodes)
+      end
+    end
+
+    @tag :live
+    test "SPEC.md M4 blocks Chat retry after text or tool identity commitment", %{
+      bundle: bundle
+    } do
+      for {kind, commitment_event} <- commitment_cases() do
+        model_id = "chat-bounded-retry-committed-#{kind}"
+        create_queue_model!(bundle, model_id)
+        %{token: token, tenant: tenant} = create_api_key_with_token!(model_id)
+        grant_active_models!(tenant)
+
+        for stream? <- [false, true] do
+          nodes =
+            configure_retry_nodes!(
+              [
+                [
+                  commitment_event,
+                  InferenceEvent.failed("worker_down", "committed attempt failed", true)
+                ]
+              ],
+              node_count: 1
+            )
+
+          conn =
+            post_chat_endpoint(
+              %{
+                "model" => "#{model_id}@v1",
+                "messages" => [%{"role" => "user", "content" => "hello"}],
+                "stream" => stream?
+              },
+              token,
+              if(stream?, do: "text/event-stream", else: "application/json")
+            )
+
+          if stream? do
+            assert conn.status == 200
+
+            assert [{:error, error}] =
+                     conn.resp_body
+                     |> parse_sse_body()
+                     |> Enum.filter(&match?({:error, _}, &1))
+
+            assert error["error"]["code"] == "worker_down"
+          else
+            assert conn.status == 500
+            assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+          end
+
+          request = latest_request!("#{model_id}@v1", stream?)
+          assert_declined_retry!(request, nodes, "output_committed", "worker_or_node_loss", kind)
+        end
+      end
+    end
+
+    @tag :live
+    test "SPEC.md M4 preserves Chat attempt 1 when no safe alternate exists", %{bundle: bundle} do
+      for {suffix, selection_mode, retry_decision} <- alternate_refusal_cases() do
+        model_id = "chat-bounded-retry-#{suffix}"
+        create_queue_model!(bundle, model_id)
+        %{token: token, tenant: tenant} = create_api_key_with_token!(model_id)
+        grant_active_models!(tenant)
+
+        for stream? <- [false, true] do
+          nodes =
+            configure_retry_nodes!(
+              [[InferenceEvent.failed("worker_down", "attempt one failed", true)]],
+              selection_mode: selection_mode,
+              node_count: 1
+            )
+
+          conn =
+            post_chat_endpoint(
+              %{
+                "model" => "#{model_id}@v1",
+                "messages" => [%{"role" => "user", "content" => "hello"}],
+                "stream" => stream?
+              },
+              token,
+              if(stream?, do: "text/event-stream", else: "application/json")
+            )
+
+          if stream? do
+            assert [{:error, error}] =
+                     conn.resp_body
+                     |> parse_sse_body()
+                     |> Enum.filter(&match?({:error, _}, &1))
+
+            assert error["error"]["code"] == "worker_down"
+          else
+            assert conn.status == 500
+            assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+          end
+
+          request = latest_request!("#{model_id}@v1", stream?)
+          assert request.error_code == "worker_down"
+          assert_declined_retry!(request, nodes, retry_decision, "worker_or_node_loss")
+        end
+      end
+    end
+
+    @tag :live
+    test "SPEC.md M4 keeps Chat terminal-conformance failures non-retryable", %{
+      bundle: bundle
+    } do
+      create_queue_model!(bundle, "chat-bounded-retry-conformance")
+
+      %{token: token, tenant: tenant} =
+        create_api_key_with_token!("chat-bounded-retry-conformance")
+
+      grant_active_models!(tenant)
+
+      for stream? <- [false, true] do
+        nodes = configure_retry_nodes!([[]], node_count: 1)
+
+        conn =
+          post_chat_endpoint(
+            %{
+              "model" => "chat-bounded-retry-conformance@v1",
+              "messages" => [%{"role" => "user", "content" => "hello"}],
+              "stream" => stream?
+            },
+            token,
+            if(stream?, do: "text/event-stream", else: "application/json")
+          )
+
+        if stream? do
+          assert [{:error, error}] =
+                   conn.resp_body
+                   |> parse_sse_body()
+                   |> Enum.filter(&match?({:error, _}, &1))
+
+          assert error["error"]["code"] == "internal_error"
+        else
+          assert conn.status == 500
+          assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+        end
+
+        request = latest_request!("chat-bounded-retry-conformance@v1", stream?)
+        assert_declined_retry!(request, nodes, "not_retryable", "terminal_conformance")
+      end
     end
   end
 

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -5,6 +5,7 @@ defmodule Orchard.API.ResponsesControllerTest do
 
   import Orchard.TestSupport.ModelRequestFixtures
   import Orchard.TestSupport.QueueAdmissionAPI
+  import Orchard.TestSupport.RetryAPI
   import Orchard.TestSupport.ToolRegistryTestSupport
 
   alias Orchard.API.Router
@@ -41,11 +42,15 @@ defmodule Orchard.API.ResponsesControllerTest do
     |> Router.call(Router.init([]))
   end
 
-  defp post_responses_endpoint(params, token, accept) do
-    build_conn()
-    |> put_req_header("accept", accept)
-    |> put_req_header("content-type", "application/json")
-    |> put_req_header("authorization", "Bearer #{token}")
+  defp post_responses_endpoint(params, token, accept, headers \\ []) do
+    conn =
+      build_conn()
+      |> put_req_header("accept", accept)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer #{token}")
+
+    headers
+    |> Enum.reduce(conn, fn {name, value}, acc -> put_req_header(acc, name, value) end)
     |> post("/v1/responses", params)
   end
 
@@ -68,6 +73,7 @@ defmodule Orchard.API.ResponsesControllerTest do
       Application.put_env(:orchard_controller, :inference, previous_inference)
       Application.put_env(:orchard_node_agent, :runtime, previous_runtime)
       QueueManager.reset()
+      clear()
       clear_responses_stub_config()
       Enum.each(bundle.cache_paths, &File.rm_rf/1)
       File.rm_rf(bundle.source_path)
@@ -1041,6 +1047,243 @@ defmodule Orchard.API.ResponsesControllerTest do
 
     assert Enum.at(events, 1).data["delta"] == ""
     assert Enum.at(events, 2).data["text"] == ""
+  end
+
+  @tag :live
+  test "SPEC.md M4 retries one uncommitted attempt across JSON and typed SSE", %{bundle: bundle} do
+    create_queue_model!(bundle, "responses-bounded-retry")
+    %{token: token, tenant: tenant} = create_api_key_with_token!("responses-bounded-retry")
+    grant_active_models!(tenant)
+
+    for stream? <- [false, true] do
+      idempotency_key = "responses-bounded-retry-#{stream?}"
+
+      nodes = configure_retry_nodes!(successful_retry_events())
+
+      Process.put(:orchard_retry_started_probe, fn request ->
+        send(self(), {:retry_api_reservation_at_attempt_two, request.reserved_output_tokens})
+      end)
+
+      conn =
+        post_responses_endpoint(
+          %{
+            "model" => "responses-bounded-retry@v1",
+            "input" => "hello",
+            "max_output_tokens" => 7,
+            "stream" => stream?
+          },
+          token,
+          if(stream?, do: "text/event-stream", else: "application/json"),
+          [{"idempotency-key", idempotency_key}]
+        )
+
+      assert conn.status == 200
+
+      public_id =
+        if stream? do
+          events = parse_typed_sse_events(conn)
+
+          assert Enum.map(events, & &1.type) == [
+                   "response.created",
+                   "response.output_text.delta",
+                   "response.output_text.done",
+                   "response.completed"
+                 ]
+
+          assert Enum.map_join(events, "", &Map.get(&1.data, "delta", "")) ==
+                   "attempt-two-only"
+
+          assert List.last(events).type == "response.completed"
+          refute collect_chunked_body(conn) =~ "attempt-one-only"
+          get_in(List.last(events).data, ["response", "id"])
+        else
+          body = Jason.decode!(conn.resp_body)
+          assert body["output_text"] == "attempt-two-only"
+          refute conn.resp_body =~ "attempt-one-only"
+          body["id"]
+        end
+
+      request = Requests.get_request_by_public_id(public_id)
+      assert request.stream == stream?
+      assert_receive {:retry_api_reservation_at_attempt_two, 7}
+      assert request.reserved_output_tokens == 0
+      assert_logical_identity!(request, idempotency_key, :metadata)
+      assert_successful_retry!(request, nodes)
+    end
+  end
+
+  @tag :live
+  test "SPEC.md M4 exposes attempt 2 failure without a third Responses attempt", %{
+    bundle: bundle
+  } do
+    create_queue_model!(bundle, "responses-bounded-retry-failure")
+
+    %{token: token, tenant: tenant} =
+      create_api_key_with_token!("responses-bounded-retry-failure")
+
+    grant_active_models!(tenant)
+
+    for stream? <- [false, true] do
+      nodes = configure_retry_nodes!(exhausted_retry_events())
+
+      conn =
+        post_responses_endpoint(
+          %{
+            "model" => "responses-bounded-retry-failure@v1",
+            "input" => "hello",
+            "stream" => stream?
+          },
+          token,
+          if(stream?, do: "text/event-stream", else: "application/json")
+        )
+
+      if stream? do
+        assert conn.status == 200
+        terminal = conn |> parse_typed_sse_events() |> List.last()
+        assert terminal.type == "response.failed"
+        assert terminal.data["response"]["error"]["code"] == "runtime_unavailable"
+      else
+        assert conn.status == 500
+        assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+      end
+
+      request = latest_request!("responses-bounded-retry-failure@v1", stream?)
+      assert request.reserved_output_tokens == 0
+      assert_failed_retry!(request, nodes)
+    end
+  end
+
+  @tag :live
+  test "SPEC.md M4 blocks Responses retry after text or tool identity commitment", %{
+    bundle: bundle
+  } do
+    for {kind, commitment_event} <- commitment_cases() do
+      model_id = "responses-bounded-retry-committed-#{kind}"
+      create_queue_model!(bundle, model_id)
+      %{token: token, tenant: tenant} = create_api_key_with_token!(model_id)
+      grant_active_models!(tenant)
+
+      for stream? <- [false, true] do
+        nodes =
+          configure_retry_nodes!(
+            [
+              [
+                commitment_event,
+                InferenceEvent.failed("worker_down", "committed attempt failed", true)
+              ]
+            ],
+            node_count: 1
+          )
+
+        conn =
+          post_responses_endpoint(
+            %{
+              "model" => "#{model_id}@v1",
+              "input" => "hello",
+              "stream" => stream?
+            },
+            token,
+            if(stream?, do: "text/event-stream", else: "application/json")
+          )
+
+        if stream? do
+          assert conn.status == 200
+          terminal = conn |> parse_typed_sse_events() |> List.last()
+          assert terminal.type == "response.failed"
+          assert terminal.data["response"]["error"]["code"] == "worker_down"
+        else
+          assert conn.status == 500
+          assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+        end
+
+        request = latest_request!("#{model_id}@v1", stream?)
+        assert_declined_retry!(request, nodes, "output_committed", "worker_or_node_loss", kind)
+      end
+    end
+  end
+
+  @tag :live
+  test "SPEC.md M4 preserves Responses attempt 1 when no safe alternate exists", %{
+    bundle: bundle
+  } do
+    for {suffix, selection_mode, retry_decision} <- alternate_refusal_cases() do
+      model_id = "responses-bounded-retry-#{suffix}"
+      create_queue_model!(bundle, model_id)
+      %{token: token, tenant: tenant} = create_api_key_with_token!(model_id)
+      grant_active_models!(tenant)
+
+      for stream? <- [false, true] do
+        nodes =
+          configure_retry_nodes!(
+            [[InferenceEvent.failed("worker_down", "attempt one failed", true)]],
+            selection_mode: selection_mode,
+            node_count: 1
+          )
+
+        conn =
+          post_responses_endpoint(
+            %{
+              "model" => "#{model_id}@v1",
+              "input" => "hello",
+              "stream" => stream?
+            },
+            token,
+            if(stream?, do: "text/event-stream", else: "application/json")
+          )
+
+        if stream? do
+          terminal = conn |> parse_typed_sse_events() |> List.last()
+          assert terminal.type == "response.failed"
+          assert terminal.data["response"]["error"]["code"] == "worker_down"
+        else
+          assert conn.status == 500
+          assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+        end
+
+        request = latest_request!("#{model_id}@v1", stream?)
+        assert request.error_code == "worker_down"
+        assert_declined_retry!(request, nodes, retry_decision, "worker_or_node_loss")
+      end
+    end
+  end
+
+  @tag :live
+  test "SPEC.md M4 keeps Responses terminal-conformance failures non-retryable", %{
+    bundle: bundle
+  } do
+    create_queue_model!(bundle, "responses-bounded-retry-conformance")
+
+    %{token: token, tenant: tenant} =
+      create_api_key_with_token!("responses-bounded-retry-conformance")
+
+    grant_active_models!(tenant)
+
+    for stream? <- [false, true] do
+      nodes = configure_retry_nodes!([[]], node_count: 1)
+
+      conn =
+        post_responses_endpoint(
+          %{
+            "model" => "responses-bounded-retry-conformance@v1",
+            "input" => "hello",
+            "stream" => stream?
+          },
+          token,
+          if(stream?, do: "text/event-stream", else: "application/json")
+        )
+
+      if stream? do
+        terminal = conn |> parse_typed_sse_events() |> List.last()
+        assert terminal.type == "response.failed"
+        assert terminal.data["response"]["error"]["code"] == "internal_error"
+      else
+        assert conn.status == 500
+        assert Jason.decode!(conn.resp_body)["error"]["code"] == "internal_error"
+      end
+
+      request = latest_request!("responses-bounded-retry-conformance@v1", stream?)
+      assert_declined_retry!(request, nodes, "not_retryable", "terminal_conformance")
+    end
   end
 
   test "streaming terminal includes assembled function_call items without new SSE event types" do

--- a/apps/orchard_controller/test/orchard/inference/output_commitment_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/output_commitment_test.exs
@@ -48,4 +48,16 @@ defmodule Orchard.Inference.OutputCommitmentTest do
 
     assert_raise ArgumentError, fn -> InferenceEvent.tool_call_delta("", "{}") end
   end
+
+  test "SPEC 5.8 commits future structured output only when the delta carries content" do
+    uncommitted = OutputCommitment.new()
+
+    assert uncommitted == OutputCommitment.observe_structured_output(uncommitted, "")
+
+    committed = OutputCommitment.observe_structured_output(uncommitted, "{")
+    assert OutputCommitment.committed?(committed)
+    assert OutputCommitment.kind(committed) == :structured_output
+
+    assert committed == OutputCommitment.observe_structured_output(committed, "ignored")
+  end
 end

--- a/apps/orchard_controller/test/support/retry_api_support.ex
+++ b/apps/orchard_controller/test/support/retry_api_support.ex
@@ -1,0 +1,521 @@
+defmodule Orchard.TestSupport.RetryAPI.Scheduler do
+  @moduledoc false
+
+  @behaviour Orchard.Scheduler.SingleNode
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.DispatchCapacity.AllocationAuthority
+  alias Orchard.DispatchCapacity.{ConformanceFixture, Evaluator}
+  alias Orchard.Inference
+  alias Orchard.TestSupport.RetryAPI
+
+  def schedule(%CanonicalRequest{} = request), do: schedule(request, [])
+
+  @impl true
+  def schedule(%CanonicalRequest{} = request, opts) do
+    excluded_node_ids = Keyword.get(opts, :exclude_node_ids, [])
+
+    case excluded_node_ids do
+      [excluded_node_id] ->
+        send(
+          self(),
+          {:retry_api_claim_count_before_alternate,
+           AllocationAuthority.claim_count(excluded_node_id)}
+        )
+
+      [] ->
+        :ok
+    end
+
+    case RetryAPI.select_node(excluded_node_ids) do
+      {:ok, node} ->
+        send(self(), {:retry_api_schedule, excluded_node_ids, node.node_id})
+        {:ok, schedule_for(request, node)}
+
+      :error ->
+        {:error, :cluster_busy,
+         %{
+           strategy: :multi_node,
+           request_id: request.public_id,
+           candidate_count: 0,
+           selected_tier: nil
+         }}
+    end
+  end
+
+  defp schedule_for(request, node) do
+    capacity_input = ConformanceFixture.input()
+
+    %{
+      strategy: :multi_node,
+      request_id: request.public_id,
+      runtime_client_target: node.target,
+      request_timeout_ms: Inference.request_timeout_ms(),
+      model_load_timeout_ms: Inference.model_load_timeout_ms(),
+      node_id: node.node_id,
+      candidate_count: RetryAPI.node_count(),
+      selected_tier: :loaded,
+      dispatch_capacity_input: capacity_input,
+      dispatch_capacity_evaluation: Evaluator.evaluate(capacity_input),
+      dispatch_capacity_acquisition_input_provider: fn -> capacity_input end,
+      dispatch_capacity_input_provider: fn -> capacity_input end
+    }
+  end
+end
+
+defmodule Orchard.TestSupport.RetryAPI.RuntimeClient do
+  @moduledoc false
+
+  alias Orchard.InferenceEvent
+  alias Orchard.RuntimeEndpoint.{Operation, PlacementCapacity}
+  alias Orchard.TestSupport.DispatchCapacityFixtures
+  alias Orchard.TestSupport.RetryAPI
+
+  def connect(target), do: {:ok, target}
+
+  def status(target, _opts) do
+    case RetryAPI.runtime_status(target) do
+      nil ->
+        {:error, :unavailable}
+
+      response ->
+        DispatchCapacityFixtures.record_authenticated_probe_evidence(response)
+        {:ok, response}
+    end
+  end
+
+  def ensure_model_loaded(_channel, %Operation.EnsureModelLoadedRequest{} = request, _opts) do
+    model = %{model_id: request.model_ref.model_id, version: request.model_ref.version}
+
+    {:ok,
+     %Operation.EnsureModelLoadedResult{
+       already_loaded: true,
+       placement_state: :loaded,
+       worker_supports_prompt_token_ids: true,
+       placement_capacity:
+         PlacementCapacity.new(%{
+           model_ref: model,
+           active_request_count: 0,
+           max_concurrency: 4,
+           source: :ensure_model_loaded_result
+         }),
+       placement_capacity_evidence_state: :valid
+     }}
+  end
+
+  def unload_model(_channel, %Operation.UnloadModelRequest{}, _opts),
+    do: {:ok, %Operation.Ack{ok: true}}
+
+  def execute_inference(channel, %Operation.ExecuteRequest{} = request, opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    stream_ref = make_ref()
+
+    send(self(), {:retry_api_execute, request.request_id, channel})
+
+    send(
+      owner,
+      {:runtime_endpoint_event, stream_ref, request.request_id, InferenceEvent.accepted(0)}
+    )
+
+    Enum.each(RetryAPI.next_attempt_events(), fn event ->
+      send(owner, {:runtime_endpoint_event, stream_ref, request.request_id, event})
+    end)
+
+    send(owner, {:runtime_endpoint_done, stream_ref, :ok})
+    {:ok, stream_ref}
+  end
+
+  def cancel_inference(_channel, %Operation.CancelRequest{}, _opts), do: :ok
+  def disconnect(_channel), do: :ok
+
+  def score_prefix_cache(_target, _request, _opts),
+    do: {:ok, %{status_code: "unavailable", score_tier: "unknown"}}
+end
+
+defmodule Orchard.TestSupport.RetryAPI do
+  @moduledoc false
+
+  import ExUnit.Assertions
+
+  alias Orchard.DispatchCapacity
+  alias Orchard.DispatchCapacity.Policy
+  alias Orchard.InferenceEvent
+  alias Orchard.Nodes.AdmissionDecision
+  alias Orchard.Nodes.Node, as: InventoryNode
+  alias Orchard.Repo
+  alias Orchard.Requests
+  alias Orchard.TestSupport.RetryAPI.{RuntimeClient, Scheduler}
+
+  @state_key {__MODULE__, :state}
+
+  def successful_retry_events do
+    [
+      [
+        InferenceEvent.progress("prefill", "attempt-one-only"),
+        InferenceEvent.output_text_delta(""),
+        InferenceEvent.failed("worker_down", "attempt one failed", true)
+      ],
+      [
+        InferenceEvent.output_text_delta("attempt-two-only"),
+        InferenceEvent.completed(
+          :finish_reason_stop,
+          %InferenceEvent.Usage{input_tokens: 1, output_tokens: 1, total_tokens: 2}
+        )
+      ]
+    ]
+  end
+
+  def exhausted_retry_events do
+    [
+      [InferenceEvent.failed("worker_down", "attempt one failed", true)],
+      [
+        InferenceEvent.failed(
+          "runtime_unavailable",
+          "attempt two failed",
+          true
+        )
+      ]
+    ]
+  end
+
+  def commitment_cases do
+    [
+      {"text", InferenceEvent.output_text_delta("committed")},
+      {"tool_call",
+       InferenceEvent.tool_call_delta(
+         "call-stable",
+         Jason.encode!(%{
+           index: 0,
+           type: "function",
+           function: %{name: "lookup_weather", arguments_delta: "{}"}
+         })
+       )}
+    ]
+  end
+
+  def alternate_refusal_cases do
+    [
+      {"no-alternative", :no_alternative, "no_alternative_node"},
+      {"same-node", :same_node, "identity_unresolved"}
+    ]
+  end
+
+  def configure_retry_nodes!(attempt_event_lists, opts \\ [])
+      when is_list(attempt_event_lists) and is_list(opts) do
+    node_count = Keyword.get(opts, :node_count, 2)
+    assert node_count in [1, 2]
+
+    target_suffix = rem(System.unique_integer([:positive]), 10_000)
+    first_target = [host: "10.13.1.1", port: 42_000 + target_suffix]
+    second_target = [host: "10.13.1.2", port: 53_000 + target_suffix]
+    first_node = insert_runtime_node!(first_target)
+    second_node = if node_count == 2, do: insert_runtime_node!(second_target)
+
+    nodes =
+      [%{node_id: first_node.id, target: first_target, inventory: first_node}]
+      |> maybe_append_second_node(second_node, second_target)
+
+    statuses =
+      Map.new(nodes, fn node ->
+        {target_key(node.target), runtime_status_payload(node.inventory, node.target)}
+      end)
+
+    Process.put(@state_key, %{
+      nodes: nodes,
+      statuses: statuses,
+      event_lists: attempt_event_lists,
+      selection_mode: Keyword.get(opts, :selection_mode, :different_node)
+    })
+
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.merge(
+        runtime_client_targets: Enum.map(nodes, & &1.target),
+        runtime_endpoint_targets: [],
+        runtime_endpoint_client_impl: RuntimeClient,
+        scheduler_impl: Scheduler
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+    %{first: first_node, second: second_node}
+  end
+
+  def clear do
+    Process.delete(@state_key)
+    Process.delete(:orchard_retry_started_probe)
+  end
+
+  def select_node(excluded_node_ids) do
+    state = fetch_state!(@state_key)
+
+    case {state.selection_mode, excluded_node_ids} do
+      {:no_alternative, [_excluded_node_id]} ->
+        :error
+
+      {:same_node, [_excluded_node_id]} ->
+        {:ok, hd(state.nodes)}
+
+      {_mode, excluded_node_ids} ->
+        state.nodes
+        |> Enum.find(fn node -> node.node_id not in excluded_node_ids end)
+        |> case do
+          nil -> :error
+          node -> {:ok, node}
+        end
+    end
+  end
+
+  def runtime_status(target) do
+    @state_key
+    |> fetch_state!()
+    |> Map.fetch!(:statuses)
+    |> Map.get(target_key(target))
+  end
+
+  def node_count do
+    @state_key
+    |> fetch_state!()
+    |> Map.fetch!(:nodes)
+    |> length()
+  end
+
+  def next_attempt_events do
+    state = fetch_state!(@state_key)
+
+    case state.event_lists do
+      [events | rest] ->
+        Process.put(@state_key, %{state | event_lists: rest})
+        events
+
+      [] ->
+        flunk("retry API fixture observed an unexpected third inference attempt")
+    end
+  end
+
+  def assert_successful_retry!(request, nodes) do
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, &{&1.event_type, &1.attempt}) == [
+             {"request_step.started", 1},
+             {"request_step.failed", 1},
+             {"request_step.started", 2},
+             {"request_step.completed", 2}
+           ]
+
+    [_, attempt_one, _, attempt_two] = Enum.map(step_events, & &1.result)
+    assert attempt_one["node_id"] == nodes.first.id
+    assert attempt_one["output_committed"] == false
+    assert attempt_one["capacity_release_outcome"] == "released"
+    assert attempt_one["retry_decision"] == "retried"
+    assert attempt_two["node_id"] == nodes.second.id
+    assert attempt_two["output_committed"] == true
+    refute Map.has_key?(attempt_two, "retry_decision")
+    assert request.node_id == nodes.second.id
+
+    assert_receive {:retry_api_schedule, [], first_node_id}
+    assert first_node_id == nodes.first.id
+    assert_receive {:retry_api_claim_count_before_alternate, 0}
+    assert_receive {:retry_api_schedule, [excluded_node_id], second_node_id}
+    assert excluded_node_id == nodes.first.id
+    assert second_node_id == nodes.second.id
+
+    assert_receive {:retry_api_execute, public_id, _target}
+    assert public_id == request.public_id
+    assert_receive {:retry_api_execute, ^public_id, _target}
+    refute_receive {:retry_api_execute, ^public_id, _target}, 0
+  end
+
+  def assert_failed_retry!(request, nodes) do
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, &{&1.event_type, &1.attempt}) == [
+             {"request_step.started", 1},
+             {"request_step.failed", 1},
+             {"request_step.started", 2},
+             {"request_step.failed", 2}
+           ]
+
+    [_, attempt_one, _, attempt_two] = Enum.map(step_events, & &1.result)
+    assert attempt_one["node_id"] == nodes.first.id
+    assert attempt_one["retry_decision"] == "retried"
+    assert attempt_two["node_id"] == nodes.second.id
+    assert attempt_two["retry_decision"] == "retry_exhausted"
+    assert request.node_id == nodes.second.id
+
+    assert_two_executions!(request, nodes)
+  end
+
+  def assert_declined_retry!(
+        request,
+        nodes,
+        expected_decision,
+        expected_failure_class,
+        expected_commitment_kind \\ nil
+      ) do
+    step_events = Requests.list_request_step_events(request)
+
+    assert Enum.map(step_events, &{&1.event_type, &1.attempt}) == [
+             {"request_step.started", 1},
+             {"request_step.failed", 1}
+           ]
+
+    terminal = List.last(step_events).result
+    assert terminal["retry_decision"] == expected_decision
+    assert terminal["failure_class"] == expected_failure_class
+
+    if expected_commitment_kind do
+      assert terminal["output_committed"]
+      assert terminal["output_commitment_kind"] == expected_commitment_kind
+    else
+      refute terminal["output_committed"]
+    end
+
+    assert_receive {:retry_api_schedule, [], first_node_id}
+    assert first_node_id == nodes.first.id
+
+    assert_receive {:retry_api_execute, public_id, _target}
+    assert public_id == request.public_id
+
+    case expected_decision do
+      "no_alternative_node" ->
+        assert_receive {:retry_api_claim_count_before_alternate, 0}
+        refute_receive {:retry_api_schedule, [_excluded_node_id], _node_id}, 0
+
+      "identity_unresolved" ->
+        assert_receive {:retry_api_claim_count_before_alternate, 0}
+        assert_receive {:retry_api_schedule, [excluded_node_id], same_node_id}
+        assert excluded_node_id == nodes.first.id
+        assert same_node_id == nodes.first.id
+
+      _other ->
+        refute_receive {:retry_api_claim_count_before_alternate, _count}, 0
+    end
+
+    refute_receive {:retry_api_execute, ^public_id, _target}, 0
+  end
+
+  def assert_logical_identity!(request, idempotency_key, capture_mode) do
+    assert request.idempotency_key == idempotency_key
+    assert request.payload_capture_mode == capture_mode
+
+    matching_requests =
+      Requests.Request
+      |> Repo.all()
+      |> Enum.filter(&(&1.idempotency_key == idempotency_key))
+
+    assert [%{id: request_id}] = matching_requests
+    assert request_id == request.id
+  end
+
+  def latest_request!(requested_model, stream?) do
+    Orchard.Requests.Request
+    |> Repo.all()
+    |> Enum.filter(&(&1.requested_model == requested_model and &1.stream == stream?))
+    |> Enum.max_by(& &1.inserted_at)
+  end
+
+  defp assert_two_executions!(request, nodes) do
+    assert_receive {:retry_api_schedule, [], first_node_id}
+    assert first_node_id == nodes.first.id
+    assert_receive {:retry_api_execute, public_id, _target}
+    assert public_id == request.public_id
+    assert_receive {:retry_api_claim_count_before_alternate, 0}
+    assert_receive {:retry_api_schedule, [excluded_node_id], second_node_id}
+    assert excluded_node_id == nodes.first.id
+    assert second_node_id == nodes.second.id
+    assert_receive {:retry_api_execute, ^public_id, _target}
+    refute_receive {:retry_api_execute, ^public_id, _target}, 0
+  end
+
+  defp insert_runtime_node!(target) do
+    unique = System.unique_integer([:positive])
+    observed_at = DateTime.utc_now()
+
+    node =
+      %InventoryNode{}
+      |> InventoryNode.changeset(%{
+        id: Ecto.UUID.generate(),
+        hostname: "retry-api-#{unique}.local",
+        display_name: "retry-api-#{unique}",
+        advertise_addr: Keyword.fetch!(target, :host),
+        rpc_port: Keyword.fetch!(target, :port),
+        state: :active,
+        health: :healthy,
+        capabilities: %{},
+        last_heartbeat_at: observed_at
+      })
+      |> Repo.insert!()
+
+    decision =
+      %AdmissionDecision{}
+      |> AdmissionDecision.changeset(%{
+        node_id: node.id,
+        decision: :admitted,
+        actor_type: "system",
+        actor_id: "retry-api-test",
+        observed_identity: %{},
+        metadata: %{},
+        decided_at: observed_at
+      })
+      |> Repo.insert!()
+
+    %Policy{}
+    |> Policy.approved_explicit_changeset(%{
+      node_id: node.id,
+      admission_decision_id: decision.id,
+      controller_dispatch_ceiling: 4,
+      approved_by_actor_type: "system",
+      approved_by_actor_id: "retry-api-test",
+      approved_at: observed_at,
+      approval_reason: "bounded retry public API fixture"
+    })
+    |> Repo.insert!()
+
+    assert {:ok, _evidence} =
+             DispatchCapacity.record_capacity_evidence(node.id, %{
+               active_request_count: 0,
+               observed_at: observed_at,
+               runtime_concurrency_limit: 4,
+               validity: :valid
+             })
+
+    node
+  end
+
+  defp runtime_status_payload(node, target) do
+    %{
+      node_metadata: %{
+        node_id: node.id,
+        display_name: node.display_name,
+        hostname: node.hostname,
+        agent_version: "0.1.0",
+        listen_host: Keyword.fetch!(target, :host),
+        listen_port: Keyword.fetch!(target, :port),
+        worker_backend: "mlx"
+      },
+      runtime_health: %{ready: true, health_code: "ok", health_message: "ready"},
+      loaded_models: [],
+      active_request_count: 0,
+      max_concurrency: 4,
+      runtime_memory_budgets: [],
+      runtime_prefix_cache_statuses: [],
+      runtime_model_placements: [],
+      supports_prompt_token_ids: false
+    }
+  end
+
+  defp maybe_append_second_node(nodes, nil, _target), do: nodes
+
+  defp maybe_append_second_node(nodes, second_node, target) do
+    nodes ++ [%{node_id: second_node.id, target: target, inventory: second_node}]
+  end
+
+  defp target_key(%{address: address}), do: target_key(address)
+
+  defp target_key(target),
+    do: {Keyword.fetch!(target, :host), Keyword.fetch!(target, :port)}
+
+  defp fetch_state!(key) do
+    Process.get(key) || raise "retry API fixture is not configured"
+  end
+end

--- a/openspec/changes/automatic-attempt-retry/tasks.md
+++ b/openspec/changes/automatic-attempt-retry/tasks.md
@@ -20,20 +20,20 @@
 ## 3. Typed single-attempt dispatcher outcome and release acknowledgement
 
 - [x] 3.1 Return a typed dispatcher outcome with identity, acceptance, events, failure, execution resolution, release outcome, and timing
-- [ ] 3.2 Make allocation release distinguish released, already released, not applicable, and unresolved
-- [ ] 3.3 Preserve idempotent defensive cleanup without converting authority failure into confirmed release
-- [ ] 3.4 Preserve quarantine for unresolved accepted execution
-- [ ] 3.5 Keep the dispatcher single-target and single-attempt
+- [x] 3.2 Make allocation release distinguish released, already released, not applicable, and unresolved
+- [x] 3.3 Preserve idempotent defensive cleanup without converting authority failure into confirmed release
+- [x] 3.4 Preserve quarantine for unresolved accepted execution
+- [x] 3.5 Keep the dispatcher single-target and single-attempt
 
 ## 4. Output Commitment and event isolation
 
 - [x] 4.1 Add a pure monotonic Output Commitment classifier
 - [x] 4.2 Commit on non-empty text and stable tool-call identity
-- [ ] 4.2a Commit on future content-bearing structured output
+- [x] 4.2a Commit on future content-bearing structured output
 - [x] 4.3 Keep accepted, progress, usage, model-load, empty text, and terminal events uncommitted
 - [x] 4.4 Record commitment before public handler or serializer delivery
 - [x] 4.5 Buffer pre-commit attempt events, flush earlier events before a committing event, expose a safe discard seam, and flush the final uncommitted attempt in order
-- [ ] 4.5a Discard attempt 1 events when attempt 2 is integrated
+- [x] 4.5a Discard attempt 1 events when attempt 2 is integrated
 - [x] 4.6 Preserve text-specific `first_token_at`
 
 ## 5. Closed failure taxonomy and cancellation
@@ -51,8 +51,8 @@
 - [x] 6.3 Record the `SPEC.md` §7.3.5 rejection reason code `previous_attempt_node_excluded` in scheduler explanations
 - [x] 6.4 Make admitted single-target scheduling fail when its Node is excluded
 - [x] 6.5 Recheck the selected Node in the orchestrator before dispatch
-- [ ] 6.6 Keep the §7.5.3 `ScorePrefixCache` caps per logical Request so attempt 2 uses only their unconsumed remainder and otherwise ranks fail-open
-- [ ] 6.7 Prove alternate scheduling runs no second compatibility status-probe wave and records `no_alternative_node` on that branch
+- [x] 6.6 Keep the §7.5.3 `ScorePrefixCache` caps per logical Request so attempt 2 uses only their unconsumed remainder and otherwise ranks fail-open
+- [x] 6.7 Prove alternate scheduling runs no second compatibility status-probe wave and records `no_alternative_node` on that branch
 
 ## 7. Breaker attribution prerequisite
 
@@ -82,13 +82,13 @@
 
 ## 10. End-to-end acceptance
 
-- [ ] 10.1 Cover attempt 1 transient failure followed by attempt 2 success and failure
-- [ ] 10.2 Cover text, tool-call, empty-text, and structured-output commitment boundaries
-- [ ] 10.3 Cover no alternative, deadline exhaustion, cancellation races, unresolved release, and same-Node defense
-- [ ] 10.4 Cover one quota reservation, idempotent duplicate observation, unchanged capture policy, and attempt-event ordering
-- [ ] 10.5 Cover breaker attribution and logical-versus-attempt metrics
+- [x] 10.1 Cover attempt 1 transient failure followed by attempt 2 success and failure
+- [x] 10.2 Cover text, tool-call, empty-text, and structured-output commitment boundaries
+- [x] 10.3 Cover no alternative, deadline exhaustion, cancellation races, unresolved release, and same-Node defense
+- [x] 10.4 Cover one quota reservation, idempotent duplicate observation, unchanged capture policy, and attempt-event ordering
+- [x] 10.5 Cover breaker attribution and logical-versus-attempt metrics
 - [x] 10.6 Cover Chat Completions and Responses in streaming and non-streaming modes
-- [ ] 10.7 Cover terminal-conformance failures as non-retryable
+- [x] 10.7 Cover terminal-conformance failures as non-retryable
 
 ## 11. Quality and completion
 


### PR DESCRIPTION
## Summary

Orchard now proves the bounded automatic retry contract end to end through both public inference APIs in JSON and streaming modes.

The tests drive the real Router, endpoint controller, Request orchestrator, dispatcher, durable Request records, quota state, breaker attribution, and metrics seams with deterministic one-Node and two-Node runtime fixtures.
They prove one safe alternate attempt under the original logical Request and fail if a third execution occurs.

This is the final verification slice of parent #121 after #301, #304, #305, and #307.

## Key decisions

- Exercise Chat Completions and Responses through their public HTTP and SSE interfaces, then inspect durable Request and attempt evidence through integration seams.
- Share one retry fixture and assertion vocabulary across both APIs to keep the acceptance matrix aligned without duplicating orchestration logic.
- Use two Nodes only when a successful or exhausted alternate attempt requires them, and one Node for commitment, no-alternative, same-Node, and terminal-conformance scenarios.
- Make release-before-acquire observable by refusing alternate scheduling until the first Node's allocation claim count reaches zero.
- Treat exact public stream shape as the event-isolation proof: Chat emits only the expected empty role chunk, attempt-two text, and terminal chunk; Responses emits only the expected four typed events.
- Preserve the existing retry design and limit production changes to the accounting and classifier gaps exposed by public-behavior tests.
- Initialize `reserved_output_tokens` from the admitted sampling limit, then clear it centrally on every terminal Request update.
- Add the future structured-output commitment seam without inventing a runtime event that Orchard does not yet emit.

## Acceptance-to-test matrix

| Contract | Concrete proof |
| --- | --- |
| Attempt 1 transient failure, empty text, attempt 2 success, and no event leakage | `ChatCompletionsControllerTest` and `ResponsesControllerTest` run the success tracer with `stream: false` and `stream: true`, assert exact public payload/event shape, and reject attempt-one content. |
| Attempt 2 failure and no third attempt | Both controller suites run an exhausted two-Node tracer in JSON and streaming modes; the scripted runtime fails on any unexpected third execution. |
| Text and stable tool-call identity commit output | Both controller suites prove retry refusal after each commitment kind in JSON and streaming modes. |
| Empty text remains retryable and structured content commits | Public success tracers include an empty attempt-one text delta; `OutputCommitmentTest` proves empty versus content-bearing structured deltas and monotonic commitment. |
| No alternative and same-Node defense preserve attempt 1 | Both controller suites cover coherent no-candidate and same-Node selections with one Node and assert the original `worker_down` failure plus bounded retry decisions. |
| Deadline and cancellation at every retry boundary | Existing `RequestOrchestratorTest` cases cover caller death and deadline lapse after failure, alternate scheduling, candidate persistence, and durable attempt-two start. |
| Release-before-acquire and different-Node selection | `RetryAPI` blocks alternate scheduling until the excluded Node claim count is zero and asserts different durable Node IDs for attempts 1 and 2. |
| One Request, quota reservation, idempotency identity, and capture snapshot | Both public success tracers assert one public Request, one idempotency key/body identity, unchanged metadata capture mode, reservation `7` at attempt-two start, and `0` after terminalization. |
| Durable atomic attempt ordering | Shared assertions require ordered attempt-start/result pairs, retry decision evidence, release evidence, and exactly two runtime executions under one Request. |
| Breaker attribution and logical-versus-attempt metrics | Existing orchestrator, breaker, RequestServer, domain-metric, and inference-attempt projection suites prove once-only attribution and bounded physical-attempt versus logical-Request telemetry. |
| Terminal-conformance remains non-retryable | Both controller suites cover missing terminal events in JSON and streaming modes with one execution and `not_retryable` durable evidence. |

## Risk Assessment

✅ **Medium**

- The production blast radius is limited to Request reservation persistence, terminal reservation cleanup, and a pure future structured-output classifier seam.
- No database migration, public API shape, retry taxonomy, scheduler policy, attempt limit, or terminal mapping changes.
- Public success, failure, commitment, event isolation, same-Node, no-alternative, accounting, breaker, and metrics paths have direct deterministic coverage.
- Terminal reservation cleanup is centralized, idempotent, and covered by the full Requests and controller suites.
- The runtime provider is scripted and single-host; real MLX and physical multi-Node behavior were not exercised by this PR.

## Validation

- `ORCHARD_TEST_NODE_AGENT_PORT=51373 mise exec -- mix test apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs apps/orchard_controller/test/orchard/api/responses_controller_test.exs apps/orchard_controller/test/orchard/inference/output_commitment_test.exs` - 95 passed in 5.7s on the final head.
- `ORCHARD_TEST_NODE_AGENT_PORT=51373 mise exec -- mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs` - 115 passed in 30.1s.
- Focused RequestServer atomicity and metric suites - 44 passed in 2.0s.
- Focused Requests, accounting, capture, idempotency, queue, and breaker suites - 217 passed in 9.3s.
- `ORCHARD_TEST_NODE_AGENT_PORT=51373 make check-elixir` - passed on the final head.
  - Format and warnings-as-errors compilation passed.
  - Strict Credo checked 746 files with 90 checks and 0 issues in 22.3s.
  - Dialyzer reported 0 errors and 0 skips in 8.47s with an up-to-date PLT.
  - macOS native test-helper staging passed.
  - Full tests: 5,195 passed, 6 skipped, and 10 integration-tagged tests excluded; aggregate app-suite time 414.1s.
  - Coverage: the same 5,195 tests passed with 6 skipped and 10 excluded; shared 67.25%, controller 85.5%, node agent 78.33%, and CLI 76.40%.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate automatic-attempt-retry --type change --strict --no-interactive` - passed.
- `git diff --check origin/main...HEAD` - passed.

Independent RepoPrompt review found no remaining blocker or important findings after strengthening exact stream isolation, centralizing shared scenario data and assertions, and reviewing the final timing-tolerance commit.

`no-mistakes axi` could not start because this repository is not initialized for No Mistakes.
Initializing a new repo-level gate was kept out of this focused retry-verification PR.

One adjacent existing persistence assertion failed reproducibly at 2 ms and 3 ms because `timeout_at` is computed before the insert that supplies `inserted_at` while the test allowed only 1 ms.
The tolerance is now 25 ms; the exact test passed in 1.0s and the full public API slice and complete Orchard gate passed afterward.

## Provider and topology

- Provider: deterministic scripted Runtime Endpoint client through the real controller orchestration path.
- Topology: one macOS host with database-backed fixtures using one or two admitted logical Nodes per scenario.
- Not exercised: real MLX inference, packaged Orchard, or physical multi-Mac/multi-Node networking.

## SPEC and OpenSpec impact

`SPEC.md` is unchanged because it already defines the authoritative bounded retry, API, streaming, accounting, breaker, and metrics contracts proven here.

The accepted `automatic-attempt-retry` OpenSpec package remains subordinate to `SPEC.md`.
This PR reconciles the landed prerequisite tasks and completes the end-to-end acceptance tasks through 10.7.
Task 11.9 remains intentionally open for post-merge archive and parent-issue reconciliation.

## Non-goals

- Retry redesign or more than two automatic attempts
- Operator Retry or cohort retry
- Hosted tool execution
- Performance benchmarks
- Dashboards and alerts
- New breaker, quota, idempotency, capture, or metric label semantics
- Real MLX or physical multi-Node qualification

Fixes #173
Related: #121


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds end-to-end bounded-retry coverage for Chat Completions and Responses while closing reservation-accounting and structured-output commitment gaps.
- Initializes each durable Request’s output-token reservation from the effective admitted generation limit.
- Clears the reservation centrally whenever a Request reaches a terminal state.
- Adds a monotonic classifier seam for future content-bearing structured output.
- Exercises successful, exhausted, committed, unavailable-alternate, and terminal-conformance retry paths across JSON and streaming APIs.
- Updates the automatic-attempt-retry OpenSpec task checklist to reflect completed work.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code defect remains after tracing the production accounting changes and retry fixture execution path.

The persisted reservation matches the effective generation limit, terminal cleanup is valid and idempotent, and the deterministic retry fixtures execute in the same process that owns their scripted state.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/inference/output_commitment.ex | Adds a monotonic structured-output commitment classifier that ignores empty deltas and preserves an existing commitment. |
| apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex | Persists the effective generation output-token limit as the Request’s initial reservation. |
| apps/orchard_controller/lib/orchard/requests.ex | Centrally and idempotently clears output-token reservations during terminal Request updates. |
| apps/orchard_controller/test/support/retry_api_support.ex | Introduces deterministic scheduler and runtime fixtures plus shared assertions for bounded retry behavior. |
| apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs | Adds public JSON and SSE coverage for bounded retry, commitment, alternate-selection, accounting, and conformance behavior. |
| apps/orchard_controller/test/orchard/api/responses_controller_test.exs | Adds equivalent public JSON and typed-SSE bounded-retry coverage for the Responses API. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Orchestrator
    participant Node1
    participant Node2
    participant DB

    Client->>API: Inference request
    API->>Orchestrator: Execute logical Request
    Orchestrator->>DB: Persist Request and reservation
    Orchestrator->>Node1: Execute attempt 1
    Node1-->>Orchestrator: Retryable failure before commitment
    Orchestrator->>DB: Record attempt 1 failure and release
    Orchestrator->>Node2: Execute one alternate attempt
    Node2-->>Orchestrator: Success or terminal failure
    Orchestrator->>DB: Record attempt 2 and terminalize
    Orchestrator->>DB: Clear reserved output tokens
    Orchestrator-->>API: Final result or stream
    API-->>Client: Public response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: stabilize persisted deadline asser..."](https://github.com/kapitan-ai/orchard/commit/6a7ea2b685dcf5188b5059d9b52d4442338a630b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58207363)</sub>

<!-- /greptile_comment -->