### PR TITLE
feat(console): add Workspace access and colleague handoff

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -241,9 +241,23 @@ Server-side tool execution MAY be added in a later phased extension. In that mod
 | ----------------------- | ---------------------------- | ---------------------------------------------------------- |
 | Tray/menu bar app       | macOS `.app` + LaunchAgent   | local status, onboarding, logs, support bundle entry point |
 | `orchardctl` CLI            | binary                       | admin/operator automation, bootstrap, diagnostics          |
-| Orchard Console         | controller LiveView          | local/operator UI for runtime status, node inventory and admission review, action previews, requests, Organizations, API Tokens, and API Clients |
-| Developer Portal        | controller LiveView          | Invite-only, Organization-scoped self-service mint, list, and revoke of a Portal User's tenant-direct API Keys |
+| Orchard Console         | controller LiveView          | local/operator UI for runtime status, node inventory and admission review, action previews, requests, Workspaces, API Tokens, and API Clients |
+| Developer Portal        | controller LiveView          | Invite-only, Workspace-scoped self-service mint, list, and revoke of a Portal User's tenant-direct API Keys |
 | Managed Postgres helper | LaunchDaemon in managed mode | local DB lifecycle only                                    |
+
+Workspace SHALL be the product-facing name for one existing Tenant governance boundary in Console and Developer Portal.
+Access SHALL be the Console navigation destination for Workspace management; it SHALL NOT imply a new cluster-wide RBAC role or hierarchy.
+Tenant schemas, UUIDs, slugs, API fields, CLI vocabulary, audit identifiers, CSV `organization`, and `/portal/:organization_slug` URLs SHALL remain compatible.
+Existing `/console/tenants` and `/console/tenants/:id` links SHALL remain usable alongside canonical `/console/access` and `/console/access/workspaces/:id` routes.
+Team SHALL remain API Client grouping metadata, without membership, authorization, model grants, or quotas.
+
+The seeded Tenant `00000000-0000-0000-0000-000000000000` SHALL be the default Workspace.
+Its untouched built-in name `Legacy Single Tenant` SHALL display as `Default workspace`; a customized name SHALL be preserved and the stable default identity indicated separately.
+Default identity SHALL be determined by UUID, not by name or slug.
+When it is the only Workspace, a new guided colleague handoff SHALL start within that scope with the Workspace step visibly resolved.
+Multiple Workspaces SHALL require deliberate selection for a new handoff, and an explicit Workspace route or scoped draft SHALL NOT be overwritten by default selection.
+Default selection SHALL NOT create model grants, Portal Users, credentials, quota exemptions, or runtime readiness.
+Page reads SHALL NOT create a replacement seed or reset existing state; a missing or unreadable seed SHALL produce a recoverable setup error.
 
 ### 2.4 Repository structure
 
@@ -2268,7 +2282,7 @@ The platform SHALL expose five API surfaces:
 
 4. **Developer Portal**
 
-   * Organization-scoped browser surface at `/portal/:organization_slug`
+   * Workspace-scoped browser surface at `/portal/:organization_slug`
    * TLS-only in `reverse_proxy` and `direct_https` transport modes
    * unavailable in degraded `plain_http_localhost` mode
    * invite-only Portal User email-and-password authentication, not Console Basic Auth and not a Public Inference Bearer
@@ -2921,16 +2935,16 @@ Apply mode SHALL require an operator-specified output path.
 Dry Run mode MAY validate an operator-specified output path without requiring one.
 The input CSV SHALL require `organization`, `api_client`, `owner_contact`, and `key_name`.
 The input CSV MAY include `team`, `owner_name`, `external_ref`, `description`, `purpose`, `expires_at`, and `metadata_json`.
-The `organization` field SHALL identify one Organization slug per input file.
+The `organization` field SHALL identify one Workspace slug per input file.
 Plaintext API Token secrets SHALL NOT be accepted in input.
-Dry Run SHALL validate Organizations, API Client identity, duplicate API Token names, optional expiry values, metadata JSON, and output destination readiness without mutating state or generating secrets.
+Dry Run SHALL validate Workspaces, API Client identity, duplicate API Token names, optional expiry values, metadata JSON, and output destination readiness without mutating state or generating secrets.
 Apply SHALL validate the output path before mutation and commit all provisioning changes as one batch.
 Apply SHALL write One-time Secret Output only after the batch succeeds.
 One-time Secret Output SHALL be a CSV with `organization`, `api_client`, `external_ref`, `key_name`, `api_token_id`, `api_token_prefix`, `api_token`, and `expires_at` columns.
 If One-time Secret Output delivery fails after a committed Apply, Orchard SHALL mark the Provisioning Batch as `output_failed`, write a redacted audit event, and return recovery guidance that names API Token prefixes for revocation or rotation.
 The output-failed recovery path SHALL NOT persist plaintext API Token secrets.
 `orchardctl cluster init` publishes its file-backed One-time Secret Output through the cluster-init-only protected publication profile in §11.9, which does not modify this bulk-provisioning contract or the `OrchardCLI.ExclusiveOutput` contract.
-Repeated provisioning SHALL match API Clients by Organization plus External Reference when present, otherwise by Organization plus API Client name.
+Repeated provisioning SHALL match API Clients by Workspace plus External Reference when present, otherwise by Workspace plus API Client name.
 Repeated provisioning SHALL reject duplicate active API Token names unless explicit Key Rotation mode is enabled.
 Key Rotation mode SHALL create a replacement API Token and revoke previous active API Tokens with the same API Client and token name.
 Repeated provisioning SHALL preserve omitted optional API Client metadata columns, clear present blank optional scalar metadata columns, and replace metadata when `metadata_json` is present.
@@ -2975,8 +2989,8 @@ shared HTTP listener and the operator-or-admin bearer boundary for `/metrics`.
 Base path: `/portal/:organization_slug`
 
 The Developer Portal SHALL be a distinct browser surface from Orchard Console.
-It SHALL NOT render operator Console chrome, other Organizations, nodes, or cluster administration.
-A Portal User SHALL be an interactive identity scoped to one Organization and SHALL authorize only Developer Portal access.
+It SHALL NOT render operator Console chrome, other Workspaces, nodes, or cluster administration.
+A Portal User SHALL be an interactive identity scoped to one Workspace and SHALL authorize only Developer Portal access.
 A Portal User SHALL NOT be treated as an Operator, Service Account, Owner Contact, Tenant Admin, Public Inference principal, or authority for Console, Operator API, or Admin API access.
 Portal sessions SHALL NOT authorize Public Inference, Operator API, Admin API, or Console access.
 
