### PR TITLE
refactor(node): make runtime gRPC listener configurable

### DIFF
--- a/apps/orchard_node_agent/lib/orchard/node.ex
+++ b/apps/orchard_node_agent/lib/orchard/node.ex
@@ -73,6 +73,11 @@ defmodule Orchard.Node do
   def listen_address, do: runtime_config()[:listen_address]
   def node_identity_root, do: runtime_config()[:node_identity_root]
   def grpc_security, do: runtime_config()[:grpc_security] || :plaintext_compatibility
+
+  @spec runtime_grpc_listener_enabled?() :: boolean()
+  def runtime_grpc_listener_enabled?,
+    do: runtime_value(:runtime_grpc_listener_enabled, true) == true
+
   def listen_host, do: listen_address()[:host]
   def listen_port, do: listen_address()[:port]
   def models_root, do: runtime_config()[:models_root]

--- a/apps/orchard_node_agent/lib/orchard/node/supervisor.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/supervisor.ex
@@ -19,14 +19,15 @@ defmodule Orchard.Node.Supervisor do
 
   @impl true
   def init(_init_arg) do
-    children = [
-      ModelManager,
-      {Task.Supervisor, name: Orchard.Node.ModelLoadTaskSupervisor},
-      RuntimeProcessReaper,
-      WorkerSupervisor,
-      {Task.Supervisor, name: Orchard.Node.RuntimeEndpointTaskSupervisor},
-      Supervisor.child_spec({GRPC.Server.Supervisor, grpc_server_opts()}, id: @grpc_server_id)
-    ]
+    children =
+      [
+        ModelManager,
+        {Task.Supervisor, name: Orchard.Node.ModelLoadTaskSupervisor},
+        RuntimeProcessReaper,
+        WorkerSupervisor,
+        {Task.Supervisor, name: Orchard.Node.RuntimeEndpointTaskSupervisor}
+      ]
+      |> maybe_add_runtime_grpc_listener()
 
     Supervisor.init(children, strategy: :rest_for_one)
   end
@@ -42,6 +43,15 @@ defmodule Orchard.Node.Supervisor do
       start_server: true,
       adapter_opts: grpc_adapter_opts(listen_address)
     ]
+  end
+
+  defp maybe_add_runtime_grpc_listener(children) do
+    if Orchard.Node.runtime_grpc_listener_enabled?() do
+      children ++
+        [Supervisor.child_spec({GRPC.Server.Supervisor, grpc_server_opts()}, id: @grpc_server_id)]
+    else
+      children
+    end
   end
 
   defp grpc_adapter_opts(listen_address) do

--- a/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
@@ -127,6 +127,7 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
       |> Keyword.fetch!(:runtime)
 
     assert runtime[:grpc_security] == :plaintext_compatibility
+    assert runtime[:runtime_grpc_listener_enabled]
   end
 
   test "runtime.exs rejects plaintext gRPC bound to a non-loopback listen host" do

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -1327,11 +1327,12 @@ defmodule OrchardNodeAgentTest do
     assert {:error, {:already_started, ^pid}} = NodeSupervisor.start_link([])
   end
 
-  test "node supervisor boots all required children including gRPC client supervisor" do
+  test "node supervisor boots all required children including the runtime gRPC listener" do
     assert is_pid(Process.whereis(NodeSupervisor))
     assert is_pid(Process.whereis(ModelManager))
     assert is_pid(Process.whereis(WorkerSupervisor))
     assert is_pid(Process.whereis(Orchard.Node.ModelLoadTaskSupervisor))
+    assert Node.runtime_grpc_listener_enabled?()
 
     child_ids =
       Supervisor.which_children(NodeSupervisor)
@@ -1346,6 +1347,40 @@ defmodule OrchardNodeAgentTest do
     # supervision tree, so client channels are no longer owned by NodeSupervisor.
     refute GRPC.Client.Supervisor in child_ids
     assert is_pid(Process.whereis(GRPC.Client.Supervisor))
+  end
+
+  test "node supervisor omits only the runtime gRPC listener when it is disabled" do
+    previous_runtime = Application.fetch_env!(:orchard_node_agent, :runtime)
+
+    Application.put_env(
+      :orchard_node_agent,
+      :runtime,
+      Keyword.merge(previous_runtime,
+        runtime_grpc_listener_enabled: false,
+        listen_address: nil,
+        grpc_security: :mutual_tls,
+        runtime_tls_identity: nil,
+        node_identity_root: nil
+      )
+    )
+
+    on_exit(fn ->
+      Application.put_env(:orchard_node_agent, :runtime, previous_runtime)
+    end)
+
+    assert {:ok, {_flags, child_specs}} = NodeSupervisor.init([])
+
+    child_ids = Enum.map(child_specs, & &1.id)
+
+    assert child_ids == [
+             ModelManager,
+             Orchard.Node.ModelLoadTaskSupervisor,
+             Orchard.Node.RuntimeProcessReaper,
+             WorkerSupervisor,
+             Orchard.Node.RuntimeEndpointTaskSupervisor
+           ]
+
+    refute NodeSupervisor.grpc_server_id() in child_ids
   end
 
   test "node agent application supervisor is running" do

--- a/config/m1_runtime_defaults.exs
+++ b/config/m1_runtime_defaults.exs
@@ -78,6 +78,7 @@ defmodule Orchard.Config.M1RuntimeDefaults do
       node_identity_path: Path.join([root, "data", "node-id"]),
       node_identity_root: Path.join([root, "config", "node-identity"]),
       grpc_security: :plaintext_compatibility,
