### PR TITLE
fix: close payload and handoff qualification gaps

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex
@@ -424,6 +424,7 @@ defmodule OrchardConsole.WorkspaceHandoffLive do
         </div>
         <div :if={@step == 4} class="mt-4 space-y-4">
           <p>Check each independent part of the handoff before sharing anything.</p>
+          <p>Cluster administration and API credentials are not included in this invitation.</p>
           <dl class="space-y-3 text-sm">
             <div><dt class="font-semibold">Workspace</dt><dd>{WorkspacePresentation.display_name(@workspace)} ({@workspace.slug})</dd></div>
             <div><dt class="font-semibold">Model access</dt><dd>{if @selected, do: grant_label(@selected.grant_state), else: "Model no longer in catalog; return to Model access"}</dd></div>

--- a/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs
@@ -97,6 +97,13 @@ defmodule OrchardConsole.WorkspaceHandoffLiveTest do
     |> render_submit()
 
     assert has_element?(view, "#handoff-step-4")
+
+    assert has_element?(
+             view,
+             "#handoff-step-4",
+             "Cluster administration and API credentials are not included in this invitation."
+           )
+
     assert Repo.aggregate(PortalUser, :count) == 1
     assert Repo.aggregate(PortalInviteToken, :count) == 0
     assert Repo.aggregate(ApiKey, :count) == 0

--- a/scripts/build-payload.sh
+++ b/scripts/build-payload.sh
@@ -867,6 +867,9 @@ copy_tree_without_metadata "$REPO_ROOT/_build/prod/rel/orchard_controller" "$STA
 copy_tree_without_metadata "$REPO_ROOT/_build/prod/rel/orchard_node_agent" "$STAGING/releases/"
 copy_tree_without_metadata "$REPO_ROOT/_build/prod/rel/orchard_cli" "$STAGING/releases/"
 
+log_info "Excluding debug-symbol bundles from staged runtime releases..."
+find -P "$STAGING/releases" -type d -name '*.dSYM' -prune -exec rm -rf {} +
+
 log_info "Remediating OTP OpenSSL Mach-O closure..."
 OPENSSL_PROVENANCE="$STAGING_BASE.openssl-provenance.txt"
 if ! "$REPO_ROOT/scripts/remediate-otp-openssl-closure.sh" --provenance-output "$OPENSSL_PROVENANCE" "$STAGING"; then

--- a/scripts/test-build-payload.sh
+++ b/scripts/test-build-payload.sh
@@ -151,6 +151,10 @@ exit 0
 BIN
   chmod +x "\$root/_build/prod/rel/\$release/bin/\$release"
   : > "\$root/_build/prod/rel/\$release/erts-16.4/bin/beam.smp"
+  nif_dir="\$root/_build/prod/rel/\$release/lib/fixture_nif-1.0/priv"
+  mkdir -p "\$nif_dir/fixture_nif.so.dSYM/Contents/Resources/DWARF"
+  printf 'runtime NIF\\n' > "\$nif_dir/fixture_nif.so"
+  printf 'debug symbols\\n' > "\$nif_dir/fixture_nif.so.dSYM/Contents/Resources/DWARF/fixture_nif.so"
   if [ "\$release" = "orchard_controller" ]; then
     app_root="\$root/_build/prod/rel/\$release/lib/orchard_controller-$FAKE_VERSION"
     mkdir -p "\$app_root/ebin"
@@ -257,6 +261,16 @@ fi
 test -d "$PAYLOAD_ROOT" || fail 'PAYLOAD_ROOT does not name a directory'
 test -d "$PAYLOAD_ROOT/support/openssl" ||
     fail 'app payload requires support/openssl even without Homebrew OpenSSL load commands'
+
+for release in orchard_controller orchard_node_agent orchard_cli; do
+    nif_path="lib/fixture_nif-1.0/priv/fixture_nif.so"
+    test -d "$REPO_ROOT/_build/prod/rel/$release/$nif_path.dSYM" ||
+        fail "source release lost its debug symbols: $release"
+    test ! -e "$PAYLOAD_ROOT/releases/$release/$nif_path.dSYM" ||
+        fail "runtime payload includes an xattr-signed debug companion: $release"
+    test -f "$PAYLOAD_ROOT/releases/$release/$nif_path" ||
+        fail "runtime payload lost its NIF: $release"
+done
 
 for staged in \
     "share/bin/orchardctl" \


### PR DESCRIPTION
Real macOS qualification found two gaps in the combined Console candidate.

