### PR TITLE
refactor(worker_mlx): share partial-marker scanning and expose text-first tool consumption

### DIFF
--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/partial_markers.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/partial_markers.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def split_partial_marker(text: str, marker: str) -> tuple[str, str]:
+    if marker == "":
+        return text, ""
+
+    max_overlap = min(len(text), len(marker) - 1)
+    for overlap in range(max_overlap, 0, -1):
+        if text.endswith(marker[:overlap]):
+            return text[:-overlap], text[-overlap:]
+    return text, ""

--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/partial_markers.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/partial_markers.py
@@ -1,3 +1,11 @@
+"""Chunk-boundary marker splitting shared by this package's streaming consumers.
+
+A framing marker can straddle two streamed chunks, so a trailing fragment that is
+a proper prefix of the marker must never be published as visible output. Splitting
+returns ``(publishable_text, retained_suffix)``; the caller carries the retained
+suffix into the next chunk.
+"""
+
 from __future__ import annotations
 
 

--- a/native/orchard_worker_mlx/src/orchard_worker_mlx/tool_calling.py
+++ b/native/orchard_worker_mlx/src/orchard_worker_mlx/tool_calling.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from orchard_worker_mlx.backends import BackendError
+from orchard_worker_mlx.partial_markers import split_partial_marker
 
 
 @dataclass(slots=True)
@@ -91,7 +92,10 @@ def build_context(session: Any, params: Any) -> ToolCallingContext | None:
 
 
 def consume_response(ctx: ToolCallingContext, response: Any) -> list[dict[str, Any]]:
-    text = getattr(response, "text", "")
+    return consume_text(ctx, getattr(response, "text", ""))
+
+
+def consume_text(ctx: ToolCallingContext, text: str) -> list[dict[str, Any]]:
     if not isinstance(text, str) or text == "":
         return []
 
@@ -163,7 +167,7 @@ def _consume_normal_text(ctx: ToolCallingContext, text: str) -> str:
     start_pos = combined.find(ctx.tool_call_start)
 
     if start_pos == -1:
-        safe_text, suffix = _split_partial_marker(combined, ctx.tool_call_start)
+        safe_text, suffix = split_partial_marker(combined, ctx.tool_call_start)
         if safe_text:
             ctx.pending_events.append({"kind": "output_text_delta", "delta": safe_text})
         ctx.text_buffer = suffix
@@ -186,7 +190,7 @@ def _consume_tool_text(ctx: ToolCallingContext, text: str) -> str:
     end_pos = combined.find(ctx.tool_call_end)
 
     if end_pos == -1:
-        safe_text, suffix = _split_partial_marker(combined, ctx.tool_call_end)
+        safe_text, suffix = split_partial_marker(combined, ctx.tool_call_end)
         ctx.tool_text_parts.append(safe_text)
         ctx.tool_end_buffer = suffix
         return ""
@@ -194,17 +198,6 @@ def _consume_tool_text(ctx: ToolCallingContext, text: str) -> str:
     ctx.tool_text_parts.append(combined[:end_pos])
     _finalize_active_tool_call(ctx)
     return combined[end_pos + len(ctx.tool_call_end) :]
-
-
-def _split_partial_marker(text: str, marker: str) -> tuple[str, str]:
-    if marker == "":
-        return text, ""
-
-    max_overlap = min(len(text), len(marker) - 1)
-    for overlap in range(max_overlap, 0, -1):
-        if text.endswith(marker[:overlap]):
-            return text[:-overlap], text[-overlap:]
-    return text, ""
 
 
 def _start_tool_call(ctx: ToolCallingContext) -> None:

--- a/native/orchard_worker_mlx/tests/test_tool_calling.py
+++ b/native/orchard_worker_mlx/tests/test_tool_calling.py
@@ -6,7 +6,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from orchard_worker_mlx.tool_calling import ToolCallingContext, consume_response, finalize
+from orchard_worker_mlx.partial_markers import split_partial_marker
+from orchard_worker_mlx.tool_calling import (
+    ToolCallingContext,
+    consume_response,
+    consume_text,
+    finalize,
+)
 
 
 def make_context(**overrides) -> ToolCallingContext:
@@ -174,3 +180,73 @@ def test_valid_call_remains_visible_when_a_later_block_fails() -> None:
     assert finalize(context) is not None
     assert context.take_pending_events() == []
     assert events[0]["tool_call_id"] == "call_0"
+
+
+@pytest.mark.parametrize(
+    ("text", "marker", "expected"),
+    [
+        ("ordinary text", "<tool_call>", ("ordinary text", "")),
+        ("before<tool_", "<tool_call>", ("before", "<tool_")),
+        ("before</tool_cal", "</tool_call>", ("before", "</tool_cal")),
+        ("ordinary text", "", ("ordinary text", "")),
+    ],
+)
+def test_split_partial_marker_preserves_only_marker_prefix_at_chunk_boundary(
+    text: str,
+    marker: str,
+    expected: tuple[str, str],
+) -> None:
+    assert split_partial_marker(text, marker) == expected
+
+
+def test_consume_response_wraps_text_first_consumption_with_identical_tool_events() -> None:
+    chunks = [
+        "Before <tool_",
+        'call>{"name":"read","arguments":{"path":"fixture.txt"}}</tool_',
+        "call> after",
+    ]
+
+    def consume_chunks(consumer):
+        parser_inputs: list[str] = []
+        context = make_context(
+            tool_parser=lambda text, tools: parser_inputs.append(text) or json.loads(text),
+        )
+        events: list[dict] = []
+        for chunk in chunks:
+            events.extend(consumer(context, chunk))
+        assert finalize(context) is None
+        events.extend(context.take_pending_events())
+        return events, parser_inputs
+
+    response_events, response_inputs = consume_chunks(
+        lambda context, text: consume_response(context, SimpleNamespace(text=text)),
+    )
+    text_events, text_inputs = consume_chunks(consume_text)
+
+    assert (
+        response_events
+        == text_events
+        == [
+            {"kind": "output_text_delta", "delta": "Before "},
+            {
+                "kind": "tool_call_delta",
+                "tool_call_id": "call_0",
+                "delta": {
+                    "index": 0,
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments_delta": '{"path":"fixture.txt"}',
+                    },
+                },
+            },
+            {"kind": "output_text_delta", "delta": " after"},
+        ]
+    )
+    assert (
+        response_inputs
+        == text_inputs
+        == [
+            '{"name":"read","arguments":{"path":"fixture.txt"}}',
+        ]
+    )