@@ -2992,7 +3006,7 @@ LIVE /portal/:organization_slug/keys
 ```
 
 Portal User accounts SHALL be operator-invite only, with no public signup or self-registration.
-Email SHALL be the Portal User identifier and SHALL be unique by normalized value within one Organization.
+Email SHALL be the Portal User identifier and SHALL be unique by normalized value within one Workspace.
 SMTP SHALL NOT be required.
 Creating a Portal User SHALL persist the invited identity and `portal_user.invited` audit row atomically without creating a Portal Invite row.
 For a Portal User in `invited` status, the Console SHALL provide Copy invite.
@@ -3004,18 +3018,18 @@ A Portal User SHALL have at most one stored invite row at a time.
 Invite invalidation SHALL delete the stored invite row rather than tombstone it, and Orchard SHALL NOT retain invite revocation history.
 Orchard SHALL NOT persist the plaintext invite token or URL.
 The operator SHALL deliver the copied invite URL out of band.
-Invite redemption SHALL be bound to the Organization identified by the route and SHALL succeed only for a valid unexpired invite owned by a Portal User who is currently `invited` in that Organization.
+Invite redemption SHALL be bound to the Workspace identified by the route and SHALL succeed only for a valid unexpired invite owned by a Portal User who is currently `invited` in that Workspace.
 Successful redemption SHALL set the Portal User's password, mark the invite redeemed, activate the Portal User, and end that Portal User's standing portal sessions.
-Wrong-Organization, disabled-user, invalidated, expired, redeemed, and unknown-token redemption failures SHALL use one generic external response and SHALL make no persisted mutation.
+Wrong-Workspace, disabled-user, invalidated, expired, redeemed, and unknown-token redemption failures SHALL use one generic external response and SHALL make no persisted mutation.
 Recopying an invite for a Portal User who remains `invited` SHALL use the same reissue flow and SHALL end that Portal User's standing portal sessions.
 
-The portal SHALL identify the Organization by slug, then authenticate one active Portal User by normalized email and password.
-Unknown Organization, unknown email, disabled Portal User, and wrong-password submissions SHALL have indistinguishable status, body shape, headers, and generic credential failure.
-`GET /portal/:organization_slug` SHALL be response-indistinguishable for Organizations with or without invited or active Portal Users and for unknown slugs.
-Failed portal logins SHALL be limited per Organization fingerprint, Portal User or email fingerprint, and source fingerprint.
-They SHALL NOT use an Organization-wide lockout.
+The portal SHALL identify the Workspace by slug, then authenticate one active Portal User by normalized email and password.
+Unknown Workspace, unknown email, disabled Portal User, and wrong-password submissions SHALL have indistinguishable status, body shape, headers, and generic credential failure.
+`GET /portal/:organization_slug` SHALL be response-indistinguishable for Workspaces with or without invited or active Portal Users and for unknown slugs.
+Failed portal logins SHALL be limited per Workspace fingerprint, Portal User or email fingerprint, and source fingerprint.
+They SHALL NOT use a Workspace-wide lockout.
 
-The operator SHALL invite and disable Portal Users from the existing Console Organization detail surface.
+The operator SHALL invite and disable Portal Users from the existing Console Workspace detail surface.
 Disabling a Portal User SHALL atomically invalidate every outstanding invite by deleting its stored row, and SHALL end only that Portal User's portal sessions.
 Disabling a Portal User SHALL NOT revoke that Portal User's API Keys.
 Invite reissue, invite redemption, and Portal User disablement SHALL NOT revoke minted API Keys.
@@ -3024,13 +3038,13 @@ Repeated disable SHALL be a true no-op that does not rewrite timestamps, advance
 The portal SHALL mint tenant-direct API Keys with `issuance_surface = 'developer_portal'` and `portal_user_id` equal to the signed-in Portal User.
 A Portal User MAY have at most 10 active portal-minted tenant-direct keys.
 Revoked and expired keys SHALL NOT count toward that ceiling.
-The mint transaction SHALL serialize on the Portal User, not the Organization.
+The mint transaction SHALL serialize on the Portal User, not the Workspace.
 Portal key mint and revoke SHALL carry the validated session tenant ID, Portal User ID, and password epoch into one outer transaction.
 That transaction SHALL lock and revalidate the Portal User before enforcing the mint cap or locking an API Key.
 The lock order for revoke SHALL be Portal User then API Key, and a stale captured epoch SHALL fail as an invalid session before any API Key lock or mutation.
 Operator-minted tenant-direct keys SHALL NOT count toward that ceiling, SHALL remain operator-only, and SHALL NOT be visible or revocable from the portal.
-The portal SHALL list and revoke only portal-minted keys whose `portal_user_id` and `tenant_id` match the signed-in Portal User and Organization.
-Keys owned by another Portal User or another Organization SHALL be indistinguishable from missing keys on portal list and revoke paths.
+The portal SHALL list and revoke only portal-minted keys whose `portal_user_id` and `tenant_id` match the signed-in Portal User and Workspace.
+Keys owned by another Portal User or another Workspace SHALL be indistinguishable from missing keys on portal list and revoke paths.
 Portal revoke SHALL take effect on the next Public Inference authentication.
 Repeated Portal revoke SHALL be a true no-op that does not rewrite `revoked_at` or `updated_at` and does not create another successful audit observation.
 
@@ -3040,7 +3054,12 @@ The portal SHALL NOT mint a new key without `portal_user_id`.
 Public Inference Bearer authentication SHALL continue to resolve every tenant-direct key as `principal_type = tenant` and SHALL NOT consult `portal_user_id`.
 
 Key secrets SHALL be shown once at creation and SHALL NOT be recoverable later.
-After mint, the portal SHALL show one `POST /v1/chat/completions` curl using a deterministic callable model already authorized for the Organization, or state that no test curl is available.
+After mint, the portal SHALL show one `POST /v1/chat/completions` curl using an active exact Model identity with enabled access for the Workspace, or state that no test curl is available.
+Selection SHALL be deterministic when no exact Model was requested.
+An explicitly requested exact Model that is inactive, unavailable, or no longer authorized SHALL NOT be silently substituted.
+Catalog availability and model authorization SHALL NOT be presented as proof of runtime readiness or request success.
+Console colleague handoff examples SHALL use a literal placeholder credential; only the actual Portal mint response SHALL display that Portal User's newly minted secret under the existing one-time display contract.
+Console guidance SHALL NOT treat the default-scoped Playground as evidence for a different Workspace.
 
 The portal SHALL be served only when public API HTTPS is enabled and the effective request scheme is HTTPS.
 Degraded `plain_http_localhost` SHALL return `404` for every portal route.

--- a/apps/orchard_controller/assets/js/app.js
+++ b/apps/orchard_controller/assets/js/app.js
@@ -4,6 +4,7 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import {WorkspaceSections} from "./workspace_sections.mjs"
 import {
   downloadNodeEnrollmentBundle,
   nodeEnrollmentBundleAcknowledgement
@@ -14,6 +15,7 @@ import {
 // ===========================================================================
 
 let Hooks = {}
+Hooks.WorkspaceSections = WorkspaceSections
 
 const QUICKSTART_COOKIE_OPTIONS = {
   path: "/console",

--- a/apps/orchard_controller/assets/js/workspace_sections.mjs
+++ b/apps/orchard_controller/assets/js/workspace_sections.mjs
@@ -1,0 +1,32 @@
+const LEGACY_SECTIONS = new Map([
+  ["tenant-summary-card", "overview"],
+  ["tenant-access-boundaries", "overview"],
+  ["tenant-model-access-card", "model_access"],
+  ["tenant-portal-invite-card", "portal_users"],
+  ["tenant-portal-invite-url-card", "portal_users"],
+  ["tenant-portal-users-card", "portal_users"],
+  ["tenant-portal-access-card", "portal_users"],
+  ["tenant-api-key-create-card", "api_credentials"],
+  ["tenant-api-key-secret-card", "api_credentials"],
+  ["tenant-api-keys-card", "api_credentials"],
+  ["tenant-api-clients-card", "api_credentials"]
+])
+
+export function legacyWorkspaceSection(hash) {
+  return LEGACY_SECTIONS.get(hash.replace(/^#/, "")) ?? null
+}
+
+export const WorkspaceSections = {
+  mounted() {
+    this.onWorkspaceHashChange = () => {
+      const section = legacyWorkspaceSection(window.location.hash)
+      if (section) this.pushEvent("legacy_section", {section})
+    }
+    window.addEventListener("hashchange", this.onWorkspaceHashChange)
+    this.onWorkspaceHashChange()
+  },
+
+  destroyed() {
+    window.removeEventListener("hashchange", this.onWorkspaceHashChange)
+  }
+}

--- a/apps/orchard_controller/assets/js/workspace_sections.test.mjs
+++ b/apps/orchard_controller/assets/js/workspace_sections.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import {legacyWorkspaceSection, WorkspaceSections} from "./workspace_sections.mjs"
+
+test("legacy anchors map only to known Workspace sections", () => {
+  assert.equal(legacyWorkspaceSection("#tenant-summary-card"), "overview")
+  assert.equal(legacyWorkspaceSection("#tenant-model-access-card"), "model_access")
+  assert.equal(legacyWorkspaceSection("#tenant-portal-invite-url-card"), "portal_users")
+  assert.equal(legacyWorkspaceSection("#tenant-api-clients-card"), "api_credentials")
+  for (const hash of ["", "#unknown", "#constructor", "#__proto__", "#portal_users", "#tenant-api-clients-card?tenant=other"]) {
+    assert.equal(legacyWorkspaceSection(hash), null)
+  }
+})
+
+test("mount bridges the initial fragment without accepting Workspace identity from the URL", () => {
+  const events = []
+  const listeners = new Map()
+  globalThis.window = {
+    location: {hash: "#tenant-portal-users-card"},
+    addEventListener: (name, listener) => listeners.set(name, listener),
+    removeEventListener: (name, listener) => {
+      assert.equal(listeners.get(name), listener)
+      listeners.delete(name)
+    }
+  }
+  const hook = {pushEvent: (name, payload) => events.push([name, payload])}
+  try {
+    WorkspaceSections.mounted.call(hook)
+    assert.deepEqual(events, [["legacy_section", {section: "portal_users"}]])
+    window.location.hash = "#unknown"
+    listeners.get("hashchange")()
+    assert.equal(events.length, 1)
+    window.location.hash = "#tenant-api-keys-card"
+    listeners.get("hashchange")()
+    assert.deepEqual(events.at(-1), ["legacy_section", {section: "api_credentials"}])
+    WorkspaceSections.destroyed.call(hook)
+    assert.equal(listeners.size, 0)
+  } finally {
+    delete globalThis.window
+  }
+})

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -139,6 +139,10 @@ defmodule Orchard.API.Router do
       live("/settings", OrchardConsole.SettingsLive, :index)
       live("/requests", OrchardConsole.RequestsLive, :index)
       live("/requests/:public_id", OrchardConsole.RequestLive, :show)
+      live("/access", OrchardConsole.TenantsLive, :index)
+      live("/access/workspaces", OrchardConsole.TenantsLive, :index)
+      live("/access/workspaces/new", OrchardConsole.TenantsLive, :new)
+      live("/access/workspaces/:id", OrchardConsole.TenantDetailLive, :show)
       live("/tenants", OrchardConsole.TenantsLive, :index)
       live("/tenants/:id", OrchardConsole.TenantDetailLive, :show)
     end

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -142,6 +142,7 @@ defmodule Orchard.API.Router do
       live("/access", OrchardConsole.TenantsLive, :index)
       live("/access/workspaces", OrchardConsole.TenantsLive, :index)
       live("/access/workspaces/new", OrchardConsole.TenantsLive, :new)
+      live("/access/workspaces/:id/handoff", OrchardConsole.WorkspaceHandoffLive, :show)
       live("/access/workspaces/:id", OrchardConsole.TenantDetailLive, :show)
       live("/tenants", OrchardConsole.TenantsLive, :index)
       live("/tenants/:id", OrchardConsole.TenantDetailLive, :show)

--- a/apps/orchard_controller/lib/orchard/console/core_components.ex
+++ b/apps/orchard_controller/lib/orchard/console/core_components.ex
@@ -1495,9 +1495,9 @@ defmodule OrchardConsole.CoreComponents do
     },
     %{
       key: :tenants,
-      label: "Organizations",
+      label: "Access",
       icon: "hero-key",
-      path: "/console/tenants",
+      path: "/console/access",
       enabled: true
     },
     %{

--- a/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
@@ -334,6 +334,7 @@ defmodule OrchardConsole.TenantDetailLive do
       </header>
 
     <p class="text-xs text-slate-500 break-all">{@tenant.slug} · {@tenant.id} <span :if={WorkspacePresentation.default?(@tenant)}>· Default</span></p>
+    <.link navigate={"/console/access/workspaces/#{@tenant.id}/handoff"} class="text-sm text-navy underline">Guide workspace access</.link>
     <nav id="tenant-access-navigation" aria-label="Workspace access sections" class="flex flex-wrap gap-2">
     <.link :for={{key, label} <- [{"overview", "Overview"}, {"model_access", "Model access"}, {"portal_users", "Portal Users"}, {"api_credentials", "API credentials"}]}
     patch={"/console/access/workspaces/#{@tenant.id}?section=#{key}"}

--- a/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex
@@ -1,14 +1,17 @@
 defmodule OrchardConsole.TenantDetailLive do
   @moduledoc """
-  Console Organization detail page with API Token and API Client management.
+  Console Workspace detail page with API Token and API Client management.
   """
 
   use OrchardConsole, :live_view
 
   alias Orchard.API.Transport
   alias Orchard.Governance
-  alias Orchard.Governance.{ApiKey, RoleBinding, TenantApiKeySummary}
+  alias Orchard.Governance.{ApiKey, PortalActivationCurl, RoleBinding, TenantApiKeySummary}
 
+  alias OrchardConsole.{WorkspaceAccess, WorkspacePresentation}
+
+  @sections ~w(overview model_access portal_users api_credentials)
   @console_audit_opts [actor_type: "operator", surface: "console"]
 
   @impl true
@@ -17,7 +20,10 @@ defmodule OrchardConsole.TenantDetailLive do
       socket
       |> assign(
         tenant_id: id,
-        page_title: "Organization",
+        section: "overview",
+        model_access: [],
+        model_access_error: nil,
+        page_title: "Workspace",
         active_nav: :tenants,
         detail_status: :loading,
         tenant: nil,
@@ -29,6 +35,7 @@ defmodule OrchardConsole.TenantDetailLive do
         portal_invite_expires_at: nil,
         portal_invite_expiry_timer_ref: nil,
         portal_https?: Transport.public_api_https_enabled?(),
+        portal_base_url: PortalActivationCurl.public_base_url(),
         load_error: nil,
         generated_secret: nil
       )
@@ -42,6 +49,51 @@ defmodule OrchardConsole.TenantDetailLive do
   end
 
   @impl true
+  def handle_params(params, _uri, socket) do
+    section = valid_section(params["section"])
+
+    socket =
+      if params["id"] == socket.assigns.tenant_id do
+        assign(socket, section: section)
+      else
+        socket
+        |> clear_portal_invite()
+        |> assign_blank_form()
+        |> assign(
+          tenant_id: params["id"],
+          tenant: nil,
+          generated_secret: nil,
+          section: section,
+          detail_status: :loading,
+          model_access: [],
+          model_access_error: nil
+        )
+        |> load_if_connected()
+      end
+
+    {:noreply, socket}
+  end
+
+  defp load_if_connected(socket) do
+    if connected?(socket), do: load_tenant_detail(socket), else: socket
+  end
+
+  defp valid_section(section) when section in @sections, do: section
+  defp valid_section(_section), do: "overview"
+
+  @impl true
+  def handle_event("legacy_section", %{"section" => section}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         "/console/access/workspaces/#{socket.assigns.tenant_id}?section=#{valid_section(section)}"
+     )}
+  end
+
+  def handle_event("refresh_model_access", _params, socket) do
+    {:noreply, load_model_access(socket)}
+  end
+
   def handle_event("create_api_key", %{"api_key" => params}, socket) do
     create_api_key(socket, params)
   end
@@ -211,8 +263,8 @@ defmodule OrchardConsole.TenantDetailLive do
       id="tenant-loading-card"
       kind={:loading}
       layout={:panel}
-      title="Organization Detail"
-      body="Loading Organization…"
+      title="Workspace Detail"
+      body="Loading Workspace…"
     />
     """
   end
@@ -222,17 +274,17 @@ defmodule OrchardConsole.TenantDetailLive do
     <div id="tenant-not-found-card" class="space-y-4">
       <.link
         id="tenant-back-to-list"
-        navigate="/console/tenants"
+        navigate="/console/access"
         class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
       >
-        <.icon name="hero-arrow-left" class="h-4 w-4" /> Back to Organizations
+        <.icon name="hero-arrow-left" class="h-4 w-4" /> Back to Workspaces
       </.link>
       <.state_message
         id="tenant-not-found-message"
         kind={:empty}
         layout={:panel}
-        title="Organization not found"
-        body="The requested Organization does not exist or the ID is invalid."
+        title="Workspace not found"
+        body="The requested Workspace does not exist or the ID is invalid."
       />
     </div>
     """
@@ -243,16 +295,16 @@ defmodule OrchardConsole.TenantDetailLive do
     <div id="tenant-error-card" class="space-y-4">
       <.link
         id="tenant-back-to-list"
-        navigate="/console/tenants"
+        navigate="/console/access"
         class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
       >
-        <.icon name="hero-arrow-left" class="h-4 w-4" /> Back to Organizations
+        <.icon name="hero-arrow-left" class="h-4 w-4" /> Back to Workspaces
       </.link>
       <.state_message
         id="tenant-error-message"
         kind={:error}
         layout={:panel}
-        title="Organization details unavailable"
+        title="Workspace details unavailable"
         body={@load_error}
       />
     </div>
@@ -261,32 +313,102 @@ defmodule OrchardConsole.TenantDetailLive do
 
   def render(%{detail_status: :ok} = assigns) do
     ~H"""
-    <div class="space-y-6">
+    <div id="workspace-detail" phx-hook="WorkspaceSections" class="space-y-6">
       <.link
         id="tenant-back-to-list"
-        navigate="/console/tenants"
+        navigate="/console/access"
         class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
       >
-        <.icon name="hero-arrow-left" class="h-4 w-4" /> Back to Organizations
+        <.icon name="hero-arrow-left" class="h-4 w-4" /> Back to Workspaces
       </.link>
 
-      <%!-- Organization Summary --%>
+      <header id="tenant-access-header" class="space-y-2">
+        <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Current Workspace
+        </p>
+        <h2 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Access for {WorkspacePresentation.display_name(@tenant)}</h2>
+        <p class="max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+          Everything on this page applies to <span class="font-medium text-slate-900 dark:text-slate-100">{WorkspacePresentation.display_name(@tenant)}</span> only.
+          Portal membership, model access, and inference credentials are separate controls. Model grants are inspected here and changed with operator tooling.
+        </p>
+      </header>
+
+    <p class="text-xs text-slate-500 break-all">{@tenant.slug} · {@tenant.id} <span :if={WorkspacePresentation.default?(@tenant)}>· Default</span></p>
+    <nav id="tenant-access-navigation" aria-label="Workspace access sections" class="flex flex-wrap gap-2">
+    <.link :for={{key, label} <- [{"overview", "Overview"}, {"model_access", "Model access"}, {"portal_users", "Portal Users"}, {"api_credentials", "API credentials"}]}
+    patch={"/console/access/workspaces/#{@tenant.id}?section=#{key}"}
+    aria-current={if @section == key, do: "page"}
+    class={["rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-navy", if(@section == key, do: "bg-navy text-white", else: "border-slate-300 text-navy dark:text-sky-400")]}>{label}</.link>
+    </nav>
+    <div id="workspace-section-model_access" hidden={@section != "model_access"} class="space-y-4">
+    <div id="tenant-model-access-card"><.card>
+    <:title>Model access</:title>
+    <:subtitle>Grants apply only to this Workspace. Enabled access does not mean a Model is placed, loaded, or ready for inference.</:subtitle>
+    <.button phx-click="refresh_model_access" variant={:secondary}>Refresh grants</.button>
+    <p :if={@model_access_error} role="alert">Model grants unavailable. Refresh to try again.</p>
+    <p :if={!@model_access_error && @model_access == []}>No catalog Models. Import a Model in Catalog before granting access.</p>
+    <div :for={row <- @model_access} id={"workspace-model-#{row.model.id}"} class="mt-4 space-y-2 rounded-lg border border-slate-200 p-4">
+      <p class="break-all font-mono text-sm">{row.model.model_id}@{row.model.version}</p>
+      <p>Grant: {grant_label(row.grant_state)} · Model state: {row.model.state}</p>
+      <p class="text-xs text-slate-500 break-all">Catalog ID: {row.model.id}</p>
+      <details><summary class="cursor-pointer text-sm text-navy">Operator commands</summary>
+        <p class="mt-2 text-sm">Run with authorized operator tooling. These commands use the existing Tenant scope identifier.</p>
+        <pre class="overflow-x-auto p-2 text-xs">{WorkspaceAccess.commands(@tenant, row.model, row.grant).grant}</pre>
+        <pre class="overflow-x-auto p-2 text-xs">{WorkspaceAccess.commands(@tenant, row.model, row.grant).inspect}</pre>
+      </details>
+    </div>
+    </.card></div>
+    </div>
+    <div id="workspace-section-overview" hidden={@section != "overview"} class="space-y-6">
+
+
+      <section
+        id="tenant-access-boundaries"
+        aria-labelledby="tenant-access-boundaries-title"
+        class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/60"
+      >
+        <h2 id="tenant-access-boundaries-title" class="font-medium text-slate-900 dark:text-slate-100">
+          Keep these access paths separate
+        </h2>
+        <div class="mt-3 grid gap-4 text-sm sm:grid-cols-3">
+          <div>
+            <p class="font-medium text-slate-900 dark:text-slate-100">Portal User</p>
+            <p class="mt-1 text-slate-600 dark:text-slate-300">
+              Signs in to this Workspace's Developer Portal. An invitation does not create an inference credential.
+            </p>
+          </div>
+          <div>
+            <p class="font-medium text-slate-900 dark:text-slate-100">Direct API Token</p>
+            <p class="mt-1 text-slate-600 dark:text-slate-300">
+              Authorizes Public Inference for this Workspace, subject to its separate model access and policy.
+            </p>
+          </div>
+          <div>
+            <p class="font-medium text-slate-900 dark:text-slate-100">API Client</p>
+            <p class="mt-1 text-slate-600 dark:text-slate-300">
+              Represents non-interactive application access and owns separately provisioned API Tokens.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <%!-- Workspace Summary --%>
       <div id="tenant-summary-card">
         <.card>
-          <:title>{@tenant.name}</:title>
-          <:subtitle>Organization details</:subtitle>
+          <:title>{WorkspacePresentation.display_name(@tenant)}</:title>
+          <:subtitle>Stable identity for this access and request scope.</:subtitle>
 
           <.detail_grid
             gap_class="gap-x-6 gap-y-3"
             class="grid-cols-2"
           >
             <.detail_field id="tenant-detail-name" label="Name" value_class="font-medium">
-              {@tenant.name}
+              {WorkspacePresentation.display_name(@tenant)}
             </.detail_field>
             <.detail_field id="tenant-detail-slug" label="Slug" mono>
               {@tenant.slug}
             </.detail_field>
-            <.detail_field id="tenant-detail-id" label="Organization ID" mono break_all>
+            <.detail_field id="tenant-detail-id" label="Workspace ID" mono break_all>
               {@tenant.id}
             </.detail_field>
             <.detail_field id="tenant-detail-created-at" label="Created" mono>
@@ -295,10 +417,14 @@ defmodule OrchardConsole.TenantDetailLive do
           </.detail_grid>
         </.card>
       </div>
-      <div id="tenant-portal-invite-card">
+      </div>
+      <div id="workspace-section-portal_users" hidden={@section != "portal_users"} class="space-y-6">
+      <div id="tenant-portal-invite-card" class="scroll-mt-6">
         <.card>
-          <:title>Invite Portal User</:title>
-          <:subtitle>Create a named Developer Portal identity. Orchard does not send email.</:subtitle>
+          <:title>Invite a Portal User</:title>
+          <:subtitle>
+            Create a named identity for this Workspace's Developer Portal. Orchard does not send email or create an API credential. After creation, use Copy invite and deliver the URL out of band.
+          </:subtitle>
           <div
             :if={!@portal_https?}
             id="tenant-portal-tls-required"
@@ -373,7 +499,9 @@ defmodule OrchardConsole.TenantDetailLive do
       <div id="tenant-portal-users-card">
         <.card>
           <:title>Portal Users</:title>
-          <:subtitle>Named identities for this Organization.</:subtitle>
+          <:subtitle>
+            Named Developer Portal identities for this Workspace only. Portal access does not grant Console or cluster administration.
+          </:subtitle>
           <p :if={@portal_users == []} class="text-sm text-slate-500 dark:text-slate-400">
             No Portal Users invited yet.
           </p>
@@ -465,12 +593,29 @@ defmodule OrchardConsole.TenantDetailLive do
       <div id="tenant-portal-access-card">
         <.card>
           <:title>Portal access</:title>
-          <:subtitle>TLS-only isolated surface without Console chrome.</:subtitle>
-          <code class="font-mono text-sm">/portal/{@tenant.slug}</code>
+          <:subtitle>
+            TLS-only sign-in for this Workspace. The Developer Portal is separate from Console and does not authorize inference by itself.
+          </:subtitle>
+          <div class="flex flex-wrap items-center gap-3">
+            <code class="font-mono text-sm">/portal/{@tenant.slug}</code>
+            <.link
+              :if={@portal_base_url}
+              id="tenant-open-portal"
+              href={portal_url(@portal_base_url, @tenant.slug)}
+              class="text-sm font-medium text-navy underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-sky-400 dark:focus-visible:ring-sky-400"
+            >
+              Open Developer Portal
+            </.link>
+            <span :if={is_nil(@portal_base_url)} class="text-xs text-amber-700 dark:text-amber-300">
+              {portal_unavailable_label(@portal_https?)}
+            </span>
+          </div>
         </.card>
       </div>
 
       <%!-- One-Time Secret Card --%>
+      </div>
+      <div id="workspace-section-api_credentials" hidden={@section != "api_credentials"} class="space-y-6">
       <div :if={@generated_secret} id="tenant-api-key-secret-card">
         <.card>
           <:title>API Token Created - Copy Your Secret</:title>
@@ -530,10 +675,12 @@ defmodule OrchardConsole.TenantDetailLive do
       </div>
 
       <%!-- Create tenant-direct API Token --%>
-      <div id="tenant-api-key-create-card">
+      <div id="tenant-api-key-create-card" class="scroll-mt-6">
         <.card>
-          <:title>Create API Token</:title>
-          <:subtitle>Issue a new API Token for this Organization.</:subtitle>
+          <:title>Create a direct API Token</:title>
+          <:subtitle>
+            Issue a Public Inference credential for this Workspace. It does not sign a person in to the Developer Portal or grant model access.
+          </:subtitle>
 
           <.simple_form
             for={@api_key_form}
@@ -549,10 +696,13 @@ defmodule OrchardConsole.TenantDetailLive do
         </.card>
       </div>
 
-      <%!-- Organization API Tokens table --%>
+      <%!-- Workspace API Tokens table --%>
       <div id="tenant-api-keys-card">
         <.card>
-          <:title>Organization API Tokens</:title>
+          <:title>Workspace API Tokens</:title>
+          <:subtitle>
+            Tenant-direct credentials minted by operator tooling or by Portal Users. Revoking a token does not change Portal membership.
+          </:subtitle>
 
           <.table id="tenant-api-keys-table" rows={@api_keys} row_id={&"api-key-#{&1.id}"}>
             <:col :let={key} label="Name">{key.name}</:col>
@@ -600,7 +750,7 @@ defmodule OrchardConsole.TenantDetailLive do
                 title="No API Tokens created yet."
               >
                 <:action>
-                  Create an API Token above to issue direct Organization access.
+                  Create a direct API Token above, or let a Portal User mint one from the Developer Portal.
                 </:action>
               </.state_message>
             </:empty>
@@ -608,10 +758,12 @@ defmodule OrchardConsole.TenantDetailLive do
         </.card>
       </div>
 
-      <div id="tenant-api-clients-card">
+      <div id="tenant-api-clients-card" class="scroll-mt-6">
         <.card>
           <:title>API Clients</:title>
-          <:subtitle>Non-interactive access, ownership context, and owned API Tokens.</:subtitle>
+          <:subtitle>
+            Non-interactive application identities and their owned API Tokens. API Clients are provisioned separately from Portal Users.
+          </:subtitle>
 
           <div
             id="tenant-api-clients-list"
@@ -665,11 +817,10 @@ defmodule OrchardConsole.TenantDetailLive do
                         {client.owner_contact}
                       </div>
                       <div
-                        :if={present?(client.team)}
                         class="mt-1 flex min-w-0 max-w-full flex-wrap items-center gap-x-1 gap-y-0.5 text-xs text-slate-500 dark:text-slate-400"
                       >
                         <span class="font-medium uppercase tracking-wide">Team</span>
-                        <span class="min-w-0 break-words">{client.team}</span>
+                        <span class="min-w-0 break-words">{if present?(client.team), do: client.team, else: "Ungrouped"}</span>
                       </div>
                     </.detail_field>
                     <.detail_field
@@ -790,6 +941,7 @@ defmodule OrchardConsole.TenantDetailLive do
             </article>
           </div>
         </.card>
+      </div>
       </div>
     </div>
     """
@@ -924,9 +1076,10 @@ defmodule OrchardConsole.TenantDetailLive do
         api_keys: api_keys,
         api_clients: api_clients,
         portal_users: portal_users,
-        page_title: "Organization #{tenant.slug}",
+        page_title: WorkspacePresentation.display_name(tenant),
         load_error: nil
       )
+      |> load_model_access()
     else
       {:error, :tenant_not_found} ->
         assign(socket, detail_status: :not_found)
@@ -935,9 +1088,22 @@ defmodule OrchardConsole.TenantDetailLive do
     _ ->
       assign(socket,
         detail_status: :error,
-        load_error: "Organization details unavailable."
+        load_error: "Workspace details unavailable."
       )
   end
+
+  defp load_model_access(%{assigns: %{tenant: nil}} = socket), do: socket
+
+  defp load_model_access(socket) do
+    case WorkspaceAccess.list(socket.assigns.tenant) do
+      {:ok, rows} -> assign(socket, model_access: rows, model_access_error: nil)
+      {:error, reason} -> assign(socket, model_access: [], model_access_error: reason)
+    end
+  end
+
+  defp grant_label(:enabled), do: "Enabled"
+  defp grant_label(:disabled), do: "Disabled"
+  defp grant_label(:not_granted), do: "Not granted"
 
   defp inference_client_access?(api_client) do
     Enum.any?(api_client.role_bindings, fn
@@ -947,6 +1113,15 @@ defmodule OrchardConsole.TenantDetailLive do
   end
 
   defp active_api_token?(%ApiKey{} = api_key), do: ApiKey.status(api_key, utc_now()) == :active
+
+  defp portal_url(base_url, slug) do
+    String.trim_trailing(base_url, "/") <> "/portal/" <> slug
+  end
+
+  defp portal_unavailable_label(false), do: "Unavailable until public API HTTPS is enabled."
+
+  defp portal_unavailable_label(true),
+    do: "The configured public HTTPS Portal address is unavailable."
 
   defp minted_via_label(%TenantApiKeySummary{issuance_surface: "developer_portal"}),
     do: "Developer Portal"

--- a/apps/orchard_controller/lib/orchard/console/tenants_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenants_live.ex
@@ -95,6 +95,7 @@ defmodule OrchardConsole.TenantsLive do
               >
                 Open workspace
               </.link>
+              <.link navigate={"/console/access/workspaces/#{tenant.id}/handoff"} class="text-sm text-navy underline">Guide access</.link>
             </:action>
 
             <:empty>

--- a/apps/orchard_controller/lib/orchard/console/tenants_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/tenants_live.ex
@@ -1,17 +1,22 @@
 defmodule OrchardConsole.TenantsLive do
   @moduledoc """
-  Console Organizations page.
+  Console Workspaces page.
   """
 
   use OrchardConsole, :live_view
 
   alias Orchard.Governance
+  alias OrchardConsole.WorkspacePresentation
 
   @impl true
   def mount(_params, _session, socket) do
     socket =
       socket
-      |> assign(page_title: "Organizations", active_nav: :tenants)
+      |> assign(
+        page_title: "Access",
+        active_nav: :tenants,
+        create_mode: socket.assigns.live_action == :new
+      )
       |> assign_loading_state()
       |> assign_blank_form()
 
@@ -23,6 +28,8 @@ defmodule OrchardConsole.TenantsLive do
   end
 
   @impl true
+  def handle_event("refresh_workspaces", _params, socket), do: {:noreply, load_tenants(socket)}
+
   def handle_event("create_tenant", %{"tenant" => params}, socket) do
     create_tenant(socket, params)
   end
@@ -34,8 +41,8 @@ defmodule OrchardConsole.TenantsLive do
       id="tenants-loading-card"
       kind={:loading}
       layout={:panel}
-      title="Organizations"
-      body="Loading Organizations…"
+      title="Workspaces"
+      body="Loading Workspaces…"
     />
     """
   end
@@ -46,19 +53,72 @@ defmodule OrchardConsole.TenantsLive do
       id="tenants-error-card"
       kind={:error}
       layout={:panel}
-      title="Organizations unavailable"
+      title="Workspaces unavailable"
       body={@load_error}
-    />
+    ><:action><.button phx-click="refresh_workspaces" variant={:secondary}>Retry</.button></:action></.state_message>
     """
   end
 
   def render(%{tenants_status: :ok} = assigns) do
     ~H"""
     <div class="space-y-6">
-      <div id="tenant-create-card">
+      <header id="tenants-page-header" class="space-y-2">
+        <h2 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Manage Workspace access</h2>
+        <p class="max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+          A Workspace is the scope for model access, Portal Users, API credentials, requests, and usage.
+          Choose a Workspace to manage its access, or create a separate scope for new work.
+        </p>
+      </header>
+
+      <.link :if={!@create_mode} navigate="/console/access/workspaces/new" class="text-sm text-navy underline">Create Workspace</.link>
+      <.link :if={@create_mode} navigate="/console/access" class="text-sm text-navy underline">Back to Workspaces</.link>
+      <p :if={!@create_mode && !Enum.any?(@tenants, &WorkspacePresentation.default?/1)} id="workspace-default-missing" role="status">Default workspace is unavailable. Refresh after checking the controller setup; no replacement scope has been created.</p>
+      <.button :if={!@create_mode} phx-click="refresh_workspaces" variant={:secondary}>Refresh Workspaces</.button>
+      <div :if={!@create_mode} id="tenants-list-card">
         <.card>
-          <:title>Create Organization</:title>
-          <:subtitle>Add a new Organization to issue API Tokens against.</:subtitle>
+          <:title>Choose a Workspace</:title>
+          <:subtitle>Access and credentials are managed independently inside each Workspace.</:subtitle>
+
+          <.table id="tenants-table" rows={@tenants} row_id={&"tenant-#{&1.id}"}>
+            <:col :let={tenant} label="Name">{WorkspacePresentation.display_name(tenant)} <span :if={WorkspacePresentation.default?(tenant)} class="text-xs text-slate-500">Default</span></:col>
+            <:col :let={tenant} label="Slug" mono>{tenant.slug}</:col>
+            <:col :let={tenant} label="Workspace ID" mono>
+              <span class="text-xs">{tenant.id}</span>
+            </:col>
+            <:col :let={tenant} label="Created" mono><.local_time value={tenant.inserted_at} format={:datetime_minute} /></:col>
+
+            <:action :let={tenant}>
+              <.link
+                id={"tenant-open-#{tenant.id}"}
+                navigate={"/console/access/workspaces/#{tenant.id}"}
+                class="inline-flex rounded-md px-2 py-1 text-sm font-medium text-navy hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-navy dark:text-sky-400 dark:hover:bg-slate-700 dark:focus-visible:ring-sky-400"
+              >
+                Open workspace
+              </.link>
+            </:action>
+
+            <:empty>
+              <.state_message
+                id="tenants-empty-state"
+                kind={:empty}
+                layout={:compact}
+                title="No Workspaces created yet."
+              >
+                <:action>
+                  Use Create Workspace to establish an isolated scope.
+                </:action>
+              </.state_message>
+            </:empty>
+          </.table>
+        </.card>
+      </div>
+
+      <div :if={@create_mode} id="tenant-create-card">
+        <.card>
+          <:title>Create a separate Workspace</:title>
+          <:subtitle>
+            This creates the scope only. It does not grant model access, invite a Portal User, or issue an API credential.
+          </:subtitle>
 
           <.simple_form
             for={@tenant_form}
@@ -83,47 +143,9 @@ defmodule OrchardConsole.TenantsLive do
                 size={:lg}
               />
             <:actions>
-              <.button type="submit" phx-disable-with="Creating…">Create Organization</.button>
+              <.button type="submit" phx-disable-with="Creating…">Create Workspace</.button>
             </:actions>
           </.simple_form>
-        </.card>
-      </div>
-
-      <div id="tenants-list-card">
-        <.card>
-          <:title>Organizations</:title>
-
-          <.table id="tenants-table" rows={@tenants} row_id={&"tenant-#{&1.id}"}>
-            <:col :let={tenant} label="Name">{tenant.name}</:col>
-            <:col :let={tenant} label="Slug" mono>{tenant.slug}</:col>
-            <:col :let={tenant} label="Organization ID" mono>
-              <span class="text-xs">{tenant.id}</span>
-            </:col>
-            <:col :let={tenant} label="Created" mono><.local_time value={tenant.inserted_at} format={:datetime_minute} /></:col>
-
-            <:action :let={tenant}>
-              <.link
-                id={"tenant-open-#{tenant.id}"}
-                navigate={"/console/tenants/#{tenant.id}"}
-                class="text-forest-600 hover:text-forest-700 dark:text-emerald-400 dark:hover:text-emerald-300 font-medium text-sm"
-              >
-                Open
-              </.link>
-            </:action>
-
-            <:empty>
-              <.state_message
-                id="tenants-empty-state"
-                kind={:empty}
-                layout={:compact}
-                title="No Organizations created yet."
-              >
-                <:action>
-                  Create an Organization above to start issuing API Tokens.
-                </:action>
-              </.state_message>
-            </:empty>
-          </.table>
         </.card>
       </div>
     </div>
@@ -137,9 +159,9 @@ defmodule OrchardConsole.TenantsLive do
       {:ok, tenant} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Created Organization #{tenant.slug}.")
+         |> put_flash(:info, "Created Workspace #{tenant.slug}.")
          |> assign_blank_form()
-         |> load_tenants()}
+         |> push_navigate(to: "/console/access/workspaces/#{tenant.id}")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         form = changeset_to_form(changeset, :tenant, %{"slug" => "", "name" => ""})
@@ -147,7 +169,7 @@ defmodule OrchardConsole.TenantsLive do
     end
   rescue
     _ ->
-      {:noreply, put_flash(socket, :error, "Unable to create tenant.")}
+      {:noreply, put_flash(socket, :error, "Unable to create Workspace.")}
   end
 
   defp assign_loading_state(socket) do
@@ -180,7 +202,11 @@ defmodule OrchardConsole.TenantsLive do
   defp load_tenants(socket) do
     assign(socket,
       tenants_status: :ok,
-      tenants: Governance.list_tenants(),
+      tenants:
+        Enum.sort_by(
+          Governance.list_tenants(),
+          &{!WorkspacePresentation.default?(&1), WorkspacePresentation.display_name(&1), &1.id}
+        ),
       load_error: nil
     )
   rescue
@@ -188,7 +214,7 @@ defmodule OrchardConsole.TenantsLive do
       assign(socket,
         tenants_status: :error,
         tenants: [],
-        load_error: "Organization data unavailable."
+        load_error: "Workspace data unavailable."
       )
   end
 end

--- a/apps/orchard_controller/lib/orchard/console/workspace_access.ex
+++ b/apps/orchard_controller/lib/orchard/console/workspace_access.ex
@@ -1,0 +1,56 @@
+defmodule OrchardConsole.WorkspaceAccess do
+  @moduledoc "Read-only exact-model grants and scoped operator command handoffs."
+
+  alias Orchard.Models
+  alias Orchard.Models.Access
+
+  @type row :: %{
+          model: Models.Model.t(),
+          grant_state: :enabled | :disabled | :not_granted,
+          grant: map() | nil
+        }
+
+  @spec list(map(), keyword()) :: {:ok, [row()]} | {:error, term()}
+  def list(tenant, opts \\ []) do
+    access_reader = Keyword.get(opts, :access_reader, &Access.list_model_access/1)
+    model_reader = Keyword.get(opts, :model_reader, &Models.list_models/0)
+
+    with {:ok, grants} <- access_reader.(tenant) do
+      by_model = Map.new(grants, &{&1.model_id, &1})
+
+      rows =
+        model_reader.()
+        |> Enum.sort_by(&{&1.model_id, &1.version, &1.id})
+        |> Enum.map(fn model ->
+          grant = Map.get(by_model, model.id)
+          %{model: model, grant: grant, grant_state: grant_state(grant)}
+        end)
+
+      {:ok, rows}
+    end
+  rescue
+    _error in [DBConnection.ConnectionError, Postgrex.Error] -> {:error, :unavailable}
+  end
+
+  @spec commands(map(), map(), map() | nil) :: %{grant: String.t(), inspect: String.t()}
+  def commands(%{id: tenant_id}, %{model_id: model_id, version: version}, grant \\ nil) do
+    exact_model = shell_quote(model_id <> "@" <> version)
+    scope = shell_quote(tenant_id)
+    policy = policy_option(grant)
+
+    %{
+      grant: "orchardctl models access grant " <> exact_model <> " --tenant " <> scope <> policy,
+      inspect: "orchardctl models access inspect " <> exact_model <> " --tenant " <> scope
+    }
+  end
+
+  defp policy_option(%{routing_policy_id: id}) when is_binary(id),
+    do: " --routing-policy-id " <> shell_quote(id)
+
+  defp policy_option(_grant), do: ""
+
+  defp grant_state(nil), do: :not_granted
+  defp grant_state(%{enabled: true}), do: :enabled
+  defp grant_state(_grant), do: :disabled
+  defp shell_quote(value), do: "'" <> String.replace(value, "'", "'\\''") <> "'"
+end

--- a/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
@@ -1,0 +1,447 @@
+defmodule OrchardConsole.WorkspaceHandoffLive do
+  @moduledoc "Guides an operator through a scoped colleague handoff without impersonating the colleague."
+  use OrchardConsole, :live_view
+
+  alias Orchard.Governance
+  alias Orchard.Governance.PortalActivationCurl
+  alias OrchardConsole.{WorkspaceAccess, WorkspacePresentation}
+
+  @steps [
+    "Workspace",
+    "Model access",
+    "Portal invitation",
+    "Review scope",
+    "Colleague handoff",
+    "First request"
+  ]
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(page_title: "Colleague handoff", active_nav: :tenants, steps: @steps)
+     |> reset(nil)}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id} = params, _uri, socket) do
+    socket = if socket.assigns.workspace_id == id, do: socket, else: reset(socket, id)
+
+    socket =
+      if connected?(socket) and socket.assigns.status == :loading, do: load(socket), else: socket
+
+    step = requested_step(params["step"], socket.assigns.step)
+    {:noreply, assign(socket, step: min(step, navigation_limit(socket.assigns)))}
+  end
+
+  @impl true
+  def handle_event("refresh", _params, socket), do: {:noreply, socket |> clear_invite() |> load()}
+
+  def handle_event("choose_model", %{"model" => %{"id" => id}}, socket) do
+    case Enum.find(socket.assigns.rows, &(&1.model.id == id)) do
+      nil ->
+        {:noreply,
+         socket
+         |> clear_invite()
+         |> assign(selected: nil, model_id: nil, unlocked: 2)
+         |> put_flash(:error, "Choose a model from this Workspace's current catalog read.")}
+
+      row ->
+        {:noreply,
+         socket
+         |> clear_invite()
+         |> assign(
+           model_id: row.model.id,
+           selected: row,
+           unlocked: max(3, socket.assigns.unlocked),
+           portal_url: portal_url(socket.assigns.workspace, row)
+         )}
+    end
+  end
+
+  def handle_event("colleague_change", %{"colleague" => %{"email" => email}}, socket) do
+    {:noreply, socket |> clear_invite() |> assign(email: email, user: nil, unlocked: 3)}
+  end
+
+  def handle_event("prepare_colleague", %{"colleague" => %{"email" => email}}, socket) do
+    socket = socket |> clear_invite() |> assign(email: email, user: nil, unlocked: 3)
+
+    if socket.assigns.status == :ok and socket.assigns.selected do
+      {:noreply, prepare_colleague(socket, String.downcase(String.trim(email)))}
+    else
+      {:noreply, put_flash(socket, :error, "Refresh Workspace data and choose a model first.")}
+    end
+  end
+
+  def handle_event("next", _params, socket) do
+    next = socket.assigns.step + 1
+
+    if next <= 6 and can_advance?(socket.assigns) do
+      {:noreply, socket |> assign(unlocked: max(next, socket.assigns.unlocked)) |> go(next)}
+    else
+      {:noreply, put_flash(socket, :error, "Complete the current selection before continuing.")}
+    end
+  end
+
+  def handle_event("issue_invite", _params, socket) do
+    if socket.assigns.status == :ok and not is_nil(socket.assigns.selected) and
+         match?(%{status: "invited"}, socket.assigns.user) do
+      {:noreply, issue_invite(clear_invite(socket))}
+    else
+      {:noreply,
+       put_flash(
+         socket,
+         :error,
+         "Only an invited Portal User in this Workspace can receive an invite link. Refresh to check their status."
+       )}
+    end
+  end
+
+  def handle_event("generated_secret_copied", _params, socket),
+    do: {:noreply, assign(socket, copy_status: :copied)}
+
+  def handle_event("generated_secret_copy_failed", _params, socket),
+    do: {:noreply, assign(socket, copy_status: :failed)}
+
+  @impl true
+  def handle_info({:expire_invite, expires_at}, socket) do
+    if socket.assigns.invite && socket.assigns.invite.expires_at == expires_at do
+      {:noreply,
+       socket
+       |> clear_invite()
+       |> put_flash(
+         :info,
+         "The invite URL expired. Refresh and issue a new link if the user is still invited."
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp reset(socket, id) do
+    socket
+    |> clear_invite()
+    |> assign(
+      workspace_id: id,
+      workspace: nil,
+      status: :loading,
+      rows: [],
+      selected: nil,
+      model_id: nil,
+      email: "",
+      user: nil,
+      step: 2,
+      unlocked: 2,
+      portal_url: nil
+    )
+  end
+
+  defp load(socket) do
+    with {:ok, workspace} <- Governance.get_tenant(socket.assigns.workspace_id),
+         {:ok, rows} <- WorkspaceAccess.list(workspace),
+         {:ok, users} <- Governance.list_portal_user_summaries(workspace) do
+      selected = Enum.find(rows, &(&1.model.id == socket.assigns.model_id))
+      user = if socket.assigns.user, do: Enum.find(users, &(&1.id == socket.assigns.user.id))
+
+      socket
+      |> assign(
+        workspace: workspace,
+        rows: rows,
+        selected: selected,
+        user: user,
+        status: :ok,
+        portal_url: portal_url(workspace, selected)
+      )
+    else
+      {:error, :tenant_not_found} ->
+        assign(socket, status: :not_found, workspace: nil, selected: nil, user: nil)
+
+      {:error, _reason} ->
+        assign(socket, status: :error)
+    end
+  rescue
+    _error in [Ecto.Query.CastError, Ecto.NoResultsError] -> assign(socket, status: :not_found)
+    _error in [Postgrex.Error, DBConnection.ConnectionError] -> assign(socket, status: :error)
+  end
+
+  defp prepare_colleague(socket, email) do
+    case Governance.list_portal_user_summaries(socket.assigns.workspace) do
+      {:ok, users} ->
+        case Enum.find(users, &(&1.email == email)) do
+          %{status: "disabled"} ->
+            put_flash(
+              socket,
+              :error,
+              "This Portal User is disabled. Use Workspace management to resolve access; no new invitation was created."
+            )
+
+          %{} = user ->
+            accept_user(socket, user)
+
+          nil ->
+            create_user(socket, email)
+        end
+
+      {:error, _reason} ->
+        put_flash(
+          socket,
+          :error,
+          "Unable to check Portal Users. Retry without changing Workspace."
+        )
+    end
+  rescue
+    _error in [Postgrex.Error, DBConnection.ConnectionError] ->
+      put_flash(
+        socket,
+        :error,
+        "Unable to save Portal User state. Retry to check whether the identity was saved; your model and email are retained."
+      )
+  end
+
+  defp create_user(socket, email) do
+    case Governance.create_portal_invite(socket.assigns.workspace, %{email: email}) do
+      {:ok, user} ->
+        accept_user(socket, user)
+
+      {:error, %Ecto.Changeset{}} ->
+        put_flash(
+          socket,
+          :error,
+          "Enter a valid colleague email. If the user was just created elsewhere, retry to use their existing identity."
+        )
+
+      {:error, :https_required} ->
+        put_flash(socket, :error, "Configure public HTTPS before creating Portal invitations.")
+
+      {:error, _reason} ->
+        put_flash(
+          socket,
+          :error,
+          "Unable to create the Portal User. Your model and email are retained for retry."
+        )
+    end
+  end
+
+  defp accept_user(socket, user), do: socket |> assign(user: user, unlocked: 4) |> go(4)
+
+  defp issue_invite(socket) do
+    base = PortalActivationCurl.public_base_url()
+
+    if base do
+      issue_invite(socket, base)
+    else
+      put_flash(
+        socket,
+        :error,
+        "Configure a public HTTPS Portal address before issuing a link for delivery."
+      )
+    end
+  end
+
+  defp issue_invite(socket, base) do
+    case Governance.copy_portal_invite(socket.assigns.workspace, socket.assigns.user.id) do
+      {:ok, invite} ->
+        timer =
+          Process.send_after(
+            self(),
+            {:expire_invite, invite.expires_at},
+            max(DateTime.diff(invite.expires_at, DateTime.utc_now(), :millisecond), 0)
+          )
+
+        query = URI.encode_query(%{"model" => identity(socket.assigns.selected.model)})
+
+        visible = %{
+          url: String.trim_trailing(base, "/") <> invite.url <> "?" <> query,
+          expires_at: invite.expires_at
+        }
+
+        assign(socket, invite: visible, invite_timer: timer, copy_status: :pending)
+
+      {:error, _reason} ->
+        put_flash(
+          socket,
+          :error,
+          "Unable to issue the invite link. The Portal User is already saved; retry link issuance without recreating them."
+        )
+    end
+  rescue
+    _error in [Postgrex.Error, DBConnection.ConnectionError] ->
+      put_flash(
+        socket,
+        :error,
+        "Unable to issue the invite link. The Portal User is already saved; retry link issuance without recreating them."
+      )
+  end
+
+  defp clear_invite(socket) do
+    if ref = socket.assigns[:invite_timer], do: Process.cancel_timer(ref)
+    assign(socket, invite: nil, invite_timer: nil, copy_status: :pending)
+  end
+
+  defp can_advance?(%{status: status}) when status != :ok, do: false
+  defp can_advance?(%{step: 1}), do: true
+  defp can_advance?(%{step: 2, selected: selected}), do: not is_nil(selected)
+
+  defp can_advance?(%{step: step, user: user, selected: selected}) when step in [4, 5],
+    do: not is_nil(selected) and not is_nil(user) and user.status != "disabled"
+
+  defp can_advance?(_assigns), do: false
+
+  defp navigation_limit(%{selected: nil}), do: 2
+  defp navigation_limit(%{user: nil, unlocked: unlocked}), do: min(3, unlocked)
+  defp navigation_limit(%{unlocked: unlocked}), do: unlocked
+
+  defp go(socket, step),
+    do: push_patch(socket, to: handoff_path(socket.assigns.workspace_id, step))
+
+  defp handoff_path(id, step), do: "/console/access/workspaces/#{id}/handoff?step=#{step}"
+
+  defp requested_step(value, fallback) do
+    case Integer.parse(value || "") do
+      {step, ""} when step in 1..6 -> step
+      _ -> fallback
+    end
+  end
+
+  defp identity(model), do: "#{model.model_id}@#{model.version}"
+  defp grant_label(:enabled), do: "Granted"
+  defp grant_label(:disabled), do: "Disabled"
+  defp grant_label(:not_granted), do: "Not granted"
+
+  defp portal_url(workspace, selected) do
+    if base = PortalActivationCurl.public_base_url() do
+      query =
+        if selected, do: "?" <> URI.encode_query(%{"model" => identity(selected.model)}), else: ""
+
+      String.trim_trailing(base, "/") <>
+        "/portal/" <> URI.encode(workspace.slug, &URI.char_unreserved?/1) <> query
+    end
+  end
+
+  defp request_example(row) do
+    body =
+      Jason.encode!(%{
+        model: identity(row.model),
+        messages: [%{role: "user", content: "Say hello in one sentence."}]
+      })
+
+    "POST /v1/chat/completions\nAuthorization: Bearer <YOUR_OWN_API_KEY>\nContent-Type: application/json\n\n" <>
+      body
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-6">
+      <.link navigate="/console/access" class="text-sm text-navy dark:text-sky-400">Back to Access</.link>
+      <.card>
+        <:title>Help a colleague use a model</:title>
+        <:subtitle>One Workspace, one exact model, and a separate personal Portal sign-in.</:subtitle>
+        <div :if={@workspace} id="handoff-scope" class="text-sm">
+          <span class="font-semibold">{WorkspacePresentation.display_name(@workspace)}</span>
+          <span class="mt-1 block font-mono break-all text-slate-500 dark:text-slate-400">{@workspace.slug}</span>
+          <p :if={@selected} class="mt-2 font-mono break-all">{identity(@selected.model)}</p>
+        </div>
+      </.card>
+      <nav aria-label="Colleague handoff steps" class="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+        <p class="mb-3 text-sm font-semibold">Step {@step} of 6: {Enum.at(@steps, @step - 1)}</p>
+        <ol class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          <li :for={{label, number} <- Enum.with_index(@steps, 1)}>
+            <.link :if={number <= @unlocked} patch={handoff_path(@workspace_id, number)} aria-current={if number == @step, do: "step"} class={["flex items-center gap-2 rounded-md p-2 text-sm", if(number == @step, do: "bg-navy/10 font-semibold text-navy dark:text-sky-400", else: "text-slate-600 dark:text-slate-300")]}>
+              <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border">{number}</span>{label}
+            </.link>
+            <span :if={number > @unlocked} aria-disabled="true" class="flex items-center gap-2 p-2 text-sm text-slate-400 dark:text-slate-500"><span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border">{number}</span>{label}</span>
+          </li>
+        </ol>
+        <p class="mt-3 text-xs text-slate-500">Steps orient this handoff. Visiting a step does not prove an invitation was accepted or a request succeeded.</p>
+      </nav>
+      <div :if={@status != :ok} id="handoff-load-state" role="status" class="rounded-lg border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-800">
+        <p>{case @status do
+          :loading -> "Loading Workspace…"
+          :not_found -> "Workspace not found. Return to Access to choose an existing Workspace."
+          :error -> "Unable to read Workspace access. Previous selections are retained, but actions are unavailable until refresh succeeds."
+        end}</p>
+        <.button :if={@status != :loading} phx-click="refresh" class="mt-4">Retry read</.button>
+      </div>
+      <section :if={@status == :ok} id={"handoff-step-#{@step}"} aria-labelledby={"handoff-heading-#{@step}"} class="rounded-lg border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-800" phx-mounted={Phoenix.LiveView.JS.focus(to: "#handoff-heading-#{@step}")}>
+        <h2 id={"handoff-heading-#{@step}"} tabindex="-1" class="text-xl font-semibold">{Enum.at(@steps, @step - 1)}</h2>
+        <div :if={@step == 1} class="mt-4 space-y-3">
+          <p>This handoff is scoped to {WorkspacePresentation.display_name(@workspace)}. Available Workspaces are destinations you can choose, not the colleague's permissions.</p>
+          <p :if={WorkspacePresentation.default?(@workspace)}>The built-in Default Workspace is already selected. This does not grant model access.</p>
+          <.link navigate="/console/access" class="text-navy dark:text-sky-400">Choose a different Workspace and start a new handoff</.link>
+        </div>
+        <div :if={@step == 2} class="mt-4 space-y-4">
+          <p>Choose an exact catalog model for this Workspace. Runtime readiness is checked separately.</p>
+          <p :if={@rows == []}>No catalog models are available. Import a model from Models, then return and refresh.</p>
+          <.form :if={@rows != []} for={to_form(%{"id" => @model_id || ""}, as: :model)} id="handoff-model-form" phx-change="choose_model">
+            <label for="handoff-model-id" class="block text-sm font-medium">Catalog model</label>
+            <select id="handoff-model-id" name="model[id]" class="mt-2 w-full rounded-md border border-slate-200 bg-slate-50 p-3 text-sm shadow-inner dark:border-slate-700 dark:bg-slate-900/60">
+              <option value="">Choose a model</option>
+              <option :for={row <- @rows} value={row.model.id} selected={@model_id == row.model.id}>{identity(row.model)} - {grant_label(row.grant_state)}</option>
+            </select>
+          </.form>
+          <div :if={@selected} id="handoff-model-access" class="space-y-3">
+            <p>Model access: <strong>{grant_label(@selected.grant_state)}</strong>. Catalog state: {@selected.model.state}.</p>
+            <div :if={@selected.grant_state != :enabled} class="space-y-2">
+              <p>An authorized administrator must grant access. You may prepare the colleague handoff while access is pending; continuing does not grant it.</p>
+              <pre class="overflow-x-auto rounded-md bg-slate-50 p-3 text-xs dark:bg-slate-900/60">{WorkspaceAccess.commands(@workspace, @selected.model, @selected.grant).grant}</pre>
+              <p>After the administrator runs the command, refresh to read the actual grant.</p>
+            </div>
+            <pre class="overflow-x-auto rounded-md bg-slate-50 p-3 text-xs dark:bg-slate-900/60">{WorkspaceAccess.commands(@workspace, @selected.model, @selected.grant).inspect}</pre>
+          </div>
+        </div>
+        <div :if={@step == 3} class="mt-4 space-y-4">
+          <p>Identify the colleague in this Workspace. Existing active Portal Users are reused; an invitation grants no model permissions and sends no email.</p>
+          <.form for={to_form(%{"email" => @email}, as: :colleague)} id="handoff-colleague-form" phx-change="colleague_change" phx-submit="prepare_colleague">
+            <.input id="handoff-colleague-email" name="colleague[email]" value={@email} type="email" label="Colleague email" required />
+            <.button type="submit" class="mt-4">Continue with this colleague</.button>
+          </.form>
+        </div>
+        <div :if={@step == 4} class="mt-4 space-y-4">
+          <p>Check each independent part of the handoff before sharing anything.</p>
+          <dl class="space-y-3 text-sm">
+            <div><dt class="font-semibold">Workspace</dt><dd>{WorkspacePresentation.display_name(@workspace)} ({@workspace.slug})</dd></div>
+            <div><dt class="font-semibold">Model access</dt><dd>{if @selected, do: grant_label(@selected.grant_state), else: "Model no longer in catalog; return to Model access"}</dd></div>
+            <div :if={@selected}><dt class="font-semibold">Catalog model</dt><dd>{@selected.model.state}; separate from runtime readiness.</dd></div>
+            <div><dt class="font-semibold">Portal User</dt><dd>{if @user, do: "#{@user.email} - #{@user.status}", else: "User no longer available; return to Portal invitation"}</dd></div>
+            <div><dt class="font-semibold">Personal API Key</dt><dd>The colleague creates their own key in the actual Portal. This Console flow does not create or inspect it.</dd></div>
+            <div><dt class="font-semibold">Runtime and request</dt><dd>Not verified by this handoff.</dd></div>
+          </dl>
+          <.link :if={@selected && @selected.model.state != :active} navigate="/console/models/catalog" class="text-navy dark:text-sky-400">Review the model's lifecycle in Catalog before making a request</.link>
+        </div>
+        <div :if={@step == 5} class="mt-4 space-y-4">
+          <p>No email is sent. Deliver the Portal link separately to the intended colleague.</p>
+          <p :if={!@user || @user.status == "disabled"}>This Portal User is unavailable or disabled. Return to Portal invitation to resolve the colleague's access before sharing a link.</p>
+          <p :if={@user && @user.status == "active"}>This Portal User is already active. They can sign in with their existing account; no new invitation is needed.</p>
+          <div :if={@user && @user.status == "invited"} class="space-y-3">
+            <p>The Portal User is saved. Issue an invite link separately. Each issuance invalidates any earlier unused invite link.</p>
+            <.button id="handoff-issue-invite" phx-click="issue_invite">{if @invite, do: "Issue replacement invite", else: "Issue invite link"}</.button>
+          </div>
+          <div :if={@invite} id="handoff-invite" class="space-y-3 rounded-md bg-slate-50 p-4 dark:bg-slate-900/60">
+            <p id="handoff-invite-value" class="break-all font-mono text-sm">{@invite.url}</p>
+            <p>Expires <.local_time id="handoff-invite-expiry" value={@invite.expires_at} format={:datetime_minute} />. Copy before leaving; plaintext cannot be recovered on reload.</p>
+            <button id="handoff-copy-invite" type="button" phx-hook="CopyGeneratedSecret" data-secret-source="handoff-invite-value" data-api-key-id="handoff-invite" class="rounded-md bg-navy px-3 py-2 text-sm text-white dark:bg-sky-500">Copy invite URL</button>
+            <p role="status">{case @copy_status do :copied -> "Invite URL copied. Delivery and acceptance are not verified."; :failed -> "Copy failed. Select and copy the visible URL, or retry."; _ -> "Not yet copied." end}</p>
+          </div>
+          <p :if={!@portal_url}>A public HTTPS Portal address is not configured. Resolve this before delivering a usable Portal handoff.</p>
+          <.link :if={@portal_url} href={@portal_url} target="_blank" rel="noopener noreferrer" class="text-navy dark:text-sky-400">Open this Workspace's Developer Portal</.link>
+          <p>The colleague manages their own credential in the Portal. Return to Model access if their model grant is still missing.</p>
+        </div>
+        <div :if={@step == 6} class="mt-4 space-y-4">
+          <p>The colleague sends a request from their own client to the configured public HTTPS endpoint using their own API Key. This is an inert example, not an executed request.</p>
+          <pre :if={@selected} id="handoff-request-example" class="overflow-x-auto rounded-md bg-slate-50 p-3 text-xs dark:bg-slate-900/60">{request_example(@selected)}</pre>
+          <p id="handoff-request-result">Request result: not observed. A valid key and model grant do not prove that a compatible Node is ready.</p>
+          <p :if={@selected && @selected.grant_state != :enabled}>Model access is still {grant_label(@selected.grant_state)}. Return to Model access and complete the administrator handoff first.</p>
+          <p :if={@selected && @selected.model.state != :active}>This catalog model is {@selected.model.state}, so it is not currently available for Public Inference.</p>
+          <p>Console Playground uses its own default Workspace context; it does not execute this selected Workspace's handoff.</p>
+        </div>
+        <div class="mt-6 flex flex-wrap items-center gap-3 border-t border-slate-200 pt-4 dark:border-slate-700">
+          <.link :if={@step > 1} patch={handoff_path(@workspace_id, @step - 1)} class="text-sm text-navy dark:text-sky-400">Back</.link>
+          <.button :if={@step in [1, 2, 4, 5]} id="handoff-next" phx-click="next" disabled={!can_advance?(assigns)}>Continue</.button>
+          <.button phx-click="refresh" variant={:secondary}>Refresh actual access and user state</.button>
+        </div>
+      </section>
+    </div>
+    """
+  end
+end

--- a/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
@@ -30,8 +30,9 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
     socket =
       if connected?(socket) and socket.assigns.status == :loading, do: load(socket), else: socket
 
-    step = requested_step(params["step"], socket.assigns.step)
-    {:noreply, assign(socket, step: min(step, navigation_limit(socket.assigns)))}
+    step = min(requested_step(params["step"], socket.assigns.step), navigation_limit(socket.assigns))
+    socket = if step == 5, do: socket, else: clear_invite(socket)
+    {:noreply, assign(socket, step: step)}
   end
 
   @impl true
@@ -84,7 +85,8 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
   end
 
   def handle_event("issue_invite", _params, socket) do
-    if socket.assigns.status == :ok and not is_nil(socket.assigns.selected) and
+    if socket.assigns.step == 5 and socket.assigns.status == :ok and
+         not is_nil(socket.assigns.selected) and
          match?(%{status: "invited"}, socket.assigns.user) do
       {:noreply, issue_invite(clear_invite(socket))}
     else
@@ -148,10 +150,12 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
         workspace: workspace,
         rows: rows,
         selected: selected,
+        model_id: if(selected, do: selected.model.id),
         user: user,
         status: :ok,
         portal_url: portal_url(workspace, selected)
       )
+      |> reconcile_navigation()
     else
       {:error, :tenant_not_found} ->
         assign(socket, status: :not_found, workspace: nil, selected: nil, user: nil)
@@ -288,8 +292,27 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
   defp can_advance?(_assigns), do: false
 
   defp navigation_limit(%{selected: nil}), do: 2
+  defp navigation_limit(%{user: %{status: "disabled"}, unlocked: unlocked}), do: min(3, unlocked)
   defp navigation_limit(%{user: nil, unlocked: unlocked}), do: min(3, unlocked)
   defp navigation_limit(%{unlocked: unlocked}), do: unlocked
+
+  defp reconcile_navigation(socket) do
+    previous_step = socket.assigns.step
+    limit = navigation_limit(socket.assigns)
+    step = min(previous_step, limit)
+    socket = assign(socket, step: step, unlocked: limit)
+
+    if step < previous_step do
+      message =
+        if socket.assigns.selected,
+          do: "Portal User is unavailable or disabled. Review the colleague before continuing.",
+          else: "Selected model is no longer in Catalog. Choose a model to continue."
+
+      socket |> put_flash(:info, message) |> go(step)
+    else
+      socket
+    end
+  end
 
   defp go(socket, step),
     do: push_patch(socket, to: handoff_path(socket.assigns.workspace_id, step))
@@ -413,7 +436,7 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
           <p>No email is sent. Deliver the Portal link separately to the intended colleague.</p>
           <p :if={!@user || @user.status == "disabled"}>This Portal User is unavailable or disabled. Return to Portal invitation to resolve the colleague's access before sharing a link.</p>
           <p :if={@user && @user.status == "active"}>This Portal User is already active. They can sign in with their existing account; no new invitation is needed.</p>
-          <div :if={@user && @user.status == "invited"} class="space-y-3">
+          <div :if={@selected && @user && @user.status == "invited"} class="space-y-3">
             <p>The Portal User is saved. Issue an invite link separately. Each issuance invalidates any earlier unused invite link.</p>
             <.button id="handoff-issue-invite" phx-click="issue_invite">{if @invite, do: "Issue replacement invite", else: "Issue invite link"}</.button>
           </div>

--- a/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
@@ -430,7 +430,7 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
             <div><dt class="font-semibold">Personal API Key</dt><dd>The colleague creates their own key in the actual Portal. This Console flow does not create or inspect it.</dd></div>
             <div><dt class="font-semibold">Runtime and request</dt><dd>Not verified by this handoff.</dd></div>
           </dl>
-          <.link :if={@selected && @selected.model.state != :active} navigate="/console/models/catalog" class="text-navy dark:text-sky-400">Review the model's lifecycle in Catalog before making a request</.link>
+          <.link :if={@selected && @selected.model.state != :active} navigate="/console/models/catalog" class="text-navy dark:text-sky-400">Review the model's lifecycle in Catalog</.link>
         </div>
         <div :if={@step == 5} class="mt-4 space-y-4">
           <p>No email is sent. Deliver the Portal link separately to the intended colleague.</p>
@@ -455,7 +455,8 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
           <pre :if={@selected} id="handoff-request-example" class="overflow-x-auto rounded-md bg-slate-50 p-3 text-xs dark:bg-slate-900/60">{request_example(@selected)}</pre>
           <p id="handoff-request-result">Request result: not observed. A valid key and model grant do not prove that a compatible Node is ready.</p>
           <p :if={@selected && @selected.grant_state != :enabled}>Model access is still {grant_label(@selected.grant_state)}. Return to Model access and complete the administrator handoff first.</p>
-          <p :if={@selected && @selected.model.state != :active}>This catalog model is {@selected.model.state}, so it is not currently available for Public Inference.</p>
+          <p :if={@selected && @selected.model.state == :deprecated}>This catalog model is deprecated. Deprecation does not by itself block inference; model access and runtime readiness still apply.</p>
+          <p :if={@selected && @selected.model.state in [:registered, :retired]}>This catalog model is {@selected.model.state}, so it is not currently available for Public Inference.</p>
           <p>Console Playground uses its own default Workspace context; it does not execute this selected Workspace's handoff.</p>
         </div>
         <div class="mt-6 flex flex-wrap items-center gap-3 border-t border-slate-200 pt-4 dark:border-slate-700">

--- a/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
@@ -30,7 +30,9 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
     socket =
       if connected?(socket) and socket.assigns.status == :loading, do: load(socket), else: socket
 
-    step = min(requested_step(params["step"], socket.assigns.step), navigation_limit(socket.assigns))
+    step =
+      min(requested_step(params["step"], socket.assigns.step), navigation_limit(socket.assigns))
+
     socket = if step == 5, do: socket, else: clear_invite(socket)
     {:noreply, assign(socket, step: step)}
   end
@@ -398,7 +400,7 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
           <p :if={@rows == []}>No catalog models are available. Import a model from Models, then return and refresh.</p>
           <.form :if={@rows != []} for={to_form(%{"id" => @model_id || ""}, as: :model)} id="handoff-model-form" phx-change="choose_model">
             <label for="handoff-model-id" class="block text-sm font-medium">Catalog model</label>
-            <select id="handoff-model-id" name="model[id]" class="mt-2 w-full rounded-md border border-slate-200 bg-slate-50 p-3 text-sm shadow-inner dark:border-slate-700 dark:bg-slate-900/60">
+            <select id="handoff-model-id" name="model[id]" class="mt-2 w-full rounded-md border border-slate-200 bg-slate-50 p-3 text-sm shadow-inner focus-visible:outline-none focus-visible:border-navy focus-visible:ring-2 focus-visible:ring-navy/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:bg-slate-900/60 dark:focus-visible:border-sky-400 dark:focus-visible:ring-sky-400/40 dark:focus-visible:ring-offset-slate-900">
               <option value="">Choose a model</option>
               <option :for={row <- @rows} value={row.model.id} selected={@model_id == row.model.id}>{identity(row.model)} - {grant_label(row.grant_state)}</option>
             </select>

--- a/apps/orchard_controller/lib/orchard/console/workspace_presentation.ex
+++ b/apps/orchard_controller/lib/orchard/console/workspace_presentation.ex
@@ -1,0 +1,13 @@
+defmodule OrchardConsole.WorkspacePresentation do
+  @moduledoc "Workspace display names over the existing Tenant identity."
+
+  @default_id "00000000-0000-0000-0000-000000000000"
+
+  @spec default?(map()) :: boolean()
+  def default?(%{id: @default_id}), do: true
+  def default?(_tenant), do: false
+
+  @spec display_name(map()) :: String.t()
+  def display_name(%{id: @default_id, name: "Legacy Single Tenant"}), do: "Default workspace"
+  def display_name(%{name: name}) when is_binary(name), do: name
+end

--- a/apps/orchard_controller/lib/orchard/governance/portal_activation_curl.ex
+++ b/apps/orchard_controller/lib/orchard/governance/portal_activation_curl.ex
@@ -8,16 +8,33 @@ defmodule Orchard.Governance.PortalActivationCurl do
 
   alias Orchard.API.Endpoint
   alias Orchard.API.Transport
+  alias Orchard.Models
 
   @prompt "Say hello in one sentence."
 
-  @spec select_callable_model(Ecto.UUID.t()) :: String.t() | nil
-  def select_callable_model(tenant_id) when is_binary(tenant_id) do
-    case visible_models_for_tenant(tenant_id) do
-      [] ->
-        nil
-    end
+  @spec select_callable_model(Ecto.UUID.t(), String.t() | nil) :: String.t() | nil
+  def select_callable_model(tenant_id, requested_model \\ nil)
+
+  def select_callable_model(tenant_id, nil) when is_binary(tenant_id) do
+    tenant_id
+    |> visible_models_for_tenant()
+    |> Enum.min_by(&model_sort_key/1, fn -> nil end)
+    |> exact_model_identity()
+  rescue
+    _error in [DBConnection.ConnectionError, Postgrex.Error] -> nil
   end
+
+  def select_callable_model(tenant_id, requested_model)
+      when is_binary(tenant_id) and is_binary(requested_model) do
+    tenant_id
+    |> visible_models_for_tenant()
+    |> Enum.find(&(exact_model_identity(&1) == requested_model))
+    |> exact_model_identity()
+  rescue
+    _error in [DBConnection.ConnectionError, Postgrex.Error] -> nil
+  end
+
+  def select_callable_model(_tenant_id, _requested_model), do: nil
 
   @spec build(String.t(), String.t() | nil, String.t() | nil) :: String.t() | nil
   def build(_token, nil, _url), do: nil
@@ -57,11 +74,12 @@ defmodule Orchard.Governance.PortalActivationCurl do
     end
   end
 
-  defp visible_models_for_tenant(_tenant_id) do
-    # GET /v1/models is not tenant-scoped yet. Do not treat the full active
-    # catalog as authorized for a portal curl.
-    []
-  end
+  defp visible_models_for_tenant(tenant_id), do: Models.list_active_models_for_tenant(tenant_id)
+
+  defp model_sort_key(model), do: {model.model_id, model.version, model.id}
+
+  defp exact_model_identity(nil), do: nil
+  defp exact_model_identity(model), do: model.model_id <> "@" <> model.version
 
   defp completions_url(base_url) do
     String.trim_trailing(base_url, "/") <> "/v1/chat/completions"

--- a/apps/orchard_controller/lib/orchard/portal/keys_live.ex
+++ b/apps/orchard_controller/lib/orchard/portal/keys_live.ex
@@ -6,15 +6,18 @@ defmodule Orchard.Portal.KeysLive do
   use Orchard.Portal, :live_view
 
   alias Orchard.Governance
+  alias Orchard.Governance.PortalActivationCurl
+  alias OrchardConsole.WorkspacePresentation
 
   @revalidate_ms 5_000
 
   @impl true
-  def mount(%{"organization_slug" => slug}, _session, socket) do
+  def mount(%{"organization_slug" => slug} = params, _session, socket) do
     socket =
       socket
       |> assign(:page_title, "API keys")
       |> assign(:organization_slug, slug)
+      |> assign(:requested_model, requested_model(params))
       |> assign(:keys, [])
       |> assign(:active_portal_count, 0)
       |> assign(:mint_open?, false)
@@ -68,6 +71,8 @@ defmodule Orchard.Portal.KeysLive do
            }
          ) do
       {:ok, result} ->
+        result = add_activation_curl(result, socket.assigns)
+
         {:noreply,
          socket
          |> assign(:mint_open?, false)
@@ -207,7 +212,10 @@ defmodule Orchard.Portal.KeysLive do
         <div>
           <h1 class="text-lg font-semibold text-slate-50">API keys</h1>
           <p class="mt-1 text-sm text-slate-400">
-            Tenant-direct keys for <span class="font-mono text-slate-300">{@organization_slug}</span>
+            Workspace: <span class="text-slate-300">{WorkspacePresentation.display_name(@current_tenant)}</span>
+          </p>
+          <p :if={@requested_model} id="portal-requested-model" class="mt-1 text-xs text-slate-400">
+            Requested Model: <span class="font-mono text-slate-300">{@requested_model}</span>
           </p>
         </div>
         <div class="flex items-center gap-3">
@@ -405,11 +413,22 @@ defmodule Orchard.Portal.KeysLive do
             {@generated_secret.curl}
           </div>
           <p
+            :if={@generated_secret.curl}
+            id="portal-curl-runtime-note"
+            class="mt-2 text-sm text-slate-300"
+          >
+            This example has not run. Runtime availability and readiness are checked when you send the request.
+          </p>
+          <p
             :if={!@generated_secret.curl}
             id="portal-no-curl"
             class="mt-2 rounded-md border border-sky-400/30 bg-sky-400/10 px-3 py-2 text-sm text-sky-200"
           >
-            No test curl is available yet because this Organization has no proven callable model. Your key was still minted.
+            <%= if @requested_model do %>
+              No request example is available because the requested Model is not active and authorized for this Workspace. Your key was still minted.
+            <% else %>
+              No request example is available because this Workspace has no active authorized Model. Your key was still minted.
+            <% end %>
           </p>
         </div>
 
@@ -495,6 +514,26 @@ defmodule Orchard.Portal.KeysLive do
         assign(socket, :keys, [])
     end
   end
+
+  defp add_activation_curl(result, assigns) do
+    model_id =
+      PortalActivationCurl.select_callable_model(
+        assigns.current_tenant.id,
+        assigns.requested_model
+      )
+
+    curl =
+      PortalActivationCurl.build(
+        result.token,
+        model_id,
+        PortalActivationCurl.public_base_url()
+      )
+
+    %{result | curl: curl}
+  end
+
+  defp requested_model(%{"model" => model}) when is_binary(model) and model != "", do: model
+  defp requested_model(_params), do: nil
 
   defp reconcile_key_limit(socket) do
     socket = refresh_keys(socket)

--- a/apps/orchard_controller/lib/orchard/portal/layouts/app.html.heex
+++ b/apps/orchard_controller/lib/orchard/portal/layouts/app.html.heex
@@ -8,7 +8,12 @@
     <div class="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
       <.logo variant={:lockup} size={:md} />
       <div class="flex items-center gap-4">
-        <span class="font-mono text-sm text-slate-300">{@organization_slug}</span>
+        <div class="text-right">
+          <p class="text-xs text-slate-400">Workspace</p>
+          <p class="text-sm text-slate-200">
+            {OrchardConsole.WorkspacePresentation.display_name(@current_tenant)}
+          </p>
+        </div>
         <form
           action={"/portal/#{@organization_slug}/logout"}
           method="post"

--- a/apps/orchard_controller/lib/orchard/portal/session_controller.ex
+++ b/apps/orchard_controller/lib/orchard/portal/session_controller.ex
@@ -14,10 +14,11 @@ defmodule Orchard.Portal.SessionController do
   plug(:put_view, html: SessionHTML)
 
   @spec new(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def new(conn, %{"organization_slug" => slug}) do
+  def new(conn, %{"organization_slug" => slug} = params) do
     slug = normalize_slug(slug)
+    requested_model = requested_model(params)
 
-    case maybe_redirect_authenticated(conn, slug) do
+    case maybe_redirect_authenticated(conn, slug, requested_model) do
       {:halt, conn} ->
         conn
 
@@ -25,6 +26,8 @@ defmodule Orchard.Portal.SessionController do
         conn
         |> assign(:page_title, "Sign in")
         |> assign(:organization_slug, slug)
+        |> assign(:requested_model, requested_model)
+        |> assign(:form_action, requested_model_path("/portal/#{slug}/session", requested_model))
         |> assign(:login_error, nil)
         |> assign(:throttled, false)
         |> assign(:retry_after, nil)
@@ -35,6 +38,7 @@ defmodule Orchard.Portal.SessionController do
   @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(conn, %{"organization_slug" => slug} = params) do
     slug = normalize_slug(slug)
+    requested_model = requested_model(params)
     email = login_email(params)
     password = login_password(params)
 
@@ -42,12 +46,14 @@ defmodule Orchard.Portal.SessionController do
       {:ok, result} ->
         conn
         |> Auth.put_session_token(result.token)
-        |> redirect(to: "/portal/#{slug}/keys")
+        |> redirect(to: requested_model_path("/portal/#{slug}/keys", requested_model))
 
       {:error, :throttled} ->
         conn
         |> assign(:page_title, "Sign in")
         |> assign(:organization_slug, slug)
+        |> assign(:requested_model, requested_model)
+        |> assign(:form_action, requested_model_path("/portal/#{slug}/session", requested_model))
         |> assign(:login_error, nil)
         |> assign(:throttled, true)
         |> assign(:retry_after, "a few minutes")
@@ -58,6 +64,8 @@ defmodule Orchard.Portal.SessionController do
         conn
         |> assign(:page_title, "Sign in")
         |> assign(:organization_slug, slug)
+        |> assign(:requested_model, requested_model)
+        |> assign(:form_action, requested_model_path("/portal/#{slug}/session", requested_model))
         |> assign(:login_error, :invalid_credentials)
         |> assign(:throttled, false)
         |> assign(:retry_after, nil)
@@ -81,14 +89,20 @@ defmodule Orchard.Portal.SessionController do
   end
 
   @spec invite(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def invite(conn, %{"organization_slug" => slug, "token" => token}) do
+  def invite(conn, %{"organization_slug" => slug, "token" => token} = params) do
     slug = normalize_slug(slug)
+    requested_model = requested_model(params)
 
     case Governance.validate_portal_invite(slug, token) do
       :ok ->
         conn
         |> assign(:page_title, "Set your password")
         |> assign(:organization_slug, slug)
+        |> assign(:requested_model, requested_model)
+        |> assign(
+          :form_action,
+          requested_model_path("/portal/#{slug}/invites/#{token}", requested_model)
+        )
         |> assign(:invite_token, token)
         |> assign(:invite_error, nil)
         |> render(:invite)
@@ -97,6 +111,11 @@ defmodule Orchard.Portal.SessionController do
         conn
         |> assign(:page_title, "Invite unavailable")
         |> assign(:organization_slug, slug)
+        |> assign(:requested_model, requested_model)
+        |> assign(
+          :form_action,
+          requested_model_path("/portal/#{slug}/invites/#{token}", requested_model)
+        )
         |> assign(:invite_token, nil)
         |> assign(:invite_error, :invalid_invite)
         |> put_status(:unprocessable_entity)
@@ -107,6 +126,7 @@ defmodule Orchard.Portal.SessionController do
   @spec redeem(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def redeem(conn, %{"organization_slug" => slug, "token" => token} = params) do
     slug = normalize_slug(slug)
+    requested_model = requested_model(params)
     invite = Map.get(params, "invite", %{})
     password = Map.get(invite, "password", "")
     confirmation = Map.get(invite, "password_confirmation", "")
@@ -120,12 +140,17 @@ defmodule Orchard.Portal.SessionController do
       {:ok, _user} ->
         conn
         |> put_flash(:notice, "Password set. Sign in with your email.")
-        |> redirect(to: "/portal/#{slug}")
+        |> redirect(to: requested_model_path("/portal/#{slug}", requested_model))
 
       {:error, _reason} ->
         conn
         |> assign(:page_title, "Set your password")
         |> assign(:organization_slug, slug)
+        |> assign(:requested_model, requested_model)
+        |> assign(
+          :form_action,
+          requested_model_path("/portal/#{slug}/invites/#{token}", requested_model)
+        )
         |> assign(:invite_token, token)
         |> assign(:invite_error, :invalid_invite)
         |> put_status(:unprocessable_entity)
@@ -133,12 +158,16 @@ defmodule Orchard.Portal.SessionController do
     end
   end
 
-  defp maybe_redirect_authenticated(conn, slug) do
+  defp maybe_redirect_authenticated(conn, slug, requested_model) do
     case Auth.session_token(conn) do
       token when is_binary(token) ->
         case Governance.validate_portal_session(token, slug) do
-          {:ok, _result} -> {:halt, redirect(conn, to: "/portal/#{slug}/keys")}
-          {:error, :invalid_session} -> :cont
+          {:ok, _result} ->
+            {:halt,
+             redirect(conn, to: requested_model_path("/portal/#{slug}/keys", requested_model))}
+
+          {:error, :invalid_session} ->
+            :cont
         end
 
       nil ->
@@ -153,6 +182,15 @@ defmodule Orchard.Portal.SessionController do
     do: password
 
   defp login_password(_params), do: ""
+
+  defp requested_model(%{"model" => model}) when is_binary(model) and model != "", do: model
+  defp requested_model(_params), do: nil
+
+  defp requested_model_path(path, nil), do: path
+
+  defp requested_model_path(path, model) do
+    path <> "?" <> URI.encode_query(%{"model" => model})
+  end
 
   defp normalize_slug(slug) when is_binary(slug), do: slug |> String.trim() |> String.downcase()
 end

--- a/apps/orchard_controller/lib/orchard/portal/session_html/invite.html.heex
+++ b/apps/orchard_controller/lib/orchard/portal/session_html/invite.html.heex
@@ -4,7 +4,10 @@
       {if @invite_token, do: "Set your password", else: "Invite unavailable"}
     </h1>
     <p :if={@invite_token} class="mt-1 text-sm text-slate-300">
-      Activate your named Portal User for {@organization_slug}.
+      Activate your named Portal User for Workspace <span class="font-mono">{@organization_slug}</span>.
+    </p>
+    <p :if={@invite_token && @requested_model} class="mt-1 text-xs text-slate-400">
+      Requested Model: <span class="font-mono text-slate-300">{@requested_model}</span>
     </p>
     <p
       :if={!@invite_token}
@@ -15,7 +18,7 @@
       This invite is invalid, expired, or already used.
     </p>
 
-    <form :if={@invite_token} action={"/portal/#{@organization_slug}/invites/#{@invite_token}"} method="post" class="mt-6 space-y-4">
+    <form :if={@invite_token} action={@form_action} method="post" class="mt-6 space-y-4">
       <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
       <div>
         <label for="invite-password" class="block text-sm font-medium text-slate-200">Password</label>

--- a/apps/orchard_controller/lib/orchard/portal/session_html/new.html.heex
+++ b/apps/orchard_controller/lib/orchard/portal/session_html/new.html.heex
@@ -13,9 +13,14 @@
 
   <section class="rounded-lg border border-slate-700 bg-slate-800 p-6">
     <h1 class="text-lg font-semibold text-slate-50">Developer portal</h1>
-    <p class="mt-1 font-mono text-sm text-slate-300">{@organization_slug}</p>
+    <p class="mt-1 text-sm text-slate-400">
+      Workspace <span class="font-mono text-slate-300">{@organization_slug}</span>
+    </p>
+    <p :if={@requested_model} class="mt-1 text-xs text-slate-400">
+      Requested Model: <span class="font-mono text-slate-300">{@requested_model}</span>
+    </p>
 
-    <form action={"/portal/#{@organization_slug}/session"} method="post" class="mt-6 space-y-4">
+    <form action={@form_action} method="post" class="mt-6 space-y-4">
       <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
 
       <div>

--- a/apps/orchard_controller/test/orchard/api/router_test.exs
+++ b/apps/orchard_controller/test/orchard/api/router_test.exs
@@ -186,14 +186,14 @@ defmodule Orchard.API.RouterTest do
       conn = get(conn, "/console/tenants")
 
       assert conn.status == 200
-      assert conn.resp_body =~ "Organizations"
+      assert conn.resp_body =~ "Workspaces"
     end
 
     test "GET /console/tenants/:id is routed", %{conn: conn} do
       conn = get(conn, "/console/tenants/#{Orchard.Governance.legacy_tenant_id()}")
 
       assert conn.status == 200
-      assert conn.resp_body =~ "Organization"
+      assert conn.resp_body =~ "Workspace"
     end
   end
 

--- a/apps/orchard_controller/test/orchard/console/auth_test.exs
+++ b/apps/orchard_controller/test/orchard/console/auth_test.exs
@@ -624,7 +624,7 @@ defmodule OrchardConsole.AuthTest do
 
       follow_up = conn |> recycle() |> get("/console/tenants")
       assert follow_up.status == 200
-      assert follow_up.resp_body =~ "Organizations"
+      assert follow_up.resp_body =~ "Workspaces"
     end
 
     test "returns 404 for /console/tenants/:id when console is disabled", %{conn: conn} do

--- a/apps/orchard_controller/test/orchard/console/auth_test.exs
+++ b/apps/orchard_controller/test/orchard/console/auth_test.exs
@@ -2,6 +2,7 @@ defmodule OrchardConsole.AuthTest do
   use Orchard.ConnCase, async: false
 
   @moduletag :live
+  @moduletag :db
 
   setup do
     previous = Application.get_env(:orchard_controller, :console, [])

--- a/apps/orchard_controller/test/orchard/console/core_components_test.exs
+++ b/apps/orchard_controller/test/orchard/console/core_components_test.exs
@@ -1670,7 +1670,7 @@ defmodule OrchardConsole.CoreComponentsTest do
       assert html =~ "Playground"
       assert html =~ "Models"
       refute html =~ "Model Hub"
-      assert html =~ "Organizations"
+      assert html =~ "Access"
       assert html =~ "Requests"
       assert html =~ "Settings"
     end
@@ -1699,7 +1699,7 @@ defmodule OrchardConsole.CoreComponentsTest do
       assert html =~ "/console/requests"
       assert html =~ "/console/models"
       refute html =~ "/console/model-hub"
-      assert html =~ "/console/tenants"
+      assert html =~ "/console/access"
       assert html =~ "/console/settings"
     end
 

--- a/apps/orchard_controller/test/orchard/console/overview_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/overview_live_test.exs
@@ -223,7 +223,7 @@ defmodule OrchardConsole.OverviewLiveTest do
       assert html =~ "Playground"
       assert has_element?(view, ~s(#console-sidebar a[href="/console/models"]), "Models")
       refute has_element?(view, ~s(#console-sidebar a[href="/console/model-hub"]), "Model Hub")
-      assert html =~ "Organizations"
+      assert html =~ "Access"
       assert html =~ "Requests"
     end
 
@@ -243,7 +243,7 @@ defmodule OrchardConsole.OverviewLiveTest do
       assert has_element?(view, ~s(#console-sidebar a[href="/console/models"]), "Models")
       refute has_element?(view, ~s(#console-sidebar a[href="/console/model-hub"]), "Model Hub")
       assert html =~ "/console/requests"
-      assert html =~ "/console/tenants"
+      assert html =~ "/console/access"
     end
 
     test "renders sidebar toggle button", %{conn: conn} do

--- a/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenant_detail_live_test.exs
@@ -4,6 +4,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
   import Phoenix.LiveViewTest
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.API.Endpoint
   alias Orchard.Governance
 
   alias Orchard.Governance.{
@@ -33,12 +34,24 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       # Initial title before connected mount sets slug-specific title
       assert html =~ "Orchard Console"
       assert html =~ "tenant-summary-card"
+      assert html =~ "tenant-access-header"
+      assert html =~ "tenant-access-navigation"
+      assert html =~ "tenant-access-boundaries"
       assert html =~ "tenant-api-key-create-card"
       assert html =~ "tenant-api-keys-card"
       assert html =~ "tenant-api-clients-card"
       assert html =~ "Detail Tenant"
       assert html =~ "detail-t"
       assert html =~ tenant.id
+      assert html =~ "Everything on this page applies to"
+
+      assert html =~
+               "Portal membership, model access, and inference credentials are separate controls"
+
+      assert html =~ "Model grants are inspected here"
+      assert html =~ "An invitation does not create an inference credential"
+      assert html =~ "subject to its separate model access and policy"
+      assert html =~ "provisioned separately from Portal Users"
       # Tenant Created timestamp uses LocalTime hook
       assert html =~ "tenant-detail-created-at"
       assert html =~ ~s(phx-hook="LocalTime")
@@ -47,13 +60,13 @@ defmodule OrchardConsole.TenantDetailLiveTest do
 
     test "shows not-found state for unknown tenant ID", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/console/tenants/#{Ecto.UUID.generate()}")
-      assert html =~ "Organization not found"
+      assert html =~ "Workspace not found"
       assert html =~ "tenant-back-to-list"
     end
 
     test "shows not-found state for malformed ID", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/console/tenants/not-a-uuid")
-      assert html =~ "Organization not found"
+      assert html =~ "Workspace not found"
     end
 
     test "shows empty API keys state", %{conn: conn, tenant: tenant} do
@@ -70,9 +83,44 @@ defmodule OrchardConsole.TenantDetailLiveTest do
 
     test "back link navigates to tenants list", %{conn: conn, tenant: tenant} do
       {:ok, _view, html} = live(conn, "/console/tenants/#{tenant.id}")
-      assert html =~ "/console/tenants"
-      assert html =~ "Back to Organizations"
+      assert html =~ "/console/access"
+      assert html =~ "Back to Workspaces"
     end
+  end
+
+  test "Workspace sections are exclusive and unknown sections fall back to Overview", %{
+    conn: conn,
+    tenant: tenant
+  } do
+    {:ok, view, _html} =
+      live(conn, "/console/access/workspaces/#{tenant.id}?section=model_access")
+
+    assert has_element?(view, "#workspace-section-overview[hidden]")
+    refute has_element?(view, "#workspace-section-model_access[hidden]")
+    assert has_element?(view, "#workspace-section-api_credentials[hidden]")
+    render_patch(view, "/console/access/workspaces/#{tenant.id}?section=unknown")
+    refute has_element?(view, "#workspace-section-overview[hidden]")
+    assert has_element?(view, "#workspace-section-model_access[hidden]")
+  end
+
+  test "changing Workspace clears revealed credentials and reloads scope", %{
+    conn: conn,
+    tenant: tenant
+  } do
+    {:ok, other} = Governance.create_tenant(%{slug: "other-detail", name: "Other"})
+
+    {:ok, view, _html} =
+      live(conn, "/console/access/workspaces/#{tenant.id}?section=api_credentials")
+
+    view
+    |> form("#tenant-api-key-create-form", api_key: %{name: "scope-secret"})
+    |> render_submit()
+
+    assert has_element?(view, "#tenant-api-key-secret-value")
+    render_patch(view, "/console/access/workspaces/#{other.id}?section=overview")
+    refute has_element?(view, "#tenant-api-key-secret-value")
+    assert has_element?(view, "#tenant-access-header", "Other")
+    refute render(view) =~ "scope-secret"
   end
 
   describe "create API key" do
@@ -111,7 +159,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert key_row =~ "—"
     end
 
-    test "renders same-Organization Developer Portal mint attribution without token secrets", %{
+    test "renders same-Workspace Developer Portal mint attribution without token secrets", %{
       conn: conn,
       tenant: tenant
     } do
@@ -161,7 +209,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       refute key_row =~ token
     end
 
-    test "renders null and cross-Organization Portal attribution as unavailable", %{
+    test "renders null and cross-Workspace Portal attribution as unavailable", %{
       conn: conn,
       tenant: tenant
     } do
@@ -343,7 +391,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert has_element?(view, "#tenant-api-client-token-revoke-#{api_key.id}")
     end
 
-    test "revokes API Client-owned API Tokens from the Organization detail page", %{
+    test "revokes API Client-owned API Tokens from the Workspace detail page", %{
       conn: conn,
       tenant: tenant
     } do
@@ -362,7 +410,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert audit_log.payload["surface"] == "console"
     end
 
-    test "revokes expired API Client-owned API Tokens from the Organization detail page", %{
+    test "revokes expired API Client-owned API Tokens from the Workspace detail page", %{
       conn: conn,
       tenant: tenant
     } do
@@ -386,7 +434,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       refute has_element?(view, "#tenant-api-client-token-revoke-#{api_key.id}")
     end
 
-    test "disables API Clients from the Organization detail page", %{
+    test "disables API Clients from the Workspace detail page", %{
       conn: conn,
       tenant: tenant
     } do
@@ -436,7 +484,7 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert audit_log.payload["surface"] == "console"
     end
 
-    test "shows error for cross-Organization API Client disable attempt", %{
+    test "shows error for cross-Workspace API Client disable attempt", %{
       conn: conn,
       tenant: tenant
     } do
@@ -498,9 +546,30 @@ defmodule OrchardConsole.TenantDetailLiveTest do
   describe "Portal Users" do
     setup do
       previous_mode = Application.get_env(:orchard_controller, :transport_mode, :__missing__)
+      previous_endpoint = Application.get_env(:orchard_controller, Endpoint, [])
       Application.put_env(:orchard_controller, :transport_mode, :direct_https)
 
+      Application.put_env(
+        :orchard_controller,
+        Endpoint,
+        Keyword.put(previous_endpoint, :url,
+          scheme: "https",
+          host: "orchard.test",
+          port: 443
+        )
+      )
+
+      :ok =
+        Endpoint.config_change(
+          [
+            {Endpoint, Application.fetch_env!(:orchard_controller, Endpoint)}
+          ],
+          []
+        )
+
       on_exit(fn ->
+        Application.put_env(:orchard_controller, Endpoint, previous_endpoint)
+
         case previous_mode do
           :__missing__ -> Application.delete_env(:orchard_controller, :transport_mode)
           mode -> Application.put_env(:orchard_controller, :transport_mode, mode)
@@ -518,6 +587,12 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       assert html =~ "tenant-portal-invite-card"
       assert html =~ "tenant-portal-users-card"
       assert html =~ "tenant-portal-access-card"
+      assert html =~ "Orchard does not send email or create an API credential"
+      assert html =~ "use Copy invite and deliver the URL out of band"
+      assert html =~ "Portal access does not grant Console or cluster administration"
+      assert html =~ "does not authorize inference by itself"
+      assert html =~ ~s(id="tenant-open-portal")
+      assert html =~ ~s(href="https://orchard.test/portal/detail-t")
       assert html =~ ~s(class="bg-navy mt-7)
       refute html =~ "bg-navy-900"
 
@@ -745,6 +820,29 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       refute row =~ "Invalidated"
     end
 
+    test "configured HTTPS mode without a public HTTPS URL does not link to an HTTP Portal", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      endpoint = Application.fetch_env!(:orchard_controller, Endpoint)
+
+      http_endpoint =
+        Keyword.put(endpoint, :url,
+          scheme: "http",
+          host: "orchard.test",
+          port: 80
+        )
+
+      Application.put_env(:orchard_controller, Endpoint, http_endpoint)
+      :ok = Endpoint.config_change([{Endpoint, http_endpoint}], [])
+
+      {:ok, _view, html} = live(conn, "/console/tenants/#{tenant.id}")
+
+      assert html =~ "The configured public HTTPS Portal address is unavailable"
+      refute html =~ ~s(id="tenant-open-portal")
+      refute html =~ ~s(href="/portal/detail-t")
+    end
+
     test "disable dismisses only the shown invite URL of the disabled Portal User", %{
       conn: conn,
       tenant: tenant
@@ -776,7 +874,9 @@ defmodule OrchardConsole.TenantDetailLiveTest do
       Application.put_env(:orchard_controller, :transport_mode, :plain_http_localhost)
       {:ok, _view, html} = live(conn, "/console/tenants/#{tenant.id}")
       assert html =~ "tenant-portal-tls-required"
+      assert html =~ "Unavailable until public API HTTPS is enabled"
       refute html =~ "tenant-portal-invite-form"
+      refute html =~ ~s(id="tenant-open-portal")
     end
   end
 

--- a/apps/orchard_controller/test/orchard/console/tenants_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenants_live_test.exs
@@ -126,6 +126,37 @@ defmodule OrchardConsole.TenantsLiveTest do
       end
     end
 
+    test "default-only Access handoff opens the existing scope at step two without side effects",
+         %{conn: conn} do
+      assert [default] = Governance.list_tenants()
+      assert default.id == Governance.legacy_tenant_id()
+
+      schemas = [
+        Orchard.Governance.Tenant,
+        Orchard.Governance.PortalUser,
+        Orchard.Governance.ApiKey,
+        Orchard.Models.TenantModelAccess
+      ]
+
+      before_counts = Enum.map(schemas, &Orchard.Repo.aggregate(&1, :count))
+      {:ok, view, _html} = live(conn, "/console/access")
+      handoff = "/console/access/workspaces/#{default.id}/handoff"
+      assert has_element?(view, "#tenant-#{default.id} a[href='#{handoff}']", "Guide access")
+
+      {:ok, handoff_view, _html} =
+        view
+        |> element("#tenant-#{default.id} a[href='#{handoff}']")
+        |> render_click()
+        |> follow_redirect(conn)
+
+      assert has_element?(handoff_view, "#handoff-scope", "Default workspace")
+      assert has_element?(handoff_view, "#handoff-step-2")
+      refute has_element?(handoff_view, "#handoff-step-1")
+      assert Enum.map(schemas, &Orchard.Repo.aggregate(&1, :count)) == before_counts
+      assert {:ok, stored} = Governance.get_tenant(default.id)
+      assert {stored.id, stored.slug, stored.name} == {default.id, default.slug, default.name}
+    end
+
     test "shows empty state when only legacy tenant is removed", %{conn: conn} do
       delete_audit_logs!()
       Orchard.Repo.delete_all(Orchard.Governance.ApiKey)

--- a/apps/orchard_controller/test/orchard/console/tenants_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/tenants_live_test.exs
@@ -17,53 +17,53 @@ defmodule OrchardConsole.TenantsLiveTest do
   describe "page rendering" do
     test "renders page title and nav", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/console/tenants")
-      assert html =~ "Organizations"
+      assert html =~ "Workspaces"
       assert html =~ "Orchard Console"
-      assert html =~ "tenant-create-card"
+      assert html =~ "A Workspace is the scope for model access"
+      refute html =~ "tenant-create-card"
       assert html =~ "tenants-list-card"
     end
 
-    test "Organizations sidebar item is active", %{conn: conn} do
+    test "Workspaces sidebar item is active", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/console/tenants")
       assert html =~ ~s(aria-current="page")
-      assert html =~ "/console/tenants"
-      assert html =~ "Organizations"
+      assert html =~ "/console/access"
+      assert html =~ "Workspaces"
     end
 
-    test "shows legacy Organization in the list", %{conn: conn} do
+    test "shows legacy Workspace in the list", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/console/tenants")
       assert html =~ Governance.legacy_tenant_slug()
-      assert html =~ Governance.legacy_tenant_name()
+      assert html =~ "Default workspace"
     end
 
-    test "renders create Organization form", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/console/tenants")
+    test "renders create Workspace form", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/console/access/workspaces/new")
       assert html =~ "tenant-create-form"
       assert html =~ "Slug"
       assert html =~ "Name"
-      assert html =~ "Create Organization"
+      assert html =~ "Create Workspace"
+      assert html =~ "does not grant model access"
+      assert html =~ "issue an API credential"
     end
   end
 
   describe "create tenant" do
     test "creates tenant and resets form", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/console/tenants")
+      {:ok, view, _html} = live(conn, "/console/access/workspaces/new")
 
-      html =
-        view
-        |> form("#tenant-create-form", tenant: %{slug: "new-tenant", name: "New Tenant"})
-        |> render_submit()
+      view
+      |> form("#tenant-create-form", tenant: %{slug: "new-tenant", name: "New Tenant"})
+      |> render_submit()
 
-      assert html =~ "Created Organization new-tenant."
-      assert html =~ "new-tenant"
-      assert html =~ "New Tenant"
-      # Created column uses LocalTime hook
-      assert html =~ ~s(phx-hook="LocalTime")
-      assert html =~ ~s(data-local-time-format="datetime_minute")
+      {path, _flash} = assert_redirect(view)
+      assert "/console/access/workspaces/" <> id = path
+      assert {:ok, tenant} = Governance.get_tenant(id)
+      assert tenant.slug == "new-tenant"
     end
 
     test "shows validation error for blank slug", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/console/tenants")
+      {:ok, view, _html} = live(conn, "/console/access/workspaces/new")
 
       html =
         view
@@ -75,7 +75,7 @@ defmodule OrchardConsole.TenantsLiveTest do
 
     test "shows validation error for duplicate slug", %{conn: conn} do
       {:ok, _} = Governance.create_tenant(%{slug: "dupe-slug", name: "Original"})
-      {:ok, view, _html} = live(conn, "/console/tenants")
+      {:ok, view, _html} = live(conn, "/console/access/workspaces/new")
 
       html =
         view
@@ -92,8 +92,38 @@ defmodule OrchardConsole.TenantsLiveTest do
       {:ok, view, _html} = live(conn, "/console/tenants")
 
       assert has_element?(view, "#tenant-open-#{tenant.id}")
+      assert has_element?(view, "#tenant-open-#{tenant.id}", "Open workspace")
       html = render(view)
-      assert html =~ "/console/tenants/#{tenant.id}"
+      assert html =~ "/console/access/workspaces/#{tenant.id}"
+    end
+
+    test "repeated Access reads preserve a customized default identity and list it first", %{
+      conn: conn
+    } do
+      {:ok, default} = Governance.get_tenant(Governance.legacy_tenant_id())
+      custom = default |> Ecto.Changeset.change(name: "Zebra research") |> Orchard.Repo.update!()
+      {:ok, other} = Governance.create_tenant(%{slug: "alpha", name: "Alpha research"})
+      count = Orchard.Repo.aggregate(Orchard.Governance.Tenant, :count)
+
+      for path <- ["/console/access", "/console/access/workspaces", "/console/tenants"] do
+        {:ok, view, _html} = live(conn, path)
+        render_click(view, "refresh_workspaces")
+
+        assert has_element?(
+                 view,
+                 "#tenants-table > tr:first-child#tenant-#{custom.id}",
+                 "Zebra research"
+               )
+
+        assert has_element?(view, "#tenant-#{other.id}", "Alpha research")
+        refute has_element?(view, "#tenant-#{custom.id}", "Default workspace")
+        assert {:ok, stored} = Governance.get_tenant(custom.id)
+
+        assert {stored.id, stored.slug, stored.name} ==
+                 {default.id, default.slug, "Zebra research"}
+
+        assert Orchard.Repo.aggregate(Orchard.Governance.Tenant, :count) == count
+      end
     end
 
     test "shows empty state when only legacy tenant is removed", %{conn: conn} do
@@ -104,7 +134,9 @@ defmodule OrchardConsole.TenantsLiveTest do
       Orchard.Repo.delete_all(Orchard.Governance.ServiceAccount)
       Orchard.Repo.delete_all(Orchard.Governance.Tenant)
       {:ok, _view, html} = live(conn, "/console/tenants")
-      assert html =~ "No Organizations created yet."
+      assert html =~ "No Workspaces created yet."
+      assert html =~ "workspace-default-missing"
+      assert html =~ "Refresh Workspaces"
     end
   end
 

--- a/apps/orchard_controller/test/orchard/console/workspace_access_test.exs
+++ b/apps/orchard_controller/test/orchard/console/workspace_access_test.exs
@@ -1,0 +1,64 @@
+defmodule OrchardConsole.WorkspaceAccessTest do
+  use ExUnit.Case, async: true
+
+  alias OrchardConsole.WorkspaceAccess
+  alias OrchardConsole.WorkspacePresentation
+
+  test "default presentation preserves custom names and UUID identity" do
+    tenant = %{id: "00000000-0000-0000-0000-000000000000", name: "Legacy Single Tenant"}
+    assert WorkspacePresentation.default?(tenant)
+    assert WorkspacePresentation.display_name(tenant) == "Default workspace"
+    assert WorkspacePresentation.display_name(%{tenant | name: "Research"}) == "Research"
+    refute WorkspacePresentation.default?(%{id: "other", name: "Legacy Single Tenant"})
+  end
+
+  test "exact catalog identities retain independent enabled disabled and missing grant states" do
+    models =
+      for {id, version} <- [{"a", "1"}, {"b", "2"}, {"c", "3"}],
+          do: %{id: id, model_id: "model", version: version}
+
+    tenant = %{id: "scope"}
+
+    reader = fn ^tenant ->
+      {:ok, [%{model_id: "a", enabled: true}, %{model_id: "b", enabled: false}]}
+    end
+
+    assert {:ok, rows} =
+             WorkspaceAccess.list(tenant, access_reader: reader, model_reader: fn -> models end)
+
+    assert Enum.map(rows, & &1.grant_state) == [:enabled, :disabled, :not_granted]
+    assert Enum.map(rows, & &1.model.version) == ["1", "2", "3"]
+  end
+
+  test "failed grant reads never appear as no grants" do
+    assert {:error, :unavailable} =
+             WorkspaceAccess.list(%{id: "scope"},
+               access_reader: fn _ -> {:error, :unavailable} end,
+               model_reader: fn -> flunk("must not read models after failed grants") end
+             )
+  end
+
+  test "re-enabling a scoped grant preserves its routing policy" do
+    commands =
+      WorkspaceAccess.commands(%{id: "scope"}, %{model_id: "model", version: "1"}, %{
+        routing_policy_id: "policy'1"
+      })
+
+    assert commands.grant =~ " --routing-policy-id 'policy'\\''1'"
+    refute commands.inspect =~ "--routing-policy-id"
+  end
+
+  test "operator commands quote exact revision and workspace scope as shell arguments" do
+    commands =
+      WorkspaceAccess.commands(%{id: "scope'1"}, %{
+        model_id: "org/model; touch x",
+        version: "rev'2"
+      })
+
+    assert commands.grant ==
+             "orchardctl models access grant 'org/model; touch x@rev'\\''2' --tenant 'scope'\\''1'"
+
+    assert commands.inspect ==
+             "orchardctl models access inspect 'org/model; touch x@rev'\\''2' --tenant 'scope'\\''1'"
+  end
+end

--- a/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
@@ -216,7 +216,8 @@ defmodule OrchardConsole.WorkspaceHandoffLiveTest do
     assert Repo.aggregate(PortalInviteToken, :count) == 0
     refute has_element?(view, "#handoff-invite-value")
     render_click(view, "refresh")
-    assert has_element?(view, "#handoff-step-5", "unavailable or disabled")
+    assert has_element?(view, "#handoff-step-3")
+    assert render(view) =~ "Portal User is unavailable or disabled"
     refute has_element?(view, "#handoff-issue-invite")
   end
 
@@ -256,11 +257,12 @@ defmodule OrchardConsole.WorkspaceHandoffLiveTest do
     render_patch(view, path(workspace) <> "?step=4")
     Repo.delete!(model)
     render_click(view, "refresh")
-    assert has_element?(view, "#handoff-step-4", "Model no longer in catalog")
+    assert has_element?(view, "#handoff-step-2")
+    assert render(view) =~ "Selected model is no longer in Catalog"
     assert has_element?(view, "#handoff-next[disabled]")
     render_click(view, "next")
     render_click(view, "issue_invite")
-    assert has_element?(view, "#handoff-step-4")
+    assert has_element?(view, "#handoff-step-2")
     assert Repo.aggregate(PortalInviteToken, :count) == 0
   end
 
@@ -324,6 +326,77 @@ defmodule OrchardConsole.WorkspaceHandoffLiveTest do
     render_click(view, "next")
     assert has_element?(view, "#handoff-colleague-email[value='access-review@example.test']")
     assert Repo.aggregate(PortalUser, :count) == 0
+  end
+
+  test "refresh returns later steps to model selection when the exact model disappears", %{
+    conn: conn,
+    workspace: workspace
+  } do
+    for step <- [5, 6] do
+      model = create_model!(%{state: :active})
+      {:ok, view, _html} = live(conn, path(workspace))
+      choose_model(view, model)
+      render_click(view, "next")
+
+      view
+      |> form("#handoff-colleague-form", colleague: %{email: "removed-#{step}@example.test"})
+      |> render_submit()
+
+      render_click(view, "next")
+      if step == 6, do: render_click(view, "next")
+      assert has_element?(view, "#handoff-step-#{step}")
+      Repo.delete!(model)
+      render_click(view, "refresh")
+
+      assert has_element?(view, "#handoff-step-2")
+      assert render(view) =~ "Selected model is no longer in Catalog"
+      refute has_element?(view, "#handoff-issue-invite")
+      refute has_element?(view, "nav[aria-label='Colleague handoff steps'] a[href$='step=5']")
+      render_patch(view, path(workspace) <> "?step=6")
+      assert has_element?(view, "#handoff-step-2")
+      render_click(view, "issue_invite")
+      assert Repo.aggregate(PortalInviteToken, :count) == 0
+    end
+  end
+
+  test "leaving the invite reveal clears its plaintext and timer before Back or reissue", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "one-time@example.test"})
+    |> render_submit()
+
+    render_click(view, "next")
+    render_click(view, "issue_invite")
+    assigns = :sys.get_state(view.pid).socket.assigns
+    first_url = assigns.invite.url
+    first_token = Repo.one!(PortalInviteToken)
+    assert has_element?(view, "#handoff-invite-value", first_url)
+
+    render_click(view, "next")
+    assert has_element?(view, "#handoff-step-6")
+    assert :sys.get_state(view.pid).socket.assigns.invite == nil
+    assert Process.read_timer(assigns.invite_timer) == false
+    render_click(view, "issue_invite")
+    assert Repo.one!(PortalInviteToken).id == first_token.id
+    render_patch(view, path(workspace) <> "?step=5")
+    refute has_element?(view, "#handoff-invite-value")
+    refute render(view) =~ first_url
+
+    render_click(view, "issue_invite")
+    assert has_element?(view, "#handoff-invite-value")
+    refute :sys.get_state(view.pid).socket.assigns.invite.url == first_url
+    assert Repo.aggregate(PortalInviteToken, :count) == 1
+    render_patch(view, path(workspace) <> "?step=4")
+    assert :sys.get_state(view.pid).socket.assigns.invite == nil
+    render_patch(view, path(workspace) <> "?step=5")
+    refute has_element?(view, "#handoff-invite-value")
   end
 
   defp choose_model(view, model),

--- a/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
@@ -1,0 +1,333 @@
+defmodule OrchardConsole.WorkspaceHandoffLiveTest do
+  use Orchard.ConnCase, async: false
+  import Phoenix.LiveViewTest
+  import Orchard.TestSupport.ModelRequestFixtures
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.API.Endpoint
+  alias Orchard.Governance
+  alias Orchard.Governance.{ApiKey, PortalInviteToken, PortalUser}
+  alias Orchard.Models.Access
+  alias Orchard.Repo
+
+  @moduletag :live
+  @moduletag :db
+
+  setup do
+    Sandbox.mode(Repo, {:shared, self()})
+    previous_mode = Application.get_env(:orchard_controller, :transport_mode)
+    previous_endpoint = Application.fetch_env!(:orchard_controller, Endpoint)
+    Application.put_env(:orchard_controller, :transport_mode, :direct_https)
+
+    endpoint =
+      Keyword.put(previous_endpoint, :url, scheme: "https", host: "orchard.test", port: 443)
+
+    Application.put_env(:orchard_controller, Endpoint, endpoint)
+    Endpoint.config_change([{Endpoint, endpoint}], [])
+
+    on_exit(fn ->
+      if previous_mode,
+        do: Application.put_env(:orchard_controller, :transport_mode, previous_mode),
+        else: Application.delete_env(:orchard_controller, :transport_mode)
+
+      Application.put_env(:orchard_controller, Endpoint, previous_endpoint)
+    end)
+
+    {:ok, workspace} =
+      Governance.create_tenant(%{slug: "handoff-workspace", name: "Handoff workspace"})
+
+    model = create_model!(%{state: :active})
+    %{workspace: workspace, model: model}
+  end
+
+  test "six steps stay visible and explicit Workspace starts at model access without granting anything",
+       %{conn: conn, workspace: workspace} do
+    {:ok, view, html} = live(conn, path(workspace))
+    assert html =~ "Step 2 of 6"
+    assert html =~ "Handoff workspace"
+
+    assert has_element?(
+             view,
+             "nav[aria-label='Colleague handoff steps'] [aria-disabled='true']",
+             "First request"
+           )
+
+    assert has_element?(view, "#handoff-step-2")
+    refute has_element?(view, "#handoff-step-3")
+    assert {:ok, []} = Access.list_model_access(workspace)
+    render_patch(view, path(workspace) <> "?step=6")
+    assert has_element?(view, "#handoff-step-2")
+  end
+
+  test "missing grant gives exact scoped administrator commands and refresh observes actual grant",
+       %{conn: conn, workspace: workspace, model: model} do
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    html = render(view)
+    assert html =~ "Not granted"
+    assert html =~ "orchardctl models access grant"
+    assert html =~ workspace.id
+    assert html =~ "#{model.model_id}@#{model.version}"
+    assert {:error, :not_granted} = Access.get_model_access(workspace, model)
+    {:ok, _grant} = Access.grant_model_access(workspace, model)
+    render_click(view, "refresh")
+    assert has_element?(view, "#handoff-model-access", "Granted")
+    refute has_element?(view, "#handoff-model-access", "orchardctl models access grant")
+  end
+
+  test "real invitation separates identity creation, link issuance, expiry and placeholder request",
+       %{conn: conn, workspace: workspace, model: model} do
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "person@example.test"})
+    |> render_submit()
+
+    assert has_element?(view, "#handoff-step-4")
+    assert Repo.aggregate(PortalUser, :count) == 1
+    assert Repo.aggregate(PortalInviteToken, :count) == 0
+    assert Repo.aggregate(ApiKey, :count) == 0
+    render_click(view, "next")
+    view |> element("#handoff-issue-invite") |> render_click()
+    assert Repo.aggregate(PortalInviteToken, :count) == 1
+
+    assert has_element?(
+             view,
+             "#handoff-invite-value",
+             "https://orchard.test/portal/handoff-workspace/invites/"
+           )
+
+    assert has_element?(view, "#handoff-invite-value", "?model=")
+    socket = :sys.get_state(view.pid).socket
+    first_url = socket.assigns.invite.url
+    render_click(view, "issue_invite")
+    refute :sys.get_state(view.pid).socket.assigns.invite.url == first_url
+    assert Repo.aggregate(PortalInviteToken, :count) == 1
+    expires_at = :sys.get_state(view.pid).socket.assigns.invite.expires_at
+    send(view.pid, {:expire_invite, expires_at})
+    refute render(view) =~ "handoff-invite-value"
+    render_click(view, "next")
+    assert has_element?(view, "#handoff-request-example", "<YOUR_OWN_API_KEY>")
+    assert has_element?(view, "#handoff-request-result", "not observed")
+    assert Repo.aggregate(ApiKey, :count) == 0
+    assert {:error, :not_granted} = Access.get_model_access(workspace, model)
+  end
+
+  test "existing active Portal User with missing grant is reused without another invite", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    {:ok, user} = Governance.create_portal_invite(workspace, %{email: "active@example.test"})
+    Repo.update_all(from(user in PortalUser, where: user.id == ^user.id), set: [status: "active"])
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "active@example.test"})
+    |> render_submit()
+
+    assert has_element?(view, "#handoff-step-4", "active")
+    render_click(view, "next")
+    refute has_element?(view, "#handoff-issue-invite")
+    assert render(view) =~ "already active"
+    assert Repo.aggregate(PortalUser, :count) == 1
+    assert Repo.aggregate(PortalInviteToken, :count) == 0
+    render_patch(view, path(workspace) <> "?step=2")
+    assert has_element?(view, "#handoff-model-access", "Not granted")
+  end
+
+  test "issuance failure retains saved identity for retry without duplicate Portal Users", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "retry@example.test"})
+    |> render_submit()
+
+    render_click(view, "next")
+    Application.put_env(:orchard_controller, :transport_mode, :plain_http_localhost)
+    render_click(view, "issue_invite")
+    assert render(view) =~ "Configure a public HTTPS Portal address"
+    assert Repo.aggregate(PortalUser, :count) == 1
+    assert Repo.aggregate(PortalInviteToken, :count) == 0
+    Application.put_env(:orchard_controller, :transport_mode, :direct_https)
+    render_click(view, "issue_invite")
+    assert has_element?(view, "#handoff-invite-value")
+    assert Repo.aggregate(PortalUser, :count) == 1
+  end
+
+  test "changing Workspace clears model, colleague draft and visible invite", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    {:ok, other} = Governance.create_tenant(%{slug: "other-handoff", name: "Other"})
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "scoped@example.test"})
+    |> render_submit()
+
+    render_click(view, "next")
+    render_click(view, "issue_invite")
+    assert has_element?(view, "#handoff-invite-value")
+    render_patch(view, path(other))
+    socket = :sys.get_state(view.pid).socket
+    assert socket.assigns.workspace.id == other.id
+    assert socket.assigns.selected == nil
+    assert socket.assigns.email == ""
+    assert socket.assigns.user == nil
+    assert socket.assigns.invite == nil
+    assert has_element?(view, "#handoff-step-2")
+    assert {:ok, []} = Governance.list_portal_users(other)
+  end
+
+  test "service rejects a user disabled after review without creating a link or duplicate", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "disabled@example.test"})
+    |> render_submit()
+
+    user = :sys.get_state(view.pid).socket.assigns.user
+    render_click(view, "next")
+    {:ok, _disabled} = Governance.disable_portal_user(workspace, user.id)
+    render_click(view, "issue_invite")
+    assert render(view) =~ "The Portal User is already saved"
+    assert Repo.aggregate(PortalUser, :count) == 1
+    assert Repo.aggregate(PortalInviteToken, :count) == 0
+    refute has_element?(view, "#handoff-invite-value")
+    render_click(view, "refresh")
+    assert has_element?(view, "#handoff-step-5", "unavailable or disabled")
+    refute has_element?(view, "#handoff-issue-invite")
+  end
+
+  test "unknown Workspace and unknown model cannot start invitation mutations", %{
+    conn: conn,
+    workspace: workspace
+  } do
+    {:ok, view, _html} = live(conn, path(workspace))
+    render_click(view, "choose_model", %{"model" => %{"id" => Ecto.UUID.generate()}})
+
+    render_click(view, "prepare_colleague", %{"colleague" => %{"email" => "invalid@example.test"}})
+
+    assert Repo.aggregate(PortalUser, :count) == 0
+    render_patch(view, "/console/access/workspaces/not-a-uuid/handoff")
+    assert has_element?(view, "#handoff-load-state", "Workspace not found")
+  end
+
+  test "refresh reports inactive model separately and removed model blocks sharing", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "catalog-change@example.test"})
+    |> render_submit()
+
+    {:ok, _model} = Orchard.Models.deprecate_model(model)
+    render_click(view, "refresh")
+    assert has_element?(view, "#handoff-step-4", "deprecated")
+    render_click(view, "next")
+    render_click(view, "next")
+    assert has_element?(view, "#handoff-step-6", "not currently available for Public Inference")
+    render_patch(view, path(workspace) <> "?step=4")
+    Repo.delete!(model)
+    render_click(view, "refresh")
+    assert has_element?(view, "#handoff-step-4", "Model no longer in catalog")
+    assert has_element?(view, "#handoff-next[disabled]")
+    render_click(view, "next")
+    render_click(view, "issue_invite")
+    assert has_element?(view, "#handoff-step-4")
+    assert Repo.aggregate(PortalInviteToken, :count) == 0
+  end
+
+  test "submit without a change event cannot retain an earlier colleague after rejection", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    {:ok, disabled} = Governance.create_portal_invite(workspace, %{email: "blocked@example.test"})
+    {:ok, _user} = Governance.disable_portal_user(workspace, disabled.id)
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "earlier@example.test"})
+    |> render_submit()
+
+    render_click(view, "next")
+    render_click(view, "issue_invite")
+    assert has_element?(view, "#handoff-invite-value")
+    render_patch(view, path(workspace) <> "?step=3")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "blocked@example.test"})
+    |> render_submit()
+
+    socket = :sys.get_state(view.pid).socket
+    assert socket.assigns.user == nil
+    assert socket.assigns.invite == nil
+    assert socket.assigns.unlocked == 3
+    assert socket.assigns.email == "blocked@example.test"
+    render_patch(view, path(workspace) <> "?step=5")
+    assert has_element?(view, "#handoff-step-3")
+    render_click(view, "issue_invite")
+    refute has_element?(view, "#handoff-invite-value")
+    assert Repo.aggregate(PortalUser, :count) == 2
+  end
+
+  test "failed invitation retains the rendered email through Back and Continue", %{
+    conn: conn,
+    workspace: workspace,
+    model: model
+  } do
+    Application.put_env(:orchard_controller, :transport_mode, :plain_http_localhost)
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "access-review@example.test"})
+    |> render_change()
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "access-review@example.test"})
+    |> render_submit()
+
+    assert render(view) =~ "Configure public HTTPS"
+    assert has_element?(view, "#handoff-colleague-email[value='access-review@example.test']")
+    render_patch(view, path(workspace) <> "?step=2")
+    render_click(view, "next")
+    assert has_element?(view, "#handoff-colleague-email[value='access-review@example.test']")
+    assert Repo.aggregate(PortalUser, :count) == 0
+  end
+
+  defp choose_model(view, model),
+    do: view |> form("#handoff-model-form", model: %{id: model.id}) |> render_change()
+
+  defp path(workspace), do: "/console/access/workspaces/#{workspace.id}/handoff"
+end

--- a/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
@@ -235,7 +235,27 @@ defmodule OrchardConsole.WorkspaceHandoffLiveTest do
     assert has_element?(view, "#handoff-load-state", "Workspace not found")
   end
 
-  test "refresh reports inactive model separately and removed model blocks sharing", %{
+  test "SPEC 6.2 registered models remain unavailable in first-request guidance", %{
+    conn: conn,
+    workspace: workspace
+  } do
+    model = create_model!(%{state: :registered})
+    {:ok, view, _html} = live(conn, path(workspace))
+    choose_model(view, model)
+    render_click(view, "next")
+
+    view
+    |> form("#handoff-colleague-form", colleague: %{email: "registered-model@example.test"})
+    |> render_submit()
+
+    render_click(view, "next")
+    render_click(view, "next")
+    assert has_element?(view, "#handoff-step-6", "registered")
+    assert has_element?(view, "#handoff-step-6", "not currently available for Public Inference")
+    refute has_element?(view, "#handoff-step-6", "Deprecation does not by itself block inference")
+  end
+
+  test "SPEC 6.2 deprecated models remain schedulable and removed models block sharing", %{
     conn: conn,
     workspace: workspace,
     model: model
@@ -253,7 +273,14 @@ defmodule OrchardConsole.WorkspaceHandoffLiveTest do
     assert has_element?(view, "#handoff-step-4", "deprecated")
     render_click(view, "next")
     render_click(view, "next")
+    assert has_element?(view, "#handoff-step-6", "Deprecation does not by itself block inference")
+    refute has_element?(view, "#handoff-step-6", "not currently available for Public Inference")
+
+    {:ok, _model} = Orchard.Models.retire_model(model.id)
+    render_click(view, "refresh")
+    assert has_element?(view, "#handoff-step-6", "retired")
     assert has_element?(view, "#handoff-step-6", "not currently available for Public Inference")
+    refute has_element?(view, "#handoff-step-6", "Deprecation does not by itself block inference")
     render_patch(view, path(workspace) <> "?step=4")
     Repo.delete!(model)
     render_click(view, "refresh")

--- a/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
@@ -60,6 +60,16 @@ defmodule OrchardConsole.WorkspaceHandoffLiveTest do
     assert has_element?(view, "#handoff-step-2")
   end
 
+  test "catalog model selector preserves DESIGN keyboard focus in light and dark themes",
+       %{conn: conn, workspace: workspace} do
+    {:ok, view, _html} = live(conn, path(workspace))
+
+    for token <-
+          ~w(focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:border-navy focus-visible:ring-navy/40 dark:focus-visible:border-sky-400 dark:focus-visible:ring-sky-400/40 dark:focus-visible:ring-offset-slate-900) do
+      assert has_element?(view, ~s(#handoff-model-id[class~="#{token}"]))
+    end
+  end
+
   test "missing grant gives exact scoped administrator commands and refresh observes actual grant",
        %{conn: conn, workspace: workspace, model: model} do
     {:ok, view, _html} = live(conn, path(workspace))

--- a/apps/orchard_controller/test/orchard/governance/portal_activation_curl_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/portal_activation_curl_test.exs
@@ -1,9 +1,14 @@
 defmodule Orchard.Governance.PortalActivationCurlTest do
-  use ExUnit.Case, async: true
+  use Orchard.DataCase, async: false
 
+  import Orchard.TestSupport.ModelRequestFixtures
+
+  alias Orchard.Governance
   alias Orchard.Governance.PortalActivationCurl
+  alias Orchard.Models.Access
 
   @token "orchard_sk_aaaaaaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
   test "quotes model identifiers that contain shell metacharacters" do
     curl =
       PortalActivationCurl.build(
@@ -28,7 +33,76 @@ defmodule Orchard.Governance.PortalActivationCurlTest do
     assert PortalActivationCurl.build(@token, nil, "https://orchard.example") == nil
   end
 
-  test "select_callable_model is fail-closed until tenant authorization exists" do
-    assert PortalActivationCurl.select_callable_model(Ecto.UUID.generate()) == nil
+  test "chooses a deterministic exact identity from active enabled grants" do
+    tenant = tenant!("portal-curl-default")
+    z_model = create_model!(%{model_id: "zeta/model", version: "v1", state: :active})
+    a_v2 = create_model!(%{model_id: "alpha/model", version: "v2", state: :active})
+    a_v1 = create_model!(%{model_id: "alpha/model", version: "v1", state: :active})
+
+    grant_model_access!(tenant, z_model)
+    grant_model_access!(tenant, a_v2)
+    grant_model_access!(tenant, a_v1)
+
+    assert PortalActivationCurl.select_callable_model(tenant.id) == "alpha/model@v1"
+  end
+
+  test "keeps an exact requested identity when it is active and enabled" do
+    tenant = tenant!("portal-curl-requested")
+    default_model = create_model!(%{model_id: "alpha/model", version: "v1", state: :active})
+    requested_model = create_model!(%{model_id: "zeta/model", version: "v2", state: :active})
+    grant_model_access!(tenant, default_model)
+    grant_model_access!(tenant, requested_model)
+
+    assert PortalActivationCurl.select_callable_model(tenant.id, "zeta/model@v2") ==
+             "zeta/model@v2"
+  end
+
+  test "does not substitute another model for an unavailable exact request" do
+    tenant = tenant!("portal-curl-no-substitute")
+    authorized_model = create_model!(%{model_id: "authorized/model", state: :active})
+    grant_model_access!(tenant, authorized_model)
+
+    assert PortalActivationCurl.select_callable_model(tenant.id, "missing/model@main") == nil
+  end
+
+  test "excludes never-granted and cross-Workspace models" do
+    tenant = tenant!("portal-curl-empty")
+    other_tenant = tenant!("portal-curl-other")
+    other_model = create_model!(%{model_id: "other/model", state: :active})
+    grant_model_access!(other_tenant, other_model)
+
+    assert PortalActivationCurl.select_callable_model(tenant.id) == nil
+    assert PortalActivationCurl.select_callable_model(tenant.id, "other/model@main") == nil
+  end
+
+  test "excludes disabled and revoked grants" do
+    disabled_tenant = tenant!("portal-curl-disabled")
+    disabled_model = create_model!(%{model_id: "disabled/model", state: :active})
+    grant_model_access!(disabled_tenant, disabled_model)
+
+    assert {:ok, %{outcome: :disabled}} =
+             Access.disable_model_access(disabled_tenant, disabled_model)
+
+    revoked_tenant = tenant!("portal-curl-revoked")
+    revoked_model = create_model!(%{model_id: "revoked/model", state: :active})
+    grant_model_access!(revoked_tenant, revoked_model)
+    assert {:ok, %{outcome: :revoked}} = Access.revoke_model_access(revoked_tenant, revoked_model)
+
+    assert PortalActivationCurl.select_callable_model(disabled_tenant.id) == nil
+    assert PortalActivationCurl.select_callable_model(revoked_tenant.id) == nil
+  end
+
+  test "excludes inactive models even when a grant remains enabled" do
+    tenant = tenant!("portal-curl-inactive")
+    model = create_model!(%{model_id: "inactive/model", state: :registered})
+    grant_model_access!(tenant, model)
+
+    assert PortalActivationCurl.select_callable_model(tenant.id) == nil
+    assert PortalActivationCurl.select_callable_model(tenant.id, "inactive/model@main") == nil
+  end
+
+  defp tenant!(slug) do
+    {:ok, tenant} = Governance.create_tenant(%{slug: slug, name: slug})
+    tenant
   end
 end

--- a/apps/orchard_controller/test/orchard/portal/keys_live_test.exs
+++ b/apps/orchard_controller/test/orchard/portal/keys_live_test.exs
@@ -2,9 +2,11 @@ defmodule Orchard.Portal.KeysLiveTest do
   use Orchard.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Orchard.TestSupport.ModelRequestFixtures
   import Orchard.TestSupport.PortalConn
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Orchard.API.Endpoint
   alias Orchard.Governance
   alias Orchard.Governance.PortalPasswordVerifier
   alias Orchard.Portal.Auth
@@ -35,9 +37,15 @@ defmodule Orchard.Portal.KeysLiveTest do
     %{tenant: tenant, user: user, token: session.token}
   end
 
-  test "empty org shows a create action, not only a table", %{conn: conn, token: token} do
+  test "empty Workspace shows a create action, not only a table", %{
+    conn: conn,
+    token: token,
+    tenant: tenant
+  } do
     {:ok, view, html} = live(authed(conn, token), "/portal/portal-keys/keys")
 
+    assert html =~ "Workspace"
+    assert html =~ tenant.name
     assert html =~ "No API keys yet"
     assert html =~ "Mint your first key"
     assert html =~ "0 / 10"
@@ -61,7 +69,7 @@ defmodule Orchard.Portal.KeysLiveTest do
     assert html =~ "orchard_sk_"
     assert html =~ "portal-secret-value"
     refute html =~ "data-secret="
-    assert html =~ "No test curl is available"
+    assert html =~ "this Workspace has no active authorized Model"
 
     view
     |> element("#portal-secret-modal form")
@@ -71,6 +79,64 @@ defmodule Orchard.Portal.KeysLiveTest do
     refute html =~ "orchard_sk_"
     assert html =~ "laptop"
     assert html =~ "orchard_kp_"
+  end
+
+  test "mint shows an inert exact-model curl from the new key without claiming runtime success",
+       %{
+         conn: conn,
+         token: token,
+         tenant: tenant
+       } do
+    default_model = create_model!(%{model_id: "alpha/model", version: "v1", state: :active})
+    requested_model = create_model!(%{model_id: "zeta/model", version: "v2", state: :active})
+    grant_model_access!(tenant, default_model)
+    grant_model_access!(tenant, requested_model)
+
+    with_public_https(fn ->
+      {:ok, view, html} =
+        live(authed(conn, token), "/portal/portal-keys/keys?model=zeta%2Fmodel%40v2")
+
+      assert html =~ "Requested Model"
+      assert html =~ "zeta/model@v2"
+      view |> element("#portal-mint-button") |> render_click()
+
+      html =
+        view
+        |> form("#portal-mint-modal form", key: %{name: "first-request"})
+        |> render_submit()
+
+      assert has_element?(view, "#portal-curl-value", "zeta/model@v2")
+      assert html =~ "Authorization: Bearer orchard_sk_"
+      assert html =~ "/v1/chat/completions"
+      assert html =~ "This example has not run"
+      assert html =~ "Runtime availability and readiness are checked when you send the request"
+      refute html =~ "Request completed"
+    end)
+  end
+
+  test "mint does not substitute another authorized model for an unavailable exact request", %{
+    conn: conn,
+    token: token,
+    tenant: tenant
+  } do
+    model = create_model!(%{model_id: "available/model", state: :active})
+    grant_model_access!(tenant, model)
+
+    with_public_https(fn ->
+      {:ok, view, _html} =
+        live(authed(conn, token), "/portal/portal-keys/keys?model=missing%2Fmodel%40main")
+
+      view |> element("#portal-mint-button") |> render_click()
+
+      html =
+        view
+        |> form("#portal-mint-modal form", key: %{name: "unavailable-model"})
+        |> render_submit()
+
+      refute has_element?(view, "#portal-curl-value")
+      assert html =~ "requested Model is not active and authorized for this Workspace"
+      assert html =~ "Your key was still minted"
+    end)
   end
 
   test "mint validation stays inside the dialog and describes the key-name input", %{
@@ -368,4 +434,24 @@ defmodule Orchard.Portal.KeysLiveTest do
   end
 
   defp cap_occurrences(html), do: length(Regex.scan(~r/Portal cap reached/, html))
+
+  defp with_public_https(fun) do
+    previous_endpoint = Application.fetch_env!(:orchard_controller, Endpoint)
+
+    endpoint =
+      Keyword.put(previous_endpoint, :url,
+        scheme: "https",
+        host: "orchard.test",
+        port: 443
+      )
+
+    try do
+      Application.put_env(:orchard_controller, Endpoint, endpoint)
+      :ok = Endpoint.config_change([{Endpoint, endpoint}], [])
+      fun.()
+    after
+      Application.put_env(:orchard_controller, Endpoint, previous_endpoint)
+      :ok = Endpoint.config_change([{Endpoint, previous_endpoint}], [])
+    end
+  end
 end

--- a/apps/orchard_controller/test/orchard/portal/session_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/portal/session_controller_test.exs
@@ -34,6 +34,8 @@ defmodule Orchard.Portal.SessionControllerTest do
       response = conn |> https_conn() |> get("/portal/#{slug}")
       body = html_response(response, 200)
       assert body =~ "Developer portal"
+      assert body =~ "Workspace"
+      assert body =~ slug
       assert body =~ "Email"
       assert body =~ "Password"
       refute body =~ "Portal password"
@@ -52,6 +54,28 @@ defmodule Orchard.Portal.SessionControllerTest do
     assert get_session(conn, Auth.session_token_key())
   end
 
+  test "exact requested Model survives login into the scoped keys page", %{conn: conn} do
+    {tenant, user} = active_user!("portal-login-model")
+    model = "mlx-community/phi-4@v2"
+    query = URI.encode_query(%{"model" => model})
+
+    page = conn |> https_conn() |> get("/portal/#{tenant.slug}?#{query}")
+    body = html_response(page, 200)
+
+    assert body =~ "Requested Model"
+    assert body =~ model
+    assert body =~ ~s|action="/portal/#{tenant.slug}/session?#{query}"|
+
+    logged_in =
+      post_form(page, "/portal/#{tenant.slug}/session?#{query}", %{
+        "_csrf_token" => csrf_token(page),
+        "session[email]" => user.email,
+        "session[password]" => @password
+      })
+
+    assert redirected_to(logged_in) == "/portal/#{tenant.slug}/keys?#{query}"
+  end
+
   test "invite redemption sets password once and redirects to login", %{conn: conn} do
     {:ok, tenant} = Governance.create_tenant(%{slug: "portal-redeem", name: "Redeem"})
     {:ok, user} = Governance.create_portal_invite(tenant, %{email: "dev@example.com"})
@@ -67,6 +91,7 @@ defmodule Orchard.Portal.SessionControllerTest do
 
     page = conn |> https_conn() |> get("/portal/#{tenant.slug}/invites/#{invite.token}")
     assert html_response(page, 200) =~ "Set your password"
+    assert page.resp_body =~ "Workspace"
     assert page.resp_body =~ ~s|id="invite-password"|
     assert page.resp_body =~ ~s|id="invite-password-confirmation"|
     assert page.resp_body =~ ~s|name="_csrf_token"|
@@ -89,6 +114,33 @@ defmodule Orchard.Portal.SessionControllerTest do
       })
 
     assert again.status == 422
+  end
+
+  test "exact requested Model survives invite redemption into login", %{conn: conn} do
+    {:ok, tenant} = Governance.create_tenant(%{slug: "portal-invite-model", name: "Invite Model"})
+    {:ok, user} = Governance.create_portal_invite(tenant, %{email: "model@example.com"})
+    {:ok, invite} = Governance.copy_portal_invite(tenant, user)
+    model = "mlx-community/phi-4@v2"
+    query = URI.encode_query(%{"model" => model})
+
+    page =
+      conn
+      |> https_conn()
+      |> get("/portal/#{tenant.slug}/invites/#{invite.token}?#{query}")
+
+    assert html_response(page, 200) =~ model
+
+    assert page.resp_body =~
+             ~s|action="/portal/#{tenant.slug}/invites/#{invite.token}?#{query}"|
+
+    redeemed =
+      post_form(page, "/portal/#{tenant.slug}/invites/#{invite.token}?#{query}", %{
+        "_csrf_token" => csrf_token(page),
+        "invite[password]" => @password,
+        "invite[password_confirmation]" => @password
+      })
+
+    assert redirected_to(redeemed) == "/portal/#{tenant.slug}?#{query}"
   end
 
   test "SPEC 7.4a invite redemption is bound to the Organization route", %{conn: conn} do

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -598,6 +598,7 @@ An already-active Portal User with missing model access needs grant recovery, no
 Keep Portal User creation and Copy invite as separate actions with real persisted status, explicit manual delivery, expiry, and reissue behavior.
 Opening the actual HTTPS Portal is a handoff, not evidence that the colleague accepted an invitation or ran a request.
 Console request guidance uses placeholder credentials and does not show completion without actual request evidence.
+Deprecated Models remain schedulable under SPEC section 6.2; handoff guidance must not describe deprecation alone as blocking inference.
 The Portal's one-time request example uses an authorized active exact Model and clearly states that runtime readiness remains unverified.
 
 ### 6.8 Workspace API Token Mint Attribution

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -590,6 +590,8 @@ Show the complete numbered sequence, current step count, and dimmed future steps
 Each step replaces the previous step's content, with a compact responsive orientation and the selected Workspace and exact Model identity kept visible.
 If the default Workspace is the only scope, resolve step 1 visibly and start at step 2 of 6.
 Preserve non-secret inputs on Back and recoverable retries; changing scope clears scoped drafts and transient secrets.
+Leaving the invite reveal step clears its plaintext URL and timer, so returning requires explicit reissue.
+Successful refresh returns to Model access when the selected Model disappears, or Portal invitation when the selected Portal User disappears or becomes disabled, and locks the later steps until their prerequisites recover.
 Model access shows actual enabled, disabled, not-granted, inactive, or unavailable evidence.
 Where browser command authority is absent, provide scoped, shell-quoted operator command guidance and a refresh action rather than an unchecked grant control.
 An already-active Portal User with missing model access needs grant recovery, not another invitation.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -544,7 +544,18 @@ When raw decision debug JSON is shown, apply the same key-based unsafe-key deny-
 
 ### 6.7 Portal User Management and Portal Isolation
 
-The Organization detail surface manages Portal Users through three stacked Console cards.
+Access opens a Workspace list with the existing default Workspace first and a secondary Create workspace action leading to a separate form.
+Display the untouched seeded name as Default workspace, preserve customized names, and use a Default badge based on stable identity.
+Workspace detail keeps its name and slug visible above reloadable Overview, Model access, Portal users, and API credentials sections.
+Section changes replace the visible content; inactive sections are hidden from layout, keyboard navigation, and the accessibility tree.
+Known legacy fragments map to their corresponding section through a whitelisted client hook, preserving the Workspace identity.
+Unknown section values fall back to Overview; unknown fragments do not change scope.
+Return controls remain visible and preserve the destination context.
+Portal membership, model access, tenant-direct API Tokens, and API Client credentials remain independently explained.
+Team appears only as optional API Client grouping metadata, including an Ungrouped state, without membership or role controls.
+Invitation instructions explain that the operator separately copies and delivers the invite URL; no email delivery is implied.
+
+The Portal users section manages Portal Users through three related Console cards.
 The first card is the Portal User invite form, with an email field and a navy primary **Invite** action.
 Submitting **Invite** creates the Portal User in `invited` status without issuing a token or showing a Portal Invite URL.
 The operator then uses **Copy invite** on that invited Portal User to issue the first token.
@@ -571,16 +582,29 @@ The operator manages developer access through Portal Invites and Portal User dis
 
 The Developer Portal remains a separate, dark-pinned surface and does not inherit the Console theme preference.
 It must not render Console chrome or operator controls.
-It remains isolated to the Organization named by the route and to the portal-minted keys owned by the signed-in Portal User.
-The three operator cards remain Console surfaces and use the existing Console card, tactile-well, focus, and navy primary-action tokens in both Console theme modes.
+It remains isolated to the Workspace named by the route and to the portal-minted keys owned by the signed-in Portal User.
+These operator cards remain Console surfaces and use the existing Console card, tactile-well, focus, and navy primary-action tokens in both Console theme modes.
 
-### 6.8 Organization API Token Mint Attribution
+The guided colleague handoff is a separate six-step journey: Workspace, Model access, Portal invitation, Review scope, Colleague handoff, and First request.
+Show the complete numbered sequence, current step count, and dimmed future steps without spreading two active steps across the entire page.
+Each step replaces the previous step's content, with a compact responsive orientation and the selected Workspace and exact Model identity kept visible.
+If the default Workspace is the only scope, resolve step 1 visibly and start at step 2 of 6.
+Preserve non-secret inputs on Back and recoverable retries; changing scope clears scoped drafts and transient secrets.
+Model access shows actual enabled, disabled, not-granted, inactive, or unavailable evidence.
+Where browser command authority is absent, provide scoped, shell-quoted operator command guidance and a refresh action rather than an unchecked grant control.
+An already-active Portal User with missing model access needs grant recovery, not another invitation.
+Keep Portal User creation and Copy invite as separate actions with real persisted status, explicit manual delivery, expiry, and reissue behavior.
+Opening the actual HTTPS Portal is a handoff, not evidence that the colleague accepted an invitation or ran a request.
+Console request guidance uses placeholder credentials and does not show completion without actual request evidence.
+The Portal's one-time request example uses an authorized active exact Model and clearly states that runtime readiness remains unverified.
 
-The Organization API Tokens table places a **Minted via** column after **Name** and before **Prefix**.
-For `issuance_surface = "developer_portal"` with a Portal User from the same Organization, render **Developer Portal** as the primary line and the normalized Portal User email as visible secondary text.
+### 6.8 Workspace API Token Mint Attribution
+
+The Workspace API Tokens table places a **Minted via** column after **Name** and before **Prefix**.
+For `issuance_surface = "developer_portal"` with a Portal User from the same Workspace, render **Developer Portal** as the primary line and the normalized Portal User email as visible secondary text.
 For `issuance_surface = "governance"` with no Portal User association, render **Operator tooling**.
-For a Developer Portal API Token whose Portal User attribution is null, missing, deleted, or associated with another Organization, render **Developer Portal** with **Attribution unavailable** as visible secondary text.
-Any inconsistent association must fail closed without exposing another Organization's Portal User email.
+For a Developer Portal API Token whose Portal User attribution is null, missing, deleted, or associated with another Workspace, render **Developer Portal** with **Attribution unavailable** as visible secondary text.
+Any inconsistent association must fail closed without exposing another Workspace's Portal User email.
 These values describe mint-time provenance only.
 They do not identify API Token ownership, the Public Inference Bearer principal, current Portal User status, effective access, or revocation state.
 Disabling a Portal User does not automatically revoke minted API Tokens, and the existing **Status** column remains the credential-state presentation.
@@ -711,9 +735,9 @@ For each pair of `{light, dark} × {sidebar-expanded, sidebar-collapsed}`:
   dark).
 - [ ] Placeholder contrast is readable.
 
-**Form input wells (Organizations + Organization Detail)**
+**Form input wells (Workspaces + Workspace Detail)**
 
-- [ ] Organization create `<.input>` renders as a tactile well.
+- [ ] Workspace create `<.input>` renders as a tactile well.
 - [ ] API Token create `<.input>` renders as a tactile well.
 
 **Form input wells (Playground)**

--- a/docs/console-ux-testing-personas.md
+++ b/docs/console-ux-testing-personas.md
@@ -5,6 +5,9 @@ The personas are research hypotheses and testing lenses, not product roles, perm
 `SPEC.md`, accepted decisions, accepted OpenSpec changes, and implemented authorization remain the product authorities.
 When this guide conflicts with those authorities, the authoritative contract wins and this guide must be corrected.
 
+Workspace is the product-facing projection of one existing Tenant, as defined in SPEC.md sections 2.3 and 7.4a and [ADR 0031](decisions/0031-workspace-display-and-access-navigation.md).
+Tenant identity, API and CLI vocabulary, audit identifiers, and existing Portal URLs remain compatible.
+
 The guide is intentionally behavioral and authority-based.
 It avoids demographic biographies and decorative personality traits that do not change a participant's task, authority, evidence, or constraints.
 External design references and transient research notes may inform a study, but they do not establish Orchard behavior.
@@ -21,7 +24,7 @@ Treat answers about unresolved contracts as research observations rather than pa
 
 The same person may exercise more than one persona in a small deployment, but each test should make the active authority boundary explicit.
 A persona name never expands the participant's credentials.
-An action is allowed only through the surface-appropriate authenticated authorization, such as an RBAC Access Level, an active Organization-scoped Portal User session for that user's portal actions, or local machine authority for host-local work.
+An action is allowed only through the surface-appropriate authenticated authorization, such as an RBAC Access Level, an active Workspace-scoped Portal User session for that user's portal actions, or local machine authority for host-local work.
 
 ## Evidence ladder
 
@@ -31,7 +34,7 @@ The following distinctions should remain visible across every relevant scenario.
 2. Enrollment and certificate-backed registration prove Node identity, but they do not grant Node Admission.
 3. Node Admission is an explicit administrator decision, while `admitted` to `active` follows automatically after fresh healthy authenticated evidence.
 4. An active Node is not necessarily eligible for a particular exact Model, policy, request, or workload.
-5. Model Catalog state is separate from Organization access and per-Node Model Placement state.
+5. Model Catalog state is separate from Workspace access and per-Node Model Placement state.
 6. Downloaded, verified, cached, loaded, eligible, authorized, selected, and successfully invoked are separate facts.
 7. Desired placement or residency policy is not proof that the desired state has been reached.
 8. A successful inference request is the final product-level proof that authorization, scheduling, runtime readiness, and execution aligned for that request.
@@ -40,19 +43,19 @@ The following distinctions should remain visible across every relevant scenario.
 
 ### Department Operator
 
-- **Job to be done:** The Department Operator makes an Organization usable for approved applications while understanding when cluster work must be handed to a platform administrator.
-- **Actual Orchard authority and prohibited actions:** The participant exercises only the effective Organization-scoped rights assigned to their principal, such as `tenant_admin`, and must not assume authority to admit or decommission Nodes, mutate the global Model Catalog, inspect another Organization, or perform cluster-wide operations.
+- **Job to be done:** The Department Operator makes a Workspace usable for approved applications while understanding when cluster work must be handed to a platform administrator.
+- **Actual Orchard authority and prohibited actions:** The participant exercises only the effective Workspace-scoped rights assigned to their principal, such as `tenant_admin`, and must not assume authority to admit or decommission Nodes, mutate the global Model Catalog, inspect another Workspace, or perform cluster-wide operations.
 - **Technical confidence and starting mental model:** The participant understands API access and service ownership, but may initially expect Orchard to behave like a hosted workspace where choosing a Model makes it immediately available.
-- **Information and system access available:** The participant can see their Organization's approved access, API Clients, API Tokens, quota, routing, and model availability surfaces that their credentials permit, plus handoff status supplied by the cluster operator.
-- **Likely misconceptions:** The participant may treat Organization, Tenant, Team, API Client, Portal User, API Token, and Access Level as interchangeable, or may assume Catalog activation grants access automatically.
-- **Evidence required before declaring success:** The participant must identify the exact Model, effective Organization access, usable credential, eligible serving path, and successful inference result without relying on a green Catalog or Node badge alone.
-- **Relevant prototype and product scenarios:** This persona leads Organization access, developer enablement, exact-Model request readiness, and the Department Operator side of Add Node and Model-placement handoffs.
+- **Information and system access available:** The participant can see their Workspace's approved access, API Clients, API Tokens, quota, routing, and model availability surfaces that their credentials permit, plus handoff status supplied by the cluster operator.
+- **Likely misconceptions:** The participant may treat Workspace, Tenant, Team, API Client, Portal User, API Token, and Access Level as interchangeable, or may assume Catalog activation grants access automatically.
+- **Evidence required before declaring success:** The participant must identify the exact Model, effective Workspace access, usable credential, eligible serving path, and successful inference result without relying on a green Catalog or Node badge alone.
+- **Relevant prototype and product scenarios:** This persona leads Workspace access, developer enablement, exact-Model request readiness, and the Department Operator side of Add Node and Model-placement handoffs.
 - **Accessibility or operational constraints:** Tests should cover keyboard operation, non-color status interpretation, one-time secret custody, and handoffs where the participant cannot access the target machine or cluster-admin controls.
 
 ### Node Host Custodian
 
 - **Job to be done:** The Node Host Custodian installs and operates Orchard on a specific machine so that a cluster administrator can establish and review trustworthy Node identity.
-- **Actual Orchard authority and prohibited actions:** The participant may exercise local machine-administrator authority to verify media, install the selected Install Role, protect enrollment material, run local join or service operations, and collect safe diagnostics, but local root authority does not grant Console admin, Node Admission, Organization access, or model-access authority.
+- **Actual Orchard authority and prohibited actions:** The participant may exercise local machine-administrator authority to verify media, install the selected Install Role, protect enrollment material, run local join or service operations, and collect safe diagnostics, but local root authority does not grant Console admin, Node Admission, Workspace access, or model-access authority.
 - **Technical confidence and starting mental model:** The participant understands macOS administration, networking, services, and protected files, but may expect successful installation or network reachability to be equivalent to cluster trust.
 - **Information and system access available:** The participant has the target machine, the approved distribution media, the protected Node Enrollment Bundle, the exact local command or guided flow, local service output, and Controller identity and trust-pin information needed for enrollment.
 - **Likely misconceptions:** The participant may confuse the Node Agent with a Worker Runtime, a Bootstrap Token with durable identity, a Node Certificate with Node Admission, or a Runtime Endpoint observation with a registered Node.
@@ -63,30 +66,30 @@ The following distinctions should remain visible across every relevant scenario.
 ### Model Curator or ML Engineer
 
 - **Job to be done:** The Model Curator introduces and qualifies an exact Model artifact while preserving provenance, capability limits, and the distinction between Catalog, files, runtime, and scheduling state.
-- **Actual Orchard authority and prohibited actions:** The participant may prepare and inspect Model Bundles, verify trusted evidence, request or perform authorized import and activation, and assemble qualification evidence, but must not infer Organization grants, Node eligibility, runtime installation, support status, or production readiness from import success alone.
+- **Actual Orchard authority and prohibited actions:** The participant may prepare and inspect Model Bundles, verify trusted evidence, request or perform authorized import and activation, and assemble qualification evidence, but must not infer Workspace grants, Node eligibility, runtime installation, support status, or production readiness from import success alone.
 - **Technical confidence and starting mental model:** The participant understands checkpoints, quantization, tokenizers, runtimes, and hardware constraints, but may initially think in model-family names instead of Orchard's exact Model identity.
 - **Information and system access available:** The participant has the source and exact version, manifest, trusted digest or detached evidence, Catalog metadata, qualification requirements, placement observations, runtime-provider evidence, and failure details allowed by their role.
 - **Likely misconceptions:** The participant may confuse a Model Bundle with the imported Artifact Bundle, trust the deprecated manifest digest as Catalog authority, treat `cached` as `loaded`, or treat a plausible response as a support claim.
-- **Evidence required before declaring success:** The participant must show exact identity, provenance, successful secure import, authoritative post-import verification, and capability-scoped qualification evidence appropriate to the claim, while naming Organization grants, current Placement state, compatibility, and inference as separate additional gates only when the claim is end-to-end application readiness.
+- **Evidence required before declaring success:** The participant must show exact identity, provenance, successful secure import, authoritative post-import verification, and capability-scoped qualification evidence appropriate to the claim, while naming Workspace grants, current Placement state, compatibility, and inference as separate additional gates only when the claim is end-to-end application readiness.
 - **Relevant prototype and product scenarios:** This persona leads exact Model discovery, acquisition, verification, placement-policy interpretation, load failure diagnosis, and qualification-boundary scenarios.
 - **Accessibility or operational constraints:** Tests should include very large artifacts, air-gapped or bandwidth-limited transfer, long verification and cold-load times, resumable progress, machine-readable failure codes, and comparison views that do not depend on dense color-only tables.
 
 ### Application Developer
 
-- **Job to be done:** The Application Developer obtains an approved credential, discovers Models visible to their Organization, and integrates a reliable inference call without needing cluster-administration knowledge.
+- **Job to be done:** The Application Developer obtains an approved credential, discovers Models visible to their Workspace, and integrates a reliable inference call without needing cluster-administration knowledge.
 - **Actual Orchard authority and prohibited actions:** The participant may authenticate Public Inference with a tenant-direct API Key that resolves to the Tenant principal, or with a service-account-owned API Token whose enabled API Client has tenant-scoped `inference_client` access.
-  Separately, an Organization-scoped Portal User may mint and revoke only their own portal-minted tenant-direct API Keys, but a Portal session does not authorize Console, Operator API, Admin API, or Public Inference by itself.
+  Separately, a Workspace-scoped Portal User may mint and revoke only their own portal-minted tenant-direct API Keys, but a Portal session does not authorize Console, Operator API, Admin API, or Public Inference by itself.
 - **Technical confidence and starting mental model:** The participant is comfortable with HTTP APIs, SDKs, and environment variables, but may expect a portal login, copied bearer credential, or visible Catalog entry to imply every other permission.
-- **Information and system access available:** The participant has their Organization-scoped Developer Portal, show-once API Key or API Token output, callable exact Model identifiers returned by `/v1/models`, example requests, stable public errors, and application logs they control.
+- **Information and system access available:** The participant has their Workspace-scoped Developer Portal, show-once API Key or API Token output, callable exact Model identifiers returned by `/v1/models`, example requests, stable public errors, and application logs they control.
 - **Likely misconceptions:** The participant may confuse Portal User identity with the Public Inference principal, expect a disabled Portal User to revoke previously minted API Keys, or assume `401`, `403`, and capacity failures mean the same thing.
-- **Evidence required before declaring success:** The participant must protect the one-time secret, authenticate with the correct bearer credential, select a Model returned for the effective Organization, receive a successful response, and distinguish credential, authorization, model, and runtime failures.
+- **Evidence required before declaring success:** The participant must protect the one-time secret, authenticate with the correct bearer credential, select a Model returned for the effective Workspace, receive a successful response, and distinguish credential, authorization, model, and runtime failures.
 - **Relevant prototype and product scenarios:** This persona leads Portal invitation, portal-minted API Key creation and revocation, `/v1/models` discovery, first inference, invalid credential, unauthorized Model, and retry-safe client behavior scenarios.
 - **Accessibility or operational constraints:** Tests should cover copy errors, screen-reader labeling of show-once secrets, keyboard-only Portal use, reduced motion, expired sessions, and environments where production secrets cannot be pasted into a browser recording or support artifact.
 
 ### On-call Operator or Platform Generalist
 
 - **Job to be done:** The On-call Operator restores safe service by locating the failed authority or runtime boundary, taking only permitted operational actions, and proving recovery with current evidence.
-- **Actual Orchard authority and prohibited actions:** The participant may use `operator` authority for runtime operations, diagnostics, request cancel or retry, and permitted Node lifecycle actions, but may not mutate Organizations, keys, or other admin-only state unless separately assigned `admin` authority.
+- **Actual Orchard authority and prohibited actions:** The participant may use `operator` authority for runtime operations, diagnostics, request cancel or retry, and permitted Node lifecycle actions, but may not mutate Workspaces, keys, or other admin-only state unless separately assigned `admin` authority.
 - **Technical confidence and starting mental model:** The participant understands distributed systems and incident response, but may be unfamiliar with the exact cluster, recent policy changes, or whether an observation is durable authority or diagnostic evidence.
 - **Information and system access available:** The participant has Console status, bounded diagnostics, lifecycle and health, freshness, Runtime Endpoint observations, scheduler explanations, request attempts, stable reason codes, audit references, and approved CLI or API operations.
 - **Likely misconceptions:** The participant may equate healthy with schedulable, active with exact-Model readiness, loaded with authorized, retryable with safe to retry after output, or Cancel Drain with a return to active service.
@@ -101,8 +104,8 @@ The following distinctions should remain visible across every relevant scenario.
 - **Technical confidence and starting mental model:** The participant understands control evidence and threat boundaries, but may not know which Orchard observations are authoritative, derived, transient, or intentionally omitted.
 - **Information and system access available:** The participant has sanitized audit records, decision references, credential prefixes, bounded status and scheduler evidence, retention and capture settings, qualification records, and approved support evidence without plaintext secrets or raw tenant content.
 - **Likely misconceptions:** The participant may treat absence from a redacted artifact as proof that an event did not occur, confuse Portal User provenance with Bearer ownership, or assume Node Certificate possession authorizes admission or production BEAM access.
-- **Evidence required before declaring success:** The participant must trace actor, scope, target, decision, timestamp, and outcome while confirming that secrets, raw content, cross-Organization identifiers, and unsafe diagnostics were not persisted or disclosed.
-- **Relevant prototype and product scenarios:** This persona leads access-denial, cross-Organization isolation, one-time secret, invitation, admission, destructive action, audit, redaction, and evidence-retention scenarios.
+- **Evidence required before declaring success:** The participant must trace actor, scope, target, decision, timestamp, and outcome while confirming that secrets, raw content, cross-Workspace identifiers, and unsafe diagnostics were not persisted or disclosed.
+- **Relevant prototype and product scenarios:** This persona leads access-denial, cross-Workspace isolation, one-time secret, invitation, admission, destructive action, audit, redaction, and evidence-retention scenarios.
 - **Accessibility or operational constraints:** Tests should cover read-only workflows, redacted or partially unavailable evidence, keyboard navigation, text alternatives for status, export review outside Console, and an explicit distinction between a verification gap and a verified absence.
 
 ## Scenario matrix
@@ -114,10 +117,10 @@ Each card may be run against a concept, clickable prototype, instrumented produc
 
 - **Contract and maturity:** `SPEC.md` sections 4.1 through 4.4 and 10.5 through 10.6 define the identity, lifecycle, trust, and admission boundaries, while `docs/operator-journey.md` identifies the complete packaged cross-machine guided flow as target product intent pending packaged acceptance.
 - **Persona:** The Node Host Custodian performs machine-local work, the Department Operator initiates and tracks the need, and a separately authorized administrator performs Node Admission.
-- **Starting state:** A healthy Controller exists, no pending enrollment exists, a supported machine has no authorized Orchard role, and an exact Model is already available to an approved Organization on at least one other path.
+- **Starting state:** A healthy Controller exists, no pending enrollment exists, a supported machine has no authorized Orchard role, and an exact Model is already available to an approved Workspace on at least one other path.
 - **Task prompt:** A new supported machine is ready to contribute inference capacity, so add it safely and show when Orchard may schedule the exact Model on it.
 - **Allowed authority:** The Department Operator may request capacity, an administrator may issue the per-Node Enrollment Bundle and later review and admit the registered Node, and the custodian may receive the protected bundle, verify media, install the `node-agent` Install Role, and complete machine-local registration.
-- **Success evidence:** The flow shows installation, bundle issuance and expiry, certificate-backed registration, administrator review, explicit admission, automatic healthy activation, exact-Model compatibility and residency, current capacity, and Organization authorization without collapsing any stage.
+- **Success evidence:** The flow shows installation, bundle issuance and expiry, certificate-backed registration, administrator review, explicit admission, automatic healthy activation, exact-Model compatibility and residency, current capacity, and Workspace authorization without collapsing any stage.
   The accepted attempt for the successful terminal request identifies the newly added Node and exact Model version and shows that final revalidation and runtime acceptance succeeded.
 - **Critical misunderstandings:** Installation is not enrollment, observation is not registration, registration is not admission, admission does not require a manual Activate action, and active is not universal workload readiness.
 - **Prototype observations:** Record where each participant changes surfaces or machines, what they transfer, whether they can resume after delay, when they ask for help, and the first point at which they claim the Node is ready.
@@ -141,38 +144,38 @@ Each card may be run against a concept, clickable prototype, instrumented produc
 ### S3: Discover and acquire an exact Model
 
 - **Contract and maturity:** `SPEC.md` sections 6.1 through 6.7 define exact Model identity, import, Catalog, verification, and distribution, while any marketplace-like discovery experience or unimplemented remote distribution path remains a prototype hypothesis rather than current product behavior.
-- **Persona:** The Model Curator leads the task and hands Organization access decisions to the Department Operator or an appropriately authorized administrator.
+- **Persona:** The Model Curator leads the task and hands Workspace access decisions to the Department Operator or an appropriately authorized administrator.
 - **Starting state:** A model family is known, but the exact checkpoint or version is not yet in the Model Catalog and no Node-local Artifact Bundle exists.
 - **Task prompt:** Find the approved exact Model, import it with trustworthy provenance, and explain what remains before an application can call it.
-- **Allowed authority:** The curator may inspect source metadata and perform only the import, verification, and Catalog actions their admin authority permits, while Organization grants, routing, and credentials require their own assigned authority.
-- **Success evidence:** The participant selects one exact Model identity, verifies source and final imported Artifact Bundle evidence, reaches the appropriate Catalog state, and names Organization access, distribution, placement, eligibility, and inference as later independent gates.
+- **Allowed authority:** The curator may inspect source metadata and perform only the import, verification, and Catalog actions their admin authority permits, while Workspace grants, routing, and credentials require their own assigned authority.
+- **Success evidence:** The participant selects one exact Model identity, verifies source and final imported Artifact Bundle evidence, reaches the appropriate Catalog state, and names Workspace access, distribution, placement, eligibility, and inference as later independent gates.
 - **Critical misunderstandings:** The Catalog is not a marketplace guarantee, a family name is not exact identity, source verification is not post-import verification, activation does not grant access, and import does not distribute files to every Node.
 - **Prototype observations:** Record search terms, version-comparison behavior, provenance checks, uncertainty about current versus target distribution, and the first status interpreted as complete.
-- **Candidate automated regression checks:** Tests should verify exact-version selection, provenance visibility, import progress and failure recovery, distinct Catalog and Placement status, activation without implicit Organization grants, and no claim of cluster-wide distribution from a controller-local import.
+- **Candidate automated regression checks:** Tests should verify exact-version selection, provenance visibility, import progress and failure recovery, distinct Catalog and Placement status, activation without implicit Workspace grants, and no claim of cluster-wide distribution from a controller-local import.
 
-### S4: Organization access and API credentials
+### S4: Workspace access and API credentials
 
-- **Contract and maturity:** `SPEC.md` sections 6.6, 7.2.2 through 7.2.3, 7.4a, and 10.2 through 10.4 define current Organization, Model grant, Portal User, API Key, API Token, and authorization behavior, while Workspace remains only a research label.
-- **Persona:** The Department Operator grants appropriate Organization access and the Application Developer completes credential and API use.
-- **Starting state:** An exact Model is active in the Catalog, but the Organization has no enabled Model grant and the developer has no usable bearer credential.
+- **Contract and maturity:** `SPEC.md` sections 6.6, 7.2.2 through 7.2.3, 7.4a, and 10.2 through 10.4 define current Workspace, Model grant, Portal User, API Key, API Token, and authorization behavior; Workspace is the user-facing name for the existing Tenant governance scope.
+- **Persona:** The Department Operator grants appropriate Workspace access and the Application Developer completes credential and API use.
+- **Starting state:** An exact Model is active in the Catalog, but the Workspace has no enabled Model grant and the developer has no usable bearer credential.
 - **Task prompt:** Give one application the minimum access required to discover and call the approved Model without granting cluster administration.
-- **Allowed authority:** A `tenant_admin` may manage Organization-scoped model access and credentials within the accepted surface.
+- **Allowed authority:** A `tenant_admin` may manage Workspace-scoped model access and credentials within the accepted surface.
   A tenant-direct API Key may discover and invoke granted Models as the Tenant principal, while a service-account-owned API Token may do so only when its enabled API Client has tenant-scoped `inference_client` access.
-  Separately, an Application Developer signed in as an Organization-scoped Portal User may manage only their own portal-minted tenant-direct API Keys.
-- **Success evidence:** The exact Model appears in `/v1/models` only after an enabled Organization grant, the bearer credential is shown once and stored safely, the effective principal and Organization are correct, and a request succeeds without cluster-scoped authority.
-- **Critical misunderstandings:** The current product-facing term is Organization rather than Workspace, Team is metadata rather than a governance boundary, Portal User is not a Public Inference principal, and Portal User disablement does not automatically revoke minted API Keys.
+  Separately, an Application Developer signed in as a Workspace-scoped Portal User may manage only their own portal-minted tenant-direct API Keys.
+- **Success evidence:** The exact Model appears in `/v1/models` only after an enabled Workspace grant, the bearer credential is shown once and stored safely, the effective principal and Workspace are correct, and a request succeeds without cluster-scoped authority.
+- **Critical misunderstandings:** Workspace is the product-facing name for Tenant, Team is optional API Client grouping metadata, Portal User is not a Public Inference principal, and Portal User disablement does not automatically revoke minted API Keys.
 - **Prototype observations:** Record whether participants can explain who owns the credential, where model access is granted, what one-time output means, and which action is needed to end both portal and key access.
-- **Candidate automated regression checks:** Tests should cover deny-by-default model listing, cross-Organization isolation, show-once secrets, disabled API Clients, revoked and expired credentials, Portal User ownership filters, separate Portal User disable and portal-minted API Key revoke, and stable `401` versus `403` behavior.
+- **Candidate automated regression checks:** Tests should cover deny-by-default model listing, cross-Workspace isolation, show-once secrets, disabled API Clients, revoked and expired credentials, Portal User ownership filters, separate Portal User disable and portal-minted API Key revoke, and stable `401` versus `403` behavior.
 
 ### S5: Model files, runtime residency, eligibility, and successful inference
 
 - **Contract and maturity:** `SPEC.md` sections 5.5 through 5.8, 6.3 through 6.10, and 7.5 define the state and eligibility boundaries, while a complete Console workflow or remote distribution step should be treated as target behavior wherever the current operator journey reports a gap.
-- **Persona:** The Model Curator and On-call Operator establish runtime facts, while the Department Operator and Application Developer establish Organization authorization and request success.
+- **Persona:** The Model Curator and On-call Operator establish runtime facts, while the Department Operator and Application Developer establish Workspace authorization and request success.
 - **Starting state:** The exact Model is active and granted, two active Nodes report different compatibility or capacity evidence, and neither has a loaded placement.
 - **Task prompt:** Make the exact Model available with low cold-start risk on suitable capacity and prove that an authorized request can be served.
-- **Allowed authority:** An administrator may set accepted cluster placement, routing, and pinning policy, a `tenant_admin` may manage only Organization-scoped keys, quota, and model access that its accepted surface authorizes, and an operator may perform permitted runtime load or diagnostic operations.
+- **Allowed authority:** An administrator may set accepted cluster placement, routing, and pinning policy, a `tenant_admin` may manage only Workspace-scoped keys, quota, and model access that its accepted surface authorizes, and an operator may perform permitted runtime load or diagnostic operations.
   A tenant-direct API Key may discover and invoke granted Models as the Tenant principal, while a service-account-owned API Token may do so only when its enabled API Client has tenant-scoped `inference_client` access.
-- **Success evidence:** The participant separately verifies acquisition, authoritative digest verification, cached files, runtime loading, exact-Model placement capacity, lifecycle and health, policy eligibility, Organization authorization, scheduler selection, dispatch-time revalidation, and a successful response.
+- **Success evidence:** The participant separately verifies acquisition, authoritative digest verification, cached files, runtime loading, exact-Model placement capacity, lifecycle and health, policy eligibility, Workspace authorization, scheduler selection, dispatch-time revalidation, and a successful response.
 - **Critical misunderstandings:** Desired placement is not observed state, downloaded is not verified, cached is not loaded, loaded is not eligible, and eligible is not proof that a particular request was authorized or selected.
 - **Prototype observations:** Record whether progress and failures remain attributable to files, verification, runtime, policy, capacity, or authorization, and whether long-running steps expose safe resume behavior.
 - **Candidate automated regression checks:** Tests should exercise every Placement transition, checksum mismatch, insufficient disk or memory, incompatible runtime, stale observation, capacity exhaustion, access denial, selection evidence, and the final successful inference path.
@@ -203,16 +206,16 @@ Each card may be run against a concept, clickable prototype, instrumented produc
 
 ### S8: Unauthorized and degraded developer access
 
-- **Contract and maturity:** `SPEC.md` sections 7.2.2 through 7.2.3, 7.4a, and 10.2 through 10.4 define the current authentication, authorization, Portal, and Organization-isolation expectations used by this scenario.
-- **Persona:** The Application Developer diagnoses the client-visible failure and the Department Operator handles any authorized Organization-side correction.
-- **Starting state:** The developer may have an invalid, revoked, expired, or wrong-Organization bearer credential, a valid API Token owned by a disabled API Client, a Portal session ended by Portal User disablement, or a request for an active Model that lacks an enabled Organization grant.
-- **Task prompt:** Determine why the application cannot call the Model and recover without exposing credential or cross-Organization information.
+- **Contract and maturity:** `SPEC.md` sections 7.2.2 through 7.2.3, 7.4a, and 10.2 through 10.4 define the current authentication, authorization, Portal, and Workspace-isolation expectations used by this scenario.
+- **Persona:** The Application Developer diagnoses the client-visible failure and the Department Operator handles any authorized Workspace-side correction.
+- **Starting state:** The developer may have an invalid, revoked, expired, or wrong-Workspace bearer credential, a valid API Token owned by a disabled API Client, a Portal session ended by Portal User disablement, or a request for an active Model that lacks an enabled Workspace grant.
+- **Task prompt:** Determine why the application cannot call the Model and recover without exposing credential or cross-Workspace information.
 - **Allowed authority:** The developer may inspect their own Portal and client output, mint and revoke only their own portal-minted tenant-direct API Keys, and retry with a bearer path authorized for Public Inference.
   Recovery from API Client Disablement requires tenant administration to re-enable the intended API Client or provision a service-account-owned API Token under an enabled API Client, while cluster changes require operator or admin authority.
-- **Success evidence:** The participant distinguishes authentication from authorization and runtime availability, replaces or corrects only the failed layer, verifies `/v1/models`, and completes a successful request with no cross-Organization disclosure.
+- **Success evidence:** The participant distinguishes authentication from authorization and runtime availability, replaces or corrects only the failed layer, verifies `/v1/models`, and completes a successful request with no cross-Workspace disclosure.
 - **Critical misunderstandings:** A `401` is not a Model-placement failure, a `403` for a valid API Token owned by a disabled API Client is not an invalid secret, disabling a Portal User does not revoke previously minted tenant-direct API Keys, and an empty visible Model list does not prove the Catalog is empty.
 - **Prototype observations:** Record whether generic external errors remain actionable through safe next steps, whether participants seek unauthorized Console access, and whether they understand which role must fix each cause.
-- **Candidate automated regression checks:** Tests should cover `401 invalid_api_key`, `403 forbidden`, `403 model_not_authorized`, indistinguishable cross-Organization Portal failures, no secret echo, no unauthorized mutation, and success after the minimum scoped correction.
+- **Candidate automated regression checks:** Tests should cover `401 invalid_api_key`, `403 forbidden`, `403 model_not_authorized`, indistinguishable cross-Workspace Portal failures, no secret echo, no unauthorized mutation, and success after the minimum scoped correction.
 
 ### S9: Partial inference failure, bounded retry, and recovery
 
@@ -242,10 +245,10 @@ Each card may be run against a concept, clickable prototype, instrumented produc
 
 - **Contract and maturity:** `SPEC.md` sections 7.4a and 10.8 through 10.10 define current secret, Portal, audit, and data-governance behavior, while a dedicated read-only reviewer role or export surface is not currently defined.
 - **Persona:** The Security and Compliance Reviewer leads a read-only review with evidence supplied by the relevant Operator or administrator.
-- **Starting state:** A workflow includes Portal invitation, portal-minted API Key mint or revoke, Model access change, Node Admission, or a destructive operation across more than one Organization.
+- **Starting state:** A workflow includes Portal invitation, portal-minted API Key mint or revoke, Model access change, Node Admission, or a destructive operation across more than one Workspace.
 - **Task prompt:** Prove who could do what, what changed, what was retained, and what sensitive material was excluded without mutating the system.
 - **Allowed authority:** The reviewer receives only approved read-only evidence, and any additional query or export must preserve tenant scope, capture policy, redaction, and least privilege.
-- **Success evidence:** The evidence links actor type, scope, target, decision, timestamp, result, and audit reference while excluding plaintext secrets, invite URLs, password material, raw request content outside policy, local paths, and another Organization's identities.
+- **Success evidence:** The evidence links actor type, scope, target, decision, timestamp, result, and audit reference while excluding plaintext secrets, invite URLs, password material, raw request content outside policy, local paths, and another Workspace's identities.
 - **Critical misunderstandings:** Portal User provenance is not Bearer ownership, a hash is not permission to reveal a secret, sanitized omission is not verified absence, and successful mutation without atomic audit evidence is not compliant success.
 - **Prototype observations:** Record which evidence reviewers cannot find, which terms imply more authority than they carry, and whether the interface distinguishes redaction, unavailability, not applicable, and verified absence.
 - **Candidate automated regression checks:** Tests should cover closed audit allowlists, transactional audit failure, tenant-scoped queries, unsafe-key redaction, generic external errors, one-time secret omission, capture-mode boundaries, and read-only evidence panels without execute controls.
@@ -254,7 +257,7 @@ Each card may be run against a concept, clickable prototype, instrumented produc
 
 - **Contract and maturity:** `SPEC.md` sections 4.1 through 4.4 and 10.5 define the trust boundaries, while `docs/operator-journey.md` defines the end-to-end handoff as target product intent and leaves the protected bundle-transfer mechanism open.
 - **Persona:** The Department Operator owns the capacity need and acceptance criteria, while the Node Host Custodian owns the target machine and an administrator retains cluster admission authority.
-- **Starting state:** The department needs more capacity, but the Department Operator cannot access the target machine and the custodian cannot access Organization or cluster administration.
+- **Starting state:** The department needs more capacity, but the Department Operator cannot access the target machine and the custodian cannot access Workspace or cluster administration.
 - **Task prompt:** Exchange the minimum protected information needed to add the machine, then return enough evidence for the department and administrator to continue without sharing credentials or extending either participant's authority.
 - **Allowed authority:** The Department Operator may describe the capacity requirement and initiate the capacity request or handoff, a separately authorized administrator provisions the Node and issues its enrollment authority, and the custodian may handle the protected bundle and machine-local steps.
   Neither the Department Operator nor the custodian may admit the Node without separate admin authority.
@@ -315,11 +318,10 @@ Do not promote raw research artifacts, participant data, prompt exports, local e
 
 These questions are not product decisions and must not be used as regression expectations until accepted by the appropriate authority.
 
-1. Should a future product-facing Workspace label replace Organization as the one-to-one Tenant projection, and how would routes, audit language, Portal URLs, CLI output, and compatibility behave during that change?
-2. What durable resource owns placement preference, what targets may it select, and what precedence applies among on-demand, cached, loaded, pinned, prewarmed, evicted, and one-time operations?
-3. What is the approved protected transfer and resumability model for Node Enrollment Bundles across browser, native app, CLI, and air-gapped environments?
-4. How should existing installs change Install Role, and who owns safe Node Identity Root handover during repair or machine administration?
-5. What packaged multi-machine acceptance evidence is required before the certificate-backed production join journey is described as supported?
-6. What precise identity and evidence should the Console use when Model Placement, Artifact Bundle digest, Node, and future multiple Runtime Endpoints intersect?
-7. What previews, permissions, audit, retry, partial-failure, and reacquisition semantics are required before remote Model-file deletion or Catalog deletion is exposed?
-8. What dedicated read-only access or export contract, if any, should support Security and Compliance Review without granting operator mutation authority?
+1. What durable resource owns placement preference, what targets may it select, and what precedence applies among on-demand, cached, loaded, pinned, prewarmed, evicted, and one-time operations?
+2. What is the approved protected transfer and resumability model for Node Enrollment Bundles across browser, native app, CLI, and air-gapped environments?
+3. How should existing installs change Install Role, and who owns safe Node Identity Root handover during repair or machine administration?
+4. What packaged multi-machine acceptance evidence is required before the certificate-backed production join journey is described as supported?
+5. What precise identity and evidence should the Console use when Model Placement, Artifact Bundle digest, Node, and future multiple Runtime Endpoints intersect?
+6. What previews, permissions, audit, retry, partial-failure, and reacquisition semantics are required before remote Model-file deletion or Catalog deletion is exposed?
+7. What dedicated read-only access or export contract, if any, should support Security and Compliance Review without granting operator mutation authority?

--- a/docs/decisions/0031-workspace-display-and-access-navigation.md
+++ b/docs/decisions/0031-workspace-display-and-access-navigation.md
@@ -1,0 +1,41 @@
+# ADR 0031: Workspace display and Access navigation
+
+## Status
+
+Accepted.
+Supersedes Organization as the product-facing Tenant label in ADR 0002 and ADR 0020 without changing their identity or authority contracts.
+
+## Context
+
+Operators need a clear starting scope and a way to distinguish model authorization, Portal membership, and inference credentials.
+The existing Tenant already supplies the governance boundary required by SPEC.md sections 5.2, 6.6, 7.2.3, and 7.4a.
+Renaming that boundary in storage or adding another hierarchy would introduce compatibility risk without resolving the navigation problem.
+
+## Decision
+
+Use Workspace for the existing Tenant in Console and Developer Portal, grouped under Access in Console navigation.
+Keep Tenant UUIDs, slugs, schemas, CLI vocabulary, API fields, CSV `organization`, audit identifiers, and Portal routes compatible.
+Retain `/console/tenants` entry points while using `/console/access` for new navigation.
+Team remains optional API Client grouping metadata and provides no authorization or membership boundary.
+
+Use the existing seeded Tenant as the default Workspace.
+Display its untouched built-in name as Default workspace; preserve customized names and identify the default by UUID.
+Do not create replacement records on page reads or infer grants, credentials, users, or readiness from default status.
+
+Separate Workspace management sections from the guided six-step colleague handoff.
+Keep one Workspace and one exact Model visible through model-access review, Portal invitation, scope review, manual colleague handoff, and first-request guidance.
+The existing Console session marker is not a per-person role identity, and the shared model-access transaction service is not a caller authorization adapter.
+This increment therefore reads model grants and prepares scoped operator commands rather than adding direct browser grant mutations.
+Actual Portal acceptance and key minting remain in the Developer Portal under their existing one-time-secret contract.
+
+## Consequences
+
+Existing installations retain their records, automation, and credential scope.
+Operators gain a default starting point without an implicit grant or new hierarchy.
+Model-grant changes still require the supported operator command workflow until an authenticated, authorized, leader-aware browser command adapter is separately implemented.
+Runtime readiness and successful inference remain evidence-based outcomes, not completion inferred from navigation or invitation state.
+
+## SPEC.md impact
+
+Updates sections 2.3 and 7.4a for Workspace terminology, default scope, compatible navigation, and exact-model request guidance.
+The governance and identity boundaries remain unchanged.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,4 +23,4 @@ Start from [`_template.md`](_template.md) when useful. Decisions already fixed b
 
 ## Decision index
 
-The current sequence ends with [ADR 0029: Deprecate Node Runtime gRPC compatibility in staged release epochs](0029-deprecate-node-runtime-grpc-compatibility.md).
+The current sequence includes [ADR 0030: Managed Node composition and activation](0030-managed-node-composition-activation.md) and ends with [ADR 0031: Workspace display and Access navigation](0031-workspace-display-and-access-navigation.md).

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -264,7 +264,7 @@ The product-facing LiveView console for local and operator UI.
 _Avoid_: Kapitan Orchard UI, admin panel
 
 **Developer Portal**:
-The Organization-scoped browser surface where an invited Portal User mints, lists, and revokes their own tenant-direct API Keys.
+The Workspace-scoped browser surface where an invited Portal User mints, lists, and revokes their own tenant-direct API Keys.
 _Avoid_: Orchard Console, Admin API, public signup
 
 **Orchard CLI**:
@@ -280,11 +280,13 @@ _Avoid_: Service Account, API Client, API Key, Tenant, Portal User
 
 **Tenant**:
 A governance boundary for model access, quotas, keys, retention, and usage accounting.
-Product-facing label: Organization.
-_Avoid_: Workspace, account, Service Account, API Key
+Product-facing label: Workspace.
+One Workspace maps to one existing Tenant UUID; the display label does not rename machine contracts or create a new hierarchy.
+The seeded Tenant is presented as the default Workspace without granting additional authority.
+_Avoid_: Organization (historical display label), account, Service Account, API Key
 
 **Team**:
-A product-facing grouping label stored as API Client metadata for filtering, reporting, and ownership context inside an Organization.
+A product-facing grouping label stored as API Client metadata for filtering, reporting, and ownership context inside a Workspace.
 _Avoid_: Tenant, Quota boundary, Routing Policy, RBAC Role
 
 **Service Account**:
@@ -293,7 +295,7 @@ Product-facing label: API Client.
 _Avoid_: User account, Tenant, API Key, Team, Portal User
 
 **Portal User**:
-An interactive, Organization-scoped identity that may sign in only to the Developer Portal and own portal-minted tenant-direct API Keys.
+An interactive, Workspace-scoped identity that may sign in only to the Developer Portal and own portal-minted tenant-direct API Keys.
 A Portal User is not a Public Inference principal, Operator, Service Account, or Owner Contact.
 _Avoid_: User account, Portal Developer, Tenant Admin, Owner Contact, Service Account
 
@@ -345,12 +347,12 @@ _Avoid_: raw CSV archive, One-time Secret Output, Audit Log
 
 **Dry Run**:
 A validation-only provisioning pass that reports intended changes and errors without creating API Clients, API Tokens, or One-time Secret Output.
-Bulk API Client Dry Run validates one Organization slug per CSV file.
+Bulk API Client Dry Run validates one Workspace slug per CSV file.
 _Avoid_: partial import, preview that mutates state
 
 **Apply**:
 A provisioning pass that commits all validated changes and emits One-time Secret Output only if the batch succeeds.
-Bulk API Client Apply validates the output path before mutation and treats the input file as an all-or-nothing batch for one Organization.
+Bulk API Client Apply validates the output path before mutation and treats the input file as an all-or-nothing batch for one Workspace.
 If One-time Secret Output delivery fails after the batch commits, Orchard marks the Provisioning Batch `output_failed` and returns API Token prefixes for revocation or rotation without persisting plaintext secrets.
 _Avoid_: Dry Run, partial import, best-effort import
 
@@ -365,7 +367,7 @@ Tenant-direct API Keys do not imply this role.
 _Avoid_: tenant admin, inference client, local dev admin
 
 **Inference Client**:
-An Access Level that permits a principal to call public inference endpoints for its Organization.
+An Access Level that permits a principal to call public inference endpoints for its Workspace.
 _Avoid_: admin, operator, tenant-admin, API Token
 
 **Quota**:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -65,7 +65,7 @@ mise exec -- bin/dev
 # 3. Import a model bundle (in the running IEx session)
 OrchardCLI.main(["models", "import", "/path/to/model-bundle", "--activate"])
 
-# 4. Create an Organization and direct API Token for /v1 API calls (in the running IEx session)
+# 4. Create a Workspace and direct API Token for /v1 API calls (in the running IEx session)
 OrchardCLI.main(["tenants", "create", "--slug", "dev", "--name", "Dev"])
 OrchardCLI.main(["api-keys", "create", "--tenant-id", "<tenant-id>", "--name", "dev"])
 
@@ -171,12 +171,13 @@ When running from a source checkout (`make dev`, `mise exec -- bin/dev`, or
 - No TLS setup is required
 
 All `curl` examples in this document use plain HTTP because they target the source dev controller.
-API examples assume `ORCHARD_API_KEY` contains a tenant-direct API Token or a service-account-owned API Token whose API Client has the `inference_client` Access Level for the Organization.
+API examples assume `ORCHARD_API_KEY` contains a tenant-direct API Token or a service-account-owned API Token whose API Client has the `inference_client` Access Level for the Workspace.
 
 ### Bulk API Client provisioning
 
-Use `orchardctl api-clients bulk-provision` when a source-dev Organization needs service-account-owned API Tokens for internal developers, applications, coding agents, or automation clients.
-The input CSV must target one Organization slug and include `organization`, `api_client`, `owner_contact`, and `key_name`.
+Use `orchardctl api-clients bulk-provision` when a source-dev Workspace needs service-account-owned API Tokens for internal developers, applications, coding agents, or automation clients.
+Workspace is the product-facing Tenant label; CLI commands and the CSV `organization` column retain their existing names.
+The input CSV must target one Workspace slug and include `organization`, `api_client`, `owner_contact`, and `key_name`.
 Optional columns are `team`, `owner_name`, `external_ref`, `description`, `purpose`, `expires_at`, and `metadata_json`.
 
 ```csv
