### PR TITLE
fix(console): align Playground readiness tenant

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/playground.ex
+++ b/apps/orchard_controller/lib/orchard/console/playground.ex
@@ -82,10 +82,14 @@ defmodule OrchardConsole.Playground do
   """
   @spec list_models() :: {:ok, [model_option()]} | {:error, map()}
   def list_models do
+    list_models_for_tenant(effective_tenant_id())
+  end
+
+  defp list_models_for_tenant(tenant_id) do
     readiness_index = runtime_readiness_index()
 
     models =
-      effective_tenant_id()
+      tenant_id
       |> models_impl().list_active_models_for_tenant()
       |> Enum.map(fn model ->
         project_model_option(
@@ -164,7 +168,7 @@ defmodule OrchardConsole.Playground do
   # ===========================================================================
 
   defp run_stream(orchestrator, owner, run_ref, params, caller_context) do
-    case ensure_model_inference_ready(params) do
+    case ensure_model_inference_ready(params, Keyword.fetch!(caller_context, :tenant_id)) do
       :ok ->
         do_run_stream(orchestrator, owner, run_ref, params, caller_context)
 
@@ -215,10 +219,10 @@ defmodule OrchardConsole.Playground do
     end
   end
 
-  defp ensure_model_inference_ready(params) when is_map(params) do
+  defp ensure_model_inference_ready(params, tenant_id) when is_map(params) do
     model_value = params |> Map.get("model", "") |> to_string() |> String.trim()
 
-    case list_models() do
+    case list_models_for_tenant(tenant_id) do
       {:ok, models} ->
         case find_model_option(models, model_value) do
           %{inference_ready: true} ->
@@ -243,7 +247,7 @@ defmodule OrchardConsole.Playground do
     end
   end
 
-  defp ensure_model_inference_ready(_params) do
+  defp ensure_model_inference_ready(_params, _tenant_id) do
     {:error, unready_stream_error("Selected model is not inference-ready.")}
   end
 

--- a/apps/orchard_controller/test/orchard/console/playground_test.exs
+++ b/apps/orchard_controller/test/orchard/console/playground_test.exs
@@ -427,6 +427,25 @@ defmodule OrchardConsole.PlaygroundTest do
       assert Keyword.get(caller_context, :tenant_id) == tenant_id
     end
 
+    test "uses an explicit caller tenant for readiness and preparation" do
+      ref = make_ref()
+      tenant_id = Ecto.UUID.generate()
+
+      stub_models(%{tenant_id => [%{model_id: "test-model", version: "v1"}]})
+
+      stub_orchestrator(
+        prepare: {:ok, fake_canonical(), %{}},
+        execute: {:ok, fake_canonical(), []},
+        capture_caller_context: true
+      )
+
+      {:ok, _pid} = Playground.start_stream(self(), ref, valid_params(), tenant_id: tenant_id)
+
+      assert_receive {:captured_caller_context, caller_context}, 1000
+      assert Keyword.get(caller_context, :tenant_id) == tenant_id
+      assert_receive {:playground, ^ref, :finished, {:ok, _}}, 1000
+    end
+
     test "rescues unexpected task exceptions" do
       ref = make_ref()
       stub_orchestrator(prepare: :raise)


### PR DESCRIPTION
## Summary

Console Playground now evaluates model readiness with the same resolved tenant that it passes to request preparation.
A model granted only to an explicit caller tenant no longer fails at the legacy-tenant readiness gate before preparation starts.

Closes #226

## What changed

- Thread the resolved caller tenant into the internal readiness lookup.
- Keep the public Console model list on its existing legacy-tenant default.
- Add a regression test for a model granted only to an explicit nonlegacy tenant.

## Validation

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `make macos-native-test-helpers`
- `env ORCHARD_TEST_NODE_AGENT_PORT=15078 mise exec -- mix test apps/orchard_controller/test/orchard/console/playground_test.exs` - 26 passed
- Adjacent Playground access and LiveView suites - 53 passed

`mise exec -- mix test` and `mise exec -- mix test --cover` were also run.
They remain red on unrelated controller, Node Agent, and CLI test failures outside this two-file diff.
This PR is opened under an explicit maintainer exception while those repository-wide failures are resolved separately.

## Risk Assessment

✅ **Medium**

- The behavioral change is limited to the tenant supplied to the existing readiness lookup.
- The public Console default remains the legacy tenant.
- Readiness remains fail-closed and no API, schema, migration, or grant semantics change.
- Repository-wide validation is currently red outside this diff, which limits release confidence until those baseline failures are repaired.

## PR Checklist

- [x] I checked whether this changes `SPEC.md` behavior.
- [x] I updated docs, tests, or decisions that the change affects.
- [x] I ran relevant validation and recorded outcomes.
- [x] I did not commit active goal packages or private local artifacts.
- [x] I did not introduce dependencies on private workbench/session context.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Console Playground readiness now uses the resolved caller tenant while the public model list retains its legacy-tenant default.
- Extracts a tenant-specific internal model-list helper.
- Passes the resolved tenant through the readiness check before request preparation.
- Adds regression coverage for a model granted only to an explicit nonlegacy tenant.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because readiness and preparation now consistently use the same resolved tenant.

The tenant is inserted into the caller context before task startup and then consumed by both readiness and preparation, while the production Console caller continues to receive the legacy-tenant default.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/console/playground.ex | Aligns readiness and preparation tenant resolution without changing the public model-list default; no actionable defect identified. |
| apps/orchard_controller/test/orchard/console/playground_test.exs | Adds focused regression coverage confirming that an explicit tenant is used by both readiness and preparation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: align playground readiness tenant"](https://github.com/kapitan-ai/orchard/commit/59343fc00553ed9d072159fe185373c36971bf4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58387329)</sub>

<!-- /greptile_comment -->