### PR DESCRIPTION
## Intent

Implement only unblocked #328 PR-1: refactor the native orchard_worker_mlx package so partial-marker scanning is shared in a small provider-neutral-within-package module and expose text-first tool consumption. Keep consume_response as a behavior-identical wrapper. Preserve exact legacy tool-call bytes, event order, and parsed calls with direct regressions. Do not add a reasoning parser, generate_events wiring, protobuf or public API changes, behavior changes, ex_dna suppressions, or unrelated refactors. The PR is a dependency for #328 PR-3 and has tracking issue #408.

## What Changed

- Extracted the private `_split_partial_marker` helper from `tool_calling.py` into a new `orchard_worker_mlx/partial_markers.py` module as `split_partial_marker`, documenting the `(publishable_text, retained_suffix)` chunk-boundary contract that streaming consumers in this package share; both the tool-call-start and tool-call-end scan paths now call the shared helper.
- Split `consume_response` into a text-first `consume_text(ctx, text)` entry point, leaving `consume_response` as a behavior-identical wrapper that forwards `getattr(response, "text", "")`. No `generate_events` wiring, protobuf, or other call-site changes.
- Added direct regressions in `tests/test_tool_calling.py`: a parametrized `split_partial_marker` case set (including the empty-marker and both real markers) and a test asserting `consume_response` and `consume_text` produce identical event sequences and identical provider-parser input across a marker-straddling chunk stream.

Pipeline validation ran the worker tool-calling and mlx parser suites plus a differential harness against the base commit (4,408 triple comparisons of legacy vs. new `consume_response` vs. `consume_text`, and 20,000 randomized probes of `split_partial_marker` against the removed private helper) with zero divergences; review raised one informational note that the inherited non-`str` guard on the new `consume_text` entry point silently returns `[]`, which is unchanged from prior behavior.

## Risk Assessment

✅ Low: A verbatim function extraction plus a one-line delegating wrapper, with the sole production call site unchanged and new direct regressions asserting identical event order, parser input bytes, and parsed calls across both consumption paths.

## Testing

I ran the targeted tool-calling suites (35 unit tests plus the 3 real mlx-lm parser tests, which I un-skipped by installing the pinned `mlx` extra, plus 25 generation/service tool tests) and then built direct equivalence evidence against the base commit, since the intent is a behavior-identical refactor. A differential harness fed 4,408 legacy-vs-shipped-vs-`consume_text` comparisons across every chunk-boundary permutation, all four terminal kinds, error paths and degenerate payloads with zero divergence, and 20,000 random probes confirmed the extracted `split_partial_marker` matches the removed private helper exactly. For product-level evidence I drove the real worker generation loop and rendered the gRPC `InferenceEvent` stream a controller receives, showing identical serialized protobuf bytes under all three wirings, and replayed the three real pinned provider parsers character-by-character. Two deliberate mutations confirmed the new regression tests actually guard the behavior. Everything passed; I removed the transient `.venv`, `.pytest_cache` and `__pycache__` directories so the worktree is clean. This change is worker-internal Python with no rendered UI surface, so no screenshot or visual artifact applies — the CLI transcripts of the worker's wire-level event stream are the closest end-user-visible surface.

<details>
<summary>Evidence: Worker wire-level transcript: streamed tool call as gRPC InferenceEvents (legacy vs shipped wrapper vs text-first are byte-identical)</summary>

<code>Orchard MLX worker — streamed tool call, wire-level transcript&#10;prompt : what is the weather in Singapore?&#10;tools : lookup_weather(city)&#10;model tokens : &#39;Checking the &#39; / &#39;forecast. &lt;tool_&#39; / &#39;call&gt;{&#34;name&#34;:&#34;lookup_weather&#34;,&#34;arg&#39; / &#39;uments&#34;:{&#34;city&#34;:&#34;Singapore&#34;}}&lt;/tool_&#39; / &#39;call&gt;&#39; / &#39; Done.&#39;&#10;&#10;--- gRPC InferenceEvent stream delivered to the controller ---&#10;[0] output_text_delta delta=&#39;Checking the &#39;&#10;[1] output_text_delta delta=&#39;forecast. &#39;&#10;[2] tool_call_delta id=call_0 delta_json={&#34;index&#34;: 0, &#34;type&#34;: &#34;function&#34;, &#34;function&#34;: {&#34;name&#34;: &#34;lookup_weather&#34;, &#34;arguments_delta&#34;: &#34;{\&#34;city\&#34;:\&#34;Singapore\&#34;}&#34;}}&#10;[3] output_text_delta delta=&#39; Done.&#39;&#10;[4] completed finish_reason=3 (FINISH_REASON_TOOL_CALLS)&#10;&#10;tool-call bytes handed to the provider parser: [&#39;{&#34;name&#34;:&#34;lookup_weather&#34;,&#34;arguments&#34;:{&#34;city&#34;:&#34;Singapore&#34;}}&#39;]&#10;&#10;--- wiring equivalence (serialized protobuf bytes) ---&#10;legacy : 5 wire events | identical-to-legacy bytes=True events=True parser-input=True&#10;shipped : 5 wire events | identical-to-legacy bytes=True events=True parser-input=True&#10;text-first : 5 wire events | identical-to-legacy bytes=True events=True parser-input=True&#10;&#10;RESULT: IDENTICAL WIRE STREAM</code>

