### PR TITLE
Show API Token mint provenance in Organization Console

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
@@ -7,7 +7,7 @@ defmodule OrchardConsole.TenantDetailLive do
 
   alias Orchard.API.Transport
   alias Orchard.Governance
-  alias Orchard.Governance.{ApiKey, RoleBinding}
+  alias Orchard.Governance.{ApiKey, RoleBinding, TenantApiKeySummary}
 
   @console_audit_opts [actor_type: "operator", surface: "console"]
 
@@ -393,6 +393,15 @@ defmodule OrchardConsole.TenantDetailLive do
 
           <.table id="tenant-api-keys-table" rows={@api_keys} row_id={&"api-key-#{&1.id}"}>
             <:col :let={key} label="Name">{key.name}</:col>
+            <:col :let={key} label="Minted via" class="min-w-40 max-w-[16rem] whitespace-normal">
+              <p>{minted_via_label(key)}</p>
+              <p
+                :if={key.issuance_surface == "developer_portal"}
+                class="mt-1 break-words text-xs text-slate-500 dark:text-slate-400"
+              >
+                {key.portal_user_email || "Attribution unavailable"}
+              </p>
+            </:col>
             <:col :let={key} label="Prefix" mono>{key.token_prefix}</:col>
             <:col :let={key} label="Created" mono><.local_time value={key.inserted_at} format={:datetime_minute} /></:col>
               <:col :let={key} label="Last Used" mono><.local_time value={key.last_used_at} format={:datetime_minute} /></:col>
@@ -743,7 +752,7 @@ defmodule OrchardConsole.TenantDetailLive do
     tenant_id = socket.assigns.tenant_id
 
     with {:ok, tenant} <- Governance.get_tenant(tenant_id),
