### PR TITLE
fix(dispatch): reject dead queued acceptance waiters

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch_capacity/allocation_authority.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch_capacity/allocation_authority.ex
@@ -77,7 +77,10 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    init_arg = %{quarantine_store: Keyword.get(opts, :quarantine_store, QuarantineStore)}
+    init_arg = %{
+      quarantine_store: Keyword.get(opts, :quarantine_store, QuarantineStore),
+      acceptance_gate_queue_observer: Keyword.get(opts, :acceptance_gate_queue_observer)
+    }
 
     case Keyword.get(opts, :name, __MODULE__) do
       nil -> GenServer.start_link(__MODULE__, init_arg)
@@ -407,7 +410,10 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
   defp release_guardian(%AcceptanceLease{}), do: :ok
 
   @impl true
-  def init(%{quarantine_store: quarantine_store}) do
+  def init(%{
+        acceptance_gate_queue_observer: acceptance_gate_queue_observer,
+        quarantine_store: quarantine_store
+      }) do
     base = %{
       authority_incarnation: make_ref(),
       claims: %{},
@@ -415,7 +421,8 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
       request_claims: %{},
       monitors: %{},
       gates: %{},
-      gate_monitors: %{}
+      gate_monitors: %{},
+      acceptance_gate_queue_observer: acceptance_gate_queue_observer
     }
 
     case resolve_quarantine_store(quarantine_store) do
@@ -533,7 +540,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
         {:reply, {:ok, lease}, state}
 
       gate ->
-        {:noreply, enqueue_gate_waiter(state, node_id, gate, {from, :infinity})}
+        {:noreply, enqueue_gate_waiter(state, node_id, gate, {from, :infinity, nil})}
     end
   end
 
@@ -550,7 +557,7 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
         {:reply, :expired, state}
 
       gate = Map.get(state.gates, node_id) ->
-        {:noreply, enqueue_gate_waiter(state, node_id, gate, {from, deadline})}
+        {:noreply, enqueue_gate_waiter(state, node_id, gate, {from, deadline, abort_pid})}
 
       true ->
         {lease, state} = put_gate_owner(state, node_id, from, :queue.new())
@@ -813,27 +820,49 @@ defmodule Orchard.DispatchCapacity.AllocationAuthority do
 
   defp enqueue_gate_waiter(state, node_id, gate, waiter) do
     waiters = :queue.in(waiter, gate.waiters)
-    %{state | gates: Map.put(state.gates, node_id, %{gate | waiters: waiters})}
+    state = %{state | gates: Map.put(state.gates, node_id, %{gate | waiters: waiters})}
+    notify_gate_queue_observer(state.acceptance_gate_queue_observer, node_id)
+    state
   end
+
+  defp notify_gate_queue_observer({observer, tag}, node_id) when is_pid(observer) do
+    send(observer, {tag, :acceptance_gate_waiter_queued, node_id})
+    :ok
+  end
+
+  defp notify_gate_queue_observer(_observer, _node_id), do: :ok
 
   defp advance_gate(state, node_id, waiters) do
     case :queue.out(waiters) do
       {:empty, _waiters} ->
         %{state | gates: Map.delete(state.gates, node_id)}
 
-      {{:value, {from, deadline}}, remaining_waiters} ->
-        grant_gate_to_waiter(state, node_id, from, deadline, remaining_waiters)
+      {{:value, {from, deadline, abort_pid}}, remaining_waiters} ->
+        grant_gate_to_waiter(state, node_id, from, deadline, abort_pid, remaining_waiters)
     end
   end
 