```text
==============================================================================
Orchard MLX worker — streamed tool call, wire-level transcript
==============================================================================
prompt        : what is the weather in Singapore?
tools         : lookup_weather(city)
model tokens  :
                'Checking the '
                'forecast. <tool_'
                'call>{"name":"lookup_weather","arg'
                'uments":{"city":"Singapore"}}</tool_'
                'call>'
                ' Done.'

--- gRPC InferenceEvent stream delivered to the controller ---
  [0] output_text_delta  delta='Checking the '
  [1] output_text_delta  delta='forecast. '
  [2] tool_call_delta    id=call_0 delta_json={"index": 0, "type": "function", "function": {"name": "lookup_weather", "arguments_delta": "{\"city\":\"Singapore\"}"}}
  [3] output_text_delta  delta=' Done.'
  [4] completed          finish_reason=3

tool-call bytes handed to the provider parser: ['{"name":"lookup_weather","arguments":{"city":"Singapore"}}']

--- wiring equivalence (serialized protobuf bytes) ---
  legacy      : 5 wire events | identical-to-legacy bytes=True events=True parser-input=True
  shipped     : 5 wire events | identical-to-legacy bytes=True events=True parser-input=True
  text-first  : 5 wire events | identical-to-legacy bytes=True events=True parser-input=True

RESULT: IDENTICAL WIRE STREAM
```
</details>
<details>
<summary>Evidence: Differential: legacy (3c69fe60) vs refactored consume_response vs new consume_text</summary>

<code>cases : 17&#10;stream chunkings : every 2-way split, per-char, random, empty-padded&#10;terminal kinds : completed, truncated, cancelled, failed&#10;triple comparisons : 4408&#10;mismatches : 0&#10;&#10;split_partial_marker vs legacy _split_partial_marker: 20000 random probes, 0 divergences&#10;degenerate payload missing .text attribute legacy=[] new=[] match=True&#10;degenerate payload text=None legacy=[] new=[] match=True&#10;degenerate payload text=b&#39;bytes&#39; legacy=[] new=[] match=True&#10;degenerate payload text=123 legacy=[] new=[] match=True&#10;degenerate payload text=&#39;&#39; legacy=[] new=[] match=True&#10;degenerate payload divergences: 0&#10;&#10;RESULT: IDENTICAL BEHAVIOR</code>

```text
==============================================================================
Differential: legacy consume_response  vs  new consume_response  vs  consume_text
==============================================================================
cases                 : 17
stream chunkings      : every 2-way split, per-char, random, empty-padded
terminal kinds        : completed, truncated, cancelled, failed
triple comparisons    : 4408
mismatches            : 0

split_partial_marker vs legacy _split_partial_marker: 20000 random probes, 0 divergences
  degenerate payload missing .text attribute  legacy=[] new=[] match=True
  degenerate payload text=None                legacy=[] new=[] match=True
  degenerate payload text=b'bytes'            legacy=[] new=[] match=True
  degenerate payload text=123                 legacy=[] new=[] match=True
  degenerate payload text=''                  legacy=[] new=[] match=True
degenerate payload divergences: 0

--- sample stream (per-token chunks, consume_text entrypoint) ---
model output : 'Before <tool_call>{"name":"read","arguments":{"path":"fixture.txt"}}</tool_call> after'
  event: {"kind": "output_text_delta", "delta": "B"}
  event: {"kind": "output_text_delta", "delta": "e"}
  event: {"kind": "output_text_delta", "delta": "f"}
  event: {"kind": "output_text_delta", "delta": "o"}
  event: {"kind": "output_text_delta", "delta": "r"}
  event: {"kind": "output_text_delta", "delta": "e"}
  event: {"kind": "output_text_delta", "delta": " "}
  event: {"kind": "tool_call_delta", "tool_call_id": "call_0", "delta": {"index": 0, "type": "function", "function": {"name": "read", "arguments_delta": "{\"path\":\"fixture.txt\"}"}}}
  event: {"kind": "output_text_delta", "delta": " "}
  event: {"kind": "output_text_delta", "delta": "a"}
  event: {"kind": "output_text_delta", "delta": "f"}
  event: {"kind": "output_text_delta", "delta": "t"}
  event: {"kind": "output_text_delta", "delta": "e"}
  event: {"kind": "output_text_delta", "delta": "r"}
  parser saw (exact legacy tool-call bytes): ['{"name":"read","arguments":{"path":"fixture.txt"}}']

RESULT: IDENTICAL BEHAVIOR
```
</details>
<details>
<summary>Evidence: Real pinned mlx-lm parsers (json_tools, qwen3_coder, mistral) streamed per character</summary>

<code>parser : json_tools start/end &#39;&lt;tool_call&gt;&#39; / &#39;&lt;/tool_call&gt;&#39;&#10;parser input (exact tool-call bytes): [&#39;{&#34;name&#34;:&#34;read&#34;,&#34;arguments&#34;:{&#34;path&#34;:&#34;fixture.txt&#34;}}&#39;]&#10;tool_call_delta: id=call_0 name=read arguments_delta={&#34;path&#34;:&#34;fixture.txt&#34;}&#10;visible assistant text: &#39;Prose before. prose after.&#39;&#10;legacy == shipped == consume_text: True; finalize error: None&#10;&#10;parser : qwen3_coder start/end &#39;&lt;tool_call&gt;&#39; / &#39;&lt;/tool_call&gt;&#39;&#10;parser input (exact tool-call bytes): [&#39;&lt;function=read&gt;\n&lt;parameter=path&gt;\nfixture.txt\n&lt;/parameter&gt;\n&lt;/function&gt;&#39;]&#10;tool_call_delta: id=call_0 name=read arguments_delta={&#34;path&#34;:&#34;fixture.txt&#34;}&#10;legacy == shipped == consume_text: True; finalize error: None&#10;&#10;parser : mistral start/end &#39;[TOOL_CALLS]&#39; / &#39;&#39; (empty end marker)&#10;parser input (exact tool-call bytes): [&#39;read[ARGS]{&#34;path&#34;:&#34;fixture.txt&#34;} prose after.&#39;]&#10;tool_call_delta: id=call_0 name=read arguments_delta={&#34;path&#34;:&#34;fixture.txt&#34;}&#10;legacy == shipped == consume_text: True; finalize error: None&#10;&#10;RESULT: IDENTICAL BEHAVIOR ON REAL PARSERS</code>

