### PR TITLE
Show current Portal Invite context and expiry in Console

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
@@ -103,7 +103,7 @@ defmodule OrchardConsole.TenantDetailLive do
         {:noreply,
          socket
          |> show_portal_invite(user_id, invite)
-         |> load_tenant_detail()}
+         |> mark_portal_invite_pending(user_id, invite.expires_at)}
 
       {:error, _reason} ->
         {:noreply, put_flash(socket, :error, "Unable to copy invite.")}
@@ -160,6 +160,19 @@ defmodule OrchardConsole.TenantDetailLive do
       portal_invite_expires_at: invite.expires_at,
       portal_invite_expiry_timer_ref: timer_ref
     )
+  end
+
+  defp mark_portal_invite_pending(socket, user_id, expires_at) do
+    portal_users =
+      Enum.map(socket.assigns.portal_users, fn
+        %{id: ^user_id} = user ->
+          %{user | invite_context: :pending, invite_expires_at: expires_at}
+
+        user ->
+          user
+      end)
+
+    assign(socket, portal_users: portal_users)
   end
 
   defp clear_portal_invite(socket) do

--- a/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
@@ -26,6 +26,8 @@ defmodule OrchardConsole.TenantDetailLive do
         portal_users: [],
         portal_invite_url: nil,
         portal_invite_user_id: nil,
+        portal_invite_expires_at: nil,
+        portal_invite_expiry_timer_ref: nil,
         portal_https?: Transport.public_api_https_enabled?(),
         load_error: nil,
         generated_secret: nil
@@ -98,7 +100,10 @@ defmodule OrchardConsole.TenantDetailLive do
   def handle_event("copy_portal_invite", %{"portal_user_id" => user_id}, socket) do
     case Governance.copy_portal_invite(socket.assigns.tenant, user_id) do
       {:ok, invite} ->
-        {:noreply, assign(socket, portal_invite_url: invite.url, portal_invite_user_id: user_id)}
+        {:noreply,
+         socket
+         |> show_portal_invite(user_id, invite)
+         |> load_tenant_detail()}
 
       {:error, _reason} ->
         {:noreply, put_flash(socket, :error, "Unable to copy invite.")}
@@ -117,10 +122,71 @@ defmodule OrchardConsole.TenantDetailLive do
 
   defp dismiss_invite_url_for(socket, user_id) do
     if socket.assigns.portal_invite_user_id == user_id do
-      assign(socket, portal_invite_url: nil, portal_invite_user_id: nil)
+      clear_portal_invite(socket)
     else
       socket
     end
+  end
+
+  @impl true
+  def handle_info(
+        {:portal_invite_expired, user_id, expires_at},
+        %{
+          assigns: %{
+            portal_invite_user_id: user_id,
+            portal_invite_expires_at: expires_at
+          }
+        } = socket
+      ) do
+    {:noreply, socket |> clear_portal_invite() |> load_tenant_detail()}
+  end
+
+  def handle_info({:portal_invite_expired, _user_id, _expires_at}, socket),
+    do: {:noreply, socket}
+
+  defp show_portal_invite(socket, user_id, invite) do
+    socket = cancel_portal_invite_timer(socket)
+
+    timer_ref =
+      Process.send_after(
+        self(),
+        {:portal_invite_expired, user_id, invite.expires_at},
+        invite_expiry_delay_ms(invite.expires_at)
+      )
+
+    assign(socket,
+      portal_invite_url: invite.url,
+      portal_invite_user_id: user_id,
+      portal_invite_expires_at: invite.expires_at,
+      portal_invite_expiry_timer_ref: timer_ref
+    )
+  end
+
+  defp clear_portal_invite(socket) do
+    socket
+    |> cancel_portal_invite_timer()
+    |> assign(
+      portal_invite_url: nil,
+      portal_invite_user_id: nil,
+      portal_invite_expires_at: nil,
+      portal_invite_expiry_timer_ref: nil
+    )
+  end
+
+  defp cancel_portal_invite_timer(socket) do
+    case socket.assigns.portal_invite_expiry_timer_ref do
+      timer_ref when is_reference(timer_ref) -> Process.cancel_timer(timer_ref)
+      _other -> false
+    end
+
+    socket
+  end
+
+  defp invite_expiry_delay_ms(expires_at) do
+    expires_at
+    |> DateTime.diff(DateTime.utc_now(), :microsecond)
+    |> max(0)
+    |> then(&div(&1 + 999, 1_000))
   end
 
   # -- Render --
@@ -237,7 +303,7 @@ defmodule OrchardConsole.TenantDetailLive do
             <.input field={@portal_invite_form[:email]} type="email" label="Email" required />
             <button
               type="submit"
