### PR TITLE
fix(models): preserve immutable imports and repair retries

### DIFF
--- a/apps/orchard_controller/lib/orchard/console/model_hub_download_coordinator.ex
+++ b/apps/orchard_controller/lib/orchard/console/model_hub_download_coordinator.ex
@@ -15,6 +15,7 @@ defmodule OrchardConsole.ModelHubDownloadCoordinator do
       %{
         key: {repo_id, requested_revision},
         repo_id: String.t(),
+        catalog_version: String.t() | nil,
         status: :starting | :downloading | :preparing | :importing | :completed | :error,
         progress: map() | nil,
         result: map() | nil,
@@ -383,7 +384,10 @@ defmodule OrchardConsole.ModelHubDownloadCoordinator do
     requested_revision = normalize_revision(Keyword.get(opts, :revision))
 
     # Build provisional starting snapshot
-    snapshot = starting_snapshot(repo_id, requested_revision)
+    snapshot =
+      repo_id
+      |> starting_snapshot(requested_revision)
+      |> Map.put(:catalog_version, Keyword.get(opts, :catalog_version))
 
     # Insert provisional job BEFORE calling seam (prevents race with fast task messages)
     job = %{

--- a/apps/orchard_controller/lib/orchard/console/model_hub_live.ex
+++ b/apps/orchard_controller/lib/orchard/console/model_hub_live.ex
@@ -157,9 +157,15 @@ defmodule OrchardConsole.ModelHubLive do
     key = held_download_key(socket.assigns.download_jobs, repo, Map.get(params, "revision", ""))
 
     case Map.get(socket.assigns.download_jobs, key) do
-      %{status: :cancelled, key: {repo_id, revision}}
+      %{status: :cancelled, key: {repo_id, revision}} = snapshot
       when is_binary(revision) and revision != "" ->
-        {:noreply, start_download_via_coordinator(socket, repo_id, revision)}
+        {:noreply,
+         start_download_via_coordinator(
+           socket,
+           repo_id,
+           revision,
+           Map.get(snapshot, :catalog_version)
+         )}
 
       _ ->
         {:noreply, socket}
@@ -1308,7 +1314,10 @@ defmodule OrchardConsole.ModelHubLive do
         visible_download_key: {repo_id, revision}
       }
       when is_binary(repo_id) and repo_id != "" ->
-        {:noreply, start_download_via_coordinator(socket, repo_id, revision)}
+        catalog_version =
+          get_in(socket.assigns.download_jobs, [{repo_id, revision}, :catalog_version])
+
+        {:noreply, start_download_via_coordinator(socket, repo_id, revision, catalog_version)}
 
       _ ->
         {:noreply, socket}

--- a/apps/orchard_controller/lib/orchard/models/importer.ex
+++ b/apps/orchard_controller/lib/orchard/models/importer.ex
@@ -25,6 +25,7 @@ defmodule Orchard.Models.Importer do
   alias Orchard.Models.ManifestParser
   alias Orchard.Models.MemoryEstimator
   alias Orchard.Models.SafeTokenizationPreflight
+  alias Orchard.Repo
 
   require Logger
 
@@ -97,20 +98,15 @@ defmodule Orchard.Models.Importer do
 
   defp import_staged_bundle(staged_path, source_manifest, artifacts_root, activate?) do
     result =
-      with {:ok, manifest} <- maybe_top_up_resident_memory(staged_path, source_manifest),
+      with {:ok, manifest} <- ManifestParser.parse_from_bundle(staged_path),
+           :ok <- validate_staged_identity(manifest, source_manifest),
+           {:ok, manifest} <- maybe_top_up_resident_memory(staged_path, manifest),
            {:ok, manifest} <- ensure_chat_template(staged_path, manifest),
            {:ok, _manifest} <- maybe_run_eager_preflight(staged_path, manifest),
            {:ok, manifest} <- ManifestParser.parse_from_bundle(staged_path),
-           {:ok, sha256} <- compute_sha256(staged_path),
-           {:ok, dest_path} <- finalize_staged(staged_path, manifest, artifacts_root) do
-        case insert_catalog_record(manifest, dest_path, sha256, activate?) do
-          {:ok, model} ->
-            {:ok, model}
-
-          {:error, _} = err ->
-            File.rm_rf(dest_path)
-            err
-        end
+           :ok <- validate_staged_identity(manifest, source_manifest),
+           {:ok, sha256} <- compute_sha256(staged_path) do
+        publish_staged_bundle(staged_path, manifest, artifacts_root, sha256, activate?)
       end
 
     case result do
@@ -121,6 +117,23 @@ defmodule Orchard.Models.Importer do
         if File.dir?(staged_path), do: File.rm_rf(staged_path)
         err
     end
+  end
+
+  defp publish_staged_bundle(staged_path, manifest, artifacts_root, sha256, activate?) do
+    Repo.transaction(fn ->
+      Repo.query!(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        ["orchard:models:artifact-publication"]
+      )
+
+      case finalize_staged(staged_path, manifest, artifacts_root) do
+        {:ok, dest_path} ->
+          insert_catalog_record(manifest, dest_path, sha256, activate?)
+
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
+    end)
   end
 
   # -- Validation -----------------------------------------------------------
@@ -141,6 +154,17 @@ defmodule Orchard.Models.Importer do
   defp validate_identity_safe(%ModelManifest{model_id: model_id, version: version}) do
     with :ok <- validate_path_segment(model_id, "model_id") do
       validate_path_segment(version, "version")
+    end
+  end
+
+  defp validate_staged_identity(manifest, source_manifest) do
+    with :ok <- validate_identity_safe(manifest) do
+      if {manifest.model_id, manifest.version} ==
+           {source_manifest.model_id, source_manifest.version} do
+        :ok
+      else
+        {:error, {:validation, "bundle identity changed during staging"}}
+      end
     end
   end
 
@@ -170,7 +194,7 @@ defmodule Orchard.Models.Importer do
   # -- Staging & copy -------------------------------------------------------
 
   defp stage_bundle(source_path, artifacts_root) do
-    staging_dir = Path.join(artifacts_root, ".staging-#{System.unique_integer([:positive])}")
+    staging_dir = Path.join(artifacts_root, ".staging-#{Ecto.UUID.generate()}")
 
     case File.mkdir_p(staging_dir) do
       :ok ->
@@ -984,7 +1008,17 @@ defmodule Orchard.Models.Importer do
       runtime_requirements: runtime_requirements_to_map(manifest.runtime_requirements)
     }
 
