### PR TITLE
feat(console): add guided Node enrollment flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,9 @@ When changing Console UI, keep `docs/DESIGN.md` and the implementation in sync. 
   end
   ```
 - **Deferred mount**: Call DB/gRPC only inside `if connected?(socket)`. Disconnected render shows loading state via `state_message`.
-- **Sensitive values**: Never put secrets in `data-*` attributes, flash, session, or URL params. Keep them in socket assigns only. JS hooks should read secrets from visible DOM elements via ID reference, not data attributes.
+- **Sensitive values**: Never put secrets in `data-*` attributes, flash, session, URL params, logs, or reusable endpoints.
+  Ordinary one-time display or copy hooks should read the value from a visible DOM element by ID.
+  A one-time non-display download may instead receive bytes through an authenticated same-origin `push_event`, provided the hook clears transient bytes, revokes object URLs, and acknowledges only a bounded non-secret identifier.
 - **Multi-tenant scoping**: Always scope child-resource DB operations (revoke, update, delete) to the parent tenant from server-side assigns. Never trust `phx-value-*` IDs alone.
 
 ## Agent Contribution Workflow

--- a/apps/orchard_cli/lib/orchard_cli/commands/node_enrollment.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/node_enrollment.ex
@@ -1,10 +1,8 @@
 defmodule OrchardCLI.Commands.NodeEnrollment do
   @moduledoc false
 
+  alias Orchard.NodeEnrollmentBundle
   alias Orchard.NodeEnrollments
-  alias Orchard.NodeTrust
-  alias OrchardCLI.CertificatePin
-  alias OrchardCLI.EndpointMetadata
   alias OrchardCLI.ExclusiveOutput
   alias OrchardCLI.RepoRuntime
 
@@ -78,51 +76,33 @@ defmodule OrchardCLI.Commands.NodeEnrollment do
   defp issue(options) do
     output = output_impl()
 
-    with {:ok, trust} <- NodeTrust.public_material(),
-         {:ok, endpoint} <- controller_https_endpoint(),
-         {:ok, reservation} <- reserve_output(output, options.output_path) do
-      issue_reserved(output, reservation, options, trust, endpoint)
-    else
+    case reserve_output(output, options.output_path) do
+      {:ok, reservation} -> issue_reserved(output, reservation, options)
       {:error, reason} -> command_error(reason)
     end
   end
 
-  defp issue_reserved(output, reservation, options, trust, endpoint) do
-    now = DateTime.utc_now()
-    expires_at = DateTime.add(now, options.expiry_seconds, :second)
-
+  defp issue_reserved(output, reservation, options) do
     attrs = %{
-      audit_metadata: %{"surface" => "local_orchardctl"},
-      cluster_id: trust.cluster_id,
       creator_id: "local-orchardctl",
       creator_type: "operator",
-      expected_controller_id: trust.controller_id,
-      expires_at: expires_at,
-      resume_verifier_metadata: %{"algorithm" => "sha256", "version" => 1},
-      trust_authority_id: trust.trust_authority_id
+      display_name: nil,
+      expiry_seconds: options.expiry_seconds,
+      surface: "local_orchardctl"
     }
 
-    with {:ok, _reconciliation} <-
-           NodeEnrollments.reconcile_stale_pending_publications(now: now),
-         {:ok, result} <- NodeEnrollments.create(attrs, now: now) do
-      publish_bundle(output, reservation, result, trust, endpoint)
-    else
+    case bundle_issuer_impl().issue(attrs) do
+      {:ok, bundle} ->
+        publish_bundle(output, reservation, bundle)
+
       {:error, reason} ->
         output.release(reservation)
         command_error(reason)
     end
   end
 
-  defp publish_bundle(output, reservation, result, trust, endpoint) do
-    bundle = enrollment_bundle(result, trust, endpoint)
-
-    case Jason.encode(bundle, pretty: true) do
-      {:ok, json} ->
-        publish_encoded_bundle(output, reservation, result.enrollment.id, json <> "\n")
-
-      {:error, _reason} ->
-        handle_publication_failure(output, reservation, result.enrollment.id)
-    end
+  defp publish_bundle(output, reservation, bundle) do
+    publish_encoded_bundle(output, reservation, bundle.enrollment.id, bundle.contents)
   end
 
   defp publish_encoded_bundle(output, reservation, enrollment_id, contents) do
@@ -194,26 +174,6 @@ defmodule OrchardCLI.Commands.NodeEnrollment do
        "Enrollment ID: #{enrollment_id}"}
   end
 
-  defp enrollment_bundle(result, trust, endpoint) do
-    %{
-      version: 1,
-      enrollment_id: result.enrollment.id,
-      node_id: result.enrollment.node_id,
-      cluster_id: trust.cluster_id,
-      expires_at: DateTime.to_iso8601(result.enrollment.expires_at),
-      issued_at: DateTime.to_iso8601(result.enrollment.issued_at),
-      controller: %{
-        https_endpoint: endpoint.address,
-        https_trust_anchor_pem: endpoint.trust_anchor_pem,
-        https_trust_spki_sha256: endpoint.trust_spki_sha256,
-        id: trust.controller_id,
-        runtime_trust_spki_sha256: trust.ca_spki_fingerprint,
-        uri_san: trust.controller_uri_san
-      },
-      token: result.bootstrap_token
-    }
-  end
-
   defp handle_publication_failure(output, reservation, enrollment_id) do
     case output.release(reservation) do
       :ok ->
@@ -259,49 +219,6 @@ defmodule OrchardCLI.Commands.NodeEnrollment do
     )
   end
 
-  defp controller_https_endpoint do
-    with {:ok, metadata} <- EndpointMetadata.read(),
-         :ok <- require_https_transport(metadata),
-         {:ok, host} <- required_metadata(metadata.public_host, :public_host),
-         {:ok, port} <- required_metadata(metadata.api_https_port, :api_https_port),
-         {:ok, ca_certfile} <- required_metadata(metadata.ca_certfile, :ca_certfile),
-         {:ok, trust} <- https_trust_material(ca_certfile) do
-      {:ok,
-       %{
-         address: "https://#{endpoint_host(host)}:#{port}",
-         trust_anchor_pem: trust.pem,
-         trust_spki_sha256: trust.spki_sha256
-       }}
-    end
-  end
-
-  defp https_trust_material(path) do
-    with {:ok, pem} <- File.read(path),
-         {:ok, der} <- CertificatePin.decode_pem(pem),
-         {:ok, fingerprint} <- CertificatePin.from_der(der) do
-      {:ok, %{pem: pem, spki_sha256: fingerprint}}
-    else
-      _reason -> {:error, :controller_https_trust_invalid}
-    end
-  end
-
-  defp require_https_transport(%{transport_mode: mode})
-       when mode in ["direct_https", "reverse_proxy"],
-       do: :ok
-
-  defp require_https_transport(_metadata), do: {:error, :controller_https_not_configured}
-
-  defp required_metadata(nil, _field), do: {:error, :controller_https_not_configured}
-  defp required_metadata(value, _field), do: {:ok, value}
-
-  defp endpoint_host(host) do
-    if String.contains?(host, ":") do
-      "[#{host}]"
-    else
-      host
-    end
-  end
-
   defp reserve_output(output, path) do
     case output.reserve(path) do
       {:ok, reservation} -> {:ok, reservation}
@@ -313,6 +230,14 @@ defmodule OrchardCLI.Commands.NodeEnrollment do
 
   defp output_impl do
     Application.get_env(:orchard_cli, :node_enrollment_output_impl, ExclusiveOutput)
+  end
+
+  defp bundle_issuer_impl do
+    Application.get_env(
+      :orchard_cli,
+      :node_enrollment_bundle_impl,
+      NodeEnrollmentBundle
+    )
   end
 
   defp command_error({:error, message, code}), do: {:error, message, code}
@@ -359,9 +284,27 @@ defmodule OrchardCLI.Commands.NodeEnrollment do
     {:error, "Error: Controller leadership could not be proven; no Enrollment was issued.", 1}
   end
 
+  defp command_error({:bundle_publication_failed, enrollment_id, :output_failed, failure_code}) do
+    {:error,
+     "Error: Enrollment #{enrollment_id} is output_failed because #{failure_label(failure_code)}. No bundle was published. Correct the Controller configuration, then create a new enrollment.",
+     1}
+  end
+
+  defp command_error(
+         {:bundle_publication_reconciliation_failed, enrollment_id, failure_code,
+          _reconciliation_reason}
+       ) do
+    {:error,
+     "Error: no bundle was published. Enrollment #{enrollment_id} remains non-redeemable pending reconciliation after #{failure_label(failure_code)}, and its provisioned Node name remains reserved. Record the Enrollment ID and retry with a distinct Node name after Controller recovery.",
+     1}
+  end
+
   defp command_error(_reason) do
     {:error, "Error: Node Enrollment issuance failed.", 1}
   end
+
+  defp failure_label(:bundle_too_large), do: "the enrollment bundle exceeded 65536 bytes"
+  defp failure_label(:bundle_encoding_failed), do: "the enrollment bundle could not be encoded"
 
   defp usage do
     "Usage: orchardctl nodes enrollment create --output PATH [--expires-in DURATION]"

--- a/apps/orchard_cli/lib/orchard_cli/commands/status.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/status.ex
@@ -10,8 +10,8 @@ defmodule OrchardCLI.Commands.Status do
     orchardctl status help  — Show usage
   """
 
+  alias Orchard.EndpointMetadata
   alias OrchardCLI.Commands.LifecycleSupport
-  alias OrchardCLI.EndpointMetadata
 
   @default_support_root "/Library/Application Support/Orchard"
   @connect_timeout_ms 2_000

--- a/apps/orchard_cli/lib/orchard_cli/commands/transport.ex
+++ b/apps/orchard_cli/lib/orchard_cli/commands/transport.ex
@@ -3,8 +3,9 @@ defmodule OrchardCLI.Commands.Transport do
   CLI handler for `orchardctl transport` commands.
   """
 
+  alias Orchard.EndpointMetadata
   alias OrchardCLI.Commands.{LifecycleSupport, TLS}
-  alias OrchardCLI.{EndpointMetadata, ShellEnv}
+  alias OrchardCLI.ShellEnv
 
   @default_support_root "/Library/Application Support/Orchard"
   @default_https_port 8443

--- a/apps/orchard_cli/test/orchard_cli/commands/node_enrollment_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/node_enrollment_test.exs
@@ -69,6 +69,18 @@ defmodule OrchardCLI.Commands.NodeEnrollmentTest.ConcurrentFailureOutput do
   def release(_reservation), do: {:error, :simulated_cleanup_failure}
 end
 
+defmodule OrchardCLI.Commands.NodeEnrollmentTest.ReconciliationFailureBundle do
+  @moduledoc false
+
+  @enrollment_id "33333333-3333-4333-8333-333333333333"
+
+  def issue(_attrs) do
+    {:error,
+     {:bundle_publication_reconciliation_failed, @enrollment_id, :bundle_too_large,
+      :database_unavailable}}
+  end
+end
+
 defmodule OrchardCLI.Commands.NodeEnrollmentTest do
   use ExUnit.Case, async: false
 
@@ -76,6 +88,7 @@ defmodule OrchardCLI.Commands.NodeEnrollmentTest do
   import Ecto.Query
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.EndpointMetadata
   alias Orchard.Governance.AuditLog
   alias Orchard.NodeEnrollments
   alias Orchard.Nodes.{Enrollment, Node}
@@ -86,8 +99,8 @@ defmodule OrchardCLI.Commands.NodeEnrollmentTest do
   alias OrchardCLI.Commands.NodeEnrollmentTest.ConcurrentFailureOutput
   alias OrchardCLI.Commands.NodeEnrollmentTest.PendingObservationOutput
   alias OrchardCLI.Commands.NodeEnrollmentTest.PublicationFailureOutput
+  alias OrchardCLI.Commands.NodeEnrollmentTest.ReconciliationFailureBundle
   alias OrchardCLI.Commands.Nodes
-  alias OrchardCLI.EndpointMetadata
 
   setup do
     :ok = Sandbox.checkout(Repo)
@@ -103,6 +116,7 @@ defmodule OrchardCLI.Commands.NodeEnrollmentTest do
     support_root = Path.join(root, "support")
 
     previous = %{
+      bundle_impl: Application.get_env(:orchard_cli, :node_enrollment_bundle_impl),
       control_plane: Application.get_env(:orchard_controller, :control_plane),
       node_trust: Application.get_env(:orchard_controller, :node_trust),
       output_impl: Application.get_env(:orchard_cli, :node_enrollment_output_impl),
@@ -116,6 +130,7 @@ defmodule OrchardCLI.Commands.NodeEnrollmentTest do
     System.put_env("ORCHARD_SUPPORT_ROOT", support_root)
     Application.put_env(:orchard_controller, :control_plane, role: :single_controller)
     Application.put_env(:orchard_controller, :node_trust, root: trust_root)
+    Application.delete_env(:orchard_cli, :node_enrollment_bundle_impl)
     Application.delete_env(:orchard_cli, :node_enrollment_output_impl)
     Application.delete_env(:orchard_cli, :node_enrollment_publication_fault_injector)
 
@@ -124,6 +139,7 @@ defmodule OrchardCLI.Commands.NodeEnrollmentTest do
       restore_env("ORCHARD_SUPPORT_ROOT", previous.support_root)
       restore_app_env(:orchard_controller, :control_plane, previous.control_plane)
       restore_app_env(:orchard_controller, :node_trust, previous.node_trust)
+      restore_app_env(:orchard_cli, :node_enrollment_bundle_impl, previous.bundle_impl)
       restore_app_env(:orchard_cli, :node_enrollment_output_impl, previous.output_impl)
 
       restore_app_env(
@@ -214,6 +230,49 @@ defmodule OrchardCLI.Commands.NodeEnrollmentTest do
     assert message =~ "output path already exists"
     assert File.read!(output_path) == "operator-owned-existing-content"
     assert_no_enrollment_mutation()
+  end
+
+  test "post-create builder failure reports the output_failed Enrollment and publishes no file",
+       %{
+         root: root
+       } do
+    https_ca_path = Path.join([root, "support", "public", "ca.crt"])
+    File.write!(https_ca_path, File.read!(https_ca_path) <> String.duplicate(" ", 65_536))
+    output_path = Path.join(root, "oversized-enrollment.json")
+
+    assert {:error, message, 1} =
+             Nodes.run(["enrollment", "create", "--output", output_path])
+
+    enrollment = Repo.one!(Enrollment)
+
+    assert message =~ enrollment.id
+    assert message =~ "is output_failed"
+    assert message =~ "exceeded 65536 bytes"
+    assert message =~ "No bundle was published"
+    refute File.exists?(output_path)
+    assert enrollment.state == :output_failed
+  end
+
+  test "unresolved post-create reconciliation reports the pending Enrollment identity", %{
+    root: root
+  } do
+    Application.put_env(
+      :orchard_cli,
+      :node_enrollment_bundle_impl,
+      ReconciliationFailureBundle
+    )
+
+    output_path = Path.join(root, "unresolved-enrollment.json")
+
+    assert {:error, message, 1} =
+             Nodes.run(["enrollment", "create", "--output", output_path])
+
+    assert message =~ "33333333-3333-4333-8333-333333333333"
+    assert message =~ "no bundle was published"
+    assert message =~ "remains non-redeemable pending reconciliation"
+    assert message =~ "provisioned Node name remains reserved"
+    assert message =~ "distinct Node name"
+    refute File.exists?(output_path)
   end
 
   test "OpenSpec task 2.3 explains how to remediate a non-owner-only output directory", %{

--- a/apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/node_join_test.exs
@@ -100,6 +100,7 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
   alias Orchard.ClusterManagement.StatusBuilder
   alias Orchard.Dispatch.GrpcNodeRuntimeClient, as: TransportClient
   alias Orchard.DispatchCapacity
+  alias Orchard.EndpointMetadata
   alias Orchard.Inference
   alias Orchard.Node.ModelManager
   alias Orchard.Node.Supervisor, as: NodeSupervisor
@@ -123,7 +124,6 @@ defmodule OrchardCLI.Commands.NodeJoinTest do
   alias Orchard.TransportTLS.PeerVerifier
   alias OrchardCLI.Commands.Node
   alias OrchardCLI.Commands.Nodes
-  alias OrchardCLI.EndpointMetadata
   alias OrchardCLI.NodeEnrollmentBundle
   alias OrchardCLI.NodeIdentity.Store
   alias OrchardCLI.PinnedHTTPS

--- a/apps/orchard_cli/test/orchard_cli/commands/transport_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/commands/transport_test.exs
@@ -234,7 +234,7 @@ defmodule OrchardCLI.Commands.TransportTest do
       assert Bitwise.band(File.stat!(public_ca).mode, 0o777) == 0o644
 
       assert {:ok, endpoint} =
-               OrchardCLI.EndpointMetadata.read(
+               Orchard.EndpointMetadata.read(
                  path: Path.join([support_root, "public", "endpoint.json"])
                )
 
@@ -395,9 +395,7 @@ defmodule OrchardCLI.Commands.TransportTest do
       assert controller_env =~ ~r/^ORCHARD_TRANSPORT_MODE="direct_https"$/m
 
       {:ok, endpoint} =
-        OrchardCLI.EndpointMetadata.read(
-          path: Path.join([support_root, "public", "endpoint.json"])
-        )
+        Orchard.EndpointMetadata.read(path: Path.join([support_root, "public", "endpoint.json"]))
 
       assert endpoint.ca_certfile == nil
     after
@@ -432,9 +430,7 @@ defmodule OrchardCLI.Commands.TransportTest do
       assert controller_env =~ ~r/^ORCHARD_API_HTTPS_PORT="9443"$/m
 
       {:ok, endpoint} =
-        OrchardCLI.EndpointMetadata.read(
-          path: Path.join([support_root, "public", "endpoint.json"])
-        )
+        Orchard.EndpointMetadata.read(path: Path.join([support_root, "public", "endpoint.json"]))
 
       assert endpoint.api_https_port == 9443
     after

--- a/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
+++ b/apps/orchard_cli/test/orchard_cli/test_temp_test.exs
@@ -1,6 +1,7 @@
 defmodule OrchardCLI.TestTempTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
+  @fresh_beam_start_timeout_ms 15_000
   @test_temp_support Path.expand("../support/test_temp.ex", __DIR__)
 
   setup do
@@ -58,7 +59,13 @@ defmodule OrchardCLI.TestTempTest do
         ])
       end)
 
-    root = await_ready!(task, ready, System.monotonic_time(:millisecond) + 5_000)
+    root =
+      await_ready!(
+        task,
+        ready,
+        System.monotonic_time(:millisecond) + @fresh_beam_start_timeout_ms
+      )
+
     assert File.dir?(root)
 
     Process.sleep(150)
@@ -89,7 +96,13 @@ defmodule OrchardCLI.TestTempTest do
         run_fresh_beam(["hold", base, label, ready, armed, release])
       end)
 
-    root = await_ready!(task, ready, System.monotonic_time(:millisecond) + 5_000)
+    root =
+      await_ready!(
+        task,
+        ready,
+        System.monotonic_time(:millisecond) + @fresh_beam_start_timeout_ms
+      )
+
     assert File.dir?(root)
     OrchardCLI.TestTemp.atomic_write!(armed, "armed")
     %{release: release, root: root, task: task}

--- a/apps/orchard_controller/assets/js/app.js
+++ b/apps/orchard_controller/assets/js/app.js
@@ -4,6 +4,10 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import {
+  downloadNodeEnrollmentBundle,
+  nodeEnrollmentBundleAcknowledgement
+} from "./node_enrollment_bundle_download.mjs"
 
 // ===========================================================================
 // LiveView Hooks
@@ -467,6 +471,24 @@ Hooks.CopyGeneratedSecret = {
 
   destroyed() {
     this.el.removeEventListener("click", this._onClick)
+  }
+}
+
+/**
+ * NodeEnrollmentBundleDownload downloads a one-time enrollment bundle from a
+ * LiveView event without placing its secret content in the DOM or a URL.
+ */
+Hooks.NodeEnrollmentBundleDownload = {
+  mounted() {
+    this.handleEvent("node_enrollment_bundle", async (payload) => {
+      let result = await downloadNodeEnrollmentBundle(payload)
+      let acknowledgement = nodeEnrollmentBundleAcknowledgement(result)
+
+      if (acknowledgement) {
+        this.pushEvent(acknowledgement.event, acknowledgement.payload)
+      }
+      payload = null
+    })
   }
 }
 

--- a/apps/orchard_controller/assets/js/node_enrollment_bundle_download.mjs
+++ b/apps/orchard_controller/assets/js/node_enrollment_bundle_download.mjs
@@ -1,0 +1,109 @@
+const MAX_BUNDLE_BYTES = 65536
+const MAX_FILENAME_BYTES = 255
+const FILENAME_PATTERN = /^orchard-[a-z0-9-]+-enrollment\.json$/
+const ENROLLMENT_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+function utf8Bytes(value) {
+  return new TextEncoder().encode(value).byteLength
+}
+
+function validEnrollmentId(enrollmentId) {
+  return typeof enrollmentId === "string" && ENROLLMENT_ID_PATTERN.test(enrollmentId)
+}
+
+export function validNodeEnrollmentBundle(payload) {
+  try {
+    return payload &&
+      validEnrollmentId(payload.enrollment_id) &&
+      typeof payload.filename === "string" && FILENAME_PATTERN.test(payload.filename) &&
+      utf8Bytes(payload.filename) <= MAX_FILENAME_BYTES &&
+      typeof payload.contents === "string" && utf8Bytes(payload.contents) > 0 &&
+      utf8Bytes(payload.contents) <= MAX_BUNDLE_BYTES
+  } catch (_error) {
+    return false
+  }
+}
+
+export function nodeEnrollmentBundleAcknowledgement(result) {
+  if (!result || !validEnrollmentId(result.enrollmentId)) return null
+
+  return {
+    event: result.ok
+      ? "node_enrollment_bundle_downloaded"
+      : "node_enrollment_bundle_download_failed",
+    payload: {enrollment_id: result.enrollmentId}
+  }
+}
+
+export async function downloadNodeEnrollmentBundle(payload, environment = {}) {
+  let enrollmentId = payload && validEnrollmentId(payload.enrollment_id)
+    ? payload.enrollment_id
+    : null
+  let contents = payload && payload.contents
+  let objectUrl = null
+  let link = null
+  let ok = false
+  let urlApi = environment.urlApi || URL
+
+  try {
+    if (!validNodeEnrollmentBundle(payload)) return {ok: false, enrollmentId}
+
+    let BlobImpl = environment.BlobImpl || Blob
+    let documentRef = environment.documentRef || document
+    let blob = new BlobImpl([contents], {type: "application/json"})
+
+    objectUrl = urlApi.createObjectURL(blob)
+    link = documentRef.createElement("a")
+    link.href = objectUrl
+    link.download = payload.filename
+    link.rel = "noopener"
+    documentRef.body.appendChild(link)
+    link.click()
+    ok = true
+  } catch (_error) {
+    ok = false
+  } finally {
+    try {
+      if (link) link.remove()
+    } catch (_error) {
+      // Cleanup is best effort; later cleanup steps must still run.
+    }
+
+    contents = null
+    if (payload && typeof payload === "object") payload.contents = null
+
+    if (objectUrl && ok) {
+      let defer = environment.defer || setTimeout
+
+      ok = await new Promise(resolve => {
+        try {
+          defer(() => {
+            try {
+              urlApi.revokeObjectURL(objectUrl)
+              resolve(true)
+            } catch (_error) {
+              resolve(false)
+            }
+          }, 0)
+        } catch (_error) {
+          try {
+            urlApi.revokeObjectURL(objectUrl)
+          } catch (_revokeError) {
+            // The scheduling failure already makes the result fail closed.
+          }
+
+          resolve(false)
+        }
+      })
+    } else if (objectUrl) {
+      try {
+        urlApi.revokeObjectURL(objectUrl)
+      } catch (_error) {
+        ok = false
+      }
+    }
+
+  }
+
+  return {ok, enrollmentId}
+}

--- a/apps/orchard_controller/assets/test/node_enrollment_bundle_download.test.mjs
+++ b/apps/orchard_controller/assets/test/node_enrollment_bundle_download.test.mjs
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  downloadNodeEnrollmentBundle,
+  nodeEnrollmentBundleAcknowledgement,
+  validNodeEnrollmentBundle
+} from "../js/node_enrollment_bundle_download.mjs"
+
+const ENROLLMENT_ID = "11111111-1111-4111-8111-111111111111"
+
+function environment({throwOnClick = false, throwOnDefer = false, throwOnRemove = false, throwOnRevoke = false} = {}) {
+  let observed = {
+    appended: false,
+    blob: null,
+    clicked: false,
+    link: null,
+    removed: false,
+    revoked: null,
+    scheduled: []
+  }
+
+  class BlobStub {
+    constructor(parts, options) {
+      this.parts = parts
+      this.options = options
+      observed.blob = this
+    }
+  }
+
+  let link = {
+    click() {
+      if (throwOnClick) throw new Error("download blocked")
+      observed.clicked = true
+    },
+    remove() {
+      if (throwOnRemove) throw new Error("link removal failed")
+      observed.removed = true
+    }
+  }
+
+  let documentRef = {
+    body: {
+      appendChild(item) {
+        observed.appended = item === link
+      }
+    },
+    createElement(tag) {
+      assert.equal(tag, "a")
+      observed.link = link
+      return link
+    }
+  }
+
+  let urlApi = {
+    createObjectURL(blob) {
+      assert.equal(blob, observed.blob)
+      return "blob:orchard-enrollment"
+    },
+    revokeObjectURL(url) {
+      if (throwOnRevoke) throw new Error("object URL revocation failed")
+      observed.revoked = url
+    }
+  }
+
+  let defer = callback => {
+    if (throwOnDefer) throw new Error("timer scheduling failed")
+    observed.scheduled.push(callback)
+  }
+
+  return {BlobImpl: BlobStub, defer, documentRef, observed, urlApi}
+}
+
+test("downloads JSON with a sanitized filename and clears transient content", async () => {
+  let payload = {
+    contents: "{\"token\":\"one-time-secret\"}\n",
+    enrollment_id: ENROLLMENT_ID,
+    filename: "orchard-render-node-03-enrollment.json"
+  }
+  let env = environment()
+
+  let result = downloadNodeEnrollmentBundle(payload, env)
+  assert.deepEqual(env.observed.blob.options, {type: "application/json"})
+  assert.equal(env.observed.link.download, "orchard-render-node-03-enrollment.json")
+  assert.equal(env.observed.link.href, "blob:orchard-enrollment")
+  assert.equal(env.observed.link.rel, "noopener")
+  assert.equal(env.observed.appended, true)
+  assert.equal(env.observed.clicked, true)
+  assert.equal(env.observed.removed, true)
+  assert.equal(env.observed.revoked, null)
+  assert.equal(payload.contents, null)
+
+  assert.equal(env.observed.scheduled.length, 1)
+  env.observed.scheduled.shift()()
+  assert.deepEqual(await result, {ok: true, enrollmentId: ENROLLMENT_ID})
+  assert.equal(env.observed.revoked, "blob:orchard-enrollment")
+})
+
+test("reports failure with only the enrollment identifier and still cleans up", async () => {
+  let payload = {
+    contents: "{\"token\":\"one-time-secret\"}\n",
+    enrollment_id: ENROLLMENT_ID,
+    filename: "orchard-worker-enrollment.json"
+  }
+  let env = environment({throwOnClick: true})
+
+  let result = await downloadNodeEnrollmentBundle(payload, env)
+
+  assert.deepEqual(result, {ok: false, enrollmentId: ENROLLMENT_ID})
+  assert.equal(JSON.stringify(result).includes("one-time-secret"), false)
+  assert.equal(env.observed.removed, true)
+  assert.equal(env.observed.revoked, "blob:orchard-enrollment")
+  assert.equal(payload.contents, null)
+})
+
+test("rejects unsafe filenames without constructing a Blob", async () => {
+  let payload = {
+    contents: "secret",
+    enrollment_id: ENROLLMENT_ID,
+    filename: "../../enrollment.json"
+  }
+  let env = environment()
+
+  assert.equal(validNodeEnrollmentBundle(payload), false)
+  assert.deepEqual(await downloadNodeEnrollmentBundle(payload, env), {
+    ok: false,
+    enrollmentId: ENROLLMENT_ID
+  })
+  assert.equal(env.observed.blob, null)
+  assert.equal(payload.contents, null)
+})
+
+test("clears content immediately and later revokes the URL when link removal fails", async () => {
+  let payload = {
+    contents: "{\"token\":\"one-time-secret\"}\n",
+    enrollment_id: ENROLLMENT_ID,
+    filename: "orchard-worker-enrollment.json"
+  }
+  let env = environment({throwOnRemove: true})
+
+  let result = downloadNodeEnrollmentBundle(payload, env)
+  assert.equal(env.observed.revoked, null)
+  assert.equal(payload.contents, null)
+  env.observed.scheduled.shift()()
+  assert.deepEqual(await result, {ok: true, enrollmentId: ENROLLMENT_ID})
+  assert.equal(env.observed.revoked, "blob:orchard-enrollment")
+})
+
+test("fails closed and clears content when deferred revocation fails", async () => {
+  let payload = {
+    contents: "{\"token\":\"one-time-secret\"}\n",
+    enrollment_id: ENROLLMENT_ID,
+    filename: "orchard-worker-enrollment.json"
+  }
+  let env = environment({throwOnRevoke: true})
+
+  let result = downloadNodeEnrollmentBundle(payload, env)
+  assert.equal(env.observed.removed, true)
+  assert.equal(payload.contents, null)
+  assert.doesNotThrow(() => env.observed.scheduled.shift()())
+  assert.deepEqual(await result, {ok: false, enrollmentId: ENROLLMENT_ID})
+})
+
+test("fails closed and revokes synchronously when cleanup scheduling fails", async () => {
+  let payload = {
+    contents: "{\"token\":\"one-time-secret\"}\n",
+    enrollment_id: ENROLLMENT_ID,
+    filename: "orchard-worker-enrollment.json"
+  }
+  let env = environment({throwOnDefer: true})
+
+  let result = await downloadNodeEnrollmentBundle(payload, env)
+
+  assert.deepEqual(result, {ok: false, enrollmentId: ENROLLMENT_ID})
+  assert.equal(env.observed.revoked, "blob:orchard-enrollment")
+  assert.equal(env.observed.scheduled.length, 0)
+  assert.equal(payload.contents, null)
+  assert.deepEqual(nodeEnrollmentBundleAcknowledgement(result), {
+    event: "node_enrollment_bundle_download_failed",
+    payload: {enrollment_id: ENROLLMENT_ID}
+  })
+})
+
+test("rejects an unbounded enrollment identifier without creating an acknowledgement", async () => {
+  let payload = {
+    contents: "secret",
+    enrollment_id: "1".repeat(1024),
+    filename: "orchard-worker-enrollment.json"
+  }
+  let env = environment()
+
+  let result = await downloadNodeEnrollmentBundle(payload, env)
+
+  assert.deepEqual(result, {ok: false, enrollmentId: null})
+  assert.equal(nodeEnrollmentBundleAcknowledgement(result), null)
+  assert.equal(env.observed.blob, null)
+  assert.equal(payload.contents, null)
+})
+
+test("rejects filenames beyond the filesystem component byte limit", async () => {
+  let payload = {
+    contents: "secret",
+    enrollment_id: ENROLLMENT_ID,
+    filename: `orchard-${"a".repeat(240)}-enrollment.json`
+  }
+  let env = environment()
+
+  assert.equal(validNodeEnrollmentBundle(payload), false)
+  assert.deepEqual(await downloadNodeEnrollmentBundle(payload, env), {
+    ok: false,
+    enrollmentId: ENROLLMENT_ID
+  })
+  assert.equal(env.observed.blob, null)
+})
+
+test("measures the one-time payload by encoded UTF-8 bytes", async () => {
+  let payload = {
+    contents: "é".repeat(600000),
+    enrollment_id: ENROLLMENT_ID,
+    filename: "orchard-worker-enrollment.json"
+  }
+  let env = environment()
+
+  assert.equal(payload.contents.length < 1048576, true)
+  assert.equal(validNodeEnrollmentBundle(payload), false)
+  assert.equal((await downloadNodeEnrollmentBundle(payload, env)).ok, false)
+  assert.equal(env.observed.blob, null)
+})
+
+test("rejects payloads above the orchardctl enrollment-file limit", async () => {
+  let payload = {
+    contents: "a".repeat(65537),
+    enrollment_id: ENROLLMENT_ID,
+    filename: "orchard-worker-enrollment.json"
+  }
+  let env = environment()
+
+  assert.equal(validNodeEnrollmentBundle(payload), false)
+  assert.equal((await downloadNodeEnrollmentBundle(payload, env)).ok, false)
+  assert.equal(env.observed.blob, null)
+})
+
+test("builds acknowledgements only for validated canonical enrollment identifiers", () => {
+  assert.deepEqual(
+    nodeEnrollmentBundleAcknowledgement({ok: true, enrollmentId: ENROLLMENT_ID}),
+    {
+      event: "node_enrollment_bundle_downloaded",
+      payload: {enrollment_id: ENROLLMENT_ID}
+    }
+  )
+  assert.deepEqual(
+    nodeEnrollmentBundleAcknowledgement({ok: false, enrollmentId: ENROLLMENT_ID}),
+    {
+      event: "node_enrollment_bundle_download_failed",
+      payload: {enrollment_id: ENROLLMENT_ID}
+    }
+  )
+  assert.equal(
+    nodeEnrollmentBundleAcknowledgement({ok: false, enrollmentId: "not-a-uuid"}),
+    null
+  )
+})

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -126,6 +126,8 @@ defmodule Orchard.API.Router do
     live_session :console, on_mount: [{OrchardConsole, :ensure_console_access}] do
       live("/", OrchardConsole.OverviewLive, :index)
       live("/nodes", OrchardConsole.NodesLive, :index)
+      live("/nodes/new", OrchardConsole.NodeEnrollmentLive, :new)
+      live("/nodes/new/:enrollment_id", OrchardConsole.NodeEnrollmentLive, :status)
       live("/nodes/pending/:candidate_id", OrchardConsole.NodeDetailLive, :candidate)
       live("/nodes/:node_id", OrchardConsole.NodeDetailLive, :node)
       live("/playground", OrchardConsole.PlaygroundLive, :index)

--- a/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
@@ -15,6 +15,7 @@ defmodule OrchardConsole.NodeDetailLive do
   }
 
   alias Orchard.ControlPlane
+  alias Orchard.NodeEnrollments
   alias Orchard.Nodes
   alias Orchard.Nodes.{AdmissionCandidate, Lifecycle, Node}
 
@@ -74,7 +75,8 @@ defmodule OrchardConsole.NodeDetailLive do
   @impl true
   def handle_event("open_admit", _params, socket) do
     if can_open_admit?(socket.assigns.target_kind, socket.assigns.record, socket.assigns.status) do
-      {:noreply, put_action(socket, :admit, default_action_inputs(:admit), false)}
+      inputs = default_admission_inputs(socket.assigns.record)
+      {:noreply, put_action(socket, :admit, inputs, false)}
     else
       {:noreply, socket}
     end
@@ -179,7 +181,7 @@ defmodule OrchardConsole.NodeDetailLive do
                     size={:sm}
                     phx-click="open_admit"
                   >
-                    Preview admit
+                    Admit Node
                   </.button>
                   <.button
                     :if={can_open_reject?(@target_kind, @record, @status)}
@@ -769,16 +771,6 @@ defmodule OrchardConsole.NodeDetailLive do
 
   defp audit_opts, do: [actor_type: "operator", actor_id: nil]
 
-  defp default_action_inputs(:admit) do
-    %{
-      "trust_evidence_ref" => "",
-      "pool_id" => "",
-      "routing_policy_id" => "",
-      "capacity_policy_reason" => "",
-      "controller_dispatch_ceiling" => 1
-    }
-  end
-
   defp default_action_inputs(:reject), do: %{"reason" => ""}
 
   defp default_action_inputs(:decommission) do
@@ -790,6 +782,38 @@ defmodule OrchardConsole.NodeDetailLive do
   defp default_action_inputs(action) when action in @lifecycle_actions do
     %{"reason" => ""}
   end
+
+  defp default_admission_inputs(node) do
+    enrollment = enrollment_for_node(node)
+
+    %{
+      "trust_evidence_ref" => trust_evidence_ref(enrollment),
+      "pool_id" => enrollment_pool_intent(enrollment),
+      "routing_policy_id" => "",
+      "capacity_policy_reason" => "",
+      "controller_dispatch_ceiling" => 1
+    }
+  end
+
+  defp enrollment_for_node(%Node{id: node_id}) do
+    case NodeEnrollments.latest_for_node(node_id) do
+      {:ok, enrollment} -> enrollment
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp enrollment_for_node(_node), do: nil
+
+  defp enrollment_pool_intent(%{audit_metadata: %{"initial_pool_id" => pool_id}})
+       when is_binary(pool_id),
+       do: pool_id
+
+  defp enrollment_pool_intent(_enrollment), do: ""
+
+  defp trust_evidence_ref(%{certificate_identifier: identifier}) when is_binary(identifier),
+    do: "node-enrollment-certificate:#{identifier}"
+
+  defp trust_evidence_ref(_enrollment), do: ""
 
   defp normalize_action_inputs(:admit, params) do
     %{
@@ -1167,7 +1191,7 @@ defmodule OrchardConsole.NodeDetailLive do
   defp action_title(:resume), do: "Resume Node Preview"
   defp action_title(:decommission), do: "Decommission Node Preview"
 
-  defp action_submit_label(:admit), do: "Admit node"
+  defp action_submit_label(:admit), do: "Admit Node"
   defp action_submit_label(:reject), do: "Reject admission"
   defp action_submit_label(:cordon), do: "Cordon node"
   defp action_submit_label(:uncordon), do: "Uncordon node"

--- a/apps/orchard_controller/lib/orchard/console/node_enrollment_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/node_enrollment_live.ex
@@ -1,0 +1,1228 @@
+defmodule OrchardConsole.NodeEnrollmentLive do
+  @moduledoc """
+  Guides an operator through secure Node Enrollment and registration.
+  """
+
+  use OrchardConsole, :live_view
+
+  alias Orchard.NodeEnrollmentBundle
+  alias Orchard.NodeEnrollments
+
+  @default_refresh_interval_ms 5_000
+  @expiry_options [
+    {"30 minutes", "1800"},
+    {"1 hour", "3600"},
+    {"4 hours", "14400"},
+    {"24 hours", "86400"}
+  ]
+  @expiry_seconds Enum.map(@expiry_options, fn {_label, value} -> String.to_integer(value) end)
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(page_title: "Add Node", active_nav: :nodes, page_mode: :workspace)
+     |> assign_initial_state()}
+  end
+
+  @impl true
+  def handle_params(
+        %{"enrollment_id" => enrollment_id},
+        _uri,
+        %{assigns: %{stage: :delivering, delivery: %{enrollment_id: enrollment_id}}} = socket
+      ) do
+    {:noreply, socket}
+  end
+
+  def handle_params(%{"enrollment_id" => enrollment_id}, _uri, socket) do
+    if connected?(socket) do
+      case safe_fetch(enrollment_id) do
+        {:ok, enrollment} ->
+          {:noreply, restore_console_enrollment(socket, enrollment)}
+
+        {:error, _reason} ->
+          {:noreply,
+           recovery_failed(
+             socket,
+             "That enrollment could not be found. Create a new enrollment to continue."
+           )}
+      end
+    else
+      {:noreply, assign(socket, stage: :loading)}
+    end
+  end
+
+  def handle_params(_params, _uri, socket) do
+    if connected?(socket) and
+         socket.assigns.stage in [
+           :loading,
+           :delivering,
+           :monitor,
+           :delivery_failed,
+           :recovery_failed
+         ] do
+      {:noreply,
+       socket
+       |> cancel_refresh()
+       |> assign_initial_state()
+       |> assign(stage: :enrollment)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("preparation_complete", _params, %{assigns: %{stage: :prepare}} = socket) do
+    {:noreply, assign(socket, stage: :enrollment)}
+  end
+
+  def handle_event("preparation_complete", _params, socket), do: {:noreply, socket}
+
+  def handle_event(
+        "issue_enrollment",
+        %{"enrollment" => params},
+        %{assigns: %{stage: :enrollment}} = socket
+      ) do
+    with {:ok, attrs, form_params} <- validate_form(params),
+         {:ok, bundle} <- safe_issue(attrs) do
+      socket =
+        socket
+        |> push_event("node_enrollment_bundle", %{
+          "contents" => bundle.contents,
+          "enrollment_id" => bundle.enrollment.id,
+          "filename" => bundle.filename
+        })
+        |> assign(
+          stage: :delivering,
+          form: to_form(form_params, as: :enrollment),
+          delivery: %{
+            enrollment_id: bundle.enrollment.id,
+            expires_at: bundle.enrollment.expires_at,
+            filename: bundle.filename,
+            node_id: bundle.enrollment.node_id,
+            display_name: bundle.enrollment.node.display_name
+          },
+          error_message: nil
+        )
+        |> push_patch(to: ~p"/console/nodes/new/#{bundle.enrollment.id}")
+
+      {:noreply, socket}
+    else
+      {:error, {:validation, form}} ->
+        {:noreply, assign(socket, form: form, error_message: nil)}
+
+      {:error, {:bundle_publication_failed, enrollment_id, :output_failed, _failure_code}} ->
+        case safe_fetch(enrollment_id) do
+          {:ok, enrollment} ->
+            {:noreply,
+             socket
+             |> restore_enrollment(enrollment)
+             |> push_patch(to: ~p"/console/nodes/new/#{enrollment.id}")}
+
+          {:error, _reason} ->
+            {:noreply,
+             recovery_failed(
+               socket,
+               "Enrollment #{enrollment_id} is output_failed and cannot be resumed. The provisioned Node remains in audit history, so create a new enrollment with a distinct Node name."
+             )}
+        end
+
+      {:error,
+       {:bundle_publication_reconciliation_failed, enrollment_id, _failure_code,
+        _reconciliation_reason}} ->
+        {:noreply,
+         assign(
+           socket,
+           error_message:
+             "No bundle was published. Enrollment #{enrollment_id} remains non-redeemable pending reconciliation, and its provisioned Node name remains reserved. Record the Enrollment ID and create a new enrollment with a distinct Node name after Controller recovery."
+         )}
+
+      {:error, reason} ->
+        {:noreply, assign(socket, error_message: issue_error(reason))}
+    end
+  end
+
+  def handle_event("issue_enrollment", _params, socket), do: {:noreply, socket}
+
+  def handle_event(
+        "node_enrollment_bundle_downloaded",
+        %{"enrollment_id" => enrollment_id},
+        %{assigns: %{stage: :delivering, delivery: %{enrollment_id: enrollment_id}}} = socket
+      ) do
+    case safe_mark_issued(enrollment_id) do
+      {:ok, enrollment} ->
+        {:noreply, enter_monitor(socket, enrollment)}
+
+      {:error, _reason} ->
+        {:noreply, reconcile_delivery(socket, enrollment_id, :downloaded)}
+    end
+  end
+
+  def handle_event(
+        "node_enrollment_bundle_download_failed",
+        %{"enrollment_id" => enrollment_id},
+        %{assigns: %{stage: :delivering, delivery: %{enrollment_id: enrollment_id}}} = socket
+      ) do
+    case safe_mark_output_failed(enrollment_id, "browser_download_failed") do
+      {:ok, enrollment} -> {:noreply, reconcile_enrollment(socket, enrollment, :failed)}
+      {:error, _reason} -> {:noreply, reconcile_delivery(socket, enrollment_id, :failed)}
+    end
+  end
+
+  def handle_event("node_enrollment_bundle_downloaded", _params, socket), do: {:noreply, socket}
+
+  def handle_event("node_enrollment_bundle_download_failed", _params, socket),
+    do: {:noreply, socket}
+
+  def handle_event("refresh_now", _params, socket) do
+    {:noreply, socket |> cancel_refresh() |> refresh_enrollment() |> schedule_refresh()}
+  end
+
+  def handle_event("create_new_enrollment", _params, socket) do
+    {:noreply,
+     socket
+     |> cancel_refresh()
+     |> assign_initial_state()
+     |> assign(stage: :enrollment)
+     |> push_patch(to: ~p"/console/nodes/new")}
+  end
+
+  @impl true
+  def handle_info(
+        {:refresh_enrollment, generation},
+        %{assigns: %{refresh_timer_ref: {_timer_ref, generation}}} = socket
+      ) do
+    {:noreply,
+     socket
+     |> assign(refresh_timer_ref: nil)
+     |> refresh_enrollment()
+     |> schedule_refresh()}
+  end
+
+  def handle_info({:refresh_enrollment, _generation}, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div
+      id="node-enrollment-download"
+      phx-hook="NodeEnrollmentBundleDownload"
+      class="mx-auto max-w-5xl space-y-6"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p class="text-sm font-medium text-sky-700 dark:text-sky-300">Nodes</p>
+          <h1 class="mt-1 text-2xl font-semibold text-slate-950 dark:text-white">Add a Node</h1>
+          <p class="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
+            Prepare a new Mac, create its one-time enrollment, then review its trust evidence before admission.
+          </p>
+        </div>
+        <.link
+          navigate={~p"/console/nodes"}
+          class="inline-flex items-center rounded-md px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
+        >
+          Back to Nodes
+        </.link>
+      </div>
+
+      <nav aria-label="Node setup progress" class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <ol class="grid gap-3 sm:grid-cols-5">
+          <.progress_step number="1" label="Prepare Mac" state={progress_state(@stage, @enrollment, 1)} />
+          <.progress_step number="2" label="Create Enrollment" state={progress_state(@stage, @enrollment, 2)} />
+          <.progress_step number="3" label="Install and Register" state={progress_state(@stage, @enrollment, 3)} />
+          <.progress_step number="4" label="Review and Admit" state={progress_state(@stage, @enrollment, 4)} />
+          <.progress_step number="5" label="Node Active" state={progress_state(@stage, @enrollment, 5)} />
+        </ol>
+      </nav>
+
+      <p
+        id="node-enrollment-live-announcer"
+        class="sr-only"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {live_announcement(@stage, @enrollment, @error_message)}
+      </p>
+
+      <.card>
+        <%= case @stage do %>
+          <% :loading -> %>
+            <.state_message
+              id="node-enrollment-status-loading"
+              kind={:loading}
+              layout={:panel}
+              title="Loading enrollment status."
+              body="Orchard will retrieve the durable enrollment state after the Console connects."
+            />
+          <% :prepare -> %>
+            <.prepare_step />
+          <% :enrollment -> %>
+            <.enrollment_step
+              form={@form}
+              error_message={@error_message}
+              expiry_options={@expiry_options}
+            />
+          <% :delivering -> %>
+            <.delivery_step delivery={@delivery} />
+          <% :monitor -> %>
+            <.monitor_step
+              delivery={@delivery}
+              enrollment={@enrollment}
+              error_message={@error_message}
+              last_checked_at={@last_checked_at}
+            />
+          <% :delivery_failed -> %>
+            <.failure_step message={@error_message} />
+          <% :recovery_failed -> %>
+            <.recovery_failure_step message={@error_message} />
+        <% end %>
+      </.card>
+    </div>
+    """
+  end
+
+  attr(:number, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:state, :atom, required: true)
+
+  defp progress_step(assigns) do
+    ~H"""
+    <li
+      class="flex items-center gap-2 sm:block"
+      aria-current={@state == :current && "step"}
+    >
+      <span
+        aria-hidden="true"
+        class={[
+        "inline-flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold",
+        progress_circle_class(@state)
+      ]}
+      >
+        <%= if @state == :complete do %>
+          <.icon name="hero-check" class="size-4" />
+        <% else %>
+          {@number}
+        <% end %>
+      </span>
+      <span class={[
+        "text-xs font-medium sm:mt-2 sm:block",
+        @state == :current && "text-navy dark:text-sky-300",
+        @state != :current && "text-slate-500 dark:text-slate-400"
+      ]}>
+        {@label}
+        <span class="sr-only">, {progress_state_label(@state)}</span>
+      </span>
+    </li>
+    """
+  end
+
+  defp prepare_step(assigns) do
+    ~H"""
+    <section id="node-prepare-step" class="space-y-6">
+      <div>
+        <p class="text-sm font-medium text-sky-700 dark:text-sky-300">Step 1 of 5</p>
+        <h2 class="mt-1 text-xl font-semibold text-slate-950 dark:text-white">Prepare the target Mac</h2>
+        <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Complete these items on the Mac you want to add. Keep this Console open on the Controller Mac.
+        </p>
+      </div>
+
+      <ol class="space-y-4">
+        <li class="flex gap-3 rounded-lg border border-slate-200 p-4 dark:border-slate-700">
+          <span class="inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-sky-100 text-sm font-semibold text-sky-800 dark:bg-sky-950 dark:text-sky-200">1</span>
+          <div>
+            <h3 class="font-medium text-slate-950 dark:text-white">Install Orchard on the target Mac</h3>
+            <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              For the validated <strong>source-development split-role path</strong>, prepare the
+              Node Agent host using the source-development runbook. For a
+              <strong>packaged multi-Mac rehearsal only</strong>, install the signed Orchard.app
+              DMG with the <strong>Node Agent Install Role</strong> and configure the target's
+              protected shared BEAM cookie and Node Agent identity from the packaging runbook.
+              On the Controller Mac, separately configure external Postgres and the explicit
+              Runtime Endpoint targets. The target Mac does not connect to Postgres. Packaged
+              multi-Mac still has open production-acceptance gaps. On the target Mac, run
+              <code class="font-mono text-xs">sudo orchardctl start</code>, then
+              <code class="font-mono text-xs">orchardctl status</code> and confirm the Node Agent
+              service is running before continuing.
+            </p>
+          </div>
+        </li>
+        <li class="flex gap-3 rounded-lg border border-slate-200 p-4 dark:border-slate-700">
+          <span class="inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-sky-100 text-sm font-semibold text-sky-800 dark:bg-sky-950 dark:text-sky-200">2</span>
+          <div>
+            <h3 class="font-medium text-slate-950 dark:text-white">Return here to create the enrollment</h3>
+            <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              Orchard will download a one-time JSON bundle. Transfer it securely to the target Mac and use it immediately.
+            </p>
+          </div>
+        </li>
+      </ol>
+
+      <div class="flex justify-end">
+        <.button id="node-preparation-complete" phx-click="preparation_complete">
+          Continue to Enrollment
+        </.button>
+      </div>
+    </section>
+    """
+  end
+
+  attr(:form, :map, required: true)
+  attr(:error_message, :string, default: nil)
+  attr(:expiry_options, :list, required: true)
+
+  defp enrollment_step(assigns) do
+    ~H"""
+    <section id="node-enrollment-step" class="space-y-6">
+      <div>
+        <p class="text-sm font-medium text-sky-700 dark:text-sky-300">Step 2 of 5</p>
+        <h2 class="mt-1 text-xl font-semibold text-slate-950 dark:text-white">Create a one-time enrollment</h2>
+        <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          The downloaded bundle contains a short-lived secret. Orchard will not display or download it again.
+        </p>
+      </div>
+
+      <.state_message
+        :if={@error_message}
+        id="node-enrollment-error"
+        kind={:error}
+        layout={:compact}
+        title="Enrollment could not be created."
+        body={@error_message}
+      />
+
+      <.form for={@form} id="node-enrollment-form" phx-submit="issue_enrollment" class="space-y-5">
+        <.input
+          field={@form[:display_name]}
+          label="Node name"
+          placeholder="render-node-03"
+          autocomplete="off"
+          required
+        />
+        <.input
+          field={@form[:pool_id]}
+          label="Initial pool intent"
+          placeholder="general"
+          autocomplete="off"
+          required
+        />
+        <p class="-mt-3 text-xs text-slate-500 dark:text-slate-400">
+          A Pool is an existing scheduling group. This intent pre-fills the admission review,
+          and you can change it before admitting the node.
+        </p>
+        <.input
+          field={@form[:expiry_seconds]}
+          type="select"
+          label="Enrollment expires after"
+          options={@expiry_options}
+        />
+
+        <div class="flex justify-end">
+          <.button id="issue-node-enrollment" type="submit" phx-disable-with="Creating enrollment...">
+            Create Enrollment and Download
+          </.button>
+        </div>
+      </.form>
+    </section>
+    """
+  end
+
+  attr(:delivery, :map, required: true)
+
+  defp delivery_step(assigns) do
+    ~H"""
+    <section id="node-enrollment-delivery-step" class="space-y-5">
+      <.state_message
+        id="node-enrollment-delivering"
+        kind={:loading}
+        layout={:panel}
+        title="Starting the one-time enrollment download."
+        body="Keep this page open until the browser reports whether it accepted the download attempt. This does not verify where the file was saved."
+      />
+      <p class="text-center text-xs font-mono text-slate-500 dark:text-slate-400">
+        {@delivery.filename}
+      </p>
+    </section>
+    """
+  end
+
+  attr(:delivery, :map, required: true)
+  attr(:enrollment, :any, default: nil)
+  attr(:error_message, :string, default: nil)
+  attr(:last_checked_at, :any, default: nil)
+
+  defp monitor_step(assigns) do
+    ~H"""
+    <section id="node-enrollment-monitor-step" class="space-y-6">
+      <div>
+        <p class="text-sm font-medium text-sky-700 dark:text-sky-300">
+          {monitor_progress_label(@enrollment)}
+        </p>
+        <h2 class="mt-1 text-xl font-semibold text-slate-950 dark:text-white">
+          {monitor_title(@enrollment, @delivery.display_name)}
+        </h2>
+        <p :if={usable_bundle?(@enrollment)} class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Move <span class="font-mono text-xs">{@delivery.filename}</span> to the target Mac, then run:
+        </p>
+      </div>
+
+      <div :if={usable_bundle?(@enrollment)} class="rounded-lg bg-slate-950 p-4 text-slate-100">
+        <code id="node-enrollment-command" class="break-all font-mono text-sm">orchardctl node join --enrollment-bundle /secure/path/on-target/{@delivery.filename}</code>
+      </div>
+      <div
+        :if={usable_bundle?(@enrollment)}
+        class="space-y-1 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
+      >
+        <p>Replace the example path with the bundle's actual path on the target Mac.</p>
+        <p>
+          Transfer it through a protected administrator channel. Keep the bundle out of chat,
+          tickets, logs, and shell history.
+        </p>
+      </div>
+
+      <.state_message
+        :if={
+          @enrollment && @enrollment.state == :pending_publication &&
+            !terminal_enrollment?(@enrollment)
+        }
+        id="node-enrollment-publication-pending"
+        kind={:loading}
+        layout={:compact}
+        title="Waiting for download confirmation."
+        body="Keep this page open. Orchard has not made this enrollment redeemable and will not display its secret again."
+      />
+
+      <.state_message
+        :if={@error_message}
+        id="node-enrollment-status-error"
+        kind={:error}
+        layout={:compact}
+        title="Enrollment status unavailable."
+        body={@error_message}
+      />
+
+      <div
+        :if={@enrollment && reviewable_for_admission?(@enrollment)}
+        id="node-enrollment-registered"
+        role="status"
+        class="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-emerald-950 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-100"
+      >
+        <p class="text-sm font-semibold">Registered - awaiting admission.</p>
+        <p class="mt-1 text-sm">
+          Review the Node's trust evidence before explicitly admitting it.
+        </p>
+      </div>
+
+      <div :if={@enrollment && terminal_enrollment?(@enrollment)} class="space-y-4">
+        <.state_message
+          id="node-enrollment-terminal-state"
+          kind={:error}
+          layout={:compact}
+          title="This enrollment can no longer register a node."
+          body={terminal_enrollment_message(@enrollment)}
+        />
+        <.button id="replace-terminal-node-enrollment" phx-click="create_new_enrollment">
+          Create New Enrollment
+        </.button>
+      </div>
+
+      <div
+        :if={
+          @enrollment && @enrollment.state != :pending_publication &&
+            !terminal_enrollment?(@enrollment)
+        }
+        id="node-enrollment-live-status"
+        aria-live="polite"
+        aria-atomic="false"
+        class="space-y-3"
+      >
+        <.status_row
+          label="Enrollment download attempt accepted"
+          complete={true}
+          detail="Browser accepted the one-time file download; target custody is not verified"
+        />
+        <.status_row
+          label="Node registered"
+          complete={registered?(@enrollment)}
+          detail={registration_detail(@enrollment)}
+        />
+        <.status_row
+          label="Admission review"
+          complete={admitted?(@enrollment)}
+          detail={admission_detail(@enrollment)}
+        />
+        <.status_row
+          label="Node active"
+          complete={activation_complete?(@enrollment)}
+          detail={activation_detail(@enrollment)}
+        />
+      </div>
+
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <p id="node-enrollment-refresh-status" class="text-xs text-slate-500 dark:text-slate-400">
+          <%= if refresh_stopped?(@enrollment) do %>
+            Automatic checks have stopped because this enrollment or Node reached a terminal state.
+            Use Refresh now to reload its durable status.
+          <% else %>
+            Orchard checks registration automatically every {refresh_interval_label()}.
+          <% end %>
+          <span :if={@last_checked_at}>
+            Last checked <.local_time value={@last_checked_at} format={:time_second} />.
+          </span>
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <.button id="node-enrollment-refresh" variant={:ghost} size={:sm} phx-click="refresh_now">
+            Refresh now
+          </.button>
+          <.link
+            :if={
+              @enrollment && reviewable_for_admission?(@enrollment) &&
+                !terminal_enrollment?(@enrollment)
+            }
+            id="review-node-admission"
+            navigate={~p"/console/nodes/#{@delivery.node_id}"}
+            class="inline-flex items-center justify-center rounded-md bg-navy px-4 py-2 text-sm font-medium text-white hover:bg-navy-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy focus-visible:ring-offset-2 dark:bg-sky-500 dark:hover:bg-sky-400 dark:focus-visible:ring-sky-400"
+          >
+            Review and Admit Node
+          </.link>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  attr(:label, :string, required: true)
+  attr(:complete, :boolean, required: true)
+  attr(:detail, :string, required: true)
+
+  defp status_row(assigns) do
+    ~H"""
+    <div class="flex items-start gap-3 rounded-lg border border-slate-200 p-4 dark:border-slate-700">
+      <span class={[
+        "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full",
+        @complete && "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+        !@complete && "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+      ]}>
+        <%= if @complete do %>
+          <.icon name="hero-check" class="size-4" />
+        <% else %>
+          <span class="size-2 rounded-full bg-current"></span>
+        <% end %>
+      </span>
+      <div>
+        <p class="text-sm font-medium text-slate-950 dark:text-white">{@label}</p>
+        <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">{@detail}</p>
+      </div>
+    </div>
+    """
+  end
+
+  attr(:message, :string, required: true)
+
+  defp failure_step(assigns) do
+    ~H"""
+    <section id="node-enrollment-failure-step" class="space-y-5">
+      <.state_message
+        id="node-enrollment-delivery-failed"
+        kind={:error}
+        layout={:panel}
+        title="Enrollment download was not completed."
+        body={@message}
+      />
+      <div class="flex justify-end">
+        <.button id="create-new-node-enrollment" phx-click="create_new_enrollment">
+          Create New Enrollment
+        </.button>
+      </div>
+    </section>
+    """
+  end
+
+  attr(:message, :string, required: true)
+
+  defp recovery_failure_step(assigns) do
+    ~H"""
+    <section id="node-enrollment-recovery-failed" class="space-y-5">
+      <.state_message
+        id="node-enrollment-recovery-error"
+        kind={:error}
+        layout={:panel}
+        title="Enrollment cannot be resumed here."
+        body={@message}
+      />
+      <div class="flex justify-end">
+        <.button id="create-console-node-enrollment" phx-click="create_new_enrollment">
+          Create New Enrollment
+        </.button>
+      </div>
+    </section>
+    """
+  end
+
+  defp assign_initial_state(socket) do
+    assign(socket,
+      stage: :prepare,
+      form:
+        to_form(
+          %{"display_name" => "", "expiry_seconds" => "3600", "pool_id" => "general"},
+          as: :enrollment
+        ),
+      delivery: nil,
+      enrollment: nil,
+      error_message: nil,
+      refresh_timer_ref: nil,
+      last_checked_at: nil,
+      expiry_options: @expiry_options
+    )
+  end
+
+  defp validate_form(params) do
+    form_params = %{
+      "display_name" => normalize_text(params["display_name"]),
+      "expiry_seconds" => normalize_text(params["expiry_seconds"]),
+      "pool_id" => normalize_text(params["pool_id"])
+    }
+
+    errors =
+      []
+      |> require_text(:display_name, form_params["display_name"], "must not be empty")
+      |> require_text(:pool_id, form_params["pool_id"], "must not be empty")
+      |> validate_expiry(form_params["expiry_seconds"])
+
+    validate_normalized_form(form_params, errors)
+  end
+
+  defp validate_normalized_form(form_params, []),
+    do: validate_shared_attrs(form_params, shared_attrs(form_params))
+
+  defp validate_normalized_form(form_params, errors),
+    do: {:error, {:validation, to_form(form_params, as: :enrollment, errors: errors)}}
+
+  defp shared_attrs(form_params) do
+    %{
+      creator_id: nil,
+      creator_type: "operator",
+      display_name: form_params["display_name"],
+      expiry_seconds: String.to_integer(form_params["expiry_seconds"]),
+      pool_id: form_params["pool_id"],
+      surface: "console"
+    }
+  end
+
+  defp validate_shared_attrs(form_params, attrs) do
+    case NodeEnrollmentBundle.validate_attrs(attrs) do
+      {:ok, normalized} ->
+        {:ok, normalized, form_params}
+
+      {:error, {:invalid_enrollment_bundle_attrs, shared_errors}} ->
+        errors = Enum.map(shared_errors, &shared_form_error/1)
+        {:error, {:validation, to_form(form_params, as: :enrollment, errors: errors)}}
+    end
+  end
+
+  defp shared_form_error({field, reason}),
+    do: {field, {shared_validation_message(field, reason), []}}
+
+  defp normalize_text(value) when is_binary(value), do: String.trim(value)
+  defp normalize_text(_value), do: ""
+
+  defp require_text(errors, field, "", message), do: [{field, {message, []}} | errors]
+  defp require_text(errors, _field, _value, _message), do: errors
+
+  defp validate_expiry(errors, value) do
+    case Integer.parse(value) do
+      {seconds, ""} when seconds in @expiry_seconds -> errors
+      _other -> [{:expiry_seconds, {"must be one of the available periods", []}} | errors]
+    end
+  end
+
+  defp shared_validation_message(:display_name, :too_long),
+    do: "must be 128 bytes or fewer"
+
+  defp shared_validation_message(:display_name, :invalid_format),
+    do: "must not contain control characters"
+
+  defp shared_validation_message(:pool_id, :too_long), do: "must be 64 bytes or fewer"
+
+  defp shared_validation_message(:pool_id, :invalid_format),
+    do: "may contain only letters, numbers, dots, underscores, and hyphens"
+
+  defp shared_validation_message(_field, _reason), do: "is invalid"
+
+  defp safe_issue(attrs) do
+    enrollment_issuer_impl().issue(attrs)
+  rescue
+    _error -> {:error, :unavailable}
+  catch
+    :exit, _reason -> {:error, :unavailable}
+    _kind, _reason -> {:error, :unavailable}
+  end
+
+  defp safe_mark_issued(enrollment_id) do
+    enrollments_impl().mark_issued(enrollment_id, actor_id: nil, actor_type: "operator")
+  rescue
+    _error -> {:error, :unavailable}
+  catch
+    :exit, _reason -> {:error, :unavailable}
+    _kind, _reason -> {:error, :unavailable}
+  end
+
+  defp safe_mark_output_failed(enrollment_id, reason) do
+    enrollments_impl().mark_output_failed(enrollment_id,
+      actor_id: nil,
+      actor_type: "operator",
+      reason: reason
+    )
+  rescue
+    _error -> {:error, :unavailable}
+  catch
+    :exit, _reason -> {:error, :unavailable}
+    _kind, _reason -> {:error, :unavailable}
+  end
+
+  defp refresh_enrollment(%{assigns: %{delivery: %{enrollment_id: id}}} = socket) do
+    case safe_fetch(id) do
+      {:ok, enrollment} ->
+        assign(socket,
+          enrollment: enrollment,
+          error_message: nil,
+          last_checked_at: DateTime.utc_now()
+        )
+
+      {:error, _reason} ->
+        assign(socket, error_message: "Orchard could not read the latest enrollment state.")
+    end
+  end
+
+  defp refresh_enrollment(socket), do: socket
+
+  defp reconcile_delivery(socket, enrollment_id, acknowledgement) do
+    case safe_fetch(enrollment_id) do
+      {:ok, enrollment} -> reconcile_enrollment(socket, enrollment, acknowledgement)
+      {:error, _reason} -> delivery_uncertain(socket)
+    end
+  end
+
+  defp reconcile_enrollment(socket, %{state: :output_failed}, acknowledgement)
+       when acknowledgement in [:downloaded, :confirmation_failed] do
+    delivery_failed(
+      socket,
+      "The browser accepted the download, but Orchard could not confirm publication. The downloaded bundle is not redeemable and did not establish Node identity or trust. The previous provisioned Node remains in audit history. Create a new enrollment with a distinct Node name."
+    )
+  end
+
+  defp reconcile_enrollment(socket, %{state: :output_failed}, _acknowledgement),
+    do: delivery_failed(socket)
+
+  defp reconcile_enrollment(socket, %{state: :pending_publication}, :downloaded) do
+    enrollment_id = socket.assigns.delivery.enrollment_id
+
+    case safe_mark_output_failed(enrollment_id, "publication_confirmation_failed") do
+      {:ok, enrollment} -> reconcile_enrollment(socket, enrollment, :confirmation_failed)
+      {:error, _reason} -> reconcile_delivery(socket, enrollment_id, :confirmation_failed)
+    end
+  end
+
+  defp reconcile_enrollment(socket, %{state: :pending_publication} = enrollment, :failed),
+    do: delivery_uncertain(socket, enrollment)
+
+  defp reconcile_enrollment(
+         socket,
+         %{state: :pending_publication} = enrollment,
+         :confirmation_failed
+       ),
+       do: delivery_uncertain(socket, enrollment)
+
+  defp reconcile_enrollment(socket, enrollment, _acknowledgement),
+    do: enter_monitor(socket, enrollment)
+
+  defp enter_monitor(socket, enrollment) do
+    socket
+    |> assign(
+      stage: :monitor,
+      enrollment: enrollment,
+      error_message: nil,
+      last_checked_at: DateTime.utc_now()
+    )
+    |> refresh_enrollment()
+    |> schedule_refresh()
+  end
+
+  defp restore_enrollment(socket, enrollment) do
+    socket
+    |> cancel_refresh()
+    |> assign(
+      stage: :monitor,
+      delivery: delivery_from_enrollment(enrollment),
+      enrollment: enrollment,
+      error_message: nil,
+      last_checked_at: DateTime.utc_now()
+    )
+    |> schedule_refresh()
+  end
+
+  defp restore_console_enrollment(socket, enrollment) do
+    if console_enrollment?(enrollment) do
+      restore_enrollment(socket, enrollment)
+    else
+      recovery_failed(
+        socket,
+        "This enrollment was created outside this Console flow. Continue from the surface that issued it, or create a new Console enrollment."
+      )
+    end
+  end
+
+  defp delivery_from_enrollment(enrollment) do
+    %{
+      enrollment_id: enrollment.id,
+      expires_at: enrollment.expires_at,
+      filename: NodeEnrollmentBundle.filename(enrollment.node.display_name),
+      node_id: enrollment.node_id,
+      display_name: enrollment.node.display_name
+    }
+  end
+
+  defp delivery_failed(socket, message \\ nil) do
+    assign(socket,
+      stage: :delivery_failed,
+      error_message:
+        message ||
+          "The browser could not download the enrollment file. No redeemable enrollment was left behind, and the bundle did not establish Node identity or trust. The previous provisioned Node remains in audit history. Check browser download permissions, then create a new enrollment with a distinct Node name."
+    )
+  end
+
+  defp delivery_uncertain(socket, enrollment \\ nil) do
+    socket
+    |> assign(
+      stage: :monitor,
+      enrollment: enrollment || socket.assigns.enrollment,
+      error_message:
+        "Orchard could not confirm the bundle delivery result. No Node identity or trust has been established while the enrollment remains non-redeemable. Keep this page open while Orchard checks the durable enrollment state.",
+      last_checked_at:
+        if(enrollment, do: DateTime.utc_now(), else: socket.assigns.last_checked_at)
+    )
+    |> schedule_refresh()
+  end
+
+  defp recovery_failed(socket, message) do
+    socket
+    |> cancel_refresh()
+    |> assign(
+      stage: :recovery_failed,
+      delivery: nil,
+      enrollment: nil,
+      error_message: message,
+      last_checked_at: nil
+    )
+  end
+
+  defp console_enrollment?(%{audit_metadata: %{"surface" => "console"}}), do: true
+  defp console_enrollment?(_enrollment), do: false
+
+  defp safe_fetch(id) do
+    enrollments_impl().fetch(id)
+  rescue
+    _error -> {:error, :unavailable}
+  catch
+    :exit, _reason -> {:error, :unavailable}
+    _kind, _reason -> {:error, :unavailable}
+  end
+
+  defp schedule_refresh(%{assigns: %{stage: :monitor, enrollment: enrollment}} = socket)
+       when not is_nil(enrollment) do
+    if refresh_stopped?(enrollment) do
+      cancel_refresh(socket)
+    else
+      schedule_monitor_refresh(socket)
+    end
+  end
+
+  defp schedule_refresh(%{assigns: %{stage: :monitor}} = socket),
+    do: schedule_monitor_refresh(socket)
+
+  defp schedule_refresh(socket), do: socket
+
+  defp schedule_monitor_refresh(socket) do
+    socket = cancel_refresh(socket)
+    generation = make_ref()
+
+    timer_ref =
+      Process.send_after(self(), {:refresh_enrollment, generation}, refresh_interval_ms())
+
+    assign(socket, refresh_timer_ref: {timer_ref, generation})
+  end
+
+  defp cancel_refresh(%{assigns: %{refresh_timer_ref: nil}} = socket), do: socket
+
+  defp cancel_refresh(socket) do
+    {timer_ref, _generation} = socket.assigns.refresh_timer_ref
+    Process.cancel_timer(timer_ref)
+    assign(socket, refresh_timer_ref: nil)
+  end
+
+  defp enrollment_issuer_impl do
+    console_config()[:node_enrollment_bundle_issuer_impl] || NodeEnrollmentBundle
+  end
+
+  defp enrollments_impl do
+    console_config()[:node_enrollments_impl] || NodeEnrollments
+  end
+
+  defp refresh_interval_ms do
+    console_config()[:refresh_interval_ms] || @default_refresh_interval_ms
+  end
+
+  defp refresh_interval_label, do: "#{div(refresh_interval_ms(), 1_000)} seconds"
+
+  defp console_config, do: Application.get_env(:orchard_controller, :console, [])
+
+  defp progress_state(:monitor, %{node: %{state: state}}, step)
+       when state in [:decommissioning, :removed] do
+    if step <= 3, do: :complete, else: :unavailable
+  end
+
+  defp progress_state(:monitor, %{node: %{state: state}}, step)
+       when state in [:cordoned, :draining, :maintenance] do
+    if step <= 4, do: :complete, else: :unavailable
+  end
+
+  defp progress_state(stage, enrollment, step) do
+    current = current_step(stage, enrollment)
+
+    cond do
+      step < current -> :complete
+      step == current -> :current
+      true -> :pending
+    end
+  end
+
+  defp current_step(:prepare, _enrollment), do: 1
+  defp current_step(:loading, _enrollment), do: 3
+  defp current_step(:enrollment, _enrollment), do: 2
+  defp current_step(:delivering, _enrollment), do: 2
+  defp current_step(:delivery_failed, _enrollment), do: 2
+  defp current_step(:recovery_failed, _enrollment), do: 2
+  defp current_step(:monitor, %{state: :pending_publication}), do: 2
+  defp current_step(:monitor, %{node: %{state: :active}}), do: 6
+
+  defp current_step(:monitor, %{node: %{state: state}})
+       when state in [:admitted, :cordoned, :draining, :maintenance, :decommissioning, :removed],
+       do: 5
+
+  defp current_step(:monitor, %{node: %{state: :registered}}), do: 4
+  defp current_step(:monitor, _enrollment), do: 3
+
+  defp monitor_step_number(enrollment), do: min(current_step(:monitor, enrollment), 5)
+
+  defp live_announcement(:delivering, _enrollment, _error_message),
+    do: "Starting the one-time enrollment download."
+
+  defp live_announcement(:delivery_failed, _enrollment, _error_message),
+    do: "Enrollment download failed. No Node identity or trust was established."
+
+  defp live_announcement(:recovery_failed, _enrollment, _error_message),
+    do: "Enrollment recovery failed."
+
+  defp live_announcement(:monitor, enrollment, error_message) when not is_nil(enrollment) do
+    cond do
+      terminal_enrollment?(enrollment) ->
+        "This enrollment can no longer register a node."
+
+      enrollment.state == :pending_publication ->
+        "Waiting for download confirmation. No Node identity or trust was established."
+
+      true ->
+        error_message || monitor_title(enrollment, enrollment.node.display_name)
+    end
+  end
+
+  defp live_announcement(_stage, _enrollment, error_message), do: error_message || ""
+
+  defp monitor_progress_label(%{node: %{state: state}})
+       when state in [:decommissioning, :removed],
+       do: "Terminal lifecycle state"
+
+  defp monitor_progress_label(%{node: %{state: state}})
+       when state in [:cordoned, :draining, :maintenance],
+       do: "Post-activation lifecycle state"
+
+  defp monitor_progress_label(enrollment),
+    do: "Step #{monitor_step_number(enrollment)} of 5"
+
+  defp progress_circle_class(:complete),
+    do: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
+
+  defp progress_circle_class(:current),
+    do: "bg-navy text-white ring-4 ring-sky-100 dark:bg-sky-500 dark:ring-sky-950"
+
+  defp progress_circle_class(:pending),
+    do: "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+
+  defp progress_circle_class(:unavailable),
+    do: "bg-slate-100 text-slate-400 dark:bg-slate-800 dark:text-slate-500"
+
+  defp progress_state_label(:complete), do: "complete"
+  defp progress_state_label(:current), do: "current step"
+  defp progress_state_label(:pending), do: "pending"
+  defp progress_state_label(:unavailable), do: "unavailable"
+
+  defp registered?(%{node: %{state: state}})
+       when state in [
+              :registered,
+              :admitted,
+              :active,
+              :cordoned,
+              :draining,
+              :maintenance,
+              :decommissioning,
+              :removed
+            ],
+       do: true
+
+  defp registered?(_enrollment), do: false
+
+  defp admitted?(%{node: %{state: state}})
+       when state in [:admitted, :active, :cordoned, :draining, :maintenance],
+       do: true
+
+  defp admitted?(_enrollment), do: false
+
+  defp reviewable_for_admission?(%{node: %{state: :registered}}), do: true
+  defp reviewable_for_admission?(_enrollment), do: false
+
+  defp activation_complete?(%{node: %{state: state}})
+       when state in [:active, :cordoned, :draining, :maintenance],
+       do: true
+
+  defp activation_complete?(_enrollment), do: false
+
+  defp terminal_enrollment?(%{state: state}) when state in [:expired, :revoked, :output_failed],
+    do: true
+
+  defp terminal_enrollment?(%{state: state, expires_at: %DateTime{} = expires_at})
+       when state in [:pending_publication, :issued] do
+    DateTime.compare(expires_at, DateTime.utc_now()) != :gt
+  end
+
+  defp terminal_enrollment?(_enrollment), do: false
+
+  defp refresh_stopped?(enrollment),
+    do: terminal_enrollment?(enrollment) or removed_node?(enrollment)
+
+  defp removed_node?(%{node: %{state: :removed}}), do: true
+  defp removed_node?(_enrollment), do: false
+
+  defp terminal_enrollment_message(%{state: :revoked}),
+    do:
+      "The enrollment was revoked. It cannot establish Node identity or trust. The provisioned Node remains in audit history, so a new enrollment needs a distinct Node name."
+
+  defp terminal_enrollment_message(%{state: :output_failed}),
+    do:
+      "Bundle delivery failed. It did not establish Node identity or trust. The provisioned Node remains in audit history, so a new enrollment needs a distinct Node name."
+
+  defp terminal_enrollment_message(_enrollment),
+    do:
+      "The enrollment expired. It cannot establish Node identity or trust. The provisioned Node remains in audit history, so a new enrollment needs a distinct Node name."
+
+  defp registration_detail(enrollment) do
+    if registered?(enrollment),
+      do: "The node agent registered successfully",
+      else: "Waiting for orchardctl node join on the target Mac"
+  end
+
+  defp admission_detail(%{node: %{state: :decommissioning}}),
+    do: "Admission actions are unavailable while the Node is being decommissioned"
+
+  defp admission_detail(%{node: %{state: :removed}}),
+    do: "Admission actions are unavailable for a removed Node"
+
+  defp admission_detail(enrollment) do
+    if admitted?(enrollment),
+      do: "Human admission decision recorded",
+      else: "Available after registration and trust evidence review"
+  end
+
+  defp activation_detail(%{node: %{state: :active}}),
+    do: "The node may receive scheduled work"
+
+  defp activation_detail(%{node: %{state: :cordoned}}),
+    do: "No new work will be scheduled; existing work may continue"
+
+  defp activation_detail(%{node: %{state: :draining}}),
+    do: "Waiting for active requests to finish; no new work will be scheduled"
+
+  defp activation_detail(%{node: %{state: :maintenance}}),
+    do: "Unschedulable while upgrades or diagnostics run"
+
+  defp activation_detail(%{node: %{state: :decommissioning}}),
+    do: "Trust revocation and cleanup are in progress"
+
+  defp activation_detail(%{node: %{state: :removed}}),
+    do: "This Node is a terminal tombstone and cannot receive work"
+
+  defp activation_detail(_enrollment),
+    do: "Activation follows admission and a fresh runtime observation"
+
+  defp usable_bundle?(%{
+         state: :issued,
+         node: %{state: :provisioned},
+         expires_at: %DateTime{} = expires_at
+       }),
+       do: DateTime.compare(expires_at, DateTime.utc_now()) == :gt
+
+  defp usable_bundle?(_enrollment), do: false
+
+  defp monitor_title(%{state: :pending_publication} = enrollment, display_name) do
+    if terminal_enrollment?(enrollment),
+      do: "Enrollment for #{display_name} expired",
+      else: "Confirm the enrollment download"
+  end
+
+  defp monitor_title(%{node: %{state: :registered}}, display_name),
+    do: "Review and admit #{display_name}"
+
+  defp monitor_title(%{node: %{state: :active}}, display_name),
+    do: "#{display_name} is active"
+
+  defp monitor_title(%{node: %{state: :admitted}}, display_name),
+    do: "Await activation for #{display_name}"
+
+  defp monitor_title(%{node: %{state: :cordoned}}, display_name),
+    do: "#{display_name} is cordoned"
+
+  defp monitor_title(%{node: %{state: :draining}}, display_name),
+    do: "#{display_name} is draining"
+
+  defp monitor_title(%{node: %{state: :maintenance}}, display_name),
+    do: "#{display_name} is in maintenance"
+
+  defp monitor_title(%{node: %{state: :decommissioning}}, display_name),
+    do: "#{display_name} is being decommissioned"
+
+  defp monitor_title(%{node: %{state: :removed}}, display_name),
+    do: "#{display_name} has been removed"
+
+  defp monitor_title(_enrollment, display_name), do: "Install and register #{display_name}"
+
+  defp issue_error(:node_trust_not_initialized),
+    do: "Node trust is not initialized on this Controller."
+
+  defp issue_error(:controller_https_not_configured),
+    do: "Configure the Controller HTTPS endpoint before creating an enrollment."
+
+  defp issue_error(:controller_https_trust_invalid),
+    do: "The Controller HTTPS trust certificate is unavailable or invalid."
+
+  defp issue_error(:controller_standby),
+    do: "This Controller is on standby. Create the enrollment on the active Controller."
+
+  defp issue_error(:controller_leadership_unproven),
+    do: "Controller leadership could not be proven, so no enrollment was issued."
+
+  defp issue_error(%Ecto.Changeset{}),
+    do: "The node name is already in use or is invalid. Choose another name."
+
+  defp issue_error(_reason),
+    do:
+      "Orchard could not create the enrollment. Verify Controller trust and HTTPS settings, then try again."
+end

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -64,6 +64,16 @@ defmodule OrchardConsole.NodesLive do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
+      <div class="flex justify-end">
+        <.link
+          id="add-node"
+          navigate={~p"/console/nodes/new"}
+          class="inline-flex items-center justify-center rounded-md bg-navy px-4 py-2 text-sm font-medium text-white hover:bg-navy-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy focus-visible:ring-offset-2 dark:bg-sky-500 dark:hover:bg-sky-400 dark:focus-visible:ring-sky-400"
+        >
+          Add Node
+        </.link>
+      </div>
+
       <%!-- Inventory Summary --%>
       <div id="nodes-summary-card">
       <.card>

--- a/apps/orchard_controller/lib/orchard/node_enrollment_bundle.ex
+++ b/apps/orchard_controller/lib/orchard/node_enrollment_bundle.ex
@@ -1,0 +1,273 @@
+defmodule Orchard.NodeEnrollmentBundle do
+  @moduledoc """
+  Issues the canonical one-time Node Enrollment bundle content.
+
+  The caller owns publication and must confirm successful delivery with
+  `Orchard.NodeEnrollments.mark_issued/2`. Until then, the Enrollment remains
+  non-redeemable in `pending_publication`.
+  """
+
+  alias Orchard.EndpointMetadata
+  alias Orchard.NodeEnrollments
+  alias Orchard.NodeTrust
+  alias Orchard.TransportTLS.CertificateIdentity
+
+  @default_expiry_seconds 3_600
+  @maximum_expiry_seconds 86_400
+  @maximum_display_name_bytes 128
+  @maximum_intent_bytes 64
+  @maximum_bundle_bytes 65_536
+  @pool_id_pattern ~r/\A[a-zA-Z0-9][a-zA-Z0-9._-]*\z/
+  @surface_pattern ~r/\A[a-zA-Z0-9][a-zA-Z0-9._-]*\z/
+  @control_character_pattern ~r/[\p{Cc}\p{Cf}]/u
+
+  @type issued_bundle :: %{
+          contents: String.t(),
+          enrollment: Orchard.Nodes.Enrollment.t(),
+          filename: String.t()
+        }
+
+  @spec issue(map(), keyword()) :: {:ok, issued_bundle()} | {:error, term()}
+  def issue(attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+
+    with {:ok, attrs} <- validate_attrs(attrs),
+         {:ok, trust} <- NodeTrust.public_material(),
+         {:ok, endpoint} <- controller_https_endpoint(),
+         {:ok, _reconciliation} <-
+           NodeEnrollments.reconcile_stale_pending_publications(now: now),
+         {:ok, result} <-
+           NodeEnrollments.create(
+             enrollment_attrs(attrs, trust, now, attrs.expiry_seconds),
+             now: now
+           ) do
+      finalize_issue(result, trust, endpoint, attrs)
+    end
+  end
+
+  @spec validate_attrs(map()) :: {:ok, map()} | {:error, term()}
+  def validate_attrs(attrs) when is_map(attrs) do
+    normalized = %{
+      creator_id: value(attrs, :creator_id),
+      creator_type: value(attrs, :creator_type, "operator"),
+      display_name: normalize_optional_text(value(attrs, :display_name)),
+      expiry_seconds: value(attrs, :expiry_seconds, @default_expiry_seconds),
+      pool_id: normalize_text(value(attrs, :pool_id, "general")),
+      surface: normalize_text(value(attrs, :surface))
+    }
+
+    errors =
+      [
+        validate_expiry(normalized.expiry_seconds),
+        validate_display_name(normalized.display_name),
+        validate_intent(:pool_id, normalized.pool_id, @pool_id_pattern),
+        validate_intent(:surface, normalized.surface, @surface_pattern)
+      ]
+      |> Enum.reject(&(&1 == :ok))
+      |> Enum.map(fn {:error, error} -> error end)
+
+    if errors == [],
+      do: {:ok, normalized},
+      else: {:error, {:invalid_enrollment_bundle_attrs, errors}}
+  end
+
+  @spec filename(String.t()) :: String.t()
+  def filename(display_name) when is_binary(display_name) do
+    stem =
+      display_name
+      |> String.downcase()
+      |> String.replace(~r/[^a-z0-9]+/u, "-")
+      |> String.trim("-")
+      |> case do
+        "" -> "node"
+        value -> String.slice(value, 0, 48)
+      end
+
+    "orchard-#{stem}-enrollment.json"
+  end
+
+  defp enrollment_attrs(attrs, trust, now, expiry_seconds) do
+    %{
+      audit_metadata: %{
+        "initial_pool_id" => attrs.pool_id,
+        "surface" => attrs.surface
+      },
+      cluster_id: trust.cluster_id,
+      creator_id: attrs.creator_id,
+      creator_type: attrs.creator_type,
+      expected_controller_id: trust.controller_id,
+      expires_at: DateTime.add(now, expiry_seconds, :second),
+      node: node_attrs(attrs.display_name),
+      resume_verifier_metadata: %{"algorithm" => "sha256", "version" => 1},
+      trust_authority_id: trust.trust_authority_id
+    }
+  end
+
+  defp encode_bundle(result, trust, endpoint) do
+    bundle = %{
+      version: 1,
+      enrollment_id: result.enrollment.id,
+      node_id: result.enrollment.node_id,
+      cluster_id: trust.cluster_id,
+      expires_at: DateTime.to_iso8601(result.enrollment.expires_at),
+      issued_at: DateTime.to_iso8601(result.enrollment.issued_at),
+      controller: %{
+        https_endpoint: endpoint.address,
+        https_trust_anchor_pem: endpoint.trust_anchor_pem,
+        https_trust_spki_sha256: endpoint.trust_spki_sha256,
+        id: trust.controller_id,
+        runtime_trust_spki_sha256: trust.ca_spki_fingerprint,
+        uri_san: trust.controller_uri_san
+      },
+      token: result.bootstrap_token
+    }
+
+    case Jason.encode(bundle, pretty: true) do
+      {:ok, json} -> validate_bundle_size(json <> "\n")
+      {:error, reason} -> {:error, {:bundle_encoding_failed, reason}}
+    end
+  end
+
+  defp validate_bundle_size(contents) when byte_size(contents) <= @maximum_bundle_bytes,
+    do: {:ok, contents}
+
+  defp validate_bundle_size(_contents), do: {:error, {:bundle_too_large, @maximum_bundle_bytes}}
+
+  defp finalize_issue(result, trust, endpoint, attrs) do
+    case encode_bundle(result, trust, endpoint) do
+      {:ok, contents} ->
+        {:ok,
+         %{
+           contents: contents,
+           enrollment: result.enrollment,
+           filename: filename(result.enrollment.node.display_name)
+         }}
+
+      {:error, reason} ->
+        reconcile_failed_issue(result.enrollment.id, attrs, reason)
+    end
+  end
+
+  defp reconcile_failed_issue(enrollment_id, attrs, reason) do
+    failure_code = publication_failure_code(reason)
+
+    opts = [
+      actor_id: attrs.creator_id || "node-enrollment-bundle",
+      actor_type: attrs.creator_type,
+      reason: Atom.to_string(failure_code)
+    ]
+
+    case NodeEnrollments.mark_output_failed(enrollment_id, opts) do
+      {:ok, _enrollment} ->
+        {:error, {:bundle_publication_failed, enrollment_id, :output_failed, failure_code}}
+
+      {:error, reconciliation_reason} ->
+        {:error,
+         {:bundle_publication_reconciliation_failed, enrollment_id, failure_code,
+          reconciliation_reason}}
+    end
+  end
+
+  defp publication_failure_code({:bundle_too_large, _maximum}), do: :bundle_too_large
+
+  defp publication_failure_code({:bundle_encoding_failed, _reason}),
+    do: :bundle_encoding_failed
+
+  defp controller_https_endpoint do
+    with {:ok, metadata} <- EndpointMetadata.read(),
+         :ok <- require_https_transport(metadata),
+         {:ok, host} <- required_metadata(metadata.public_host),
+         {:ok, port} <- required_metadata(metadata.api_https_port),
+         {:ok, ca_certfile} <- required_metadata(metadata.ca_certfile),
+         {:ok, trust} <- https_trust_material(ca_certfile) do
+      {:ok,
+       %{
+         address: "https://#{endpoint_host(host)}:#{port}",
+         trust_anchor_pem: trust.pem,
+         trust_spki_sha256: trust.spki_sha256
+       }}
+    end
+  end
+
+  defp https_trust_material(path) do
+    with {:ok, pem} <- File.read(path),
+         {:ok, fingerprint} <- CertificateIdentity.spki_fingerprint_from_pem(pem) do
+      {:ok, %{pem: pem, spki_sha256: fingerprint}}
+    else
+      _reason -> {:error, :controller_https_trust_invalid}
+    end
+  end
+
+  defp require_https_transport(%{transport_mode: mode})
+       when mode in ["direct_https", "reverse_proxy"],
+       do: :ok
+
+  defp require_https_transport(_metadata), do: {:error, :controller_https_not_configured}
+
+  defp required_metadata(nil), do: {:error, :controller_https_not_configured}
+  defp required_metadata(value), do: {:ok, value}
+
+  defp endpoint_host(host) do
+    if String.contains?(host, ":"), do: "[#{host}]", else: host
+  end
+
+  defp node_attrs(display_name) when is_binary(display_name) and display_name != "",
+    do: %{display_name: display_name}
+
+  defp node_attrs(_display_name), do: %{}
+
+  defp validate_expiry(seconds)
+       when is_integer(seconds) and seconds > 0 and seconds <= @maximum_expiry_seconds,
+       do: :ok
+
+  defp validate_expiry(_seconds), do: invalid(:expiry_seconds, :out_of_range)
+
+  defp validate_display_name(nil), do: :ok
+
+  defp validate_display_name(display_name) when is_binary(display_name) do
+    cond do
+      display_name == "" ->
+        invalid(:display_name, :empty)
+
+      byte_size(display_name) > @maximum_display_name_bytes ->
+        invalid(:display_name, :too_long)
+
+      !String.valid?(display_name) ->
+        invalid(:display_name, :invalid_format)
+
+      Regex.match?(@control_character_pattern, display_name) ->
+        invalid(:display_name, :invalid_format)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_display_name(_display_name), do: invalid(:display_name, :invalid_format)
+
+  defp validate_intent(field, value, pattern) when is_binary(value) do
+    cond do
+      value == "" -> invalid(field, :empty)
+      byte_size(value) > @maximum_intent_bytes -> invalid(field, :too_long)
+      !Regex.match?(pattern, value) -> invalid(field, :invalid_format)
+      true -> :ok
+    end
+  end
+
+  defp validate_intent(field, _value, _pattern), do: invalid(field, :invalid_format)
+
+  defp invalid(field, reason), do: {:error, {field, reason}}
+
+  defp normalize_optional_text(nil), do: nil
+  defp normalize_optional_text(value), do: normalize_text(value)
+
+  defp normalize_text(value) when is_binary(value), do: String.trim(value)
+  defp normalize_text(value), do: value
+
+  defp value(attrs, key, default \\ nil) do
+    case Map.fetch(attrs, key) do
+      {:ok, found} -> found
+      :error -> Map.get(attrs, Atom.to_string(key), default)
+    end
+  end
+end

--- a/apps/orchard_controller/lib/orchard/node_enrollments.ex
+++ b/apps/orchard_controller/lib/orchard/node_enrollments.ex
@@ -49,6 +49,22 @@ defmodule Orchard.NodeEnrollments do
     end
   end
 
+  @spec latest_for_node(Ecto.UUID.t()) ::
+          {:ok, Enrollment.t()} | {:error, :enrollment_not_found}
+  def latest_for_node(node_id) do
+    with {:ok, node_id} <- Ecto.UUID.cast(node_id),
+         %Enrollment{} = enrollment <-
+           Enrollment
+           |> where([enrollment], enrollment.node_id == ^node_id)
+           |> order_by([enrollment], desc: enrollment.issued_at)
+           |> limit(1)
+           |> Repo.one() do
+      {:ok, Repo.preload(enrollment, :node)}
+    else
+      _reason -> {:error, :enrollment_not_found}
+    end
+  end
+
   @spec mark_output_failed(Ecto.UUID.t(), keyword()) ::
           {:ok, Enrollment.t()}
           | {:error, :enrollment_not_found | :invalid_enrollment_state | term()}

--- a/apps/orchard_controller/lib/orchard/requests.ex
+++ b/apps/orchard_controller/lib/orchard/requests.ex
@@ -645,18 +645,52 @@ defmodule Orchard.Requests do
   end
 
   defp persist_schedule(request, schedule, normalized_schedule) do
-    attrs =
-      %{
-        scheduler_decision:
-          CapturePolicy.schedule_attrs(request.payload_capture_mode, normalized_schedule, %{
-            requested_model: request.requested_model
-          })
-      }
-      |> maybe_put_schedule_node_id(schedule)
+    case schedule_write_action(request, normalized_schedule) do
+      :unchanged ->
+        {:ok, request}
 
-    request
-    |> Request.schedule_changeset(attrs)
-    |> Repo.update()
+      :reject ->
+        Repo.rollback(:already_terminal)
+
+      :update ->
+        attrs =
+          %{
+            scheduler_decision:
+              CapturePolicy.schedule_attrs(request.payload_capture_mode, normalized_schedule, %{
+                requested_model: request.requested_model
+              })
+          }
+          |> maybe_put_schedule_node_id(schedule)
+
+        request
+        |> Request.schedule_changeset(attrs)
+        |> Repo.update()
+    end
+  end
+
+  defp schedule_write_action(request, normalized_schedule) do
+    current_queue_result = get_in(request.scheduler_decision || %{}, ["queue_result"])
+    incoming_queue_result = Map.get(normalized_schedule, "queue_result")
+
+    cond do
+      terminal_queue_result?(current_queue_result) ->
+        if current_queue_result == incoming_queue_result, do: :unchanged, else: :reject
+
+      request.state in Request.terminal_states() ->
+        :reject
+
+      true ->
+        :update
+    end
+  end
+
+  defp terminal_queue_result?(queue_result) do
+    queue_result in ~w(
+      interrupted_before_dispatch
+      interrupted_controller_restarted
+      queue_full
+      queue_timeout
+    )
   end
 
   defp maybe_put_schedule_node_id(attrs, schedule) do

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -1057,42 +1057,59 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
         "messages" => [%{"role" => "user", "content" => "hello"}]
       }
 
+      Process.put(:queue_admission_runtime_pids, [])
       first = Task.async(fn -> post_chat(params, token) end)
+      Process.put(:queue_admission_runtime_tasks, [first])
 
-      assert_receive {:queue_admission_runtime_started, first_pid, first_request_id,
-                      "chat-queue-tenant-active-cap-model"},
-                     2_000
+      try do
+        {first_pid, first_request_id} =
+          runtime_start_message("chat-queue-tenant-active-cap-model", 5_000)
 
-      second = Task.async(fn -> post_chat(params, token) end)
+        remember_runtime_pid(first_pid)
+        second = Task.async(fn -> post_chat(params, token) end)
+        Process.put(:queue_admission_runtime_tasks, [second, first])
 
-      assert wait_for_queued_request("chat-queue-tenant-active-cap-model@v1")
+        assert wait_for_queued_request("chat-queue-tenant-active-cap-model@v1")
 
-      refute_receive {:queue_admission_runtime_started, _pid, _request_id,
-                      "chat-queue-tenant-active-cap-model"},
-                     100
+        refute_receive {:queue_admission_runtime_started, _pid, _request_id,
+                        "chat-queue-tenant-active-cap-model"},
+                       100
 
-      send(first_pid, :queue_admission_runtime_release)
-      first_conn = Task.await(first, 5_000)
+        send(first_pid, :queue_admission_runtime_release)
+        first_conn = Task.await(first, 5_000)
 
-      assert_receive {:queue_admission_runtime_started, second_pid, second_request_id,
-                      "chat-queue-tenant-active-cap-model"},
-                     2_000
+        {second_pid, second_request_id} =
+          runtime_start_message("chat-queue-tenant-active-cap-model", 5_000)
 
-      assert first_conn.status == 200
-      refute second_request_id == first_request_id
+        remember_runtime_pid(second_pid)
+        assert first_conn.status == 200
+        refute second_request_id == first_request_id
 
-      send(second_pid, :queue_admission_runtime_release)
-      second_conn = Task.await(second, 5_000)
+        send(second_pid, :queue_admission_runtime_release)
+        second_conn = Task.await(second, 5_000)
 
-      assert second_conn.status == 200
+        assert second_conn.status == 200
 
-      immediate =
-        request_with_queue_result!("chat-queue-tenant-active-cap-model@v1", "immediate")
+        immediate =
+          request_with_queue_result!("chat-queue-tenant-active-cap-model@v1", "immediate")
 
-      queued = request_with_queue_result!("chat-queue-tenant-active-cap-model@v1", "queued")
+        queued = request_with_queue_result!("chat-queue-tenant-active-cap-model@v1", "queued")
 
-      assert_queue_metadata(immediate, "immediate", granted?: true)
-      assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
+        assert_queue_metadata(immediate, "immediate", granted?: true)
+        assert_queue_metadata(queued, "queued", queued?: true, granted?: true)
+      after
+        Enum.each(Process.get(:queue_admission_runtime_pids, []), fn pid ->
+          send(pid, :queue_admission_runtime_release)
+        end)
+
+        Enum.each(
+          Process.get(:queue_admission_runtime_tasks, []),
+          &Task.shutdown(&1, :brutal_kill)
+        )
+
+        Process.delete(:queue_admission_runtime_pids)
+        Process.delete(:queue_admission_runtime_tasks)
+      end
     end
 
     test "SPEC.md §7.2.7 returns top-level chat envelopes for busy and queue execute errors" do

--- a/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
+++ b/apps/orchard_controller/test/orchard/beam_peer_grants_test.exs
@@ -397,25 +397,41 @@ defmodule Orchard.BeamPeerGrantsTest do
     authorization_root: authorization_root
   } do
     now = DateTime.utc_now()
-    assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
+    :ok = Sandbox.checkin(Repo)
+    on_exit(&clean_unboxed_grant_fixture/0)
 
-    assert {:ok, _controller} =
-             ControllerInstances.ensure_local(
-               private_ipv4: "10.0.0.10",
-               membership_scope: :remote_beam,
-               node_trust_root: trust_root,
-               authorization_root_path: authorization_root,
-               now: now
-             )
+    nodes =
+      Sandbox.unboxed_run(Repo, fn ->
+        assert {:ok, trust} = NodeTrust.initialize(root: trust_root, now: now)
 
-    nodes = [register_node!(trust, now, "10.0.0.20"), register_node!(trust, now, "10.0.0.21")]
+        assert {:ok, _controller} =
+                 ControllerInstances.ensure_local(
+                   private_ipv4: "10.0.0.10",
+                   membership_scope: :remote_beam,
+                   node_trust_root: trust_root,
+                   authorization_root_path: authorization_root,
+                   now: now
+                 )
+
+        [
+          register_node!(trust, now, "10.0.0.20"),
+          register_node!(trust, now, "10.0.0.21")
+        ]
+      end)
+
     parent = self()
 
     tasks =
       Enum.map(nodes, fn node ->
         Task.async(fn ->
           send(parent, {:admission_ready, self()})
-          receive do: (:admit -> Nodes.admit_node(node.id, admission_attrs(), now: now))
+
+          receive do
+            :admit ->
+              Sandbox.unboxed_run(Repo, fn ->
+                Nodes.admit_node(node.id, admission_attrs(), now: now)
+              end)
+          end
         end)
       end)
 
@@ -435,19 +451,21 @@ defmodule Orchard.BeamPeerGrantsTest do
 
     {winner_node, winner_grant} = winner
 
-    assert {:ok, _delivery} =
-             BeamPeerGrants.deliver(
-               delivery_request(winner_grant),
-               authenticated_peer!(winner_node.id),
-               now: now
-             )
+    Sandbox.unboxed_run(Repo, fn ->
+      assert {:ok, _delivery} =
+               BeamPeerGrants.deliver(
+                 delivery_request(winner_grant),
+                 authenticated_peer!(winner_node.id),
+                 now: now
+               )
 
-    assert Repo.aggregate(Grant, :count, :id) == 1
-    assert Repo.get!(Grant, winner_grant.id).state == :active
+      assert Repo.aggregate(Grant, :count, :id) == 1
+      assert Repo.get!(Grant, winner_grant.id).state == :active
 
-    assert [loser] = Enum.reject(nodes, &(&1.id == winner_node.id))
-    assert Repo.get!(Node, loser.id).state == :registered
-    assert BeamPeerGrants.list_for_node(loser.id) == []
+      assert [loser] = Enum.reject(nodes, &(&1.id == winner_node.id))
+      assert Repo.get!(Node, loser.id).state == :registered
+      assert BeamPeerGrants.list_for_node(loser.id) == []
+    end)
   end
 
   test "SPEC.md §7.5.0 admission uses the global grant transaction lock order", %{

--- a/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
@@ -47,10 +47,12 @@ defmodule OrchardConsole.NodeDetailLiveTest do
   use Orchard.ConnCase, async: false
 
   import Orchard.TestSupport.ModelRequestFixtures, only: [create_model!: 1]
+  import Ecto.Query
   import Phoenix.LiveViewTest
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.DispatchCapacity.Policy
+  alias Orchard.NodeEnrollments
   alias Orchard.Nodes
   alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
   alias Orchard.NodeTrust
@@ -115,7 +117,7 @@ defmodule OrchardConsole.NodeDetailLiveTest do
       assert html =~ "node-detail-scheduling"
       assert html =~ "Blocked"
       assert html =~ "node_not_admitted"
-      assert html =~ "Preview admit"
+      assert html =~ "Admit Node"
       assert html =~ "Preview reject"
     end
 
@@ -202,7 +204,7 @@ defmodule OrchardConsole.NodeDetailLiveTest do
       assert html =~ "node-detail-inventory-evidence"
       assert html =~ "node-detail-compatibility-evidence"
       assert html =~ "Preview reject"
-      refute html =~ "Preview admit"
+      refute html =~ "Admit Node"
     end
 
     test "renders not found state for missing candidates", %{conn: conn} do
@@ -237,7 +239,7 @@ defmodule OrchardConsole.NodeDetailLiveTest do
 
       refute html =~ "otherwise clears it"
       assert html =~ "Preview reject"
-      refute html =~ "Preview admit"
+      refute html =~ "Admit Node"
     end
 
     test "renders command sequence as a visibly numbered recessed code well", %{conn: conn} do
@@ -302,6 +304,46 @@ defmodule OrchardConsole.NodeDetailLiveTest do
   end
 
   describe "admission action previews" do
+    test "pre-fills the non-authoritative pool intent from Node Enrollment", %{conn: conn} do
+      trust = establish_local_controller_identity!()
+      now = DateTime.utc_now()
+
+      assert {:ok, result} =
+               NodeEnrollments.create(
+                 %{
+                   cluster_id: trust.cluster_id,
+                   expected_controller_id: trust.controller_id,
+                   trust_authority_id: trust.trust_authority_id,
+                   creator_type: "operator",
+                   expires_at: DateTime.add(now, 3_600, :second),
+                   node: %{display_name: "pool-intent-node"},
+                   audit_metadata: %{
+                     "surface" => "console",
+                     "initial_pool_id" => "general"
+                   }
+                 },
+                 now: now
+               )
+
+      from(node in Node, where: node.id == ^result.enrollment.node_id)
+      |> Repo.update_all(
+        set: [
+          state: :registered,
+          hostname: "pool-intent-node.local",
+          advertise_addr: "10.40.0.20",
+          rpc_port: 50_071,
+          connect_host: "10.40.0.20",
+          connect_port: 50_071
+        ]
+      )
+
+      {:ok, view, _html} = live(conn, "/console/nodes/#{result.enrollment.node_id}")
+      view |> element("#node-detail-open-admit") |> render_click()
+
+      assert has_element?(view, "#action-pool-id[value='general']")
+      assert render(view) =~ "Admit Node Preview"
+    end
+
     test "previews and executes node admit with shared blockers and confirmation", %{conn: conn} do
       trust = establish_local_controller_identity!()
 

--- a/apps/orchard_controller/test/orchard/console/node_enrollment_live_integration_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_enrollment_live_integration_test.exs
@@ -1,0 +1,259 @@
+defmodule OrchardConsole.NodeEnrollmentLiveIntegrationTest do
+  use Orchard.ConnCase, async: false
+
+  import Ecto.Query
+  import Phoenix.LiveViewTest
+
+  alias Orchard.EndpointMetadata
+  alias Orchard.Governance.AuditLog
+  alias Orchard.NodeEnrollments
+  alias Orchard.Nodes.Enrollment
+  alias Orchard.Nodes.Node
+  alias Orchard.NodeTrust
+  alias Orchard.NodeTrust.PKI
+  alias Orchard.Repo
+
+  @moduletag :db
+  @moduletag :live
+
+  setup do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "orchard-console-node-enrollment-#{System.unique_integer([:positive])}"
+      )
+
+    trust_root = Path.join(root, "node-trust")
+    support_root = Path.join(root, "support")
+
+    previous = %{
+      console: Application.get_env(:orchard_controller, :console, []),
+      control_plane: Application.get_env(:orchard_controller, :control_plane),
+      node_trust: Application.get_env(:orchard_controller, :node_trust),
+      support_root: System.get_env("ORCHARD_SUPPORT_ROOT")
+    }
+
+    File.mkdir_p!(root)
+    File.chmod!(root, 0o700)
+    System.put_env("ORCHARD_SUPPORT_ROOT", support_root)
+    Application.put_env(:orchard_controller, :control_plane, role: :single_controller)
+    Application.put_env(:orchard_controller, :node_trust, root: trust_root)
+
+    Application.put_env(
+      :orchard_controller,
+      :console,
+      previous.console
+      |> Keyword.delete(:node_enrollment_bundle_issuer_impl)
+      |> Keyword.delete(:node_enrollments_impl)
+      |> Keyword.put(:refresh_interval_ms, 60_000)
+    )
+
+    on_exit(fn ->
+      File.rm_rf!(root)
+      restore_env("ORCHARD_SUPPORT_ROOT", previous.support_root)
+      restore_app_env(:orchard_controller, :console, previous.console)
+      restore_app_env(:orchard_controller, :control_plane, previous.control_plane)
+      restore_app_env(:orchard_controller, :node_trust, previous.node_trust)
+    end)
+
+    assert {:ok, _trust} =
+             NodeTrust.initialize(root: trust_root, actor_id: "console-test-operator")
+
+    configure_https_endpoint!(support_root)
+    {:ok, support_root: support_root}
+  end
+
+  test "Console publishes the real canonical builder bytes without persisting a secret", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "console-real-builder-node",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    assert_push_event(view, "node_enrollment_bundle", %{
+      "contents" => contents,
+      "enrollment_id" => enrollment_id,
+      "filename" => "orchard-console-real-builder-node-enrollment.json"
+    })
+
+    bundle = Jason.decode!(contents)
+
+    assert bundle["version"] == 1
+    assert bundle["enrollment_id"] == enrollment_id
+    assert String.starts_with?(bundle["token"], "orch_enr_")
+    assert bundle["controller"]["https_endpoint"] == "https://controller.orchard.test:443"
+
+    assert {:ok, pending} = NodeEnrollments.fetch(enrollment_id)
+    assert pending.state == :pending_publication
+    assert pending.audit_metadata == %{"initial_pool_id" => "general", "surface" => "console"}
+    refute inspect(pending) =~ bundle["token"]
+
+    audit_payloads =
+      Repo.all(
+        from(audit in AuditLog,
+          where: audit.target_id == ^enrollment_id,
+          select: audit.payload
+        )
+      )
+
+    refute inspect(audit_payloads) =~ bundle["token"]
+
+    render_hook(view, "node_enrollment_bundle_downloaded", %{
+      "enrollment_id" => enrollment_id
+    })
+
+    assert {:ok, issued} = NodeEnrollments.fetch(enrollment_id)
+    assert issued.state == :issued
+  end
+
+  test "real bundle builder accepts an RSA operator HTTPS trust anchor", %{
+    support_root: support_root
+  } do
+    https_ca_path = Path.join([support_root, "public", "ca.crt"])
+    generate_rsa_self_signed_certificate!(https_ca_path)
+
+    assert {:ok, issued} =
+             Orchard.NodeEnrollmentBundle.issue(%{
+               display_name: "rsa-operator-ca-node",
+               expiry_seconds: 3_600,
+               pool_id: "general",
+               surface: "console"
+             })
+
+    bundle = Jason.decode!(issued.contents)
+
+    assert bundle["controller"]["https_trust_anchor_pem"] == File.read!(https_ca_path)
+
+    assert bundle["controller"]["https_trust_spki_sha256"] =~
+             ~r/^sha256-[A-Za-z0-9_-]{43}$/
+  end
+
+  test "shared builder rejects an enrollment file above the orchardctl limit and reconciles it",
+       %{
+         support_root: support_root
+       } do
+    https_ca_path = Path.join([support_root, "public", "ca.crt"])
+    File.write!(https_ca_path, File.read!(https_ca_path) <> String.duplicate(" ", 65_536))
+
+    assert {:error,
+            {:bundle_publication_failed, failed_enrollment_id, :output_failed, :bundle_too_large}} =
+             Orchard.NodeEnrollmentBundle.issue(%{
+               display_name: "oversized-enrollment-node",
+               expiry_seconds: 3_600,
+               pool_id: "general",
+               surface: "console"
+             })
+
+    node = Repo.get_by!(Node, display_name: "oversized-enrollment-node")
+    enrollment = Repo.get_by!(Enrollment, node_id: node.id)
+
+    assert enrollment.id == failed_enrollment_id
+    assert enrollment.state == :output_failed
+
+    failure_audit =
+      Repo.one!(
+        from(audit in AuditLog,
+          where:
+            audit.target_id == ^enrollment.id and
+              audit.action == "node_enrollment.output_failed",
+          select: audit.payload
+        )
+      )
+
+    assert failure_audit["reason"] == "bundle_too_large"
+
+    {:ok, view, _html} = live(build_conn(), "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    html =
+      view
+      |> form("#node-enrollment-form",
+        enrollment: %{
+          display_name: "oversized-console-enrollment-node",
+          expiry_seconds: "3600",
+          pool_id: "general"
+        }
+      )
+      |> render_submit()
+
+    console_node = Repo.get_by!(Node, display_name: "oversized-console-enrollment-node")
+    console_enrollment = Repo.get_by!(Enrollment, node_id: console_node.id)
+
+    assert_patch(view, "/console/nodes/new/#{console_enrollment.id}")
+    assert html =~ "This enrollment can no longer register a node"
+    assert html =~ "new enrollment needs a distinct Node name"
+    assert console_enrollment.state == :output_failed
+  end
+
+  defp configure_https_endpoint!(support_root) do
+    assert {:ok, %{ca_certificate_pem: https_ca_pem}} =
+             PKI.generate(
+               Ecto.UUID.generate(),
+               Ecto.UUID.generate(),
+               Ecto.UUID.generate(),
+               Ecto.UUID.generate(),
+               DateTime.utc_now()
+             )
+
+    https_ca_path = Path.join([support_root, "public", "ca.crt"])
+    File.mkdir_p!(Path.dirname(https_ca_path))
+    File.write!(https_ca_path, https_ca_pem)
+
+    assert :ok =
+             EndpointMetadata.write(%{
+               transport_mode: "direct_https",
+               public_host: "controller.orchard.test",
+               api_https_port: 443,
+               plain_http_port: nil,
+               api_bind_ip: "0.0.0.0",
+               ca_certfile: https_ca_path,
+               generated_by: "console-node-enrollment-test"
+             })
+  end
+
+  defp generate_rsa_self_signed_certificate!(certfile) do
+    openssl =
+      System.find_executable("openssl") ||
+        flunk("openssl is required for Node Enrollment bundle integration tests")
+
+    keyfile = Path.rootname(certfile) <> ".key"
+
+    {output, status} =
+      System.cmd(
+        openssl,
+        [
+          "req",
+          "-x509",
+          "-newkey",
+          "rsa:2048",
+          "-nodes",
+          "-keyout",
+          keyfile,
+          "-out",
+          certfile,
+          "-days",
+          "365",
+          "-subj",
+          "/CN=controller.orchard.test"
+        ],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+
+  defp restore_app_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_app_env(app, key, value), do: Application.put_env(app, key, value)
+end

--- a/apps/orchard_controller/test/orchard/console/node_enrollment_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_enrollment_live_test.exs
@@ -1,0 +1,897 @@
+defmodule OrchardConsole.NodeEnrollmentLiveTest.Tracker do
+  @moduledoc false
+
+  use Agent
+
+  def start_link(_opts) do
+    Agent.start_link(
+      fn ->
+        %{
+          calls: [],
+          enrollment_state: :issued,
+          expires_at: DateTime.add(DateTime.utc_now(), 3_600, :second),
+          issue_result: :default,
+          mark_issued_result: :default,
+          mark_output_failed_result: :default,
+          node_state: :provisioned,
+          surface: "console"
+        }
+      end,
+      name: __MODULE__
+    )
+  end
+
+  def record(call),
+    do: Agent.update(__MODULE__, &Map.update!(&1, :calls, fn calls -> [call | calls] end))
+
+  def calls, do: Agent.get(__MODULE__, &Enum.reverse(&1.calls))
+  def issue_result, do: Agent.get(__MODULE__, & &1.issue_result)
+  def set_issue_result(result), do: Agent.update(__MODULE__, &Map.put(&1, :issue_result, result))
+  def node_state, do: Agent.get(__MODULE__, & &1.node_state)
+  def set_node_state(state), do: Agent.update(__MODULE__, &Map.put(&1, :node_state, state))
+  def enrollment_state, do: Agent.get(__MODULE__, & &1.enrollment_state)
+
+  def set_enrollment_state(state),
+    do: Agent.update(__MODULE__, &Map.put(&1, :enrollment_state, state))
+
+  def mark_issued_result, do: Agent.get(__MODULE__, & &1.mark_issued_result)
+
+  def set_mark_issued_result(result),
+    do: Agent.update(__MODULE__, &Map.put(&1, :mark_issued_result, result))
+
+  def mark_output_failed_result, do: Agent.get(__MODULE__, & &1.mark_output_failed_result)
+
+  def set_mark_output_failed_result(result),
+    do: Agent.update(__MODULE__, &Map.put(&1, :mark_output_failed_result, result))
+
+  def expires_at, do: Agent.get(__MODULE__, & &1.expires_at)
+  def set_expires_at(value), do: Agent.update(__MODULE__, &Map.put(&1, :expires_at, value))
+  def surface, do: Agent.get(__MODULE__, & &1.surface)
+  def set_surface(value), do: Agent.update(__MODULE__, &Map.put(&1, :surface, value))
+end
+
+defmodule OrchardConsole.NodeEnrollmentLiveTest.IssuerStub do
+  @moduledoc false
+
+  alias Orchard.Nodes.{Enrollment, Node}
+  alias OrchardConsole.NodeEnrollmentLiveTest.Tracker
+
+  @enrollment_id "11111111-1111-4111-8111-111111111111"
+  @node_id "22222222-2222-4222-8222-222222222222"
+
+  def issue(attrs) do
+    Tracker.record({:issue, attrs})
+
+    case Tracker.issue_result() do
+      :default -> issue_bundle(attrs)
+      result -> result
+    end
+  end
+
+  defp issue_bundle(attrs) do
+    enrollment = %Enrollment{
+      id: @enrollment_id,
+      node_id: @node_id,
+      node: node(attrs.display_name, :provisioned),
+      state: :pending_publication,
+      expires_at: DateTime.add(DateTime.utc_now(), attrs.expiry_seconds, :second)
+    }
+
+    {:ok,
+     %{
+       contents: ~s({"token":"orch_enr_one_time_secret"}) <> "\n",
+       enrollment: enrollment,
+       filename: "orchard-render-node-03-enrollment.json"
+     }}
+  end
+
+  def node(display_name, state) do
+    %Node{id: @node_id, display_name: display_name, state: state, health: :unreachable}
+  end
+end
+
+defmodule OrchardConsole.NodeEnrollmentLiveTest.EnrollmentsStub do
+  @moduledoc false
+
+  alias Orchard.Nodes.Enrollment
+  alias OrchardConsole.NodeEnrollmentLiveTest.{IssuerStub, Tracker}
+
+  @enrollment_id "11111111-1111-4111-8111-111111111111"
+  @node_id "22222222-2222-4222-8222-222222222222"
+
+  def mark_issued(@enrollment_id, opts) do
+    Tracker.record({:mark_issued, @enrollment_id, opts})
+
+    case Tracker.mark_issued_result() do
+      :default -> {:ok, enrollment(:issued)}
+      result -> result
+    end
+  end
+
+  def mark_output_failed(@enrollment_id, opts) do
+    Tracker.record({:mark_output_failed, @enrollment_id, opts})
+
+    case Tracker.mark_output_failed_result() do
+      :default ->
+        {:ok, enrollment(:output_failed)}
+
+      {:error_after_state, state, reason} ->
+        Tracker.set_enrollment_state(state)
+        {:error, reason}
+
+      result ->
+        result
+    end
+  end
+
+  def fetch(@enrollment_id) do
+    Tracker.record({:fetch, @enrollment_id})
+    {:ok, enrollment(Tracker.enrollment_state())}
+  end
+
+  defp enrollment(state) do
+    %Enrollment{
+      id: @enrollment_id,
+      node_id: @node_id,
+      node: IssuerStub.node("render-node-03", Tracker.node_state()),
+      state: state,
+      expires_at: Tracker.expires_at(),
+      audit_metadata: %{"surface" => Tracker.surface()}
+    }
+  end
+end
+
+defmodule OrchardConsole.NodeEnrollmentLiveTest do
+  use Orchard.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias __MODULE__.{EnrollmentsStub, IssuerStub, Tracker}
+
+  @enrollment_id "11111111-1111-4111-8111-111111111111"
+
+  @moduletag :live
+
+  setup do
+    previous = Application.get_env(:orchard_controller, :console, [])
+    start_supervised!(Tracker)
+
+    Application.put_env(
+      :orchard_controller,
+      :console,
+      Keyword.merge(previous,
+        node_enrollment_bundle_issuer_impl: IssuerStub,
+        node_enrollments_impl: EnrollmentsStub,
+        refresh_interval_ms: 60_000
+      )
+    )
+
+    on_exit(fn -> Application.put_env(:orchard_controller, :console, previous) end)
+
+    :ok
+  end
+
+  test "renders the ordered new-machine setup journey", %{conn: conn} do
+    {:ok, view, html} = live(conn, "/console/nodes/new")
+
+    assert html =~ "Add a Node"
+    assert html =~ "Prepare the target Mac"
+    assert html =~ "Install Orchard on the target Mac"
+    assert html =~ "Node Agent Install Role"
+    assert html =~ "packaged multi-Mac rehearsal"
+    assert html =~ "source-development split-role path"
+    assert html =~ "shared BEAM cookie"
+    assert html =~ "Runtime Endpoint targets"
+    assert html =~ "On the Controller Mac"
+    assert html =~ "The target Mac does not connect to Postgres"
+    assert html =~ "sudo orchardctl start"
+    assert html =~ "orchardctl status"
+    assert html =~ "confirm the Node Agent"
+    assert html =~ "service is running"
+    assert html =~ "Continue to Enrollment"
+    assert html =~ ~s(id="node-enrollment-live-announcer")
+    assert html =~ ~s(aria-live="polite")
+    assert html =~ ~s(aria-current="step")
+    assert html =~ "current step"
+    refute html =~ "another machine"
+
+    html = view |> element("#node-preparation-complete") |> render_click()
+
+    assert html =~ "Create a one-time enrollment"
+    assert html =~ "Initial pool intent"
+    assert html =~ "A Pool is an existing scheduling group"
+    assert html =~ "you can change it before admitting the node"
+  end
+
+  test "disconnected status render shows loading instead of a stale wizard step", %{conn: conn} do
+    html =
+      conn
+      |> get("/console/nodes/new/#{@enrollment_id}")
+      |> html_response(200)
+
+    assert html =~ "Loading enrollment status"
+    refute html =~ "Prepare the target Mac"
+    refute Tracker.calls() |> Enum.any?(&match?({:fetch, @enrollment_id}, &1))
+  end
+
+  test "validates enrollment input before calling the issuer", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    html =
+      render_submit(view, "issue_enrollment", %{
+        "enrollment" => %{"display_name" => "", "expiry_seconds" => "999", "pool_id" => ""}
+      })
+
+    assert html =~ "must not be empty"
+    assert html =~ "must be one of the available periods"
+    assert Tracker.calls() == []
+  end
+
+  test "uses the shared bundle limits before calling the issuer", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    html =
+      render_submit(view, "issue_enrollment", %{
+        "enrollment" => %{
+          "display_name" => String.duplicate("é", 65),
+          "expiry_seconds" => "3600",
+          "pool_id" => "general pool"
+        }
+      })
+
+    assert html =~ "must be 128 bytes or fewer"
+    assert html =~ "may contain only letters, numbers, dots, underscores, and hyphens"
+    assert Tracker.calls() == []
+  end
+
+  test "reports a post-create reconciliation failure with its durable Enrollment identity", %{
+    conn: conn
+  } do
+    Tracker.set_issue_result(
+      {:error,
+       {:bundle_publication_reconciliation_failed, @enrollment_id, :bundle_too_large,
+        :database_unavailable}}
+    )
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    html =
+      view
+      |> form("#node-enrollment-form",
+        enrollment: %{
+          display_name: "render-node-03",
+          expiry_seconds: "3600",
+          pool_id: "general"
+        }
+      )
+      |> render_submit()
+
+    assert html =~ @enrollment_id
+    assert html =~ "No bundle was published"
+    assert html =~ "remains non-redeemable pending reconciliation"
+    assert html =~ "provisioned Node name remains reserved"
+    assert html =~ "distinct Node name"
+    refute html =~ "Verify Controller trust and HTTPS settings, then try again"
+  end
+
+  test "delivers the one-time bundle without rendering its secret and confirms issuance", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    html =
+      view
+      |> form("#node-enrollment-form",
+        enrollment: %{
+          display_name: "render-node-03",
+          expiry_seconds: "3600",
+          pool_id: "general"
+        }
+      )
+      |> render_submit()
+
+    assert_push_event(view, "node_enrollment_bundle", %{
+      "contents" => contents,
+      "enrollment_id" => @enrollment_id,
+      "filename" => "orchard-render-node-03-enrollment.json"
+    })
+
+    assert_patch(view, "/console/nodes/new/#{@enrollment_id}")
+
+    assert contents =~ "orch_enr_one_time_secret"
+    refute html =~ "orch_enr_one_time_secret"
+    refute html =~ "data-copy-text"
+    assert html =~ "Starting the one-time enrollment download"
+
+    html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "orchardctl node join --enrollment-bundle"
+    assert html =~ "/secure/path/on-target/orchard-render-node-03-enrollment.json"
+    assert html =~ "Replace the example path with the bundle"
+    refute html =~ "~/Downloads/orchard-render-node-03-enrollment.json"
+    assert html =~ "Keep the bundle out of chat"
+    assert html =~ "tickets, logs, and shell history"
+    assert html =~ "Browser accepted the one-time file download; target custody is not verified"
+    assert html =~ ~s(aria-live="polite")
+    assert html =~ "Waiting for orchardctl node join on the target Mac"
+
+    assert {:issue, attrs} = Enum.at(Tracker.calls(), 0)
+    assert attrs.display_name == "render-node-03"
+    assert attrs.pool_id == "general"
+    assert attrs.expiry_seconds == 3_600
+    assert Enum.any?(Tracker.calls(), &match?({:mark_issued, @enrollment_id, _opts}, &1))
+  end
+
+  test "preparation completion cannot bypass an in-progress delivery stage", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html = render_click(view, "preparation_complete", %{})
+
+    assert html =~ "Starting the one-time enrollment download"
+    refute html =~ "Create a one-time enrollment"
+  end
+
+  test "surfaces registration automatically and hands off to admission review", %{conn: conn} do
+    Tracker.set_node_state(:registered)
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "Registered - awaiting admission"
+    assert html =~ "The node agent registered successfully"
+    assert html =~ "Review and Admit Node"
+    assert html =~ "/console/nodes/22222222-2222-4222-8222-222222222222"
+  end
+
+  test "polling advances a waiting enrollment to registered without an operator status action", %{
+    conn: conn
+  } do
+    console = Application.fetch_env!(:orchard_controller, :console)
+
+    Application.put_env(
+      :orchard_controller,
+      :console,
+      Keyword.put(console, :refresh_interval_ms, 10)
+    )
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    waiting_html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert waiting_html =~ "Waiting for orchardctl node join on the target Mac"
+    Tracker.set_node_state(:registered)
+
+    Process.sleep(25)
+    registered_html = render(view)
+
+    assert registered_html =~ "Registered - awaiting admission"
+    assert registered_html =~ "Review and Admit Node"
+  end
+
+  test "fails closed when the browser reports that download failed", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_download_failed", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "No redeemable enrollment was left behind"
+    assert html =~ "did not establish Node identity or trust"
+    assert html =~ "Enrollment download failed. No Node identity or trust was established."
+    assert html =~ "Create New Enrollment"
+
+    assert Enum.any?(
+             Tracker.calls(),
+             &match?({:mark_output_failed, @enrollment_id, _opts}, &1)
+           )
+  end
+
+  test "ignores a stale failure acknowledgement after successful issuance", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    assert render_hook(view, "node_enrollment_bundle_downloaded", %{
+             "enrollment_id" => @enrollment_id
+           }) =~ "orchardctl node join --enrollment-bundle"
+
+    html =
+      render_hook(view, "node_enrollment_bundle_download_failed", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "orchardctl node join --enrollment-bundle"
+    refute html =~ "No redeemable enrollment was left behind"
+
+    refute Enum.any?(
+             Tracker.calls(),
+             &match?({:mark_output_failed, @enrollment_id, _opts}, &1)
+           )
+  end
+
+  test "recovers when issuance committed but its response was lost", %{conn: conn} do
+    Tracker.set_mark_issued_result({:error, :simulated_response_loss})
+    Tracker.set_enrollment_state(:issued)
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "orchardctl node join --enrollment-bundle"
+    refute html =~ "could not activate this enrollment"
+    assert Enum.any?(Tracker.calls(), &match?({:fetch, @enrollment_id}, &1))
+
+    refute Enum.any?(
+             Tracker.calls(),
+             &match?({:mark_output_failed, @enrollment_id, _opts}, &1)
+           )
+  end
+
+  test "explains a downloaded bundle invalidated by confirmation failure", %{conn: conn} do
+    Tracker.set_mark_issued_result({:error, :simulated_confirmation_failure})
+    Tracker.set_enrollment_state(:pending_publication)
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "browser accepted the download"
+    assert html =~ "downloaded bundle is not redeemable"
+    assert html =~ "did not establish Node identity or trust"
+    refute html =~ "browser could not download"
+  end
+
+  test "preserves successful browser acknowledgement when issuance reconciles to output failure",
+       %{
+         conn: conn
+       } do
+    Tracker.set_mark_issued_result({:error, :simulated_response_loss})
+    Tracker.set_enrollment_state(:output_failed)
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "browser accepted the download"
+    assert html =~ "downloaded bundle is not redeemable"
+    refute html =~ "browser could not download"
+  end
+
+  test "preserves successful browser acknowledgement when invalidation commits but its response is lost",
+       %{
+         conn: conn
+       } do
+    Tracker.set_mark_issued_result({:error, :simulated_confirmation_failure})
+    Tracker.set_enrollment_state(:pending_publication)
+
+    Tracker.set_mark_output_failed_result(
+      {:error_after_state, :output_failed, :simulated_response_loss}
+    )
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "browser accepted the download"
+    assert html =~ "downloaded bundle is not redeemable"
+    refute html =~ "browser could not download"
+  end
+
+  test "does not claim output failure when durable state became issued", %{conn: conn} do
+    Tracker.set_mark_output_failed_result({:error, :invalid_enrollment_state})
+    Tracker.set_enrollment_state(:issued)
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_download_failed", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "orchardctl node join --enrollment-bundle"
+    refute html =~ "No redeemable enrollment was left behind"
+    assert Enum.any?(Tracker.calls(), &match?({:fetch, @enrollment_id}, &1))
+  end
+
+  test "keeps a failed acknowledgement uncertain while durable publication is pending", %{
+    conn: conn
+  } do
+    Tracker.set_mark_output_failed_result({:error, :simulated_transition_failure})
+    Tracker.set_enrollment_state(:pending_publication)
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_download_failed", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "Waiting for download confirmation"
+    assert html =~ "could not confirm the bundle delivery result"
+    assert html =~ "No Node identity or trust has been established"
+    refute html =~ "No redeemable enrollment was left behind"
+  end
+
+  test "ignores duplicate issue events after the first bundle is created", %{conn: conn} do
+    params = %{
+      "enrollment" => %{
+        "display_name" => "render-node-03",
+        "expiry_seconds" => "3600",
+        "pool_id" => "general"
+      }
+    }
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    render_submit(view, "issue_enrollment", params)
+    render_submit(view, "issue_enrollment", params)
+
+    assert Enum.count(Tracker.calls(), &match?({:issue, _attrs}, &1)) == 1
+  end
+
+  test "does not issue or redisplay a bundle when delivery acknowledgement is lost", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    html =
+      view
+      |> form("#node-enrollment-form",
+        enrollment: %{
+          display_name: "render-node-03",
+          expiry_seconds: "3600",
+          pool_id: "general"
+        }
+      )
+      |> render_submit()
+
+    assert html =~ "Starting the one-time enrollment download"
+    refute html =~ "orch_enr_one_time_secret"
+    refute Enum.any?(Tracker.calls(), &match?({:mark_issued, _, _}, &1))
+
+    Tracker.set_enrollment_state(:pending_publication)
+
+    {:ok, _reconnected_view, reconnected_html} =
+      live(conn, "/console/nodes/new/#{@enrollment_id}")
+
+    assert reconnected_html =~ "Waiting for download confirmation"
+    refute reconnected_html =~ "orchardctl node join --enrollment-bundle"
+    refute reconnected_html =~ "orch_enr_one_time_secret"
+  end
+
+  test "shows only terminal recovery for an expired pending publication", %{conn: conn} do
+    Tracker.set_enrollment_state(:pending_publication)
+    Tracker.set_expires_at(DateTime.add(DateTime.utc_now(), -1, :second))
+
+    {:ok, _view, html} = live(conn, "/console/nodes/new/#{@enrollment_id}")
+
+    assert html =~ "This enrollment can no longer register a node"
+    assert html =~ "The enrollment expired"
+    assert html =~ "Create New Enrollment"
+    refute html =~ "Waiting for download confirmation"
+    refute html =~ "Confirm the enrollment download"
+  end
+
+  test "restores an issued enrollment monitor from its non-secret URL", %{conn: conn} do
+    Tracker.set_enrollment_state(:issued)
+
+    {:ok, _view, html} = live(conn, "/console/nodes/new/#{@enrollment_id}")
+
+    assert html =~ "Install and register render-node-03"
+    assert html =~ "orchardctl node join --enrollment-bundle"
+    assert html =~ "orchard-render-node-03-enrollment.json"
+    refute html =~ "orch_enr_one_time_secret"
+    assert Enum.any?(Tracker.calls(), &match?({:fetch, @enrollment_id}, &1))
+  end
+
+  test "does not make browser publication claims for a CLI-created enrollment", %{conn: conn} do
+    Tracker.set_enrollment_state(:issued)
+    Tracker.set_surface("local_orchardctl")
+
+    {:ok, _view, html} = live(conn, "/console/nodes/new/#{@enrollment_id}")
+
+    assert html =~ "Enrollment cannot be resumed here"
+    assert html =~ "created outside this Console flow"
+    refute html =~ "Enrollment download attempt accepted"
+    refute html =~ "orchardctl node join --enrollment-bundle"
+  end
+
+  test "browser back to the base route resets durable status to the enrollment form", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    assert_patch(view, "/console/nodes/new/#{@enrollment_id}")
+
+    html = render_patch(view, "/console/nodes/new")
+
+    assert html =~ "Create a one-time enrollment"
+    refute html =~ "Starting the one-time enrollment download"
+    assert Enum.count(Tracker.calls(), &match?({:issue, _attrs}, &1)) == 1
+  end
+
+  test "names revoked and expired terminal states and offers a new enrollment", %{conn: conn} do
+    for {state, expires_at, expected} <- [
+          {:revoked, DateTime.add(DateTime.utc_now(), 3_600, :second), "was revoked"},
+          {:issued, DateTime.add(DateTime.utc_now(), -1, :second), "expired"}
+        ] do
+      Tracker.set_enrollment_state(state)
+      Tracker.set_expires_at(expires_at)
+
+      {:ok, view, _html} = live(conn, "/console/nodes/new")
+      view |> element("#node-preparation-complete") |> render_click()
+
+      view
+      |> form("#node-enrollment-form",
+        enrollment: %{
+          display_name: "render-node-03",
+          expiry_seconds: "3600",
+          pool_id: "general"
+        }
+      )
+      |> render_submit()
+
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+      html = view |> element("#node-enrollment-refresh") |> render_click()
+
+      assert html =~ "can no longer register a node"
+      assert html =~ expected
+      assert html =~ "Create New Enrollment"
+      assert html =~ "distinct Node name"
+      assert html =~ "Automatic checks have stopped"
+      refute html =~ "Orchard checks registration automatically"
+
+      html = view |> element("#replace-terminal-node-enrollment") |> render_click()
+      assert_patch(view, "/console/nodes/new")
+      assert html =~ "Create a one-time enrollment"
+    end
+  end
+
+  test "keeps a consumed enrollment visible after its token expiry", %{conn: conn} do
+    Tracker.set_enrollment_state(:consumed)
+    Tracker.set_node_state(:registered)
+    Tracker.set_expires_at(DateTime.add(DateTime.utc_now(), -1, :second))
+
+    {:ok, view, _html} = live(conn, "/console/nodes/new")
+    view |> element("#node-preparation-complete") |> render_click()
+
+    view
+    |> form("#node-enrollment-form",
+      enrollment: %{
+        display_name: "render-node-03",
+        expiry_seconds: "3600",
+        pool_id: "general"
+      }
+    )
+    |> render_submit()
+
+    html =
+      render_hook(view, "node_enrollment_bundle_downloaded", %{
+        "enrollment_id" => @enrollment_id
+      })
+
+    assert html =~ "Registered - awaiting admission"
+    assert html =~ "Review and Admit Node"
+    refute html =~ "orchardctl node join --enrollment-bundle"
+    refute html =~ "Move orchard-render-node-03-enrollment.json to the target Mac"
+    refute html =~ "can no longer register a node"
+    refute html =~ "Create New Enrollment"
+  end
+
+  test "renders post-registration lifecycle states without returning to join guidance", %{
+    conn: conn
+  } do
+    Tracker.set_enrollment_state(:consumed)
+
+    for {state, title, detail} <- [
+          {:registered, "Review and admit render-node-03",
+           "Available after registration and trust evidence review"},
+          {:admitted, "Await activation for render-node-03",
+           "Activation follows admission and a fresh runtime observation"},
+          {:active, "render-node-03 is active", "The node may receive scheduled work"},
+          {:cordoned, "render-node-03 is cordoned", "No new work will be scheduled"},
+          {:draining, "render-node-03 is draining", "Waiting for active requests to finish"},
+          {:maintenance, "render-node-03 is in maintenance",
+           "Unschedulable while upgrades or diagnostics run"},
+          {:decommissioning, "render-node-03 is being decommissioned",
+           "Trust revocation and cleanup are in progress"},
+          {:removed, "render-node-03 has been removed", "This Node is a terminal tombstone"}
+        ] do
+      Tracker.set_node_state(state)
+
+      {:ok, _view, html} = live(conn, "/console/nodes/new/#{@enrollment_id}")
+
+      assert html =~ title
+      assert html =~ detail
+      assert html =~ "The node agent registered successfully"
+      refute html =~ "Waiting for orchardctl node join on the target Mac"
+
+      if state == :registered do
+        assert html =~ "Review and Admit Node"
+      else
+        refute html =~ "Review and Admit Node"
+      end
+
+      if state in [:decommissioning, :removed] do
+        assert html =~ "Terminal lifecycle state"
+        refute html =~ "Step 5 of 5"
+        refute html =~ ~r/Review and Admit\s*<span class="sr-only">, complete/
+        assert html =~ ~r/Review and Admit\s*<span class="sr-only">, unavailable/
+      else
+        refute html =~ "Terminal lifecycle state"
+      end
+
+      if state == :removed do
+        assert html =~ "Automatic checks have stopped"
+        refute html =~ "Orchard checks registration automatically"
+      else
+        assert html =~ "Orchard checks registration automatically"
+      end
+
+      if state in [:cordoned, :draining, :maintenance] do
+        assert html =~ "Post-activation lifecycle state"
+        refute html =~ ~r/Node Active\s*<span class="sr-only">, current step/
+        assert html =~ ~r/Node Active\s*<span class="sr-only">, unavailable/
+      end
+    end
+  end
+end

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -645,6 +645,8 @@ defmodule OrchardConsole.NodesLiveTest do
     test "renders nodes page with section titles", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/console/nodes")
 
+      assert html =~ "Add Node"
+      assert html =~ "/console/nodes/new"
       assert html =~ "Inventory Summary"
       assert html =~ "Registered Nodes"
       assert html =~ "Live Cluster"

--- a/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch_capacity/request_dispatcher_claim_test.exs
@@ -2008,11 +2008,12 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
     node_id = claim_node_id()
     node = insert_admitted_node!(target, heartbeat_at, node_id)
     request_id = "request-cancel-drain-durable-unreachable"
+    request_timeout_ms = 1_500
 
     schedule = %{
       capacity_schedule(authority, node.id, request_id)
-      | request_timeout_ms: @expiring_request_timeout_ms,
-        timeout_at: DateTime.add(DateTime.utc_now(), @expiring_request_timeout_ms, :millisecond)
+      | request_timeout_ms: request_timeout_ms,
+        timeout_at: DateTime.add(DateTime.utc_now(), request_timeout_ms, :millisecond)
     }
 
     dispatch =
@@ -2023,8 +2024,8 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
         )
       end)
 
-    assert_receive {:pre_acceptance_cancel_received, _emitter}, 1_000
-    assert_receive :pre_acceptance_disconnected, 1_000
+    assert_receive {:pre_acceptance_cancel_received, _emitter}, 5_000
+    assert_receive :pre_acceptance_disconnected, 5_000
     assert_dispatch_failure(Task.await(dispatch), :request_timeout)
     assert Repo.get!(Node, node.id).health == :unhealthy
 
@@ -2910,8 +2911,8 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
-      | request_timeout_ms: 60,
-        timeout_at: DateTime.add(DateTime.utc_now(), 60, :millisecond)
+      | request_timeout_ms: 1_000,
+        timeout_at: DateTime.add(DateTime.utc_now(), 1_000, :millisecond)
     }
 
     assert_dispatch_failure(
@@ -3033,8 +3034,8 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
 
     schedule = %{
       capacity_schedule(authority, node_id, request_id)
-      | request_timeout_ms: 1_000,
-        timeout_at: DateTime.add(DateTime.utc_now(), 1_000, :millisecond)
+      | request_timeout_ms: 1_500,
+        timeout_at: DateTime.add(DateTime.utc_now(), 1_500, :millisecond)
     }
 
     {:ok, held_lease} = QueueManager.acquire_acceptance_gate(node_id, authority: authority)
@@ -3053,10 +3054,10 @@ defmodule Orchard.DispatchCapacity.RequestDispatcherClaimTest do
       assert :ok = QueueManager.release_acceptance_gate(held_lease, authority: authority)
 
       # A deadline that excluded the 600ms gate wait would cancel no earlier
-      # than 1_600ms after dispatch started, so the upper bound still proves
+      # than 2,100ms after dispatch started, so the upper bound still proves
       # acceptance waiting and streaming share one request timeout.
-      assert_receive {:cancel_received, emitter}, 700
-      assert System.monotonic_time(:millisecond) - started_at < 1_400
+      assert_receive {:cancel_received, emitter}, 1_300
+      assert System.monotonic_time(:millisecond) - started_at < 2_000
 
       send(emitter, :finish_cancel)
       _events = assert_dispatch_success(Task.await(dispatch))

--- a/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/queue_manager_test.exs
@@ -1292,7 +1292,7 @@ defmodule Orchard.Inference.QueueManagerTest do
     tenant_a = Ecto.UUID.generate()
     tenant_b = Ecto.UUID.generate()
 
-    with_queue_admission_config(queue_config(max_wait_ms: 1_000), fn ->
+    with_queue_admission_config(queue_config(max_wait_ms: 5_000), fn ->
       assert {:ok, held_grant} =
                QueueManager.acquire(admission_request("req-held", tenant_id: tenant_a))
 
@@ -1314,16 +1314,16 @@ defmodule Orchard.Inference.QueueManagerTest do
       assert wait_until(fn -> queue_entry_awaiting?(ticket_b1) end)
 
       assert :ok = QueueManager.release(held_grant)
-      assert_receive {:await_result, :a1, {:ok, grant_a1}}, 1_000
+      assert_receive {:await_result, :a1, {:ok, grant_a1}}, 3_000
       refute_receive {:await_result, :a2, _}, 20
       refute_receive {:await_result, :b1, _}, 20
 
       assert :ok = QueueManager.release(grant_a1)
-      assert_receive {:await_result, :b1, {:ok, grant_b1}}, 1_000
+      assert_receive {:await_result, :b1, {:ok, grant_b1}}, 3_000
       refute_receive {:await_result, :a2, _}, 20
 
       assert :ok = QueueManager.release(grant_b1)
-      assert_receive {:await_result, :a2, {:ok, grant_a2}}, 1_000
+      assert_receive {:await_result, :a2, {:ok, grant_a2}}, 3_000
 
       assert :ok = QueueManager.release(grant_a2)
       stop_awaiter(awaiter_a1)
@@ -1479,7 +1479,7 @@ defmodule Orchard.Inference.QueueManagerTest do
   end
 
   test "requeue defers an active grant behind the lane retry interval" do
-    config = queue_config(max_wait_ms: 500, poll_interval_ms: 200)
+    config = queue_config(max_wait_ms: 2_000, poll_interval_ms: 200)
 
     with_queue_admission_config(config, fn ->
       request = admission_request("req-requeue")
@@ -1491,7 +1491,7 @@ defmodule Orchard.Inference.QueueManagerTest do
       assert wait_until(fn -> queue_entry_awaiting?(ticket) end)
       refute Task.yield(awaiter, 50)
 
-      assert {:ok, requeued_grant} = Task.await(awaiter, 1_000)
+      assert {:ok, requeued_grant} = Task.await(awaiter, 3_000)
       assert requeued_grant.queue_result == :queued
       assert requeued_grant.queue_wait_ms >= config[:poll_interval_ms]
 
@@ -3078,7 +3078,7 @@ defmodule Orchard.Inference.QueueManagerTest do
                  public_id: db_request.public_id,
                  caller_pid: caller
                ),
-               config: queue_config(max_wait_ms: 1_000)
+               config: queue_config(max_wait_ms: 5_000)
              )
 
     parent = self()
@@ -3090,7 +3090,7 @@ defmodule Orchard.Inference.QueueManagerTest do
 
     assert wait_until(fn -> queue_entry_awaiting?(ticket) end)
     assert :ok = QueueManager.release(grant)
-    assert_receive {:post_grant_await_result, {:ok, %QueueManager.Grant{}}}, 1_000
+    assert_receive {:post_grant_await_result, {:ok, %QueueManager.Grant{}}}, 3_000
     assert wait_until(fn -> Requests.get_request!(db_request.id).state == :cancelled end)
 
     request = Requests.get_request!(db_request.id)
@@ -3126,7 +3126,7 @@ defmodule Orchard.Inference.QueueManagerTest do
                  public_id: db_request.public_id,
                  caller_pid: caller
                ),
-               config: queue_config(max_wait_ms: 20)
+               config: queue_config(max_wait_ms: 100)
              )
 
     parent = self()
@@ -3136,7 +3136,7 @@ defmodule Orchard.Inference.QueueManagerTest do
       send(parent, {:post_timeout_await_result, result})
     end)
 
-    assert_receive {:post_timeout_await_result, {:error, :queue_timeout, metadata}}, 1_000
+    assert_receive {:post_timeout_await_result, {:error, :queue_timeout, metadata}}, 3_000
     assert metadata.queue_result == :queue_timeout
     assert wait_until(fn -> Requests.get_request!(db_request.id).state == :timed_out end)
 

--- a/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs
@@ -1013,6 +1013,27 @@ defmodule Orchard.Inference.RequestOrchestratorTest.PreAwaitTerminalQueueManager
   end
 end
 
+defmodule Orchard.Inference.RequestOrchestratorTest.ImmediateGrantQueueManager do
+  @moduledoc false
+
+  alias Orchard.Inference.QueueManager
+
+  def acquire(request) do
+    {:ok,
+     %QueueManager.Grant{
+       server: __MODULE__,
+       grant_id: Ecto.UUID.generate(),
+       queue_key: "#{request.model_id}@#{request.version}",
+       queue_result: :immediate,
+       queue_granted_at:
+         DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_iso8601(),
+       queue_wait_ms: 0
+     }}
+  end
+
+  def release(_grant), do: :ok
+end
+
 defmodule Orchard.Inference.RequestOrchestratorTest.RecordingQueueManager do
   @moduledoc false
 
@@ -2393,11 +2414,11 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     assert :ok = QueueManager.release(held_grant)
 
     assert wait_until(fn ->
-             request = Requests.get_request_by_public_id(canonical.public_id)
+             request = request_without_preloads(canonical.public_id)
              get_in(request.scheduler_decision, ["queue_result"]) == "queue_timeout"
            end)
 
-    request = Requests.get_request_by_public_id(canonical.public_id)
+    request = request_without_preloads(canonical.public_id)
     assert request.state == :timed_out
     assert request.http_status == 504
     assert request.error_code == "queue_timeout"
@@ -2471,6 +2492,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     bundle: bundle
   } do
     put_queue_admission_config(enabled: true)
+    put_immediate_grant_queue_manager()
     put_capturing_runtime_adapter_config()
 
     model = create_active_model!(bundle, "request-orchestrator-queue-disconnect")
@@ -2498,7 +2520,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
   test "queue admission requeues post-grant cluster_busy then schedules when live capacity returns",
        %{bundle: bundle} do
     metric_ref = attach_scheduler_rejection_metric()
-    put_queue_admission_config(enabled: true, max_wait_ms: 2_000, poll_interval_ms: 500)
+    put_queue_admission_config(enabled: true, max_wait_ms: 5_000, poll_interval_ms: 500)
     put_live_capacity_scheduler_config()
     put_capturing_runtime_adapter_config()
 
@@ -2507,51 +2529,52 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical =
       canonical_request("request-orchestrator-live-capacity-requeue",
         stream?: false,
-        admission: %{queue_wait_ms: 2_000}
+        admission: %{queue_wait_ms: 5_000}
       )
 
     public_id = canonical.public_id
 
     task = Task.async(fn -> RequestOrchestrator.execute(canonical, model) end)
 
-    assert {:live_capacity_schedule_attempt, scheduler_pid, ^public_id} = live_capacity_attempt()
+    try do
+      assert {:live_capacity_schedule_attempt, scheduler_pid, ^public_id} =
+               live_capacity_attempt(3_000)
 
-    send(scheduler_pid, {:live_capacity_schedule_reply, {:error, :cluster_busy}})
-    assert wait_until(fn -> request_state(canonical.public_id) == :queued end)
-    refute_receive {:captured_execute_request, _request}, 50
+      send(scheduler_pid, {:live_capacity_schedule_reply, {:error, :cluster_busy}})
+      refute_receive {:captured_execute_request, _request}, 50
 
-    queued_request = Requests.get_request_by_public_id(canonical.public_id)
-    assert_queue_metadata(queued_request, "queued", queued?: true)
-    assert queued_request.scheduler_decision["queue_wait_reason"] == "live_node_capacity"
-    refute Map.has_key?(queued_request.scheduler_decision || %{}, "queue_grant_id")
+      assert {:live_capacity_schedule_attempt, retry_scheduler_pid, ^public_id} =
+               live_capacity_attempt(3_000)
 
-    assert {:live_capacity_schedule_attempt, retry_scheduler_pid, ^public_id} =
-             live_capacity_attempt(1_500)
+      assert {:ok, schedule} = StubLiveCapacityScheduler.schedule_success(canonical)
 
-    assert {:ok, schedule} = StubLiveCapacityScheduler.schedule_success(canonical)
+      send(retry_scheduler_pid, {:live_capacity_schedule_reply, {:ok, schedule}})
 
-    send(retry_scheduler_pid, {:live_capacity_schedule_reply, {:ok, schedule}})
+      assert_receive {:captured_execute_request, _request}, 3_000
+      assert {:ok, ^canonical, events} = Task.await(task, 5_000)
+      assert Enum.any?(events, &InferenceEvent.terminal?/1)
 
-    assert_receive {:captured_execute_request, _request}, 500
-    assert {:ok, ^canonical, events} = Task.await(task, 2_000)
-    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+      request = Requests.get_request_by_public_id(canonical.public_id)
+      states = request_event_states(request)
 
-    request = Requests.get_request_by_public_id(canonical.public_id)
-    states = request_event_states(request)
+      assert state_before?(states, :admitted, :queued)
+      assert state_before?(states, :queued, :scheduled)
+      assert_queue_metadata(request, "queued", queued?: true, granted?: true)
+      assert request.scheduler_decision["queue_wait_reason"] == "live_node_capacity"
+      refute_receive {^metric_ref, _measurements, _metadata}
 
-    assert state_before?(states, :admitted, :queued)
-    assert state_before?(states, :queued, :scheduled)
-    assert_queue_metadata(request, "queued", queued?: true, granted?: true)
-    refute_receive {^metric_ref, _measurements, _metadata}
-
-    assert {:ok, next_grant} = hold_queue_lane(canonical)
-    assert :ok = QueueManager.release(next_grant)
+      assert {:ok, next_grant} = hold_queue_lane(canonical)
+      assert :ok = QueueManager.release(next_grant)
+    after
+      Task.shutdown(task, :brutal_kill)
+      QueueManager.reset()
+    end
   end
 
   test "queue admission requeues post-grant model_busy then schedules when live capacity returns",
        %{bundle: bundle} do
     metric_ref = attach_scheduler_rejection_metric()
-    put_queue_admission_config(enabled: true, max_wait_ms: 2_000, poll_interval_ms: 500)
+    put_queue_admission_config(enabled: true, max_wait_ms: 5_000, poll_interval_ms: 500)
     put_live_capacity_scheduler_config()
     put_capturing_runtime_adapter_config()
 
@@ -2560,48 +2583,49 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical =
       canonical_request("request-orchestrator-single-node-capacity-requeue",
         stream?: false,
-        admission: %{queue_wait_ms: 2_000}
+        admission: %{queue_wait_ms: 5_000}
       )
 
     public_id = canonical.public_id
 
     task = Task.async(fn -> RequestOrchestrator.execute(canonical, model) end)
 
-    assert {:live_capacity_schedule_attempt, scheduler_pid, ^public_id} = live_capacity_attempt()
+    try do
+      assert {:live_capacity_schedule_attempt, scheduler_pid, ^public_id} =
+               live_capacity_attempt(3_000)
 
-    send(scheduler_pid, {:live_capacity_schedule_reply, {:error, :model_busy}})
-    assert wait_until(fn -> request_state(canonical.public_id) == :queued end)
-    refute_receive {:captured_execute_request, _request}, 50
+      send(scheduler_pid, {:live_capacity_schedule_reply, {:error, :model_busy}})
+      refute_receive {:captured_execute_request, _request}, 50
 
-    queued_request = Requests.get_request_by_public_id(canonical.public_id)
-    assert_queue_metadata(queued_request, "queued", queued?: true)
+      assert {:live_capacity_schedule_attempt, retry_scheduler_pid, ^public_id} =
+               live_capacity_attempt(3_000)
 
-    assert queued_request.scheduler_decision["queue_wait_reason"] ==
-             "requested_model_path_capacity"
+      assert {:ok, schedule} = StubLiveCapacityScheduler.schedule_success(canonical)
 
-    refute Map.has_key?(queued_request.scheduler_decision || %{}, "queue_grant_id")
+      send(retry_scheduler_pid, {:live_capacity_schedule_reply, {:ok, schedule}})
 
-    assert {:live_capacity_schedule_attempt, retry_scheduler_pid, ^public_id} =
-             live_capacity_attempt(1_500)
+      assert_receive {:captured_execute_request, _request}, 3_000
+      assert {:ok, ^canonical, events} = Task.await(task, 5_000)
+      assert Enum.any?(events, &InferenceEvent.terminal?/1)
 
-    assert {:ok, schedule} = StubLiveCapacityScheduler.schedule_success(canonical)
+      request = Requests.get_request_by_public_id(canonical.public_id)
+      states = request_event_states(request)
 
-    send(retry_scheduler_pid, {:live_capacity_schedule_reply, {:ok, schedule}})
+      assert state_before?(states, :admitted, :queued)
+      assert state_before?(states, :queued, :scheduled)
+      assert_queue_metadata(request, "queued", queued?: true, granted?: true)
 
-    assert_receive {:captured_execute_request, _request}, 500
-    assert {:ok, ^canonical, events} = Task.await(task, 2_000)
-    assert Enum.any?(events, &InferenceEvent.terminal?/1)
+      assert request.scheduler_decision["queue_wait_reason"] ==
+               "requested_model_path_capacity"
 
-    request = Requests.get_request_by_public_id(canonical.public_id)
-    states = request_event_states(request)
+      refute_receive {^metric_ref, _measurements, _metadata}
 
-    assert state_before?(states, :admitted, :queued)
-    assert state_before?(states, :queued, :scheduled)
-    assert_queue_metadata(request, "queued", queued?: true, granted?: true)
-    refute_receive {^metric_ref, _measurements, _metadata}
-
-    assert {:ok, next_grant} = hold_queue_lane(canonical)
-    assert :ok = QueueManager.release(next_grant)
+      assert {:ok, next_grant} = hold_queue_lane(canonical)
+      assert :ok = QueueManager.release(next_grant)
+    after
+      Task.shutdown(task, :brutal_kill)
+      QueueManager.reset()
+    end
   end
 
   test "queue admission times out post-grant cluster_busy without dispatching", %{bundle: bundle} do
@@ -3893,12 +3917,12 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     canonical =
       canonical_request("request-orchestrator-started-alternate-timeout",
         stream?: false,
-        admission: %{timeout_ms: 60}
+        admission: %{timeout_ms: 1_000}
       )
 
     public_id = canonical.public_id
 
-    Process.put(:orchard_retry_started_probe, fn _request -> Process.sleep(80) end)
+    Process.put(:orchard_retry_started_probe, fn _request -> Process.sleep(1_100) end)
 
     assert {:error, {:dispatch_failed, :request_timeout}} =
              RequestOrchestrator.execute(canonical, model)
@@ -5393,6 +5417,17 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     Application.put_env(:orchard_controller, :inference, inference)
   end
 
+  defp put_immediate_grant_queue_manager do
+    inference =
+      Application.fetch_env!(:orchard_controller, :inference)
+      |> Keyword.put(
+        :queue_manager_impl,
+        Orchard.Inference.RequestOrchestratorTest.ImmediateGrantQueueManager
+      )
+
+    Application.put_env(:orchard_controller, :inference, inference)
+  end
+
   defp put_recording_queue_manager do
     inference =
       Application.fetch_env!(:orchard_controller, :inference)
@@ -5465,6 +5500,10 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end
   end
 
+  defp request_without_preloads(public_id) do
+    Repo.one!(from(request in Orchard.Requests.Request, where: request.public_id == ^public_id))
+  end
+
   defp wait_until(fun, attempts \\ 50)
   defp wait_until(_fun, 0), do: false
 
@@ -5477,7 +5516,7 @@ defmodule Orchard.Inference.RequestOrchestratorTest do
     end
   end
 
-  defp live_capacity_attempt(timeout \\ 500) do
+  defp live_capacity_attempt(timeout) do
     receive do
       {:live_capacity_schedule_attempt, _scheduler_pid, _public_id} = attempt -> attempt
     after

--- a/apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs
+++ b/apps/orchard_controller/test/orchard/models/safe_tokenization_preflight_test.exs
@@ -98,7 +98,7 @@ defmodule Orchard.Models.SafeTokenizationPreflightTest do
                  SafeTokenizationPreflight.run(preflight_input(tmp_dir))
 
         elapsed_ms = System.monotonic_time(:millisecond) - started_at
-        assert elapsed_ms < 500
+        assert elapsed_ms < 1_000
       end)
     end)
   end

--- a/apps/orchard_controller/test/orchard/node_enrollment_bundle_test.exs
+++ b/apps/orchard_controller/test/orchard/node_enrollment_bundle_test.exs
@@ -1,0 +1,53 @@
+defmodule Orchard.NodeEnrollmentBundleTest do
+  use ExUnit.Case, async: true
+
+  alias Orchard.NodeEnrollmentBundle
+
+  test "rejects invalid shared issuance attributes before trust or persistence work" do
+    cases = [
+      {%{}, :surface, :invalid_format},
+      {%{expiry_seconds: 0}, :expiry_seconds, :out_of_range},
+      {%{expiry_seconds: 86_401}, :expiry_seconds, :out_of_range},
+      {%{pool_id: "general pool"}, :pool_id, :invalid_format},
+      {%{pool_id: String.duplicate("a", 65)}, :pool_id, :too_long},
+      {%{surface: String.duplicate("a", 65)}, :surface, :too_long},
+      {%{display_name: "render\nnode"}, :display_name, :invalid_format},
+      {%{display_name: String.duplicate("é", 65)}, :display_name, :too_long}
+    ]
+
+    for {attrs, field, reason} <- cases do
+      assert {:error, {:invalid_enrollment_bundle_attrs, errors}} =
+               NodeEnrollmentBundle.issue(attrs)
+
+      assert {field, reason} in errors
+    end
+  end
+
+  test "normalizes valid shared issuance attributes" do
+    assert {:ok, attrs} =
+             NodeEnrollmentBundle.validate_attrs(%{
+               "display_name" => "  render-node-03  ",
+               "expiry_seconds" => 3_600,
+               "pool_id" => "general",
+               "surface" => "console"
+             })
+
+    assert attrs.display_name == "render-node-03"
+    assert attrs.expiry_seconds == 3_600
+    assert attrs.pool_id == "general"
+    assert attrs.surface == "console"
+  end
+
+  test "keeps the CLI auto-generated display name contract" do
+    assert {:ok, attrs} =
+             NodeEnrollmentBundle.validate_attrs(%{
+               display_name: nil,
+               surface: "local_orchardctl"
+             })
+
+    assert attrs.display_name == nil
+    assert attrs.pool_id == "general"
+    assert attrs.surface == "local_orchardctl"
+    assert attrs.expiry_seconds == 3_600
+  end
+end

--- a/apps/orchard_controller/test/orchard/node_enrollments_test.exs
+++ b/apps/orchard_controller/test/orchard/node_enrollments_test.exs
@@ -1,11 +1,13 @@
 defmodule Orchard.NodeEnrollmentsTest do
-  use Orchard.DataCase, async: true
+  use Orchard.DataCase, async: false
 
   import Ecto.Query
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.Governance.AuditLog
   alias Orchard.NodeEnrollment.PKI
   alias Orchard.NodeEnrollments
+  alias Orchard.Nodes.{Enrollment, Node}
   alias Orchard.Repo
 
   test "OpenSpec task 2.1 creates a versioned Node Enrollment with hash-only token persistence" do
@@ -168,7 +170,79 @@ defmodule Orchard.NodeEnrollmentsTest do
     refute inspect(audits) =~ result.bootstrap_token
   end
 
-  defp create_pending!(now) do
+  test "concurrent publication success and failure serialize to one durable outcome" do
+    now = ~U[2026-07-10 03:30:00Z]
+    result = begin_unboxed_pending!(now)
+    enrollment_id = result.enrollment.id
+
+    issued_task =
+      Task.async(fn ->
+        receive do
+          :go ->
+            Sandbox.unboxed_run(Repo, fn ->
+              NodeEnrollments.mark_issued(enrollment_id, now: now)
+            end)
+        end
+      end)
+
+    failed_task =
+      Task.async(fn ->
+        receive do
+          :go ->
+            Sandbox.unboxed_run(Repo, fn ->
+              NodeEnrollments.mark_output_failed(enrollment_id, now: now)
+            end)
+        end
+      end)
+
+    send(issued_task.pid, :go)
+    send(failed_task.pid, :go)
+
+    results = [Task.await(issued_task), Task.await(failed_task)]
+
+    assert Enum.count(results, &match?({:ok, _enrollment}, &1)) == 1
+    assert Enum.count(results, &(&1 == {:error, :invalid_enrollment_state})) == 1
+
+    {enrollment, actions} =
+      Sandbox.unboxed_run(Repo, fn ->
+        assert {:ok, enrollment} = NodeEnrollments.fetch(enrollment_id)
+
+        actions =
+          Repo.all(
+            from(audit in AuditLog,
+              where: audit.target_id == ^enrollment_id,
+              order_by: [asc: audit.id],
+              select: audit.action
+            )
+          )
+
+        {enrollment, actions}
+      end)
+
+    assert enrollment.state in [:issued, :output_failed]
+
+    expected_transition =
+      if enrollment.state == :issued,
+        do: "node_enrollment.issued",
+        else: "node_enrollment.output_failed"
+
+    assert actions == ["node_enrollment.publication_pending", expected_transition]
+  end
+
+  test "returns the Enrollment for a provisioned node without exposing its token" do
+    now = ~U[2026-07-10 04:00:00Z]
+    result = create_pending!(now)
+
+    assert {:ok, enrollment} = NodeEnrollments.latest_for_node(result.enrollment.node_id)
+    assert enrollment.id == result.enrollment.id
+    assert enrollment.node.id == result.enrollment.node_id
+    refute inspect(enrollment) =~ result.bootstrap_token
+
+    assert {:error, :enrollment_not_found} =
+             NodeEnrollments.latest_for_node(Ecto.UUID.generate())
+  end
+
+  defp create_pending!(now, display_name \\ "stale-publication") do
     assert {:ok, result} =
              NodeEnrollments.create(
                %{
@@ -178,10 +252,35 @@ defmodule Orchard.NodeEnrollmentsTest do
                  creator_type: "operator",
                  creator_id: "local-test-operator",
                  expires_at: DateTime.add(now, 3_600, :second),
-                 node: %{display_name: "stale-publication"}
+                 node: %{display_name: display_name}
                },
                now: now
              )
+
+    result
+  end
+
+  defp begin_unboxed_pending!(now) do
+    :ok = Sandbox.checkin(Repo)
+    display_name = "publication-race-#{System.unique_integer([:positive])}"
+    result = Sandbox.unboxed_run(Repo, fn -> create_pending!(now, display_name) end)
+    enrollment_id = result.enrollment.id
+    node_id = result.enrollment.node_id
+
+    on_exit(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        Repo.query!("ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_append_only")
+
+        try do
+          Repo.delete_all(from(audit in AuditLog, where: audit.target_id == ^enrollment_id))
+        after
+          Repo.query!("ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_append_only")
+        end
+
+        Repo.delete_all(from(enrollment in Enrollment, where: enrollment.id == ^enrollment_id))
+        Repo.delete_all(from(node in Node, where: node.id == ^node_id))
+      end)
+    end)
 
     result
   end

--- a/apps/orchard_controller/test/orchard/nodes_test.exs
+++ b/apps/orchard_controller/test/orchard/nodes_test.exs
@@ -3338,13 +3338,13 @@ defmodule Orchard.NodesTest do
       assert {:queued, first_ticket} =
                QueueManager.acquire(
                  queue_admission_request("req-node-placement-omitted-a", "omitted-model"),
-                 config: queue_config(capacity: 0)
+                 config: queue_config(capacity: 0, max_wait_ms: 5_000)
                )
 
       assert {:queued, second_ticket} =
                QueueManager.acquire(
                  queue_admission_request("req-node-placement-omitted-b", "omitted-model"),
-                 config: queue_config(capacity: 0)
+                 config: queue_config(capacity: 0, max_wait_ms: 5_000)
                )
 
       first_awaiter = start_holding_awaiter(first_ticket, :first_omitted_result)
@@ -3367,7 +3367,7 @@ defmodule Orchard.NodesTest do
 
       insert_node_from_status!(target, loaded_status)
       assert {:ok, _node} = observe_status(target, loaded_status, DateTime.utc_now())
-      assert {:ok, second_grant} = Task.await(second_awaiter, 2_000)
+      assert {:ok, second_grant} = Task.await(second_awaiter, 5_000)
       assert second_grant.queue_result == :queued
 
       assert :ok = QueueManager.release(second_grant)

--- a/apps/orchard_controller/test/orchard/requests_test.exs
+++ b/apps/orchard_controller/test/orchard/requests_test.exs
@@ -1278,6 +1278,54 @@ defmodule Orchard.RequestsTest do
                  node_id: nil
                })
     end
+
+    test "rejects a stale schedule write after terminalization" do
+      request = create_request!(%{public_id: "req_schedule_terminal", state: :queued})
+
+      terminal_decision = %{
+        queueing_enabled: true,
+        queue_key: "model@v1",
+        queue_result: "queue_timeout"
+      }
+
+      assert {:ok, terminal} = Requests.record_schedule(request, terminal_decision)
+
+      assert {:error, :already_terminal} =
+               Requests.record_schedule(terminal, %{
+                 queueing_enabled: true,
+                 queue_key: "model@v1",
+                 queue_result: "queued"
+               })
+
+      assert {:ok, terminal} = Requests.mark_terminal(terminal, %{state: :timed_out})
+
+      assert {:error, :already_terminal} =
+               Requests.record_schedule(terminal, %{
+                 queueing_enabled: true,
+                 queue_key: "model@v1",
+                 queue_result: "queued"
+               })
+
+      immutable_before_retry = Requests.get_request!(request.id)
+      alternate_node_id = Ecto.UUID.generate()
+
+      assert {:ok, idempotent} =
+               Requests.record_schedule(terminal, %{
+                 queueing_enabled: false,
+                 queue_key: "different@v2",
+                 queue_result: "queue_timeout",
+                 node_id: alternate_node_id
+               })
+
+      assert idempotent == immutable_before_retry
+      assert idempotent.node_id != alternate_node_id
+      assert idempotent.scheduler_decision == immutable_before_retry.scheduler_decision
+
+      persisted = Requests.get_request!(request.id)
+      assert persisted == immutable_before_retry
+      assert persisted.state == :timed_out
+      assert persisted.scheduler_decision["queue_result"] == "queue_timeout"
+    end
   end
 
   describe "list_recent_requests/1" do

--- a/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/beam_peer_grant_store_test.exs
@@ -12,6 +12,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
   @fixture_activation_backdate_seconds 60
   @fixture_validity_seconds 30 * 24 * 60 * 60
   @fixture_anchor_tolerance_seconds 3600
+  @child_start_attempts 250
 
   defmodule FakeControlTransport do
     def retrieve(target, credential, request) do
@@ -711,7 +712,7 @@ defmodule Orchard.Node.BeamPeerGrantStoreTest do
         )
       end)
 
-    wait_until(fn -> File.exists?(ready_path) end)
+    wait_until(fn -> File.exists?(ready_path) end, @child_start_attempts)
     Process.sleep(250)
     refute File.exists?(result_path)
     assert File.exists?(temporary)

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -22,11 +22,7 @@ defmodule Orchard.Node.WorkerCustodyTest do
     assert {:ok, _apps} = Application.ensure_all_started(:orchard_node_agent)
     CustodyTestHelpers.assert_reaper_empty!(1_000)
 
-    root =
-      Path.join(
-        "/tmp",
-        "oc-#{System.unique_integer([:positive, :monotonic])}"
-      )
+    root = unique_tmp_root!()
 
     models_root = Path.join(root, "models")
     model_ref = %ModelRef{model_id: "custody/test", version: "v1"}
@@ -41,6 +37,20 @@ defmodule Orchard.Node.WorkerCustodyTest do
       root: root,
       socket_path: Path.join(root, "worker.sock")
     }
+  end
+
+  defp unique_tmp_root! do
+    root =
+      Path.join(
+        "/tmp",
+        "oc-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    case File.mkdir(root) do
+      :ok -> root
+      {:error, :eexist} -> unique_tmp_root!()
+      {:error, reason} -> raise "could not create custody test root #{root}: #{inspect(reason)}"
+    end
   end
 
   test "SPEC.md §4.9 explicit unload reaps the exact stub runtime PID and socket", context do

--- a/apps/orchard_shared/lib/orchard/endpoint_metadata.ex
+++ b/apps/orchard_shared/lib/orchard/endpoint_metadata.ex
@@ -1,4 +1,4 @@
-defmodule OrchardCLI.EndpointMetadata do
+defmodule Orchard.EndpointMetadata do
   @moduledoc """
   Reads and writes the non-secret controller endpoint metadata sidecar.
 

--- a/apps/orchard_shared/lib/orchard/transport_tls/certificate_identity.ex
+++ b/apps/orchard_shared/lib/orchard/transport_tls/certificate_identity.ex
@@ -30,15 +30,15 @@ defmodule Orchard.TransportTLS.CertificateIdentity do
   )
 
   Record.defrecord(
-    :subject_public_key_info,
-    :SubjectPublicKeyInfo,
-    Record.extract(:SubjectPublicKeyInfo, from_lib: "public_key/include/public_key.hrl")
+    :certificate,
+    :Certificate,
+    Record.extract(:Certificate, from_lib: "public_key/include/public_key.hrl")
   )
 
   Record.defrecord(
-    :algorithm_identifier,
-    :AlgorithmIdentifier,
-    Record.extract(:AlgorithmIdentifier, from_lib: "public_key/include/public_key.hrl")
+    :tbs_certificate,
+    :TBSCertificate,
+    Record.extract(:TBSCertificate, from_lib: "public_key/include/public_key.hrl")
   )
 
   Record.defrecord(
@@ -98,24 +98,10 @@ defmodule Orchard.TransportTLS.CertificateIdentity do
           {:ok, String.t()} | {:error, :invalid_certificate_identity}
   def spki_fingerprint_from_pem(pem) when is_binary(pem) do
     der = decode_certificate!(pem)
-    certificate = :public_key.pkix_decode_cert(der, :otp)
-    tbs = otp_certificate(certificate, :tbsCertificate)
-    public_key_info = otp_tbs_certificate(tbs, :subjectPublicKeyInfo)
-    algorithm = otp_subject_public_key_info(public_key_info, :algorithm)
-    point = otp_subject_public_key_info(public_key_info, :subjectPublicKey)
-
-    encoded =
-      subject_public_key_info(
-        algorithm:
-          algorithm_identifier(
-            algorithm: public_key_algorithm(algorithm, :algorithm),
-            parameters: public_key_algorithm(algorithm, :parameters)
-          ),
-        subjectPublicKey: encoded_public_point(point)
-      )
-      |> then(&:public_key.der_encode(:SubjectPublicKeyInfo, &1))
-
-    {:ok, fingerprint(encoded)}
+    decoded = :public_key.der_decode(:Certificate, der)
+    tbs = certificate(decoded, :tbsCertificate)
+    public_key_info = tbs_certificate(tbs, :subjectPublicKeyInfo)
+    {:ok, fingerprint(:public_key.der_encode(:SubjectPublicKeyInfo, public_key_info))}
   rescue
     _error -> {:error, :invalid_certificate_identity}
   catch
@@ -231,9 +217,6 @@ defmodule Orchard.TransportTLS.CertificateIdentity do
       point when is_binary(point) -> {{:ECPoint, point}, parameters}
     end
   end
-
-  defp encoded_public_point({:ECPoint, point}), do: point
-  defp encoded_public_point(point) when is_binary(point), do: point
 
   defp certificate_public_point(der) do
     {{:ECPoint, point}, _parameters} = certificate_public_key(der)

--- a/apps/orchard_shared/test/orchard/endpoint_metadata_test.exs
+++ b/apps/orchard_shared/test/orchard/endpoint_metadata_test.exs
@@ -1,7 +1,7 @@
-defmodule OrchardCLI.EndpointMetadataTest do
+defmodule Orchard.EndpointMetadataTest do
   use ExUnit.Case, async: true
 
-  alias OrchardCLI.EndpointMetadata
+  alias Orchard.EndpointMetadata
 
   @schema_keys ~w(
     api_bind_ip

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -818,10 +818,6 @@ subsequent page loads. Live OS-appearance changes require the client theme
 control to register a `matchMedia` change listener; without JavaScript,
 `system` cannot resolve and the Console uses the light selector state.
 
-Tailwind's `dark:` utilities and Console dark custom rules are keyed from
-`<html data-theme="dark">`. Do not mix media-query driven app CSS with this
-selector contract.
-
 ### 13.3 Control Contract
 
 The theme control is a three-segment radiogroup mounted in the sidebar footer
@@ -840,3 +836,104 @@ fits inside the clipped sidebar without adding a second control style.
 This state-model addition satisfies §12 Change Discipline. It does not relax
 §11: no new Tailwind color tokens, font extensions, palette values, or `@theme`
 changes are part of theme mode control.
+
+Tailwind's `dark:` utilities and Console dark custom rules are keyed from
+`<html data-theme="dark">`.
+Do not mix media-query driven app CSS with this selector contract.
+
+---
+
+## 14. Guided Setup And One-Time Output
+
+Guided setup connects operator actions to system-observed state without inventing a second lifecycle model.
+These rules apply to Node Enrollment and to later multi-step setup experiences.
+
+### 14.1 Progress Structure
+
+- Use one ordered progress list with numbered steps and short verb labels.
+- Completed, current, pending, and blocked steps pair color with an icon, number, line style, or visible state text.
+- The accessible label must name the durable lifecycle or operation state.
+- Presentation labels such as **Activating** must not replace a persisted lifecycle value.
+- The main content starts with the current operator outcome, not an implementation phase name.
+- Each operator action states where it runs, what it produces, and what it does not prove.
+- Automatic state changes use a polite live region and never move keyboard focus.
+
+### 14.2 Recommended Order
+
+When independent prerequisites may occur in either order, the normal guided path still recommends the order that minimizes expiry, custody, and recovery risk.
+The interface may explain that the system does not require that order.
+It must not present operational independence as a reason to make the operator choose an order without guidance.
+
+For Node Enrollment, prepare the target Mac before issuing the short-lived bundle.
+Installation, configured service state, enrollment, registration, trust, admission, authorization, health, and scheduling remain separate visible concepts.
+
+### 14.3 Current Blocker And Recovery
+
+- Show one primary current blocker instead of a stack of warning-colored incomplete states.
+- State what is waiting, why it matters, and the exact corrective action.
+- Include stable reason codes as supplemental technical detail when the shared domain contract provides them.
+- Do not use warning or error treatment for ordinary system-managed waiting.
+- Terminal failures name whether identity, trust, or durable state was created.
+- Recovery actions must be safe for the exact state and must not imply that confirmation can bypass a blocker.
+
+### 14.4 Automatic Observation
+
+- Registration, service observation, authorization delivery, health, and activation refresh automatically at a bounded interval.
+- Show the last successful check time.
+- A **Refresh now** control may remain as a fallback.
+- Never ask the operator to record or certify a system fact that Orchard can observe directly.
+- Do not add a manual **Activate** action when lifecycle advancement is system-managed.
+
+### 14.5 One-Time Secret Output
+
+One-time secret output is visible or deliverable exactly once.
+Keep secret material in socket-owned transient state only for the response that delivers it.
+Never place it in a URL, flash message, session, cookie, log, audit payload, `data-*` attribute, or reusable endpoint.
+
+When a client hook consumes one-time output, deliver the bytes through an authenticated same-origin event.
+The hook must clear its in-memory reference and revoke any object URL after success or failure.
+The acknowledgement returns only a bounded non-secret identifier.
+The server validates that identifier against socket-owned state before changing durable publication state.
+
+Delivery failure, disconnect, or lost acknowledgement must fail closed.
+The interface must not redisplay, resend, restore, or silently renew the same secret.
+The recovery action creates new one-time output under a new durable record.
+It does not reissue onto the previous provisioned record, and the interface must say that a distinct Node name is required when uniqueness is enforced.
+
+### 14.6 Browser Download
+
+A browser download proves only that the client accepted a download attempt.
+It does not prove destination-file custody, protected transfer, or target-machine use.
+Copy must tell the operator to use a protected administrative transfer channel and keep the file out of chat, logs, tickets, and shell history.
+
+Use `application/json` for a Node Enrollment Bundle and a bounded sanitized filename.
+The visible page may show the filename and exact consuming command, but not the Bootstrap Token or raw bundle content.
+After delivery, say that the browser accepted the download attempt and continue with durable status only.
+Do not call that acknowledgement confirmed target custody or transfer.
+
+### 14.7 Form And Action Copy
+
+- Use **New machine**, not **Another machine**, for the machine being added.
+- Use **Create enrollment** for the Controller-side operation.
+- Use **Download bundle** for browser delivery.
+- Use **Create Enrollment and Download** when one action performs both operations.
+- Use **Admit Node** for the explicit human authorization boundary.
+- Use **Create new enrollment** for expired, revoked, or failed output.
+- Identify `orchardctl node join --enrollment-bundle PATH` as a target-Mac command.
+- Describe Pool as an existing scheduling group and say where it can be changed.
+- Do not use **Ready** as an umbrella state.
+
+### 14.8 Browser Verification
+
+For a guided Node Enrollment change, verify at least these states in light and dark mode:
+
+- Add Node discovery from the Nodes workspace.
+- Ordered target-Mac preparation and Controller enrollment creation.
+- Form validation and disabled action behavior.
+- Successful one-time download and exact join command.
+- Download failure without secret redisplay.
+- Registration waiting with automatic refresh and last-checked time.
+- Registered handoff to explicit admission review.
+- Expired, revoked, and output-failed recovery.
+- Narrow viewport wrapping for filenames, identifiers, commands, and evidence.
+- Keyboard focus, live-region announcements, and reduced motion.

--- a/openspec/changes/add-console-node-enrollment-flow/design.md
+++ b/openspec/changes/add-console-node-enrollment-flow/design.md
@@ -1,0 +1,161 @@
+## Context
+
+The secure enrollment tracer already owns the durable identity and trust transitions.
+`Orchard.NodeEnrollments.create/2` allocates a `provisioned` Node and a `pending_publication` Enrollment while returning the Bootstrap Token exactly once.
+`mark_issued/2` makes that Enrollment redeemable only after protected output publication succeeds.
+`orchardctl node join --enrollment-bundle PATH` validates the bundle locally, pins the Controller, generates the Node key locally, redeems the token, and registers the Node.
+Node Admission remains an explicit administrator mutation, and later fresh healthy authenticated evidence advances `admitted -> active` automatically.
+
+The Console currently exposes inventory, pending admission review, detailed status, and action previews.
+It does not create or publish Node Enrollment Bundles.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Connect the existing secure domain operations through a usable Console journey.
+- Give the operator one recommended order and identify where every action runs.
+- Produce the same versioned bundle from CLI and Console.
+- Keep one-time secret output fail-closed across success, client failure, disconnect, and lost acknowledgement.
+- Monitor durable registration and activation state automatically.
+- Preserve the existing explicit admission and scheduler eligibility boundaries.
+
+**Non-Goals:**
+
+- Implement the target-Mac Orchard.app **Join existing Orchard** workflow.
+- Certify packaged multi-Mac operation.
+- Add automatic admission.
+- Add cross-restart guided-setup checkpoints.
+- Add enrollment revocation, reissue, list, or retention management surfaces.
+- Treat Pool intent as trust, registration evidence, or a scheduler guarantee.
+- Change Node lifecycle states or add a persisted `activating` state.
+
+## Decision 1: One Guided Controller Console Route
+
+The Nodes workspace links to `/console/nodes/new`.
+One LiveView owns the Controller-side sequence:
+
+1. Explain that the operator is preparing a new machine.
+2. Separate the validated source-development split-role path from the packaged multi-Mac rehearsal path and name the packaged path's remaining prerequisites and acceptance gap.
+3. Collect intended Node name, initial Pool intent, and bundle lifetime.
+4. Create one Enrollment and push one browser download event.
+5. Show the exact target-Mac join command.
+6. Poll the durable Enrollment and Node records every five seconds.
+7. When registration completes, link to the existing Node admission review.
+
+The route does not persist arbitrary wizard checkpoints.
+Refresh before issuance restarts the explanation and form.
+Refresh after issuance recovers from durable Node and Enrollment state only when the URL names that non-secret Enrollment identifier.
+The recovery route accepts only Enrollments whose audit metadata identifies the Console publication surface.
+Returning to `/console/nodes/new` resets any delivery or monitor state to a fresh enrollment form.
+The Bootstrap Token never enters the URL.
+Recovery of `pending_publication` shows only that browser confirmation is unresolved and never shows a join command.
+
+## Decision 2: CLI And Console Share Bundle Construction
+
+Bundle construction moves behind one Controller-owned public function that receives the intended Node metadata, expiry, actor, and publication surface.
+It reads public Node trust and non-secret Controller endpoint metadata, reconciles stale pending publications, creates the Enrollment, and returns encoded bundle bytes plus non-secret metadata.
+The shared function validates bounded display-name, Pool-intent, publication-surface, and expiry inputs before trust reads or persistence so CLI and Console cannot diverge.
+
+The function does not mark the Enrollment issued.
+Each publication adapter owns its delivery confirmation:
+
+- CLI confirms exclusive owner-only file publication before `mark_issued/2`.
+- Console confirms the client-side browser delivery start before `mark_issued/2`.
+
+The artifact fields and JSON encoding are identical across both adapters.
+
+## Decision 3: Browser Delivery Is One-Time And Fail-Closed
+
+After successful domain creation, the LiveView sends the encoded bundle through one authenticated same-origin LiveView event.
+The secret is never placed in a URL, flash message, session, cookie, log, audit payload, `data-*` attribute, or reusable server-side download endpoint.
+
+The client hook:
+
+1. Receives the bytes in memory.
+2. Creates an `application/json` Blob.
+3. Starts a download with a sanitized filename.
+4. Revokes the object URL.
+5. Clears its in-memory reference.
+6. Reports success or failure with only the Enrollment identifier.
+
+On reported success, the server verifies that the identifier matches the current pending issuance and calls `mark_issued/2`.
+On reported failure, it calls `mark_output_failed/2` and shows a safe recovery action.
+The issuance event is accepted only while the socket is at the enrollment-form stage, so duplicate or fabricated submissions cannot replace the in-flight delivery.
+Acknowledgements apply only while that exact Enrollment is in the socket-owned delivery stage, so stale success or failure events cannot overwrite a later UI state.
+If a durable transition returns an ambiguous error, Console fetches the current Enrollment and derives its claim from stored state instead of assuming success or failure.
+If a failure acknowledgement leaves the durable Enrollment in `pending_publication`, Console reports an uncertain state and continues polling rather than claiming completed output failure.
+If the client disconnects or acknowledgement is lost, the Enrollment remains non-redeemable in `pending_publication` and the existing stale-publication reconciler later moves it to `output_failed`.
+The Console never resends or redisplays that bundle.
+
+Browser success proves only that the client accepted the download attempt.
+It does not prove the destination filesystem, later transfer channel, or target-Mac custody.
+The UI says this directly and requires the operator to protect the file during transfer.
+
+## Decision 4: Registration And Activation Are Observed, Not Recorded
+
+The Console polls durable Enrollment and Node state every five seconds and offers **Refresh now** as a fallback.
+Polling uses one replaceable timer generation so manual refresh or reconnect cannot accumulate competing poll loops.
+It never asks the operator to record package installation, service start, registration, Peer Grant activation, or Node activation.
+
+Before registration, the page shows one current blocker:
+
+- Run `orchardctl node join --enrollment-bundle PATH` on the target Mac.
+
+After registration, the page links to Node detail and explicit admission review.
+After admission, existing Node detail polling continues to show system-managed authorization, health, and lifecycle evidence.
+No manual **Activate** action is added.
+
+## Decision 5: Pool Is Admission Intent
+
+The first slice presents `general` as the default initial Pool intent.
+The operator may change it before issuance.
+The value is carried as non-secret Enrollment audit metadata and prefilled during admission review when available.
+It does not alter lifecycle, trust, registration, or scheduling eligibility by itself.
+
+Custom Pool management remains outside this flow.
+The UI calls Pool an existing scheduling group and says that it can be changed during admission review.
+
+## Decision 6: Failure Copy Names Cause And Recovery
+
+The flow renders one primary blocker or failure card at a time.
+Every failure contains:
+
+- what failed;
+- why the current Enrollment cannot continue;
+- whether trust or identity was established;
+- the safe next action.
+
+Expired, revoked, and `output_failed` Enrollments remain non-redeemable.
+An already `consumed` Enrollment remains in the registration and admission lifecycle even after its original token expiry.
+After consumption or registration, Console hides bundle-transfer instructions and the join command because the one-time registration action has completed.
+The recovery action is **Create new enrollment**.
+The flow never offers restore, secret redisplay, or automatic renewal.
+The first slice does not reissue onto the previous provisioned Node: the old record remains for audit, and a new Enrollment requires a distinct Node name.
+
+## Security And Privacy
+
+- Bootstrap Token and encoded bundle bytes exist only in the domain call result, one LiveView push event, and transient browser memory.
+- Logs and audit payloads contain only bounded identifiers, timestamps, surface, and non-secret intent.
+- LiveView event acknowledgements carry only the Enrollment identifier.
+- The server validates all acknowledgement identifiers against socket-owned state.
+- The server accepts bundle issuance only from the socket-owned enrollment-form stage.
+- Durable status recovery requires `audit_metadata["surface"] == "console"` before browser-specific claims are rendered.
+- Child-resource reads are scoped to the server-side Enrollment and Node relationship.
+- Filename sanitization permits only a bounded safe basename.
+- Browser download does not weaken Controller leadership, trust initialization, HTTPS endpoint, expiry, or one-use gates.
+
+## Accessibility And Motion
+
+- Progress uses text, numbers, and state labels rather than color alone.
+- Dynamic polling results use a polite live region.
+- Focus order follows document order and all controls retain the shared focus ring.
+- Failure and blocker text is visible without tooltips.
+- Automatic state refresh does not automatically move focus.
+- Reduced-motion preferences disable decorative progress animation.
+
+## Rollback
+
+Removing the Add Node route, link, and client hook returns Console behavior to the existing CLI-guidance path.
+The shared bundle builder remains usable by CLI and does not change the artifact contract.
+No migration is required for the first slice because Pool intent uses existing sanitized audit metadata.

--- a/openspec/changes/add-console-node-enrollment-flow/proposal.md
+++ b/openspec/changes/add-console-node-enrollment-flow/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Orchard already implements secure Node Enrollment creation, certificate-backed registration, explicit Node Admission, and automatic activation after fresh authenticated evidence.
+The Console does not expose the normal operator journey that connects those capabilities.
+Operators must discover CLI commands from a candidate detail screen, create protected output outside the Console, transfer it to the target Mac, and manually reconstruct where registration and admission stand.
+
+A moderated usability study of the proposed Console flow found one task-blocking problem: the operator could not determine how to carry the Enrollment Bundle to the target Mac or which command consumed it.
+The revised prototype resolved that failure by presenting one recommended order, a one-time bundle download, the exact target-Mac command, automatic status refresh, explicit admission, and clear failure recovery.
+
+## What Changes
+
+- Add an **Add Node** action to the Console Nodes workspace.
+- Add a guided Controller Console flow for preparing a new machine, creating one Node Enrollment, downloading its one-time bundle, and monitoring registration automatically.
+- Show the exact `orchardctl node join --enrollment-bundle PATH` command and identify that it runs on the target Mac.
+- Keep the Enrollment in `pending_publication` until the authenticated LiveView client reports that browser delivery started successfully.
+- Mark failed browser delivery as `output_failed`, never redisplay the same secret, and direct the operator to create a new enrollment.
+- Preserve explicit human Node Admission and automatic `admitted -> active` promotion from fresh healthy authenticated evidence.
+- Clarify that the initial `general` Pool is admission intent, not trust, and remains changeable during admission review.
+- Add reusable Console design rules for guided progress, one current blocker, automatic polling, one-time secret output, and recovery.
+- Keep packaged multi-Mac acceptance, setup resumability across app restarts, and automatic admission outside this slice.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `operator-first-run-journey`: Adds the Controller Console Node Enrollment flow, browser-delivery custody rules, automatic registration monitoring, and handoff into explicit admission review.
+
+## Impact
+
+- Product contract: adds guided Console behavior under the existing Controller-plus-worker journey without claiming packaged multi-Mac support.
+- Console: adds one LiveView route, Add Node entry point, guided UI, browser-download hook, and focused tests.
+- Enrollment domain: centralizes bundle construction so CLI and Console produce the same versioned artifact.
+- Shared endpoint discovery: makes non-secret Controller endpoint metadata available to both CLI and Console without adding a reverse dependency.
+- Security: one-time Bootstrap Token material remains response-only, is not stored in client persistence, and cannot be redisplayed.
+- `SPEC.md`: no lifecycle, trust, scheduling, or packaging semantics change.

--- a/openspec/changes/add-console-node-enrollment-flow/specs/operator-first-run-journey/spec.md
+++ b/openspec/changes/add-console-node-enrollment-flow/specs/operator-first-run-journey/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Console Guides Node Enrollment Through Existing Trust Boundaries
+Orchard Console SHALL expose **Add Node** from the Nodes workspace and guide an authorized administrator through one Controller-side Node Enrollment journey.
+The journey SHALL identify the target Mac and Controller Console action locations separately.
+The journey SHALL present installation preparation before short-lived Enrollment issuance as the recommended order.
+The journey SHALL show the exact `orchardctl node join --enrollment-bundle PATH` command as a target-Mac action.
+The journey SHALL NOT treat installation, download, transfer, service start, or endpoint observation as registration, trust, admission, activation, or scheduling eligibility.
+The journey SHALL preserve explicit Node Admission and automatic activation from fresh healthy authenticated evidence.
+This refines `SPEC.md` §§4.2 through 4.6, 7.4, 7.5.4, and 10.6.
+
+#### Scenario: Administrator discovers Add Node
+- **WHEN** an authorized administrator opens the Console Nodes workspace
+- **THEN** the workspace offers **Add Node** as the primary creation action
+- **THEN** existing Node inventory and untrusted Runtime Endpoint evidence remain separate
+
+#### Scenario: Guided preparation names the action location
+- **WHEN** the administrator opens **Add Node**
+- **THEN** Console identifies installation preparation as a target-Mac action
+- **THEN** Console identifies Enrollment creation as a Controller Console action
+- **THEN** Console recommends preparing the target Mac before creating the short-lived bundle
+
+#### Scenario: Issued bundle has one target command
+- **WHEN** Console delivers a Node Enrollment Bundle successfully
+- **THEN** Console shows `orchardctl node join --enrollment-bundle PATH`
+- **THEN** Console says to run the command on the target Mac with the downloaded bundle path
+- **THEN** Console does not report the Node as registered until certificate-backed redemption completes
+
+### Requirement: Console Browser Delivery Is One-Time And Fail-Closed
+Orchard Console SHALL support one-time Node Enrollment Bundle delivery through an authenticated same-origin browser session when browser delivery is selected.
+Console browser delivery SHALL use the same versioned artifact contract as CLI publication.
+The Enrollment SHALL remain `pending_publication` until the client reports that the download attempt started successfully.
+The Bootstrap Token and encoded bundle bytes MUST NOT enter a URL, flash message, session, cookie, log, audit payload, `data-*` attribute, or reusable download endpoint.
+The client SHALL clear transient bundle bytes and revoke any object URL after starting or failing the download.
+On reported client failure, Orchard SHALL mark the Enrollment `output_failed` and SHALL NOT allow redemption.
+On disconnect or lost acknowledgement, Orchard SHALL leave the Enrollment non-redeemable until stale-publication reconciliation marks it `output_failed`.
+Console SHALL NOT redisplay, resend, restore, or automatically renew the same bundle.
+Browser delivery SHALL NOT claim to prove destination-file custody or protected transfer to the target Mac.
+This refines `SPEC.md` §§7.5.4, 8.1, and 10.2.
+
+#### Scenario: Browser accepts one-time delivery
+- **WHEN** the authenticated client starts a download for the newly created bundle
+- **THEN** the client acknowledges only the Enrollment identifier
+- **THEN** Orchard verifies that identifier against socket-owned pending issuance state
+- **THEN** Orchard marks the Enrollment `issued`
+- **THEN** Console removes the one-time bundle bytes from reachable application state
+
+#### Scenario: Browser delivery fails
+- **WHEN** the client cannot create or start the bundle download
+- **THEN** the client reports failure with only the Enrollment identifier
+- **THEN** Orchard marks the Enrollment `output_failed`
+- **THEN** Console explains that no Node identity or trust was established
+- **THEN** Console offers **Create new enrollment** without redisplaying the failed bundle
+
+#### Scenario: Delivery acknowledgement is lost
+- **WHEN** the client disconnects after Enrollment creation without a valid success or failure acknowledgement
+- **THEN** the Enrollment remains `pending_publication` and cannot be redeemed
+- **THEN** stale-publication reconciliation may mark it `output_failed`
+- **THEN** reconnecting does not redisplay or resend the same bundle
+- **THEN** a URL containing only the non-secret Enrollment identifier restores durable status
+- **THEN** a still-`pending_publication` Enrollment does not expose a join command
+
+#### Scenario: Delivery acknowledgements race
+- **WHEN** a stale client success or failure acknowledgement arrives after Console has left delivery state
+- **THEN** Console ignores it
+- **WHEN** a publication transition returns an ambiguous error
+- **THEN** Console reconciles the claim against the durable Enrollment state
+- **THEN** Console does not claim output failure for an Enrollment already stored as `issued` or `consumed`
+- **THEN** Console does not claim completed output failure while the Enrollment remains `pending_publication`
+
+#### Scenario: Duplicate issuance event arrives
+- **WHEN** an issuance event arrives after Console has left the enrollment-form stage
+- **THEN** Console ignores the event
+- **THEN** Console does not create another provisioned Node or replace the in-flight Enrollment
+
+#### Scenario: Durable recovery respects publication surface
+- **WHEN** a status URL names an Enrollment created by a non-Console publication surface
+- **THEN** Console does not claim that a browser accepted its download
+- **THEN** Console does not reconstruct a browser download path or command
+- **THEN** Console directs the operator to continue from the issuing surface or create a new Console Enrollment
+
+#### Scenario: Administrator returns to the base Add Node route
+- **WHEN** browser navigation returns from an Enrollment status URL to `/console/nodes/new`
+- **THEN** Console clears the previous delivery and monitor state
+- **THEN** Console shows a fresh enrollment form without issuing another bundle
+
+### Requirement: Console Observes Registration Automatically
+After successful bundle delivery, Console SHALL poll durable Enrollment and Node state automatically at a bounded interval.
+Console SHALL show the last successful check time and MAY offer **Refresh now** as a fallback.
+Console SHALL NOT ask the operator to record package installation, service start, registration, transport authorization, health, or activation.
+Before registration, Console SHALL present one current blocker with the exact target-Mac action and expected result.
+After registration, Console SHALL link to the existing explicit admission review.
+After admission, Node activation SHALL remain system-managed and SHALL require fresh healthy authenticated evidence.
+
+#### Scenario: Registration remains pending
+- **WHEN** the Enrollment is issued and its Node remains `provisioned`
+- **THEN** Console says to run the generated join command on the target Mac
+- **THEN** Console continues automatic checks without requiring an operator status action
+- **THEN** scheduling remains blocked
+
+#### Scenario: Registration completes
+- **WHEN** certificate-backed redemption advances the Node to `registered`
+- **THEN** the next automatic check shows **Registered - awaiting admission**
+- **THEN** Console offers a link to admission review
+- **THEN** Console does not admit or activate the Node automatically
+
+#### Scenario: Enrollment can no longer register
+- **WHEN** the Enrollment is expired, revoked, or `output_failed`
+- **THEN** Console names the terminal state and why the bundle cannot be used
+- **THEN** Console states that trust and Node identity were not established by that bundle
+- **THEN** Console offers **Create new enrollment** and does not offer restore or redisplay
+
+#### Scenario: Consumed enrollment passes its original expiry
+- **WHEN** an Enrollment is `consumed` and its original token expiry passes
+- **THEN** Console continues to show durable registration, admission, and activation state
+- **THEN** Console does not show bundle-transfer instructions or a join command
+- **THEN** Console does not treat the completed one-time redemption as an expired recovery flow
+
+### Requirement: Initial Pool Is Non-Authoritative Admission Intent
+The Console Add Node form SHALL present `general` as the default initial Pool intent and SHALL explain that a Pool is an existing scheduling group.
+The Pool intent MAY be changed before issuance and during admission review.
+Pool intent SHALL NOT establish identity, trust, registration, admission, activation, or request-time scheduling eligibility.
+Custom Pool management SHALL remain outside the Add Node journey.
+
+#### Scenario: Administrator accepts the general Pool intent
+- **WHEN** the administrator creates an Enrollment without changing Pool intent
+- **THEN** Console records `general` as bounded non-secret intent
+- **THEN** admission review may prefill `general`
+- **THEN** admission execution still revalidates every trust, policy, capacity, leadership, and write-path blocker
+
+#### Scenario: Active Node is evaluated per request
+- **WHEN** the admitted Node later becomes `active`
+- **THEN** Console may say Orchard can consider the Node for scheduling
+- **THEN** Console does not claim that every exact Model is compatible, loaded, eligible, or guaranteed dispatch

--- a/openspec/changes/add-console-node-enrollment-flow/tasks.md
+++ b/openspec/changes/add-console-node-enrollment-flow/tasks.md
@@ -1,0 +1,31 @@
+## 1. Contract And Design
+
+- [x] 1.1 Add this OpenSpec proposal, design, tasks, and operator-first-run requirement delta.
+- [x] 1.2 Add reusable guided-progress, blocker, automatic polling, one-time secret output, and recovery rules to `docs/DESIGN.md`.
+- [x] 1.3 Validate the change strictly before product-code implementation.
+
+## 2. Shared Enrollment Publication Contract
+
+- [x] 2.1 Move non-secret Controller endpoint metadata into a shared module consumed by CLI and Console.
+- [x] 2.2 Add a Controller-owned Node Enrollment Bundle builder that creates one `pending_publication` Enrollment and returns the canonical encoded artifact without marking it issued.
+- [x] 2.3 Refactor the CLI publication adapter to use the shared builder while preserving owner-only exclusive output and failure reconciliation.
+- [x] 2.4 Add focused builder and adapter tests for canonical bundle fields, owner-only CLI publication, Console one-time delivery, and secret exclusion from audit metadata.
+
+## 3. Console Add Node Flow
+
+- [x] 3.1 Add `/console/nodes/new` and an **Add Node** action on the Nodes workspace.
+- [x] 3.2 Add the ordered preparation and enrollment form with intended Node name, `general` Pool intent, and bounded expiry.
+- [x] 3.3 Add the one-time browser delivery hook, acknowledgement validation, issued transition, output-failure transition, and no-redisplay behavior.
+- [x] 3.4 Add the exact target-Mac join command, secure transfer guidance, automatic five-second polling, last-checked time, and manual refresh fallback.
+- [x] 3.5 Hand registered Nodes into the existing Node detail and explicit admission review without a manual registration or activation action.
+- [x] 3.6 Prefill admission Pool intent when available while preserving execution-time blocker revalidation.
+
+## 4. Verification
+
+- [x] 4.1 Add LiveView tests for discovery, ordered guidance, validation, success, client delivery failure, lost acknowledgement, expiry, revocation, registration polling, and admission handoff.
+- [x] 4.2 Add client-hook tests for Blob type, sanitized filename, acknowledgement payload, failure payload, object URL revocation, and memory cleanup.
+- [x] 4.3 Run focused domain, CLI, Console, asset, and browser tests.
+- [x] 4.4 Run `mise exec -- mix format`, compile with warnings as errors, Credo strict, Dialyzer, the complete test suite, and coverage.
+- [x] 4.5 Run strict validation for this change and the complete OpenSpec tree.
+- [x] 4.6 Perform browser design QA against the accepted MagicPath v4 flow at matching desktop states and record evidence in the implementation PR rather than a committed transient report.
+- [x] 4.7 Obtain independent review of the final diff before handoff.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "npm": "11.13.0"
   },
   "scripts": {
-    "openspec": "OPENSPEC_TELEMETRY=0 openspec"
+    "openspec": "OPENSPEC_TELEMETRY=0 openspec",
+    "test:assets": "node --test apps/orchard_controller/assets/test/*.test.mjs"
   },
   "devDependencies": {
     "@fission-ai/openspec": "1.10.0",


### PR DESCRIPTION
## Context

Orchard had Node lifecycle and enrollment primitives, but the Console did not provide a complete guided path from creating an enrollment through preparing a target host, downloading the one-time Enrollment Bundle, running `orchardctl node join`, observing registration, and performing explicit human admission.

This change adds that end-to-end guided flow while preserving Orchard's existing trust, lifecycle, and scheduling boundaries.

## What changed

- Add a guided Add Node LiveView wizard linked from the Nodes surface.
- Generate and deliver a one-time, short-lived JSON Enrollment Bundle with explicit Console provenance.
- Provide the exact `orchardctl node join --enrollment-bundle PATH` handoff and distinguish source-development setup from packaged multi-Mac rehearsal.
- Poll registration state automatically and keep human admission explicit before the Node becomes active and eligible.
- Fail closed across duplicate events, reload recovery, stale acknowledgements, download cleanup failures, and publication races.
- Move shared Runtime Endpoint metadata into `orchard_shared` for Console and CLI use.
- Add the OpenSpec change package and reusable Console guidance to `docs/DESIGN.md`.
- Add focused regression coverage for enrollment, download, CLI, dispatch, request lifecycle, TLS identity, and concurrent test isolation.

## Verification

- `make check-elixir`
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate add-console-node-enrollment-flow --type change --strict --no-interactive`
- Repository-wide strict OpenSpec validation, 41 changes passed
- Enrollment download asset tests, 11 passed
- Desktop and mobile browser QA in light and dark modes
- Exact-head RP Oracle review: GO
- Exact-head Fable 5 High review: GO
- Exact-head Grok 4.6 review: GO
- Exact-head OpenAI GPT-5.6 Sol Pro review through OpenRouter: GO

