### PR TITLE
fix(node): honor worker readiness polling deadlines

### DIFF
--- a/apps/orchard_controller/test/orchard/inference/tool_capability_readiness_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/tool_capability_readiness_test.exs
@@ -198,7 +198,7 @@ defmodule Orchard.Inference.ToolCapabilityReadinessTest do
           id: Ecto.UUID.generate(),
           hostname: "host-#{unique}.local",
           display_name: "node-#{unique}",
-          advertise_addr: "10.0.0.#{rem(unique, 255)}",
+          advertise_addr: "node-#{unique}.test",
           rpc_port: 9444,
           state: :active,
           health: :healthy,

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -823,16 +823,29 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   defp try_connect_and_check(socket_path, port, deadline) do
     remaining_ms = deadline - System.monotonic_time(:millisecond)
 
-    case connect_worker_socket(socket_path) do
+    case connect_worker_socket(socket_path,
+           await_timeout: max(0, min(remaining_ms, @poll_interval_ms))
+         ) do
       {:ok, channel} ->
-        check_connected_worker(channel, socket_path, port, deadline, remaining_ms)
+        check_connected_worker(channel, socket_path, port, deadline)
 
       {:error, _reason} ->
         retry_wait_for_worker_ready(socket_path, port, deadline)
     end
   end
 