-  defp grant_gate_to_waiter(state, node_id, {owner, _tag} = from, deadline, remaining_waiters) do
-    if gate_waiter_live?(owner, deadline) do
-      {lease, state} = put_gate_owner(state, node_id, from, remaining_waiters)
-      GenServer.reply(from, {:ok, lease})
-      state
-    else
-      GenServer.reply(from, :expired)
-      advance_gate(state, node_id, remaining_waiters)
+  defp grant_gate_to_waiter(
+         state,
+         node_id,
+         {owner, _tag} = from,
+         deadline,
+         abort_pid,
+         remaining_waiters
+       ) do
+    cond do
+      is_pid(abort_pid) and not Process.alive?(abort_pid) ->
+        GenServer.reply(from, :caller_down)
+        advance_gate(state, node_id, remaining_waiters)
+
+      gate_waiter_live?(owner, deadline) ->
+        {lease, state} = put_gate_owner(state, node_id, from, remaining_waiters)
+        GenServer.reply(from, {:ok, lease})
+        state
+
+      true ->
+        GenServer.reply(from, :expired)
+        advance_gate(state, node_id, remaining_waiters)
     end
   end
 

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs
@@ -638,6 +638,65 @@ defmodule Orchard.DispatchCapacity.AllocationAuthorityTest do
     assert :ok = QueueManager.release_acceptance_gate(lease, authority: authority)
   end
 
+  test "SPEC 5.9 a dead queued caller is skipped before later FIFO waiters" do
+    test_pid = self()
+    observer_tag = make_ref()
+
+    authority =
+      start_supervised!(
+        {AllocationAuthority, name: nil, acceptance_gate_queue_observer: {test_pid, observer_tag}}
+      )
+
+    node_id = Ecto.UUID.generate()
+    caller = spawn(fn -> Process.sleep(:infinity) end)
+    caller_ref = Process.monitor(caller)
+
+    assert {:ok, holder} =
+             AllocationAuthority.try_acquire_acceptance_gate(authority, node_id, 100)
+
+    waiter =
+      Task.async(fn ->
+        AllocationAuthority.try_acquire_acceptance_gate(
+          authority,
+          node_id,
+          1_000,
+          nil,
+          caller
+        )
+      end)
+
+    assert_receive {^observer_tag, :acceptance_gate_waiter_queued, ^node_id}
+
+    successor =
+      Task.async(fn ->
+        {:ok, lease} = AllocationAuthority.acquire_acceptance_gate(authority, node_id)
+        send(test_pid, {:successor_granted, self()})
+
+        receive do
+          :release -> AllocationAuthority.release_acceptance_gate(authority, lease)
+        end
+      end)
+
+    assert_receive {^observer_tag, :acceptance_gate_waiter_queued, ^node_id}
+
+    Process.exit(caller, :kill)
+    assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
+
+    assert :ok = AllocationAuthority.release_acceptance_gate(authority, holder)
+
+    assert {:error, :dispatch_capacity_caller_down} = Task.await(waiter)
+    assert_receive {:successor_granted, successor_pid}
+    assert successor_pid == successor.pid
+
+    send(successor.pid, :release)
+    assert :ok = Task.await(successor)
+
+    assert {:ok, next_lease} =
+             AllocationAuthority.try_acquire_acceptance_gate(authority, node_id, 100)
+
+    assert :ok = AllocationAuthority.release_acceptance_gate(authority, next_lease)
+  end
+
   test "SPEC 5.9 a policy mutation gives up bounded instead of waiting out a dispatch" do
     authority = start_supervised!({AllocationAuthority, name: nil})
     node_id = Ecto.UUID.generate()

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -2963,10 +2963,17 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
   end
 
   test "SPEC 5.9 caller death while waiting for acceptance prevents execution" do
-    authority = start_supervised!({AllocationAuthority, name: nil})
+    observer_tag = make_ref()
+
+    authority =
+      start_supervised!(
+        {AllocationAuthority, name: nil, acceptance_gate_queue_observer: {self(), observer_tag}}
+      )
+
     node_id = claim_node_id()
     request_id = "request-caller-death-during-acceptance-wait"
     caller = spawn(fn -> Process.sleep(:infinity) end)
+    caller_ref = Process.monitor(caller)
 
     {:ok, held_lease} = QueueManager.acquire_acceptance_gate(node_id, authority: authority)
 
@@ -2983,11 +2990,25 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     try do
       assert_receive :model_loaded
+      assert_receive {^observer_tag, :acceptance_gate_waiter_queued, ^node_id}
       Process.exit(caller, :kill)
+      assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
+
       assert :ok = QueueManager.release_acceptance_gate(held_lease, authority: authority)
 