The full Elixir gate passed, including formatting, warnings-as-errors compilation, Credo, Dialyzer, tests, and coverage.

## Risk Assessment

⚠️ **Medium**

- The change touches security-sensitive one-time enrollment material, Console state transitions, CLI handoff, and request concurrency tests.
- Bundle delivery and acknowledgement paths fail closed, and reload, duplicate-event, stale-event, and publication-race cases have direct regression coverage.
- Explicit human admission remains required, and activation and scheduling eligibility are not implied by bundle issuance or registration alone.
- No database migration or compatibility-breaking API change is introduced.
- Browser QA proves the download-attempt and cleanup behavior, but cannot prove destination custody after the browser accepts the download.
- Packaged multi-machine production acceptance remains outside this PR.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a guided Console workflow for creating, downloading, monitoring, and explicitly admitting a Node enrollment.
- Adds one-time browser delivery of bounded enrollment bundles with acknowledgement and cleanup handling.
- Centralizes bundle issuance and Runtime Endpoint metadata for Console and CLI consumers.
- Adds enrollment recovery, polling, admission defaults, operator guidance, and focused regression coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the available follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/console/node_enrollment_live.ex | Implements the guided enrollment wizard, durable recovery, delivery acknowledgement, registration polling, and explicit admission handoff. |
| apps/orchard_controller/lib/orchard/node_enrollment_bundle.ex | Centralizes bounded enrollment-bundle construction and publication-state reconciliation for Console and CLI callers. |
| apps/orchard_controller/lib/orchard/node_enrollments.ex | Extends enrollment state handling and lookup support used by the guided workflow. |
| apps/orchard_controller/assets/js/node_enrollment_bundle_download.mjs | Validates and downloads one-time bundle payloads while clearing transient content and acknowledging only the enrollment identifier. |
| apps/orchard_cli/lib/orchard_cli/commands/node_enrollment.ex | Delegates CLI enrollment issuance to the shared bundle issuer while retaining exclusive output publication behavior. |
| apps/orchard_shared/lib/orchard/endpoint_metadata.ex | Moves Runtime Endpoint metadata into orchard_shared for use by both Controller and CLI applications. |
| apps/orchard_controller/lib/orchard/console/node_detail_live.ex | Prefills admission inputs from the Node enrollment’s certificate and initial pool metadata. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor Operator
    participant Console as Console LiveView
    participant Enrollment as Enrollment Service
    participant Browser as Browser Hook
    participant CLI as orchardctl on Node
    Operator->>Console: Create enrollment
    Console->>Enrollment: Issue pending bundle
    Enrollment-->>Console: Bundle and enrollment ID
    Console->>Browser: Push one-time bundle
    Browser->>Browser: Download and clear transient bytes
    Browser-->>Console: Acknowledge bounded enrollment ID
    Console->>Enrollment: Mark issued
    Operator->>CLI: node join --enrollment-bundle PATH
    CLI->>Enrollment: Redeem and register
    Console->>Enrollment: Poll registration state
    Operator->>Console: Review and admit Node
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into najibninaba/add..."](https://github.com/kapitan-ai/orchard/commit/050a8647e1ac8878a3c9c090df5bff3aef280379) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60595077)</sub>

<!-- /greptile_comment -->