### PR TITLE
fix(inference): preserve negotiated acceptance-proof attempt evidence

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -742,6 +742,8 @@ Those attempts SHALL use `inference_turn:t1:a1` and `inference_turn:t1:a2`, rema
 Attempt 1 terminal evidence SHALL precede attempt 2 started evidence in request-event sequence order.
 A successful attempt SHALL carry no `retry_decision`.
 An unsuccessful attempt 2 SHALL carry `retry_decision = "retry_exhausted"` unless caller cancellation or disconnect caused its terminal outcome, in which case `cancelled` SHALL take precedence, or a Controller-detected negotiated acceptance-proof failure under §7.5.3a wins the terminal race before deadline terminalization is proven, in which case it SHALL carry `not_retryable`. An already-proven deadline terminalization retains `retry_exhausted`.
+Deadline terminalization is proven when the Request's absolute deadline is already exhausted at attempt 2's retry boundary, mirroring attempt 1's `budget_exhausted` precedence over `not_retryable`.
+That `not_retryable` exception is available only to an attempt 2 whose `attempt_outcome` is `failed` with `output_committed = false`; a `cancelled`, `timed_out`, or `interrupted` attempt 2, and any attempt 2 that committed output, SHALL retain `cancelled` or `retry_exhausted`.
 Attempt 1 SHALL never carry `retry_exhausted`.
 
 The orchestrator SHALL append exactly one `request_step.started` event for each Inference Attempt.
@@ -1808,7 +1810,7 @@ Unknown classes, unknown codes, deterministic failures, `retryable: false`, term
 Retry-capable failures are limited to resolved pre-acceptance Node or transport unavailability, the closed transient model-load categories, resolved worker or Node loss before acceptance, and an accepted pre-commit transient failure whose drain proves termination.
 
 The attempt 1 decline precedence SHALL be `output_committed`, `cancelled`, `budget_exhausted`, `not_retryable`, `identity_unresolved`, `occupancy_unresolved`, then `no_alternative_node`.
-An unsuccessful attempt 2 SHALL record `retry_exhausted` unless caller cancellation or disconnect caused its terminal outcome, in which case it SHALL record `cancelled`, or a Controller-detected negotiated acceptance-proof failure under §7.5.3a wins the terminal race before deadline terminalization is proven, in which case it SHALL record `not_retryable`; no attempt 2 outcome SHALL trigger a third attempt. An already-proven deadline terminalization retains `retry_exhausted`.
+An unsuccessful attempt 2 SHALL record `retry_exhausted` unless caller cancellation or disconnect caused its terminal outcome, in which case it SHALL record `cancelled`, or a Controller-detected negotiated acceptance-proof failure under §7.5.3a wins the terminal race before deadline terminalization is proven, in which case it SHALL record `not_retryable`; no attempt 2 outcome SHALL trigger a third attempt. An already-proven deadline terminalization retains `retry_exhausted`, and §3.7.1 owns the evaluable boundary for that exception.
 If no different eligible Node exists, Orchard SHALL start no second attempt, SHALL NOT re-enter the queue or extend a budget, and SHALL preserve attempt 1's stable public failure while recording `no_alternative_node` as internal evidence.
 Attempt 1's stable failure classification SHALL be fixed in its typed outcome, and any breaker-eligible failure effect SHALL be durable before the fresh alternate scheduler decision.
 The alternate scheduler decision is side-effect-free with respect to dispatch.

--- a/SPEC.md
+++ b/SPEC.md
@@ -741,7 +741,7 @@ One logical Request MAY contain at most two Inference Attempts for its first Inf
 Those attempts SHALL use `inference_turn:t1:a1` and `inference_turn:t1:a2`, remain under the same Request row and Request FSM, and SHALL NOT repeat admission, quota reservation, idempotency resolution, queue admission, or Payload Capture Mode resolution.
 Attempt 1 terminal evidence SHALL precede attempt 2 started evidence in request-event sequence order.
 A successful attempt SHALL carry no `retry_decision`.
-An unsuccessful attempt 2 SHALL carry `retry_decision = "retry_exhausted"` unless caller cancellation or disconnect caused its terminal outcome, in which case `cancelled` SHALL take precedence.
+An unsuccessful attempt 2 SHALL carry `retry_decision = "retry_exhausted"` unless caller cancellation or disconnect caused its terminal outcome, in which case `cancelled` SHALL take precedence, or a Controller-detected negotiated acceptance-proof failure under §7.5.3a wins the terminal race before deadline terminalization is proven, in which case it SHALL carry `not_retryable`. An already-proven deadline terminalization retains `retry_exhausted`.
 Attempt 1 SHALL never carry `retry_exhausted`.
 
 The orchestrator SHALL append exactly one `request_step.started` event for each Inference Attempt.
@@ -1808,7 +1808,7 @@ Unknown classes, unknown codes, deterministic failures, `retryable: false`, term
 Retry-capable failures are limited to resolved pre-acceptance Node or transport unavailability, the closed transient model-load categories, resolved worker or Node loss before acceptance, and an accepted pre-commit transient failure whose drain proves termination.
 
 The attempt 1 decline precedence SHALL be `output_committed`, `cancelled`, `budget_exhausted`, `not_retryable`, `identity_unresolved`, `occupancy_unresolved`, then `no_alternative_node`.
-An unsuccessful attempt 2 SHALL record `retry_exhausted` unless caller cancellation or disconnect caused its terminal outcome, in which case it SHALL record `cancelled`; no attempt 2 outcome SHALL trigger a third attempt.
+An unsuccessful attempt 2 SHALL record `retry_exhausted` unless caller cancellation or disconnect caused its terminal outcome, in which case it SHALL record `cancelled`, or a Controller-detected negotiated acceptance-proof failure under §7.5.3a wins the terminal race before deadline terminalization is proven, in which case it SHALL record `not_retryable`; no attempt 2 outcome SHALL trigger a third attempt. An already-proven deadline terminalization retains `retry_exhausted`.
 If no different eligible Node exists, Orchard SHALL start no second attempt, SHALL NOT re-enter the queue or extend a budget, and SHALL preserve attempt 1's stable public failure while recording `no_alternative_node` as internal evidence.
 Attempt 1's stable failure classification SHALL be fixed in its typed outcome, and any breaker-eligible failure effect SHALL be durable before the fresh alternate scheduler decision.
 The alternate scheduler decision is side-effect-free with respect to dispatch.
@@ -2654,7 +2654,7 @@ Reasoning-control failures use this closed mapping:
 | Failure phase | Public status, type, and code | `param` | Durable attempt evidence | Retry behavior |
 |---|---|---|---|---|
 | The exact model artifact and chat-template contract cannot honor an accepted explicit control | `400 invalid_request_error`, `unsupported_reasoning_control` | the accepted public reasoning-control field; `nil` for the Console | no attempt and no Request write | non-retryable |
-| No eligible endpoint proves the exact negotiated tuple, or execution acceptance reports a different loaded-worker tuple before model invocation | `503 server_error`, `runtime_incompatible` | `nil` | `pre_acceptance_unavailable` plus `runtime_incompatible` and `retry_decision = not_retryable` when an attempt exists | non-retryable |
+| No eligible endpoint proves the exact negotiated tuple, or execution acceptance reports a different loaded-worker tuple before model invocation | `503 server_error`, `runtime_incompatible` | `nil` | `pre_acceptance_unavailable` plus `runtime_incompatible` and `retry_decision = not_retryable` when an attempt exists and the proof failure wins the terminal race; caller cancellation/disconnect and already-proven deadline terminalization retain their §3.7.1 decisions | non-retryable |
 | Parser or generation-policy conformance fails after model invocation | `500 api_error`, `internal_error` | `nil` | `terminal_conformance` plus `internal_error` | non-retryable |
 
 Messages for these mappings SHALL be bounded, content-free, and Controller-owned.
@@ -3690,7 +3690,7 @@ That proof SHALL echo the complete tuple and identify the loaded worker incarnat
 The Node Agent and Worker Runtime MUST NOT begin model execution, emit content, or emit usage before producing that proof.
 The Controller SHALL validate the proof before accepting the attempt as running or forwarding any later event.
 A missing, malformed, stale, or mismatched proof SHALL fail as `runtime_incompatible` before model invocation and SHALL NOT be repaired by a later status observation.
-That Controller-detected acceptance failure SHALL record `retry_decision = not_retryable` and MUST NOT trigger Automatic Attempt Retry.
+That Controller-detected acceptance failure SHALL record `retry_decision = not_retryable` and MUST NOT trigger Automatic Attempt Retry, unless caller cancellation or disconnect caused the terminal outcome or deadline terminalization was already proven before the proof failure won the terminal race; those outcomes retain `cancelled` and `retry_exhausted`, respectively.
 An arbitrary Worker or Runtime Endpoint `Failed` event with code `runtime_incompatible` SHALL remain insufficient to authorize retry.
 The concrete additive encoding for the tuple, worker incarnation, and acceptance proof remains blocked behind a separately accepted Runtime Endpoint contract.
 