+      runtime_grpc_listener_enabled: true,
       display_name: nil,
       listen_address: [host: @default_runtime_host, port: @default_runtime_port],
       models_root: Path.join(root, "models"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -558,6 +558,7 @@ default_node_runtime = fn root ->
     node_identity_path: Path.join([root, "data", "node-id"]),
     node_identity_root: Path.join([root, "config", "node-identity"]),
     grpc_security: :plaintext_compatibility,
+    runtime_grpc_listener_enabled: true,
     display_name: nil,
     listen_address: [host: "127.0.0.1", port: 50_061],
     models_root: Path.join(root, "models"),


### PR DESCRIPTION
## Summary

The Node Agent can now omit only its Runtime Endpoint gRPC compatibility listener through an internal, default-enabled runtime setting.
This creates the supervision seam needed for future BEAM-only validation without changing any supported source, test, or packaged profile.

The gRPC compatibility service remains enabled by default.
This PR does not add an operator-facing setting, remove gRPC behavior, or change Peer Grant or Worker Runtime protocols.

Closes #339

## Contract and scope

- `SPEC.md` remains unchanged because the existing gRPC compatibility contract remains available and default-enabled.
- No OpenSpec package is required for this internal preparatory seam.
- Current PR base: `b5e6702d00c4c2f5c3ec55f1a2dff7e8d11a1e75`
- Current PR head: `b04c45ab60388398a70af0ff2b9069912841d4c2`

## TDD evidence

Before the implementation, `mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs:1353` failed with `missing orchard_node_agent listen port`.
That demonstrated the previous supervisor still evaluated listener configuration while constructing the disabled child list.

The regression test now sets unusable listener and TLS configuration, calls `Orchard.Node.Supervisor.init/1`, and verifies the exact remaining five-child order.

## Validation

Exact final head after the review-fix commit:

- `mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs` - 108 passed
- `mise exec -- mix test apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs` - 20 passed
- `mise exec -- mix format` - passed
- `mise exec -- mix compile --warnings-as-errors` - passed
- `mise exec -- mix credo --strict` - 756 files, 16,842 modules/functions, no issues
- `mise exec -- mix dialyzer` - 0 errors, 0 skipped
- `make macos-native-test-helpers` - passed
- `mise exec -- mix test apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs apps/orchard_node_agent/test/orchard_node_agent_test.exs` - 137 passed

Exact final head full-suite validation:

- `mise exec -- mix test` - shared 218 passed; controller 3,738 passed and 5 skipped; Node Agent 434 passed; CLI 675 passed, 1 skipped, and 10 excluded
- `mise exec -- mix test --cover` - passed; shared 67.04%, controller 84.4%, Node Agent 79.20%, CLI 76.06%

## Review notes

- The release-safe packaged runtime default is explicit and covered.
- The setting defaults to `true` in both the runtime defaults and accessor fallback.
- The disabled branch does not call `grpc_server_opts/0`, so it does not evaluate listener or credential configuration.
- Existing `grpc_server_id/0` and `grpc_server_opts/0` callers remain unchanged.
- The gRPC server child remains last under the existing `:rest_for_one` strategy when enabled.

## Risk Assessment

✅ **Low**

- Blast radius is limited to Node Agent supervisor child construction.
- Supported profiles retain the existing default-enabled gRPC listener.
- The new disabled path is directly covered with invalid listener and TLS inputs.
- Residual risk is limited to a future internal caller setting a non-boolean value, which safely leaves the listener disabled rather than introducing a new operator contract.

## PR checklist

- [x] Checked the requested behavior against `SPEC.md`.
- [x] Added the affected regression coverage; no product docs or decision record required changes.
- [x] Ran the applicable validation workflow and recorded exact outcomes above.
- [x] Added no active goal package, private artifact, or machine-local evidence.
- [x] Added no dependency on workbench or session state.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces an internal, default-enabled setting that allows the Node Agent supervisor to omit the runtime gRPC compatibility listener without evaluating listener or TLS configuration.
- Adds a runtime accessor with an enabled-by-default fallback.
- Conditionally appends the gRPC listener while preserving existing child order.
- Aligns source and packaged runtime defaults on `runtime_grpc_listener_enabled: true`.
- Adds coverage for packaged defaults and the disabled-listener supervisor branch.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported release-default omission is fixed at the current head.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_node_agent/lib/orchard/node.ex | Adds the boolean runtime-listener accessor with a default-enabled fallback. |
| apps/orchard_node_agent/lib/orchard/node/supervisor.ex | Builds the core child list independently and conditionally appends the runtime gRPC listener. |
| apps/orchard_node_agent/test/orchard_node_agent_test.exs | Covers both the default-enabled listener and disabled branch without requiring valid listener or TLS configuration. |
| apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs | Verifies that packaged runtime configuration enables the compatibility listener by default. |
| config/m1_runtime_defaults.exs | Adds the enabled listener setting to source runtime defaults. |
| config/runtime.exs | Adds the same enabled listener setting to release-safe defaults, resolving the prior alignment finding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(node): align packaged gRPC listener ..."](https://github.com/kapitan-ai/orchard/commit/b04c45ab60388398a70af0ff2b9069912841d4c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58893730)</sub>

<!-- /greptile_comment -->