### PR TITLE
docs(portal): define atomic lifecycle audit contract

### DIFF
--- a/openspec/changes/define-portal-lifecycle-audit-contract/.openspec.yaml
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/define-portal-lifecycle-audit-contract/design.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/design.md
@@ -1,0 +1,213 @@
+## Context
+
+PR #300 reconciled the accepted Portal lifecycle with shipped behavior.
+Portal User creation persists only an `invited` identity.
+The first Copy invite action issues the initial invite, later Copy actions reissue through the same path, and the single hash-only invite row is deleted and replaced without retained invalidation history.
+Redemption is invited-only, Organization-bound, and uses `POST /portal/:organization_slug/invites/:token`.
+Initial issuance, reissue, redemption, and disablement end the target Portal User's sessions, while existing API Keys remain valid until explicit revocation.
+
+`SPEC.md` section 10.9 nevertheless requires audit evidence for Portal invitation, reissue, redemption, disablement, and API Key creation and revocation.
+The current Portal governance functions use direct `Repo` transactions and do not insert those rows.
+The ordinary governance paths already provide an atomic audit transaction and post-commit success telemetry seam through `AuditWriter.transaction/1`.
+
+The current metrics implementation recognizes eleven bounded audit action domains, while the accepted metrics worksheet and descriptor ceiling still reserve only 24 audit series from an earlier eight-domain snapshot.
+The implementation catalog also includes 229 attempt and retry series that the accepted metrics contract still assigns to issue #121 and excludes from its 2,588-series worksheet.
+This proposal adds only the `portal_user` audit domain and makes the accepted future target explicit at twelve domains and three outcomes.
+It does not adopt the separate attempt and retry metric families into the accepted contract.
+The archived metrics design remains historical and is not rewritten.
+
+## Decision Status
+
+The six choices below are recommendations presented for owner review.
+Merging or accepting the proposal is the act that approves them.
+Until then, the shipped lifecycle remains authoritative and no implementation should infer these choices from issue #279.
+
+| Decision frontier | Recommendation | Evidence and trade-off |
+|---|---|---|
+| Separate creation and first issuance | Use `portal_user.invited` and `portal_user.invite_issued` | PR #300 defines separate mutations that may occur far apart and have different secret and session effects. |
+| Successful redemption actor | Use `actor_type = "user"` and the Portal User ID | A successful locked redemption identifies the exact Portal User, but this is provenance only and grants no new Portal or Bearer authority. `system` plus null would lose that attribution. |
+| Committed row versus persisted outcome | Persist only committed effective mutations and no outcome field | The existing schema has no outcome column, and a committed append-only row already represents success. Telemetry remains the bounded outcome projection. |
+| Repeat and no-op transitions | Do not mutate or write another success row | This matches ordinary API Key revoke precedent and prevents audit inflation. Copy invite is never a no-op because it always creates a fresh secret and expiry. |
+| Shared Console operator identity | Use `operator`, null actor ID, and `surface = "console"` | Current Console authentication establishes no first-class named operator, and `SPEC.md` explicitly permits null actor ID for this boundary. |
+| Bounded metadata | Allow only per-action keys and omit `previous_invite_existed` | `surface` and `expires_at` are useful non-secret context. The action name already records issued versus reissued, so persisting a second classifier creates redundant history. |
+
+## Goals
+
+- Define stable action names for the existing Portal lifecycle.
+- Keep authoritative mutation and required audit evidence atomic.
+- Preserve PR #300 lifecycle and persistence decisions.
+- Record actor and target provenance without granting new authority.
+- Keep every audit payload bounded and secret-free.
+- Preserve post-commit-only success telemetry.
+- Keep audit metrics within the exact pilot series ceiling.
+
+## Decisions
+
+### Five Portal User Actions And Existing API Key Actions
+
+The proposed Portal User actions are:
+
+- `portal_user.invited`
+- `portal_user.invite_issued`
+- `portal_user.invite_reissued`
+- `portal_user.invite_redeemed`
+- `portal_user.disabled`
+
+Portal-owned API Key creation and effective revocation reuse `api_key.created` and `api_key.revoked`.
+No `portal_api_key.*`, `portal_invite.*`, or other alias is introduced.
+
+### Tenant-Scoped Atomic Audit Writes
+
+Every required row uses `scope = "tenant"` and the owning Organization's non-null `tenant_id`.
+The authoritative mutation and audit insertion execute inside one outermost `AuditWriter.transaction/1` boundary.
+Wrapping `AuditWriter.transaction/1` inside a pre-existing raw `Repo.transaction/1` is prohibited because successful audit telemetry could then be published before the authoritative outer commit.
+An audit insertion failure rolls back the mutation and prevents any secret-bearing success result from being published.
+Best-effort audit insertion after mutation commit is prohibited.
+
+### Issued-Versus-Reissued Classification Under Lock
+
+Copy invite acquires the existing Portal User `FOR UPDATE` lock before classification.
+No stored invite row at that point selects `portal_user.invite_issued`.
+An existing invite row selects `portal_user.invite_reissued`.
+The transaction then deletes any prior row, stores exactly one replacement hash-only row, ends the target user's sessions, and inserts the classified audit row.
+
+Classification outside the lock is prohibited because concurrent Copy actions could observe stale state.
+Token generation and expiry calculation before the lock are also prohibited because a delayed transaction could otherwise replace a newer invite with an older expiry.
+The transaction generates both after acquiring the Portal User lock, persists that exact expiry in the replacement invite and audit payload, and returns the matching plaintext URL only after commit.
+No schema column, audit payload key, or retained history row records `previous_invite_existed`.
+
+### Effective Transitions And No-Ops
+
+Audit rows represent effective committed transitions only.
+A duplicate Portal User creation, invalid redemption, cross-Organization failure, or rejected key mutation creates no success row.
+Every successful Copy invite remains effective because it produces a fresh token and expiry.
+Repeated disable of an already disabled Portal User must not rewrite `disabled_at`, advance the session epoch, delete more state, or create another success row.
+Repeated revoke of an already revoked Portal-owned key returns the persisted state without another mutation or success row.
+
+### Actor And Target Provenance
+
+Console creation, Copy invite, and disable use `actor_type = "operator"`, null `actor_id`, and payload `surface = "console"`.
+Successful redemption, Portal key creation, and Portal key revocation use `actor_type = "user"`, `actor_id = portal_user.id`, and payload `surface = "developer_portal"`.
+Redemption records successful possession of a valid invite for that Portal User.
+It does not claim a pre-existing authenticated Portal session and does not make the Portal User a platform or Public Inference principal.
+The audit-log persistence column is text today, and `user` is already part of the `SPEC.md` actor vocabulary, so this recommendation requires no actor-type schema migration.
+
+Portal User lifecycle actions use `target_type = "portal_user"` and the affected Portal User UUID.
+They do not target the ephemeral invite row, token, hash, URL, or email address.
+API Key actions use `target_type = "api_key"`, the affected API Key UUID, and the matching `api_key_id` foreign key.
+
+### Secret-Free Bounded Payloads
+
+The lifecycle payload contract is:
+
+| Action | Required payload keys | Permitted optional keys |
+|---|---|---|
+| `portal_user.invited` | `surface` | none |
+| `portal_user.invite_issued` | `surface`, `expires_at` | none |
+| `portal_user.invite_reissued` | `surface`, `expires_at` | none |
+| `portal_user.invite_redeemed` | `surface` | none |
+| `portal_user.disabled` | `surface` | none |
+
+For Console actions, `surface` is exactly `console`.
+For redemption and Portal-owned API Key actions, `surface` is exactly `developer_portal`.
+Invite `expires_at` is the replacement invite expiry encoded as a UTC ISO 8601 string.
+
+Portal-owned `api_key.created` and `api_key.revoked` require `name`, `token_prefix`, `owner_type`, `surface`, `issuance_surface`, and `portal_user_id`.
+They include `expires_at` when the key has an expiry and omit it otherwise.
+For those rows, `owner_type` is exactly `tenant`, `surface` and `issuance_surface` are exactly `developer_portal`, `portal_user_id` is the canonical Portal User UUID string, and `expires_at` is a UTC ISO 8601 string.
+The API Key target and actor fields remain authoritative when a payload field duplicates that provenance.
+
+Payloads must exclude invite tokens, invite hashes, invite URLs, passwords, password hashes, Portal session tokens, Portal session hashes, API Key plaintext secrets, API Key secret hashes, request headers, source addresses, raw errors, arbitrary request parameters, emails, and `previous_invite_existed`.
+
+### Post-Commit Success Telemetry
+
+Audit insertion occurs inside the authoritative transaction.
+The `orchard_audit_events_total{action,outcome}` observation with `outcome = "succeeded"` is emitted only after the outer transaction commits.
+A rollback cannot emit a phantom success observation.
+Audit insertion failure may remain a bounded `failed` telemetry observation after the failure is known, but it does not create an audit row or change the authoritative mutation outcome.
+
+### Bounded Portal User Metrics Domain
+
+All five `portal_user.*` actions normalize to the single metrics action domain `portal_user`.
+Concrete action suffixes, Portal User IDs, tenant IDs, emails, and target IDs never become audit metric labels.
+The existing outcomes remain `succeeded`, `failed`, and `denied`.
+
+Current code recognizes eleven audit action domains.
+Adding `portal_user` produces twelve domains and a family ceiling of 36 series.
+Replacing the accepted worksheet's 24-series audit subtotal with 36 changes the accepted pilot total from 2,588 to 2,600 and leaves 2,400 series below the 5,000-series ceiling.
+The current catalog total of 2,817 includes 229 attempt and retry series that the accepted contract excludes.
+Their reconciliation remains owned by issue #121 and must occur before the later implementation can update the catalog total without silently accepting unrelated behavior.
+
+## Transaction Flows
+
+### Console Portal User Creation
+
+1. Validate the Organization-scoped creation input.
+2. Insert the invited Portal User and `portal_user.invited` row in one audit transaction.
+3. Roll back both rows if either insert fails.
+4. Create no Portal Invite token or URL.
+
+### Copy Invite
+
+1. Resolve and lock the invited Portal User inside the transaction.
+2. Classify issued or reissued from the stored invite row under that lock.
+3. Generate the fresh token and calculate its expiry after acquiring the lock.
+4. Delete any prior invite row and insert one replacement hash-only row with that exact expiry.
+5. End that Portal User's standing sessions.
+6. Insert the classified audit row with the same expiry.
+7. Commit before returning the matching show-once plaintext URL.
+
+### Invite Redemption
+
+1. Preserve the current generic preflight and Organization-bound candidate discovery.
+2. Lock and recheck the invited Portal User, then lock the valid invite.
+3. Activate the user, mark the invite redeemed, and end that user's sessions.
+4. Insert `portal_user.invite_redeemed` with Portal User provenance.
+5. Commit before returning success.
+
+### Portal User Disablement
+
+1. Lock the tenant-scoped Portal User.
+2. Return the persisted state without mutation when already disabled.
+3. Otherwise disable the user, delete outstanding unused invites, and end that user's sessions.
+4. Insert `portal_user.disabled` in the same transaction.
+5. Leave every API Key unchanged.
+
+### Portal API Key Mint And Revoke
+
+Portal key mint carries the validated session's tenant ID, Portal User ID, and password epoch into the audit transaction.
+It locks the tenant-scoped Portal User first, requires that user to remain active and the captured epoch to equal the locked `session_epoch`, applies the existing cap check, inserts the key and `api_key.created` row atomically, and returns the show-once secret only after commit.
+
+Portal revoke carries the same session identity and epoch into the audit transaction.
+It locks and revalidates the tenant-scoped Portal User first, then locks the tenant-, Portal User-, and issuance-surface-scoped API Key.
+The lock order is always Portal User then API Key.
+It records only an active-to-revoked transition with `api_key.revoked` and treats an already revoked key as a no-op.
+
+## Failure Semantics
+
+- Audit insertion failure rolls back every authoritative row mutation in the operation.
+- Invalid and ineligible invite redemptions keep the current generic external response and persist no mutation or success audit.
+- A wrong-Organization request cannot consume an invite or produce a success audit in either Organization.
+- A stale pre-transaction Portal session cannot authorize mint or revoke after the locked Portal User state or session epoch no longer permits it.
+- Telemetry failure remains non-authoritative and cannot reverse a committed audit row or domain mutation.
+
+## Alternatives Rejected
+
+- A single `portal_user.invite_copied` action was rejected because it hides the creation-to-first-issuance boundary settled by PR #300.
+- An outcome field in every audit payload was rejected because the committed append-only row already represents success and the bounded metric owns outcome projection.
+- `system` plus null for successful redemption was rejected as the recommendation because it loses the Portal User provenance established by locked token validation.
+- A named Console actor was rejected because current Console authentication does not establish one.
+- Persisting `previous_invite_existed` was rejected because the action name already carries that classification.
+- An invite-row target was rejected because invite rows are deliberately deleted and are not retained lifecycle history.
+- Best-effort audit after commit and pre-commit success telemetry were rejected because they can create mutation-without-audit or phantom-success states.
+- Rewriting the archived PR #300 or metrics designs was rejected because archived packages are historical evidence.
+
+## Risks And Review Focus
+
+- Action names become durable audit vocabulary after acceptance, so owner review must approve them explicitly.
+- Successful redemption provenance must not be read as a new authentication or authorization grant.
+- Current Portal disable and revoke behavior rewrites timestamps on repeats, so later implementation must deliberately adopt the proposed no-op contract.
+- Portal mint and revoke validate their sessions before their mutation transactions today, so later implementation must carry the validated identity and epoch into the transaction and recheck both under a Portal User lock before any API Key lock.
+- The accepted metrics spec and current implementation disagree about both the audit-domain count and issue #121-owned attempt/retry families, so this package updates only the accepted audit subtotal and leaves the unrelated 229-series drift for its owning change.
+- No ADR is warranted for this focused refinement unless owner review selects a broader identity or authority model.
+- No glossary change is warranted because `Operator`, `Portal User`, `API Key`, and `Audit Log` already name every domain concept used here.