-    Models.create_model(attrs)
+    # A rejected insert must not release the publication lock before cleanup.
+    changeset = Models.Model.changeset(%Models.Model{}, attrs)
+
+    case Repo.insert(changeset, mode: :savepoint) do
+      {:ok, model} ->
+        model
+
+      {:error, reason} ->
+        File.rm_rf(dest_path)
+        Repo.rollback(reason)
+    end
   end
 
   defp capability_evidence_to_map(nil), do: nil

--- a/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
@@ -1918,6 +1918,22 @@ defmodule OrchardConsole.ModelHubLiveTest do
         repo = hd(results).repo_id
         version = "rev-llama-tool-admission"
 
+        assert {:ok, original} =
+                 Orchard.Models.create_model(%{
+                   model_id: repo,
+                   version: "rev-llama",
+                   state: :registered,
+                   format: "mlx",
+                   artifact_uri: "file:///synthetic-existing-model",
+                   artifact_sha256: String.duplicate("a", 64),
+                   artifact_size_bytes: 0,
+                   resident_memory_bytes: 0,
+                   kv_cache_bytes_per_token: 0,
+                   prefill_workspace_bytes_per_token: 0,
+                   tokenizer: %{},
+                   runtime_requirements: %{}
+                 })
+
         render_submit(view, "repair_model", %{
           "model_hub_repair" => %{"catalog_version" => version}
         })
@@ -1946,7 +1962,12 @@ defmodule OrchardConsole.ModelHubLiveTest do
             view
           end
 
-        render_click(view, @event, %{"repo_id" => repo, "revision" => "rev-llama"})
+        render_click(view, @event, %{
+          "repo_id" => repo,
+          "revision" => "rev-llama",
+          "catalog_version" => "forged-browser-version"
+        })
+
         assert_receive {:stub_download_ref, _new_ref, ^repo, retry_opts}
         assert retry_opts[:revision] == "rev-llama"
 
@@ -1956,8 +1977,8 @@ defmodule OrchardConsole.ModelHubLiveTest do
           retry: retry_opts[:catalog_version]
         }
 
-        IO.inspect(observed, label: "P2 repair #{@terminal} remount=#{@remount}")
         assert observed == %{starting: version, terminal: version, retry: version}
+        assert Orchard.Models.get_model!(original.id) == original
       end
     end
 

--- a/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
+++ b/apps/orchard_controller/test/orchard/console/model_hub_live_test.exs
@@ -1903,6 +1903,64 @@ defmodule OrchardConsole.ModelHubLiveTest do
       assert opts[:catalog_version] == "rev-llama-tool-admission"
     end
 
+    for {terminal, event} <- [{:error, "retry_download"}, {:cancelled, "restart_download"}],
+        remount <- [false, true] do
+      @terminal terminal
+      @event event
+      @remount remount
+      @tag :regression_402
+      test "SPEC 6.4 repair Catalog version survives #{@terminal}, remount=#{@remount}", %{
+        conn: conn
+      } do
+        {:ok, view, _html} = live(conn, "/console/model-hub")
+        results = load_initial_results_and_detail(view)
+        enter_catalog(view)
+        repo = hd(results).repo_id
+        version = "rev-llama-tool-admission"
+
+        render_submit(view, "repair_model", %{
+          "model_hub_repair" => %{"catalog_version" => version}
+        })
+
+        assert_receive {:stub_download_ref, ref, ^repo, initial_opts}
+        assert initial_opts[:catalog_version] == version
+        assert initial_opts[:revision] == "rev-llama"
+        starting = OrchardConsole.ModelHubDownloadCoordinator.latest_snapshot()
+
+        send_download_started(ref, %{repo_id: repo, revision: "rev-llama"})
+
+        code =
+          if @terminal == :cancelled, do: "download_cancelled", else: "download_import_failed"
+
+        send_download_error(ref, %{code: code})
+        terminal = OrchardConsole.ModelHubDownloadCoordinator.latest_snapshot()
+        assert terminal.status == @terminal
+        render(view)
+
+        view =
+          if @remount do
+            stop_view(view)
+            {:ok, remounted, _html} = live(conn, "/console/model-hub")
+            remounted
+          else
+            view
+          end
+
+        render_click(view, @event, %{"repo_id" => repo, "revision" => "rev-llama"})
+        assert_receive {:stub_download_ref, _new_ref, ^repo, retry_opts}
+        assert retry_opts[:revision] == "rev-llama"
+
+        observed = %{
+          starting: Map.get(starting, :catalog_version),
+          terminal: Map.get(terminal, :catalog_version),
+          retry: retry_opts[:catalog_version]
+        }
+
+        IO.inspect(observed, label: "P2 repair #{@terminal} remount=#{@remount}")
+        assert observed == %{starting: version, terminal: version, retry: version}
+      end
+    end
+
     test "repair import rejects a Catalog version that matches the selected source revision", %{
       conn: conn
     } do

--- a/apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs
+++ b/apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs
@@ -1,15 +1,17 @@
 defmodule Orchard.Models.Importer402RegressionTest do
   use Orchard.DataCase, async: false
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias Orchard.ArtifactBundle
   alias Orchard.Models
   alias Orchard.Models.Importer
 
   @fixture Path.expand("../../fixtures/bundles/test-model-bundle", __DIR__)
 
-  # Investigation-only copy of the exact production AST. The only inserted code
-  # is a message barrier before staging or after destination validation. All
-  # validation, filesystem operations and catalog calls remain the real code.
+  # Compile a renamed production AST with barriers at otherwise private race
+  # boundaries. No filesystem, parser or database operations are replaced.
+  # The separate public-entrypoint test verifies the actual module's lock too;
+  # this instrumentation is not a cross-BEAM or crash-recovery test.
   setup_all do
     source = Path.expand("../../../lib/orchard/models/importer.ex", __DIR__)
     ast = source |> File.read!() |> Code.string_to_quoted!()
@@ -29,6 +31,12 @@ defmodule Orchard.Models.Importer402RegressionTest do
 
           {:defp, meta, [head, [do: body]]}
 
