### PR TITLE
feat(console): separate Node evidence and action sections

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/node_detail_live.ex
@@ -14,6 +14,8 @@ defmodule OrchardConsole.NodeDetailLive do
     StatusBuilder
   }
 
+  alias Phoenix.LiveView.JS
+
   alias Orchard.ControlPlane
   alias Orchard.NodeEnrollments
   alias Orchard.Nodes
@@ -34,6 +36,8 @@ defmodule OrchardConsole.NodeDetailLive do
        page_title: "Node Detail",
        active_nav: :nodes,
        page_mode: :workspace,
+       section: :overview,
+       return_section: :inventory,
        target_kind: nil,
        target_id: nil,
        load_status: :loading,
@@ -43,6 +47,7 @@ defmodule OrchardConsole.NodeDetailLive do
        memory_budget: nil,
        action: nil,
        refresh_timer: nil,
+       last_successful_refresh: nil,
        message: nil
      )}
   end
@@ -51,10 +56,40 @@ defmodule OrchardConsole.NodeDetailLive do
   def handle_params(params, _uri, socket) do
     {target_kind, target_id} = target_from_params(socket.assigns.live_action, params)
 
+    section =
+      case params["section"] do
+        "evidence" -> :evidence
+        "actions" -> :actions
+        _ -> :overview
+      end
+
+    socket =
+      assign(socket,
+        section: section,
+        return_section:
+          if(params["from"] == "admissions" or target_kind == :candidate,
+            do: :admissions,
+            else: :inventory
+          )
+      )
+
+    if socket.assigns.target_kind == target_kind and socket.assigns.target_id == target_id do
+      {:noreply, socket}
+    else
+      load_target(socket, target_kind, target_id)
+    end
+  end
+
+  defp load_target(socket, target_kind, target_id) do
     socket =
       assign(socket,
         target_kind: target_kind,
         target_id: target_id,
+        record: nil,
+        status: nil,
+        latest_decision: nil,
+        memory_budget: nil,
+        last_successful_refresh: nil,
         load_status: :loading,
         action: nil,
         message: nil
@@ -69,10 +104,30 @@ defmodule OrchardConsole.NodeDetailLive do
 
   @impl true
   def handle_info(:refresh_node_detail, socket) do
-    {:noreply, socket |> load_detail() |> schedule_refresh()}
+    {:noreply, socket |> cancel_refresh() |> load_detail() |> schedule_refresh()}
   end
 
   @impl true
+  def handle_event("refresh_detail", _params, socket) do
+    {:noreply, socket |> cancel_refresh() |> load_detail() |> schedule_refresh()}
+  end
+
+  def handle_event(event, _params, %{assigns: %{load_status: :stale}} = socket)
+      when event in [
+             "open_admit",
+             "open_reject",
+             "open_lifecycle",
+             "action_change",
+             "execute_action"
+           ] do
+    {:noreply,
+     put_flash(
+       socket,
+       :error,
+       "Refresh Node detail successfully before reviewing or executing an action."
+     )}
+  end
+
   def handle_event("open_admit", _params, socket) do
     if can_open_admit?(socket.assigns.target_kind, socket.assigns.record, socket.assigns.status) do
       inputs = default_admission_inputs(socket.assigns.record)
@@ -148,12 +203,25 @@ defmodule OrchardConsole.NodeDetailLive do
   def render(assigns) do
     ~H"""
     <div id="node-detail-page" class="space-y-6">
+    <div class="flex flex-wrap items-center justify-between gap-3">
       <.link
-        navigate={~p"/console/nodes"}
+        navigate={~p"/console/nodes?#{[section: @return_section]}"}
         class="inline-flex items-center rounded-md px-2 py-1 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-navy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-sky-300 dark:focus-visible:ring-sky-400"
       >
-        Back to Nodes
-      </.link>
+    Back to Nodes
+    </.link>
+    <.button id="node-detail-refresh" variant={:secondary} size={:sm} phx-click="refresh_detail" phx-disable-with="Refreshing...">
+    <.icon name="hero-arrow-path" class="mr-1.5 h-4 w-4" />
+    {if @load_status in [:error, :stale], do: "Retry refresh", else: "Refresh detail"}
+    </.button>
+    </div>
+    <div :if={@load_status == :stale} id="node-detail-refresh-warning" role="status" class="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100">
+    <p class="font-semibold">Refresh failed. Showing the last successful detail.</p>
+    <p class="mt-1">Current state is unconfirmed. Action previews are unavailable until a refresh succeeds.</p>
+    </div>
+    <p :if={@last_successful_refresh} id="node-detail-last-success" class="text-xs text-slate-500 dark:text-slate-400">
+    Last successful page refresh <.local_time value={@last_successful_refresh} format={:datetime_second} />. Observation times are shown with their evidence below.
+    </p>
 
       <%= cond do %>
         <% @load_status == :loading -> %>
@@ -164,55 +232,28 @@ defmodule OrchardConsole.NodeDetailLive do
           <.state_message id="node-detail-error" kind={:error} layout={:panel} title="Node detail unavailable." body={@message} />
         <% true -> %>
           <div id="node-detail-content" class="space-y-6">
+    <nav id="node-detail-sections" aria-label="Node detail sections" class="flex flex-wrap gap-2">
+    <.link :for={{section, label} <- [overview: "Overview", evidence: "Evidence", actions: "Actions"]}
+    id={"node-detail-section-#{section}"} patch={detail_section_path(@target_kind, @target_id, section, @return_section)}
+    aria-current={if @section == section, do: "page"}
+    class={["rounded-md border px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:focus-visible:ring-sky-400", if(@section == section, do: "border-navy bg-navy text-white dark:border-sky-500 dark:bg-sky-500 dark:hover:bg-sky-400", else: "border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800")]}>
+    {label}
+    </.link>
+    </nav>
             <div id="node-detail-header-card">
               <.card>
                 <:title>{detail_title(@target_kind, @record)}</:title>
                 <:subtitle>{detail_subtitle(@target_kind, @record)}</:subtitle>
 
-                <div
-                  :if={detail_action_buttons?(@target_kind, @record, @status)}
-                  id="node-detail-actions"
-                  class="mb-4 flex flex-wrap gap-2"
-                >
-                  <.button
-                    :if={can_open_admit?(@target_kind, @record, @status)}
-                    id="node-detail-open-admit"
-                    variant={:primary}
-                    size={:sm}
-                    phx-click="open_admit"
-                  >
-                    Admit Node
-                  </.button>
-                  <.button
-                    :if={can_open_reject?(@target_kind, @record, @status)}
-                    id="node-detail-open-reject"
-                    variant={:danger}
-                    size={:sm}
-                    phx-click="open_reject"
-                  >
-                    Preview reject
-                  </.button>
-                  <.button
-                    :for={lifecycle_action <- lifecycle_action_buttons(@target_kind, @record)}
-                    id={"node-detail-open-lifecycle-#{lifecycle_action}"}
-                    variant={lifecycle_action_variant(lifecycle_action)}
-                    size={:sm}
-                    phx-click="open_lifecycle"
-                    phx-value-action={lifecycle_action}
-                  >
-                    {lifecycle_action_button_label(lifecycle_action)}
-                  </.button>
-                </div>
-
                 <div class="flex flex-wrap items-center gap-2">
                   <.badge tone={admission_category_tone(status_value(@status, :admission, :category))}>
-                    {format_status_value(status_value(@status, :admission, :category))}
+                    Admission: {format_status_value(status_value(@status, :admission, :category))}
                   </.badge>
                   <.badge tone={health_tone(status_value(@status, :health, :status))}>
-                    {format_status_value(status_value(@status, :health, :status))}
+                    Health: {format_status_value(status_value(@status, :health, :status))}
                   </.badge>
                   <.badge tone={freshness_tone(status_value(@status, :freshness, :status))}>
-                    {format_status_value(status_value(@status, :freshness, :status))}
+                    Observation: {format_status_value(status_value(@status, :freshness, :status))}
                   </.badge>
                   <span class="text-xs font-mono text-slate-500 dark:text-slate-400">
                     {resource_id(@target_kind, @record)}
@@ -221,9 +262,53 @@ defmodule OrchardConsole.NodeDetailLive do
               </.card>
             </div>
 
-            <div id="node-detail-status-groups" class="grid gap-4 lg:grid-cols-2">
+            <div id="node-detail-actions-section" hidden={@section != :actions} class="space-y-4">
+              <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100">Actions</h2>
+              <p class="text-sm text-slate-600 dark:text-slate-300">Review consequences and required confirmations before changing this Node.</p>
+              <p :if={@load_status == :stale} class="text-sm text-amber-800 dark:text-amber-200">Refresh successfully to make actions available again.</p>
+                <div
+                  :if={@load_status == :ok and detail_action_buttons?(@target_kind, @record, @status)}
+                  id="node-detail-actions"
+                  class="mb-4 flex flex-wrap gap-2"
+                >
+                  <.button
+                    :if={can_open_admit?(@target_kind, @record, @status)}
+                    id="node-detail-open-admit"
+                    variant={:primary}
+                    size={:sm}
+                    phx-click={JS.push_focus() |> JS.push("open_admit") |> JS.focus(to: "#node-action-preview-heading")}
+                  >
+                    Admit Node
+                  </.button>
+                  <.button
+                    :if={can_open_reject?(@target_kind, @record, @status)}
+                    id="node-detail-open-reject"
+                    variant={:danger}
+                    size={:sm}
+                    phx-click={JS.push_focus() |> JS.push("open_reject") |> JS.focus(to: "#node-action-preview-heading")}
+                  >
+                    Preview reject
+                  </.button>
+                  <.button
+                    :for={lifecycle_action <- lifecycle_action_buttons(@target_kind, @record)}
+                    id={"node-detail-open-lifecycle-#{lifecycle_action}"}
+                    variant={lifecycle_action_variant(lifecycle_action)}
+                    size={:sm}
+                    phx-click={JS.push_focus() |> JS.push("open_lifecycle") |> JS.focus(to: "#node-action-preview-heading")}
+                    phx-value-action={lifecycle_action}
+                  >
+                    {lifecycle_action_button_label(lifecycle_action)}
+                  </.button>
+                </div>
+
+
+            <.action_preview_panel :if={@action} action={@action} />
+            </div>
+
+
+            <div id="node-detail-status-groups" hidden={@section == :actions} class={if @section == :actions, do: "hidden", else: "grid gap-4 lg:grid-cols-2"}>
               <.status_group
-                id="node-detail-lifecycle"
+                id="node-detail-lifecycle" hidden={@section != :overview}
                 title="Lifecycle"
                 badge={format_status_value(status_value(@status, :lifecycle, :state))}
                 tone={lifecycle_tone(status_value(@status, :lifecycle, :state))}
@@ -239,7 +324,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.status_group>
 
               <.status_group
-                id="node-detail-admission"
+                id="node-detail-admission" hidden={@section != :overview}
                 title="Admission"
                 badge={format_status_value(status_value(@status, :admission, :category))}
                 tone={admission_category_tone(status_value(@status, :admission, :category))}
@@ -258,7 +343,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.status_group>
 
               <.status_group
-                id="node-detail-health"
+                id="node-detail-health" hidden={@section != :overview}
                 title="Health"
                 badge={format_status_value(status_value(@status, :health, :status))}
                 tone={health_tone(status_value(@status, :health, :status))}
@@ -271,7 +356,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.status_group>
 
               <.status_group
-                id="node-detail-freshness"
+                id="node-detail-freshness" hidden={@section != :overview}
                 title="Freshness"
                 badge={format_status_value(status_value(@status, :freshness, :status))}
                 tone={freshness_tone(status_value(@status, :freshness, :status))}
@@ -295,23 +380,36 @@ defmodule OrchardConsole.NodeDetailLive do
               </.status_group>
 
               <.status_group
-                id="node-detail-transport"
-                title="Transport"
+                id="node-detail-transport" hidden={@section != :evidence}
+                title={transport_title(@target_kind)}
                 badge={format_status_value(status_value(@status, :transport, :status))}
                 tone={transport_tone(status_value(@status, :transport, :status))}
               >
                 <.detail_grid id="node-detail-transport-grid" class="sm:grid-cols-2">
-                  <.detail_field id="node-detail-transport-status" label="Transport" mono>
+                  <.detail_field id="node-detail-transport-status" label={transport_label(@target_kind)} mono>
                     {format_status_value(status_value(@status, :transport, :status))}
                   </.detail_field>
                   <.detail_field id="node-detail-target-ref" label="Target" mono break_all>
                     {target_ref(@target_kind, @record)}
                   </.detail_field>
+                  <.detail_field
+                    :if={@target_kind == :candidate}
+                    id="node-detail-transport-observed-at"
+                    label="Observed At"
+                    mono
+                  >
+                    <.local_time
+                      :if={@record.last_observed_at}
+                      value={@record.last_observed_at}
+                      format={:datetime_second}
+                    />
+                    <span :if={!@record.last_observed_at}>Never observed</span>
+                  </.detail_field>
                 </.detail_grid>
               </.status_group>
 
               <.status_group
-                id="node-detail-runtime"
+                id="node-detail-runtime" hidden={@section != :evidence}
                 title="Runtime"
                 badge={format_status_value(status_value(@status, :runtime, :status))}
                 tone={runtime_tone(status_value(@status, :runtime, :status))}
@@ -330,7 +428,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.status_group>
 
               <.status_group
-                id="node-detail-compatibility"
+                id="node-detail-compatibility" hidden={@section != :evidence}
                 title="Compatibility"
                 badge={format_status_value(status_value(@status, :compatibility, :status))}
                 tone={compatibility_tone(status_value(@status, :compatibility, :status))}
@@ -343,7 +441,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.status_group>
 
               <.status_group
-                id="node-detail-scheduling"
+                id="node-detail-scheduling" hidden={@section != :overview}
                 title="Scheduling"
                 badge={scheduling_badge(status_value(@status, :scheduling, :eligible))}
                 tone={scheduling_tone(status_value(@status, :scheduling, :eligible))}
@@ -363,7 +461,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.status_group>
             </div>
 
-            <div :if={@memory_budget} id="node-detail-memory-budget">
+            <div :if={@memory_budget} id="node-detail-memory-budget" hidden={@section != :evidence}>
               <.card>
                 <:title>Memory Telemetry</:title>
                 <:subtitle>Observe-only memory-budget diagnostics. This section is non-gating.</:subtitle>
@@ -426,7 +524,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.card>
             </div>
 
-            <div id="node-detail-warnings-card">
+            <div id="node-detail-warnings-card" hidden={@section != :overview}>
               <.card>
                 <:title>Warnings</:title>
                 <.coded_entry_list
@@ -438,7 +536,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.card>
             </div>
 
-            <div :if={@latest_decision} id="node-detail-latest-decision-card">
+            <div :if={@latest_decision} id="node-detail-latest-decision-card" hidden={@section != :actions}>
               <.card variant={:secondary}>
                 <:title>Latest Admission Decision</:title>
                 <.detail_grid id="node-detail-latest-decision-grid" class="sm:grid-cols-3">
@@ -457,7 +555,7 @@ defmodule OrchardConsole.NodeDetailLive do
 
             <div
               :if={observed_candidate_guidance?(@target_kind, @status)}
-              id="node-detail-enrollment-guidance-card"
+              id="node-detail-enrollment-guidance-card" hidden={@section != :actions}
             >
               <.card>
                 <:title>Enrollment Guidance</:title>
@@ -505,7 +603,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.card>
             </div>
 
-            <div :if={@target_kind == :candidate} id="node-detail-candidate-evidence-card">
+            <div :if={@target_kind == :candidate} id="node-detail-candidate-evidence-card" hidden={@section != :evidence}>
               <.card>
                 <:title>Candidate Evidence</:title>
                 <:subtitle>Observed candidate evidence is preserved as review context.</:subtitle>
@@ -528,7 +626,8 @@ defmodule OrchardConsole.NodeDetailLive do
                 </div>
                 <div :if={@record.node_id} class="mt-4">
                   <.link
-                    navigate={~p"/console/nodes/#{@record.node_id}"}
+                    id="node-detail-review-linked-node"
+                    navigate={~p"/console/nodes/#{@record.node_id}?from=admissions"}
                     class="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium text-navy hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-sky-300 dark:hover:bg-slate-800 dark:focus-visible:ring-sky-400"
                   >
                     Review linked node
@@ -537,7 +636,7 @@ defmodule OrchardConsole.NodeDetailLive do
               </.card>
             </div>
 
-            <.action_preview_panel :if={@action} action={@action} />
+
           </div>
       <% end %>
     </div>
@@ -547,6 +646,12 @@ defmodule OrchardConsole.NodeDetailLive do
   # ===========================================================================
   # Data loading
   # ===========================================================================
+
+  defp detail_section_path(:node, id, section, origin),
+    do: ~p"/console/nodes/#{id}?#{[section: section, from: origin]}"
+
+  defp detail_section_path(:candidate, id, section, origin),
+    do: ~p"/console/nodes/pending/#{id}?#{[section: section, from: origin]}"
 
   defp target_from_params(:candidate, %{"candidate_id" => candidate_id}),
     do: {:candidate, candidate_id}
@@ -563,6 +668,7 @@ defmodule OrchardConsole.NodeDetailLive do
         |> assign(
           page_title: "#{node.display_name || node.hostname || "Node"} Detail",
           load_status: :ok,
+          last_successful_refresh: DateTime.utc_now(),
           record: node,
           status: status,
           latest_decision: latest_decision,
@@ -573,6 +679,8 @@ defmodule OrchardConsole.NodeDetailLive do
 
       {:error, :node_not_found} ->
         assign(socket,
+          page_title: "Node Detail",
+          last_successful_refresh: nil,
           load_status: :not_found,
           record: nil,
           status: nil,
@@ -602,6 +710,7 @@ defmodule OrchardConsole.NodeDetailLive do
         |> assign(
           page_title: "#{candidate_display_label(candidate)} Detail",
           load_status: :ok,
+          last_successful_refresh: DateTime.utc_now(),
           record: candidate,
           status: status,
           latest_decision: latest_decision,
@@ -612,6 +721,8 @@ defmodule OrchardConsole.NodeDetailLive do
 
       {:error, :candidate_not_found} ->
         assign(socket,
+          page_title: "Node Detail",
+          last_successful_refresh: nil,
           load_status: :not_found,
           record: nil,
           status: nil,
@@ -631,6 +742,10 @@ defmodule OrchardConsole.NodeDetailLive do
       detail_error(socket)
   end
 
+  defp detail_error(%{assigns: %{record: record}} = socket) when not is_nil(record) do
+    assign(socket, load_status: :stale, action: nil, message: "Node detail refresh failed.")
+  end
+
   defp detail_error(socket) do
     assign(socket,
       load_status: :error,
@@ -646,7 +761,14 @@ defmodule OrchardConsole.NodeDetailLive do
   defp refresh_open_action(%{assigns: %{action: nil}} = socket), do: socket
 
   defp refresh_open_action(%{assigns: %{action: action}} = socket) do
-    refreshed = put_action(socket, action.kind, action.inputs, action.confirmed)
+    refreshed = put_action(socket, action.kind, action.inputs, false)
+
+    refreshed =
+      if refreshed.assigns.action.preview == action.preview do
+        assign(refreshed, action: %{refreshed.assigns.action | confirmed: action.confirmed})
+      else
+        refreshed
+      end
 
     case action.error do
       nil -> refreshed
@@ -996,6 +1118,18 @@ defmodule OrchardConsole.NodeDetailLive do
     end
   end
 
+  defp current_preview_state(preview) do
+    current = preview_value(preview, :current)
+
+    case status_value(current, :resource, :type) do
+      type when type in [:admission_candidate, "admission_candidate"] ->
+        status_value(current, :admission, :category)
+
+      _ ->
+        status_value(current, :lifecycle, :state)
+    end
+  end
+
   defp preview_value(preview, key) when is_map(preview), do: map_get(preview, key)
   defp preview_value(_preview, _key), do: nil
 
@@ -1160,6 +1294,12 @@ defmodule OrchardConsole.NodeDetailLive do
     do: :error
 
   defp transport_tone(_status), do: :neutral
+
+  defp transport_title(:candidate), do: "Transport at last observation"
+  defp transport_title(_target_kind), do: "Transport"
+
+  defp transport_label(:candidate), do: "Observed transport"
+  defp transport_label(_target_kind), do: "Transport"
 
   defp runtime_tone("ready"), do: :success
   defp runtime_tone("not_ready"), do: :error
@@ -1343,13 +1483,14 @@ defmodule OrchardConsole.NodeDetailLive do
 
   attr(:id, :string, required: true)
   attr(:title, :string, required: true)
+  attr(:hidden, :boolean, default: false)
   attr(:badge, :string, default: nil)
   attr(:tone, :atom, default: :neutral)
   slot(:inner_block, required: true)
 
   defp status_group(assigns) do
     ~H"""
-    <div id={@id}>
+    <div id={@id} hidden={@hidden}>
       <.card padding={:sm}>
         <:title>
           <span class="flex flex-wrap items-center gap-2">
@@ -1446,16 +1587,17 @@ defmodule OrchardConsole.NodeDetailLive do
 
   defp action_preview_panel(assigns) do
     ~H"""
-    <div id="node-action-preview">
+    <div id="node-action-preview" role="region" aria-label={action_title(@action.kind)} class="scroll-mt-6">
       <.card class={action_panel_class(@action.kind)}>
-        <:title>{action_title(@action.kind)}</:title>
+        <:title><span id="node-action-preview-heading" tabindex="-1" phx-mounted={JS.focus()} class="block scroll-mt-6">{action_title(@action.kind)}</span></:title>
         <:subtitle>{action_explanation(@action.kind)}</:subtitle>
 
+        <.button id="action-close-preview" variant={:secondary} size={:sm} phx-click={JS.push("cancel_action") |> JS.pop_focus()} class="mb-4">Close preview</.button>
         <form id={action_form_id(@action.kind)} phx-change="action_change" phx-submit="execute_action" class="space-y-5">
           <div id="action-preview-summary" class="grid gap-4 lg:grid-cols-3">
             <.detail_grid id="action-preview-current" class="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-950">
               <.detail_field id="action-preview-current-state" label="Current" mono>
-                {format_status_value(nested_preview_value(@action.preview, :current, :state))}
+                {format_status_value(current_preview_state(@action.preview))}
               </.detail_field>
               <.detail_field id="action-preview-active-requests" label="Active Requests" mono>
                 {format_optional(preview_value(@action.preview, :active_request_count))}
@@ -1635,8 +1777,8 @@ defmodule OrchardConsole.NodeDetailLive do
           </p>
 
           <div class="flex flex-wrap justify-end gap-2">
-            <.button id="action-cancel" variant={:secondary} phx-click="cancel_action">
-              Cancel
+            <.button id="action-cancel" variant={:secondary} phx-click={JS.push("cancel_action") |> JS.pop_focus()}>
+              Close preview
             </.button>
             <.button
               id="action-submit"

--- a/apps/orchard_controller/lib/orchard/console/node_enrollment_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/node_enrollment_live.ex
@@ -376,7 +376,7 @@ defmodule OrchardConsole.NodeEnrollmentLive do
     <section id="node-enrollment-step" class="space-y-6">
       <div>
         <p class="text-sm font-medium text-sky-700 dark:text-sky-300">Step 2 of 5</p>
-        <h2 class="mt-1 text-xl font-semibold text-slate-950 dark:text-white">Create a one-time enrollment</h2>
+        <h2 id="node-enrollment-heading" tabindex="-1" phx-mounted={Phoenix.LiveView.JS.focus(to: "#node-enrollment-heading")} class="mt-1 text-xl font-semibold text-slate-950 dark:text-white">Create a one-time enrollment</h2>
         <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
           The downloaded bundle contains a short-lived secret. Orchard will not display or download it again.
         </p>
@@ -580,7 +580,7 @@ defmodule OrchardConsole.NodeEnrollmentLive do
                 !terminal_enrollment?(@enrollment)
             }
             id="review-node-admission"
-            navigate={~p"/console/nodes/#{@delivery.node_id}"}
+            navigate={~p"/console/nodes/#{@delivery.node_id}?section=actions&from=admissions"}
             class="inline-flex items-center justify-center rounded-md bg-navy px-4 py-2 text-sm font-medium text-white hover:bg-navy-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy focus-visible:ring-offset-2 dark:bg-sky-500 dark:hover:bg-sky-400 dark:focus-visible:ring-sky-400"
           >
             Review and Admit Node

--- a/apps/orchard_controller/lib/orchard/console/nodes_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/nodes_live.ex
@@ -37,7 +37,12 @@ defmodule OrchardConsole.NodesLive do
   def mount(_params, _session, socket) do
     socket =
       socket
-      |> assign(page_title: "Nodes", active_nav: :nodes, page_mode: :workspace)
+      |> assign(
+        page_title: "Nodes",
+        active_nav: :nodes,
+        page_mode: :workspace,
+        section: :inventory
+      )
 
     if connected?(socket) do
       {:ok, socket |> load_nodes_page() |> schedule_refresh()}
@@ -47,8 +52,21 @@ defmodule OrchardConsole.NodesLive do
   end
 
   @impl true
+  def handle_params(params, _uri, socket) do
+    section =
+      case params["section"] do
+        "admissions" -> :admissions
+        "runtime" -> :runtime
+        "diagnostics" -> :diagnostics
+        _ -> :inventory
+      end
+
+    {:noreply, assign(socket, section: section)}
+  end
+
+  @impl true
   def handle_info(:refresh_nodes, socket) do
-    {:noreply, socket |> load_nodes_page() |> schedule_refresh()}
+    {:noreply, socket |> cancel_refresh() |> load_nodes_page() |> schedule_refresh()}
   end
 
   @impl true
@@ -74,8 +92,31 @@ defmodule OrchardConsole.NodesLive do
         </.link>
       </div>
 
+    <nav id="nodes-sections" aria-label="Nodes sections" class="flex flex-wrap gap-2">
+    <.link :for={{section, label} <- [inventory: "Inventory", admissions: "Admission Review", runtime: "Runtime", diagnostics: "Diagnostics"]}
+    id={"nodes-section-#{section}"} patch={~p"/console/nodes?#{[section: section]}"}
+    aria-current={if @section == section, do: "page"}
+    class={["rounded-md border px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:focus-visible:ring-sky-400", if(@section == section, do: "border-navy bg-navy text-white dark:border-sky-500 dark:bg-sky-500 dark:hover:bg-sky-400", else: "border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800")]}>
+    {label}
+    </.link>
+    </nav>
+        <div id="nodes-freshness" class="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+          <span :if={@last_refreshed_at == nil} class="font-mono">Waiting for first live update</span>
+          <span :if={@last_refreshed_at != nil} class="font-mono">
+            Last refresh attempt <.local_time value={@last_refreshed_at} format={:time_second} />
+          </span>
+          <span :if={@last_refreshed_at != nil}>· Auto-refreshing every {refresh_interval_label()}</span>
+          <.button
+            id="nodes-refresh-now"
+            variant={:ghost}
+            size={:sm}
+            phx-click="refresh_now"
+          >
+            Refresh now
+          </.button>
+        </div>
       <%!-- Inventory Summary --%>
-      <div id="nodes-summary-card">
+      <div id="nodes-summary-card" hidden={@section != :inventory}>
       <.card>
         <:title>Inventory Summary</:title>
         <:subtitle>Persisted node inventory with periodic runtime refresh.</:subtitle>
@@ -88,26 +129,12 @@ defmodule OrchardConsole.NodesLive do
           <.summary_tile id="nodes-summary-unreachable" label="Unreachable" value={format_count(@inventory.summary.by_health[:unreachable])} tone={:error} />
         </div>
 
-        <div id="nodes-freshness" class="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
-          <span :if={@last_refreshed_at == nil} class="font-mono">Waiting for first live update</span>
-          <span :if={@last_refreshed_at != nil} class="font-mono">
-            Last refreshed <.local_time value={@last_refreshed_at} format={:time_second} />
-          </span>
-          <span :if={@last_refreshed_at != nil}>· Auto-refreshing every {refresh_interval_label()}</span>
-          <.button
-            id="nodes-refresh-now"
-            variant={:ghost}
-            size={:sm}
-            phx-click="refresh_now"
-          >
-            Refresh now
-          </.button>
-        </div>
+
       </.card>
       </div>
 
       <%!-- Admission Review Queue --%>
-      <div id="nodes-pending-admissions-card">
+      <div id="nodes-pending-admissions-card" hidden={@section != :admissions}>
       <.card>
         <:title>Admission Review</:title>
         <:subtitle>{pending_admissions_subtitle(@pending_admissions)}</:subtitle>
@@ -180,13 +207,14 @@ defmodule OrchardConsole.NodesLive do
       </div>
 
       <%!-- Main Grid --%>
-      <div class="grid gap-6 xl:grid-cols-12">
-        <div class="xl:col-span-8">
+      <div class="space-y-6">
+        <div hidden={@section != :inventory}>
           <div class="space-y-6">
           <%!-- Persisted Inventory Table --%>
-          <div id="nodes-inventory-card">
+          <div id="nodes-inventory-card" hidden={@section != :inventory}>
           <.card>
             <:title>Registered Nodes</:title>
+            <:subtitle>Lifecycle and health are separate. Inspect a Node for admission, observation freshness, and scheduling evidence.</:subtitle>
 
             <%= cond do %>
               <% @inventory.status == :loading -> %>
@@ -211,14 +239,19 @@ defmodule OrchardConsole.NodesLive do
                   </:col>
                   <:col :let={node} label="Hostname" mono>{node.hostname}</:col>
                   <:col :let={node} label="Address" mono>{format_address(node)}</:col>
-                  <:col :let={node} label="State">
+                  <:col :let={node} label="Lifecycle">
                     <.badge tone={state_badge_tone(node.state)}>{node.state}</.badge>
                   </:col>
                   <:col :let={node} label="Health">
                     <.badge tone={health_badge_tone(node.health)}>{node.health}</.badge>
                   </:col>
                   <:col :let={node} label="Agent Version" mono>{node.agent_version || "—"}</:col>
-                  <:col :let={node} label="Last Seen" mono><.local_time value={node.last_heartbeat_at} format={:datetime_second} /></:col>
+                  <:col :let={node} label="Last Seen" mono><.local_time value={node.last_heartbeat_at} format={:datetime_second} /></:col><:action :let={node}>
+    <.link navigate={~p"/console/nodes/#{node.id}"} class="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium text-navy hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-sky-300 dark:hover:bg-slate-800" aria-label={"Inspect #{node.display_name || node.hostname || node.id}"}>
+    Inspect Node <.icon name="hero-arrow-left" class="ml-1 h-4 w-4 rotate-180" />
+    </.link>
+    </:action>
+
                 </.table>
               <% true -> %>
                 <.state_message id="nodes-inventory-error" kind={:error} layout={:compact} title="Node inventory unavailable." body={@inventory.message} />
@@ -229,9 +262,9 @@ defmodule OrchardConsole.NodesLive do
         </div>
 
         <%!-- Live Cluster Column --%>
-        <div class="xl:col-span-4 space-y-6">
+        <div hidden={@section not in [:runtime, :diagnostics]} class="space-y-6">
           <%!-- Cluster Summary Card --%>
-          <div id="nodes-live-cluster-card">
+          <div id="nodes-live-cluster-card" hidden={@section != :runtime}>
           <.card variant={:rail} padding={:sm}>
             <:title>Live Cluster</:title>
             <:subtitle><%= cluster_subtitle(@cluster) %></:subtitle>
@@ -257,7 +290,7 @@ defmodule OrchardConsole.NodesLive do
           </div>
 
           <%!-- Control Plane Card --%>
-          <div id="nodes-control-plane-status-card">
+          <div id="nodes-control-plane-status-card" hidden={@section != :diagnostics}>
           <.card variant={:rail} padding={:sm}>
             <:title>Control Plane</:title>
             <:subtitle>{control_plane_subtitle(@control_plane)}</:subtitle>
@@ -305,7 +338,7 @@ defmodule OrchardConsole.NodesLive do
           </div>
 
           <%!-- Per-Target Runtime Cards --%>
-          <div id="nodes-runtime-targets" class="space-y-4">
+          <div id="nodes-runtime-targets" hidden={@section != :runtime} class="space-y-4">
             <div :for={t <- @cluster.targets} id={"nodes-runtime-card-#{t.target_dom_id}"}>
               <.card variant={:rail} padding={:sm}>
                 <:title><%= target_card_title(t) %></:title>
@@ -438,7 +471,7 @@ defmodule OrchardConsole.NodesLive do
         </div>
       </div>
 
-      <div id="nodes-safe-tokenization-telemetry-card">
+      <div id="nodes-safe-tokenization-telemetry-card" hidden={@section != :diagnostics}>
       <.card variant={:secondary}>
         <:title>Safe Tokenization Counters</:title>
         <:subtitle>Process-local observe-only counters since counter process start.</:subtitle>
@@ -804,8 +837,17 @@ defmodule OrchardConsole.NodesLive do
   end
 
   defp fetch_inventory do
-    rows = Nodes.list_nodes()
-    summary = Nodes.summary()
+    rows = Nodes.list_nodes_for_upgrade!()
+    health_counts = Enum.frequencies_by(rows, & &1.health)
+
+    summary = %{
+      total: length(rows),
+      by_health:
+        Map.new(Orchard.Nodes.Node.health_values(), fn health ->
+          {health, Map.get(health_counts, health, 0)}
+        end)
+    }
+
     NodesPageData.inventory(rows, summary)
   rescue
     _ ->
@@ -813,7 +855,10 @@ defmodule OrchardConsole.NodesLive do
         status: :error,
         rows: [],
         statuses: [],
-        summary: %{total: 0, by_health: %{healthy: 0, degraded: 0, unhealthy: 0, unreachable: 0}},
+        summary: %{
+          total: nil,
+          by_health: %{healthy: nil, degraded: nil, unhealthy: nil, unreachable: nil}
+        },
         message: "Node inventory unavailable."
       }
   end
@@ -1214,8 +1259,11 @@ defmodule OrchardConsole.NodesLive do
   defp rejected_review_count_label(1), do: "1 rejected record visible for audit."
   defp rejected_review_count_label(count), do: "#{count} rejected records visible for audit."
 
-  defp pending_detail_path(%{kind: :candidate, id: id}), do: ~p"/console/nodes/pending/#{id}"
-  defp pending_detail_path(%{kind: :node, id: id}), do: ~p"/console/nodes/#{id}"
+  defp pending_detail_path(%{kind: :candidate, id: id}),
+    do: ~p"/console/nodes/pending/#{id}?section=actions&from=admissions"
+
+  defp pending_detail_path(%{kind: :node, id: id}),
+    do: ~p"/console/nodes/#{id}?section=actions&from=admissions"
 
   defp status_value(status, group, key) when is_map(status) do
     case map_get(status, group) do

--- a/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_detail_live_test.exs
@@ -57,6 +57,7 @@ defmodule OrchardConsole.NodeDetailLiveTest do
   alias Orchard.Nodes.{AdmissionCandidate, AdmissionDecision, Node}
   alias Orchard.NodeTrust
   alias Orchard.Repo
+  alias Phoenix.HTML.Safe
 
   @moduletag :live
   @moduletag :db
@@ -96,6 +97,188 @@ defmodule OrchardConsole.NodeDetailLiveTest do
   end
 
   describe "node detail drill-in" do
+    test "refresh after deletion clears the old title and refresh timestamp", %{conn: conn} do
+      node = insert_node!(%{display_name: "deleted-node-detail", state: :registered})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+      assert has_element?(view, "#node-detail-last-success")
+      Repo.delete!(node)
+      view |> element("#node-detail-refresh") |> render_click()
+      assert has_element?(view, "#node-detail-not-found")
+      refute has_element?(view, "#node-detail-last-success")
+      refute has_element?(view, "#node-detail-content")
+      assert :sys.get_state(view.pid).socket.assigns.page_title == "Node Detail"
+    end
+
+    test "detail sections replace visible evidence and preserve an open action", %{conn: conn} do
+      node = insert_node!(%{state: :registered, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+      assert has_element?(view, "#node-detail-lifecycle:not([hidden])")
+      assert has_element?(view, "#node-detail-runtime[hidden]")
+      view |> element("#node-detail-section-evidence") |> render_click()
+      assert has_element?(view, "#node-detail-runtime:not([hidden])")
+      assert has_element?(view, "#node-detail-lifecycle[hidden]")
+      view |> element("#node-detail-section-actions") |> render_click()
+      assert has_element?(view, "#node-detail-actions-section:not([hidden])")
+      view |> element("#node-detail-open-admit") |> render_click()
+      assert has_element?(view, "#node-action-preview")
+      view |> element("#node-detail-section-overview") |> render_click()
+      assert has_element?(view, "#node-detail-actions-section[hidden]")
+      view |> element("#node-detail-section-actions") |> render_click()
+      assert has_element?(view, "#node-action-preview")
+      view |> element("#action-close-preview") |> render_click()
+      refute has_element?(view, "#node-action-preview")
+      assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "deep linked Actions retains Admission Review return context", %{conn: conn} do
+      node = insert_node!(%{state: :registered, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}?section=actions&from=admissions")
+      assert has_element?(view, "#node-detail-section-actions[aria-current='page']")
+      assert has_element?(view, "a[href='/console/nodes?section=admissions']")
+      view |> element("#node-detail-section-evidence") |> render_click()
+      assert has_element?(view, "a[href='/console/nodes?section=admissions']")
+    end
+
+    test "candidate evidence labels historical transport and keeps Admission Review through the linked Node",
+         %{conn: conn} do
+      node = insert_node!(%{state: :registered, health: :healthy})
+      observed_at = DateTime.add(DateTime.utc_now(), -120, :second)
+
+      candidate =
+        insert_candidate!(%{
+          node_id: node.id,
+          compatibility_evidence: %{"health" => "healthy"},
+          last_observed_at: observed_at
+        })
+
+      {:ok, view, html} =
+        live(conn, "/console/nodes/pending/#{candidate.id}?section=evidence&from=admissions")
+
+      assert html =~ "Observation: Unreachable"
+
+      assert has_element?(
+               view,
+               "#node-detail-transport:not([hidden])",
+               "Transport at last observation"
+             )
+
+      assert has_element?(view, "#node-detail-transport-status", "Observed transport")
+      assert has_element?(view, "#node-detail-transport-observed-at")
+
+      expected_time = observed_at |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+      assert has_element?(
+               view,
+               ~s(#node-detail-transport-observed-at time[datetime="#{expected_time}"])
+             )
+
+      linked_path = "/console/nodes/#{node.id}?from=admissions"
+      assert has_element?(view, "#node-detail-review-linked-node[href='#{linked_path}']")
+
+      {:ok, linked_view, _html} =
+        view
+        |> element("#node-detail-review-linked-node")
+        |> render_click()
+        |> follow_redirect(conn)
+
+      assert has_element?(linked_view, "a[href='/console/nodes?section=admissions']")
+    end
+
+    test "manual refresh reloads inventory detail without a lifecycle action", %{conn: conn} do
+      node = insert_node!(%{display_name: "before-refresh", state: :registered, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+      node |> Ecto.Changeset.change(display_name: "after-refresh") |> Repo.update!()
+      html = view |> element("#node-detail-refresh") |> render_click()
+      assert html =~ "after-refresh"
+      assert html =~ "Last successful page refresh"
+      assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "failed refresh retains labeled evidence and blocks actions until recovery", %{
+      conn: conn
+    } do
+      node = insert_node!(%{display_name: "retained-node", state: :registered, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+      socket = :sys.get_state(view.pid).socket
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        parent = self()
+
+        spawn(fn ->
+          Repo.put_dynamic_repo(:unavailable_node_detail_repo)
+          result = OrchardConsole.NodeDetailLive.handle_event("refresh_detail", %{}, socket)
+          send(parent, {:unavailable_refresh, result})
+        end)
+
+        assert_receive {:unavailable_refresh, {:noreply, stale}}, 2000
+
+        Process.cancel_timer(stale.assigns.refresh_timer)
+        assert stale.assigns.load_status == :stale
+        assert stale.assigns.record.id == node.id
+        assert stale.assigns.last_successful_refresh == socket.assigns.last_successful_refresh
+        assert stale.assigns.action == nil
+
+        html =
+          stale.assigns
+          |> OrchardConsole.NodeDetailLive.render()
+          |> Safe.to_iodata()
+          |> IO.iodata_to_binary()
+
+        assert html =~ "Showing the last successful detail"
+        refute html =~ "id=\"node-detail-actions\""
+
+        {:noreply, blocked} =
+          OrchardConsole.NodeDetailLive.handle_event(
+            "open_lifecycle",
+            %{"action" => "cordon"},
+            stale
+          )
+
+        assert blocked.assigns.action == nil
+        assert blocked.assigns.flash["error"] =~ "Refresh Node detail successfully"
+
+        {:noreply, recovered} =
+          OrchardConsole.NodeDetailLive.handle_event(
+            "refresh_detail",
+            %{},
+            stale
+          )
+
+        Process.cancel_timer(recovered.assigns.refresh_timer)
+        assert recovered.assigns.load_status == :ok
+        assert recovered.assigns.record.id == node.id
+      end)
+    end
+
+    test "action preview opens before evidence and closes without executing", %{conn: conn} do
+      node = insert_node!(%{state: :registered, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+      html = view |> element("#node-detail-open-admit") |> render_click()
+      {header, _} = :binary.match(html, "id=\"node-detail-header-card\"")
+      {preview, _} = :binary.match(html, "id=\"node-action-preview\"")
+      {evidence, _} = :binary.match(html, "id=\"node-detail-status-groups\"")
+      assert header < preview
+      assert preview < evidence
+      assert has_element?(view, "#node-action-preview-heading[tabindex='-1'][phx-mounted]")
+      view |> element("#action-close-preview") |> render_click()
+      refute has_element?(view, "#node-action-preview")
+      assert Repo.get!(Node, node.id).state == :registered
+    end
+
+    test "a queued refresh cancels the currently scheduled detail timer", %{conn: conn} do
+      node = insert_node!(%{state: :registered, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+      timer = Process.send_after(self(), :unexpected_detail_timer, 60_000)
+      socket = Phoenix.Component.assign(:sys.get_state(view.pid).socket, refresh_timer: timer)
+
+      {:noreply, refreshed} =
+        OrchardConsole.NodeDetailLive.handle_info(:refresh_node_detail, socket)
+
+      assert Process.read_timer(timer) == false
+      assert is_reference(refreshed.assigns.refresh_timer)
+      Process.cancel_timer(refreshed.assigns.refresh_timer)
+    end
+
     test "renders separated status groups and pending actions", %{conn: conn} do
       node =
         insert_node!(%{
@@ -463,9 +646,78 @@ defmodule OrchardConsole.NodeDetailLiveTest do
                "Resolve blockers and confirm the preview before executing."
              )
     end
+
+    test "retains confirmation when a refresh leaves the action preview unchanged", %{conn: conn} do
+      node = insert_node!(%{state: :active, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}?section=actions")
+
+      view |> element("#node-detail-open-lifecycle-cordon") |> render_click()
+
+      view
+      |> form("#node-action-form", %{"action" => %{"confirmed" => "true"}})
+      |> render_change()
+
+      assert :sys.get_state(view.pid).socket.assigns.action.confirmed
+
+      send(view.pid, :refresh_node_detail)
+      _ = :sys.get_state(view.pid)
+
+      assert :sys.get_state(view.pid).socket.assigns.action.confirmed
+      assert has_element?(view, "#action-confirmed[checked]")
+    end
+
+    test "clears confirmation when refreshed authoritative preview facts change", %{conn: conn} do
+      node = insert_node!(%{state: :active, health: :healthy})
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}?section=actions")
+
+      view |> element("#node-detail-open-lifecycle-cordon") |> render_click()
+
+      view
+      |> form("#node-action-form", %{"action" => %{"confirmed" => "true"}})
+      |> render_change()
+
+      assert :sys.get_state(view.pid).socket.assigns.action.confirmed
+
+      node
+      |> Ecto.Changeset.change(health: :degraded)
+      |> Repo.update!()
+
+      send(view.pid, :refresh_node_detail)
+      _ = :sys.get_state(view.pid)
+
+      refute :sys.get_state(view.pid).socket.assigns.action.confirmed
+      refute has_element?(view, "#action-confirmed[checked]")
+      assert has_element?(view, "#action-submit[disabled]")
+      assert has_element?(view, "#node-detail-header-card", "Health: Degraded")
+    end
   end
 
   describe "lifecycle action previews" do
+    test "Current reports Node lifecycle and stays unknown when current evidence is absent", %{
+      conn: conn
+    } do
+      node = insert_node!(state: :cordoned, health: :healthy)
+      {:ok, view, _html} = live(conn, "/console/nodes/#{node.id}")
+      view |> element("#node-detail-open-lifecycle-uncordon") |> render_click()
+      assert has_element?(view, "#action-preview-current-state", "Cordoned")
+      socket = :sys.get_state(view.pid).socket
+      action = Map.update!(socket.assigns.action, :preview, &Map.put(&1, :current, %{}))
+      assigns = Phoenix.Component.assign(socket, :action, action).assigns
+      html = render_component(&OrchardConsole.NodeDetailLive.render/1, assigns)
+
+      assert html
+             |> LazyHTML.from_document()
+             |> LazyHTML.query("#action-preview-current-state")
+             |> LazyHTML.text() =~ "unknown"
+    end
+
+    test "Current reports the candidate admission category before rejection", %{conn: conn} do
+      candidate = insert_candidate!(target_ref: "10.4.0.92:50071")
+      {:ok, view, _html} = live(conn, "/console/nodes/pending/#{candidate.id}")
+      view |> element("#node-detail-open-reject") |> render_click()
+      assert has_element?(view, "#action-preview-current-state", "Pending observed")
+    end
+
     test "renders lifecycle preview affordances for node rows only", %{conn: conn} do
       node = insert_node!(state: :active, display_name: "lifecycle-affordance-node")
       candidate = insert_candidate!(target_ref: "10.4.0.88:50071")

--- a/apps/orchard_controller/test/orchard/console/node_enrollment_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/node_enrollment_live_test.exs
@@ -197,6 +197,8 @@ defmodule OrchardConsole.NodeEnrollmentLiveTest do
 
     html = view |> element("#node-preparation-complete") |> render_click()
 
+    assert has_element?(view, "#node-enrollment-heading[tabindex='-1'][phx-mounted]")
+    refute has_element?(view, "#node-preparation-complete")
     assert html =~ "Create a one-time enrollment"
     assert html =~ "Initial pool intent"
     assert html =~ "A Pool is an existing scheduling group"
@@ -372,7 +374,11 @@ defmodule OrchardConsole.NodeEnrollmentLiveTest do
     assert html =~ "Registered - awaiting admission"
     assert html =~ "The node agent registered successfully"
     assert html =~ "Review and Admit Node"
-    assert html =~ "/console/nodes/22222222-2222-4222-8222-222222222222"
+
+    assert has_element?(
+             view,
+             "#review-node-admission[href='/console/nodes/22222222-2222-4222-8222-222222222222?section=actions&from=admissions']"
+           )
   end
 
   test "polling advances a waiting enrollment to registered without an operator status action", %{
@@ -410,6 +416,7 @@ defmodule OrchardConsole.NodeEnrollmentLiveTest do
     Process.sleep(25)
     registered_html = render(view)
 
+    refute has_element?(view, "#node-enrollment-monitor-step [phx-mounted]")
     assert registered_html =~ "Registered - awaiting admission"
     assert registered_html =~ "Review and Admit Node"
   end

--- a/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/nodes_live_test.exs
@@ -642,6 +642,77 @@ defmodule OrchardConsole.NodesLiveTest do
   # ---------------------------------------------------------------------------
 
   describe "GET /console/nodes" do
+    test "a queued refresh cancels the currently scheduled inventory timer", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/console/nodes")
+      timer = Process.send_after(self(), :unexpected_inventory_timer, 60_000)
+      socket = Phoenix.Component.assign(:sys.get_state(view.pid).socket, refresh_timer: timer)
+      {:noreply, refreshed} = OrchardConsole.NodesLive.handle_info(:refresh_nodes, socket)
+      assert Process.read_timer(timer) == false
+      assert is_reference(refreshed.assigns.refresh_timer)
+      Process.cancel_timer(refreshed.assigns.refresh_timer)
+    end
+
+    test "unavailable inventory reports unknown counts rather than an empty fleet", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/console/nodes")
+      socket = :sys.get_state(view.pid).socket
+      parent = self()
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        spawn(fn ->
+          Repo.put_dynamic_repo(:unavailable_inventory_repo)
+
+          send(
+            parent,
+            {:inventory_refresh,
+             OrchardConsole.NodesLive.handle_event("refresh_now", %{}, socket)}
+          )
+        end)
+
+        assert_receive {:inventory_refresh, {:noreply, failed}}, 2000
+        Process.cancel_timer(failed.assigns.refresh_timer)
+        assert failed.assigns.inventory.status == :error
+        assert failed.assigns.inventory.summary.total == nil
+
+        assert Enum.all?(failed.assigns.inventory.summary.by_health, fn {_health, count} ->
+                 is_nil(count)
+               end)
+      end)
+    end
+
+    test "section navigation replaces visible content and survives refresh", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/console/nodes")
+      assert has_element?(view, "#nodes-inventory-card:not([hidden])")
+      assert has_element?(view, "#nodes-pending-admissions-card[hidden]")
+      view |> element("#nodes-section-admissions") |> render_click()
+      assert_patch(view, "/console/nodes?section=admissions")
+      assert has_element?(view, "#nodes-pending-admissions-card:not([hidden])")
+      assert has_element?(view, "#nodes-inventory-card[hidden]")
+      view |> element("#nodes-refresh-now") |> render_click()
+      assert has_element?(view, "#nodes-section-admissions[aria-current='page']")
+      view |> element("#nodes-section-runtime") |> render_click()
+      assert has_element?(view, "#nodes-live-cluster-card:not([hidden])")
+      assert has_element?(view, "#nodes-control-plane-status-card[hidden]")
+      view |> element("#nodes-section-diagnostics") |> render_click()
+      assert has_element?(view, "#nodes-safe-tokenization-telemetry-card:not([hidden])")
+      assert has_element?(view, "#nodes-runtime-targets[hidden]")
+    end
+
+    test "Add Node remains a shared destination across all Nodes sections", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/console/nodes")
+
+      for section <- ~w(inventory admissions runtime diagnostics) do
+        render_patch(view, "/console/nodes?section=#{section}")
+        assert has_element?(view, "#add-node[href='/console/nodes/new']", "Add Node")
+        refute has_element?(view, "[hidden] #add-node")
+        assert has_element?(view, "#nodes-section-#{section}[aria-current='page']")
+      end
+    end
+
+    test "unknown section falls back to Inventory", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/console/nodes?section=not-a-section")
+      assert has_element?(view, "#nodes-section-inventory[aria-current='page']")
+    end
+
     test "renders nodes page with section titles", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/console/nodes")
 
@@ -649,6 +720,7 @@ defmodule OrchardConsole.NodesLiveTest do
       assert html =~ "/console/nodes/new"
       assert html =~ "Inventory Summary"
       assert html =~ "Registered Nodes"
+      assert html =~ "Lifecycle and health are separate"
       assert html =~ "Live Cluster"
       assert html =~ "Control Plane"
     end
@@ -658,9 +730,9 @@ defmodule OrchardConsole.NodesLiveTest do
 
       assert html =~ ~s(class="text-xl font-semibold text-slate-900 dark:text-slate-100")
       assert html =~ ~s(class="max-w-none px-6 sm:px-8 lg:px-10 py-6")
-      assert html =~ ~s(class="grid gap-6 xl:grid-cols-12")
-      assert html =~ ~s(class="xl:col-span-8")
-      assert html =~ ~s(class="xl:col-span-4 space-y-6")
+      assert has_element?(view, "#nodes-sections[aria-label=\"Nodes sections\"]")
+      assert has_element?(view, "#nodes-inventory-card:not([hidden])")
+      assert has_element?(view, "#nodes-live-cluster-card[hidden]")
 
       cluster = element(view, "#nodes-live-cluster-card") |> render()
       assert cluster =~ "bg-slate-100/70"
@@ -877,6 +949,7 @@ defmodule OrchardConsole.NodesLiveTest do
       {:ok, _view, html} = live(conn, "/console/nodes")
 
       assert html =~ "test-node"
+      assert html =~ "Inspect Node"
       assert html =~ "test.local"
       assert html =~ "192.168.1.10:50071"
       assert html =~ "active"
@@ -1552,7 +1625,7 @@ defmodule OrchardConsole.NodesLiveTest do
       {:ok, _view, html} = live(conn, "/console/nodes")
 
       assert html =~ "nodes-freshness"
-      assert html =~ "Last refreshed"
+      assert html =~ "Last refresh attempt"
       assert html =~ ~s(phx-hook="LocalTime")
       assert html =~ ~s(data-local-time-format="time_second")
     end

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -503,12 +503,25 @@ Blocker rows must read as non-bypassable and must disable or omit the execute co
 Warnings and consequences may use compact badges plus short copy, but stable codes remain visible or inspectable when the code is part of the user-facing contract.
 Confirmation requirements sit directly above the execution control they gate.
 Page-local preview panels are valid for node actions when they keep review context visible.
+Node action previews appear in the Actions section directly after the available action controls.
+Opening a preview focuses its panel, and closing it restores focus to the originating control.
+If refreshed action facts or consequences change, clear the prior confirmation and require the operator to review the updated preview.
+Candidate transport and raw identity evidence retain their observation time and are not labeled as current health.
 Typed-identifier confirmation inputs require the operator to retype the exact target identifier; do not prefill, autocomplete, or accept partial matches.
 Consequence acknowledgement controls default to unacknowledged and name the consequence they accept.
 The execute control stays disabled until every confirmation requirement is satisfied, and satisfying requirements never bypasses blockers.
 When one page offers several previewable actions, show one open preview panel at a time so review context stays unambiguous.
 
+Nodes uses Inventory, Admission, Runtime, and Diagnostics as page-local sections.
+Node detail uses Overview, Evidence, and Actions with shared identity and refresh context.
+Section links update a whitelisted URL parameter and replace the visible section rather than scrolling to another card.
+Inactive sections are hidden from both keyboard navigation and the accessibility tree; the selected navigation link exposes `aria-current`.
+
 Node detail drill-ins keep lifecycle, admission, health, freshness, transport, runtime, compatibility, scheduling, warnings, and observe-only memory telemetry in labeled groups instead of flattening them into a generic table.
+Node detail provides an explicit read-only refresh action.
+If refresh fails, retain the last successful evidence for the same target with its observation time and a visible stale warning.
+Stale evidence cannot authorize an action preview or execution; a successful refresh restores those controls.
+Changing the target clears retained evidence before loading the new target.
 The memory telemetry group renders only when runtime memory-budget data is present, stays labeled as observe-only and non-gating, and fails open to omission when no budget is reported.
 Use `<.detail_grid>`, `<.detail_field>`, and compact status badges for grouped facts.
 Source and compatibility badges should stay close to the identity or inventory field they qualify.

--- a/openspec/changes/console-nodes-navigation/.openspec.yaml
+++ b/openspec/changes/console-nodes-navigation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/console-nodes-navigation/design.md
+++ b/openspec/changes/console-nodes-navigation/design.md
@@ -1,0 +1,20 @@
+## Decisions
+
+Use whitelisted query parameters for reloadable sections, with a safe default for unsupported values.
+Hide inactive sections from both keyboard navigation and the accessibility tree.
+Keep target identity and refresh status outside section-specific content.
+
+Retain last-successful evidence only for the same target, label it stale after a failed read, and block action preview and execution until refresh succeeds.
+Clear confirmation when refreshed action consequences change.
+Restore focus after manually opening or closing a preview; automatic polling must not move focus.
+
+Enrollment handoff opens the registered Node's Actions section and preserves Admission as its return destination.
+An explicit successful Prepare action focuses the enrollment heading for the next step.
+Registration remains distinct from admission and runtime readiness.
+
+## Risks and validation
+
+Stale evidence must never authorize lifecycle mutation.
+Regression tests cover refresh failure and recovery, changed previews, invalid sections, target changes, admission return context, and manual enrollment focus.
+Browser review covers selected-section visibility and narrow layouts.
+No database migration is required.

--- a/openspec/changes/console-nodes-navigation/proposal.md
+++ b/openspec/changes/console-nodes-navigation/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Node inventory and diagnosis currently mix admission, runtime evidence, and lifecycle actions on long pages.
+Operators need explicit navigation and recovery that preserves the authority of current evidence.
+
+## What Changes
+
+- Separate Nodes into Inventory, Admission, Runtime, and Diagnostics sections and Node detail into Overview, Evidence, and Actions.
+- Preserve labeled last-successful evidence after refresh failure while blocking actions until recovery.
+- Preserve admission return context, focus action previews, and focus the next enrollment step after an explicit Prepare action.
+
+## Capabilities
+
+### New Capabilities
+
+- `console-node-navigation`: Task-focused Node navigation, evidence recovery, and enrollment handoff context.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+SPEC.md remains unchanged and authoritative.
+This change builds on the Add Node enrollment flow without changing enrollment custody, lifecycle transitions, trust, scheduling, or action authorization.
+Affected surfaces are three Console LiveViews, their tests, and docs/DESIGN.md.

--- a/openspec/changes/console-nodes-navigation/specs/console-node-navigation/spec.md
+++ b/openspec/changes/console-nodes-navigation/specs/console-node-navigation/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Preserve Node diagnosis context on refresh failure
+
+The Console SHALL offer a read-only Node detail refresh and distinguish lifecycle, health, and evidence freshness.
+After a failed refresh, the Console SHALL retain the last successful evidence for the same target with a stale warning and its refresh time.
+Action preview and execution SHALL remain unavailable until refresh succeeds.
+Changing targets SHALL clear the retained evidence.
+
+#### Scenario: Refresh fails after successful diagnosis
+- **WHEN** the operator refreshes a previously loaded Node and the read fails
+- **THEN** the existing evidence remains visible as stale and the operator can retry without executing a Node action
+
+#### Scenario: Refresh recovers
+- **WHEN** a subsequent refresh succeeds
+- **THEN** the evidence and timestamp update and normal action eligibility is restored
+
+#### Scenario: Inspect an action preview
+- **WHEN** the operator opens a Node action preview
+- **THEN** it appears in the Actions section and receives focus, with a close control that returns focus to the originating action
+
+### Requirement: Task-focused Node sections
+
+The Nodes page SHALL separate Inventory, Admission, Runtime, and Diagnostics through page-local navigation.
+Node detail SHALL separate Overview, Evidence, and Actions while retaining shared target identity and refresh state.
+Sections SHALL use whitelisted URL parameters and replace visible content instead of acting as scroll anchors.
+Inactive sections SHALL not remain reachable through keyboard navigation or the accessibility tree.
+
+#### Scenario: Inspect evidence and return
+- **WHEN** an operator switches from Node Overview to Evidence and reloads the URL
+- **THEN** Evidence remains selected for the same target and Overview and Actions content remains hidden
+
+#### Scenario: Unknown section
+- **WHEN** a Node URL supplies an unsupported section
+- **THEN** the page selects its default section without changing the target or authorizing an action
+
+#### Scenario: Refreshed action facts change
+- **WHEN** an open action preview changes after a data refresh
+- **THEN** prior confirmation is cleared and execution requires review and confirmation of the updated preview
+- **AND** a refresh with unchanged preview facts preserves the operator's confirmation
+
+#### Scenario: Historical candidate evidence
+- **WHEN** Evidence shows an admission candidate observed by a prior runtime status read
+- **THEN** transport evidence identifies that observation and its timestamp rather than implying a current health check
+
+#### Scenario: Follow a linked admitted Node
+- **WHEN** the operator follows a candidate's linked Node from Admission Review
+- **THEN** Back to Nodes preserves the Admission Review origin
+
+### Requirement: Enrollment handoff preserves action context
+
+The enrollment flow SHALL open the registered Node in Actions with Admission as its return destination.
+An explicit successful Prepare action SHALL focus the next step heading without moving focus during automatic observation.
+
+#### Scenario: Registered Node is ready for review
+- **WHEN** an operator follows Review and Admit Node
+- **THEN** the correct Node opens in Actions and Back returns to Admission
+
+#### Scenario: Preparation advances the flow
+- **WHEN** the operator successfully completes Prepare
+- **THEN** the next step is visible and its heading receives focus
+- **AND** later automatic observations do not move focus

--- a/openspec/changes/console-nodes-navigation/tasks.md
+++ b/openspec/changes/console-nodes-navigation/tasks.md
@@ -1,0 +1,12 @@
+## 1. Navigation and recovery
+
+- [x] 1.1 Add accessible query-backed inventory and detail sections with contextual return navigation.
+- [x] 1.2 Preserve same-target stale evidence and block actions until successful refresh.
+- [x] 1.3 Preserve enrollment-to-admission context and manual-step focus without moving focus during polling.
+- [x] 1.4 Cover navigation, refresh recovery, and action confirmation with regression tests.
+
+## 2. Validation
+
+- [x] 2.1 Run the applicable Elixir quality workflow and strict OpenSpec validation.
+- [x] 2.2 Verify Node sections and enrollment handoff in the local browser review build.
+- [ ] 2.3 On later archive or sync, review generated specs for placeholder prose.


### PR DESCRIPTION
Node diagnosis currently mixes inventory, admission, runtime evidence, and lifecycle controls on long pages.
This change gives operators task-focused sections and retains labeled evidence after a failed refresh while preventing stale facts from authorizing actions.

## Changes

- Add query-backed Inventory, Admission, Runtime, and Diagnostics sections, plus Overview, Evidence, and Actions on Node detail.
- Preserve same-target evidence with a stale warning on read failure and restore action eligibility only after a successful refresh.
- Clear confirmation when refreshed action facts change and preserve target and Admission return context.
- Focus explicit action previews and the next enrollment step without moving focus during automatic observation.

## Validation

The final combined stack at `671608e7` passed the repository workflow:

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `make macos-native-test-helpers`
- `mise exec -- mix test`: 5,304 passed, 6 skipped, 10 excluded.
- `mise exec -- mix test --cover`: the same test result; Shared 68.04%, Controller 85.0%, Node agent 79.92%, CLI 75.79%.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`: 45 passed.
- `mise exec -- node --test --experimental-test-coverage apps/orchard_controller/assets/js/*.test.mjs`: 2 passed; 100% line, branch, and function coverage.

Stack order: #360 (Models) → #361 (Nodes) → #362 (Access).

Independent review of this slice against its immediate Models parent returned GO with no concrete blocker.

A further independent review of the complete stack returned GO for this unchanged slice.

## Risk Assessment

✅ **Medium**

- The change affects Node diagnosis and the route into lifecycle actions; backend admission, trust, and mutation authorization remain authoritative.
- Stale evidence cannot authorize preview or execution, and changing targets clears retained evidence.
- No database migration is required; query sections are whitelisted and inactive content is removed from keyboard navigation and the accessibility tree.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganizes Node console workflows into task-focused, query-backed sections while retaining labeled evidence after refresh failures and preventing stale facts from enabling actions.
- Adds Inventory, Admission, Runtime, and Diagnostics sections to the Nodes page.
- Adds Overview, Evidence, and Actions sections to Node detail.
- Preserves same-target evidence during failed refreshes and restores action availability after successful refresh.
- Preserves Admission return context and adds explicit focus behavior for action previews and enrollment steps.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/console/node_detail_live.ex | Adds section navigation, stale-evidence handling, explicit refresh controls, action gating, confirmation refresh behavior, and focus management. |
| apps/orchard_controller/lib/orchard/console/nodes_live.ex | Splits the Nodes workspace into query-backed Inventory, Admission, Runtime, and Diagnostics sections while preserving shared navigation and refresh controls. |
| apps/orchard_controller/lib/orchard/console/node_enrollment_live.ex | Preserves Admission return context and focuses the next enrollment step without changing automatic observation focus. |
| apps/orchard_controller/test/orchard/console/node_detail_live_test.exs | Covers section navigation, stale refresh recovery, action blocking, confirmation refresh behavior, and return-context preservation. |
| apps/orchard_controller/test/orchard/console/nodes_live_test.exs | Covers section selection, invalid-section fallback, refresh persistence, hidden inactive content, and shared destinations. |
| apps/orchard_controller/test/orchard/console/node_enrollment_live_test.exs | Verifies enrollment navigation context and focus-related behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor Operator
    participant UI as Node Detail LiveView
    participant Store as Node Data Source

    UI->>Store: Refresh current target
    alt Refresh succeeds
        Store-->>UI: Current record and status
        UI->>UI: Mark evidence current
        UI->>UI: Rebuild preview and validate confirmation
        UI-->>Operator: Enable eligible actions
    else Refresh fails after prior success
        Store-->>UI: Error
        UI->>UI: Retain prior evidence as stale
        UI->>UI: Clear open action
        UI-->>Operator: Show stale warning and disable actions
    else Initial refresh fails
        Store-->>UI: Error
        UI-->>Operator: Show unavailable state
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(console): preserve enrollment admiss..."](https://github.com/kapitan-ai/orchard/commit/00b39dbd0416518a5de164834125bccdf36eac37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60879999)</sub>

<!-- /greptile_comment -->