### PR TITLE
fix: reject oversized worker socket paths before launch

### DIFF
--- a/apps/orchard_node_agent/lib/orchard/node/model_load_failure.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/model_load_failure.ex
@@ -233,6 +233,15 @@ defmodule Orchard.Node.ModelLoadFailure do
       )
 
   # --- RUNTIME_UNAVAILABLE ---
+  def from_reason({:worker_socket_path_too_long, _details}),
+    do:
+      new(
+        :MODEL_LOAD_FAILURE_CATEGORY_RUNTIME_UNAVAILABLE,
+        "worker_socket_path_too_long",
+        "worker socket path exceeds the host limit; set ORCHARD_WORKER_SOCKET_DIR " <>
+          "to a shorter directory owned by the node-agent user and restart the node agent"
+      )
+
   def from_reason(:worker_executable_not_found),
     do:
       new(

--- a/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
+++ b/apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex
@@ -40,6 +40,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
 
   @poll_interval_ms 50
   @rpc_timeout_ms 1_000
+  # sockaddr_un reserves 104 bytes on macOS and 108 on Linux, including the NUL.
+  @max_worker_socket_path_bytes if(:os.type() == {:unix, :linux}, do: 107, else: 103)
   # Slice of the shutdown budget reserved to confirm an uncatchable SIGKILL.
   @kill_confirm_ms 250
   @default_generation_mode "batch"
@@ -290,7 +292,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     owner_pid = Keyword.get(opts, :owner, self())
 
     result =
-      with {:ok, resolved_model_path} <- resolve_model_path(model_ref, models_root),
+      with :ok <- validate_socket_path(socket_path),
+           {:ok, resolved_model_path} <- resolve_model_path(model_ref, models_root),
            {:ok, resolved_executable} <- resolve_executable(executable),
            :ok <- ensure_socket_parent(socket_path),
            :ok <- ensure_log_parent(log_path),
@@ -663,6 +666,18 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
     |> File.mkdir_p()
   end
 
+  defp validate_socket_path(socket_path) do
+    if byte_size(socket_path) <= @max_worker_socket_path_bytes do
+      :ok
+    else
+      {:error,
+       {:worker_socket_path_too_long,
+        "worker socket path is #{byte_size(socket_path)} bytes; maximum is " <>
+          "#{@max_worker_socket_path_bytes} bytes. Set ORCHARD_WORKER_SOCKET_DIR " <>
+          "to a shorter directory owned by the node-agent user"}}
+    end
+  end
+
   defp ensure_log_parent(log_path) do
     log_path
     |> Path.dirname()
@@ -888,20 +903,22 @@ defmodule Orchard.Node.WorkerRuntimeAdapter do
   @spec connect_worker_socket(String.t(), keyword()) ::
           {:ok, Orchard.GRPCTypes.channel()} | {:error, term()}
   def connect_worker_socket(socket_path, opts \\ []) when is_binary(socket_path) do
-    %Channel{
-      host: {:local, String.to_charlist(socket_path)},
-      port: 0,
-      scheme: "unix",
-      cred: nil,
-      ref: make_ref(),
-      adapter: Gun,
-      codec: Proto,
-      interceptors: [],
-      compressor: nil,
-      accepted_compressors: [],
-      headers: []
-    }
-    |> Gun.connect(opts)
+    with :ok <- validate_socket_path(socket_path) do
+      %Channel{
+        host: {:local, String.to_charlist(socket_path)},
+        port: 0,
+        scheme: "unix",
+        cred: nil,
+        ref: make_ref(),
+        adapter: Gun,
+        codec: Proto,
+        interceptors: [],
+        compressor: nil,
+        accepted_compressors: [],
+        headers: []
+      }
+      |> Gun.connect(opts)
+    end
   end
 
   # Classify worker health from GetStatus response.

--- a/apps/orchard_node_agent/test/orchard/node/worker_runtime_adapter_test.exs
+++ b/apps/orchard_node_agent/test/orchard/node/worker_runtime_adapter_test.exs
@@ -33,6 +33,8 @@ defmodule Orchard.Node.WorkerRuntimeAdapterTest do
   alias Orchard.InferenceEvent.{Completed, OutputTextDelta, TokenDelta}
   alias Orchard.Node.WorkerRuntimeAdapter
 
+  @socket_path_limit if(:os.type() == {:unix, :linux}, do: 107, else: 103)
+
   defmodule OpenUnavailableWorkerService do
     use GRPC.Server, service: WorkerRuntimeService.Service
 
@@ -479,6 +481,49 @@ defmodule Orchard.Node.WorkerRuntimeAdapterTest do
     end)
   end
 