@@ -1297,7 +1298,7 @@ All-in-one local boot (dev):
    - Controller boots: Endpoint, Repo, membership owner, Inference supervisor, Runtime Endpoint clients
    - Node-agent boots: ModelManager, WorkerSupervisor, Runtime Endpoint task supervisor, gRPC server
 3. Import at least one model bundle with `OrchardCLI.main(["models", "import", "<path>", "--activate"])`
-4. Create an Organization and API Token with `OrchardCLI.main(["tenants", ...])` and
+4. Create a Workspace and API Token with `OrchardCLI.main(["tenants", ...])` and
    `OrchardCLI.main(["api-keys", ...])`
 5. Source-dev HTTP is live at `/health/live`; status-only `/health/ready` can
    remain degraded under the staged `orchard.readiness.legacy_m0.v1` predicate and

--- a/docs/operator-journey.md
+++ b/docs/operator-journey.md
@@ -86,7 +86,7 @@ The selected Install Role decides which LaunchDaemons are installed and managed.
 
 | Path | Install Role | Console outcome | Inference outcome | Material current differences |
 |---|---|---|---|---|
-| All-in-one | `all` | Available after Controller configuration, first-admin initialization, Console enablement, and service start. | Possible on the same Mac after Organization/API Token creation and local model import. | No cross-Mac cookie transfer or remote model path is needed, but external Postgres is still required in the current build. |
+| All-in-one | `all` | Available after Controller configuration, first-admin initialization, Console enablement, and service start. | Possible on the same Mac after Workspace/API Token creation and local model import. | No cross-Mac cookie transfer or remote model path is needed, but external Postgres is still required in the current build. |
 | Controller-only | `controller` | Available after the same Controller setup. | Not possible until at least one eligible Runtime Endpoint is configured and model-ready. | This path is useful for governance and Console setup but is not a complete first-inference topology. |
 | Controller plus workers | `controller` on the Controller and `node-agent` on each worker Mac. | Available after Controller setup. | Technically exercisable through the current private-network first cut after explicit targets and worker-reachable model staging, but it is not the finished certificate-backed join journey. | Every worker adds a root-owned env edit, shared-cookie delivery, private-network checks, an explicit Controller target entry, and model staging. |
 