-      assert {:ok, outcome} = Task.yield(dispatch, 250)
-      assert_dispatch_failure(outcome, :request_caller_disconnect)
+      assert %AttemptOutcome{
+               attempt_outcome: :cancelled,
+               node_id: ^node_id,
+               accepted: false,
+               events: [],
+               failure: %{
+                 "failure_class" => "cancellation",
+                 "failure_code" => "request_caller_disconnect"
+               },
+               execution_resolution: :not_started,
+               capacity_release_outcome: :released,
+               output_committed: false
+             } = Task.await(dispatch)
 
       refute_receive :execute_called
       assert AllocationAuthority.claim_count(authority, node_id) == 0


### PR DESCRIPTION
## Context

Linux portable control-plane run `33320467369` exposed a caller-death race in the dispatch acceptance gate.
The request caller died while the dispatch guardian waited behind a held per-Node gate, but the FIFO queue had discarded the caller PID.
When the holder released the gate, the authority could grant the dead caller's guardian before `RequestDispatcher` observed its separate `DOWN` message, allowing execution to complete instead of returning `request_caller_disconnect`.

This change restores the existing `SPEC.md` section 5.9 contract.
It does not change policy, persistence, APIs, or the accepted-request boundary.

## What changed

- Preserve the optional caller abort PID in every bounded acceptance-gate FIFO entry.
- Re-check caller liveness at the queued handoff before creating a lease.
- Reply with the existing caller-down result and advance to the next live FIFO waiter without leaking gate ownership or monitor state.
- Add an optional non-blocking queue observer used only to synchronize deterministic tests.
- Add authority-level coverage proving a dead head waiter is skipped before a live successor.
- Strengthen the dispatcher regression to wait for the exact queued state and assert the complete cancelled `AttemptOutcome`, no runtime execution, released capacity, and a reusable gate.

## Verification

TDD proof:

- Red: `mise exec -- mix test apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs:641`
  - Seed `463774`
  - Expected `{:error, :dispatch_capacity_caller_down}` but received an acceptance lease.
- Green stress: `mise exec -- mix test --repeat-until-failure 50 apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs:641 apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs:2965`
  - 51 consecutive runs completed, 102 focused test executions passed.
- `mise exec -- mix test apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs`
  - 109 passed.
- `mise exec -- mix test apps/orchard_controller/test/orchard/dispatch_capacity`
  - 175 passed.

Required Orchard workflow:

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
  - 750 files, 90 checks, no issues.
- `mise exec -- mix dialyzer`
  - 0 errors, 0 skipped.
- `make macos-native-test-helpers`
- `mise exec -- mix test`
  - `orchard_shared`: 218 passed.
  - `orchard_controller`: 3,705 passed, 5 skipped.
  - `orchard_node_agent`: 431 passed.
  - `orchard_cli`: 681 passed, 1 skipped, 10 excluded.
- `mise exec -- mix test --cover`
  - `orchard_shared`: 67.29%.
  - `orchard_controller`: 85.5%.
  - `orchard_node_agent`: 78.91%.
  - `orchard_cli`: 76.40%.

Independent review:

- RepoPrompt Investigate and pair passes confirmed the lost queue state as the root cause and recommended the narrow authority handoff fix.
- RepoPrompt Review returned GO with no production correctness blocker.
- RepoPrompt Oracle returned GO and its deterministic dispatcher-test recommendation is included in this diff.

## Risk Assessment

⚠️ **Medium**

- The blast radius is limited to the serialized per-Node dispatch acceptance gate, but this is a concurrency-sensitive execution boundary.
- The change is fail-closed for a caller already known to be dead at queued handoff.
- Live FIFO ordering, deadline handling, guardian cleanup, and later-waiter progress remain covered.
- There is no schema, migration, API, packaging, compatibility, or accepted-request boundary change.

Closes #321


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves caller identity in bounded acceptance-gate waiters and skips callers known to be dead when the FIFO handoff occurs. It also adds a test-only queue observer and deterministic authority/dispatcher regression coverage.

- Adds `abort_pid` to queued gate entries and returns the existing caller-down result during handoff.
- Advances directly to the next live FIFO waiter without assigning ownership to a known-dead caller.
- Strengthens tests for cancellation outcome, capacity release, runtime suppression, and gate reuse.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The caller-death handoff race should be fixed before merging because a caller can still die between the liveness snapshot and lease grant, allowing runtime execution to begin.

