### PR TITLE
test: prove listener-free BEAM runtime endpoint

### DIFF
--- a/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs
@@ -194,6 +194,28 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert disabled[:beam_peer_grants] == [enabled: false]
   end
 
+  test "runtime.exs recognizes a source-dev Node peer-grant descriptor as its authorization mode" do
+    identity_root = Path.join(System.tmp_dir!(), "orchard-runtime-node-identity")
+    descriptor_path = Path.join(identity_root, "peer-grant-descriptor.json")
+    manifest_path = Path.join(identity_root, "launch.json")
+    node_name = "orchard_node_agent_cccccccccccc4ccc8ccccccccccccccc@10.0.0.20"
+
+    config =
+      read_runtime_config!(
+        %{
+          "ORCHARD_BEAM_PEER_GRANT_DESCRIPTOR" => descriptor_path,
+          "ORCHARD_BEAM_DISTRIBUTION_LAUNCH_MANIFEST" => manifest_path,
+          "ORCHARD_BEAM_NODE_NAME" => node_name,
+          "ORCHARD_NODE_IDENTITY_ROOT" => identity_root,
+          "ORCHARD_RUNTIME_ENDPOINT_TRANSPORT" => "beam",
+          "ORCHARD_SOURCE_DEV_ROLE" => "node_agent"
+        },
+        :dev
+      )
+
+    assert is_list(config)
+  end
+
   test "SPEC.md §7.5.0 production grant bootstrap requires its preflight launch manifest" do
     identity_root = Path.join(System.tmp_dir!(), "orchard-runtime-node-identity")
     descriptor_path = Path.join(identity_root, "peer-grant-descriptor.json")
@@ -372,7 +394,7 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     assert runtime[:worker_memory_budget_overhead_bytes] == 268_435_456
   end
 
-  defp read_runtime_config!(overrides) do
+  defp read_runtime_config!(overrides, env \\ :prod) do
     support_root = Path.join(System.tmp_dir!(), "orchard-runtime-env-validation")
 
     base = %{
@@ -385,7 +407,7 @@ defmodule Orchard.Node.RuntimeEnvValidationTest do
     |> Map.merge(overrides)
     |> put_config_env!()
 
-    Config.Reader.read!(runtime_config_path(), env: :prod)
+    Config.Reader.read!(runtime_config_path(), env: env)
   end
 
   defp read_dev_config!(overrides) do

--- a/bin/dev-node-agent
+++ b/bin/dev-node-agent
@@ -54,9 +54,38 @@ orchard_source_dev_cleanup_workers \
 # Start only the source-dev node-agent app. The sub-app mix.exs reuses the
 # umbrella config path, but does not boot the Phoenix/controller application.
 echo "==> Starting Orchard dev node-agent (role: node-agent)"
-echo "==> gRPC endpoint: ${ORCHARD_NODE_AGENT_LISTEN_HOST}:${resolved_port}"
+if [[ "${ORCHARD_SOURCE_DEV_NODE_VALIDATION_PROFILE:-}" == "listener_free_runtime_endpoint" ]]; then
+  echo "==> gRPC endpoint: disabled by listener-free validation profile"
+else
+  echo "==> gRPC endpoint: ${ORCHARD_NODE_AGENT_LISTEN_HOST}:${resolved_port}"
+fi
 echo "==> Worker executable: ${ORCHARD_WORKER_EXECUTABLE}"
 cd "$REPO_ROOT/apps/orchard_node_agent"
+
+if [[ "${ORCHARD_SOURCE_DEV_NODE_VALIDATION_PROFILE:-}" == "listener_free_runtime_endpoint" ]]; then
+  validation_script="$REPO_ROOT/scripts/support/listener-free-beam-runtime-endpoint.exs"
+
+  if [[ "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT}" != "beam" ]]; then
+    echo "error: listener_free_runtime_endpoint requires BEAM Runtime Endpoint transport" >&2
+    exit 64
+  fi
+
+  if [[ -z "${ORCHARD_LISTENER_FREE_RUNTIME_ENDPOINT_READY_FILE:-}" ]]; then
+    echo "error: ORCHARD_LISTENER_FREE_RUNTIME_ENDPOINT_READY_FILE is required by the validation profile" >&2
+    exit 64
+  fi
+
+  echo "==> Validation profile: listener-free BEAM Runtime Endpoint"
+
+  if [[ "${ORCHARD_SOURCE_DEV_NO_COMPILE:-0}" == "1" ]]; then
+    exec iex ${ORCHARD_BEAM_IEX_ARGS[@]+"${ORCHARD_BEAM_IEX_ARGS[@]}"} -S mix run \
+      --no-compile --no-start --no-halt "$validation_script" node
+  else
+    exec iex ${ORCHARD_BEAM_IEX_ARGS[@]+"${ORCHARD_BEAM_IEX_ARGS[@]}"} -S mix run \
+      --no-start --no-halt "$validation_script" node
+  fi
+fi
+
 if [[ "${ORCHARD_RUNTIME_ENDPOINT_TRANSPORT}" == "beam" ]]; then
   if [[ "${ORCHARD_SOURCE_DEV_NO_COMPILE:-0}" == "1" ]]; then
     exec iex ${ORCHARD_BEAM_IEX_ARGS[@]+"${ORCHARD_BEAM_IEX_ARGS[@]}"} -S mix run --no-compile --no-halt

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1619,7 +1619,10 @@ if config_env() == :dev do
       env_optional_string.("ORCHARD_RUNTIME_ENDPOINT_TRANSPORT")
     )
 
