### PR TITLE
fix(api): trust valid loopback client forwarding

### DIFF
--- a/apps/orchard_controller/lib/orchard/api/trusted_forwarded_headers.ex
+++ b/apps/orchard_controller/lib/orchard/api/trusted_forwarded_headers.ex
@@ -112,7 +112,7 @@ defmodule Orchard.API.TrustedForwardedHeaders do
       |> Enum.reverse()
       |> Enum.find(&(not trusted_ip?(&1, proxies)))
       |> case do
-        nil -> :error
+        nil -> {:ok, hd(chain)}
         remote_ip -> {:ok, remote_ip}
       end
     else

--- a/apps/orchard_controller/test/orchard/api/forwarded_headers_test.exs
+++ b/apps/orchard_controller/test/orchard/api/forwarded_headers_test.exs
@@ -39,6 +39,37 @@ defmodule Orchard.API.ForwardedHeadersTest do
     assert conn.remote_ip == {203, 0, 113, 10}
   end
 
+  test "SPEC 10.7: reverse_proxy preserves HTTPS for clients inside trusted proxy CIDRs" do
+    Application.put_env(:orchard_controller, :transport_mode, :reverse_proxy)
+
+    cases = [
+      {"127.0.0.1", {127, 0, 0, 1}},
+      {"::1", {0, 0, 0, 0, 0, 0, 0, 1}},
+      {"::1, 127.0.0.1", {0, 0, 0, 0, 0, 0, 0, 1}}
+    ]
+
+    for {forwarded_for, client_ip} <- cases do
+      conn =
+        {127, 0, 0, 1}
+        |> forwarded_conn(forwarded_for)
+        |> Endpoint.call([])
+
+      assert conn.status == 200
+      assert conn.scheme == :https
+      assert conn.host == "orchard.example.test"
+      assert conn.port == 443
+      assert conn.remote_ip == client_ip
+      assert conn.private.orchard_forwarded_headers_trusted?
+
+      portal =
+        {127, 0, 0, 1}
+        |> forwarded_conn(forwarded_for, "/portal/loopback-client")
+        |> Endpoint.call([])
+
+      assert html_response(portal, 200) =~ "Developer portal"
+    end
+  end
+
   test "SPEC 10.7: reverse_proxy ignores spoofed forwarded headers from untrusted peer" do
     Application.put_env(:orchard_controller, :transport_mode, :reverse_proxy)
 
@@ -208,8 +239,8 @@ defmodule Orchard.API.ForwardedHeadersTest do
     Map.update!(conn, :req_headers, &[{header, value} | &1])
   end
 
-  defp forwarded_conn(peer_ip, forwarded_for \\ "203.0.113.10") do
-    Phoenix.ConnTest.build_conn(:get, "/health/live")
+  defp forwarded_conn(peer_ip, forwarded_for \\ "203.0.113.10", path \\ "/health/live") do
+    Phoenix.ConnTest.build_conn(:get, path)
     |> Map.put(:remote_ip, peer_ip)
     |> Plug.Conn.put_req_header("x-forwarded-for", forwarded_for)
     |> Plug.Conn.put_req_header("x-forwarded-proto", "https")


### PR DESCRIPTION
Opening the Developer Portal through a same-host HTTPS reverse proxy returned 404 when both the proxy and browser client were on loopback.
The forwarded-header parser rejected the entire valid header set because every client-chain address matched a trusted proxy CIDR, leaving the effective scheme as HTTP.

When a valid chain contains only trusted addresses, Orchard now uses its leftmost address as the client instead of discarding the HTTPS rewrite headers.
The regression exercises IPv4, IPv6, a multi-hop trusted chain, and the actual Portal login route.
Both independent macOS qualification sessions reproduced the original failure.
The all-trusted-chain fallback also matches the traversal used by [Express's proxy-addr implementation](https://github.com/jshttp/proxy-addr/blob/master/index.js).

This fixes the reverse-proxy workflow documented in `docs/local-dev.md` under the existing SPEC 10.7 contract.
It sits above #364 in the Console qualification stack.

## Validation

- Focused forwarded-header regression: failed before the implementation change; passed after it, including existing spoofed-peer, spoofed-chain, malformed-header, and duplicate-header checks.
- `ORCHARD_TEST_NODE_AGENT_PORT=15371 make check-elixir MIX_TEST_PLATFORM_ARGS='--seed 323426'`: passed the repository workflow in order: `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, macOS helper staging, `mix test`, and `mix test --cover`.
- Plain and coverage runs each passed 5,306 tests, with 6 skips and 10 exclusions; no failures.
- `ORCHARD_TEST_REAL_AMORE=1 mise exec -- scripts/test-build-dmg.sh`: passed the credential-free real-Amore fixture smoke.
- `git diff --check`: passed.
- Independent mawarduri browser recheck passed on final combined SHA `d2c335a5`: same-host HTTPS Portal sign-in returned 200 with loopback forwarding, using an isolated Firefox profile that trusts only the session CA.
- No synthetic non-loopback forwarded-client workaround or browser certificate-warning bypass was used.
- All required GitHub CI checks passed.

## Risk Assessment

**Medium**

- The change affects client-IP and public HTTPS derivation in reverse-proxy mode when every address in a valid forwarded chain belongs to configured trusted proxy CIDRs.
- Untrusted socket peers still have all forwarded headers stripped.
- Malformed or duplicate header sets still fail closed, and chains containing an untrusted hop still select the rightmost untrusted address.
- Direct HTTPS and local plain-HTTP transport behavior are unchanged.











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves forwarded HTTPS metadata when a valid forwarding chain consists entirely of trusted addresses.
- Selects the leftmost address as the client for an all-trusted chain.
- Adds IPv4, IPv6, multi-hop, and Developer Portal route regression coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains within the eligible follow-up review scope.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/api/trusted_forwarded_headers.ex | Changes the all-trusted forwarding-chain fallback from rejection to selecting the leftmost parsed address. |
| apps/orchard_controller/test/orchard/api/forwarded_headers_test.exs | Adds loopback IPv4, IPv6, multi-hop, and Portal-route coverage while extending the request helper to accept a path. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Reverse-proxy request] --> B{Socket peer trusted?}
  B -- No --> C[Strip forwarded headers]
  B -- Yes --> D{Headers valid?}
  D -- No --> C
  D -- Yes --> E[Scan X-Forwarded-For right to left]
  E --> F{Untrusted address found?}
  F -- Yes --> G[Use rightmost untrusted address]
  F -- No --> H[Use leftmost trusted address]
  G --> I[Apply forwarded HTTPS rewrite]
  H --> I
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(api): trust valid loopback client fo..."](https://github.com/kapitan-ai/orchard/commit/ab279655ee34904d6c62210b02e82b94feb2ac57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60898324)</sub>

<!-- /greptile_comment -->