### PR TITLE
docs: define Node Runtime gRPC deprecation contract

### DIFF
--- a/docs/decisions/0029-deprecate-node-runtime-grpc-compatibility.md
+++ b/docs/decisions/0029-deprecate-node-runtime-grpc-compatibility.md
@@ -1,0 +1,47 @@
+# ADR: Deprecate Node Runtime gRPC compatibility in staged release epochs
+
+## Status
+
+Proposed under issue #350.
+
+## Context
+
+ADR 0001 made the first-party Runtime Endpoint path BEAM-first while retaining `NodeRuntimeService` for explicit compatibility and possible future adapter use.
+ADR 0012 retained separate gRPC and mTLS control roles for production BEAM authorization and recovery.
+The provider-neutral Worker Runtime contract in ADR 0025 also retains a separate Node Agent-local gRPC and Unix-domain-socket boundary.
+
+PR #341 made the Node Runtime listener configurable, and PR #346 proved a listener-free source-development BEAM operation matrix with a deterministic validation adapter.
+The current contract still requires all-in-one gRPC loopback, explicit split-role and packaged gRPC fallback, a default-enabled Node Runtime listener, mixed Controller and Node Agent versions, and rollback-safe releases.
+The BEAM path and Worker Runtime also still consume generated `cluster.v1.runtime` message types.
+
+## Decision
+
+Deprecate `NodeRuntimeService` only as the first-party Controller-to-Node Agent Runtime Endpoint compatibility transport.
+Keep the transport-independent Runtime Endpoint Interface as the durable boundary.
+Keep Peer Grant/control and Worker Runtime gRPC boundaries outside this deprecation.
+Keep future non-BEAM adapters possible without promising the current protocol permanently.
+
+Use staged Bridge, Deprecation, Floor, and Removal release epochs.
+The Bridge Release qualifies every affected supported profile on the non-gRPC path while retaining compatibility.
+The Deprecation Release makes the non-gRPC path the only default and makes the runtime listener default-off while retaining explicit rollback.
+The non-destructive Floor Release retains every compatibility asset and records the exact minimum-version cutover only after every participant runs that version and proves removal readiness.
+The Removal Release requires that earlier cutover and removes the first-party runtime adapters and listener only after actual `N`, `N-1`, and reverse Controller rollback pairings pass.
+
+Migrate all-in-one source development first through a same-VM Runtime Endpoint client that does not require gRPC loopback or distributed Erlang networking.
+Retain explicit gRPC restart as immediate rollback in that first slice.
+
+Delete four layers independently and in order: listener and profile defaults, first-party runtime adapters, runtime protobuf messages and generated bindings, then shared dependency ownership.
+Runtime-message deletion remains blocked while BEAM internals or the Worker Runtime contract consume those messages.
+Shared dependency removal remains blocked while Peer Grant/control or Worker Runtime boundaries consume gRPC or protobuf.
+
+## Consequences
+
+The deprecation can advance without conflating listener absence with protobuf independence or weakening pre-BEAM authorization.
+All-in-one source development gains a simpler same-VM architecture before any supported rollback surface is removed.
+The staged release epochs require more qualification time but provide a non-circular Controller and Node Agent `N` and `N-1` window plus a tested Controller rollback pairing.
+An unknown supported external consumer blocks adapter removal, but speculative future adapter language does not force permanent retention of `NodeRuntimeService`.
+
+## SPEC.md impact
+
+Update required in §§1.2, 7.5, 10.6, 11, and 13 only as accepted implementation stages change the current all-in-one, compatibility, listener, packaged, version, or rollback contract.
+This proposal does not change `SPEC.md` or runtime behavior.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,4 +23,4 @@ Start from [`_template.md`](_template.md) when useful. Decisions already fixed b
 
 ## Decision index
 
-The current sequence ends with [ADR 0028: Local model support claims require manual qualification](0028-mandatory-manual-model-qualification.md).
+The current sequence ends with [ADR 0029: Deprecate Node Runtime gRPC compatibility in staged release epochs](0029-deprecate-node-runtime-grpc-compatibility.md).

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -247,8 +247,9 @@ _Avoid_: Worker Runtime Interface, Node Lifecycle Interface, transport protocol
 
 **gRPC Compatibility Adapter**:
 The current adapter that maps Runtime Endpoint Interface semantics to `proto/cluster/v1` and `NodeRuntimeService`.
-It remains an explicit mTLS compatibility, diagnostics, external-provider, recovery, and operator opt-out path while keeping the durable Controller domain contract transport-independent.
-_Avoid_: Runtime Endpoint Interface, Worker Runtime Interface, first-party BEAM mesh
+It is the current explicit first-party Controller-to-Node Runtime Endpoint compatibility and operator opt-out mode.
+It does not name the separate Peer Grant/control or Worker Runtime gRPC boundaries, and any future reuse by a non-BEAM adapter requires its own accepted contract.
+_Avoid_: Runtime Endpoint Interface, Worker Runtime Interface, Peer Grant control path, first-party BEAM mesh
 
 **Worker Runtime Interface**:
 The provider-neutral, versioned Node Agent-local execution process contract for readiness, model loading and unloading, inference streaming, cancellation, health, diagnostics, and normalized failures.

