### PR TITLE
feat: audit Portal lifecycle mutations atomically

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2985,8 +2985,12 @@ LIVE /portal/:organization_slug/keys
 Portal User accounts SHALL be operator-invite only, with no public signup or self-registration.
 Email SHALL be the Portal User identifier and SHALL be unique by normalized value within one Organization.
 SMTP SHALL NOT be required.
+Creating a Portal User SHALL persist the invited identity and `portal_user.invited` audit row atomically without creating a Portal Invite row.
 For a Portal User in `invited` status, the Console SHALL provide Copy invite.
 Each Copy invite action SHALL mint a fresh single-use token, persist only its hash, extend the invite expiry, and invalidate every prior unused invite token for that Portal User.
+A Copy invite mutation SHALL lock the Portal User before observing invite-row state, generating the token, or calculating the expiry.
+The first committed Copy invite SHALL use `portal_user.invite_issued`, and a later committed replacement SHALL use `portal_user.invite_reissued`.
+Concurrent Copy actions SHALL serialize so exactly one initial issue is recorded and every later replacement extends the stored expiry.
 A Portal User SHALL have at most one stored invite row at a time.
 Invite invalidation SHALL delete the stored invite row rather than tombstone it, and Orchard SHALL NOT retain invite revocation history.
 Orchard SHALL NOT persist the plaintext invite token or URL.
@@ -3006,15 +3010,20 @@ The operator SHALL invite and disable Portal Users from the existing Console Org
 Disabling a Portal User SHALL atomically invalidate every outstanding invite by deleting its stored row, and SHALL end only that Portal User's portal sessions.
 Disabling a Portal User SHALL NOT revoke that Portal User's API Keys.
 Invite reissue, invite redemption, and Portal User disablement SHALL NOT revoke minted API Keys.
+Repeated disable SHALL be a true no-op that does not rewrite timestamps, advance the session epoch, or create another successful audit observation.
 
 The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'` and `portal_user_id` equal to the signed-in Portal User.
 A Portal User MAY have at most 10 active portal-minted tenant-direct keys.
 Revoked and expired keys SHALL NOT count toward that ceiling.
 The mint transaction SHALL serialize on the Portal User, not the Organization.
+Portal key mint and revoke SHALL carry the validated session tenant ID, Portal User ID, and password epoch into one outer transaction.
+That transaction SHALL lock and revalidate the Portal User before enforcing the mint cap or locking an API Key.
+The lock order for revoke SHALL be Portal User then API Key, and a stale captured epoch SHALL fail as an invalid session before any API Key lock or mutation.
 Operator-minted tenant-direct keys SHALL NOT count toward that ceiling, SHALL remain operator-only, and SHALL NOT be visible or revocable from the portal.
 The portal SHALL list and revoke only portal-minted keys whose `portal_user_id` and `tenant_id` match the signed-in Portal User and Organization.
 Keys owned by another Portal User or another Organization SHALL be indistinguishable from missing keys on portal list and revoke paths.
 Portal revoke SHALL take effect on the next Public Inference authentication.
+Repeated Portal revoke SHALL be a true no-op that does not rewrite `revoked_at` or `updated_at` and does not create another successful audit observation.
 
 Legacy portal-minted keys with `portal_user_id IS NULL` SHALL remain valid `orchard_sk_*` Bearer credentials until explicitly revoked.
 Legacy unowned portal-minted keys SHALL remain operator-visible only, SHALL NOT be claimable by a Portal User, and SHALL NOT be listed or revoked from the portal.
@@ -4687,6 +4696,12 @@ Metric labels SHALL use closed vocabularies and SHALL NOT contain Request IDs, N
 * `orchard_api_key_auth_failures_total`
 * `orchard_audit_events_total{action,outcome}`
 
+The audit action label SHALL use only `tenant`, `api_key`, `service_account`, `role_binding`, `routing_policy`, `tenant_model_access`, `support_bundle`, `node_admission`, `node_lifecycle`, `circuit_breaker`, `cluster`, or `portal_user`.
+The audit outcome label SHALL use only `succeeded`, `failed`, or `denied`.
+Those twelve domains and three outcomes reserve exactly 36 audit series.
+The accepted Portal lifecycle metrics floor is 2,600 series.
+The already accepted and implemented inference attempt and retry families add 229 series, so the runtime worksheet SHALL total 2,829 and retain 2,171 series of headroom below the 5,000-series ceiling.
+
 ### 9.2 Tracing
 
 Required trace spans:
@@ -4976,7 +4991,26 @@ Audit logs SHALL capture:
 * support bundle generation
 * upgrade actions
 
-Audit payloads SHALL exclude plaintext API Token secrets, Portal User passwords, Portal Invite tokens and URLs, and Developer Portal session tokens.
+Every effective Portal User creation, invite issue or reissue, redemption, disablement, Portal-owned API Key mint, and effective revoke SHALL commit its tenant-scoped audit row inside the same outermost `AuditWriter.transaction/1` boundary as the authoritative mutation.
+The mutation and audit row SHALL roll back together when audit insertion fails, and no secret-bearing success result SHALL be returned.
+Successful audit telemetry SHALL be emitted only after that outer transaction commits.
+A direct audit insertion inside an unmanaged transaction SHALL fail before persistence.
+A savepoint-rolled-back audit row SHALL NOT publish a queued success observation.
+Failure to verify post-commit metric eligibility SHALL mark metrics reporting degraded without altering the already committed domain result or withholding its success value, and a later successful verification MAY recover that degradation.
+A rejected request or true no-op SHALL NOT create a success audit row or succeeded audit observation.
+
+Portal User creation SHALL use `portal_user.invited`.
+First invite issuance SHALL use `portal_user.invite_issued`, invite replacement SHALL use `portal_user.invite_reissued`, redemption SHALL use `portal_user.invite_redeemed`, and effective disablement SHALL use `portal_user.disabled`.
+Portal-owned API Key mint and effective revoke SHALL reuse `api_key.created` and `api_key.revoked`.
+Console actions SHALL use `actor_type = 'operator'`, null `actor_id`, and `surface = 'console'`.
+Redemption and Portal-owned key actions SHALL use `actor_type = 'user'`, the Portal User ID as `actor_id`, and `surface = 'developer_portal'` as provenance only.
+Portal User actions SHALL target the Portal User, while key actions SHALL target the API Key and set the matching `api_key_id`.
+
+Portal lifecycle audit payloads SHALL use closed per-action allowlists.
+`portal_user.invited`, `portal_user.invite_redeemed`, and `portal_user.disabled` SHALL contain exactly `surface`.
+`portal_user.invite_issued` and `portal_user.invite_reissued` SHALL contain exactly `surface` and the committed invite `expires_at`.
+Portal-owned `api_key.created` and `api_key.revoked` SHALL contain only `name`, `token_prefix`, `owner_type`, `surface`, `issuance_surface`, `portal_user_id`, and `expires_at` when present.
+Audit payloads SHALL exclude plaintext API Token secrets, API Key secret hashes, Portal User email addresses or passwords, Portal Invite tokens, hashes, or URLs, Developer Portal session tokens or hashes, raw request fields, source addresses, raw errors, and `previous_invite_existed`.
 Provisioning Batch records SHALL include non-secret counts, status, input hash, timestamps, and sanitized error summaries only.
 Observed target references and admission-candidate metadata in audit payloads SHALL be sanitized and MUST NOT include secrets.
 

--- a/apps/orchard_controller/lib/orchard/governance/audit_writer.ex
+++ b/apps/orchard_controller/lib/orchard/governance/audit_writer.ex
@@ -3,12 +3,22 @@ defmodule Orchard.Governance.AuditWriter do
 
   alias Ecto.Changeset
   alias Orchard.Metrics.SeriesAdmission
+  alias Orchard.Metrics.Status
   alias Orchard.Repo
 
   @pending_events_key {__MODULE__, :pending_events}
+  @commit_verification_degradation {:audit_commit_verification, :unavailable}
 
   @spec transaction((-> result)) :: {:ok, result} | {:error, term()} when result: term()
   def transaction(fun) when is_function(fun, 0) do
+    if Process.get(@pending_events_key, :unset) == :unset and Repo.in_transaction?() do
+      {:error, :audit_writer_not_outermost}
+    else
+      run_transaction(fun)
+    end
+  end
+
+  defp run_transaction(fun) do
     previous_events = Process.get(@pending_events_key, :unset)
     Process.put(@pending_events_key, [])
 
@@ -25,10 +35,20 @@ defmodule Orchard.Governance.AuditWriter do
 
   @spec insert(Changeset.t()) :: {:ok, struct()} | {:error, Changeset.t()}
   def insert(%Changeset{} = changeset) do
-    action = Changeset.get_field(changeset, :action)
-    result = Repo.insert(changeset)
-    emit_or_defer(action, result)
-    result
+    if unmanaged_transaction?() do
+      {:error,
+       Changeset.add_error(
+         changeset,
+         :base,
+         "audit writer must own the outermost transaction",
+         validation: :audit_writer_not_outermost
+       )}
+    else
+      action = Changeset.get_field(changeset, :action)
+      result = Repo.insert(changeset)
+      emit_or_defer(action, result)
+      result
+    end
   end
 
   defp emit_or_defer(action, {:ok, _audit_log} = result) do
@@ -41,7 +61,7 @@ defmodule Orchard.Governance.AuditWriter do
   defp emit_or_defer(action, result), do: emit_safely(action, result)
 
   defp publish_committed_events({:ok, _value} = result, events, :unset) do
-    Enum.each(events, fn {action, insert_result} -> emit_safely(action, insert_result) end)
+    Enum.each(events, fn {action, insert_result} -> emit_if_committed(action, insert_result) end)
     result
   end
 
@@ -54,6 +74,29 @@ defmodule Orchard.Governance.AuditWriter do
 
   defp restore_pending_events(:unset), do: Process.delete(@pending_events_key)
   defp restore_pending_events(events), do: Process.put(@pending_events_key, events)
+
+  defp unmanaged_transaction? do
+    Process.get(@pending_events_key, :unset) == :unset and Repo.in_transaction?()
+  end
+
+  defp emit_if_committed(action, {:ok, %{__struct__: schema, id: id}} = result) do
+    committed = commit_verifier().get(schema, id)
+    Status.recover(@commit_verification_degradation)
+    if committed, do: emit_safely(action, result)
+  rescue
+    _exception -> degrade_commit_verification()
+  catch
+    _kind, _reason -> degrade_commit_verification()
+  end
+
+  defp commit_verifier do
+    Application.get_env(:orchard_controller, :audit_commit_verifier_impl, Repo)
+  end
+
+  defp degrade_commit_verification do
+    Status.degrade(@commit_verification_degradation)
+    {:error, :metrics_degraded}
+  end
 
   defp emit_safely(action, result) do
     with {:ok, action_domain} <- action_domain(action) do
@@ -80,6 +123,7 @@ defmodule Orchard.Governance.AuditWriter do
   defp action_domain("node_trust." <> _rest), do: {:ok, "node_admission"}
   defp action_domain("node_lifecycle." <> _rest), do: {:ok, "node_lifecycle"}
   defp action_domain("circuit_breaker." <> _rest), do: {:ok, "circuit_breaker"}
+  defp action_domain("portal_user." <> _rest), do: {:ok, "portal_user"}
   defp action_domain("provisioning_batch." <> _rest), do: {:ok, "service_account"}
   defp action_domain("cluster" <> _rest), do: {:ok, "cluster"}
   defp action_domain(_action), do: :error