The new handoff rejects callers already dead when inspected, but caller death and the dispatcher monitor notification remain unsynchronized with lease creation, preserving a reachable execution-after-disconnect window.

**Files Needing Attention:** apps/orchard_controller/lib/orchard/dispatch_capacity/allocation_authority.ex
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/dispatch_capacity/allocation_authority.ex | Carries caller PIDs through the FIFO and skips known-dead waiters, but the snapshot liveness check leaves a check-to-grant caller-death window. |
| apps/orchard_controller/test/orchard/dispatch_capacity/allocation_authority_test.exs | Adds deterministic coverage for a caller that is confirmed dead before gate release and verifies live-successor progress and gate reuse. |
| apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs | Synchronizes on queue insertion and verifies the complete cancellation outcome, no runtime call, released capacity, and reusable gate. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Dispatcher
    participant Authority
    participant Runtime
    Caller->>Dispatcher: Dispatch request
    Dispatcher->>Authority: Queue gate request with abort_pid
    Note over Authority: Existing holder releases gate
    Authority->>Authority: "Process.alive?(abort_pid) == true"
    Caller--xDispatcher: Caller exits
    Authority-->>Dispatcher: Grant acceptance lease
    alt DOWN not yet in dispatcher mailbox
        Dispatcher->>Runtime: Start inference
        Dispatcher-->>Dispatcher: Receive caller DOWN later
    else DOWN already available
        Dispatcher->>Authority: Release lease
        Dispatcher-->>Caller: Caller-disconnect cancellation
    end
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kapitan-ai%2Forchard%22%20on%20the%20existing%20branch%20%22najibninaba%2Ffix-dispatch-caller-death-race%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22najibninaba%2Ffix-dispatch-caller-death-race%22.%0A%0AGreploop%20kapitan-ai%2Forchard%20PR%20%23323%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=kapitan-ai%2Forchard&pr=323&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kapitan-ai%2Forchard%22%20on%20the%20existing%20branch%20%22najibninaba%2Ffix-dispatch-caller-death-race%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22najibninaba%2Ffix-dispatch-caller-death-race%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Forchard_controller%2Flib%2Forchard%2Fdispatch_capacity%2Fallocation_authority.ex%3A851-854%0A**Caller%20death%20remains%20unsynchronized**%0A%0AWhen%20the%20caller%20exits%20after%20%60Process.alive%3F%2F1%60%20returns%20true%20but%20before%20its%20monitor%20notification%20is%20processed%2C%20the%20authority%20grants%20the%20guardian%20a%20lease%20and%20the%20dispatcher%20can%20start%20inference%20for%20the%20disconnected%20caller.%20This%20leaves%20the%20caller-disconnect%20contract%20violated%20at%20the%20new%20check-to-grant%20boundary.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=kapitan-ai%2Forchard&pr=323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Forchard_controller%2Flib%2Forchard%2Fdispatch_capacity%2Fallocation_authority.ex%3A851-854%0A**Caller%20death%20remains%20unsynchronized**%0A%0AWhen%20the%20caller%20exits%20after%20%60Process.alive%3F%2F1%60%20returns%20true%20but%20before%20its%20monitor%20notification%20is%20processed%2C%20the%20authority%20grants%20the%20guardian%20a%20lease%20and%20the%20dispatcher%20can%20start%20inference%20for%20the%20disconnected%20caller.%20This%20leaves%20the%20caller-disconnect%20contract%20violated%20at%20the%20new%20check-to-grant%20boundary.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=kapitan-ai%2Forchard&pr=323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/orchard_controller/lib/orchard/dispatch_capacity/allocation_authority.ex:851-854
**Caller death remains unsynchronized**

When the caller exits after `Process.alive?/1` returns true but before its monitor notification is processed, the authority grants the guardian a lease and the dispatcher can start inference for the disconnected caller. This leaves the caller-disconnect contract violated at the new check-to-grant boundary.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dispatch): reject dead queued accept..."](https://github.com/kapitan-ai/orchard/commit/34945fa511807bdf3b5015683a4ece0da1a36568) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58508067)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->