-  peer_grants_enabled? = env_bool.("ORCHARD_BEAM_PEER_GRANTS_ENABLED", false)
+  peer_grants_enabled? =
+    env_bool.("ORCHARD_BEAM_PEER_GRANTS_ENABLED", false) or
+      (source_dev_role == :node_agent and
+         not is_nil(env_optional_string.("ORCHARD_BEAM_PEER_GRANT_DESCRIPTOR")))
 
   source_dev_node_name =
     env_optional_string.("ORCHARD_BEAM_NODE_NAME") ||

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -939,6 +939,7 @@ The tracer and its supporting flows are validated by
 `scripts/test-beam-peer-grant-expiry-smoke.sh`,
 `scripts/test-beam-legacy-first-connect-smoke.sh`, and
 `scripts/test-source-dev-beam-bootstrap.sh`.
+The application smoke starts the admitted Node with its Runtime Endpoint gRPC listener disabled before supervision, proves that no listener process or TCP socket appears, and exercises status, model load, completion streaming, active cancellation, prefix-cache scoring, unload, activation, and heartbeat persistence through the real BEAM client and server modules.
 
 ## Testing
 

--- a/scripts/support/beam-peer-grant-control-application.exs
+++ b/scripts/support/beam-peer-grant-control-application.exs
@@ -2,8 +2,13 @@ Code.require_file(Path.join(__DIR__, "beam-peer-grant-control-files.exs"))
 
 defmodule Orchard.BeamPeerGrantControlApplication do
   alias Orchard.BeamPeerGrantControlFiles
-  alias Orchard.{BeamPeerGrants, NodeEnrollments, Nodes, NodeTrust, Repo}
+  alias Orchard.BeamPeerGrants
+  alias Orchard.DispatchCapacity.{AllocationAuthority, QuarantineStore}
   alias Orchard.NodeEnrollment.PKI
+  alias Orchard.NodeEnrollments
+  alias Orchard.Nodes
+  alias Orchard.NodeTrust
+  alias Orchard.Repo
   alias OrchardCLI.NodeIdentity.Store
 
   @stop_timeout_ms 120_000
@@ -24,6 +29,8 @@ defmodule Orchard.BeamPeerGrantControlApplication do
     Application.put_env(:orchard_controller, :control_plane, role: :single_controller)
     Application.put_env(:orchard_controller, :start_endpoint, false)
     {:ok, _apps} = Application.ensure_all_started(:orchard_controller)
