### PR TITLE
refactor(inference): lay canonical reasoning and exact render-identity foundation

### DIFF
--- a/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
@@ -30,6 +30,35 @@ defmodule Orchard.Inference.CanonicalRequestSerializer do
       "admission" => serialize_admission(canonical.admission),
       "resolved_policy" => serialize_resolved_policy(canonical.resolved_policy)
     }
+    |> maybe_put_reasoning(canonical.reasoning)
+  end
+
+  defp maybe_put_reasoning(serialized, %CanonicalRequest.Reasoning{
+         generation_policy: generation_policy,
+         projection: projection,
+         source: source,
+         effective_contract: %{mode: :legacy}
+       })
+       when generation_policy == :model_default and projection == :legacy_blended and
+              source == :omitted_public do
+    serialized
+  end
+
+  defp maybe_put_reasoning(
+         serialized,
+         %CanonicalRequest.Reasoning{
+           generation_policy: generation_policy,
+           projection: projection,
+           source: source,
+           effective_contract: %{mode: :negotiated} = effective_contract
+         }
+       ) do
+    Map.put(serialized, "reasoning", %{
+      "generation_policy" => Atom.to_string(generation_policy),
+      "projection" => Atom.to_string(projection),
+      "source" => Atom.to_string(source),
+      "effective_contract" => normalize_plain_data(effective_contract)
+    })
   end
 
   @spec sampling_params(CanonicalRequest.Sampling.t()) :: map()

--- a/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
+++ b/apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
@@ -46,19 +46,14 @@ defmodule Orchard.Inference.CanonicalRequestSerializer do
 
   defp maybe_put_reasoning(
          serialized,
-         %CanonicalRequest.Reasoning{
-           generation_policy: generation_policy,
-           projection: projection,
-           source: source,
-           effective_contract: %{mode: :negotiated} = effective_contract
-         }
+         %CanonicalRequest.Reasoning{effective_contract: %{mode: :negotiated}} = reasoning
        ) do
-    Map.put(serialized, "reasoning", %{
-      "generation_policy" => Atom.to_string(generation_policy),
-      "projection" => Atom.to_string(projection),
-      "source" => Atom.to_string(source),
-      "effective_contract" => normalize_plain_data(effective_contract)
-    })
+    Map.put(serialized, "reasoning", CanonicalRequest.Reasoning.to_wire(reasoning))
+  end
+
+  defp maybe_put_reasoning(_serialized, reasoning) do
+    raise ArgumentError,
+          "canonical request reasoning must be a supported legacy or negotiated contract before serialization, got: #{inspect(reasoning)}"
   end
 
   @spec sampling_params(CanonicalRequest.Sampling.t()) :: map()

--- a/apps/orchard_controller/lib/orchard/tokenizer/client.ex
+++ b/apps/orchard_controller/lib/orchard/tokenizer/client.ex
@@ -19,6 +19,7 @@ defmodule Orchard.Tokenizer.Client do
 
   @render_and_count_contract_version 2
   @render_and_count_segmented_contract_version 3
+  @render_and_count_reasoning_contract_version 4
   @default_timeout_ms 5_000
   @default_runtime_max_stdout_bytes 16_777_216
   @control_token_catalog_kinds ~w(huggingface_tokenizer_json tokenizer_json)
@@ -132,6 +133,18 @@ defmodule Orchard.Tokenizer.Client do
   def mode, do: Orchard.Inference.tokenizer_mode()
   def executable, do: Orchard.Inference.tokenizer_executable()
 
+  defp default_tokenize(
+         %CanonicalRequest{reasoning: %{effective_contract: %{mode: :negotiated}}} = request,
+         opts
+       ) do
+    if mode() == :port do
+      port_tokenize(request, opts)
+    else
+      {:error,
+       {:invalid_input, "negotiated reasoning tokenization requires tokenizer_mode=:port"}}
+    end
+  end
+
   defp default_tokenize(%CanonicalRequest{} = request, opts) do
     case mode() do
       :fake -> fake_tokenize(request)
@@ -175,6 +188,13 @@ defmodule Orchard.Tokenizer.Client do
     end
   end
 
+  defp build_tokenization_plan(
+         %CanonicalRequest{reasoning: %{effective_contract: %{mode: :negotiated}}} = request,
+         opts
+       ) do
+    build_negotiated_plan(request, opts)
+  end
+
   defp build_tokenization_plan(%CanonicalRequest{} = request, opts) do
     case Orchard.Inference.tokenizer_safe_mode() do
       :off -> build_legacy_plan(request, opts)
@@ -186,6 +206,21 @@ defmodule Orchard.Tokenizer.Client do
   defp build_legacy_plan(%CanonicalRequest{} = request, opts) do
     with {:ok, assets} <- resolve_legacy_assets(opts) do
       {:ok, %{mode: :legacy, payload: legacy_payload(request, assets)}}
+    end
+  end
+
+  defp build_negotiated_plan(
+         %CanonicalRequest{reasoning: %CanonicalRequest.Reasoning{} = reasoning} = request,
+         opts
+       ) do
+    with {:ok, assets} <- resolve_legacy_assets(opts),
+         {:ok, identity} <- negotiated_identity(opts) do
+      {:ok,
+       %{
+         mode: :negotiated,
+         expected_reasoning: serialize_reasoning(reasoning),
+         payload: negotiated_payload(request, Map.merge(assets, identity))
+       }}
     end
   end
 
@@ -248,6 +283,16 @@ defmodule Orchard.Tokenizer.Client do
     }
   end
 
+  defp negotiated_payload(%CanonicalRequest{} = request, assets) do
+    %{
+      contract_version: @render_and_count_reasoning_contract_version,
+      command: "render_and_count_reasoning",
+      assets: assets,
+      request:
+        Map.put(request_payload(request), :reasoning, serialize_reasoning(request.reasoning))
+    }
+  end
+
   defp segmented_payload(%CanonicalRequest{} = request, assets, safe_tokenization) do
     %{
       contract_version: @render_and_count_segmented_contract_version,
@@ -260,6 +305,21 @@ defmodule Orchard.Tokenizer.Client do
       request: request_payload(request)
     }
   end
+
+  defp serialize_reasoning(%CanonicalRequest.Reasoning{} = reasoning) do
+    %{
+      "generation_policy" => Atom.to_string(reasoning.generation_policy),
+      "projection" => Atom.to_string(reasoning.projection),
+      "source" => Atom.to_string(reasoning.source),
+      "effective_contract" =>
+        Map.new(reasoning.effective_contract, fn {key, value} ->
+          {Atom.to_string(key), serialize_reasoning_value(value)}
+        end)
+    }
+  end
+
+  defp serialize_reasoning_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp serialize_reasoning_value(value), do: value
 
   defp request_payload(%CanonicalRequest{} = request) do
     %{
@@ -519,6 +579,26 @@ defmodule Orchard.Tokenizer.Client do
          tokenizer_path: resolved_tokenizer_path,
          chat_template_path: resolved_chat_template_path
        }}
+    end
+  end
+
+  defp negotiated_identity(opts) do
+    with bundle_sha256 when is_binary(bundle_sha256) <- Keyword.get(opts, :bundle_sha256),
+         true <- String.match?(bundle_sha256, @sha256_hex),
+         %ModelManifest{chat_template: %{sha256: chat_template_digest}} <-
+           Keyword.get(opts, :manifest),
+         true <-
+           is_binary(chat_template_digest) and String.match?(chat_template_digest, @sha256_hex) do
+      {:ok,
+       %{
+         model_artifact_digest: bundle_sha256,
+         chat_template_digest: chat_template_digest
+       }}
+    else
+      _other ->
+        {:error,
+         {:invalid_input,
+          "negotiated reasoning requires trusted lowercase model artifact and chat template SHA-256 digests"}}
     end
   end
 
@@ -830,6 +910,41 @@ defmodule Orchard.Tokenizer.Client do
 
   defp normalize_response(
          %{
+           "contract_version" => @render_and_count_reasoning_contract_version,
+           "ok" => true,
+           "result" => %{
+             "rendered_prompt" => rendered_prompt,
+             "input_token_count" => input_token_count,
+             "reasoning" => reasoning
+           }
+         },
+         0,
+         %{mode: :negotiated, expected_reasoning: expected_reasoning}
+       )
+       when is_binary(rendered_prompt) and is_integer(input_token_count) and
+              input_token_count >= 0 and is_map(reasoning) do
+    if reasoning == expected_reasoning do
+      {:ok, %{rendered_prompt: rendered_prompt, input_token_count: input_token_count}}
+    else
+      {:error, :invalid_response}
+    end
+  end
+
+  defp normalize_response(
+         %{
+           "contract_version" => @render_and_count_reasoning_contract_version,
+           "ok" => false,
+           "error" => %{"category" => category, "message" => message}
+         },
+         _exit_status,
+         %{mode: :negotiated}
+       )
+       when is_binary(category) and is_binary(message) do
+    {:error, {normalize_error_category(category), message}}
+  end
+
+  defp normalize_response(
+         %{
            "contract_version" => @render_and_count_segmented_contract_version,
            "ok" => true,
            "result" => result
@@ -1063,6 +1178,7 @@ defmodule Orchard.Tokenizer.Client do
     do: normalize_error_category(category)
 
   defp normalize_error_category("invalid_input"), do: :invalid_input
+  defp normalize_error_category("unsupported_reasoning_control"), do: :invalid_input
   defp normalize_error_category("missing_assets"), do: :missing_assets
   defp normalize_error_category("unsupported_tokenizer"), do: :unsupported_tokenizer
 

--- a/apps/orchard_controller/lib/orchard/tokenizer/client.ex
+++ b/apps/orchard_controller/lib/orchard/tokenizer/client.ex
@@ -192,7 +192,15 @@ defmodule Orchard.Tokenizer.Client do
          %CanonicalRequest{reasoning: %{effective_contract: %{mode: :negotiated}}} = request,
          opts
        ) do
-    build_negotiated_plan(request, opts)
+    case Orchard.Inference.tokenizer_safe_mode() do
+      :off ->
+        build_negotiated_plan(request, opts)
+
+      safe_mode ->
+        {:error,
+         {:invalid_input,
+          "negotiated reasoning tokenization has no segmented caller-string rendering yet and refuses tokenizer_safe_mode=#{inspect(safe_mode)}"}}
+    end
   end
 
   defp build_tokenization_plan(%CanonicalRequest{} = request, opts) do
@@ -213,12 +221,12 @@ defmodule Orchard.Tokenizer.Client do
          %CanonicalRequest{reasoning: %CanonicalRequest.Reasoning{} = reasoning} = request,
          opts
        ) do
-    with {:ok, assets} <- resolve_legacy_assets(opts),
+    with {:ok, assets} <- resolve_negotiated_assets(opts),
          {:ok, identity} <- negotiated_identity(opts) do
       {:ok,
        %{
          mode: :negotiated,
-         expected_reasoning: serialize_reasoning(reasoning),
+         expected_reasoning: CanonicalRequest.Reasoning.to_wire(reasoning),
          payload: negotiated_payload(request, Map.merge(assets, identity))
        }}
     end
@@ -289,7 +297,11 @@ defmodule Orchard.Tokenizer.Client do
       command: "render_and_count_reasoning",
       assets: assets,
       request:
-        Map.put(request_payload(request), :reasoning, serialize_reasoning(request.reasoning))
+        Map.put(
+          request_payload(request),
+          :reasoning,
+          CanonicalRequest.Reasoning.to_wire(request.reasoning)
+        )
     }
   end
 
@@ -305,21 +317,6 @@ defmodule Orchard.Tokenizer.Client do
       request: request_payload(request)
     }
   end
-
-  defp serialize_reasoning(%CanonicalRequest.Reasoning{} = reasoning) do
-    %{
-      "generation_policy" => Atom.to_string(reasoning.generation_policy),
-      "projection" => Atom.to_string(reasoning.projection),
-      "source" => Atom.to_string(reasoning.source),
-      "effective_contract" =>
-        Map.new(reasoning.effective_contract, fn {key, value} ->
-          {Atom.to_string(key), serialize_reasoning_value(value)}
-        end)
-    }
-  end
-
-  defp serialize_reasoning_value(value) when is_atom(value), do: Atom.to_string(value)
-  defp serialize_reasoning_value(value), do: value
 
   defp request_payload(%CanonicalRequest{} = request) do
     %{
@@ -603,12 +600,20 @@ defmodule Orchard.Tokenizer.Client do
   end
 
   defp resolve_segmented_assets(opts) do
-    manifest = Keyword.get(opts, :manifest)
-    bundle_root = Keyword.get(opts, :bundle_root)
+    with {:ok, manifest_assets} <- extract_manifest_assets(Keyword.get(opts, :manifest)),
+         :ok <- ensure_segmented_tokenizer_kind(manifest_assets.tokenizer_kind) do
+      resolve_configured_assets(manifest_assets, Keyword.get(opts, :bundle_root))
+    end
+  end
 
-    with {:ok, manifest_assets} <- extract_manifest_assets(manifest),
-         :ok <- ensure_segmented_tokenizer_kind(manifest_assets.tokenizer_kind),
-         {:ok, resolved_tokenizer_path} <-
+  defp resolve_negotiated_assets(opts) do
+    with {:ok, manifest_assets} <- extract_manifest_assets(Keyword.get(opts, :manifest)) do
+      resolve_configured_assets(manifest_assets, Keyword.get(opts, :bundle_root))
+    end
+  end
+
+  defp resolve_configured_assets(manifest_assets, bundle_root) do
+    with {:ok, resolved_tokenizer_path} <-
            resolve_asset_path(manifest_assets.tokenizer_path, bundle_root),
          {:ok, resolved_chat_template_path} <-
            resolve_asset_path(manifest_assets.chat_template_path, bundle_root),
@@ -654,7 +659,7 @@ defmodule Orchard.Tokenizer.Client do
       {:error, _reason} ->
         {:error,
          {:missing_assets,
-          "safe tokenization requires tokenizer.config_path or sibling tokenizer_config.json"}}
+          "manifest-configured rendering requires tokenizer.config_path or sibling tokenizer_config.json"}}
     end
   end
 

--- a/apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs
@@ -171,6 +171,25 @@ defmodule Orchard.Inference.CanonicalRequestSerializerTest do
     end
   end
 
