### PR TITLE
fix(mlx): derive smoke timeout from phase budgets

### DIFF
--- a/apps/orchard_cli/test/orchard_cli/mlx_smoke_script_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/mlx_smoke_script_test.exs
@@ -1,0 +1,166 @@
+defmodule OrchardCLI.MLXSmokeScriptTest do
+  use ExUnit.Case, async: true
+
+  @repo_root Path.expand("../../../..", __DIR__)
+  @budget_helper Path.join(@repo_root, "scripts/support/mlx-smoke-budget.sh")
+  @smoke_script Path.join(@repo_root, "scripts/smoke-mlx.sh")
+  @custom_budget_env [
+    {"MLX_SMOKE_SOURCE_HASH_TIMEOUT_MS", "11"},
+    {"MLX_SMOKE_ACQUISITION_TIMEOUT_MS", "17"},
+    {"MLX_SMOKE_WORKER_READY_TIMEOUT_MS", "13"},
+    {"MLX_SMOKE_WORKER_LOAD_TIMEOUT_MS", "19"},
+    {"MLX_SMOKE_RPC_HEADROOM_MS", "23"},
+    {"MLX_SMOKE_INFERENCE_TIMEOUT_MS", "29"},
+    {"MLX_SMOKE_CLEANUP_HEADROOM_MS", "31"}
+  ]
+
+  test "MLX smoke derives and passes its ExUnit timeout without running a model" do
+    assert {"143\n", 0} =
+             System.cmd(
+               "bash",
+               [
+                 "-c",
+                 "source \"$1\"; mlx_smoke_exunit_timeout_ms 11 17 13 19 23 29 31",
+                 "bash",
+                 @budget_helper
+               ],
+               stderr_to_stdout: true
+             )
+
+    with_smoke_fixture(fn fixture ->
+      assert {output, 0} =
+               System.cmd("bash", [@smoke_script],
+                 cd: @repo_root,
+                 env:
+                   [
+                     {"ORCHARD_MLX_SMOKE_MODEL_PATH", fixture.bundle},
+                     {"ORCHARD_MLX_SMOKE_TEST_LOG", fixture.log},
+                     {"PATH", fixture.bin <> ":" <> System.get_env("PATH", "")}
+                   ] ++ @custom_budget_env,
+                 stderr_to_stdout: true
+               )
+
+      assert output =~
+               "mise exec -- mix test --only mlx_smoke --timeout 143"
+
+      assert File.read!(fixture.log) =~
+               nul_record([
+                 "exec",
+                 "--",
+                 "mix",
+                 "test",
+                 "apps/orchard_node_agent/test/orchard_node_agent_test.exs",
+                 "--only",
+                 "mlx_smoke",
+                 "--timeout",
+                 "143"
+               ])
+    end)
+  end
+
+  test "MLX smoke reports Python failure and stops before Elixir" do
+    with_smoke_fixture(fn fixture ->
+      assert {output, 1} = run_smoke(fixture, "python")
+
+      assert output =~ "Python smoke:  FAIL (exit 23)"
+      assert output =~ "Elixir smoke:  NOT RUN"
+      assert output =~ "Reason:        Python smoke tests failed"
+      refute File.read!(fixture.log) =~ nul_record(["exec", "--", "mix", "test"])
+    end)
+  end
+
+  test "MLX smoke reports Elixir failure" do
+    with_smoke_fixture(fn fixture ->
+      assert {output, 1} = run_smoke(fixture, "elixir")
+
+      assert output =~ "Python smoke:  PASS"
+      assert output =~ "Elixir smoke:  FAIL (exit 42)"
+      assert output =~ "Reason:        Elixir smoke tests failed"
+    end)
+  end
+
+  defp run_smoke(fixture, fail_phase) do
+    System.cmd("bash", [@smoke_script],
+      cd: @repo_root,
+      env: [
+        {"ORCHARD_MLX_SMOKE_MODEL_PATH", fixture.bundle},
+        {"ORCHARD_MLX_SMOKE_TEST_LOG", fixture.log},
+        {"ORCHARD_MLX_SMOKE_TEST_FAIL_PHASE", fail_phase},
+        {"PATH", fixture.bin <> ":" <> System.get_env("PATH", "")}
+      ],
+      stderr_to_stdout: true
+    )
+  end
+
+  defp nul_record(arguments), do: Enum.join(["CALL" | arguments] ++ ["END", ""], <<0>>)
+
+  defp with_smoke_fixture(fun) do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-mlx-smoke-script-test-#{System.unique_integer([:positive])}"
+      )
+
+    fixture = %{
+      bin: Path.join(root, "bin"),
+      bundle: Path.join(root, "bundle"),
+      log: Path.join(root, "mise.log")
+    }
+
+    try do
+      File.mkdir_p!(fixture.bin)
+      File.mkdir_p!(fixture.bundle)
+      File.write!(Path.join(fixture.bundle, "manifest.json"), "{}\n")
+      write_fake_uname!(fixture.bin)
+      write_fake_mise!(fixture.bin)
+      fun.(fixture)
+    after
+      File.rm_rf(root)
+    end
+  end
+
+  defp write_fake_uname!(bin) do
+    path = Path.join(bin, "uname")
+
+    File.write!(path, """
+    #!/bin/sh
+    case "$1" in
+      -s) printf 'Darwin\n' ;;
+      -m) printf 'arm64\n' ;;
+      *) exec /usr/bin/uname "$@" ;;
+    esac
+    """)
+
+    File.chmod!(path, 0o755)
+  end
+
+  defp write_fake_mise!(bin) do
+    path = Path.join(bin, "mise")
+
+    File.write!(path, """
+    #!/bin/sh
+    {
+      printf 'CALL\\0'
+      printf '%s\\0' "$@"
+      printf 'END\\0'
+    } >> "$ORCHARD_MLX_SMOKE_TEST_LOG"
+
+    case "${ORCHARD_MLX_SMOKE_TEST_FAIL_PHASE:-}" in
+      python)
+        case " $* " in
+          *" pytest "*) exit 23 ;;
+        esac
+        ;;
+      elixir)
+        if [ "$1" = "exec" ] && [ "$2" = "--" ] && [ "$3" = "mix" ] && [ "$4" = "test" ]; then
+          exit 42
+        fi
+        ;;
+    esac
+
+    exit 0
+    """)
+
+    File.chmod!(path, 0o755)
+  end
+end

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -4549,6 +4549,14 @@ defmodule OrchardNodeAgentTest do
     @tag :mlx_smoke
     test "opt-in MLX real generation through full node-agent path" do
       mlx_bundle_path = unquote(@mlx_smoke_model_path)