--- a/openspec/changes/deprecate-node-runtime-grpc-compatibility/.openspec.yaml
+++ b/openspec/changes/deprecate-node-runtime-grpc-compatibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/deprecate-node-runtime-grpc-compatibility/design.md
+++ b/openspec/changes/deprecate-node-runtime-grpc-compatibility/design.md
@@ -1,0 +1,316 @@
+## Context
+
+The Runtime Endpoint Interface is Orchard's transport-independent Controller-facing execution boundary.
+The first-party Node Agent is its v1 endpoint.
+`NodeRuntimeService` is one compatibility adapter for that interface, not the interface itself.
+
+The current product contract contains four different facts that cannot be collapsed into one removal decision.
+
+- Split-role source development defaults to BEAM but preserves explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` operation on port `50071`.
+- All-in-one `bin/dev` rejects BEAM and uses gRPC loopback as its active Controller-to-Node Runtime Endpoint path.
+- Packaged Controller and Node Agent releases default to BEAM but preserve explicit gRPC fallback, listener configuration, generated operator environments, and launchd behavior.
+- Peer Grant/control and Worker Runtime boundaries use gRPC or protobuf for roles that the first-party Runtime Endpoint migration does not replace.
+
+PR #341 made the Node Runtime listener independently configurable without changing any supported default.
+PR #346 then proved a listener-free source-development BEAM operation matrix using a real Controller, a real Node Agent, the real BEAM client and endpoint, and a deterministic validation adapter.
+PR #346 does not prove packaged operation, real MLX execution, physical multi-host behavior, mixed Product Versions, rolling upgrades, rollback, or removal of protobuf-shaped internals.
+
+The current Product Version is a development version, and repository evidence does not establish which published release cohorts operators run.
+This design therefore names relative compatibility epochs and evidence gates rather than inventing an immediate SemVer removal floor.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define exactly which `NodeRuntimeService` role is deprecated.
+- Preserve every independent gRPC and protobuf boundary not replaced by this change.
+- Inventory current consumers, supported compatibility modes, implementation dependencies, test coupling, and speculative future-adapter language.
+- Define how all-in-one, split-role source development, packaged releases, mixed versions, and rollback move through the deprecation.
+- Define observable evidence gates between warning, default-off, adapter removal, protobuf deletion, and dependency cleanup.
+- Identify the smallest reversible first implementation slice.
+
+**Non-Goals:**
+
+- Any runtime, shell, configuration, packaging, CLI, protobuf, generated-code, or dependency behavior change in this proposal.
+- A listener default change or executable deprecation warning.
+- Removal or replacement of Peer Grant, enrollment, certificate lifecycle, delivery, recovery, diagnostics, or other pre-BEAM control traffic.
+- A Node Agent-to-Worker Runtime protocol change.
+- Repository-wide removal of gRPC or protobuf.
+- A promise that every future non-BEAM Runtime Endpoint adapter uses BEAM or the current `NodeRuntimeService` protocol.
+- A claim that repository search proves no unknown external consumer exists.
+
+## Boundary Decision
+
+The deprecation target is the first-party Controller-to-Node Agent Runtime Endpoint operations currently carried by `cluster.v1.NodeRuntimeService`.
+
+The following boundaries remain supported and outside this deprecation.
+
+- `Orchard.RuntimeEndpoint.Client` and the complete transport-independent Runtime Endpoint operation and observation model.
+- Certificate-authenticated `ControllerPeerGrantService` delivery and recovery.
+- Enrollment, Node and Controller certificate lifecycle, trust recovery, diagnostics, and other pre-BEAM control responsibilities that still require an explicit authenticated control path.
+- The provider-neutral Node Agent-to-Worker Runtime interface over local gRPC and Unix-domain sockets.
+- `common.proto`, `events.proto`, and shared gRPC/protobuf dependencies while any retained boundary consumes them.
+- A future non-BEAM Runtime Endpoint adapter designed under its own accepted protocol contract.
+
+Removal of the current runtime compatibility protocol does not authorize any retained boundary to move onto BEAM.
+It also does not authorize external or partially trusted endpoints to join the first-party BEAM mesh.
+
+## Consumer And Compatibility Inventory
+
+### Product and public API promises
+
+Repository product contracts expose `NodeRuntimeService` as an internal `cluster.v1` compatibility service rather than a tenant-facing public API.
+The public `/v1/responses` and `/v1/chat/completions` contracts depend on stable Runtime Endpoint outcomes, not on this transport.
+No accepted repository contract or current issue and PR evidence identifies a supported external product that directly consumes `NodeRuntimeService`.
+This is bounded repository and project evidence, not proof that no private or historical consumer exists.
+
+### Supported operator compatibility modes
+
+| Surface | Current commitment | Removal implication |
+|---|---|---|
+| All-in-one `bin/dev` | Active gRPC loopback on the source-development port and explicit rejection of BEAM | Must migrate first and retain explicit immediate rollback during its first slice |
+| Split-role source development | BEAM default with explicit `grpc` opt-out and `ORCHARD_RUNTIME_CLIENT_TARGETS` | Opt-out cannot be removed before a released compatibility baseline and rollback proof |
+| Packaged Controller | BEAM default with explicit gRPC fallback and generated operator environment support | Fallback cannot be removed before packaged, lifecycle, real-runtime, and mixed-version qualification |
+| Packaged Node Agent | Runtime listener remains default-enabled and listener host, port, TLS credentials, and readiness remain configured | Default-off and removal require separate profile gates |
+| Orchard.app, DMG, and launchd | Payload wrappers and generated environments preserve both BEAM and gRPC profiles | App update and rollback evidence must cover the selected release baseline |
+
+### First-party implementation dependencies
+
+| Layer | Current consumers and coupling |
+|---|---|
+| Controller interface and selection | `Orchard.RuntimeEndpoint.Client`, `BeamClient`, `GrpcCompatibilityClient`, inference configuration, and activation probes |
+| Direct gRPC dispatch | `GrpcNodeRuntimeClient` and `NodeRuntimeService.Stub` |
+| Domain mapping | `GrpcCompatibilityMapper`, shared `GrpcMapping`, Node Agent `RuntimeEndpointMapper`, status observation normalization, and inference event mapping |
+| Scheduler, lifecycle, inference, and diagnostics | single-node and multi-node schedulers, request dispatch, inference, Nodes observation paths, activation, Console diagnostics, and CLI join probes |
+| Node Agent service | `RuntimeServer`, Node `Endpoint`, `GRPC.Server.Supervisor`, listener settings, TLS credentials, readiness, and supervision tests |
+| Protocol and generation | `proto/cluster/v1/runtime.proto`, generated Elixir `runtime.pb.ex`, generated Python `runtime_pb2.py` and `runtime_pb2_grpc.py`, root generation tasks, and drift tests |
+| Worker Runtime imports | the provider-neutral Worker Runtime schema and MLX implementation still import runtime request, response, acknowledgement, model, and inference-event messages from `cluster.v1` |
+
+### Transport-only and compatibility test coupling
+
+Controller adapter, mapper, scheduler, dispatch, activation, observation, and inference suites directly construct gRPC compatibility messages or clients.
+Node Agent suites start the compatibility server and assert listener supervision and readiness behavior.
+CLI node-join, generated-environment, payload-wrapper, and transport tests encode the compatibility configuration contract.
+Source-development, shutdown-custody, payload-release, and packaging smoke paths select gRPC explicitly in some scenarios.
+These tests are removal work, not evidence that the transport is part of the public inference API.
+
+### Speculative future adapters
+
+ADR 0001 and the accepted runtime-endpoints specification allow the current protocol to be reused or evolved for a future non-BEAM adapter.
+No current repository implementation, accepted adapter contract, or supported external consumer requires that reuse.
+The extension point belongs to the Runtime Endpoint Interface, not to `NodeRuntimeService` permanence.
+
+## Topology Migration
+
+### Stage A: all-in-one source-development migration
+
+The first implementation slice changes only the active all-in-one source-development Runtime Endpoint path.
+All-in-one `bin/dev` will use a same-VM transport-independent Runtime Endpoint client by default.
+It will not enable distributed Erlang networking merely to call the Node Agent inside the same BEAM VM.
+
+The slice retains explicit gRPC selection, the listener, both adapters, all protocol bindings, and dependencies.
+Its rollback is an immediate restart with the explicit gRPC selection.
+The source-development port remains available for the rollback mode.
+
+This slice closes the only source-development topology that still requires gRPC for its active first-party path.
+It does not change split-role or packaged behavior.
+
+### Stage B: Bridge Release baseline
+
+The Bridge Release is the first released Product Version in which every affected supported topology has a qualified non-gRPC first-party path while the runtime compatibility adapters and listeners remain available.
+The Bridge Release may warn when operators explicitly select the runtime gRPC compatibility mode or enable its listener.
+Warnings must identify the selected compatibility surface without implying that Peer Grant/control or Worker Runtime gRPC is deprecated.
+
+The Bridge Release is not a removal floor.
+It exists so mixed-version and rollback evidence can be gathered from a shipped baseline before destructive cleanup.
+
+### Stage D: Deprecation Release baseline
+
+The Deprecation Release makes the non-gRPC path the only default for every qualified first-party profile.
+The Node Runtime listener is default-off for those profiles and is enabled only by the explicit compatibility profile.
+The Controller adapter, Node Agent server adapter, protocol bindings, and dependencies remain present.
+
+The explicit compatibility mode remains a rollback tool during this release.
+Upgrade preflight reports gRPC-only configuration and every endpoint that cannot prove the required non-gRPC capability, identity, authorization, and reachability.
+
+### Stage F: Floor Release and compatibility cutover
+
+The Floor Release is a non-destructive release after the Deprecation Release.
+It retains the runtime listener, both runtime adapters, protocol bindings, and shared dependencies.
+It ships the preflight and durable compatibility-cutover mechanism that can raise one cluster's minimum Controller and Node Agent Product Version to the exact Floor Release only after every participating Controller and Node Agent runs that version and proves removal readiness.
+
+The cutover records the exact Product Version floor, non-gRPC capability contract, participating Controller and Node Agent identities and versions, evidence timestamp, and operator approval.
+It rejects a stale, incomplete, or mixed cohort and leaves the prior floor unchanged.
+After cutover, update and rollback preflight rejects any Controller or Node Agent older than the recorded Floor Release before mutation, even though the Floor Release artifacts still retain the compatibility adapters.
+
+The Floor Release therefore separates the compatibility-floor decision from destructive cleanup and makes the floor observable before Stage X.
+
+### Stage X: Runtime adapter removal
+
+The Removal Release removes the first-party Controller and Node Agent `NodeRuntimeService` adapters and the runtime listener.
+It rejects `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`, `ORCHARD_RUNTIME_CLIENT_TARGETS`, and listener-only runtime compatibility configuration with a clear minimum-version error.
+It requires a previously recorded Floor Release compatibility cutover and refuses mutation when the cutover is absent, stale, or names another Product Version.
+
+The Removal Release does not automatically delete runtime protobuf messages or shared dependencies.
+
+## Mixed-Version And Rollback Contract
+
+The Controller `N` requirement to support Node Agent `N` and `N-1` remains normative.
+Rollback additionally requires a newer Node Agent to work with the immediately previous Controller across each staged rollout, even though that reverse direction is not the general support promise.
+
+Bridge, Deprecation, Floor, and Removal are compatibility epochs, not substitutes for Product Versions.
+Before an epoch is assigned, its accepting change must enumerate the exact Product Versions in that epoch and the complete Controller `N` with Node Agent `N` and `N-1` matrix for every real release transition.
+Any intervening Product Version must appear in that matrix rather than being skipped by a symbolic epoch label.
+
+The exact Product Version immediately before the Removal Release must belong to the Floor epoch.
+The Removal Controller must operate the immediately previous Floor Node Agent over the non-gRPC path as its actual `N-1` obligation.
+The Floor Controller must operate the Removal Node Agent over the non-gRPC path as the bounded Controller rollback pairing.
+Every earlier version must be rejected by the recorded Floor cutover before an X mutation begins.
+
+Version strings are necessary but insufficient.
+Preflight must also prove the effective non-gRPC capability, exact identity and authorization, target reachability, required operation and event contract, and absence of unresolved gRPC-only configuration.
+
+The rollback floor must be raised through the durable Floor Release cutover while all compatibility assets remain installed.
+The Removal Release may consume that earlier decision but must not create or raise the floor itself.
+
+## Four Deletion Layers
+
+### Layer 1: listener exposure and profile defaults
+
+Ordering:
+
+1. Migrate the active all-in-one source-development path while retaining explicit gRPC rollback.
+2. Qualify listener-free non-gRPC behavior for each supported split-role and packaged profile.
+3. Add scoped compatibility warnings in the Bridge Release.
+4. Make the Node Runtime listener default-off only in the Deprecation Release and only for qualified profiles.
+5. Ship the non-destructive Floor Release, complete the durable compatibility cutover, and reject rollback below its exact Product Version before adapter removal.
+
+Prerequisites include profile-specific operation parity, bootstrap, liveness, diagnostics, packaging, real topology, mixed-version, and rollback evidence.
+The rollback point remains explicit compatibility selection until the Floor cutover is completed.
+After the Floor cutover and before Removal, the complete Floor Release remains the rollback point with all compatibility assets still installed.
+
+Current decision: GO only for the first all-in-one implementation slice after proposal acceptance.
+Current decision: NO-GO for changing split-role or packaged listener defaults.
+
+### Layer 2: first-party runtime client and server adapters
+
+Remove `GrpcCompatibilityClient`, `GrpcNodeRuntimeClient`, compatibility mappers, `RuntimeServer`, service registration, and compatibility-specific callers only in the Removal Release.
+No supported profile, generated operator environment, smoke path, CLI command, actual `N` and `N-1` pair, or Floor Controller with Removal Node Agent rollback pair may still select these adapters.
+
+Rollback after this layer requires installing the complete Floor Release artifacts and is allowed only because the Floor Controller with Removal Node Agent pairing was qualified before removal.
+
+Current decision: NO-GO.
+
+### Layer 3: runtime protobuf messages and generated bindings
+
+First replace protobuf-shaped BEAM internals and transport-independent domain seams before deleting runtime messages.
+Then remove `runtime.proto`, generated Elixir and Python runtime bindings, and generation inputs only after all first-party adapters are gone and the provider-neutral Worker Runtime contract no longer imports those messages.
+
+Listener absence and adapter removal do not prove this layer safe.
+PR #346's deterministic adapter itself still exercises protobuf-shaped runtime types.
+
+Rollback after message deletion requires restoring a coherent schema, generated bindings, and every dependent package together.
+
+Current decision: NO-GO.
+
+### Layer 4: shared gRPC and protobuf dependencies
+
+Re-evaluate dependency ownership only after the first three layers are complete.
+The repository may narrow which applications own gRPC server, client, protobuf, and generation dependencies without deleting them globally.
+Global removal remains blocked while Peer Grant/control or Worker Runtime boundaries consume them.
+
+Current decision: NO-GO for repository-wide dependency removal.
+
+## Acceptance Evidence Gates
+
+Each default promotion, listener change, adapter removal, and message deletion must record exact commit, Product Version, topology, commands, and sanitized pass or fail evidence.
+Evidence must cover the following areas at the stage that claims them.
+
+- Runtime Endpoint operation parity for status, model readiness, unload, inference streaming, active cancellation, prefix-cache scoring, and every accepted additive operation.
+- Observation normalization for identity, availability, health, placements, aggregate and placement capacity, runtime telemetry, capabilities, and version-skew omission behavior.
+- Bootstrap and authorization for same-VM local operation, source-development BEAM, and production Peer Grant paths without circular credential delivery.
+- Active and idle liveness, reconnect, restart, heartbeat persistence, scheduler exclusion, and no automatic same-request gRPC fallback.
+- Diagnostics and lifecycle callers, including activation, node join, recovery, CLI probes, Console status, and support paths.
+- Real MLX execution across the retained Worker Runtime boundary.
+- Orchard.app, DMG, payload wrapper, launchd, installed-service, update, rollback, and retained-state behavior.
+- Real supported topologies, including physical multi-host operation where the profile claims it.
+- Controller and Node Agent `N` and `N-1` operation plus the explicitly required reverse Controller rollback pairing.
+- Preflight rejection of too-old versions, incompatible capabilities, unresolved gRPC-only configuration, and missing identity, authorization, or reachability evidence before mutation.
+
+PR #346 satisfies only the source-development listener-free transport-isolation subset for its deterministic validation adapter.
+It is reusable evidence for Stage A and later source-development gates, but it is not packaged, real-MLX, physical multi-host, mixed-version, upgrade, rollback, or protobuf-deletion qualification.
+
+## Supported External Consumer Decision
+
+No supported external or non-BEAM `NodeRuntimeService` consumer was found in the repository, current issues and PRs, accepted decisions, packaging, configuration, or test history reviewed for this change.
+The supported consumers found are Orchard's own Controller, Node Agent, CLI and tests, generated bindings, and explicit operator compatibility profiles.
+
+This bounded absence does not justify surprise removal.
+The Bridge Release warning and release notes must provide an operator reporting path for an unknown consumer before the Deprecation Release makes the listener default-off.
+Any validated supported consumer discovered before Stage X blocks adapter removal until it migrates or receives a separately accepted compatibility decision.
+
+## Decisions And Alternatives
+
+### Use a same-VM local client for all-in-one source development
+
+The all-in-one topology already runs the Controller and Node Agent in one BEAM VM.
+Its first-party Runtime Endpoint path will use a transport-independent same-VM client rather than opening a network protocol to itself.
+
+Alternative: start a named local distributed Erlang node and route the call through `BeamClient`.
+Rejected because same-VM operation does not need EPMD, cookie material, distribution listeners, or the high-trust BEAM boundary.
+
+Alternative: disable the split-role listener first.
+Rejected as the first slice because split-role already defaults to BEAM and the change would not remove the all-in-one contract exception.
+
+### Use Bridge, Deprecation, Floor, and Removal release epochs
+
+Relative epochs keep the contract reviewable without inventing a SemVer or deployed-cohort fact that the repository does not establish.
+The accepted implementation sequence must map every epoch to exact released Product Versions, enumerate every actual `N` and `N-1` pairing, and preserve its artifacts before advancing.
+The non-destructive Floor Release and durable cutover raise the compatibility floor before the Removal Release deletes anything.
+
+Alternative: remove adapters in the first release where all profiles default to the non-gRPC path.
+Rejected because it combines promotion, compatibility-floor change, and destructive cleanup without a shipped rollback baseline.
+
+### Keep future adapters protocol-independent
+
+Future external or non-BEAM Runtime Endpoints remain possible through the Runtime Endpoint Interface.
+They require their own trust, protocol, compatibility, and qualification decision.
+
+Alternative: retain `NodeRuntimeService` indefinitely because a future adapter might use it.
+Rejected because no current consumer requires that promise and speculative reuse does not justify a permanent first-party protocol obligation.
+
+## Risks / Trade-offs
+
+- [Risk] An unknown external consumer relies on the nominally internal `cluster.v1` service.
+  - Mitigation: Keep conclusions bounded, provide a Bridge Release warning and reporting window, and block removal on any validated supported consumer.
+- [Risk] Removing the explicit runtime gRPC mode reduces recovery options when BEAM authorization or reachability fails.
+  - Mitigation: Retain explicit compatibility through the Deprecation Release and qualify non-gRPC recovery before Stage X.
+- [Risk] A version-only preflight admits a pair that cannot actually communicate.
+  - Mitigation: Require effective capability, identity, authorization, target, and operation-contract evidence in addition to Product Version.
+- [Risk] Protobuf deletion breaks the BEAM path or Worker Runtime even after the TCP listener is gone.
+  - Mitigation: Make domain decoupling and provider-neutral Worker Runtime imports explicit prerequisites for Layer 3.
+- [Risk] A broad dependency cleanup removes Peer Grant/control or Worker Runtime gRPC accidentally.
+  - Mitigation: Reassess dependency ownership last and preserve each retained boundary through direct tests.
+- [Risk] PR #346 is treated as production qualification.
+  - Mitigation: Name its exact deterministic source-development scope at every stage that cites it.
+
+## Migration Plan
+
+1. Accept this scoped contract without changing runtime behavior.
+2. Implement and qualify the same-VM all-in-one Runtime Endpoint path while retaining explicit gRPC rollback.
+3. Establish and release the Bridge epoch after every affected supported profile has qualified non-gRPC operation and scoped compatibility warnings.
+4. Establish and release the Deprecation epoch after default-off listener behavior, packaged lifecycle, mixed-version, and rollback qualification pass.
+5. Ship the non-destructive Floor Release with all compatibility assets intact and map every epoch to exact Product Versions and actual version pairings.
+6. Complete the durable compatibility cutover only after every participating Controller and Node Agent runs the Floor Release and proves removal readiness.
+7. Remove first-party `NodeRuntimeService` adapters and listener only after Removal Controller with Floor Node Agent and Floor Controller with Removal Node Agent evidence passes and the earlier Floor cutover is present.
+8. Decouple runtime protobuf-shaped domain and Worker Runtime imports before deleting runtime messages and generated bindings.
+9. Reassess shared dependency ownership without weakening Peer Grant/control or Worker Runtime boundaries.
+
+Rollback before Stage X selects the explicit runtime gRPC compatibility profile and restarts the affected services.
+Rollback at or after Stage X installs the complete preserved Floor Release artifacts and uses the prequalified Floor Controller with Removal Node Agent pairing until Node Agents are rolled back safely.
+
+## Open Questions
+
+- Which future released Product Versions will be assigned to the Bridge, Deprecation, Floor, and Removal epochs after their evidence gates pass?
+- Which operator-facing warning and reporting surface will collect evidence of an unknown `NodeRuntimeService` consumer during the Bridge Release?
+- Which accepted Worker Runtime ownership slice will remove the remaining `cluster.v1.runtime` message imports before Layer 3 can proceed?

--- a/openspec/changes/deprecate-node-runtime-grpc-compatibility/proposal.md
+++ b/openspec/changes/deprecate-node-runtime-grpc-compatibility/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Orchard's first-party Controller-to-Node Runtime Endpoint path is BEAM-first in split-role source development and packaged releases, but the durable contract still requires the gRPC/protobuf `NodeRuntimeService` compatibility transport.
+All-in-one `bin/dev` still uses gRPC loopback, split-role and packaged profiles still support explicit gRPC selection, and the Node Agent still exposes the compatibility listener by default.
+
+PR #346 proves that a real source-development Controller and Node Agent can complete the validated Runtime Endpoint operation matrix while the Node Runtime gRPC listener is absent.
+That proof does not cover all-in-one operation, packaged lifecycle, real MLX, physical two-Mac operation, mixed versions, upgrades, rollback, or protobuf independence.
+
+One accepted compatibility contract is required before implementation changes any supported default, listener, adapter, generated binding, or dependency.
+
+## What Changes
+
+- Deprecate `NodeRuntimeService` only as the first-party Controller-to-Node Runtime Endpoint compatibility transport.
+- Preserve the transport-independent Runtime Endpoint Interface and require all first-party migration work to keep its operation and observation semantics stable.
+- Preserve certificate-authenticated Peer Grant, enrollment, certificate lifecycle, delivery, recovery, diagnostics, and other pre-BEAM control roles unless a separate accepted change replaces them.
+- Preserve the Node Agent-to-Worker Runtime gRPC and Unix-domain-socket boundary.
+- Preserve a future non-BEAM Runtime Endpoint adapter extension point without promising that `NodeRuntimeService` or `cluster.v1` remains its permanent protocol.
+- Define a staged all-in-one, split-role, packaged, mixed-version, and rollback migration using Bridge, Deprecation, Floor, and Removal release epochs rather than naming an unsupported SemVer floor.
+- Treat listener and profile defaults, first-party runtime adapters, runtime protobuf messages and generated bindings, and shared gRPC/protobuf dependencies as four independent deletion layers.
+- Make all-in-one source-development migration to a same-VM transport-independent Runtime Endpoint client the first implementation slice after this proposal is accepted.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `runtime-endpoints`: Defines the scoped `NodeRuntimeService` deprecation boundary, topology migration, mixed-version and rollback gates, consumer evidence, and deletion ordering.
+
+## Impact
+
+- Product contract: `SPEC.md` §§1.2, 7.5, 10.6, 11, and 13 require reconciliation only as each accepted implementation stage changes supported behavior.
+- Runtime Endpoint contract: `openspec/specs/runtime-endpoints/spec.md` currently requires all-in-one gRPC loopback, explicit split-role and packaged gRPC compatibility, and preservation of `NodeRuntimeService` as a possible adapter protocol.
+- Decisions: ADR 0001's bounded gRPC retention is narrowed by proposed ADR 0029, while ADR 0012 and ADR 0025 remain fully in force for Peer Grant/control and Worker Runtime boundaries.
+- Source development: `bin/dev`, `bin/dev-controller`, `bin/dev-node-agent`, `config/dev.exs`, and source-development transport tests encode current defaults and rollback surfaces.
+- Packaged operation: release configuration, payload wrappers, generated environment files, Orchard.app/DMG lifecycle, and launchd profiles encode current BEAM defaults and explicit gRPC fallback.
+- Runtime adapters: Controller compatibility clients and mappers, scheduler and lifecycle callers, Node Agent server and listener supervision, and CLI probes remain live until their stage gates pass.
+- Protocol ownership: `runtime.proto`, generated Elixir and Python bindings, BEAM-side protobuf-shaped internals, and Worker Runtime imports prevent early runtime-message deletion.
+- No runtime behavior, default, listener, generated binding, dependency, or `SPEC.md` text changes in this proposal.

--- a/openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md
@@ -55,6 +55,34 @@ Split-role and packaged defaults and listeners MUST NOT change until their profi
 - **WHEN** the all-in-one migration is implemented
 - **THEN** packaged Controller, Node Agent, Orchard.app, DMG, launchd, generated environment, listener, and rollback behavior remain unchanged
 
+### Requirement: Source-dev Runtime Endpoint Topology Bootstrap
+Orchard SHALL support Source-dev BEAM Runtime Endpoint mode for the split-role `bin/dev-controller` and `bin/dev-node-agent` entrypoints.
+When Source-dev BEAM mode is selected, both split-role processes SHALL start as named distributed BEAM nodes before Runtime Endpoint work is attempted.
+All-in-one `bin/dev` SHALL use same-VM transport-independent Runtime Endpoint semantics by default without requiring a gRPC loopback, EPMD, cookie material, or BEAM Distribution.
+All-in-one `bin/dev` SHALL reject explicit Source-dev BEAM mode before starting Mix.
+All-in-one `bin/dev` SHALL retain explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` selection as restart-only compatibility rollback and SHALL NOT fall back to gRPC automatically after a Runtime Endpoint operation fails.
+This refines the source-development Runtime Endpoint topology in `SPEC.md` §§1.2 and 7.5.
+
+#### Scenario: Split-role BEAM mode starts distributed nodes
+- **WHEN** a contributor starts `bin/dev-controller` and `bin/dev-node-agent` with Source-dev BEAM Runtime Endpoint mode selected
+- **THEN** each process starts with a configured BEAM node name
+- **THEN** Runtime Endpoint operations use BEAM Distribution rather than the gRPC Compatibility Adapter
+
+#### Scenario: All-in-one dev defaults to same-VM Runtime Endpoint semantics
+- **WHEN** a contributor starts all-in-one `bin/dev` without selecting a transport override
+- **THEN** the Controller invokes the local Node Agent through Runtime Endpoint Interface semantics inside the same BEAM VM
+- **THEN** Orchard does not require a Node Runtime gRPC loopback connection or BEAM Distribution for that path
+
+#### Scenario: All-in-one dev rejects BEAM mode
+- **WHEN** a contributor starts all-in-one `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
+- **THEN** Orchard rejects the launch before running Mix
+- **THEN** the contributor is directed to use `bin/dev-controller` and `bin/dev-node-agent`
+
+#### Scenario: All-in-one dev explicitly restarts on gRPC compatibility
+- **WHEN** a contributor restarts all-in-one `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`
+- **THEN** Orchard uses the retained single-host gRPC compatibility loopback
+- **THEN** a failed same-VM Runtime Endpoint operation does not trigger automatic gRPC fallback
+
 ### Requirement: Bridge Deprecation Floor And Removal Release Gates
 Orchard SHALL map each Bridge, Deprecation, Floor, and Removal epoch to exact released Product Versions only after that epoch's evidence gate passes.
 The mapping SHALL enumerate every Product Version in each epoch and every actual Controller `N` with Node Agent `N` and `N-1` pairing rather than using epoch labels as version substitutes.
@@ -162,34 +190,6 @@ Any validated supported consumer discovered before adapter removal SHALL block r
 
 ## MODIFIED Requirements
 
-### Requirement: Source-dev BEAM Split-role Bootstrap
-Orchard SHALL support Source-dev BEAM Runtime Endpoint mode for the split-role `bin/dev-controller` and `bin/dev-node-agent` entrypoints.
-When Source-dev BEAM mode is selected, both split-role processes SHALL start as named distributed BEAM nodes before Runtime Endpoint work is attempted.
-All-in-one `bin/dev` SHALL use same-VM transport-independent Runtime Endpoint semantics by default without requiring a gRPC loopback, EPMD, cookie material, or BEAM Distribution.
-All-in-one `bin/dev` SHALL reject explicit Source-dev BEAM mode before starting Mix.
-All-in-one `bin/dev` SHALL retain explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` selection as restart-only compatibility rollback and SHALL NOT fall back to gRPC automatically after a Runtime Endpoint operation fails.
-This refines the source-dev BEAM rollout rules in `SPEC.md` §1.2 and §7.5.
-
-#### Scenario: Split-role BEAM mode starts distributed nodes
-- **WHEN** a contributor starts `bin/dev-controller` and `bin/dev-node-agent` with Source-dev BEAM Runtime Endpoint mode selected
-- **THEN** each process starts with a configured BEAM node name
-- **THEN** Runtime Endpoint operations use BEAM Distribution rather than the gRPC Compatibility Adapter
-
-#### Scenario: All-in-one dev defaults to same-VM Runtime Endpoint semantics
-- **WHEN** a contributor starts all-in-one `bin/dev` without selecting a transport override
-- **THEN** the Controller invokes the local Node Agent through Runtime Endpoint Interface semantics inside the same BEAM VM
-- **THEN** Orchard does not require a Node Runtime gRPC loopback connection or BEAM Distribution for that path
-
-#### Scenario: All-in-one dev rejects BEAM mode
-- **WHEN** a contributor starts all-in-one `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
-- **THEN** Orchard rejects the launch before running Mix
-- **THEN** the contributor is directed to use `bin/dev-controller` and `bin/dev-node-agent`
-
-#### Scenario: All-in-one dev explicitly restarts on gRPC compatibility
-- **WHEN** a contributor restarts all-in-one `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`
-- **THEN** Orchard uses the retained single-host gRPC compatibility loopback
-- **THEN** a failed same-VM Runtime Endpoint operation does not trigger automatic gRPC fallback
-
 ### Requirement: All-in-one Source Dev Uses Same-VM Runtime Endpoint Semantics
 All-in-one `bin/dev` SHALL use same-VM transport-independent Runtime Endpoint semantics by default without requiring a Node Runtime gRPC loopback connection or BEAM Distribution.
 All-in-one `bin/dev` SHALL reject explicit BEAM mode with a clear error.
@@ -209,3 +209,7 @@ All-in-one `bin/dev` SHALL retain explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=g
 - **WHEN** a contributor restarts `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`
 - **THEN** Orchard uses the retained single-host gRPC compatibility loopback
 - **THEN** Orchard does not select gRPC automatically after a same-VM Runtime Endpoint operation fails
+
+## REMOVED Requirements
+
+### Requirement: Source-dev BEAM Split-role Bootstrap

--- a/openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md
@@ -1,3 +1,8 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: All-in-one Source Dev Remains Single-host gRPC Loopback`
+- TO: `### Requirement: All-in-one Source Dev Uses Same-VM Runtime Endpoint Semantics`
+
 ## ADDED Requirements
 
 ### Requirement: Scoped Node Runtime gRPC Compatibility Deprecation