-              class="bg-navy-900 mt-7 rounded-md px-4 py-2 text-sm font-semibold text-white"
+              class="bg-navy mt-7 rounded-md px-4 py-2 text-sm font-semibold text-white hover:bg-navy-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy/40 focus-visible:ring-offset-2 dark:bg-sky-500 dark:hover:bg-sky-400 dark:focus-visible:ring-sky-400/40"
             >
               Invite
             </button>
@@ -249,19 +315,45 @@ defmodule OrchardConsole.TenantDetailLive do
         <.card>
           <:title>Invite URL - copy now</:title>
           <:subtitle>This URL is shown only for this Copy invite action.</:subtitle>
-          <code id="tenant-portal-invite-url-value" class="block break-all rounded bg-slate-100 p-3 font-mono text-sm">
-            {@portal_invite_url}
-          </code>
-          <button
-            id="tenant-portal-invite-url-copy"
-            type="button"
-            phx-hook="CopyGeneratedSecret"
-            data-secret-source="tenant-portal-invite-url-value"
-            data-api-key-id="portal-invite"
-            class="mt-3 rounded-md bg-navy-900 px-3 py-1.5 text-sm font-medium text-white"
+          <div
+            id={"tenant-portal-invite-reveal-#{DateTime.to_unix(@portal_invite_expires_at, :microsecond)}"}
+            phx-mounted={
+              Phoenix.LiveView.JS.focus(to: "#tenant-portal-invite-url-copy")
+            }
           >
-            Copy invite URL
-          </button>
+            <p
+              id="tenant-portal-invite-url-guidance"
+              class="sr-only"
+              role="status"
+              aria-live="polite"
+            >
+              One-time invite URL ready. Copy it before leaving this page.
+            </p>
+            <code
+              id="tenant-portal-invite-url-value"
+              class="block break-all rounded bg-slate-100 p-3 font-mono text-sm text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+            >
+              {@portal_invite_url}
+            </code>
+            <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              Expires <.local_time
+                id="tenant-portal-invite-url-expires-at"
+                value={@portal_invite_expires_at}
+                format={:datetime_minute}
+              />
+            </p>
+            <button
+              id="tenant-portal-invite-url-copy"
+              type="button"
+              phx-hook="CopyGeneratedSecret"
+              data-secret-source="tenant-portal-invite-url-value"
+              data-api-key-id="portal-invite"
+              aria-describedby="tenant-portal-invite-url-guidance"
+              class="mt-3 rounded-md bg-navy px-3 py-1.5 text-sm font-medium text-white hover:bg-navy-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy/40 focus-visible:ring-offset-2 dark:bg-sky-500 dark:hover:bg-sky-400 dark:focus-visible:ring-sky-400/40"
+            >
+              Copy invite URL
+            </button>
+          </div>
         </.card>
       </div>
 
@@ -269,19 +361,76 @@ defmodule OrchardConsole.TenantDetailLive do
         <.card>
           <:title>Portal Users</:title>
           <:subtitle>Named identities for this Organization.</:subtitle>
-          <p :if={@portal_users == []} class="text-sm text-slate-500">No Portal Users invited yet.</p>
-          <div :for={user <- @portal_users} id={"portal-user-#{user.id}"} class="flex items-center justify-between border-t py-3">
-            <div>
-              <p class="font-medium">{user.email}</p>
-              <p class="text-sm text-slate-500">{String.capitalize(user.status)}</p>
+          <p :if={@portal_users == []} class="text-sm text-slate-500 dark:text-slate-400">
+            No Portal Users invited yet.
+          </p>
+          <div
+            :for={user <- @portal_users}
+            id={"portal-user-#{user.id}"}
+            class="flex flex-col gap-3 border-t py-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div class="min-w-0">
+              <p class="break-all font-medium">{user.email}</p>
+              <p class="text-sm text-slate-500 dark:text-slate-400">
+                {String.capitalize(user.status)}
+              </p>
+              <p
+                :if={user.invite_context == :not_issued}
+                id={"portal-user-invite-context-#{user.id}"}
+                class="text-xs text-slate-500 dark:text-slate-400"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                Not issued
+              </p>
+              <p
+                :if={user.invite_context == :pending}
+                id={"portal-user-invite-context-#{user.id}"}
+                class="text-xs text-slate-500 dark:text-slate-400"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                Pending - Expires <.local_time
+                  id={"portal-user-invite-expires-at-#{user.id}"}
+                  value={user.invite_expires_at}
+                  format={:datetime_minute}
+                />
+              </p>
+              <p
+                :if={user.invite_context == :expired}
+                id={"portal-user-invite-context-#{user.id}"}
+                class="text-xs text-slate-500 dark:text-slate-400"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                Expired - Expired at <.local_time
+                  id={"portal-user-invite-expires-at-#{user.id}"}
+                  value={user.invite_expires_at}
+                  format={:datetime_minute}
+                />
+              </p>
+              <p
+                :if={user.invite_context == :redeemed}
+                id={"portal-user-invite-context-#{user.id}"}
+                class="text-xs text-slate-500 dark:text-slate-400"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                Redeemed
+              </p>
             </div>
