### PR TITLE
fix(models): deprecate manifest sha256

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1827,7 +1827,7 @@ The target model contract SHALL represent artifact format independently from com
 An artifact MAY declare more than one compatible provider or acceleration requirement set.
 Portable model policy MUST NOT rewrite artifact format as a runtime-provider name.
 
-The current `format`, `adapter`, `min_agent_capability`, MLX manifest values, database constraints, and accepted model bundles remain valid migration inputs.
+The current `format`, `adapter`, `min_agent_capability`, MLX manifest values other than the explicitly deprecated top-level `sha256`, database constraints, and accepted model bundles remain valid migration inputs.
 They SHALL NOT be removed, reinterpreted, or made non-authoritative until additive replacements, backward decoding, data migration, and scheduler cutover pass separate review and acceptance.
 
 Offline-importable model bundle SHALL be a tarball or directory with manifest:
@@ -1839,7 +1839,6 @@ Offline-importable model bundle SHALL be a tarball or directory with manifest:
   "format": "mlx",
   "artifact_layout": "directory",
   "entrypoint": "weights/",
-  "sha256": "hex",
   "size_bytes": 1234567890,
   "resident_memory_bytes": 6442450944,
   "kv_cache_bytes_per_token": 16384,
@@ -1876,6 +1875,18 @@ Offline-importable model bundle SHALL be a tarball or directory with manifest:
   }
 }
 ```
+
+Top-level Model Manifest `sha256` is optional, deprecated compatibility metadata.
+Supported consumers SHALL accept otherwise valid manifests with or without it and SHALL continue rejecting unknown keys.
+When present, it SHALL be a non-empty string but SHALL NOT supply, override, or be compared with the authoritative Catalog Artifact Bundle digest.
+BundleBuilder SHALL retain its current legacy emission during this compatibility phase.
+Producer omission MUST be implemented only in a separate accepted change that cites repo-owned minimum-consumer-version evidence proving every supported consumer accepts omission.
+
+`models.artifact_sha256` SHALL remain the authoritative lowercase SHA-256 digest of the final stored Artifact Bundle after secure staging and all importer-owned mutations.
+The existing digest algorithm recursively collects regular files, rejects symlinks and unsupported entries, sorts bundle-relative paths, and hashes each relative path followed by the file's exact bytes.
+The digest domain SHALL include the relative path and exact final bytes of `manifest.json`.
+The authoritative value SHALL NOT be written into `manifest.json`, because doing so would make the digest depend on its own encoded value.
+This contract change SHALL NOT rehash existing Catalog rows or introduce a new digest algorithm.
 
 Manifest fields added for safe tokenization are optional and SHALL NOT require a
 manifest version bump in the Phase 1 compatibility posture. Older manifests
@@ -2019,13 +2030,18 @@ Models SHALL be imported via:
 
 Import steps:
 
-1. parse manifest
-2. verify required fields
-3. compute sha256
-4. optionally verify detached signature
-5. insert catalog record
-6. store artifact in controller artifact root
-7. mark catalog state `registered`
+1. optionally verify transferred Model Bundle media against detached evidence obtained through an independently trusted channel
+2. parse the manifest
+3. verify required fields
+4. securely stage the bundle and apply importer-owned manifest mutations
+5. compute `models.artifact_sha256` over the final staged Artifact Bundle
+6. store the Artifact Bundle in the controller artifact root
+7. insert the Catalog record with the independently computed digest
+8. mark Catalog state `registered`
+
+Post-import verification SHALL recompute the digest over the final stored Artifact Bundle and compare it with the authoritative Catalog value or a trusted external export.
+The importer SHALL NOT copy the legacy manifest `sha256` into the Catalog or compare that value with the Catalog digest.
+Pre-import detached media verification and post-import Catalog verification are distinct checkpoints because importer-owned mutations may change the final stored tree.
 
 ### 6.6 Model publication
 
@@ -2034,6 +2050,8 @@ A model becomes tenant-visible only when:
 * catalog state transitions `registered -> active`
 * at least one tenant is granted access
 * routing policy resolution exists or default applies
+
+Publication SHALL NOT change `models.artifact_sha256` or promote legacy manifest `sha256` to authoritative state.
 
 ### 6.7 Model distribution
 
@@ -2050,6 +2068,8 @@ Distribution modes:
    * optional mounted path identical on all nodes
 
 Air-gapped systems MUST support mode 1 and mode 2.
+Operator-controlled pre-import media verification and post-import verification of the final controller-stored Artifact Bundle SHALL use the distinct checkpoints defined in §6.5 and §11.7, never the deprecated manifest field.
+This change does not define Runtime Endpoint distribution, Node acquisition enforcement, signature verification, or archive-container digest requirements.
 
 ### 6.8 Load/unload semantics
 
@@ -4954,10 +4974,15 @@ Air-gapped install SHALL support:
 Offline install flow:
 
 1. transfer the signed DMG distribution set and model bundles
-2. install `Orchard.app` and run its root-authorized lifecycle for the selected role
-3. run `orchardctl cluster init`
-4. import model bundles from removable media
-5. bootstrap/join nodes via offline-generated token or imported certs
+2. verify transferred model media against detached evidence obtained through an independently trusted channel
+3. install `Orchard.app` and run its root-authorized lifecycle for the selected role
+4. run `orchardctl cluster init`
+5. import model bundles from removable media
+6. recompute each final stored Artifact Bundle digest and compare it with the authoritative Catalog value or a trusted external export
+7. bootstrap/join nodes via offline-generated token or imported certs
+
+Top-level Model Manifest `sha256` SHALL NOT be used for either verification checkpoint.
+Pre-import media evidence and the final post-import Artifact Bundle digest may differ when import rewrites `manifest.json`.
 
 ### 11.8 Tray/menu bar app
 

--- a/apps/orchard_controller/lib/orchard/models/manifest_parser.ex
+++ b/apps/orchard_controller/lib/orchard/models/manifest_parser.ex
@@ -202,7 +202,8 @@ defmodule Orchard.Models.ManifestParser do
   end
 
   defp atomize_and_build(string_map) do
-    with {:ok, atom_map} <- atomize_top_level(string_map),
+    with :ok <- validate_legacy_sha256(string_map),
+         {:ok, atom_map} <- atomize_top_level(string_map),
          {:ok, atom_map} <- atomize_nested(atom_map, :tokenizer, @tokenizer_key_map),
          {:ok, atom_map} <- atomize_nested(atom_map, :chat_template, @chat_template_key_map),
          {:ok, atom_map} <- atomize_safe_tokenization(atom_map),
@@ -210,6 +211,21 @@ defmodule Orchard.Models.ManifestParser do
            atomize_nested(atom_map, :runtime_requirements, @runtime_requirements_key_map),
          :ok <- validate_safe_tokenization(atom_map) do
       build_manifest(atom_map)
+    end
+  end
+
+  defp validate_legacy_sha256(string_map) do
+    case Map.fetch(string_map, "sha256") do
+      :error ->
+        :ok
+
+      {:ok, value} when is_binary(value) and value != "" ->
+        :ok
+
+      {:ok, value} ->
+        {:error,
+         {:validation,
+          "sha256 must be omitted or contain a non-empty string, got: #{inspect(value)}"}}
     end
   end
 

--- a/apps/orchard_controller/test/orchard/models/importer_test.exs
+++ b/apps/orchard_controller/test/orchard/models/importer_test.exs
@@ -910,8 +910,11 @@ defmodule Orchard.Models.ImporterTest do
       end)
     end
 
-    test "eager preflight runs before SHA computation", %{artifacts_root: artifacts_root} do
-      source_dir = create_safe_bundle(artifacts_root)
+    test "SPEC 6.5 stores the final post-rewrite tree digest independently of legacy sha256", %{
+      artifacts_root: artifacts_root
+    } do
+      legacy_sha256 = String.duplicate("f", 64)
+      source_dir = create_safe_bundle(artifacts_root, %{"sha256" => legacy_sha256})
       write_tokenizer_config!(source_dir)
       {:ok, pre_rewrite_sha} = Orchard.ArtifactBundle.tree_sha256(source_dir)
       helper = write_preflight_helper!(artifacts_root, compatible_preflight_response())
@@ -922,6 +925,7 @@ defmodule Orchard.Models.ImporterTest do
 
         assert model.artifact_sha256 == imported_sha
         refute model.artifact_sha256 == pre_rewrite_sha
+        refute model.artifact_sha256 == legacy_sha256
       end)
     end
   end

--- a/apps/orchard_controller/test/orchard/models/manifest_parser_test.exs
+++ b/apps/orchard_controller/test/orchard/models/manifest_parser_test.exs
@@ -68,6 +68,27 @@ defmodule Orchard.Models.ManifestParserTest do
                ManifestParser.parse_json(json)
     end
 
+    test "SPEC 6.4 accepts a manifest without deprecated top-level sha256" do
+      json =
+        valid_manifest_json()
+        |> Jason.decode!()
+        |> Map.delete("sha256")
+        |> Jason.encode!()
+
+      assert {:ok, %ModelManifest{sha256: nil}} = ManifestParser.parse_json(json)
+    end
+
+    test "SPEC 6.4 rejects an explicitly null deprecated top-level sha256" do
+      json =
+        valid_manifest_json()
+        |> Jason.decode!()
+        |> Map.put("sha256", nil)
+        |> Jason.encode!()
+
+      assert {:error, {:validation, message}} = ManifestParser.parse_json(json)
+      assert message =~ "sha256"
+    end
+
     test "parses safe_tokenization and defaults compatible=true when absent" do
       json =
         valid_manifest_json_with_safe_tokenization()

--- a/apps/orchard_controller/test/orchard/models/manifest_schema_contract_test.exs
+++ b/apps/orchard_controller/test/orchard/models/manifest_schema_contract_test.exs
@@ -38,6 +38,21 @@ defmodule Orchard.Models.ManifestSchemaContractTest do
            ]
   end
 
+  test "SPEC 6.4 top-level manifest fields distinguish required optional and deprecated keys" do
+    contract = load_contract!()
+
+    assert contract["required_top_level_keys"] ==
+             ~w(artifact_layout capabilities entrypoint format model_id runtime_requirements tokenizer version)
+
+    assert contract["optional_top_level_keys"] ==
+             ~w(chat_template kv_cache_bytes_per_token max_context_tokens prefill_workspace_bytes_per_token resident_memory_bytes safe_tokenization sha256 size_bytes)
+
+    assert contract["deprecated_top_level_keys"] == ["sha256"]
+
+    assert Enum.sort(contract["required_top_level_keys"] ++ contract["optional_top_level_keys"]) ==
+             contract["top_level_keys"]
+  end
+
   test "SPEC 6.4 safe-tokenization incompatibility category enum contract is sorted and partitioned" do
     contract = load_contract!()
     category_sets = contract_category_sets(contract)

--- a/apps/orchard_shared/lib/orchard/model_manifest.ex
+++ b/apps/orchard_shared/lib/orchard/model_manifest.ex
@@ -116,7 +116,6 @@ defmodule Orchard.ModelManifest do
     :format,
     :artifact_layout,
     :entrypoint,
-    :sha256,
     :capabilities,
     :tokenizer,
     :runtime_requirements
@@ -144,7 +143,7 @@ defmodule Orchard.ModelManifest do
           format: String.t(),
           artifact_layout: String.t(),
           entrypoint: String.t(),
-          sha256: String.t(),
+          sha256: String.t() | nil,
           size_bytes: non_neg_integer() | nil,
           resident_memory_bytes: non_neg_integer() | nil,
           kv_cache_bytes_per_token: non_neg_integer() | nil,
@@ -179,7 +178,6 @@ defmodule Orchard.ModelManifest do
       :format,
       :artifact_layout,
       :entrypoint,
-      :sha256,
       :capabilities,
       :tokenizer,
       :runtime_requirements
@@ -189,9 +187,9 @@ defmodule Orchard.ModelManifest do
       :version,
       :format,
       :artifact_layout,
-      :entrypoint,
-      :sha256
+      :entrypoint
     ])
+    |> validate_optional_string_field!(:sha256)
     |> validate_max_context_tokens!()
     |> validate_optional_non_negative_integers!([
       :size_bytes,
@@ -231,6 +229,20 @@ defmodule Orchard.ModelManifest do
     end)
 
     struct
+  end
+
+  defp validate_optional_string_field!(struct, key) do
+    case Map.fetch!(struct, key) do
+      nil ->
+        struct
+
+      value when is_binary(value) and value != "" ->
+        struct
+
+      value ->
+        raise ArgumentError,
+              "#{inspect(__MODULE__)} requires #{inspect(key)} to be nil or a non-empty binary, got: #{inspect(value)}"
+    end
   end
 
   defp validate_max_context_tokens!(%__MODULE__{max_context_tokens: nil} = struct), do: struct

--- a/apps/orchard_shared/test/fixtures/manifest_schema/README.md
+++ b/apps/orchard_shared/test/fixtures/manifest_schema/README.md
@@ -2,6 +2,11 @@
 
 `v1.json` is a product-owned contract fixture for Orchard model-manifest schema behavior described by SPEC §6.4. The fixture is consumed by product tests to keep manifest parser, controller, and worker assumptions aligned without changing canonical bundle fixture manifests.
 
+`top_level_keys` is the closed set accepted by supported consumers.
+`required_top_level_keys` and `optional_top_level_keys` partition that set.
+`deprecated_top_level_keys` identifies accepted compatibility metadata that is not authoritative product state.
+Top-level `sha256` is optional and deprecated because the Catalog's `models.artifact_sha256` is computed independently over the final stored Artifact Bundle.
+
 ## Safe-tokenization incompatibility categories
 
 The manifest verdict enum `safe_tokenization.incompatibility_reason.category` is jointly owned by:

--- a/apps/orchard_shared/test/fixtures/manifest_schema/v1.json
+++ b/apps/orchard_shared/test/fixtures/manifest_schema/v1.json
@@ -18,6 +18,29 @@
     "tokenizer",
     "version"
   ],
+  "required_top_level_keys": [
+    "artifact_layout",
+    "capabilities",
+    "entrypoint",
+    "format",
+    "model_id",
+    "runtime_requirements",
+    "tokenizer",
+    "version"
+  ],
+  "optional_top_level_keys": [
+    "chat_template",
+    "kv_cache_bytes_per_token",
+    "max_context_tokens",
+    "prefill_workspace_bytes_per_token",
+    "resident_memory_bytes",
+    "safe_tokenization",
+    "sha256",
+    "size_bytes"
+  ],
+  "deprecated_top_level_keys": [
+    "sha256"
+  ],
   "nested_keys": {
     "chat_template": [
       "path",

--- a/apps/orchard_shared/test/orchard/artifact_bundle_test.exs
+++ b/apps/orchard_shared/test/orchard/artifact_bundle_test.exs
@@ -42,6 +42,22 @@ defmodule Orchard.ArtifactBundleTest do
       assert hash_a == @fixture_hash
     end
 
+    test "SPEC 6.4 includes the exact final manifest.json bytes", %{tmp_dir: tmp_dir} do
+      bundle = Path.join(tmp_dir, "manifest_bytes_bundle")
+      manifest_path = Path.join(bundle, "manifest.json")
+      File.mkdir_p!(bundle)
+
+      File.write!(manifest_path, ~s({"sha256":"legacy-a"}))
+
+      assert {:ok, "dc47c752f00aa0aeb5bf2bca15e2a93d3e2a52cf1fe184e1d150415a695517e7"} =
+               ArtifactBundle.tree_sha256(bundle)
+
+      File.write!(manifest_path, ~s({"sha256":"legacy-b"}))
+
+      assert {:ok, "f02a56e9dbd23c8fb9c3e60eb668246551c7eef8e876d8555bece25432f50129"} =
+               ArtifactBundle.tree_sha256(bundle)
+    end
+
     test "returns error for nonexistent directory" do
       assert {:error, {:hash_failed, _}} = ArtifactBundle.tree_sha256("/nonexistent/path")
     end

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1138,7 +1138,7 @@ replace the script's `cp -L` copy with `ln -s`.
 | `format` | `"mlx"` | Required |
 | `artifact_layout` | `"directory"` | Required |
 | `entrypoint` | `"."` | Path to model weights dir (`.` = bundle root) |
-| `sha256` | 64-char hex | `BundleBuilder` computes this from bundle files |
+| `sha256` | Optional deprecated string | Compatibility metadata only. `BundleBuilder` currently emits `"pending"`; do not use it as integrity evidence. |
 | `max_context_tokens` | From `config.json` `max_position_embeddings` | |
 | `tokenizer.kind` | `"huggingface_tokenizer_json"` | Required |
 | `tokenizer.path` | `"tokenizer.json"` | Relative to bundle root |
@@ -1146,6 +1146,28 @@ replace the script's `cp -L` copy with `ln -s`.
 | `chat_template.sha256` | SHA-256 of template bytes | Auto-filled on import when the template file exists |
 | `runtime_requirements.adapter` | `"mlx_lm"` | Required |
 | `runtime_requirements.min_agent_capability` | `"mlx"` | Required |
+
+### Verifying Model Bundle Media And Imported Artifacts
+
+Pre-import media verification and post-import Catalog verification protect different byte sets.
+Do not compare either checkpoint with top-level manifest `sha256`.
+
+Before import, verify the transferred archive or directory against detached evidence obtained through an independently trusted channel.
+For an archive, this can be a sidecar digest checked with the platform's SHA-256 tool before extraction.
+Orchard does not currently derive trusted pre-import evidence from `manifest.json`.
+
+After import, recompute the digest over the final stored Artifact Bundle and compare it with `models.artifact_sha256` in the Catalog:
+
+```elixir
+model = Orchard.Models.get_model_by_identity("model-id", "version")
+artifact_path = String.replace_prefix(model.artifact_uri, "file://", "")
+{:ok, stored_tree_sha256} = Orchard.ArtifactBundle.tree_sha256(artifact_path)
+stored_tree_sha256 == model.artifact_sha256
+```
+
+The final digest includes every regular file's bundle-relative path and exact bytes, including the final `manifest.json` after importer-owned rewrites.
+It may legitimately differ from detached pre-import media evidence.
+BundleBuilder will keep emitting the legacy field until a separate accepted change cites repo-owned minimum-consumer-version evidence proving omission safe.
 
 ### Recommended Smoke Models
 

--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py
@@ -283,7 +283,7 @@ class BundleManifest:
     format: str
     artifact_layout: str
     entrypoint: str
-    sha256: str
+    sha256: str | None
     max_context_tokens: int | None
     capabilities: tuple[str, ...]
     tokenizer: TokenizerSpec
@@ -330,7 +330,6 @@ _REQUIRED_STRING_FIELDS = (
     "format",
     "artifact_layout",
     "entrypoint",
-    "sha256",
 )
 
 _OPTIONAL_NON_NEGATIVE_INT_FIELDS = (
@@ -384,6 +383,9 @@ def parse_manifest_json(payload: str) -> BundleManifest:
     # --- required string fields ---
     for field in _REQUIRED_STRING_FIELDS:
         _require_non_empty_string(data, field)
+
+    if "sha256" in data:
+        _require_non_empty_string(data, "sha256")
 
     # --- max_context_tokens (optional — nil for models without declared context window) ---
     max_ctx = data.get("max_context_tokens")
@@ -446,7 +448,7 @@ def parse_manifest_json(payload: str) -> BundleManifest:
         format=data["format"],
         artifact_layout=data["artifact_layout"],
         entrypoint=data["entrypoint"],
-        sha256=data["sha256"],
+        sha256=data.get("sha256"),
         max_context_tokens=max_ctx,
         capabilities=tuple(caps),
         tokenizer=tokenizer_spec,

--- a/native/orchard_worker_mlx/tests/test_manifest_schema_contract.py
+++ b/native/orchard_worker_mlx/tests/test_manifest_schema_contract.py
@@ -33,6 +33,16 @@ def test_worker_known_keys_match_manifest_schema_contract() -> None:
     assert contract["worker_validates_top_level_keys"] is True
     assert _KNOWN_TOP_LEVEL_KEYS == set(contract["top_level_keys"])
 
+    required_keys = set(contract["required_top_level_keys"])
+    optional_keys = set(contract["optional_top_level_keys"])
+    deprecated_keys = set(contract["deprecated_top_level_keys"])
+
+    assert required_keys | optional_keys == _KNOWN_TOP_LEVEL_KEYS
+    assert required_keys.isdisjoint(optional_keys)
+    assert "sha256" not in required_keys
+    assert "sha256" in optional_keys
+    assert deprecated_keys == {"sha256"}
+
     nested_keys = contract["nested_keys"]
     assert _KNOWN_TOKENIZER_KEYS == set(nested_keys["tokenizer"])
     assert _KNOWN_CHAT_TEMPLATE_KEYS == set(nested_keys["chat_template"])

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -246,6 +246,15 @@ def test_parse_manifest_json_without_optional_fields() -> None:
     assert manifest.resident_memory_bytes is None
 
 
+def test_spec_6_4_parse_manifest_json_without_deprecated_sha256() -> None:
+    data = _read_fixture_manifest_dict()
+    del data["sha256"]
+
+    manifest = parse_manifest_json(json.dumps(data))
+
+    assert manifest.sha256 is None
+
+
 def test_manifest_is_frozen() -> None:
     manifest = parse_manifest_json(_read_fixture_manifest())
     with pytest.raises(AttributeError):
@@ -309,6 +318,18 @@ def test_manifest_empty_string_required_field() -> None:
         parse_manifest_json(json.dumps(data))
     assert exc_info.value.code == "manifest_validation_error"
     assert "version" in exc_info.value.message
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_manifest_present_deprecated_sha256_must_remain_non_empty(value: object) -> None:
+    data = _read_fixture_manifest_dict()
+    data["sha256"] = value
+
+    with pytest.raises(ModelLoaderError) as exc_info:
+        parse_manifest_json(json.dumps(data))
+
+    assert exc_info.value.code == "manifest_validation_error"
+    assert "sha256" in exc_info.value.message
 
 
 def test_manifest_bad_max_context_tokens() -> None:

--- a/openspec/changes/deprecate-manifest-sha256/.openspec.yaml
+++ b/openspec/changes/deprecate-manifest-sha256/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/deprecate-manifest-sha256/design.md
+++ b/openspec/changes/deprecate-manifest-sha256/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The Model Manifest currently requires a top-level `sha256` string in the shared Elixir domain and MLX worker parser.
+BundleBuilder writes the placeholder `"pending"`, while the importer ignores that value and computes `models.artifact_sha256` from the staged tree after importer-owned manifest rewrites.
+`Orchard.ArtifactBundle.tree_sha256/1` includes every regular file, so `manifest.json` and its exact final bytes are inside the authoritative digest domain.
+
+Putting that same digest inside `manifest.json` would require a SHA-256 fixed point because writing the value changes the bytes being hashed.
+The accepted owner decision is to remove this false authority from the manifest contract without changing the existing tree-hash algorithm or stored Catalog values.
+
+No repo-owned minimum-worker-version or equivalent compatibility gate currently proves that every supported consumer accepts omission.
+Producer emission must therefore remain unchanged during this compatibility phase.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make top-level Model Manifest `sha256` optional in supported Elixir and MLX worker consumers while continuing to reject unknown keys.
+- Make a present legacy value non-authoritative and prevent it from supplying, overriding, or being compared with `models.artifact_sha256`.
+- Specify `models.artifact_sha256` as the digest of the final stored Artifact Bundle, including exact final `manifest.json` bytes after importer-owned rewrites.
+- Prove through public seams that importer storage equals a fresh digest of the final stored tree.
+- Document detached pre-import media verification and post-import Catalog verification as distinct checkpoints.
+- Preserve BundleBuilder legacy emission until a separately accepted compatibility gate authorizes omission.
+
+**Non-Goals:**
+
+- A framed tree-hash v2 or any other new digest algorithm.
+- Catalog rehashing, digest-version columns, or existing-row migration.
+- `payload_sha256`, manifest canonicalization, or exclusion of manifest bytes.
+- Runtime Endpoint distribution, Node acquisition verification, signatures, or archive-container digests.
+- New capability negotiation or minimum-version policy.
+
+## Decisions
+
+### Keep one authoritative stored-tree digest
+
+`models.artifact_sha256` remains the only authoritative Artifact Bundle digest.
+The importer computes it after secure staging and every importer-owned mutation, then stores the result with the Catalog record.
+This preserves existing data and ensures all final stored manifest bytes remain inside the digest domain.
+
+Alternative: put the same value into `manifest.json`.
+Rejected because the manifest is itself hashed and therefore creates an infeasible fixed-point contract.
+
+Alternative: add `payload_sha256` or normalize the manifest during hashing.
+Rejected because either approach creates another digest domain or changes the existing algorithm beyond issue #256.
+
+### Treat manifest `sha256` as optional deprecated compatibility metadata
+
+Consumers keep `sha256` in their closed set of known keys, accept omission, and preserve a present string only as compatibility metadata.
+No import or Catalog path reads that field as integrity evidence.
+Unknown top-level and nested keys remain rejected.
+
+The shared fixture will declare top-level known, required, optional, and deprecated keys so Elixir and Python tests enforce the same schema posture.
+
+### Retain producer emission until a separate compatibility gate
+
+BundleBuilder continues emitting its existing legacy value in this change.
+Removing the field is a separate follow-up that must cite repo-owned accepted evidence that every supported consumer version accepts manifests without it.
+This change does not invent a capability protocol or infer safety from current source tests alone.
+
+### Separate verification checkpoints
+
+Before import, an operator verifies transferred Model Bundle media against detached evidence received through an independently trusted channel.
+After import, Orchard recomputes the digest of the final stored Artifact Bundle and compares it with the authoritative Catalog value.
+These values may differ when the importer rewrites `manifest.json`, so documentation must not present either checkpoint as a substitute for the other.
+This change leaves Runtime Endpoint distribution, Node acquisition enforcement, signatures, and archive-container digest semantics to separate accepted work.
+
+## Risks / Trade-offs
+
+- [Risk] Existing manifests continue to display a misleading legacy value during the compatibility phase.
+  - Mitigation: Mark it deprecated and non-authoritative in the contract, fixture, and operator documentation, and track producer omission as a precise gated follow-up.
+- [Risk] Making the field optional in shared types could accidentally broaden other validation.
+  - Mitigation: Keep closed-key validation and add explicit unknown-key regression coverage in both consumers.
+- [Risk] Tests could compare against a digest calculated before importer rewrites.
+  - Mitigation: Exercise the public importer and recompute from the final stored path returned through the Catalog record.
+- [Risk] The historical unframed tree serialization has separate structural ambiguity.
+  - Mitigation: Keep that security-hardening decision out of this slice and avoid presenting this PR as a new adversarial-transfer integrity design.
+
+## Migration Plan
+
+1. Update `SPEC.md`, the OpenSpec capability, shared fixture, and operator documentation.
+2. Deploy consumer optionality across the shared Elixir manifest and MLX worker parser while BundleBuilder continues legacy emission.
+3. Verify old manifests with `sha256` and new compatibility-test manifests without it across all supported consumers.
+4. In a separate change, remove producer emission only after repo-owned accepted minimum-consumer evidence proves omission safe.
+
+Rollback restores the previous consumer requirement and documentation without rehashing or migrating Catalog data.
+
+## Open Questions
+
+- Which future repo-owned release or support-policy artifact will constitute the accepted minimum-consumer-version gate for stopping BundleBuilder emission?

--- a/openspec/changes/deprecate-manifest-sha256/proposal.md
+++ b/openspec/changes/deprecate-manifest-sha256/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Model Bundles currently emit a top-level `sha256` placeholder that consumers require but the importer ignores, while the authoritative Catalog digest is computed over the final stored Artifact Bundle, including `manifest.json`.
+This ambiguity makes the manifest appear usable as integrity evidence even though embedding the same self-inclusive digest would require an infeasible fixed point.
+
+## What Changes
+
+- Deprecate top-level Model Manifest `sha256` and make it optional, accepted, and non-authoritative in supported Elixir and MLX worker consumers.
+- Preserve `models.artifact_sha256` as the authoritative digest over the final stored Artifact Bundle, including the exact final bytes of `manifest.json` after importer-owned rewrites.
+- Keep transitional BundleBuilder emission until a separately accepted compatibility gate proves every supported consumer accepts omission.
+- Distinguish detached pre-import media verification from post-import Catalog verification in the product contract and operator documentation.
+- Reconcile `SPEC.md` §§6.4-6.7 and §11.7 without changing the digest algorithm, rehashing Catalog rows, or adding a second payload digest.
+
+## Capabilities
+
+### New Capabilities
+
+- `model-bundle-digest-contract`: Defines Model Manifest digest compatibility, authoritative Artifact Bundle hashing, and the distinct pre-import and post-import verification checkpoints.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Product contract: `SPEC.md` §§6.4-6.7 and §11.7.
+- Elixir consumers: shared `Orchard.ModelManifest`, Controller manifest parsing/import, and schema contract tests.
+- Python consumer: MLX worker manifest parsing and schema contract tests.
+- Shared manifest schema fixture and operator guidance in `docs/local-dev.md`.
+- BundleBuilder continues emitting the legacy field in this change because no accepted minimum-worker-version gate proves removal safe.
+- No Runtime Endpoint distribution, Node acquisition verification, signature, archive-container digest, Catalog migration, or digest-algorithm behavior changes.

--- a/openspec/changes/deprecate-manifest-sha256/specs/model-bundle-digest-contract/spec.md
+++ b/openspec/changes/deprecate-manifest-sha256/specs/model-bundle-digest-contract/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Deprecated manifest digest compatibility
+Per `SPEC.md` §6.4, supported Model Manifest consumers SHALL accept otherwise valid manifests with or without top-level `sha256`.
+The field SHALL remain a known key during the compatibility phase, SHALL be deprecated and non-authoritative when present, and SHALL NOT supply, override, or be compared with the Catalog Artifact Bundle digest.
+When present, the field SHALL contain a non-empty string; omission is distinct from an explicit JSON `null`.
+Consumers MUST continue to reject unknown manifest keys.
+
+#### Scenario: Consumer accepts omitted legacy digest
+- **WHEN** a supported consumer receives an otherwise valid Model Manifest without top-level `sha256`
+- **THEN** the consumer accepts the manifest and represents the legacy value as absent
+
+#### Scenario: Consumer accepts present legacy digest without authority
+- **WHEN** a supported consumer receives an otherwise valid Model Manifest with top-level `sha256`
+- **THEN** the consumer accepts the manifest without using that value as Artifact Bundle integrity evidence
+
+#### Scenario: Consumer rejects a present non-string legacy digest
+- **WHEN** a Model Manifest includes top-level `sha256` with JSON `null` or another non-string value
+- **THEN** the consumer rejects the manifest rather than treating the field as omitted
+
+#### Scenario: Consumer rejects an unknown key
+- **WHEN** a Model Manifest includes a top-level key outside the closed known-key set
+- **THEN** the consumer rejects the manifest even though `sha256` itself is optional
+
+### Requirement: Authoritative final Artifact Bundle digest
+Per `SPEC.md` §§6.4-6.6, `models.artifact_sha256` SHALL contain the lowercase SHA-256 digest computed over the final stored Artifact Bundle after secure staging and all importer-owned mutations.
+The digest domain SHALL include every regular file under the Artifact Bundle root, including the relative path and exact final bytes of `manifest.json`, using the existing `Orchard.ArtifactBundle.tree_sha256/1` algorithm.
+The importer SHALL persist the computed value independently of any legacy manifest `sha256` value.
+
+#### Scenario: Final manifest bytes affect the authoritative digest
+- **WHEN** only the exact bytes of `manifest.json` change in an Artifact Bundle
+- **THEN** the recomputed Artifact Bundle digest changes
+
+#### Scenario: Importer stores the final post-rewrite digest
+- **WHEN** import succeeds after an importer-owned manifest rewrite
+- **THEN** `models.artifact_sha256` equals a fresh digest of the final stored Artifact Bundle tree
+
+#### Scenario: Legacy value cannot override Catalog authority
+- **WHEN** two otherwise identical import inputs carry different present legacy `sha256` strings
+- **THEN** each Catalog digest is derived from its final stored tree and neither legacy string is copied into the Catalog digest field
+
+### Requirement: Distinct offline verification checkpoints
+Per `SPEC.md` §§6.5, 6.7, and 11.7, pre-import detached media verification and post-import Catalog verification SHALL be distinct checkpoints.
+Pre-import verification SHALL compare transferred Model Bundle media with detached verification evidence obtained through an independently trusted channel.
+Post-import verification SHALL recompute the final stored Artifact Bundle digest and compare it with the authoritative Catalog value or a trusted external export.
+This requirement SHALL NOT define Runtime Endpoint distribution, Node acquisition enforcement, signatures, or archive-container digest semantics.
+
+#### Scenario: Verify transferred media before import
+- **WHEN** an operator transfers a Model Bundle into an offline environment
+- **THEN** the operator verifies the transferred media against independently trusted detached evidence before import
+
+#### Scenario: Verify final storage after import
+- **WHEN** Orchard import has completed and may have rewritten `manifest.json`
+- **THEN** post-import verification uses the final stored tree and the authoritative Catalog digest rather than the legacy manifest field
+
+### Requirement: Gated producer deprecation
+BundleBuilder SHALL retain top-level `sha256` emission during this compatibility phase.
+Producer omission MUST be implemented only in a separate accepted change that cites repo-owned minimum-consumer-version evidence proving every supported consumer accepts omission.
+
+#### Scenario: Current builder preserves compatibility output
+- **WHEN** BundleBuilder creates a Model Manifest before the compatibility gate is accepted
+- **THEN** it continues emitting the legacy top-level `sha256` key
+
+#### Scenario: Producer omission remains a gated follow-up
+- **WHEN** no repo-owned accepted compatibility gate proves omission safe
+- **THEN** this change does not remove the field or invent capability negotiation

--- a/openspec/changes/deprecate-manifest-sha256/tasks.md
+++ b/openspec/changes/deprecate-manifest-sha256/tasks.md
@@ -1,0 +1,27 @@
+## 1. Contract Reconciliation
+
+- [x] 1.1 Reconcile `SPEC.md` §§6.4-6.7 and §11.7 with optional non-authoritative manifest `sha256`, authoritative final-tree Catalog hashing, and distinct verification checkpoints.
+- [x] 1.2 Update the shared manifest schema fixture and its documentation to declare known, required, optional, and deprecated top-level keys.
+
+## 2. Consumer Compatibility Through TDD
+
+- [x] 2.1 Add a failing public Elixir manifest-parser test for omitted `sha256` while retaining unknown-key rejection, then minimally make the shared domain accept absence.
+- [x] 2.2 Add a failing public MLX worker manifest-parser test for omitted `sha256` while retaining unknown-key rejection, then minimally make the worker accept absence.
+- [x] 2.3 Keep BundleBuilder legacy `sha256` emission unchanged and add or retain focused coverage proving transitional emission.
+
+## 3. Authoritative Digest Proof Through TDD
+
+- [x] 3.1 Add a public Artifact Bundle characterization test proving exact `manifest.json` bytes remain inside the tree digest, preserving the existing algorithm unchanged.
+- [x] 3.2 Add a public importer characterization test proving a present legacy value cannot supply or override `models.artifact_sha256` and that storage equals a fresh digest of the final post-rewrite tree.
+
+## 4. Operator Guidance And Compatibility Gate
+
+- [x] 4.1 Correct `docs/local-dev.md` so it distinguishes deprecated manifest metadata, detached pre-import media verification, and post-import Catalog verification.
+- [x] 4.2 Document the producer-removal follow-up as requiring repo-owned accepted minimum-consumer-version evidence without inventing capability negotiation.
+
+## 5. Validation And Review
+
+- [x] 5.1 Run focused Elixir and native MLX worker tests during each red-green slice and record red-before-green evidence.
+- [x] 5.2 Run the applicable full Elixir and native Python formatting, linting, test, typing where configured, and coverage workflows from `AGENTS.md`.
+- [x] 5.3 Run strict validation for `deprecate-manifest-sha256` and strict all-change OpenSpec validation, then obtain independent RP Review or Oracle review and resolve validated findings.
+- [x] 5.4 Confirm this active change is not archived or synced in this PR and preserve the required future review to remove generated placeholder prose after archive or sync.


### PR DESCRIPTION
## Summary

This deprecates top-level Model Manifest `sha256` as optional, non-authoritative compatibility metadata across Orchard's supported Elixir and MLX worker consumers.
The Catalog's `models.artifact_sha256` remains authoritative over the final stored Artifact Bundle, including the exact final bytes of `manifest.json`, without changing the existing tree-hash algorithm or creating a self-referential manifest digest.

## Contract

- Reconciles `SPEC.md` §§6.4-6.7 and §11.7 through OpenSpec change `deprecate-manifest-sha256`.
- Accepts valid manifests with or without top-level `sha256`, while preserving closed-key rejection and rejecting a present null, empty, or non-string value.
- Keeps a present legacy value out of Catalog digest authority, comparison, and override paths.
- Proves that exact final `manifest.json` bytes remain in the authoritative tree digest and that importer storage equals a fresh digest of the final post-rewrite tree.
- Separates detached pre-import media verification from post-import verification against the Catalog digest.

## Compatibility gate

BundleBuilder continues to emit the legacy field in this compatibility phase.
Producer omission remains a separate accepted change that must cite repo-owned minimum-consumer-version evidence proving every supported consumer accepts omission.
This PR does not add capability negotiation.

## Validation

- `ORCHARD_TEST_NODE_AGENT_PORT=50123 make check-elixir`
  - Format, warnings-as-errors compilation, Credo strict, Dialyzer, and the complete non-coverage test workflow passed.
  - The bundled coverage phase hit three unrelated controller timing failures; each exact failing test passed on reproduction, and the subsequent full coverage run passed the shared, controller, and node-agent applications.
- `ORCHARD_TEST_NODE_AGENT_PORT=50123 make cover`
  - Shared: 217 passed, 67.22% total coverage.
  - Controller: 3,679 passed, 85.5% total coverage.
  - Node agent: 412 passed, 78.57% total coverage.
  - The CLI phase hit one unrelated piped-stdin timeout.
- `ORCHARD_TEST_NODE_AGENT_PORT=50123 mise exec -- mix test --cover apps/orchard_cli/test/orchard_cli/packaging_wrapper_test.exs:52`
  - Exact timeout reproduction passed in 0.9 seconds.
- `ORCHARD_TEST_NODE_AGENT_PORT=50123 mise exec -- mix test --cover apps/orchard_cli/test`
  - 681 passed, 1 skipped, 10 excluded, 76.40% total coverage.
- `mise exec -- uv run --directory native/orchard_worker_mlx ruff format`
  - 18 files unchanged.
- `mise exec -- uv run --directory native/orchard_worker_mlx ruff check`
  - Passed.
- `mise exec -- uv run --directory native/orchard_worker_mlx pytest`
  - 635 passed, 6 skipped.
- `mise exec -- uv run --directory native/orchard_worker_mlx pytest --cov`
  - 635 passed, 6 skipped, 84% total coverage, 91% for `model_loader.py`.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate deprecate-manifest-sha256 --type change --strict --no-interactive`
  - Passed.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
  - 33 passed, 0 failed.