```text
==============================================================================
Pinned mlx-lm tool parsers — per-character streaming through the worker
==============================================================================

parser        : json_tools
  start/end   : '<tool_call>' / '</tool_call>'
  model output: 'Prose before. <tool_call>{"name":"read","arguments":{"path":"fixture.txt"}}</tool_call> prose after.'
  parser input (exact tool-call bytes): ['{"name":"read","arguments":{"path":"fixture.txt"}}']
  tool_call_delta: id=call_0 name=read arguments_delta={"path":"fixture.txt"}
  decoded arguments: {'path': 'fixture.txt'}
  visible assistant text: 'Prose before.  prose after.'
  event kinds : ['output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'tool_call_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta']
  legacy == shipped == consume_text: True; finalize error: None

parser        : qwen3_coder
  start/end   : '<tool_call>' / '</tool_call>'
  model output: 'Prose before. <tool_call><function=read>\n<parameter=path>\nfixture.txt\n</parameter>\n</function></tool_call> prose after.'
  parser input (exact tool-call bytes): ['<function=read>\n<parameter=path>\nfixture.txt\n</parameter>\n</function>']
  tool_call_delta: id=call_0 name=read arguments_delta={"path":"fixture.txt"}
  decoded arguments: {'path': 'fixture.txt'}
  visible assistant text: 'Prose before.  prose after.'
  event kinds : ['output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'tool_call_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta']
  legacy == shipped == consume_text: True; finalize error: None

parser        : mistral
  start/end   : '[TOOL_CALLS]' / ''
  model output: 'Prose before. [TOOL_CALLS]read[ARGS]{"path":"fixture.txt"} prose after.'
  parser input (exact tool-call bytes): ['read[ARGS]{"path":"fixture.txt"} prose after.']
  tool_call_delta: id=call_0 name=read arguments_delta={"path":"fixture.txt"}
  decoded arguments: {'path': 'fixture.txt'}
  visible assistant text: 'Prose before. '
  event kinds : ['output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'output_text_delta', 'tool_call_delta']
  legacy == shipped == consume_text: True; finalize error: None

RESULT: IDENTICAL BEHAVIOR ON REAL PARSERS
```
</details>
<details>
<summary>Evidence: Differential harness source (legacy vs refactored equivalence)</summary>