-            <div class="flex gap-2">
+            <div class="flex shrink-0 gap-2 self-end sm:self-auto">
               <button
                 :if={user.status == "invited"}
                 type="button"
                 phx-click="copy_portal_invite"
                 phx-value-portal_user_id={user.id}
-                class="rounded border px-3 py-1.5 text-sm"
+                aria-label={"Copy invite for #{user.email}"}
+                class="rounded border px-3 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy/40 focus-visible:ring-offset-2 dark:focus-visible:ring-sky-400/40"
               >
                 Copy invite
               </button>
@@ -290,7 +439,8 @@ defmodule OrchardConsole.TenantDetailLive do
                 type="button"
                 phx-click="disable_portal_user"
                 phx-value-portal_user_id={user.id}
-                class="rounded border border-red-300 px-3 py-1.5 text-sm text-red-700"
+                aria-label={"Disable #{user.email}"}
+                class="rounded border border-red-300 px-3 py-1.5 text-sm text-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/40 focus-visible:ring-offset-2 dark:text-red-300"
               >
                 Disable
               </button>
@@ -745,7 +895,7 @@ defmodule OrchardConsole.TenantDetailLive do
     with {:ok, tenant} <- Governance.get_tenant(tenant_id),
          {:ok, api_keys} <- Governance.list_api_keys_for_tenant(tenant),
          {:ok, api_clients} <- Governance.list_api_clients_for_tenant(tenant),
-         {:ok, portal_users} <- Governance.list_portal_users(tenant) do
+         {:ok, portal_users} <- Governance.list_portal_user_summaries(tenant) do
       assign(socket,
         detail_status: :ok,
         tenant: tenant,

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -79,7 +79,14 @@ defmodule Orchard.Governance do
     as: :redeem_invite
 
   defdelegate disable_portal_user(tenant, user), to: PortalGovernance, as: :disable_user
+
   defdelegate list_portal_users(tenant), to: PortalGovernance, as: :list_users
+
+  @spec list_portal_user_summaries(Tenant.t() | Ecto.UUID.t()) ::
+          {:ok, [Orchard.Governance.PortalUserSummary.t()]} | {:error, :tenant_not_found}
+  defdelegate list_portal_user_summaries(tenant),
+    to: PortalGovernance,
+    as: :list_user_summaries
 
   defdelegate create_portal_session(slug, email, password, source),
     to: PortalGovernance,

--- a/apps/orchard_controller/lib/orchard/governance/portal_governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance/portal_governance.ex
@@ -18,6 +18,7 @@ defmodule Orchard.Governance.PortalGovernance do
     PortalPasswordVerifier,
     PortalSession,
     PortalUser,
+    PortalUserSummary,
     Tenant
   }
 
@@ -92,6 +93,48 @@ defmodule Orchard.Governance.PortalGovernance do
        |> Repo.all()}
     end
   end
+
+  @spec list_user_summaries(Tenant.t() | Ecto.UUID.t()) ::
+          {:ok, [PortalUserSummary.t()]} | {:error, :tenant_not_found}
+  def list_user_summaries(tenant_or_id) do
+    current = now()
+
+    with {:ok, tenant} <- tenant(tenant_or_id) do
+      {:ok,
+       PortalUser
+       |> join(:left, [u], invite in PortalInviteToken, on: invite.portal_user_id == u.id)
+       |> where([u], u.tenant_id == ^tenant.id)
+       |> order_by([u], asc: u.email)
+       |> select([u, invite], {u.id, u.email, u.status, invite.expires_at, invite.redeemed_at})
+       |> Repo.all()
+       |> Enum.map(fn {id, email, status, expires_at, redeemed_at} ->
+         {invite_context, invite_expires_at} =
+           invite_presentation(status, expires_at, redeemed_at, current)
+
+         %PortalUserSummary{
+           id: id,
+           email: email,
+           status: status,
+           invite_context: invite_context,
+           invite_expires_at: invite_expires_at
+         }
+       end)}
+    end
+  end
+
+  defp invite_presentation("invited", nil, _redeemed_at, _current), do: {:not_issued, nil}
+
+  defp invite_presentation("invited", expires_at, _redeemed_at, current) do
+    if DateTime.compare(expires_at, current) == :gt,
+      do: {:pending, expires_at},
+      else: {:expired, expires_at}
+  end
+
+  defp invite_presentation("active", _expires_at, redeemed_at, _current)
+       when not is_nil(redeemed_at),
+       do: {:redeemed, nil}
+
+  defp invite_presentation(_status, _expires_at, _redeemed_at, _current), do: {nil, nil}
 
   def login(slug, email, password, source) do
     email = PortalUser.normalize_email(email)