- Independent RepoPrompt Oracle re-review: GO, with all prior findings resolved and no remaining correctness or scope blockers.

## Risk Assessment

✅ **Medium**

- This changes a cross-language manifest compatibility contract and the normative product specification.
- Existing manifests remain accepted, omitted legacy fields become accepted, and unknown keys remain fail-closed.
- The authoritative digest algorithm, Catalog rows, and stored bundle format do not change.
- Transitional builder emission limits mixed-version rollout risk.
- Residual risk is the misleading legacy field remaining visible until a separate evidence-backed compatibility gate permits producer omission.

## Checklist

- [x] Checked and reconciled `SPEC.md` behavior.
- [x] Updated affected documentation, shared fixtures, and public consumer tests.
- [x] Ran relevant validation and recorded exact outcomes.
- [x] Kept local execution artifacts and private context out of the commit.

Closes #256


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consistently deprecates the top-level Model Manifest `sha256` while retaining it as optional compatibility metadata and preserving the Catalog’s final-tree digest as authoritative.

- Aligns the Elixir and MLX manifest consumers so omission is accepted while present invalid values and unknown keys remain rejected.
- Extends the shared schema contract and regression coverage for required, optional, and deprecated keys.
- Documents that pre-import detached verification and post-import Catalog verification cover distinct byte sets.
- Keeps BundleBuilder’s legacy emission unchanged until a separate compatibility gate permits omission.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the cross-language compatibility contract implemented consistently and no actionable failure identified.