+        {{:., _, [{:__aliases__, _, [:File]}, :rm_rf]}, _, [{:dest_path, _, _}]} = call ->
+          quote do
+            Orchard.Models.Importer402RegressionTest.barrier(:cleanup_destination)
+            unquote(call)
+          end
+
         other ->
           other
       end)
@@ -37,31 +45,187 @@ defmodule Orchard.Models.Importer402RegressionTest do
     :ok
   end
 
-  setup do
+  setup tags do
     root = Path.join(System.tmp_dir!(), "orchard-402-#{System.unique_integer([:positive])}")
     File.mkdir_p!(root)
-    on_exit(fn -> File.rm_rf!(root) end)
+
+    if tags[:unboxed], do: Sandbox.checkin(Repo)
+
+    on_exit(fn ->
+      if tags[:unboxed] do
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.delete_all(
+            from(model in Models.Model,
+              where: like(model.artifact_uri, ^("file://" <> root <> "/%"))
+            )
+          )
+        end)
+      end
+
+      File.rm_rf!(root)
+    end)
+
     %{root: root, artifacts: Path.join(root, "artifacts")}
   end
 
+  @tag :unboxed
   test "SPEC 6.4/6.5 concurrent overlapping imports preserve every catalog digest", ctx do
     outer = bundle(ctx.root, "outer", "owner/model", "v1")
     inner = bundle(ctx.root, "inner", "owner/model/v1/nested", "repair")
-    task = paused_import(inner, ctx.artifacts, :move_staged_to_dest)
+    parent = self()
+
+    task =
+      session_task(fn ->
+        Process.put(:import_barrier, {:move_staged_to_dest, parent})
+
+        apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
+          inner,
+          [artifacts_root: ctx.artifacts]
+        ])
+      end)
+
     assert_receive {:barrier, :move_staged_to_dest, pid}
+    assert_receive {:session, ^pid, inner_backend}
     refute File.exists?(Path.join(ctx.artifacts, "owner/model/v1"))
 
-    assert {:ok, original} = Importer.import_bundle(outer, artifacts_root: ctx.artifacts)
-    assert_digest(original)
+    contender =
+      session_task(fn -> Importer.import_bundle(outer, artifacts_root: ctx.artifacts) end)
+
+    contender_pid = contender.pid
+    assert_receive {:session, ^contender_pid, outer_backend}
+    refute inner_backend == outer_backend
+
+    # The old implementation completes A here; the coordinated implementation
+    # waits on B's database lock. Neither ordering relies on a timed sleep.
+    observed = await_publication_or_lock(contender, outer_backend, 500)
     send(pid, :continue)
     nested_result = Task.await(task)
-    rows = Models.list_models()
-    IO.inspect({nested_result, Enum.map(rows, &{&1.model_id, &1.version})}, label: "P1 outcome")
 
-    # Re-read the surviving rows, not just the return values from import.
+    outer_result =
+      case observed do
+        {:finished, result} -> result
+        :waiting -> Task.await(contender)
+      end
+
+    rows = Sandbox.unboxed_run(Repo, &Models.list_models/0)
+
     Enum.each(rows, &assert_digest/1)
-    assert match?({:error, _}, nested_result)
-    assert Path.wildcard(Path.join(ctx.artifacts, ".staging-*")) == []
+    assert Enum.count([outer_result, nested_result], &match?({:ok, _}, &1)) == 1
+    assert Enum.count([outer_result, nested_result], &match?({:error, _}, &1)) == 1
+    assert Path.wildcard(Path.join(ctx.artifacts, ".staging-*"), match_dot: true) == []
+  end
+
+  @tag :unboxed
+  test "SPEC 6.5 failed catalog publication cleans up before another importer can publish below it",
+       ctx do
+    source = bundle(ctx.root, "source", "owner/model", "v1")
+    parent = self()
+
+    failed =
+      session_task(fn ->
+        Process.put(:import_barrier, {:stage_bundle, parent})
+
+        apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
+          source,
+          [artifacts_root: ctx.artifacts]
+        ])
+      end)
+
+    assert_receive {:barrier, :stage_bundle, failed_pid}
+    assert_receive {:session, ^failed_pid, failed_backend}
+
+    # A concurrent import into another root wins the Catalog identity after the
+    # first importer checked for duplicates, forcing insertion-time rollback.
+    original_root = Path.join(ctx.root, "original-artifacts")
+
+    assert {:ok, original} =
+             Sandbox.unboxed_run(Repo, fn ->
+               Importer.import_bundle(source, artifacts_root: original_root)
+             end)
+
+    send(failed_pid, {:continue, :cleanup_destination})
+    assert_receive {:barrier, :cleanup_destination, ^failed_pid}
+
+    nested = bundle(ctx.root, "nested", "owner/model/v1/nested", "repair")
+
+    contender =
+      session_task(fn -> Importer.import_bundle(nested, artifacts_root: ctx.artifacts) end)
+
+    contender_pid = contender.pid
+    assert_receive {:session, ^contender_pid, contender_backend}
+    refute failed_backend == contender_backend
+    observed = await_publication_or_lock(contender, contender_backend, 500)
+    send(failed_pid, :continue)
+
+    assert {:error, %Ecto.Changeset{}} = Task.await(failed)
+
+    result =
+      case observed do
+        {:finished, result} -> result
+        :waiting -> Task.await(contender)
+      end
+
+    assert {:ok, repaired} = result
+    assert_digest(original)
+    assert_digest(repaired)
+    assert Path.wildcard(Path.join(ctx.artifacts, ".staging-*"), match_dot: true) == []
+  end
+
+  @tag :unboxed
+  test "SPEC 6.5 public imports contend on the same database publication guard", ctx do
+    source = bundle(ctx.root, "source", "owner/model", "v1")
+    nested = bundle(ctx.root, "nested", "owner/model/v1/nested", "repair")
+    parent = self()
+
+    holder =
+      session_task(fn ->
+        Repo.transaction(fn ->
+          Repo.query!("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+            "orchard:models:artifact-publication"
+          ])
+
+          send(parent, :guard_held)
+
+          receive do
+            :release -> :ok
+          after
+            10_000 -> raise "publication guard was not released"
+          end
+        end)
+      end)
+
+    assert_receive :guard_held
+
+    tasks =
+      for bundle <- [source, nested] do
+        task =
+          session_task(fn -> Importer.import_bundle(bundle, artifacts_root: ctx.artifacts) end)
+
+        pid = task.pid
+        assert_receive {:session, ^pid, backend}
+        assert :waiting == await_publication_or_lock(task, backend, 500)
+        task
+      end
+
+    send(holder.pid, :release)
+    assert {:ok, :ok} = Task.await(holder)
+    results = Enum.map(tasks, &Task.await/1)
+    assert Enum.count(results, &match?({:ok, _}, &1)) == 1
+    assert Enum.count(results, &match?({:error, _}, &1)) == 1
+    Sandbox.unboxed_run(Repo, fn -> Enum.each(Models.list_models(), &assert_digest/1) end)
+    assert Path.wildcard(Path.join(ctx.artifacts, ".staging-*"), match_dot: true) == []
+  end
+
+  test "SPEC 6.5 staging uses UUIDs rather than counters local to a controller or CLI VM", ctx do
+    source = bundle(ctx.root, "source", "owner/model", "v1")
+    task = paused_import(source, ctx.artifacts, :move_staged_to_dest)
+    assert_receive {:barrier, :move_staged_to_dest, pid}
+    [staged] = Path.wildcard(Path.join(ctx.artifacts, ".staging-*"), match_dot: true)
+    suffix = staged |> Path.basename() |> String.replace_prefix(".staging-", "")
+    send(pid, :continue)
+    assert {:ok, model} = Task.await(task)
+    assert {:ok, ^suffix} = Ecto.UUID.cast(suffix)
+    assert_digest(model)
   end
 
   for replacement <- ["v2/nested", "v2"] do