```text
"""Differential harness: legacy (3c69fe60) vs refactored (e123cdd2) tool-call streaming.

Feeds identical model-output streams, chunked every way, through:
  A. legacy  consume_response(ctx, response)   -- base commit implementation
  B. new     consume_response(ctx, response)   -- behavior-identical wrapper
  C. new     consume_text(ctx, text)           -- newly exposed text-first entrypoint

and asserts A == B == C for emitted event order/bytes, the exact text handed to
the provider tool parser, the finalize() outcome, and the residual buffers.
"""

from __future__ import annotations

import importlib.util
import json
import random
import re
import sys
from pathlib import Path
from types import SimpleNamespace

HERE = Path(__file__).parent


def _load_legacy():
    spec = importlib.util.spec_from_file_location(
        "legacy_tool_calling", HERE / "legacy_tool_calling.py"
    )
    module = importlib.util.module_from_spec(spec)
    sys.modules["legacy_tool_calling"] = module
    spec.loader.exec_module(module)
    return module


legacy = _load_legacy()
import orchard_worker_mlx.tool_calling as new  # noqa: E402
from orchard_worker_mlx.partial_markers import split_partial_marker  # noqa: E402

TOOLS = [
    {
        "type": "function",
        "function": {
            "name": "read",
            "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
        },
    },
    {
        "type": "function",
        "function": {
            "name": "write",
            "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
        },
    },
]


# --- provider-shaped parsers (stand-ins for the pinned mlx-lm parsers) -------


def json_parser(text, tools):
    return json.loads(text)


def qwen3_coder_parser(text, tools):
    name = re.search(r"<function=([^>]+)>", text).group(1)
    args = dict(re.findall(r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>", text, re.S))
    return {"name": name, "arguments": args}


def mistral_parser(text, tools):
    name, _, payload = text.partition("[ARGS]")
    return {"name": name.strip(), "arguments": json.loads(payload)}


def multi_parser(text, tools):
    return json.loads(text)


def exploding_parser(text, tools):
    raise RuntimeError(f"provider blew up on secret content: {text}")


def bad_shape_parser(text, tools):
    return "not-a-dict"


CASES = [
    # (label, start, end, parser, tool_choice-ish, stream)
    ("plain text, no markers", "<tool_call>", "</tool_call>", json_parser, None,
     "Hello operator, no tools today."),
    ("qwen json tool call", "<tool_call>", "</tool_call>", json_parser, None,
     'Before <tool_call>{"name":"read","arguments":{"path":"fixture.txt"}}</tool_call> after'),
    ("two tool calls interleaved with prose", "<tool_call>", "</tool_call>", json_parser, None,
     'a<tool_call>{"name":"read","arguments":{"path":"a.txt"}}</tool_call>'
     'mid<tool_call>{"name":"write","arguments":{"path":"b.txt"}}</tool_call>end'),
    ("qwen3_coder xml body", "<tool_call>", "</tool_call>", qwen3_coder_parser, None,
     "<tool_call><function=read>\n<parameter=path>\nfixture.txt\n</parameter>\n"
     "</function></tool_call>"),
    ("mistral bracket marker, empty end marker", "[TOOL_CALLS]", "", mistral_parser, None,
     'chat [TOOL_CALLS]read[ARGS]{"path":"fixture.txt"}'),
    ("parser returns a list of calls", "<tool_call>", "</tool_call>", multi_parser, None,
     '<tool_call>[{"name":"read","arguments":{"path":"a"}},'
     '{"name":"write","arguments":{"path":"b"}}]</tool_call>'),
    ("teasing false-start marker prefixes", "<tool_call>", "</tool_call>", json_parser, None,
     '<tool<tool_c<tool_call>{"name":"read","arguments":{"path":"x"}}</tool></tool_call>tail'),
    ("self-overlapping marker", "<<tool>>", "<</tool>>", json_parser, None,
     '<<<tool>>{"name":"read","arguments":{}}<<</tool>>z'),
    ("unicode + unterminated tool call", "<tool_call>", "</tool_call>", json_parser, None,
     'héllo ✅ <tool_call>{"name":"read","arg'),
    ("parser raises", "<tool_call>", "</tool_call>", exploding_parser, None,
     'x<tool_call>garbage</tool_call>y'),
    ("parser returns wrong shape", "<tool_call>", "</tool_call>", bad_shape_parser, None,
     '<tool_call>{}</tool_call>'),
    ("unrequested function name", "<tool_call>", "</tool_call>", json_parser, None,
     '<tool_call>{"name":"delete","arguments":{}}</tool_call>'),
    ("non-object arguments", "<tool_call>", "</tool_call>", json_parser, None,
     '<tool_call>{"name":"read","arguments":"nope"}</tool_call>'),
    ("named tool_choice satisfied", "<tool_call>", "</tool_call>", json_parser,
     {"named": "read", "required": True},
     '<tool_call>{"name":"read","arguments":{"path":"a"}}</tool_call>'),
    ("named tool_choice violated", "<tool_call>", "</tool_call>", json_parser,
     {"named": "read", "required": True},
     '<tool_call>{"name":"write","arguments":{"path":"a"}}</tool_call>'),
    ("required tool_choice never satisfied", "<tool_call>", "</tool_call>", json_parser,
     {"named": None, "required": True},
     'just prose'),
    ("empty stream chunks", "<tool_call>", "</tool_call>", json_parser, None, ""),
]

TERMINALS = ["completed", "truncated", "cancelled", "failed"]


def chunkings(text):
    yield "whole", [text] if text else [""]
    yield "per-char", list(text) if text else [""]
    if text:
        for i in range(1, len(text)):
            yield f"split@{i}", [text[:i], text[i:]]
        rng = random.Random(1337)
        for trial in range(5):
            cuts = sorted(rng.sample(range(1, len(text)), min(3, max(1, len(text) - 1))))
            parts, prev = [], 0
            for c in cuts:
                parts.append(text[prev:c])
                prev = c
            parts.append(text[prev:])
            yield f"random{trial}", parts
    # interleaved empty chunks (worker emits empty text deltas)
    yield "empty-padded", ["", text, ""]


def build_ctx(module, case, parser_inputs):
    _, start, end, parser, choice, _ = case

    def recording_parser(text, tools):
        parser_inputs.append(text)
        return parser(text, tools)

    named = choice["named"] if choice else None
    required = choice["required"] if choice else False
    return module.ToolCallingContext(
        tools=TOOLS,
        parser_type="harness",
        tool_choice="auto",
        tool_call_start=start,
        tool_call_end=end,
        tool_parser=recording_parser,
        named_tool_name=named,
        requires_tool_call=required,
    )


def run(module, case, chunks, terminal, entry):
    parser_inputs: list[str] = []
    ctx = build_ctx(module, case, parser_inputs)
    events: list[dict] = []
    for chunk in chunks:
        if entry == "text":
            events.extend(module.consume_text(ctx, chunk))
        else:
            events.extend(module.consume_response(ctx, SimpleNamespace(text=chunk)))
    err = module.finalize(ctx, terminal_kind=terminal)
    trailing = ctx.take_pending_events()
    return {
        "events": events,
        "trailing_events": trailing,
        "parser_inputs": parser_inputs,
        "error": None if err is None else [err.code, err.message, err.retryable],
        "residual": {
            "text_buffer": ctx.text_buffer,
            "tool_end_buffer": ctx.tool_end_buffer,
            "in_tool_call": ctx.in_tool_call,
            "saw_tool_call": ctx.saw_tool_call,
            "next_tool_index": ctx.next_tool_index,
        },
    }


def main() -> int:
    comparisons = 0
    mismatches = []
    for case in CASES:
        label, _, _, _, _, stream = case
        for chunk_label, chunks in chunkings(stream):
            for terminal in TERMINALS:
                base = run(legacy, case, chunks, terminal, "response")
                wrapper = run(new, case, chunks, terminal, "response")
                textfirst = run(new, case, chunks, terminal, "text")
                comparisons += 1
                if not (base == wrapper == textfirst):
                    mismatches.append((label, chunk_label, terminal, base, wrapper, textfirst))

    print("=" * 78)
    print("Differential: legacy consume_response  vs  new consume_response  vs  consume_text")
    print("=" * 78)
    print(f"cases                 : {len(CASES)}")
    print(f"stream chunkings      : every 2-way split, per-char, random, empty-padded")
    print(f"terminal kinds        : {', '.join(TERMINALS)}")
    print(f"triple comparisons    : {comparisons}")
    print(f"mismatches            : {len(mismatches)}")
    for m in mismatches[:5]:
        print("\nMISMATCH", m[0], m[1], m[2])
        print("  legacy   :", m[3])
        print("  wrapper  :", m[4])
        print("  consume_text:", m[5])
    print()

    # Shared-module identity: the extracted helper is the same function the legacy
    # private helper implemented, used for BOTH the start and the end marker.
    probe_fail = 0
    markers = ["<tool_call>", "</tool_call>", "[TOOL_CALLS]", "<<tool>>", ""]
    alphabet = "<>/tool_calTOLSabc[]"
    rng = random.Random(7)
    for marker in markers:
        for _ in range(4000):
            text = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 14)))
            if split_partial_marker(text, marker) != legacy._split_partial_marker(text, marker):
                probe_fail += 1
    print(f"split_partial_marker vs legacy _split_partial_marker: "
          f"{len(markers) * 4000} random probes, {probe_fail} divergences")

    # Degenerate payloads the wrapper must keep absorbing exactly as before.
    degenerate = [
        ("missing .text attribute", SimpleNamespace()),
        ("text=None", SimpleNamespace(text=None)),
        ("text=b'bytes'", SimpleNamespace(text=b"bytes")),
        ("text=123", SimpleNamespace(text=123)),
        ("text=''", SimpleNamespace(text="")),
    ]
    degen_fail = 0
    for label, response in degenerate:
        legacy_ctx = build_ctx(legacy, CASES[1], [])
        new_ctx = build_ctx(new, CASES[1], [])
        legacy_out = legacy.consume_response(legacy_ctx, response)
        new_out = new.consume_response(new_ctx, response)
        same = legacy_out == new_out and legacy_ctx.text_buffer == new_ctx.text_buffer
        degen_fail += 0 if same else 1
        print(f"  degenerate payload {label:<24} legacy={legacy_out!r} new={new_out!r} match={same}")
    print(f"degenerate payload divergences: {degen_fail}")

    # Sample transcript: what the worker actually emits for a streamed tool call.
    case = CASES[1]
    inputs: list[str] = []
    ctx = build_ctx(new, case, inputs)
    print("\n--- sample stream (per-token chunks, consume_text entrypoint) ---")
    print(f"model output : {case[5]!r}")
    emitted = []
    for ch in case[5]:
        emitted.extend(new.consume_text(ctx, ch))
    assert new.finalize(ctx) is None
    emitted.extend(ctx.take_pending_events())
    for ev in emitted:
        print("  event:", json.dumps(ev, ensure_ascii=False))
    print(f"  parser saw (exact legacy tool-call bytes): {inputs!r}")

    ok = not mismatches and probe_fail == 0 and degen_fail == 0
    print("\nRESULT:", "IDENTICAL BEHAVIOR" if ok else "DIVERGENCE DETECTED")
    return 0 if ok else 1


if __name__ == "__main__":
    raise SystemExit(main())
```
</details>
<details>
<summary>Evidence: End-to-end worker wire transcript script</summary>