Both supported manifest consumers accept omission while rejecting invalid present values, and existing import and acquisition paths continue deriving integrity authority from the final stored bundle digest rather than the deprecated manifest field.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/models/manifest_parser.ex | Validates an omitted legacy digest distinctly from a present null, empty, or non-string value while retaining closed-key parsing. |
| apps/orchard_shared/lib/orchard/model_manifest.ex | Makes `sha256` optional in the shared domain type without relaxing validation of present values. |
| native/orchard_worker_mlx/src/orchard_worker_mlx/model_loader.py | Mirrors the optional-field contract in the MLX worker; no production loading or integrity path consumes the resulting optional value. |
| apps/orchard_shared/test/fixtures/manifest_schema/v1.json | Adds a consistent required/optional partition and marks only top-level `sha256` as deprecated. |
| SPEC.md | Establishes the final stored bundle tree digest as authoritative and separates pre-import from post-import verification. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    B[BundleBuilder] -->|Legacy sha256 still emitted| M[Model Manifest]
    M --> E[Elixir Manifest Parser]
    M --> P[MLX Worker Parser]
    E -->|sha256 present or omitted| I[Secure Import and Manifest Rewrites]
    I --> H[Compute Final Tree SHA-256]
    H --> C[Catalog models.artifact_sha256]
    C --> V[Post-import Verification]
    D[Detached Trusted Evidence] --> X[Pre-import Media Verification]
    X --> I
    M -. Deprecated sha256 is not integrity evidence .-> C
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): deprecate manifest sha256"](https://github.com/kapitan-ai/orchard/commit/dab418afecab268485dee30edd19a88b3d9c3278) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58320454)</sub>

<!-- /greptile_comment -->