--- a/apps/orchard_controller/lib/orchard/governance/portal_governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance/portal_governance.ex
@@ -9,6 +9,8 @@ defmodule Orchard.Governance.PortalGovernance do
   alias Orchard.Governance.{
     ApiKey,
     ApiKeySecret,
+    AuditLog,
+    AuditWriter,
     PortalApiKeySummary,
     PortalInviteToken,
     PortalLoginThrottle,
@@ -32,12 +34,8 @@ defmodule Orchard.Governance.PortalGovernance do
     attrs = Map.new(attrs)
 
     with :ok <- require_https(), {:ok, tenant} <- tenant(tenant_or_id) do
-      %PortalUser{}
-      |> PortalUser.invite_changeset(%{
-        tenant_id: tenant.id,
-        email: attrs[:email] || attrs["email"]
-      })
-      |> Repo.insert()
+      AuditWriter.transaction(fn -> create_invite_transaction(tenant, attrs) end)
+      |> unwrap()
     end
   end
 
@@ -45,17 +43,14 @@ defmodule Orchard.Governance.PortalGovernance do
     with :ok <- require_https(),
          {:ok, tenant} <- tenant(tenant_or_id),
          {:ok, user} <- user_for_tenant(tenant.id, id(user_or_id)) do
-      token = "orchard_pi_" <> random_secret()
-      expires_at = DateTime.add(now(), @invite_seconds, :second)
-
-      Repo.transaction(fn -> copy_invite_transaction(tenant, user.id, token, expires_at) end)
+      AuditWriter.transaction(fn -> copy_invite_transaction(tenant, user.id) end)
       |> unwrap()
     end
   end
 
   def redeem_invite(slug, token, password) do
     with :ok <- require_https(), {:ok, password_hash} <- PortalPassword.hash(password) do
-      Repo.transaction(fn -> redeem_invite_transaction(slug, token, password_hash) end)
+      AuditWriter.transaction(fn -> redeem_invite_transaction(slug, token, password_hash) end)
       |> unwrap()
     end
   end
@@ -83,7 +78,7 @@ defmodule Orchard.Governance.PortalGovernance do
 
   def disable_user(tenant_or_id, user_or_id) do
     with {:ok, tenant} <- tenant(tenant_or_id) do
-      Repo.transaction(fn -> disable_user_transaction(tenant.id, id(user_or_id)) end)
+      AuditWriter.transaction(fn -> disable_user_transaction(tenant.id, id(user_or_id)) end)
       |> unwrap()
     end
   end
@@ -145,9 +140,12 @@ defmodule Orchard.Governance.PortalGovernance do
     attrs = Map.new(attrs)
 
     with :ok <- require_https(),
-         {:ok, %{tenant: tenant, portal_user: user}} <- validate(session_token, slug),
+         {:ok, %{tenant: tenant, portal_user: user, session: session}} <-
+           validate(session_token, slug),
          generated <- ApiKeySecret.generate() do
-      Repo.transaction(fn -> mint_key_transaction(tenant, user, attrs, generated) end)
+      identity = session_identity(tenant, user, session)
+
+      AuditWriter.transaction(fn -> mint_key_transaction(identity, attrs, generated) end)
       |> unwrap()
     end
   end
@@ -189,8 +187,11 @@ defmodule Orchard.Governance.PortalGovernance do
 
   def revoke_key(session_token, slug, key_or_id) do
     with :ok <- require_https(),
-         {:ok, %{tenant: tenant, portal_user: user}} <- validate(session_token, slug) do
-      Repo.transaction(fn -> revoke_key_transaction(tenant, user, key_or_id) end)
+         {:ok, %{tenant: tenant, portal_user: user, session: session}} <-
+           validate(session_token, slug) do
+      identity = session_identity(tenant, user, session)
+
+      AuditWriter.transaction(fn -> revoke_key_transaction(identity, key_or_id) end)
       |> unwrap()
     end
   end
@@ -203,17 +204,34 @@ defmodule Orchard.Governance.PortalGovernance do
     _ -> :ok
   end
 
+  defp create_invite_transaction(tenant, attrs) do
+    case %PortalUser{}
+         |> PortalUser.invite_changeset(%{
+           tenant_id: tenant.id,
+           email: attrs[:email] || attrs["email"]
+         })
+         |> Repo.insert() do
+      {:ok, user} ->
+        insert_portal_user_audit!(user, "portal_user.invited", user.inserted_at)
+        user
+
+      {:error, changeset} ->
+        Repo.rollback(changeset)
+    end
+  end
+
   defp redeem_invite_transaction(slug, token, password_hash) do
-    current = now()
     tenant = redemption_tenant!(slug)
     user_id = redemption_user_id!(tenant.id, token)
     user = lock_invited_user!(tenant.id, user_id, :invalid_invite)
+    current = now()
     invite = lock_valid_invite!(user.id, token, current)
 
     case user |> PortalUser.activation_changeset(password_hash) |> Repo.update() do
       {:ok, active} ->
         invite |> Changeset.change(redeemed_at: current) |> Repo.update!()
         delete_sessions(user.id)
+        insert_portal_user_audit!(user, "portal_user.invite_redeemed", current)
         active
 
       {:error, reason} ->
@@ -221,8 +239,26 @@ defmodule Orchard.Governance.PortalGovernance do
     end
   end
 
-  defp copy_invite_transaction(tenant, user_id, token, expires_at) do
+  defp copy_invite_transaction(tenant, user_id) do
     user = lock_invited_user!(tenant.id, user_id, :portal_user_not_invited)
+    previous_invite = Repo.get_by(PortalInviteToken, portal_user_id: user.id)
+
+    action =
+      if previous_invite, do: "portal_user.invite_reissued", else: "portal_user.invite_issued"
+
+    :telemetry.execute(
+      [:orchard, :governance, :portal_invite, :before_secret_generation],
+      %{},
+      %{portal_user_id: user.id}
+    )
+
+    occurred_at = now()
+    token = "orchard_pi_" <> random_secret()
+
+    expires_at =
+      occurred_at
+      |> DateTime.add(@invite_seconds, :second)
+      |> extending_expiry(previous_invite)
 
     from(row in PortalInviteToken, where: row.portal_user_id == ^user.id)
     |> Repo.delete_all()
@@ -236,6 +272,7 @@ defmodule Orchard.Governance.PortalGovernance do
     |> Repo.insert!()
 
     delete_sessions(user.id)
+    insert_portal_user_audit!(user, action, occurred_at, expires_at)
     %{token: token, url: "/portal/#{tenant.slug}/invites/#{token}", expires_at: expires_at}
   end
 
@@ -291,30 +328,37 @@ defmodule Orchard.Governance.PortalGovernance do
 
     if is_nil(user), do: Repo.rollback(:portal_user_not_found)
 
-    case user |> PortalUser.disable_changeset(now()) |> Repo.update() do
-      {:ok, disabled} ->
-        from(invite in PortalInviteToken,
-          where: invite.portal_user_id == ^user.id and is_nil(invite.redeemed_at)
-        )
-        |> Repo.delete_all()
+    if user.status == "disabled" do
+      user
+    else
+      occurred_at = now()
 
-        delete_sessions(user.id)
-        disabled
+      case user |> PortalUser.disable_changeset(occurred_at) |> Repo.update() do
+        {:ok, disabled} ->
+          from(invite in PortalInviteToken,
+            where: invite.portal_user_id == ^user.id and is_nil(invite.redeemed_at)
+          )
+          |> Repo.delete_all()
 
-      {:error, reason} ->
-        Repo.rollback(reason)
+          delete_sessions(user.id)
+          insert_portal_user_audit!(disabled, "portal_user.disabled", occurred_at)
+          disabled
+
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
     end
   end
 
-  defp mint_key_transaction(tenant, user, attrs, generated) do
-    PortalUser |> where([u], u.id == ^user.id) |> lock("FOR UPDATE") |> Repo.one!()
+  defp mint_key_transaction(identity, attrs, generated) do
+    user = lock_active_session_user!(identity)
 
-    if active_key_count(tenant.id, user.id) >= @active_key_limit,
+    if active_key_count(identity.tenant_id, user.id) >= @active_key_limit,
       do: Repo.rollback(:portal_key_limit_reached)
 
     case %ApiKey{}
          |> ApiKey.tenant_direct_changeset(%{
-           tenant_id: tenant.id,
+           tenant_id: identity.tenant_id,
            portal_user_id: user.id,
            name: attrs[:name] || attrs["name"],
            token_prefix: generated.token_prefix,
@@ -322,27 +366,44 @@ defmodule Orchard.Governance.PortalGovernance do
            issuance_surface: "developer_portal"
          })
          |> Repo.insert() do
-      {:ok, key} -> %{api_key: %{key | secret_hash: nil}, token: generated.token, curl: nil}
-      {:error, reason} -> Repo.rollback(reason)
+      {:ok, key} ->
+        insert_portal_api_key_audit!(user, key, "api_key.created", key.inserted_at)
+        %{api_key: %{key | secret_hash: nil}, token: generated.token, curl: nil}
+
+      {:error, reason} ->
+        Repo.rollback(reason)
     end
   end
 
-  defp revoke_key_transaction(tenant, user, key_or_id) do
+  defp revoke_key_transaction(identity, key_or_id) do
+    user = lock_active_session_user!(identity)
+
     key =
       ApiKey
-      |> where([key], key.id == ^id(key_or_id) and key.tenant_id == ^tenant.id)
+      |> where([key], key.id == ^id(key_or_id) and key.tenant_id == ^identity.tenant_id)
       |> where(
         [key],
-        key.portal_user_id == ^user.id and key.issuance_surface == "developer_portal"
+        key.portal_user_id == ^identity.portal_user_id and
+          key.issuance_surface == "developer_portal"
       )
       |> lock("FOR UPDATE")
       |> Repo.one()
 
     if is_nil(key), do: Repo.rollback(:api_key_not_found)
 
-    case key |> ApiKey.revoke_changeset(%{revoked_at: now()}) |> Repo.update() do
-      {:ok, revoked} -> %{revoked | secret_hash: nil}
-      {:error, reason} -> Repo.rollback(reason)
+    if key.revoked_at do
+      %{key | secret_hash: nil}
+    else
+      occurred_at = now()
+
+      case key |> ApiKey.revoke_changeset(%{revoked_at: occurred_at}) |> Repo.update() do
+        {:ok, revoked} ->
+          insert_portal_api_key_audit!(user, revoked, "api_key.revoked", occurred_at)
+          %{revoked | secret_hash: nil}
+
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
     end
   end
 
@@ -483,6 +544,120 @@ defmodule Orchard.Governance.PortalGovernance do
 
   defp delete_sessions(user_id) do
     from(row in PortalSession, where: row.portal_user_id == ^user_id) |> Repo.delete_all()
+  end
+
+  defp insert_portal_user_audit!(user, action, occurred_at, expires_at \\ nil) do
+    {actor_type, actor_id, surface} = portal_user_audit_provenance(user, action)
+
+    %AuditLog{}
+    |> audit_log_impl().changeset(%{
+      scope: "tenant",
+      tenant_id: user.tenant_id,
+      api_key_id: nil,
+      actor_type: actor_type,
+      actor_id: actor_id,
+      action: action,
+      target_type: "portal_user",
+      target_id: user.id,
+      occurred_at: occurred_at,
+      payload: portal_user_audit_payload(surface, expires_at)
+    })
+    |> AuditWriter.insert()
+    |> case do
+      {:ok, _audit_log} -> :ok
+      {:error, _changeset} -> Repo.rollback(:audit_write_failed)
+    end
+  end
+
+  defp audit_log_impl do
+    Application.get_env(:orchard_controller, :governance_audit_log_impl, AuditLog)
+  end
+
+  defp insert_portal_api_key_audit!(user, key, action, occurred_at) do
+    %AuditLog{}
+    |> audit_log_impl().changeset(%{
+      scope: "tenant",
+      tenant_id: key.tenant_id,
+      api_key_id: key.id,
+      actor_type: "user",
+      actor_id: user.id,
+      action: action,
+      target_type: "api_key",
+      target_id: key.id,
+      occurred_at: occurred_at,
+      payload: portal_api_key_audit_payload(user, key)
+    })
+    |> AuditWriter.insert()
+    |> case do
+      {:ok, _audit_log} -> :ok
+      {:error, _changeset} -> Repo.rollback(:audit_write_failed)
+    end
+  end
+
+  defp portal_api_key_audit_payload(user, key) do
+    %{
+      "name" => key.name,
+      "token_prefix" => key.token_prefix,
+      "owner_type" => "tenant",
+      "surface" => "developer_portal",
+      "issuance_surface" => "developer_portal",
+      "portal_user_id" => user.id
+    }
+    |> maybe_put_expiry(key.expires_at)
+  end
+
+  defp maybe_put_expiry(payload, nil), do: payload
+
+  defp maybe_put_expiry(payload, expires_at),
+    do: Map.put(payload, "expires_at", DateTime.to_iso8601(expires_at))
+
+  defp session_identity(tenant, user, session),
+    do: %{
+      tenant_id: tenant.id,
+      portal_user_id: user.id,
+      session_epoch: session.password_epoch
+    }
+
+  defp lock_active_session_user!(identity) do
+    user =
+      PortalUser
+      |> where(
+        [row],
+        row.id == ^identity.portal_user_id and row.tenant_id == ^identity.tenant_id
+      )
+      |> lock("FOR UPDATE")
+      |> Repo.one()
+
+    if is_nil(user) or user.status != "active" or user.session_epoch != identity.session_epoch,
+      do: Repo.rollback(:invalid_session)
+
+    user
+  end
+
+  defp portal_user_audit_provenance(_user, action)
+       when action in [
+              "portal_user.invited",
+              "portal_user.invite_issued",
+              "portal_user.invite_reissued",
+              "portal_user.disabled"
+            ],
+       do: {"operator", nil, "console"}
+
+  defp portal_user_audit_provenance(user, "portal_user.invite_redeemed"),
+    do: {"user", user.id, "developer_portal"}
+
+  defp portal_user_audit_payload(surface, nil), do: %{"surface" => surface}
+
+  defp portal_user_audit_payload(surface, expires_at) do
+    %{"surface" => surface, "expires_at" => DateTime.to_iso8601(expires_at)}
+  end
+
+  defp extending_expiry(candidate, nil), do: candidate
+
+  defp extending_expiry(candidate, %PortalInviteToken{expires_at: previous}) do
+    if DateTime.compare(candidate, previous) == :gt,
+      do: candidate,
+      else: DateTime.add(previous, 1, :microsecond)
   end
 
   defp user_for_tenant(tenant_id, user_id) do

--- a/apps/orchard_controller/lib/orchard/metrics/catalog.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/catalog.ex
@@ -183,11 +183,11 @@ defmodule Orchard.Metrics.Catalog do
       name: "orchard_audit_events_total",
       type: :counter,
       labels: [:action, :outcome],
-      ceiling: 24
+      ceiling: 36
     }
   ]
 
-  @worksheet_total 2_817
+  @worksheet_total 2_829
   @series_ceiling 5_000
 
   @spec descriptors() :: [map()]
@@ -201,7 +201,7 @@ defmodule Orchard.Metrics.Catalog do
     end
   end
 
-  @spec worksheet_total() :: 2_817
+  @spec worksheet_total() :: 2_829
   def worksheet_total, do: @worksheet_total
 
   @spec series_ceiling() :: 5_000

--- a/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
+++ b/apps/orchard_controller/lib/orchard/metrics/normalizer.ex
@@ -17,7 +17,7 @@ defmodule Orchard.Metrics.Normalizer do
     quota_reason:
       ~w(requests_per_minute input_tokens_per_day output_tokens_per_day tenant_concurrency),
     audit_action:
-      ~w(tenant api_key service_account role_binding routing_policy tenant_model_access support_bundle node_admission node_lifecycle circuit_breaker cluster),
+      ~w(tenant api_key service_account role_binding routing_policy tenant_model_access support_bundle node_admission node_lifecycle circuit_breaker cluster portal_user),
     audit_outcome: ~w(succeeded failed denied)
   }
 