--- a/openspec/changes/define-portal-lifecycle-audit-contract/proposal.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+`SPEC.md` requires audit evidence for Portal User invitation, reissue, redemption, disablement, and API Key creation and revocation.
+The shipped Portal governance paths do not write those audit rows today.
+PR #300 settled the invitation lifecycle but deliberately left audit actor, action, and outcome vocabulary for a separate owner decision.
+The next safe slice is therefore a focused contract for atomic Portal lifecycle audit evidence, including Portal-owned API Key mint and revoke.
+
+## What Changes
+
+- Propose five stable Portal User audit actions for owner review: `portal_user.invited`, `portal_user.invite_issued`, `portal_user.invite_reissued`, `portal_user.invite_redeemed`, and `portal_user.disabled`.
+- Reuse `api_key.created` and `api_key.revoked` for Portal-owned API Key mutations rather than creating Portal-specific aliases.
+- Require each effective Portal mutation and its tenant-scoped audit row to commit or roll back through one outermost `AuditWriter.transaction/1` boundary.
+- Require first issuance versus reissue to be classified from invite-row state observed under the existing Portal User lock.
+- Require Copy invite token generation and expiry calculation after that lock is acquired so each serialized reissue extends the stored expiry.
+- Require audit rows to represent committed effective transitions, with no duplicate row for a rejected request or a true no-op.
+- Define actor, target, and payload rules that preserve Console operator provenance and Portal User provenance without granting new authority.
+- Require successful audit telemetry only after the authoritative transaction commits.
+- Add `portal_user` as one bounded audit metric domain and reconcile the audit-family ceiling with the current eleven-domain implementation plus this new domain.
+
+## Recommended Decisions Requiring Owner Review
+
+This active change is the review vehicle for the following recommendations.
+None of them is already accepted merely because it appears in this proposal.
+
+1. **Separate creation and first issuance events.**
+   Approve `portal_user.invited` for creation of the invited identity and `portal_user.invite_issued` for the first Copy invite action because PR #300 established them as separate committed mutations.
+2. **Attribute successful redemption to Portal User provenance.**
+   Approve `actor_type = "user"` and `actor_id = portal_user.id` for `portal_user.invite_redeemed`, while stating that invite possession is audit provenance only and does not make a Portal User a platform or Public Inference principal.
+3. **Treat the committed row as the successful outcome.**
+   Approve one audit row only for an effective committed mutation, without persisting an `outcome` field in the row or payload.
+   Audit insertion failure rolls back the mutation, and only post-commit telemetry may report `succeeded`.
+4. **Do not audit rejected requests or true no-ops as successes.**
+   Approve mutation-free repeated disable and revoke behavior with no duplicate audit row or success telemetry.
+   Every successful Copy invite remains an effective mutation because it mints a fresh token and expiry.
+5. **Preserve the shared Console operator model.**
+   Approve `actor_type = "operator"`, null `actor_id`, and `surface = "console"` until Orchard has an authenticated first-class Console operator identity.
+6. **Use a strict non-secret payload allowlist.**
+   Approve `surface` for every event, `expires_at` for invite issue or reissue, and the existing bounded API Key metadata plus Portal ownership provenance for key events.
+   Do not persist `previous_invite_existed`; the issued or reissued action name already records that classification.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `developer-api-key-portal`: Defines atomic audit rows, action names, actor and target provenance, effective-transition semantics, and secret-free payloads for the existing Portal lifecycle and Portal-owned API Key operations.
+- `controller-prometheus-metrics`: Adds the bounded `portal_user` audit domain and reconciles the audit-series worksheet and family ceiling.
+
+## Impact
+
+- `SPEC.md` impact: the proposed contract refines sections 7.4a, 8.2, 9.1, and 10.9 without contradicting their current requirements.
+  This shaping PR does not edit `SPEC.md`; an accepted implementation must reconcile the apex contract and accepted specs together if the owner approves these recommendations.
+- Product behavior impact in this PR: none.
+- Persistence impact in this PR: none.
+- Future governance impact: Portal User creation, invite issue and reissue, redemption, disablement, and Portal-owned key mint and revoke gain mandatory atomic audit evidence.
+- Future behavior impact: repeated disable and revoke become true no-ops, and Portal key mint and revoke reject a session whose captured epoch no longer matches the locked Portal User.
+- Future concurrency impact: invite issuance classification, token generation, and expiry calculation occur under the existing Portal User lock, while key mutation authority is revalidated with the lock order Portal User then API Key.
+- Future metrics impact: the accepted bounded audit action vocabulary grows to include `portal_user`, for 36 audit series, 2,600 accepted pilot series, and 2,400 series of headroom.
+  Current code separately includes 229 attempt and retry series that the accepted metrics contract still assigns to issue #121; this package does not absorb or approve that drift.
+- Documentation impact in this PR: one active OpenSpec package only.
+
+## Non-Goals
+
+- Do not implement product code, migrations, tests, or metrics changes in this shaping PR.
+- Do not reintroduce `invalidated_at`, retained invite invalidation history, or another invite-state column.
+- Do not define active-user recovery, replacement invites, Portal User re-enablement, or Portal User deletion.
+- Do not change the canonical `POST /portal/:organization_slug/invites/:token` redemption route.
+- Do not change invited-only, Organization-bound redemption or generic mutation-free failure behavior.
+- Do not revoke API Keys automatically when a Portal User is disabled or an invite is issued, reissued, or redeemed.
+- Do not design Console key labels or another Console management surface.
+- Do not persist `previous_invite_existed`, invite tokens, invite hashes, invite URLs, passwords, password hashes, session tokens, session hashes, API Key secrets, or API Key secret hashes in audit evidence.
+- Do not close issue #279.
+- Keep issue #270 independent.
+- Do not add an ADR or glossary term unless owner review selects a broader identity or authority model than the existing `Operator`, `Portal User`, and `Audit Log` concepts.