@@ -122,15 +122,15 @@ For each worker Mac, the operator currently:
 This sequence does not execute the target `provisioned -> registered -> admitted -> active` trust flow.
 The shared cookie is current transport access material and must not be described as Node identity or Node Enrollment.
 
-### Organization, Model, And First Inference
+### Workspace, Model, And First Inference
 
 After Console is reachable, the operator currently:
 
-1. Creates an Organization.
+1. Opens the existing Default workspace under Access, or creates a separate Workspace when another governance scope is needed.
 2. Creates a tenant-direct API Token for bootstrap or manual use, or provisions an API Client and API Token for a named non-interactive principal.
 3. Stores the one-time API Token output securely.
 4. Imports and activates a Model Bundle.
-5. Grants the Model to each approved Organization with `orchardctl models access grant`; activation alone authorizes nothing, and the Console Playground needs the same grant for the seeded `legacy` Tenant.
+5. Grants the Model to each approved Workspace with `orchardctl models access grant`; activation alone authorizes nothing, and the Console Playground needs the same grant for the seeded `legacy` Tenant.
 6. Verifies that the model source is reachable by the Node Agent that will load it.
 7. Confirms `/v1/models` lists the granted active model.
 8. Runs a small request through Playground or the Public Inference API.
@@ -168,7 +168,7 @@ Future implementation PRs should record sanitized timings against the measuremen
 | Static target missing or wrong | Console diagnostics and scheduler cannot reach the intended Node Agent. | Correct the Controller target list and restart or reconfigure the Controller. |
 | Endpoint observed but not trusted | Admission execution remains blocked and the endpoint is not schedulable. | Complete the future certificate-backed registration flow when implemented; observation alone is insufficient. |
 | Lost first-admin credential | Admin API access is unavailable. | Use local `orchardctl cluster init --force-new-admin --yes` break-glass recovery and audit the new credential. |