+  test "serialize/1 rejects a reasoning policy that skipped canonical validation" do
+    canonical = %CanonicalRequest{
+      internal_id: Ecto.UUID.generate(),
+      public_id: "chatcmpl-unvalidated",
+      endpoint: :chat_completions,
+      tenant_id: Ecto.UUID.generate(),
+      model_ref: %CanonicalRequest.ModelRef{model_id: "test-model", version: "v1"},
+      sampling: %CanonicalRequest.Sampling{},
+      response_format: %CanonicalRequest.ResponseFormat{},
+      tooling: %CanonicalRequest.Tooling{},
+      admission: %CanonicalRequest.Admission{timeout_ms: 10_000},
+      resolved_policy: %CanonicalRequest.ResolvedPolicy{}
+    }
+
+    assert_raise ArgumentError, ~r/reasoning must be a supported legacy or negotiated/, fn ->
+      CanonicalRequestSerializer.serialize(canonical)
+    end
+  end
+
   defp negotiated_contract do
     %{
       mode: :negotiated,

--- a/apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs
@@ -100,6 +100,42 @@ defmodule Orchard.Inference.CanonicalRequestSerializerTest do
 
     refute Map.has_key?(serialized, :endpoint)
     refute Map.has_key?(serialized, "prompt_token_ids")
+    refute Map.has_key?(serialized, "reasoning")
+  end
+
+  test "serialize/1 retains a complete negotiated reasoning identity" do
+    canonical =
+      CanonicalRequest.new(%{
+        internal_id: Ecto.UUID.generate(),
+        public_id: "chatcmpl-negotiated",
+        endpoint: :chat_completions,
+        tenant_id: Ecto.UUID.generate(),
+        model_ref: %{model_id: "test-model", version: "v1"},
+        admission: %{timeout_ms: 10_000},
+        reasoning: %{
+          generation_policy: :disabled,
+          projection: :final_only,
+          source: :console_default,
+          effective_contract: negotiated_contract()
+        }
+      })
+
+    assert CanonicalRequestSerializer.serialize(canonical)["reasoning"] == %{
+             "generation_policy" => "disabled",
+             "projection" => "final_only",
+             "source" => "console_default",
+             "effective_contract" => %{
+               "mode" => "negotiated",
+               "model_artifact_digest" => String.duplicate("a", 64),
+               "chat_template_digest" => String.duplicate("b", 64),
+               "render_contract" => "synthetic-render-v1",
+               "render_contract_version" => "1",
+               "parser_family" => "synthetic-parser",
+               "parser_version" => "1",
+               "runtime_contract_version" => "1",
+               "event_binding_version" => "1"
+             }
+           }
   end
 
   test "serialize/1 rejects embedded structs in plain data fields" do
@@ -133,5 +169,19 @@ defmodule Orchard.Inference.CanonicalRequestSerializerTest do
     assert_raise ArgumentError, ~r/admission timeout must be a positive integer/, fn ->
       CanonicalRequestSerializer.serialize(canonical)
     end
+  end
+
+  defp negotiated_contract do
+    %{
+      mode: :negotiated,
+      model_artifact_digest: String.duplicate("a", 64),
+      chat_template_digest: String.duplicate("b", 64),
+      render_contract: "synthetic-render-v1",
+      render_contract_version: "1",
+      parser_family: "synthetic-parser",
+      parser_version: "1",
+      runtime_contract_version: "1",
+      event_binding_version: "1"
+    }
   end
 end

--- a/apps/orchard_controller/test/orchard/inference/chat_request_normalizer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_request_normalizer_test.exs
@@ -25,6 +25,13 @@ defmodule Orchard.Inference.ChatRequestNormalizerTest do
       assert req.sampling == %Sampling{temperature: 1.0, top_p: 1.0}
       assert req.response_format == %ResponseFormat{type: :text}
 
+      assert req.reasoning == %CanonicalRequest.Reasoning{
+               generation_policy: :model_default,
+               projection: :legacy_blended,
+               source: :omitted_public,
+               effective_contract: %{mode: :legacy}
+             }
+
       assert req.tooling == %Tooling{
                tools: [],
                requested_tools: [],

--- a/apps/orchard_controller/test/orchard/inference/chat_request_validator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_request_validator_test.exs
@@ -40,6 +40,18 @@ defmodule Orchard.Inference.ChatRequestValidatorTest do
       assert {:error, :unsupported_parameter, "frequency_penalty"} =
                ChatRequestValidator.validate(params)
     end
+
+    test "rejects unaccepted reasoning controls and arbitrary template keyword arguments" do
+      assert {:error, :unsupported_parameter, "reasoning"} =
+               @valid_params
+               |> Map.put("reasoning", %{"effort" => "low"})
+               |> ChatRequestValidator.validate()
+
+      assert {:error, :unsupported_parameter, "template_kwargs"} =
+               @valid_params
+               |> Map.put("template_kwargs", %{"enable_thinking" => false})
+               |> ChatRequestValidator.validate()
+    end
   end
 
   describe "required fields" do

--- a/apps/orchard_controller/test/orchard/inference/responses_request_normalizer_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/responses_request_normalizer_test.exs
@@ -32,6 +32,13 @@ defmodule Orchard.Inference.ResponsesRequestNormalizerTest do
     assert request.admission.timeout_ms == Orchard.Inference.request_timeout_ms()
     assert request.sampling.max_output_tokens == 128
     assert request.metadata == %{}
+
+    assert request.reasoning == %CanonicalRequest.Reasoning{
+             generation_policy: :model_default,
+             projection: :legacy_blended,
+             source: :omitted_public,
+             effective_contract: %{mode: :legacy}
+           }
   end
 
   test "prepends instructions as a system message and rewrites input_text parts" do

--- a/apps/orchard_controller/test/orchard/inference/responses_request_validator_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/responses_request_validator_test.exs
@@ -26,6 +26,18 @@ defmodule Orchard.Inference.ResponsesRequestValidatorTest do
     assert {:ok, _} = ResponsesRequestValidator.validate(params)
   end
 
+  test "rejects unaccepted reasoning controls and arbitrary template keyword arguments" do
+    assert {:error, :unsupported_parameter, "reasoning"} =
+             @valid_params
+             |> Map.put("reasoning", %{"effort" => "low"})
+             |> ResponsesRequestValidator.validate()
+
+    assert {:error, :unsupported_parameter, "template_kwargs"} =
+             @valid_params
+             |> Map.put("template_kwargs", %{"enable_thinking" => false})
+             |> ResponsesRequestValidator.validate()
+  end
+
   test "accepts array input items with text content parts" do
     params = %{
       @valid_params

--- a/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
+++ b/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
@@ -180,6 +180,98 @@ defmodule Orchard.Tokenizer.ClientTest do
   end
 
   test "negotiated reasoning sends only the v4 closed contract and verifies returned identity" do
+    fixture_root = fixture_root_with_tokenizer_config!()
+
+    {capture_executable, capture_file} =
+      write_capture_request_executable!(negotiated_capture_response())
+
+    on_exit(fn ->
+      File.rm(capture_executable)
+      File.rm(capture_file)
+      File.rm_rf!(fixture_root)
+    end)
+
+    with_inference_overrides(
+      [
+        tokenizer_mode: :port,
+        tokenizer_executable: capture_executable
+      ],
+      fn ->
+        assert {:ok, %{rendered_prompt: "negotiated", input_token_count: 2}} =
+                 Client.tokenize(negotiated_request(),
+                   manifest: huggingface_manifest(),
+                   bundle_root: fixture_root,
+                   bundle_sha256: trusted_bundle_sha256()
+                 )
+
+        assert {:ok, raw_request} = File.read(capture_file)
+
+        assert %{
+                 "contract_version" => 4,
+                 "command" => "render_and_count_reasoning",
+                 "assets" => %{
+                   "model_artifact_digest" => model_artifact_digest,
+                   "chat_template_digest" => chat_template_digest,
+                   "tokenizer_config_path" => tokenizer_config_path
+                 },
+                 "request" => %{
+                   "reasoning" => %{
+                     "generation_policy" => "disabled",
+                     "projection" => "final_only",
+                     "source" => "console_default",
+                     "effective_contract" => %{"mode" => "negotiated"} = effective_contract
+                   }
+                 }
+               } = Jason.decode!(raw_request)
+
+        assert effective_contract["model_artifact_digest"] == model_artifact_digest
+        assert effective_contract["chat_template_digest"] == chat_template_digest
+
+        assert tokenizer_config_path ==
+                 realpath!(Path.join(fixture_root, "tokenizer_config.json"))
+      end
+    )
+  end
+
+  test "negotiated reasoning resolves the manifest-declared tokenizer config path" do
+    fixture_root = fixture_root_with_tokenizer_config!()
+    declared_root = Path.join(fixture_root, "declared")
+    File.mkdir_p!(declared_root)
+    File.write!(Path.join(declared_root, "tokenizer_config.json"), Jason.encode!(%{}))
+
+    {capture_executable, capture_file} =
+      write_capture_request_executable!(negotiated_capture_response())
+
+    on_exit(fn ->
+      File.rm(capture_executable)
+      File.rm(capture_file)
+      File.rm_rf!(fixture_root)
+    end)
+
+    manifest = manifest_with_tokenizer_config_path("declared/tokenizer_config.json")
+
+    with_inference_overrides(
+      [
+        tokenizer_mode: :port,
+        tokenizer_executable: capture_executable
+      ],
+      fn ->
+        assert {:ok, %{rendered_prompt: "negotiated"}} =
+                 Client.tokenize(negotiated_request(),
+                   manifest: manifest,
+                   bundle_root: fixture_root,
+                   bundle_sha256: trusted_bundle_sha256()
+                 )
+
+        assert {:ok, raw_request} = File.read(capture_file)
+
+        assert Jason.decode!(raw_request)["assets"]["tokenizer_config_path"] ==
+                 realpath!(Path.join(declared_root, "tokenizer_config.json"))
+      end
+    )
+  end
+
+  test "negotiated reasoning fails closed without a tokenizer config asset" do
     {capture_executable, capture_file} =
       write_capture_request_executable!(negotiated_capture_response())
 
@@ -194,36 +286,51 @@ defmodule Orchard.Tokenizer.ClientTest do
         tokenizer_executable: capture_executable
       ],
       fn ->
-        assert {:ok, %{rendered_prompt: "negotiated", input_token_count: 2}} =
+        assert {:error, {:missing_assets, message}} =
                  Client.tokenize(negotiated_request(),
                    manifest: huggingface_manifest(),
                    bundle_root: huggingface_fixture_root(),
                    bundle_sha256: trusted_bundle_sha256()
                  )
 
-        assert {:ok, raw_request} = File.read(capture_file)
-
-        assert %{
-                 "contract_version" => 4,
-                 "command" => "render_and_count_reasoning",
-                 "assets" => %{
-                   "model_artifact_digest" => model_artifact_digest,
-                   "chat_template_digest" => chat_template_digest
-                 },
-                 "request" => %{
-                   "reasoning" => %{
-                     "generation_policy" => "disabled",
-                     "projection" => "final_only",
-                     "source" => "console_default",
-                     "effective_contract" => %{"mode" => "negotiated"} = effective_contract
-                   }
-                 }
-               } = Jason.decode!(raw_request)
-
-        assert effective_contract["model_artifact_digest"] == model_artifact_digest
-        assert effective_contract["chat_template_digest"] == chat_template_digest
+        assert message =~ "tokenizer.config_path"
+        refute File.exists?(capture_file)
       end
     )
+  end
+
+  test "negotiated reasoning refuses safe tokenization modes that demand segmented rendering" do
+    fixture_root = fixture_root_with_tokenizer_config!()
+
+    {capture_executable, capture_file} =
+      write_capture_request_executable!(negotiated_capture_response())
+
+    on_exit(fn ->
+      File.rm(capture_executable)
+      File.rm(capture_file)
+      File.rm_rf!(fixture_root)
+    end)
+
+    for safe_mode <- [:on, :reject] do
+      with_inference_overrides(
+        [
+          tokenizer_mode: :port,
+          tokenizer_safe_mode: safe_mode,
+          tokenizer_executable: capture_executable
+        ],
+        fn ->
+          assert {:error, {:invalid_input, message}} =
+                   Client.tokenize(negotiated_request(),
+                     manifest: safe_huggingface_manifest(),
+                     bundle_root: fixture_root,
+                     bundle_sha256: trusted_bundle_sha256()
+                   )
+
+          assert message =~ "tokenizer_safe_mode=#{inspect(safe_mode)}"
+          refute File.exists?(capture_file)
+        end
+      )
+    end
   end
 
   test "negotiated reasoning rejects a mismatched helper identity" do
@@ -247,8 +354,13 @@ defmodule Orchard.Tokenizer.ClientTest do
         }
       })
 
+    fixture_root = fixture_root_with_tokenizer_config!()
     response_executable = write_response_executable!(response)
-    on_exit(fn -> File.rm(response_executable) end)
+
+    on_exit(fn ->
+      File.rm(response_executable)
+      File.rm_rf!(fixture_root)
+    end)
 
     with_inference_overrides(
       [
@@ -259,7 +371,7 @@ defmodule Orchard.Tokenizer.ClientTest do
         assert {:error, :invalid_response} =
                  Client.tokenize(negotiated_request(),
                    manifest: huggingface_manifest(),
-                   bundle_root: huggingface_fixture_root(),
+                   bundle_root: fixture_root,
                    bundle_sha256: trusted_bundle_sha256()
                  )
       end
@@ -2728,6 +2840,13 @@ defmodule Orchard.Tokenizer.ClientTest do
       | tokenizer: %Tokenizer{tokenizer | config_path: config_path},
         safe_tokenization: safe_tokenization()
     }
+  end
+
+  defp manifest_with_tokenizer_config_path(config_path) do
+    base = huggingface_manifest()
+    %Tokenizer{} = tokenizer = base.tokenizer
+
+    %ModelManifest{base | tokenizer: %Tokenizer{tokenizer | config_path: config_path}}
   end
 
   defp explicit_preflight_compatible_manifest(opts \\ []) do

--- a/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
+++ b/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
@@ -179,6 +179,93 @@ defmodule Orchard.Tokenizer.ClientTest do
     )
   end
 