```text
"""End-to-end worker transcript: model tokens -> generate_events -> gRPC InferenceEvent.

Drives the real orchard_worker_mlx generation loop (fake mlx stream_generate, real
tool-calling mediation) and renders the protobuf events a controller actually
receives, for three tool-consumption wirings:

  legacy       generation.consume_tool_response = legacy consume_response (3c69fe60)
  shipped      generation.consume_tool_response = new consume_response wrapper
  text-first   generation.consume_tool_response = adapter over the new consume_text

All three wire streams must be byte-identical.
"""

from __future__ import annotations

import importlib.util
import json
import sys
import threading
from dataclasses import dataclass
from pathlib import Path
from types import SimpleNamespace
from unittest.mock import MagicMock

HERE = Path(__file__).parent
spec = importlib.util.spec_from_file_location("legacy_tool_calling", HERE / "legacy_tool_calling.py")
legacy = importlib.util.module_from_spec(spec)
sys.modules["legacy_tool_calling"] = legacy
spec.loader.exec_module(legacy)

from orchard_worker_mlx import generation  # noqa: E402
from orchard_worker_mlx.generation import GenerationDeps, generate_events  # noqa: E402
from orchard_worker_mlx.service import build_inference_event  # noqa: E402
from orchard_worker_mlx.tool_calling import consume_response, consume_text  # noqa: E402

TOOLS_JSON = (
    b'[{"type":"function","function":{"name":"lookup_weather","parameters":'
    b'{"type":"object","properties":{"city":{"type":"string"}}}}}]'
)

# How the model actually emits: markers straddle token boundaries.
MODEL_TOKENS = [
    "Checking the ",
    "forecast. <tool_",
    'call>{"name":"lookup_weather","arg',
    'uments":{"city":"Singapore"}}</tool_',
    "call>",
    " Done.",
]


@dataclass
class FakeGenerationResponse:
    text: str
    token: int
    finish_reason: str | None = None


def json_tool_parser(text, tools):
    PARSER_INPUTS.append(text)
    return json.loads(text)


PARSER_INPUTS: list[str] = []


def make_session():
    session = MagicMock()
    session.model = MagicMock(name="FakeModel")
    session.tokenizer = MagicMock(name="FakeTokenizer")
    session.tokenizer.encode.return_value = [1, 2, 3]
    session.eos_token_ids = ()
    session.decode_cancel_stride = 1
    session.prefill_step_size = 2048
    session.clear_cache = MagicMock()
    session.prefix_cache = None
    session.memory_budget_status = SimpleNamespace(
        budget_available=False, target_working_set_bytes=0
    )
    session.tool_calling = {"supported": True, "parser_type": "json_tools"}
    session.tokenizer.tool_parser = json_tool_parser
    session.tokenizer.tool_call_start = "<tool_call>"
    session.tokenizer.tool_call_end = "</tool_call>"
    return session


def make_request():
    request = MagicMock()
    request.rendered_prompt_utf8 = b"what is the weather in Singapore?"
    request.input_tokens = 3
    request.prompt_token_ids = []
    request.return_token_ids = False
    request.return_logprobs = False
    params = MagicMock()
    params.max_output_tokens = 64
    params.temperature = 0.0
    params.top_p = 0.0
    params.stop_sequences = []
    params.tools_json = TOOLS_JSON
    params.tool_choice_json = b'"auto"'
    request.params = params
    return request


def make_deps():
    responses = [
        FakeGenerationResponse(text=t, token=10 + i) for i, t in enumerate(MODEL_TOKENS)
    ]
    responses[-1].finish_reason = "stop"

    def fake_stream_generate(model, tokenizer, prompt_ids, **kwargs):
        yield from responses

    return GenerationDeps(
        stream_generate=fake_stream_generate,
        make_sampler=lambda **kwargs: MagicMock(name="FakeSampler"),
        make_prompt_cache=None,
        trim_prompt_cache=None,
        synchronize=None,
    )


def run(wiring):
    PARSER_INPUTS.clear()
    original = generation.consume_tool_response
    generation.consume_tool_response = wiring
    try:
        dict_events = list(generate_events(make_session(), make_request(), threading.Event(),
                                           deps=make_deps()))
    finally:
        generation.consume_tool_response = original
    wire = [build_inference_event(e) for e in dict_events]
    return dict_events, [e.SerializeToString() for e in wire], wire, list(PARSER_INPUTS)


WIRINGS = {
    "legacy      ": legacy.consume_response,
    "shipped     ": consume_response,
    "text-first  ": lambda ctx, response: consume_text(ctx, getattr(response, "text", "")),
}

results = {name: run(fn) for name, fn in WIRINGS.items()}

print("=" * 78)
print("Orchard MLX worker — streamed tool call, wire-level transcript")
print("=" * 78)
print("prompt        : what is the weather in Singapore?")
print("tools         : lookup_weather(city)")
print("model tokens  :")
for t in MODEL_TOKENS:
    print(f"                {t!r}")
print()

_, _, wire, parser_inputs = results["shipped     "]
print("--- gRPC InferenceEvent stream delivered to the controller ---")
for i, event in enumerate(wire):
    kind = event.WhichOneof("event")
    if kind == "output_text_delta":
        print(f"  [{i}] output_text_delta  delta={event.output_text_delta.delta!r}")
    elif kind == "tool_call_delta":
        print(f"  [{i}] tool_call_delta    id={event.tool_call_delta.tool_call_id} "
              f"delta_json={event.tool_call_delta.delta_json}")
    elif kind == "completed":
        print(f"  [{i}] completed          finish_reason={event.completed.finish_reason}")
    else:
        print(f"  [{i}] {kind}")
print()
print(f"tool-call bytes handed to the provider parser: {parser_inputs!r}")
print()

print("--- wiring equivalence (serialized protobuf bytes) ---")
baseline = results["legacy      "]
ok = True
for name, (dict_events, wire_bytes, _, inputs) in results.items():
    same_wire = wire_bytes == baseline[1]
    same_dicts = dict_events == baseline[0]
    same_inputs = inputs == baseline[3]
    ok = ok and same_wire and same_dicts and same_inputs
    print(f"  {name}: {len(wire_bytes)} wire events | "
          f"identical-to-legacy bytes={same_wire} events={same_dicts} parser-input={same_inputs}")
print()
print("RESULT:", "IDENTICAL WIRE STREAM" if ok else "DIVERGENCE DETECTED")
raise SystemExit(0 if ok else 1)
```
</details>
<details>
<summary>Evidence: Real mlx-lm parser differential script</summary>

