### PR TITLE
fix(inference): map reasoning conformance failures to content-free internal errors

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -534,6 +534,13 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   defp failure_source(code)
        when code in [
+              "reasoning_parser_conformance_failed",
+              "reasoning_policy_conformance_failed"
+            ],
+       do: %{category: :terminal_conformance, code: code}
+
+  defp failure_source(code)
+       when code in [
               "runtime_endpoint_missing_terminal",
               "runtime_endpoint_duplicate_terminal",
               "runtime_endpoint_post_terminal_event"

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -12,6 +12,8 @@ defmodule Orchard.Inference.ChatError do
   alias Orchard.InferenceEvent
   alias Orchard.Requests.InferenceAttemptFailure
 
+  @reasoning_conformance_codes InferenceAttemptFailure.reasoning_conformance_codes()
+
   @type kind ::
           :missing_required_field
           | :unsupported_parameter
@@ -357,27 +359,12 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
-  def api_mapping(%__MODULE__{kind: :reasoning_conformance}) do
-    %{
-      status: :internal_server_error,
-      type: "api_error",
-      code: "internal_error",
-      message: "Internal error",
-      param: nil
-    }
-  end
-
-  def api_mapping(%__MODULE__{kind: :runtime_endpoint_conformance}) do
-    %{
-      status: :internal_server_error,
-      type: "api_error",
-      code: "internal_error",
-      message: "Internal error",
-      param: nil
-    }
-  end
-
-  def api_mapping(%__MODULE__{kind: :orchestration_crash}) do
+  def api_mapping(%__MODULE__{kind: kind})
+      when kind in [
+             :reasoning_conformance,
+             :runtime_endpoint_conformance,
+             :orchestration_crash
+           ] do
     %{
       status: :internal_server_error,
       type: "api_error",
@@ -425,16 +412,13 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
-  def sse_mapping(%__MODULE__{kind: :reasoning_conformance}) do
-    %{
-      type: "server_error",
-      code: "internal_error",
-      message: "Internal error",
-      param: nil
-    }
-  end
-
-  def sse_mapping(%__MODULE__{kind: :runtime_endpoint_conformance}) do
+  def sse_mapping(%__MODULE__{kind: kind})
+      when kind in [
+             :reasoning_conformance,
+             :runtime_endpoint_conformance,
+             :internal,
+             :orchestration_crash
+           ] do
     %{
       type: "server_error",
       code: "internal_error",
@@ -448,24 +432,6 @@ defmodule Orchard.Inference.ChatError do
       type: "server_error",
       code: error.source_code,
       message: error.source_message,
-      param: nil
-    }
-  end
-
-  def sse_mapping(%__MODULE__{kind: :internal}) do
-    %{
-      type: "server_error",
-      code: "internal_error",
-      message: "Internal error",
-      param: nil
-    }
-  end
-
-  def sse_mapping(%__MODULE__{kind: :orchestration_crash}) do
-    %{
-      type: "server_error",
-      code: "internal_error",
-      message: "Internal error",
       param: nil
     }
   end
@@ -642,15 +608,10 @@ defmodule Orchard.Inference.ChatError do
        when code in ["request_client_disconnect", "request_caller_disconnect"],
        do: :request_cancelled
 
-  defp failed_event_kind(code) do
-    if InferenceAttemptFailure.reasoning_conformance_code?(code) do
-      :reasoning_conformance
-    else
-      runtime_endpoint_failed_event_kind(code)
-    end
-  end
+  defp failed_event_kind(code) when code in @reasoning_conformance_codes,
+    do: :reasoning_conformance
 
-  defp runtime_endpoint_failed_event_kind(code)
+  defp failed_event_kind(code)
        when code in [
               "runtime_endpoint_missing_terminal",
               "runtime_endpoint_duplicate_terminal",
@@ -658,7 +619,7 @@ defmodule Orchard.Inference.ChatError do
             ],
        do: :runtime_endpoint_conformance
 
-  defp runtime_endpoint_failed_event_kind(_code), do: :request_failed
+  defp failed_event_kind(_code), do: :request_failed
 
   defp tokenization_internal_message(detail) when is_binary(detail),
     do: "Tokenization failed: #{detail}"

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -10,6 +10,7 @@ defmodule Orchard.Inference.ChatError do
 
   alias Orchard.Inference.ModelLoadFailure
   alias Orchard.InferenceEvent
+  alias Orchard.Requests.InferenceAttemptFailure
 
   @type kind ::
           :missing_required_field
@@ -31,6 +32,7 @@ defmodule Orchard.Inference.ChatError do
           | :request_cancelled
           | :request_interrupted
           | :request_failed
+          | :reasoning_conformance
           | :runtime_endpoint_conformance
           | :orchestration_crash
           | :internal
@@ -355,6 +357,16 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def api_mapping(%__MODULE__{kind: :reasoning_conformance}) do
+    %{
+      status: :internal_server_error,
+      type: "api_error",
+      code: "internal_error",
+      message: "Internal error",
+      param: nil
+    }
+  end
+
   def api_mapping(%__MODULE__{kind: :runtime_endpoint_conformance}) do
     %{
       status: :internal_server_error,
@@ -409,6 +421,15 @@ defmodule Orchard.Inference.ChatError do
       type: "server_error",
       code: "request_cancelled",
       message: "Request was cancelled",
+      param: nil
+    }
+  end
+
+  def sse_mapping(%__MODULE__{kind: :reasoning_conformance}) do
+    %{
+      type: "server_error",
+      code: "internal_error",
+      message: "Internal error",
       param: nil
     }
   end
@@ -546,6 +567,15 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def terminal_attrs(%__MODULE__{kind: :reasoning_conformance}) do
+    %{
+      state: :failed,
+      http_status: 500,
+      error_code: "internal_error",
+      error_message: "Internal error"
+    }
+  end
+
   def terminal_attrs(%__MODULE__{kind: :runtime_endpoint_conformance} = error) do
     %{
       state: :failed,
@@ -612,7 +642,15 @@ defmodule Orchard.Inference.ChatError do
        when code in ["request_client_disconnect", "request_caller_disconnect"],
        do: :request_cancelled
 
-  defp failed_event_kind(code)
+  defp failed_event_kind(code) do
+    if InferenceAttemptFailure.reasoning_conformance_code?(code) do
+      :reasoning_conformance
+    else
+      runtime_endpoint_failed_event_kind(code)
+    end
+  end
+
+  defp runtime_endpoint_failed_event_kind(code)
        when code in [
               "runtime_endpoint_missing_terminal",
               "runtime_endpoint_duplicate_terminal",
@@ -620,7 +658,7 @@ defmodule Orchard.Inference.ChatError do
             ],
        do: :runtime_endpoint_conformance
 
-  defp failed_event_kind(_code), do: :request_failed
+  defp runtime_endpoint_failed_event_kind(_code), do: :request_failed
 
   defp tokenization_internal_message(detail) when is_binary(detail),
     do: "Tokenization failed: #{detail}"

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
@@ -30,6 +30,9 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
   )
   @acceptance_proof_failure_class "pre_acceptance_unavailable"
   @acceptance_proof_failure_code "runtime_incompatible"
+  @reasoning_conformance_codes ~w(
+    reasoning_parser_conformance_failed reasoning_policy_conformance_failed
+  )
   @type evidence :: %{required(String.t()) => String.t()}
 
   @spec stable_error_codes() :: [String.t()]
@@ -50,6 +53,10 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
 
   def acceptance_proof_failure?(_failure_class, _failure_code), do: false
 
+  @spec reasoning_conformance_code?(term()) :: boolean()
+  def reasoning_conformance_code?(code) when code in @reasoning_conformance_codes, do: true
+  def reasoning_conformance_code?(_code), do: false
+
   @spec normalize(map()) :: evidence()
   def normalize(source) when is_map(source) do
     category = value(source, :category)
@@ -59,7 +66,7 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
     {failure_class, failure_code} = classify(category, code, phase)
 
     %{"failure_class" => failure_class, "failure_code" => failure_code}
-    |> maybe_put_raw_source_code(code, failure_code)
+    |> maybe_put_raw_source_code(category, code, failure_code)
   end
 
   def normalize(_source),
@@ -81,7 +88,7 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
         {"deadline", deadline_code(code)}
 
       category in [:terminal_conformance, "terminal_conformance"] ->
-        {"terminal_conformance", "orchestration_error"}
+        {"terminal_conformance", terminal_conformance_code(code)}
 
       category in [:capacity, "capacity", :capacity_rejection, "capacity_rejection"] ->
         {capacity_failure_class(code), capacity_code(code)}
@@ -156,6 +163,11 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
 
   defp pre_acceptance_code(_code), do: "internal_error"
 
+  defp terminal_conformance_code(code) when code in @reasoning_conformance_codes,
+    do: "internal_error"
+
+  defp terminal_conformance_code(_code), do: "orchestration_error"
+
   defp capacity_failure_class("dispatch_capacity_caller_down"), do: "cancellation"
 
   defp capacity_failure_class("dispatch_capacity_node_identity_mismatch"),
@@ -182,10 +194,20 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
   defp controller_code(code) when code in ["orchestration_error", "request_interrupted"], do: code
   defp controller_code(_code), do: "internal_error"
 
-  defp maybe_put_raw_source_code(evidence, nil, _stable), do: evidence
-  defp maybe_put_raw_source_code(evidence, stable, stable), do: evidence
+  defp maybe_put_raw_source_code(
+         evidence,
+         category,
+         code,
+         _stable
+       )
+       when category in [:terminal_conformance, "terminal_conformance"] and
+              code in @reasoning_conformance_codes,
+       do: evidence
 
-  defp maybe_put_raw_source_code(evidence, raw_source_code, _stable),
+  defp maybe_put_raw_source_code(evidence, _category, nil, _stable), do: evidence
+  defp maybe_put_raw_source_code(evidence, _category, stable, stable), do: evidence
+
+  defp maybe_put_raw_source_code(evidence, _category, raw_source_code, _stable),
     do: Map.put(evidence, "raw_source_code", raw_source_code)
 
   defp value(source, key), do: Map.get(source, key, Map.get(source, Atom.to_string(key)))

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
@@ -44,6 +44,9 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
   @spec model_load_codes() :: [String.t()]
   def model_load_codes, do: @model_load_codes
 
+  @spec reasoning_conformance_codes() :: [String.t()]
+  def reasoning_conformance_codes, do: @reasoning_conformance_codes
+
   @spec acceptance_proof_failure?(String.t(), String.t()) :: boolean()
   def acceptance_proof_failure?(
         @acceptance_proof_failure_class,
@@ -66,7 +69,7 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
     {failure_class, failure_code} = classify(category, code, phase)
 
     %{"failure_class" => failure_class, "failure_code" => failure_code}
-    |> maybe_put_raw_source_code(category, code, failure_code)
+    |> maybe_put_raw_source_code(code, failure_code)
   end
 
   def normalize(_source),
@@ -194,20 +197,14 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
   defp controller_code(code) when code in ["orchestration_error", "request_interrupted"], do: code
   defp controller_code(_code), do: "internal_error"
 
-  defp maybe_put_raw_source_code(
-         evidence,
-         category,
-         code,
-         _stable
-       )
-       when category in [:terminal_conformance, "terminal_conformance"] and
-              code in @reasoning_conformance_codes,
+  defp maybe_put_raw_source_code(evidence, code, _stable)
+       when code in @reasoning_conformance_codes,
        do: evidence
 
-  defp maybe_put_raw_source_code(evidence, _category, nil, _stable), do: evidence
-  defp maybe_put_raw_source_code(evidence, _category, stable, stable), do: evidence
+  defp maybe_put_raw_source_code(evidence, nil, _stable), do: evidence
+  defp maybe_put_raw_source_code(evidence, stable, stable), do: evidence
 
-  defp maybe_put_raw_source_code(evidence, _category, raw_source_code, _stable),
+  defp maybe_put_raw_source_code(evidence, raw_source_code, _stable),
     do: Map.put(evidence, "raw_source_code", raw_source_code)
 
   defp value(source, key), do: Map.get(source, key, Map.get(source, Atom.to_string(key)))

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -900,6 +900,45 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
                "Inference failed: model did not emit any required tool calls"
     end
 
+    test "SPEC.md §7.5.3a hides reasoning conformance details in sync Chat errors" do
+      worker_message = "<think>worker marker bytes and model output</think>"
+
+      for code <- [
+            "reasoning_parser_conformance_failed",
+            "reasoning_policy_conformance_failed"
+          ] do
+        canonical = stub_chat_canonical(false)
+
+        stub_chat_orchestrator(
+          prepare: {:ok, canonical, %{}},
+          execute:
+            {:ok, canonical,
+             [
+               InferenceEvent.accepted(1_710_000_123_000),
+               InferenceEvent.failed(code, worker_message, false)
+             ]}
+        )
+
+        conn =
+          post_chat(%{
+            "model" => "stub-tool-model@v1",
+            "messages" => [%{"role" => "user", "content" => "hello"}]
+          })
+
+        assert conn.status == 500
+
+        assert Jason.decode!(conn.resp_body)["error"] == %{
+                 "code" => "internal_error",
+                 "message" => "Internal error",
+                 "param" => nil,
+                 "type" => "api_error"
+               }
+
+        refute conn.resp_body =~ code
+        refute conn.resp_body =~ worker_message
+      end
+    end
+
     test "SPEC 7.5.5 non-stream terminal conformance failure is a generic 500" do
       canonical = stub_chat_canonical(false)
 
@@ -1786,6 +1825,48 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       request = Requests.get_request_by_public_id(request_id)
       assert request.state == :failed
       assert_tool_serializer_failure!(request)
+    end
+
+    test "SPEC.md §7.5.3a hides reasoning conformance details in streaming Chat errors" do
+      worker_message = "<think>worker marker bytes and model output</think>"
+
+      for code <- [
+            "reasoning_parser_conformance_failed",
+            "reasoning_policy_conformance_failed"
+          ] do
+        stub_chat_orchestrator(
+          prepare: {:ok, stub_chat_canonical(), %{}},
+          events: [
+            InferenceEvent.accepted(1_710_000_123_000),
+            InferenceEvent.failed(code, worker_message, false)
+          ],
+          execute: {:ok, stub_chat_canonical(), []}
+        )
+
+        conn =
+          post_chat(%{
+            "model" => "stub-tool-model@v1",
+            "messages" => [%{"role" => "user", "content" => "hello"}],
+            "stream" => true
+          })
+
+        assert conn.status == 200
+        events = parse_sse_body(conn.resp_body)
+
+        assert [{:error, payload}] =
+                 Enum.filter(events, fn {type, _payload} -> type == :error end)
+
+        assert payload["error"] == %{
+                 "code" => "internal_error",
+                 "message" => "Internal error",
+                 "param" => nil,
+                 "type" => "server_error"
+               }
+
+        refute Enum.any?(events, fn {type, _payload} -> type == :done end)
+        refute conn.resp_body =~ code
+        refute conn.resp_body =~ worker_message
+      end
     end
 
     test "SPEC 7.5.5 streaming terminal conformance failure emits one generic SSE error" do

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -525,6 +525,41 @@ defmodule Orchard.API.ResponsesControllerTest do
              "Inference failed: model emitted tool call outside required function lookup_weather"
   end
 
+  test "SPEC.md §7.5.3a hides reasoning conformance details in sync Responses errors" do
+    worker_message = "<think>worker marker bytes and model output</think>"
+
+    for code <- [
+          "reasoning_parser_conformance_failed",
+          "reasoning_policy_conformance_failed"
+        ] do
+      canonical = stub_responses_canonical(false)
+
+      stub_responses_orchestrator(
+        prepare: {:ok, canonical, %{}},
+        execute:
+          {:ok, canonical,
+           [
+             InferenceEvent.accepted(1_710_000_123_000),
+             InferenceEvent.failed(code, worker_message, false)
+           ]}
+      )
+
+      conn = post_responses(%{"model" => "stub-tool-model@v1", "input" => "hello"})
+
+      assert conn.status == 500
+
+      assert Jason.decode!(conn.resp_body)["error"] == %{
+               "code" => "internal_error",
+               "message" => "Internal error",
+               "param" => nil,
+               "type" => "api_error"
+             }
+
+      refute conn.resp_body =~ code
+      refute conn.resp_body =~ worker_message
+    end
+  end
+
   test "SPEC 7.5.5 sync terminal conformance failure is a generic 500" do
     canonical = stub_responses_canonical(false)
 
@@ -1705,6 +1740,46 @@ defmodule Orchard.API.ResponsesControllerTest do
     request = Requests.get_request_by_public_id(request_id)
     assert request.state == :failed
     assert_tool_serializer_failure!(request)
+  end
+
+  test "SPEC.md §7.5.3a hides reasoning conformance details in streaming Responses errors" do
+    worker_message = "<think>worker marker bytes and model output</think>"
+
+    for code <- [
+          "reasoning_parser_conformance_failed",
+          "reasoning_policy_conformance_failed"
+        ] do
+      stub_responses_orchestrator(
+        prepare: {:ok, stub_responses_canonical(true), %{}},
+        events: [
+          InferenceEvent.accepted(1_710_000_123_000),
+          InferenceEvent.failed(code, worker_message, false)
+        ],
+        execute: {:ok, stub_responses_canonical(true), []}
+      )
+
+      conn =
+        post_responses(%{
+          "model" => "stub-tool-model@v1",
+          "input" => "hello",
+          "stream" => true
+        })
+
+      assert conn.status == 200
+      events = parse_typed_sse_events(conn)
+      assert Enum.map(events, & &1.type) == ["response.created", "response.failed"]
+
+      assert List.last(events).data["response"]["error"] == %{
+               "code" => "internal_error",
+               "message" => "Internal error",
+               "param" => nil,
+               "type" => "server_error"
+             }
+
+      refute String.contains?(collect_chunked_body(conn), "[DONE]")
+      refute String.contains?(collect_chunked_body(conn), code)
+      refute String.contains?(collect_chunked_body(conn), worker_message)
+    end
   end
 
   test "SPEC 7.5.5 streaming terminal conformance failure emits response.failed" do

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -194,6 +194,17 @@ defmodule Orchard.Dispatch.DispatchTest.TerminalContractClient do
     ]
   end
 
+  defp events_for("req-dispatch-reasoning-conformance-" <> code)
+       when code in [
+              "reasoning_parser_conformance_failed",
+              "reasoning_policy_conformance_failed"
+            ] do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.failed(code, "<think>untrusted model output</think>", false)
+    ]
+  end
+
   defp events_for("req-dispatch-preaccept-" <> code),
     do: [InferenceEvent.failed(code, "capacity exhausted", false)]
 
@@ -687,6 +698,33 @@ defmodule Orchard.Dispatch.DispatchTest do
                    "failure_code" => "internal_error"
                  },
                  output_committed: false