--- a/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
+++ b/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
@@ -13,6 +13,7 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
 
     @enforce_keys [
       :attempt,
+      :attempt_outcome,
       :output_committed,
       :caller_status,
       :deadline_status,
@@ -28,6 +29,7 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
 
     @type t :: %__MODULE__{
             attempt: 1 | 2,
+            attempt_outcome: :failed | :cancelled | :timed_out | :interrupted,
             output_committed: boolean(),
             caller_status: :live | :cancelled,
             deadline_status: :remaining | :exhausted,
@@ -82,6 +84,7 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
 
   @spec new(%{
           attempt: 1 | 2,
+          attempt_outcome: :failed | :cancelled | :timed_out | :interrupted,
           output_committed: boolean(),
           caller_status: :live | :cancelled,
           deadline_status: :remaining | :exhausted,
@@ -132,6 +135,7 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
 
   defp build_boundary(%{
          attempt: attempt,
+         attempt_outcome: attempt_outcome,
          output_committed: output_committed,
          caller_status: caller_status,
          deadline_status: deadline_status,
@@ -142,7 +146,8 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
          identity_resolution: identity_resolution,
          execution_resolution: execution_resolution,
          capacity_release_outcome: capacity_release_outcome
-       }) do
+       })
+       when attempt_outcome in [:failed, :cancelled, :timed_out, :interrupted] do
     :ok = validate_request_facts(attempt, output_committed, caller_status, deadline_status)
 
     :ok =
@@ -158,6 +163,7 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
 
     %Boundary{
       attempt: attempt,
+      attempt_outcome: attempt_outcome,
       output_committed: output_committed,
       caller_status: caller_status,
       deadline_status: deadline_status,
@@ -243,11 +249,17 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
     if retry_eligible?(boundary), do: nil, else: {:declined, :not_retryable}
   end
 
-  defp attempt_two_decision(%Boundary{failure_class: failure_class, failure_code: failure_code}) do
+  defp attempt_two_decision(%Boundary{
+         attempt_outcome: :failed,
+         failure_class: failure_class,
+         failure_code: failure_code
+       }) do
     if InferenceAttemptFailure.acceptance_proof_failure?(failure_class, failure_code),
       do: :not_retryable,
       else: :retry_exhausted
   end
+
+  defp attempt_two_decision(%Boundary{}), do: :retry_exhausted
 
   defp alternate_decision(:different_node), do: :retried
   defp alternate_decision(:no_candidate), do: :no_alternative_node

--- a/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
+++ b/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
@@ -104,6 +104,16 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
   def pre_schedule(%Boundary{attempt: 2, caller_status: :cancelled}),
     do: {:declined, :cancelled}
 
+  def pre_schedule(%Boundary{attempt: 2, deadline_status: :exhausted}),
+    do: {:declined, :retry_exhausted}
+
+  def pre_schedule(%Boundary{
+        attempt: 2,
+        failure_class: "pre_acceptance_unavailable",
+        failure_code: "runtime_incompatible"
+      }),
+      do: {:declined, :not_retryable}
+
   def pre_schedule(%Boundary{attempt: 2}), do: {:declined, :retry_exhausted}
 
   def pre_schedule(%Boundary{attempt: 1} = boundary),

--- a/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
+++ b/apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex
@@ -4,6 +4,7 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
   """
 
   alias Orchard.Inference.ModelLoadFailure
+  alias Orchard.Requests.InferenceAttemptFailure
 
   @type model_load_category :: Orchard.Inference.ModelLoadFailure.category() | nil
 
@@ -107,14 +108,11 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
   def pre_schedule(%Boundary{attempt: 2, deadline_status: :exhausted}),
     do: {:declined, :retry_exhausted}
 
-  def pre_schedule(%Boundary{
-        attempt: 2,
-        failure_class: "pre_acceptance_unavailable",
-        failure_code: "runtime_incompatible"
-      }),
-      do: {:declined, :not_retryable}
+  def pre_schedule(%Boundary{attempt: 2, output_committed: true}),
+    do: {:declined, :retry_exhausted}
 
-  def pre_schedule(%Boundary{attempt: 2}), do: {:declined, :retry_exhausted}
+  def pre_schedule(%Boundary{attempt: 2} = boundary),
+    do: {:declined, attempt_two_decision(boundary)}
 
   def pre_schedule(%Boundary{attempt: 1} = boundary),
     do: Enum.find_value(@attempt_one_gates, :eligible_for_alternate, &gate_decision(&1, boundary))
@@ -243,6 +241,12 @@ defmodule Orchard.Inference.AttemptRetryClassifier do
 
   defp taxonomy_verdict(%Boundary{} = boundary) do
     if retry_eligible?(boundary), do: nil, else: {:declined, :not_retryable}
+  end
+
+  defp attempt_two_decision(%Boundary{failure_class: failure_class, failure_code: failure_code}) do
+    if InferenceAttemptFailure.acceptance_proof_failure?(failure_class, failure_code),
+      do: :not_retryable,
+      else: :retry_exhausted
   end
 
   defp alternate_decision(:different_node), do: :retried

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -1449,6 +1449,7 @@ defmodule Orchard.Inference.RequestOrchestrator do
 
     %{
       attempt: attempt,
+      attempt_outcome: outcome.attempt_outcome,
       output_committed: outcome.output_committed,
       caller_status: snapshot.caller_status,
       deadline_status: snapshot.deadline_status,

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
@@ -28,6 +28,8 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
   @model_load_codes ~w(
     load_timeout acquisition_failed runtime_unavailable resource_exhausted model_invalid internal_error
   )
+  @acceptance_proof_failure_class "pre_acceptance_unavailable"
+  @acceptance_proof_failure_code "runtime_incompatible"
   @type evidence :: %{required(String.t()) => String.t()}
 
   @spec stable_error_codes() :: [String.t()]
@@ -38,6 +40,15 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
 
   @spec model_load_codes() :: [String.t()]
   def model_load_codes, do: @model_load_codes
+
+  @spec acceptance_proof_failure?(String.t(), String.t()) :: boolean()
+  def acceptance_proof_failure?(
+        @acceptance_proof_failure_class,
+        @acceptance_proof_failure_code
+      ),
+      do: true
+
+  def acceptance_proof_failure?(_failure_class, _failure_code), do: false
 
   @spec normalize(map()) :: evidence()
   def normalize(source) when is_map(source) do

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
@@ -134,7 +134,13 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
   defp model_load_code(_code), do: "internal_error"
 
   defp pre_acceptance_code(code)
-       when code in ["node_unavailable", "node_timeout", "runtime_unavailable", "rpc_unavailable"],
+       when code in [
+              "node_unavailable",
+              "node_timeout",
+              "runtime_incompatible",
+              "runtime_unavailable",
+              "rpc_unavailable"
+            ],
        do: code
 
   defp pre_acceptance_code(_code), do: "internal_error"

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
@@ -261,7 +261,7 @@ defmodule Orchard.Requests.InferenceAttemptResult do
     with :ok <- require_failure_field(result, "failure_class"),
          :ok <- require_failure_field(result, "failure_code"),
          :ok <- require_failure_field(result, "retry_decision") do
-      validate_retry_decision(attempt, result["retry_decision"])
+      validate_retry_decision(attempt, result)
     end
   end
 
@@ -271,10 +271,25 @@ defmodule Orchard.Requests.InferenceAttemptResult do
       else: {:error, "unsuccessful attempts require #{field}"}
   end
 
-  defp validate_retry_decision(1, decision) when decision in @attempt_one_decisions, do: :ok
-  defp validate_retry_decision(2, decision) when decision in @attempt_two_decisions, do: :ok
+  defp validate_retry_decision(1, %{"retry_decision" => decision})
+       when decision in @attempt_one_decisions,
+       do: :ok
 
-  defp validate_retry_decision(attempt, _decision),
+  defp validate_retry_decision(
+         2,
+         %{
+           "retry_decision" => "not_retryable",
+           "failure_class" => "pre_acceptance_unavailable",
+           "failure_code" => "runtime_incompatible"
+         }
+       ),
+       do: :ok
+
+  defp validate_retry_decision(2, %{"retry_decision" => decision})
+       when decision in @attempt_two_decisions,
+       do: :ok
+
+  defp validate_retry_decision(attempt, _result),
     do: {:error, "retry_decision is invalid for attempt #{attempt}"}
 
   defp validate_outcome_failure_consistency(%{

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex
@@ -275,22 +275,29 @@ defmodule Orchard.Requests.InferenceAttemptResult do
        when decision in @attempt_one_decisions,
        do: :ok
 
-  defp validate_retry_decision(
-         2,
-         %{
-           "retry_decision" => "not_retryable",
-           "failure_class" => "pre_acceptance_unavailable",
-           "failure_code" => "runtime_incompatible"
-         }
-       ),
-       do: :ok
-
   defp validate_retry_decision(2, %{"retry_decision" => decision})
        when decision in @attempt_two_decisions,
        do: :ok
 
+  defp validate_retry_decision(2, result) do
+    if acceptance_proof_exception?(result),
+      do: :ok,
+      else: {:error, "retry_decision is invalid for attempt 2"}
+  end
+
   defp validate_retry_decision(attempt, _result),
     do: {:error, "retry_decision is invalid for attempt #{attempt}"}
+
+  defp acceptance_proof_exception?(%{
+         "retry_decision" => "not_retryable",
+         "attempt_outcome" => "failed",
+         "output_committed" => false,
+         "failure_class" => failure_class,
+         "failure_code" => failure_code
+       }),
+       do: InferenceAttemptFailure.acceptance_proof_failure?(failure_class, failure_code)
+
+  defp acceptance_proof_exception?(_result), do: false
 
   defp validate_outcome_failure_consistency(%{
          "attempt_outcome" => "cancelled",

--- a/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
@@ -218,8 +218,32 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
            }) == {:declined, :identity_unresolved}
   end
 
-  test "SPEC.md §7.2.7 bounds attempt 2 to cancellation or retry exhaustion" do
-    assert classify(%{attempt: 2, caller_status: :cancelled}) == {:declined, :cancelled}
+  test "SPEC.md §§3.7.1, 5.8, and 7.5.3a preserves the typed acceptance-proof exception" do
+    acceptance_proof_failure = %{
+      failure_class: "pre_acceptance_unavailable",
+      failure_code: "runtime_incompatible",
+      runtime_retryable: false
+    }
+
+    assert classify(acceptance_proof_failure) == {:declined, :not_retryable}
+
+    assert classify(Map.put(acceptance_proof_failure, :attempt, 2)) ==
+             {:declined, :not_retryable}
+
+    assert classify(Map.merge(acceptance_proof_failure, %{attempt: 2, caller_status: :cancelled})) ==
+             {:declined, :cancelled}
+
+    assert classify(
+             Map.merge(acceptance_proof_failure, %{attempt: 2, deadline_status: :exhausted})
+           ) == {:declined, :retry_exhausted}
+
+    assert classify(%{
+             attempt: 2,
+             failure_class: "runtime_failure",
+             failure_code: "runtime_incompatible",
+             runtime_retryable: false
+           }) == {:declined, :retry_exhausted}
+
     assert classify(%{attempt: 2, caller_status: :live}) == {:declined, :retry_exhausted}
   end
 

--- a/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
@@ -237,6 +237,9 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
              Map.merge(acceptance_proof_failure, %{attempt: 2, deadline_status: :exhausted})
            ) == {:declined, :retry_exhausted}
 
+    assert classify(Map.merge(acceptance_proof_failure, %{attempt: 2, output_committed: true})) ==
+             {:declined, :retry_exhausted}
+
     assert classify(%{
              attempt: 2,
              failure_class: "runtime_failure",

--- a/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs
@@ -1,7 +1,9 @@
 defmodule Orchard.Inference.AttemptRetryClassifierTest do
   use ExUnit.Case, async: true
 
+  alias Orchard.Dispatch.AttemptOutcome
   alias Orchard.Inference.AttemptRetryClassifier
+  alias Orchard.Requests.InferenceAttemptResult
 
   @runtime_codes ~w(
     node_unavailable node_timeout runtime_unavailable resource_exhausted timeout
@@ -250,6 +252,63 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
     assert classify(%{attempt: 2, caller_status: :live}) == {:declined, :retry_exhausted}
   end
 
+  test "SPEC.md §3.7.1 classifies typed attempt 2 proof outcomes into valid durable results" do
+    for {attempt_outcome, expected} <- [
+          {:failed, :not_retryable},
+          {:timed_out, :retry_exhausted},
+          {:interrupted, :retry_exhausted}
+        ] do
+      outcome = proof_outcome(attempt_outcome)
+
+      for deadline_status <- [:remaining, :exhausted] do
+        expected_decision = if deadline_status == :exhausted, do: :retry_exhausted, else: expected
+
+        assert {:declined, decision} =
+                 classify_outcome(outcome, %{deadline_status: deadline_status})
+
+        assert decision == expected_decision
+        assert {:ok, result} = durable_result(outcome, decision)
+        assert result["retry_decision"] == Atom.to_string(expected_decision)
+        assert result["attempt_outcome"] == Atom.to_string(attempt_outcome)
+      end
+    end
+  end
+
+  test "SPEC.md §3.7.1 keeps cancellation ahead of typed proof outcomes and exhausted deadlines" do
+    for attempt_outcome <- [:failed, :timed_out, :interrupted],
+        deadline_status <- [:remaining, :exhausted] do
+      outcome = proof_outcome(attempt_outcome)
+
+      assert classify_outcome(outcome, %{
+               caller_status: :cancelled,
+               deadline_status: deadline_status,
+               output_committed: true
+             }) == {:declined, :cancelled}
+
+      assert {:ok, cancelled} =
+               outcome
+               |> Map.from_struct()
+               |> Map.merge(%{
+                 attempt_outcome: :cancelled,
+                 failure: %{
+                   "failure_class" => "cancellation",
+                   "failure_code" => "request_cancelled"
+                 }
+               })
+               |> AttemptOutcome.new()
+
+      assert {:declined, decision} =
+               classify_outcome(cancelled, %{
+                 caller_status: :cancelled,
+                 deadline_status: deadline_status
+               })
+
+      assert decision == :cancelled
+      assert {:ok, result} = durable_result(cancelled, decision)
+      assert result["retry_decision"] == "cancelled"
+    end
+  end
+
   test "constructor requires every exact fact and rejects raw source codes" do
     assert_raise ArgumentError, fn ->
       base_facts()
@@ -263,10 +322,21 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
       |> AttemptRetryClassifier.new()
     end
 
-    assert_raise FunctionClauseError, fn ->
-      # Dynamic dispatch avoids a compile-time type warning for this intentional invalid input.
-      # credo:disable-for-next-line Credo.Check.Refactor.Apply
-      apply(AttemptRetryClassifier, :new, [Map.delete(base_facts(), :capacity_release_outcome)])
+    for field <- [:attempt_outcome, :capacity_release_outcome] do
+      assert_raise FunctionClauseError, fn ->
+        # Dynamic dispatch avoids a compile-time type warning for this intentional invalid input.
+        # credo:disable-for-next-line Credo.Check.Refactor.Apply
+        apply(AttemptRetryClassifier, :new, [Map.delete(base_facts(), field)])
+      end
+    end
+
+    for invalid_outcome <- [:completed, "failed", nil] do
+      assert_raise FunctionClauseError, fn ->
+        # credo:disable-for-next-line Credo.Check.Refactor.Apply
+        apply(AttemptRetryClassifier, :new, [
+          Map.put(base_facts(), :attempt_outcome, invalid_outcome)
+        ])
+      end
     end
 
     assert_raise FunctionClauseError, fn ->
@@ -280,9 +350,68 @@ defmodule Orchard.Inference.AttemptRetryClassifierTest do
   defp boundary(overrides),
     do: base_facts() |> Map.merge(overrides) |> AttemptRetryClassifier.new()
 
+  defp proof_outcome(attempt_outcome) do
+    {:ok, outcome} =
+      AttemptOutcome.new(%{
+        attempt_outcome: attempt_outcome,
+        node_id: "00000000-0000-4000-a000-000000000002",
+        accepted: false,
+        events: [],
+        failure: %{
+          "failure_class" => "pre_acceptance_unavailable",
+          "failure_code" => "runtime_incompatible"
+        },
+        execution_resolution: :not_started,
+        capacity_release_outcome: :released,
+        started_at: ~U[2026-08-12 10:00:00.000000Z],
+        ended_at: ~U[2026-08-12 10:00:01.000000Z],
+        first_token_at: nil,
+        output_committed: false,
+        output_commitment_kind: nil,
+        delivery_state: :pending,
+        delivered_event_count: 0,
+        runtime_retryable: false
+      })
+
+    outcome
+  end
+
+  defp classify_outcome(outcome, overrides) do
+    outcome
+    |> Map.from_struct()
+    |> Map.take(Map.keys(base_facts()))
+    |> Map.merge(%{
+      attempt: 2,
+      failure_class: outcome.failure["failure_class"],
+      failure_code: outcome.failure["failure_code"]
+    })
+    |> Map.merge(overrides)
+    |> classify()
+  end
+
+  defp durable_result(outcome, decision) do
+    result = %{
+      attempt_outcome: Atom.to_string(outcome.attempt_outcome),
+      node_id: outcome.node_id,
+      accepted: outcome.accepted,
+      output_committed: outcome.output_committed,
+      execution_resolution: Atom.to_string(outcome.execution_resolution),
+      capacity_release_outcome: Atom.to_string(outcome.capacity_release_outcome),
+      started_at: outcome.started_at,
+      ended_at: outcome.ended_at,
+      excluded_node_ids: ["00000000-0000-4000-a000-000000000001"],
+      failure_class: outcome.failure["failure_class"],
+      failure_code: outcome.failure["failure_code"],
+      retry_decision: Atom.to_string(decision)
+    }
+
+    InferenceAttemptResult.new("request_step.#{outcome.attempt_outcome}", 2, result)
+  end
+
   defp base_facts do
     %{
       attempt: 1,
+      attempt_outcome: :failed,
       output_committed: false,
       caller_status: :live,
       deadline_status: :remaining,

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
@@ -70,13 +70,31 @@ defmodule Orchard.Requests.InferenceAttemptFailureTest do
   end
 
   test "SPEC.md §7.2.7 preserves runtime-incompatible pre-acceptance evidence" do
-    assert InferenceAttemptFailure.normalize(%{
-             category: :pre_acceptance,
-             code: :runtime_incompatible
-           }) == %{
+    evidence =
+      InferenceAttemptFailure.normalize(%{
+        category: :pre_acceptance,
+        code: :runtime_incompatible
+      })
+
+    assert evidence == %{
              "failure_class" => "pre_acceptance_unavailable",
              "failure_code" => "runtime_incompatible"
            }
+
+    assert InferenceAttemptFailure.acceptance_proof_failure?(
+             evidence["failure_class"],
+             evidence["failure_code"]
+           )
+  end
+
+  test "SPEC.md §7.5.3a closes the shared acceptance-proof evidence pair" do
+    for {failure_class, failure_code} <- [
+          {"pre_acceptance_unavailable", "runtime_unavailable"},
+          {"runtime_failure", "runtime_incompatible"},
+          {"pre_acceptance_unavailable", "internal_error"}
+        ] do
+      refute InferenceAttemptFailure.acceptance_proof_failure?(failure_class, failure_code)
+    end
   end
 
   test "unknown source failures fail closed" do

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
@@ -69,6 +69,16 @@ defmodule Orchard.Requests.InferenceAttemptFailureTest do
            }
   end
 
+  test "SPEC.md §7.2.7 preserves runtime-incompatible pre-acceptance evidence" do
+    assert InferenceAttemptFailure.normalize(%{
+             category: :pre_acceptance,
+             code: :runtime_incompatible
+           }) == %{
+             "failure_class" => "pre_acceptance_unavailable",
+             "failure_code" => "runtime_incompatible"
+           }
+  end
+
   test "unknown source failures fail closed" do
     assert InferenceAttemptFailure.normalize(%{category: :unknown, code: :private_code}) == %{
              "failure_class" => "controller_failure",

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
@@ -66,6 +66,41 @@ defmodule Orchard.Requests.InferenceAttemptResultTest do
     end
   end
 
+  test "SPEC.md §7.2.7 permits typed attempt 2 acceptance-proof failure evidence" do
+    assert {:ok, attempt_2} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               2,
+               failed_result(%{
+                 "failure_class" => "pre_acceptance_unavailable",
+                 "failure_code" => "runtime_incompatible",
+                 "node_id" => @node_2,
+                 "excluded_node_ids" => [@node_1],
+                 "retry_decision" => "not_retryable"
+               })
+             )
+
+    assert attempt_2["retry_decision"] == "not_retryable"
+
+    for {failure_class, failure_code} <- [
+          {"pre_acceptance_unavailable", "runtime_unavailable"},
+          {"runtime_failure", "runtime_incompatible"}
+        ] do
+      assert {:error, _reason} =
+               InferenceAttemptResult.new(
+                 "request_step.failed",
+                 2,
+                 failed_result(%{
+                   "failure_class" => failure_class,
+                   "failure_code" => failure_code,
+                   "node_id" => @node_2,
+                   "excluded_node_ids" => [@node_1],
+                   "retry_decision" => "not_retryable"
+                 })
+               )
+    end
+  end
+
   test "orphaned enriched fields and contradictory decisions fail closed" do
     assert InferenceAttemptResult.enriched?(%{"failure_class" => "runtime_failure"})
 

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs
@@ -101,6 +101,44 @@ defmodule Orchard.Requests.InferenceAttemptResultTest do
     end
   end
 
+  test "SPEC.md §3.7.1 bounds the attempt 2 acceptance-proof exception to failed uncommitted evidence" do
+    acceptance_proof_evidence = %{
+      "failure_class" => "pre_acceptance_unavailable",
+      "failure_code" => "runtime_incompatible",
+      "node_id" => @node_2,
+      "excluded_node_ids" => [@node_1],
+      "retry_decision" => "not_retryable"
+    }
+
+    assert {:error, _timed_out_reason} =
+             InferenceAttemptResult.new(
+               "request_step.timed_out",
+               2,
+               failed_result(Map.put(acceptance_proof_evidence, "attempt_outcome", "timed_out"))
+             )
+
+    assert {:error, _interrupted_reason} =
+             InferenceAttemptResult.new(
+               "request_step.interrupted",
+               2,
+               failed_result(Map.put(acceptance_proof_evidence, "attempt_outcome", "interrupted"))
+             )
+
+    assert {:error, _committed_reason} =
+             InferenceAttemptResult.new(
+               "request_step.failed",
+               2,
+               failed_result(
+                 Map.merge(acceptance_proof_evidence, %{
+                   "accepted" => true,
+                   "output_committed" => true,
+                   "output_commitment_kind" => "text",
+                   "execution_resolution" => "terminated"
+                 })
+               )
+             )
+  end
+
   test "orphaned enriched fields and contradictory decisions fail closed" do
     assert InferenceAttemptResult.enriched?(%{"failure_class" => "runtime_failure"})
 

--- a/apps/orchard_controller/test/orchard/requests/request_server_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/request_server_test.exs
@@ -3,6 +3,7 @@ defmodule Orchard.Requests.RequestServerTest do
 
   @moduletag :db
 
+  alias Orchard.Metrics.InferenceAttemptProjection
   alias Orchard.Requests
   alias Orchard.Requests.{RequestServer, RequestStepEvent}
 
@@ -273,6 +274,46 @@ defmodule Orchard.Requests.RequestServerTest do
                RequestServer.start_attempt_two(request.id, attempt_two_schedule(node_id), steps)
     end
 
+    test "SPEC.md §§3.7.1 and 7.5.3a persists attempt two acceptance-proof evidence" do
+      request = running_request!()
+      node_id = Ecto.UUID.generate()
+
+      assert {:ok, _} = Requests.append_request_step_events(request, [started_step(1, %{})])
+
+      assert :ok =
+               RequestServer.start_attempt_two(
+                 request.id,
+                 attempt_two_schedule(node_id),
+                 attempt_two_boundary(node_id)
+               )
+
+      assert {:error, _reason} =
+               RequestStepEvent.new(
+                 attempt_two_terminal_attrs(node_id, "runtime_failure", "runtime_incompatible")
+               )
+
+      assert {:ok, _events} =
+               Requests.append_request_step_events(request, [
+                 RequestStepEvent.new!(
+                   attempt_two_terminal_attrs(
+                     node_id,
+                     "pre_acceptance_unavailable",
+                     "runtime_incompatible"
+                   )
+                 )
+               ])
+
+      step_events = Requests.list_request_step_events(request)
+      terminal = List.last(step_events).result
+
+      assert terminal["failure_class"] == "pre_acceptance_unavailable"
+      assert terminal["failure_code"] == "runtime_incompatible"
+      assert terminal["retry_decision"] == "not_retryable"
+
+      assert {:ok, %{retry: %{reason: "retried", result: "failed"}}} =
+               InferenceAttemptProjection.project(step_events)
+    end
+
     test "declined attempt one evidence never authorizes the retry edge" do
       request = running_request!()
       node_id = Ecto.UUID.generate()
@@ -377,15 +418,47 @@ defmodule Orchard.Requests.RequestServerTest do
     })
   end
 
-  defp attempt_two_started_step(excluded_node_id) do
-    RequestStepEvent.new!(%{
-      event_type: "request_step.started",
+  defp attempt_two_terminal_attrs(excluded_node_id, failure_class, failure_code) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    %{
+      event_type: "request_step.failed",
       step_id: RequestStepEvent.inference_turn_step_id(1, 2),
       step_type: "inference_turn",
       turn_index: 1,
       attempt: 2,
+      boundary: "post_observation",
+      result: %{
+        "attempt_outcome" => "failed",
+        "started_at" => now,
+        "ended_at" => now,
+        "accepted" => false,
+        "output_committed" => false,
+        "execution_resolution" => "not_started",
+        "capacity_release_outcome" => "released",
+        "excluded_node_ids" => [excluded_node_id],
+        "node_id" => Ecto.UUID.generate(),
+        "failure_class" => failure_class,
+        "failure_code" => failure_code,
+        "runtime_retryable" => false,
+        "retry_decision" => "not_retryable"
+      }
+    }
+  end
+
+  defp attempt_two_started_step(excluded_node_id) do
+    started_step(2, %{"excluded_node_ids" => [excluded_node_id]})
+  end
+
+  defp started_step(attempt, result) do
+    RequestStepEvent.new!(%{
+      event_type: "request_step.started",
+      step_id: RequestStepEvent.inference_turn_step_id(1, attempt),
+      step_type: "inference_turn",
+      turn_index: 1,
+      attempt: attempt,
       boundary: "pre_side_effect",
-      result: %{"excluded_node_ids" => [excluded_node_id]}
+      result: result
     })
   end
 end

--- a/docs/decisions/0019-one-request-bounded-alternate-node-retry.md
+++ b/docs/decisions/0019-one-request-bounded-alternate-node-retry.md
@@ -7,6 +7,25 @@ Accepted.
 Issue #164 reconciles this decision into `SPEC.md` and the Automatic Attempt Retry OpenSpec package.
 Implementation remains scoped to the blocker-linked tickets under parent objective #121.
 
+### Amendment 2026-09-11
+
+Issue #403 adds one narrow attempt 2 exception to the retry contract. A
+Controller-detected negotiated acceptance-proof failure under `SPEC.md` §7.5.3a
+records `not_retryable` on an unsuccessful attempt 2 that terminalizes as a
+failure with no committed output. Caller cancellation or disconnect still
+records `cancelled`, and an already-proven deadline terminalization still
+records `retry_exhausted`, so cancellation is no longer the sole attempt 2
+exception.
+
+`SPEC.md` §§3.7.1, 5.8, and 7.5.3a now own that rule and override the three
+statements below that make `cancelled` the only attempt 2 exception: the
+capacity-rejection discussion in "Retryability", the attempt 2 sentence in
+"Attempt evidence and metrics", and the breaker-interaction sentence in
+"Circuit breaker interaction". Those sections stay as authored to record the
+state that motivated this decision. Every other part of this decision, including
+the closed `retry_decision` vocabulary and the attempt 1 decline precedence,
+stands unchanged.
+
 ## Context
 
 `SPEC.md` §§5.8-5.9 and §§12.1-12.3 require at most one automatic retry before Output Commitment on a different Node when one exists.

--- a/openspec/specs/automatic-attempt-retry/spec.md
+++ b/openspec/specs/automatic-attempt-retry/spec.md
@@ -27,12 +27,17 @@ This requirement traces to `SPEC.md` §3.6, §3.7.1, §5.3, §5.4, §5.8, §5.9,
 - **AND** Orchard starts no third attempt
 
 #### Scenario: Attempt 2 negotiated acceptance proof fails
-- **WHEN** a Controller-detected negotiated acceptance-proof failure terminalizes attempt 2 before deadline terminalization is proven
+- **WHEN** a Controller-detected negotiated acceptance-proof failure terminalizes attempt 2 as `failed` with no committed output before deadline terminalization is proven
 - **THEN** its terminal evidence records `not_retryable`
 - **AND** Orchard starts no third attempt
 
 #### Scenario: Deadline precedes attempt 2 negotiated acceptance proof failure
-- **WHEN** deadline terminalization is proven before a Controller-detected negotiated acceptance-proof failure wins the terminal race
+- **WHEN** the Request's absolute deadline is already exhausted at attempt 2's retry boundary and a Controller-detected negotiated acceptance-proof failure would otherwise apply
+- **THEN** its terminal evidence records `retry_exhausted`
+- **AND** Orchard starts no third attempt
+
+#### Scenario: Attempt 2 commits output before its negotiated acceptance proof failure evidence
+- **WHEN** attempt 2 committed output and its terminal evidence would otherwise carry a Controller-detected negotiated acceptance-proof failure
 - **THEN** its terminal evidence records `retry_exhausted`
 - **AND** Orchard starts no third attempt
 

--- a/openspec/specs/automatic-attempt-retry/spec.md
+++ b/openspec/specs/automatic-attempt-retry/spec.md
@@ -22,7 +22,17 @@ This requirement traces to `SPEC.md` §3.6, §3.7.1, §5.3, §5.4, §5.8, §5.9,
 - **AND** the Request terminalizes once from attempt 2
 
 #### Scenario: Attempt 2 fails
-- **WHEN** attempt 2 ends unsuccessfully without caller cancellation or disconnect
+- **WHEN** attempt 2 ends unsuccessfully without caller cancellation or disconnect and without a Controller-detected negotiated acceptance-proof failure winning the terminal race
+- **THEN** its terminal evidence records `retry_exhausted`
+- **AND** Orchard starts no third attempt
+
+#### Scenario: Attempt 2 negotiated acceptance proof fails
+- **WHEN** a Controller-detected negotiated acceptance-proof failure terminalizes attempt 2 before deadline terminalization is proven
+- **THEN** its terminal evidence records `not_retryable`
+- **AND** Orchard starts no third attempt
+
+#### Scenario: Deadline precedes attempt 2 negotiated acceptance proof failure
+- **WHEN** deadline terminalization is proven before a Controller-detected negotiated acceptance-proof failure wins the terminal race
 - **THEN** its terminal evidence records `retry_exhausted`
 - **AND** Orchard starts no third attempt
 


### PR DESCRIPTION
## Intent

Fix the two current-origin inference-attempt evidence defects surfaced during #327 planning, without implementing #327's deferred Runtime Endpoint protocol or reasoning feature. Preserve pre_acceptance_unavailable plus runtime_incompatible as the closed durable evidence pair. Apply the owner-approved narrow contract exception: a Controller-detected negotiated acceptance-proof failure on attempt 2 records not_retryable; caller cancellation or disconnect remains cancelled; an already-proven deadline terminalization remains retry_exhausted. Reconcile SPEC.md and the main automatic-attempt-retry OpenSpec spec, update the classifier and durable-event validator, and add regressions for attempts 1 and 2 plus cancellation, deadline, and failure-class races. The tracking issue is #403. Do not add protocol fields, worker behavior, or unrelated refactors.

## What Changed

- `InferenceAttemptFailure` keeps `runtime_incompatible` in the closed `pre_acceptance_unavailable` code set instead of normalizing it to `internal_error`, and exports `acceptance_proof_failure?/2` as the shared predicate for that evidence pair.
- Attempt 2 retry classification is no longer unconditionally `retry_exhausted`: `AttemptRetryClassifier` decides cancellation, then already-exhausted deadline, then committed output, then `not_retryable` for a Controller-detected acceptance-proof failure; `InferenceAttemptResult` mirrors that as a bounded durable-event exception, admitting `not_retryable` on attempt 2 only for a `failed`, uncommitted attempt carrying the acceptance-proof pair.
- Reconciles the contract across `SPEC.md` §§3.7.1/5.8/7.5.3a, the `automatic-attempt-retry` OpenSpec spec (new scenarios for the acceptance-proof failure, deadline precedence, and committed output), and an amendment to ADR 0019; adds regressions for attempts 1 and 2 plus the cancellation, deadline, and failure-class races in the classifier, both validators, and `RequestServer` persistence.

## Risk Assessment

✅ Low: The follow-up commit reconciled the contradicting ADR, bounded the attempt-2 exception to failed-uncommitted evidence in the fail-closed validator, defined the deadline-proof boundary normatively in SPEC.md, and replaced the duplicated class/code pair with a single shared predicate, leaving a well-bounded and internally consistent change whose only remaining concerns are unreachable until the deferred #327 producer lands.

## Testing

Exercised the fix end-to-end through the real Controller chain into Postgres and back out through the operator-visible read-back surfaces, comparing the target commit against the base commit on an identical driver. The before/after diff shows both defects and their product impact: pre-fix the durable row recorded failure_code=internal_error (the runtime_incompatible hint is stripped by CapturePolicy), and the attempt-2 not_retryable write was rejected so no attempt-2 evidence persisted and the metrics projection returned :invalid_attempt_evidence; post-fix the pre_acceptance_unavailable/runtime_incompatible pair persists with retry_decision=not_retryable and the projection reports one failed logical retry, while cancellation, already-proven deadline terminalization, committed output, and every other failure pair keep their existing decisions. Added one focused durable-persistence regression that the shipped unit tests did not cover; it is red on base and green on target. All 176 tests in the affected controller slice and the 13 end-to-end HTTP retry integration tests pass. No screenshot or rendered-UI artifact applies: this change touches only Controller classification and durable request-event evidence, so the closest end-user surfaces are the persisted Postgres rows and the metrics projection, both captured as transcripts. #327's Runtime Endpoint acceptance-proof wire encoding is deferred by design, so no Node can emit this failure yet; the proof-failure input is injected at exactly the Controller boundary that protocol will feed, with all downstream code being production code. The transient evidence database was dropped and the worktree is clean apart from the intentional new test.

<details>
<summary>Evidence: Before/after diff of the end-to-end attempt-evidence run (base vs target)</summary>

<code>normalize(%{category: :pre_acceptance, code: :runtime_incompatible}) =&gt;&#10;- %{&#34;failure_class&#34; =&gt; &#34;pre_acceptance_unavailable&#34;, &#34;failure_code&#34; =&gt; &#34;internal_error&#34;, &#34;raw_source_code&#34; =&gt; &#34;runtime_incompatible&#34;}&#10;+ %{&#34;failure_class&#34; =&gt; &#34;pre_acceptance_unavailable&#34;, &#34;failure_code&#34; =&gt; &#34;runtime_incompatible&#34;}&#10;&#10;scenario retry_decision&#10;attempt 1, acceptance-proof failure not_retryable&#10;-attempt 2, acceptance-proof failure wins the race retry_exhausted&#10;+attempt 2, acceptance-proof failure wins the race not_retryable&#10;attempt 2, caller cancelled/disconnected cancelled&#10;attempt 2, deadline terminalization already proven retry_exhausted&#10;attempt 2, output already committed retry_exhausted&#10;&#10;-appended attempt 2 terminal evidence: ERROR {:invalid_step_event, 1, &#34;retry_decision is invalid for attempt 2&#34;}&#10;+appended attempt 2 terminal evidence: ok&#10;+seq=5 request_step.failed attempt=2&#10;+{&#10;+ &#34;failure_code&#34;: &#34;runtime_incompatible&#34;,&#10;+ &#34;failure_class&#34;: &#34;pre_acceptance_unavailable&#34;,&#10;+ &#34;retry_decision&#34;: &#34;not_retryable&#34;,&#10;+ &#34;attempt_outcome&#34;: &#34;failed&#34;,&#10;+ &#34;output_committed&#34;: false&#10;+}&#10;&#10;Metrics.InferenceAttemptProjection.project/1 =&gt;&#10;- {:error, :invalid_attempt_evidence}&#10;+ {:ok, %{retry: %{reason: &#34;retried&#34;, result: &#34;failed&#34;}, attempts: [...attempt 1 worker_or_node_loss, attempt 2 pre_acceptance_unavailable...]}}&#10;&#10;6. Attempt 1 acceptance-proof failure as persisted for an operator&#10;- &#34;failure_code&#34;: &#34;internal_error&#34;,&#10;+ &#34;failure_code&#34;: &#34;runtime_incompatible&#34;,</code>

```text
--- /var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/no-mistakes-evidence/01M26DMYM5SAXWKN0TTA5ZAT46/before-fix-attempt-evidence.txt	2026-09-11 04:16:15
+++ /var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/no-mistakes-evidence/01M26DMYM5SAXWKN0TTA5ZAT46/after-fix-attempt-evidence.txt	2026-09-11 04:16:07
@@ -5,7 +5,7 @@
 1. Durable evidence pair produced by the Controller failure normalizer
 ==============================================================================
 normalize(%{category: :pre_acceptance, code: :runtime_incompatible}) =>
-  %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "internal_error", "raw_source_code" => "runtime_incompatible"}
+  %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "runtime_incompatible"}
 
 other pre-acceptance codes still normalize unchanged:
   :node_unavailable => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "node_unavailable"}
@@ -20,7 +20,7 @@
 scenario                                                  retry_decision
 ------------------------------------------------------------------------------
 attempt 1, acceptance-proof failure                       not_retryable
-attempt 2, acceptance-proof failure wins the race         retry_exhausted
+attempt 2, acceptance-proof failure wins the race         not_retryable
 attempt 2, caller cancelled/disconnected                  cancelled
 attempt 2, deadline terminalization already proven        retry_exhausted
 attempt 2, output already committed                       retry_exhausted
@@ -30,8 +30,8 @@
 ==============================================================================
 3. Persisting the attempt 1 -> attempt 2 evidence chain to Postgres
 ==============================================================================
-created request req_403_evidence_35652 (edde3986-c1be-4dc6-8fdd-4d2c6c6b3ad8)
-appended attempt 2 terminal evidence: ERROR {:invalid_step_event, 1, "retry_decision is invalid for attempt 2"}
+created request req_403_evidence_30854 (d09985ba-2e8a-41a0-8c93-4ddb908215c1)
+appended attempt 2 terminal evidence: ok
 
 Rows read back from Postgres (request_events, capture policy applied):
 
@@ -61,7 +61,26 @@
 {
 }
 
+seq=5 request_step.failed attempt=2
+{
+    "node_id": "00000000-0000-4000-a000-000000000002",
+    "accepted": false,
+    "ended_at": "2026-09-11T04:00:01.000000Z",
+    "started_at": "2026-09-11T04:00:00.000000Z",
+    "failure_code": "runtime_incompatible",
+    "failure_class": "pre_acceptance_unavailable",
+    "retry_decision": "not_retryable",
+    "attempt_outcome": "failed",
+    "output_committed": false,
+    "excluded_node_ids": [
+        "00000000-0000-4000-a000-000000000001"
+    ],
+    "runtime_retryable": false,
+    "execution_resolution": "not_started",
+    "capacity_release_outcome": "released"
+}
 
+
 ==============================================================================
 4. Operator-visible read-back surfaces
 ==============================================================================
@@ -69,15 +88,33 @@
   request_step.started attempt=1 failure_class=nil failure_code=nil retry_decision=nil
   request_step.failed attempt=1 failure_class="worker_or_node_loss" failure_code="worker_down" retry_decision="retried"
   request_step.started attempt=2 failure_class=nil failure_code=nil retry_decision=nil
+  request_step.failed attempt=2 failure_class="pre_acceptance_unavailable" failure_code="runtime_incompatible" retry_decision="not_retryable"
 
 Metrics.InferenceAttemptProjection.project/1 =>
-  {:error, :invalid_attempt_evidence}
+  {:ok,
+ %{
+   retry: %{reason: "retried", result: "failed"},
+   attempts: [
+     %{
+       attempt: 1,
+       failure_class: "worker_or_node_loss",
+       outcome: "failed",
+       duration_seconds: 1.0
+     },
+     %{
+       attempt: 2,
+       failure_class: "pre_acceptance_unavailable",
+       outcome: "failed",
+       duration_seconds: 1.0
+     }
+   ]
+ }}
 
 ==============================================================================
 5. The durable validator keeps the exception bounded
 ==============================================================================
 accepted durable writes:
-  attempt 2 acceptance-proof failure (the approved exception)               UNEXPECTED REJECTION: retry_decision is invalid for attempt 2
+  attempt 2 acceptance-proof failure (the approved exception)               ok (retry_decision=not_retryable)
   attempt 2 cancellation keeps cancelled                                    ok (retry_decision=cancelled)
   attempt 2 deadline keeps retry_exhausted                                  ok (retry_decision=retry_exhausted)
   attempt 1 acceptance-proof failure keeps not_retryable                    ok (retry_decision=not_retryable)
@@ -94,14 +131,14 @@
 ==============================================================================
 6. Attempt 1 acceptance-proof failure as persisted for an operator
 ==============================================================================
-durable request_step.failed row for req_403_attempt1_36036:
+durable request_step.failed row for req_403_attempt1_30982:
 
 {
     "node_id": "00000000-0000-4000-a000-000000000001",
     "accepted": false,
     "ended_at": "2026-09-11T04:00:01.000000Z",
     "started_at": "2026-09-11T04:00:00.000000Z",
-    "failure_code": "internal_error",
+    "failure_code": "runtime_incompatible",
     "failure_class": "pre_acceptance_unavailable",
     "retry_decision": "not_retryable",
     "attempt_outcome": "failed",
```
</details>
<details>
<summary>Evidence: Post-fix end-to-end transcript (normalizer, classifier races, persisted Postgres rows, projection, bounded validator)</summary>

```text
==> orchard_controller
Compiling 16 files (.ex)

==============================================================================
1. Durable evidence pair produced by the Controller failure normalizer
==============================================================================
normalize(%{category: :pre_acceptance, code: :runtime_incompatible}) =>
  %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "runtime_incompatible"}

other pre-acceptance codes still normalize unchanged:
  :node_unavailable => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "node_unavailable"}
  :node_timeout => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "node_timeout"}
  :runtime_unavailable => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "runtime_unavailable"}
  :rpc_unavailable => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "rpc_unavailable"}
  :bogus_code => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "internal_error", "raw_source_code" => "bogus_code"}

==============================================================================
2. Retry classifier decisions at the attempt-2 terminal race
==============================================================================
scenario                                                  retry_decision
------------------------------------------------------------------------------
attempt 1, acceptance-proof failure                       not_retryable
attempt 2, acceptance-proof failure wins the race         not_retryable
attempt 2, caller cancelled/disconnected                  cancelled
attempt 2, deadline terminalization already proven        retry_exhausted
attempt 2, output already committed                       retry_exhausted
attempt 2, ordinary runtime failure (not the proof pair)  retry_exhausted
attempt 2, pre-acceptance node loss (not the proof pair)  retry_exhausted

==============================================================================
3. Persisting the attempt 1 -> attempt 2 evidence chain to Postgres
==============================================================================
created request req_403_evidence_30854 (d09985ba-2e8a-41a0-8c93-4ddb908215c1)
appended attempt 2 terminal evidence: ok

Rows read back from Postgres (request_events, capture policy applied):

seq=1 request_step.started attempt=1
{
}

seq=2 request_step.failed attempt=1
{
    "node_id": "00000000-0000-4000-a000-000000000001",
    "accepted": false,
    "ended_at": "2026-09-11T04:00:01.000000Z",
    "started_at": "2026-09-11T04:00:00.000000Z",
    "failure_code": "worker_down",
    "failure_class": "worker_or_node_loss",
    "retry_decision": "retried",
    "attempt_outcome": "failed",
    "output_committed": false,
    "excluded_node_ids": [
    ],
    "runtime_retryable": true,
    "execution_resolution": "not_started",
    "capacity_release_outcome": "released"
}

seq=3 request_step.started attempt=2
{
}

seq=5 request_step.failed attempt=2
{
    "node_id": "00000000-0000-4000-a000-000000000002",
    "accepted": false,
    "ended_at": "2026-09-11T04:00:01.000000Z",
    "started_at": "2026-09-11T04:00:00.000000Z",
    "failure_code": "runtime_incompatible",
    "failure_class": "pre_acceptance_unavailable",
    "retry_decision": "not_retryable",
    "attempt_outcome": "failed",
    "output_committed": false,
    "excluded_node_ids": [
        "00000000-0000-4000-a000-000000000001"
    ],
    "runtime_retryable": false,
    "execution_resolution": "not_started",
    "capacity_release_outcome": "released"
}


==============================================================================
4. Operator-visible read-back surfaces
==============================================================================
Requests.list_request_step_events/1 =>
  request_step.started attempt=1 failure_class=nil failure_code=nil retry_decision=nil
  request_step.failed attempt=1 failure_class="worker_or_node_loss" failure_code="worker_down" retry_decision="retried"
  request_step.started attempt=2 failure_class=nil failure_code=nil retry_decision=nil
  request_step.failed attempt=2 failure_class="pre_acceptance_unavailable" failure_code="runtime_incompatible" retry_decision="not_retryable"

Metrics.InferenceAttemptProjection.project/1 =>
  {:ok,
 %{
   retry: %{reason: "retried", result: "failed"},
   attempts: [
     %{
       attempt: 1,
       failure_class: "worker_or_node_loss",
       outcome: "failed",
       duration_seconds: 1.0
     },
     %{
       attempt: 2,
       failure_class: "pre_acceptance_unavailable",
       outcome: "failed",
       duration_seconds: 1.0
     }
   ]
 }}

==============================================================================
5. The durable validator keeps the exception bounded
==============================================================================
accepted durable writes:
  attempt 2 acceptance-proof failure (the approved exception)               ok (retry_decision=not_retryable)
  attempt 2 cancellation keeps cancelled                                    ok (retry_decision=cancelled)
  attempt 2 deadline keeps retry_exhausted                                  ok (retry_decision=retry_exhausted)
  attempt 1 acceptance-proof failure keeps not_retryable                    ok (retry_decision=not_retryable)

rejected durable writes:
  attempt 2 not_retryable with runtime_failure/runtime_incompatible         rejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable with pre_acceptance_unavailable/runtime_unavailablerejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable on a timed_out attempt                            rejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable on an interrupted attempt                         rejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable after output commitment                           rejected: retry_decision is invalid for attempt 2
  attempt 2 cancelled evidence relabelled not_retryable                     rejected: retry_decision is invalid for attempt 2


==============================================================================
6. Attempt 1 acceptance-proof failure as persisted for an operator
==============================================================================
durable request_step.failed row for req_403_attempt1_30982:

{
    "node_id": "00000000-0000-4000-a000-000000000001",
    "accepted": false,
    "ended_at": "2026-09-11T04:00:01.000000Z",
    "started_at": "2026-09-11T04:00:00.000000Z",
    "failure_code": "runtime_incompatible",
    "failure_class": "pre_acceptance_unavailable",
    "retry_decision": "not_retryable",
    "attempt_outcome": "failed",
    "output_committed": false,
    "excluded_node_ids": [
    ],
    "runtime_retryable": false,
    "execution_resolution": "not_started",
    "capacity_release_outcome": "released"
}
```
</details>
<details>
<summary>Evidence: Pre-fix end-to-end transcript (same driver, base-commit implementation files)</summary>

```text
==> orchard_controller
Compiling 16 files (.ex)

==============================================================================
1. Durable evidence pair produced by the Controller failure normalizer
==============================================================================
normalize(%{category: :pre_acceptance, code: :runtime_incompatible}) =>
  %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "internal_error", "raw_source_code" => "runtime_incompatible"}

other pre-acceptance codes still normalize unchanged:
  :node_unavailable => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "node_unavailable"}
  :node_timeout => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "node_timeout"}
  :runtime_unavailable => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "runtime_unavailable"}
  :rpc_unavailable => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "rpc_unavailable"}
  :bogus_code => %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "internal_error", "raw_source_code" => "bogus_code"}

==============================================================================
2. Retry classifier decisions at the attempt-2 terminal race
==============================================================================
scenario                                                  retry_decision
------------------------------------------------------------------------------
attempt 1, acceptance-proof failure                       not_retryable
attempt 2, acceptance-proof failure wins the race         retry_exhausted
attempt 2, caller cancelled/disconnected                  cancelled
attempt 2, deadline terminalization already proven        retry_exhausted
attempt 2, output already committed                       retry_exhausted
attempt 2, ordinary runtime failure (not the proof pair)  retry_exhausted
attempt 2, pre-acceptance node loss (not the proof pair)  retry_exhausted

==============================================================================
3. Persisting the attempt 1 -> attempt 2 evidence chain to Postgres
==============================================================================
created request req_403_evidence_35652 (edde3986-c1be-4dc6-8fdd-4d2c6c6b3ad8)
appended attempt 2 terminal evidence: ERROR {:invalid_step_event, 1, "retry_decision is invalid for attempt 2"}

Rows read back from Postgres (request_events, capture policy applied):

seq=1 request_step.started attempt=1
{
}

seq=2 request_step.failed attempt=1
{
    "node_id": "00000000-0000-4000-a000-000000000001",
    "accepted": false,
    "ended_at": "2026-09-11T04:00:01.000000Z",
    "started_at": "2026-09-11T04:00:00.000000Z",
    "failure_code": "worker_down",
    "failure_class": "worker_or_node_loss",
    "retry_decision": "retried",
    "attempt_outcome": "failed",
    "output_committed": false,
    "excluded_node_ids": [
    ],
    "runtime_retryable": true,
    "execution_resolution": "not_started",
    "capacity_release_outcome": "released"
}

seq=3 request_step.started attempt=2
{
}


==============================================================================
4. Operator-visible read-back surfaces
==============================================================================
Requests.list_request_step_events/1 =>
  request_step.started attempt=1 failure_class=nil failure_code=nil retry_decision=nil
  request_step.failed attempt=1 failure_class="worker_or_node_loss" failure_code="worker_down" retry_decision="retried"
  request_step.started attempt=2 failure_class=nil failure_code=nil retry_decision=nil

Metrics.InferenceAttemptProjection.project/1 =>
  {:error, :invalid_attempt_evidence}

==============================================================================
5. The durable validator keeps the exception bounded
==============================================================================
accepted durable writes:
  attempt 2 acceptance-proof failure (the approved exception)               UNEXPECTED REJECTION: retry_decision is invalid for attempt 2
  attempt 2 cancellation keeps cancelled                                    ok (retry_decision=cancelled)
  attempt 2 deadline keeps retry_exhausted                                  ok (retry_decision=retry_exhausted)
  attempt 1 acceptance-proof failure keeps not_retryable                    ok (retry_decision=not_retryable)

rejected durable writes:
  attempt 2 not_retryable with runtime_failure/runtime_incompatible         rejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable with pre_acceptance_unavailable/runtime_unavailablerejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable on a timed_out attempt                            rejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable on an interrupted attempt                         rejected: retry_decision is invalid for attempt 2
  attempt 2 not_retryable after output commitment                           rejected: retry_decision is invalid for attempt 2
  attempt 2 cancelled evidence relabelled not_retryable                     rejected: retry_decision is invalid for attempt 2


==============================================================================
6. Attempt 1 acceptance-proof failure as persisted for an operator
==============================================================================
durable request_step.failed row for req_403_attempt1_36036:

{
    "node_id": "00000000-0000-4000-a000-000000000001",
    "accepted": false,
    "ended_at": "2026-09-11T04:00:01.000000Z",
    "started_at": "2026-09-11T04:00:00.000000Z",
    "failure_code": "internal_error",
    "failure_class": "pre_acceptance_unavailable",
    "retry_decision": "not_retryable",
    "attempt_outcome": "failed",
    "output_committed": false,
    "excluded_node_ids": [
    ],
    "runtime_retryable": false,
    "execution_resolution": "not_started",
    "capacity_release_outcome": "released"
}
```
</details>
<details>
<summary>Evidence: Attempt-2 durable evidence acceptance matrix</summary>

<code>Durable attempt-2 evidence acceptance matrix (Orchard.Requests.InferenceAttemptResult.new/3)&#10;&#10;attempt 2 terminal evidence retry_exhausted cancelled not_retryable&#10;---------------------------------------------------------------------------------------------&#10;failed / proof pair / uncommitted accepted rejected accepted&#10;failed / proof pair / committed accepted rejected rejected&#10;failed / runtime_failure / uncommitted accepted rejected rejected&#10;cancelled / cancellation rejected accepted rejected&#10;timed_out / deadline accepted rejected rejected&#10;interrupted / controller_failure accepted rejected rejected</code>

```text
Durable attempt-2 evidence acceptance matrix (Orchard.Requests.InferenceAttemptResult.new/3)

attempt 2 terminal evidence               retry_exhausted  cancelled        not_retryable    
---------------------------------------------------------------------------------------------
failed / proof pair / uncommitted         accepted         rejected         accepted         
failed / proof pair / committed           accepted         rejected         rejected         
failed / runtime_failure / uncommitted    accepted         rejected         rejected         
cancelled / cancellation                  rejected         accepted         rejected         
timed_out / deadline                      accepted         rejected         rejected         
interrupted / controller_failure          accepted         rejected         rejected         
```
</details>
<details>
<summary>Evidence: Shipped regressions run against pre-fix implementation (red check)</summary>

<code>1) test SPEC.md §7.5.3a closes the shared acceptance-proof evidence pair (Orchard.Requests.InferenceAttemptFailureTest)&#10;2) test SPEC.md §7.2.7 preserves runtime-incompatible pre-acceptance evidence (Orchard.Requests.InferenceAttemptFailureTest)&#10;3) test SPEC.md §§3.7.1, 5.8, and 7.5.3a preserves the typed acceptance-proof exception (Orchard.Inference.AttemptRetryClassifierTest)&#10;4) test SPEC.md §7.2.7 permits typed attempt 2 acceptance-proof failure evidence (Orchard.Requests.InferenceAttemptResultTest)</code>

```text
==> orchard_controller
Compiling 16 files (.ex)
==> orchard_controller
04:16:37.269 [warning] Metrics reporting degraded: {:gauge, :scheduler_queue_depth}
04:16:37.269 [warning] Metrics reporting degraded: {:gauge, :node_heartbeat_lag}
04:16:37.269 [warning] Metrics reporting degraded: {:gauge, :node_available_memory}
04:16:37.269 [warning] Metrics reporting degraded: {:gauge, :node_swap_used}
04:16:37.269 [warning] Metrics reporting degraded: {:gauge, :active_requests}
04:16:37.269 [warning] Metrics reporting degraded: {:gauge, :model_resident}
Running ExUnit with seed: 295612, max_cases: 36

..

  1) test SPEC.md §7.5.3a closes the shared acceptance-proof evidence pair (Orchard.Requests.InferenceAttemptFailureTest)
     apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs:90
     ** (UndefinedFunctionError) function Orchard.Requests.InferenceAttemptFailure.acceptance_proof_failure?/2 is undefined or private
     code: for {failure_class, failure_code} <- [
     stacktrace:
       (orchard_controller 0.5.0-dev) Orchard.Requests.InferenceAttemptFailure.acceptance_proof_failure?("pre_acceptance_unavailable", "runtime_unavailable")
       test/orchard/requests/inference_attempt_failure_test.exs:96: anonymous fn/2 in Orchard.Requests.InferenceAttemptFailureTest."test SPEC.md §7.5.3a closes the shared acceptance-proof evidence pair"/1
       (elixir 1.20.0) lib/enum.ex:2622: Enum."-reduce/3-lists^foldl/2-0-"/3
       test/orchard/requests/inference_attempt_failure_test.exs:91: (test)



  2) test SPEC.md §7.2.7 preserves runtime-incompatible pre-acceptance evidence (Orchard.Requests.InferenceAttemptFailureTest)
     apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs:72
     Assertion with == failed
     code:  assert evidence == %{
              "failure_class" => "pre_acceptance_unavailable",
              "failure_code" => "runtime_incompatible"
            }
     left:  %{
              "failure_class" => "pre_acceptance_unavailable",
              "failure_code" => "internal_error",
              "raw_source_code" => "runtime_incompatible"
            }
     right: %{
              "failure_class" => "pre_acceptance_unavailable",
              "failure_code" => "runtime_incompatible"
            }
     stacktrace:
       test/orchard/requests/inference_attempt_failure_test.exs:79: (test)

...........

  3) test SPEC.md §§3.7.1, 5.8, and 7.5.3a preserves the typed acceptance-proof exception (Orchard.Inference.AttemptRetryClassifierTest)
     apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs:221
     Assertion with == failed
     code:  assert classify(Map.put(acceptance_proof_failure, :attempt, 2)) == {:declined, :not_retryable}
     left:  {:declined, :retry_exhausted}
     right: {:declined, :not_retryable}
     stacktrace:
       test/orchard/inference/attempt_retry_classifier_test.exs:230: (test)

..............

  4) test SPEC.md §7.2.7 permits typed attempt 2 acceptance-proof failure evidence (Orchard.Requests.InferenceAttemptResultTest)
     apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs:69
     match (=) failed
     code:  assert {:ok, attempt_2} =
              InferenceAttemptResult.new(
                "request_step.failed",
                2,
                failed_result(%{
                  "failure_class" => "pre_acceptance_unavailable",
                  "failure_code" => "runtime_incompatible",
                  "node_id" => @node_2,
                  "excluded_node_ids" => [@node_1],
                  "retry_decision" => "not_retryable"
                })
              )
     left:  {:ok, attempt_2}
     right: {:error, "retry_decision is invalid for attempt 2"}
     stacktrace:
       test/orchard/requests/inference_attempt_result_test.exs:70: (test)

...    warning: Orchard.Requests.InferenceAttemptFailure.acceptance_proof_failure?/2 is undefined or private
    │
 84 │     assert InferenceAttemptFailure.acceptance_proof_failure?(
    │                                    ~
    │
    └─ test/orchard/requests/inference_attempt_failure_test.exs:84:36: Orchard.Requests.InferenceAttemptFailureTest."test SPEC.md §7.2.7 preserves runtime-incompatible pre-acceptance evidence"/1
    └─ test/orchard/requests/inference_attempt_failure_test.exs:96:38: Orchard.Requests.InferenceAttemptFailureTest."test SPEC.md §7.5.3a closes the shared acceptance-proof evidence pair"/1


Finished in 0.05 seconds (0.05s async, 0.00s sync)

Result: 30/34 passed
Failed: 4 tests
```
</details>
- Evidence: Evidence driver script (reproduces the end-to-end transcript) (local file: <code>/var/folders/xv/bz_t5kd57p3dv4nm5g5n_0fm0000gn/T/no-mistakes-evidence/01M26DMYM5SAXWKN0TTA5ZAT46/attempt_evidence_403.exs</code>)
<details>
<summary>Evidence: Attempt-2 acceptance matrix script</summary>

```text
Logger.configure(level: :warning)
alias Orchard.Requests.InferenceAttemptResult

node_1 = "00000000-0000-4000-a000-000000000001"
node_2 = "00000000-0000-4000-a000-000000000002"

base = fn overrides ->
  Map.merge(
    %{
      "attempt_outcome" => "failed",
      "started_at" => ~U[2026-09-11 04:00:00.000000Z],
      "ended_at" => ~U[2026-09-11 04:00:01.000000Z],
      "accepted" => false,
      "output_committed" => false,
      "execution_resolution" => "not_started",
      "capacity_release_outcome" => "released",
      "excluded_node_ids" => [node_1],
      "node_id" => node_2
    },
    overrides
  )
end

committed = %{
  "accepted" => true,
  "output_committed" => true,
  "output_commitment_kind" => "text",
  "execution_resolution" => "terminated"
}

cases = [
  {"failed / proof pair / uncommitted", "request_step.failed",
   base.(%{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "runtime_incompatible"})},
  {"failed / proof pair / committed", "request_step.failed",
   base.(Map.merge(committed, %{"failure_class" => "pre_acceptance_unavailable", "failure_code" => "runtime_incompatible"}))},
  {"failed / runtime_failure / uncommitted", "request_step.failed",
   base.(%{"failure_class" => "runtime_failure", "failure_code" => "runtime_unavailable"})},
  {"cancelled / cancellation", "request_step.cancelled",
   base.(%{"attempt_outcome" => "cancelled", "failure_class" => "cancellation", "failure_code" => "request_caller_disconnect"})},
  {"timed_out / deadline", "request_step.timed_out",
   base.(%{"attempt_outcome" => "timed_out", "failure_class" => "deadline", "failure_code" => "request_timeout"})},
  {"interrupted / controller_failure", "request_step.interrupted",
   base.(%{"attempt_outcome" => "interrupted", "failure_class" => "controller_failure", "failure_code" => "request_interrupted"})}
]

decisions = ~w(retry_exhausted cancelled not_retryable)

IO.puts("Durable attempt-2 evidence acceptance matrix (Orchard.Requests.InferenceAttemptResult.new/3)\n")
IO.puts(String.pad_trailing("attempt 2 terminal evidence", 42) <> Enum.map_join(decisions, "", &String.pad_trailing(&1, 17)))
IO.puts(String.duplicate("-", 93))

for {label, event_type, result} <- cases do
  row =
    Enum.map_join(decisions, "", fn decision ->
      verdict =
        case InferenceAttemptResult.new(event_type, 2, Map.put(result, "retry_decision", decision)) do
          {:ok, _} -> "accepted"
          {:error, _} -> "rejected"
        end

      String.pad_trailing(verdict, 17)
    end)

  IO.puts(String.pad_trailing(label, 42) <> row)
end

IO.puts("")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- 🚨 `docs/decisions/0019-one-request-bounded-alternate-node-retry.md:141` - Accepted decision record 0019 still states the old closed attempt-2 rule and now contradicts SPEC.md, the OpenSpec spec, and the implementation this branch ships. Line 141: &#34;An unsuccessful attempt 2 records `retry_exhausted` ... except that caller cancellation or disconnect records `cancelled`&#34;; line 81: &#34;caller cancellation remains the sole `cancelled` exception&#34;; line 181: &#34;Attempt 2 records `retry_exhausted` for every unsuccessful non-cancellation outcome and `cancelled` for caller cancellation&#34;. The branch adds a third attempt-2 value (`not_retryable`) in SPEC.md:744/1811, openspec/specs/automatic-attempt-retry/spec.md:29-32, attempt_retry_classifier.ex:110-115, and inference_attempt_result.ex:278-286, and the ADR itself declares &#34;This classification is normative for the retry contract&#34; (line 84). AGENTS.md states: &#34;If `SPEC.md`, docs, OpenSpec materials, tests, or implementation disagree about product behavior, treat the PR as blocked until the branch reconciles the conflict.&#34; The user intent named SPEC.md and the OpenSpec spec as the reconciliation targets but did not scope out docs/decisions, and this ADR is the durable record the OpenSpec spec traces to. Resolve by amending 0019 in place, superseding it, or explicitly recording that SPEC.md §3.7.1 now overrides those three sentences.
- ⚠️ `apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex:278` - The new attempt-2 `not_retryable` exception keys only on `failure_class`/`failure_code`, so the fail-closed validator also accepts `attempt_outcome: &#34;timed_out&#34;` paired with `retry_decision: &#34;not_retryable&#34;` on attempt 2. A `timed_out` attempt is by definition a proven deadline terminalization, which SPEC.md:744 says &#34;retains `retry_exhausted`&#34;, so the validator would durably admit evidence the contract forbids. The sibling consistency rule for `cancelled` (line 295-302) already closes the equivalent hole for cancellation by requiring `attempt_outcome == &#34;cancelled&#34;` with `failure_class == &#34;cancellation&#34;`; the deadline side has no counterpart. Adding `&#34;attempt_outcome&#34; =&gt; &#34;failed&#34;` to the new clause (or an equivalent rejection of `timed_out` + `not_retryable` on attempt 2) would make the closed vocabulary match the SPEC sentence the change introduces. Not reachable from today&#39;s orchestrator (`public_dispatch_reason/1` maps every `pre_acceptance_unavailable` outcome to state `:failed`), but this validator is the durable gate for when the deferred #327 producer lands.
- ℹ️ `apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex:107` - The new deadline clause encodes &#34;an already-proven deadline terminalization&#34; (SPEC.md:744) as `deadline_status: :exhausted`, which `retry_gate_snapshot/3` in request_orchestrator.ex:1470-1478 computes as a wall-clock check (`RequestDeadline.remaining_ms(timeout_at, DateTime.utc_now()) &gt; 0`) taken at classification time, after breaker persistence. Because it is ordered ahead of the acceptance-proof clause, an attempt 2 that actually terminalized on the proof failure (`attempt_outcome: :failed`, `pre_acceptance_unavailable` + `runtime_incompatible`) records `retry_exhausted` whenever the absolute deadline has merely elapsed by classification time, even though no deadline terminalization occurred — the case SPEC.md:744 says &#34;SHALL carry `not_retryable`&#34;. The ordering does mirror attempt 1&#39;s `budget_exhausted`-before-`not_retryable` precedence, so this may be the intended reading of &#34;proven&#34;; flagging it because the added test at attempt_retry_classifier_test.exs:238-240 fixes this interpretation as the contract and it will become reachable when #327&#39;s producer lands.
- ℹ️ `apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex:2068` - Forward-looking note, not a defect in this change: `public_dispatch_reason/1` matches `pre_acceptance_unavailable` on class alone and returns `{:model_load_failed, ModelLoadFailure.from_model_load_code(&#34;runtime_unavailable&#34;)}`, so an attempt-carrying acceptance-proof failure would surface the model-load `runtime_unavailable` public error rather than the `503 server_error` + `runtime_incompatible` mapping that the SPEC.md:2657 row now pairs with this durable evidence. Unreachable today because nothing produces the `pre_acceptance_unavailable` + `runtime_incompatible` pair (the producer is deferred behind #327), and the public mapping belongs to that deferred protocol work — recording it so the gap is not lost when the tuple negotiation lands.
- ℹ️ `apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex:110` - The `{&#34;pre_acceptance_unavailable&#34;, &#34;runtime_incompatible&#34;}` pair is now hardcoded independently in the classifier (lines 110-115) and the durable validator (inference_attempt_result.ex:278-286), and the two must agree exactly: the orchestrator hard-matches `{:ok, normalized} = InferenceAttemptResult.new(...)` at request_orchestrator.ex:2608, so a classifier decision the validator rejects crashes request handling with a MatchError rather than failing closed. The codebase already exports shared vocabularies for exactly this coupling (`InferenceAttemptFailure.failure_classes/0`, `stable_error_codes/0`, `InferenceAttemptResult.attempt_one_retry_decisions/0`); a single exported constant for the acceptance-proof pair would follow that convention and remove the silent-divergence path.

🔧 Fix: bound attempt-2 acceptance-proof exception and reconcile ADR 0019
2 issues (1 warning, 1 info) still open:
- ⚠️ `apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex:113` - This commit adds SPEC.md:747 &#34;a `cancelled`, `timed_out`, or `interrupted` attempt 2 ... SHALL retain `cancelled` or `retry_exhausted`&#34; and enforces all three in the validator (inference_attempt_result.ex:290-298), but the classifier can only observe two of them. `Boundary` carries no `attempt_outcome` fact, so `attempt_two_decision/1` decides purely on the class/code pair. The `cancelled` case is covered incidentally because `retry_gate_snapshot/3` (request_orchestrator.ex:1471) maps `attempt_outcome: :cancelled` to `caller_status: :cancelled`; `output_committed` got its own clause at line 110. There is no equivalent for `timed_out` or `interrupted`: an attempt 2 with those outcomes carrying the acceptance-proof pair, a live caller, and remaining deadline yields `:not_retryable` from the classifier, which the validator then rejects, and request_orchestrator.ex:2608 hard-matches `{:ok, normalized} = InferenceAttemptResult.new(...)` — so the divergence raises MatchError instead of producing the `retry_exhausted` the new SPEC sentence mandates. Not reachable today (nothing produces the pair, `:interrupted` is never an AttemptOutcome, and every current `:timed_out` producer yields deadline-class evidence), but the two boundaries now enforce different condition sets and the failure mode is a crash rather than fail-closed. Carrying `attempt_outcome` into `Boundary` — or defaulting `attempt_two_decision/1` to `:retry_exhausted` for any non-plain-failure outcome — would close it symmetrically.
- ℹ️ `apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex:2068` - Unchanged from round 1 and still accurate; recorded so it is not lost. `public_dispatch_reason/1` matches `pre_acceptance_unavailable` on class alone and returns `{:model_load_failed, ModelLoadFailure.from_model_load_code(&#34;runtime_unavailable&#34;)}`, so an attempt-carrying acceptance-proof failure would surface the model-load `runtime_unavailable` public error rather than the `503 server_error` + `runtime_incompatible` mapping that SPEC.md:2657 pairs with this durable evidence. Unreachable today because nothing produces the pair, and the public mapping belongs to the deferred #327 protocol work rather than to this evidence-only change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`MIX_ENV=test mix test apps/orchard_controller/test/orchard/inference/attempt_retry_classifier_test.exs apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs` (34 passed)</code>
- <code>`MIX_ENV=test mix test` across the affected controller slice: attempt_retry_classifier, attempt_context, inference_attempt_failure, inference_attempt_result, request_step_event, request_server, capture_policy, inference_attempt_projection, requests_test (176 passed)</code>
- <code>`MIX_ENV=test mix test apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs:{1240,1280,1350,1390,1440,1490,1530}` — end-to-end HTTP retry paths incl. attempt-2 retry_exhausted (7 passed)</code>
- <code>`MIX_ENV=test mix test apps/orchard_controller/test/orchard/api/responses_controller_test.exs:{1080,1140,1185,1230,1275,1320}` — same retry paths on /v1/responses (6 passed)</code>
- <code>Red/green check: `git checkout b50fb80c -- attempt_retry_classifier.ex inference_attempt_failure.ex inference_attempt_result.ex` then reran the three regression files — 4 of the 5 new tests fail against pre-fix code; files restored and worktree verified clean</code>
- <code>Manual end-to-end evidence driver on a dedicated migrated Postgres database (`orchard_403_evidence`): `MIX_ENV=dev PGDATABASE=orchard_403_evidence mix run --no-start attempt_evidence_403.exs`, run once at the target commit and once with the three implementation files reverted to base</code>
- <code>Durable acceptance matrix for attempt 2 across failed/cancelled/timed_out/interrupted outcomes x retry_exhausted/cancelled/not_retryable: `MIX_ENV=dev PGDATABASE=orchard_403_evidence mix run --no-start attempt2_matrix.exs`</code>
- <code>Added and ran a new focused regression `apps/orchard_controller/test/orchard/requests/request_server_test.exs:277` (&#34;SPEC.md §§3.7.1 and 7.5.3a persists attempt two acceptance-proof evidence&#34;) — green on target, red on base</code>
- <code>Cleanup: dropped the transient `orchard_403_evidence` database and confirmed `git status --porcelain` shows only the intentional test-file change</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CHANGELOG.md` - The attempt-2 acceptance-proof `not_retryable` exception has no CHANGELOG entry yet, and I intentionally did not add one. CHANGELOG.md is grouped by the date a change landed on `main` and is written retroactively in weekly batches by dedicated docs PRs (#370, #317, #275, #244); post-2026-09-06 merges (#392, #394, #397) likewise carry no entries. Adding a new dated section here would invent a release grouping and duplicate that process&#39;s ownership. Follow-up: the next weekly changelog PR should record that an unsuccessful attempt 2 can now carry `not_retryable` for a Controller-detected negotiated acceptance-proof failure, while cancellation keeps `cancelled` and proven deadline terminalization keeps `retry_exhausted`.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves the negotiated acceptance-proof failure pair and introduces a tightly bounded attempt-2 `not_retryable` exception.
- Carries `attempt_outcome` into retry classification so failed, cancelled, timed-out, interrupted, deadline-exhausted, and output-committed states retain the documented precedence.
- Shares the acceptance-proof predicate between normalization, classification, and durable validation.
- Reconciles SPEC.md, OpenSpec, ADR 0019, and regression coverage for persistence and metrics projection.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/inference/attempt_retry_classifier.ex | Adds attempt-outcome-aware attempt-2 precedence and uses the shared acceptance-proof predicate. |
| apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex | Supplies the terminal attempt outcome to the retry-classification boundary. |
| apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex | Preserves runtime-incompatible pre-acceptance evidence and centralizes recognition of the closed proof-failure pair. |
| apps/orchard_controller/lib/orchard/requests/inference_attempt_result.ex | Admits attempt-2 not-retryable evidence only for failed, uncommitted acceptance-proof failures. |
| SPEC.md | Defines cancellation, deadline, commitment, and acceptance-proof precedence for attempt 2. |
| docs/decisions/0019-one-request-bounded-alternate-node-retry.md | Explicitly amends the decision record and identifies the historical statements superseded by the updated specification. |
| openspec/specs/automatic-attempt-retry/spec.md | Adds scenarios covering proof failure, deadline precedence, and committed output. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Attempt 2 terminal outcome] --> B{Caller cancelled?}
  B -- Yes --> C[cancelled]
  B -- No --> D{Deadline exhausted?}
  D -- Yes --> E[retry_exhausted]
  D -- No --> F{Output committed?}
  F -- Yes --> E
  F -- No --> G{Failed with acceptance-proof pair?}
  G -- Yes --> H[not_retryable]
  G -- No --> E
  C --> I[Durable attempt validation]
  E --> I
  H --> I
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/attempt-fai..."](https://github.com/kapitan-ai/orchard/commit/0e00067bcade262ab70d3d12359ad5e215bfb7bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62782678)</sub>

<!-- /greptile_comment -->