### PR TITLE
fix(node): cache verified model artifacts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2069,7 +2069,19 @@ Distribution modes:
 
 Air-gapped systems MUST support mode 1 and mode 2.
 Operator-controlled pre-import media verification and post-import verification of the final controller-stored Artifact Bundle SHALL use the distinct checkpoints defined in §6.5 and §11.7, never the deprecated manifest field.
-This change does not define Runtime Endpoint distribution, Node acquisition enforcement, signature verification, or archive-container digest requirements.
+Node acquisition SHALL perform authoritative `Orchard.ArtifactBundle.tree_sha256/1` verification against the Catalog digest on first acquisition and whenever durable verification evidence is absent, invalid, path- or digest-mismatched, or inconsistent with the current cache inventory.
+A Node MAY skip the full byte rehash only when a versioned receipt outside the Artifact Bundle binds the authoritative Catalog digest and canonical cache path to a complete, unchanged filesystem inventory of every directory and regular file.
+The inventory SHALL reject symlinks and unsupported entries and SHALL include relative paths, types, sizes, modes, ownership, device and inode identity, link counts, and modification and change times.
+Before authoritative hashing, the Node SHALL normalize every bundle directory and regular-file modification time to a reserved historical value without changing bundle bytes, then bind the resulting complete inventory after hashing.
+An ordinary later write SHALL therefore change the bound metadata even when the portable filesystem change-time surface reports only whole-second resolution and the write occurs immediately.
+Staging promotion MAY treat the cache-root directory metadata changed by the trusted rename as a one-time transition, but descendant inventory evidence SHALL remain stable and the published receipt SHALL bind the complete final root metadata.
+The receipt is an acceleration hint, not a competing digest or trust root, and SHALL NOT be stored inside or otherwise alter the authoritative Artifact Bundle digest domain.
+Any receipt read, validation, inventory, or stability failure SHALL fail closed to authoritative tree hashing.
+Receipt content SHALL receive owner-only permissions before atomic publication, and any authoritative verification failure SHALL invalidate prior acceleration evidence.
+Before normalizing an existing cache for full verification, the Node SHALL successfully remove its prior receipt and SHALL fail closed if revocation cannot be confirmed.
+An operator SHALL be able to force authoritative verification for every cache load, bypassing receipts and refreshing them only after success.
+Logs SHALL distinguish first or forced full verification, receipt-matched fast-path verification, receipt invalidation, and verification failure without including local artifact paths, source URIs, digests, or file inventory contents.
+Signature verification and archive-container digest requirements remain outside this change.
 
 ### 6.8 Load/unload semantics
 

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -1713,7 +1713,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         )
       end)
 
-    assert_receive {:pre_acceptance_cancel_received, emitter}, 1_000
+    assert_receive {:pre_acceptance_cancel_received, emitter}, 5_000
     assert AllocationAuthority.claim_count(authority, node_id) == 1
     send(emitter, :finish_cancel_after_acceptance)
 
@@ -1809,7 +1809,7 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
           )
         end)
 
-      assert_receive {:pre_acceptance_cancel_received, emitter}, 1_000
+      assert_receive {:pre_acceptance_cancel_received, emitter}, 5_000
       assert AllocationAuthority.claim_count(authority, node_id) == 1
       send(emitter, :finish_cancel)
 

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -3790,7 +3790,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
        %{bundle: bundle} do
     nodes = configure_alternate_attempt_nodes!()
     put_alternate_attempt_scheduler_config()
-    Process.put(:orchard_retry_persist_probe, fn -> Process.sleep(80) end)
+    Process.put(:orchard_retry_persist_probe, fn -> Process.sleep(800) end)
     stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
 
     model = create_active_model!(bundle, "request-orchestrator-persist-budget")
@@ -3798,7 +3798,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical =
       canonical_request("request-orchestrator-persist-budget",
         stream?: false,
-        admission: %{timeout_ms: 40}
+        admission: %{timeout_ms: 500}
       )
 
     assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)
@@ -3818,7 +3818,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
        %{bundle: bundle} do
     nodes = configure_alternate_attempt_nodes!()
     put_alternate_attempt_scheduler_config()
-    Process.put(:orchard_alternate_schedule_sleep_ms, 80)
+    Process.put(:orchard_alternate_schedule_sleep_ms, 800)
     stub_runtime_events([InferenceEvent.failed("worker_down", "worker exited", true)])
 
     model = create_active_model!(bundle, "request-orchestrator-alternate-budget")
@@ -3826,7 +3826,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical =
       canonical_request("request-orchestrator-alternate-budget",
         stream?: false,
-        admission: %{timeout_ms: 40}
+        admission: %{timeout_ms: 500}
       )
 
     assert {:ok, ^canonical, events} = RequestOrchestrator.execute(canonical, model)

--- a/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
+++ b/apps/orchard_controller/test/orchard/scheduler/multi_node_test.exs
@@ -355,7 +355,7 @@ defmodule Orchard.Scheduler.MultiNodeTest do
       receive do
         :stop -> :ok
       after
-        5_000 -> :ok
+        30_000 -> :ok
       end
     end)
   end

--- a/apps/orchard_controller/test/test_helper.exs
+++ b/apps/orchard_controller/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start()
+ExUnit.start(assert_receive_timeout: 5_000)
 
 case Process.whereis(Orchard.TestSupport.RepoManager) do
   nil ->

--- a/apps/orchard_node_agent/lib/orchard/node.ex
+++ b/apps/orchard_node_agent/lib/orchard/node.ex
@@ -76,6 +76,11 @@ defmodule Orchard.Node do
   def listen_host, do: listen_address()[:host]
   def listen_port, do: listen_address()[:port]
   def models_root, do: runtime_config()[:models_root]
+
+  @spec force_full_model_verification?() :: boolean()
+  def force_full_model_verification?,
+    do: runtime_value(:force_full_model_verification, false) == true
+
   def worker_socket_dir, do: runtime_config()[:worker_socket_dir]
   def worker_executable, do: runtime_config()[:worker_executable] || @default_worker_executable
   def worker_backend, do: runtime_config()[:worker_backend] || @default_worker_backend

--- a/apps/orchard_node_agent/lib/orchard/node/model_acquisition.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_acquisition.ex
@@ -11,6 +11,7 @@ defmodule Orchard.Node.ModelAcquisition do
   alias Orchard.ArtifactBundle
   alias Orchard.Node.ModelAcquisition.Request
   alias Orchard.Node.ModelAcquisition.Source
+  alias Orchard.Node.ModelAcquisition.VerificationReceipt
 
   @type outcome :: :cache_hit | :materialized
 
