### PR TITLE
fix: stabilize CI bootstrap and lifecycle tests

### DIFF
--- a/.github/workflows/required-validation.yml
+++ b/.github/workflows/required-validation.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          version: 2026.9.2
           cache: false
 
       - name: Validate Product Version consistency
@@ -171,6 +172,7 @@ jobs:
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          version: 2026.9.2
           cache: false
 
       - name: Install conformance dependencies
@@ -217,6 +219,7 @@ jobs:
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          version: 2026.9.2
           cache: false
 
       - name: Install Elixir dependencies
@@ -256,6 +259,7 @@ jobs:
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          version: 2026.9.2
           cache: false
 
       - name: Bootstrap MLX environment from lockfile
@@ -298,6 +302,7 @@ jobs:
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          version: 2026.9.2
           cache: false
 
       - name: Install repository dependencies
@@ -345,6 +350,7 @@ jobs:
       - name: Install pinned toolchain
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          version: 2026.9.2
           cache: true
 
       - name: Install OpenSpec dependencies

--- a/apps/orchard_cli/test/support/console_pty_harness.c
+++ b/apps/orchard_cli/test/support/console_pty_harness.c
@@ -1182,6 +1182,9 @@ static void run_guard_pre_ready_death(int master, int slave, pid_t child,
   pid_t guard = read_marked_pid(master, &capture, "__ORCHARD_GUARD_PID__:");
   read_marked_path(master, &capture, "__ORCHARD_CUSTODY_DIR__:", completion_dir,
                    sizeof(completion_dir));
+  /* PID publication can precede the guard opening its custody directory. */
+  if (read_marked_pid(master, &capture, "__ORCHARD_GUARD_PRE_READY__:") != guard)
+    fail("guard-pre-ready-pid");
   int length = snprintf(moved_dir, sizeof(moved_dir), "%s.moved", completion_dir);
   if (length < 0 || (size_t)length >= sizeof(moved_dir)) fail("moved-path-size");
   if (rename(completion_dir, moved_dir) != 0) fail("guard-custody-dir-rename");

--- a/apps/orchard_controller/test/orchard/governance/portal_lifecycle_audit_test.exs
+++ b/apps/orchard_controller/test/orchard/governance/portal_lifecycle_audit_test.exs
@@ -252,7 +252,7 @@ defmodule Orchard.Governance.PortalLifecycleAuditTest do
                "portal_user.invite_reissued" => 1
              }
 