-| Model activated but not granted to the calling Organization | `/v1/models` omits the model and inference fails with `403 model_not_authorized`. | Grant the Tenant/Model pair with `orchardctl models access grant`; see [`../apps/orchard_cli/README.md`](../apps/orchard_cli/README.md). |
+| Model activated but not granted to the calling Workspace | `/v1/models` omits the model and inference fails with `403 model_not_authorized`. | Grant the Tenant/Model pair with `orchardctl models access grant`; see [`../apps/orchard_cli/README.md`](../apps/orchard_cli/README.md). |
 | Controller-local model source on a remote worker | Model acquisition fails with an unavailable path or artifact. | Pre-stage the verified bundle on the worker or provide a worker-reachable source. |
 | Worker or Controller upgrade interrupts readiness | Service status, heartbeat, or requests become unavailable. | Follow the packaging runbook's service-level backup, preflight, update, and health checks, and use cordon, drain, and resume only where lifecycle-managed Nodes exist. |
 
@@ -201,20 +201,21 @@ It is not a claim about the current build.
 4. Orchard runs migrations and the distinct first-admin and internal Node trust initialization operations.
 5. Orchard enables Console and starts services.
 6. The local Node Agent registers through the same identity model used by remote Nodes, and guided setup performs the same explicit audited Node Admission operation with confirmation inside the setup flow.