--- a/openspec/changes/define-portal-lifecycle-audit-contract/specs/controller-prometheus-metrics/spec.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/specs/controller-prometheus-metrics/spec.md
@@ -1,0 +1,92 @@
+## MODIFIED Requirements
+
+### Requirement: Bounded Label Contract
+
+Categorical inputs SHALL normalize only to the bounded values in the design.
+HTTP status SHALL normalize to `informational`, `success`, `redirect`, `client_error`, or `server_error`, rather than materializing individual status codes.
+Current terminal Request status SHALL normalize only to `completed`, `failed`, `cancelled`, `timed_out`, or `interrupted`.
+Scheduler result, tier, rejection reason, quota reason, audit action domain, and audit outcome SHALL use only the design's listed values and pair constraints.
+Audit action domain SHALL normalize only to `tenant`, `api_key`, `service_account`, `role_binding`, `routing_policy`, `tenant_model_access`, `support_bundle`, `node_admission`, `node_lifecycle`, `circuit_breaker`, `cluster`, or `portal_user`.
+Audit outcome SHALL normalize only to `succeeded`, `failed`, or `denied`.
+Unknown categorical inputs SHALL be dropped and reporting marked degraded.
+
+The pilot SHALL admit at most 4 distinct Tenant identifiers, 4 distinct model identifiers, 4 distinct Node identifiers, and 8 HTTP endpoint categories across all exposed families in one reporter generation.
+A shared atomic Cardinality Ledger SHALL charge an identifier when its first exposed tuple is admitted.
+Counter/histogram references SHALL remain charged for the generation; gauge replacement SHALL release a reference only when no counter, histogram, or other gauge family still references that identifier.
+The `tenant` label SHALL be the canonical stable raw Tenant identifier, `model` the canonical model identifier, and `node` the stable physical Node identifier.
+The protected site-local endpoint SHALL NOT hash, alias, truncate, or substitute Tenant identifiers.
+No HMAC pilot alias SHALL exist.
+Any later external metrics egress SHALL remove tenant and user dimensions before transmission under issue #115; external egress is not implemented by this change.
+
+#### Scenario: Protected Tenant dimension
+
+- **WHEN** an authorized site-local scrape contains a family with `tenant`
+- **THEN** the value is the canonical stable raw Tenant identifier
+- **AND** no user dimension or HMAC alias is present
+
+#### Scenario: Raw HTTP codes do not multiply series
+
+- **WHEN** HTTP responses use different concrete codes in the same status class
+- **THEN** they share the corresponding bounded status label
+- **AND** no `100` through `599` status-value Cartesian product is materialized
+
+#### Scenario: Invalid categorical value
+
+- **WHEN** a source supplies a value outside its bounded normalization
+- **THEN** Orchard does not materialize that label tuple
+- **AND** reporting becomes degraded without changing the source operation
+
+#### Scenario: Portal lifecycle actions share one bounded domain
+
+- **WHEN** a committed audit action is `portal_user.invited`, `portal_user.invite_issued`, `portal_user.invite_reissued`, `portal_user.invite_redeemed`, or `portal_user.disabled`
+- **THEN** its audit metric action label SHALL normalize to `portal_user`
+- **AND** the concrete action suffix, Portal User ID, Tenant ID, email, and target ID SHALL NOT become metric labels
+
+### Requirement: Active Series Ceiling
+
+The Controller SHALL materialize at most 5,000 active Prometheus series.
+A counter or gauge SHALL cost one series for each active label tuple.
+A histogram with `B` finite boundaries and `L` active domain-label tuples SHALL cost `(B + 3) * L`.
+
+The pilot worksheet SHALL be exactly:
+
+- HTTP requests 280; HTTP duration 560;
+- inference requests 160; inference duration 1,040;
+- input tokens 16; output tokens 16; decode throughput 176;
+- scheduler decisions 6; scheduler duration 14; queue depth 4; scheduler rejections 7;
+- heartbeat lag 4; available memory 4; swap used 4; active requests 16;
+- model-load duration 208; model resident 16; worker crashes 16;
+- quota rejections 16; API-key authentication failures 1; audit events 36.
+
+The total SHALL be 2,600, leaving 2,400 series of headroom below 5,000.
+
+Orchard SHALL own a bounded in-memory Series Admission registry in front of counter and histogram emission and a shared atomic Cardinality Ledger across event and gauge paths.
+Series Admission SHALL normalize a new label tuple, calculate the tuple's complete family cost, and atomically admit it only within the identifier, family worksheet, and global ceilings before emitting to the core reporter.
+Series Admission and the core reporter SHALL share one generation: they SHALL restart together with empty state, or metrics SHALL remain fail-closed until both cleanly start in the same new generation.
+Previously admitted counter/histogram tuples and their identifier references SHALL remain charged for that generation.
+The Gauge Snapshot Store SHALL validate the complete candidate replacement against its family and global ceilings before replacement.
+No unsupported core pre-materialization API is required.
+
+A rejected tuple or snapshot SHALL NOT be aliased or coalesced.
+It SHALL mark reporting degraded, emit only a bounded rate-limited structured log, and make authorized scrapes return `503`.
+A valid later gauge snapshot MAY clear gauge degradation; missed counter/histogram history SHALL NOT be reconstructed.
+Admission unavailability, meaning a bounded deadline expiry, an unavailable admission or ledger process, or a contained exception, SHALL be tracked as a distinct recoverable degradation class that a later successful admission MAY clear, while a rejected counter/histogram tuple SHALL keep its generation degraded.
+
+#### Scenario: Prospective counter tuple exceeds a ceiling
+
+- **WHEN** Orchard's Series Admission registry determines that a normalized tuple would exceed its family or global ceiling
+- **THEN** it does not emit the first event for that tuple to the core reporter
+- **AND** authoritative Controller work continues
+- **AND** authorized scrapes return sanitized `503`
+
+#### Scenario: Histogram budget is calculated
+
+- **WHEN** a histogram has `B` finite boundaries and `L` active domain-label tuples
+- **THEN** its worksheet subtotal is exactly `(B + 3) * L`
+
+#### Scenario: Portal User audit domain remains within the pilot ceiling
+
+- **WHEN** the twelve bounded audit action domains combine with the three bounded audit outcomes
+- **THEN** the audit-events family ceiling SHALL be exactly 36 series
+- **AND** the pilot total SHALL be 2,600 series
+- **AND** the 5,000-series ceiling SHALL retain 2,400 series of headroom