+    {:ok, _quarantine_store} = QuarantineStore.start_link()
+    {:ok, _allocation_authority} = AllocationAuthority.start_link()
 
     {:ok, enrollment} =
       NodeEnrollments.create(
@@ -81,6 +88,8 @@ defmodule Orchard.BeamPeerGrantControlApplication do
       Nodes.admit_node(
         enrollment.enrollment.node_id,
         %{
+          capacity_policy_reason: "listener-free BEAM Runtime Endpoint smoke",
+          controller_dispatch_ceiling: 1,
           trust_evidence_ref: "application-smoke:#{Ecto.UUID.generate()}",
           pool_id: Ecto.UUID.generate(),
           routing_policy_id: Ecto.UUID.generate()

--- a/scripts/support/listener-free-beam-runtime-endpoint.exs
+++ b/scripts/support/listener-free-beam-runtime-endpoint.exs
@@ -1,0 +1,414 @@
+if System.argv() == ["node"] do
+  defmodule Orchard.ListenerFreeBeamRuntimeEndpointValidation.Adapter do
+    @behaviour Orchard.Node.RuntimeAdapter
+
+    alias Orchard.Cluster.V1.{ExecuteInferenceRequest, ModelRef, ScorePrefixCacheResponse}
+    alias Orchard.InferenceEvent
+
+    @impl true
+    def get_status(_adapter_state, _opts) do
+      {:ok, %{ready: true, health_code: "", health_message: "", max_concurrency: 1}}
+    end
+
+    @impl true
+    def load_model(%ModelRef{} = model_ref, _opts) do
+      {:ok, %{model_ref: model_ref, generations: %{}}}
+    end
+
+    @impl true
+    def unload_model(_adapter_state, _opts), do: :ok
+
+    @impl true
+    def start_generation(adapter_state, %ExecuteInferenceRequest{} = request, opts) do
+      owner = Keyword.fetch!(opts, :owner)
+      generation_ref = make_ref()
+      mode = generation_mode(request.metadata_json)
+
+      {:ok, pid} =
+        Task.start(fn ->
+          if mode == :cancel do
+            Process.sleep(:infinity)
+          else
+            usage = %InferenceEvent.Usage{
+              input_tokens: request.input_tokens,
+              output_tokens: 2,
+              total_tokens: request.input_tokens + 2
+            }
+
+            send(
+              owner,
+              {:runtime_adapter_event, generation_ref,
+               InferenceEvent.output_text_delta("orchard ")}
+            )
+
+            send(
+              owner,
+              {:runtime_adapter_event, generation_ref, InferenceEvent.output_text_delta("ready")}
+            )
+
+            send(
+              owner,
+              {:runtime_adapter_event, generation_ref,
+               InferenceEvent.completed(:finish_reason_stop, usage)}
+            )
+
+            send(owner, {:runtime_adapter_done, generation_ref})
+          end
+        end)
+
+      generations = Map.put(adapter_state.generations, generation_ref, %{owner: owner, pid: pid})
+      {:ok, generation_ref, %{adapter_state | generations: generations}}
+    end
+
+    @impl true
+    def cancel_generation(adapter_state, generation_ref, _opts) do
+      case Map.pop(adapter_state.generations, generation_ref) do
+        {nil, _generations} ->
+          {:ok, adapter_state}
+
+        {%{owner: owner, pid: pid}, generations} ->
+          Process.exit(pid, :kill)
+
+          send(
+            owner,
+            {:runtime_adapter_event, generation_ref,
+             InferenceEvent.failed("cancelled", "request cancelled", false)}
+          )
+
+          send(owner, {:runtime_adapter_done, generation_ref})
+          {:ok, %{adapter_state | generations: generations}}
+      end
+    end
+
+    @impl true
+    def finish_generation(adapter_state, generation_ref, _opts) do
+      %{adapter_state | generations: Map.delete(adapter_state.generations, generation_ref)}
+    end
+
+    def score_prefix_cache(_adapter_state, _request, _opts) do
+      {:ok,
+       %ScorePrefixCacheResponse{
+         status_code: "ok",
+         resident_fingerprint_match: true,
+         score_tier: "resident_fingerprint",
+         session_started_unix_ms: 1
+       }}
+    end
+
+    defp generation_mode(metadata_json) do
+      case Jason.decode(metadata_json) do
+        {:ok, %{"validation_mode" => "cancel"}} -> :cancel
+        _other -> :complete
+      end
+    end
+  end
+end
+
+defmodule Orchard.ListenerFreeBeamRuntimeEndpointValidation do
+  @grpc_server_id Orchard.Node.GRPCServer
+
+  if System.argv() == ["node"] do
+    @adapter Orchard.ListenerFreeBeamRuntimeEndpointValidation.Adapter
+
+    def start_node! do
+      root = System.fetch_env!("ORCHARD_BEAM_SMOKE_ROOT")
+      ready_file = System.fetch_env!("ORCHARD_LISTENER_FREE_RUNTIME_ENDPOINT_READY_FILE")
+
+      runtime =
+        :orchard_node_agent
+        |> Application.fetch_env!(:runtime)
+        |> Keyword.merge(
+          runtime_grpc_listener_enabled: false,
+          runtime_adapter_impl: @adapter,
+          fake_runtime?: true,
+          models_root: Path.join([root, "support", "models"]),
+          worker_socket_dir: Path.join([root, "support", "worker-sockets"]),
+          worker_log_dir: Path.join([root, "support", "worker-logs"])
+        )
+
+      Application.put_env(:orchard_node_agent, :runtime, runtime)
+
+      false = Orchard.Node.runtime_grpc_listener_enabled?()
+      {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
+      assert_grpc_server_absent!()
+      assert_port_closed!(Orchard.Node.listen_port())
+      File.write!(ready_file, "listener disabled before supervisor initialization\n")
+    end
+
+    defp assert_grpc_server_absent! do
+      false =
+        Orchard.Node.Supervisor
+        |> Supervisor.which_children()
+        |> Enum.any?(fn {id, _pid, _type, _modules} -> id == @grpc_server_id end)
+    end
+  end
+
+  defp assert_port_closed!(port) do
+    case :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false], 100) do
+      {:error, :econnrefused} ->
+        :ok
+
+      {:ok, socket} ->
+        :gen_tcp.close(socket)
+        raise "Node Runtime TCP port #{port} is listening"
+
+      {:error, reason} ->
+        raise "Node Runtime TCP port #{port} check failed: #{inspect(reason)}"
+    end
+  end
+
+  if System.argv() != ["node"] do
+    alias Orchard.ArtifactBundle
+    alias Orchard.Inference
+    alias Orchard.InferenceEvent
+    alias Orchard.Repo
+
+    alias Orchard.RuntimeEndpoint.{
+      BeamClient,
+      ModelRef,
+      Observation,
+      Operation,
+      Target
+    }
+
+    @server Orchard.Node.RuntimeEndpoint
+    @model_id "validation/listener-free"
+    @model_version "v1"
+    @timeout 5_000
+
+    def run_controller!(root, node_id, runtime_port) do
+      BeamClient = Inference.runtime_endpoint_client()
+      target = active_target!(node_id)
+      %Target{transport: :beam} = target
+      {:ok, %BeamClient{server_module: @server} = connection} = BeamClient.connect(target)
+
+      assert_remote_grpc_server_absent!(connection.node)
+      assert_port_closed!(runtime_port)
+
+      {:ok, %Observation{availability: :available}} =
+        BeamClient.status(connection, timeout: @timeout)
+
+      assert_port_closed!(runtime_port)
+
+      bundle = stage_bundle!(root)
+      model_ref = ModelRef.new!(@model_id, @model_version)
+
+      load_request = %Operation.EnsureModelLoadedRequest{
+        model_ref: model_ref,
+        node_id: node_id,
+        artifact_sha256: bundle.hash,
+        preload: true,
+        deadline_unix_ms: deadline(),
+        artifact_source_uri: bundle.source_uri
+      }
+
+      {:ok, %Operation.EnsureModelLoadedResult{placement_state: :loaded}} =
+        BeamClient.ensure_model_loaded(connection, load_request, timeout: @timeout)
+
+      assert_port_closed!(runtime_port)
+      completion_kinds = run_completion!(connection, model_ref)
+      assert_port_closed!(runtime_port)
+      cancellation_kinds = run_active_cancellation!(connection, model_ref)
+      assert_port_closed!(runtime_port)
+
+      score_request = %Operation.PrefixCacheScoreRequest{
+        request_id: "listener-free-score",
+        controller_session_id: "listener-free-session",
+        model_ref: model_ref,
+        cache_affinity_fingerprint: "hmac-sha256:" <> String.duplicate("a", 64),
+        deadline_unix_ms: deadline()
+      }
+
+      {:ok,
+       %Operation.PrefixCacheScoreResult{
+         status_code: "ok",
+         resident_fingerprint_match: true,
+         score_tier: "resident_fingerprint"
+       }} = BeamClient.score_prefix_cache(connection, score_request, timeout: @timeout)
+
+      assert_port_closed!(runtime_port)
+
+      unload_request = %Operation.UnloadModelRequest{
+        model_ref: model_ref,
+        force: false,
+        evict: false,
+        deadline_unix_ms: deadline()
+      }
+
+      {:ok, %Operation.Ack{ok: true}} =
+        BeamClient.unload_model(connection, unload_request, timeout: @timeout)
+
+      {:ok, %Observation{placements: []}} = BeamClient.status(connection, timeout: @timeout)
+      assert_persistence!(node_id)
+      assert_port_closed!(runtime_port)
+      :ok = BeamClient.disconnect(connection)
+
+      evidence = [
+        "listener process absent: true",
+        "runtime tcp listener absent at every checkpoint: true",
+        "beam server module: #{inspect(@server)}",
+        "completion events: #{Enum.join(completion_kinds, ",")}",
+        "active cancellation events: #{Enum.join(cancellation_kinds, ",")}",
+        "prefix cache score: resident_fingerprint",
+        "model unload observed: true",
+        "node activation and heartbeat persistence: true",
+        "automatic node runtime grpc fallback: false"
+      ]
+
+      File.write!(
+        Path.join(root, "controller.listener-free.complete"),
+        Enum.join(evidence, "\n") <> "\n"
+      )
+
+      :ok
+    end
+
+    defp run_completion!(connection, model_ref) do
+      request =
+        execute_request("listener-free-complete", model_ref, ~s({"validation_mode":"complete"}))
+
+      {:ok, stream_ref} = BeamClient.execute_inference(connection, request, owner: self())
+      events = collect_stream!(stream_ref, request.request_id, [])
+      kinds = Enum.map(events, &InferenceEvent.kind/1)
+      true = :accepted in kinds
+      true = :output_text_delta in kinds
+      :completed = List.last(kinds)
+      wait_until!(fn -> active_request_count(connection) == 0 end)
+      kinds
+    end
+
+    defp run_active_cancellation!(connection, model_ref) do
+      request =
+        execute_request("listener-free-cancel", model_ref, ~s({"validation_mode":"cancel"}))
+
+      {:ok, stream_ref} = BeamClient.execute_inference(connection, request, owner: self())
+
+      {:runtime_endpoint_event, ^stream_ref, request_id, %InferenceEvent{} = accepted} =
+        receive_event!(stream_ref, request.request_id)
+
+      :accepted = InferenceEvent.kind(accepted)
+      wait_until!(fn -> active_request_count(connection) == 1 end)
+
+      cancel_request = %Operation.CancelRequest{
+        request_id: request_id,
+        controller_session_id: request.controller_session_id
+      }
+
+      :ok = BeamClient.cancel_inference(connection, cancel_request, timeout: @timeout)
+      events = [accepted | collect_stream!(stream_ref, request.request_id, [])]
+      wait_until!(fn -> active_request_count(connection) == 0 end)
+      kinds = Enum.map(events, &InferenceEvent.kind/1)
+
+      true =
+        Enum.any?(events, fn
+          %InferenceEvent{event: %InferenceEvent.Failed{code: "cancelled"}} -> true
+          _event -> false
+        end)
+
+      kinds
+    end
+
+    defp execute_request(request_id, model_ref, metadata_json) do
+      %Operation.ExecuteRequest{
+        request_id: request_id,
+        controller_session_id: "listener-free-session",
+        model_ref: model_ref,
+        rendered_prompt_utf8: "hello orchard",
+        input_tokens: 2,
+        params: %{max_output_tokens: 16},
+        deadline_unix_ms: deadline(),
+        metadata_json: metadata_json,
+        cache_affinity_fingerprint: "hmac-sha256:" <> String.duplicate("a", 64)
+      }
+    end
+
+    defp collect_stream!(stream_ref, request_id, events) do
+      receive do
+        {:runtime_endpoint_event, ^stream_ref, ^request_id, %InferenceEvent{} = event} ->
+          collect_stream!(stream_ref, request_id, [event | events])
+
+        {:runtime_endpoint_done, ^stream_ref, :ok} ->
+          Enum.reverse(events)
+
+        {:runtime_endpoint_done, ^stream_ref, reason} ->
+          raise "Runtime Endpoint stream failed: #{inspect(reason)}"
+      after
+        @timeout -> raise "Runtime Endpoint stream timed out for #{request_id}"
+      end
+    end
+
+    defp receive_event!(stream_ref, request_id) do
+      receive do
+        {:runtime_endpoint_event, ^stream_ref, ^request_id, %InferenceEvent{}} = message ->
+          message
+      after
+        @timeout -> raise "Runtime Endpoint did not accept #{request_id}"
+      end
+    end
+
+    defp active_request_count(connection) do
+      {:ok, observation} = BeamClient.status(connection, timeout: @timeout)
+      observation.aggregate_active_request_count
+    end
+
+    defp active_target!(node_id) do
+      Inference.activation_probe_runtime_endpoint_targets()
+      |> Enum.find(&(&1.node_id == node_id))
+      |> case do
+        nil -> raise "active BEAM Runtime Endpoint target not found for #{node_id}"
+        target -> target
+      end
+    end
+
+    defp stage_bundle!(root) do
+      source_path = Path.join(root, "model-source")
+      cache_path = Path.join([root, "support", "models", @model_id, @model_version])
+      File.mkdir_p!(Path.join(source_path, "weights"))
+      File.write!(Path.join(source_path, "config.json"), ~s({"model_type":"validation"}))
+      File.write!(Path.join(source_path, "tokenizer.json"), ~s({"version":"1.0"}))
+      File.write!(Path.join([source_path, "weights", "model.safetensors"]), "validation")
+      {:ok, hash} = ArtifactBundle.tree_sha256(source_path)
+      File.rm_rf!(cache_path)
+      File.mkdir_p!(cache_path)
+      :ok = ArtifactBundle.copy_directory(source_path, cache_path)
+      %{hash: hash, source_uri: "file://#{source_path}"}
+    end
+
+    defp assert_remote_grpc_server_absent!(remote_node) do
+      children =
+        :rpc.call(remote_node, Supervisor, :which_children, [Orchard.Node.Supervisor], @timeout)
+
+      false = Enum.any?(children, fn {id, _pid, _type, _modules} -> id == @grpc_server_id end)
+    end
+
+    defp assert_persistence!(node_id) do
+      %{rows: [["active", true, count]]} =
+        Repo.query!(
+          "SELECT state::text, last_heartbeat_at IS NOT NULL, " <>
+            "(SELECT count(*) FROM node_heartbeats WHERE node_id::text = $1) " <>
+            "FROM nodes WHERE id::text = $1",
+          [node_id]
+        )
+
+      true = count > 0
+    end
+
+    defp wait_until!(fun, attempts \\ 50)
+    defp wait_until!(_fun, 0), do: raise("condition did not become true")
+
+    defp wait_until!(fun, attempts) do
+      if fun.() do
+        :ok
+      else
+        Process.sleep(100)
+        wait_until!(fun, attempts - 1)
+      end
+    end
+
+    defp deadline, do: System.system_time(:millisecond) + 10_000
+  end
+end
+
+if System.argv() == ["node"] do
+  Orchard.ListenerFreeBeamRuntimeEndpointValidation.start_node!()
+end

--- a/scripts/test-beam-peer-grant-application-smoke.sh
+++ b/scripts/test-beam-peer-grant-application-smoke.sh
@@ -82,6 +82,11 @@ if [[ -z "$IPV4" ]]; then
   exit 64
 fi
 
+unset ORCHARD_BEAM_NODE_NAME
+unset ORCHARD_BEAM_COOKIE_FILE
+unset ORCHARD_RUNTIME_ENDPOINT_TARGETS
+unset ORCHARD_RUNTIME_CLIENT_TARGETS
+
 SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/orchard-beam-peer-grant-app.XXXXXX")"
 chmod 700 "$SMOKE_ROOT"
 mkdir -p "$SMOKE_ROOT/descriptor"
@@ -98,6 +103,7 @@ CONTROL_PORT="${ORCHARD_BEAM_TRACER_CONTROL_PORT:-$((55000 + $$ % 500))}"
 CONTROLLER_DIST_PORT="${ORCHARD_BEAM_TRACER_CONTROLLER_DIST_PORT:-$((56000 + $$ % 500))}"
 NODE_DIST_PORT="${ORCHARD_BEAM_TRACER_NODE_DIST_PORT:-$((57000 + $$ % 500))}"
 DATABASE="orchard_peer_grant_smoke_$$"
+RUNTIME_PORT="${ORCHARD_BEAM_TRACER_RUNTIME_PORT:-$((59000 + $$ % 500))}"
 
 cleanup() {
   stop_process "$CONTROLLER_PID"
@@ -117,6 +123,7 @@ trap cleanup EXIT
 
 export MIX_ENV=dev
 export PGDATABASE="$DATABASE"
+export ORCHARD_SUPPORT_ROOT="$SMOKE_ROOT/support"
 export ORCHARD_BEAM_TRACER_IPV4="$IPV4"
 export ORCHARD_BEAM_EPMD_PORT="$EPMD_PORT"
 export ORCHARD_BEAM_PEER_GRANT_CONTROL_HOST="$IPV4"
@@ -129,13 +136,24 @@ export ORCHARD_BEAM_PEER_GRANT_STATE_ROOT="$SMOKE_ROOT/launch"
 export ORCHARD_BEAM_PEER_GRANTS_ENABLED=true
 export ORCHARD_BEAM_PEER_GRANT_MODE=grant_control
 export ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam
+export ORCHARD_SOURCE_DEV_NODE_VALIDATION_PROFILE=listener_free_runtime_endpoint
+export ORCHARD_LISTENER_FREE_RUNTIME_ENDPOINT_READY_FILE="$SMOKE_ROOT/node.listener-free.ready"
+export ORCHARD_NODE_AGENT_LISTEN_HOST=127.0.0.1
+export ORCHARD_NODE_AGENT_LISTEN_PORT="$RUNTIME_PORT"
+export ORCHARD_RUNTIME_CLIENT_PORT="$RUNTIME_PORT"
+export ORCHARD_BEAM_SMOKE_ROOT="$SMOKE_ROOT"
 export ORCHARD_SOURCE_DEV_ROLE=controller
 export ORCHARD_BEAM_DIST_PORT_MIN="$CONTROLLER_DIST_PORT"
 export ORCHARD_BEAM_DIST_PORT_MAX="$CONTROLLER_DIST_PORT"
 export PORT="$((58000 + $$ % 500))"
 
-mise exec -- mix ecto.create --quiet
-mise exec -- mix ecto.migrate --quiet
+ORCHARD_BEAM_PEER_GRANTS_ENABLED=false ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc \
+  mise exec -- mix ecto.create --quiet
+ORCHARD_BEAM_PEER_GRANTS_ENABLED=false ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc \
+  mise exec -- mix ecto.migrate --quiet
+
+export ORCHARD_CONTROLLER_MEMBERSHIP_HOST="$IPV4"
+export ORCHARD_BEAM_NODE_NAME="orchard_controller@$IPV4"
 
 mise exec -- mix run --no-start \
   "$REPO_ROOT/scripts/support/beam-peer-grant-control-application.exs" \
@@ -149,6 +167,7 @@ if ! wait_for_file "$SMOKE_ROOT/control.ready" "$CONTROL_PID"; then
 fi
 
 source "$SMOKE_ROOT/scope.env"
+export ORCHARD_CONTROLLER_MEMBERSHIP_HOST="$IPV4"
 export ORCHARD_BEAM_NODE_NAME="$NODE_NAME"
 
 mise exec -- "$REPO_ROOT/bin/source-dev-peer-grant" node-retrieve
@@ -184,6 +203,12 @@ export ORCHARD_BEAM_DIST_PORT_MAX="$NODE_DIST_PORT"
 mise exec -- "$REPO_ROOT/bin/source-dev-peer-grant" node-run \
   <&8 >"$SMOKE_ROOT/node.log" 2>&1 &
 NODE_PID=$!
+
+if ! wait_for_file "$ORCHARD_LISTENER_FREE_RUNTIME_ENDPOINT_READY_FILE" "$NODE_PID"; then
+  cat "$SMOKE_ROOT/node.log" >&2
+  echo "error: listener-free Node Agent profile did not become ready" >&2
+  exit 1
+fi
 
 export ORCHARD_BEAM_NODE_NAME="$CONTROLLER_NAME"
 export ORCHARD_BEAM_DIST_PORT_MIN="$CONTROLLER_DIST_PORT"
@@ -222,6 +247,30 @@ if (( active != 1 )); then
 fi
 
 cat "$SMOKE_ROOT/active.log"
+
+validation_command="Code.require_file(\"$REPO_ROOT/scripts/support/listener-free-beam-runtime-endpoint.exs\"); Orchard.ListenerFreeBeamRuntimeEndpointValidation.run_controller!(\"$SMOKE_ROOT\", \"$NODE_ID\", $RUNTIME_PORT)"
+printf '%s\n' "$validation_command" >&9
+
+if ! wait_for_file "$SMOKE_ROOT/controller.listener-free.complete" "$CONTROLLER_PID"; then
+  cat "$SMOKE_ROOT/node.log" >&2
+  cat "$SMOKE_ROOT/controller.log" >&2
+  echo "error: listener-free Runtime Endpoint operation matrix did not complete" >&2
+  exit 1
+fi
+
+cat "$SMOKE_ROOT/controller.listener-free.complete"
+
+persisted="$(
+  psql --no-psqlrc --tuples-only --no-align \
+    --command "SELECT state::text || ':' || (last_heartbeat_at IS NOT NULL)::text || ':' || (SELECT count(*) FROM node_heartbeats WHERE node_id = '$NODE_ID')::text FROM nodes WHERE id = '$NODE_ID'"
+)"
+
+if [[ ! "$persisted" =~ ^active:true:([1-9][0-9]*)$ ]]; then
+  echo "error: expected active Node with last_heartbeat_at and persisted heartbeat rows, got: $persisted" >&2
+  exit 1
+fi
+
+printf 'activation and heartbeat persistence: %s\n' "$persisted"
 
 stop_process "$CONTROLLER_PID"
 CONTROLLER_PID=""


### PR DESCRIPTION
## Context and outcome

Closes #344.

This adds committed acceptance evidence that an admitted source-dev Node can serve the Runtime Endpoint operation matrix over the real BEAM client and `Orchard.Node.RuntimeEndpoint` server while its Runtime Endpoint gRPC listener is disabled before supervision starts.

The validation proves status, model load, completion streaming, active cancellation, prefix-cache scoring, unload, Node activation, and heartbeat persistence without a listening Runtime Endpoint TCP socket or automatic gRPC fallback.

## What changed

- Added an opt-in `listener_free_runtime_endpoint` profile to `bin/dev-node-agent` for the composed peer-grant application smoke.
- Added a role-aware validation script with a deterministic validation adapter on the Node and the real controller-side BEAM client/server path.
- Added repeated assertions that the gRPC supervisor child is absent and the configured Runtime Endpoint TCP port refuses connections throughout the operation matrix.
- Updated the composed peer-grant harness to satisfy the current admission contract and verify persistence independently through PostgreSQL.
- Recognized the Node peer-grant descriptor as the source-dev authorization mode in the development runtime guard, with regression coverage.
- Documented the listener-free acceptance surface in `docs/local-dev.md`.

Production defaults are unchanged.
The gRPC compatibility path remains available.
The real MLX worker process boundary is intentionally out of scope for this transport-isolation smoke.

## Verification

- `scripts/test-beam-peer-grant-application-smoke.sh`
  - Passed the listener-free BEAM operation matrix.
  - Confirmed no gRPC supervisor child and no Runtime Endpoint TCP listener at every checkpoint.
  - Confirmed activation and persisted heartbeat evidence.
  - Passed the existing focused controller and node-agent suites and the expiry, tracer, and legacy first-connect smokes.
- `MIX_ENV=test mise exec -- mix test apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs`
  - 30 passed.
- `scripts/test-source-dev-beam-bootstrap.sh`
  - Passed.
- `mise exec -- mix format`
  - Passed.
- `mise exec -- mix compile --warnings-as-errors`
  - Passed.
- `mise exec -- mix credo --strict`
  - 757 files, 90 checks, no issues.
- `mise exec -- mix dialyzer`
  - Passed with 0 errors.
- `make macos-native-test-helpers`
  - Passed.
- `mise exec -- mix test`
  - `orchard_shared`: 218 passed.
  - `orchard_controller`: 3,738 passed, 5 skipped.
  - `orchard_node_agent`: 435 passed.
  - `orchard_cli`: 675 passed, 1 skipped, 10 excluded.
- `mise exec -- mix test --cover`
  - Passed.
  - Coverage totals: shared 67.04%, controller 84.5%, node agent 78.94%, CLI 76.06%.
- `git diff --cached --check`
  - Passed before commit.
- `bash -n bin/dev-node-agent scripts/test-beam-peer-grant-application-smoke.sh`
  - Passed.

RepoPrompt reviewed the final diff after two fixes for completion cleanup ordering and strict closed-port detection.
No P0 or P1 blockers remain.

## Risk Assessment

✅ **Medium**

- The blast radius is limited to source-development configuration and committed validation harnesses.
- The new Node profile is opt-in and does not change the normal `bin/dev-node-agent` path.
- The development runtime guard only recognizes an already-required peer-grant descriptor for the Node role.
- Listener absence checks fail closed on any result other than an explicit connection refusal.
- There are no database migrations, public API changes, production default changes, or removals of the gRPC compatibility path.
- The validation adapter proves transport isolation and operation mapping, while the real MLX worker boundary remains covered by its existing suites.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in source-development profile and acceptance smoke proving that the Runtime Endpoint operation matrix works over BEAM while the Node’s gRPC listener remains disabled.
- Adds a deterministic Node runtime adapter covering status, model lifecycle, streaming completion, cancellation, and prefix-cache scoring.
- Repeatedly verifies that neither the gRPC supervisor child nor the configured TCP listener appears.
- Extends the peer-grant smoke to validate Node activation and heartbeat persistence.
- Recognizes a Node peer-grant descriptor as the source-development authorization mode and adds regression coverage.
- Documents the listener-free validation surface.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code defect or independently actionable non-blocking concern was identified.

The opt-in launch profile, authorization inference, deterministic runtime adapter, and composed smoke remain consistent with the inspected source-development contracts and cleanup ordering.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| config/runtime.exs | Infers source-development Node peer-grant authorization from the descriptor expected by the launcher; no actionable defect was found. |
| bin/dev-node-agent | Adds an opt-in listener-free launch path with required transport and readiness-file validation. |
| scripts/support/listener-free-beam-runtime-endpoint.exs | Implements the deterministic adapter and controller-side BEAM operation matrix with listener and persistence checks. |
| scripts/test-beam-peer-grant-application-smoke.sh | Composes the listener-free profile into the peer-grant smoke and verifies readiness, operation completion, and persisted heartbeat state. |
| scripts/support/beam-peer-grant-control-application.exs | Starts inference-capacity dependencies omitted in grant-control mode and supplies the admission fields required by the smoke. |
| apps/orchard_node_agent/test/orchard/node/runtime_env_validation_test.exs | Adds development-environment regression coverage for descriptor-derived Node authorization. |
| docs/local-dev.md | Documents the transport-isolation behavior exercised by the application smoke. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Smoke as Smoke Harness
    participant Controller as Controller BEAM Client
    participant Node as Node RuntimeEndpoint
    participant Adapter as Validation Adapter
    participant DB as PostgreSQL

    Smoke->>Node: Start listener-free validation profile
    Node->>Node: Disable gRPC listener before supervision
    Node-->>Smoke: Write readiness evidence
    Smoke->>Controller: Run operation matrix
    Controller->>Node: Connect over BEAM
    Controller->>Node: Status / load / execute / cancel / score / unload
    Node->>Adapter: Dispatch runtime operations
    Adapter-->>Node: Runtime events and terminal results
    Node-->>Controller: BEAM responses and stream events
    Controller->>DB: Verify activation and heartbeat persistence
    Controller-->>Smoke: Write completion evidence
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: prove listener-free BEAM runtime e..."](https://github.com/kapitan-ai/orchard/commit/16b23594d3abeedd3b5f639de00cf00ab81ed1c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58925502)</sub>

<!-- /greptile_comment -->