+               } =
+                 RequestDispatcher.dispatch(
+                   build_schedule(request_id),
+                   execute_request(request_id),
+                   model_load_request(bundle),
+                   client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient
+                 )
+      end
+    end
+
+    test "SPEC.md §7.5.3a reasoning conformance is uncommitted terminal evidence", %{
+      bundle: bundle
+    } do
+      for code <- [
+            "reasoning_parser_conformance_failed",
+            "reasoning_policy_conformance_failed"
+          ] do
+        request_id = "req-dispatch-reasoning-conformance-#{code}"
+
+        assert %AttemptOutcome{
+                 attempt_outcome: :failed,
+                 accepted: true,
+                 output_committed: false,
+                 failure: %{
+                   "failure_class" => "terminal_conformance",
+                   "failure_code" => "internal_error"
+                 }
                } =
                  RequestDispatcher.dispatch(
                    build_schedule(request_id),

--- a/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Inference.ChatErrorTest do
   alias Orchard.API.InferenceControllerSupport
   alias Orchard.Inference.{ChatError, ModelLoadFailure}
   alias Orchard.InferenceEvent
+  alias Orchard.Requests.CapturePolicy
 
   test "prepare validation mappings preserve OpenAI envelope fields" do
     error = ChatError.from_prepare_reason({:validation, {:missing_required_field, "model"}})
@@ -186,6 +187,54 @@ defmodule Orchard.Inference.ChatErrorTest do
                error_code: code,
                error_message: message
              }