+      worker_load_timeout_ms = mlx_smoke_budget_ms!("MLX_SMOKE_WORKER_LOAD_TIMEOUT_MS")
+      worker_ready_timeout_ms = mlx_smoke_budget_ms!("MLX_SMOKE_WORKER_READY_TIMEOUT_MS")
+      ensure_loaded_timeout_ms = mlx_smoke_budget_ms!("MLX_SMOKE_ENSURE_LOADED_TIMEOUT_MS")
+
+      ensure_loaded_rpc_timeout_ms =
+        mlx_smoke_budget_ms!("MLX_SMOKE_ENSURE_LOADED_RPC_TIMEOUT_MS")
+
+      inference_timeout_ms = mlx_smoke_budget_ms!("MLX_SMOKE_INFERENCE_TIMEOUT_MS")
 
       # Read manifest from the real bundle
       manifest_json = File.read!(Path.join(mlx_bundle_path, "manifest.json"))
@@ -4556,8 +4564,11 @@ defmodule OrchardNodeAgentTest do
       model_id = manifest_data["model_id"]
       version = manifest_data["version"]
 
-      # Compute hash for the real bundle
-      {:ok, hash} = ArtifactBundle.tree_sha256(mlx_bundle_path)
+      {hash_elapsed_us, hash_result} =
+        :timer.tc(fn -> ArtifactBundle.tree_sha256(mlx_bundle_path) end)
+
+      IO.puts("MLX smoke bundle hash completed in #{div(hash_elapsed_us, 1_000)} ms")
+      assert {:ok, hash} = hash_result
 
       source_uri = "file://#{mlx_bundle_path}"
 
@@ -4566,8 +4577,8 @@ defmodule OrchardNodeAgentTest do
           runtime_adapter_impl: Orchard.Node.WorkerRuntimeAdapter,
           fake_runtime?: false,
           worker_backend: "mlx",
-          worker_load_timeout_ms: 120_000,
-          worker_ready_timeout_ms: 30_000
+          worker_load_timeout_ms: worker_load_timeout_ms,
+          worker_ready_timeout_ms: worker_ready_timeout_ms
         ],
         fn ->
           with_channel(fn channel ->
@@ -4578,15 +4589,25 @@ defmodule OrchardNodeAgentTest do
               version: version,
               artifact_sha256: hash,
               preload: true,
-              deadline_unix_ms: System.system_time(:millisecond) + 120_000,
+              deadline_unix_ms: System.system_time(:millisecond) + ensure_loaded_timeout_ms,
               artifact_source_uri: source_uri
             }