+  test "negotiated reasoning sends only the v4 closed contract and verifies returned identity" do
+    {capture_executable, capture_file} =
+      write_capture_request_executable!(negotiated_capture_response())
+
+    on_exit(fn ->
+      File.rm(capture_executable)
+      File.rm(capture_file)
+    end)
+
+    with_inference_overrides(
+      [
+        tokenizer_mode: :port,
+        tokenizer_executable: capture_executable
+      ],
+      fn ->
+        assert {:ok, %{rendered_prompt: "negotiated", input_token_count: 2}} =
+                 Client.tokenize(negotiated_request(),
+                   manifest: huggingface_manifest(),
+                   bundle_root: huggingface_fixture_root(),
+                   bundle_sha256: trusted_bundle_sha256()
+                 )
+
+        assert {:ok, raw_request} = File.read(capture_file)
+
+        assert %{
+                 "contract_version" => 4,
+                 "command" => "render_and_count_reasoning",
+                 "assets" => %{
+                   "model_artifact_digest" => model_artifact_digest,
+                   "chat_template_digest" => chat_template_digest
+                 },
+                 "request" => %{
+                   "reasoning" => %{
+                     "generation_policy" => "disabled",
+                     "projection" => "final_only",
+                     "source" => "console_default",
+                     "effective_contract" => %{"mode" => "negotiated"} = effective_contract
+                   }
+                 }
+               } = Jason.decode!(raw_request)
+
+        assert effective_contract["model_artifact_digest"] == model_artifact_digest
+        assert effective_contract["chat_template_digest"] == chat_template_digest
+      end
+    )
+  end
+
+  test "negotiated reasoning rejects a mismatched helper identity" do
+    response =
+      negotiated_capture_response(%{
+        "reasoning" => %{
+          "generation_policy" => "disabled",
+          "projection" => "final_only",
+          "source" => "console_default",
+          "effective_contract" => %{
+            "mode" => "negotiated",
+            "model_artifact_digest" => trusted_bundle_sha256(),
+            "chat_template_digest" => String.duplicate("b", 64),
+            "render_contract" => "synthetic-render-v1",
+            "render_contract_version" => "1",
+            "parser_family" => "synthetic-parser",
+            "parser_version" => "unexpected",
+            "runtime_contract_version" => "1",
+            "event_binding_version" => "1"
+          }
+        }
+      })
+
+    response_executable = write_response_executable!(response)
+    on_exit(fn -> File.rm(response_executable) end)
+
+    with_inference_overrides(
+      [
+        tokenizer_mode: :port,
+        tokenizer_executable: response_executable
+      ],
+      fn ->
+        assert {:error, :invalid_response} =
+                 Client.tokenize(negotiated_request(),
+                   manifest: huggingface_manifest(),
+                   bundle_root: huggingface_fixture_root(),
+                   bundle_sha256: trusted_bundle_sha256()
+                 )
+      end
+    )
+  end
+
   test "port mode rejects contract v3 response for render_and_count" do
     response_executable =
       write_response_executable!(%{
@@ -2598,6 +2685,27 @@ defmodule Orchard.Tokenizer.ClientTest do
     CanonicalRequest.new(Map.merge(base, Map.new(overrides)))
   end
 
+  defp negotiated_request do
+    canonical_request(%{
+      reasoning: %{
+        generation_policy: :disabled,
+        projection: :final_only,
+        source: :console_default,
+        effective_contract: %{
+          mode: :negotiated,
+          model_artifact_digest: trusted_bundle_sha256(),
+          chat_template_digest: String.duplicate("b", 64),
+          render_contract: "synthetic-render-v1",
+          render_contract_version: "1",
+          parser_family: "synthetic-parser",
+          parser_version: "1",
+          runtime_contract_version: "1",
+          event_binding_version: "1"
+        }
+      }
+    })
+  end
+
   defp huggingface_manifest do
     manifest_with_chat_template("chat_template.jinja")
   end
@@ -2957,6 +3065,35 @@ defmodule Orchard.Tokenizer.ClientTest do
 
   defp restore_skip_sentinel_preflight_env(value) do
     System.put_env("ORCHARD_TOKENIZER_SKIP_SENTINEL_PREFLIGHT", value)
+  end
+
+  defp negotiated_capture_response(overrides \\ %{}) do
+    result =
+      Map.merge(
+        %{
+          "rendered_prompt" => "negotiated",
+          "input_token_count" => 2,
+          "reasoning" => %{
+            "generation_policy" => "disabled",
+            "projection" => "final_only",
+            "source" => "console_default",
+            "effective_contract" => %{
+              "mode" => "negotiated",
+              "model_artifact_digest" => trusted_bundle_sha256(),
+              "chat_template_digest" => String.duplicate("b", 64),
+              "render_contract" => "synthetic-render-v1",
+              "render_contract_version" => "1",
+              "parser_family" => "synthetic-parser",
+              "parser_version" => "1",
+              "runtime_contract_version" => "1",
+              "event_binding_version" => "1"
+            }
+          }
+        },
+        overrides
+      )
+
+    %{contract_version: 4, ok: true, result: result}
   end
 
   defp legacy_capture_response do

--- a/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
+++ b/apps/orchard_controller/test/orchard/tokenizer_client_test.exs
@@ -299,6 +299,24 @@ defmodule Orchard.Tokenizer.ClientTest do
     )
   end
 
+  test "negotiated reasoning refuses tokenizer modes other than :port" do
+    fixture_root = fixture_root_with_tokenizer_config!()
+    on_exit(fn -> File.rm_rf!(fixture_root) end)
+
+    for tokenizer_mode <- [:fake, nil] do
+      with_inference_overrides([tokenizer_mode: tokenizer_mode], fn ->
+        assert {:error, {:invalid_input, message}} =
+                 Client.tokenize(negotiated_request(),
+                   manifest: huggingface_manifest(),
+                   bundle_root: fixture_root,
+                   bundle_sha256: trusted_bundle_sha256()
+                 )
+
+        assert message == "negotiated reasoning tokenization requires tokenizer_mode=:port"
+      end)
+    end
+  end
+
   test "negotiated reasoning refuses safe tokenization modes that demand segmented rendering" do
     fixture_root = fixture_root_with_tokenizer_config!()
 

--- a/apps/orchard_shared/lib/orchard/canonical_request.ex
+++ b/apps/orchard_shared/lib/orchard/canonical_request.ex
@@ -95,6 +95,31 @@ defmodule Orchard.CanonicalRequest do
             source: source(),
             effective_contract: effective_contract()
           }
+
+    @doc """
+    Renders the canonical reasoning policy into the single string-keyed wire shape
+    shared by durable persistence and tokenizer helper payloads.
+    """
+    @spec to_wire(t()) :: %{required(String.t()) => String.t() | map()}
+    def to_wire(%__MODULE__{} = reasoning) do
+      %{
+        "generation_policy" => Atom.to_string(reasoning.generation_policy),
+        "projection" => Atom.to_string(reasoning.projection),
+        "source" => Atom.to_string(reasoning.source),
+        "effective_contract" =>
+          Map.new(reasoning.effective_contract, fn {key, value} ->
+            {Atom.to_string(key), wire_value(value)}
+          end)
+      }
+    end
+
+    defp wire_value(value) when is_atom(value), do: Atom.to_string(value)
+    defp wire_value(value) when is_binary(value), do: value
+
+    defp wire_value(value) do
+      raise ArgumentError,
+            "#{inspect(__MODULE__)} effective_contract values must be atoms or binaries, got: #{inspect(value)}"
+    end
   end
 
   defmodule Admission do

--- a/apps/orchard_shared/lib/orchard/canonical_request.ex
+++ b/apps/orchard_shared/lib/orchard/canonical_request.ex
@@ -61,6 +61,42 @@ defmodule Orchard.CanonicalRequest do
           }
   end
 
+  defmodule Reasoning do
+    @moduledoc false
+
+    defstruct generation_policy: :model_default,
+              projection: :legacy_blended,
+              source: :omitted_public,
+              effective_contract: %{mode: :legacy}
+
+    @type generation_policy :: :model_default | :disabled | :enabled
+    @type projection :: :legacy_blended | :final_only | :reasoning_structured
+    @type source :: :omitted_public | :explicit_public | :console_default | :console_explicit
+
+    @type legacy_contract :: %{required(:mode) => :legacy}
+
+    @type negotiated_contract :: %{
+            required(:mode) => :negotiated,
+            required(:model_artifact_digest) => String.t(),
+            required(:chat_template_digest) => String.t(),
+            required(:render_contract) => String.t(),
+            required(:render_contract_version) => String.t(),
+            required(:parser_family) => String.t(),
+            required(:parser_version) => String.t(),
+            required(:runtime_contract_version) => String.t(),
+            required(:event_binding_version) => String.t()
+          }
+
+    @type effective_contract :: legacy_contract() | negotiated_contract()
+
+    @type t :: %__MODULE__{
+            generation_policy: generation_policy(),
+            projection: projection(),
+            source: source(),
+            effective_contract: effective_contract()
+          }
+  end
+
   defmodule Admission do
     @moduledoc false
 
@@ -93,7 +129,15 @@ defmodule Orchard.CanonicalRequest do
           }
   end
 
-  alias __MODULE__.{Admission, ModelRef, ResolvedPolicy, ResponseFormat, Sampling, Tooling}
+  alias __MODULE__.{
+    Admission,
+    ModelRef,
+    Reasoning,
+    ResolvedPolicy,
+    ResponseFormat,
+    Sampling,
+    Tooling
+  }
 
   @enforce_keys [:internal_id, :public_id, :endpoint, :tenant_id, :model_ref]
   defstruct internal_id: nil,
@@ -114,6 +158,7 @@ defmodule Orchard.CanonicalRequest do
             stream_include_usage: false,
             sampling: nil,
             response_format: nil,
+            reasoning: nil,
             tooling: nil,
             metadata: %{},
             admission: nil,
@@ -141,6 +186,7 @@ defmodule Orchard.CanonicalRequest do
           stream_include_usage: boolean(),
           sampling: Sampling.t(),
           response_format: ResponseFormat.t(),
+          reasoning: Reasoning.t(),
           tooling: Tooling.t(),
           metadata: map(),
           admission: Admission.t(),
@@ -160,11 +206,13 @@ defmodule Orchard.CanonicalRequest do
     |> cast_nested(:model_ref, ModelRef)
     |> cast_nested(:sampling, Sampling)
     |> cast_nested(:response_format, ResponseFormat)
+    |> cast_nested(:reasoning, Reasoning)
     |> cast_nested(:tooling, Tooling)
     |> cast_nested(:admission, Admission)
     |> cast_nested(:resolved_policy, ResolvedPolicy)
     |> put_default_struct(:sampling, %Sampling{})
     |> put_default_struct(:response_format, %ResponseFormat{})
+    |> put_default_struct(:reasoning, %Reasoning{})
     |> put_default_struct(:tooling, %Tooling{})
     |> put_default_struct(:admission, %Admission{})
     |> put_default_struct(:resolved_policy, %ResolvedPolicy{})
@@ -182,6 +230,7 @@ defmodule Orchard.CanonicalRequest do
     |> validate_store!()
     |> validate_stream!()
     |> validate_sampling!()
+    |> validate_reasoning!()
     |> validate_tooling!()
     |> validate_metadata!()
     |> validate_response_format!()
@@ -402,6 +451,107 @@ defmodule Orchard.CanonicalRequest do
             "#{inspect(__MODULE__)} sampling contains invalid temperature/top_p/max_output_tokens/stop/seed values: #{inspect(sampling)}"
     end
   end