--- a/apps/orchard_controller/lib/orchard/governance/portal_user_summary.ex
+++ b/apps/orchard_controller/lib/orchard/governance/portal_user_summary.ex
@@ -1,0 +1,18 @@
+defmodule Orchard.Governance.PortalUserSummary do
+  @moduledoc """
+  Secret-free Portal User row for Console presentation.
+  """
+
+  @enforce_keys [:id, :email, :status, :invite_context, :invite_expires_at]
+  defstruct [:id, :email, :status, :invite_context, :invite_expires_at]
+
+  @type invite_context :: :not_issued | :pending | :expired | :redeemed | nil
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          email: String.t(),
+          status: String.t(),
+          invite_context: invite_context(),
+          invite_expires_at: DateTime.t() | nil
+        }
+end

--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -5,11 +5,12 @@ defmodule OrchardConsole.TenantDetailLiveTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance
-  alias Orchard.Governance.AuditLog
+  alias Orchard.Governance.{AuditLog, PortalInviteToken}
   alias Orchard.Repo
 
   @moduletag :live
   @moduletag :db
+  @portal_password "sixteen-chars-ok"
 
   setup do
     Sandbox.mode(Orchard.Repo, {:shared, self()})
@@ -386,7 +387,8 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "tenant-portal-invite-card"
       assert html =~ "tenant-portal-users-card"
       assert html =~ "tenant-portal-access-card"
