### PR TITLE
docs: prepare Apache-2.0 source-only publication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ Najib retains final authority over project direction, contribution acceptance, m
 AI-assisted work must have an accountable human contributor who reviews and stands behind the result.
 Keep discussions and contributions respectful.
 
+## Contribution Terms
+
+By submitting a pull request, you agree that your Orchard-authored contributions are licensed under [Apache-2.0](LICENSE) and confirm that you have the right to submit them under those terms.
+Identify any included third-party material and preserve its applicable licenses and notices.
+DCO sign-off trailers and a separate contributor license agreement are not required.
+
 ## Getting Started
 
 - Read `README.md` for product overview and status.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Keep discussions and contributions respectful.
 
 ## Change Workflow
 
+The direct-PR path does not waive the participation requirements above.
 Small changes can go directly through a normal PR:
 
 - typo and docs clarifications

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,14 @@ This repository is the collaborator-facing source of truth.
 If these disagree about product behavior, treat the PR as blocked until the
 branch reconciles the conflict. `SPEC.md` wins until explicitly updated.
 
+## Participation
+
+Issues and feedback are welcome.
+Implementation participation requires prior maintainer agreement.
+Najib retains final authority over project direction, contribution acceptance, merges, releases, and publication.
+AI-assisted work must have an accountable human contributor who reviews and stands behind the result.
+Keep discussions and contributions respectful.
+
 ## Getting Started
 
 - Read `README.md` for product overview and status.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+Copyright 2026 AI Singapore
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="#use-it-from-your-code"><img alt="OpenAI-compatible" src="https://img.shields.io/badge/API-OpenAI--compatible-412991?logo=openai&logoColor=white"></a>
   <a href="https://github.com/ml-explore/mlx"><img alt="MLX" src="https://img.shields.io/badge/inference-MLX--LM-FF6F00"></a>
   <a href="#tech-stack"><img alt="Postgres" src="https://img.shields.io/badge/Postgres-16%2B-4169E1?logo=postgresql&logoColor=white"></a>
-  <a href="#license"><img alt="License" src="https://img.shields.io/badge/license-Proprietary-6B7280"></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-6B7280"></a>
 </p>
 
 <p align="center">
@@ -29,6 +29,12 @@
   <a href="SPEC.md"><img alt="Spec-traced" src="https://img.shields.io/badge/build-spec--traced-2563EB"></a>
   <a href="openspec/README.md"><img alt="OpenSpec" src="https://img.shields.io/badge/OpenSpec-strict%20validation-2563EB"></a>
 </p>
+
+> **Experimental source-only publication.**
+> Orchard is published here as source only under the Apache License 2.0, with Copyright 2026 AI Singapore, for covered Orchard-authored software and technical documentation.
+> No official binary, supported release, SLA, or maintenance commitment is provided.
+> Existing tags are pre-public development history and do not identify supported releases.
+> Any future macOS binary remains subject to the existing build, verification, signing, notarization, stapling, and publication gates.
 
 ## Why Orchard
 
@@ -97,9 +103,10 @@ your network and under your audit trail.
 **Packaging and availability**
 
 - The approved macOS native distribution profile uses a signed and notarized DMG containing `Orchard.app`, with an app-owned, root-authorized service lifecycle and role selection for `all`, `controller`, and `node-agent` hosts.
-- The initial source-availability transition may be source-first.
-  Source availability does not promise a supported public binary, which requires an explicit release decision and completed release gates.
-  Source availability also does not change Orchard's licensing terms.
+- The initial source-availability transition is source-only under the repository's Apache-2.0 grant for covered Orchard-authored software and technical documentation.
+  Source visibility alone grants no rights beyond the applicable license terms.
+  It does not provide an official binary, supported release, SLA, or maintenance commitment.
+- A supported public binary requires an explicit release decision and completion of every applicable build, verification, signing, notarization, stapling, and publication gate.
 - Native PKG is not a supported current distribution channel. Any future native
   package requires a fresh accepted OpenSpec proposal and implementing PR.
 - Packaged controller installs use operator-managed external PostgreSQL 16+;
@@ -358,4 +365,13 @@ better fault tolerance, and native macOS integration.
 
 ## License
 
