### PR TITLE
chore: speed up orb Erlang setup

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -9,6 +9,7 @@ step() {
 
 step "Installing missing system packages"
 packages=(
+  acl
   autoconf
   build-essential
   libncurses-dev
@@ -47,7 +48,12 @@ fi
 
 step "Installing the pinned Orchard toolchain"
 mise trust --yes mise.toml
-mise install
+# Amp orbs run Debian 12, which mise cannot map to one of its compatible
+# precompiled Erlang targets. Without the explicit target, mise falls back to
+# compiling OTP from source and can consume the entire orb setup window.
+MISE_ERLANG_PRECOMPILED_OS=ubuntu-22.04 \
+  MISE_ERLANG_COMPILE=false \
+  mise install
 
 step "Starting and tuning PostgreSQL"
 postgres_config="$(find /etc/postgresql -path '*/main/postgresql.conf' -print -quit)"


### PR DESCRIPTION
## Summary
- use mise's compatible precompiled Erlang build in Debian 12 Amp orbs
- fail instead of silently falling back to a source build
- install the ACL utilities required by Linux CLI custody tests

## Validation
- cold setup: 34.6s
- warm setup: 6.7s
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false make test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR speeds up Amp orb setup by selecting a compatible precompiled Erlang build and disabling slow source-build fallback.
- Adds the ACL utilities required by Linux CLI custody tests.
- Forces the Debian 12 orb path to use mise’s Ubuntu 22.04 precompiled Erlang target.
- Leaves the repository’s local and CI toolchain installation paths unchanged.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking issues identified.

The precompiled Erlang override is confined to the Amp orb setup path, the normal local and CI installation paths remain unaffected, and the supplied setup validation indicates the intended Debian 12 environment completes successfully.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .agents/setup | Adds the `acl` package and scopes precompiled-only Erlang installation settings to the Amp orb setup script; no actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: speed up orb Erlang setup"](https://github.com/kapitan-ai/orchard/commit/bd4dcef1245a57e3eba35d45040cdcf785c2af44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62578899)</sub>

<!-- /greptile_comment -->