-7. The operator creates or confirms an Organization and inference credential.
+7. The operator confirms the existing Default workspace or deliberately chooses another Workspace, then provisions a separate inference credential.
 8. The operator imports one Model Bundle.
 9. Orchard verifies, places, and loads the model on the local Node Agent.
 10. Playground runs a small inference and shows the selected Node and model version.
 
 ### Target Developer Portal Access
 
-1. The operator opens the Organization in Console and creates a Portal User in `invited` status by email.
+1. The operator opens a Workspace under Access and checks its exact Model grant separately from Portal membership.
+   The guided handoff can reuse an existing active Portal User; otherwise the operator creates a Portal User in `invited` status by email.
 2. Console shows the invited Portal User without issuing a token or displaying a Portal Invite URL.
 3. The operator selects **Copy invite** to issue the first single-use token, and Console shows the Portal Invite URL once for out-of-band delivery.
 4. While the Portal User remains invited, each later **Copy invite** action deletes the previous unused invite row, issues a fresh hash-only token with an extended expiry, and shows the replacement URL once.
-5. The developer redeems the Portal Invite, chooses a password, and signs in to the Organization-scoped Developer Portal.
+5. The developer redeems the Portal Invite, chooses a password, and signs in to the Workspace-scoped Developer Portal.
 6. When access must end, the operator disables that Portal User, which atomically deletes every outstanding invite, ends only that user's portal sessions, and does not automatically revoke minted API Keys.