+    end
+  end
+
+  test "SPEC.md §7.5.3a reasoning conformance stays Controller-owned under every capture mode" do
+    worker_message = "<think>marker bytes and model output</think>"
+
+    for code <- [
+          "reasoning_parser_conformance_failed",
+          "reasoning_policy_conformance_failed"
+        ] do
+      error =
+        code
+        |> InferenceEvent.failed(worker_message, false)
+        |> ChatError.from_failed_event()
+
+      assert error.kind == :reasoning_conformance
+
+      assert ChatError.api_mapping(error) == %{
+               status: :internal_server_error,
+               type: "api_error",
+               code: "internal_error",
+               message: "Internal error",
+               param: nil
+             }
+
+      assert ChatError.sse_mapping(error) == %{
+               type: "server_error",
+               code: "internal_error",
+               message: "Internal error",
+               param: nil
+             }
+
+      assert ChatError.terminal_attrs(error) == %{
+               state: :failed,
+               http_status: 500,
+               error_code: "internal_error",
+               error_message: "Internal error"
+             }
+
+      for mode <- [:none, :metadata, :full] do
+        attrs =
+          error |> ChatError.terminal_attrs() |> then(&CapturePolicy.terminal_attrs(mode, &1))
+
+        assert attrs.error_code == "internal_error"
+        assert attrs.error_message in [nil, "Internal error"]
+        refute inspect(attrs) =~ code
+        refute inspect(attrs) =~ worker_message
+      end
     end
   end
 

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
@@ -58,6 +58,28 @@ defmodule Orchard.Requests.InferenceAttemptFailureTest do
     end
   end
 