-  defp check_connected_worker(channel, socket_path, port, deadline, remaining_ms) do
+  defp check_connected_worker(channel, socket_path, port, deadline) do
+    remaining_ms = deadline - System.monotonic_time(:millisecond)
+
+    if remaining_ms <= 0 do
+      _ = disconnect_channel(channel)
+      {:error, :worker_ready_timeout}
+    else
+      check_worker_status(channel, socket_path, port, deadline, remaining_ms)
+    end
+  end
+
+  defp check_worker_status(channel, socket_path, port, deadline, remaining_ms) do
     timeout_ms = min(remaining_ms, @rpc_timeout_ms)
 
     case WorkerRuntimeService.Stub.get_status(
@@ -861,7 +874,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   end
 
   defp retry_wait_for_worker_ready(socket_path, port, deadline) do
-    Process.sleep(@poll_interval_ms)
+    remaining_ms = max(0, deadline - System.monotonic_time(:millisecond))
+    Process.sleep(min(remaining_ms, @poll_interval_ms))
     do_wait_for_worker_ready(socket_path, port, deadline)
   end
 
@@ -869,10 +883,11 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   # does not register it with the connection supervisor refresh path. Gun's
   # open_unix/2 success typing expects the local socket path as a charlist.
   # Public only so tests can assert direct UDS channel behavior without worker startup.
-  # credo:disable-for-lines:3 ExSlop.Check.Readability.DocFalseOnPublicFunction
+  # credo:disable-for-lines:4 ExSlop.Check.Readability.DocFalseOnPublicFunction
   @doc false
-  @spec connect_worker_socket(String.t()) :: {:ok, Orchard.GRPCTypes.channel()} | {:error, term()}
-  def connect_worker_socket(socket_path) when is_binary(socket_path) do
+  @spec connect_worker_socket(String.t(), keyword()) ::
+          {:ok, Orchard.GRPCTypes.channel()} | {:error, term()}
+  def connect_worker_socket(socket_path, opts \\ []) when is_binary(socket_path) do
     %Channel{
       host: {:local, String.to_charlist(socket_path)},
       port: 0,
@@ -886,7 +901,7 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
       accepted_compressors: [],
       headers: []
     }
-    |> Gun.connect([])
+    |> Gun.connect(opts)
   end
 
   # Classify worker health from GetStatus response.

--- a/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs
@@ -7,10 +7,24 @@ defmodule Orchard.Node.WorkerCustodyTest do
   alias Orchard.Cluster.V1.ModelRef
   alias Orchard.Node.CustodyTestHelpers
   alias Orchard.Node.RuntimeProcessReaper
+  alias Orchard.Node.Worker.V1.{WorkerRuntimeService, WorkerStatusResponse}
   alias Orchard.Node.WorkerProcess
   alias Orchard.Node.WorkerProcessLifecycle
   alias Orchard.Node.WorkerRuntimeAdapter
   alias Orchard.Node.WorkerSupervisor
+
+  defmodule ReadyWorkerService do
+    use GRPC.Server, service: WorkerRuntimeService.Service
+
+    def get_status(_request, _stream), do: %WorkerStatusResponse{ready: true}
+    def load_model(_request, _stream), do: %Orchard.Cluster.V1.Ack{ok: true}
+  end
+
+  defmodule ReadyWorkerEndpoint do
+    use GRPC.Endpoint
+
+    run(ReadyWorkerService)
+  end
 
   @shutdown_timeout_ms 200
   @stale_identity "0 Thu Jan 1 00:00:00 1970"
@@ -51,6 +65,71 @@ defmodule Orchard.Node.WorkerCustodyTest do
       {:error, :eexist} -> unique_tmp_root!()
       {:error, reason} -> raise "could not create custody test root #{root}: #{inspect(reason)}"
     end
+  end
+
+  test "SPEC.md §4.9 worker readiness honors its budget when the UDS never appears", context do
+    executable = waiting_worker!(context)
+    started = System.monotonic_time(:millisecond)
+
+    assert {:error, :worker_ready_timeout} =
+             load_runtime(context, executable: executable, ready_timeout_ms: 100)
+
+    assert System.monotonic_time(:millisecond) - started < 2_000
+    CustodyTestHelpers.assert_reaper_empty!(1_000)
+    refute File.exists?(context.socket_path)
+  end
+
+  test "SPEC.md §4.9 readiness accepts a worker UDS that starts asynchronously",
+       context do
+    executable = waiting_worker!(context)
+    test_pid = self()
+
+    server =
+      Task.async(fn ->
+        send(test_pid, {:worker_server_waiting, self()})
+
+        receive do
+          :start -> run_delayed_worker_server(context)
+          :stop -> :ok
+        end
+      end)
+
+    try do
+      assert_receive {:worker_server_waiting, server_pid}, 2_000
+      send(server_pid, :start)
+
+      assert {:ok, state} =
+               load_runtime(context, executable: executable, ready_timeout_ms: 2_000)
+
+      assert :ok = WorkerRuntimeAdapter.unload_model(state, skip_rpc: true)
+      CustodyTestHelpers.assert_reaper_empty!(1_000)
+    after
+      send(server.pid, :stop)
+      Task.await(server)
+    end
+  end
+
+  defp run_delayed_worker_server(context) do
+    Process.sleep(150)
+
+    {:ok, supervisor} =
+      GRPC.Server.Supervisor.start_link(
+        endpoint: ReadyWorkerEndpoint,
+        port: 0,
+        start_server: true,
+        adapter_opts: [ip: {:local, context.socket_path}]
+      )
+
+    receive do
+      :stop -> Supervisor.stop(supervisor)
+    end
+  end
+
+  defp waiting_worker!(context) do
+    executable = Path.join(context.root, "waiting-worker")
+    File.write!(executable, "#!/bin/sh\nexec sleep 30\n")
+    File.chmod!(executable, 0o755)
+    executable
   end
 
   test "SPEC.md §4.9 explicit unload reaps the exact stub runtime PID and socket", context do
@@ -444,20 +523,24 @@ defmodule Orchard.Node.WorkerCustodyTest do
   end
 
   defp load_stub_runtime!(context) do
-    assert {:ok, state} =
-             WorkerRuntimeAdapter.load_model(context.model_ref,
-               backend: "stub",
-               executable: worker_executable(),
-               load_timeout_ms: 5_000,
-               log_path: context.log_path,
-               models_root: context.models_root,
-               owner: self(),
-               ready_timeout_ms: 5_000,
-               shutdown_timeout_ms: @shutdown_timeout_ms,
-               socket_path: context.socket_path
-             )
-
+    assert {:ok, state} = load_runtime(context, [])
     state
+  end
+
+  defp load_runtime(context, opts) do
+    defaults = [
+      backend: "stub",
+      executable: worker_executable(),
+      load_timeout_ms: 5_000,
+      log_path: context.log_path,
+      models_root: context.models_root,
+      owner: self(),
+      ready_timeout_ms: 5_000,
+      shutdown_timeout_ms: @shutdown_timeout_ms,
+      socket_path: context.socket_path
+    ]
+
+    WorkerRuntimeAdapter.load_model(context.model_ref, Keyword.merge(defaults, opts))
   end
 
   defp exited_port! do


### PR DESCRIPTION
The BEAM-first real-MLX qualification exposed a Node-to-Worker startup defect: the intended 50 ms readiness poll could block for five seconds inside the gRPC/Gun connection retry path.
A worker that was already listening before its readiness deadline could be killed as timed out, and a configured 100 ms budget took 5,075 ms to return locally.

The adapter now caps each initial connection wait by the polling interval and remaining readiness budget.
It recalculates the remaining budget before GetStatus, closes a channel that connects after expiry, and caps the retry sleep by the same deadline.
The five-second runtime default and the successful channel's reconnect settings remain unchanged.
This preserves the existing worker readiness and custody contracts without changing BEAM transport, certificate verification, admission, or runtime defaults.
The full suite also exposed a test-fixture address collision caused by reducing unique integers modulo 255; the fixture now retains the complete unique integer in a reserved `.test` hostname.

## Validation

- Never-listening UDS regression: failed before the fix, with a 100 ms readiness budget taking 5,075 ms; passed after the fix.
- Asynchronous UDS startup is covered through the real gRPC client/server boundary, with a synchronized fixture and a two-second readiness budget.
- The full worker custody suite passed 11 tests during focused validation.
- `PGDATABASE_TEST=orchard_worker_ready_test ORCHARD_TEST_NODE_AGENT_PORT=24972 make check-elixir MIX_TEST_PLATFORM_ARGS='--seed 323426'`: passed format, warnings-as-errors compilation, strict Credo, Dialyzer, macOS helper staging, plain tests, and coverage.
  Each test run passed 5,308 tests with six skips, ten exclusions, and zero failures.
  Coverage: Shared 68.04%, Controller 85.0%, Node 79.84%, CLI 75.79%.
- `PGDATABASE_TEST=orchard_worker_ready_test ORCHARD_TEST_NODE_AGENT_PORT=24972 mise exec -- mix test apps/orchard_controller/test/orchard/inference/tool_capability_readiness_test.exs --seed 323426`: three passed after correcting the fixture collision.
- Independent review: GO with no remaining P1/P2 findings in the complete three-file patch, including the fixture correction; the reviewer did not independently execute the quality workflow.
- `git diff --check`: passed.

The independent pre-fix real-MLX reproduction used delayed worker startup and confirmed `worker_ready_timeout` while the worker log already showed a listening socket.
Why the original cold process took longer to bind remains inferred; the blocking connection-poll defect was reproduced separately.
The independent real-MLX recheck on exact `6b475c81d6a434ad3b96a0b3168c10598ad0de7a` confirmed the fix under the unchanged five-second readiness default.
With 3,500 ms injected startup delay, the socket was ready at 4.17 s and the model loaded at 4.89 s; with 4,000 ms delay, these were 4.67 s and 5.40 s.
Total model load includes work after readiness, so the 5.40 s total does not violate the readiness budget.
A 4,500 ms delay correctly timed out at 5.02 s, and a deliberately forced 300 ms budget returned in 314 ms.
The post-cold matrix passed both APIs non-streaming and SSE, cancellation, recovery, warm repeats, Workspace denial, and missing credentials.
All 18 requests were attributed to enrolled/admitted/Active Node `6e0d6d58-78d4-41b0-8a56-fa19d6bc5008`: 11 completed, one cancelled, and six cold-window failures; 120 heartbeats persisted with the Node Runtime gRPC child absent and its listener closed.
The exact unchanged model was `mlx-community/Qwen3-0.6B-4bit@73e3e38d981303bc594367cd910ea6eb48349da8`, artifact SHA-256 `d30ebd70f4a436c152939ec8f4c798c8a2096fb210445781833e4bf4e60f5dd4`.
The retained session harness ran `LABEL=<label> REPRO_WORKER_DELAY_MS=<0|3500|4000|4500> READY_TIMEOUT_MS=5000 ./run.sh` in its `beam-mlx/repro` directory, then `LABEL=cycle1 ./cold-cycle-6b47.sh` and `./api-matrix-6b47.sh` in `beam-mlx`.
These are isolated mawarduri source-dev harness commands, not new repository entrypoints.
Cold requests still reject before durable loaded-placement evidence: the last observed failure was 09:53:13.169 UTC, the loaded heartbeat persisted at 09:53:13.830, and the 09:53:14.112 request succeeded.
This is the SPEC §5.9 production revalidation boundary, with generic HTTP 500 capacity-error mapping retained separately; this PR does not change dispatch authority or claim immediate cold-first-request success.
All required CI checks passed on this SHA.
[Final report](https://app.devin.ai/attachments/8c3bba14-7bf0-40fa-b824-604f904933b8/REPORT.md) and [cold-window diagnosis](https://app.devin.ai/attachments/b4026a12-d324-4c07-8f47-312b6ae9774b/cold-window-capacity-rejection-6b47.md).
The earlier 1e8cbac0 warm API, Portal, and Node-identity qualification remains separately attributed; this patch does not claim to resolve its cold-window capacity-rejection classification or Console presentation findings.

## Risk Assessment

✅ **Medium**

- The change affects initial worker connection timing for the existing Node-to-Worker gRPC/UDS path.
- Deadlines and process custody remain enforced; late or failed connections are closed.
- No transport-default migration, dependency change, model change, certificate change, or packaged bootstrap implementation is included.



















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR bounds worker readiness connection attempts, status checks, and retry sleeps by the configured deadline while retaining the existing runtime connection defaults.
- Recomputes the remaining readiness budget after connecting and closes channels established after expiry.
- Adds never-listening and asynchronously-starting UDS regression coverage.
- Replaces a collision-prone test IP fixture with a unique reserved `.test` hostname.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex | Bounds initial connection, status polling, and retry sleeping by the remaining readiness deadline. |
| apps/orchard_node_agent/test/orchard/node/worker_custody_test.exs | Adds regression coverage for an absent worker socket and delayed asynchronous UDS startup. |
| apps/orchard_controller/test/orchard/inference/tool_capability_readiness_test.exs | Preserves fixture uniqueness by using the complete unique integer in a reserved test hostname. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as WorkerRuntimeAdapter
    participant G as gRPC/Gun
    participant W as Worker
    loop Until readiness deadline
        A->>G: Connect with min(50ms, remaining budget)
        alt Connected before deadline
            G-->>A: Channel
            A->>W: GetStatus with bounded timeout
            W-->>A: Status
        else Connection fails
            G-->>A: Error
            A->>A: Sleep min(50ms, remaining budget)
        else Connection completes after expiry
            G-->>A: Channel
            A->>G: Close channel
            A-->>A: worker_ready_timeout
        end
    end
```
</details>

<sub>Reviews (9): Last reviewed commit: ["fix(node): honor worker readiness pollin..."](https://github.com/kapitan-ai/orchard/commit/cb1d829449f824552c0f51b7a918d0192523abc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60924941)</sub>

<!-- /greptile_comment -->