### PR TITLE
fix(packaging): preserve the required OpenSSL payload directory

### DIFF
--- a/scripts/build-payload.sh
+++ b/scripts/build-payload.sh
@@ -858,7 +858,7 @@ validate_captured_source_identity
 # Create staging directory
 log_info "Creating payload staging..."
 STAGING="$EXPECTED_STAGING_ROOT"
-mkdir -p "$STAGING"/{releases,native,share/{bin,launchd},config,logs,support}
+mkdir -p "$STAGING"/{releases,native,share/{bin,launchd},config,logs,support/openssl}
 STAGING_CREATED=true
 
 # Copy releases

--- a/scripts/test-build-payload.sh
+++ b/scripts/test-build-payload.sh
@@ -255,6 +255,8 @@ fi
 # The printed path is the handoff contract with scripts/build-app.sh, so it must
 # name a real staged tree rather than a value the build merely intended.
 test -d "$PAYLOAD_ROOT" || fail 'PAYLOAD_ROOT does not name a directory'
+test -d "$PAYLOAD_ROOT/support/openssl" ||
+    fail 'app payload requires support/openssl even without Homebrew OpenSSL load commands'
 
 for staged in \
     "share/bin/orchardctl" \


### PR DESCRIPTION
The documented payload build can succeed on a Mac with statically linked OpenSSL, then fail in `build-app.sh` with `missing payload path: support/openssl`.
The payload builder now always stages that directory, matching the existing app and service-lifecycle contract even when no OpenSSL libraries need bundling.

The existing hermetic payload test already exercises the no-remediation case.
It now asserts that the required directory exists and fails on the previous implementation.

## Validation

- `mise exec -- scripts/test-build-payload.sh`: reproduced the missing directory before the fix; passed after it.
- `mise exec -- scripts/test-build-app.sh`: passed.
- `mise exec -- scripts/test-app-service-lifecycle.sh`: passed under a temporary root.
- `mise exec -- scripts/test-app-signing.sh`: passed.
- `mise exec -- scripts/test-build-dmg.sh`: passed with the deterministic Amore substitute.
- `mise exec -- scripts/test-payload-signing-contracts.sh`: passed.
- `bash -n scripts/build-payload.sh scripts/test-build-payload.sh`: passed.
- `git diff --check`: passed.

Independent Namespace E2E reproduced the original failure with the real documented payload build on macOS 15.7.5 and OTP 29 using statically linked OpenSSL.
Independent Namespace production qualification passed at combined SHA `d2c335a5`: fresh payload, app build, ad-hoc signing, real-Amore DMG assembly, disk-image verification, and mounted-app signature checks.
The required OpenSSL directory was present without manual repair.
A separate dSYM packaging defect discovered during that qualification is corrected in #366.
This is credential-free ad-hoc qualification, not Developer ID or notarized distribution.

This follow-up sits above #362 in the Console stack because the defect was found while qualifying the combined build.
It follows the existing packaging contract and requires no SPEC change.

## Risk Assessment

**Low**

- The change affects the staged macOS payload directory layout.
- Hosts that bundle OpenSSL libraries retain the same directory and remediation path.
- Hosts that need no remediation gain the empty directory already required by the app assembler and lifecycle installer.











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves the required OpenSSL payload directory even when no dynamic OpenSSL libraries need remediation.
- Creates `support/openssl` during initial payload staging.
- Extends the hermetic payload test to enforce the downstream directory contract.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/build-payload.sh | Creates the OpenSSL payload directory unconditionally, satisfying the existing app assembly and lifecycle installation contract. |
| scripts/test-build-payload.sh | Verifies that payload builds preserve `support/openssl` in the no-remediation case. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(packaging): preserve the required Op..."](https://github.com/kapitan-ai/orchard/commit/e9677ab2bab05bbbdbc5dbc15d2b970a81f97384) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60893200)</sub>

<!-- /greptile_comment -->