@@ -80,10 +244,9 @@ defmodule Orchard.Models.Importer402RegressionTest do
         result: result,
         rows: Enum.map(Models.list_models(), &{&1.model_id, &1.version}),
         stored: Path.wildcard(Path.join(ctx.artifacts, "**/manifest.json")),
-        staging: Path.wildcard(Path.join(ctx.artifacts, ".staging-*"))
+        staging: Path.wildcard(Path.join(ctx.artifacts, ".staging-*"), match_dot: true)
       }
 
-      IO.inspect(observed, label: "P2 staged identity #{@replacement}")
       assert match?({:error, _}, result)
       assert observed.rows == []
       assert observed.stored == []
@@ -112,6 +275,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
 
         receive do
           :continue -> :ok
+          {:continue, next_point} -> Process.put(:import_barrier, {next_point, parent})
         after
           10_000 -> raise "investigation barrier was not released"
         end
@@ -132,6 +296,49 @@ defmodule Orchard.Models.Importer402RegressionTest do
         [artifacts_root: artifacts]
       ])
     end)
+  end
+
+  defp session_task(fun) do
+    parent = self()
+
+    Task.async(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        [[backend]] = Repo.query!("SELECT pg_backend_pid()").rows
+        send(parent, {:session, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_publication_or_lock(_task, _backend, 0),
+    do: flunk("import neither published nor waited for its lock")
+
+  defp await_publication_or_lock(task, backend, attempts) do
+    case Task.yield(task, 0) do
+      {:ok, result} ->
+        {:finished, result}
+
+      nil ->
+        waiting =
+          Sandbox.unboxed_run(Repo, fn ->
+            Repo.query!(
+              """
+              SELECT EXISTS (
+                SELECT 1 FROM pg_locks
+                WHERE pid = $1 AND locktype = 'advisory' AND NOT granted
+              )
+              """,
+              [backend]
+            ).rows
+          end)
+
+        if waiting == [[true]] do
+          :waiting
+        else
+          Process.sleep(10)
+          await_publication_or_lock(task, backend, attempts - 1)
+        end
+    end
   end
 
   defp bundle(root, name, model_id, version) do

--- a/apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs
+++ b/apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs
@@ -25,7 +25,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
         when name in [:stage_bundle, :move_staged_to_dest] ->
           body =
             quote do
-              Orchard.Models.Importer402RegressionTest.barrier(unquote(name))
+              unquote(__MODULE__).barrier(unquote(name))
               unquote(body)
             end
 
@@ -33,7 +33,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
 
         {{:., _, [{:__aliases__, _, [:File]}, :rm_rf]}, _, [{:dest_path, _, _}]} = call ->
           quote do
-            Orchard.Models.Importer402RegressionTest.barrier(:cleanup_destination)
+            unquote(__MODULE__).barrier(:cleanup_destination)
             unquote(call)
           end
 
@@ -41,8 +41,8 @@ defmodule Orchard.Models.Importer402RegressionTest do
           other
       end)
 
-    Code.compile_quoted(ast, source)
-    :ok
+    [{instrumented_importer, _bytecode}] = Code.compile_quoted(ast, source)
+    %{instrumented_importer: instrumented_importer}
   end
 
   setup tags do
@@ -69,7 +69,8 @@ defmodule Orchard.Models.Importer402RegressionTest do
   end
 
   @tag :unboxed
-  test "SPEC 6.4/6.5 concurrent overlapping imports preserve every catalog digest", ctx do
+  test "SPEC 6.4/6.5 concurrent overlapping imports preserve every catalog digest",
+       %{instrumented_importer: importer} = ctx do
     outer = bundle(ctx.root, "outer", "owner/model", "v1")
     inner = bundle(ctx.root, "inner", "owner/model/v1/nested", "repair")
     parent = self()
@@ -78,10 +79,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
       session_task(fn ->
         Process.put(:import_barrier, {:move_staged_to_dest, parent})
 
-        apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
-          inner,
-          [artifacts_root: ctx.artifacts]
-        ])
+        importer.import_bundle(inner, artifacts_root: ctx.artifacts)
       end)
 
     assert_receive {:barrier, :move_staged_to_dest, pid}
@@ -117,7 +115,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
 
   @tag :unboxed
   test "SPEC 6.5 failed catalog publication cleans up before another importer can publish below it",
-       ctx do
+       %{instrumented_importer: importer} = ctx do
     source = bundle(ctx.root, "source", "owner/model", "v1")
     parent = self()
 
@@ -125,10 +123,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
       session_task(fn ->
         Process.put(:import_barrier, {:stage_bundle, parent})
 
-        apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
-          source,
-          [artifacts_root: ctx.artifacts]
-        ])
+        importer.import_bundle(source, artifacts_root: ctx.artifacts)
       end)
 
     assert_receive {:barrier, :stage_bundle, failed_pid}