+
+  defp validate_reasoning!(
+         %__MODULE__{
+           reasoning: %Reasoning{
+             generation_policy: generation_policy,
+             projection: projection,
+             source: source,
+             effective_contract: effective_contract
+           }
+         } = struct
+       )
+       when generation_policy in [:model_default, :disabled, :enabled] and
+              projection in [:legacy_blended, :final_only, :reasoning_structured] and
+              source in [:omitted_public, :explicit_public, :console_default, :console_explicit] do
+    validate_reasoning_combination!(generation_policy, projection, source, effective_contract)
+    struct
+  end
+
+  defp validate_reasoning!(%__MODULE__{reasoning: reasoning}) do
+    raise ArgumentError,
+          "#{inspect(__MODULE__)} reasoning must include a supported generation_policy, projection, source, and effective_contract, got: #{inspect(reasoning)}"
+  end
+
+  defp validate_reasoning_combination!(
+         :model_default,
+         :legacy_blended,
+         :omitted_public,
+         %{mode: :legacy} = effective_contract
+       ) do
+    if Map.keys(effective_contract) == [:mode] do
+      :ok
+    else
+      invalid_reasoning_contract!(
+        "omitted_public legacy reasoning must use exactly %{mode: :legacy}",
+        effective_contract
+      )
+    end
+  end
+
+  defp validate_reasoning_combination!(
+         :disabled,
+         :final_only,
+         :console_default,
+         effective_contract
+       ) do
+    validate_negotiated_reasoning_contract!(effective_contract)
+  end
+
+  defp validate_reasoning_combination!(generation_policy, :final_only, source, effective_contract)
+       when generation_policy in [:model_default, :disabled, :enabled] and
+              source in [:console_explicit, :explicit_public] do
+    validate_negotiated_reasoning_contract!(effective_contract)
+  end
+
+  defp validate_reasoning_combination!(generation_policy, projection, source, effective_contract) do
+    invalid_reasoning_contract!(
+      "unsupported reasoning combination #{inspect({generation_policy, projection, source})}",
+      effective_contract
+    )
+  end
+
+  defp validate_negotiated_reasoning_contract!(%{mode: :negotiated} = effective_contract) do
+    expected_keys = [
+      :mode,
+      :model_artifact_digest,
+      :chat_template_digest,
+      :render_contract,
+      :render_contract_version,
+      :parser_family,
+      :parser_version,
+      :runtime_contract_version,
+      :event_binding_version
+    ]
+
+    if Map.keys(effective_contract) |> Enum.sort() == Enum.sort(expected_keys) and
+         Enum.all?(
+           expected_keys -- [:mode],
+           &valid_contract_identity?(Map.get(effective_contract, &1))
+         ) do
+      :ok
+    else
+      invalid_reasoning_contract!(
+        "negotiated reasoning requires every exact identity field as a non-empty binary",
+        effective_contract
+      )
+    end
+  end
+
+  defp validate_negotiated_reasoning_contract!(effective_contract) do
+    invalid_reasoning_contract!(
+      "negotiated reasoning requires mode: :negotiated and every exact identity field",
+      effective_contract
+    )
+  end
+
+  defp invalid_reasoning_contract!(reason, effective_contract) do
+    raise ArgumentError,
+          "#{inspect(__MODULE__)} #{reason}, got: #{inspect(effective_contract)}"
+  end
+
+  defp valid_contract_identity?(value), do: is_binary(value) and value != ""
 
   defp validate_tooling!(
          %__MODULE__{

--- a/apps/orchard_shared/test/orchard/canonical_request_test.exs
+++ b/apps/orchard_shared/test/orchard/canonical_request_test.exs
@@ -147,6 +147,44 @@ defmodule Orchard.CanonicalRequestTest do
     end
   end
 
+  test "Reasoning.to_wire/1 renders one string-keyed shape for legacy and negotiated policies" do
+    assert CanonicalRequest.Reasoning.to_wire(base_request().reasoning) == %{
+             "generation_policy" => "model_default",
+             "projection" => "legacy_blended",
+             "source" => "omitted_public",
+             "effective_contract" => %{"mode" => "legacy"}
+           }
+
+    negotiated = %CanonicalRequest.Reasoning{
+      generation_policy: :disabled,
+      projection: :final_only,
+      source: :console_default,
+      effective_contract: negotiated_contract()
+    }
+
+    assert CanonicalRequest.Reasoning.to_wire(negotiated)["effective_contract"] == %{
+             "mode" => "negotiated",
+             "model_artifact_digest" => String.duplicate("a", 64),
+             "chat_template_digest" => String.duplicate("b", 64),
+             "render_contract" => "synthetic-render-v1",
+             "render_contract_version" => "1",
+             "parser_family" => "synthetic-parser",
+             "parser_version" => "1",
+             "runtime_contract_version" => "1",
+             "event_binding_version" => "1"
+           }
+  end
+
+  test "Reasoning.to_wire/1 rejects effective contract values that are not atoms or binaries" do
+    reasoning = %CanonicalRequest.Reasoning{
+      effective_contract: Map.put(negotiated_contract(), :render_contract_version, 1)
+    }
+
+    assert_raise ArgumentError, ~r/must be atoms or binaries/, fn ->
+      CanonicalRequest.Reasoning.to_wire(reasoning)
+    end
+  end
+
   defp negotiated_contract do
     %{
       mode: :negotiated,

--- a/apps/orchard_shared/test/orchard/canonical_request_test.exs
+++ b/apps/orchard_shared/test/orchard/canonical_request_test.exs
@@ -67,6 +67,100 @@ defmodule Orchard.CanonicalRequestTest do
                  end
   end
 
+  test "new/1 gives omitted public requests the exact legacy reasoning contract from SPEC.md 3.4" do
+    assert base_request().reasoning == %CanonicalRequest.Reasoning{
+             generation_policy: :model_default,
+             projection: :legacy_blended,
+             source: :omitted_public,
+             effective_contract: %{mode: :legacy}
+           }
+  end
+
+  test "new/1 accepts a complete negotiated final-only contract" do
+    request =
+      CanonicalRequest.new(%{
+        internal_id: "internal-negotiated",
+        public_id: "public-negotiated",
+        endpoint: :chat_completions,
+        tenant_id: "tenant-1",
+        model_ref: %{model_id: "model", version: "v1"},
+        reasoning: %{
+          generation_policy: :disabled,
+          projection: :final_only,
+          source: :console_default,
+          effective_contract: negotiated_contract()
+        }
+      })
+
+    assert request.reasoning.effective_contract == negotiated_contract()
+  end
+
+  test "new/1 rejects a contradictory console default reasoning policy" do
+    assert_raise ArgumentError, ~r/unsupported reasoning combination/, fn ->
+      CanonicalRequest.new(%{
+        internal_id: "internal-invalid-console",
+        public_id: "public-invalid-console",
+        endpoint: :chat_completions,
+        tenant_id: "tenant-1",
+        model_ref: %{model_id: "model", version: "v1"},
+        reasoning: %{
+          generation_policy: :enabled,
+          projection: :final_only,
+          source: :console_default,
+          effective_contract: negotiated_contract()
+        }
+      })
+    end
+  end
+
+  test "new/1 rejects legacy identity fields and unavailable structured projection" do
+    assert_raise ArgumentError, ~r/must use exactly/, fn ->
+      CanonicalRequest.new(%{
+        internal_id: "internal-invalid-legacy",
+        public_id: "public-invalid-legacy",
+        endpoint: :chat_completions,
+        tenant_id: "tenant-1",
+        model_ref: %{model_id: "model", version: "v1"},
+        reasoning: %{
+          generation_policy: :model_default,
+          projection: :legacy_blended,
+          source: :omitted_public,
+          effective_contract: %{mode: :legacy, parser_family: "invented"}
+        }
+      })
+    end
+
+    assert_raise ArgumentError, ~r/unsupported reasoning combination/, fn ->
+      CanonicalRequest.new(%{
+        internal_id: "internal-invalid-structured",
+        public_id: "public-invalid-structured",
+        endpoint: :chat_completions,
+        tenant_id: "tenant-1",
+        model_ref: %{model_id: "model", version: "v1"},
+        reasoning: %{
+          generation_policy: :enabled,
+          projection: :reasoning_structured,
+          source: :explicit_public,
+          effective_contract: negotiated_contract()
+        }
+      })
+    end
+  end
+
+  defp negotiated_contract do
+    %{
+      mode: :negotiated,
+      model_artifact_digest: String.duplicate("a", 64),
+      chat_template_digest: String.duplicate("b", 64),
+      render_contract: "synthetic-render-v1",
+      render_contract_version: "1",
+      parser_family: "synthetic-parser",
+      parser_version: "1",
+      runtime_contract_version: "1",
+      event_binding_version: "1"
+    }
+  end
+
   defp base_request do
     CanonicalRequest.new(%{
       internal_id: "internal-1",

--- a/native/orchard_tokenizer/README.md
+++ b/native/orchard_tokenizer/README.md
@@ -22,6 +22,16 @@ downloaded template and returns bounded booleans for parser recognition and
 definition/history rendering, never prompts or generated content. See package
 tests for the validated surface.
 
+Contract v4 adds the `render_and_count_reasoning` command for the negotiated
+reasoning contract in `../../SPEC.md` §3.5. Template arguments come only from
+the closed registry in `src/orchard_tokenizer/reasoning_contracts.py`, keyed by
+the exact model artifact digest, chat-template digest, generation policy, and
+projection; callers cannot pass template keyword arguments. That product
+registry is intentionally empty until an exact qualified artifact, template,
+and version tuple is accepted, so every negotiated request currently fails
+closed with `unsupported_reasoning_control`; package tests cover the contract
+with synthetic exact-identity fixtures.
+
 ## Validation
 
 Contract-v3 segmented rendering decodes tool-call history argument JSON into objects before template rendering and caller-string tagging.

--- a/native/orchard_tokenizer/src/orchard_tokenizer/cli.py
+++ b/native/orchard_tokenizer/src/orchard_tokenizer/cli.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
@@ -21,6 +22,7 @@ from orchard_tokenizer.catalog import (
     extract_safe_tokenization_catalog,
     extract_wrapper_tool_markers,
 )
+from orchard_tokenizer.reasoning_contracts import resolve as resolve_reasoning_contract
 from orchard_tokenizer.safe_segmented import (
     MarkerPair,
     SafeSegmentedError,
@@ -57,7 +59,10 @@ _EXTRACTABLE_SPECIAL_TOKENS: Final[frozenset[str]] = frozenset(
 )
 
 CONTRACT_VERSION: Final[int] = 3
-SUPPORTED_CONTRACT_VERSIONS: Final[frozenset[int]] = frozenset({1, 2, CONTRACT_VERSION})
+REASONING_RENDER_CONTRACT_VERSION: Final[int] = 4
+SUPPORTED_CONTRACT_VERSIONS: Final[frozenset[int]] = frozenset(
+    {1, 2, CONTRACT_VERSION, REASONING_RENDER_CONTRACT_VERSION}
+)
 HF_TOKENIZER_KINDS: Final[set[str]] = {"huggingface_tokenizer_json", "tokenizer_json"}
 SENTENCEPIECE_KINDS: Final[set[str]] = {
     "sentencepiece_model",
@@ -235,6 +240,19 @@ def execute_contract(payload: dict[str, Any]) -> dict[str, Any]:
     if command == "render_and_count":
         return _execute_render_and_count(payload, int(contract_version))
 
+    if command == "render_and_count_reasoning":
+        if int(contract_version) != REASONING_RENDER_CONTRACT_VERSION:
+            raise TokenizerCliError(
+                "invalid_input",
+                "render_and_count_reasoning requires contract_version 4",
+                2,
+            )
+
+        return {
+            "contract_version": int(contract_version),
+            **_execute_render_and_count_reasoning(payload),
+        }
+
     if command == "render_and_count_segmented":
         if int(contract_version) != CONTRACT_VERSION:
             raise TokenizerCliError(
@@ -365,6 +383,109 @@ def _execute_render_and_count(payload: dict[str, Any], contract_version: int) ->
         "contract_version": contract_version,
         "rendered_prompt": rendered_prompt,
         "input_token_count": input_token_count,
+    }
+
+
+def _execute_render_and_count_reasoning(payload: dict[str, Any]) -> dict[str, Any]:
+    _require_exact_keys(payload, {"contract_version", "command", "assets", "request"}, "payload")
+    assets = require_mapping(payload, "assets")
+    request = require_mapping(payload, "request")
+    _require_exact_keys(
+        assets,
+        {
+            "tokenizer_kind",
+            "tokenizer_path",
+            "chat_template_path",
+            "model_artifact_digest",
+            "chat_template_digest",
+        },
+        "assets",
+    )
+    _require_exact_keys(
+        request,
+        {"input_items", "tools", "tool_choice", "reasoning"},
+        "request",
+    )
+
+    tokenizer_kind = require_non_empty_string(assets, "tokenizer_kind", category="invalid_input")
+    tokenizer_path = Path(
+        require_non_empty_string(assets, "tokenizer_path", category="missing_assets")
+    )
+    chat_template_path = Path(
+        require_non_empty_string(assets, "chat_template_path", category="missing_assets")
+    )
+    model_artifact_digest = _require_sha256_digest(assets, "model_artifact_digest")
+    chat_template_digest = _require_sha256_digest(assets, "chat_template_digest")
+    _verify_chat_template_digest(chat_template_path, chat_template_digest)
+
+    reasoning = require_mapping(request, "reasoning")
+    _require_exact_keys(
+        reasoning,
+        {"generation_policy", "projection", "source", "effective_contract"},
+        "request.reasoning",
+    )
+    generation_policy = _require_reasoning_enum(
+        reasoning,
+        "generation_policy",
+        {"model_default", "disabled", "enabled"},
+    )
+    projection = _require_reasoning_enum(
+        reasoning,
+        "projection",
+        {"final_only"},
+    )
+    source = _require_reasoning_enum(
+        reasoning,
+        "source",
+        {"console_default", "console_explicit", "explicit_public"},
+    )
+
+    resolved_contract = resolve_reasoning_contract(
+        model_artifact_digest,
+        chat_template_digest,
+        generation_policy,
+        projection,
+    )
+
+    if resolved_contract is None:
+        raise TokenizerCliError(
+            "unsupported_reasoning_control",
+            "no exact tokenizer reasoning contract supports this request",
+            2,
+        )
+
+    if reasoning["effective_contract"] != resolved_contract.effective_contract:
+        raise TokenizerCliError(
+            "unsupported_reasoning_control",
+            "requested reasoning contract does not match the exact tokenizer contract",
+            2,
+        )
+
+    messages = normalize_messages(request)
+    tools = normalize_optional_tools(request["tools"])
+    tool_choice = request["tool_choice"]
+    prompt_lines = [f"{message['role']} {message['content']}" for message in messages]
+    tokenizer_config_path = tokenizer_path.parent / "tokenizer_config.json"
+    rendered_prompt = render_prompt(
+        messages,
+        prompt_lines,
+        chat_template_path,
+        tokenizer_config_path,
+        tools=tools,
+        tool_choice=tool_choice,
+        template_arguments=resolved_contract.template_arguments,
+    )
+    input_token_count = count_tokens(rendered_prompt, tokenizer_kind, tokenizer_path)
+
+    return {
+        "rendered_prompt": rendered_prompt,
+        "input_token_count": input_token_count,
+        "reasoning": {
+            "generation_policy": generation_policy,
+            "projection": projection,
+            "source": source,
+            "effective_contract": resolved_contract.effective_contract,
+        },
     }
 
 
@@ -747,6 +868,57 @@ def _first_diff_offset(left: str, right: str) -> int:
     return min(len(left), len(right))
 
 
+def _require_exact_keys(value: dict[str, Any], expected: set[str], field_name: str) -> None:
+    if set(value) != expected:
+        raise TokenizerCliError(
+            "invalid_input",
+            f"{field_name} has unsupported or missing fields",
+            2,
+        )
+
+
+def _require_sha256_digest(payload: dict[str, Any], field_name: str) -> str:
+    value = require_non_empty_string(payload, field_name, category="invalid_input")
+
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise TokenizerCliError(
+            "invalid_input",
+            f"{field_name} must be a lowercase SHA-256 digest",
+            2,
+        )
+
+    return value
+
+
+def _verify_chat_template_digest(path: Path, expected_digest: str) -> None:
+    try:
+        actual_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise TokenizerCliError(
+            "missing_assets", f"chat template asset is missing: {path}", 3
+        ) from exc
+
+    if actual_digest != expected_digest:
+        raise TokenizerCliError(
+            "unsupported_reasoning_control",
+            "chat template digest does not match the exact tokenizer contract",
+            2,
+        )
+
+
+def _require_reasoning_enum(payload: dict[str, Any], field_name: str, supported: set[str]) -> str:
+    value = payload.get(field_name)
+
+    if value in supported:
+        return cast(str, value)
+
+    raise TokenizerCliError(
+        "invalid_input",
+        f"request.reasoning.{field_name} is unsupported",
+        2,
+    )
+
+
 def require_mapping(payload: dict[str, Any], field_name: str) -> dict[str, Any]:
     value = payload.get(field_name)
 
@@ -1026,6 +1198,7 @@ def render_prompt(
     tool_choice: Any = None,
     render_time: datetime | None = None,
     marker_pairs: Sequence[MarkerPair] = (),
+    template_arguments: Mapping[str, bool] | None = None,
 ) -> str:
     if not chat_template_path.is_file():
         raise TokenizerCliError(
@@ -1067,6 +1240,7 @@ def render_prompt(
             tools=tools,
             tool_choice=tool_choice,
             **special_tokens,
+            **(template_arguments or {}),
         )
     except TemplateRequestError as exc:
         raise TokenizerCliError(

--- a/native/orchard_tokenizer/src/orchard_tokenizer/cli.py
+++ b/native/orchard_tokenizer/src/orchard_tokenizer/cli.py
@@ -60,6 +60,7 @@ _EXTRACTABLE_SPECIAL_TOKENS: Final[frozenset[str]] = frozenset(
 
 CONTRACT_VERSION: Final[int] = 3
 REASONING_RENDER_CONTRACT_VERSION: Final[int] = 4
+RENDER_AND_COUNT_CONTRACT_VERSIONS: Final[frozenset[int]] = frozenset({1, 2, CONTRACT_VERSION})
 SUPPORTED_CONTRACT_VERSIONS: Final[frozenset[int]] = frozenset(
     {1, 2, CONTRACT_VERSION, REASONING_RENDER_CONTRACT_VERSION}
 )
@@ -238,6 +239,13 @@ def execute_contract(payload: dict[str, Any]) -> dict[str, Any]:
         )
 
     if command == "render_and_count":
+        if int(contract_version) not in RENDER_AND_COUNT_CONTRACT_VERSIONS:
+            raise TokenizerCliError(
+                "invalid_input",
+                "render_and_count requires contract_version 1, 2, or 3",
+                2,
+            )
+
         return _execute_render_and_count(payload, int(contract_version))
 
     if command == "render_and_count_reasoning":
@@ -395,6 +403,7 @@ def _execute_render_and_count_reasoning(payload: dict[str, Any]) -> dict[str, An
         {
             "tokenizer_kind",
             "tokenizer_path",
+            "tokenizer_config_path",
             "chat_template_path",
             "model_artifact_digest",
             "chat_template_digest",
@@ -411,11 +420,22 @@ def _execute_render_and_count_reasoning(payload: dict[str, Any]) -> dict[str, An
     tokenizer_path = Path(
         require_non_empty_string(assets, "tokenizer_path", category="missing_assets")
     )
+    tokenizer_config_path = Path(
+        require_non_empty_string(assets, "tokenizer_config_path", category="missing_assets")
+    )
     chat_template_path = Path(
         require_non_empty_string(assets, "chat_template_path", category="missing_assets")
     )
     model_artifact_digest = _require_sha256_digest(assets, "model_artifact_digest")
     chat_template_digest = _require_sha256_digest(assets, "chat_template_digest")
+
+    if not tokenizer_config_path.is_file():
+        raise TokenizerCliError(
+            "missing_assets",
+            f"tokenizer config asset is missing: {tokenizer_config_path}",
+            3,
+        )
+
     _verify_chat_template_digest(chat_template_path, chat_template_digest)
 
     reasoning = require_mapping(request, "reasoning")
@@ -465,7 +485,6 @@ def _execute_render_and_count_reasoning(payload: dict[str, Any]) -> dict[str, An
     tools = normalize_optional_tools(request["tools"])
     tool_choice = request["tool_choice"]
     prompt_lines = [f"{message['role']} {message['content']}" for message in messages]
-    tokenizer_config_path = tokenizer_path.parent / "tokenizer_config.json"
     rendered_prompt = render_prompt(
         messages,
         prompt_lines,

--- a/native/orchard_tokenizer/src/orchard_tokenizer/reasoning_contracts.py
+++ b/native/orchard_tokenizer/src/orchard_tokenizer/reasoning_contracts.py
@@ -1,0 +1,91 @@
+"""Closed exact-identity render contracts for negotiated reasoning requests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final, TypeAlias
+
+ContractKey: TypeAlias = tuple[str, str]
+PolicyKey: TypeAlias = tuple[str, str]
+ContractRegistration: TypeAlias = Mapping[str, object]
+
+_IDENTITY_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "render_contract",
+        "render_contract_version",
+        "parser_family",
+        "parser_version",
+        "runtime_contract_version",
+        "event_binding_version",
+    }
+)
+_REQUIRED_REGISTRATION_FIELDS: Final[frozenset[str]] = _IDENTITY_FIELDS | {"template_arguments"}
+
+# Product registrations are intentionally empty until an exact imported artifact,
+# template, render/parser/runtime/event versions, and qualification evidence are
+# accepted together. This registry is the only authority for negotiated rendering;
+# callers cannot supply template keyword arguments.
+REASONING_RENDER_CONTRACTS: Final[
+    Mapping[ContractKey, Mapping[PolicyKey, ContractRegistration]]
+] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedReasoningContract:
+    """Exact render identity and static template arguments for one policy."""
+
+    effective_contract: dict[str, str]
+    template_arguments: dict[str, bool]
+
+
+def resolve(
+    model_artifact_digest: str,
+    chat_template_digest: str,
+    generation_policy: str,
+    projection: str,
+) -> ResolvedReasoningContract | None:
+    """Return the registered exact contract, or ``None`` when unsupported."""
+    registration = REASONING_RENDER_CONTRACTS.get(
+        (model_artifact_digest, chat_template_digest), {}
+    ).get((generation_policy, projection))
+
+    if registration is None:
+        return None
+
+    return _resolved_contract(
+        model_artifact_digest,
+        chat_template_digest,
+        registration,
+    )
+
+
+def _resolved_contract(
+    model_artifact_digest: str,
+    chat_template_digest: str,
+    registration: ContractRegistration,
+) -> ResolvedReasoningContract:
+    if set(registration) != _REQUIRED_REGISTRATION_FIELDS:
+        raise ValueError("reasoning contract registration has unsupported fields")
+
+    identity = {field: registration.get(field) for field in _IDENTITY_FIELDS}
+
+    if not all(isinstance(value, str) and value for value in identity.values()):
+        raise ValueError("reasoning contract registration has invalid identity metadata")
+
+    template_arguments = registration.get("template_arguments")
+    if not isinstance(template_arguments, Mapping) or not all(
+        isinstance(key, str) and key and isinstance(value, bool)
+        for key, value in template_arguments.items()
+    ):
+        raise ValueError("reasoning contract registration has invalid template arguments")
+
+    return ResolvedReasoningContract(
+        effective_contract={
+            "mode": "negotiated",
+            "model_artifact_digest": model_artifact_digest,
+            "chat_template_digest": chat_template_digest,
+            **identity,
+        },
+        template_arguments=dict(template_arguments),
+    )

--- a/native/orchard_tokenizer/tests/test_cli.py
+++ b/native/orchard_tokenizer/tests/test_cli.py
@@ -235,9 +235,12 @@ def tokenization_payload(
     }
 
 
-def test_reasoning_render_contract_requires_an_exact_registered_identity(capsys) -> None:
+def test_reasoning_render_contract_requires_an_exact_registered_identity(
+    tmp_path: Path, capsys
+) -> None:
     payload = reasoning_tokenization_payload(
         tokenizer_path=fixture_root() / "tokenizer.json",
+        tokenizer_config_path=write_tokenizer_config(tmp_path),
         chat_template_path=fixture_root() / "chat_template.jinja",
     )
 
@@ -269,21 +272,16 @@ def test_reasoning_render_contract_uses_only_synthetic_registered_template_argum
         "REASONING_RENDER_CONTRACTS",
         {
             (model_digest, template_digest): {
-                ("disabled", "final_only"): {
-                    "render_contract": "synthetic-render-v1",
-                    "render_contract_version": "1",
-                    "parser_family": "synthetic-parser",
-                    "parser_version": "1",
-                    "runtime_contract_version": "1",
-                    "event_binding_version": "1",
-                    "template_arguments": {"enable_thinking": False},
-                }
+                ("disabled", "final_only"): synthetic_registration(
+                    template_arguments={"enable_thinking": False}
+                )
             }
         },
     )
 
     payload = reasoning_tokenization_payload(
         tokenizer_path=fixture_root() / "tokenizer.json",
+        tokenizer_config_path=write_tokenizer_config(tmp_path),
         chat_template_path=template_path,
         model_artifact_digest=model_digest,
         chat_template_digest=template_digest,
@@ -308,9 +306,10 @@ def test_reasoning_render_contract_uses_only_synthetic_registered_template_argum
     }
 
 
-def test_reasoning_render_contract_rejects_request_template_kwargs(capsys) -> None:
+def test_reasoning_render_contract_rejects_request_template_kwargs(tmp_path: Path, capsys) -> None:
     payload = reasoning_tokenization_payload(
         tokenizer_path=fixture_root() / "tokenizer.json",
+        tokenizer_config_path=write_tokenizer_config(tmp_path),
         chat_template_path=fixture_root() / "chat_template.jinja",
     )
     payload["request"]["template_kwargs"] = {"enable_thinking": False}
@@ -322,9 +321,104 @@ def test_reasoning_render_contract_rejects_request_template_kwargs(capsys) -> No
     assert response["error"]["message"] == "request has unsupported or missing fields"
 
 
+def test_reasoning_render_contract_reads_the_declared_tokenizer_config_path(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    template_path = tmp_path / "chat_template.jinja"
+    template_path.write_text("{{ eos_token }}|{{ messages[-1]['content'] }}", encoding="utf-8")
+    template_digest = hashlib.sha256(template_path.read_bytes()).hexdigest()
+    model_digest = "a" * 64
+    declared_config_root = tmp_path / "declared"
+    declared_config_root.mkdir()
+
+    monkeypatch.setattr(
+        reasoning_contracts,
+        "REASONING_RENDER_CONTRACTS",
+        {
+            (model_digest, template_digest): {
+                ("disabled", "final_only"): synthetic_registration(template_arguments={})
+            }
+        },
+    )
+
+    payload = reasoning_tokenization_payload(
+        tokenizer_path=fixture_root() / "tokenizer.json",
+        tokenizer_config_path=write_tokenizer_config(
+            declared_config_root, {"eos_token": "<|declared-eos|>"}
+        ),
+        chat_template_path=template_path,
+        model_artifact_digest=model_digest,
+        chat_template_digest=template_digest,
+    )
+
+    assert main(["--request-json", json.dumps(payload)]) == 0
+
+    response = json.loads(capsys.readouterr().out)
+    assert response["result"]["rendered_prompt"] == "<|declared-eos|>|hello orchard"
+
+
+def test_reasoning_render_contract_fails_closed_without_a_tokenizer_config_asset(
+    tmp_path: Path, capsys
+) -> None:
+    payload = reasoning_tokenization_payload(
+        tokenizer_path=fixture_root() / "tokenizer.json",
+        tokenizer_config_path=tmp_path / "tokenizer_config.json",
+        chat_template_path=fixture_root() / "chat_template.jinja",
+    )
+
+    assert main(["--request-json", json.dumps(payload)]) == 3
+
+    response = json.loads(capsys.readouterr().out)
+    assert response["contract_version"] == 4
+    assert response["error"]["category"] == "missing_assets"
+    assert "tokenizer config asset is missing" in response["error"]["message"]
+
+
+def test_render_and_count_rejects_the_reasoning_contract_version(capsys) -> None:
+    payload = tokenization_payload(
+        tokenizer_kind="huggingface_tokenizer_json",
+        tokenizer_path=fixture_root() / "tokenizer.json",
+        chat_template_path=fixture_root() / "chat_template.jinja",
+        contract_version=4,
+    )
+
+    assert main(["--request-json", json.dumps(payload)]) == 2
+
+    response = json.loads(capsys.readouterr().out)
+    assert response == {
+        "contract_version": 4,
+        "ok": False,
+        "error": {
+            "category": "invalid_input",
+            "message": "render_and_count requires contract_version 1, 2, or 3",
+        },
+    }
+
+
+def synthetic_registration(*, template_arguments: dict[str, bool]) -> dict[str, Any]:
+    return {
+        "render_contract": "synthetic-render-v1",
+        "render_contract_version": "1",
+        "parser_family": "synthetic-parser",
+        "parser_version": "1",
+        "runtime_contract_version": "1",
+        "event_binding_version": "1",
+        "template_arguments": template_arguments,
+    }
+
+
+def write_tokenizer_config(
+    directory: Path, contents: dict[str, Any] | None = None, name: str = "tokenizer_config.json"
+) -> Path:
+    tokenizer_config_path = directory / name
+    tokenizer_config_path.write_text(json.dumps(contents or {}), encoding="utf-8")
+    return tokenizer_config_path
+
+
 def reasoning_tokenization_payload(
     *,
     tokenizer_path: Path,
+    tokenizer_config_path: Path,
     chat_template_path: Path,
     model_artifact_digest: str = "a" * 64,
     chat_template_digest: str | None = None,
@@ -339,6 +433,7 @@ def reasoning_tokenization_payload(
         "assets": {
             "tokenizer_kind": "huggingface_tokenizer_json",
             "tokenizer_path": str(tokenizer_path),
+            "tokenizer_config_path": str(tokenizer_config_path),
             "chat_template_path": str(chat_template_path),
             "model_artifact_digest": model_artifact_digest,
             "chat_template_digest": template_digest,

--- a/native/orchard_tokenizer/tests/test_cli.py
+++ b/native/orchard_tokenizer/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from copy import deepcopy
 from pathlib import Path
@@ -13,7 +14,7 @@ from tokenizers.models import BPE
 from tokenizers.pre_tokenizers import ByteLevel
 from tokenizers.trainers import BpeTrainer
 
-from orchard_tokenizer import __version__
+from orchard_tokenizer import __version__, reasoning_contracts
 from orchard_tokenizer.cli import (
     TokenizerCliError,
     build_error_response,
@@ -230,6 +231,141 @@ def tokenization_payload(
                 {"role": "system", "content": "orchard"},
                 {"role": "user", "content": [{"type": "text", "text": "hello orchard"}]},
             ]
+        },
+    }
+
+
+def test_reasoning_render_contract_requires_an_exact_registered_identity(capsys) -> None:
+    payload = reasoning_tokenization_payload(
+        tokenizer_path=fixture_root() / "tokenizer.json",
+        chat_template_path=fixture_root() / "chat_template.jinja",
+    )
+
+    assert main(["--request-json", json.dumps(payload)]) == 2
+
+    response = json.loads(capsys.readouterr().out)
+    assert response == {
+        "contract_version": 4,
+        "ok": False,
+        "error": {
+            "category": "unsupported_reasoning_control",
+            "message": "no exact tokenizer reasoning contract supports this request",
+        },
+    }
+
+
+def test_reasoning_render_contract_uses_only_synthetic_registered_template_arguments(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    template_path = tmp_path / "chat_template.jinja"
+    template_path.write_text(
+        "{{ enable_thinking }}|{{ messages[-1]['content'] }}", encoding="utf-8"
+    )
+    template_digest = hashlib.sha256(template_path.read_bytes()).hexdigest()
+    model_digest = "a" * 64
+
+    monkeypatch.setattr(
+        reasoning_contracts,
+        "REASONING_RENDER_CONTRACTS",
+        {
+            (model_digest, template_digest): {
+                ("disabled", "final_only"): {
+                    "render_contract": "synthetic-render-v1",
+                    "render_contract_version": "1",
+                    "parser_family": "synthetic-parser",
+                    "parser_version": "1",
+                    "runtime_contract_version": "1",
+                    "event_binding_version": "1",
+                    "template_arguments": {"enable_thinking": False},
+                }
+            }
+        },
+    )
+
+    payload = reasoning_tokenization_payload(
+        tokenizer_path=fixture_root() / "tokenizer.json",
+        chat_template_path=template_path,
+        model_artifact_digest=model_digest,
+        chat_template_digest=template_digest,
+    )
+
+    assert main(["--request-json", json.dumps(payload)]) == 0
+
+    response = json.loads(capsys.readouterr().out)
+    assert response["contract_version"] == 4
+    assert response["ok"] is True
+    assert response["result"]["rendered_prompt"] == "False|hello orchard"
+    assert response["result"]["reasoning"]["effective_contract"] == {
+        "mode": "negotiated",
+        "model_artifact_digest": model_digest,
+        "chat_template_digest": template_digest,
+        "render_contract": "synthetic-render-v1",
+        "render_contract_version": "1",
+        "parser_family": "synthetic-parser",
+        "parser_version": "1",
+        "runtime_contract_version": "1",
+        "event_binding_version": "1",
+    }
+
+
+def test_reasoning_render_contract_rejects_request_template_kwargs(capsys) -> None:
+    payload = reasoning_tokenization_payload(
+        tokenizer_path=fixture_root() / "tokenizer.json",
+        chat_template_path=fixture_root() / "chat_template.jinja",
+    )
+    payload["request"]["template_kwargs"] = {"enable_thinking": False}
+
+    assert main(["--request-json", json.dumps(payload)]) == 2
+
+    response = json.loads(capsys.readouterr().out)
+    assert response["error"]["category"] == "invalid_input"
+    assert response["error"]["message"] == "request has unsupported or missing fields"
+
+
+def reasoning_tokenization_payload(
+    *,
+    tokenizer_path: Path,
+    chat_template_path: Path,
+    model_artifact_digest: str = "a" * 64,
+    chat_template_digest: str | None = None,
+) -> dict[str, Any]:
+    template_digest = (
+        chat_template_digest or hashlib.sha256(chat_template_path.read_bytes()).hexdigest()
+    )
+
+    return {
+        "contract_version": 4,
+        "command": "render_and_count_reasoning",
+        "assets": {
+            "tokenizer_kind": "huggingface_tokenizer_json",
+            "tokenizer_path": str(tokenizer_path),
+            "chat_template_path": str(chat_template_path),
+            "model_artifact_digest": model_artifact_digest,
+            "chat_template_digest": template_digest,
+        },
+        "request": {
+            "input_items": [
+                {"role": "system", "content": "orchard"},
+                {"role": "user", "content": "hello orchard"},
+            ],
+            "tools": [],
+            "tool_choice": None,
+            "reasoning": {
+                "generation_policy": "disabled",
+                "projection": "final_only",
+                "source": "console_default",
+                "effective_contract": {
+                    "mode": "negotiated",
+                    "model_artifact_digest": model_artifact_digest,
+                    "chat_template_digest": template_digest,
+                    "render_contract": "synthetic-render-v1",
+                    "render_contract_version": "1",
+                    "parser_family": "synthetic-parser",
+                    "parser_version": "1",
+                    "runtime_contract_version": "1",
+                    "event_binding_version": "1",
+                },
+            },
         },
     }
 

--- a/openspec/changes/define-reasoning-output-contract/tasks.md
+++ b/openspec/changes/define-reasoning-output-contract/tasks.md
@@ -10,10 +10,10 @@
 
 ## 2. Implement canonical policy and rendering
 
-- [ ] 2.1 Add canonical generation policy, projection, provenance, and exact effective-contract types without changing omitted-request behavior.
-- [ ] 2.2 Add closed tokenizer mappings for supported exact model artifact and chat-template contracts.
-- [ ] 2.3 Return and validate exact model artifact, chat-template, render contract, parser, runtime contract, and event-binding metadata before dispatch.
-- [ ] 2.4 Reject arbitrary template keyword arguments and unsupported explicit controls before scheduling or dispatch.
+- [x] 2.1 Add canonical generation policy, projection, provenance, and exact effective-contract types without changing omitted-request behavior.
+- [x] 2.2 Add a closed tokenizer mapping infrastructure for supported exact model artifact and chat-template contracts. The production registry is intentionally empty until an exact qualified tuple is accepted; synthetic exact-identity fixtures cover the fail-closed contract.
+- [x] 2.3 Return and validate exact model artifact, chat-template, render contract, parser, runtime contract, and event-binding metadata before dispatch.
+- [x] 2.4 Reject arbitrary template keyword arguments and unsupported explicit controls before scheduling or dispatch.
 
 ## 3. Implement negotiated runtime contracts
 


### PR DESCRIPTION
## Intent

Implement #326's provider-neutral canonical reasoning-policy and exact render-identity foundation without exposing a public reasoning field or starting #327/#328. Omitted Chat Completions and Responses retain byte-compatible legacy model_default plus legacy_blended behavior and their existing body-hash/idempotency domain. Add a closed, fail-closed static tokenizer mapping and V4 helper negotiation, but deliberately leave the production registry empty because no approved model tuple exists; use synthetic exact-identity fixtures only. Reject public reasoning/template kwargs and invalid canonical pairs. Do not add runtime-endpoint negotiation, parser/projection, retry, capture, or Console work. A real Qwen3.8 tuple remains blocked until later #196 qualification/#391 exact artifact/template/version evidence.

## What Changed

- Added `Orchard.CanonicalRequest.Reasoning` in `orchard_shared` (`generation_policy`, `projection`, `source`, `effective_contract`) with a closed accept/reject matrix over canonical tuples: `%{mode: :legacy}` only for `model_default`/`legacy_blended`/`omitted_public`, and `mode: :negotiated` only with every exact identity field (artifact/template digests, render contract + version, parser family + version, runtime contract, event binding) present as a non-empty binary. `new/1` defaults every request to the legacy triple, and `CanonicalRequestSerializer` omits the `reasoning` key for exactly that default — so persisted `canonical_request` bodies, `body_hash`, and the idempotency domain stay byte-compatible for omitted Chat Completions and Responses requests; any other shape raises `ArgumentError` like the module's other malformed-input paths.
- Added tokenizer helper contract v4 (`render_and_count_reasoning`). `Orchard.Tokenizer.Client` builds a negotiated plan only under `tokenizer_mode=:port` and `tokenizer_safe_mode=:off` (rejecting `:on`/`:reject` as `invalid_input`, since segmented caller-string rendering does not exist for the v4 shape yet), and rejects the response unless the helper's returned reasoning echo equals the requested contract byte-for-byte. The native helper resolves template arguments solely from a closed registry keyed on `(model_artifact_digest, chat_template_digest)` × `(generation_policy, projection)`, re-hashes the on-disk chat template against the manifest digest, and accepts no caller-supplied template kwargs. The production registry in `reasoning_contracts.py` is intentionally empty pending an approved qualified model tuple, so every negotiated request fails closed with `unsupported_reasoning_control`; `render_and_count` is pinned to contract versions 1–3. Segmented asset resolution was factored into a shared manifest-configured resolver so the negotiated path resolves `tokenizer.config_path` (with sibling fallback) the same way.
- Test and doc coverage: canonical reasoning pair matrix, serializer legacy-omission and negotiated wire shape, tokenizer client v4 plan construction / echo mismatch / mode and safe-mode refusals, and native CLI coverage driven by synthetic exact-identity fixtures. Validator tests pin that public `reasoning` and `template_kwargs` stay rejected as `unsupported_parameter` on both endpoints; `native/orchard_tokenizer/README.md` documents the v4 command and the deliberately empty registry, and the OpenSpec change's phase-2 tasks are marked done with the empty-registry qualification noted. No runtime-endpoint negotiation, parser/projection, retry, capture, or Console work is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk Assessment

✅ Low: The follow-up commit resolves every round-1 finding the user chose to fix with direct test coverage on both the Elixir and Python sides, strengthens the negotiated path to fail closed rather than silently degrade, and leaves the legacy render path, serializer output, and body-hash/idempotency domain provably unchanged while the reasoning registry stays empty and unreachable in production.

## Testing

Baseline targeted suites for every changed file passed (canonical request 12, serializer/validators/normalizers 97, tokenizer client 75, native CLI 165), as did the adjacent safe-tokenization and tokenizer telemetry tests touched by the asset-resolution refactor. On top of those I produced product-level evidence: real HTTP transcripts showing `reasoning`/`template_kwargs` rejected with 400 on both public endpoints and omitted requests returning normal 200s with a persisted canonical request that has no `reasoning` key and an unchanged body-hash/idempotency domain (409 on a changed body); captured helper stdin payloads proving omitted requests still send the byte-identical contract v2 `render_and_count` shape while only negotiated requests send v4; and real `orchard-tokenizer` CLI runs proving the production registry is empty, every negotiated render fails closed, caller template kwargs and digest tampering are refused, and negotiated rendering works only via a synthetic exact-identity registration. There is no visual artifact because the change is deliberately scoped away from Console/UI work — the intent forbids Console changes and the diff touches no Console file, so the end-user surfaces here are the HTTP API and the tokenizer CLI, both captured as transcripts. I closed one coverage gap with a focused regression test for the negotiated-reasoning `tokenizer_mode != :port` guard; no failures, flakes, or unresolved setup issues remain.

<details>
<summary>Evidence: Public reasoning/template controls rejected on both endpoints (HTTP 400 transcripts)</summary>

<code>$ curl -sS -X POST http://localhost:4000/v1/responses -d &#39;{&#34;input&#34;:&#34;hi&#34;,&#34;model&#34;:&#34;reasoning-evidence-model@v1&#34;,&#34;reasoning&#34;:{&#34;effort&#34;:&#34;low&#34;}}&#39;&#10;HTTP/1.1 400 Bad Request&#10;{&#10;&#34;error&#34;: {&#10;&#34;code&#34;: &#34;unsupported_parameter&#34;,&#10;&#34;message&#34;: &#34;Unsupported parameter: reasoning&#34;,&#10;&#34;param&#34;: &#34;reasoning&#34;,&#10;&#34;type&#34;: &#34;invalid_request_error&#34;&#10;}&#10;}</code>

```text
Public reasoning/template controls are not exposed (#326 keeps the field private)
=========================================================================

$ curl -sS -X POST http://localhost:4000/v1/chat/completions \
    -H 'authorization: Bearer $ORCHARD_API_KEY' \
    -H 'content-type: application/json' \
    -d '{"messages":[{"content":"hi","role":"user"}],"model":"reasoning-evidence-model@v1","reasoning":{"effort":"low"}}'
HTTP/1.1 400 Bad Request
content-type: application/json; charset=utf-8

{
  "error": {
    "code": "unsupported_parameter",
    "message": "Unsupported parameter: reasoning",
    "param": "reasoning",
    "type": "invalid_request_error"
  }
}

$ curl -sS -X POST http://localhost:4000/v1/chat/completions \
    -H 'authorization: Bearer $ORCHARD_API_KEY' \
    -H 'content-type: application/json' \
    -d '{"messages":[{"content":"hi","role":"user"}],"model":"reasoning-evidence-model@v1","template_kwargs":{"enable_thinking":false}}'
HTTP/1.1 400 Bad Request
content-type: application/json; charset=utf-8

{
  "error": {
    "code": "unsupported_parameter",
    "message": "Unsupported parameter: template_kwargs",
    "param": "template_kwargs",
    "type": "invalid_request_error"
  }
}

$ curl -sS -X POST http://localhost:4000/v1/responses \
    -H 'authorization: Bearer $ORCHARD_API_KEY' \
    -H 'content-type: application/json' \
    -d '{"input":"hi","model":"reasoning-evidence-model@v1","reasoning":{"effort":"low"}}'
HTTP/1.1 400 Bad Request
content-type: application/json; charset=utf-8

{
  "error": {
    "code": "unsupported_parameter",
    "message": "Unsupported parameter: reasoning",
    "param": "reasoning",
    "type": "invalid_request_error"
  }
}

$ curl -sS -X POST http://localhost:4000/v1/responses \
    -H 'authorization: Bearer $ORCHARD_API_KEY' \
    -H 'content-type: application/json' \
    -d '{"input":"hi","model":"reasoning-evidence-model@v1","template_kwargs":{"enable_thinking":false}}'
HTTP/1.1 400 Bad Request
content-type: application/json; charset=utf-8

{
  "error": {
    "code": "unsupported_parameter",
    "message": "Unsupported parameter: template_kwargs",
    "param": "template_kwargs",
    "type": "invalid_request_error"
  }
}
```
</details>
<details>
<summary>Evidence: Omitted reasoning keeps legacy behaviour, canonical payload without a reasoning key, and the existing body-hash/idempotency domain</summary>

<code>Canonical request has a `reasoning` key: false&#10;In-memory policy: %Orchard.CanonicalRequest.Reasoning{generation_policy: :model_default, projection: :legacy_blended, source: :omitted_public, effective_contract: %{mode: :legacy}}&#10;&#10;Persisted body_hash: e46d25ef327bad6416b32f7e9d4e9567168116be4a15aa8e3804bf0e14dc0b7f&#10;SHA-256 of public body: e46d25ef327bad6416b32f7e9d4e9567168116be4a15aa8e3804bf0e14dc0b7f&#10;Hashes match: true (same key + different body -&gt; 409 idempotency_mismatch)</code>

```text
# Omitted reasoning keeps byte-compatible legacy behaviour (#326)

Both public surfaces were called without any reasoning control, through the
real router, fake MLX runtime, and fake tokenizer.

## POST /v1/chat/completions -> 200

`` `json
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "orchard ready",
        "role": "assistant"
      }
    }
  ],
  "created": 1789057612,
  "id": "chatcmpl-c4830de6-7f8a-4707-9c1b-e930107c836c",
  "model": "reasoning-evidence-model@v1",
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 2,
    "prompt_tokens": 4,
    "total_tokens": 6
  }
}
`` `

Persisted canonical request (tenant capture mode `full`):

`` `json
{
  "admission": {
    "max_cold_start_ms": 15000,
    "queue_wait_ms": 3000,
    "timeout_ms": 23000
  },
  "api_key_id": "7686eae1-b536-4f6d-98ce-34b6e049f69c",
  "endpoint": "chat_completions",
  "input_items": [
    {
      "content": "hello orchard",
      "role": "user"
    }
  ],
  "input_token_count": 4,
  "internal_id": "c4830de6-7f8a-4707-9c1b-e930107c836c",
  "metadata": {},
  "model_ref": {
    "model_id": "reasoning-evidence-model",
    "version": "v1"
  },
  "principal_id": "de644047-a210-4229-a5e5-08c65b34314f",
  "principal_type": "tenant",
  "public_id": "chatcmpl-c4830de6-7f8a-4707-9c1b-e930107c836c",
  "rendered_prompt": "user hello orchard\nassistant",
  "resolved_policy": {
    "allowed_pool_ids": [],
    "max_active_requests": null,
    "quota_id": null,
    "residency_preference": "allow_cold_load",
    "routing_policy_id": null
  },
  "response_format": {
    "type": "text"
  },
  "sampling": {
    "max_output_tokens": null,
    "seed": null,
    "stop": [],
    "temperature": 1.0,
    "top_p": 1.0
  },
  "service_account_id": null,
  "store": true,
  "stream": false,
  "stream_include_usage": false,
  "tenant_id": "de644047-a210-4229-a5e5-08c65b34314f",
  "tooling": {
    "execution_snapshot": {
      "entries": []
    },
    "registry_snapshot": {
      "entries": []
    },
    "requested_tools": [],
    "tool_choice": null,
    "tools": []
  }
}
`` `

Canonical request has a `reasoning` key: false
In-memory canonical reasoning policy resolved by the normalizer:
`%Orchard.CanonicalRequest.Reasoning{generation_policy: :model_default, projection: :legacy_blended, source: :omitted_public, effective_contract: %{mode: :legacy}}`

## POST /v1/responses -> 200

`` `json
{
  "created_at": 1789057613,
  "error": null,
  "id": "resp_946aad9e-2002-451c-b24a-7eefca56e0f7",
  "metadata": {},
  "model": "reasoning-evidence-model@v1",
  "object": "response",
  "output": [
    {
      "content": [
        {
          "annotations": [],
          "text": "orchard ready",
          "type": "output_text"
        }
      ],
      "role": "assistant",
      "type": "message"
    }
  ],
  "output_text": "orchard ready",
  "status": "completed",
  "usage": {
    "input_tokens": 4,
    "output_tokens": 2,
    "total_tokens": 6
  }
}
`` `

Persisted canonical request:

`` `json
{
  "admission": {
    "max_cold_start_ms": 15000,
    "queue_wait_ms": 3000,
    "timeout_ms": 23000
  },
  "api_key_id": "7686eae1-b536-4f6d-98ce-34b6e049f69c",
  "endpoint": "responses",
  "input_items": [
    {
      "content": "hello orchard",
      "role": "user"
    }
  ],
  "input_token_count": 4,
  "internal_id": "eb08cc81-8fa0-4f64-a92b-814edc78bf51",
  "metadata": {},
  "model_ref": {
    "model_id": "reasoning-evidence-model",
    "version": "v1"
  },
  "principal_id": "de644047-a210-4229-a5e5-08c65b34314f",
  "principal_type": "tenant",
  "public_id": "resp_946aad9e-2002-451c-b24a-7eefca56e0f7",
  "rendered_prompt": "user hello orchard\nassistant",
  "resolved_policy": {
    "allowed_pool_ids": [],
    "max_active_requests": null,
    "quota_id": null,
    "residency_preference": "allow_cold_load",
    "routing_policy_id": null
  },
  "response_format": {
    "type": "text"
  },
  "sampling": {
    "max_output_tokens": null,
    "seed": null,
    "stop": [],
    "temperature": 1.0,
    "top_p": 1.0
  },
  "service_account_id": null,
  "store": true,
  "stream": false,
  "stream_include_usage": false,
  "tenant_id": "de644047-a210-4229-a5e5-08c65b34314f",
  "tooling": {
    "execution_snapshot": {
      "entries": []
    },
    "registry_snapshot": {
      "entries": []
    },
    "requested_tools": [],
    "tool_choice": null,
    "tools": []
  }
}
`` `

Canonical request has a `reasoning` key: false

## Body-hash / idempotency domain unchanged

Persisted `body_hash` for the accepted request:
`e46d25ef327bad6416b32f7e9d4e9567168116be4a15aa8e3804bf0e14dc0b7f`

SHA-256 over the normalized *public* request body only:
`e46d25ef327bad6416b32f7e9d4e9567168116be4a15aa8e3804bf0e14dc0b7f`

Hashes match: true

Replaying the same `Idempotency-Key` with a different public body still
conflicts, so the idempotency domain is unchanged:

`` `
$ curl -sS -X POST http://localhost:4000/v1/chat/completions \
    -H 'idempotency-key: evidence-key-203' -H 'content-type: application/json' \
    -d '{"messages":[{"content":"changed","role":"user"}],"model":"reasoning-evidence-model@v1"}'
HTTP/1.1 409 Conflict

{
  "error": {
    "code": "idempotency_mismatch",
    "message": "This Idempotency-Key has already been used with a different request body",
    "param": "Idempotency-Key",
    "type": "conflict_error"
  }
}
`` `
```
</details>
<details>
<summary>Evidence: orchard-tokenizer v4 CLI transcript: empty production registry, fail-closed paths, synthetic negotiated render</summary>

<code>$ python -c &#34;...print(dict(REASONING_RENDER_CONTRACTS))&#34;&#10;{}&#10;&#10;$ orchard-tokenizer --request-json &#34;$(cat v4-negotiated-request.json)&#34;&#10;{&#34;contract_version&#34;: 4, &#34;ok&#34;: false, &#34;error&#34;: {&#34;category&#34;: &#34;unsupported_reasoning_control&#34;, &#34;message&#34;: &#34;no exact tokenizer reasoning contract supports this request&#34;}}&#10;exit status: 2&#10;&#10;# synthetic registration only&#10;{&#34;contract_version&#34;: 4, &#34;ok&#34;: true, &#34;result&#34;: {&#34;rendered_prompt&#34;: &#34;&lt;no-think&gt;user hello orchard\nassistant&#34;, &#34;input_token_count&#34;: 9, &#34;reasoning&#34;: {...&#34;effective_contract&#34;: {&#34;mode&#34;: &#34;negotiated&#34;, ...}}}}</code>

```text
# orchard-tokenizer v4 reasoning contract — real CLI transcript

Run with `mise exec -- uv run --directory native/orchard_tokenizer orchard-tokenizer`.

## The production render-contract registry is intentionally empty (#326)

`` `
$ python -c "from orchard_tokenizer.reasoning_contracts import REASONING_RENDER_CONTRACTS as r; print(dict(r))"
{}
`` `

No approved model tuple is registered, so every negotiated render fails closed:

`` `
$ orchard-tokenizer --request-json "$(cat v4-negotiated-request.json)"
{"contract_version": 4, "ok": false, "error": {"category": "unsupported_reasoning_control", "message": "no exact tokenizer reasoning contract supports this request"}}
exit status: 2
`` `

## Callers cannot smuggle template keyword arguments

`` `
$ orchard-tokenizer --request-json "$(cat v4-caller-template-kwargs.json)"
{"contract_version": 4, "ok": false, "error": {"category": "invalid_input", "message": "request has unsupported or missing fields"}}
exit status: 2
`` `

## Declared chat-template digest must match the template bytes

`` `
$ orchard-tokenizer --request-json "$(cat v4-tampered-template-digest.json)"
{"contract_version": 4, "ok": false, "error": {"category": "unsupported_reasoning_control", "message": "chat template digest does not match the exact tokenizer contract"}}
exit status: 2
`` `

## The legacy render_and_count command refuses contract version 4

`` `
$ orchard-tokenizer --request-json "$(cat v4-on-legacy-command.json)"
{"contract_version": 4, "ok": false, "error": {"category": "invalid_input", "message": "render_and_count requires contract_version 1, 2, or 3"}}
exit status: 2
`` `

## Negotiated rendering works only through a registered exact identity

The driver below (`fixtures/synthetic_negotiation_driver.py`) registers a **synthetic**
tuple for the synthetic template `{% if enable_thinking %}<think>{% else %}<no-think>{% endif %}…`.
Only the registry supplies `enable_thinking`, and the helper echoes the exact identity back.

`` `
# generation_policy=disabled
$ orchard-tokenizer --request-json '<v4 disabled payload>'
{"contract_version": 4, "ok": true, "result": {"rendered_prompt": "<no-think>user hello orchard\nassistant", "input_token_count": 9, "reasoning": {"generation_policy": "disabled", "projection": "final_only", "source": "console_default", "effective_contract": {"mode": "negotiated", "model_artifact_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "chat_template_digest": "3ab1c35822b40c0b256bc284852a17be5593d7d3c8b0bfe70b8354d01025f920", "event_binding_version": "1", "render_contract": "synthetic-render-v1", "parser_version": "1", "parser_family": "synthetic-parser", "runtime_contract_version": "1", "render_contract_version": "1"}}}}
exit status: 0

# generation_policy=enabled
$ orchard-tokenizer --request-json '<v4 enabled payload>'
{"contract_version": 4, "ok": true, "result": {"rendered_prompt": "<think>user hello orchard\nassistant", "input_token_count": 7, "reasoning": {"generation_policy": "enabled", "projection": "final_only", "source": "console_explicit", "effective_contract": {"mode": "negotiated", "model_artifact_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "chat_template_digest": "3ab1c35822b40c0b256bc284852a17be5593d7d3c8b0bfe70b8354d01025f920", "event_binding_version": "1", "render_contract": "synthetic-render-v1", "parser_version": "1", "parser_family": "synthetic-parser", "runtime_contract_version": "1", "render_contract_version": "1"}}}}
exit status: 0

`` `
```
</details>
<details>
<summary>Evidence: Tokenizer helper wire contract: legacy v2 payload unchanged, v4 only for negotiated, fail-closed modes</summary>

<code>Omitted request -&gt; {&#34;command&#34;: &#34;render_and_count&#34;, &#34;contract_version&#34;: 2, &#34;request&#34;: {&#34;input_items&#34;: [...], &#34;tool_choice&#34;: null, &#34;tools&#34;: []}} (no reasoning field)&#10;Negotiated request -&gt; {&#34;command&#34;: &#34;render_and_count_reasoning&#34;, &#34;contract_version&#34;: 4, ... &#34;reasoning&#34;: {&#34;effective_contract&#34;: {&#34;mode&#34;: &#34;negotiated&#34;, ...}}}&#10;&#10;fake mode -&gt; {:error, {:invalid_input, &#34;negotiated reasoning tokenization requires tokenizer_mode=:port&#34;}} (helper invoked: false)&#10;safe_mode=:on -&gt; {:error, {:invalid_input, &#34;...refuses tokenizer_safe_mode=:on&#34;}} (helper invoked: false)&#10;identity drift -&gt; {:error, :invalid_response}</code>

```text
# Tokenizer helper wire contract per canonical reasoning policy

## Omitted public request (legacy model_default + legacy_blended)

Helper stdin payload written by Orchard.Tokenizer.Client:

`` `json
{
  "assets": {
    "chat_template_path": "/private/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/orchard-wire-capture-8450/chat_template.jinja",
    "tokenizer_kind": "huggingface_tokenizer_json",
    "tokenizer_path": "/private/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/orchard-wire-capture-8450/tokenizer.json"
  },
  "command": "render_and_count",
  "contract_version": 2,
  "request": {
    "input_items": [
      {
        "content": "hello orchard",
        "role": "user"
      }
    ],
    "tool_choice": null,
    "tools": []
  }
}
`` `

Client return value: `{:ok, %{rendered_prompt: "user hello orchard", input_token_count: 4}}`

## Negotiated request (synthetic exact identity)

Helper stdin payload written by Orchard.Tokenizer.Client:

`` `json
{
  "assets": {
    "chat_template_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
    "chat_template_path": "/private/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/orchard-wire-capture-8450/chat_template.jinja",
    "model_artifact_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
    "tokenizer_config_path": "/private/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/orchard-wire-capture-8450/tokenizer_config.json",
    "tokenizer_kind": "huggingface_tokenizer_json",
    "tokenizer_path": "/private/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/orchard-wire-capture-8450/tokenizer.json"
  },
  "command": "render_and_count_reasoning",
  "contract_version": 4,
  "request": {
    "input_items": [
      {
        "content": "hello orchard",
        "role": "user"
      }
    ],
    "reasoning": {
      "effective_contract": {
        "chat_template_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
        "event_binding_version": "1",
        "mode": "negotiated",
        "model_artifact_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
        "parser_family": "synthetic-parser",
        "parser_version": "1",
        "render_contract": "synthetic-render-v1",
        "render_contract_version": "1",
        "runtime_contract_version": "1"
      },
      "generation_policy": "disabled",
      "projection": "final_only",
      "source": "console_default"
    },
    "tool_choice": null,
    "tools": []
  }
}
`` `

Client return value: `{:ok, %{rendered_prompt: "<no-think>user hello orchard", input_token_count: 6}}`

## Negotiated request while the tokenizer runs in fake mode

Client return value: `{:error, {:invalid_input, "negotiated reasoning tokenization requires tokenizer_mode=:port"}}`
Helper was invoked: false

## Negotiated request while safe/segmented rendering is required

Client return value: `{:error, {:invalid_input, "negotiated reasoning tokenization has no segmented caller-string rendering yet and refuses tokenizer_safe_mode=:on"}}`
Helper was invoked: false

## Helper echoes a different exact identity than the controller negotiated

Client return value: `{:error, :invalid_response}`
Helper was invoked: true
```
</details>
<details>
<summary>Evidence: Canonical reasoning pair matrix (3 accepted, 5 rejected)</summary>

<code>contradictory enabled/final_only/console_default -&gt; REJECTED ** (ArgumentError) unsupported reasoning combination {:enabled, :final_only, :console_default}&#10;legacy pair carrying invented identity fields -&gt; REJECTED omitted_public legacy reasoning must use exactly %{mode: :legacy}&#10;structured projection (not implemented yet) -&gt; REJECTED unsupported reasoning combination {:enabled, :reasoning_structured, :explicit_public}&#10;negotiated pair missing parser_version -&gt; REJECTED negotiated reasoning requires every exact identity field as a non-empty binary&#10;negotiated pair with a legacy contract body -&gt; REJECTED negotiated reasoning requires mode: :negotiated and every exact identity field</code>

```text
# Canonical reasoning policy pair matrix (Orchard.CanonicalRequest.new/1)

omitted public request (no reasoning supplied)
  ACCEPTED  -> %Orchard.CanonicalRequest.Reasoning{generation_policy: :model_default, projection: :legacy_blended, source: :omitted_public, effective_contract: %{mode: :legacy}}

negotiated disabled/final_only/console_default
  ACCEPTED  -> %Orchard.CanonicalRequest.Reasoning{generation_policy: :disabled, projection: :final_only, source: :console_default, effective_contract: %{mode: :negotiated, model_artifact_digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", chat_template_digest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", render_contract: "synthetic-render-v1", render_contract_version: "1", parser_family: "synthetic-parser", parser_version: "1", runtime_contract_version: "1", event_binding_version: "1"}}

negotiated enabled/final_only/explicit_public
  ACCEPTED  -> %Orchard.CanonicalRequest.Reasoning{generation_policy: :enabled, projection: :final_only, source: :explicit_public, effective_contract: %{mode: :negotiated, model_artifact_digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", chat_template_digest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", render_contract: "synthetic-render-v1", render_contract_version: "1", parser_family: "synthetic-parser", parser_version: "1", runtime_contract_version: "1", event_binding_version: "1"}}

contradictory enabled/final_only/console_default
  REJECTED  -> ** (ArgumentError) Orchard.CanonicalRequest unsupported reasoning combination {:enabled, :final_only, :console_default}, got: %{mode: :negotiated, model_artifact_digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", chat_template_digest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", render_contract: "synthetic-render-v1", render_contract_version: "1", parser_family: "synthetic-parser", parser_version: "1", runtime_contract_version: "1", event_binding_version: "1"}

legacy pair carrying invented identity fields
  REJECTED  -> ** (ArgumentError) Orchard.CanonicalRequest omitted_public legacy reasoning must use exactly %{mode: :legacy}, got: %{mode: :legacy, parser_family: "invented"}

structured projection (not implemented yet)
  REJECTED  -> ** (ArgumentError) Orchard.CanonicalRequest unsupported reasoning combination {:enabled, :reasoning_structured, :explicit_public}, got: %{mode: :negotiated, model_artifact_digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", chat_template_digest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", render_contract: "synthetic-render-v1", render_contract_version: "1", parser_family: "synthetic-parser", parser_version: "1", runtime_contract_version: "1", event_binding_version: "1"}

negotiated pair missing parser_version
  REJECTED  -> ** (ArgumentError) Orchard.CanonicalRequest negotiated reasoning requires every exact identity field as a non-empty binary, got: %{mode: :negotiated, model_artifact_digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", chat_template_digest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", render_contract: "synthetic-render-v1", render_contract_version: "1", parser_family: "synthetic-parser", runtime_contract_version: "1", event_binding_version: "1"}

negotiated pair with a legacy contract body
  REJECTED  -> ** (ArgumentError) Orchard.CanonicalRequest negotiated reasoning requires mode: :negotiated and every exact identity field, got: %{mode: :legacy}
```
</details>
<details>
<summary>Evidence: Forbidden-scope boundary check (no Console/runtime-endpoint/retry/capture/parser work, no Qwen tuple)</summary>

```text
Scope-boundary check for #326 (base b50fb80c -> target 42b48414)
================================================================

$ git diff --name-only b50fb80c..42b48414
apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex
apps/orchard_controller/lib/orchard/tokenizer/client.ex
apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs
apps/orchard_controller/test/orchard/inference/chat_request_normalizer_test.exs
apps/orchard_controller/test/orchard/inference/chat_request_validator_test.exs
apps/orchard_controller/test/orchard/inference/responses_request_normalizer_test.exs
apps/orchard_controller/test/orchard/inference/responses_request_validator_test.exs
apps/orchard_controller/test/orchard/tokenizer_client_test.exs
apps/orchard_shared/lib/orchard/canonical_request.ex
apps/orchard_shared/test/orchard/canonical_request_test.exs
native/orchard_tokenizer/src/orchard_tokenizer/cli.py
native/orchard_tokenizer/src/orchard_tokenizer/reasoning_contracts.py
native/orchard_tokenizer/tests/test_cli.py
openspec/changes/define-reasoning-output-contract/tasks.md

$ git diff --name-only b50fb80c..42b48414 | grep -Ei 'console|runtime_endpoint|retry|capture|proto|parser|projection'
(no matches -- no Console, runtime-endpoint negotiation, retry, capture,
 proto, or parser/projection surface was touched)

$ grep -rni qwen native/orchard_tokenizer/src/orchard_tokenizer/reasoning_contracts.py
(no matches -- no real Qwen3.8 tuple is registered)

$ python -c "from orchard_tokenizer.reasoning_contracts import REASONING_RENDER_CONTRACTS as r; print(dict(r))"
{}
```
</details>
- Evidence: Evidence fixtures and driver scripts used to produce the transcripts (local file: <code>/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/no-mistakes-evidence/01M260K3ZY3W2N5Q6QCHVA3V5V/fixtures</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed ✅</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/tokenizer/client.ex:191` - The new negotiated clause of build_tokenization_plan/2 is matched before the tokenizer_safe_mode() dispatch, so a negotiated-reasoning request never reaches build_safe_plan_or_degrade/2 or build_safe_plan_or_reject/2. Under tokenizer_safe_mode=:reject — where an operator has explicitly demanded fail-closed segmented rendering and the legacy path is refused outright — a negotiated request would instead render through the v4 payload with no caller-string marker segmentation, no catalog/compatibility-cache gating, and no prompt_token_ids for capable workers, and unlike the :on degrade path it emits no unsafe_mode_active / degraded_no_manifest_catalog telemetry, so the downgrade is silent. SPEC.md ~L614 states safe-tokenization caller-string segmentation SHALL protect free-form caller-authored prompt material unconditionally. Not reachable today (no normalizer builds a negotiated request and the registry is empty), but this is exactly the seam #327/#328 will switch on. Suggest either gating negotiated plans on tokenizer_safe_mode (rejecting negotiated when safe mode is not :off until the segmented v4 shape exists) or folding the negotiated payload into the segmented plan.
- ⚠️ `native/orchard_tokenizer/src/orchard_tokenizer/cli.py:447` - _execute_render_and_count_reasoning hardcodes tokenizer_config_path = tokenizer_path.parent / &#34;tokenizer_config.json&#34;, and the Elixir side feeds it via resolve_legacy_assets/1 (client.ex:216), whose asset map has no tokenizer_config_path — the v4 assets exact-key set is {tokenizer_kind, tokenizer_path, chat_template_path, model_artifact_digest, chat_template_digest}. The v3 segmented path already solved this: resolve_segmented_assets/1 resolves manifest tokenizer.config_path with a sibling fallback (client.ex:641). For a manifest that declares a non-sibling tokenizer.config_path, the negotiated render reads the wrong or no tokenizer_config.json, so _load_special_tokens returns nothing and the prompt renders with missing special tokens (silently when the template does not reference required tokens, as a missing_assets error when it does) — while the response still asserts an exact render identity keyed on the chat-template digest. Not reachable until a registry tuple lands, but it undercuts the exactness claim the v4 contract is built to make.
- ℹ️ `native/orchard_tokenizer/src/orchard_tokenizer/cli.py:60` - Adding 4 to SUPPORTED_CONTRACT_VERSIONS also makes the plain &#34;render_and_count&#34; command accept contract_version 4 (execute_contract has no version pin for that command), returning a v4-shaped success envelope with no digest verification, no reasoning echo, and no registry lookup. render_and_count_segmented and preflight_safe_tokenization both pin their version explicitly. The Elixir client is unaffected — its v4 normalize_response clauses require plan mode :negotiated and a &#34;reasoning&#34; key, so such a response falls through to :invalid_response — so this is helper-surface widening only, and it mirrors the pre-existing acceptance of v3 for render_and_count. Pinning render_and_count to {1, 2, 3} would keep the v4 envelope exclusively owned by the closed reasoning contract.
- ℹ️ `apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex:36` - maybe_put_reasoning/2 has only two clauses (exact legacy triple, and negotiated). Anything else — most plausibly reasoning: nil on a CanonicalRequest built by struct literal rather than new/1, as Orchard.Scheduler.SingleNode.synthetic_request/1 does at single_node.ex:819 — raises FunctionClauseError, which serialize_canonical_request/1 (request_orchestrator.ex:3052) does not catch since it only rescues ArgumentError, turning a serialization problem into an orchestration crash. Every other malformed shape in this module (serialize_admission/1) deliberately raises ArgumentError so the caller can degrade gracefully. Currently unreachable through the serialize call path because all production requests go through CanonicalRequest.new/1, which always installs a %Reasoning{} default; a catch-all clause raising ArgumentError would match the module&#39;s own convention.
- ℹ️ `apps/orchard_controller/lib/orchard/tokenizer/client.ex:1181` - normalize_error_category(&#34;unsupported_reasoning_control&#34;) collapses to :invalid_input, which chat_error.ex:97 maps to :tokenization_invalid_request (a client 4xx). That is right for the &#34;no exact tokenizer reasoning contract supports this request&#34; case, but the same helper category is also raised by _verify_chat_template_digest when the on-disk chat template no longer matches the manifest digest — server-side artifact/manifest drift, which the comparable safe_tokenization_incompatible_template category deliberately routes to :tokenization_internal instead. Worth deciding whether contract drift should be its own error_reason category rather than being reported to callers as a bad request.
- ℹ️ `apps/orchard_controller/lib/orchard/tokenizer/client.ex:309` - serialize_reasoning/1 here and maybe_put_reasoning/2 in canonical_request_serializer.ex:56 independently render the same %CanonicalRequest.Reasoning{} into the identical four-key string-keyed wire shape (with atom-to-string coercion duplicated as serialize_reasoning_value/1 vs normalize_plain_data/1). Hoisting one encoder onto Orchard.CanonicalRequest.Reasoning in orchard_shared would keep the persisted-body shape and the helper-payload shape from drifting independently as the contract grows.

🔧 Fix: fail closed negotiated reasoning tokenization contract
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_shared/test/orchard/canonical_request_test.exs` (12 passed)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference/canonical_request_serializer_test.exs apps/orchard_controller/test/orchard/inference/chat_request_validator_test.exs apps/orchard_controller/test/orchard/inference/responses_request_validator_test.exs apps/orchard_controller/test/orchard/inference/chat_request_normalizer_test.exs apps/orchard_controller/test/orchard/inference/responses_request_normalizer_test.exs` (97 passed)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/tokenizer_client_test.exs` (75 passed, including the regression test I added for `negotiated reasoning refuses tokenizer modes other than :port`)</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/dispatch/safe_tokenization_smoke_test.exs apps/orchard_controller/test/orchard/api/safe_tokenization_lifecycle_test.exs apps/orchard_controller/test/orchard/tokenizer/telemetry_counters_test.exs apps/orchard_controller/test/orchard/tokenizer/catalog_drift_test.exs` (20 passed — segmented asset-resolution refactor)</code>
- <code>`mise exec -- uv run --directory native/orchard_tokenizer pytest tests/test_cli.py` (165 passed) and `-k &#34;reasoning or contract_version&#34;` (6 selected)</code>
- <code>Temporary ExUnit evidence test through `Orchard.API.Router`: POST /v1/chat/completions and POST /v1/responses with `reasoning` and `template_kwargs` (400 envelopes), omitted-reasoning 200 responses, persisted `canonical_request` inspection, `body_hash` vs `Orchard.Requests.Idempotency.build_context/3`, and Idempotency-Key mismatch 409 — created, run, then removed from the tree</code>
- <code>Real helper CLI: `mise exec -- uv run --directory native/orchard_tokenizer orchard-tokenizer --request-json &#34;$(cat v4-negotiated-request.json)&#34;` plus the caller-template-kwargs, tampered-template-digest, and v4-on-`render_and_count` variants</code>
- <code>`mise exec -- uv run --directory native/orchard_tokenizer python -c &#34;from orchard_tokenizer.reasoning_contracts import REASONING_RENDER_CONTRACTS as r; print(dict(r))&#34;` (prints `{}`)</code>
- <code>`mise exec -- uv run --directory native/orchard_tokenizer python fixtures/synthetic_negotiation_driver.py disabled enabled` — synthetic exact-identity registration drives `&lt;no-think&gt;` / `&lt;think&gt;` rendering and identity echo</code>
- <code>`ERL_LIBS=$PWD/_build/dev/lib mise exec -- elixir fixtures/helper_wire_capture.exs` — captures the helper stdin payload for legacy vs negotiated requests and the fake-mode / safe-mode / identity-mismatch fail-closed paths</code>
- <code>`ERL_LIBS=$PWD/_build/dev/lib mise exec -- elixir fixtures/canonical_pairs.exs` — accept/reject matrix for eight canonical reasoning tuples</code>
- <code>`git diff --name-only b50fb80c..42b48414 | grep -Ei &#39;console|runtime_endpoint|retry|capture|proto|parser|projection&#39;` and `grep -rni qwen native/orchard_tokenizer/src/orchard_tokenizer/reasoning_contracts.py` — forbidden-scope checks (no matches)</code>
- <code>`git diff --numstat b50fb80c..42b48414 -- &#39;apps/**/test/**&#39;` — confirms no pre-existing legacy assertion was deleted or relaxed</code>

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

- ℹ️ `SPEC.md:586` - SPEC.md §3.5 enumerates the tokenizer helper contract ladder as &#34;Tokenizer contract v2 requirements&#34; and &#34;Tokenizer contract v3 adds ...&#34;, but the implementation now also speaks contract v4 (`render_and_count_reasoning`) with no correspondingly named normative section. Nothing in §3.5 is factually wrong — the negotiated-reasoning tokenizer requirements (closed mapping per exact artifact and template digest, returned render metadata, no caller template kwargs) are already stated there without a version label, and the negotiated path is unreachable until #327/#328. I did not add a &#34;Tokenizer contract v4&#34; section because that is a normative contract addition, which AGENTS.md routes through an accepted OpenSpec change rather than a docs housekeeping pass. Follow-up judgment call for the owner: either name the v4 helper contract in §3.5 when the negotiated path becomes reachable, or state explicitly that helper contract version numbering is implementation detail owned by the code.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR establishes a private canonical reasoning policy and an exact-identity tokenizer contract while preserving omitted requests’ legacy serialization and helper behavior.
- Adds validated legacy and negotiated canonical reasoning representations.
- Adds fail-closed tokenizer-helper contract v4 with exact identity verification and a deliberately empty production registry.
- Rejects public reasoning/template controls and adds focused Elixir and Python contract coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_shared/lib/orchard/canonical_request.ex | Adds the closed canonical reasoning matrix, strict negotiated identity validation, and shared wire serialization. |
| apps/orchard_controller/lib/orchard/inference/canonical_request_serializer.ex | Preserves legacy serialized bodies by omitting the default reasoning policy and serializes validated negotiated identities. |
| apps/orchard_controller/lib/orchard/tokenizer/client.ex | Adds v4 negotiated-plan construction, mode and safe-mode refusal guards, configured asset resolution, and exact response-echo validation. |
| native/orchard_tokenizer/src/orchard_tokenizer/cli.py | Implements the pinned v4 reasoning command with closed asset validation, template-digest verification, registry negotiation, and identity echoing. |
| native/orchard_tokenizer/src/orchard_tokenizer/reasoning_contracts.py | Defines the closed exact-identity reasoning registry while intentionally leaving production registrations empty. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API
    participant Canonical as CanonicalRequest
    participant Client as Tokenizer Client
    participant Helper as Tokenizer Helper
    API->>Canonical: Normalize request
    alt reasoning omitted
        Canonical->>Client: Legacy reasoning policy
        Client->>Helper: render_and_count (v2)
        Helper-->>Client: rendered prompt and token count
    else negotiated reasoning
        Canonical->>Client: Exact negotiated identity
        Client->>Client: Require port mode and safe mode off
        Client->>Helper: render_and_count_reasoning (v4)
        Helper->>Helper: Resolve registry tuple and verify template digest
        alt exact tuple supported
            Helper-->>Client: Render plus exact reasoning echo
            Client->>Client: Verify byte-exact echo
        else unsupported or drifted identity
            Helper-->>Client: Fail closed
        end
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/326-canoni..."](https://github.com/kapitan-ai/orchard/commit/628df6e249a0bbe3f500a32b794c5eedf0b1c628) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62682603)</sub>

<!-- /greptile_comment -->