@@ -154,3 +159,53 @@ Any validated supported consumer discovered before adapter removal SHALL block r
 #### Scenario: No external consumer is found in repository evidence
 - **WHEN** repository, issue, PR, packaging, configuration, test, and history searches find only Orchard-owned consumers and speculative future-adapter language
 - **THEN** the change records that bounded absence without claiming that no private or historical consumer exists
+
+## MODIFIED Requirements
+
+### Requirement: Source-dev BEAM Split-role Bootstrap
+Orchard SHALL support Source-dev BEAM Runtime Endpoint mode for the split-role `bin/dev-controller` and `bin/dev-node-agent` entrypoints.
+When Source-dev BEAM mode is selected, both split-role processes SHALL start as named distributed BEAM nodes before Runtime Endpoint work is attempted.
+All-in-one `bin/dev` SHALL use same-VM transport-independent Runtime Endpoint semantics by default without requiring a gRPC loopback, EPMD, cookie material, or BEAM Distribution.
+All-in-one `bin/dev` SHALL reject explicit Source-dev BEAM mode before starting Mix.
+All-in-one `bin/dev` SHALL retain explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` selection as restart-only compatibility rollback and SHALL NOT fall back to gRPC automatically after a Runtime Endpoint operation fails.
+This refines the source-dev BEAM rollout rules in `SPEC.md` §1.2 and §7.5.
+
+#### Scenario: Split-role BEAM mode starts distributed nodes
+- **WHEN** a contributor starts `bin/dev-controller` and `bin/dev-node-agent` with Source-dev BEAM Runtime Endpoint mode selected
+- **THEN** each process starts with a configured BEAM node name
+- **THEN** Runtime Endpoint operations use BEAM Distribution rather than the gRPC Compatibility Adapter
+
+#### Scenario: All-in-one dev defaults to same-VM Runtime Endpoint semantics
+- **WHEN** a contributor starts all-in-one `bin/dev` without selecting a transport override
+- **THEN** the Controller invokes the local Node Agent through Runtime Endpoint Interface semantics inside the same BEAM VM
+- **THEN** Orchard does not require a Node Runtime gRPC loopback connection or BEAM Distribution for that path
+
+#### Scenario: All-in-one dev rejects BEAM mode
+- **WHEN** a contributor starts all-in-one `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
+- **THEN** Orchard rejects the launch before running Mix
+- **THEN** the contributor is directed to use `bin/dev-controller` and `bin/dev-node-agent`
+
+#### Scenario: All-in-one dev explicitly restarts on gRPC compatibility
+- **WHEN** a contributor restarts all-in-one `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`
+- **THEN** Orchard uses the retained single-host gRPC compatibility loopback
+- **THEN** a failed same-VM Runtime Endpoint operation does not trigger automatic gRPC fallback
+
+### Requirement: All-in-one Source Dev Uses Same-VM Runtime Endpoint Semantics
+All-in-one `bin/dev` SHALL use same-VM transport-independent Runtime Endpoint semantics by default without requiring a Node Runtime gRPC loopback connection or BEAM Distribution.
+All-in-one `bin/dev` SHALL reject explicit BEAM mode with a clear error.
+Split-role scripts SHALL remain the only supported source-development BEAM entrypoints.
+All-in-one `bin/dev` SHALL retain explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` selection as restart-only compatibility rollback and SHALL NOT fall back to gRPC automatically after a Runtime Endpoint operation fails.
+
+#### Scenario: All-in-one uses same-VM Runtime Endpoint semantics by default
+- **WHEN** `bin/dev` starts without an explicit Runtime Endpoint transport override
+- **THEN** the Controller invokes the local Node Agent through Runtime Endpoint Interface semantics inside the same BEAM VM
+- **THEN** startup does not require a Node Runtime gRPC loopback listener, EPMD, cookie material, or BEAM Distribution
+
+#### Scenario: All-in-one rejects explicit BEAM mode
+- **WHEN** `bin/dev` starts with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=beam`
+- **THEN** startup fails with a clear error directing the operator to the split-role scripts
+
+#### Scenario: All-in-one explicitly restarts on gRPC compatibility
+- **WHEN** a contributor restarts `bin/dev` with `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc`
+- **THEN** Orchard uses the retained single-host gRPC compatibility loopback
+- **THEN** Orchard does not select gRPC automatically after a same-VM Runtime Endpoint operation fails