@@ -218,7 +213,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
 
   test "SPEC 6.5 staging uses UUIDs rather than counters local to a controller or CLI VM", ctx do
     source = bundle(ctx.root, "source", "owner/model", "v1")
-    task = paused_import(source, ctx.artifacts, :move_staged_to_dest)
+    task = paused_import(ctx.instrumented_importer, source, ctx.artifacts, :move_staged_to_dest)
     assert_receive {:barrier, :move_staged_to_dest, pid}
     [staged] = Path.wildcard(Path.join(ctx.artifacts, ".staging-*"), match_dot: true)
     suffix = staged |> Path.basename() |> String.replace_prefix(".staging-", "")
@@ -232,7 +227,7 @@ defmodule Orchard.Models.Importer402RegressionTest do
     @replacement replacement
     test "SPEC 6.4 rejects staged identity replacement with #{@replacement}", ctx do
       source = bundle(ctx.root, "source", "owner/model", "v1")
-      task = paused_import(source, ctx.artifacts, :stage_bundle)
+      task = paused_import(ctx.instrumented_importer, source, ctx.artifacts, :stage_bundle)
       assert_receive {:barrier, :stage_bundle, pid}
       path = Path.join(source, "manifest.json")
       manifest = path |> File.read!() |> Jason.decode!()
@@ -255,14 +250,10 @@ defmodule Orchard.Models.Importer402RegressionTest do
   end
 
   test "barrier-free instrumented import stores a complete synthetic bundle with correct digest",
-       ctx do
+       %{instrumented_importer: importer} = ctx do
     source = bundle(ctx.root, "control", "owner/model", "v1")
 
-    assert {:ok, model} =
-             apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
-               source,
-               [artifacts_root: ctx.artifacts]
-             ])
+    assert {:ok, model} = importer.import_bundle(source, artifacts_root: ctx.artifacts)
 
     assert model.version == "v1"
     assert_digest(model)
@@ -285,16 +276,13 @@ defmodule Orchard.Models.Importer402RegressionTest do
     end
   end
 
-  defp paused_import(source, artifacts, point) do
+  defp paused_import(importer, source, artifacts, point) do
     parent = self()
 
     Task.async(fn ->
       Process.put(:import_barrier, {point, parent})
 
-      apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
-        source,
-        [artifacts_root: artifacts]
-      ])
+      importer.import_bundle(source, artifacts_root: artifacts)
     end)
   end
 

--- a/apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs
+++ b/apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs
@@ -1,0 +1,158 @@
+defmodule Orchard.Models.Importer402RegressionTest do
+  use Orchard.DataCase, async: false
+
+  alias Orchard.ArtifactBundle
+  alias Orchard.Models
+  alias Orchard.Models.Importer
+
+  @fixture Path.expand("../../fixtures/bundles/test-model-bundle", __DIR__)
+
+  # Investigation-only copy of the exact production AST. The only inserted code
+  # is a message barrier before staging or after destination validation. All
+  # validation, filesystem operations and catalog calls remain the real code.
+  setup_all do
+    source = Path.expand("../../../lib/orchard/models/importer.ex", __DIR__)
+    ast = source |> File.read!() |> Code.string_to_quoted!()
+
+    ast =
+      Macro.postwalk(ast, fn
+        {:defmodule, meta, [_name, body]} ->
+          {:defmodule, meta, [Orchard.Models.Importer402Instrumented, body]}
+
+        {:defp, meta, [{name, _, _} = head, [do: body]]}
+        when name in [:stage_bundle, :move_staged_to_dest] ->
+          body =
+            quote do
+              Orchard.Models.Importer402RegressionTest.barrier(unquote(name))
+              unquote(body)
+            end
+
+          {:defp, meta, [head, [do: body]]}
+
+        other ->
+          other
+      end)
+
+    Code.compile_quoted(ast, source)
+    :ok
+  end
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "orchard-402-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    %{root: root, artifacts: Path.join(root, "artifacts")}
+  end
+
+  test "SPEC 6.4/6.5 concurrent overlapping imports preserve every catalog digest", ctx do
+    outer = bundle(ctx.root, "outer", "owner/model", "v1")
+    inner = bundle(ctx.root, "inner", "owner/model/v1/nested", "repair")
+    task = paused_import(inner, ctx.artifacts, :move_staged_to_dest)
+    assert_receive {:barrier, :move_staged_to_dest, pid}
+    refute File.exists?(Path.join(ctx.artifacts, "owner/model/v1"))
+
+    assert {:ok, original} = Importer.import_bundle(outer, artifacts_root: ctx.artifacts)
+    assert_digest(original)
+    send(pid, :continue)
+    nested_result = Task.await(task)
+    rows = Models.list_models()
+    IO.inspect({nested_result, Enum.map(rows, &{&1.model_id, &1.version})}, label: "P1 outcome")
+
+    # Re-read the surviving rows, not just the return values from import.
+    Enum.each(rows, &assert_digest/1)
+    assert match?({:error, _}, nested_result)
+    assert Path.wildcard(Path.join(ctx.artifacts, ".staging-*")) == []
+  end
+
+  for replacement <- ["v2/nested", "v2"] do
+    @replacement replacement
+    test "SPEC 6.4 rejects staged identity replacement with #{@replacement}", ctx do
+      source = bundle(ctx.root, "source", "owner/model", "v1")
+      task = paused_import(source, ctx.artifacts, :stage_bundle)
+      assert_receive {:barrier, :stage_bundle, pid}
+      path = Path.join(source, "manifest.json")
+      manifest = path |> File.read!() |> Jason.decode!()
+      File.write!(path, Jason.encode!(Map.put(manifest, "version", @replacement)))
+      send(pid, :continue)
+      result = Task.await(task)
+
+      observed = %{
+        result: result,
+        rows: Enum.map(Models.list_models(), &{&1.model_id, &1.version}),
+        stored: Path.wildcard(Path.join(ctx.artifacts, "**/manifest.json")),
+        staging: Path.wildcard(Path.join(ctx.artifacts, ".staging-*"))
+      }
+
+      IO.inspect(observed, label: "P2 staged identity #{@replacement}")
+      assert match?({:error, _}, result)
+      assert observed.rows == []
+      assert observed.stored == []
+      assert observed.staging == []
+    end
+  end
+
+  test "barrier-free instrumented import stores a complete synthetic bundle with correct digest",
+       ctx do
+    source = bundle(ctx.root, "control", "owner/model", "v1")
+
+    assert {:ok, model} =
+             apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
+               source,
+               [artifacts_root: ctx.artifacts]
+             ])
+
+    assert model.version == "v1"
+    assert_digest(model)
+  end
+
+  def barrier(point) do
+    case Process.get(:import_barrier) do
+      {^point, parent} ->
+        send(parent, {:barrier, point, self()})
+
+        receive do
+          :continue -> :ok
+        after
+          10_000 -> raise "investigation barrier was not released"
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp paused_import(source, artifacts, point) do
+    parent = self()
+
+    Task.async(fn ->
+      Process.put(:import_barrier, {point, parent})
+
+      apply(Orchard.Models.Importer402Instrumented, :import_bundle, [
+        source,
+        [artifacts_root: artifacts]
+      ])
+    end)
+  end
+
+  defp bundle(root, name, model_id, version) do
+    path = Path.join(root, name)
+    File.cp_r!(@fixture, path)
+    manifest_path = Path.join(path, "manifest.json")
+    manifest = manifest_path |> File.read!() |> Jason.decode!()
+    manifest = Map.merge(manifest, %{"model_id" => model_id, "version" => version})
+
+    manifest =
+      update_in(manifest["safe_tokenization"], fn safe ->
+        Map.merge(safe, %{"compatible" => true, "template_compatible" => true})
+      end)
+
+    File.write!(manifest_path, Jason.encode!(manifest))
+    path
+  end
+
+  defp assert_digest(model) do
+    path = String.replace_prefix(model.artifact_uri, "file://", "")
+    assert {:ok, digest} = ArtifactBundle.tree_sha256(path)
+    assert model.artifact_sha256 == digest
+  end
+end