-7. The operator separately reviews Organization API Keys in Console and deliberately revokes known keys when key access must also end.
+7. The operator separately reviews Workspace API Keys in Console and deliberately revokes known keys when key access must also end.
 
 Each effective Portal lifecycle action commits its tenant-scoped audit evidence with the authoritative mutation.
 Portal User creation and first Copy invite remain separate audited actions, and later Copy actions are recorded as reissues.

--- a/openspec/changes/console-access-workspaces/.openspec.yaml
+++ b/openspec/changes/console-access-workspaces/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/console-access-workspaces/design.md
+++ b/openspec/changes/console-access-workspaces/design.md
@@ -1,0 +1,159 @@
+## Context
+
+The existing Console combines scope creation, Portal users, tenant-direct credentials, and API Clients under Organizations.
+The durable boundary is `Tenant`, and model access remains deny-by-default under SPEC.md sections 5.2, 6.6, 7.2.3, and 10.9.
+SPEC.md section 7.4a gives Portal Users a separate interactive session and self-service tenant-direct API Keys.
+Console authentication currently supplies a Basic-auth or development session marker, not a per-person Workspace role identity.
+The shared model-access service exists, but calling it directly from a new LiveView would not itself establish authenticated, leader-aware command authority.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give operators an Access destination and a clear, plural Workspace list.
+- Keep one Workspace and an exact catalog model visible through a colleague handoff.
+- Preserve return paths, deep links, keyboard focus, empty/error recovery, and the accepted Models and Nodes navigation.
+- Use real Portal and credential operations where implemented and truthful handoffs where authority or runtime support is absent.
+
+**Non-Goals:**
+
+- No new organization hierarchy, installation-wide Workspace switcher, or ownership transfer of Models and Nodes.
+- No new Team identities, memberships, policy, or quotas.
+- No schema, API field, CLI flag, audit identifier, or existing Portal URL rename.
+- No synthetic invitation acceptance, automatic email, automatic model grant, credential impersonation, or simulated request success in the product.
+- No new browser-based cluster RoleBinding editor or actor-specific Console RBAC in this change.
+
+## Decisions
+
+### Product terminology with stable machine contracts
+
+Use Workspace in Console and Developer Portal headings, forms, explanations, and new navigation.
+A Workspace maps to exactly one existing Tenant UUID; existing IDs, slugs, records, grants, and isolation survive unchanged.
+Keep `tenant_id`, `/admin/v1/tenants`, local command vocabulary, CSV `organization`, audit event names, and `/portal/:organization_slug` URLs stable.
+Describe this mapping in SPEC.md section 2.3, section 7.4a, the glossary, and relevant provisioning/Portal documentation before changing UI copy.
+Do not blanket-replace Organization or Tenant inside protocol examples, code identifiers, historical records, or accepted technical contracts.
+A wholesale storage/protocol rename was considered but would add compatibility risk without improving the intended navigation.
+
+### Default Workspace for onboarding
+
+Fresh installations already seed one Tenant with the stable UUID `00000000-0000-0000-0000-000000000000` and slug `legacy` in the governance foundation migration.
+Use this record as the default Workspace rather than creating a second onboarding Tenant.
+Display the untouched built-in name `Legacy Single Tenant` as `Default workspace` in product surfaces; preserve an operator-customized name and identify the same record with a Default badge.
+Default identity is determined by the stable UUID, not by matching a name or slug.
+Keep persisted names, slug, IDs, credentials, grants, and legacy Portal links compatible.
+Show this Workspace first in Access with a primary Open workspace action and keep Create Workspace secondary.
+When it is the only Workspace, a new colleague handoff starts in it directly with its identity visible, avoiding a redundant scope-creation or selection form.
+When multiple Workspaces exist, require deliberate scope selection for a new handoff; never overwrite an explicit Workspace route or an existing scoped draft with the default.
+
+Default means a starting governance scope, not an automatic model grant, invited user, credential, quota exemption, or ready runtime.
+The Console Playground's existing seeded Tenant maps to this same default Workspace; request guidance must still report its actual scope and authorization.
+The existing migration supplies the fresh-install record; repeated page visits, restarts, or upgrades must not insert duplicates or reset customized state.
+If the expected seeded record is missing or cannot be read, show a setup/recovery error rather than silently creating it from a page read or selecting another Workspace.
+Additional Workspace creation remains available for later separation of projects or access.
+
+### Access and Workspace routes
+
+
+| Destination | New canonical route | Content |
+| --- | --- | --- |
+| Access | `/console/access` | Workspace list, scope explanation, create action |
+| Workspace list alias | `/console/access/workspaces` | Same list, no second competing destination |
+| Create Workspace | `/console/access/workspaces/new` | Separate creation form with a return path |
+| Workspace detail | `/console/access/workspaces/:id` | Overview by default |
+| Workspace sections | Detail URL with whitelisted `section` | Overview, Model access, Portal users, API credentials |
+| Colleague handoff | Detail URL with explicit handoff state | Scoped model and invitation journey |
+
+Existing `/console/tenants` and `/console/tenants/:id` remain compatible entry points to the same underlying records and authentication boundary.
+Preserve useful legacy anchors with a whitelisted client hook that reads the initial URL fragment and patches to its corresponding section.
+Fragments are not sent to Phoenix, so this mapping cannot rely on server-side handle_params alone.
+The hook accepts only known legacy fragment identifiers, preserves the server-resolved Workspace, and ignores unknown fragments without changing scope.
+Workspace section navigation switches content rather than scrolling through an unrelated stack of cards.
+Each section retains the Workspace name, slug, and accessible return control.
+Access is a cluster-level navigation container; the first increment manages Workspace access and explicitly distinguishes cluster administration without presenting an unimplemented cluster-permissions tab.
+
+### Two implementation increments
+
+**Increment A: navigation and real scoped management.**
+Deliver the terminology mapping, compatible routes, Workspace overview and sections, real model-access reads, and the existing Portal user/API credential management paths.
+Model access shows exact catalog identity and enabled, disabled, or not-granted state, with failed reads distinct from denial or emptiness.
+Offer a scoped administrator handoff using the supported operator workflow instead of a new unchecked grant mutation.
+Team appears only as API Client grouping metadata, with an Ungrouped state and no membership controls.
+
+**Increment B: guided colleague handoff.**
+Carry one server-resolved Workspace through Model access, Portal invitation, Review scope, and Colleague handoff.
+A six-step orientation includes Choose Workspace and First request, but completion reflects actual evidence rather than advancement through the UI.
+When model access is missing, preserve the colleague email and model context while preparing the existing operator handoff; refresh reads confirm whether a grant actually changed.
+Creating a Portal User creates its invited identity but does not issue an invite link.
+Copy invite issues or reissues a fresh single-use token through the existing service, invalidating the previous token.
+If link issuance fails after user creation, retain the persisted user state and retry issuance without recreating the user.
+The flow preserves expiry, disablement, and one-time-secret contracts.
+The operator separately copies and delivers the invite URL; no email is implied.
+Portal acceptance and key creation occur in the actual Portal as the colleague, not through a Console role-switch simulation.
+
+The personal developer path uses the Portal User's own tenant-direct API Key, as specified in section 7.4a.
+Application/API Client provisioning remains a separate workflow; a Portal invitation does not create an API Client or a RoleBinding.
+The existing PortalActivationCurl model selector currently returns no models even though tenant-filtered active listing is implemented.
+Reconcile that selector with the existing authorization read model, including exact-version selection and exclusion of inactive or unauthorized models.
+Preserve the handoff-selected exact Model when it remains authorized; report its absence or changed eligibility rather than silently substituting another Model.
+Use deterministic selection only when no exact Model was requested.
+Console request examples always use a literal placeholder credential and remain inert.
+Only the actual Portal mint response may show that Portal User's newly minted secret or curl during its existing one-time display; no key is carried back into Console handoff state.
+Neither surface may select somebody else's token or mark an unexecuted request successful.
+The existing Console Playground resolves its seeded legacy Tenant and must not be presented as a request executed in the selected Workspace.
+
+### Journey presentation and review criteria
+
+The guided colleague flow has six ordered steps: Workspace, Model access, Portal invitation, Review scope, Colleague handoff, and First request.
+Keep the full sequence and current step number visible, with unavailable future steps dimmed and non-interactive.
+Each step replaces the previous content instead of appending another card or scrolling to a separate destination.
+The management sections support returning operators and do not substitute for this guided journey.
+Use Orchard's existing surface, typography, icon, color, focus, motion, and responsive tokens under docs/DESIGN.md.
+
+Starting in the only default Workspace resolves step 1 visibly; it does not remove that step, renumber the journey, or imply Model access has been granted.
+The current Workspace name remains visible through all subsequent steps, alongside exact Model identity where relevant.
+When selection is necessary, explain that the list contains available destinations, not the invitee's permissions.
+Model access in this journey applies to one Workspace; administration of one Model across multiple Workspaces remains a separate Model-management task.
+
+Back and retry within a Workspace preserve safe non-secret selections and inputs, with focus returned to the relevant heading or originating control.
+A previously activated Portal User with a missing Model grant returns to the grant/handoff task without requiring another invitation or resetting unrelated completed work.
+Runtime availability, Model grant state, invitation state, and credential readiness are labeled separately; a successful step does not imply the next condition is met.
+Verify navigation and recovery at narrow widths with natural page scrolling, reachable bottom controls, and no document-level horizontal overflow.
+
+### Authority and recovery
+
+
+Existing Console authentication and each existing service's server-side scope checks remain mandatory.
+New model grant mutations are deferred until an authenticated, authorized, leader-aware Controller command path is explicitly available; a direct `Models.Access` call is not sufficient.
+The denial branch from a prototype does not justify inventing a per-person Console role system.
+All child-resource reads and mutations resolve the Workspace from the server-held target and verify that resource ownership matches it.
+Changing Workspace clears scoped selection, invitation draft, and secret-bearing UI state; Back within the same Workspace retains non-secret inputs where safe.
+A Workspace selection list describes destinations and never claims that the invitee has access to every listed Workspace.
+Re-read relevant scope and status at submission; stale data or unavailable services cannot display successful mutations.
+Do not put credentials, invite secrets, or raw tokens into query parameters, data attributes, flashes, reports, or durable handoff drafts.
+
+### Durable rationale
+
+Update the glossary's current instruction to avoid Workspace and add a focused decision record for display terminology versus stable machine vocabulary.
+Keep the prior API Client/Team decision intact and explicitly preserve its non-authorizing Team semantics.
+The existing Models slice remains separate; it does not silently acquire Workspace or identity-management scope.
+
+## Risks / Trade-offs
+
+- Mixed display and machine vocabulary can confuse operators; document the exact mapping near integration examples and retain recognizable command names.
+- A scoped page can imply resource ownership; keep Models and Nodes cluster-scoped and describe grants as Workspace access to exact catalog records.
+- Creating an invitation can be mistaken for delivering it or granting inference; show persisted invitation state, manual delivery, and separate credential/model access explicitly.
+- The guided journey cannot complete every step in every deployment; preserve progress and show the real blocker rather than a simulated success.
+- Legacy deep links can target hidden content; cover old routes and section anchors in browser and route regressions.
+
+## Migration Plan
+
+First reconcile SPEC, glossary, tactical design, and product docs with the display mapping.
+Then add compatible routing and Workspace sections, followed by the scoped handoff increment.
+No data migration is required.
+Keep existing routes and machine fields through rollout; rollback restores the old display without transforming records or credentials.
+Run the required Elixir workflow, coverage, strict OpenSpec validation, and light/dark/narrow browser checks for each implementation increment.
+
+## Open Questions
+
+The proposal recommends the display-only rename boundary and Team-as-metadata behavior above.
+A first-class Team system and a new authenticated Console actor model require separate product and security decisions and are not prerequisites for Increment A.

--- a/openspec/changes/console-access-workspaces/proposal.md
+++ b/openspec/changes/console-access-workspaces/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The Console exposes Organization and Tenant terminology while operators need a clear place to manage Workspace access and help a colleague use a model.
+The existing page mixes scope creation, Portal membership, and credentials, making it difficult to see which action grants which authority.
+
+## What Changes
+
+- Replace the Organizations navigation destination with Access and make Workspaces its primary entry.
+- Present the existing seeded Tenant as the default Workspace so onboarding does not require creating a scope first.
+- Adopt Workspace as the one-to-one product-facing label for the existing Tenant governance boundary in Console and Developer Portal prose.
+- Preserve Tenant schemas, IDs, machine-facing API and CLI names, audit identifiers, existing Portal URLs, and legacy Console links.
+- Separate a Workspace's Overview, Model access, Portal users, and API credentials into real navigable sections.
+- Define a guided colleague handoff that keeps one Workspace and the selected model visible through model access, invitation review, and delivery instructions.
+- Preserve separate model grants, Portal authentication, API credentials, and cluster administration; no action implies completion of another.
+- Keep Team as optional API Client grouping metadata, with no new membership or authorization object.
+
+## Capabilities
+
+### New Capabilities
+
+- `console-access-workspaces`: Access navigation, Workspace presentation, compatibility routes, scoped sections, and grounded colleague handoff.
+
+### Modified Capabilities
+
+None of the existing authorization, credential issuance, or inference requirements change.
+Existing product prose referring to Organizations must be reconciled with the new display terminology as implementation proceeds.
+
+## Impact
+
+SPEC.md impact: update the Console and Developer Portal product terminology and navigation descriptions, while retaining the normative Tenant authorization boundary and existing role and credential semantics.
+Update docs/glossary/CONTEXT.md, docs/DESIGN.md, relevant Portal and provisioning documentation, and the explanatory wording in affected OpenSpec main specs.
+The proposal remains subordinate to the current SPEC until these contract changes are made together with implementation.
+Affected code includes Console navigation, routes, current Tenant LiveViews or their successors, Workspace-scoped model-grant integration, and Portal display copy.
+No database or public machine-protocol migration is proposed.
+The implementation must preserve the accepted Models and Nodes navigation and their regression coverage.

--- a/openspec/changes/console-access-workspaces/specs/console-access-workspaces/spec.md
+++ b/openspec/changes/console-access-workspaces/specs/console-access-workspaces/spec.md
@@ -50,6 +50,8 @@ A prepared handoff SHALL not imply that the grant changed or that runtime infere
 The guided handoff SHALL retain the server-resolved Workspace and exact selected catalog Model through access inspection, invitation preparation, scope review, and manual delivery.
 It SHALL preserve the separation of grants, Portal membership, and inference credentials in SPEC.md section 7.4a.
 Switching Workspace SHALL clear previous scoped drafts and secret-bearing state.
+Successful refresh SHALL reconcile the current step and unlocked navigation with the selected Model and Portal User that still exist.
+Missing selected Models SHALL return the operator to Model access; missing or disabled Portal Users SHALL return the operator to Portal invitation.
 
 #### Scenario: Scope is reviewed before invitation
 - **WHEN** the operator reviews an invitation
@@ -59,6 +61,14 @@ Switching Workspace SHALL clear previous scoped drafts and secret-bearing state.
 - **WHEN** a child-resource event supplies an identifier belonging to another Workspace
 - **THEN** the server rejects it without reading or mutating the other Workspace's resource
 
+#### Scenario: Selected Model disappears during handoff
+- **WHEN** refresh no longer finds the exact selected Model while the operator is in a later step
+- **THEN** the handoff returns to Model access and later steps remain unavailable until their prerequisites are restored
+
+#### Scenario: Portal User becomes disabled during handoff
+- **WHEN** refresh finds the selected Portal User disabled or missing
+- **THEN** the handoff returns to Portal invitation and cannot issue an invite from a later step
+
 ### Requirement: Invitation outcomes reflect actual service state
 
 Portal User creation, invite-token issuance or reissue, activation, expiry, disablement, and secret display SHALL preserve the existing Developer Portal contract.
@@ -66,6 +76,8 @@ Creating the invited Portal User SHALL not be presented as issuing or delivering
 Copy invite SHALL issue or reissue a fresh single-use token and invalidate the previous token.
 The Console SHALL distinguish preparation from successful creation and manual delivery.
 Failure SHALL retain safe non-secret inputs and offer retry without fabricating invitation success or sending email.
+Leaving the invite reveal step SHALL discard its plaintext URL and cancel its display-expiry timer.
+Invite issuance SHALL be available only in that step with a selected Model and an invited Portal User.
 
 #### Scenario: Invitation service fails
 - **WHEN** invitation creation fails after review
@@ -83,6 +95,10 @@ Failure SHALL retain safe non-secret inputs and offer retry without fabricating 
 #### Scenario: Link issuance fails after user creation
 - **WHEN** the Portal User exists but Copy invite fails
 - **THEN** recovery preserves the user and retries link issuance without recreating the user or fabricating a link
+
+#### Scenario: Return to invite delivery after leaving it
+- **WHEN** the operator leaves the invite reveal step and later returns
+- **THEN** the previous plaintext URL remains unavailable and another explicit issuance is required to show a new link
 
 ### Requirement: Credential and first-request handoff is truthful
 

--- a/openspec/changes/console-access-workspaces/specs/console-access-workspaces/spec.md
+++ b/openspec/changes/console-access-workspaces/specs/console-access-workspaces/spec.md
@@ -1,0 +1,151 @@
+## ADDED Requirements
+
+### Requirement: Workspace display preserves the Tenant boundary
+
+The Console and Developer Portal SHALL use Workspace as the product-facing label for exactly one existing Tenant governance boundary, reconciling SPEC.md sections 2.3 and 7.4a and the glossary before implementation.
+The change SHALL preserve Tenant UUIDs, slugs, persisted relationships, API/CLI vocabulary, audit identifiers, and existing Portal URLs.
+Team SHALL remain non-authorizing API Client metadata as required by the existing service-account provisioning decision.
+
+#### Scenario: Existing scope is opened after the display change
+- **WHEN** an operator opens an existing Organization through an old Console URL
+- **THEN** the same Tenant record appears as a Workspace with unchanged grants, users, and credentials
+- **AND** existing integration commands and Portal links remain valid
+
+#### Scenario: Team grouping is inspected
+- **WHEN** an operator groups API Clients by Team
+- **THEN** the UI describes grouping metadata and exposes no Team membership or permission controls
+
+### Requirement: Access provides scoped section navigation
+
+Access SHALL provide a plural Workspace list and separate Workspace creation.
+Workspace detail SHALL provide Overview, Model access, Portal users, and API credentials through whitelisted, reloadable section navigation.
+Inactive sections SHALL not remain accessible through keyboard navigation or the accessibility tree.
+Models and Nodes SHALL retain their cluster-level ownership and navigation.
+
+#### Scenario: Returning operator manages credentials
+- **WHEN** an operator chooses a Workspace and opens API credentials
+- **THEN** the page displays that Workspace identity, reload preserves the section, and Back returns to the Workspace list
+
+#### Scenario: Legacy deep link targets a section
+- **WHEN** an old Tenant detail URL or recognized section anchor is opened
+- **THEN** the corresponding Workspace and intended section remain reachable under the existing authentication boundary
+
+### Requirement: Model access is grounded in persisted grants
+
+The Model access section SHALL read exact catalog identities and distinguish enabled, disabled, not-granted, and unavailable evidence under SPEC.md sections 6.6 and 10.9.
+Revoked grants SHALL appear as absent unless separately evidenced; current grant reads SHALL not distinguish them from never-granted records.
+The initial increment SHALL provide a scoped supported operator handoff for changes rather than creating a new unchecked mutation path.
+A prepared handoff SHALL not imply that the grant changed or that runtime inference is ready.
+
+#### Scenario: Model grant is missing
+- **WHEN** the selected Workspace has no enabled grant for a selected exact Model
+- **THEN** the page shows the actual grant state and can prepare a scoped administrator handoff without granting access
+
+#### Scenario: Grant read fails
+- **WHEN** the persisted access read fails
+- **THEN** the page shows unavailable evidence and retry instead of reporting no access or successful authorization
+
+### Requirement: Colleague handoff retains one Workspace
+
+The guided handoff SHALL retain the server-resolved Workspace and exact selected catalog Model through access inspection, invitation preparation, scope review, and manual delivery.
+It SHALL preserve the separation of grants, Portal membership, and inference credentials in SPEC.md section 7.4a.
+Switching Workspace SHALL clear previous scoped drafts and secret-bearing state.
+
+#### Scenario: Scope is reviewed before invitation
+- **WHEN** the operator reviews an invitation
+- **THEN** the page shows the recipient, one Workspace, selected Model access state, and that cluster administration and API credentials are not included
+
+#### Scenario: Request to another Workspace is forged
+- **WHEN** a child-resource event supplies an identifier belonging to another Workspace
+- **THEN** the server rejects it without reading or mutating the other Workspace's resource
+
+### Requirement: Invitation outcomes reflect actual service state
+
+Portal User creation, invite-token issuance or reissue, activation, expiry, disablement, and secret display SHALL preserve the existing Developer Portal contract.
+Creating the invited Portal User SHALL not be presented as issuing or delivering an invite link.
+Copy invite SHALL issue or reissue a fresh single-use token and invalidate the previous token.
+The Console SHALL distinguish preparation from successful creation and manual delivery.
+Failure SHALL retain safe non-secret inputs and offer retry without fabricating invitation success or sending email.
+
+#### Scenario: Invitation service fails
+- **WHEN** invitation creation fails after review
+- **THEN** the recipient and Workspace remain available for recovery and no pending invitation is falsely displayed
+
+#### Scenario: Portal User is created
+- **WHEN** the service confirms creation of the invited Portal User
+- **THEN** the Console shows that persisted user state and that no invite link has yet been issued or delivered
+
+#### Scenario: Invite link is issued
+- **WHEN** Copy invite successfully issues or reissues an invite token
+- **THEN** the Console offers the single-use link through the existing one-time display and explains manual delivery
+- **AND** it does not assert that the colleague received or accepted it
+
+#### Scenario: Link issuance fails after user creation
+- **WHEN** the Portal User exists but Copy invite fails
+- **THEN** recovery preserves the user and retries link issuance without recreating the user or fabricating a link
+
+### Requirement: Credential and first-request handoff is truthful
+
+Portal authentication SHALL not stand in for inference credentials or Console/operator authority.
+The personal developer path SHALL use the Portal User's own tenant-direct API Key under SPEC.md section 7.4a; API Client provisioning SHALL remain separate.
+Console examples SHALL contain a literal placeholder and never retain an actual inference key.
+Only the real Portal mint response SHALL show the signed-in Portal User's newly minted secret or curl under its existing one-time-display contract.
+A request guide SHALL not expose another principal's credential or display simulated acceptance, dispatch, or completion.
+The Console Playground's seeded legacy Tenant SHALL not be represented as the chosen Workspace's request context.
+
+#### Scenario: Colleague has accepted but has no key
+- **WHEN** a colleague has Portal access without an inference credential
+- **THEN** the guide explains the actual Portal self-service key path and preserves separate model grant and runtime readiness checks
+
+#### Scenario: First request has not run
+- **WHEN** only an invitation or request example has been prepared
+- **THEN** the journey identifies the remaining external action and does not mark First request completed
+
+#### Scenario: Requested handoff Model is unavailable
+- **WHEN** the handoff names an exact Model that is no longer active or authorized for the colleague's Workspace
+- **THEN** request guidance reports that state and does not silently substitute another Model
+- **AND** examples without a requested Model choose deterministically from the authorized active set
+
+### Requirement: Default Workspace removes scope-creation friction
+
+Orchard SHALL use the existing seeded Tenant as the default Workspace on fresh installations, preserving its stable identity and existing relationships.
+The untouched built-in display name SHALL appear as Default workspace; customized names SHALL be preserved with a Default indicator.
+Default designation SHALL be based on stable identity rather than display-name or slug matching.
+The default Workspace SHALL not receive implicit model grants, credentials, Portal membership, or runtime readiness.
+
+#### Scenario: First onboarding task
+- **WHEN** a new installation has only its seeded default Workspace
+- **THEN** the operator can start a colleague handoff in that Workspace without creating or choosing a scope first
+- **AND** the selected Workspace remains visibly identified throughout the handoff
+
+#### Scenario: Existing installation is upgraded
+- **WHEN** the existing seeded Tenant already has keys, grants, users, or a customized name
+- **THEN** the same record becomes the default Workspace presentation without creating another Tenant, resetting its name, or changing its relationships
+
+#### Scenario: Another Workspace is selected
+- **WHEN** the operator opens an explicit Workspace route or selects a Workspace from multiple choices
+- **THEN** default-onboarding behavior does not replace that selected scope or its draft
+
+#### Scenario: Seeded Workspace is unavailable
+- **WHEN** the seeded Workspace record is missing or cannot be read
+- **THEN** onboarding shows a recoverable setup/read error without creating records during page reads or silently falling back to another Workspace
+
+### Requirement: Guided steps preserve visible orientation
+
+The guided flow SHALL display Workspace, Model access, Portal invitation, Review scope, Colleague handoff, and First request as six ordered steps with a current step number.
+Each step SHALL replace the prior visible content rather than append a scroll destination.
+Unavailable future steps SHALL remain visible, dimmed, and non-interactive.
+Workspace management sections SHALL not be presented as completion of the guided handoff.
+
+#### Scenario: Default Workspace starts the journey
+- **WHEN** the only default Workspace is selected automatically for onboarding
+- **THEN** step 1 remains visibly resolved and the operator enters Model access as step 2 of 6 with the Workspace name visible
+- **AND** no grant, invitation, or request completion is inferred
+
+#### Scenario: Return after invitation activation
+- **WHEN** the colleague already has an activated Portal User but Model access is missing
+- **THEN** recovery returns to the scoped Model access handoff without creating another invitation or resetting completed Portal activation
+
+#### Scenario: Narrow viewport navigation
+- **WHEN** the guided journey is used at a narrow viewport
+- **THEN** the current step, Workspace, primary action, and return/retry controls remain reachable without horizontal page overflow or scrolling to an appended step