@@ -19,8 +20,9 @@ defmodule Orchard.Node.ModelAcquisition do
 
   Returns `{:ok, final_path, outcome}` or `{:error, reason}`.
   """
-  @spec ensure_cached(Request.t()) :: {:ok, String.t(), outcome()} | {:error, term()}
-  def ensure_cached(%Request{} = request) do
+  @spec ensure_cached(Request.t(), keyword()) ::
+          {:ok, String.t(), outcome()} | {:error, term()}
+  def ensure_cached(%Request{} = request, opts \\ []) do
     :telemetry.execute(
       [:orchard, :node, :model_acquisition, :start],
       %{system_time: System.system_time()},
@@ -32,7 +34,7 @@ defmodule Orchard.Node.ModelAcquisition do
     )
 
     start_time = System.monotonic_time(:millisecond)
-    result = do_ensure_cached(request)
+    result = do_ensure_cached(request, opts)
     duration_ms = System.monotonic_time(:millisecond) - start_time
 
     case result do
@@ -54,23 +56,23 @@ defmodule Orchard.Node.ModelAcquisition do
     result
   end
 
-  defp do_ensure_cached(%Request{} = request) do
-    case check_existing_cache(request) do
+  defp do_ensure_cached(%Request{} = request, opts) do
+    case check_existing_cache(request, opts) do
       {:ok, _path, _outcome} = hit ->
         hit
 
       :reacquire ->
-        acquire_and_verify(request)
+        acquire_and_verify(request, opts)
 
       {:error, _} = err ->
         err
     end
   end
 
-  defp check_existing_cache(%Request{} = request) do
+  defp check_existing_cache(%Request{} = request, opts) do
     cond do
       File.dir?(request.final_path) ->
-        verify_existing_cache(request)
+        verify_existing_cache(request, opts)
 
       request.artifact_source_uri == nil ->
         {:error, :missing_artifact_source_uri}
@@ -80,23 +82,52 @@ defmodule Orchard.Node.ModelAcquisition do
     end
   end
 
-  defp verify_existing_cache(%Request{} = request) do
-    case ArtifactBundle.tree_sha256(request.final_path) do
-      {:ok, hash} when hash == request.artifact_sha256 ->
-        Logger.info(
-          "Cache hit for #{request.model_id}@#{request.version} at #{request.final_path}"
-        )
+  defp verify_existing_cache(%Request{} = request, opts) do
+    if Keyword.get(opts, :force_full?, false) do
+      verify_existing_cache_after_invalidation(request, :operator_forced, opts)
+    else
+      case VerificationReceipt.check(request) do
+        :match ->
+          log_verification(request, :info, :fast, :receipt_matched)
+          {:ok, request.final_path, :cache_hit}
 
-        {:ok, request.final_path, :cache_hit}
+        {:miss, reason} ->
+          maybe_log_invalidation(request, reason)
+          verify_existing_cache_after_invalidation(request, reason, opts)
+      end
+    end
+  end
 
-      {:ok, _mismatched_hash} ->
+  defp verify_existing_cache_after_invalidation(request, reason, opts) do
+    case VerificationReceipt.invalidate(request) do
+      :ok ->
+        verify_existing_cache_fully(request, reason, opts)
+
+      {:error, :receipt_invalidation_failed} = error ->
+        log_verification(request, :warning, :failed, :receipt_invalidation_failed)
+        error
+    end
+  end
+
+  defp verify_existing_cache_fully(request, reason, opts) do
+    log_verification(request, :info, :full, reason)
+
+    case authoritative_verify(request.final_path, request.artifact_sha256) do
+      {:ok, evidence} ->
+        case persist_receipt(request, evidence, :verified, opts) do
+          :ok ->
+            {:ok, request.final_path, :cache_hit}
+
+          {:error, reason} ->
+            fail_closed_after_receipt_rejection(request, reason)
+        end
+
+      {:error, :artifact_hash_mismatch} ->
+        log_verification(request, :warning, :failed, :artifact_hash_mismatch)
         handle_stale_cache(request, :artifact_hash_mismatch)
 
       {:error, reason} ->
-        Logger.warning(
-          "Failed to verify cache for #{request.model_id}@#{request.version}: #{inspect(reason)}"
-        )
-
+        log_verification(request, :warning, :failed, :verification_error)
         handle_stale_cache(request, {:cache_verification_failed, reason})
     end
   end
@@ -104,23 +135,29 @@ defmodule Orchard.Node.ModelAcquisition do
   defp handle_stale_cache(%Request{artifact_source_uri: nil}, error), do: {:error, error}
 
   defp handle_stale_cache(%Request{} = request, _error) do
-    Logger.warning(
-      "Cache stale or unreadable for #{request.model_id}@#{request.version}, reacquiring"
-    )
+    Logger.warning("Model cache stale or unreadable; reacquiring #{model_ref(request)}")
 
     File.rm_rf(request.final_path)
     :reacquire
   end
 
-  defp acquire_and_verify(%Request{} = request) do
-    with :ok <- prepare_staging(request),
+  defp acquire_and_verify(%Request{} = request, opts) do
+    with :ok <- VerificationReceipt.invalidate(request),
+         :ok <- prepare_staging(request),
          :ok <- materialize_source(request),
-         :ok <- verify_staging(request),
-         :ok <- finalize_staging(request) do
-      Logger.info("Materialized #{request.model_id}@#{request.version} at #{request.final_path}")
+         {:ok, evidence} <- verify_staging(request),
+         :ok <- finalize_staging(request),
+         :ok <- persist_receipt(request, evidence, :promoted, opts) do
+      Logger.info("Materialized #{model_ref(request)}")
 
       {:ok, request.final_path, :materialized}
     else
+      {:error, {:verification_receipt_rejected, _reason}} = error ->
+        _ = VerificationReceipt.invalidate(request)
+        File.rm_rf(request.final_path)
+        cleanup_staging(request)
+        error
+
       {:error, _} = err ->
         # Always clean up staging on failure
         cleanup_staging(request)
@@ -152,17 +189,102 @@ defmodule Orchard.Node.ModelAcquisition do
   defp select_adapter(scheme), do: {:error, {:unsupported_source_scheme, scheme}}
 
   defp verify_staging(%Request{} = request) do
-    case ArtifactBundle.tree_sha256(request.staging_path) do
-      {:ok, hash} when hash == request.artifact_sha256 ->
-        :ok
+    log_verification(request, :info, :full, :first_acquisition)
 
-      {:ok, _mismatched_hash} ->
+    case authoritative_verify(request.staging_path, request.artifact_sha256) do
+      {:ok, evidence} ->
+        {:ok, evidence}
+
+      {:error, :artifact_hash_mismatch} ->
+        log_verification(request, :warning, :failed, :artifact_hash_mismatch)
         {:error, :artifact_hash_mismatch}
 
       {:error, reason} ->
+        log_verification(request, :warning, :failed, :verification_error)
         {:error, {:verification_failed, reason}}
     end
   end
+
+  defp authoritative_verify(path, expected_hash) do
+    with {:ok, before_evidence, verification_boundary} <-
+           VerificationReceipt.prepare_for_verification(path),
+         {:ok, ^expected_hash} <- ArtifactBundle.tree_sha256(path),
+         {:ok, after_evidence} <- VerificationReceipt.inventory_evidence(path),
+         true <- before_evidence.fingerprint == after_evidence.fingerprint do
+      {:ok, Map.put(after_evidence, :verified_at, verification_boundary)}
+    else
+      {:ok, _mismatched_hash} -> {:error, :artifact_hash_mismatch}
+      false -> {:error, :artifact_changed_during_verification}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp persist_receipt(request, evidence, mode, opts) do
+    persistor = Keyword.get(opts, :receipt_persistor, &persist_receipt_data/3)
+    result = persistor.(request, evidence, mode)
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, :receipt_write_failed} ->
+        log_receipt_failure(request, :receipt_write_failed)
+        :ok
+
+      {:error, reason} ->
+        bounded_reason = bounded_receipt_reason(reason)
+        log_receipt_failure(request, bounded_reason)
+        log_verification(request, :warning, :failed, bounded_reason)
+        {:error, {:verification_receipt_rejected, bounded_reason}}
+    end
+  end
+
+  defp persist_receipt_data(request, evidence, mode) do
+    case mode do
+      :verified -> VerificationReceipt.record_verified(request, evidence)
+      :promoted -> VerificationReceipt.record(request, evidence)
+    end
+  end
+
+  defp log_receipt_failure(request, reason) do
+    Logger.warning(
+      "Unable to persist model cache verification receipt for #{model_ref(request)} " <>
+        "reason=#{reason}"
+    )
+  end
+
+  defp bounded_receipt_reason(reason)
+       when reason in [
+              :inventory_changed_after_verification,
+              :inventory_changed_after_normalization,
+              :inventory_unreadable,
+              :receipt_invalidation_failed,
+              :receipt_write_failed
+            ],
+       do: reason
+
+  defp bounded_receipt_reason(_reason), do: :receipt_persistence_failed
+
+  defp fail_closed_after_receipt_rejection(request, reason) do
+    with :ok <- VerificationReceipt.invalidate(request) do
+      handle_stale_cache(request, reason)
+    end
+  end
+
+  defp maybe_log_invalidation(_request, :receipt_missing), do: :ok
+
+  defp maybe_log_invalidation(request, reason) do
+    log_verification(request, :warning, :invalidated, reason)
+  end
+
+  defp log_verification(request, level, path, reason) do
+    Logger.log(
+      level,
+      "Model cache verification #{model_ref(request)} verification_path=#{path} reason=#{reason}"
+    )
+  end
+
+  defp model_ref(request), do: "#{request.model_id}@#{request.version}"
 
   defp finalize_staging(%Request{} = request) do
     # Ensure parent directory exists for the final path

--- a/apps/orchard_node_agent/lib/orchard/node/model_acquisition/verification_receipt.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_acquisition/verification_receipt.ex
@@ -1,0 +1,364 @@
+defmodule Orchard.Node.ModelAcquisition.VerificationReceipt do
+  @moduledoc """
+  Persists path-bound filesystem evidence for a previously verified model artifact.
+
+  A receipt is an acceleration hint only. The Catalog digest remains authoritative,
+  and any missing or mismatched evidence must fall back to a full tree hash.
+  """
+
+  alias Orchard.FS
+  alias Orchard.Node.ModelAcquisition.Request
+
+  @receipt_version 1
+  @receipt_dir ".verification"
+  @normalized_mtime 946_684_800
+
+  @type inventory_evidence :: %{
+          fingerprint: String.t(),
+          descendant_fingerprint: String.t()
+        }
+
+  @type verified_evidence :: %{
+          fingerprint: String.t(),
+          descendant_fingerprint: String.t(),
+          verified_at: integer()
+        }
+
+  @type miss_reason ::
+          :receipt_missing
+          | :receipt_unreadable
+          | :receipt_invalid
+          | :receipt_version_mismatch
+          | :artifact_digest_mismatch
+          | :path_mismatch
+          | :inventory_changed
+          | :inventory_unreadable
+
+  @spec check(Request.t()) :: :match | {:miss, miss_reason()}
+  def check(%Request{} = request) do
+    with {:ok, receipt} <- read_receipt(request),
+         :ok <- validate_receipt(receipt, request),
+         {:ok, evidence} <- inventory_evidence(request.final_path),
+         :ok <- validate_evidence(receipt, evidence) do
+      :match
+    else
+      {:error, reason} -> {:miss, reason}
+    end
+  end
+
+  @spec record(Request.t(), verified_evidence()) :: :ok | {:error, term()}
+  def record(%Request{} = request, verified_evidence) do
+    with {:ok, promoted_evidence} <- inventory_evidence(request.final_path),
+         true <- promotion_descendants_stable?(verified_evidence, promoted_evidence),
+         {:ok, final_evidence} <- inventory_evidence(request.final_path),
+         true <- promotion_descendants_stable?(verified_evidence, final_evidence),
+         true <- promoted_evidence.fingerprint == final_evidence.fingerprint,
+         :ok <- write_receipt(request, final_evidence, System.system_time(:second)) do
+      :ok
+    else
+      false -> {:error, :inventory_changed_after_verification}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec record_verified(Request.t(), verified_evidence()) :: :ok | {:error, term()}
+  def record_verified(%Request{} = request, verified_evidence),
+    do: publish_verified_receipt(request, verified_evidence)
+
+  @spec invalidate(Request.t()) :: :ok | {:error, :receipt_invalidation_failed}
+  def invalidate(%Request{} = request) do
+    case File.rm(receipt_path(request)) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, _reason} -> {:error, :receipt_invalidation_failed}
+    end
+  end
+
+  @spec inventory_fingerprint(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def inventory_fingerprint(root_path) do
+    with {:ok, evidence} <- inventory_evidence(root_path) do
+      {:ok, evidence.fingerprint}
+    end
+  end
+
+  @doc """
+  Captures the complete filesystem inventory used to bind a verification receipt.
+
+  Symlinks, unsupported entries, and unreadable inventory fail closed.
+  """
+  @spec inventory_evidence(String.t(), keyword()) ::
+          {:ok, inventory_evidence()} | {:error, term()}
+  def inventory_evidence(root_path, opts \\ []) do
+    require_normalized_mtime? = Keyword.get(opts, :require_normalized_mtime?, false)
+
+    with {:ok, entries} <-
+           collect_inventory(root_path, root_path, [], require_normalized_mtime?) do
+      fingerprint =
+        entries
+        |> Enum.sort()
+        |> :erlang.term_to_binary([:deterministic])
+        |> sha256_hex()
+
+      descendant_entries = Enum.reject(entries, &root_entry?/1)
+
+      descendant_fingerprint =
+        descendant_entries
+        |> Enum.sort()
+        |> :erlang.term_to_binary([:deterministic])
+        |> sha256_hex()
+
+      {:ok,
+       %{
+         fingerprint: fingerprint,
+         descendant_fingerprint: descendant_fingerprint
+       }}
+    end
+  end
+
+  @doc """
+  Normalizes bundle modification times and captures stable inventory evidence.
+
+  The reserved modification time makes a later ordinary write visible even when the
+  filesystem reports change times only to whole-second resolution.
+  """
+  @spec prepare_for_verification(String.t()) ::
+          {:ok, inventory_evidence(), integer()} | {:error, term()}
+  def prepare_for_verification(root_path) do
+    with :ok <- normalize_mtimes(root_path),
+         {:ok, evidence} <- inventory_evidence(root_path, require_normalized_mtime?: true) do
+      {:ok, evidence, System.system_time(:second)}
+    end
+  end
+
+  defp read_receipt(request) do
+    case File.read(receipt_path(request)) do
+      {:ok, encoded} -> decode_receipt(encoded)
+      {:error, :enoent} -> {:error, :receipt_missing}
+      {:error, _reason} -> {:error, :receipt_unreadable}
+    end
+  end
+
+  defp decode_receipt(encoded) do
+    case Jason.decode(encoded) do
+      {:ok, receipt} when is_map(receipt) -> {:ok, receipt}
+      _other -> {:error, :receipt_invalid}
+    end
+  end
+
+  defp validate_receipt(receipt, request) do
+    cond do
+      receipt["version"] != @receipt_version -> {:error, :receipt_version_mismatch}
+      receipt["artifact_sha256"] != request.artifact_sha256 -> {:error, :artifact_digest_mismatch}
+      receipt["path_sha256"] != request_path_sha256(request) -> {:error, :path_mismatch}
+      not valid_fingerprint?(receipt["inventory_sha256"]) -> {:error, :receipt_invalid}
+      not valid_verification_time?(receipt["verified_at_posix"]) -> {:error, :receipt_invalid}
+      true -> :ok
+    end
+  end
+
+  defp validate_evidence(receipt, evidence),
+    do: equality_result(receipt["inventory_sha256"], evidence.fingerprint, :inventory_changed)
+
+  defp valid_fingerprint?(value) do
+    is_binary(value) and byte_size(value) == 64 and String.match?(value, ~r/\A[0-9a-f]{64}\z/)
+  end
+
+  defp valid_verification_time?(value) do
+    is_integer(value) and value > 0 and value <= System.system_time(:second)
+  end
+
+  defp publish_verified_receipt(request, verified_evidence) do
+    with {:ok, current_evidence} <- inventory_evidence(request.final_path),
+         true <- verified_evidence_stable?(verified_evidence, current_evidence),
+         :ok <- write_receipt(request, current_evidence, verified_evidence.verified_at) do
+      :ok
+    else
+      false -> {:error, :inventory_changed_after_verification}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp verified_evidence_stable?(verified_evidence, current_evidence) do
+    current_evidence.fingerprint == verified_evidence.fingerprint
+  end
+
+  defp promotion_descendants_stable?(verified_evidence, current_evidence) do
+    current_evidence.descendant_fingerprint == verified_evidence.descendant_fingerprint
+  end
+
+  defp equality_result(value, value, _reason), do: :ok
+  defp equality_result(_left, _right, reason), do: {:error, reason}
+
+  defp root_entry?(
+         {relative_path, _type, _size, _mode, _links, _major, _minor, _inode, _uid, _gid, _mtime,
+          _ctime}
+       ),
+       do: relative_path == "."
+
+  defp write_receipt(request, evidence, verified_at) do
+    path = receipt_path(request)
+
+    receipt = %{
+      "version" => @receipt_version,
+      "artifact_sha256" => request.artifact_sha256,
+      "path_sha256" => request_path_sha256(request),
+      "inventory_sha256" => evidence.fingerprint,
+      "verified_at_posix" => verified_at
+    }
+
+    try do
+      File.mkdir_p!(Path.dirname(path))
+
+      FS.atomic_write!(path, Jason.encode!(receipt),
+        modes: [:binary, :write],
+        permissions: 0o600
+      )
+
+      :ok
+    rescue
+      File.Error -> {:error, :receipt_write_failed}
+    end
+  end
+
+  defp receipt_path(request) do
+    identity =
+      sha256_hex(request_path_sha256(request) <> <<0>> <> request.artifact_sha256)
+
+    Path.join([request.models_root, @receipt_dir, identity <> ".json"])
+  end
+
+  defp request_path_sha256(request) do
+    request.models_root
+    |> canonical_path()
+    |> Path.join(Path.relative_to(request.final_path, request.models_root))
+    |> Path.expand()
+    |> sha256_hex()
+  end
+
+  defp sha256_hex(data),
+    do: data |> then(&:crypto.hash(:sha256, &1)) |> Base.encode16(case: :lower)
+
+  defp canonical_path(path) do
+    case Orchard.PathUtils.resolve_realpath(path) do
+      {:ok, canonical} -> canonical
+      {:error, _reason} -> Path.expand(path)
+    end
+  end
+
+  defp collect_inventory(path, root_path, acc, require_normalized_mtime?) do
+    case File.lstat(path, time: :posix) do
+      {:ok, %File.Stat{type: :directory} = stat} ->
+        with :ok <- validate_normalized_mtime(stat, require_normalized_mtime?),
+             {:ok, entries} <- File.ls(path) do
+          next_acc = [inventory_entry(path, root_path, stat) | acc]
+          collect_children(entries, path, root_path, next_acc, require_normalized_mtime?)
+        else
+          {:error, :inventory_changed_after_normalization} = error -> error
+          {:error, _reason} -> {:error, :inventory_unreadable}
+        end
+
+      {:ok, %File.Stat{type: :regular} = stat} ->
+        with :ok <- validate_normalized_mtime(stat, require_normalized_mtime?) do
+          {:ok, [inventory_entry(path, root_path, stat) | acc]}
+        end
+
+      {:ok, %File.Stat{}} ->
+        {:error, :inventory_unreadable}
+
+      {:error, _reason} ->
+        {:error, :inventory_unreadable}
+    end
+  end
+
+  defp normalize_mtimes(path) do
+    case File.lstat(path, time: :posix) do
+      {:ok, %File.Stat{type: :directory} = stat} ->
+        with {:ok, entries} <- File.ls(path),
+             :ok <- normalize_children_mtimes(entries, path),
+             :ok <- normalize_mtime(path, stat) do
+          :ok
+        else
+          {:error, _reason} -> {:error, :inventory_unreadable}
+        end
+
+      {:ok, %File.Stat{type: :regular} = stat} ->
+        normalize_mtime(path, stat)
+
+      {:ok, %File.Stat{}} ->
+        {:error, :inventory_unreadable}
+
+      {:error, _reason} ->
+        {:error, :inventory_unreadable}
+    end
+  end
+
+  defp normalize_children_mtimes([], _parent), do: :ok
+
+  defp normalize_children_mtimes([entry | rest], parent) do
+    with :ok <- normalize_mtimes(Path.join(parent, entry)) do
+      normalize_children_mtimes(rest, parent)
+    end
+  end
+
+  defp normalize_mtime(_path, %File.Stat{mtime: @normalized_mtime}), do: :ok
+
+  defp normalize_mtime(path, _stat) do
+    case File.touch(path, @normalized_mtime) do
+      :ok -> :ok
+      {:error, _reason} -> {:error, :inventory_unreadable}
+    end
+  end
+
+  defp validate_normalized_mtime(_stat, false), do: :ok
+
+  defp validate_normalized_mtime(%File.Stat{mtime: @normalized_mtime}, true), do: :ok
+
+  defp validate_normalized_mtime(%File.Stat{}, true),
+    do: {:error, :inventory_changed_after_normalization}
+
+  defp collect_children([], _parent, _root_path, acc, _require_normalized_mtime?),
+    do: {:ok, acc}
+
+  defp collect_children(
+         [entry | rest],
+         parent,
+         root_path,
+         acc,
+         require_normalized_mtime?
+       ) do
+    case collect_inventory(
+           Path.join(parent, entry),
+           root_path,
+           acc,
+           require_normalized_mtime?
+         ) do
+      {:ok, next_acc} ->
+        collect_children(rest, parent, root_path, next_acc, require_normalized_mtime?)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp inventory_entry(path, root_path, stat) do
+    relative_path = Path.relative_to(path, root_path)
+
+    entry =
+      {
+        relative_path,
+        stat.type,
+        stat.size,
+        stat.mode,
+        stat.links,
+        stat.major_device,
+        stat.minor_device,
+        stat.inode,
+        stat.uid,
+        stat.gid,
+        stat.mtime,
+        stat.ctime
+      }
+
+    entry
+  end
+end

--- a/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_manager.ex
@@ -602,7 +602,10 @@ defmodule Orchard.Node.ModelManager do
 
     result =
       with {:ok, acq_request} <- AcquisitionRequest.from_proto(request, models_root),
-           {:ok, _path, _outcome} <- ModelAcquisition.ensure_cached(acq_request),
+           {:ok, _path, _outcome} <-
+             ModelAcquisition.ensure_cached(acq_request,
+               force_full?: Node.force_full_model_verification?()
+             ),
            {:ok, remaining_ms} <- remaining_load_budget(request) do
         start_and_load_worker(key, request, remaining_ms, manager)
       end

--- a/apps/orchard_node_agent/test/orchard/node/model_acquisition_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/model_acquisition_test.exs
@@ -1,10 +1,13 @@
 defmodule Orchard.Node.ModelAcquisitionTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
 
   alias Orchard.ArtifactBundle
   alias Orchard.Cluster.V1.EnsureModelLoadedRequest
   alias Orchard.Node.ModelAcquisition
   alias Orchard.Node.ModelAcquisition.Request
+  alias Orchard.Node.ModelAcquisition.VerificationReceipt
 
   setup do
     tmp_dir =
@@ -46,6 +49,29 @@ defmodule Orchard.Node.ModelAcquisitionTest do
       assert {:ok, ^expected_hash} = ArtifactBundle.tree_sha256(final_path)
     end
 
+    test "first acquisition seeds a receipt for the next unchanged load", ctx do
+      request = build_request(ctx)
+
+      assert count_tree_hash_calls(fn ->
+               assert {:ok, _path, :materialized} = ModelAcquisition.ensure_cached(request)
+               assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+             end) == 1
+
+      [receipt_path] = Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
+      assert %File.Stat{mode: mode} = File.stat!(receipt_path)
+      assert Bitwise.band(mode, 0o777) == 0o600
+
+      receipt = receipt_path |> File.read!() |> Jason.decode!()
+      assert {:ok, evidence} = VerificationReceipt.inventory_evidence(request.final_path)
+      assert evidence.fingerprint == receipt["inventory_sha256"]
+      assert File.stat!(request.final_path, time: :posix).mtime == 946_684_800
+
+      assert File.stat!(
+               Path.join(request.final_path, "weights/model.safetensors"),
+               time: :posix
+             ).mtime == 946_684_800
+    end
+
     test "returns cache_hit when bundle already exists and hash matches", ctx do
       request = build_request(ctx)
 
@@ -54,6 +80,200 @@ defmodule Orchard.Node.ModelAcquisitionTest do
       :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
 
       assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+    end
+
+    test "SPEC 6.7 previously verified unchanged cache skips the second tree hash", ctx do
+      request = build_request(ctx)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      log =
+        capture_info_log(fn ->
+          tree_hash_calls =
+            count_tree_hash_calls(fn ->
+              assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+              assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+            end)
+
+          assert tree_hash_calls == 1
+        end)
+
+      assert log =~ "verification_path=full"
+      assert log =~ "verification_path=fast"
+      refute log =~ request.final_path
+    end
+
+    test "SPEC 6.7 immediate same-size shard tampering invalidates the receipt", ctx do
+      request = build_request(ctx)
+      no_source_request = build_request(ctx, artifact_source_uri: nil)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+
+      shard = Path.join(request.final_path, "weights/model.safetensors")
+      File.write!(shard, "evil-weights-data")
+
+      log =
+        capture_info_log(fn ->
+          assert count_tree_hash_calls(fn ->
+                   assert {:error, :artifact_hash_mismatch} =
+                            ModelAcquisition.ensure_cached(no_source_request)
+                 end) == 1
+        end)
+
+      assert log =~ "verification_path=invalidated"
+      assert log =~ "verification_path=failed"
+      refute log =~ request.final_path
+    end
+
+    test "SPEC 6.7 truncated shard invalidates the receipt and is rejected", ctx do
+      request = build_request(ctx)
+      no_source_request = build_request(ctx, artifact_source_uri: nil)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+
+      shard = Path.join(request.final_path, "weights/model.safetensors")
+      File.write!(shard, "short")
+
+      assert count_tree_hash_calls(fn ->
+               assert {:error, :artifact_hash_mismatch} =
+                        ModelAcquisition.ensure_cached(no_source_request)
+             end) == 1
+    end
+
+    test "operator can force authoritative verification of an unchanged receipt", ctx do
+      request = build_request(ctx)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+
+      log =
+        capture_info_log(fn ->
+          assert count_tree_hash_calls(fn ->
+                   assert {:ok, _path, :cache_hit} =
+                            ModelAcquisition.ensure_cached(request, force_full?: true)
+                 end) == 1
+        end)
+
+      assert log =~ "verification_path=full"
+      assert log =~ "reason=operator_forced"
+    end
+
+    test "forced verification fails before hashing when the prior receipt cannot be revoked",
+         ctx do
+      request = build_request(ctx)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+      verification_dir = Path.join(ctx.models_root, ".verification")
+      File.chmod!(verification_dir, 0o500)
+
+      try do
+        assert count_tree_hash_calls(fn ->
+                 assert {:error, :receipt_invalidation_failed} =
+                          ModelAcquisition.ensure_cached(request, force_full?: true)
+               end) == 0
+      after
+        File.chmod!(verification_dir, 0o700)
+      end
+    end
+
+    test "malformed receipt fails closed to authoritative verification", ctx do
+      request = build_request(ctx)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+      [receipt_path] = Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
+      File.write!(receipt_path, "not-json")
+
+      log =
+        capture_info_log(fn ->
+          assert count_tree_hash_calls(fn ->
+                   assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+                 end) == 1
+        end)
+
+      assert log =~ "verification_path=invalidated"
+      assert log =~ "reason=receipt_invalid"
+    end
+
+    test "future receipt timestamp fails closed to authoritative verification", ctx do
+      request = build_request(ctx)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+      [receipt_path] = Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
+
+      receipt = receipt_path |> File.read!() |> Jason.decode!()
+      future_receipt = Map.put(receipt, "verified_at_posix", System.system_time(:second) + 3_600)
+      File.write!(receipt_path, Jason.encode!(future_receipt))
+
+      log =
+        capture_info_log(fn ->
+          assert count_tree_hash_calls(fn ->
+                   assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+                 end) == 1
+        end)
+
+      assert log =~ "verification_path=invalidated"
+      assert log =~ "reason=receipt_invalid"
+    end
+
+    test "forced verification failure invalidates the prior receipt", ctx do
+      request = build_request(ctx)
+      no_source_request = build_request(ctx, artifact_source_uri: nil)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+
+      assert [_receipt_path] =
+               Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
+
+      shard = Path.join(request.final_path, "weights/model.safetensors")
+      File.write!(shard, "evil-weights-data")
+
+      assert {:error, :artifact_hash_mismatch} =
+               ModelAcquisition.ensure_cached(no_source_request, force_full?: true)
+
+      assert [] = Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
+
+      assert count_tree_hash_calls(fn ->
+               assert {:error, :artifact_hash_mismatch} =
+                        ModelAcquisition.ensure_cached(no_source_request)
+             end) == 1
+    end
+
+    test "receipt persistence failure logs only a bounded reason and falls back next load", ctx do
+      request = build_request(ctx)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      persistor = fn _persisted_request, _evidence, :verified ->
+        {:error, :receipt_write_failed}
+      end
+
+      log =
+        capture_info_log(fn ->
+          assert {:ok, _path, :cache_hit} =
+                   ModelAcquisition.ensure_cached(request, receipt_persistor: persistor)
+        end)
+
+      assert log =~ "reason=receipt_write_failed"
+      refute log =~ ctx.models_root
+      refute log =~ request.final_path
+      refute log =~ ctx.source_uri
+
+      assert count_tree_hash_calls(fn ->
+               assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+             end) == 1
     end
 
     test "returns error when source URI is blank and cache is missing", ctx do
@@ -97,7 +317,15 @@ defmodule Orchard.Node.ModelAcquisitionTest do
     test "hash mismatch does not promote staging directory", ctx do
       request = build_request(ctx, artifact_sha256: String.duplicate("0", 64))
 
-      assert {:error, :artifact_hash_mismatch} = ModelAcquisition.ensure_cached(request)
+      log =
+        capture_info_log(fn ->
+          assert {:error, :artifact_hash_mismatch} = ModelAcquisition.ensure_cached(request)
+        end)
+
+      assert log =~ "verification_path=full"
+      assert log =~ "verification_path=failed"
+      assert log =~ "reason=artifact_hash_mismatch"
+      refute log =~ request.final_path
 
       # Final path should not exist
       refute File.exists?(request.final_path)
@@ -131,6 +359,129 @@ defmodule Orchard.Node.ModelAcquisitionTest do
       # Cache should now have correct content
       expected_hash = ctx.hash
       assert {:ok, ^expected_hash} = ArtifactBundle.tree_sha256(request.final_path)
+    end
+  end
+
+  describe "verification receipt publication" do
+    test "initial verification inventory rejects an entry that lost the sentinel mtime", ctx do
+      assert {:ok, _evidence, _verified_at} =
+               VerificationReceipt.prepare_for_verification(ctx.source_dir)
+
+      File.write!(Path.join(ctx.source_dir, "weights/model.safetensors"), "evil-weights-data")
+
+      assert {:error, :inventory_changed_after_normalization} =
+               VerificationReceipt.inventory_evidence(ctx.source_dir,
+                 require_normalized_mtime?: true
+               )
+    end
+
+    test "existing-cache mutation rejected during receipt publication fails closed", ctx do
+      request = build_request(ctx, artifact_source_uri: nil)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      persistor = fn persisted_request, evidence, :verified ->
+        File.write!(
+          Path.join(persisted_request.final_path, "weights/model.safetensors"),
+          "evil-weights-data"
+        )
+
+        VerificationReceipt.record_verified(persisted_request, evidence)
+      end
+
+      log =
+        capture_info_log(fn ->
+          assert {:error, {:verification_receipt_rejected, :inventory_changed_after_verification}} =
+                   ModelAcquisition.ensure_cached(request, receipt_persistor: persistor)
+        end)
+
+      assert log =~ "verification_path=failed"
+      assert log =~ "reason=inventory_changed_after_verification"
+      assert [] = Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
+    end
+
+    test "post-promotion mutation rejected during receipt publication removes the cache", ctx do
+      request = build_request(ctx)
+
+      persistor = fn persisted_request, evidence, :promoted ->
+        File.write!(
+          Path.join(persisted_request.final_path, "weights/model.safetensors"),
+          "evil-weights-data"
+        )
+
+        VerificationReceipt.record(persisted_request, evidence)
+      end
+
+      assert {:error, {:verification_receipt_rejected, :inventory_changed_after_verification}} =
+               ModelAcquisition.ensure_cached(request, receipt_persistor: persistor)
+
+      refute File.exists?(request.final_path)
+      refute File.exists?(request.staging_path)
+      assert [] = Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
+    end
+
+    test "failed reacquisition invalidates an older receipt through a symlinked models root",
+         ctx do
+      physical_root = Path.join(ctx.tmp_dir, "physical-models")
+      symlinked_root = Path.join(ctx.tmp_dir, "symlinked-models")
+      File.mkdir_p!(physical_root)
+      File.ln_s!(physical_root, symlinked_root)
+
+      request = build_request(%{ctx | models_root: symlinked_root})
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+
+      assert [_receipt_path] =
+               Path.wildcard(Path.join([physical_root, ".verification", "*.json"]))
+
+      File.rm_rf!(request.final_path)
+      File.write!(Path.join(ctx.source_dir, "weights/model.safetensors"), "corrupt-source")
+
+      assert {:error, :artifact_hash_mismatch} = ModelAcquisition.ensure_cached(request)
+      assert [] = Path.wildcard(Path.join([physical_root, ".verification", "*.json"]))
+    end
+
+    test "post-publication root metadata change invalidates the complete inventory", ctx do
+      request = build_request(ctx)
+      no_source_request = build_request(ctx, artifact_source_uri: nil)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, _path, :cache_hit} = ModelAcquisition.ensure_cached(request)
+
+      File.chmod!(request.final_path, 0o700)
+
+      log =
+        capture_info_log(fn ->
+          assert count_tree_hash_calls(fn ->
+                   assert {:ok, _path, :cache_hit} =
+                            ModelAcquisition.ensure_cached(no_source_request)
+                 end) == 1
+        end)
+
+      assert log =~ "verification_path=invalidated"
+      assert log =~ "reason=inventory_changed"
+    end
+
+    test "rejects an inventory change after authoritative verification", ctx do
+      request = build_request(ctx)
+      File.mkdir_p!(request.final_path)
+      :ok = ArtifactBundle.copy_directory(ctx.source_dir, request.final_path)
+
+      assert {:ok, evidence, verification_boundary} =
+               VerificationReceipt.prepare_for_verification(request.final_path)
+
+      File.write!(Path.join(request.final_path, "weights/model.safetensors"), "evil-weights-data")
+
+      assert {:error, :inventory_changed_after_verification} =
+               VerificationReceipt.record(
+                 request,
+                 Map.put(evidence, :verified_at, verification_boundary)
+               )
+
+      assert [] = Path.wildcard(Path.join([ctx.models_root, ".verification", "*.json"]))
     end
   end
 
@@ -211,5 +562,30 @@ defmodule Orchard.Node.ModelAcquisitionTest do
 
     {:ok, request} = Request.from_proto(proto, ctx.models_root)
     request
+  end
+
+  defp count_tree_hash_calls(fun) do
+    mfa = {ArtifactBundle, :tree_sha256, 1}
+    :erlang.trace_pattern(mfa, true, [:call_count])
+    {:call_count, before_count} = :erlang.trace_info(mfa, :call_count)
+
+    try do
+      fun.()
+      {:call_count, after_count} = :erlang.trace_info(mfa, :call_count)
+      after_count - before_count
+    after
+      :erlang.trace_pattern(mfa, false, [:call_count])
+    end
+  end
+
+  defp capture_info_log(fun) do
+    previous_level = Logger.level()
+    Logger.configure(level: :info)
+
+    try do
+      capture_log(fun)
+    after
+      Logger.configure(level: previous_level)
+    end
   end
 end

--- a/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
@@ -44,6 +44,23 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert runtime[:worker_memory_budget_mode] == "enforce"
   end
 
+  test "runtime.exs enables forced full model verification in prod" do
+    runtime =
+      read_runtime_config!(%{"ORCHARD_FORCE_FULL_MODEL_VERIFICATION" => "true"})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:force_full_model_verification]
+  end
+
+  test "runtime.exs rejects an invalid forced-verification boolean in prod" do
+    assert_raise RuntimeError,
+                 ~r/ORCHARD_FORCE_FULL_MODEL_VERIFICATION must be a boolean/,
+                 fn ->
+                   read_runtime_config!(%{"ORCHARD_FORCE_FULL_MODEL_VERIFICATION" => "sometimes"})
+                 end
+  end
+
   test "runtime.exs rejects invalid ORCHARD_WORKER_MEMORY_BUDGET_MODE in prod" do
     assert_raise RuntimeError,
                  ~r/ORCHARD_WORKER_MEMORY_BUDGET_MODE must be disabled\|observe\|enforce/,
@@ -100,6 +117,7 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert runtime[:worker_memory_budget_mode] == "observe"
     assert runtime[:worker_memory_budget_utilization] == 0.90
     assert runtime[:worker_memory_budget_overhead_bytes] == 1_073_741_824
+    refute runtime[:force_full_model_verification]
   end
 
   test "runtime.exs preserves packaged BEAM default without requiring gRPC identity" do
@@ -222,6 +240,15 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
 
     assert runtime[:worker_backend] == "stub"
     assert runtime[:worker_generation_mode] == "stream"
+  end
+
+  test "dev.exs enables forced full model verification" do
+    runtime =
+      read_dev_config!(%{"ORCHARD_FORCE_FULL_MODEL_VERIFICATION" => "true"})
+      |> Keyword.fetch!(:orchard_node_agent)
+      |> Keyword.fetch!(:runtime)
+
+    assert runtime[:force_full_model_verification]
   end
 
   test "dev.exs keeps worker sockets under a short worktree-specific root" do

--- a/apps/orchard_shared/lib/orchard/fs.ex
+++ b/apps/orchard_shared/lib/orchard/fs.ex
@@ -3,7 +3,7 @@ defmodule Orchard.FS do
   Shared filesystem helpers for artifact-safe writes.
   """
 