+  test "SPEC.md §4.10 rejects an oversized socket before model loading or socket cleanup" do
+    root = Path.join("/tmp", "orchard-socket-#{System.unique_integer([:positive])}")
+    socket_path = Path.join(root, String.duplicate("s", 112 - byte_size(root) - 1))
+    File.mkdir_p!(root)
+    File.write!(socket_path, "existing artifact")
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    assert {:error, {:worker_socket_path_too_long, message}} =
+             WorkerRuntimeAdapter.load_model(%ModelRef{model_id: "test/model", version: "v1"},
+               socket_path: socket_path,
+               models_root: Path.join(root, "missing-models")
+             )
+
+    assert message =~ "112 bytes"
+    assert message =~ "#{@socket_path_limit} bytes"
+    assert message =~ "ORCHARD_WORKER_SOCKET_DIR"
+    assert File.read!(socket_path) == "existing artifact"
+  end
+
+  test "connect_worker_socket rejects a UTF-8 path one byte over the host limit without starting Gun" do
+    socket_path = "/tmp/" <> String.duplicate("é", div(@socket_path_limit - 5, 2)) <> "s"
+
+    assert {:error, {:worker_socket_path_too_long, message}} =
+             WorkerRuntimeAdapter.connect_worker_socket(socket_path)
+
+    assert message =~ "#{@socket_path_limit + 1} bytes"
+    assert message =~ "#{@socket_path_limit} bytes"
+  end
+
+  test "connect_worker_socket serves gRPC at the host socket path limit" do
+    filename = "orchard-boundary-#{System.unique_integer([:positive])}"
+    socket_path = "/tmp/" <> String.pad_trailing(filename, @socket_path_limit - 5, "s")
+
+    with_worker_runtime_unix_server(
+      MemoryBudgetEndpoint,
+      fn channel, _socket_path ->
+        assert {:ok, %{ready: true}} =
+                 WorkerRuntimeAdapter.get_status(%{channel: channel}, timeout_ms: 500)
+      end,
+      socket_path
+    )
+  end
+
   test "connect_worker_socket uses a direct UDS channel without connection supervisor refresh" do
     with_worker_runtime_unix_server(MemoryBudgetEndpoint, fn channel, socket_path ->
       assert %GRPC.Channel{
@@ -778,13 +823,14 @@ defmodule Orchard.Node.WorkerRuntimeAdapterTest do
     end
   end
 
-  defp with_worker_runtime_unix_server(endpoint, fun)
+  defp with_worker_runtime_unix_server(endpoint, fun, socket_path \\ nil)
        when is_atom(endpoint) and is_function(fun, 2) do
     socket_path =
-      Path.join(
-        System.tmp_dir!(),
-        "orchard-worker-runtime-adapter-#{System.unique_integer([:positive])}.sock"
-      )
+      socket_path ||
+        Path.join(
+          System.tmp_dir!(),
+          "orchard-worker-runtime-adapter-#{System.unique_integer([:positive])}.sock"
+        )
 
     File.rm(socket_path)
 

--- a/apps/orchard_node_agent/test/orchard_node_agent_test.exs
+++ b/apps/orchard_node_agent/test/orchard_node_agent_test.exs
@@ -4222,6 +4222,33 @@ defmodule OrchardNodeAgentTest do
 
   # -- Worker lifecycle telemetry tests ----------------------------------------
 
+  test "SPEC.md §4.10 model loading reports actionable oversized socket configuration", %{
+    bundle: bundle
+  } do
+    with_runtime_config(
+      [
+        runtime_adapter_impl: Orchard.Node.WorkerRuntimeAdapter,
+        fake_runtime?: false,
+        worker_socket_dir: "/tmp/" <> String.duplicate("s", 103)
+      ],
+      fn ->
+        with_channel(fn channel ->
+          assert {:ok, response} =
+                   NodeRuntimeStub.ensure_model_loaded(
+                     channel,
+                     ensure_model_loaded_request(bundle)
+                   )
+
+          assert response.placement_state == :PLACEMENT_STATE_FAILED
+          assert response.failure_category == :MODEL_LOAD_FAILURE_CATEGORY_RUNTIME_UNAVAILABLE
+          assert response.failure_code == "worker_socket_path_too_long"
+          assert response.failure_message =~ "ORCHARD_WORKER_SOCKET_DIR"
+          wait_until(fn -> worker_count() == 0 end)
+        end)
+      end
+    )
+  end
+
   describe "worker lifecycle telemetry" do
     test "successful load emits manager and runtime start/stop telemetry", %{bundle: bundle} do
       with_real_worker_runtime(fn ->

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -322,6 +322,10 @@ back to that same full digest whenever the receipt is missing, invalid, or no
 longer matches the cache tree.
 By default, source-dev worker Unix sockets live under a short, worktree-specific `/tmp/od-<hash>/ws` directory to avoid macOS Unix socket path length limits.
 Set `ORCHARD_WORKER_SOCKET_DIR` to override that location.
+On macOS, the complete worker socket path must fit within 103 UTF-8 bytes, including the directory, separator, and generated `orchard-worker-<16 hex digits>.sock` filename.
+Keep the expanded directory path at most 66 bytes and use a directory owned by the node-agent user, isolated from other running instances.
+Linux validation allows 107 bytes for the complete path, or 70 bytes for the directory.
+An oversized path returns `worker_socket_path_too_long` before launching a worker or removing an existing socket; shorten `ORCHARD_WORKER_SOCKET_DIR` and restart the node agent.
 `ORCHARD_FAKE_RUNTIME` is a release/runtime config knob; source-dev tests use
 the fake runtime through `config/test.exs`, not a dev env override.
 Batch generation mode can admit multiple same-model requests up to the worker-reported limit.


### PR DESCRIPTION
A source-development inference run on macOS failed with Gun `badarg` because its generated worker socket path was 112 bytes, exceeding the Unix socket address limit.
The node agent now rejects an oversized path before removing an existing socket or starting a worker and returns actionable `worker_socket_path_too_long` guidance through the Node Runtime Endpoint.

The check counts UTF-8 bytes and preserves the platform boundary: 103 bytes on macOS and 107 on Linux.
It also protects direct socket connections and documents the existing `ORCHARD_WORKER_SOCKET_DIR` override.
No SPEC behavior or default socket-directory change is required.

## Verification

```sh
ORCHARD_TEST_NODE_AGENT_PORT=15182 \
PGDATABASE_TEST=orchard_socket_fix_test \
make check-elixir
```

Passed formatting, warnings-as-errors compilation, strict Credo, Dialyzer, macOS helper staging, the full test suite, and coverage.
Both test runs reported 5,315 passed, six existing skips, and ten existing CLI integration exclusions.
Node-agent coverage was 80.12%.

Regression coverage reproduces the original oversized-path failure, checks UTF-8 byte counting, preserves existing files on rejection, connects successfully at the macOS boundary, and verifies the sanitized failure over the Node gRPC interface with no orphan worker.
Independent code review found no actionable issues, and `git diff --check` passed.

## Risk Assessment

✅ **Low**

- Limited to worker socket-path validation and model-load failure reporting.
- Invalid paths fail before cleanup or process launch; valid paths retain existing behavior.
- No persistence, schema, scheduling, API-shape, or default-directory changes.
- Linux byte limits are covered by platform-aware validation; the live socket boundary test ran on macOS.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds platform-aware UTF-8 byte-length validation for worker Unix socket paths before filesystem cleanup, worker launch, or direct Gun connection. It also maps oversized paths to an actionable Node Runtime failure, adds boundary and regression coverage, and documents the existing socket-directory override.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

The validation uses the correct UTF-8 byte boundaries for the repository’s supported Linux and macOS targets, runs before destructive or launch operations, propagates through the existing failure model, and is covered at rejection and acceptance boundaries.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_node_agent/lib/orchard/node/worker_runtime_adapter.ex | Validates Linux and macOS worker socket-path limits before side effects and direct UDS connections, with no actionable defect identified. |
| apps/orchard_node_agent/lib/orchard/node/model_load_failure.ex | Maps oversized socket paths to a sanitized runtime-unavailable response with corrective configuration guidance. |
| apps/orchard_node_agent/test/orchard/node/worker_runtime_adapter_test.exs | Covers oversized UTF-8 paths, preservation of an existing socket artifact, and successful connection at the platform boundary. |
| apps/orchard_node_agent/test/orchard_node_agent_test.exs | Verifies the oversized-path failure is surfaced through the Node Runtime endpoint without leaving a worker process. |
| docs/local-dev.md | Documents the existing worker socket-directory override and platform-specific directory byte budgets. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reject oversized worker socket path..."](https://github.com/kapitan-ai/orchard/commit/ebaadc1c936849609da83f8d59dbaec9ac8f60b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61572087)</sub>

<!-- /greptile_comment -->