+
+            {ensure_loaded_elapsed_us, ensure_loaded_result} =
+              :timer.tc(fn ->
+                NodeRuntimeStub.ensure_model_loaded(channel, ensure_req,
+                  timeout: ensure_loaded_rpc_timeout_ms
+                )
+              end)
+
+            IO.puts(
+              "MLX smoke acquisition, worker readiness, and model load completed in #{div(ensure_loaded_elapsed_us, 1_000)} ms"
+            )
 
             assert {:ok,
                     %EnsureModelLoadedResponse{
                       placement_state: :PLACEMENT_STATE_LOADED
-                    }} =
-                     NodeRuntimeStub.ensure_model_loaded(channel, ensure_req, timeout: 125_000)
+                    }} = ensure_loaded_result
 
             # Execute real generation
             gen_req = %ExecuteInferenceRequest{
@@ -4597,7 +4618,7 @@ defmodule OrchardNodeAgentTest do
               rendered_prompt_utf8: "The capital of France is",
               input_tokens: 6,
               params: %GenerationParams{max_output_tokens: 8, temperature: 0.0},
-              deadline_unix_ms: System.system_time(:millisecond) + 60_000,
+              deadline_unix_ms: System.system_time(:millisecond) + inference_timeout_ms,
               metadata_json: ~s({"source":"mlx_smoke"})
             }
 
@@ -4644,6 +4665,13 @@ defmodule OrchardNodeAgentTest do
           end)
         end
       )
+    end
+
+    defp mlx_smoke_budget_ms!(name) do
+      case System.fetch_env!(name) |> Integer.parse() do
+        {value, ""} when value >= 0 -> value
+        _ -> raise ArgumentError, "#{name} must be a non-negative integer millisecond budget"
+      end
     end
   end
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1039,9 +1039,12 @@ its own location.
    then runs `pytest tests/test_cli.py -k mlx_backend_real -v` in the worker
    package — exercises real model load/unload and streaming generation via gRPC
 3. **Elixir smoke** (step 2/2): runs
-   `mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs --only mlx_smoke`
-   from the repo root — exercises the full node-agent stack including acquisition,
-   worker lifecycle, and gRPC inference
+   `mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs --only mlx_smoke --timeout 455000`
+   from the repo root.
+   It exercises the full node-agent stack including acquisition, worker lifecycle, and gRPC inference.
+   The script derives this command-scoped timeout from its source hashing, acquisition/cache verification, sequential worker readiness and model load, RPC headroom, inference, and cleanup phase budgets instead of changing ExUnit's global default.
+   Those exported budgets also configure the real test's worker, request, and RPC deadlines, so the harness and operation limits cannot drift independently.
+   The Elixir smoke reports both the initial bundle tree-hash duration and the elapsed acquisition/readiness/load phase.
 
 Python runs first because it tests the lower-level worker directly. If Python
 fails, Elixir smoke is skipped (the full stack depends on a working worker).
@@ -1086,10 +1089,12 @@ cd native/orchard_worker_mlx
 mise exec -- uv sync --locked --extra mlx
 mise exec -- uv run pytest tests/test_cli.py -k mlx_backend_real -v
 
-# Elixir only, from the repo root
+# Elixir full-stack smoke, from the repo root
 cd ../..
-mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs --only mlx_smoke
+mise exec -- ./scripts/smoke-mlx.sh
 ```
+
+Use the repository-owned script for the real Elixir path so it exports the shared phase budgets and passes their derived timeout to ExUnit.
 
 ## Preparing a Smoke Test Bundle from HuggingFace
 

--- a/scripts/smoke-mlx.sh
+++ b/scripts/smoke-mlx.sh
@@ -12,6 +12,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# shellcheck source=support/mlx-smoke-budget.sh
+source "$SCRIPT_DIR/support/mlx-smoke-budget.sh"
+mlx_smoke_configure_budgets
+
 # ---------------------------------------------------------------------------
 # Status tracking
 # ---------------------------------------------------------------------------
@@ -147,13 +151,15 @@ echo ""
 # Step 2: Elixir node-agent smoke tests
 # ---------------------------------------------------------------------------
 echo "==> [2/2] Elixir node-agent MLX smoke tests"
-echo "    mise exec -- mix test --only mlx_smoke"
+echo "    mise exec -- mix test --only mlx_smoke --timeout $MLX_SMOKE_EXUNIT_TIMEOUT_MS"
 echo ""
 
 set +e
 (
   cd "$REPO_ROOT" && \
-  mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs --only mlx_smoke
+  mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs \
+    --only mlx_smoke \
+    --timeout "$MLX_SMOKE_EXUNIT_TIMEOUT_MS"
 )
 ELIXIR_EXIT=$?
 set -e

--- a/scripts/support/mlx-smoke-budget.sh
+++ b/scripts/support/mlx-smoke-budget.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+mlx_smoke_sum_ms() {
+  local total_ms=0
+  local value
+
+  for value in "$@"; do
+    case "$value" in
+      '' | *[!0-9]*)
+        printf 'MLX smoke phase budgets must be non-negative integer milliseconds\n' >&2
+        return 64
+        ;;
+    esac
+
+    total_ms="$((10#$total_ms + 10#$value))"
+  done
+
+  printf '%s\n' "$total_ms"
+}
+
+mlx_smoke_exunit_timeout_ms() {
+  if [ "$#" -ne 7 ]; then
+    printf 'mlx_smoke_exunit_timeout_ms requires seven phase budgets\n' >&2
+    return 64
+  fi
+
+  mlx_smoke_sum_ms "$@"
+}
+
+mlx_smoke_configure_budgets() {
+  : "${MLX_SMOKE_SOURCE_HASH_TIMEOUT_MS:=60000}"
+  : "${MLX_SMOKE_ACQUISITION_TIMEOUT_MS:=120000}"
+  : "${MLX_SMOKE_WORKER_READY_TIMEOUT_MS:=30000}"
+  : "${MLX_SMOKE_WORKER_LOAD_TIMEOUT_MS:=120000}"
+  : "${MLX_SMOKE_RPC_HEADROOM_MS:=5000}"
+  : "${MLX_SMOKE_INFERENCE_TIMEOUT_MS:=60000}"
+  : "${MLX_SMOKE_CLEANUP_HEADROOM_MS:=60000}"
+
+  MLX_SMOKE_EXUNIT_TIMEOUT_MS="$(
+    mlx_smoke_exunit_timeout_ms \
+      "$MLX_SMOKE_SOURCE_HASH_TIMEOUT_MS" \
+      "$MLX_SMOKE_ACQUISITION_TIMEOUT_MS" \
+      "$MLX_SMOKE_WORKER_READY_TIMEOUT_MS" \
+      "$MLX_SMOKE_WORKER_LOAD_TIMEOUT_MS" \
+      "$MLX_SMOKE_RPC_HEADROOM_MS" \
+      "$MLX_SMOKE_INFERENCE_TIMEOUT_MS" \
+      "$MLX_SMOKE_CLEANUP_HEADROOM_MS"
+  )"
+
+  MLX_SMOKE_ENSURE_LOADED_TIMEOUT_MS="$(
+    mlx_smoke_sum_ms \
+      "$MLX_SMOKE_ACQUISITION_TIMEOUT_MS" \
+      "$MLX_SMOKE_WORKER_READY_TIMEOUT_MS" \
+      "$MLX_SMOKE_WORKER_LOAD_TIMEOUT_MS"
+  )"
+
+  MLX_SMOKE_ENSURE_LOADED_RPC_TIMEOUT_MS="$((
+    10#$MLX_SMOKE_ENSURE_LOADED_TIMEOUT_MS + 10#$MLX_SMOKE_RPC_HEADROOM_MS
+  ))"
+
+  export \
+    MLX_SMOKE_SOURCE_HASH_TIMEOUT_MS \
+    MLX_SMOKE_ACQUISITION_TIMEOUT_MS \
+    MLX_SMOKE_WORKER_READY_TIMEOUT_MS \
+    MLX_SMOKE_WORKER_LOAD_TIMEOUT_MS \
+    MLX_SMOKE_RPC_HEADROOM_MS \
+    MLX_SMOKE_INFERENCE_TIMEOUT_MS \
+    MLX_SMOKE_CLEANUP_HEADROOM_MS \
+    MLX_SMOKE_ENSURE_LOADED_TIMEOUT_MS \
+    MLX_SMOKE_ENSURE_LOADED_RPC_TIMEOUT_MS \
+    MLX_SMOKE_EXUNIT_TIMEOUT_MS
+}


### PR DESCRIPTION
## Summary

The repository-owned MLX smoke now gives ExUnit a command-scoped timeout derived from the work the smoke itself authorizes.
Large bundle hashing, acquisition, sequential worker readiness and model load, inference, and cleanup no longer compete with ExUnit's unrelated 60-second default.

## Behavior and boundaries

- `scripts/smoke-mlx.sh` exports one configurable set of phase budgets and derives a 455,000 ms ExUnit timeout from their sum.
- The real Elixir smoke consumes the same worker, request, RPC, and inference budgets, so the operation and harness limits cannot drift independently.
- The initial source hash and the full acquisition/readiness/load phase now report elapsed milliseconds.
- Routine regression tests invoke the real shell script with a tiny manifest-only bundle and fake executables.
  They verify derived timeout arguments with exact NUL-delimited argv and preserve Python short-circuit plus Elixir failure reporting without downloading or loading a model.
- The timeout remains scoped to the opt-in MLX command.
  Global and unrelated ExUnit timeouts, product runtime defaults, readiness contracts, and release gates are unchanged.

## Risk Assessment

✅ **Low**

- The blast radius is limited to the opt-in Apple Silicon MLX verification script, its tagged test, regression coverage, and local-development documentation.
- No schema, dependency, public API, product runtime, CI requirement, or global ExUnit timeout changes.
- Failure paths remain fail-visible and nonzero, including Python failure before Elixir and Elixir failure after Python passes.
- A cached 0.6B bundle completed the source-development MLX workflow, but a fresh roughly 30 GB run was not available in this worktree.
  The issue remains open for that final acceptance proof.

## Verification

- [x] Base fetched from `origin/main`: `7a60bc8e952f444fb40733fd02a891718224fe26`.
- [x] `bash -n scripts/smoke-mlx.sh scripts/support/mlx-smoke-budget.sh` passed.
- [x] `ORCHARD_TEST_NODE_AGENT_PORT=50155 mise exec -- mix test apps/orchard_cli/test/orchard_cli/mlx_smoke_script_test.exs` passed: 3 tests.
- [x] RepoPrompt read-only review reported no remaining actionable findings after the budget-source, sequential-phase, acquisition, elapsed-evidence, argv, failure-path, and documentation fixes.
- [x] `ORCHARD_TEST_NODE_AGENT_PORT=50155 make check-elixir` passed format, warnings-as-errors compilation, strict Credo, Dialyzer, helper staging, and the full non-coverage umbrella suite: 4,982 tests passed, 6 skipped, 10 excluded.
- [x] The first combined coverage attempt hit a local fixed-port custody race when port `50155` remained occupied between the test and coverage phases.
  `ORCHARD_TEST_NODE_AGENT_PORT=50156 mise exec -- mix test --cover` then passed on a verified-free isolated port: shared 67.25%, controller 85.5%, node agent 78.33%, CLI 76.40%.
- [x] `mise exec -- python /Users/najib/.agents/skills/orchard-e2e-verification/scripts/orchard_e2e.py run --repo /Users/najib/.codex/worktrees/3089/orchard` passed in 37.936 seconds against cached `mlx-community/Qwen3-0.6B-4bit`.
  The MLX helper took 12.605 seconds, invoked ExUnit with `--timeout 455000`, logged a 364 ms source hash and 2,360 ms acquisition/readiness/load phase, and observed real inference.
  This is source-development proof, not CI or release acceptance.

Related to #255.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the MLX smoke test’s fixed ExUnit timeout with a command-scoped timeout derived from shared phase budgets.
- Adds a shell helper that validates, exports, and combines MLX smoke budgets.
- Applies the same worker, request, RPC, and inference budgets within the real Elixir smoke.
- Adds regression coverage for timeout arguments and failure propagation.
- Documents the repository-owned invocation and reports elapsed hashing and loading times.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable changed-code defects identified.

The shared budgets are consistently derived, exported, consumed by the smoke path, and covered by regression tests without changing unrelated runtime or global ExUnit defaults.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/support/mlx-smoke-budget.sh | Defines validated phase-budget defaults and derives the ensure-loaded RPC and aggregate ExUnit timeouts. |
| scripts/smoke-mlx.sh | Loads the shared budgets and passes their derived timeout only to the opt-in MLX ExUnit command. |
| apps/orchard_node_agent/test/orchard_node_agent_test.exs | Replaces fixed MLX smoke deadlines with exported budgets and adds elapsed-time reporting. |
| apps/orchard_cli/test/orchard_cli/mlx_smoke_script_test.exs | Adds isolated regression tests for exact timeout propagation and Python/Elixir failure handling. |
| docs/local-dev.md | Documents the derived timeout, shared budgets, timing output, and repository-owned smoke invocation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mlx): derive smoke timeout from phas..."](https://github.com/kapitan-ai/orchard/commit/833b3897ff33893d94cadfcc3a46f25dbb3808bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58232342)</sub>

<!-- /greptile_comment -->