-  @type atomic_write_opts :: [modes: [File.mode()]]
+  @type atomic_write_opts :: [modes: [File.mode()], permissions: non_neg_integer()]
 
   @doc """
   Writes `content` to `path` through a same-filesystem temporary file.
@@ -16,8 +16,10 @@ defmodule Orchard.FS do
   def atomic_write!(path, content, opts \\ []) when is_binary(path) do
     tmp_path = atomic_temp_path(path)
     modes = Keyword.get(opts, :modes, [:binary])
+    permissions = Keyword.get(opts, :permissions)
 
     try do
+      prepare_temp_file!(tmp_path, permissions)
       File.write!(tmp_path, content, modes)
       File.rename!(tmp_path, path)
       :ok
@@ -26,6 +28,13 @@ defmodule Orchard.FS do
         File.rm(tmp_path)
         reraise(error, __STACKTRACE__)
     end
+  end
+
+  defp prepare_temp_file!(_tmp_path, nil), do: :ok
+
+  defp prepare_temp_file!(tmp_path, permissions) do
+    File.open!(tmp_path, [:write, :exclusive], fn _file -> :ok end)
+    File.chmod!(tmp_path, permissions)
   end
 
   @spec atomic_temp_path(Path.t()) :: Path.t()

--- a/apps/orchard_shared/test/orchard/fs_test.exs
+++ b/apps/orchard_shared/test/orchard/fs_test.exs
@@ -21,6 +21,14 @@ defmodule Orchard.FSTest do
     refute Enum.any?(File.ls!(ctx.root), &String.starts_with?(&1, ".tmp-"))
   end
 
+  test "applies requested permissions before publishing content", ctx do
+    assert :ok =
+             FS.atomic_write!(ctx.manifest_path, ~s({"private":true}), permissions: 0o600)
+
+    assert %File.Stat{mode: mode} = File.stat!(ctx.manifest_path)
+    assert Bitwise.band(mode, 0o777) == 0o600
+  end
+
   test "concurrent writers never leave half-written content", ctx do
     payloads =
       for index <- 1..24 do

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -576,6 +576,7 @@ config :orchard_node_agent,
       node_runtime_defaults,
       node_identity_root: dev_node_identity_root,
       listen_address: [host: dev_node_agent_listen_host, port: dev_runtime_port],
+      force_full_model_verification: env_bool.("ORCHARD_FORCE_FULL_MODEL_VERIFICATION", false),
       worker_executable:
         env_source_dev_path.("ORCHARD_WORKER_EXECUTABLE") ||
           Path.join([repo_root, "native", "orchard_worker_mlx", "bin", "orchard-worker-mlx"]),

--- a/config/m1_runtime_defaults.exs
+++ b/config/m1_runtime_defaults.exs
@@ -81,6 +81,7 @@ defmodule Orchard.Config.M1RuntimeDefaults do
       display_name: nil,
       listen_address: [host: @default_runtime_host, port: @default_runtime_port],
       models_root: Path.join(root, "models"),
+      force_full_model_verification: false,
       worker_socket_dir: Path.join([root, "data", "worker-sockets"]),
       worker_executable: "orchard-worker-mlx",
       worker_backend: "mlx",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -561,6 +561,7 @@ default_node_runtime = fn root ->
     display_name: nil,
     listen_address: [host: "127.0.0.1", port: 50_061],
     models_root: Path.join(root, "models"),
+    force_full_model_verification: false,
     worker_socket_dir: Path.join([root, "data", "worker-sockets"]),
     worker_executable: "orchard-worker-mlx",
     worker_backend: "mlx",
@@ -1440,6 +1441,8 @@ if config_env() == :prod do
             ],
             models_root:
               System.get_env("ORCHARD_MODELS_ROOT") || Path.join(orchard_support_root, "models"),
+            force_full_model_verification:
+              env_bool.("ORCHARD_FORCE_FULL_MODEL_VERIFICATION", false),
             worker_socket_dir:
               System.get_env("ORCHARD_WORKER_SOCKET_DIR") ||
                 Path.join([orchard_support_root, "data", "worker-sockets"]),

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -298,6 +298,7 @@ ELIXIR
 | `ORCHARD_NODE_IDENTITY_ROOT` | `tmp/dev/config/node-identity` | Owner-only root for the Node key, issued Node Certificate, and runtime trust persisted during `orchardctl node join`. Override only when the support-root layout is intentionally changed. |
 | `ORCHARD_RUNTIME_CLIENT_PORT` | Same as listen port | Controller gRPC client port (must match listen port) |
 | `ORCHARD_MODELS_ROOT` | `tmp/dev/models` | Model artifact storage |
+| `ORCHARD_FORCE_FULL_MODEL_VERIFICATION` | `false` | Bypass verification receipts and recompute the authoritative Catalog tree digest on every cache load. Restart the Node Agent after changing it. |
 | `ORCHARD_WORKER_SOCKET_DIR` | `/tmp/od-<hash>/ws` | Worker UDS directory |
 | `ORCHARD_WORKER_EXECUTABLE` | `native/orchard_worker_mlx/bin/orchard-worker-mlx` (repo-root) | Worker binary path. Override via env var; default resolves from repo root in source-dev mode. |
 | `ORCHARD_WORKER_BACKEND` | `mlx` | Worker backend (`mlx` or `stub`) |
@@ -312,6 +313,12 @@ bin/dev-node-agent` after changing them. Use `ORCHARD_WORKER_BACKEND=stub` for
 cluster mechanics or rollback testing when real MLX inference is not required;
 when `ORCHARD_WORKER_GENERATION_MODE` is unset, the stub backend resolves to
 stream mode automatically.
+Set `ORCHARD_FORCE_FULL_MODEL_VERIFICATION=true` when an operator needs every
+cache load to ignore durable verification receipts and recompute the full
+Catalog-authoritative Artifact Bundle digest.
+The default fast path still performs a complete metadata inventory and falls
+back to that same full digest whenever the receipt is missing, invalid, or no
+longer matches the cache tree.
 By default, source-dev worker Unix sockets live under a short, worktree-specific `/tmp/od-<hash>/ws` directory to avoid macOS Unix socket path length limits.
 Set `ORCHARD_WORKER_SOCKET_DIR` to override that location.
 `ORCHARD_FAKE_RUNTIME` is a release/runtime config knob; source-dev tests use

--- a/openspec/changes/cache-model-verification-receipts/.openspec.yaml
+++ b/openspec/changes/cache-model-verification-receipts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/cache-model-verification-receipts/design.md
+++ b/openspec/changes/cache-model-verification-receipts/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`models.artifact_sha256` is the authoritative digest of the final Artifact Bundle tree.
+Node acquisition currently recomputes the full tree digest for every cached load even when the cache has not changed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Avoid repeated content reads for a previously verified unchanged cache.
+- Detect ordinary edits, replacement, addition, removal, truncation, symlinks, and unsupported entries before accepting the fast path.
+- Fall back to authoritative hashing for every uncertainty and retain current reacquisition behavior after a digest mismatch.
+- Keep receipt persistence crash-safe and outside the Artifact Bundle digest domain.
+
+**Non-Goals:**
+
+- Defend against a privileged hostile writer that can manipulate both cache metadata and Node-owned receipts.
+- Change the Catalog digest algorithm or Model Manifest contract.
+- Add a cache database, transport field, or controller API.
+
+## Decisions
+
+### A receipt is acceleration evidence only
+
+The receipt records a format version, the expected Catalog digest, a hash of the canonical cache path, and a hash of the complete sorted filesystem inventory.
+The inventory includes directories and regular files with relative path, type, size, mode, ownership, device and inode identity, link count, modification time, and change time.
+Staging promotion may change the cache root's rename metadata, so publication permits that one-time root transition only after all descendant evidence remains stable.
+The published receipt binds the complete final root and descendant inventory, so later root metadata changes invalidate the fast path.
+Because the portable `File.Stat` surface exposes whole-second timestamps, authoritative verification first normalizes every directory and regular-file modification time to a reserved historical value without changing bundle bytes.
+The hash and published receipt bind the normalized complete inventory, so a later ordinary write changes the modification-time evidence even when it occurs immediately within the same change-time second.
+The receipt never replaces or supplies the Catalog digest.
+
+### Receipts live outside Artifact Bundles
+
+Receipts live under the Node models root in a separate `.verification` namespace.
+The receipt filename is derived from the canonical models root, the request-relative final path, and expected digest, so its identity remains stable when the final path is temporarily absent without exposing a local path or accepting an unvalidated request digest as a direct path component.
+
+### Every uncertainty falls back to a stable full verification
+
+A missing, malformed, unreadable, version-mismatched, path-mismatched, digest-mismatched, or inventory-mismatched receipt is removed and causes a full tree hash.
+Full verification compares inventory fingerprints before and after hashing so concurrent ordinary mutation cannot publish a receipt for an unstable tree.
+A crash before receipt publication leaves no trusted acceleration evidence and therefore causes a full hash on the next load.
+Receipt temporary files receive owner-only permissions before atomic rename, and persistence errors expose only bounded reason atoms.
+An atomic receipt-write failure is nonfatal because it leaves no acceleration evidence and forces a full hash on the next load.
+Inventory or stability rejection during receipt publication fails the current acquisition closed and removes or reacquires the affected cache.
+Any authoritative verification failure removes the prior receipt before returning or reacquiring.
+Full verification of an existing cache removes the prior receipt before metadata normalization and fails closed if that revocation cannot be confirmed.
+The initial post-normalization inventory accepts only entries that still carry the reserved modification time, closing the crash and concurrent-write windows before hashing begins.
+
+### Operator force-full is process configuration
+
+`ORCHARD_FORCE_FULL_MODEL_VERIFICATION=true` is the minimal cross-transport operator route.
+It bypasses receipt eligibility for every cache load until the Node Agent restarts with the setting disabled.
+This avoids widening Runtime Endpoint protocols or overloading unrelated force semantics.
+
+## Risks / Trade-offs
+
+- Metadata comparison is O(files) and still pays traversal and stat cost, but avoids reading artifact bytes.
+- First verification performs an O(files) metadata-normalization pass before hashing.
+- Filesystem metadata is not cryptographic evidence against a privileged writer with equivalent local authority.
+- A metadata change that preserves correct content causes a full hash and receipt refresh, preferring integrity over maximum cache-hit rate.
+- Atomic receipt publication does not remove the pre-existing time-of-check-to-use boundary between verification and worker file access.
+
+## Migration Plan
+
+Existing caches have no receipts and therefore receive one authoritative verification on their first load after upgrade.
+Successful verification creates the receipt for subsequent unchanged loads.
+Rollback ignores the sidecar namespace and restores full hashing on every load.

--- a/openspec/changes/cache-model-verification-receipts/proposal.md
+++ b/openspec/changes/cache-model-verification-receipts/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+An unchanged cached model currently pays the full Artifact Bundle byte-hash cost on every load.
+The measured field example for a roughly 28 GB artifact spent about 21 seconds hashing before worker startup.
+
+## What Changes
+
+- Preserve the Catalog digest and `Orchard.ArtifactBundle.tree_sha256/1` as the sole integrity authority.
+- Persist a versioned path- and digest-bound verification receipt outside each Artifact Bundle after successful full verification.
+- Allow unchanged filesystem inventory to skip the repeated byte walk while sending every missing or invalid receipt and every inventory mutation to authoritative verification.
+- Add an operator configuration that forces full verification on every cache load.
+- Add attributable logs for full, fast, invalidated, and failed verification paths without local filesystem paths or digest values.
+
+## Capabilities
+
+### New Capabilities
+
+- `node-model-cache-verification`: Defines durable verification receipts, fail-closed invalidation, forced verification, and verification-path observability.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Product contract: `SPEC.md` §6.7.
+- Node Agent acquisition: `Orchard.Node.ModelAcquisition` and its ModelManager entry point.
+- Runtime configuration and source-development operator guidance.
+- No Catalog schema, manifest, digest algorithm, Runtime Endpoint protocol, or controller import behavior changes.

--- a/openspec/changes/cache-model-verification-receipts/specs/node-model-cache-verification/spec.md
+++ b/openspec/changes/cache-model-verification-receipts/specs/node-model-cache-verification/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Authoritative first and fallback verification
+
+Node acquisition SHALL verify first acquisition against the authoritative Catalog Artifact Bundle digest with `Orchard.ArtifactBundle.tree_sha256/1`.
+It SHALL perform the same authoritative verification whenever durable receipt evidence is missing, invalid, or inconsistent with the current cache tree.
+
+#### Scenario: First acquisition verifies exact bytes
+
+- **WHEN** a Node materializes an Artifact Bundle that is not already cached
+- **THEN** it computes the authoritative tree digest before promoting the staging directory
+
+#### Scenario: Invalid receipt falls back to authoritative verification
+
+- **WHEN** a cached Artifact Bundle has missing, malformed, mismatched, unreadable, or unstable verification evidence
+- **THEN** the Node recomputes the authoritative tree digest before returning a cache hit
+
+#### Scenario: Publication instability fails the acquisition closed
+
+- **WHEN** the cache inventory changes after authoritative hashing but before receipt publication
+- **THEN** the Node does not return the affected cache as verified and instead fails or reacquires it
+
+#### Scenario: Failed reacquisition invalidates prior evidence
+
+- **WHEN** staging verification fails for a cache path and digest that had an older receipt
+- **THEN** the Node removes that receipt even when the final cache path is absent
+
+#### Scenario: Existing receipt revocation is mandatory
+
+- **WHEN** the Node cannot confirm removal of prior acceleration evidence before full verification
+- **THEN** it fails the load before normalizing or hashing the existing cache
+
+#### Scenario: Initial normalized inventory is unstable
+
+- **WHEN** any bundle entry loses the reserved modification time before the initial inventory completes
+- **THEN** the Node fails verification before hashing and does not publish a receipt
+
+### Requirement: Path- and digest-bound fast path
+
+A Node SHALL skip the full content hash only when a versioned receipt outside the Artifact Bundle binds the expected Catalog digest and canonical cache path to an unchanged complete filesystem inventory.
+Before authoritative hashing, the Node SHALL normalize every bundle directory and regular-file modification time to a reserved historical value without changing bundle bytes.
+Receipt publication SHALL bind that complete normalized inventory so an immediate later ordinary write cannot reuse the verified inventory fingerprint even when change times have only whole-second resolution.
+The receipt SHALL remain acceleration evidence only and SHALL NOT modify or compete with the authoritative Artifact Bundle digest.
+
+#### Scenario: Second unchanged load skips content hashing
+
+- **WHEN** a previously verified cache has an exact receipt and inventory match
+- **THEN** acquisition returns a cache hit without invoking `tree_sha256/1`
+
+#### Scenario: Ordinary same-size mutation invalidates the fast path
+
+- **WHEN** a shard is overwritten without changing its byte length
+- **THEN** changed filesystem metadata invalidates the receipt and authoritative verification rejects the altered tree
+
+#### Scenario: Immediate same-second mutation invalidates the fast path
+
+- **WHEN** a shard is overwritten with equal-length bytes immediately after receipt publication
+- **THEN** the reserved modification-time marker makes the inventory evidence distinct and the Node performs authoritative verification
+
+#### Scenario: Truncation invalidates the fast path
+
+- **WHEN** a shard is truncated after receipt publication
+- **THEN** changed size and metadata invalidate the receipt and authoritative verification rejects the altered tree
+
+### Requirement: Forced full verification
+
+Operators SHALL have a documented Node Agent setting that bypasses receipts and recomputes the authoritative tree digest on every cache load.
+
+#### Scenario: Operator forces verification
+
+- **WHEN** `ORCHARD_FORCE_FULL_MODEL_VERIFICATION=true` is active
+- **THEN** an unchanged receipt does not skip authoritative tree hashing
+
+### Requirement: Verification-path observability
+
+Node logs SHALL distinguish full, fast, invalidated, and failed verification paths.
+Those logs SHALL NOT include local artifact paths, source URIs, digest values, or inventory contents.
+
+#### Scenario: Logs identify the path safely
+
+- **WHEN** acquisition takes any verification path
+- **THEN** the log names that path and a bounded reason without exposing local filesystem or artifact integrity data

--- a/openspec/changes/cache-model-verification-receipts/tasks.md
+++ b/openspec/changes/cache-model-verification-receipts/tasks.md
@@ -1,0 +1,20 @@
+## 1. Contract
+
+- [x] 1.1 Reconcile `SPEC.md` §6.7 with authoritative first/full verification and receipt-only acceleration.
+- [x] 1.2 Record receipt binding, invalidation, crash ordering, force-full behavior, logs, and threat boundaries.
+
+## 2. Test-Driven Implementation
+
+- [x] 2.1 Characterize the repeated full hash through the public acquisition seam, then require the second unchanged load to skip it.
+- [x] 2.2 Cover same-size tampering, truncation, forced verification, path-safe logs, and receipt invalidation.
+- [x] 2.3 Persist receipts atomically outside Artifact Bundles and retain the existing Catalog digest algorithm unchanged.
+
+## 3. Operator Route
+
+- [x] 3.1 Add and document `ORCHARD_FORCE_FULL_MODEL_VERIFICATION` for source-development and packaged Node Agent configuration.
+
+## 4. Validation And Review
+
+- [x] 4.1 Run focused acquisition, adjacent source-adapter, ModelManager, and Artifact Bundle tests.
+- [x] 4.2 Run the complete Orchard Elixir format, compile, Credo, Dialyzer, test, and coverage workflow.
+- [x] 4.3 Run strict OpenSpec validation and obtain independent contract and diff review.


### PR DESCRIPTION
## Summary

Unchanged verified model caches now avoid the repeated full Artifact Bundle rehash that made every load pay the integrity cost again.
The Catalog tree digest remains the sole authority, while a durable receipt accelerates only an exact path, digest, and filesystem-inventory match.

## Integrity policy

- First acquisition and every uncertain cache state still run `Orchard.ArtifactBundle.tree_sha256/1` against the Catalog digest.
- Receipts live outside the Artifact Bundle and bind the canonical cache identity, expected digest, and a complete sorted inventory.
- Full verification normalizes bundle modification times to a reserved historical marker before hashing. This makes an immediate equal-length write visible even on the portable whole-second timestamp surface.
- Receipt revocation must succeed before an existing cache can be normalized or reverified. Revocation uncertainty fails closed.
- Receipt publication is owner-only and atomic. A write failure leaves the cache usable but forces another full verification on the next load.
- `ORCHARD_FORCE_FULL_MODEL_VERIFICATION=true` bypasses receipts across Node Agent transports.
- Verification logs identify `full`, `fast`, `invalidated`, and `failed` paths with bounded reasons and no local paths, source URIs, digests, or inventory data.

## Performance evidence

Issue #253 reports about 21 seconds to rehash a 29.5 GB cached model on every load.
The final local benchmark used one 64 MiB shard:

| Path | Elapsed |
| --- | ---: |
| First materialization and verification | 157.650 ms |
| Unchanged receipt hit | 2.277 ms |
| Operator-forced full verification | 57.523 ms |

The fast path still scans metadata in O(files), but it does not read every model byte.

## Verification

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict` - 16,773 modules/functions, zero issues
- `mise exec -- mix dialyzer` - zero errors
- `make macos-native-test-helpers`
- `ORCHARD_TEST_NODE_AGENT_PORT=50253 mise exec -- mix test --seed 852472` - shared 218 passed; controller 3,703 passed and 5 skipped; node-agent 431 passed; CLI 681 passed, 1 skipped, and 10 excluded
- `ORCHARD_TEST_NODE_AGENT_PORT=50253 mise exec -- mix test --cover --seed 852472` - full umbrella coverage run passed
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate cache-model-verification-receipts --type change --strict --no-interactive`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` - 34 passed, 0 failed

Independent contract and diff review reached GO with no remaining blockers.
The full gates also exposed existing timing-sensitive controller tests, so this PR widens only their test deadlines and hold windows. Runtime behavior is unchanged by that commit.

## Risk Assessment

⚠️ **Medium**

- Blast radius is limited to Node Agent model-cache verification, shared atomic-file permissions, configuration, and test-only controller timing windows.
- The first full verification of an existing cache changes directory and regular-file modification times, but does not change bundle bytes or the authoritative tree digest.
- Missing, malformed, mismatched, unreadable, or unstable receipts fail closed to full verification.
- The pre-existing verification-to-worker-use time-of-check-to-use window remains.
- Single-flight coordination remains process-local. Multiple Node Agent OS processes sharing one cache root are outside this slice.
- A privileged hostile writer that can alter both bundles and Node-owned receipts remains outside the stated threat model.

## Rollout and monitoring

- Owner: PR author for the first 24 hours after deployment.
- Confirm each newly acquired or pre-existing cache records one `verification_path=full` before later unchanged loads record `verification_path=fast`.
- Watch model-acquisition duration, unexpected `invalidated` frequency, `failed` reasons, and repeated receipt-write warnings.
- If receipt acceleration is suspect, set `ORCHARD_FORCE_FULL_MODEL_VERIFICATION=true` and restart the Node Agent to restore full verification on every load.
- Revert this PR if metadata normalization or receipt handling causes an operational regression.

Closes #253


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds durable, path- and inventory-bound receipts that allow unchanged Node Agent model caches to bypass repeated full artifact hashing while retaining the Catalog digest as the authority.
- Normalizes artifact modification times and records complete filesystem metadata after authoritative verification.
- Invalidates uncertain receipts and falls back to full verification, with an operator override to force that path.
- Publishes receipts atomically with owner-only permissions and adds bounded verification-path logging.
- Extends cache-verification, configuration, filesystem-permission, and timing-sensitive controller tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking defects identified.

Receipt mismatches and uncertain filesystem states fall back to authoritative verification or fail closed, while publication failures preserve correctness by requiring later re-verification.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_node_agent/lib/orchard/node/model_acquisition.ex | Integrates receipt-based fast verification, forced full verification, fail-closed invalidation, bounded logging, and receipt publication into acquisition. |
| apps/orchard_node_agent/lib/orchard/node/model_acquisition/verification_receipt.ex | Implements versioned receipt validation, canonical path binding, filesystem inventory collection, metadata normalization, atomic publication, and invalidation. |
| apps/orchard_node_agent/lib/orchard/node/model_manager.ex | Passes the operator-configured full-verification override into the model acquisition pipeline. |
| apps/orchard_shared/lib/orchard/fs.ex | Extends atomic writes to apply requested permissions to temporary files before publication. |
| config/runtime.exs | Adds release-time parsing and propagation of the force-full-model-verification environment setting. |
| apps/orchard_node_agent/test/orchard/node/model_acquisition_test.exs | Adds extensive coverage for receipt hits, invalidation, tampering, publication failures, metadata stability, logging, and forced verification. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Model load request] --> B{Cache directory exists?}
    B -- No --> C[Materialize into staging]
    B -- Yes --> D{Force full verification?}
    D -- No --> E{Receipt and inventory match?}
    E -- Yes --> F[Fast cache hit]
    E -- No --> G[Invalidate receipt]
    D -- Yes --> G
    G --> H[Normalize metadata]
    H --> I[Hash artifact tree]
    I --> J{Catalog digest matches and inventory stable?}
    J -- No --> K[Reject or reacquire]
    J -- Yes --> L[Publish receipt]
    C --> H
    L --> M[Load worker]
    F --> M
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(controller): harden async timing wi..."](https://github.com/kapitan-ai/orchard/commit/043604c54a4f8817fb669d35b26d7566e7c34795) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58462393)</sub>

<!-- /greptile_comment -->