--- a/openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md
+++ b/openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md
@@ -1,0 +1,156 @@
+## ADDED Requirements
+
+### Requirement: Scoped Node Runtime gRPC Compatibility Deprecation
+Per `SPEC.md` §§1.2, 7.5, 10.6, 11, and 13, Orchard SHALL deprecate `cluster.v1.NodeRuntimeService` only as the first-party Controller-to-Node Agent Runtime Endpoint compatibility transport through explicit Bridge, Deprecation, Floor, and Removal release epochs.
+The transport-independent Runtime Endpoint Interface SHALL remain the durable Controller-facing contract.
+Certificate-authenticated Peer Grant, enrollment, certificate lifecycle, delivery, recovery, diagnostics, and other pre-BEAM control roles SHALL remain outside this deprecation unless separately replaced through an accepted change.
+The Node Agent-to-Worker Runtime gRPC and Unix-domain-socket boundary SHALL remain outside this deprecation.
+Future non-BEAM Runtime Endpoint adapters MAY use a separately accepted protocol and MUST NOT require permanent retention of `NodeRuntimeService` merely because an adapter extension point exists.
+
+#### Scenario: First-party compatibility transport is deprecated
+- **WHEN** Orchard advances through an accepted `NodeRuntimeService` deprecation stage
+- **THEN** only the first-party Controller-to-Node Runtime Endpoint compatibility role changes
+- **THEN** Runtime Endpoint Interface operations and observations remain transport-independent
+
+#### Scenario: Peer Grant control remains required
+- **WHEN** the first-party Runtime Endpoint path no longer uses `NodeRuntimeService`
+- **THEN** certificate-authenticated Peer Grant delivery and recovery remain available through their separately owned control protocol
+- **THEN** Orchard does not treat BEAM as the credential-delivery mechanism required to establish its own authorization
+
+#### Scenario: Worker Runtime remains local and provider-neutral
+- **WHEN** the Controller-to-Node runtime compatibility transport is disabled or removed
+- **THEN** the Node Agent continues to supervise Worker Runtime processes through the separately owned provider-neutral local boundary
+
+#### Scenario: Future non-BEAM adapter is proposed
+- **WHEN** a future external or non-BEAM Runtime Endpoint requires a transport protocol
+- **THEN** its accepted adapter contract selects an appropriate protocol without assuming `NodeRuntimeService` permanence
+
+### Requirement: Staged Runtime Compatibility Topology Migration
+Orchard SHALL migrate the active all-in-one source-development Runtime Endpoint path before disabling the runtime compatibility listener in any supported profile.
+All-in-one source development SHALL use a same-VM transport-independent Runtime Endpoint client by default without requiring distributed Erlang networking.
+The first all-in-one migration SHALL retain explicit gRPC selection, the runtime listener, both adapters, all runtime protobuf bindings, and every shared dependency as immediate rollback assets.
+Split-role and packaged defaults and listeners MUST NOT change until their profile-specific evidence gates pass in a later accepted stage.
+
+#### Scenario: All-in-one first slice uses same-VM runtime semantics
+- **WHEN** the accepted first implementation slice migrates all-in-one `bin/dev`
+- **THEN** the Controller invokes the local Node Agent through Runtime Endpoint Interface semantics inside the same BEAM VM
+- **THEN** the active path does not require a Node Runtime gRPC loopback connection, EPMD, cookie material, or BEAM distribution listeners
+
+#### Scenario: All-in-one first slice rolls back
+- **WHEN** the new all-in-one source-development path cannot complete a required Runtime Endpoint operation
+- **THEN** a contributor may restart all-in-one source development with explicit gRPC compatibility selection
+- **THEN** Orchard does not retry the failed request automatically through gRPC
+
+#### Scenario: Split-role default is unchanged by the first slice
+- **WHEN** the all-in-one migration is implemented
+- **THEN** split-role source development retains its current BEAM default and explicit gRPC opt-out
+- **THEN** its listener behavior remains unchanged
+
+#### Scenario: Packaged profiles are unchanged by the first slice
+- **WHEN** the all-in-one migration is implemented
+- **THEN** packaged Controller, Node Agent, Orchard.app, DMG, launchd, generated environment, listener, and rollback behavior remain unchanged
+
+### Requirement: Bridge Deprecation Floor And Removal Release Gates
+Orchard SHALL map each Bridge, Deprecation, Floor, and Removal epoch to exact released Product Versions only after that epoch's evidence gate passes.
+The mapping SHALL enumerate every Product Version in each epoch and every actual Controller `N` with Node Agent `N` and `N-1` pairing rather than using epoch labels as version substitutes.
+The Bridge Release SHALL qualify every affected supported profile on the non-gRPC first-party path while retaining compatibility adapters and listeners.
+The Deprecation Release SHALL make the non-gRPC path the only default for qualified profiles, make the runtime listener default-off, and retain explicit compatibility as rollback.
+The non-destructive Floor Release SHALL retain every compatibility asset and provide a durable compatibility cutover that raises one cluster's exact minimum Product Version only after every participating Controller and Node Agent runs the Floor Release and proves removal readiness.
+The Removal Release SHALL require that previously completed exact Floor Release cutover before removing the first-party runtime adapters and listener.
+The Removal Release MUST NOT create or raise the compatibility floor that authorizes its own destructive cleanup.
+
+#### Scenario: Bridge baseline is not yet qualified
+- **WHEN** any affected supported profile lacks operation, real topology, real runtime, packaging, mixed-version, or rollback evidence
+- **THEN** Orchard does not declare the Bridge Release baseline complete
+- **THEN** listener defaults remain unchanged
+
+#### Scenario: Deprecation baseline remains reversible
+- **WHEN** a qualified profile runs the Deprecation Release
+- **THEN** its non-gRPC first-party path is the default
+- **THEN** explicit compatibility selection can still enable the runtime adapter and listener for rollback
+
+#### Scenario: Floor cutover is attempted with a mixed cohort
+- **WHEN** any participating Controller or Node Agent does not run the exact Floor Release or lacks removal-readiness evidence
+- **THEN** Orchard rejects the cutover and leaves the prior compatibility floor unchanged
+- **THEN** every runtime compatibility asset remains installed
+
+#### Scenario: Floor cutover completes before removal
+- **WHEN** every participating Controller and Node Agent runs the exact Floor Release and proves the required capability contract
+- **THEN** Orchard durably records the exact Product Version floor, capability contract, participating identities and versions, evidence time, and operator approval
+- **THEN** later update and rollback preflight rejects versions below that floor before mutation
+
+#### Scenario: Removal is attempted from an older baseline
+- **WHEN** the exact Floor Release cutover is absent, stale, or does not cover every participant in a Removal Release update
+- **THEN** preflight rejects the update before mutation
+- **THEN** the operator receives a clear floor and compatibility explanation
+
+### Requirement: Runtime Compatibility Mixed-Version And Rollback Matrix
+Before assigning Product Versions to an epoch, Orchard SHALL enumerate every real Controller `N` with Node Agent `N` and `N-1` pairing across that transition.
+The exact Product Version immediately before the Removal Release SHALL belong to the Floor epoch.
+The Removal Release Controller SHALL support the immediately previous Floor Release Node Agent over the non-gRPC path as its actual `N-1` obligation.
+The Floor Release Controller SHALL support the Removal Release Node Agent over the non-gRPC path as the bounded Controller rollback pairing.
+Before any participant advances to the Removal Release, the exact Floor Release cutover SHALL cover all participating Controllers and Node Agents.
+Compatibility preflight SHALL verify effective non-gRPC capability, identity, authorization, reachability, and operation-contract evidence in addition to Product Version.
+
+#### Scenario: Removal Controller operates previous Node Agent
+- **WHEN** a Removal Release Controller communicates with the immediately previous Floor Release Node Agent
+- **THEN** the pair completes the supported Runtime Endpoint operation and observation contract over the non-gRPC path
+
+#### Scenario: Controller rolls back after Node Agent removal update
+- **WHEN** a Node Agent runs the Removal Release and the Controller rolls back to the Floor Release
+- **THEN** the pair completes the bounded rollback contract over the non-gRPC path
+- **THEN** it does not require the removed Node Runtime listener
+
+#### Scenario: An intervening Product Version exists
+- **WHEN** a real Product Version exists between two assigned compatibility epochs
+- **THEN** the accepting change includes that version in the exact support and rollback matrix
+- **THEN** Orchard does not infer compatibility from the symbolic epoch labels
+
+#### Scenario: Version matches but capability evidence fails
+- **WHEN** a participant reports a nominally compatible Product Version but cannot prove required non-gRPC capability, identity, authorization, reachability, or operation compatibility
+- **THEN** preflight rejects the staged update before mutation
+
+### Requirement: Independent Runtime Compatibility Deletion Layers
+Orchard SHALL treat listener exposure and profile defaults, first-party runtime client and server adapters, runtime protobuf messages and generated bindings, and shared gRPC/protobuf dependencies as four independent deletion layers in that order.
+Each layer SHALL have its own consumer search, prerequisites, exact validation evidence, and rollback point.
+Listener absence MUST NOT prove adapter or protobuf deletion safe.
+Adapter removal MUST NOT prove runtime-message deletion safe while BEAM internals, Worker Runtime schemas, generated bindings, tests, or packages still consume those messages.
+`NodeRuntimeService` removal MUST NOT authorize deletion of shared gRPC or protobuf dependencies used by Peer Grant/control or Worker Runtime boundaries.
+
+#### Scenario: Runtime listener is absent
+- **WHEN** a qualified profile runs without the Node Runtime TCP listener
+- **THEN** Orchard treats only listener exposure as proven absent
+- **THEN** adapter, runtime-message, generated-binding, and shared-dependency deletion remain separately gated
+
+#### Scenario: Runtime adapters have no supported consumer
+- **WHEN** every supported profile, CLI path, generated operator environment, smoke path, and mixed-version pair no longer selects the first-party runtime adapters
+- **THEN** Orchard may remove those adapters in the accepted Removal Release
+- **THEN** runtime protobuf messages remain until their own consumers are removed
+
+#### Scenario: Worker Runtime imports runtime messages
+- **WHEN** the provider-neutral Worker Runtime schema or an implementation still imports `cluster.v1.runtime` messages
+- **THEN** Orchard does not delete those runtime messages or generated bindings
+
+#### Scenario: Retained control protocol uses gRPC
+- **WHEN** Peer Grant delivery, recovery, or another separately retained control role still uses gRPC or protobuf
+- **THEN** Orchard preserves the required shared dependencies and direct validation
+
+### Requirement: Runtime Compatibility Evidence And Consumer Gate
+Before each default promotion, listener change, adapter removal, or runtime-message deletion, Orchard SHALL record exact sanitized evidence for every behavior claimed by that stage.
+The evidence SHALL cover applicable Runtime Endpoint operation parity, observation normalization, bootstrap, liveness, diagnostics, cancellation, packaging, real-runtime, real-topology, mixed-version, upgrade, and rollback behavior.
+Repository and project searches MAY establish that no supported external `NodeRuntimeService` consumer is known, but MUST NOT be represented as universal proof of absence.
+Any validated supported consumer discovered before adapter removal SHALL block removal until it migrates or receives a separate accepted compatibility decision.
+
+#### Scenario: PR 346 evidence is reused
+- **WHEN** PR #346 is cited as listener-free evidence
+- **THEN** Orchard credits only its deterministic source-development BEAM Runtime Endpoint operation matrix and listener-absence proof
+- **THEN** Orchard does not infer packaged, real-MLX, physical multi-host, mixed-version, upgrade, rollback, or protobuf-independence qualification
+
+#### Scenario: Unknown consumer is reported during deprecation
+- **WHEN** an operator reports a supported `NodeRuntimeService` consumer during the Bridge or Deprecation stage
+- **THEN** Orchard validates the consumer against the supported product contract
+- **THEN** a validated supported consumer blocks adapter removal until its compatibility path is resolved
+
+#### Scenario: No external consumer is found in repository evidence
+- **WHEN** repository, issue, PR, packaging, configuration, test, and history searches find only Orchard-owned consumers and speculative future-adapter language
+- **THEN** the change records that bounded absence without claiming that no private or historical consumer exists