--- a/openspec/changes/define-portal-lifecycle-audit-contract/specs/developer-api-key-portal/spec.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/specs/developer-api-key-portal/spec.md
@@ -1,0 +1,148 @@
+## ADDED Requirements
+
+### Requirement: Portal Lifecycle Mutations Produce Atomic Tenant Audit Evidence
+
+Every effective Portal User lifecycle mutation SHALL commit one tenant-scoped audit row inside the same outermost `AuditWriter.transaction/1` boundary as its authoritative state changes.
+`AuditWriter.transaction/1` SHALL NOT be nested inside another transaction that owns the authoritative mutation.
+The row and mutation SHALL roll back together when audit insertion fails.
+Portal User creation SHALL use `portal_user.invited`.
+The first Copy invite action SHALL use `portal_user.invite_issued`, and a later Copy invite action that replaces an invite observed under the locked Portal User SHALL use `portal_user.invite_reissued`.
+Successful invite redemption SHALL use `portal_user.invite_redeemed`.
+An effective Portal User disablement SHALL use `portal_user.disabled`.
+Portal-owned API Key mint and effective revoke SHALL reuse `api_key.created` and `api_key.revoked`.
+
+Every row SHALL use the owning Organization's `tenant_id`.
+Portal User actions SHALL target `target_type = 'portal_user'` and the affected Portal User ID.
+API Key actions SHALL target `target_type = 'api_key'`, the affected API Key ID, and the matching `api_key_id`.
+Console actions SHALL use `actor_type = 'operator'`, a null `actor_id`, and `surface = 'console'` until Console authenticates a first-class operator identity.
+Successful redemption and Portal-owned key mutations SHALL use `actor_type = 'user'`, the Portal User ID as `actor_id`, and `surface = 'developer_portal'` as audit provenance only.
+This provenance SHALL NOT make a Portal User an Operator, Public Inference principal, or other platform principal.
+
+Audit rows SHALL represent committed effective mutations without a persisted outcome field.
+A rejected request or true no-op SHALL NOT create a success audit row.
+Successful audit telemetry SHALL be emitted only after the authoritative transaction commits, and a rolled-back transaction SHALL NOT emit a succeeded observation.
+This refines `SPEC.md` sections 7.4a, 8.2, 9.1, and 10.9.
+
+#### Scenario: Portal User creation records the invited identity
+
+- **WHEN** Console successfully creates a Portal User
+- **THEN** the Portal User and one `portal_user.invited` audit row SHALL commit atomically
+- **AND** the row SHALL be tenant-scoped, use the shared Console operator provenance, and target the Portal User
+- **AND** creation SHALL NOT mint or store a Portal Invite token or return a Portal Invite URL
+
+#### Scenario: First Copy invite is classified under the Portal User lock
+
+- **WHEN** an operator uses Copy invite and no invite row exists after the invited Portal User is locked
+- **THEN** Orchard SHALL classify the mutation as `portal_user.invite_issued`
+- **AND** Orchard SHALL generate the fresh token and calculate its expiry after acquiring that lock
+- **AND** the replacement hash-only invite row, target-user session termination, and audit row SHALL commit atomically
+- **AND** the invite row and audit payload SHALL use that exact expiry
+- **AND** the plaintext URL SHALL be returned only after the transaction commits
+
+#### Scenario: Later Copy invite is classified as reissue under the lock
+
+- **WHEN** an operator uses Copy invite and an invite row exists after the invited Portal User is locked
+- **THEN** Orchard SHALL classify the mutation as `portal_user.invite_reissued`
+- **AND** Orchard SHALL generate the fresh token and calculate its expiry after acquiring that lock
+- **AND** Orchard SHALL delete and replace the prior invite row without retaining invalidation history
+- **AND** the replacement hash-only invite row, target-user session termination, and audit row SHALL commit atomically
+
+#### Scenario: Concurrent Copy invite actions use locked mutation-time classification
+
+- **WHEN** concurrent Copy invite actions target one invited Portal User with no stored invite
+- **THEN** classification SHALL serialize on the Portal User lock
+- **AND** exactly one committed action SHALL be `portal_user.invite_issued`
+- **AND** each later committed replacement SHALL be `portal_user.invite_reissued`
+- **AND** each serialized replacement SHALL calculate expiry under the lock so the stored expiry extends rather than moves backward
+- **AND** classification SHALL NOT depend on pre-transaction state
+
+#### Scenario: Successful redemption records Portal User provenance
+
+- **WHEN** a valid unexpired Organization-bound invite activates its currently invited Portal User through `POST /portal/:organization_slug/invites/:token`
+- **THEN** activation, `redeemed_at`, target-user session termination, and `portal_user.invite_redeemed` SHALL commit atomically
+- **AND** the audit actor SHALL be `user` with the activated Portal User ID
+- **AND** that actor provenance SHALL NOT authorize the Portal User outside the Developer Portal
+
+#### Scenario: Ineligible redemption remains mutation-free and unaudited as success
+
+- **WHEN** redemption uses the wrong Organization or an invalid, expired, redeemed, disabled-user, or unknown invite
+- **THEN** Orchard SHALL preserve the existing generic invalid-invite response
+- **AND** Orchard SHALL persist no lifecycle mutation or success audit row
+- **AND** a valid invite submitted through the wrong Organization SHALL remain usable through its owning Organization
+
+#### Scenario: Disable records only an effective transition
+
+- **WHEN** an operator disables a Portal User who is not already disabled
+- **THEN** the status change, outstanding-unused-invite deletion, target-user session termination, and `portal_user.disabled` SHALL commit atomically
+- **AND** the audit row SHALL use shared Console operator provenance and target the Portal User
+- **AND** the Portal User's API Keys SHALL remain unchanged
+
+#### Scenario: Repeated disable is a true no-op
+
+- **WHEN** an operator disables a Portal User who is already disabled
+- **THEN** Orchard SHALL return the persisted disabled state without rewriting `disabled_at` or advancing the session epoch
+- **AND** Orchard SHALL NOT create another `portal_user.disabled` row or succeeded audit observation
+
+#### Scenario: Portal key mint reuses the API Key action
+
+- **WHEN** an authorized Portal User mints a tenant-direct API Key
+- **THEN** Orchard SHALL carry the validated session tenant ID, Portal User ID, and password epoch into the transaction
+- **AND** Orchard SHALL lock that tenant-scoped Portal User first and revalidate active status and the captured epoch before cap enforcement
+- **AND** the key and one `api_key.created` audit row SHALL commit atomically while cap enforcement remains serialized on that Portal User
+- **AND** the row SHALL target the API Key and record the Portal User as actor provenance
+- **AND** Orchard SHALL return the show-once key secret only after the transaction commits
+
+#### Scenario: Portal key revoke records only an effective transition
+
+- **WHEN** an authorized Portal User revokes their active Portal-owned API Key
+- **THEN** Orchard SHALL lock and revalidate the tenant-scoped Portal User against the captured session epoch before locking the API Key
+- **AND** the lock order SHALL be Portal User then API Key
+- **AND** the active-to-revoked transition and one `api_key.revoked` row SHALL commit atomically
+- **AND** the row SHALL target the API Key and record the Portal User as actor provenance
+- **AND** a later revoke of the already revoked key SHALL create no mutation, duplicate row, or succeeded observation
+
+#### Scenario: Stale Portal session cannot authorize a key mutation
+
+- **WHEN** a Portal key mint or revoke reaches the transaction after the validated session epoch no longer matches the locked Portal User
+- **THEN** Orchard SHALL reject the mutation as an invalid session
+- **AND** Orchard SHALL NOT create, revoke, or lock an API Key before that rejection
+- **AND** Orchard SHALL NOT create a success audit row or succeeded observation
+
+#### Scenario: Audit insertion failure rolls back the mutation
+
+- **WHEN** a required Portal lifecycle or Portal-owned API Key audit insertion fails
+- **THEN** the authoritative domain mutation SHALL roll back
+- **AND** no secret-bearing success result SHALL be published
+- **AND** no `outcome = 'succeeded'` audit observation SHALL be emitted
+
+### Requirement: Portal Audit Payloads Are Bounded And Secret-Free
+
+Portal lifecycle audit payloads SHALL use a closed per-action allowlist.
+`portal_user.invited`, `portal_user.invite_redeemed`, and `portal_user.disabled` SHALL include exactly `surface`.
+`portal_user.invite_issued` and `portal_user.invite_reissued` SHALL include exactly `surface` and `expires_at`.
+Console `surface` SHALL be `console`, and redemption `surface` SHALL be `developer_portal`.
+Invite `expires_at` SHALL be the replacement invite expiry encoded as a UTC ISO 8601 string.
+
+Portal-owned `api_key.created` and `api_key.revoked` SHALL include `name`, `token_prefix`, `owner_type`, `surface`, `issuance_surface`, and `portal_user_id`.
+They SHALL include `expires_at` when the key has an expiry and SHALL omit it otherwise.
+`owner_type` SHALL be `tenant`.
+`surface` and `issuance_surface` SHALL be `developer_portal`.
+`portal_user_id` SHALL be the canonical Portal User UUID string, and API Key `expires_at` SHALL be a UTC ISO 8601 string.
+
+Payloads SHALL NOT contain an invite token, invite hash, invite URL, password, password hash, Portal session token, Portal session hash, API Key plaintext secret, API Key secret hash, email address, request header, source address, raw error, arbitrary request parameter, or `previous_invite_existed`.
+The issue-versus-reissue action name SHALL be the only durable classification of whether a prior invite row existed.
+This refines `SPEC.md` sections 8.2, 10.8, and 10.9.
+
+#### Scenario: Invite issue payload contains only bounded non-secret context
+
+- **WHEN** Orchard commits `portal_user.invite_issued` or `portal_user.invite_reissued`
+- **THEN** the payload SHALL contain only the originating surface and the new expiry
+- **AND** the target columns SHALL identify the Portal User
+- **AND** the payload SHALL NOT retain the prior invite's existence, token, hash, URL, or any user email
+
+#### Scenario: Portal API Key payload excludes key secrets
+
+- **WHEN** Orchard commits a Portal-owned `api_key.created` or `api_key.revoked` row
+- **THEN** the payload MAY contain only the approved bounded API Key and Portal provenance fields
+- **AND** the target columns and `api_key_id` SHALL identify the API Key
+- **AND** the payload SHALL NOT contain the plaintext secret or secret hash