--- a/apps/orchard_controller/lib/orchard/nodes.ex
+++ b/apps/orchard_controller/lib/orchard/nodes.ex
@@ -2767,7 +2767,7 @@ defmodule Orchard.Nodes do
 
   defp record_dispatch_transport_failure_transaction(target_lookup, failure) do
     normalize_dispatch_database_failure(fn ->
-      Repo.transaction(fn ->
+      AuditWriter.transaction(fn ->
         validate_dispatch_transport_identity(target_lookup, failure.node_id)
         record_dispatch_transport_breaker(target_lookup, failure)
       end)

--- a/apps/orchard_controller/test/orchard/governance/audit_writer_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/audit_writer_test.exs
@@ -1,8 +1,12 @@
+defmodule Orchard.Governance.AuditWriterTest.RaisingCommitVerifier do
+  def get(_schema, _id), do: raise("forced commit verification failure")
+end
+
 defmodule Orchard.Governance.AuditWriterTest do
   use Orchard.DataCase, async: false
 
   alias Orchard.Governance.{AuditLog, AuditWriter}
-  alias Orchard.Metrics.Normalizer
+  alias Orchard.Metrics.{Normalizer, Status}
   alias Orchard.Repo
 
   setup do
@@ -24,9 +28,154 @@ defmodule Orchard.Governance.AuditWriterTest do
     {"node_trust.initialized", "node_admission", "succeeded"},
     {"node_lifecycle.cordoned", "node_lifecycle", "succeeded"},
     {"circuit_breaker.node.cleared", "circuit_breaker", "succeeded"},
+    {"portal_user.invited", "portal_user", "succeeded"},
     {"provisioning_batch.failed", "service_account", "failed"},
     {"cluster_admin_bootstrap.minted", "cluster", "succeeded"}
   ]
+
+  test "SPEC.md §10.9 refuses to run inside an independently owned Repo transaction" do
+    ref = attach_metric()
+    owner = self()
+
+    assert {:ok, {:error, :audit_writer_not_outermost}} =
+             Repo.transaction(fn ->
+               AuditWriter.transaction(fn ->
+                 send(owner, :audit_callback_ran)
+
+                 "tenant.created"
+                 |> valid_changeset()
+                 |> AuditWriter.insert()
+               end)
+             end)
+
+    refute_received :audit_callback_ran
+    refute_receive {^ref, _measurements, _metadata}
+    refute Repo.get_by(AuditLog, action: "tenant.created")
+  end
+
+  test "SPEC.md §10.9 refuses a direct audit insert inside an unmanaged transaction" do
+    ref = attach_metric()
+
+    assert {:ok, {:error, changeset}} =
+             Repo.transaction(fn ->
+               "tenant.created"
+               |> valid_changeset()
+               |> AuditWriter.insert()
+             end)
+
+    assert "audit writer must own the outermost transaction" in errors_on(changeset).base
+    refute_receive {^ref, _measurements, _metadata}
+    refute Repo.get_by(AuditLog, action: "tenant.created")
+  end
+
+  test "SPEC.md §9.1 nested audit transactions publish only after the outer commit" do
+    ref = attach_metric()
+
+    assert {:ok, :committed} =
+             AuditWriter.transaction(fn ->
+               assert {:ok, {:ok, %AuditLog{}}} =
+                        AuditWriter.transaction(fn ->
+                          "tenant.created"
+                          |> valid_changeset()
+                          |> AuditWriter.insert()
+                        end)
+
+               refute_receive {^ref, _measurements, _metadata}
+               :committed
+             end)
+
+    assert_receive {^ref, %{value: 1}, %{action: "tenant", outcome: "succeeded"}}
+  end
+
+  test "SPEC.md §9.1 nested audit success cannot escape an outer rollback" do
+    ref = attach_metric()
+
+    assert {:error, :forced_outer_rollback} =
+             AuditWriter.transaction(fn ->
+               assert {:ok, {:ok, %AuditLog{}}} =
+                        AuditWriter.transaction(fn ->
+                          "tenant.created"
+                          |> valid_changeset()
+                          |> AuditWriter.insert()
+                        end)
+
+               Repo.rollback(:forced_outer_rollback)
+             end)
+
+    refute_receive {^ref, _measurements, _metadata}
+    refute Repo.get_by(AuditLog, action: "tenant.created")
+  end
+
+  test "SPEC.md §9.1 a raw inner savepoint rollback cannot publish queued success" do
+    ref = attach_metric()
+
+    assert {:ok, :outer_committed} =
+             AuditWriter.transaction(fn ->
+               Repo.query!("SAVEPOINT audit_writer_inner")
+
+               assert {:ok, %AuditLog{}} =
+                        "tenant.created"
+                        |> valid_changeset()
+                        |> AuditWriter.insert()
+
+               Repo.query!("ROLLBACK TO SAVEPOINT audit_writer_inner")
+
+               :outer_committed
+             end)
+
+    refute_receive {^ref, _measurements, _metadata}
+    refute Repo.get_by(AuditLog, action: "tenant.created")
+  end
+
+  test "SPEC.md §9.1 post-commit verification failure cannot change the committed result" do
+    previous = Application.get_env(:orchard_controller, :audit_commit_verifier_impl, :missing)
+
+    Application.put_env(
+      :orchard_controller,
+      :audit_commit_verifier_impl,
+      Orchard.Governance.AuditWriterTest.RaisingCommitVerifier
+    )
+
+    on_exit(fn ->
+      Status.recover({:audit_commit_verification, :unavailable})
+
+      case previous do
+        :missing -> Application.delete_env(:orchard_controller, :audit_commit_verifier_impl)
+        value -> Application.put_env(:orchard_controller, :audit_commit_verifier_impl, value)
+      end
+    end)
+
+    ref = attach_metric()
+
+    assert {:ok, :committed} =
+             AuditWriter.transaction(fn ->
+               assert {:ok, %AuditLog{}} =
+                        "tenant.created"
+                        |> valid_changeset()
+                        |> AuditWriter.insert()
+
+               :committed
+             end)
+
+    assert Repo.get_by(AuditLog, action: "tenant.created")
+    refute_receive {^ref, _measurements, _metadata}
+    assert :ets.member(Status, {:audit_commit_verification, :unavailable})
+
+    Application.put_env(:orchard_controller, :audit_commit_verifier_impl, Repo)
+
+    assert {:ok, :verified} =
+             AuditWriter.transaction(fn ->
+               assert {:ok, %AuditLog{}} =
+                        "tenant.updated"
+                        |> valid_changeset()
+                        |> AuditWriter.insert()
+
+               :verified
+             end)
+
+    assert_receive {^ref, %{value: 1}, %{action: "tenant", outcome: "succeeded"}}
+    refute :ets.member(Status, {:audit_commit_verification, :unavailable})
+  end
 
   test "SPEC.md §9.1 emits one bounded audit event for every current audit action domain" do
     ref = attach_metric()

--- a/apps/orchard_controller/test/orchard/governance/portal_lifecycle_audit_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/portal_lifecycle_audit_test.exs
@@ -1,0 +1,842 @@
+defmodule Orchard.Governance.PortalLifecycleAuditTest.InvalidAuditLog do
+  alias Orchard.Governance.AuditLog
+
+  def changeset(audit_log, attrs) do
+    attrs = attrs |> Map.new() |> Map.delete(:target_type) |> Map.delete("target_type")
+    AuditLog.changeset(audit_log, attrs)
+  end
+end
+
+defmodule Orchard.Governance.PortalLifecycleAuditTest do
+  use Orchard.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.Governance
+
+  alias Orchard.Governance.{
+    ApiKey,
+    AuditLog,
+    PortalInviteToken,
+    PortalPasswordVerifier,
+    PortalSession,
+    PortalUser,
+    Tenant
+  }
+
+  alias Orchard.Repo
+
+  @password "sixteen-chars-ok"
+
+  setup do
+    if Process.whereis(PortalPasswordVerifier) == nil do
+      start_supervised!(PortalPasswordVerifier)
+    end
+
+    if Process.whereis(Orchard.Metrics.Supervisor) == nil do
+      start_supervised!(Orchard.Metrics.Supervisor)
+    end
+
+    previous_mode = Application.get_env(:orchard_controller, :transport_mode, :__missing__)
+    Application.put_env(:orchard_controller, :transport_mode, :direct_https)
+
+    on_exit(fn ->
+      case previous_mode do
+        :__missing__ -> Application.delete_env(:orchard_controller, :transport_mode)
+        mode -> Application.put_env(:orchard_controller, :transport_mode, mode)
+      end
+    end)
+
+    :ok
+  end
+
+  test "SPEC.md §10.9 Portal User creation commits one bounded invited audit row" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "audit-create", name: "Audit Create"})
+
+    assert {:ok, user} =
+             Governance.create_portal_invite(tenant, %{email: "private@example.com"})
+
+    audit =
+      Repo.one!(
+        from(row in AuditLog,
+          where: row.action == "portal_user.invited" and row.target_id == ^user.id
+        )
+      )
+
+    assert audit.scope == "tenant"
+    assert audit.tenant_id == tenant.id
+    assert audit.api_key_id == nil
+    assert audit.actor_type == "operator"
+    assert audit.actor_id == nil
+    assert audit.target_type == "portal_user"
+    assert audit.target_id == user.id
+    assert audit.occurred_at == user.inserted_at
+    assert audit.payload == %{"surface" => "console"}
+
+    payload = Jason.encode!(audit.payload)
+    refute payload =~ user.email
+    refute payload =~ "token"
+    refute payload =~ "password"
+    refute payload =~ "previous_invite_existed"
+
+    refute Repo.exists?(
+             from(invite in PortalInviteToken, where: invite.portal_user_id == ^user.id)
+           )
+  end
+
+  test "SPEC.md §7.4a first Copy invite classifies and audits under the Portal User lock" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "audit-first-copy", name: "First Copy"})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "copy@example.com"})
+
+    assert {:ok, result} = Governance.copy_portal_invite(tenant, user)
+
+    invite = Repo.get_by!(PortalInviteToken, portal_user_id: user.id)
+
+    audit =
+      Repo.one!(
+        from(row in AuditLog,
+          where: row.action == "portal_user.invite_issued" and row.target_id == ^user.id
+        )
+      )
+
+    assert audit.scope == "tenant"
+    assert audit.tenant_id == tenant.id
+    assert audit.api_key_id == nil
+    assert audit.actor_type == "operator"
+    assert audit.actor_id == nil
+    assert audit.target_type == "portal_user"
+    assert audit.target_id == user.id
+
+    assert audit.payload == %{
+             "surface" => "console",
+             "expires_at" => DateTime.to_iso8601(result.expires_at)
+           }
+
+    assert result.expires_at == invite.expires_at
+    assert result.expires_at == DateTime.add(audit.occurred_at, 604_800, :second)
+    assert invite.token_hash == :crypto.hash(:sha256, result.token)
+
+    evidence = Jason.encode!(audit.payload)
+    refute evidence =~ result.token
+    refute evidence =~ result.url
+    refute evidence =~ user.email
+    refute evidence =~ Base.encode16(invite.token_hash)
+    refute evidence =~ "previous_invite_existed"
+  end
+
+  test "SPEC.md §7.4a concurrent Copy invite calls serialize issued then reissued classification" do
+    :ok = Sandbox.checkin(Repo)
+    slug = "audit-copy-race-#{System.unique_integer([:positive])}"
+    on_exit(fn -> clean_unboxed_tenant!(slug) end)
+
+    {tenant, user} =
+      Sandbox.unboxed_run(Repo, fn ->
+        {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: "Copy Race"})
+        {:ok, user} = Governance.create_portal_invite(tenant, %{email: "race@example.com"})
+        {tenant, user}
+      end)
+
+    start_ref = make_ref()
+    release_lock_ref = make_ref()
+    continue_secret_ref = make_ref()
+    user_id = user.id
+    parent = self()
+
+    handler_id = {__MODULE__, :invite_secret_generation, System.unique_integer([:positive])}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:orchard, :governance, :portal_invite, :before_secret_generation],
+        fn _event, _measurements, metadata, _config ->
+          send(parent, {:before_invite_secret, self(), metadata.portal_user_id})
+
+          receive do
+            {^continue_secret_ref, :continue} -> :ok
+          after
+            5_000 -> raise "timed out waiting to generate the invite secret"
+          end
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    lock_holder =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.transaction(fn ->
+            PortalUser
+            |> where([row], row.id == ^user.id)
+            |> lock("FOR UPDATE")
+            |> Repo.one!()
+
+            send(parent, {:portal_user_lock_held, self()})
+
+            receive do
+              ^release_lock_ref -> :ok
+            after
+              5_000 -> raise "timed out holding the Portal User lock"
+            end
+          end)
+        end)
+      end)
+
+    assert_receive {:portal_user_lock_held, lock_holder_pid}, 2_000
+
+    copy_task = fn ->
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          [[backend_pid]] = Repo.query!("SELECT pg_backend_pid()").rows
+          send(parent, {:copy_ready, self(), backend_pid})
+
+          receive do
+            ^start_ref -> {backend_pid, Governance.copy_portal_invite(tenant, user)}
+          after
+            5_000 -> raise "timed out waiting to start the Copy race"
+          end
+        end)
+      end)
+    end
+
+    first_task = copy_task.()
+    second_task = copy_task.()
+
+    assert_receive {:copy_ready, first_task_pid, first_backend_pid}, 2_000
+    assert_receive {:copy_ready, second_task_pid, second_backend_pid}, 2_000
+    refute first_backend_pid == second_backend_pid
+
+    backend_by_task = %{
+      first_task_pid => first_backend_pid,
+      second_task_pid => second_backend_pid
+    }
+
+    send(first_task.pid, start_ref)
+    send(second_task.pid, start_ref)
+
+    assert_backends_waiting_for_lock!([first_backend_pid, second_backend_pid])
+    refute_received {:before_invite_secret, _pid, ^user_id}
+    send(lock_holder_pid, release_lock_ref)
+    assert {:ok, :ok} = Task.await(lock_holder, 2_000)
+
+    assert_receive {:before_invite_secret, first_copy_pid, ^user_id}, 2_000
+
+    second_backend_pid =
+      backend_by_task |> Map.delete(first_copy_pid) |> Map.values() |> List.first()
+
+    assert_backends_waiting_for_lock!([second_backend_pid])
+    refute_received {:before_invite_secret, _pid, ^user_id}
+    send(first_copy_pid, {continue_secret_ref, :continue})
+
+    assert_receive {:before_invite_secret, second_copy_pid, ^user_id}, 2_000
+    refute second_copy_pid == first_copy_pid
+    send(second_copy_pid, {continue_secret_ref, :continue})
+
+    results =
+      [Task.await(first_task, 5_000), Task.await(second_task, 5_000)]
+      |> Enum.map(fn {_backend_pid, {:ok, result}} -> result end)
+
+    Sandbox.unboxed_run(Repo, fn ->
+      audits =
+        AuditLog
+        |> where([row], row.target_id == ^user.id)
+        |> where(
+          [row],
+          row.action in ["portal_user.invite_issued", "portal_user.invite_reissued"]
+        )
+        |> Repo.all()
+
+      assert Enum.frequencies_by(audits, & &1.action) == %{
+               "portal_user.invite_issued" => 1,
+               "portal_user.invite_reissued" => 1
+             }
+
+      [earlier_expiry, later_expiry] = results |> Enum.map(& &1.expires_at) |> Enum.sort()
+      assert DateTime.compare(later_expiry, earlier_expiry) == :gt
+
+      reissued = Enum.find(audits, &(&1.action == "portal_user.invite_reissued"))
+      issued = Enum.find(audits, &(&1.action == "portal_user.invite_issued"))
+
+      issued_expiry = DateTime.from_iso8601(issued.payload["expires_at"]) |> elem(1)
+      reissued_expiry = DateTime.from_iso8601(reissued.payload["expires_at"]) |> elem(1)
+
+      assert Enum.any?(results, &(&1.expires_at == issued_expiry))
+      assert Enum.any?(results, &(&1.expires_at == reissued_expiry))
+      assert issued.occurred_at == DateTime.add(issued_expiry, -604_800, :second)
+      assert reissued_expiry == later_expiry
+      assert DateTime.compare(reissued.occurred_at, issued.occurred_at) in [:eq, :gt]
+      assert DateTime.compare(reissued.occurred_at, reissued_expiry) == :lt
+
+      assert reissued.scope == "tenant"
+      assert reissued.tenant_id == tenant.id
+      assert reissued.api_key_id == nil
+      assert reissued.actor_type == "operator"
+      assert reissued.actor_id == nil
+      assert reissued.target_type == "portal_user"
+      assert reissued.target_id == user.id
+
+      assert reissued.payload == %{
+               "surface" => "console",
+               "expires_at" => DateTime.to_iso8601(later_expiry)
+             }
+
+      current_invite = Repo.get_by!(PortalInviteToken, portal_user_id: user.id)
+      assert current_invite.expires_at == later_expiry
+      assert Enum.any?(results, &(&1.token |> digest() == current_invite.token_hash))
+    end)
+
+    clean_unboxed_tenant!(slug)
+  end
+
+  test "SPEC.md §10.9 invite redemption commits Portal User provenance atomically" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "audit-redeem", name: "Audit Redeem"})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "redeem@example.com"})
+    {:ok, invite_result} = Governance.copy_portal_invite(tenant, user)
+
+    assert {:ok, active} =
+             Governance.redeem_portal_invite(tenant.slug, invite_result.token, @password)
+
+    invite = Repo.get_by!(PortalInviteToken, portal_user_id: user.id)
+
+    audit =
+      Repo.one!(
+        from(row in AuditLog,
+          where: row.action == "portal_user.invite_redeemed" and row.target_id == ^user.id
+        )
+      )
+
+    assert audit.scope == "tenant"
+    assert audit.tenant_id == tenant.id
+    assert audit.api_key_id == nil
+    assert audit.actor_type == "user"
+    assert audit.actor_id == user.id
+    assert audit.target_type == "portal_user"
+    assert audit.target_id == user.id
+    assert audit.occurred_at == invite.redeemed_at
+    assert audit.payload == %{"surface" => "developer_portal"}
+    assert active.status == "active"
+  end
+
+  test "SPEC.md §10.9 invalid redemption attempts emit no succeeded audit row or metric" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "audit-invalid-redeem", name: "Invalid"})
+
+    {:ok, replaced_user} =
+      Governance.create_portal_invite(tenant, %{email: "replaced@example.com"})
+
+    {:ok, replaced_token} = Governance.copy_portal_invite(tenant, replaced_user)
+    {:ok, current_token} = Governance.copy_portal_invite(tenant, replaced_user)
+
+    {:ok, expired_user} =
+      Governance.create_portal_invite(tenant, %{email: "expired@example.com"})
+
+    {:ok, expired_token} = Governance.copy_portal_invite(tenant, expired_user)
+
+    PortalInviteToken
+    |> Repo.get_by!(portal_user_id: expired_user.id)
+    |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -1, :second))
+    |> Repo.update!()
+
+    {:ok, disabled_user} =
+      Governance.create_portal_invite(tenant, %{email: "disabled@example.com"})
+
+    {:ok, disabled_token} = Governance.copy_portal_invite(tenant, disabled_user)
+    {:ok, _disabled} = Governance.disable_portal_user(tenant, disabled_user)
+
+    {:ok, redeemed_user} =
+      Governance.create_portal_invite(tenant, %{email: "redeemed@example.com"})
+
+    {:ok, redeemed_token} = Governance.copy_portal_invite(tenant, redeemed_user)
+    {:ok, _active} = Governance.redeem_portal_invite(tenant.slug, redeemed_token.token, @password)
+
+    {:ok, other_tenant} =
+      Governance.create_tenant(%{slug: "audit-invalid-redeem-other", name: "Other"})
+
+    ref = attach_audit_metric()
+
+    for token <- [
+          "orchard_pi_invalid",
+          replaced_token.token,
+          expired_token.token,
+          disabled_token.token,
+          redeemed_token.token
+        ] do
+      assert {:error, :invalid_invite} =
+               Governance.redeem_portal_invite(tenant.slug, token, @password)
+    end
+
+    assert {:error, :invalid_invite} =
+             Governance.redeem_portal_invite(other_tenant.slug, current_token.token, @password)
+
+    assert {:ok, _active} =
+             Governance.redeem_portal_invite(tenant.slug, current_token.token, @password)
+
+    assert Repo.aggregate(
+             from(row in AuditLog,
+               where:
+                 row.tenant_id == ^tenant.id and
+                   row.action == "portal_user.invite_redeemed"
+             ),
+             :count
+           ) == 2
+
+    assert_receive {^ref, %{value: 1}, %{action: "portal_user", outcome: "succeeded"}}
+    refute_receive {^ref, _measurements, _metadata}
+  end
+
+  test "SPEC.md §10.9 disable audits one effective transition and repeats as a true no-op" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "audit-disable", name: "Audit Disable"})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "disable@example.com"})
+
+    assert {:ok, disabled} = Governance.disable_portal_user(tenant, user)
+
+    audit =
+      Repo.one!(
+        from(row in AuditLog,
+          where: row.action == "portal_user.disabled" and row.target_id == ^user.id
+        )
+      )
+
+    assert audit.scope == "tenant"
+    assert audit.tenant_id == tenant.id
+    assert audit.api_key_id == nil
+    assert audit.actor_type == "operator"
+    assert audit.actor_id == nil
+    assert audit.target_type == "portal_user"
+    assert audit.target_id == user.id
+    assert audit.occurred_at == disabled.disabled_at
+    assert audit.payload == %{"surface" => "console"}
+
+    ref = attach_audit_metric()
+    assert {:ok, repeated} = Governance.disable_portal_user(tenant, user)
+    assert repeated.disabled_at == disabled.disabled_at
+    assert repeated.session_epoch == disabled.session_epoch
+    assert repeated.updated_at == disabled.updated_at
+
+    assert Repo.aggregate(
+             from(row in AuditLog,
+               where: row.action == "portal_user.disabled" and row.target_id == ^user.id
+             ),
+             :count
+           ) == 1
+
+    refute_receive {^ref, _measurements, %{outcome: "succeeded"}}, 100
+  end
+
+  test "SPEC.md §10.9 Portal key mint commits one bounded user-provenance audit row" do
+    {tenant, user, session} = active_session!("audit-key-mint")
+
+    assert {:ok, minted} =
+             Governance.create_portal_api_key(session.token, tenant.slug, %{name: "workstation"})
+
+    audit = Repo.get_by!(AuditLog, action: "api_key.created", api_key_id: minted.api_key.id)
+
+    assert audit.scope == "tenant"
+    assert audit.tenant_id == tenant.id
+    assert audit.api_key_id == minted.api_key.id
+    assert audit.actor_type == "user"
+    assert audit.actor_id == user.id
+    assert audit.target_type == "api_key"
+    assert audit.target_id == minted.api_key.id
+    assert audit.occurred_at == minted.api_key.inserted_at
+
+    assert audit.payload == %{
+             "name" => "workstation",
+             "token_prefix" => minted.api_key.token_prefix,
+             "owner_type" => "tenant",
+             "surface" => "developer_portal",
+             "issuance_surface" => "developer_portal",
+             "portal_user_id" => user.id
+           }
+
+    evidence = Jason.encode!(audit.payload)
+    refute evidence =~ minted.token
+    refute evidence =~ "secret_hash"
+    refute evidence =~ user.email
+  end
+
+  test "SPEC.md §10.9 Portal key revoke audits one effective transition and repeats as a no-op" do
+    {tenant, user, session} = active_session!("audit-key-revoke")
+
+    {:ok, minted} =
+      Governance.create_portal_api_key(session.token, tenant.slug, %{name: "retired"})
+
+    assert {:ok, revoked} =
+             Governance.revoke_portal_api_key(session.token, tenant.slug, minted.api_key)
+
+    audit = Repo.get_by!(AuditLog, action: "api_key.revoked", api_key_id: minted.api_key.id)
+
+    assert audit.scope == "tenant"
+    assert audit.tenant_id == tenant.id
+    assert audit.api_key_id == minted.api_key.id
+    assert audit.actor_type == "user"
+    assert audit.actor_id == user.id
+    assert audit.target_type == "api_key"
+    assert audit.target_id == minted.api_key.id
+    assert audit.occurred_at == revoked.revoked_at
+
+    assert audit.payload == %{
+             "name" => "retired",
+             "token_prefix" => minted.api_key.token_prefix,
+             "owner_type" => "tenant",
+             "surface" => "developer_portal",
+             "issuance_surface" => "developer_portal",
+             "portal_user_id" => user.id
+           }
+
+    ref = attach_audit_metric()
+
+    assert {:ok, repeated} =
+             Governance.revoke_portal_api_key(session.token, tenant.slug, minted.api_key)
+
+    assert repeated.revoked_at == revoked.revoked_at
+    assert repeated.updated_at == revoked.updated_at
+
+    assert Repo.aggregate(
+             from(row in AuditLog,
+               where: row.action == "api_key.revoked" and row.api_key_id == ^minted.api_key.id
+             ),
+             :count
+           ) == 1
+
+    refute_receive {^ref, _measurements, %{outcome: "succeeded"}}, 100
+  end
+
+  test "SPEC.md §7.4a Portal key mint rejects an epoch that becomes stale after validation" do
+    {tenant, user, session} = active_session!("audit-stale-mint")
+
+    {result, queries} =
+      while_validation_is_paused(
+        fn ->
+          Governance.create_portal_api_key(session.token, tenant.slug, %{name: "stale-mint"})
+        end,
+        fn -> increment_session_epoch!(user) end
+      )
+
+    assert result == {:error, :invalid_session}
+    refute Enum.any?(queries, &String.contains?(&1, ~s|FROM "api_keys"|))
+    refute Repo.get_by(ApiKey, name: "stale-mint")
+    refute Repo.get_by(AuditLog, action: "api_key.created", actor_id: user.id)
+  end
+
+  test "SPEC.md §7.4a Portal key revoke rejects a stale epoch before locking the API key" do
+    {tenant, user, session} = active_session!("audit-stale-revoke")
+    {:ok, minted} = Governance.create_portal_api_key(session.token, tenant.slug, %{name: "kept"})
+
+    {result, queries} =
+      while_validation_is_paused(
+        fn ->
+          Governance.revoke_portal_api_key(session.token, tenant.slug, minted.api_key)
+        end,
+        fn ->
+          increment_session_epoch!(user)
+        end
+      )
+
+    assert result == {:error, :invalid_session}
+    refute Enum.any?(queries, &String.contains?(&1, ~s|FROM "api_keys"|))
+    persisted = Repo.get!(ApiKey, minted.api_key.id)
+    assert persisted.revoked_at == nil
+    refute Repo.get_by(AuditLog, action: "api_key.revoked", api_key_id: persisted.id)
+  end
+
+  test "SPEC.md §10.9 every lifecycle action rolls its domain mutation back on audit failure" do
+    {:ok, creation_tenant} =
+      Governance.create_tenant(%{slug: "audit-fail-create", name: "Audit Fail Create"})
+
+    {:ok, issue_tenant} =
+      Governance.create_tenant(%{slug: "audit-fail-issue", name: "Audit Fail Issue"})
+
+    {:ok, issue_user} =
+      Governance.create_portal_invite(issue_tenant, %{email: "issue@example.com"})
+
+    {:ok, reissue_tenant} =
+      Governance.create_tenant(%{slug: "audit-fail-reissue", name: "Audit Fail Reissue"})
+
+    {:ok, reissue_user} =
+      Governance.create_portal_invite(reissue_tenant, %{email: "reissue@example.com"})
+
+    {:ok, _first_reissue} = Governance.copy_portal_invite(reissue_tenant, reissue_user)
+    original_reissue = Repo.get_by!(PortalInviteToken, portal_user_id: reissue_user.id)
+
+    {:ok, redeem_tenant} =
+      Governance.create_tenant(%{slug: "audit-fail-redeem", name: "Audit Fail Redeem"})
+
+    {:ok, redeem_user} =
+      Governance.create_portal_invite(redeem_tenant, %{email: "redeem@example.com"})
+
+    {:ok, redeem_invite} = Governance.copy_portal_invite(redeem_tenant, redeem_user)
+
+    {disable_tenant, disable_user, disable_session} = active_session!("audit-fail-disable")
+
+    {:ok, disable_key} =
+      Governance.create_portal_api_key(disable_session.token, disable_tenant.slug, %{
+        name: "survives-disable"
+      })
+
+    {mint_tenant, mint_user, mint_session} = active_session!("audit-fail-mint")
+    {revoke_tenant, _revoke_user, revoke_session} = active_session!("audit-fail-revoke")
+
+    {:ok, revoke_key} =
+      Governance.create_portal_api_key(revoke_session.token, revoke_tenant.slug, %{
+        name: "survives-revoke"
+      })
+
+    ref = attach_audit_metric()
+
+    with_invalid_audit(fn ->
+      assert {:error, :audit_write_failed} =
+               Governance.create_portal_invite(creation_tenant, %{
+                 email: "rolled-back@example.com"
+               })
+
+      assert {:error, :audit_write_failed} =
+               Governance.copy_portal_invite(issue_tenant, issue_user)
+
+      assert {:error, :audit_write_failed} =
+               Governance.copy_portal_invite(reissue_tenant, reissue_user)
+
+      assert {:error, :audit_write_failed} =
+               Governance.redeem_portal_invite(
+                 redeem_tenant.slug,
+                 redeem_invite.token,
+                 @password
+               )
+
+      assert {:error, :audit_write_failed} =
+               Governance.disable_portal_user(disable_tenant, disable_user)
+
+      assert {:error, :audit_write_failed} =
+               Governance.create_portal_api_key(mint_session.token, mint_tenant.slug, %{
+                 name: "rolled-back-key"
+               })
+
+      assert {:error, :audit_write_failed} =
+               Governance.revoke_portal_api_key(
+                 revoke_session.token,
+                 revoke_tenant.slug,
+                 revoke_key.api_key
+               )
+    end)
+
+    refute Repo.get_by(PortalUser,
+             tenant_id: creation_tenant.id,
+             email: "rolled-back@example.com"
+           )
+
+    refute Repo.get_by(PortalInviteToken, portal_user_id: issue_user.id)
+
+    persisted_reissue = Repo.get_by!(PortalInviteToken, portal_user_id: reissue_user.id)
+    assert persisted_reissue.id == original_reissue.id
+    assert persisted_reissue.token_hash == original_reissue.token_hash
+    assert persisted_reissue.expires_at == original_reissue.expires_at
+
+    persisted_redeem_user = Repo.get!(PortalUser, redeem_user.id)
+    persisted_redeem_invite = Repo.get_by!(PortalInviteToken, portal_user_id: redeem_user.id)
+    assert persisted_redeem_user.status == "invited"
+    assert persisted_redeem_invite.redeemed_at == nil
+
+    persisted_disable_user = Repo.get!(PortalUser, disable_user.id)
+    assert persisted_disable_user.status == "active"
+    assert persisted_disable_user.session_epoch == disable_user.session_epoch
+    assert Repo.get_by!(PortalSession, token_hash: digest(disable_session.token))
+    assert Repo.get!(ApiKey, disable_key.api_key.id).revoked_at == nil
+
+    refute Repo.get_by(ApiKey,
+             portal_user_id: mint_user.id,
+             name: "rolled-back-key"
+           )
+
+    assert Repo.get!(ApiKey, revoke_key.api_key.id).revoked_at == nil
+
+    for _action <- 1..5 do
+      assert_receive {^ref, %{value: 1}, %{action: "portal_user", outcome: "failed"}}
+    end
+
+    for _action <- 1..2 do
+      assert_receive {^ref, %{value: 1}, %{action: "api_key", outcome: "failed"}}
+    end
+
+    refute_received {^ref, _measurements, %{outcome: "succeeded"}}
+  end
+
+  defp active_session!(slug) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: slug})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "#{slug}@example.com"})
+    {:ok, invite} = Governance.copy_portal_invite(tenant, user)
+    {:ok, user} = Governance.redeem_portal_invite(tenant.slug, invite.token, @password)
+
+    {:ok, session} =
+      Governance.create_portal_session(
+        tenant.slug,
+        user.email,
+        @password,
+        "203.0.113.#{System.unique_integer([:positive])}"
+      )
+
+    {tenant, user, session}
+  end
+
+  defp while_validation_is_paused(operation, mutation) do
+    parent = self()
+    start_ref = make_ref()
+    handler_id = {__MODULE__, :paused_validation, System.unique_integer([:positive])}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:orchard, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          send(parent, {:observed_query, self(), metadata.query})
+
+          if String.contains?(metadata.query, ~s|FROM "portal_users" AS p0|) and
+               not String.contains?(metadata.query, "FOR UPDATE") do
+            send(parent, {:portal_user_validated, self()})
+
+            receive do
+              :continue_after_epoch_change -> :ok
+            after
+              2_000 -> raise "timed out waiting for the epoch change"
+            end
+          end
+        end,
+        nil
+      )
+
+    task =
+      Task.async(fn ->
+        Sandbox.allow(Repo, parent, self())
+
+        receive do
+          ^start_ref -> operation.()
+        end
+      end)
+
+    try do
+      send(task.pid, start_ref)
+      assert_receive {:portal_user_validated, task_pid}, 2_000
+      mutation.()
+      send(task_pid, :continue_after_epoch_change)
+      result = Task.await(task, 2_000)
+      {result, collect_observed_queries(task.pid, [])}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  defp increment_session_epoch!(user) do
+    user
+    |> Ecto.Changeset.change(session_epoch: user.session_epoch + 1)
+    |> Repo.update!()
+  end
+
+  defp collect_observed_queries(task_pid, queries) do
+    receive do
+      {:observed_query, ^task_pid, query} ->
+        collect_observed_queries(task_pid, [query | queries])
+    after
+      0 -> Enum.reverse(queries)
+    end
+  end
+
+  defp assert_backends_waiting_for_lock!(backend_pids) do
+    deadline = System.monotonic_time(:millisecond) + 2_000
+    await_backend_lock_wait(backend_pids, deadline)
+  end
+
+  defp await_backend_lock_wait(backend_pids, deadline) do
+    waiting_count =
+      Sandbox.unboxed_run(Repo, fn ->
+        [[count]] =
+          Repo.query!(
+            "SELECT count(DISTINCT pid) FROM pg_locks WHERE pid = ANY($1::integer[]) AND NOT granted",
+            [backend_pids]
+          ).rows
+
+        count
+      end)
+
+    cond do
+      waiting_count == length(backend_pids) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("expected database backends #{inspect(backend_pids)} to be waiting on locks")
+
+      true ->
+        Process.sleep(10)
+        await_backend_lock_wait(backend_pids, deadline)
+    end
+  end
+
+  defp with_invalid_audit(fun) do
+    key = :governance_audit_log_impl
+    previous = Application.get_env(:orchard_controller, key, :missing)
+
+    Application.put_env(
+      :orchard_controller,
+      key,
+      Orchard.Governance.PortalLifecycleAuditTest.InvalidAuditLog
+    )
+
+    try do
+      fun.()
+    after
+      case previous do
+        :missing -> Application.delete_env(:orchard_controller, key)
+        value -> Application.put_env(:orchard_controller, key, value)
+      end
+    end
+  end
+
+  defp attach_audit_metric do
+    owner = self()
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:orchard, :metrics, :audit_events],
+        fn _event, measurements, metadata, _config ->
+          send(owner, {ref, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    ref
+  end
+
+  defp clean_unboxed_tenant!(slug) do
+    Sandbox.unboxed_run(Repo, fn ->
+      case Repo.get_by(Tenant, slug: slug) do
+        nil ->
+          :ok
+
+        tenant ->
+          user_ids =
+            PortalUser
+            |> where([user], user.tenant_id == ^tenant.id)
+            |> select([user], user.id)
+            |> Repo.all()
+
+          Repo.query!("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")
+
+          try do
+            Repo.delete_all(from(row in AuditLog, where: row.tenant_id == ^tenant.id))
+          after
+            Repo.query!("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
+          end
+
+          Repo.delete_all(from(row in PortalSession, where: row.portal_user_id in ^user_ids))
+          Repo.delete_all(from(row in PortalInviteToken, where: row.portal_user_id in ^user_ids))
+          Repo.delete_all(from(row in ApiKey, where: row.portal_user_id in ^user_ids))
+          Repo.delete_all(from(row in PortalUser, where: row.id in ^user_ids))
+          Repo.delete!(tenant)
+      end
+    end)
+  end
+
+  defp digest(token), do: :crypto.hash(:sha256, token)
+end

--- a/apps/orchard_controller/test/orchard/metrics/metrics_test.exs
+++ b/apps/orchard_controller/test/orchard/metrics/metrics_test.exs
@@ -134,17 +134,35 @@ defmodule Orchard.MetricsTest do
     assert Enum.uniq_by(descriptors, &Catalog.event_name(&1.family)) == descriptors
   end
 
-  test "SPEC.md §9.1 worksheet includes bounded attempt and retry families" do
+  test "SPEC.md §9.1 worksheet reconciles the accepted floor with runtime attempt families" do
     calculated =
       Enum.reduce(Catalog.descriptors(), 0, fn descriptor, total ->
         cost = if descriptor.type == :histogram, do: length(descriptor.buckets) + 3, else: 1
         total + descriptor.ceiling * cost
       end)
 
-    assert calculated == 2_817
-    assert Catalog.worksheet_total() == 2_817
+    assert calculated == 2_829
+    assert Catalog.worksheet_total() == 2_829
     assert Catalog.series_ceiling() == 5_000
-    assert Catalog.series_ceiling() - calculated == 2_183
+    assert calculated - 2_600 == 229
+    assert Catalog.series_ceiling() - calculated == 2_171
+  end
+
+  test "SPEC.md §9.1 admits exactly twelve audit domains by three outcomes" do
+    domains =
+      ~w(tenant api_key service_account role_binding routing_policy tenant_model_access support_bundle node_admission node_lifecycle circuit_breaker cluster portal_user)
+
+    outcomes = ~w(succeeded failed denied)
+
+    assert descriptor!(:audit_events).ceiling == length(domains) * length(outcomes)
+
+    for action <- domains, outcome <- outcomes do
+      assert {:ok, %{action: ^action, outcome: ^outcome}} =
+               Normalizer.normalize(:audit_events, %{action: action, outcome: outcome})
+    end
+
+    assert {:error, :invalid_labels} =
+             Normalizer.normalize(:audit_events, %{action: "portal_user_id", outcome: "succeeded"})
   end
 
   test "bounded normalization rejects unknown categorical values and preserves identifiers" do

--- a/apps/orchard_controller/test/orchard/portal/keys_live_test.exs
+++ b/apps/orchard_controller/test/orchard/portal/keys_live_test.exs
@@ -116,7 +116,10 @@ defmodule Orchard.Portal.KeysLiveTest do
 
     {:ok, view, _html} = live(authed(conn, token), "/portal/portal-keys/keys")
     view |> element("#portal-revoke-#{minted.api_key.id}") |> render_click()
-    Repo.delete!(minted.api_key)
+
+    minted.api_key
+    |> Ecto.Changeset.change(portal_user_id: nil)
+    |> Repo.update!()
 
     view
     |> form("#portal-revoke-modal form", confirmation: "stale-revoke")

--- a/docs/operator-journey.md
+++ b/docs/operator-journey.md
@@ -216,6 +216,11 @@ It is not a claim about the current build.
 6. When access must end, the operator disables that Portal User, which atomically deletes every outstanding invite, ends only that user's portal sessions, and does not automatically revoke minted API Keys.
 7. The operator separately reviews Organization API Keys in Console and deliberately revokes known keys when key access must also end.
 
+Each effective Portal lifecycle action commits its tenant-scoped audit evidence with the authoritative mutation.
+Portal User creation and first Copy invite remain separate audited actions, and later Copy actions are recorded as reissues.
+Repeated disable and repeated key revoke are true no-ops, so operators should not expect duplicate audit rows or rewritten timestamps.
+Audit evidence records bounded actor, target, surface, expiry, and key provenance only and never stores an invite URL, password, session token, API Key secret, email address, or raw request field.
+
 ### Target Controller-Only Journey
 
 The Controller setup is identical through first Console access, but setup labels the cluster **No inference capacity** until a Node becomes active and model-ready.

--- a/openspec/changes/define-portal-lifecycle-audit-contract/design.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/design.md
@@ -6,21 +6,20 @@ The first Copy invite action issues the initial invite, later Copy actions reiss
 Redemption is invited-only, Organization-bound, and uses `POST /portal/:organization_slug/invites/:token`.
 Initial issuance, reissue, redemption, and disablement end the target Portal User's sessions, while existing API Keys remain valid until explicit revocation.
 
-`SPEC.md` section 10.9 nevertheless requires audit evidence for Portal invitation, reissue, redemption, disablement, and API Key creation and revocation.
-The current Portal governance functions use direct `Repo` transactions and do not insert those rows.
-The ordinary governance paths already provide an atomic audit transaction and post-commit success telemetry seam through `AuditWriter.transaction/1`.
+`SPEC.md` section 10.9 requires audit evidence for Portal invitation, reissue, redemption, disablement, and API Key creation and revocation.
+Before this slice, Portal governance functions used direct `Repo` transactions and did not insert those rows.
+The implementation now uses the established atomic audit transaction and post-commit success telemetry seam through `AuditWriter.transaction/1`.
 
-The current metrics implementation recognizes eleven bounded audit action domains, while the accepted metrics worksheet and descriptor ceiling still reserve only 24 audit series from an earlier eight-domain snapshot.
-The implementation catalog also includes 229 attempt and retry series that the accepted metrics contract still assigns to issue #121 and excludes from its 2,588-series worksheet.
-This proposal adds only the `portal_user` audit domain and makes the accepted future target explicit at twelve domains and three outcomes.
-It does not adopt the separate attempt and retry metric families into the accepted contract.
+Before this implementation slice, metrics recognized eleven bounded audit action domains while the descriptor ceiling still reserved only 24 audit series from an earlier eight-domain snapshot.
+The separately accepted issue #121 attempt and retry families contribute a 229-series runtime delta beyond the Portal lifecycle floor.
+This change adds only the `portal_user` audit domain and makes the accepted target explicit at twelve domains and three outcomes.
+It keeps the attempt and retry accounting distinct rather than attributing that delta to Portal lifecycle work.
 The archived metrics design remains historical and is not rewritten.
 
 ## Decision Status
 
-The six choices below are recommendations presented for owner review.
-Merging or accepting the proposal is the act that approves them.
-Until then, the shipped lifecycle remains authoritative and no implementation should infer these choices from issue #279.
+PR #322 accepted the six choices below as the contract for this implementation slice.
+The implementation must preserve the shipped PR #300 lifecycle while applying these audit, no-op, lock-order, and telemetry decisions.
 
 | Decision frontier | Recommendation | Evidence and trade-off |
 |---|---|---|
@@ -45,7 +44,7 @@ Until then, the shipped lifecycle remains authoritative and no implementation sh
 
 ### Five Portal User Actions And Existing API Key Actions
 
-The proposed Portal User actions are:
+The accepted Portal User actions are:
 
 - `portal_user.invited`
 - `portal_user.invite_issued`
@@ -132,11 +131,11 @@ All five `portal_user.*` actions normalize to the single metrics action domain `
 Concrete action suffixes, Portal User IDs, tenant IDs, emails, and target IDs never become audit metric labels.
 The existing outcomes remain `succeeded`, `failed`, and `denied`.
 
-Current code recognizes eleven audit action domains.
+The pre-change code recognized eleven audit action domains.
 Adding `portal_user` produces twelve domains and a family ceiling of 36 series.
 Replacing the accepted worksheet's 24-series audit subtotal with 36 changes the accepted pilot total from 2,588 to 2,600 and leaves 2,400 series below the 5,000-series ceiling.
-The current catalog total of 2,817 includes 229 attempt and retry series that the accepted contract excludes.
-Their reconciliation remains owned by issue #121 and must occur before the later implementation can update the catalog total without silently accepting unrelated behavior.
+The separately accepted issue #121 attempt and retry families add 229 runtime series.
+The reconciled runtime catalog is therefore 2,829 and retains 2,171 series below the ceiling.
 
 ## Transaction Flows
 
@@ -195,7 +194,7 @@ It records only an active-to-revoked transition with `api_key.revoked` and treat
 
 - A single `portal_user.invite_copied` action was rejected because it hides the creation-to-first-issuance boundary settled by PR #300.
 - An outcome field in every audit payload was rejected because the committed append-only row already represents success and the bounded metric owns outcome projection.
-- `system` plus null for successful redemption was rejected as the recommendation because it loses the Portal User provenance established by locked token validation.
+- `system` plus null for successful redemption was rejected because it loses the Portal User provenance established by locked token validation.
 - A named Console actor was rejected because current Console authentication does not establish one.
 - Persisting `previous_invite_existed` was rejected because the action name already carries that classification.
 - An invite-row target was rejected because invite rows are deliberately deleted and are not retained lifecycle history.
@@ -204,10 +203,9 @@ It records only an active-to-revoked transition with `api_key.revoked` and treat
 
 ## Risks And Review Focus
 
-- Action names become durable audit vocabulary after acceptance, so owner review must approve them explicitly.
+- The accepted action names are durable audit vocabulary, so later renaming requires an explicit contract change.
 - Successful redemption provenance must not be read as a new authentication or authorization grant.
-- Current Portal disable and revoke behavior rewrites timestamps on repeats, so later implementation must deliberately adopt the proposed no-op contract.
-- Portal mint and revoke validate their sessions before their mutation transactions today, so later implementation must carry the validated identity and epoch into the transaction and recheck both under a Portal User lock before any API Key lock.
-- The accepted metrics spec and current implementation disagree about both the audit-domain count and issue #121-owned attempt/retry families, so this package updates only the accepted audit subtotal and leaves the unrelated 229-series drift for its owning change.
-- No ADR is warranted for this focused refinement unless owner review selects a broader identity or authority model.
+- The outermost audit transaction must remain the authoritative owner so later refactors cannot publish success before commit.
+- The accepted 2,600-series Portal lifecycle floor and the separate 229-series attempt and retry delta must remain distinguishable even though the runtime catalog reports their 2,829-series sum.
+- No ADR is warranted because this focused refinement does not select a broader identity or authority model.
 - No glossary change is warranted because `Operator`, `Portal User`, `API Key`, and `Audit Log` already name every domain concept used here.

--- a/openspec/changes/define-portal-lifecycle-audit-contract/proposal.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
 `SPEC.md` requires audit evidence for Portal User invitation, reissue, redemption, disablement, and API Key creation and revocation.
-The shipped Portal governance paths do not write those audit rows today.
-PR #300 settled the invitation lifecycle but deliberately left audit actor, action, and outcome vocabulary for a separate owner decision.
-The next safe slice is therefore a focused contract for atomic Portal lifecycle audit evidence, including Portal-owned API Key mint and revoke.
+Before this implementation, the shipped Portal governance paths did not write those audit rows.
+PR #300 settled the invitation lifecycle, and PR #322 accepted the actor, action, outcome, no-op, concurrency, and metrics decisions for this slice.
+This change implements that focused contract for atomic Portal lifecycle audit evidence, including Portal-owned API Key mint and revoke.
 
 ## What Changes
 
-- Propose five stable Portal User audit actions for owner review: `portal_user.invited`, `portal_user.invite_issued`, `portal_user.invite_reissued`, `portal_user.invite_redeemed`, and `portal_user.disabled`.
+- Use five accepted Portal User audit actions: `portal_user.invited`, `portal_user.invite_issued`, `portal_user.invite_reissued`, `portal_user.invite_redeemed`, and `portal_user.disabled`.
 - Reuse `api_key.created` and `api_key.revoked` for Portal-owned API Key mutations rather than creating Portal-specific aliases.
 - Require each effective Portal mutation and its tenant-scoped audit row to commit or roll back through one outermost `AuditWriter.transaction/1` boundary.
 - Require first issuance versus reissue to be classified from invite-row state observed under the existing Portal User lock.
@@ -17,25 +17,24 @@ The next safe slice is therefore a focused contract for atomic Portal lifecycle 
 - Require successful audit telemetry only after the authoritative transaction commits.
 - Add `portal_user` as one bounded audit metric domain and reconcile the audit-family ceiling with the current eleven-domain implementation plus this new domain.
 
-## Recommended Decisions Requiring Owner Review
+## Accepted Decisions
 
-This active change is the review vehicle for the following recommendations.
-None of them is already accepted merely because it appears in this proposal.
+PR #322 accepted the following decisions as the contract for this implementation slice.
 
 1. **Separate creation and first issuance events.**
-   Approve `portal_user.invited` for creation of the invited identity and `portal_user.invite_issued` for the first Copy invite action because PR #300 established them as separate committed mutations.
+   Use `portal_user.invited` for creation of the invited identity and `portal_user.invite_issued` for the first Copy invite action because PR #300 established them as separate committed mutations.
 2. **Attribute successful redemption to Portal User provenance.**
-   Approve `actor_type = "user"` and `actor_id = portal_user.id` for `portal_user.invite_redeemed`, while stating that invite possession is audit provenance only and does not make a Portal User a platform or Public Inference principal.
+   Use `actor_type = "user"` and `actor_id = portal_user.id` for `portal_user.invite_redeemed`, while stating that invite possession is audit provenance only and does not make a Portal User a platform or Public Inference principal.
 3. **Treat the committed row as the successful outcome.**
-   Approve one audit row only for an effective committed mutation, without persisting an `outcome` field in the row or payload.
+   Persist one audit row only for an effective committed mutation, without persisting an `outcome` field in the row or payload.
    Audit insertion failure rolls back the mutation, and only post-commit telemetry may report `succeeded`.
 4. **Do not audit rejected requests or true no-ops as successes.**
-   Approve mutation-free repeated disable and revoke behavior with no duplicate audit row or success telemetry.
+   Keep repeated disable and revoke mutation-free with no duplicate audit row or success telemetry.
    Every successful Copy invite remains an effective mutation because it mints a fresh token and expiry.
 5. **Preserve the shared Console operator model.**
-   Approve `actor_type = "operator"`, null `actor_id`, and `surface = "console"` until Orchard has an authenticated first-class Console operator identity.
+   Use `actor_type = "operator"`, null `actor_id`, and `surface = "console"` until Orchard has an authenticated first-class Console operator identity.
 6. **Use a strict non-secret payload allowlist.**
-   Approve `surface` for every event, `expires_at` for invite issue or reissue, and the existing bounded API Key metadata plus Portal ownership provenance for key events.
+   Allow `surface` for every event, `expires_at` for invite issue or reissue, and the existing bounded API Key metadata plus Portal ownership provenance for key events.
    Do not persist `previous_invite_existed`; the issued or reissued action name already records that classification.
 
 ## Capabilities
@@ -47,20 +46,17 @@ None of them is already accepted merely because it appears in this proposal.
 
 ## Impact
 
-- `SPEC.md` impact: the proposed contract refines sections 7.4a, 8.2, 9.1, and 10.9 without contradicting their current requirements.
-  This shaping PR does not edit `SPEC.md`; an accepted implementation must reconcile the apex contract and accepted specs together if the owner approves these recommendations.
-- Product behavior impact in this PR: none.
-- Persistence impact in this PR: none.
-- Future governance impact: Portal User creation, invite issue and reissue, redemption, disablement, and Portal-owned key mint and revoke gain mandatory atomic audit evidence.
-- Future behavior impact: repeated disable and revoke become true no-ops, and Portal key mint and revoke reject a session whose captured epoch no longer matches the locked Portal User.
-- Future concurrency impact: invite issuance classification, token generation, and expiry calculation occur under the existing Portal User lock, while key mutation authority is revalidated with the lock order Portal User then API Key.
-- Future metrics impact: the accepted bounded audit action vocabulary grows to include `portal_user`, for 36 audit series, 2,600 accepted pilot series, and 2,400 series of headroom.
-  Current code separately includes 229 attempt and retry series that the accepted metrics contract still assigns to issue #121; this package does not absorb or approve that drift.
-- Documentation impact in this PR: one active OpenSpec package only.
+- `SPEC.md` impact: sections 7.4a, 9.1, and 10.9 now state the accepted atomic lifecycle, bounded payload, no-op, lock-order, and metrics contracts.
+- Product behavior impact: repeated disable and revoke are true no-ops, and Portal key mint and revoke reject a session whose captured epoch no longer matches the locked Portal User.
+- Persistence impact: every effective Portal lifecycle and Portal-owned key mutation now commits one append-only audit row atomically without a schema change.
+- Governance impact: Portal User creation, invite issue and reissue, redemption, disablement, and Portal-owned key mint and revoke have mandatory atomic audit evidence.
+- Concurrency impact: invite issuance classification, token generation, and expiry calculation occur under the existing Portal User lock, while key mutation authority is revalidated with the lock order Portal User then API Key.
+- Metrics impact: the bounded audit action vocabulary grows to include `portal_user`, for 36 audit series and a 2,600-series accepted Portal lifecycle floor.
+  The separately accepted issue #121 attempt and retry families add 229 runtime series, producing a 2,829-series runtime worksheet and 2,171 series of headroom.
+- Documentation impact: the apex contract, accepted capability specs, this active package, and the operator journey are reconciled.
 
 ## Non-Goals
 
-- Do not implement product code, migrations, tests, or metrics changes in this shaping PR.
 - Do not reintroduce `invalidated_at`, retained invite invalidation history, or another invite-state column.
 - Do not define active-user recovery, replacement invites, Portal User re-enablement, or Portal User deletion.
 - Do not change the canonical `POST /portal/:organization_slug/invites/:token` redemption route.
@@ -70,4 +66,4 @@ None of them is already accepted merely because it appears in this proposal.
 - Do not persist `previous_invite_existed`, invite tokens, invite hashes, invite URLs, passwords, password hashes, session tokens, session hashes, API Key secrets, or API Key secret hashes in audit evidence.
 - Do not close issue #279.
 - Keep issue #270 independent.
-- Do not add an ADR or glossary term unless owner review selects a broader identity or authority model than the existing `Operator`, `Portal User`, and `Audit Log` concepts.
+- Do not add an ADR or glossary term unless a future accepted change selects a broader identity or authority model than the existing `Operator`, `Portal User`, and `Audit Log` concepts.

--- a/openspec/changes/define-portal-lifecycle-audit-contract/specs/controller-prometheus-metrics/spec.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/specs/controller-prometheus-metrics/spec.md
@@ -58,7 +58,9 @@ The pilot worksheet SHALL be exactly:
 - model-load duration 208; model resident 16; worker crashes 16;
 - quota rejections 16; API-key authentication failures 1; audit events 36.
 
-The total SHALL be 2,600, leaving 2,400 series of headroom below 5,000.
+The accepted Portal lifecycle floor SHALL be 2,600, leaving 2,400 series before separately accepted attempt and retry families.
+The implemented issue #121 attempt and retry families SHALL remain a distinct 229-series runtime delta.
+The runtime worksheet SHALL therefore total 2,829 and retain 2,171 series of headroom below 5,000.
 
 Orchard SHALL own a bounded in-memory Series Admission registry in front of counter and histogram emission and a shared atomic Cardinality Ledger across event and gauge paths.
 Series Admission SHALL normalize a new label tuple, calculate the tuple's complete family cost, and atomically admit it only within the identifier, family worksheet, and global ceilings before emitting to the core reporter.
@@ -84,9 +86,10 @@ Admission unavailability, meaning a bounded deadline expiry, an unavailable admi
 - **WHEN** a histogram has `B` finite boundaries and `L` active domain-label tuples
 - **THEN** its worksheet subtotal is exactly `(B + 3) * L`
 
-#### Scenario: Portal User audit domain remains within the pilot ceiling
+#### Scenario: Portal audit domain remains within the runtime ceiling
 
 - **WHEN** the twelve bounded audit action domains combine with the three bounded audit outcomes
 - **THEN** the audit-events family ceiling SHALL be exactly 36 series
-- **AND** the pilot total SHALL be 2,600 series
-- **AND** the 5,000-series ceiling SHALL retain 2,400 series of headroom
+- **AND** the accepted Portal lifecycle floor SHALL be 2,600 series
+- **AND** the runtime worksheet SHALL be 2,829 after the distinct 229-series attempt and retry delta
+- **AND** the 5,000-series ceiling SHALL retain 2,171 series of headroom

--- a/openspec/changes/define-portal-lifecycle-audit-contract/specs/developer-api-key-portal/spec.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/specs/developer-api-key-portal/spec.md
@@ -21,6 +21,9 @@ This provenance SHALL NOT make a Portal User an Operator, Public Inference princ
 Audit rows SHALL represent committed effective mutations without a persisted outcome field.
 A rejected request or true no-op SHALL NOT create a success audit row.
 Successful audit telemetry SHALL be emitted only after the authoritative transaction commits, and a rolled-back transaction SHALL NOT emit a succeeded observation.
+A direct audit insertion inside an unmanaged transaction SHALL fail before persistence.
+A rolled-back savepoint SHALL NOT leave a publishable success observation.
+Post-commit metric verification failure SHALL mark metrics reporting degraded without altering the committed domain result or withholding its show-once success value, and a later successful verification MAY recover that degradation.
 This refines `SPEC.md` sections 7.4a, 8.2, 9.1, and 10.9.
 
 #### Scenario: Portal User creation records the invited identity

--- a/openspec/changes/define-portal-lifecycle-audit-contract/tasks.md
+++ b/openspec/changes/define-portal-lifecycle-audit-contract/tasks.md
@@ -1,5 +1,8 @@
 ## 1. Owner Review Gates
 
+PR #322 is the authoritative acceptance record for this section.
+These historical owner-review boxes remain unchanged in this implementation scope.
+
 - [ ] 1.1 Approve or revise `portal_user.invited`, `portal_user.invite_issued`, `portal_user.invite_reissued`, `portal_user.invite_redeemed`, and `portal_user.disabled`.
 - [ ] 1.2 Approve separate Portal User creation and first invite issuance events.
 - [ ] 1.3 Approve `user` plus Portal User ID as successful redemption and Portal key actor provenance.
@@ -11,41 +14,41 @@
 
 ## 2. Portal Audit Implementation
 
-- [ ] 2.1 Make one outermost `AuditWriter.transaction/1` call own each Portal User creation, invite issue or reissue, redemption, disablement, and Portal-owned API Key mint or revoke mutation.
-- [ ] 2.2 Insert the required tenant-scoped audit row in the same transaction as each effective mutation.
-- [ ] 2.3 Roll back the complete mutation and withhold any secret-bearing success result when audit insertion fails.
-- [ ] 2.4 Classify initial issuance versus reissue from invite-row state observed under the locked Portal User.
-- [ ] 2.5 Generate the Copy invite token and calculate its expiry only after the Portal User lock, persist that exact expiry in the invite and audit row, and return the matching plaintext URL only after commit.
-- [ ] 2.6 Carry the validated Portal session tenant ID, Portal User ID, and password epoch into key mutations; lock and revalidate the active Portal User and matching epoch before applying the Portal User then API Key lock order.
-- [ ] 2.7 Make repeated disable and Portal revoke true no-ops with no timestamp rewrite, session-epoch change, duplicate audit row, or success telemetry.
-- [ ] 2.8 Enforce the approved actor, target, and secret-free payload contract.
-- [ ] 2.9 Preserve Portal User-first lock ordering for Copy invite, redemption, disablement, and Portal-owned key mutations.
+- [x] 2.1 Make one outermost `AuditWriter.transaction/1` call own each Portal User creation, invite issue or reissue, redemption, disablement, and Portal-owned API Key mint or revoke mutation.
+- [x] 2.2 Insert the required tenant-scoped audit row in the same transaction as each effective mutation.
+- [x] 2.3 Roll back the complete mutation and withhold any secret-bearing success result when audit insertion fails.
+- [x] 2.4 Classify initial issuance versus reissue from invite-row state observed under the locked Portal User.
+- [x] 2.5 Generate the Copy invite token and calculate its expiry only after the Portal User lock, persist that exact expiry in the invite and audit row, and return the matching plaintext URL only after commit.
+- [x] 2.6 Carry the validated Portal session tenant ID, Portal User ID, and password epoch into key mutations; lock and revalidate the active Portal User and matching epoch before applying the Portal User then API Key lock order.
+- [x] 2.7 Make repeated disable and Portal revoke true no-ops with no timestamp rewrite, session-epoch change, duplicate audit row, or success telemetry.
+- [x] 2.8 Enforce the approved actor, target, and secret-free payload contract.
+- [x] 2.9 Preserve Portal User-first lock ordering for Copy invite, redemption, disablement, and Portal-owned key mutations.
 
 ## 3. Metrics Implementation
 
-- [ ] 3.1 Map every `portal_user.*` audit action to the bounded `portal_user` action domain.
-- [ ] 3.2 Add `portal_user` to the metrics normalizer's closed audit action vocabulary.
-- [ ] 3.3 Raise the audit-events family ceiling from 24 to 36.
-- [ ] 3.4 Reconcile the accepted worksheet to 2,600 total series and 2,400 series of headroom without absorbing the issue #121-owned 229-series attempt/retry drift into this change.
-- [ ] 3.5 Prove that successful audit telemetry is emitted only after the outermost `AuditWriter.transaction/1` commits, including a regression test that forbids publishing from a nested audit transaction before an outer rollback.
+- [x] 3.1 Map every `portal_user.*` audit action to the bounded `portal_user` action domain.
+- [x] 3.2 Add `portal_user` to the metrics normalizer's closed audit action vocabulary.
+- [x] 3.3 Raise the audit-events family ceiling from 24 to 36.
+- [x] 3.4 Reconcile the 2,600-series accepted Portal lifecycle floor with the distinct issue #121-owned 229-series attempt/retry delta, yielding a 2,829-series runtime worksheet and 2,171 series of headroom.
+- [x] 3.5 Prove that successful audit telemetry is emitted only after the outermost `AuditWriter.transaction/1` commits, including a regression test that forbids publishing from a nested audit transaction before an outer rollback.
 
 ## 4. Regression Coverage
 
-- [ ] 4.1 Cover each effective action's tenant scope, actor, target, timestamp, and payload.
-- [ ] 4.2 Inject audit insertion failures and prove complete mutation rollback and absence of success telemetry.
-- [ ] 4.3 Cover concurrent first Copy invite classification and prove one issued event followed by reissued events, lock-time token and expiry generation, and monotonically extending stored expiry under serialization.
-- [ ] 4.4 Cover repeated disable and repeated revoke as mutation-free no-ops.
-- [ ] 4.5 Cover invalid, expired, redeemed, wrong-Organization, disabled-user, and unknown-token redemption as mutation-free without success audit evidence.
-- [ ] 4.6 Assert that every prohibited secret, secret-derived value, email, raw request field, and `previous_invite_existed` is absent.
-- [ ] 4.7 Cover the twelve-domain by three-outcome metrics ceiling.
-- [ ] 4.8 Cover Portal key mint and revoke rejection when the validated session epoch is stale at locked mutation time, and prove the API Key is not locked or mutated first.
+- [x] 4.1 Cover each effective action's tenant scope, actor, target, timestamp, and payload.
+- [x] 4.2 Inject audit insertion failures and prove complete mutation rollback and absence of success telemetry.
+- [x] 4.3 Cover concurrent first Copy invite classification and prove one issued event followed by reissued events, lock-time token and expiry generation, and monotonically extending stored expiry under serialization.
+- [x] 4.4 Cover repeated disable and repeated revoke as mutation-free no-ops.
+- [x] 4.5 Cover invalid, expired, redeemed, wrong-Organization, disabled-user, and unknown-token redemption as mutation-free without success audit evidence.
+- [x] 4.6 Assert that every prohibited secret, secret-derived value, email, raw request field, and `previous_invite_existed` is absent.
+- [x] 4.7 Cover the twelve-domain by three-outcome metrics ceiling.
+- [x] 4.8 Cover Portal key mint and revoke rejection when the validated session epoch is stale at locked mutation time, and prove the API Key is not locked or mutated first.
 
 ## 5. Contract Reconciliation And Validation
 
-- [ ] 5.1 Reconcile accepted owner decisions into `SPEC.md`, accepted OpenSpec specs, product docs, and implementation tests in the later implementation PR.
-- [ ] 5.2 Run the complete applicable Elixir format, compile, Credo, Dialyzer, test, and coverage workflow for implementation changes.
-- [ ] 5.3 Run focused Portal governance, Console, endpoint, audit writer, and metrics suites.
-- [ ] 5.4 Run strict targeted and all-spec OpenSpec validation.
-- [ ] 5.5 Scan accepted specs and the change package for placeholder purpose text, unfinished markers, and contradictory stale lifecycle language.
-- [ ] 5.6 Obtain independent contract and code review before archive.
-- [ ] 5.7 Record a future Devin or mawarduri trigger only if implementation later reaches a genuinely macOS-specific Orchard.app, launchd, Keychain, DMG-installed, HTTPS, clipboard, or accessibility boundary that portable browser tests and hosted macOS CI cannot prove.
+- [x] 5.1 Reconcile accepted owner decisions into `SPEC.md`, accepted OpenSpec specs, product docs, and implementation tests in this implementation PR.
+- [x] 5.2 Run the complete applicable Elixir format, compile, Credo, Dialyzer, test, and coverage workflow for implementation changes.
+- [x] 5.3 Run focused Portal governance, Console, endpoint, audit writer, and metrics suites.
+- [x] 5.4 Run strict targeted and all-spec OpenSpec validation.
+- [x] 5.5 Scan accepted specs and the change package for placeholder purpose text, unfinished markers, and contradictory stale lifecycle language.
+- [x] 5.6 Obtain independent contract and code review before archive.
+- [x] 5.7 Record a future Devin or mawarduri trigger only if implementation later reaches a genuinely macOS-specific Orchard.app, launchd, Keychain, DMG-installed, HTTPS, clipboard, or accessibility boundary that portable browser tests and hosted macOS CI cannot prove.

--- a/openspec/specs/controller-prometheus-metrics/spec.md
+++ b/openspec/specs/controller-prometheus-metrics/spec.md
@@ -86,6 +86,8 @@ Categorical inputs SHALL normalize only to the bounded values in the design.
 HTTP status SHALL normalize to `informational`, `success`, `redirect`, `client_error`, or `server_error`, rather than materializing individual status codes.
 Current terminal Request status SHALL normalize only to `completed`, `failed`, `cancelled`, `timed_out`, or `interrupted`.
 Scheduler result, tier, rejection reason, quota reason, audit action domain, and audit outcome SHALL use only the design's listed values and pair constraints.
+Audit action domain SHALL normalize only to `tenant`, `api_key`, `service_account`, `role_binding`, `routing_policy`, `tenant_model_access`, `support_bundle`, `node_admission`, `node_lifecycle`, `circuit_breaker`, `cluster`, or `portal_user`.
+Audit outcome SHALL normalize only to `succeeded`, `failed`, or `denied`.
 Unknown categorical inputs SHALL be dropped and reporting marked degraded.
 
 The pilot SHALL admit at most 4 distinct Tenant identifiers, 4 distinct model identifiers, 4 distinct Node identifiers, and 8 HTTP endpoint categories across all exposed families in one reporter generation.
@@ -111,17 +113,23 @@ Any later external metrics egress SHALL remove tenant and user dimensions before
 - **THEN** Orchard does not materialize that label tuple
 - **AND** reporting becomes degraded without changing the source operation
 
+#### Scenario: Portal lifecycle actions share one bounded domain
+
+- **WHEN** a committed audit action begins with `portal_user.`
+- **THEN** its audit metric action label SHALL normalize to `portal_user`
+- **AND** the concrete suffix, Portal User ID, Tenant ID, email, and target ID SHALL NOT become metric labels
+
 ### Requirement: Logical Request Accounting Across Attempts
 Existing §9.1 logical-Request, admission, scheduler/queue, quota, authentication, audit, token, and client-visible metrics SHALL count at their named logical boundary and SHALL NOT count once per execution attempt.
 Logical inference Request duration SHALL span all attempts.
 Input tokens SHALL count once, output tokens SHALL use final logical chargeable usage, and client-visible terminal status SHALL count once.
-Attempt and retry metric families remain owned by issue #121 and SHALL NOT be added by this change.
+Attempt and retry families SHALL remain distinct from the accepted logical-Request floor and SHALL contribute their separately accepted 229-series runtime delta.
 
 #### Scenario: One logical Request uses multiple attempts
 - **WHEN** a logical Request performs more than one execution attempt before terminalizing
 - **THEN** §9.1 logical Request and client-visible terminal metrics count the Request once
 - **AND** input and final output token accounting are not duplicated
-- **AND** this package emits no attempt or retry family
+- **AND** attempt and retry families count only their separately defined attempt boundaries
 
 ### Requirement: Gauge Snapshot Reconciliation And Staleness
 Orchard SHALL own a bounded in-memory Gauge Snapshot Store that receives complete normalized snapshots from `telemetry_poller` and atomically replaces each gauge family's current map.
@@ -156,9 +164,10 @@ The pilot worksheet SHALL be exactly:
 - scheduler decisions 6; scheduler duration 14; queue depth 4; scheduler rejections 7;
 - heartbeat lag 4; available memory 4; swap used 4; active requests 16;
 - model-load duration 208; model resident 16; worker crashes 16;
-- quota rejections 16; API-key authentication failures 1; audit events 24.
+- quota rejections 16; API-key authentication failures 1; audit events 36.
 
-The total SHALL be 2,588, leaving 2,412 series of headroom below 5,000.
+The accepted Portal lifecycle floor SHALL be 2,600, leaving 2,400 series before separately accepted attempt and retry families.
+The implemented attempt and retry families SHALL add 229 series, so the runtime worksheet SHALL total 2,829 and retain 2,171 series of headroom below 5,000.
 
 Orchard SHALL own a bounded in-memory Series Admission registry in front of counter and histogram emission and a shared atomic Cardinality Ledger across event and gauge paths.
 Series Admission SHALL normalize a new label tuple, calculate the tuple's complete family cost, and atomically admit it only within the identifier, family worksheet, and global ceilings before emitting to the core reporter.
@@ -182,6 +191,14 @@ Admission unavailability, meaning a bounded deadline expiry, an unavailable admi
 - **WHEN** a histogram has `B` finite boundaries and `L` active domain-label tuples
 - **THEN** its worksheet subtotal is exactly `(B + 3) * L`
 
+#### Scenario: Portal audit domain remains within the runtime ceiling
+
+- **WHEN** the twelve bounded audit domains combine with the three bounded outcomes
+- **THEN** the audit-events family ceiling SHALL be exactly 36 series
+- **AND** the accepted Portal lifecycle floor SHALL be 2,600 series
+- **AND** the runtime worksheet SHALL be 2,829 after the 229-series attempt and retry delta
+- **AND** the 5,000-series ceiling SHALL retain 2,171 series of headroom
+
 ### Requirement: Metrics Failure Isolation
 Metrics initialization, event handling, polling, aggregation, admission, snapshot storage, and rendering SHALL be non-authoritative and SHALL NOT prevent Controller boot or alter inference, admission, quota, scheduling, dispatch, recovery, or persistence outcomes.
 Telemetry handlers SHALL perform only bounded in-memory normalization and Series Admission and SHALL be exception-contained with no database, network, filesystem, or domain mutation.
@@ -203,7 +220,7 @@ Rendering SHALL be bounded and SHALL return complete core-plus-gauge exposition 
 - **AND** metrics reporting alone becomes disabled or degraded
 
 ### Requirement: Excluded Observability Surfaces
-This change SHALL NOT add attempt or retry metrics, a collector, metrics backend, tracing, dashboards, alerts, external egress, a Node Agent metrics endpoint, a separate Controller listener, or an HMAC Tenant alias.
+This capability SHALL NOT add another attempt or retry family, a collector, metrics backend, tracing, dashboards, alerts, external egress, a Node Agent metrics endpoint, a separate Controller listener, or an HMAC Tenant alias.
 
 #### Scenario: Worker-crash seam scope is reviewed
 - **WHEN** the issue #123 worker-crash implementation is inspected

--- a/openspec/specs/developer-api-key-portal/spec.md
+++ b/openspec/specs/developer-api-key-portal/spec.md
@@ -226,6 +226,114 @@ This refines `SPEC.md` §7.4a and §10.2.
 - **AND** the next Public Inference request presents that key
 - **THEN** authentication SHALL fail with `401 invalid_api_key`
 
+### Requirement: Portal Lifecycle Mutations Produce Atomic Tenant Audit Evidence
+
+Every effective Portal User lifecycle mutation SHALL commit one tenant-scoped audit row inside the same outermost `AuditWriter.transaction/1` boundary as its authoritative state changes.
+`AuditWriter.transaction/1` SHALL NOT be nested inside another transaction that owns the authoritative mutation.
+The row and mutation SHALL roll back together when audit insertion fails.
+Portal User creation SHALL use `portal_user.invited`.
+The first Copy invite action SHALL use `portal_user.invite_issued`, and a later Copy invite action that replaces an invite observed under the locked Portal User SHALL use `portal_user.invite_reissued`.
+Successful invite redemption SHALL use `portal_user.invite_redeemed`.
+An effective Portal User disablement SHALL use `portal_user.disabled`.
+Portal-owned API Key mint and effective revoke SHALL reuse `api_key.created` and `api_key.revoked`.
+
+Every row SHALL use the owning Organization's `tenant_id`.
+Portal User actions SHALL target `target_type = 'portal_user'` and the affected Portal User ID.
+API Key actions SHALL target `target_type = 'api_key'`, the affected API Key ID, and the matching `api_key_id`.
+Console actions SHALL use `actor_type = 'operator'`, a null `actor_id`, and `surface = 'console'`.
+Successful redemption and Portal-owned key mutations SHALL use `actor_type = 'user'`, the Portal User ID as `actor_id`, and `surface = 'developer_portal'` as audit provenance only.
+This provenance SHALL NOT make a Portal User an Operator, Public Inference principal, or other platform principal.
+
+Audit rows SHALL represent committed effective mutations without a persisted outcome field.
+A rejected request or true no-op SHALL NOT create a success audit row.
+Successful audit telemetry SHALL be emitted only after the authoritative transaction commits, and a rolled-back transaction SHALL NOT emit a succeeded observation.
+A direct audit insertion inside an unmanaged transaction SHALL fail before persistence.
+A rolled-back savepoint SHALL NOT leave a publishable success observation.
+Post-commit metric verification failure SHALL mark metrics reporting degraded without altering the committed domain result or withholding its show-once success value, and a later successful verification MAY recover that degradation.
+This refines `SPEC.md` sections 7.4a, 8.2, 9.1, and 10.9.
+
+#### Scenario: Creation and first issuance remain separate atomic mutations
+
+- **WHEN** Console creates a Portal User and later uses Copy invite for the first time
+- **THEN** creation SHALL atomically commit the invited identity and one `portal_user.invited` row without minting an invite
+- **AND** first Copy SHALL observe no invite under the Portal User lock and atomically commit the hash-only invite and one `portal_user.invite_issued` row
+- **AND** the plaintext invite URL SHALL be returned only after commit
+
+#### Scenario: Concurrent Copy invite actions classify under the Portal User lock
+
+- **WHEN** concurrent Copy invite actions target one invited Portal User with no stored invite
+- **THEN** exactly one committed action SHALL be `portal_user.invite_issued`
+- **AND** each later committed replacement SHALL be `portal_user.invite_reissued`
+- **AND** token generation and expiry calculation SHALL occur after the lock so each stored expiry extends rather than moves backward
+
+#### Scenario: Successful redemption and disablement are atomic
+
+- **WHEN** a valid invite activates its currently invited Portal User, or an operator effectively disables a Portal User
+- **THEN** the authoritative state and session changes SHALL commit with exactly one matching audit row
+- **AND** redemption SHALL use Portal User provenance while disablement SHALL use shared Console operator provenance
+- **AND** disabled-user or otherwise ineligible redemption SHALL remain mutation-free without success evidence
+
+#### Scenario: Repeated disable is a true no-op
+
+- **WHEN** an operator disables an already disabled Portal User
+- **THEN** Orchard SHALL return the persisted state without rewriting timestamps or advancing the session epoch
+- **AND** Orchard SHALL create no duplicate row or succeeded observation
+
+#### Scenario: Portal key mutations revalidate authority before the key lock
+
+- **WHEN** a validated Portal session requests key mint or own-key revoke
+- **THEN** Orchard SHALL carry the tenant ID, Portal User ID, and password epoch into the transaction
+- **AND** Orchard SHALL lock and revalidate that tenant-scoped active Portal User before cap enforcement or an API Key lock
+- **AND** revoke SHALL use the lock order Portal User then API Key
+- **AND** an effective mutation and its matching API Key audit row SHALL commit atomically
+
+#### Scenario: Stale session or repeated revoke creates no success evidence
+
+- **WHEN** the captured session epoch no longer matches the locked Portal User, or the owned key is already revoked
+- **THEN** stale authority SHALL fail before an API Key is locked or mutated
+- **AND** repeated revoke SHALL preserve its timestamps
+- **AND** neither path SHALL create a duplicate row or succeeded observation
+
+#### Scenario: Audit insertion failure rolls back the mutation
+
+- **WHEN** a required Portal lifecycle or Portal-owned API Key audit insertion fails
+- **THEN** the authoritative domain mutation SHALL roll back
+- **AND** no secret-bearing success result SHALL be published
+- **AND** no `outcome = 'succeeded'` audit observation SHALL be emitted
+
+### Requirement: Portal Audit Payloads Are Bounded And Secret-Free
+
+Portal lifecycle audit payloads SHALL use a closed per-action allowlist.
+`portal_user.invited`, `portal_user.invite_redeemed`, and `portal_user.disabled` SHALL include exactly `surface`.
+`portal_user.invite_issued` and `portal_user.invite_reissued` SHALL include exactly `surface` and `expires_at`.
+Console `surface` SHALL be `console`, and redemption `surface` SHALL be `developer_portal`.
+Invite `expires_at` SHALL be the replacement invite expiry encoded as a UTC ISO 8601 string.
+
+Portal-owned `api_key.created` and `api_key.revoked` SHALL include `name`, `token_prefix`, `owner_type`, `surface`, `issuance_surface`, and `portal_user_id`.
+They SHALL include `expires_at` when the key has an expiry and SHALL omit it otherwise.
+`portal_user_id` SHALL be encoded as the canonical Portal User UUID string.
+API Key `expires_at`, when present, SHALL be encoded as a UTC ISO 8601 string.
+`owner_type` SHALL be `tenant`.
+`surface` and `issuance_surface` SHALL be `developer_portal`.
+
+Payloads SHALL NOT contain an invite token, invite hash, invite URL, password, password hash, Portal session token, Portal session hash, API Key plaintext secret, API Key secret hash, email address, request header, source address, raw error, arbitrary request parameter, or `previous_invite_existed`.
+The issue-versus-reissue action name SHALL be the only durable classification of whether a prior invite row existed.
+This refines `SPEC.md` sections 8.2, 10.8, and 10.9.
+
+#### Scenario: Invite payload contains only bounded non-secret context
+
+- **WHEN** Orchard commits a Portal User lifecycle audit row
+- **THEN** the payload SHALL contain exactly the fields allowed for that action
+- **AND** the target columns SHALL identify the Portal User
+- **AND** the payload SHALL retain no token, hash, URL, email, raw request field, or prior-invite flag
+
+#### Scenario: Portal API Key payload excludes key secrets
+
+- **WHEN** Orchard commits a Portal-owned `api_key.created` or `api_key.revoked` row
+- **THEN** the payload MAY contain only the approved bounded API Key and Portal provenance fields
+- **AND** the target columns and `api_key_id` SHALL identify the API Key
+- **AND** the payload SHALL NOT contain the plaintext secret or secret hash
+
 ### Requirement: Legacy Unowned Portal Keys Remain Operator-Visible Bearers
 
 Portal-minted keys with null `portal_user_id` SHALL remain valid `orchard_sk_*` Bearer credentials until explicitly revoked.


### PR DESCRIPTION
## Summary

Portal User and Portal-owned API Key lifecycle mutations now commit their audit evidence atomically.
If the audit insert fails, the authoritative mutation rolls back and secret-bearing success results are withheld.

- Cover all seven effective lifecycle actions with canonical actor, target, provenance, and bounded payload fields.
- Preserve true no-op behavior for repeated disables and revocations without success telemetry.
- Serialize invite issuance and redemption with Portal User-first row locks, and generate invite secrets only after lock acquisition and classification.
- Emit success metrics only after the outermost transaction commits, with a 12-action by 3-result bounded family.
- Reconcile `SPEC.md`, operator guidance, main OpenSpec specs, and the accepted active change package from #322.

## Design decisions

- `Orchard.Governance.AuditWriter` owns the outer transaction boundary and verifies persisted audit rows before post-commit emission.
- Nested audited operations defer emission to the outer commit, while unmanaged raw `Repo.transaction/1` callers are rejected to avoid savepoint rollback phantoms.
- A post-commit verification failure degrades controller health without changing the already committed caller result.
- Portal lifecycle lock order is Portal User first, then invite or API Key state, with identity and epoch revalidation before secret generation.
- The OpenSpec change remains active, and its historical owner-review checklist state is preserved.

## Validation

- `env ORCHARD_TEST_NODE_AGENT_PORT=15179 make check-elixir`
  - formatting passed
  - compilation with warnings as errors passed
  - strict Credo passed across 755 source files with no findings
  - Dialyzer passed with zero errors
  - full non-coverage and coverage suites passed: shared 218, controller 3,736 with 5 skipped, node agent 431, CLI 675 with 1 skipped and 10 excluded
- Focused Portal lifecycle audit suite passed: 11 tests, including real PostgreSQL lock contention and monotonic invite expiry.
- Adjacent Portal, AuditWriter, node, circuit-breaker, and metrics suites passed.
- Targeted OpenSpec strict validation passed.
- Full OpenSpec strict validation passed: 38 of 38 packages.
- `git diff --check` passed.
- Final RepoPrompt Pair review returned GO.
- Final RepoPrompt Oracle review returned GO with no remaining findings.

## Risk Assessment

⚠️ **Medium**

- Blast radius includes Portal governance mutations and the shared `AuditWriter` transaction and post-commit path, plus the adjacent node audit caller.
- No database migration, API route, token format, or secret-storage format changes are included.
- Audit insert failure is fail-closed, repeated no-op mutations remain silent, and post-commit verifier failure preserves committed caller semantics while degrading health.
- Concurrency and transaction-coupling risks are covered by real database contention tests, focused failure matrices, the full Orchard quality gate, and independent Pair and Oracle review.

## Related

Implements the lifecycle audit contract accepted in #322.

Related: #279


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Portal User and Portal-owned API-key lifecycle mutations atomic with their audit records and defers successful audit telemetry until commit verification.

- Adds audited transaction ownership and post-commit verification to `AuditWriter`.
- Adds Portal lifecycle audit records, canonical provenance and payloads, row locking, stale-session checks, and idempotent disable/revoke behavior.
- Extends the bounded audit metric vocabulary and updates the governing specifications, tests, and operator documentation.
- Moves dispatch transport-failure recording under the audited transaction boundary.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code defect remains after tracing the transaction, lifecycle, and metrics paths.

The lifecycle mutations and audit rows share an outer transaction, stale Portal sessions are revalidated under lock before key mutations, no-op operations avoid duplicate audit evidence, and successful telemetry is deferred until committed audit rows are verified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/governance/audit_writer.ex | Adds outer transaction ownership, nested event deferral, unmanaged-transaction rejection, and post-commit audit verification without an accepted defect. |
| apps/orchard_controller/lib/orchard/governance/portal_governance.ex | Moves Portal lifecycle mutations and audit insertion into shared atomic transactions while adding lock-based revalidation and true no-op handling. |
| apps/orchard_controller/lib/orchard/nodes.ex | Moves dispatch transport-failure persistence under `AuditWriter.transaction`, preserving existing result and rollback handling. |
| apps/orchard_controller/lib/orchard/metrics/catalog.ex | Expands the bounded audit metric ceiling from 24 to 36 series and reconciles the worksheet total. |
| apps/orchard_controller/lib/orchard/metrics/normalizer.ex | Adds `portal_user` to the closed audit-action label vocabulary. |
| apps/orchard_controller/test/orchard/governance/audit_writer_test.exs | Covers unmanaged transactions, nested rollback behavior, savepoint rollback, commit verification degradation, and recovery. |
| apps/orchard_controller/test/orchard/governance/portal_lifecycle_audit_test.exs | Adds focused atomicity, audit-contract, concurrency, no-op, stale-session, and secret-withholding coverage. |
| SPEC.md | Defines the authoritative Portal lifecycle audit, locking, no-op, payload, telemetry, and metric-cardinality contracts. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Portal as PortalGovernance
    participant Writer as AuditWriter
    participant DB as PostgreSQL
    participant Metrics

    Caller->>Portal: Lifecycle mutation
    Portal->>Writer: transaction(fun)
    Writer->>DB: BEGIN
    Portal->>DB: Lock and revalidate authoritative rows
    Portal->>DB: Apply lifecycle mutation
    Portal->>Writer: Insert audit record
    Writer->>DB: Insert audit record
    alt mutation or audit fails
        Writer->>DB: ROLLBACK
        Writer-->>Caller: Error without secret-bearing success
    else transaction commits
        Writer->>DB: COMMIT
        Writer->>DB: Verify committed audit record
        alt verification succeeds
            Writer->>Metrics: Emit bounded success observation
        else verification unavailable
            Writer->>Metrics: Mark reporting degraded
        end
        Writer-->>Caller: Committed result
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: audit Portal lifecycle mutations a..."](https://github.com/kapitan-ai/orchard/commit/8fefcf64bdaba6efbc0eb5c3abfabd1f850c6faf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58861342)</sub>

<!-- /greptile_comment -->