--- a/openspec/changes/admit-model-tool-capabilities/design.md
+++ b/openspec/changes/admit-model-tool-capabilities/design.md
@@ -26,6 +26,16 @@ The importer continues to reject a duplicate `model_id@version`. To repair an ex
 
 Versions are single path components. Namespaced model IDs remain valid, but finalization rejects destinations beneath an existing bundle as well as existing destinations, preventing distinct identities from mutating an immutable ancestor.
 
+Publication uses one Postgres transaction-scoped advisory lock for model imports, shared by all importer processes using the Catalog. Destination and ancestor checks, parent creation, rename, Catalog insertion, and cleanup after a rejected insertion occur while holding that lock. Staging, preflight, and hashing remain concurrent. A Catalog-wide lock avoids treating overlapping namespaced identities or alternate paths to the same artifact root as independent lock domains; the short publication phase trades some import throughput for immutable artifacts. Process-local locks and a second unlocked filesystem check do not protect imports from other controller processes.
+
+Catalog insertion uses a savepoint: a rejected database constraint must roll back only the insertion, retaining the outer transaction's advisory lock until filesystem cleanup finishes. Without the savepoint, Postgres aborts the transaction and releases the lock before cleanup.
+
+Staging directories use UUID suffixes rather than VM-local counters, keeping concurrent CLI and controller staging independent before publication acquires its database lock.
+
+The staged manifest must retain the initially validated `model_id` and `version` and pass path-safety validation before importer-owned mutations or publication. Replacing source metadata during copying does not select a new import identity.
+
+The download coordinator retains the explicit Catalog version in its server-owned snapshot. Failure/retry and cancellation/restart reuse that version and the exact source revision, including after Console remount; event parameters cannot override the retained version.
+
 ### Validate inline schemas before any request work
 
 An inline `function` tool must have a non-empty name; optional `parameters` must be a JSON object. Invalid shape fails the shared validation used by Chat Completions and Responses before model capability checks, persistence, prompt rendering, scheduling, or dispatch. JSON Schema semantics are not evaluated in this slice.

--- a/openspec/changes/admit-model-tool-capabilities/specs/model-tool-capability-admission/spec.md
+++ b/openspec/changes/admit-model-tool-capabilities/specs/model-tool-capability-admission/spec.md
@@ -79,6 +79,23 @@ Orchard SHALL NOT silently change an existing Catalog model's capabilities, Arti
 - **THEN** Orchard SHALL reject the import without changing the existing bundle or Catalog digest
 - **AND THEN** Console SHALL reject separator-bearing versions before transfer
 
+#### Scenario: Concurrent overlapping imports preserve stored digests
+
+- **WHEN** imports for overlapping artifact destinations run concurrently in separate importer processes
+- **THEN** destination validation, finalization, Catalog publication, and failure cleanup SHALL be coordinated so neither import can change an already published Artifact Bundle
+- **AND THEN** every surviving Catalog row retains the digest of its final stored bundle
+
+#### Scenario: Source identity changes during staging
+
+- **WHEN** the copied manifest identity differs from the initially validated identity, including a different otherwise valid version
+- **THEN** the importer SHALL reject it and remove staging without creating a Catalog row or final destination
+
+#### Scenario: Repair survives retry and restart
+
+- **WHEN** a repair attempt fails or is cancelled and the operator retries or restarts, including after Console remount
+- **THEN** the coordinator SHALL retain the selected distinct Catalog version and exact source revision in server-owned state
+- **AND THEN** retry and restart SHALL reuse those values rather than browser-supplied replacements
+
 ### Requirement: Inline function schemas fail before dispatch
 
 For both `/v1/chat/completions` and `/v1/responses`, an inline function tool SHALL have a non-empty name. If present, `parameters` SHALL be a JSON object. Invalid values SHALL return the existing invalid-request validation error before request persistence, prompt rendering, scheduling, or Worker Runtime dispatch. This requirement validates shape only and does not evaluate JSON Schema semantics.

--- a/openspec/changes/admit-model-tool-capabilities/tasks.md
+++ b/openspec/changes/admit-model-tool-capabilities/tasks.md
@@ -18,6 +18,10 @@
 
 ## 4. Validation and handoff
 
+Validation checkmarks record completed workflows, not certification of later
+commits. The follow-up PR must bind fresh validation results to its exact
+published head after integration with main.
+
 - [x] 4.1 Run focused Elixir and native tests, strict OpenSpec validation, and the full applicable Orchard quality workflow.