-         {:ok, api_keys} <- Governance.list_api_keys_for_tenant(tenant),
+         {:ok, api_keys} <- Governance.list_tenant_api_key_summaries(tenant),
          {:ok, api_clients} <- Governance.list_api_clients_for_tenant(tenant),
          {:ok, portal_users} <- Governance.list_portal_users(tenant) do
       assign(socket,
@@ -776,13 +785,24 @@ defmodule OrchardConsole.TenantDetailLive do
 
   defp active_api_token?(%ApiKey{} = api_key), do: ApiKey.status(api_key, utc_now()) == :active
 
+  defp minted_via_label(%TenantApiKeySummary{issuance_surface: "developer_portal"}),
+    do: "Developer Portal"
+
+  defp minted_via_label(%TenantApiKeySummary{}), do: "Operator tooling"
+
   defp present?(value) when is_binary(value), do: String.trim(value) != ""
   defp present?(_value), do: false
 
   attr(:api_key, :map, required: true)
 
   defp api_token_status_badge(assigns) do
-    assigns = assign(assigns, :status, ApiKey.status(assigns.api_key, utc_now()))
+    status =
+      case assigns.api_key do
+        %ApiKey{} = api_key -> ApiKey.status(api_key, utc_now())
+        %TenantApiKeySummary{} = api_key -> TenantApiKeySummary.status(api_key, utc_now())
+      end
+
+    assigns = assign(assigns, :status, status)
 
     ~H"""
     <.badge :if={@status == :active} tone={:success}>Active</.badge>

--- a/apps/orchard_controller/lib/orchard/governance.ex
+++ b/apps/orchard_controller/lib/orchard/governance.ex
@@ -15,10 +15,12 @@ defmodule Orchard.Governance do
     ApiKeySecret,
     AuditLog,
     AuditWriter,
+    PortalUser,
     ProvisioningBatch,
     RoleBinding,
     ServiceAccount,
-    Tenant
+    Tenant,
+    TenantApiKeySummary
   }
 
   alias Orchard.Repo
@@ -671,6 +673,40 @@ defmodule Orchard.Governance do
         |> Enum.map(&redact_api_key/1)
 
       {:ok, api_keys}
+    end
+  end
+
+  @spec list_tenant_api_key_summaries(Tenant.t() | Ecto.UUID.t()) ::
+          {:ok, [TenantApiKeySummary.t()]} | {:error, :tenant_not_found}
+  def list_tenant_api_key_summaries(%Tenant{id: tenant_id}),
+    do: list_tenant_api_key_summaries(tenant_id)
+
+  def list_tenant_api_key_summaries(tenant_id) do
+    with {:ok, tenant_id} <- normalize_tenant_id(tenant_id),
+         {:ok, _tenant} <- fetch_tenant(tenant_id) do
+      summaries =
+        ApiKey
+        |> where([api_key], api_key.tenant_id == ^tenant_id)
+        |> join(:left, [api_key], portal_user in PortalUser,
+          on:
+            portal_user.id == api_key.portal_user_id and
+              portal_user.tenant_id == api_key.tenant_id
+        )
+        |> order_by([api_key], desc: api_key.inserted_at, desc: api_key.id)
+        |> select([api_key, portal_user], %TenantApiKeySummary{
+          id: api_key.id,
+          name: api_key.name,
+          token_prefix: api_key.token_prefix,
+          issuance_surface: api_key.issuance_surface,
+          portal_user_email: portal_user.email,
+          expires_at: api_key.expires_at,
+          last_used_at: api_key.last_used_at,
+          revoked_at: api_key.revoked_at,
+          inserted_at: api_key.inserted_at
+        })
+        |> Repo.all()
+
+      {:ok, summaries}
     end
   end
 

--- a/apps/orchard_controller/lib/orchard/governance/tenant_api_key_summary.ex
+++ b/apps/orchard_controller/lib/orchard/governance/tenant_api_key_summary.ex
@@ -1,0 +1,39 @@
+defmodule Orchard.Governance.TenantApiKeySummary do
+  @moduledoc """
+  Secret-free tenant-direct API Token row for Console presentation.
+  """
+
+  @enforce_keys [
+    :id,
+    :name,
+    :token_prefix,
+    :issuance_surface,
+    :portal_user_email,
+    :expires_at,
+    :last_used_at,
+    :revoked_at,
+    :inserted_at
+  ]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          name: String.t(),
+          token_prefix: String.t(),
+          issuance_surface: String.t(),
+          portal_user_email: String.t() | nil,
+          expires_at: DateTime.t() | nil,
+          last_used_at: DateTime.t() | nil,
+          revoked_at: DateTime.t() | nil,
+          inserted_at: DateTime.t()
+        }
+
+  @spec status(t(), DateTime.t()) :: :active | :expired | :revoked
+  def status(%__MODULE__{revoked_at: %DateTime{}}, _now), do: :revoked
+
+  def status(%__MODULE__{expires_at: %DateTime{} = expires_at}, %DateTime{} = now) do
+    if DateTime.compare(expires_at, now) == :gt, do: :active, else: :expired
+  end
+
+  def status(%__MODULE__{}, %DateTime{}), do: :active
+end

--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -5,7 +5,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance
-  alias Orchard.Governance.AuditLog
+  alias Orchard.Governance.{ApiKey, ApiKeySecret, AuditLog, PortalUser}
   alias Orchard.Repo
 
   @moduletag :live
@@ -100,6 +100,129 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert key_row =~ ~s(data-local-time-format="datetime_minute")
       # Last Used is nil — should show placeholder without hook
       assert key_row =~ "—"
+    end
+
+    test "renders same-Organization Developer Portal mint attribution without token secrets", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      portal_user =
+        %PortalUser{}
+        |> PortalUser.invite_changeset(%{
+          tenant_id: tenant.id,
+          email: "  Developer@Example.COM "
+        })
+        |> Repo.insert!()
+
+      {api_key, token} = create_portal_api_key_record!(tenant, portal_user)
+      {:ok, view, html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      assert html =~ "Minted via"
+
+      key_row = view |> element("#api-key-#{api_key.id}") |> render()
+      assert key_row =~ "Developer Portal"
+      assert key_row =~ "developer@example.com"
+      refute key_row =~ token
+
+      table_card = view |> element("#tenant-api-keys-card") |> render()
+      assert table_card =~ ~r/Name.*Minted via.*Prefix/s
+      assert table_card =~ "overflow-x-auto"
+
+      minted_via_cell =
+        view |> element("#api-key-#{api_key.id} td:nth-child(2)") |> render()
+
+      assert minted_via_cell =~ "min-w-40 max-w-[16rem] whitespace-normal"
+      assert minted_via_cell =~ "break-words"
+      assert minted_via_cell =~ "text-slate-500 dark:text-slate-400"
+      refute minted_via_cell =~ "<button"
+      refute minted_via_cell =~ "<a"
+      refute minted_via_cell =~ "tabindex"
+    end
+
+    test "renders governance mints as Operator tooling", %{conn: conn, tenant: tenant} do
+      {:ok, %{api_key: api_key, token: token}} =
+        Governance.create_api_key(tenant, %{name: "operator-token"})
+
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      key_row = view |> element("#api-key-#{api_key.id}") |> render()
+      assert key_row =~ "Operator tooling"
+      refute key_row =~ "Developer Portal"
+      refute key_row =~ "Attribution unavailable"
+      refute key_row =~ token
+    end
+
+    test "renders null and cross-Organization Portal attribution as unavailable", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      other_tenant =
+        Governance.create_tenant(%{slug: "detail-other", name: "Detail Other"})
+        |> elem(1)
+
+      other_portal_user =
+        %PortalUser{}
+        |> PortalUser.invite_changeset(%{
+          tenant_id: other_tenant.id,
+          email: "private@other.example"
+        })
+        |> Repo.insert!()
+
+      {legacy_key, legacy_token} =
+        create_portal_api_key_record!(tenant, other_portal_user, %{
+          name: "legacy-token",
+          portal_user_id: nil
+        })
+
+      {cross_key, cross_token} =
+        create_portal_api_key_record!(tenant, other_portal_user, %{name: "cross-token"})
+
+      {:ok, view, html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      for {api_key, token} <- [{legacy_key, legacy_token}, {cross_key, cross_token}] do
+        key_row = view |> element("#api-key-#{api_key.id}") |> render()
+        assert key_row =~ "Developer Portal"
+        assert key_row =~ "Attribution unavailable"
+        refute key_row =~ token
+      end
+
+      refute html =~ other_portal_user.email
+    end
+
+    test "keeps expired and deliberately revoked rendering separate from mint provenance", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      portal_user =
+        %PortalUser{}
+        |> PortalUser.invite_changeset(%{
+          tenant_id: tenant.id,
+          email: "status@example.com"
+        })
+        |> Repo.insert!()
+
+      expires_at =
+        DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:microsecond)
+
+      {api_key, _token} =
+        create_portal_api_key_record!(tenant, portal_user, %{expires_at: expires_at})
+
+      {:ok, view, _html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      expired_row = view |> element("#api-key-#{api_key.id}") |> render()
+      assert expired_row =~ "Expired"
+      assert expired_row =~ "Developer Portal"
+      assert expired_row =~ portal_user.email
+      assert has_element?(view, "#tenant-api-key-revoke-#{api_key.id}")
+
+      html = render_click(view, "revoke_api_key", %{"id" => api_key.id})
+      revoked_row = view |> element("#api-key-#{api_key.id}") |> render()
+
+      assert html =~ "Revoked API Token portal-token."
+      assert revoked_row =~ "Revoked"
+      assert revoked_row =~ "Developer Portal"
+      assert revoked_row =~ portal_user.email
+      refute has_element?(view, "#tenant-api-key-revoke-#{api_key.id}")
     end
 
     test "secret card is NOT shown on fresh page visit", %{conn: conn, tenant: tenant} do
@@ -474,5 +597,29 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       Governance.create_api_client_api_token(api_client, Map.merge(%{name: "prod"}, token_attrs))
 
     %{api_client: api_client, api_key: api_key, token: token}
+  end
+
+  defp create_portal_api_key_record!(tenant, portal_user, overrides \\ %{}) do
+    generated = ApiKeySecret.generate()
+
+    attrs =
+      Map.merge(
+        %{
+          tenant_id: tenant.id,
+          portal_user_id: portal_user.id,
+          name: "portal-token",
+          token_prefix: generated.token_prefix,
+          secret_hash: generated.secret_hash,
+          issuance_surface: "developer_portal"
+        },
+        overrides
+      )
+
+    api_key =
+      %ApiKey{}
+      |> ApiKey.tenant_direct_changeset(attrs)
+      |> Repo.insert!()
+
+    {api_key, generated.token}
   end
 end

--- a/apps/orchard_controller/test/orchard/governance/governance_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/governance_test.exs
@@ -48,7 +48,16 @@ defmodule Orchard.GovernanceTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance
-  alias Orchard.Governance.{ApiKey, ApiKeySecret, AuditLog, RoleBinding, Tenant}
+
+  alias Orchard.Governance.{
+    ApiKey,
+    ApiKeySecret,
+    AuditLog,
+    PortalUser,
+    RoleBinding,
+    Tenant,
+    TenantApiKeySummary
+  }
 
   describe "create_tenant/1" do
     test "creates a tenant, ignores caller-supplied ids, and writes one audit row" do
@@ -878,6 +887,159 @@ defmodule Orchard.GovernanceTest do
 
     test "returns error for malformed tenant ID" do
       assert {:error, :tenant_not_found} = Governance.list_api_keys_for_tenant("bad")
+    end
+  end
+
+  describe "list_tenant_api_key_summaries/1" do
+    test "SPEC 7.4a projects same-Organization Developer Portal mint attribution without secrets" do
+      tenant = create_tenant!("tenant-key-summary")
+
+      portal_user =
+        %PortalUser{}
+        |> PortalUser.invite_changeset(%{
+          tenant_id: tenant.id,
+          email: "  Developer@Example.COM "
+        })
+        |> Repo.insert!()
+
+      api_key =
+        create_api_key_record!(tenant, %{
+          portal_user_id: portal_user.id,
+          issuance_surface: "developer_portal"
+        })
+
+      assert {:ok, [%TenantApiKeySummary{} = summary]} =
+               Governance.list_tenant_api_key_summaries(tenant)
+
+      assert Map.from_struct(summary) == %{
+               id: api_key.id,
+               name: api_key.name,
+               token_prefix: api_key.token_prefix,
+               issuance_surface: "developer_portal",
+               portal_user_email: "developer@example.com",
+               expires_at: api_key.expires_at,
+               last_used_at: api_key.last_used_at,
+               revoked_at: api_key.revoked_at,
+               inserted_at: api_key.inserted_at
+             }
+
+      refute Map.has_key?(summary, :secret_hash)
+      refute Map.has_key?(summary, :password_hash)
+      refute Map.has_key?(summary, :session_epoch)
+    end
+
+    test "SPEC 7.4a preserves mint attribution and API Token state when the Portal User is disabled" do
+      tenant = create_tenant!("tenant-key-disabled-user-summary")
+
+      portal_user =
+        %PortalUser{}
+        |> PortalUser.invite_changeset(%{
+          tenant_id: tenant.id,
+          email: "disabled-mint@example.com"
+        })
+        |> Repo.insert!()
+
+      api_key =
+        create_api_key_record!(tenant, %{
+          portal_user_id: portal_user.id,
+          issuance_surface: "developer_portal"
+        })
+
+      assert {:ok, disabled_user} = Governance.disable_portal_user(tenant, portal_user)
+      assert disabled_user.status == "disabled"
+
+      assert {:ok,
+              [
+                %TenantApiKeySummary{
+                  id: key_id,
+                  portal_user_email: "disabled-mint@example.com",
+                  revoked_at: nil
+                }
+              ]} = Governance.list_tenant_api_key_summaries(tenant)
+
+      assert key_id == api_key.id
+      assert Repo.get!(ApiKey, api_key.id).revoked_at == nil
+    end
+
+    test "SPEC 7.4a projects governance mints without Portal User attribution" do
+      tenant = create_tenant!("tenant-key-governance-summary")
+      api_key = create_api_key_record!(tenant)
+
+      assert {:ok,
+              [
+                %TenantApiKeySummary{
+                  id: key_id,
+                  issuance_surface: "governance",
+                  portal_user_email: nil
+                }
+              ]} = Governance.list_tenant_api_key_summaries(tenant)
+
+      assert key_id == api_key.id
+    end
+
+    test "SPEC 7.4a keeps null and deleted Developer Portal attribution unavailable" do
+      tenant = create_tenant!("tenant-key-unattributed-summary")
+
+      portal_user =
+        %PortalUser{}
+        |> PortalUser.invite_changeset(%{
+          tenant_id: tenant.id,
+          email: "deleted@example.com"
+        })
+        |> Repo.insert!()
+
+      null_key =
+        create_api_key_record!(tenant, %{
+          name: "legacy-null",
+          issuance_surface: "developer_portal"
+        })
+
+      deleted_key =
+        create_api_key_record!(tenant, %{
+          name: "deleted-user",
+          portal_user_id: portal_user.id,
+          issuance_surface: "developer_portal"
+        })
+
+      Repo.delete!(portal_user)
+
+      assert {:ok, summaries} = Governance.list_tenant_api_key_summaries(tenant)
+
+      assert Enum.map(summaries, &{&1.id, &1.portal_user_email}) == [
+               {deleted_key.id, nil},
+               {null_key.id, nil}
+             ]
+    end
+
+    test "SPEC 7.4a fails closed for cross-Organization Portal User references" do
+      tenant = create_tenant!("tenant-key-cross-summary")
+      other_tenant = create_tenant!("tenant-key-cross-other")
+
+      other_portal_user =
+        %PortalUser{}
+        |> PortalUser.invite_changeset(%{
+          tenant_id: other_tenant.id,
+          email: "private@other.example"
+        })
+        |> Repo.insert!()
+
+      api_key =
+        create_api_key_record!(tenant, %{
+          portal_user_id: other_portal_user.id,
+          issuance_surface: "developer_portal"
+        })
+
+      assert {:ok,
+              [
+                %TenantApiKeySummary{
+                  id: key_id,
+                  issuance_surface: "developer_portal",
+                  portal_user_email: nil
+                } = summary
+              ]} = Governance.list_tenant_api_key_summaries(tenant)
+
+      assert key_id == api_key.id
+      refute inspect(summary) =~ other_portal_user.email
     end
   end
 


### PR DESCRIPTION
Issue #343 requires the Organization API Tokens table to show where each token was minted while preserving tenant isolation, credential status, and secret handling.

## What changed

- Add a secret-free TenantApiKeySummary projection for Console reads.
- Join Portal User attribution only when both the user ID and Organization ID match.
- Show Minted via between Name and Prefix:
  - Developer Portal plus the normalized Portal User email
  - Developer Portal plus Attribution unavailable for missing, deleted, null, or cross-Organization attribution
  - Operator tooling for governance mints
- Keep provenance separate from active, expired, and revoked status.
- Preserve the existing revoke action and local table scrolling.
- Add focused governance and LiveView coverage for tenant isolation, secret exclusion, disabled users, deleted users, status, revocation, semantics, and responsive class contracts.

This traces to SPEC.md section 7.4a and the accepted Console copy in issue #343. No OpenSpec package or schema migration is needed because the existing provenance fields already define the behavior.

## Verification

TDD:
- Query seam started red on the missing summary module and function, then passed.
- LiveView seam started red on the missing Minted via column, then passed.
- Focused Governance and Tenant Detail LiveView suite: 88 passed.

Repository quality workflow:
- mise exec -- mix format
- mise exec -- mix compile --warnings-as-errors
- mise exec -- mix credo --strict
- mise exec -- mix dialyzer
- make macos-native-test-helpers
- env ORCHARD_TEST_NODE_AGENT_PORT=15171 mise exec -- mix test
  - 5,075 passed, 6 skipped, 10 excluded
- env ORCHARD_TEST_NODE_AGENT_PORT=15171 mise exec -- mix test --cover --seed 822658
  - 5,075 passed, 6 skipped, 10 excluded
  - shared 67.04%, controller 84.5%, node agent 78.94%, CLI 76.06%

The documented port override was used because an unrelated process already owned the default test port 15071. It was preserved.

Browser acceptance used a genuine trusted HTTPS Orchard session:
- Desktop and tablet in light and dark themes
- Mobile at 390 by 844
- Local table scrolling without document overflow
- Long email wrapping inside the provenance cell
- No interactive control in the provenance cell
- Keyboard revoke changed Expired to Revoked while preserving provenance
- No private cross-Organization email rendered
- No browser page errors

Independent RepoPrompt reviews:
- Pair review: no blocker or important defect.
- Final Oracle review on the latest diff: GO, no fixes required.
- PR #348 is still open. If it lands first, its overlapping test helpers must be preserved during integration.

## Risk Assessment

✅ **Low**

- The blast radius is limited to the tenant detail Console read model, table rendering, and focused tests.
- The query returns a bounded, secret-free struct and scopes both the API Token and Portal User join to the same Organization.
- Missing or cross-Organization attribution fails closed to visible unavailable copy.
- No database migration, API contract change, minting behavior change, or automatic revocation behavior is introduced.
- Existing status and revoke paths remain covered.

Closes #343



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a secret-free tenant API-token projection and displays tenant-scoped mint provenance in the Organization Console.
- Attributes Developer Portal mints only through a same-Organization Portal User join.
- Falls back to unavailable attribution without exposing cross-Organization email addresses.
- Preserves token status and revocation behavior while adding focused governance and LiveView coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex | Loads secret-free summaries and renders provenance while preserving status and revoke behavior. |
| apps/orchard_controller/lib/orchard/governance.ex | Adds a tenant-scoped projection whose Portal User join includes both user and tenant identity. |
| apps/orchard_controller/lib/orchard/governance/tenant_api_key_summary.ex | Defines the bounded read model and status semantics without credential-secret fields. |
| apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs | Covers provenance rendering, unavailable attribution, secret exclusion, status, revocation, and layout contracts. |
| apps/orchard_controller/test/orchard/governance/governance_test.exs | Covers projection shape, tenant isolation, disabled and deleted users, and token-state preservation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[Tenant] --> Q[Tenant-scoped API token query]
  Q --> J{Same-Organization Portal User?}
  J -->|Yes| E[Developer Portal + email]
  J -->|No, portal mint| U[Developer Portal + Attribution unavailable]
  Q -->|Governance mint| O[Operator tooling]
  E --> C[Organization Console table]
  U --> C
  O --> C
```
</details>

<sub>Reviews (2): Last reviewed commit: ["merge: integrate current main into API t..."](https://github.com/kapitan-ai/orchard/commit/5ad9f075f4d655b975df3ec9b616c98d92f03f2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58959276)</sub>

<!-- /greptile_comment -->