-      assert html =~ "bg-navy"
+      assert html =~ ~s(class="bg-navy mt-7)
+      refute html =~ "bg-navy-900"
 
       html =
         view
@@ -397,6 +399,18 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "Invited"
       assert {:ok, [user]} = Governance.list_portal_users(tenant)
       assert user.email == "dev@example.com"
+
+      user_row = view |> element("#portal-user-#{user.id}") |> render()
+      assert user_row =~ "Not issued"
+      refute user_row =~ "Invalidated"
+      assert user_row =~ ~s(class="text-sm text-slate-500 dark:text-slate-400")
+      assert user_row =~ ~s(class="text-xs text-slate-500 dark:text-slate-400")
+      assert user_row =~ "flex flex-col gap-3"
+      assert user_row =~ "sm:flex-row"
+      assert user_row =~ "break-all"
+      assert user_row =~ "shrink-0"
+      assert user_row =~ ~s(aria-label="Copy invite for dev@example.com")
+      assert user_row =~ ~s(aria-label="Disable dev@example.com")
     end
 
     test "Copy invite reissues a transient URL and disable leaves owned keys alone", %{
@@ -409,8 +423,30 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       first = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
       assert first =~ "tenant-portal-invite-url-card"
       assert first =~ "/portal/detail-t/invites/orchard_pi_"
+      assert first =~ "Pending"
       assert first =~ ~s(phx-hook="CopyGeneratedSecret")
       assert first =~ ~s(data-secret-source="tenant-portal-invite-url-value")
+      assert first =~ ~s(aria-describedby="tenant-portal-invite-url-guidance")
+      assert first =~ "One-time invite URL ready"
+      assert first =~ "phx-mounted"
+
+      url_value = view |> element("#tenant-portal-invite-url-value") |> render()
+      assert url_value =~ "bg-slate-100"
+      assert url_value =~ "text-slate-900"
+      assert url_value =~ "dark:bg-slate-800"
+      assert url_value =~ "dark:text-slate-100"
+
+      assert first =~ ~s(class="mt-3 rounded-md bg-navy )
+      refute first =~ "bg-navy-900"
+
+      assert {:ok, [summary]} = Governance.list_portal_user_summaries(tenant)
+
+      expected_iso =
+        summary.invite_expires_at |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+      assert first =~ ~s(id="tenant-portal-invite-url-expires-at")
+      assert first =~ ~s(class="mt-2 text-xs text-slate-500 dark:text-slate-400")
+      assert first =~ ~s(datetime="#{expected_iso}")
 
       second = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
       refute first == second
@@ -419,6 +455,140 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "Disabled"
       card_dismissed = not String.contains?(html, "tenant-portal-invite-url-card")
       assert card_dismissed
+    end
+
+    test "renders Pending invite context with localized expiry", %{conn: conn, tenant: tenant} do
+      {:ok, user} = Governance.create_portal_invite(tenant, %{email: "pending@example.com"})
+      {:ok, invite} = Governance.copy_portal_invite(tenant, user)
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      row = view |> element("#portal-user-#{user.id}") |> render()
+      expected_iso = invite.expires_at |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+      assert row =~ "Invited"
+      assert row =~ "Pending"
+      assert row =~ "Expires"
+      assert row =~ ~s(id="portal-user-invite-expires-at-#{user.id}")
+      assert row =~ ~s(datetime="#{expected_iso}")
+      assert row =~ ~s(phx-hook="LocalTime")
+      assert row =~ ~s(data-local-time-format="datetime_minute")
+    end
+
+    test "current invite expiry clears the URL before refreshing the row to Expired", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      {:ok, user} = Governance.create_portal_invite(tenant, %{email: "timer@example.com"})
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      shown = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
+      [invite_url] = Regex.run(~r{/portal/detail-t/invites/orchard_pi_[\w-]+}, shown)
+      assert {:ok, [summary]} = Governance.list_portal_user_summaries(tenant)
+
+      PortalInviteToken
+      |> Repo.get_by!(portal_user_id: user.id)
+      |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -1, :second))
+      |> Repo.update!()
+
+      send(view.pid, {:portal_invite_expired, user.id, summary.invite_expires_at})
+      html = render(view)
+
+      refute html =~ "tenant-portal-invite-url-card"
+      refute html =~ invite_url
+      assert html =~ "Expired"
+      assert html =~ "Copy invite"
+    end
+
+    test "reissue replaces URL, expiry, and stale pending transition", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      {:ok, user} = Governance.create_portal_invite(tenant, %{email: "reissue@example.com"})
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      first = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
+      [first_url] = Regex.run(~r{/portal/detail-t/invites/orchard_pi_[\w-]+}, first)
+      [first_focus_region] = Regex.run(~r{tenant-portal-invite-reveal-\d+}, first)
+      assert {:ok, [first_summary]} = Governance.list_portal_user_summaries(tenant)
+
+      second = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
+      [second_url] = Regex.run(~r{/portal/detail-t/invites/orchard_pi_[\w-]+}, second)
+      [second_focus_region] = Regex.run(~r{tenant-portal-invite-reveal-\d+}, second)
+      assert {:ok, [second_summary]} = Governance.list_portal_user_summaries(tenant)
+
+      refute first_url == second_url
+      refute first_focus_region == second_focus_region
+
+      assert DateTime.compare(second_summary.invite_expires_at, first_summary.invite_expires_at) ==
+               :gt
+
+      send(view.pid, {:portal_invite_expired, user.id, first_summary.invite_expires_at})
+      html = render(view)
+
+      assert html =~ "tenant-portal-invite-url-card"
+      assert html =~ second_url
+      refute html =~ first_url
+      assert html =~ "Pending"
+    end
+
+    test "navigation and reconnect do not restore the plaintext invite URL", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      {:ok, user} = Governance.create_portal_invite(tenant, %{email: "ephemeral@example.com"})
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      shown = render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
+      [invite_url] = Regex.run(~r{/portal/detail-t/invites/orchard_pi_[\w-]+}, shown)
+
+      {:ok, _list_view, _html} = live(conn, "/console/tenants")
+      {:ok, _navigated_view, navigated_html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      refute navigated_html =~ "tenant-portal-invite-url-card"
+      refute navigated_html =~ invite_url
+      assert navigated_html =~ "Pending"
+
+      {:ok, _reconnected_view, reconnected_html} = live(conn, "/console/tenants/#{tenant.id}")
+      refute reconnected_html =~ "tenant-portal-invite-url-card"
+      refute reconnected_html =~ invite_url
+      assert reconnected_html =~ "Pending"
+    end
+
+    test "renders Expired invite context with localized expiry", %{conn: conn, tenant: tenant} do
+      {:ok, user} = Governance.create_portal_invite(tenant, %{email: "expired@example.com"})
+      {:ok, _invite} = Governance.copy_portal_invite(tenant, user)
+      expires_at = DateTime.add(DateTime.utc_now(), -1, :second)
+
+      PortalInviteToken
+      |> Repo.get_by!(portal_user_id: user.id)
+      |> Ecto.Changeset.change(expires_at: expires_at)
+      |> Repo.update!()
+
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+      row = view |> element("#portal-user-#{user.id}") |> render()
+
+      assert row =~ "Invited"
+      assert row =~ "Expired"
+      assert row =~ "Expired at"
+      assert row =~ ~s(id="portal-user-invite-expires-at-#{user.id}")
+      assert row =~ ~s(phx-hook="LocalTime")
+    end
+
+    test "keeps Active primary with subordinate Redeemed context", %{conn: conn, tenant: tenant} do
+      {:ok, user} = Governance.create_portal_invite(tenant, %{email: "active@example.com"})
+      {:ok, invite} = Governance.copy_portal_invite(tenant, user)
+
+      {:ok, _active} =
+        Governance.redeem_portal_invite(tenant.slug, invite.token, @portal_password)
+
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      row = view |> element("#portal-user-#{user.id}") |> render()
+
+      assert row =~ "Active"
+      assert row =~ "Redeemed"
+      refute row =~ "Copy invite"
+      refute row =~ "Invalidated"
     end
 
     test "disable dismisses only the shown invite URL of the disabled Portal User", %{

--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -457,6 +457,29 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert card_dismissed
     end
 
+    test "copy invite keeps the show-once URL without a fallible tenant-detail reload", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      {:ok, user} =
+        Governance.create_portal_invite(tenant, %{email: "durable-reveal@example.com"})
+
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      {html, queries} =
+        capture_repo_queries(fn ->
+          render_click(view, "copy_portal_invite", %{"portal_user_id" => user.id})
+        end)
+
+      view_queries = for {pid, query} <- queries, pid == view.pid, do: query
+
+      assert html =~ "tenant-portal-invite-url-card"
+      assert html =~ "Pending"
+      refute Enum.any?(view_queries, &String.contains?(&1, ~s|FROM "tenants"|))
+      refute Enum.any?(view_queries, &String.contains?(&1, ~s|FROM "api_keys"|))
+      refute Enum.any?(view_queries, &String.contains?(&1, ~s|FROM "api_clients"|))
+    end
+
     test "renders Pending invite context with localized expiry", %{conn: conn, tenant: tenant} do
       {:ok, user} = Governance.create_portal_invite(tenant, %{email: "pending@example.com"})
       {:ok, invite} = Governance.copy_portal_invite(tenant, user)
@@ -644,5 +667,34 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       Governance.create_api_client_api_token(api_client, Map.merge(%{name: "prod"}, token_attrs))
 
     %{api_client: api_client, api_key: api_key, token: token}
+  end
+
+  defp capture_repo_queries(fun) do
+    handler_id = {__MODULE__, :repo_queries, System.unique_integer([:positive])}
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:orchard, :repo, :query],
+      fn _event, _measurements, metadata, _config ->
+        send(test_pid, {handler_id, self(), metadata.query})
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, drain_repo_queries(handler_id, [])}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  defp drain_repo_queries(handler_id, queries) do
+    receive do
+      {^handler_id, pid, query} -> drain_repo_queries(handler_id, [{pid, query} | queries])
+    after
+      0 -> Enum.reverse(queries)
+    end
   end
 end

--- a/apps/orchard_controller/test/orchard/governance/named_portal_user_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/named_portal_user_test.exs
@@ -5,7 +5,15 @@ defmodule Orchard.Governance.NamedPortalUserTest do
   import Orchard.TestSupport.ModelRequestFixtures, only: [create_request!: 1]
 
   alias Orchard.Governance
-  alias Orchard.Governance.{ApiKey, ApiKeySecret, PortalInviteToken, PortalSession, PortalUser}
+
+  alias Orchard.Governance.{
+    ApiKey,
+    ApiKeySecret,
+    PortalInviteToken,
+    PortalSession,
+    PortalUser,
+    PortalUserSummary
+  }
 
   @password "sixteen-chars-ok"
 
@@ -59,6 +67,81 @@ defmodule Orchard.Governance.NamedPortalUserTest do
              Governance.redeem_portal_invite(tenant.slug, second.token, @password)
   end
 
+  test "SPEC 7.4a lists a tenant-scoped secret-free Not issued Portal User summary" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "summary", name: "Summary"})
+    {:ok, other_tenant} = Governance.create_tenant(%{slug: "summary-other", name: "Other"})
+
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "dev@example.com"})
+    {:ok, other_user} = Governance.create_portal_invite(other_tenant, %{email: user.email})
+    {:ok, _other_invite} = Governance.copy_portal_invite(other_tenant, other_user)
+
+    assert {:ok, [%PortalUserSummary{} = summary]} =
+             Governance.list_portal_user_summaries(tenant)
+
+    assert Map.from_struct(summary) == %{
+             id: user.id,
+             email: user.email,
+             status: "invited",
+             invite_context: :not_issued,
+             invite_expires_at: nil
+           }
+  end
+
+  test "SPEC 7.4a lists a pending invite with its committed expiry" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "pending-summary", name: "Pending"})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "pending@example.com"})
+    {:ok, invite} = Governance.copy_portal_invite(tenant, user)
+
+    assert {:ok,
+            [
+              %PortalUserSummary{
+                status: "invited",
+                invite_context: :pending,
+                invite_expires_at: expires_at
+              }
+            ]} = Governance.list_portal_user_summaries(tenant)
+
+    assert expires_at == invite.expires_at
+  end
+
+  test "SPEC 7.4a lists an invite at or past expiry as Expired" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "expired-summary", name: "Expired"})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "expired@example.com"})
+    {:ok, _invite} = Governance.copy_portal_invite(tenant, user)
+
+    expires_at = DateTime.add(DateTime.utc_now(), -1, :second)
+
+    PortalInviteToken
+    |> Repo.get_by!(portal_user_id: user.id)
+    |> Ecto.Changeset.change(expires_at: expires_at)
+    |> Repo.update!()
+
+    assert {:ok,
+            [
+              %PortalUserSummary{
+                status: "invited",
+                invite_context: :expired,
+                invite_expires_at: ^expires_at
+              }
+            ]} = Governance.list_portal_user_summaries(tenant)
+  end
+
+  test "SPEC 7.4a keeps Active primary with subordinate Redeemed context" do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "redeemed-summary", name: "Redeemed"})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "redeemed@example.com"})
+    {:ok, invite} = Governance.copy_portal_invite(tenant, user)
+    {:ok, _active} = Governance.redeem_portal_invite(tenant.slug, invite.token, @password)
+
+    assert {:ok,
+            [
+              %PortalUserSummary{
+                status: "active",
+                invite_context: :redeemed,
+                invite_expires_at: nil
+              }
+            ]} = Governance.list_portal_user_summaries(tenant)
+  end
+
   test "SPEC 7.4a disablement invalidates an outstanding invite without reactivation" do
     {:ok, tenant} = Governance.create_tenant(%{slug: "disable-invite", name: "Disable Invite"})
     {:ok, user} = Governance.create_portal_invite(tenant, %{email: "dev@example.com"})