-- [ ] 4.2 Commit, run the no-mistakes AXI pipeline, push, create a PR, and wait for CI checks-passed without merging.
-- [ ] 4.3 Repeat the full applicable Elixir quality workflow for publication coordination and repair-version retention.
+- [ ] 4.2 Complete required CI and human review for the follow-up PR before merging.
+- [x] 4.3 Repeat the full applicable Elixir quality workflow for publication coordination and repair-version retention.

--- a/openspec/changes/admit-model-tool-capabilities/tasks.md
+++ b/openspec/changes/admit-model-tool-capabilities/tasks.md
@@ -8,6 +8,8 @@
 - [x] 2.1 Add tokenizer-only preflight for recognized parser plus synthetic definition and structured-history rendering.
 - [x] 2.2 Generate fail-closed evidence and Catalog capabilities in BundleBuilder without model-name heuristics.
 - [x] 2.3 Preserve sidecar provenance in the Artifact Bundle and Catalog through normal import, keep the worker manifest N-1 compatible, and keep duplicate identities immutable.
+- [x] 2.4 Coordinate concurrent Artifact Bundle publication through Postgres and reject staged identity changes.
+- [x] 2.5 Retain the server-owned repair Catalog version through retry, restart, and remount.
 
 ## 3. Request safety
 
@@ -18,3 +20,4 @@
 
 - [x] 4.1 Run focused Elixir and native tests, strict OpenSpec validation, and the full applicable Orchard quality workflow.
 - [ ] 4.2 Commit, run the no-mistakes AXI pipeline, push, create a PR, and wait for CI checks-passed without merging.
+- [ ] 4.3 Repeat the full applicable Elixir quality workflow for publication coordination and repair-version retention.


### PR DESCRIPTION
## Summary

Follow up #402 with regression fixes for immutable Artifact Bundle publication and explicit Model Hub repair imports:

- Serialize destination/ancestor validation, rename, Catalog insertion, and failure cleanup with one Postgres transaction-scoped advisory lock. Insert through a savepoint so a constraint failure cannot release the publication lock before cleanup. Copying, preflight, and hashing remain concurrent; staging uses UUIDs rather than VM-local counters.
- Reject staged manifest identities that are unsafe or differ from the initially validated `model_id` and `version`, before importer mutations and again before publication.
- Retain the selected repair Catalog version in server-owned coordinator snapshots through failure/retry, cancellation/restart, and Console remount. Browser parameters cannot replace it.

The original race allowed both overlapping identities to publish and changed the stored tree beneath an existing Catalog digest. Both an unsafe staged version and a different valid staged version were accepted. Repair retries silently lost the explicit Catalog version. Deterministic regressions reproduced these failures before the fixes.

No inference, model qualification, runtime protocol, deployment, or existing Catalog capability mutation is introduced.

## Contract and links

- `SPEC.md` impact: **No SPEC.md change.** Enforces existing §§6.4–6.5 requirements for immutable/non-overlapping bundles, safe versions, authoritative final-tree digests, and distinct explicit repair imports.
- OpenSpec / decision / docs: updates `openspec/changes/admit-model-tool-capabilities/{design.md,tasks.md,specs/model-tool-capability-admission/spec.md}` with publication coordination, staged-identity, retry/remount scenarios, and exact-head validation requirements. No new migration or dependency.
- Issues: Related: #402. Integrated on main after #401 and #405. No issue-closing directive; this is a follow-up PR, not an update to the merged #402.

## Validation