The app could pass signature verification and then fail DMG assembly because copied Elixir releases included argon2 dSYM debug companions.
Those files received signatures stored only in extended attributes, which the existing metadata-free DMG copy strips.
The payload builder now removes dSYM directories from staged releases before signing, while preserving source debug symbols and runtime NIFs.
The signature and entitlement verification gates remain intact.
This follows [Apple's guidance](https://developer.apple.com/documentation/xcode/building-your-app-to-include-debugging-information) to retain matching debug-symbol companions for crash diagnosis while keeping them separate from the distributed runtime.

The new handoff's Review scope step also omitted the explicit OpenSpec statement that cluster administration and API credentials are not included.
The step now displays that scope boundary before the operator proceeds.

Both fixes follow existing contracts: runtime-only payload content and the accepted `console-access-workspaces` Review scope scenario.
This follow-up sits above #365 in the Console qualification stack.

## Validation

- `mise exec -- scripts/test-build-payload.sh`: new debug-companion exclusion regression failed before the fix and passed after it; covers all three releases, retained runtime NIFs, and preserved source debug symbols.
- `ORCHARD_TEST_NODE_AGENT_PORT=15371 mise exec -- mix test apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs`: 14 passed and 1 failed before the copy change; all 15 passed afterward through the actual step transition.
- `mise exec -- scripts/test-build-app.sh`: passed.
- `mise exec -- scripts/test-app-service-lifecycle.sh`: passed under a temporary root.
- `mise exec -- scripts/test-app-signing.sh`: passed.
- `mise exec -- scripts/test-build-dmg.sh`: passed with the deterministic fixture.
- `ORCHARD_TEST_REAL_AMORE=1 mise exec -- scripts/test-build-dmg.sh`: passed the credential-free real-Amore fixture smoke.
- `mise exec -- scripts/test-payload-signing-contracts.sh`: passed.
- `bash -n scripts/build-payload.sh scripts/test-build-payload.sh`: passed.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`: all 45 items passed.
- `git diff --check`: passed.
- `ORCHARD_TEST_NODE_AGENT_PORT=15371 make check-elixir MIX_TEST_PLATFORM_ARGS='--seed 323426'`: passed the required workflow in order: `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, macOS helper staging, `mix test`, and `mix test --cover`.
- Plain and coverage runs each passed 5,306 tests, with 6 skips and 10 exclusions; no failures.
- Controller coverage: 85.0%.
- Independent Namespace production qualification on `d2c335a5`: fresh payload, app build, ad-hoc signing/verification, real-Amore DMG assembly (194 seconds), `hdiutil verify`, mounted-app deep/strict codesign, and repository signature verification all passed without manual payload edits.
- Source dSYM companions were retained separately with a manifest; none were staged in the runtime payload.
- DMG SHA-256: `4fdcd2be1da38a6350eabc1f50877c9897312aef456e2c9bfc13a4335b4a4b4b`.
- Independent Namespace browser recheck on `d2c335a5`: Review scope exclusion copy passed; HTTPS Portal invitation redemption passed with genuine `X-Forwarded-For: 127.0.0.1`.
- The older Portal-users copy action still produces a relative invitation path (pre-existing, outside this patch); the new colleague handoff copies an absolute URL and redeems successfully.
- [Independent report](https://app.devin.ai/attachments/46d7868e-7416-40a5-98e4-af99f3f2f80f/REPORT.md) and [browser matrix](https://app.devin.ai/attachments/8645e095-c46a-4550-8171-5f986d8635db/MATRIX.md).
- All required GitHub CI checks and the Greptile check passed on `d2c335a5`.
- Qualification is ad-hoc; Developer ID signing, notarization, and publication of the full Orchard artifact were not performed.

The later combined head `1e8cbac0579728ebee190383322b7213d8aafd2e` adds only #367's smoke-harness isolation fix.
Its separate single-host source-dev BEAM-first qualification proves real MLX, automatic Node activation, persisted request-to-Node correlation, both APIs, and the Portal credential lifecycle (20/21 checks passed; cold first-request failure retained).
See #367 for exact commands and the [BEAM-first report](https://app.devin.ai/attachments/e361ad72-1205-45f2-870a-3e090e7c98a7/REPORT.md).
The final combined source `6b475c81d6a434ad3b96a0b3168c10598ad0de7a` adds #368's worker-readiness polling fix, with 5,308 tests passing in both full plain/coverage runs and all required CI passing.
Real-MLX delayed startup and the post-cold API/SSE/cancel/recovery matrix passed on that SHA; successful requests correlate to the new active enrolled BEAM Node.
Cold requests still fail closed until a durable heartbeat reports the loaded placement, with generic HTTP 500 classification retained as a separate limitation.
[Final independent report](https://app.devin.ai/attachments/8c3bba14-7bf0-40fa-b824-604f904933b8/REPORT.md).
The production ad-hoc DMG result remains attributed to d2c335a5; no installed packaged or physical multi-host BEAM journey is claimed.
That evidence does not change the d2c335a5 provenance or installed-runtime limits of the packaging result above.

## Risk Assessment

**Low**

- Payload pruning affects only `.dSYM` directories in staged Elixir releases; source build outputs and loadable NIFs are retained.
- App and DMG signature, entitlement, closure, and manifest checks are unchanged.
- Handoff changes only the displayed scope explanation; grants, invitations, and credentials retain their existing behavior.















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes debug-symbol bundles from staged Elixir releases while retaining runtime NIFs and source debug symbols, and adds the missing invitation-scope boundary to the colleague handoff review.
- Prunes `.dSYM` directories from copied runtime releases before closure remediation and signing.
- Adds regression coverage across all three staged releases.
- Clarifies that invitations exclude cluster administration and API credentials, with LiveView coverage through the actual step transition.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/build-payload.sh | Removes debug-symbol directory bundles from staged release payloads before signing without modifying source release outputs. |
| scripts/test-build-payload.sh | Adds fixtures and assertions proving source symbols remain, staged symbols are excluded, and runtime NIFs survive for all releases. |
| apps/orchard_controller/lib/orchard/console/workspace_handoff_live.ex | Adds the required invitation-scope exclusion statement to the Review scope step. |
| apps/orchard_controller/test/orchard/console/workspace_handoff_live_test.exs | Verifies the scope statement after the real handoff transition into the review step. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix: close payload and handoff qualifica..."](https://github.com/kapitan-ai/orchard/commit/1c9f4101805029674ab5c2ad76fc18e2595dd071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60900649)</sub>

<!-- /greptile_comment -->