```text
"""Real pinned mlx-lm tool parsers streamed through legacy vs refactored consumption.

Uses the actual mlx_lm.tool_parsers markers and parse functions (the same ones the
worker binds at load time) rather than stand-ins, streaming one character at a time
so every marker straddles a chunk boundary.
"""

from __future__ import annotations

import importlib
import importlib.util
import json
import sys
from pathlib import Path
from types import SimpleNamespace

HERE = Path(__file__).parent
spec = importlib.util.spec_from_file_location("legacy_tool_calling", HERE / "legacy_tool_calling.py")
legacy = importlib.util.module_from_spec(spec)
sys.modules["legacy_tool_calling"] = legacy
spec.loader.exec_module(legacy)

import orchard_worker_mlx.tool_calling as new  # noqa: E402

TOOLS = [
    {
        "type": "function",
        "function": {
            "name": "read",
            "parameters": {
                "type": "object",
                "properties": {"path": {"type": "string"}},
                "required": ["path"],
            },
        },
    }
]

BODIES = {
    "json_tools": '{"name":"read","arguments":{"path":"fixture.txt"}}',
    "qwen3_coder": "<function=read>\n<parameter=path>\nfixture.txt\n</parameter>\n</function>",
    "mistral": 'read[ARGS]{"path":"fixture.txt"}',
}


def drive(module, parser, text, entry):
    seen: list[str] = []

    def recording(body, tools):
        seen.append(body)
        return parser.parse_tool_call(body, tools)

    ctx = module.ToolCallingContext(
        tools=TOOLS,
        parser_type="real",
        tool_choice="auto",
        tool_call_start=parser.tool_call_start,
        tool_call_end=parser.tool_call_end,
        tool_parser=recording,
    )
    events = []
    for char in text:
        if entry == "text":
            events.extend(module.consume_text(ctx, char))
        else:
            events.extend(module.consume_response(ctx, SimpleNamespace(text=char)))
    err = module.finalize(ctx)
    events.extend(ctx.take_pending_events())
    return events, seen, err


print("=" * 78)
print("Pinned mlx-lm tool parsers — per-character streaming through the worker")
print("=" * 78)
ok = True
for name, body in BODIES.items():
    parser = importlib.import_module(f"mlx_lm.tool_parsers.{name}")
    text = "Prose before. " + parser.tool_call_start + body + parser.tool_call_end + " prose after."
    base = drive(legacy, parser, text, "response")
    ship = drive(new, parser, text, "response")
    tfirst = drive(new, parser, text, "text")
    identical = base == ship == tfirst
    ok = ok and identical and base[2] is None

    print(f"\nparser        : {name}")
    print(f"  start/end   : {parser.tool_call_start!r} / {parser.tool_call_end!r}")
    print(f"  model output: {text!r}")
    print(f"  parser input (exact tool-call bytes): {ship[1]!r}")
    tool_events = [e for e in ship[0] if e["kind"] == "tool_call_delta"]
    text_deltas = "".join(e["delta"] for e in ship[0] if e["kind"] == "output_text_delta")
    for e in tool_events:
        fn = e["delta"]["function"]
        print(f"  tool_call_delta: id={e['tool_call_id']} name={fn['name']} "
              f"arguments_delta={fn['arguments_delta']}")
        print(f"  decoded arguments: {json.loads(fn['arguments_delta'])}")
    print(f"  visible assistant text: {text_deltas!r}")
    print(f"  event kinds : {[e['kind'] for e in ship[0]]}")
    print(f"  legacy == shipped == consume_text: {identical}; finalize error: {ship[2]}")

print("\nRESULT:", "IDENTICAL BEHAVIOR ON REAL PARSERS" if ok else "DIVERGENCE DETECTED")
raise SystemExit(0 if ok else 1)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `native/orchard_worker_mlx/src/orchard_worker_mlx/tool_calling.py:99` - `consume_text` is annotated `text: str` but keeps the inherited `not isinstance(text, str)` guard that silently returns `[]`. The guard is only needed for `consume_response`&#39;s untyped `getattr(response, &#34;text&#34;, &#34;&#34;)` result; on the new text-first entry point it means a future caller (e.g. #328 PR-3) passing a non-str silently drops the chunk instead of failing. Behavior is unchanged from before this refactor and moving the guard into the `consume_response` wrapper would also be behavior-identical, so no action is required for this PR.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- uv run --frozen --directory native/orchard_worker_mlx --extra mlx pytest tests/test_tool_calling.py tests/test_mlx_tool_calling.py -q` — 38 passed; the 3 real mlx-lm parser tests ran instead of skipping because I installed the pinned `mlx` extra</code>
- <code>`mise exec -- uv run --frozen --directory native/orchard_worker_mlx pytest tests/test_generation.py tests/test_service.py -k &#34;tool&#34; -q` — 25 passed (worker generate loop + gRPC event builder tool paths)</code>
- <code>Differential harness vs base commit 3c69fe60: 17 stream cases × (whole / per-character / every 2-way split / seeded-random / empty-padded chunkings) × 4 terminal kinds = 4,408 triple comparisons of legacy `consume_response` vs new `consume_response` vs new `consume_text`, comparing event order and bytes, exact provider-parser input, finalize error tuple, and residual buffers — 0 mismatches</code>
- <code>20,000 randomized probes of `split_partial_marker` against the removed private `_split_partial_marker` across 5 marker shapes (including `&#34;&#34;` and a self-overlapping marker) — 0 divergences</code>
- <code>Degenerate payload equivalence: response with missing `.text`, `text=None`, `text=b&#34;bytes&#34;`, `text=123`, `text=&#34;&#34;` — legacy and wrapper both absorb identically</code>
- <code>End-to-end worker transcript: real `generate_events` loop with markers straddling token boundaries, each event converted via `service.build_inference_event`, run under legacy consumption / shipped wrapper / text-first `consume_text` — identical serialized protobuf bytes</code>
- <code>Real pinned parsers `mlx_lm.tool_parsers.{json_tools,qwen3_coder,mistral}` streamed one character at a time through all three consumption paths — identical events, identical tool-call bytes, no finalize error</code>
- <code>Mutation check 1: off-by-one in `split_partial_marker`&#39;s overlap window → `tests/test_tool_calling.py` fails (restored immediately; `git diff --stat` empty)</code>
- <code>Mutation check 2: `consume_response` made non-transparent (`str(...).strip()`) → `tests/test_tool_calling.py` fails (restored immediately; `git diff --stat` empty)</code>
- <code>Scope audit: `grep` for `consume_response`/`consume_text`/`partial_markers` across the repo confirms `generation.py` wiring unchanged; no `.proto`, `.ex`, `.exs`, or `.credo.exs` changes; no `noqa`/`credo:disable`/`type: ignore` added</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a behavior-preserving refactor of MLX worker tool-call streaming.
- Extracts partial-marker scanning into a small shared package module.
- Adds a text-first `consume_text` entry point while retaining `consume_response` as a compatibility wrapper.
- Adds direct regression coverage for marker boundaries and equivalent event/parser behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, packaging, security, or repository-rule issues identified.

The extracted helper remains inside the automatically packaged Python directory, both marker scan paths use it consistently, and the compatibility wrapper directly preserves the prior response-text behavior with regression coverage for emitted events and parser input.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| native/orchard_worker_mlx/src/orchard_worker_mlx/partial_markers.py | Extracts the existing chunk-boundary marker-prefix scanner without changing its behavior. |
| native/orchard_worker_mlx/src/orchard_worker_mlx/tool_calling.py | Delegates response consumption to the new text-first entry point and uses the shared marker scanner on both framing paths. |
| native/orchard_worker_mlx/tests/test_tool_calling.py | Adds focused tests for partial-marker splitting and response-versus-text consumption equivalence. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into refactor/worker..."](https://github.com/kapitan-ai/orchard/commit/d139c10a0de620d9b660876e70ed9898d2858e70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62916986)</sub>

<!-- /greptile_comment -->