**Exact tested head:** [7dd008b53f64de5dc597aee34c093ab5fa606967](https://github.com/kapitan-ai/orchard/commit/7dd008b53f64de5dc597aee34c093ab5fa606967), tree `a24446ea46592a194ae98448489b7d7ff0b8574d`, based on [5917c4d0e2f64b3ffd447f05fdbf0733469a7108](https://github.com/kapitan-ai/orchard/commit/5917c4d0e2f64b3ffd447f05fdbf0733469a7108). All local commands below were rerun on that head after #401 integration, including the task-metadata reconciliation. Head/tree were identical before and after validation; no formatter or tracked-file changes occurred. Historical candidates' results are not used to certify this head.

Environment: Linux x86_64, 8 CPUs/15 GiB RAM, pinned mise toolchain, normal `MIX_ENV` for compile/static checks, and a dedicated disposable local Postgres database. Test commands used this command-scoped prefix:

```sh
PGHOST=localhost PGDATABASE_TEST=orchard_402_main401 GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false
```

The Git override applies only to disposable Git fixtures; no global configuration, assertions, or quality checks were changed. Database setup succeeded with:

```sh
PGHOST=localhost PGDATABASE_TEST=orchard_402_main401 MIX_ENV=test mise exec -- mix ecto.create
PGHOST=localhost PGDATABASE_TEST=orchard_402_main401 MIX_ENV=test mise exec -- mix ecto.migrate
```

| Command or check | Result |
| --- | --- |
| `mise exec -- mix format` | Exit 0; no tracked changes |
| `mise exec -- mix compile --warnings-as-errors` | Exit 0; normal environment, no warnings |
| `mise exec -- mix credo --strict` | Exit 0; 90 checks/772 files, no findings, including ex_slop/ex_dna |
| `mise exec -- mix dialyzer` | Exit 0; zero errors or skipped errors |
| `make test` with the test prefix above | Exit 0; **5,225 passed, 5 skipped, 148 excluded** |
| `make cover` with the test prefix above | Exit 0; **5,225 passed, 5 skipped, 148 excluded** |
| `make validate-product-version` | Exit 0; `0.5.0-dev` across five Mix project surfaces |
| `git diff --check` | Exit 0 |

The following focused command, using the same test prefix, passed **211 tests**, exit 0:

```sh
mise exec -- mix test apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs apps/orchard_controller/test/orchard/models/importer_test.exs apps/orchard_controller/test/orchard/console/model_hub_download_coordinator_test.exs apps/orchard_controller/test/orchard/console/model_hub_live_test.exs --seed 0
```

Both strict OpenSpec commands passed; targeted change valid and all-item validation **53/53**:

```sh
OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate admit-model-tool-capabilities --type change --strict --no-interactive
OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive
```

Both full test runs: shared 236, controller 3,974, node agent 473, CLI 542 passed. Linux wrappers use `--exclude macos`; the existing CLI integration exclusions and conditional skips are unchanged. Coverage: shared 67.05%, controller 85.0%, node agent 72.42%, CLI 71.53%; changed importer 79.6%, coordinator 95.3%, LiveView 93.6%.

**Remote CI and human review remain merge prerequisites.** This executed classifier command selects all five lanes because OpenSpec is affected:

```sh
git diff --name-only 5917c4d0e2f64b3ffd447f05fdbf0733469a7108 HEAD | scripts/ci/classify-required-validation-paths.sh
```

Output: `portable=true`, `conformance=true`, `macos=true`, `mlx=true`, `packaging=true`. Local Elixir results do not certify the complete Linux CI script, dedicated conformance script, or native/hardware/MLX/macOS/packaging lanes. No actual model inference or download was performed locally. Those selected remote checks and the `Required Orchard validation gate` must pass on the published head; no CI result is presumed here.

## User-facing evidence

No appearance changes; screenshots are not applicable. Console interaction checks exercise repair submission, failure/retry and cancellation/restart both before and after remount, exact source-revision retention, rejection of forged browser Catalog versions, and preservation of the existing Catalog row. Existing rendered controls and LiveView event paths are covered.

Importer tests use synthetic bundles and real filesystem/parser/database operations. Private race boundaries use test-only AST message barriers; distinct PostgreSQL sessions and observed advisory-lock waiters coordinate the ordering. Assertions recompute surviving stored-tree digests. A separate test uses the uninstrumented public importer entrypoint for both contenders. No actual cross-BEAM race or crash-recovery proof is claimed.

## Risk, rollout, and rollback

**Medium risk:** changes the shared import publication boundary and repair job state. One Catalog-wide lock intentionally serializes the short publication phase across CLI/controller importers, including overlapping namespaces and alternate artifact-root paths. Concurrent copying and hashing are unaffected; publication contention may increase import latency. Expected rejected inserts clean up before the lock is released. This is not filesystem/database crash atomicity, and interrupted operations may still require operator inspection.

Compatibility: existing artifacts, Catalog rows, source revisions, and database schema are unchanged. Ordinary downloads retain their existing behavior. Old running code does not participate in the new publication guard, so operators should quiesce imports while upgrading controller and CLI import processes; do not rely on mixed-version publication safety. Existing in-memory repair jobs created by old code have no retained Catalog version and should be restarted through a fresh explicit repair submission.

Rollout: deploy through the normal separately authorized release process after required CI and human review. This PR performs no deployment. Exercise a synthetic import and repair retry in a controlled environment, then observe import latency, duplicate/destination errors, and unexpected leftover staging directories. Verify stored-tree digests for representative imports; do not silently rewrite existing Catalog digests. Previously corrupted artifacts are not repaired by this change.

Rollback: quiesce imports before reverting the code through the normal release process. There is no schema migration to reverse. Preserve existing artifacts and Catalog data; reverting restores the old concurrency risk, so avoid overlapping concurrent imports and re-enter repair versions explicitly until a corrected release is available.

## Checklist

- [x] Affected documentation, tests, and OpenSpec material are updated; no SPEC text change is needed.
- [x] Exact-head local validation outcomes are recorded above; the `Required Orchard validation gate` remains a prerequisite before merge.
- [ ] Required PR review and resolution of review conversations remain merge prerequisites.
- [x] No active goal packages, private local artifacts, or private workbench/session dependencies are committed.
- [ ] An accountable human contributor must review and stand behind the AI-assisted work before merge.
- [x] No new third-party material or dependency was introduced; existing licenses and notices are unchanged.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens immutable model-bundle publication and preserves explicit repair-import state.

- Serializes the publication-critical filesystem and Catalog operations with a PostgreSQL transaction-scoped advisory lock.
- Uses a savepoint so rejected Catalog inserts are cleaned up before releasing the publication guard.
- Validates staged bundle identity before mutation and publication, and uses UUID staging paths.
- Retains the server-owned repair Catalog version through errors, cancellation, retry/restart, and LiveView remount.
- Adds focused concurrency, identity-tampering, and repair-state regression coverage plus matching OpenSpec updates.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed publication and repair-retry paths consistently implementing their documented contracts.

No actionable failure remained after checking transaction return semantics, Catalog insertion equivalence, lock coverage across production import entrypoints, staged-identity provenance, and coordinator snapshot lifecycle.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/models/importer.ex | Adds staged-identity validation, UUID staging, and transactionally coordinated artifact publication with savepoint-protected failure cleanup. |
| apps/orchard_controller/lib/orchard/console/model_hub_download_coordinator.ex | Stores the selected repair Catalog version in coordinator-owned job snapshots. |
| apps/orchard_controller/lib/orchard/console/model_hub_live.ex | Reuses the retained server-side Catalog version for retry and restart events rather than browser parameters. |
| apps/orchard_controller/test/orchard/models/importer_402_regression_test.exs | Adds deterministic coverage for overlapping publication, rejected-insert cleanup, advisory-lock contention, UUID staging, and staged-identity replacement. |
| apps/orchard_controller/test/orchard/console/model_hub_live_test.exs | Covers repair-version retention across failure, cancellation, retry/restart, forged event parameters, and remount. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller as CLI / Console
  participant Importer
  participant FS as Artifact filesystem
  participant DB as PostgreSQL Catalog

  Caller->>Importer: import_bundle(source)
  Importer->>FS: Copy to UUID staging directory
  Importer->>Importer: Parse and validate staged identity
  Importer->>Importer: Preflight, reparse, revalidate, hash
  Importer->>DB: Begin transaction
  Importer->>DB: Acquire publication advisory lock
  Importer->>FS: Validate destination and ancestors
  Importer->>FS: Rename staging to final destination
  Importer->>DB: Insert Catalog row via savepoint
  alt Insert succeeds
    DB-->>Importer: Commit and release lock
    Importer-->>Caller: "{:ok, model}"
  else Insert is rejected
    Importer->>FS: Remove final destination
    DB-->>Importer: Roll back and release lock
    Importer-->>Caller: "{:error, reason}"
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: bind repair validation evidence to..."](https://github.com/kapitan-ai/orchard/commit/7dd008b53f64de5dc597aee34c093ab5fa606967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62947724)</sub>

<!-- /greptile_comment -->