### PR TITLE
docs(console): define API Token mint attribution copy

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -555,6 +555,18 @@ It must not render Console chrome or operator controls.
 It remains isolated to the Organization named by the route and to the portal-minted keys owned by the signed-in Portal User.
 The three operator cards remain Console surfaces and use the existing Console card, tactile-well, focus, and navy primary-action tokens in both Console theme modes.
 
+### 6.8 Organization API Token Mint Attribution
+
+The Organization API Tokens table places a **Minted via** column after **Name** and before **Prefix**.
+For `issuance_surface = "developer_portal"` with a Portal User from the same Organization, render **Developer Portal** as the primary line and the normalized Portal User email as visible secondary text.
+For `issuance_surface = "governance"` with no Portal User association, render **Operator tooling**.
+For a Developer Portal API Token whose Portal User attribution is null, missing, deleted, or associated with another Organization, render **Developer Portal** with **Attribution unavailable** as visible secondary text.
+Any inconsistent association must fail closed without exposing another Organization's Portal User email.
+These values describe mint-time provenance only.
+They do not identify API Token ownership, the Public Inference Bearer principal, current Portal User status, effective access, or revocation state.
+Disabling a Portal User does not automatically revoke minted API Tokens, and the existing **Status** column remains the credential-state presentation.
+Render both provenance lines in one noninteractive semantic table cell, use existing neutral light and dark theme tokens, allow the secondary line to wrap, and retain the shared table's local horizontal-scroll behavior on narrow viewports.
+
 ---
 
 ## 7. Motion


### PR DESCRIPTION
## Context

Issue #343 needs approved neutral Console copy before implementation can be dispatched.
The selected heading is **Minted via**.

## What changed

- Define the three normal Organization API Token mint-attribution presentations in `docs/DESIGN.md`.
- Keep same-Organization Portal User email visible as secondary text for Developer Portal mints.
- Use **Operator tooling** for governance mints and **Attribution unavailable** for null, missing, deleted, or cross-Organization Portal User attribution.
- Preserve the distinction between mint-time provenance, Bearer principal identity, Portal User status, and API Token revocation state.
- Define the existing semantic table cell, theme, wrapping, and narrow-layout behavior for the new column.

## Verification

- `git diff --check` - passed.
- Reviewed the final diff against `SPEC.md` sections 7.4a and 10.2, ADR 0020, the current Organization API Tokens table, and the shared Console table contract.
- OpenSpec validation was not run because this change selects lower-authority product copy without changing provenance semantics, authentication, or another accepted product contract.
- The Elixir workflow was not run because this is a documentation-only change with no Elixir, template, test, dependency, or generated-file delta.

## Risk Assessment

✅ **Low**

- Blast radius is limited to tactical Console design guidance.
- There is no runtime, schema, migration, API, authentication, authorization, secret handling, or compatibility change.
- The wording explicitly fails closed for inconsistent attribution and preserves deliberate API Token revocation as a separate action.
- Browser, LiveView, query, and regression coverage remain implementation work under #343.

## Out of scope

- Implementing the projection or Console column
- Changing API Token validity or Bearer principal resolution
- Automatic revocation on Portal User disablement
- Updating #343 to `ready-for-agent` before this contract change is merged

Related: #343
Related: #279


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents the approved Console presentation contract for Organization API Token mint attribution.
- Adds the **Minted via** column placement and labels for Developer Portal, operator, and unavailable attribution.
- Preserves organization privacy boundaries and distinguishes mint provenance from principal identity, user status, access, and token revocation.
- Defines semantic-cell, theme, wrapping, and narrow-layout behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new guidance matches existing token provenance and revocation semantics, and no concrete reachable failure or repository-rule violation was identified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/DESIGN.md | Adds consistent, privacy-preserving design guidance for API Token mint attribution without changing runtime behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(console): define API Token mint att..."](https://github.com/kapitan-ai/orchard/commit/43c4af703ab67accf143d6bc9ff3ef08c1576edf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58927164)</sub>

<!-- /greptile_comment -->