-      [earlier_expiry, later_expiry] = results |> Enum.map(& &1.expires_at) |> Enum.sort()
+      [earlier_expiry, later_expiry] = results |> Enum.map(& &1.expires_at) |> Enum.sort(DateTime)
       assert DateTime.compare(later_expiry, earlier_expiry) == :gt
 
       reissued = Enum.find(audits, &(&1.action == "portal_user.invite_reissued"))

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -32,6 +32,10 @@ mise trust
 mise install
 ```
 
+Required CI bootstraps mise `2026.9.2` through explicit `version` inputs in `.github/workflows/required-validation.yml`.
+This bootstrap pin is separate from the runtime and developer-tool pins in `mise.toml`.
+Update every mise-action invocation together only after the matching platform release assets and signed checksums are published.
+
 The pinned toolchain currently covers:
 
 | Tool | Pin | Purpose |

--- a/scripts/ci/test-platform-test-routing.sh
+++ b/scripts/ci/test-platform-test-routing.sh
@@ -17,6 +17,32 @@ fail() {
   exit 1
 }
 
+if ! awk '
+  function check_mise_step() {
+    if (!mise_step) return
+    count++
+    if (version !~ /^[0-9][0-9][0-9][0-9]\.[0-9]+\.[0-9]+$/) invalid = 1
+    if (count == 1) bootstrap_version = version
+    if (version != bootstrap_version) invalid = 1
+  }
+  /^      - / {
+    check_mise_step()
+    mise_step = 0
+    version = ""
+  }
+  /uses: jdx\/mise-action@/ { mise_step = 1 }
+  /^          version:/ {
+    version = $2
+    gsub(/["\047]/, "", version)
+  }
+  END {
+    check_mise_step()
+    exit invalid || count == 0
+  }
+' "$WORKFLOW"; then
+  fail 'every mise-action step must pin the same explicit bootstrap version'
+fi
+
 line_number() {
   local content="$1"
   local pattern="$2"

--- a/scripts/test-payload-orchardctl-console-pty.sh
+++ b/scripts/test-payload-orchardctl-console-pty.sh
@@ -127,7 +127,7 @@ sed \
   -e "s|^ORCHARD_ROOT=.*$|ORCHARD_ROOT=\"$STAGED_ROOT\"|" \
   -e "s|^ORCHARD_CLI=.*$|ORCHARD_CLI=\"$WAIT_FIXTURE\"|" \
   -e "s|^SAFE_PATH=.*$|SAFE_PATH=\"$TOOLS:/usr/bin:/bin:/usr/sbin:/sbin\"|" \
-  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { while guard_parent_matches; do /bin/sleep 0.01 \|\| :; done; return 1; }|' \
+  -e 's|^guard_pre_ready_barrier() { :; }$|guard_pre_ready_barrier() { printf "__ORCHARD_GUARD_PRE_READY__:%s\\n" "$_guard_pid"; while guard_parent_matches; do /bin/sleep 0.01 \|\| :; done; return 1; }|' \
   "$REPO_ROOT/packaging/payload/bin/orchardctl" > "$GUARD_ORCHARDCTL"
 chmod 0755 "$GUARD_ORCHARDCTL"
 


### PR DESCRIPTION
The concurrent Copy invite audit test [failed on expiry ordering](https://github.com/kapitan-ai/orchard/actions/runs/34204395187) because it structurally sorted `DateTime` structs.
[CI bootstrap also failed](https://github.com/kapitan-ai/orchard/actions/runs/34209289637) after following the mise version feed to `2026.9.3` before its release assets were available.
The [packaged Console PTY test](https://github.com/kapitan-ai/orchard/actions/runs/34211713430/job/102014053281) also raced custody-directory replacement against guard startup, so the guard could correctly reject the replacement and exit before the test's `SIGKILL`.
This fixes these validation failures while preserving the existing safety assertions and gates.

- Use `Enum.sort(DateTime)` so the existing strict expiry, concurrency, audit, and token assertions evaluate chronological order.
- Pin all mise-action invocations to the published `2026.9.2` release, retain signed checksum verification, and document the bootstrap pin separately from `mise.toml`.
- Extend the platform workflow contract check to reject missing or inconsistent mise pins, including newly added lanes.
- Synchronize the pre-readiness guard-death scenario on a child-emitted, PID-bound marker after custody validation; retain the required successful `SIGKILL`, no-CLI-launch, terminal-restoration, and replacement-directory assertions.

`SPEC.md` impact: none.
Production code, schemas, APIs, runtime tool versions, and packaging behavior are unchanged.

## Validation

Validated on Darwin 25.6.0 arm64 with zsh 5.9, Elixir 1.20.0, Erlang/OTP 29.0.2, and Apple clang 17.0.0.
The bootstrap amendment was validated using the downloaded, signature-verified mise `2026.9.2` binary and an isolated test database and port.

- Deterministic expiry reproduction: structural sorting places `08:44:26.000001Z` before `08:44:25.999999Z`, returning `:lt` in the existing assertion; the semantic comparator returns chronological order and `:gt`.
- `mise exec -- mix test apps/orchard_controller/test/orchard/governance/portal_lifecycle_audit_test.exs`: 11 passed.
- Published mise Linux x64 asset: HTTP 200; downloaded Linux x64 and macOS arm64 archive SHA256 hashes matched the manifest, whose minisign signature passed the pinned action's verifier.
- `scripts/ci/test-classify-required-validation-paths.sh`: passed.
- `scripts/ci/test-required-validation-gate.sh`: passed.
- `scripts/ci/test-platform-test-routing.sh`: passed; mutation checks rejected implicit latest, one missing pin, inconsistent pins, and a future unpinned lane.
- `bash -n scripts/ci/test-platform-test-routing.sh`: passed.
- `mise exec -- mix format`: passed.
- `mise exec -- mix compile --warnings-as-errors`: passed.
- `mise exec -- mix credo --strict`: passed, no findings.
- `mise exec -- mix dialyzer`: passed.
- `make macos-native-test-helpers`: passed.
- `mise exec -- mix test` under mise `2026.9.2` on bootstrap commit `287bc5ae`: 5,311 passed, six skipped, 10 excluded.
- `mise exec -- mix test --cover` on that commit: passed with the same test counts.
- Subsequent PTY test-only fix: deterministic scheduling probe failed three out of three times before synchronization (`guard-identity-mismatch`, then `guard-kill` with `ESRCH`) and passed three out of three times afterward.
- `mise exec -- mix test apps/orchard_cli/test/orchard_cli/commands/console_pty_test.exs --cover`: 34 passed.
- `scripts/test-payload-orchardctl-controller-runtime.sh`: passed.
- `scripts/test-payload-orchardctl-console-pty.sh`: passed, including the original guard-death scenario and adjacent wrapper races.
- `scripts/test-payload-orchardctl-controller-release.sh`: passed.
- `scripts/test-app-service-lifecycle.sh`: passed using a temporary installation root.
- `bash -n scripts/test-payload-orchardctl-console-pty.sh` and strict C harness compilation: passed.

The initial local full run had six node-agent failures because the fresh worktree lacked the Python worker entrypoint.
After `mise exec -- uv sync --locked --directory native/orchard_worker_mlx` and a successful worker `--help` check, the full test and coverage reruns passed.

## Risk Assessment

✅ **Low**

- Changes are confined to a test comparator, a PTY test fixture and harness, CI bootstrap inputs, workflow regression checks, and tooling documentation.
- Strict concurrency and expiry assertions remain intact; required validation lanes and the aggregate gate are preserved.
- The bootstrap pin uses a published release with verified signed checksums; no production migration or compatibility change is introduced.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stabilizes CI bootstrap and lifecycle tests without changing production behavior.
- Pins every required-validation mise bootstrap to release `2026.9.2`.
- Adds a workflow contract check requiring consistent explicit mise pins.
- Sorts invite expiries using chronological `DateTime` ordering.
- Synchronizes the guard-death PTY test after custody validation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/required-validation.yml | Pins all six mise-action invocations consistently to the published bootstrap release. |
| scripts/ci/test-platform-test-routing.sh | Adds a contract check requiring every mise-action step to use the same explicit version. |
| apps/orchard_cli/test/support/console_pty_harness.c | Waits for and validates the guard’s PID-bound pre-readiness marker before replacing custody state. |
| scripts/test-payload-orchardctl-console-pty.sh | Emits the synchronization marker from the guard after custody validation while holding it before readiness. |
| apps/orchard_controller/test/orchard/governance/portal_lifecycle_audit_test.exs | Uses semantic DateTime ordering for concurrent invite-expiry assertions. |
| docs/tooling.md | Documents the CI bootstrap pin separately from repository runtime-tool pins. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test: synchronize guard custody before d..."](https://github.com/kapitan-ai/orchard/commit/b99bb0ce1522cabb6918e418aa653a20012e98de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61525391)</sub>

<!-- /greptile_comment -->