-Proprietary. All rights reserved.
+Covered Orchard-authored software and technical documentation in this repository are licensed under the Apache License, Version 2.0.
+Copyright 2026 AI Singapore.
+See [`LICENSE`](LICENSE).
+
+This experimental publication is source-only.
+It provides no official binary, supported release, SLA, or maintenance commitment.
+Third-party software, models, tokenizers, assets, and other separately licensed material are excluded from this grant and retain their own terms and notices.
+See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) for tracked third-party notices.
+The Orchard logos and distinctive brand assets are excluded from this grant, including `apps/orchard_controller/priv/static/images/` and `assets/brand/`.
+No trademark rights are granted.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,8 @@ A nested policy must not broaden support, relax this root policy, or override `S
 Orchard does not currently publish a security-supported release line.
 The repository identifies current development code as `0.5.0-dev`, but that identifier is not a released-version support commitment.
 Security reports concerning current development code are welcome.
+This repository is an experimental source-only publication.
+Source availability provides no official binary, supported release, SLA, or maintenance commitment.
 
 The Controller `N` and Node Agent `N` and `N-1` compatibility rule in `SPEC.md` is a target contract.
 No concrete Current or Previous Supported Release Line should be inferred until the active release-governance work is accepted and implemented.

--- a/SPEC.md
+++ b/SPEC.md
@@ -5134,9 +5134,12 @@ Its final distribution format, host manager, paths, service integration, and pub
 No Linux distribution is supported by this contract-only amendment.
 
 The macOS native distribution profile SHALL use a signed and notarized **DMG** containing `Orchard.app` for interactive installation and the app-owned root-authorized service lifecycle.
-The initial source-availability transition MAY be source-first, meaning Orchard source is readable in this repository before any public binary is published.
-Source availability SHALL NOT be represented as public binary availability or support, and a supported public binary requires an explicit release decision plus every applicable build, verification, signing, notarization, stapling, and publication gate.
-Source availability SHALL NOT be represented as a change to Orchard's licensing terms, which remain the terms stated in the repository.
+The initial source-availability transition SHALL be source-only under the Apache License, Version 2.0, for covered Orchard-authored software and technical documentation, with Copyright 2026 AI Singapore.
+Third-party software, models, tokenizers, assets, and other separately licensed material SHALL be excluded from that grant and remain subject to their own terms and notices.
+Orchard logos and distinctive brand assets, including tracked assets under `apps/orchard_controller/priv/static/images/` and `assets/brand/`, are excluded from that grant, and trademark rights are not granted.
+Source visibility alone SHALL NOT grant rights beyond the applicable license terms.
+Source availability SHALL NOT be represented as public binary availability or support, and initial source publication provides no official binary, supported release, SLA, or maintenance commitment.
+A supported public binary requires an explicit release decision plus every applicable build, verification, signing, notarization, stapling, and publication gate.
 Native PKG distribution is not a supported current Orchard distribution channel.
 Legacy PKG receipt detection SHALL be retained solely to prevent silent app ownership takeover of an existing installation, as required by §11.4, and does not define a supported distribution channel, a release artifact, or a validation gate.
 Any future native package or additional distribution channel SHALL require a fresh accepted OpenSpec proposal and a separate implementing pull request that updates this contract, security posture, operator documentation, and validation gates before support is claimed.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,60 @@
+# Third-party notices
+
+These notices cover copied third-party material included in the Orchard source tree.
+The identified material retains its upstream license rather than Orchard's Apache-2.0 license.
+Dependencies and model artifacts obtained separately retain their own licenses.
+
+## Topbar 3.0.0
+
+`apps/orchard_controller/assets/vendor/topbar.js` contains [Topbar 3.0.0](https://github.com/buunguyen/topbar/blob/adfb2a2efc50aef8c24901082d8e32e75a567e27/topbar.js), licensed under the MIT License as identified in its [package metadata](https://github.com/buunguyen/topbar/blob/adfb2a2efc50aef8c24901082d8e32e75a567e27/package.json).
+The copyright line below is retained from the copied file.
+
+```text
+Copyright (c) 2024 Buu Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Heroicons v2.2.0
+
+`apps/orchard_controller/lib/orchard/console/core_components.ex` embeds SVG paths from [Heroicons v2.2.0](https://github.com/tailwindlabs/heroicons/tree/v2.2.0), licensed under the [MIT License](https://github.com/tailwindlabs/heroicons/blob/v2.2.0/LICENSE).
+
+```text
+MIT License
+
+Copyright (c) Tailwind Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/decisions/0032-source-only-apache-publication.md
+++ b/docs/decisions/0032-source-only-apache-publication.md
@@ -1,0 +1,31 @@
+# ADR 0032: Source-only Apache-2.0 publication
+
+## Status
+
+Accepted.
+Date: 2026-09-07.
+
+## Context
+
+Orchard needs a durable boundary for its initial source publication before any official binary release.
+The publication must preserve the existing macOS distribution gates and the terms for material that Orchard does not own.
+
+## Decision
+
+Covered Orchard-authored software and technical documentation are published under the Apache License, Version 2.0, with Copyright 2026 AI Singapore.
+The repository remains hosted at `kapitan-ai/orchard`.
+The publication is source-only and experimental, and source visibility alone grants no rights beyond the applicable license terms.
+Third-party software, models, tokenizers, assets, and other separately licensed material are excluded from that grant and remain subject to their own terms and notices.
+Orchard logos and distinctive brand assets are excluded, and no trademark rights are granted.
+Najib retains final authority over project direction, contribution acceptance, merges, releases, and publication.
+No official binary, supported release, SLA, or maintenance commitment is provided by this publication.
+Existing tags remain unsupported pre-public development history; this decision does not authorize deleting, rewriting, or promoting them into releases.
+Future macOS binaries remain subject to the existing build, verification, signing, notarization, stapling, and publication gates.
+
+## Consequences
+
+The repository has a clear source license and publication boundary without changing runtime behavior or authorizing binary distribution.
+
+## SPEC.md impact
+
+Updates §11 for the initial source-only Apache-2.0 grant and preserves the existing binary release gates.

--- a/docs/decisions/0032-source-only-apache-publication.md
+++ b/docs/decisions/0032-source-only-apache-publication.md
@@ -18,6 +18,10 @@ The publication is source-only and experimental, and source visibility alone gra
 Third-party software, models, tokenizers, assets, and other separately licensed material are excluded from that grant and remain subject to their own terms and notices.
 Orchard logos and distinctive brand assets are excluded, and no trademark rights are granted.
 Najib retains final authority over project direction, contribution acceptance, merges, releases, and publication.
+Implementation participation requires prior maintainer agreement, and AI-assisted work retains an accountable human contributor.
+Submitting a pull request constitutes agreement to license Orchard-authored contributions under Apache-2.0 and confirmation of the right to submit them under those terms.
+Contributors must identify included third-party material and preserve its applicable licenses and notices.
+This license-based contribution policy supersedes the earlier DCO 1.1 certification requirement for new contributions; neither DCO sign-off trailers nor a separate CLA are required.
 No official binary, supported release, SLA, or maintenance commitment is provided by this publication.
 Existing tags remain unsupported pre-public development history; this decision does not authorize deleting, rewriting, or promoting them into releases.
 Future macOS binaries remain subject to the existing build, verification, signing, notarization, stapling, and publication gates.

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -59,9 +59,10 @@ The Acceptance Profile that proves a portable Controller, including a Linux Cont
 _Avoid_: Mixed-platform Platform Profile, deployment topology alone, Linux support claim without acceptance
 
 **Initial Source-Availability Transition**:
-The first period in which Orchard source is readable in this repository before any supported public binary is published.
-It neither promises a supported public binary nor changes Orchard's licensing terms.
-_Avoid_: Curated OSS, open source release, public binary availability, licensing change
+The first period in which Orchard source is readable in this repository under the Apache-2.0 grant for covered Orchard-authored software and technical documentation defined in `SPEC.md` §11.
+Third-party material and distinctive brand assets remain excluded from that grant, and source visibility alone grants no rights beyond the applicable license terms.
+This source-only publication provides no official binary, supported release, SLA, or maintenance commitment.
+_Avoid_: Curated OSS, supported binary release, public binary availability, support commitment
 
 **Normative Build Contract**:
 The top-level product and system contract that governs Orchard behavior and resolves conflicts between docs, tests, and implementation.

--- a/docs/process.md
+++ b/docs/process.md
@@ -48,7 +48,10 @@ Native PKG is not a current supported Orchard channel.
 Restoring it or introducing another channel requires a fresh OpenSpec proposal
 and a separate implementing pull request that reconcile `SPEC.md`, decisions,
 security posture, operator docs, artifact governance, and validation gates.
-The initial source-availability transition does not promise a supported public binary.
+The initial source-availability transition is source-only under the repository's explicit Apache-2.0 grant for covered Orchard-authored software and technical documentation.
+Source visibility alone grants no rights beyond the applicable license terms.
+No official binary, supported release, SLA, or maintenance commitment follows from source availability.
+Third-party terms and notices remain applicable to their material.
 Public binary support requires an explicit release decision and completion of every applicable build, verification, signing, notarization, stapling, and publication gate.
 
 ## Re-Grounding Rule

--- a/openspec/changes/align-model-load-deadline/design.md
+++ b/openspec/changes/align-model-load-deadline/design.md
@@ -12,21 +12,17 @@ model_load_timeout =
   )
 ```
 
-<ref_snippet file="/Users/najib/Hacks/orchard/.worktrees/issue-222-first-cold/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex" lines="798-803" />
+The stage-cap calculation lives in `apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex`.
 
-This cap is passed as the RPC `timeout:` to the Runtime Endpoint client
-(<ref_snippet file="/Users/najib/Hacks/orchard/.worktrees/issue-222-first-cold/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex" lines="1294-1297" />),
-but the `EnsureModelLoadedRequest` itself carries the absolute Request deadline:
+The dispatcher passes this cap as the RPC `timeout:` to the Runtime Endpoint client, but the `EnsureModelLoadedRequest` itself carries the absolute Request deadline:
 
 ```elixir
 deadline_unix_ms: deadline_ms   # ~120 s
 ```
 
-<ref_snippet file="/Users/najib/Hacks/orchard/.worktrees/issue-222-first-cold/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex" lines="1748-1756" />
+The request is constructed in `apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex`.
 
-The Node Agent derives its waiter expiry, load budget, and worker timeout from that
-field (<ref_snippet file="/Users/najib/Hacks/orchard/.worktrees/issue-222-first-cold/apps/orchard_node_agent/lib/orchard/node/model_manager.ex" lines="788-791" />),
-so it continues loading long after the controller has abandoned the request.
+The Node Agent derives its waiter expiry, load budget, and worker timeout from that field in `apps/orchard_node_agent/lib/orchard/node/model_manager.ex`, so it continues loading long after the controller has abandoned the request.
 
 ## Decision: rewrite `deadline_unix_ms` at dispatch
 

--- a/openspec/changes/source-only-apache-publication/design.md
+++ b/openspec/changes/source-only-apache-publication/design.md
@@ -1,0 +1,25 @@
+# Design
+
+## Decision
+
+Publish covered Orchard-authored software and technical documentation under Apache-2.0, with `Copyright 2026 AI Singapore`.
+Preserve third-party license terms and notices for actually tracked copied material.
+Repository hosting remains `kapitan-ai/orchard`; Najib retains project direction, contribution acceptance, merge, release, and publication authority.
+
+## Boundaries
+
+The initial publication is source-only and experimental.
+The existing macOS app/DMG contract remains applicable to future binary distribution.
+This change does not publish a binary, create a release tag, promise support, or alter GitHub access and workflow settings.
+Publication-surface findings and raw evidence remain local or in the relevant private review, not in committed audit logs.
+
+## Participation
+
+Issues and feedback are welcome, and implementation participation requires prior maintainer agreement.
+The precise inbound contribution certification policy must be resolved before cutover; this change does not silently substitute a feedback-only policy or introduce CLA machinery.
+
+## Validation
+
+Validate this OpenSpec change strictly before implementation and before handoff.
+Review license text against the Apache source, attribution against tracked assets, and links and contract wording against the final diff.
+Retain existing required quality gates without adding hosted real-model inference.

--- a/openspec/changes/source-only-apache-publication/design.md
+++ b/openspec/changes/source-only-apache-publication/design.md
@@ -11,7 +11,7 @@ Repository hosting remains `kapitan-ai/orchard`; Najib retains project direction
 The initial publication is source-only and experimental.
 The existing macOS app/DMG contract remains applicable to future binary distribution.
 This change does not publish a binary, create a release tag, promise support, or alter GitHub access and workflow settings.
-Publication-surface findings and raw evidence remain local or in the relevant private review, not in committed audit logs.
+Publication-surface findings and raw evidence remain local or in a review surface that remains access-restricted after repository cutover, not in committed audit logs.
 
 ## Participation
 

--- a/openspec/changes/source-only-apache-publication/design.md
+++ b/openspec/changes/source-only-apache-publication/design.md
@@ -16,7 +16,9 @@ Publication-surface findings and raw evidence remain local or in a review surfac
 ## Participation
 
 Issues and feedback are welcome, and implementation participation requires prior maintainer agreement.
-The precise inbound contribution certification policy must be resolved before cutover; this change does not silently substitute a feedback-only policy or introduce CLA machinery.
+Contributors agree to submit Orchard-authored contributions under Apache-2.0, confirm their right to submit them, and preserve applicable third-party licenses and notices as described in `CONTRIBUTING.md`.
+AI-assisted work retains an accountable human contributor.
+This license-based policy replaces the earlier DCO 1.1 certification requirement; neither DCO sign-off trailers nor a separate CLA are required.
 
 ## Validation
 

--- a/openspec/changes/source-only-apache-publication/proposal.md
+++ b/openspec/changes/source-only-apache-publication/proposal.md
@@ -1,0 +1,27 @@
+# Source-only Apache-2.0 publication
+
+## Why
+
+Orchard is preparing its initial source-only publication under Apache License 2.0 with AI Singapore as copyright holder.
+The repository must state the license grant explicitly while preserving its experimental status and separate binary release gates.
+
+## What Changes
+
+- Add the root Apache-2.0 license and preserve attribution for tracked third-party material.
+- Reconcile `SPEC.md` §11, README, contribution guidance, and security status for source-only publication.
+- Record AI Singapore copyright attribution, Kapitan-AI hosting, and Najib's continuing project authority in a short decision.
+- Keep security/access configuration and the final visibility action subject to separate owner approval.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `packaging-deployment`: explicitly license the initial source-only publication while retaining all public binary release gates.
+
+## Impact
+
+The accepted `packaging-deployment` requirement states that the initial publication is source-only under an explicit Apache-2.0 grant for covered Orchard-authored software and technical documentation, with Copyright 2026 AI Singapore and retained third-party terms and notices.
+Source visibility alone grants no rights beyond the applicable license terms.
+No official binary, supported release line, SLA, or maintenance commitment is introduced.
+The existing macOS build, verification, signing, notarization, stapling, and publication gates remain unchanged.
+There are no runtime, API, or packaging implementation changes.

--- a/openspec/changes/source-only-apache-publication/proposal.md
+++ b/openspec/changes/source-only-apache-publication/proposal.md
@@ -10,6 +10,7 @@ The repository must state the license grant explicitly while preserving its expe
 - Add the root Apache-2.0 license and preserve attribution for tracked third-party material.
 - Reconcile `SPEC.md` §11, README, contribution guidance, and security status for source-only publication.
 - Record AI Singapore copyright attribution, Kapitan-AI hosting, and Najib's continuing project authority in a short decision.
+- Use license-based contribution terms with confirmation of submission rights, prior maintainer agreement, and human accountability, without DCO sign-offs or a separate CLA.
 - Keep security/access configuration and the final visibility action subject to separate owner approval.
 
 ## Capabilities

--- a/openspec/changes/source-only-apache-publication/specs/packaging-deployment/spec.md
+++ b/openspec/changes/source-only-apache-publication/specs/packaging-deployment/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Source Availability Does Not Imply Public Binary Support
+
+Per `SPEC.md` §11, Orchard's initial publication SHALL be source-only under the repository's explicit Apache-2.0 grant for covered Orchard-authored software and technical documentation, with Copyright 2026 AI Singapore.
+Third-party software, models, tokenizers, assets, and other separately licensed material SHALL be excluded from that grant and remain subject to their own terms and notices.
+Orchard logos and distinctive brand assets under `apps/orchard_controller/priv/static/images/` and `assets/brand/` SHALL be excluded from that grant, and trademark rights are not granted.
+Source availability SHALL NOT be represented as public binary availability or support.
+Source visibility alone SHALL NOT grant rights beyond the applicable license terms.
+A supported public binary SHALL require an explicit release decision and completion of every applicable build, verification, signing, notarization, stapling, and publication gate.
+Initial source publication SHALL NOT provide an official binary, supported release line, SLA, or maintenance commitment.
+
+#### Scenario: Source is available before public binaries
+
+- **WHEN** Orchard source is published without an approved public binary release
+- **THEN** the repository states the applicable source license and preserves third-party attribution
+- **AND** the grant preserves the stated logo and distinctive-brand exclusions and applicable trademark terms
+- **AND** documentation does not promise an official binary, supported release, or support commitment
+- **AND** the approved Orchard.app-inside-DMG design remains unchanged

--- a/openspec/changes/source-only-apache-publication/tasks.md
+++ b/openspec/changes/source-only-apache-publication/tasks.md
@@ -6,8 +6,8 @@
 
 ## 2. Publication readiness
 
-- [ ] 2.1 Audit tracked source, reachable history, and relevant GitHub publication surfaces; report redacted findings and coverage limits privately.
-- [ ] 2.2 Present concrete security/access configuration recommendations and any remaining inbound contribution decision for owner approval.
-- [ ] 2.3 Validate OpenSpec and the exact final documentation/license diff; prepare a draft PR and cutover assessment.
+- [x] 2.1 Audit tracked source, reachable history, and relevant GitHub publication surfaces; report redacted findings and coverage limits privately.
+- [x] 2.2 Present concrete security/access configuration recommendations and any remaining inbound contribution decision for owner approval.
+- [x] 2.3 Validate OpenSpec and the exact final documentation/license diff; prepare a draft PR and cutover assessment.
 
 Visibility changes, destructive remediation, merges, tags, releases, and binary publication require separate authorization.

--- a/openspec/changes/source-only-apache-publication/tasks.md
+++ b/openspec/changes/source-only-apache-publication/tasks.md
@@ -1,0 +1,13 @@
+## 1. Publication contract
+
+- [x] 1.1 Add Apache-2.0 license and required tracked-source attribution.
+- [x] 1.2 Reconcile SPEC, README, contribution, security, and process wording.
+- [x] 1.3 Record the settled source-only licensing and project-authority decision.
+
+## 2. Publication readiness
+
+- [ ] 2.1 Audit tracked source, reachable history, and relevant GitHub publication surfaces; report redacted findings and coverage limits privately.
+- [ ] 2.2 Present concrete security/access configuration recommendations and any remaining inbound contribution decision for owner approval.
+- [ ] 2.3 Validate OpenSpec and the exact final documentation/license diff; prepare a draft PR and cutover assessment.
+
+Visibility changes, destructive remediation, merges, tags, releases, and binary publication require separate authorization.

--- a/openspec/changes/source-only-apache-publication/tasks.md
+++ b/openspec/changes/source-only-apache-publication/tasks.md
@@ -9,5 +9,6 @@
 - [x] 2.1 Audit tracked source, reachable history, and relevant GitHub publication surfaces; report redacted findings and coverage limits privately.
 - [x] 2.2 Present concrete security/access configuration recommendations and any remaining inbound contribution decision for owner approval.
 - [x] 2.3 Validate OpenSpec and the exact final documentation/license diff; prepare a draft PR and cutover assessment.
+- [x] 2.4 Record the owner's license-based contribution policy in contribution guidance and the decision record, superseding the earlier DCO requirement.
 
 Visibility changes, destructive remediation, merges, tags, releases, and binary publication require separate authorization.

--- a/openspec/specs/packaging-deployment/spec.md
+++ b/openspec/specs/packaging-deployment/spec.md
@@ -22,17 +22,20 @@ The app-owned lifecycle SHALL remain the current root-authorized path for role-a
 
 ### Requirement: Source Availability Does Not Imply Public Binary Support
 
-Orchard SHALL permit the initial source-availability transition to be source-first without publishing a supported public binary.
-Source availability SHALL NOT be represented as public binary availability or support.
-Source availability SHALL NOT be represented as a change to Orchard's licensing terms.
+Orchard's initial source-availability transition SHALL be source-only under the Apache License, Version 2.0, for covered Orchard-authored software and technical documentation, with Copyright 2026 AI Singapore.
+Third-party software, models, tokenizers, assets, and other separately licensed material SHALL be excluded from that grant and remain subject to their own terms and notices.
+Orchard logos and distinctive brand assets under `apps/orchard_controller/priv/static/images/` and `assets/brand/` SHALL be excluded from that grant, and trademark rights are not granted.
+Source visibility alone SHALL NOT grant rights beyond the applicable license terms.
+Source availability SHALL NOT be represented as public binary availability or support, and initial source publication provides no official binary, supported release, SLA, or maintenance commitment.
 A supported public binary SHALL require an explicit release decision and completion of every applicable build, verification, signing, notarization, stapling, and publication gate.
 
 #### Scenario: Source is available before public binaries
 
 - **WHEN** Orchard source is available without an approved public binary release
-- **THEN** documentation does not promise a supported downloadable binary
+- **THEN** documentation states the Apache-2.0 grant for covered Orchard-authored software and technical documentation
+- **AND** source visibility alone does not grant rights beyond the applicable license terms
+- **AND** documentation does not promise an official binary, supported release, or support commitment
 - **AND** the approved Orchard.app-inside-DMG design remains unchanged
-- **AND** Orchard's licensing terms are unchanged by that availability
 
 ### Requirement: Native PKG Distribution Is Not Supported
 


### PR DESCRIPTION
## Summary

Prepare Orchard's initial source-only publication under Apache License 2.0 with AI Singapore copyright attribution, while retaining third-party terms and the separate gates for any supported public binary.
The public guidance describes an experimental project with maintainer-controlled implementation participation and no SLA or maintenance commitment.

`SPEC.md` §11 and the packaging OpenSpec requirement now state the explicit source grant.
Topbar and Heroicons retain their MIT notices, and current machine-specific OpenSpec references use repository-relative paths.
Najib retains project direction, contribution acceptance, merge, release, and publication authority.
Contributors agree to Apache-2.0 terms for Orchard-authored contributions, confirm their submission rights, and preserve third-party licenses and notices.
This license-based policy supersedes the earlier DCO requirement; neither DCO sign-offs nor a separate CLA are required.

The inbound-contribution policy is settled.
Publication-surface disposition and cutover controls remain separate from review and merge readiness for this source-license change.
The private readiness assessment separately covers retained history and GitHub security/access settings.
Merging this change does not authorize a visibility change, history rewrite, tag, release, or binary publication.

## Validation

- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate source-only-apache-publication --type change --strict --no-interactive`: passed.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`: 47 passed, 0 failed.
- `git diff --check`: passed.
- Local documentation and license check: 13 documents and 55 repository links passed; Apache terms match the official text and Heroicons MIT text matches upstream.
- `scripts/ci/test-classify-required-validation-paths.sh`: passed.
- `scripts/ci/test-required-validation-gate.sh`: passed.
- `scripts/ci/test-platform-test-routing.sh`: passed.

This is a documentation/license change; runtime implementations and required CI gates are unchanged.
The repository's existing CI classifier still selects all required validation lanes for the contract change.
Real-model inference qualification remains on-premises.

## Risk Assessment

✅ **Medium**

- The change defines source license and participation expectations, so license scope and attribution require careful review.
- Runtime behavior, migrations, packaging code, workflows, credentials, and GitHub access settings are unchanged.
- Historical publication findings and external settings remain explicit cutover work; this PR does not claim publication readiness.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares Orchard for an experimental, source-only Apache-2.0 publication while preserving third-party terms, brand exclusions, and separate binary-release gates.

- Adds the Apache-2.0 license and notices for copied Topbar and Heroicons material.
- Aligns the normative specification, OpenSpec requirements, README, security policy, process documentation, and glossary.
- Defines contribution licensing, maintainer authority, and the replacement of the earlier DCO policy.
- Replaces machine-specific OpenSpec references with repository-relative paths.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with its licensing and publication guidance consistently aligned across the reviewed repository surfaces.

No concrete changed-code defect, conflicting contribution gate, repository-rule violation, or unsupported publication claim remained after review.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| LICENSE | Adds the standard Apache License 2.0 text with AI Singapore’s 2026 copyright attribution. |
| THIRD_PARTY_NOTICES.md | Records retained MIT terms and attribution for copied Topbar and Heroicons material. |
| README.md | Documents the source-only Apache-2.0 publication, exclusions, experimental status, and unchanged binary-release gates. |
| CONTRIBUTING.md | Establishes participation authority and Apache-2.0 inbound contribution terms without DCO or separate CLA requirements. |
| SPEC.md | Makes the source-only license grant, third-party and brand exclusions, and binary-publication conditions normative. |
| openspec/specs/packaging-deployment/spec.md | Synchronizes the durable packaging specification with the source-only publication contract. |
| docs/decisions/0032-source-only-apache-publication.md | Records the accepted licensing, participation, support, and publication-boundary decision. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: adopt lean license-based contribut..."](https://github.com/kapitan-ai/orchard/commit/66d6468ad3168846f60880722f588875a5802a23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61262719)</sub>

<!-- /greptile_comment -->