### PR TITLE
docs: clarify contributor access and merge authority

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,26 @@ branch reconciles the conflict. `SPEC.md` wins until explicitly updated.
 
 Issues and feedback are welcome.
 Implementation participation requires prior maintainer agreement.
+Implementation PRs are limited to designated contributors who are members of the `kapitan-ai` organization with Orchard-specific access through the `orchard-contributors` team, and to Najib as project owner.
+Organization membership alone does not grant implementation access.
+Public contributors should share bug reports, reproduction steps, analysis, and proposals in issues before writing an implementation for submission.
 Najib retains final authority over project direction, contribution acceptance, merges, releases, and publication.
 AI-assisted work must have an accountable human contributor who reviews and stands behind the result.
 Keep discussions and contributions respectful.
+
+### Repository Access And Merging
+
+The `orchard-contributors` team has Write access to Orchard so designated contributors can create branches, submit PRs, and review changes.
+GitHub restricts PR creation to repository collaborators with Write access or higher.
+Public issues remain enabled.
+Access to other organization repositories is granted separately; organization base repository permission is None.
+
+Only Najib may merge PRs into `main`.
+Branch protection restricts updates to `najibninaba` and requires a PR, the up-to-date `Required Orchard validation gate`, and resolved review conversations.
+These requirements apply to administrators, and force pushes and branch deletion are disabled.
+The required approving-review count remains zero so Najib can merge his own PRs after satisfying those gates.
+Review participation and team Write access do not confer authority to merge into `main`.
+Repository Admin access is reserved for Najib; granting it to another person would expand the merge-control trust boundary.
 
 ## Contribution Terms
 


### PR DESCRIPTION
Orchard now uses repository-specific contributor access and restricts updates to main to Najib.
Document the contribution boundary so contributors know that public issues are welcome, implementation requires designation, and Write access does not confer merge authority.

The documentation preserves Najib's ability to merge his own PRs after the existing validation and conversation gates pass.
This clarifies the approved collaboration policy and does not change SPEC.md product behavior.

## Validation

- `git diff --check` passed.
- Live GitHub API readback confirms main updates are restricted to najibninaba, with no team or App allowlist entries.
- Required PR protection, strict Required Orchard validation gate, conversation resolution, admin enforcement, zero required approvals, and disabled force pushes/deletion are preserved.
- Luqman retains Write through orchard-contributors after removing his direct grant.
- Organization base permission is None; Luqman's existing Read access to orchard-onboarding remains intact.
- Public issues remain enabled and PR creation remains collaborators_only.
- Product tests were not run because this PR changes contribution documentation only.

## Risk Assessment

✅ **Low**

- This PR changes only CONTRIBUTING.md and documents separately applied, verified access settings.
- No application code, runtime behavior, CI workflow, or license terms change.
- Repository Admin access remains a privileged trust boundary; the policy reserves it for Najib.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR clarifies Orchard’s contributor eligibility, repository access model, and merge authority.
- Limits implementation PRs to designated Orchard contributors and the project owner
- Documents Write access, public issue access, and repository-specific permissions
- Records the branch-protection gates and reserves merges into `main` for Najib

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The change affects documentation only, and the new contributor-access and merge-policy language has no demonstrated conflict with repository guidance or the stated verified GitHub configuration.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Adds contributor-access and merge-authority guidance consistent with the repository’s existing validation and governance documentation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify contributor access and mer..."](https://github.com/kapitan-ai/orchard/commit/f779da9981c87d8d3839a073b4b3c860d38067e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62024617)</sub>

<!-- /greptile_comment -->