+  test "SPEC.md §7.5.3a maps only closed reasoning conformance codes to internal_error" do
+    for code <- [
+          :reasoning_parser_conformance_failed,
+          :reasoning_policy_conformance_failed
+        ] do
+      assert InferenceAttemptFailure.normalize(%{
+               category: :terminal_conformance,
+               code: code,
+               message: "<think>untrusted model output</think>"
+             }) == %{
+               "failure_class" => "terminal_conformance",
+               "failure_code" => "internal_error"
+             }
+
+      assert InferenceAttemptFailure.reasoning_conformance_code?(Atom.to_string(code))
+    end
+
+    refute InferenceAttemptFailure.reasoning_conformance_code?(
+             "runtime_endpoint_missing_terminal"
+           )
+  end
+
   test "untrusted pre-acceptance codes do not acquire retryable stable codes" do
     assert InferenceAttemptFailure.normalize(%{
              category: :pre_acceptance,

--- a/openspec/specs/runtime-endpoints/spec.md
+++ b/openspec/specs/runtime-endpoints/spec.md
@@ -716,6 +716,31 @@ This requirement traces to `SPEC.md` §5.8, §§12.1-12.3, §12.7, and `docs/dec
 - **AND** normalizes restricted-capture durable evidence to the existing stable Controller-owned terminal failure code
 - **AND** no Automatic Attempt Retry begins
 
+### Requirement: Reasoning conformance failure codes are a closed shared vocabulary
+`reasoning_parser_conformance_failed` and `reasoning_policy_conformance_failed` SHALL be the only Runtime Endpoint `Failed` codes that report a post-execution negotiated reasoning parser or generation-policy conformance failure.
+A producer SHALL emit exactly those spellings and the Controller SHALL recognize exactly those spellings; no other spelling, prefix, synonym, or category pairing SHALL receive reasoning conformance treatment.
+Both codes SHALL classify as the `terminal_conformance` failure class with the stable Controller-owned failure code `internal_error`, and SHALL remain non-retryable.
+The Controller MUST NOT expose the source code, source message, parser control markers, or model output through the synchronous HTTP body, the streaming error event, or durable terminal evidence, and SHALL retain no raw source code for either code under `none`, `metadata`, or `full` capture.
+A reasoning-only conformance failure commits no validated content-bearing output and SHALL record `output_committed = false`.
+This vocabulary is a shared failure-code contract only: it adds no protobuf field, no public reasoning control, and no parser behavior, and it SHALL NOT broaden the `orchestration_error` default that every other `terminal_conformance` code keeps.
+This requirement traces to `SPEC.md` §7.2.7 and §7.5.3a.
+
+#### Scenario: Parser conformance failure stays content-free
+- **WHEN** a negotiated attempt fails post-execution with `reasoning_parser_conformance_failed`
+- **THEN** the synchronous and streaming public errors carry only `internal_error` with a generic message
+- **AND** durable terminal evidence records `terminal_conformance` plus `internal_error` with no raw source code under any capture mode
+- **AND** no Automatic Attempt Retry begins
+
+#### Scenario: Generation-policy conformance failure stays content-free
+- **WHEN** a negotiated attempt fails post-execution with `reasoning_policy_conformance_failed`
+- **THEN** Orchard applies the same content-free `terminal_conformance` plus `internal_error` outcome
+- **AND** the reasoning-only failure records `output_committed = false`
+
+#### Scenario: Reasoning-like code outside the closed pair is not reasoning conformance
+- **WHEN** a Runtime Endpoint `Failed` event carries a reasoning-like code that is not one of the two closed spellings
+- **THEN** Orchard does not apply the reasoning conformance classification or mapping
+- **AND** the code follows the existing unknown-code classification instead
+
 ### Requirement: Execution resolution precedes retry
 The Controller SHALL allow a pre-acceptance failure to qualify for retry only after cleanup and capacity release are affirmatively resolved.
 An accepted pre-commit failure MAY qualify only when a valid terminal event or cancellation drain proves execution termination.


### PR DESCRIPTION
## Intent

Implement #328 PR-2 / #327 D4 terminal conformance only: recognize exactly reasoning_parser_conformance_failed and reasoning_policy_conformance_failed as post-execution terminal_conformance + internal_error. Preserve runtime_endpoint_* terminal-conformance classifications as orchestration_error; do not implement the parser, alter protobufs or public reasoning controls, broaden terminal-conformance defaults, or change retry semantics beyond the existing non-retryable mapping. The dedicated ChatError mapping must keep worker code, message, marker bytes, and model output out of sync HTTP, SSE, and durable terminal evidence, and reasoning-only failures remain output_committed=false. Include SPEC.md §7.5.3a regressions across Chat, Responses, streaming, and capture modes.

## What Changed

- `RequestDispatcher.failure_source/1` now routes the closed pair `reasoning_parser_conformance_failed` / `reasoning_policy_conformance_failed` into the `terminal_conformance` category, and `InferenceAttemptFailure` maps exactly those two codes to the stable code `internal_error` (all other `terminal_conformance` codes, including the `runtime_endpoint_*` family, keep `orchestration_error`) while suppressing `raw_source_code` under every capture mode.
- `ChatError` gains a dedicated `:reasoning_conformance` kind whose sync, SSE, and durable `terminal_attrs` mappings emit only a generic `internal_error` / "Internal error", keeping the worker code, worker message, reasoning marker bytes, and model output out of caller-visible and persisted evidence; identical `api_mapping/1` and `sse_mapping/1` clauses were collapsed into shared guarded clauses.
- Added SPEC.md §7.5.3a regressions across Chat and Responses (sync and streaming), dispatch classification, capture modes, and the closed-vocabulary unit tests, plus an OpenSpec `runtime-endpoints` requirement recording the two codes as the only recognized reasoning conformance spellings — no protobuf, parser, public reasoning control, or retry-semantics changes.

## Risk Assessment

✅ Low: All four owner-directed fixes are applied and verified behavior-preserving by clause-order analysis, the closed code vocabulary is now recorded in the accepted OpenSpec capability spec following established repo precedent, and the only remaining items are two info-level hygiene cleanups with no behavioral impact.

## Testing

<code>Ran the smallest relevant automated slice first (the 12 new §7.5.3a selectors, then the two full ChatError/InferenceAttemptFailure unit files), then the broader affected surface for the three changed modules: full `dispatch_test.exs`, the full Chat and Responses controller suites, and the capture-policy/attempt-outcome/step-event regression set — 256 tests across those runs, all passing, no failures or flakes. Because passing unit tests alone do not show what an API caller actually receives, I additionally drove the real Chat and Responses endpoints end-to-end through the real scheduler and RequestDispatcher with a worker message carrying `&lt;think&gt;` marker bytes and a fake secret, and captured the verbatim wire bytes alongside the Postgres rows read back after terminalization. Both closed reasoning codes yield a content-free `internal_error` on sync HTTP, on the single streaming SSE error with no `[DONE]`, and on `response.failed`, and durable evidence records `terminal_conformance` + `internal_error` with `output_committed=false`, `not_retryable`, and no `raw_source_code` under `none`, `metadata`, and `full` capture — with neither the source code nor the worker message anywhere in caller-visible or persisted fields. Two controls confirm the mapping did not overreach: `runtime_endpoint_missing_terminal` still resolves to `orchestration_error`, and a near-miss spelling keeps the pre-existing unknown-code classification. This change is API/persistence-facing with no rendered UI surface, so the reviewer-visible evidence is CLI/HTTP transcripts and persisted database state rather than screenshots. The transient evidence harness was deleted and the worktree is clean.</code>

<details>
<summary>Evidence: End-to-end wire + durable evidence, all 16 endpoint/mode/code cases</summary>

```text
# SPEC.md §7.5.3a terminal conformance — end-to-end evidence

Captured by driving the real `/v1/chat/completions` and `/v1/responses`
endpoints through the real scheduler and `Orchard.Dispatch.RequestDispatcher`
against a single trusted Node whose Runtime Endpoint stream terminalizes with
the code under test. Every body below is the verbatim bytes the HTTP caller
received; every durable row below is read back from Postgres after the request
terminalized.

Worker-supplied failure message injected on the reasoning cases (must never
appear in any caller-visible or durable field):

`` `
<think>SECRET-CHAIN-OF-THOUGHT: launch code 4815162342</think>LEAKED-FINAL-TEXT
`` `

## POST /v1/chat/completions · non-streaming · `reasoning_parser_conformance_failed` (worker-emitted Failed code)

HTTP status: **500**
Content-Type: `application/json; charset=utf-8`

Caller-visible response bytes:

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/chat/completions · streaming · `reasoning_parser_conformance_failed` (worker-emitted Failed code)

HTTP status: **200**
Content-Type: `text/event-stream`

Caller-visible response bytes:

`` `
data: {"error":{"code":"internal_error","message":"Internal error","type":"server_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/chat/completions · non-streaming · `reasoning_policy_conformance_failed` (worker-emitted Failed code)

HTTP status: **500**
Content-Type: `application/json; charset=utf-8`

Caller-visible response bytes:

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/chat/completions · streaming · `reasoning_policy_conformance_failed` (worker-emitted Failed code)

HTTP status: **200**
Content-Type: `text/event-stream`

Caller-visible response bytes:

`` `
data: {"error":{"code":"internal_error","message":"Internal error","type":"server_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/chat/completions · non-streaming · `runtime_endpoint_missing_terminal` (Controller-synthesized, contrast case)

HTTP status: **500**
Content-Type: `application/json; charset=utf-8`

Caller-visible response bytes:

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "orchestration_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/chat/completions · streaming · `runtime_endpoint_missing_terminal` (Controller-synthesized, contrast case)

HTTP status: **200**
Content-Type: `text/event-stream`

Caller-visible response bytes:

`` `
data: {"error":{"code":"internal_error","message":"Internal error","type":"server_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "orchestration_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/chat/completions · non-streaming · `reasoning_parser_conformance_failure` (near-miss spelling outside the closed pair, contrast case)

HTTP status: **500**
Content-Type: `application/json; charset=utf-8`

Caller-visible response bytes:

`` `
{"error":{"code":"internal_error","message":"Inference failed: near-miss reasoning-like code detail","type":"server_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "runtime_failure",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/chat/completions · streaming · `reasoning_parser_conformance_failure` (near-miss spelling outside the closed pair, contrast case)

HTTP status: **200**
Content-Type: `text/event-stream`

Caller-visible response bytes:

`

... [3649 bytes truncated] ...

emitted Failed code)

HTTP status: **500**
Content-Type: `application/json; charset=utf-8`

Caller-visible response bytes:

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/responses · streaming · `reasoning_policy_conformance_failed` (worker-emitted Failed code)

HTTP status: **200**
Content-Type: `text/event-stream`

Caller-visible response bytes:

`` `
event: response.created
data: {"type":"response.created","response":{"error":null,"id":"resp_c3640124-f120-44ef-babc-e12c2925e1d1","output":[],"status":"in_progress","metadata":{},"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0},"model":"evidence-responses-reasoning@v1","object":"response","created_at":1789113769,"output_text":""}}

event: response.failed
data: {"type":"response.failed","response":{"error":{"code":"internal_error","message":"Internal error","type":"server_error","param":null},"id":"resp_c3640124-f120-44ef-babc-e12c2925e1d1","output":[],"status":"failed","metadata":{},"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0},"model":"evidence-responses-reasoning@v1","object":"response","created_at":1789113769,"output_text":""}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/responses · non-streaming · `runtime_endpoint_missing_terminal` (Controller-synthesized, contrast case)

HTTP status: **500**
Content-Type: `application/json; charset=utf-8`

Caller-visible response bytes:

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "orchestration_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/responses · streaming · `runtime_endpoint_missing_terminal` (Controller-synthesized, contrast case)

HTTP status: **200**
Content-Type: `text/event-stream`

Caller-visible response bytes:

`` `
event: response.created
data: {"type":"response.created","response":{"error":null,"id":"resp_8fa6698e-50f7-471b-920d-6505b3922cb1","output":[],"status":"in_progress","metadata":{},"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0},"model":"evidence-responses-reasoning@v1","object":"response","created_at":1789113769,"output_text":""}}

event: response.failed
data: {"type":"response.failed","response":{"error":{"code":"internal_error","message":"Internal error","type":"server_error","param":null},"id":"resp_8fa6698e-50f7-471b-920d-6505b3922cb1","output":[],"status":"failed","metadata":{},"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0},"model":"evidence-responses-reasoning@v1","object":"response","created_at":1789113769,"output_text":""}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "orchestration_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/responses · non-streaming · `reasoning_parser_conformance_failure` (near-miss spelling outside the closed pair, contrast case)

HTTP status: **500**
Content-Type: `application/json; charset=utf-8`

Caller-visible response bytes:

`` `
{"error":{"code":"internal_error","message":"Inference failed: near-miss reasoning-like code detail","type":"server_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "runtime_failure",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **false** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**

## POST /v1/responses · streaming · `reasoning_parser_conformance_failure` (near-miss spelling outside the closed pair, contrast case)

HTTP status: **200**
Content-Type: `text/event-stream`

Caller-visible response bytes:

`` `
event: response.created
data: {"type":"response.created","response":{"error":null,"id":"resp_9fd84f12-59a2-44ab-9049-1da0690404bb","output":[],"status":"in_progress","metadata":{},"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0},"model":"evidence-responses-reasoning@v1","object":"response","created_at":1789113769,"output_text":""}}

event: response.failed
data: {"type":"response.failed","response":{"error":{"code":"reasoning_parser_conformance_failure","message":"near-miss reasoning-like code detail","type":"server_error","param":null},"id":"resp_9fd84f12-59a2-44ab-9049-1da0690404bb","output":[],"status":"failed","metadata":{},"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0},"model":"evidence-responses-reasoning@v1","object":"response","created_at":1789113769,"output_text":""}}
`` `

Durable `requests` row (Postgres):

`` `
state             = :failed
http_status       = 500
error_code        = "internal_error"
error_message     = nil
response_payload  = nil
response_preview  = nil
`` `

Durable terminal Inference Attempt evidence (`request_step_events.result`):

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "execution_resolution" => "terminated",
  "failure_class" => "runtime_failure",
  "failure_code" => "internal_error",
  "output_committed" => false,
  "retry_decision" => "not_retryable"
}
`` `

Source code echoed in caller bytes: **true** ·
reasoning worker message in caller bytes: **false** ·
reasoning worker message in durable evidence: **false**
```
</details>
<details>
<summary>Evidence: Durable evidence under every tenant capture mode (none/metadata/full)</summary>

```text
# SPEC.md §7.5.3a reasoning conformance — durable evidence under every capture mode

Same real end-to-end `/v1/chat/completions` path, with the owning tenant's
`request_body_capture_mode` set to each of `none`, `metadata`, and `full`
before the request runs.

## capture mode `none` · `reasoning_parser_conformance_failed`

Caller-visible response bytes (HTTP 500):

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
payload_capture_mode = :none
state                = :failed
http_status          = 500
error_code           = "internal_error"
error_message        = nil
canonical_request    = nil
response_payload     = nil
`` `

Durable terminal Inference Attempt evidence:

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "capacity_release_outcome" => "released",
  "ended_at" => "2026-09-11T08:02:49.499919Z",
  "excluded_node_ids" => [],
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "http_status" => 500,
  "input_tokens" => 0,
  "node_id" => "4ab059b7-1f21-4f2a-ae93-95cb3ab5ea7a",
  "output_committed" => false,
  "output_tokens" => 0,
  "retry_decision" => "not_retryable",
  "runtime_retryable" => false,
  "started_at" => "2026-09-11T08:02:49.498685Z"
}
`` `

`raw_source_code` retained: **false** ·
source code anywhere in durable evidence: **false** ·
worker message anywhere in durable evidence: **false**

## capture mode `none` · `reasoning_policy_conformance_failed`

Caller-visible response bytes (HTTP 500):

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
payload_capture_mode = :none
state                = :failed
http_status          = 500
error_code           = "internal_error"
error_message        = nil
canonical_request    = nil
response_payload     = nil
`` `

Durable terminal Inference Attempt evidence:

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "capacity_release_outcome" => "released",
  "ended_at" => "2026-09-11T08:02:49.507265Z",
  "excluded_node_ids" => [],
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "http_status" => 500,
  "input_tokens" => 0,
  "node_id" => "b421cbd6-b867-4f86-98fc-d400317947ac",
  "output_committed" => false,
  "output_tokens" => 0,
  "retry_decision" => "not_retryable",
  "runtime_retryable" => false,
  "started_at" => "2026-09-11T08:02:49.506425Z"
}
`` `

`raw_source_code` retained: **false** ·
source code anywhere in durable evidence: **false** ·
worker message anywhere in durable evidence: **false**

## capture mode `metadata` · `reasoning_parser_conformance_failed`

Caller-visible response bytes (HTTP 500):

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
payload_capture_mode = :metadata
state                = :failed
http_status          = 500
error_code           = "internal_error"
error_message        = nil
canonical_request    = nil
response_payload     = nil
`` `

Durable terminal Inference Attempt evidence:

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "capacity_release_outcome" => "released",
  "ended_at" => "2026-09-11T08:02:49.514078Z",
  "excluded_node_ids" => [],
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "http_status" => 500,
  "input_tokens" => 0,
  "node_id" => "beeea5f8-7bdf-4405-853e-cb0ec4ce367f",
  "output_committed" => false,
  "output_tokens" => 0,
  "retry_decision" => "not_retryable",
  "runtime_retryable" => false,
  "started_at" => "2026-09-11T08:02:49.513271Z"
}
`` `

`raw_source_code` retained: **false** ·
source code anywhere in durable evidence: **false** ·
worker message anywhere in durable evidence: **false**

## capture mode `metadata` · `reasoning_policy_conformance_failed`

Caller-visible response bytes (HTTP 500):

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
payload_capture_mode = :metadata
state                = :failed
http_status          = 500
error_code           = "internal_error"
error_message        = nil
canonical_request    = nil
response_payload     = nil
`` `

Durable terminal Inference Attempt evidence:

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "capacity_release_outcome" => "released",
  "ended_at" => "2026-09-11T08:02:49.520656Z",
  "excluded_node_ids" => [],
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "http_status" => 500,
  "input_tokens" => 0,
  "node_id" => "007eb00d-3bb7-4e39-ab92-c8207cc91ea2",
  "output_committed" => false,
  "output_tokens" => 0,
  "retry_decision" => "not_retryable",
  "runtime_retryable" => false,
  "started_at" => "2026-09-11T08:02:49.519913Z"
}
`` `

`raw_source_code` retained: **false** ·
source code anywhere in durable evidence: **false** ·
worker message anywhere in durable evidence: **false**

## capture mode `full` · `reasoning_parser_conformance_failed`

Caller-visible response bytes (HTTP 500):

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
payload_capture_mode = :full
state                = :failed
http_status          = 500
error_code           = "internal_error"
error_message        = "Internal error"
canonical_request    = %{"admission" => %{"max_cold_start_ms" => 15000, "queue_wait_ms" => 3000, "timeout_ms" => 23000}, "api_key_id" => "1371b7bb-a8e7-4202-beeb-4fbc652cd40f", "endpoint" => "chat_completions", "input_items" => [%{"content" => "hello", "role" => "user"}], "input_token_count" => 3, "internal_id" => "72beb155-69d8-4b29-bc68-dfaf4a037e77", "metadata" => %{}, "model_ref" => %{"model_id" => "evidence-capture-reasoning", "version" => "v1"}, "principal_id" => "dd519ea6-7d9e-475b-bb61-441d5a75f8be", "principal_type" => "tenant", "public_id" => "chatcmpl-72beb155-69d8-4b29-bc68-dfaf4a037e77", "rendered_prompt" => "user hello\nassistant", "resolved_policy" => %{"allowed_pool_ids" => [], "max_active_requests" => nil, "quota_id" => nil, "residency_preference" => "allow_cold_load", "routing_policy_id" => nil}, "response_format" => %{"type" => "text"}, "sampling" => %{"max_output_tokens" => nil, "seed" => nil, "stop" => [], "temperature" => 1.0, "top_p" => 1.0}, "service_account_id" => nil, "store" => true, "stream" => false, "stream_include_usage" => false, "tenant_id" => "dd519ea6-7d9e-475b-bb61-441d5a75f8be", "tooling" => %{"execution_snapshot" => %{"entries" => []}, "registry_snapshot" => %{"entries" => []}, "requested_tools" => [], "tool_choice" => nil, "tools" => []}}
response_payload     = nil
`` `

Durable terminal Inference Attempt evidence:

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "capacity_release_outcome" => "released",
  "ended_at" => "2026-09-11T08:02:49.527635Z",
  "error_message" => "Internal error",
  "excluded_node_ids" => [],
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "http_status" => 500,
  "input_tokens" => 0,
  "node_id" => "566b0c67-5fb9-4dd2-b197-b7717411d799",
  "output_committed" => false,
  "output_tokens" => 0,
  "retry_decision" => "not_retryable",
  "runtime_retryable" => false,
  "started_at" => "2026-09-11T08:02:49.526804Z"
}
`` `

`raw_source_code` retained: **false** ·
source code anywhere in durable evidence: **false** ·
worker message anywhere in durable evidence: **false**

## capture mode `full` · `reasoning_policy_conformance_failed`

Caller-visible response bytes (HTTP 500):

`` `
{"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
`` `

Durable `requests` row (Postgres):

`` `
payload_capture_mode = :full
state                = :failed
http_status          = 500
error_code           = "internal_error"
error_message        = "Internal error"
canonical_request    = %{"admission" => %{"max_cold_start_ms" => 15000, "queue_wait_ms" => 3000, "timeout_ms" => 23000}, "api_key_id" => "c51f7816-89c0-4c21-a089-409bb3c22d85", "endpoint" => "chat_completions", "input_items" => [%{"content" => "hello", "role" => "user"}], "input_token_count" => 3, "internal_id" => "9a78df35-b23f-4d74-80c3-b3c34c4f760f", "metadata" => %{}, "model_ref" => %{"model_id" => "evidence-capture-reasoning", "version" => "v1"}, "principal_id" => "dd62a62e-d340-4a41-9b1b-2c77675a32be", "principal_type" => "tenant", "public_id" => "chatcmpl-9a78df35-b23f-4d74-80c3-b3c34c4f760f", "rendered_prompt" => "user hello\nassistant", "resolved_policy" => %{"allowed_pool_ids" => [], "max_active_requests" => nil, "quota_id" => nil, "residency_preference" => "allow_cold_load", "routing_policy_id" => nil}, "response_format" => %{"type" => "text"}, "sampling" => %{"max_output_tokens" => nil, "seed" => nil, "stop" => [], "temperature" => 1.0, "top_p" => 1.0}, "service_account_id" => nil, "store" => true, "stream" => false, "stream_include_usage" => false, "tenant_id" => "dd62a62e-d340-4a41-9b1b-2c77675a32be", "tooling" => %{"execution_snapshot" => %{"entries" => []}, "registry_snapshot" => %{"entries" => []}, "requested_tools" => [], "tool_choice" => nil, "tools" => []}}
response_payload     = nil
`` `

Durable terminal Inference Attempt evidence:

`` `
%{
  "accepted" => true,
  "attempt_outcome" => "failed",
  "capacity_release_outcome" => "released",
  "ended_at" => "2026-09-11T08:02:49.534594Z",
  "error_message" => "Internal error",
  "excluded_node_ids" => [],
  "execution_resolution" => "terminated",
  "failure_class" => "terminal_conformance",
  "failure_code" => "internal_error",
  "http_status" => 500,
  "input_tokens" => 0,
  "node_id" => "b758515e-7879-489b-8d05-f7a0434ea44a",
  "output_committed" => false,
  "output_tokens" => 0,
  "retry_decision" => "not_retryable",
  "runtime_retryable" => false,
  "started_at" => "2026-09-11T08:02:49.533810Z"
}
`` `

`raw_source_code` retained: **false** ·
source code anywhere in durable evidence: **false** ·
worker message anywhere in durable evidence: **false**
```
</details>
<details>
<summary>Evidence: Compact evidence summary (inline)</summary>

<code>| endpoint | mode | source code | HTTP | failure_class | failure_code | output_committed | retry_decision | raw_source_code |&#10;|----------------------|---------------|--------------------------------------|------|----------------------|---------------------|------------------|----------------|-----------------|&#10;| /v1/chat/completions | non-streaming | reasoning_parser_conformance_failed | 500 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/chat/completions | streaming | reasoning_parser_conformance_failed | 200 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/chat/completions | non-streaming | reasoning_policy_conformance_failed | 500 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/chat/completions | streaming | reasoning_policy_conformance_failed | 200 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/chat/completions | non-streaming | runtime_endpoint_missing_terminal | 500 | terminal_conformance | orchestration_error | false | not_retryable | no |&#10;| /v1/chat/completions | streaming | runtime_endpoint_missing_terminal | 200 | terminal_conformance | orchestration_error | false | not_retryable | no |&#10;| /v1/chat/completions | non-streaming | reasoning_parser_conformance_failure | 500 | runtime_failure | internal_error | false | not_retryable | no |&#10;| /v1/chat/completions | streaming | reasoning_parser_conformance_failure | 200 | runtime_failure | internal_error | false | not_retryable | no |&#10;| /v1/responses | non-streaming | reasoning_parser_conformance_failed | 500 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/responses | streaming | reasoning_parser_conformance_failed | 200 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/responses | non-streaming | reasoning_policy_conformance_failed | 500 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/responses | streaming | reasoning_policy_conformance_failed | 200 | terminal_conformance | internal_error | false | not_retryable | no |&#10;| /v1/responses | non-streaming | runtime_endpoint_missing_terminal | 500 | terminal_conformance | orchestration_error | false | not_retryable | no |&#10;| /v1/responses | streaming | runtime_endpoint_missing_terminal | 200 | terminal_conformance | orchestration_error | false | not_retryable | no |&#10;| /v1/responses | non-streaming | reasoning_parser_conformance_failure | 500 | runtime_failure | internal_error | false | not_retryable | no |&#10;| /v1/responses | streaming | reasoning_parser_conformance_failure | 200 | runtime_failure | internal_error | false | not_retryable | no |&#10;&#10;Representative caller-visible bytes (verbatim):&#10;chat sync reasoning_parser_conformance_failed {&#34;error&#34;:{&#34;code&#34;:&#34;internal_error&#34;,&#34;message&#34;:&#34;Internal error&#34;,&#34;type&#34;:&#34;api_error&#34;,&#34;param&#34;:null}}&#10;chat stream reasoning_policy_conformance_failed data: {&#34;error&#34;:{&#34;code&#34;:&#34;internal_error&#34;,&#34;message&#34;:&#34;Internal error&#34;,&#34;type&#34;:&#34;server_error&#34;,&#34;param&#34;:null}} (no data: [DONE])&#10;resp stream reasoning_parser_conformance_failed event: response.failed -&gt; response.error = {&#34;code&#34;:&#34;internal_error&#34;,&#34;message&#34;:&#34;Internal error&#34;,&#34;type&#34;:&#34;server_error&#34;,&#34;param&#34;:null}&#10;&#10;Closed-vocabulary control: the near-miss spelling `reasoning_parser_conformance_failure`&#10;keeps the pre-existing unknown-code classification (runtime_failure, worker code/message&#10;echoed on the SSE error), so the new mapping recognizes exactly the two closed spellings.&#10;&#10;Durable evidence under every tenant capture mode (none / metadata / full), both reasoning&#10;codes: failure_class=terminal_conformance, failure_code=internal_error, no raw_source_code&#10;key, and neither the source code nor the worker message appears anywhere in the persisted&#10;requests row or terminal Inference Attempt evidence. Under `full` capture the canonical&#10;request is still persisted and error_message is the generic &#34;Internal error&#34;.</code>

```text
| endpoint             | mode          | source code                          | HTTP | failure_class        | failure_code        | output_committed | retry_decision | raw_source_code |
|----------------------|---------------|--------------------------------------|------|----------------------|---------------------|------------------|----------------|-----------------|
| /v1/chat/completions | non-streaming | reasoning_parser_conformance_failed  | 500  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/chat/completions | streaming     | reasoning_parser_conformance_failed  | 200  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/chat/completions | non-streaming | reasoning_policy_conformance_failed  | 500  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/chat/completions | streaming     | reasoning_policy_conformance_failed  | 200  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/chat/completions | non-streaming | runtime_endpoint_missing_terminal    | 500  | terminal_conformance | orchestration_error | false            | not_retryable  | no              |
| /v1/chat/completions | streaming     | runtime_endpoint_missing_terminal    | 200  | terminal_conformance | orchestration_error | false            | not_retryable  | no              |
| /v1/chat/completions | non-streaming | reasoning_parser_conformance_failure | 500  | runtime_failure      | internal_error      | false            | not_retryable  | no              |
| /v1/chat/completions | streaming     | reasoning_parser_conformance_failure | 200  | runtime_failure      | internal_error      | false            | not_retryable  | no              |
| /v1/responses        | non-streaming | reasoning_parser_conformance_failed  | 500  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/responses        | streaming     | reasoning_parser_conformance_failed  | 200  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/responses        | non-streaming | reasoning_policy_conformance_failed  | 500  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/responses        | streaming     | reasoning_policy_conformance_failed  | 200  | terminal_conformance | internal_error      | false            | not_retryable  | no              |
| /v1/responses        | non-streaming | runtime_endpoint_missing_terminal    | 500  | terminal_conformance | orchestration_error | false            | not_retryable  | no              |
| /v1/responses        | streaming     | runtime_endpoint_missing_terminal    | 200  | terminal_conformance | orchestration_error | false            | not_retryable  | no              |
| /v1/responses        | non-streaming | reasoning_parser_conformance_failure | 500  | runtime_failure      | internal_error      | false            | not_retryable  | no              |
| /v1/responses        | streaming     | reasoning_parser_conformance_failure | 200  | runtime_failure      | internal_error      | false            | not_retryable  | no              |

Representative caller-visible bytes (verbatim):
  chat  sync   reasoning_parser_conformance_failed  {"error":{"code":"internal_error","message":"Internal error","type":"api_error","param":null}}
  chat  stream reasoning_policy_conformance_failed  data: {"error":{"code":"internal_error","message":"Internal error","type":"server_error","param":null}}   (no data: [DONE])
  resp  stream reasoning_parser_conformance_failed  event: response.failed -> response.error = {"code":"internal_error","message":"Internal error","type":"server_error","param":null}

Closed-vocabulary control: the near-miss spelling `reasoning_parser_conformance_failure`
keeps the pre-existing unknown-code classification (runtime_failure, worker code/message
echoed on the SSE error), so the new mapping recognizes exactly the two closed spellings.

Durable evidence under every tenant capture mode (none / metadata / full), both reasoning
codes: failure_class=terminal_conformance, failure_code=internal_error, no raw_source_code
key, and neither the source code nor the worker message appears anywhere in the persisted
requests row or terminal Inference Attempt evidence. Under `full` capture the canonical
request is still persisted and error_message is the generic "Internal error".
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex:33` - The two recognized code strings have no normative record anywhere outside Controller code and these tests: `grep -rn &#39;reasoning_parser_conformance_failed\|reasoning_policy_conformance_failed&#39; SPEC.md docs openspec proto apps` matches only the new lib/test lines. Their siblings are recorded twice — `docs/decisions/0019-one-request-bounded-alternate-node-retry.md:81` and `openspec/specs/runtime-endpoints/spec.md:700` both name `runtime_endpoint_missing_terminal`/`_duplicate_terminal`/`_post_terminal_event` — and `openspec/changes/define-negotiated-reasoning-runtime-encoding/design.md:120` records D4 only as &#34;make `terminal_conformance + internal_error` representable&#34;, never fixing a code spelling. Because the parser slice is deliberately out of scope here, nothing binds the later emitting side to these exact strings. Concrete failure: the worker slice emits `parser_conformance_failed` (or `reasoning_parser_conformance_failure`); `reasoning_conformance_code?/1` returns false, `failed_event_kind/1` falls through to `:request_failed`, and `api_mapping` (chat_error.ex:349) returns `&#34;Inference failed: #{message}&#34;` while `terminal_attrs` (chat_error.ex:588) persists the raw worker code and message — reopening exactly the leak this change closes, with no test failing. Recommend recording the closed pair in a decision record or the runtime-endpoints OpenSpec spec alongside the `runtime_endpoint_*` codes (no proto or parser change needed).
- ℹ️ `apps/orchard_controller/lib/orchard/inference/chat_error.ex:645` - The refactor turns the former guarded catch-all into a two-hop dispatch whose fallback name no longer describes its role: `runtime_endpoint_failed_event_kind/1` is now the general fallback for every unrecognized code and returns `:request_failed`. The repo already has a precedent that keeps the flat guard-clause style — `capture_policy.ex:27` does `@stable_error_codes Orchard.Requests.InferenceAttemptFailure.stable_error_codes()` at compile time. Exposing `reasoning_conformance_codes/0` the same way lets this be a single guarded clause (`defp failed_event_kind(code) when code in @reasoning_conformance_codes, do: :reasoning_conformance`) with the original catch-all restored, removing both the `if` and the misnamed helper.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex:197` - The new `maybe_put_raw_source_code/4` clause conditions suppression on both `category in [:terminal_conformance, &#34;terminal_conformance&#34;]` and the code, while the mapping it protects (`terminal_conformance_code/1`, line 166) keys on the code alone. Today the category half is unreachable-distinguishing — `failure_source/1` is the only producer of these codes and always pairs them with `:terminal_conformance` — but if a future path routed one through the `failure_source/1` catch-all (`%{category: :runtime, code: reason}`, request_dispatcher.ex:566), the worker code would be persisted as `raw_source_code`. Dropping the category condition makes the invariant hold on the code alone and is behavior-identical for every reachable input.
- ℹ️ `apps/orchard_controller/lib/orchard/inference/chat_error.ex:360` - `api_mapping/1` for `:reasoning_conformance` (line 360) is byte-identical to the immediately following `:runtime_endpoint_conformance` clause (line 370) and to `:orchestration_crash` (line 380); `sse_mapping/1` for `:reasoning_conformance` (line 428) is likewise identical to `:runtime_endpoint_conformance` (line 437), `:internal` (line 455), and `:orchestration_crash` (line 464). Each pair can collapse to one `when kind in [...]` clause with no behavior change. `terminal_attrs/1` must stay split — `:runtime_endpoint_conformance` (line 579) intentionally passes through source code and message.
- ℹ️ `apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex:535` - The new `failure_source/1` clause (line 535) and the adjacent `runtime_endpoint_*` clause (line 542) have identical bodies (`%{category: :terminal_conformance, code: code}`); the two code lists could be one five-element guard list, since `terminal_conformance_code/1` already discriminates downstream. Keeping them separate does document the two distinct failure sources, so this is a judgment call rather than a defect.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex:166` - Tradeoff note, not a defect: both codes now collapse to `terminal_conformance + internal_error` with `raw_source_code` suppressed under every capture mode, so durable evidence cannot distinguish a parser conformance failure from a generation-policy one, nor either from another `terminal_conformance` internal error. SPEC.md:767 would permit the raw source code under `full` (&#34;A raw source failure code MAY persist separately only under `full`&#34;), and the `runtime_endpoint_*` siblings do retain it. The stated intent explicitly requires the worker code out of durable terminal evidence, so this is the author&#39;s deliberate choice — recorded only so the observability cost is visible.

🔧 Fix: record closed reasoning conformance vocabulary; flatten mappings
2 infos still open:
- ℹ️ `apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex:59` - `reasoning_conformance_code?/1` has no production caller left. It was added in c8b6e8f3 solely for `ChatError.failed_event_kind/1`, and 95c932fb replaced that call with the compile-time `@reasoning_conformance_codes InferenceAttemptFailure.reasoning_conformance_codes()` attribute (chat_error.ex:15). `grep -rn &#39;reasoning_conformance_code?&#39; apps` now matches only its own definition and its unit test (inference_attempt_failure_test.exs:75, :78), leaving two public accessors over one closed list. Removing the predicate and rewriting those two assertions against `reasoning_conformance_codes/0` keeps a single accessor; the internal guards at lines 169 and 201 already use the module attribute directly and need no change.
- ℹ️ `openspec/specs/runtime-endpoints/spec.md:739` - The newly added scenario &#34;Reasoning-like code outside the closed pair is not reasoning conformance&#34; is normative but has no covering regression. The nearest assertion, `refute InferenceAttemptFailure.reasoning_conformance_code?(&#34;runtime_endpoint_missing_terminal&#34;)` (inference_attempt_failure_test.exs:78), uses a different code family rather than a reasoning-like near-miss spelling, and it disappears entirely if the orphaned predicate is removed. The behavior the scenario asserts is real and worth pinning because it is the drift consequence the OpenSpec requirement exists to prevent: `normalize(%{category: :terminal_conformance, code: &#34;reasoning_parser_conformance_failure&#34;})` yields `terminal_conformance` + `orchestration_error` plus a retained `raw_source_code`, and `ChatError.failed_event_kind/1` falls through to `:request_failed`, whose `api_mapping/1` (chat_error.ex:350) interpolates the worker message. One assertion on each of those two functions covers the scenario.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference/chat_error_test.exs apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs` — 33 passed (includes the new closed-vocabulary and all-capture-mode regressions)</code>
- <code>`mise exec -- mix test` on the 12 new §7.5.3a / §7.5.5 selectors: `dispatch_test.exs:711,779,820,890`, `chat_completions_controller_test.exs:903,942,1830,1872`, `responses_controller_test.exs:528,563,1745,1785` — 12 passed</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs` — 31 passed</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs apps/orchard_controller/test/orchard/api/responses_controller_test.exs` — 102 passed</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/requests/capture_policy_test.exs apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs apps/orchard_controller/test/orchard/dispatch/attempt_outcome_test.exs apps/orchard_controller/test/orchard/requests/inference_attempt_result_test.exs apps/orchard_controller/test/orchard/requests/request_step_event_test.exs apps/orchard_controller/test/orchard/metrics/inference_attempt_projection_test.exs` — 78 passed</code>
- <code>Evidence-producing manual run: a transient ExUnit harness (`Orchard.API.ReasoningConformanceEvidenceTest`, since deleted) posted through the real `Orchard.API.Endpoint` to `/v1/chat/completions` and `/v1/responses`, sync and streaming, using `configure_retry_nodes!/2` so the real scheduler + `RequestDispatcher` ran against a single trusted Node, for `reasoning_parser_conformance_failed`, `reasoning_policy_conformance_failed`, Controller-synthesized `runtime_endpoint_missing_terminal`, and the near-miss spelling `reasoning_parser_conformance_failure`; recorded verbatim response bytes, `content-type`, and the `requests` row plus terminal `request_step_events.result` read back from Postgres (16 cases)</code>
- <code>Evidence-producing manual run: same real Chat path repeated with the owning tenant&#39;s `request_body_capture_mode` set to `:none`, `:metadata`, and `:full` for both reasoning codes, dumping `payload_capture_mode`, `error_code`, `error_message`, `canonical_request`, and the full terminal attempt evidence (6 cases)</code>
- <code>Leak assertions computed over the captured bytes and persisted rows: `String.contains?` checks for the source code and for the injected `&lt;think&gt;SECRET-CHAIN-OF-THOUGHT: launch code 4815162342&lt;/think&gt;LEAKED-FINAL-TEXT` worker message — false in every reasoning case, caller-visible and durable</code>
- <code>`git status --porcelain` after cleanup — clean; transient harness file removed, diff confirmed to touch no `proto/`, `packaging/`, or `config/` files</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR classifies the two closed reasoning-conformance failure codes as content-free terminal conformance errors while preserving the existing behavior for runtime-endpoint and unknown failures.

- Adds dispatcher and durable-evidence classification for the exact reasoning parser and policy codes.
- Adds generic synchronous, streaming, and persisted `internal_error` mappings that omit worker-controlled details.
- Adds Chat, Responses, dispatch, capture-mode, and normalization regressions.
- Records the closed failure-code vocabulary in the runtime-endpoints OpenSpec.
- Two non-blocking cleanup opportunities remain around near-miss coverage and an unused public predicate.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge; the remaining findings are non-blocking test-hardening and API-cleanup opportunities.

The changed runtime paths consistently map the two exact reasoning-conformance codes to generic, non-retryable terminal evidence without exposing worker details, and no behavioral failure was established. The only accepted concerns are missing direct coverage for the newly documented near-miss scenario and an unused public predicate.

**Files Needing Attention:** apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs; apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex | Correctly routes the exact two binary reasoning-conformance codes into terminal-conformance classification. |
| apps/orchard_controller/lib/orchard/inference/chat_error.ex | Adds content-free API, SSE, and durable mappings while preserving byte-equivalent mappings for existing error kinds. |
| apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex | Correctly normalizes and redacts the closed pair, but introduces an unused public predicate duplicating the exported code list. |
| apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs | Covers positive mappings and capture behavior but does not directly exercise the new reasoning-like near-miss contract. |
| openspec/specs/runtime-endpoints/spec.md | Clearly records the exact shared vocabulary, content-free evidence requirements, and unchanged fallback semantics. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Runtime Endpoint Failed event] --> B{Failure code}
  B -->|Closed reasoning pair| C[terminal_conformance]
  C --> D[Stable internal_error]
  D --> E[Generic sync or SSE error]
  D --> F[Content-free durable evidence]
  B -->|runtime_endpoint_*| G[terminal_conformance]
  G --> H[Stable orchestration_error]
  B -->|Other code| I[Existing unknown-code path]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kapitan-ai%2Forchard%22%20on%20the%20existing%20branch%20%22fix%2F328-terminal-conformance-internal-error%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F328-terminal-conformance-internal-error%22.%0A%0AGreploop%20kapitan-ai%2Forchard%20PR%20%23422%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=kapitan-ai%2Forchard&pr=422&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kapitan-ai%2Forchard%22%20on%20the%20existing%20branch%20%22fix%2F328-terminal-conformance-internal-error%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F328-terminal-conformance-internal-error%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Forchard_controller%2Ftest%2Forchard%2Frequests%2Finference_attempt_failure_test.exs%3A78-80%0A**Near-miss%20behavior%20untested**%0A%0AThe%20new%20closed-vocabulary%20scenario%20is%20not%20covered%20with%20a%20reasoning-like%20near-miss.%20The%20only%20negative%20assertion%20uses%20%60runtime_endpoint_missing_terminal%60%2C%20so%20a%20future%20prefix%20or%20synonym%20match%20could%20violate%20the%20requirement%20without%20failing%20this%20focused%20regression%20suite.%20Add%20a%20case%20such%20as%20%60reasoning_parser_conformance_failure%60%20that%20verifies%20both%20normalization%20and%20%60ChatError%60%20retain%20the%20existing%20unknown-code%20behavior.%0A%0A%23%23%23%20Issue%202%0Aapps%2Forchard_controller%2Flib%2Forchard%2Frequests%2Finference_attempt_failure.ex%3A59-61%0A**Redundant%20public%20predicate**%0A%0A%60reasoning_conformance_code%3F%2F1%60%20has%20no%20production%20caller%20after%20%60ChatError%60%20switched%20to%20the%20exported%20compile-time%20code%20list%3B%20only%20its%20own%20unit%20test%20uses%20it.%20Keeping%20two%20public%20accessors%20for%20the%20same%20closed%20vocabulary%20adds%20unnecessary%20maintenance%20work.%20Remove%20the%20predicate%20and%20assert%20directly%20against%20%60reasoning_conformance_codes%2F0%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=kapitan-ai%2Forchard&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Forchard_controller%2Ftest%2Forchard%2Frequests%2Finference_attempt_failure_test.exs%3A78-80%0A**Near-miss%20behavior%20untested**%0A%0AThe%20new%20closed-vocabulary%20scenario%20is%20not%20covered%20with%20a%20reasoning-like%20near-miss.%20The%20only%20negative%20assertion%20uses%20%60runtime_endpoint_missing_terminal%60%2C%20so%20a%20future%20prefix%20or%20synonym%20match%20could%20violate%20the%20requirement%20without%20failing%20this%20focused%20regression%20suite.%20Add%20a%20case%20such%20as%20%60reasoning_parser_conformance_failure%60%20that%20verifies%20both%20normalization%20and%20%60ChatError%60%20retain%20the%20existing%20unknown-code%20behavior.%0A%0A%23%23%23%20Issue%202%0Aapps%2Forchard_controller%2Flib%2Forchard%2Frequests%2Finference_attempt_failure.ex%3A59-61%0A**Redundant%20public%20predicate**%0A%0A%60reasoning_conformance_code%3F%2F1%60%20has%20no%20production%20caller%20after%20%60ChatError%60%20switched%20to%20the%20exported%20compile-time%20code%20list%3B%20only%20its%20own%20unit%20test%20uses%20it.%20Keeping%20two%20public%20accessors%20for%20the%20same%20closed%20vocabulary%20adds%20unnecessary%20maintenance%20work.%20Remove%20the%20predicate%20and%20assert%20directly%20against%20%60reasoning_conformance_codes%2F0%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=kapitan-ai%2Forchard&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs:78-80
**Near-miss behavior untested**

The new closed-vocabulary scenario is not covered with a reasoning-like near-miss. The only negative assertion uses `runtime_endpoint_missing_terminal`, so a future prefix or synonym match could violate the requirement without failing this focused regression suite. Add a case such as `reasoning_parser_conformance_failure` that verifies both normalization and `ChatError` retain the existing unknown-code behavior.

### Issue 2
apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex:59-61
**Redundant public predicate**

`reasoning_conformance_code?/1` has no production caller after `ChatError` switched to the exported compile-time code list; only its own unit test uses it. Keeping two public accessors for the same closed vocabulary adds unnecessary maintenance work. Remove the predicate and assert directly against `reasoning_conformance_codes/0`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["no-mistakes(review): record closed reaso..."](https://github.com/kapitan-ai/orchard/commit/95c932fb0d4885294f6cdde6773c607df59c39fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62988777)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->