--- a/openspec/changes/define-portal-lifecycle-audit-contract/tasks.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/tasks.md
@@ -1,0 +1,51 @@
+## 1. Owner Review Gates
+
+- [ ] 1.1 Approve or revise `portal_user.invited`, `portal_user.invite_issued`, `portal_user.invite_reissued`, `portal_user.invite_redeemed`, and `portal_user.disabled`.
+- [ ] 1.2 Approve separate Portal User creation and first invite issuance events.
+- [ ] 1.3 Approve `user` plus Portal User ID as successful redemption and Portal key actor provenance.
+- [ ] 1.4 Approve committed-effective-transition audit rows without a persisted outcome field.
+- [ ] 1.5 Approve no duplicate success audit for rejected requests, repeated disable, or repeated revoke.
+- [ ] 1.6 Approve Console `operator` provenance with null actor ID and `surface = "console"`.
+- [ ] 1.7 Approve the per-action non-secret payload allowlist and the exclusion of `previous_invite_existed`.
+- [ ] 1.8 Confirm that PR #300 invite lifecycle, route, persistence, and key-survival semantics remain unchanged while accepting the explicit repeated-disable, repeated-revoke, and stale-session behavior changes in this proposal.
+
+## 2. Portal Audit Implementation
+
+- [ ] 2.1 Make one outermost `AuditWriter.transaction/1` call own each Portal User creation, invite issue or reissue, redemption, disablement, and Portal-owned API Key mint or revoke mutation.
+- [ ] 2.2 Insert the required tenant-scoped audit row in the same transaction as each effective mutation.
+- [ ] 2.3 Roll back the complete mutation and withhold any secret-bearing success result when audit insertion fails.
+- [ ] 2.4 Classify initial issuance versus reissue from invite-row state observed under the locked Portal User.
+- [ ] 2.5 Generate the Copy invite token and calculate its expiry only after the Portal User lock, persist that exact expiry in the invite and audit row, and return the matching plaintext URL only after commit.
+- [ ] 2.6 Carry the validated Portal session tenant ID, Portal User ID, and password epoch into key mutations; lock and revalidate the active Portal User and matching epoch before applying the Portal User then API Key lock order.
+- [ ] 2.7 Make repeated disable and Portal revoke true no-ops with no timestamp rewrite, session-epoch change, duplicate audit row, or success telemetry.
+- [ ] 2.8 Enforce the approved actor, target, and secret-free payload contract.
+- [ ] 2.9 Preserve Portal User-first lock ordering for Copy invite, redemption, disablement, and Portal-owned key mutations.
+
+## 3. Metrics Implementation
+
+- [ ] 3.1 Map every `portal_user.*` audit action to the bounded `portal_user` action domain.
+- [ ] 3.2 Add `portal_user` to the metrics normalizer's closed audit action vocabulary.
+- [ ] 3.3 Raise the audit-events family ceiling from 24 to 36.
+- [ ] 3.4 Reconcile the accepted worksheet to 2,600 total series and 2,400 series of headroom without absorbing the issue #121-owned 229-series attempt/retry drift into this change.
+- [ ] 3.5 Prove that successful audit telemetry is emitted only after the outermost `AuditWriter.transaction/1` commits, including a regression test that forbids publishing from a nested audit transaction before an outer rollback.
+
+## 4. Regression Coverage
+
+- [ ] 4.1 Cover each effective action's tenant scope, actor, target, timestamp, and payload.
+- [ ] 4.2 Inject audit insertion failures and prove complete mutation rollback and absence of success telemetry.
+- [ ] 4.3 Cover concurrent first Copy invite classification and prove one issued event followed by reissued events, lock-time token and expiry generation, and monotonically extending stored expiry under serialization.
+- [ ] 4.4 Cover repeated disable and repeated revoke as mutation-free no-ops.
+- [ ] 4.5 Cover invalid, expired, redeemed, wrong-Organization, disabled-user, and unknown-token redemption as mutation-free without success audit evidence.
+- [ ] 4.6 Assert that every prohibited secret, secret-derived value, email, raw request field, and `previous_invite_existed` is absent.
+- [ ] 4.7 Cover the twelve-domain by three-outcome metrics ceiling.
+- [ ] 4.8 Cover Portal key mint and revoke rejection when the validated session epoch is stale at locked mutation time, and prove the API Key is not locked or mutated first.
+
+## 5. Contract Reconciliation And Validation
+
+- [ ] 5.1 Reconcile accepted owner decisions into `SPEC.md`, accepted OpenSpec specs, product docs, and implementation tests in the later implementation PR.
+- [ ] 5.2 Run the complete applicable Elixir format, compile, Credo, Dialyzer, test, and coverage workflow for implementation changes.
+- [ ] 5.3 Run focused Portal governance, Console, endpoint, audit writer, and metrics suites.
+- [ ] 5.4 Run strict targeted and all-spec OpenSpec validation.
+- [ ] 5.5 Scan accepted specs and the change package for placeholder purpose text, unfinished markers, and contradictory stale lifecycle language.
+- [ ] 5.6 Obtain independent contract and code review before archive.
+- [ ] 5.7 Record a future Devin or mawarduri trigger only if implementation later reaches a genuinely macOS-specific Orchard.app, launchd, Keychain, DMG-installed, HTTPS, clipboard, or accessibility boundary that portable browser tests and hosted macOS CI cannot prove.