@@ -70,7 +153,7 @@ defmodule Orchard.Governance.NamedPortalUserTest do
     assert {:error, :invalid_invite} =
              Governance.redeem_portal_invite(tenant.slug, invite.token, @password)
 
-    assert {:ok, [persisted]} = Governance.list_portal_users(tenant)
+    assert {:ok, [%PortalUser{} = persisted]} = Governance.list_portal_users(tenant)
     assert persisted.status == "disabled"
 
     assert Repo.aggregate(

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -543,6 +543,12 @@ After it disappears, **Copy invite** reissues a fresh hashed token, invalidates 
 The operator delivers the copied URL out of band.
 The third card contains the Portal Users list, where each row places the Portal User email above its status and aligns the contextual actions to the trailing edge.
 Render the status as plain secondary text rather than a badge, and do not add a separate invite-state column.
+Keep Portal User status primary and render current invitation context as subordinate text in the same status area.
+An invited user with no current invite row shows **Not issued**.
+An invited user with a current unredeemed row shows **Pending** with localized expiry while the expiry is in the future, or **Expired** with localized expiry at or after expiry.
+An active user with the retained redeemed row keeps **Active** primary and shows **Redeemed** as subordinate invitation context.
+Do not show **Invalidated**, because accepted invalidation deletes the row and retains no history.
+The transient show-once URL card shows the same committed localized expiry, disappears when that expiry arrives, and replaces its URL, expiry, and pending transition on reissue.
 Invited rows expose **Copy invite** and **Disable**.
 Active rows expose **Disable**.
 Disabled rows expose no actions.


### PR DESCRIPTION
## Context and outcome

The tenant detail Console previously exposed only the Portal user's account status.
Operators could not tell whether an invited user had no invite, a live invite, an expired invite, or a redeemed invite without leaving the Console.

This change adds that context and the applicable expiry while keeping invite plaintext show-once and socket-local.

Closes #342

## What changed

- Add a tenant-scoped, secret-free Portal user summary projection for Console reads while preserving the existing public `list_portal_users/1` contract.
- Render `Not issued`, `Pending`, `Expired`, and `Redeemed` invite context beside each Portal user, including localized expiry time for pending and expired invites.
- Keep newly issued invite URLs show-once, automatically remove them at their committed expiry, and reject stale timer messages after reissue.
- Update the matching cached Portal-user summary immediately after invite issuance, avoiding a fallible full tenant-detail reload that could hide the committed show-once URL.
- Restore focus to the refreshed copy control after issue or reissue and improve responsive layout, dark-mode contrast, live-region semantics, and per-user action labels.
- Document the invite-context presentation and show-once behavior in `docs/DESIGN.md`.

## Verification

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `make macos-native-test-helpers`
- `mise exec -- mix test`
- `mise exec -- mix test --cover`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`
- `git diff --check`

Focused tests passed 44/44.
The full umbrella suite passed: 218 shared, 3,749 controller with 5 skipped, 434 node-agent, and 675 CLI with 1 skipped and 10 excluded.
Fresh coverage reports were generated for every umbrella application with no failed-test manifests.
The first pre-review full test run hit one unrelated dispatch queue timing failure; the exact test passed in isolation, and subsequent complete suite runs passed cleanly.

The regression for the review finding proves invite issuance performs no post-commit tenant, API-key, or API-client collection reload.
It also passed 21 consecutive runs during RepoPrompt pair review.

Genuine HTTPS browser verification used an isolated database and trusted local TLS at desktop, tablet, and mobile viewports in light and dark modes.
It covered all four invite contexts, localized expiry rendering, issue and reissue replacement, expiry advancement, focus restoration, navigation loss of plaintext, disable cleanup, responsive stacking, live-region semantics, and absence of invite secrets in datasets.
A final HTTPS smoke on the reviewed head confirmed the current contexts and secret-free DOM after the review fix.

RepoPrompt pair review and Oracle final diff review both returned merge-ready with no actionable blockers after the review fix.

## Risk Assessment

✅ **Low**

- Blast radius is limited to the tenant detail Portal-user presentation and a new read-only summary seam.
- The existing public Portal-user listing contract remains unchanged.
- There is no schema migration, API lifecycle change, or persistence change.
- Invite plaintext remains show-once and is not added to database projections, URLs, flash, session, or DOM data attributes.
- Pending rows loaded without plaintext do not tick over automatically until another event or reload; that broader refresh behavior remains intentionally out of scope for #342.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds tenant-scoped Portal invite summaries and displays current invitation context and expiry in the Console while preserving show-once plaintext handling.
- Adds secret-free `PortalUserSummary` projections for Console reads.
- Displays Not issued, Pending, Expired, and Redeemed states with localized timestamps.
- Keeps issued URLs socket-local, clears them at expiry, and ignores stale expiry messages after reissue.
- Fixes the prior post-commit reveal-loss path by avoiding a fallible tenant-detail reload after successful issuance.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported post-commit reveal-loss path is removed, and no blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex | Adds socket-local invite reveal and expiry lifecycle handling, renders invitation context, and removes the fallible post-copy detail reload. |
| apps/orchard_controller/lib/orchard/governance/portal_governance.ex | Adds a tenant-scoped, secret-free query that derives invitation presentation state from status and token timestamps. |
| apps/orchard_controller/lib/orchard/governance/portal_user_summary.ex | Defines the Console-facing Portal user summary contract without invite secrets. |
| apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs | Covers reveal durability, expiry, stale timers, focus behavior, navigation loss, and all invitation contexts. |
| apps/orchard_controller/test/orchard/governance/named_portal_user_test.exs | Verifies tenant scoping and the Not issued, Pending, Expired, and Redeemed summary projections. |
| docs/DESIGN.md | Documents invitation-context presentation and transient URL expiry behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor Operator
  participant LiveView as TenantDetailLive
  participant Governance
  participant DB
  Operator->>LiveView: Copy invite
  LiveView->>Governance: copy_portal_invite(tenant, user_id)
  Governance->>DB: Commit replacement invite
  DB-->>Governance: URL and committed expiry
  Governance-->>LiveView: invite
  LiveView->>LiveView: Store URL socket-locally
  LiveView->>LiveView: Mark summary Pending
  LiveView->>LiveView: Schedule expiry message
  LiveView-->>Operator: Show one-time URL and expiry
  Note over LiveView: No tenant-detail reload after issuance
  LiveView->>LiveView: Expiry message matching current invite
  LiveView->>LiveView: Clear plaintext
  LiveView->>Governance: Reload summaries
  Governance->>DB: Read current invite context
  Governance-->>LiveView: Expired summary
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: preserve portal invite reveal after..."](https://github.com/kapitan-ai/orchard/commit/9221ee4157e11017128a12937aabfddae6fdc68f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58935580)</sub>

<!-- /greptile_comment -->