--- a/openspec/changes/deprecate-node-runtime-grpc-compatibility/tasks.md
+++ b/openspec/changes/deprecate-node-runtime-grpc-compatibility/tasks.md
@@ -1,0 +1,109 @@
+## 1. Contract Acceptance
+
+- [x] 1.1 Inventory `NodeRuntimeService`, current consumers, supported compatibility profiles, configuration, packaging, tests, generated bindings, history, and bounded external-consumer evidence.
+- [x] 1.2 Define the scoped deprecation boundary and preserve Peer Grant/control, Worker Runtime, Runtime Endpoint Interface, and future adapter extension-point boundaries.
+- [x] 1.3 Define all-in-one, split-role, packaged, mixed-version, rollback, evidence, and four-layer deletion gates.
+- [ ] 1.4 Obtain collaborator acceptance of this proposal.
+- [ ] 1.5 Map future Bridge, Deprecation, Floor, and Removal epochs to exact released Product Versions and complete actual `N`, `N-1`, and reverse Controller rollback matrices only after their gates pass.
+
+## 2. First Implementation Slice
+
+- [ ] 2.1 Implement a same-VM transport-independent Runtime Endpoint client for all-in-one source development through public-seam TDD.
+- [ ] 2.2 Make all-in-one `bin/dev` select the same-VM client by default while retaining explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` rollback.
+- [ ] 2.3 Keep the Node Runtime listener, both runtime adapters, every protobuf source and generated binding, split-role behavior, packaged behavior, and shared dependencies unchanged.
+- [ ] 2.4 Prove the all-in-one operation matrix with the real Node Agent and real MLX Worker Runtime, including status, load, streaming inference, active cancellation, prefix-cache scoring, unload, observation persistence, and no automatic gRPC fallback.
+- [ ] 2.5 Prove an immediate restart into explicit gRPC compatibility mode and rerun the existing gRPC all-in-one smoke.
+- [ ] 2.6 Reconcile `SPEC.md`, the accepted runtime-endpoints specification, ADR 0001, `docs/local-dev.md`, scripts, and focused tests in the implementing pull request.
+
+### Copy-ready issue proposal
+
+**Title:** Migrate all-in-one source development to the transport-independent Runtime Endpoint path
+
+**Scope:**
+
+- Add a same-VM Runtime Endpoint client for the all-in-one Controller and Node Agent that already run in one BEAM VM.
+- Make all-in-one `bin/dev` use that client for its active first-party runtime path by default.
+- Retain explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` selection as immediate rollback.
+- Keep the Node Runtime gRPC listener enabled and keep both adapters, all generated bindings, split-role profiles, packaged profiles, Peer Grant/control, and Worker Runtime protocols unchanged.
+
+**Acceptance criteria:**
+
+- All-in-one `bin/dev` boots without requiring a Node Runtime gRPC loopback connection for its active first-party Runtime Endpoint path.
+- The implementation uses the transport-independent Runtime Endpoint Interface and does not enable named distributed Erlang, EPMD, a cookie, or distribution listeners for same-VM calls.
+- Status, model load and unload, real-MLX streaming inference, active cancellation, prefix-cache scoring, Runtime Endpoint observation persistence, activation, and liveness behavior pass through the same public seams as the current all-in-one path.
+- No Runtime Endpoint request automatically falls back from the new path to gRPC.
+- Explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` restarts the current all-in-one compatibility topology and passes its existing smoke.
+- Split-role source development, packaged Controller and Node Agent releases, Orchard.app/DMG and launchd behavior, listener defaults, protobufs, generated bindings, dependencies, Peer Grant/control, and Worker Runtime behavior remain unchanged.
+- `SPEC.md`, the accepted runtime-endpoints specification, ADR 0001, source-development documentation, and focused tests are reconciled in the same pull request.
+- The full applicable Orchard Elixir workflow, all-in-one end-to-end smoke, strict OpenSpec validation, and architecture review pass at the exact head.
+
+**Non-goals:**
+
+- No split-role or packaged default change.
+- No listener disablement or deprecation warning.
+- No compatibility adapter, protobuf, generated binding, or dependency removal.
+- No Peer Grant/control or Worker Runtime protocol change.
+- No claim of packaged, physical multi-host, mixed-version, upgrade, or rollback qualification beyond the explicit gRPC restart proof in this slice.
+
+**Validation:**
+
+- Reproduce the existing all-in-one gRPC path before implementation.
+- Add a failing public-seam test for the same-VM client before implementation.
+- Run focused Runtime Endpoint, inference, scheduler, Node Agent, and configuration suites during iteration.
+- Run the applicable full Elixir workflow from `AGENTS.md`.
+- Run the real all-in-one MLX end-to-end smoke on the new path and the existing gRPC rollback smoke.
+- Run strict validation for this OpenSpec change and the complete OpenSpec tree.
+
+**Risk Assessment:** Medium.
+
+- The blast radius is the primary all-in-one source-development inference topology.
+- Immediate explicit gRPC rollback remains available and unchanged.
+- The main risks are same-VM lifecycle divergence, accidental fallback, and observation or cancellation behavior drifting from the current Runtime Endpoint Interface.
+- Real-MLX, public-seam, restart, and architecture-review evidence bound those risks.
+
+## 3. Bridge Release
+
+- [ ] 3.1 Qualify non-gRPC operation for every affected supported source-development and packaged profile, including real topology, real runtime, bootstrap, liveness, diagnostics, packaging, and rollback evidence.
+- [ ] 3.2 Add a scoped operator warning for explicit `NodeRuntimeService` compatibility selection or listener enablement without warning about retained Peer Grant/control or Worker Runtime boundaries.
+- [ ] 3.3 Publish and preserve the Bridge Release artifacts before any default-off or removal work begins.
+- [ ] 3.4 Provide an operator reporting path for an unknown external `NodeRuntimeService` consumer and resolve any validated supported consumer before advancing.
+
+## 4. Deprecation Release
+
+- [ ] 4.1 Make the non-gRPC first-party path the only default for each qualified profile.
+- [ ] 4.2 Make the Node Runtime listener default-off for qualified profiles and enable it only through the explicit compatibility profile.
+- [ ] 4.3 Retain Controller and Node Agent compatibility adapters, runtime messages, generated bindings, and dependencies as rollback assets.
+- [ ] 4.4 Prove Bridge and Deprecation mixed-version operation plus the reverse Controller rollback pairing.
+- [ ] 4.5 Make upgrade preflight report gRPC-only configuration and missing non-gRPC capability, identity, authorization, and reachability before mutation.
+- [ ] 4.6 Publish and preserve the Deprecation Release artifacts before raising the removal floor.
+
+## 5. Floor Release And Compatibility Cutover
+
+- [ ] 5.1 Ship a non-destructive Floor Release that retains the runtime listener, both runtime adapters, protocol bindings, and shared dependencies.
+- [ ] 5.2 Enumerate the exact Product Versions in every compatibility epoch and prove every real Controller `N` with Node Agent `N` and `N-1` pairing through the Floor Release.
+- [ ] 5.3 Add a durable compatibility cutover that records the exact Floor Product Version, capability contract, participating identities and versions, evidence time, and operator approval.
+- [ ] 5.4 Reject the cutover unless every participating Controller and Node Agent already runs the Floor Release and proves non-gRPC removal readiness.
+- [ ] 5.5 After cutover, reject update or rollback below the recorded Floor Release before mutation while all compatibility assets remain installed.
+
+## 6. Removal Release
+
+- [ ] 6.1 Require the previously recorded exact Floor Release cutover before an adapter-removal update begins and never create or raise that floor inside the Removal Release.
+- [ ] 6.2 Prove Removal Controller with the immediately previous Floor Node Agent as the actual `N-1` pairing and Floor Controller with Removal Node Agent as the bounded Controller rollback pairing.
+- [ ] 6.3 Remove the first-party Controller compatibility clients and mappers, Node Agent runtime server and listener, and compatibility-only callers and tests.
+- [ ] 6.4 Reject retired runtime gRPC transport, target, listener, and credential configuration with a clear minimum-version error.
+- [ ] 6.5 Preserve Peer Grant/control and Worker Runtime gRPC boundaries and their direct tests.
+
+## 7. Runtime Protobuf Decoupling
+
+- [ ] 7.1 Replace protobuf-shaped BEAM and domain internals with transport-independent Runtime Endpoint types before deleting any runtime message.
+- [ ] 7.2 Migrate the provider-neutral Worker Runtime contract away from `cluster.v1.runtime` message imports through a separate accepted change with compatible generated bindings.
+- [ ] 7.3 Remove `runtime.proto` and generated Elixir and Python runtime bindings only after no supported adapter, Worker Runtime, test, package, or generation task consumes them.
+- [ ] 7.4 Preserve shared `common.proto`, `events.proto`, Peer Grant schemas, and shared dependencies wherever consumers remain.
+
+## 8. Validation And Review
+
+- [x] 8.1 Run `git diff --check` for this contract-only change.
+- [x] 8.2 Run strict validation for `deprecate-node-runtime-grpc-compatibility` and strict validation for the complete OpenSpec tree.
+- [x] 8.3 Obtain a pre-edit RepoPrompt architecture review plus Oracle sequencing challenge and incorporate blocker and important findings.
+- [x] 8.4 Obtain a final diff-scoped RepoPrompt architecture review and resolve blocker or important findings.
+- [x] 8.5 Confirm the proposal changes no runtime behavior, defaults, listeners, generated code, dependencies, or `SPEC.md` text.


### PR DESCRIPTION
## Context and outcome

This defines a staged deprecation contract for `NodeRuntimeService` only as Orchard's first-party Controller-to-Node Runtime Endpoint compatibility transport.

The transport-independent Runtime Endpoint Interface remains the durable boundary.
Peer Grant/control gRPC and the Node Agent-to-Worker Runtime gRPC and Unix-domain-socket boundary remain supported and outside this deprecation.
A future non-BEAM Runtime Endpoint adapter remains possible without making the current protobuf its permanent protocol.

Closes #350.

## Decision

- Migrate all-in-one source development first through a same-VM Runtime Endpoint client while retaining explicit gRPC restart as immediate rollback.
- Use Bridge, Deprecation, Floor, and Removal compatibility epochs that must map to exact released Product Versions and every actual `N`, `N-1`, and reverse Controller rollback pairing.
- Add a non-destructive Floor Release and durable exact-version cutover before any adapter removal.
- Delete four layers independently and in order: listener and profile defaults, first-party runtime adapters, runtime protobuf messages and generated bindings, then shared dependency ownership.
- Keep runtime-message deletion blocked while BEAM internals or the Worker Runtime contract consume `cluster.v1.runtime` types.
- Keep repository-wide gRPC/protobuf dependency removal blocked while Peer Grant/control or Worker Runtime boundaries consume them.

## Consumer evidence and uncertainty

The inventory covers the Controller compatibility clients, direct dispatch client, mappers, activation, inference, scheduler, node lifecycle, diagnostics, Node Agent server and listener supervision, runtime configuration, generated environments, packaging wrappers, Orchard.app/DMG and launchd profiles, tests, protobuf generation, Elixir bindings, and Python bindings.

The supported consumers found are Orchard's own Controller, Node Agent, CLI and tests, generated bindings, and explicit operator compatibility profiles.
No accepted repository contract, current issue or PR, packaging surface, or history reviewed for this change identifies a supported external `NodeRuntimeService` product consumer.
That is bounded repository and project evidence, not universal proof of absence.
Any validated supported consumer reported before removal blocks that stage until it migrates or receives a separate accepted decision.

## Topology, compatibility, and rollback

- Stage A is the only current implementation go after proposal acceptance: migrate the active all-in-one `bin/dev` path while keeping the listener, both adapters, bindings, dependencies, split-role behavior, and packaged behavior unchanged.
- The Bridge epoch qualifies every affected supported profile on the non-gRPC path and adds a scoped warning and consumer-reporting window while compatibility remains available.
- The Deprecation epoch makes the non-gRPC path the only default for qualified profiles and makes the runtime listener default-off while explicit compatibility remains a rollback mode.
- The Floor epoch retains all compatibility assets and records a durable exact Product Version cutover only after every participant runs that release and proves removal readiness.
- The Removal epoch requires that earlier Floor cutover, proves Removal Controller with the immediately previous Floor Node Agent as the actual `N-1` pairing, and proves Floor Controller with Removal Node Agent as the bounded Controller rollback pairing.
- Runtime protobuf and shared dependency cleanup remain later independently gated layers.

PR #346 is used only as deterministic source-development listener-free transport evidence.
It is not treated as packaged, real-MLX, physical multi-host, mixed-version, upgrade, rollback, or protobuf-independence qualification.

## First implementation slice after acceptance

Proposed issue title: `Migrate all-in-one source development to the transport-independent Runtime Endpoint path`.

The slice adds a same-VM Runtime Endpoint client, makes all-in-one `bin/dev` use it by default, retains explicit `ORCHARD_RUNTIME_ENDPOINT_TRANSPORT=grpc` rollback, and proves the real-MLX all-in-one operation matrix plus the existing gRPC restart smoke.
It does not change split-role or packaged defaults, listeners, adapters, protobufs, generated bindings, dependencies, Peer Grant/control, or Worker Runtime protocols.
The copy-ready scope, acceptance criteria, non-goals, validation, and risk assessment are in `tasks.md`.

## Files

- Added the complete `deprecate-node-runtime-grpc-compatibility` OpenSpec proposal, design, tasks, metadata, and runtime-endpoints delta.
- Added proposed ADR 0029 because the protocol boundary, release floor, deletion ordering, and rollback choice meet Orchard's decision-record threshold.
- Corrected the glossary so `gRPC Compatibility Adapter` no longer conflates the first-party runtime mode with Peer Grant/control or Worker Runtime gRPC.
- Left `SPEC.md` unchanged because this proposal does not yet change supported behavior.

## Review feedback disposition

- Greptile's valid delta-classification P1 was fixed at `c3d7693769bb66757c3e975b124b789d1a5bf338`. The delta now removes and replaces the obsolete bootstrap requirement, and renames plus modifies the existing all-in-one requirement instead of adding a competing requirement.
- Greptile's later apex-contract P1 was reviewed and not addressed as a repository change. This OpenSpec package remains an unarchived contract-only proposal, `SPEC.md` remains the current behavior contract, and `tasks.md` 2.6 plus proposed ADR 0029 require the implementing PR to reconcile `SPEC.md` before changing behavior. The rationale was posted and the thread was resolved.
- Greptile reviewed the current head, left a thumbs-up, and its check is green.

## Verification

Live base at this refresh: `58a872514b716d9e0cefc30e7c1dcba9058c9e41`.

Final head: `c3d7693769bb66757c3e975b124b789d1a5bf338`.

- `git diff --check origin/main...HEAD` passed at the current head.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate deprecate-node-runtime-grpc-compatibility --type change --strict --no-interactive` passed at the current head.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive` passed with 38 items and 0 failures at the current head.
- Accepted specs contain no `Purpose TBD`, TODO, or placeholder prose.
- Pre-edit RepoPrompt architecture review and focused Oracle sequencing challenge completed.
- Final deep diff-scoped RepoPrompt architecture review raised four important findings about delta classification, floor timing, symbolic version labels, and proposed glossary language. All four were corrected, and its final re-review reported no blocker or important findings.
- All required GitHub checks are terminal and green, including the Required Orchard validation gate and Greptile Review.
- No Mistakes was not run because `no-mistakes status` reports that the repository is not initialized, and this task did not enable it.

## Risk Assessment

✅ **Low**

- The blast radius is limited to proposed contract, decision, and glossary text.
- There are no runtime, configuration, listener, packaging, generated-code, dependency, database, or public API behavior changes.
- The contract fails closed between warning, default-off, floor cutover, adapter removal, protobuf deletion, and dependency cleanup.
- Residual risk is an unknown external consumer or a future version assignment that cannot satisfy the exact compatibility matrix, and either condition blocks removal rather than being inferred away.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defines a staged contract for deprecating the first-party Controller-to-Node Runtime gRPC compatibility transport while retaining unrelated gRPC boundaries and rollback assets. It also changes the proposed all-in-one default without reconciling the apex product contract.
- Adds ADR 0029 and a complete OpenSpec proposal covering Bridge, Deprecation, Floor, and Removal epochs.
- Replaces the proposed all-in-one gRPC-loopback requirement with same-VM Runtime Endpoint semantics and explicit gRPC rollback.
- Separates listener, adapter, protobuf-binding, and dependency removal into independently gated layers.
- Clarifies the glossary boundary of the gRPC Compatibility Adapter.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because its normative all-in-one default conflicts with the unchanged apex product contract.

The OpenSpec delta mandates same-VM all-in-one operation while the proposal and ADR defer the required SPEC.md reconciliation, leaving authoritative product contracts in disagreement.

**Files Needing Attention:** openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md, openspec/changes/deprecate-node-runtime-grpc-compatibility/proposal.md, docs/decisions/0029-deprecate-node-runtime-grpc-compatibility.md
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md | Correctly removes the prior duplicate OpenSpec defaults, but establishes a new normative default that remains inconsistent with unchanged SPEC.md. |
| openspec/changes/deprecate-node-runtime-grpc-compatibility/design.md | Defines the staged migration, compatibility floor, rollback matrix, and deletion ordering in detail. |
| openspec/changes/deprecate-node-runtime-grpc-compatibility/proposal.md | Accurately scopes the deprecation but explicitly defers reconciliation of the conflicting apex contract. |
| docs/decisions/0029-deprecate-node-runtime-grpc-compatibility.md | Records the architectural decision while stating that SPEC.md remains unchanged despite the proposed default transition. |
| openspec/changes/deprecate-node-runtime-grpc-compatibility/tasks.md | Provides implementation and qualification work for the staged migration. |
| docs/glossary/CONTEXT.md | Narrows the compatibility-adapter term without conflating Peer Grant/control or Worker Runtime boundaries. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kapitan-ai%2Forchard%22%20on%20the%20existing%20branch%20%22najibninaba%2Fissue-350-grpc-deprecation-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22najibninaba%2Fissue-350-grpc-deprecation-contract%22.%0A%0AGreploop%20kapitan-ai%2Forchard%20PR%20%23351%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=kapitan-ai%2Forchard&pr=351&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kapitan-ai%2Forchard%22%20on%20the%20existing%20branch%20%22najibninaba%2Fissue-350-grpc-deprecation-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22najibninaba%2Fissue-350-grpc-deprecation-contract%22.%0A%0A%23%23%23%20Issue%201%0Aopenspec%2Fchanges%2Fdeprecate-node-runtime-grpc-compatibility%2Fspecs%2Fruntime-endpoints%2Fspec.md%3A193-194%0A**Apex%20contract%20remains%20contradictory**%0A%0AWhen%20this%20accepted%20change%20is%20synchronized%20or%20used%20for%20the%20first%20all-in-one%20implementation%20slice%2C%20the%20replacement%20requirement%20mandates%20same-VM%20operation%20while%20the%20unchanged%20%60SPEC.md%60%20still%20mandates%20gRPC%20loopback%2C%20leaving%20contributors%20with%20conflicting%20authoritative%20defaults.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=kapitan-ai%2Forchard&pr=351&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenspec%2Fchanges%2Fdeprecate-node-runtime-grpc-compatibility%2Fspecs%2Fruntime-endpoints%2Fspec.md%3A193-194%0A**Apex%20contract%20remains%20contradictory**%0A%0AWhen%20this%20accepted%20change%20is%20synchronized%20or%20used%20for%20the%20first%20all-in-one%20implementation%20slice%2C%20the%20replacement%20requirement%20mandates%20same-VM%20operation%20while%20the%20unchanged%20%60SPEC.md%60%20still%20mandates%20gRPC%20loopback%2C%20leaving%20contributors%20with%20conflicting%20authoritative%20defaults.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=kapitan-ai%2Forchard&pr=351&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openspec/changes/deprecate-node-runtime-grpc-compatibility/specs/runtime-endpoints/spec.md:193-194
**Apex contract remains contradictory**

When this accepted change is synchronized or used for the first all-in-one implementation slice, the replacement requirement mandates same-VM operation while the unchanged `SPEC.md` still mandates gRPC loopback, leaving contributors with conflicting authoritative defaults.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Address PR review feedback (#351)"](https://github.com/kapitan-ai/orchard/commit/c3d7693769bb66757c3e975b124b789d1a5bf338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58971906)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/kapitan-ai/orchard/blob/main/AGENTS.md))

<!-- /greptile_comment -->