### PR DESCRIPTION
## Summary

This proposal gives owners one review vehicle for atomic audit evidence across the settled Portal User lifecycle and Portal-owned API Key mutations.
It follows the invite-lifecycle reconciliation in #300 and keeps implementation separate until the audit vocabulary and provenance rules are accepted.

The proposed contract:

- defines distinct Portal User creation, first-issue, reissue, redemption, and disable actions;
- reuses `api_key.created` and `api_key.revoked` for Portal-owned keys;
- makes one outermost `AuditWriter.transaction/1` boundary own each effective mutation and audit row;
- emits successful audit telemetry only after commit;
- classifies Copy invite under the Portal User lock and generates the matching token and expiry after that lock;
- revalidates Portal key mutation authority under the Portal User lock before any API Key lock;
- defines strict actor, target, and secret-free payload representations; and
- adds one bounded `portal_user` audit metric domain.

The accepted metrics worksheet moves from 2,588 to 2,600 series, with 2,400 series of headroom.
The current catalog's separate 229-series attempt and retry drift remains with its existing owner and is not accepted through this proposal.

## Owner decisions

Review is requested on six explicit recommendations:

1. Record Portal User creation and first invite issuance as separate events.
2. Attribute successful redemption and Portal key mutations to `actor_type = "user"` with the Portal User ID as provenance only.
3. Treat a committed append-only row as the successful outcome without a persisted outcome field.
4. Write no duplicate success row for rejected requests or true repeated-disable and repeated-revoke no-ops.
5. Keep shared Console provenance as `operator`, null actor ID, and `surface = "console"`.
6. Use the strict per-action payload allowlist and omit `previous_invite_existed`.