--- a/openspec/changes/console-access-workspaces/specs/console-access-workspaces/spec.md
+++ b/openspec/changes/console-access-workspaces/specs/console-access-workspaces/spec.md
@@ -165,3 +165,9 @@ Workspace management sections SHALL not be presented as completion of the guided
 #### Scenario: Narrow viewport navigation
 - **WHEN** the guided journey is used at a narrow viewport
 - **THEN** the current step, Workspace, primary action, and return/retry controls remain reachable without horizontal page overflow or scrolling to an appended step
+
+#### Scenario: Deprecated catalog state remains separate from inference readiness
+- **WHEN** the handoff's selected Model is deprecated
+- **THEN** the Console SHALL explain that deprecation alone does not block inference under SPEC section 6.2
+- **AND** Workspace access and runtime readiness SHALL remain separate prerequisites
+- **AND** registered and retired Models SHALL still be identified as unavailable for Public Inference

--- a/openspec/changes/console-access-workspaces/tasks.md
+++ b/openspec/changes/console-access-workspaces/tasks.md
@@ -1,0 +1,41 @@
+## 1. Contract and terminology
+
+- [x] 1.1 Reconcile SPEC.md sections 2.3 and 7.4a, glossary, and affected product/OpenSpec wording with Workspace as the display label while preserving Tenant machine contracts.
+- [x] 1.2 Add the terminology decision and tactical Access/Workspace navigation rules to the appropriate decision record and docs/DESIGN.md.
+- [x] 1.3 Record a route, legacy-anchor, and wording inventory to ensure existing Console and Portal links retain their behavior.
+
+## 2. Access navigation and Workspace sections
+
+- [x] 2.1 Add Access navigation and canonical compatible Workspace routes without changing the existing authentication boundary.
+- [x] 2.2 Separate Workspace listing and creation, with loading, empty, and error states plus existing route-level authentication rejection coverage and usable return paths.
+- [x] 2.3 Implement reloadable Overview, Model access, Portal users, and API credentials sections with persistent Workspace identity and inaccessible inactive sections.
+- [x] 2.4 Preserve current Portal and API Client controls, distinguish client ownership from role scope, and retain Team as optional grouping metadata only.
+- [x] 2.5 Add regressions for legacy URLs and client-bridged fragments, invalid section parameters, target switching, and forged cross-Workspace child-resource identifiers.
+- [x] 2.6 Present the existing seeded Tenant as Default workspace, preserve customized names, and start single-Workspace onboarding without redundant scope selection.
+- [x] 2.7 Test fresh-install seed visibility, stable identity, no duplicate/reset on repeated access, explicit non-default scope preservation, and missing-seed/read-error recovery.
+
+## 3. Model access evidence and operator handoff
+
+- [x] 3.1 Read existing Workspace grants and exact catalog identities through Models.Access, distinguishing enabled, disabled, not-granted, inactive Model, and unavailable states.
+- [x] 3.2 Generate scoped grant and inspect command handoffs from server-held identities with proper shell argument quoting and no secrets.
+- [x] 3.3 Add grant-state, read-failure, exact-version, cross-Workspace, and command-injection regression coverage without introducing new browser grant mutations.
+
+## 4. Guided colleague handoff
+
+- [x] 4.1 Implement one-Workspace model/invitation/review/delivery navigation using the existing Portal services and actual persisted states.
+- [x] 4.2 Preserve non-secret draft inputs during safe recovery and clear scoped/secret state when the Workspace changes.
+- [x] 4.3 Show explicit manual delivery, existing HTTPS prerequisites, expiry, reissue, disablement, and separate credential provisioning without simulating acceptance.
+- [x] 4.4 Reconcile PortalActivationCurl's stale empty-model selector with the existing tenant-filtered active Model listing; generate an inert exact-model request example using placeholders in Console and preserving real secrets only in the actual Portal mint response's existing one-time display.
+- [x] 4.5 Test no-grant, disabled grant and absent grant (revoked or never granted), inactive Model, deterministic selection, cross-Workspace exclusion, and runtime-unverified copy for request examples.
+- [x] 4.6 Verify that request guidance never marks an unexecuted request complete or misrepresents the Console Playground's legacy Tenant as the chosen Workspace.
+- [x] 4.7 Preserve the six-step sequence, current step count, dimmed future steps, default-Workspace resolved first step, and content replacement rather than appended cards.
+- [x] 4.8 Test activated-Portal-User plus missing-grant recovery without reinvitation, safe Back/retry state retention, and visible scope on narrow screens.
+
+## 5. Validation and review
+
+- [x] 5.1 Run strict OpenSpec validation before implementation and before handoff; reconcile any SPEC conflict before proceeding.
+- [x] 5.2 Run the applicable AGENTS.md Elixir workflow, including full tests and coverage, and relevant Portal/auth/model-access/CLI suites for each implementation increment.
+- [x] 5.3 Verify browser navigation, light/dark themes, narrow layouts, keyboard focus, invitation failure/retry, and scope continuity with disposable fixtures.
+- [x] 5.4 Run independent simulated Department Operator, authorized administrator, and Application Developer walkthroughs; distinguish findings from real participant testing.
+- [x] 5.5 Present the runnable increment and actual verification boundaries for user review without merging.
+- [ ] 5.6 After later archive or sync, review generated main specs and remove placeholder prose such as Purpose TBD.

--- a/openspec/specs/api-client-provisioning/spec.md
+++ b/openspec/specs/api-client-provisioning/spec.md
@@ -6,7 +6,7 @@ These requirements cover canonical credential issuance with legacy compatibility
 
 ## Requirements
 ### Requirement: API Clients are non-interactive principals
-Orchard SHALL support API Clients as product-facing Service Accounts within an Organization.
+Orchard SHALL support API Clients as product-facing Service Accounts within a Workspace.
 An API Client SHALL be a non-interactive principal that may own API Tokens and tenant-scoped or cluster-scoped Access Levels where explicitly authorized.
 Owner Contact and Team SHALL be metadata on the API Client and SHALL NOT authenticate, authorize, own quota, define model access, define routing policy, or create a nested Tenant.
 This changes `SPEC.md` §10.3 and §10.4 by making the service-account principal path the default for bulk-provisioned public inference access.
@@ -94,14 +94,14 @@ Tenant-direct API Keys SHALL remain valid for manual, bootstrap, and compatibili
 This changes `SPEC.md` §7.4.4, §8.2, §10.2, and §10.3 by requiring bulk-created credentials to resolve through Service Account ownership.
 
 #### Scenario: Bulk row creates API Client and API Token
-- **WHEN** an operator applies a valid bulk provisioning row for Organization `acme`, API Client `alice-codex-dev`, Owner Contact `alice@example.com`, and key name `default`
-- **THEN** Orchard creates or updates the API Client inside Organization `acme`
+- **WHEN** an operator applies a valid bulk provisioning row for Workspace `acme`, API Client `alice-codex-dev`, Owner Contact `alice@example.com`, and key name `default`
+- **THEN** Orchard creates or updates the API Client inside Workspace `acme`
 - **AND** Orchard creates an API Token owned by that API Client
 - **AND** Orchard does not create a tenant-direct API Key for that row
 
 ### Requirement: Bulk provisioning uses stable API Client identity and safe token creation
-Bulk provisioning SHALL match API Clients by Organization plus External Reference when an External Reference is present.
-Bulk provisioning SHALL otherwise match API Clients by Organization plus API Client name.
+Bulk provisioning SHALL match API Clients by Workspace plus External Reference when an External Reference is present.
+Bulk provisioning SHALL otherwise match API Clients by Workspace plus API Client name.
 Bulk provisioning SHALL NOT silently create duplicate active API Tokens when the same API Client and key name already have an active token.
 Bulk provisioning SHALL reject rows targeting disabled API Clients.
 Replacement token creation SHALL require an explicit Key Rotation mode.
@@ -114,7 +114,7 @@ This changes `SPEC.md` §10.2 and §10.9 by defining safe repeated provisioning 
 
 ### Requirement: Bulk provisioning supports dry run and all-or-nothing apply
 The bulk provisioning CLI SHALL support Dry Run and Apply modes.
-Dry Run SHALL validate the entire input, duplicate behavior, referenced Organizations, API Client identity, API Token names, optional expiry values, JSON metadata, and output destination readiness without mutating state or generating token secrets.
+Dry Run SHALL validate the entire input, duplicate behavior, referenced Workspaces, API Client identity, API Token names, optional expiry values, JSON metadata, and output destination readiness without mutating state or generating token secrets.
 Apply SHALL reject the entire batch before creating token secrets when validation fails.
 Apply SHALL commit all validated provisioning changes as one batch or roll back the batch on failure.
 Post-commit One-time Secret Output delivery failure SHALL mark the Provisioning Batch `output_failed`, emit a redacted audit event, and return API Token prefixes for revocation or rotation.
@@ -210,12 +210,12 @@ This changes `SPEC.md` §10.9 by adding bulk provisioning audit requirements.
 - **AND** no audit payload includes a plaintext API Token secret
 
 ### Requirement: Console surfaces API Client management without bulk secret export
-Orchard Console SHALL show Organizations, API Clients, Team metadata, Owner Contact metadata, API Token prefixes, creation timestamps, last-used timestamps, revocation state, expiry state, and API Client Disablement state.
+Orchard Console SHALL show Workspaces, API Clients, Team metadata, Owner Contact metadata, API Token prefixes, creation timestamps, last-used timestamps, revocation state, expiry state, and API Client Disablement state.
 Orchard Console SHALL allow operators with sufficient access to revoke API Tokens and disable API Clients.
 The first slice SHALL NOT require Console bulk secret export or a bulk Admin API endpoint.
 This changes `SPEC.md` §2.3 and §10.3 by defining the initial Console management surface for API Client access.
 
 #### Scenario: Console shows API Client token provenance
-- **WHEN** an operator opens an Organization's API Client management view
+- **WHEN** an operator opens a Workspace's API Client management view
 - **THEN** Orchard Console shows each API Client with Team and Owner Contact metadata
 - **AND** Orchard Console shows owned API Tokens by prefix without plaintext token secrets

--- a/openspec/specs/developer-api-key-portal/spec.md
+++ b/openspec/specs/developer-api-key-portal/spec.md
@@ -8,8 +8,8 @@ These requirements cover identity and invite lifecycle, isolated authentication,
 ### Requirement: Developer Portal Is Isolated From Every Platform Authority
 
 Orchard SHALL expose a Developer Portal browser surface at `/portal/:organization_slug` that is distinct from Orchard Console.
-The portal SHALL NOT render operator Console chrome, other Organizations, nodes, or cluster administration.
-A Portal User SHALL authorize only the Developer Portal for that Portal User's Organization.
+The portal SHALL NOT render operator Console chrome, other Workspaces, nodes, or cluster administration.
+A Portal User SHALL authorize only the Developer Portal for that Portal User's Workspace.
 A Portal User session SHALL NOT authorize Public Inference, Operator API, Admin API, or Console access.
 This refines `SPEC.md` §2.3, §7.1, and §7.4a.
 
@@ -33,11 +33,11 @@ This refines `SPEC.md` §2.3, §7.1, and §7.4a.
 
 ### Requirement: Portal Users Are Operator-Invited Named Identities
 
-A Portal User SHALL belong to exactly one Organization and use email as an identifier unique by normalized value within that Organization.
+A Portal User SHALL belong to exactly one Workspace and use email as an identifier unique by normalized value within that Workspace.
 An operator SHALL create Portal User accounts.
 Creating a Portal User SHALL persist only the Portal User in `invited` status.
 Creation SHALL NOT mint or store a Portal Invite token and SHALL NOT return or display a Portal Invite URL.
-The Developer Portal SHALL NOT offer public signup, self-registration, or shared Organization password authentication.
+The Developer Portal SHALL NOT offer public signup, self-registration, or shared Workspace password authentication.
 SMTP SHALL NOT be required.
 This refines `SPEC.md` §7.4a and §8.
 
@@ -54,11 +54,11 @@ This refines `SPEC.md` §7.4a and §8.
 - **AND** Orchard SHALL NOT create a Portal Invite row
 - **AND** Console SHALL NOT return or display a Portal Invite URL
 
-#### Scenario: Same email can identify users in different Organizations
+#### Scenario: Same email can identify users in different Workspaces
 
-- **WHEN** two Organizations invite the same normalized email
-- **THEN** each Organization MAY have its own Portal User for that email
-- **AND** each Portal User SHALL remain scoped to its own Organization
+- **WHEN** two Workspaces invite the same normalized email
+- **THEN** each Workspace MAY have its own Portal User for that email
+- **AND** each Portal User SHALL remain scoped to its own Workspace
 
 ### Requirement: Copy Invite Issues Or Reissues A Hash-Only Token
 
@@ -69,9 +69,9 @@ A Portal User SHALL have at most one stored invite row at a time.
 Deleting the stored row SHALL be the invite invalidation mechanism, and Orchard SHALL NOT retain invite invalidation or revocation history.
 Orchard SHALL NOT persist the plaintext token or invite URL.
 The operator SHALL deliver the URL out of band without an SMTP dependency.
-Invite redemption SHALL be bound to the Organization identified by the route and SHALL activate only a Portal User who is currently `invited` in that Organization.
+Invite redemption SHALL be bound to the Workspace identified by the route and SHALL activate only a Portal User who is currently `invited` in that Workspace.
 Invite redemption SHALL use the canonical `POST /portal/:organization_slug/invites/:token` route.
-Wrong-Organization, disabled-user, invalidated, expired, redeemed, and unknown-token redemption failures SHALL use one generic external response and SHALL make no persisted mutation.
+Wrong-Workspace, disabled-user, invalidated, expired, redeemed, and unknown-token redemption failures SHALL use one generic external response and SHALL make no persisted mutation.
 This refines `SPEC.md` §7.4a, §8, §10.8, and §10.9.
 
 #### Scenario: First Copy invite issues the initial token
@@ -102,11 +102,11 @@ This refines `SPEC.md` §7.4a, §8, §10.8, and §10.9.
 - **THEN** the Portal User SHALL remain disabled
 - **AND** the outstanding invite SHALL be invalid when disablement commits
 
-#### Scenario: Wrong Organization does not consume an invite
+#### Scenario: Wrong Workspace does not consume an invite
 
-- **WHEN** a caller submits one Organization's valid invite through another Organization's route
+- **WHEN** a caller submits one Workspace's valid invite through another Workspace's route
 - **THEN** Orchard SHALL return the generic invalid-invite response
-- **AND** the invite SHALL remain redeemable through its owning Organization's route
+- **AND** the invite SHALL remain redeemable through its owning Workspace's route
 
 #### Scenario: Ineligible redemption is generic and mutation-free
 
@@ -116,27 +116,27 @@ This refines `SPEC.md` §7.4a, §8, §10.8, and §10.9.
 
 ### Requirement: Named Login Failures Are Indistinguishable
 
-The Developer Portal SHALL authenticate an active Portal User with Organization slug, normalized email, and password.
-Unknown Organization, unknown email, disabled Portal User, and wrong password SHALL produce indistinguishable status, body shape, headers, and generic credential failure.
-`GET /portal/:organization_slug` SHALL be response-indistinguishable for Organizations with invited users, Organizations with active users, Organizations with no users, and unknown slugs.
-Failed login limits SHALL be keyed by Organization fingerprint, Portal User or email fingerprint, and source fingerprint without an Organization-wide lockout.
+The Developer Portal SHALL authenticate an active Portal User with Workspace slug, normalized email, and password.
+Unknown Workspace, unknown email, disabled Portal User, and wrong password SHALL produce indistinguishable status, body shape, headers, and generic credential failure.
+`GET /portal/:organization_slug` SHALL be response-indistinguishable for Workspaces with invited users, Workspaces with active users, Workspaces with no users, and unknown slugs.
+Failed login limits SHALL be keyed by Workspace fingerprint, Portal User or email fingerprint, and source fingerprint without a Workspace-wide lockout.
 This refines `SPEC.md` §7.4a.
 
 #### Scenario: Credential failures share one response contract
 
-- **WHEN** callers submit an unknown Organization, unknown email, disabled Portal User, and wrong password
+- **WHEN** callers submit an unknown Workspace, unknown email, disabled Portal User, and wrong password
 - **THEN** every submission SHALL receive the same credential-failure status, body shape, and headers
 - **AND** Orchard SHALL perform a bounded password-verification path without disclosing which identity exists
 
-#### Scenario: One identity and source cannot lock the Organization
+#### Scenario: One identity and source cannot lock the Workspace
 
 - **WHEN** one source exceeds failed-login backoff for one Portal User or email fingerprint
-- **THEN** another Portal User or source MAY still attempt login for the Organization
-- **AND** Orchard SHALL NOT create an Organization-wide lockout
+- **THEN** another Portal User or source MAY still attempt login for the Workspace
+- **AND** Orchard SHALL NOT create a Workspace-wide lockout
 
 ### Requirement: Portal Sessions Belong To One Portal User
 
-Every Developer Portal session SHALL belong to one `portal_user_id` and that Portal User's Organization.
+Every Developer Portal session SHALL belong to one `portal_user_id` and that Portal User's Workspace.
 Initial invite issuance, invite reissue, invite redemption, and Portal User disablement SHALL end that Portal User's standing sessions.
 Portal User disablement SHALL invalidate every outstanding invite in the same transaction that changes the user's status and ends the user's sessions.
 Disabling a Portal User SHALL NOT automatically revoke owned API Keys.
@@ -179,7 +179,7 @@ This refines `SPEC.md` §7.4a, §8, and §10.2.
 
 Each Portal User SHALL NOT have more than 10 active portal-minted tenant-direct keys.
 Revoked and expired keys SHALL NOT count toward the ceiling.
-The mint operation SHALL serialize cap enforcement on the Portal User rather than the Organization.
+The mint operation SHALL serialize cap enforcement on the Portal User rather than the Workspace.
 This refines `SPEC.md` §7.4a and §10.2.
 
 #### Scenario: Eleventh active key for one Portal User is rejected
@@ -192,23 +192,23 @@ This refines `SPEC.md` §7.4a and §10.2.
 #### Scenario: One user's cap does not consume another user's allowance
 
 - **WHEN** one Portal User owns 10 active portal-minted keys
-- **AND** another Portal User in the same Organization has fewer than 10 active portal-minted keys
+- **AND** another Portal User in the same Workspace has fewer than 10 active portal-minted keys
 - **THEN** the second Portal User MAY mint another owned key
 
 ### Requirement: Portal List And Revoke Are Own-Keys-Only
 
-The portal SHALL list and revoke only keys whose `portal_user_id` and `tenant_id` match the signed-in Portal User and Organization.
-Keys owned by another Portal User, keys owned by another Organization, operator-minted keys, and missing keys SHALL be indistinguishable on portal list and revoke paths.
+The portal SHALL list and revoke only keys whose `portal_user_id` and `tenant_id` match the signed-in Portal User and Workspace.
+Keys owned by another Portal User, keys owned by another Workspace, operator-minted keys, and missing keys SHALL be indistinguishable on portal list and revoke paths.
 Portal revoke SHALL take effect on the next Public Inference authentication.
 This refines `SPEC.md` §7.4a and §10.2.
 
 #### Scenario: Portal Users cannot see each other's keys
 
-- **WHEN** two Portal Users belong to the same Organization and each owns portal-minted keys
+- **WHEN** two Portal Users belong to the same Workspace and each owns portal-minted keys
 - **THEN** each Portal User SHALL list only their own keys
 - **AND** neither Portal User SHALL learn the other Portal User's key names, prefixes, or status
 
-#### Scenario: Inconsistent cross-Organization key ownership is excluded
+#### Scenario: Inconsistent cross-Workspace key ownership is excluded
 
 - **WHEN** a portal-minted key records the signed-in `portal_user_id` but a different `tenant_id`
 - **THEN** the key SHALL be absent from the Portal User's list
@@ -237,7 +237,7 @@ Successful invite redemption SHALL use `portal_user.invite_redeemed`.
 An effective Portal User disablement SHALL use `portal_user.disabled`.
 Portal-owned API Key mint and effective revoke SHALL reuse `api_key.created` and `api_key.revoked`.
 
-Every row SHALL use the owning Organization's `tenant_id`.
+Every row SHALL use the owning Workspace's `tenant_id`.
 Portal User actions SHALL target `target_type = 'portal_user'` and the affected Portal User ID.
 API Key actions SHALL target `target_type = 'api_key'`, the affected API Key ID, and the matching `api_key_id`.
 Console actions SHALL use `actor_type = 'operator'`, a null `actor_id`, and `surface = 'console'`.
@@ -348,16 +348,19 @@ This refines `SPEC.md` §7.4a, §8, and §10.2.
 - **AND** operators SHALL be able to inspect and revoke it
 - **AND** every Portal User SHALL be unable to list, claim, or revoke it
 
-### Requirement: Activation Curl Uses One Deterministic Callable Model
+### Requirement: Activation Curl Uses One Authorized Exact Model
 
-After a successful mint, the portal SHALL show one `POST /v1/chat/completions` curl that uses a deterministic callable model already authorized for the Organization, or state that no test curl is available.
-If no callable model can be proven, the key mint SHALL still succeed.
+After a successful mint, the portal SHALL show one `POST /v1/chat/completions` curl using an active exact Model with enabled access for the Workspace, or state that no test curl is available.
+Selection SHALL be deterministic when no exact Model was requested.
+An unavailable or unauthorized requested exact Model SHALL NOT be silently substituted.
+Model availability and authorization SHALL NOT imply runtime readiness or request success.
+If no eligible Model can be proven, the key mint SHALL still succeed.
 The full secret SHALL appear only at creation and SHALL NOT be recoverable later.
 This refines `SPEC.md` §7.2.3, §7.2.4, and §7.4a.
 
-#### Scenario: No callable model still mints the key
+#### Scenario: No eligible model still mints the key
 
-- **WHEN** a Portal User mints a key for an Organization with no proven callable model
+- **WHEN** a Portal User mints a key for a Workspace with no active authorized Model
 - **THEN** Orchard SHALL persist the key
 - **AND** the portal SHALL state that no test curl is available
 - **AND** the secret SHALL still be shown once


### PR DESCRIPTION
Operators need to see a Workspace's exact model access and hand a colleague into the separate Developer Portal without confusing an invitation, an API credential, and a successful request.
This change makes Access the Workspace destination and adds a guided colleague handoff over the existing Tenant governance boundary.

## Changes

- Define Workspace as the product-facing Tenant name in SPEC and ADR 0031 while retaining UUIDs, API and CLI vocabulary, CSV fields, and legacy routes.
- Show the existing default Workspace by stable identity, preserve customized names, and keep Workspace reads free of setup mutations.
- Separate overview, model access, Portal users, and API credentials, with exact grants and shell-quoted administrator commands.
- Preserve an exact model hint through HTTPS Portal login and invite redemption, and generate a curl only for an active model authorized for that Workspace.
- Reconcile handoff steps with refreshed access facts and clear invitation plaintext when leaving the reveal step.
- Guide colleague preparation, scope review, manual invitation delivery, and a placeholder first request without implying delivery, activation, runtime readiness, or request success.

## Validation

The final combined stack at `c5b2bbdd` passed the repository workflow on macOS:

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix credo --strict`
- `mise exec -- mix dialyzer`
- `make macos-native-test-helpers`
- `mise exec -- mix test --seed 323426`: 5,305 passed, 6 skipped, 10 excluded.
- `mise exec -- mix test --cover --seed 323426`: the same test result; Shared 68.04%, Controller 84.9%, Node agent 79.92%, CLI 75.79%.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`: 45 passed.
- `mise exec -- node --test --experimental-test-coverage apps/orchard_controller/assets/js/*.test.mjs`: 2 passed; 100% line, branch, and function coverage.

Greptile identified missing keyboard focus styling on the handoff model selector.
The fix uses the existing light/dark Console focus tokens and includes a regression test that failed before the correction.
The full coverage run also exposed missing SQL sandbox ownership in the Console authentication suite.
Adding its database tag cleared the failure in both full runs with the original failing seed.

Independent Fusion macOS E2E completed the main Access/Portal journeys on `c5b2bbdd`: invitation redemption, password setup/login, credential minting, real authorized inference, revocation returning 401, replacement-key recovery, and Workspace denial.
Final combined `d2c335a5` browser checks also passed actual loopback HTTPS Portal redemption and the explicit Review scope exclusion copy added in #366.
The same-host proxy correction is in #365.
The older Portal-users copy action still emits a relative invitation path; the new handoff emits an absolute URL and was successfully redeemed.
Final mawarduri Console admission also passed with an audit row on `d2c335a5`.
That qualification selected the explicit gRPC compatibility path; its plaintext/mTLS mismatch does not establish a missing BEAM activation path.
The corrected gap is that the BEAM-first product journey was not exercised in that run.
The exact-head follow-up on `1e8cbac0579728ebee190383322b7213d8aafd2e` now proves a real-MLX BEAM-first journey on one source-development Mac.
The enrolled and admitted Node reached Active automatically, persisted 360 heartbeats, and had no Node Runtime gRPC supervisor child or listener.
All 14 completed requests correlate through persisted Node identity, the BEAM target and canonical name, placement, and real MLX worker request logs.
Both public APIs passed non-streaming and SSE requests, client-abort cancellation and recovery, and Workspace/no-credential denial checks.
The trusted-HTTPS Portal passed invitation redemption, key minting, successful inference, revocation returning 401, replacement-key recovery, and a Playground request.
The exact model was `mlx-community/Qwen3-0.6B-4bit@73e3e38d981303bc594367cd910ea6eb48349da8`, artifact SHA-256 `d30ebd70f4a436c152939ec8f4c798c8a2096fb210445781833e4bf4e60f5dd4`.
The 1e8 matrix passed 20/21 checks: the first cold request returned 504 `load_timeout`, followed by cold-window 503s and a 500 capacity-rejection retry.
The bounded worker-readiness fix is now published in #368 at `6b475c81d6a434ad3b96a0b3168c10598ad0de7a`, with the full Elixir workflow passing 5,308 tests in both plain and coverage runs and all required CI checks passing.
The independent real-MLX recheck on that exact source confirmed successful 3,500/4,000 ms delayed startup and passed the post-cold API/SSE/cancellation/recovery/access-denial matrix.
All 18 recorded requests link to newly enrolled/admitted/Active Node `6e0d6d58-78d4-41b0-8a56-fa19d6bc5008`: 11 completed, one cancelled, and six cold-window failures; 120 heartbeats persisted with the Runtime gRPC listener absent.
Cold requests still fail closed until the first persisted heartbeat reports loaded-placement evidence, as required by SPEC §5.9; the first request after that observation succeeded.
Generic HTTP 500 capacity-error presentation and immediate cold-first-request readiness remain separate follow-ups.
The Portal/browser evidence above remains attributed to 1e8cbac0 and was not rerun on 6b475c81.
The Node Evidence panel's inventory-only Unknown statuses, clipped Portal key Actions column, and long first-request example remain separate presentation findings.
The complete deterministic Peer Grant application smoke also passed with the bounded test isolation fix in #367, including 179 focused tests, expiry, tracer, legacy compatibility, and listener-free operations.
These are single-host source-dev results; packaged activation and physical multi-host inference were not qualified.
#351 remains a staged proposal with no runtime-default implementation, and Peer Grant/control gRPC and Node-to-Worker gRPC/UDS remain separate supported boundaries.
These browser samples are not an exhaustive accessibility/adversarial-event audit.
[Namespace report](https://app.devin.ai/attachments/46d7868e-7416-40a5-98e4-af99f3f2f80f/REPORT.md); [final mawarduri report](https://app.devin.ai/attachments/b7be5462-40b1-4527-a2ee-af63b9b081c3/REPORT.md).

[BEAM-first qualification report](https://app.devin.ai/attachments/e361ad72-1205-45f2-870a-3e090e7c98a7/REPORT.md).
[Final 6b475c81 report](https://app.devin.ai/attachments/8c3bba14-7bf0-40fa-b824-604f904933b8/REPORT.md) and [cold-window diagnosis](https://app.devin.ai/attachments/b4026a12-d324-4c07-8f47-312b6ae9774b/cold-window-capacity-rejection-6b47.md).
The real-MLX harness used isolated EPMD/control/Distribution/HTTP/HTTPS ports, a synthetic database and identities, the production MLX adapter, and an explicit pre-start listener-disable seam without changing product defaults.
The retained report records the session commands; the deterministic command and regression results are in #367.

Stack order: #360 (Models) → #361 (Nodes) → #362 (Access) → #364 (payload layout) → #365 (loopback HTTPS) → #366 (dSYM packaging and scope copy) → #367 (BEAM smoke isolation) → #368 (worker readiness polling).

Independent review identified stale handoff steps after refresh and invite plaintext retained after leaving its step.
Both were reproduced, fixed, and reviewed again with a GO verdict.
Browser verification covered refreshed model-access recovery and clearing the invite reveal.

A further independent review found that the handoff incorrectly described deprecated Models as unavailable for inference.
The correction follows SPEC section 6.2, tests registered, deprecated, retired, and removed Models, and received a final GO verdict.

## Risk Assessment

✅ **Medium**

- The slice changes Console access flows and Portal presentation; Tenant scoping, Portal sessions, credential issuance, and backend authorization remain the enforcement boundaries.
- Explicit model requests are not silently substituted, and Console examples contain placeholder credentials.
- No database migration or new RBAC hierarchy is introduced; Team remains API Client grouping metadata, and existing Tenant and Portal routes remain compatible.















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Access the Console destination for Workspace governance and adds a guided colleague handoff into the Developer Portal.

- Presents stable Workspace identity while preserving existing Tenant APIs, UUIDs, and legacy routes.
- Separates model access, Portal users, and API credentials into explicit Workspace-scoped sections.
- Preserves exact model selection through Portal authentication and invitation redemption.
- Adds guided handoff state reconciliation, scoped invitation handling, and activation curl generation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains from the previously reported focus-visibility issue.

The handoff model selector now carries the complete light and dark focus-visible treatment, and no prior finding remains outstanding.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex | Adds the guided Workspace handoff flow; the previously reported model-selector focus treatment is complete at the current head. |
| apps/orchard_controller/lib/orchard/console/tenant_detail_live.ex | Reorganizes Workspace access into overview, model-access, Portal-user, and API-credential sections. |
| apps/orchard_controller/lib/orchard/console/workspace_access.ex | Adds read-only exact-model grant presentation and scoped operator command generation. |
| apps/orchard_controller/lib/orchard/governance/portal_activation_curl.ex | Selects an active, authorized exact model for Portal activation request examples. |
| apps/orchard_controller/lib/orchard/portal/session_controller.ex | Carries the exact model hint through Portal login and invitation redemption. |
| apps/orchard_controller/assets/js/workspace_sections.mjs | Maps legacy Workspace detail fragments to canonical section navigation without accepting Workspace identity from the URL. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Console Access] --> B[Select Workspace]
  B --> C[Review exact model grants]
  C --> D[Prepare Portal User]
  D --> E[Copy invitation for manual delivery]
  E --> F[Developer Portal redemption]
  F --> G[Mint Workspace API credential]
  G --> H[Generate request for authorized active model]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(console): preserve handoff focus and..."](https://github.com/kapitan-ai/orchard/commit/6eac66dbcbb461e5ed2355449325a5970a7181c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60880002)</sub>

<!-- /greptile_comment -->