## Scope boundaries

- No product code, migration, runtime metric, or test implementation changes.
- No `SPEC.md`, ADR, glossary, or Console design change before owner acceptance.
- No reintroduction of invite invalidation history or `invalidated_at`.
- No change to the invited-only, Organization-bound POST redemption route.
- No automatic API Key revocation when a Portal User is disabled.
- No closure of the related lifecycle issue.

## Verification

- `env OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate define-portal-lifecycle-audit-contract --type change --strict --no-interactive` - passed.
- `env OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` - 36 passed, 0 failed.
- `git diff --cached --check` - passed before commit.
- Placeholder scan for standalone `TBD` or `Purpose TBD` prose - no matches.
- Independent RepoPrompt Oracle review - GO with no remaining actionable findings.

The Elixir workflow was not run because the diff contains only one active OpenSpec package and no product code or runtime configuration.

## Risk Assessment

✅ **Low**

- Runtime blast radius is zero because this PR changes only an unaccepted OpenSpec proposal.
- No database, authorization, secret handling, API, or telemetry behavior changes in this PR.
- The package keeps all six durable audit decisions behind explicit owner review.
- Later implementation remains blocked on acceptance and on independent reconciliation of the attempt and retry metrics drift.

## Related

Related: #279

Related: #121


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only proposal defines the future atomic audit contract for Portal User lifecycle and Portal-owned API Key mutations.

- Establishes stable actions, actor and target provenance, bounded secret-free payloads, effective-transition semantics, and post-commit telemetry.
- Specifies locking and transaction boundaries for invite, redemption, disablement, key mint, and key revoke flows.
- Adds the bounded `portal_user` metrics domain and updates the accepted audit worksheet from 24 to 36 series and the pilot total from 2,588 to 2,600.
- Defers all runtime, migration, metric, and test implementation work until the owner decisions are accepted.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge as a documentation-only proposal with internally consistent lifecycle, transaction, and metrics requirements.

The proposal introduces no executable changes, and its specified transaction boundaries, concurrency rules, deferred implementation tasks, and worksheet arithmetic are mutually consistent with the investigated repository contracts.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openspec/changes/define-portal-lifecycle-audit-contract/design.md | Defines the proposed audit vocabulary, atomic transaction model, locking rules, provenance, payload allowlists, failure semantics, and metrics accounting without changing runtime behavior. |
| openspec/changes/define-portal-lifecycle-audit-contract/specs/developer-api-key-portal/spec.md | Adds complete behavioral requirements and scenarios for atomic Portal lifecycle and API Key audit evidence, including concurrency and stale-session handling. |
| openspec/changes/define-portal-lifecycle-audit-contract/specs/controller-prometheus-metrics/spec.md | Adds the bounded portal_user domain and consistently updates the audit ceiling and accepted worksheet arithmetic. |
| openspec/changes/define-portal-lifecycle-audit-contract/tasks.md | Tracks owner gates, deferred implementation, regression coverage, and later contract reconciliation for all proposed requirements. |
| openspec/changes/define-portal-lifecycle-audit-contract/proposal.md | Clearly states the owner decisions, scope boundaries, deferred implementation impact, and intentionally unresolved metrics drift. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Portal as Portal Governance
    participant User as Locked Portal User
    participant Domain as Invite or API Key
    participant Audit as AuditWriter
    participant DB as Database
    participant Metrics as Audit Telemetry

    Caller->>Portal: Request lifecycle mutation
    Portal->>Audit: Begin outermost transaction
    Audit->>DB: Begin transaction
    Portal->>User: Lock and revalidate state or session epoch
    Portal->>Domain: Apply effective mutation
    Portal->>Audit: Insert tenant-scoped audit row
    Audit->>DB: Commit mutation and audit atomically
    DB-->>Audit: Commit succeeds
    Audit->>Metrics: Emit succeeded observation after commit
    Audit-->>Portal: Return committed result
    Portal-->>Caller: Return success or show-once secret
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(portal): define lifecycle audit con..."](https://github.com/kapitan-ai/orchard/commit/22116f771374fb75519ad22b6dd052b8306c017e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58506118)</sub>

<!-- /greptile_comment -->