### PR TITLE
feat(controller): add operator-only request retry endpoint

### DIFF
--- a/apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex
@@ -90,13 +90,4 @@ defmodule Orchard.API.Ops.RequestRetriesController do
       "This controller has not proven local leadership."
     )
   end
-
-  defp send_error(conn, _reason) do
-    AdminErrorHelpers.send_error(
-      conn,
-      :internal_server_error,
-      "operator_retry_failed",
-      "Operator retry could not be completed."
-    )
-  end
 end

--- a/apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex
@@ -1,0 +1,75 @@
+defmodule Orchard.API.Ops.RequestRetriesController do
+  @moduledoc false
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Orchard.API.AdminErrorHelpers
+  alias Orchard.ControlPlane
+  alias Orchard.Requests.OperatorRetry
+
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def create(conn, %{"id" => request_id}) do
+    with :ok <- ControlPlane.authorize_write_path(:operator_request_retry),
+         {:ok, request} <- OperatorRetry.retry(request_id) do
+      conn
+      |> put_status(:created)
+      |> json(%{
+        id: request.public_id,
+        object: "request",
+        retry_of_request_id: request.retry_of_request_id,
+        state: Atom.to_string(request.state)
+      })
+    else
+      {:error, reason} -> send_error(conn, reason)
+    end
+  end
+
+  defp send_error(conn, :request_not_found) do
+    AdminErrorHelpers.send_error(conn, :not_found, "request_not_found", "Request was not found.")
+  end
+
+  defp send_error(conn, :retry_source_not_eligible) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :conflict,
+      "retry_source_not_eligible",
+      "Request is not eligible for operator retry."
+    )
+  end
+
+  defp send_error(conn, :retry_source_unavailable) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :unprocessable_entity,
+      "retry_source_unavailable",
+      "Retry source canonical request is unavailable."
+    )
+  end
+
+  defp send_error(conn, :operator_retry_limit_reached) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :conflict,
+      "operator_retry_limit_reached",
+      "The original Request has reached the operator retry limit."
+    )
+  end
+
+  defp send_error(conn, :controller_standby) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :service_unavailable,
+      "controller_standby",
+      "This controller is in standby mode."
+    )
+  end
+
+  defp send_error(conn, :controller_leadership_unproven) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :service_unavailable,
+      "controller_leadership_unproven",
+      "This controller has not proven local leadership."
+    )
+  end
+end

--- a/apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex
+++ b/apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex
@@ -46,6 +46,24 @@ defmodule Orchard.API.Ops.RequestRetriesController do
     )
   end
 
+  defp send_error(conn, :retry_source_not_authorized) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :conflict,
+      "retry_source_not_authorized",
+      "Retry source Tenant is no longer authorized for an active source Model."
+    )
+  end
+
+  defp send_error(conn, :retry_dispatch_incomplete) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :internal_server_error,
+      "retry_dispatch_incomplete",
+      "Retry descendant was created but its dispatch outcome could not be recorded."
+    )
+  end
+
   defp send_error(conn, :operator_retry_limit_reached) do
     AdminErrorHelpers.send_error(
       conn,
@@ -70,6 +88,15 @@ defmodule Orchard.API.Ops.RequestRetriesController do
       :service_unavailable,
       "controller_leadership_unproven",
       "This controller has not proven local leadership."
+    )
+  end
+
+  defp send_error(conn, _reason) do
+    AdminErrorHelpers.send_error(
+      conn,
+      :internal_server_error,
+      "operator_retry_failed",
+      "Operator retry could not be completed."
     )
   end
 end

--- a/apps/orchard_controller/lib/orchard/api/router.ex
+++ b/apps/orchard_controller/lib/orchard/api/router.ex
@@ -86,6 +86,7 @@ defmodule Orchard.API.Router do
     pipe_through(:operator_api)
 
     get("/health", HealthController, :show)
+    post("/requests/:id/retry", RequestRetriesController, :create)
     get("/scheduler/explanations/:request_id", SchedulerExplanationsController, :show)
     get("/circuit-breakers/nodes/:node_id", CircuitBreakersController, :show_node)
     post("/circuit-breakers/nodes/:node_id/clear", CircuitBreakersController, :clear_node)

--- a/apps/orchard_controller/lib/orchard/inference/admission_policy.ex
+++ b/apps/orchard_controller/lib/orchard/inference/admission_policy.ex
@@ -26,6 +26,7 @@ defmodule Orchard.Inference.AdmissionPolicy do
           {:max_cold_start_ms, non_neg_integer()},
           {:queue_wait_ms, non_neg_integer()},
           {:timeout_ms, pos_integer()},
+          {:effective_timeout_ms, pos_integer()},
           {:residency_preference, ResolvedPolicy.residency_preference()},
           {:quota_id, String.t() | nil},
           {:routing_policy_id, String.t() | nil},
@@ -83,6 +84,12 @@ defmodule Orchard.Inference.AdmissionPolicy do
   For a resolved `allow_cold_load` policy, the effective deadline is the
   configured or explicit generation budget plus queue wait and cold-start
   budgets.
+
+  `:effective_timeout_ms` supplies a deadline that already includes whatever
+  budgets apply to it. It is used as given, subject only to the deployment
+  ceiling, so a caller that carries an authoritative deadline can also supply
+  explicit `:queue_wait_ms` and `:max_cold_start_ms` budgets without those
+  budgets being added to that deadline a second time.
   """
   @spec resolve(CanonicalRequest.t(), resolve_opts()) :: CanonicalRequest.t()
   def resolve(%CanonicalRequest{} = request, opts \\ []) when is_list(opts) do
@@ -160,20 +167,7 @@ defmodule Orchard.Inference.AdmissionPolicy do
   end
 
   defp resolve_timeout_ms(current, queue_wait_ms, max_cold_start_ms, residency_preference, opts) do
-    timeout_ms =
-      cond do
-        keyword_integer?(opts, :timeout_ms) ->
-          Keyword.fetch!(opts, :timeout_ms)
-
-        is_integer(current) and current > 0 ->
-          current
-
-        true ->
-          case Inference.request_timeout_ms() do
-            timeout when is_integer(timeout) and timeout > 0 -> timeout
-            _other -> 30_000
-          end
-      end
+    timeout_ms = generation_timeout_ms(current, opts)
 
     effective_timeout_ms =
       if policy_timeout?(opts, residency_preference) do
@@ -183,6 +177,29 @@ defmodule Orchard.Inference.AdmissionPolicy do
       end
 
     cap_timeout_ms(effective_timeout_ms)
+  end
+
+  defp generation_timeout_ms(current, opts) do
+    cond do
+      keyword_positive_integer?(opts, :effective_timeout_ms) ->
+        Keyword.fetch!(opts, :effective_timeout_ms)
+
+      keyword_integer?(opts, :timeout_ms) ->
+        Keyword.fetch!(opts, :timeout_ms)
+
+      is_integer(current) and current > 0 ->
+        current
+
+      true ->
+        configured_timeout_ms()
+    end
+  end
+
+  defp configured_timeout_ms do
+    case Inference.request_timeout_ms() do
+      timeout when is_integer(timeout) and timeout > 0 -> timeout
+      _other -> 30_000
+    end
   end
 
   defp cap_timeout_ms(timeout_ms) do
@@ -200,7 +217,9 @@ defmodule Orchard.Inference.AdmissionPolicy do
   end
 
   defp policy_timeout?(opts, :allow_cold_load) do
-    Keyword.has_key?(opts, :max_cold_start_ms) or Keyword.has_key?(opts, :residency_preference)
+    not keyword_positive_integer?(opts, :effective_timeout_ms) and
+      (Keyword.has_key?(opts, :max_cold_start_ms) or
+         Keyword.has_key?(opts, :residency_preference))
   end
 
   defp policy_timeout?(_opts, _residency_preference), do: false
@@ -245,6 +264,13 @@ defmodule Orchard.Inference.AdmissionPolicy do
   defp keyword_integer?(opts, key) do
     case Keyword.fetch(opts, key) do
       {:ok, value} when is_integer(value) and value >= 0 -> true
+      _other -> false
+    end
+  end
+
+  defp keyword_positive_integer?(opts, key) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} when is_integer(value) and value > 0 -> true
       _other -> false
     end
   end

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -113,15 +113,18 @@ defmodule Orchard.Inference.RequestOrchestrator do
   Admission is resolved again as a fail-safe, so the deployment deadline
   ceiling, the persistable-deadline check, and canonical serialization stay on
   one path for every Request persistence caller. `:capture_mode` overrides the
-  tenant-resolved capture mode. The resolved canonical request is returned so
-  callers dispatch the values they persisted.
+  tenant-resolved capture mode. `:admission_opts` are forwarded to
+  `Orchard.Inference.AdmissionPolicy.resolve/2` for callers that hold
+  authoritative admission values the zero-means-unset defaults would otherwise
+  replace. The resolved canonical request is returned so callers dispatch the
+  values they persisted.
   """
   @spec persistable_request_attrs(CanonicalRequest.t(), map(), keyword()) ::
           {:ok, map(), CanonicalRequest.t()} | {:error, term()}
   def persistable_request_attrs(%CanonicalRequest{} = canonical, model, opts \\ []) do
     # Internal callers may bypass the public normalizers, so resolve admission
     # again as a fail-safe immediately before serializing and persisting.
-    canonical = AdmissionPolicy.resolve(canonical)
+    canonical = AdmissionPolicy.resolve(canonical, Keyword.get(opts, :admission_opts, []))
 
     with :ok <- validate_persistable_timeout(canonical),
          {:ok, serialized_canonical} <- serialize_canonical_request(canonical) do

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -83,7 +83,36 @@ defmodule Orchard.Inference.RequestOrchestrator do
     end
   end
 
-  @doc false
+  @doc """
+  Dispatches an already-persisted Request through the normal lifecycle.
+
+  Callers must provide a validated canonical request that corresponds to the
+  persisted row; this function does not create another Request row.
+  """
+  @spec execute_persisted(Request.t(), CanonicalRequest.t(), map(), keyword()) :: execute_result()
+  def execute_persisted(
+        %Request{} = db_request,
+        %CanonicalRequest{} = canonical,
+        model,
+        opts \\ []
+      ) do
+    previous_started_at = Process.put({__MODULE__, :metrics_started_at}, System.monotonic_time())
+
+    try do
+      with :ok <- validate_resolved_tooling(canonical) do
+        dispatch_persisted_request(db_request, canonical, model, opts)
+      end
+    after
+      restore_metrics_started_at(previous_started_at)
+    end
+  end
+
+  @doc """
+  Validates a scheduler selection before dispatch.
+
+  A selection cannot use a Node excluded by an earlier failed attempt and must
+  identify its selected target consistently.
+  """
   @spec validate_scheduler_selection(map(), [Ecto.UUID.t()]) ::
           :ok | {:error, {:dispatch_failed, :identity_unresolved}}
   def validate_scheduler_selection(_schedule, []), do: :ok
@@ -101,10 +130,19 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp do_execute(canonical, model, opts) do
+    idempotency = Keyword.get(opts, :idempotency)
+
+    with :ok <- validate_resolved_tooling(canonical),
+         :ok <- put_request_validated_context(canonical),
+         {:ok, db_request, canonical} <- persist_request(canonical, model, idempotency) do
+      dispatch_persisted_request(db_request, canonical, model, opts)
+    end
+  end
+
+  defp dispatch_persisted_request(db_request, canonical, model, opts) do
     event_handler = Keyword.get(opts, :event_handler)
     caller = Keyword.get(opts, :caller, self())
     success_persistence = Keyword.get(opts, :success_persistence)
-    idempotency = Keyword.get(opts, :idempotency)
 
     step_event_appender =
       Keyword.get(opts, :step_event_appender, &Requests.append_request_step_events/2)
@@ -112,28 +150,24 @@ defmodule Orchard.Inference.RequestOrchestrator do
     terminal_persister =
       Keyword.get(opts, :terminal_persister, &Requests.mark_terminal_with_step_events/3)
 
-    with :ok <- validate_resolved_tooling(canonical),
-         :ok <- put_request_validated_context(canonical),
-         {:ok, db_request, canonical} <- persist_request(canonical, model, idempotency) do
-      put_request_persisted_context(db_request, canonical)
+    put_request_persisted_context(db_request, canonical)
 
-      DomainMetrics.input_accounted(
-        canonical.tenant_id,
-        canonical.model_ref.model_id,
-        canonical.input_token_count
-      )
+    DomainMetrics.input_accounted(
+      canonical.tenant_id,
+      canonical.model_ref.model_id,
+      canonical.input_token_count
+    )
 
-      start_and_dispatch(
-        db_request,
-        canonical,
-        model,
-        caller,
-        event_handler,
-        success_persistence,
-        step_event_appender,
-        terminal_persister
-      )
-    end
+    start_and_dispatch(
+      db_request,
+      canonical,
+      model,
+      caller,
+      event_handler,
+      success_persistence,
+      step_event_appender,
+      terminal_persister
+    )
   end
 
   defp start_and_dispatch(
@@ -2780,7 +2814,12 @@ defmodule Orchard.Inference.RequestOrchestrator do
     }
   end
 
-  defp validate_resolved_tooling(%CanonicalRequest{tooling: tooling}) do
+  @doc """
+  Validates that canonical tooling was fully resolved before dispatch.
+  """
+  @spec validate_resolved_tooling(CanonicalRequest.t()) ::
+          :ok | {:error, {:invalid_canonical_tooling, String.t()}}
+  def validate_resolved_tooling(%CanonicalRequest{tooling: tooling}) do
     case unresolved_tooling_reason(tooling) do
       nil -> :ok
       reason -> {:error, {:invalid_canonical_tooling, reason}}

--- a/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
+++ b/apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex
@@ -108,6 +108,31 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   @doc """
+  Builds the persistable Request attrs for a prepared canonical request.
+
+  Admission is resolved again as a fail-safe, so the deployment deadline
+  ceiling, the persistable-deadline check, and canonical serialization stay on
+  one path for every Request persistence caller. `:capture_mode` overrides the
+  tenant-resolved capture mode. The resolved canonical request is returned so
+  callers dispatch the values they persisted.
+  """
+  @spec persistable_request_attrs(CanonicalRequest.t(), map(), keyword()) ::
+          {:ok, map(), CanonicalRequest.t()} | {:error, term()}
+  def persistable_request_attrs(%CanonicalRequest{} = canonical, model, opts \\ []) do
+    # Internal callers may bypass the public normalizers, so resolve admission
+    # again as a fail-safe immediately before serializing and persisting.
+    canonical = AdmissionPolicy.resolve(canonical)
+
+    with :ok <- validate_persistable_timeout(canonical),
+         {:ok, serialized_canonical} <- serialize_canonical_request(canonical) do
+      capture_mode =
+        Keyword.get_lazy(opts, :capture_mode, fn -> effective_capture_mode(canonical) end)
+
+      {:ok, request_attrs(canonical, model, serialized_canonical, capture_mode), canonical}
+    end
+  end
+
+  @doc """
   Validates a scheduler selection before dispatch.
 
   A selection cannot use a Node excluded by an earlier failed attempt and must
@@ -1562,16 +1587,8 @@ defmodule Orchard.Inference.RequestOrchestrator do
   end
 
   defp persist_request(canonical, model, idempotency) do
-    # Internal callers may bypass the public normalizers, so resolve admission
-    # again as a fail-safe immediately before serializing and persisting.
-    canonical = AdmissionPolicy.resolve(canonical)
-
-    with :ok <- validate_persistable_timeout(canonical),
-         {:ok, serialized_canonical} <- serialize_canonical_request(canonical) do
-      capture_mode = effective_capture_mode(canonical)
-
-      canonical
-      |> request_attrs(model, serialized_canonical, capture_mode)
+    with {:ok, attrs, canonical} <- persistable_request_attrs(canonical, model) do
+      attrs
       |> put_idempotency_attrs(idempotency)
       |> Requests.create_request()
       |> handle_create_request_result(idempotency, canonical)

--- a/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
+++ b/apps/orchard_controller/lib/orchard/requests/capture_policy.ex
@@ -136,6 +136,12 @@ defmodule Orchard.Requests.CapturePolicy do
   @spec strictest_mode() :: mode()
   def strictest_mode, do: :none
 
+  @doc "Returns the narrower of two valid capture modes."
+  @spec narrower(mode(), mode()) :: mode()
+  def narrower(left, right) when left in @capture_modes and right in @capture_modes do
+    if capture_rank(left) <= capture_rank(right), do: left, else: right
+  end
+
   @spec normalize_mode(term()) :: {:ok, mode()} | :error
   def normalize_mode(mode) when mode in @capture_modes, do: {:ok, mode}
 
@@ -147,6 +153,10 @@ defmodule Orchard.Requests.CapturePolicy do
   end
 
   def normalize_mode(_mode), do: :error
+
+  defp capture_rank(:none), do: 0
+  defp capture_rank(:metadata), do: 1
+  defp capture_rank(:full), do: 2
 
   @spec create_attrs(mode(), map()) :: map()
   def create_attrs(:full, attrs), do: put_key(attrs, :request_shape, request_shape(:full, attrs))

--- a/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
+++ b/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
@@ -3,18 +3,18 @@ defmodule Orchard.Requests.OperatorRetry do
 
   import Ecto.Query
 
+  require Logger
+
   alias Orchard.CanonicalRequest
   alias Orchard.Governance.Tenant
 
   alias Orchard.Inference.{
     ChatResponseSerializer,
-    RequestDeadline,
     RequestOrchestrator,
     ResponsesSerializer
   }
 
-  alias Orchard.Inference.CanonicalRequestSerializer
-  alias Orchard.Models.Model
+  alias Orchard.Models.{Access, Model}
   alias Orchard.Repo
   alias Orchard.Requests
   alias Orchard.Requests.{CapturePolicy, Request}
@@ -47,7 +47,6 @@ defmodule Orchard.Requests.OperatorRetry do
   @sampling_keys ~w(temperature top_p max_output_tokens stop seed)
   @response_format_keys ~w(type)
   @tooling_keys ~w(tools requested_tools tool_choice registry_snapshot execution_snapshot)
-  @admission_keys ~w(timeout_ms queue_wait_ms max_cold_start_ms)
   @resolved_policy_keys ~w(
     quota_id
     routing_policy_id
@@ -65,13 +64,15 @@ defmodule Orchard.Requests.OperatorRetry do
   @type retry_error ::
           :operator_retry_limit_reached
           | :request_not_found
+          | :retry_dispatch_incomplete
+          | :retry_source_not_authorized
           | :retry_source_not_eligible
           | :retry_source_unavailable
 
-  @spec retry(String.t()) :: {:ok, Request.t()} | {:error, retry_error()}
-  def retry(public_id) do
+  @spec retry(String.t(), keyword()) :: {:ok, Request.t()} | {:error, retry_error()}
+  def retry(public_id, dispatch_opts \\ []) do
     with {:ok, reservation} <- reserve(public_id) do
-      dispatch(reservation)
+      dispatch(reservation, dispatch_opts)
     end
   end
 
@@ -88,12 +89,14 @@ defmodule Orchard.Requests.OperatorRetry do
          :ok <- ensure_retryable(source),
          {:ok, original} <- lock_original(source),
          {:ok, tenant} <- lock_tenant(source.tenant_id),
-         {:ok, model} <- fetch_source_model(source),
-         {:ok, canonical} <- rebuild_legacy_canonical(source, model),
+         {:ok, model} <- fetch_active_source_model(source),
+         {:ok, routing_opts} <- authorize_current_access(source, model),
+         {:ok, canonical} <- rebuild_legacy_canonical(source, model, routing_opts),
          :ok <- ensure_dispatchable_canonical(canonical),
          :ok <- ensure_retry_capacity(original.id),
-         {:ok, request} <- create_descendant(source, original, tenant, model, canonical) do
-      %{request: request, canonical: canonical, model: model}
+         {:ok, request, persisted_canonical} <-
+           create_descendant(source, original, tenant, model, canonical) do
+      %{request: request, canonical: persisted_canonical, model: model}
     else
       {:error, reason} -> Repo.rollback(reason)
     end
@@ -152,24 +155,72 @@ defmodule Orchard.Requests.OperatorRetry do
     end
   end
 
-  defp fetch_source_model(%Request{model_id: model_id}) when is_binary(model_id) do
+  defp fetch_active_source_model(%Request{model_id: model_id}) when is_binary(model_id) do
     case Repo.get(Model, model_id) do
-      %Model{} = model -> {:ok, model}
+      %Model{state: :active} = model -> {:ok, model}
+      %Model{} -> {:error, :retry_source_not_authorized}
       nil -> {:error, :retry_source_unavailable}
     end
   end
 
-  defp fetch_source_model(%Request{}), do: {:error, :retry_source_unavailable}
+  defp fetch_active_source_model(%Request{}), do: {:error, :retry_source_unavailable}
 
-  defp rebuild_legacy_canonical(source, model) do
+  defp authorize_current_access(%Request{tenant_id: tenant_id}, %Model{id: model_id}) do
+    case Access.authorize(tenant_id, model_id) do
+      {:ok, _routing_opts} = authorized -> authorized
+      {:error, :model_not_authorized} -> {:error, :retry_source_not_authorized}
+    end
+  end
+
+  defp rebuild_legacy_canonical(source, model, routing_opts) do
     canonical = source.canonical_request
 
     with :ok <- ensure_omitted_legacy_contract(canonical),
          :ok <- ensure_source_identity(canonical, source, model),
          {:ok, attrs} <- decode_canonical_attrs(canonical, source) do
-      build_canonical(attrs)
+      attrs
+      |> apply_current_access(routing_opts)
+      |> build_canonical()
     end
   end
+
+  defp apply_current_access(attrs, routing_opts) do
+    %{
+      attrs
+      | admission: current_admission(attrs.admission, routing_opts),
+        resolved_policy: current_resolved_policy(attrs.resolved_policy, routing_opts)
+    }
+  end
+
+  defp current_admission(admission, routing_opts) do
+    %{
+      admission
+      | queue_wait_ms: narrower_budget(admission.queue_wait_ms, routing_opts[:queue_wait_ms]),
+        max_cold_start_ms:
+          narrower_budget(admission.max_cold_start_ms, routing_opts[:max_cold_start_ms])
+    }
+  end
+
+  defp current_resolved_policy(resolved_policy, routing_opts) do
+    %{
+      resolved_policy
+      | routing_policy_id: routing_opts[:routing_policy_id],
+        allowed_pool_ids: Keyword.get(routing_opts, :allowed_pool_ids, []),
+        max_active_requests:
+          Keyword.get(routing_opts, :max_active_requests, resolved_policy.max_active_requests),
+        residency_preference:
+          Keyword.get(
+            routing_opts,
+            :residency_preference,
+            resolved_policy.residency_preference
+          )
+    }
+  end
+
+  defp narrower_budget(retained, current) when is_integer(current) and current >= 0,
+    do: min(retained, current)
+
+  defp narrower_budget(retained, _current), do: retained
 
   defp ensure_omitted_legacy_contract(canonical) when is_map(canonical) do
     if Map.has_key?(canonical, "reasoning") do
@@ -224,18 +275,18 @@ defmodule Orchard.Requests.OperatorRetry do
 
   defp decode_canonical_attrs(canonical, source) do
     with true <- required_keys?(canonical, @canonical_keys),
+         true <- required_keys?(canonical["model_ref"], ~w(model_id version)),
+         true <- required_keys?(canonical["sampling"], @sampling_keys),
+         true <- required_keys?(canonical["tooling"], @tooling_keys),
          {:ok, endpoint} <- decode_endpoint(canonical["endpoint"]),
          {:ok, principal_type} <- decode_principal_type(canonical["principal_type"]),
          {:ok, response_format} <- decode_response_format(canonical["response_format"]),
          {:ok, resolved_policy} <- decode_resolved_policy(canonical["resolved_policy"]),
+         {:ok, admission} <- decode_admission(canonical["admission"]),
          {:ok, registry_snapshot} <-
            decode_tool_snapshot(canonical["tooling"]["registry_snapshot"]),
          {:ok, execution_snapshot} <-
-           decode_tool_snapshot(canonical["tooling"]["execution_snapshot"]),
-         true <- required_keys?(canonical["model_ref"], ~w(model_id version)),
-         true <- required_keys?(canonical["sampling"], @sampling_keys),
-         true <- required_keys?(canonical["tooling"], @tooling_keys),
-         true <- required_keys?(canonical["admission"], @admission_keys) do
+           decode_tool_snapshot(canonical["tooling"]["execution_snapshot"]) do
       internal_id = Ecto.UUID.generate()
 
       {:ok,
@@ -274,11 +325,7 @@ defmodule Orchard.Requests.OperatorRetry do
            execution_snapshot: execution_snapshot
          },
          metadata: canonical["metadata"],
-         admission: %{
-           timeout_ms: canonical["admission"]["timeout_ms"],
-           queue_wait_ms: canonical["admission"]["queue_wait_ms"],
-           max_cold_start_ms: canonical["admission"]["max_cold_start_ms"]
-         },
+         admission: admission,
          resolved_policy: resolved_policy
        }}
     else
@@ -323,6 +370,24 @@ defmodule Orchard.Requests.OperatorRetry do
       _invalid -> {:error, :retry_source_unavailable}
     end
   end
+
+  defp decode_admission(%{
+         "timeout_ms" => timeout_ms,
+         "queue_wait_ms" => queue_wait_ms,
+         "max_cold_start_ms" => max_cold_start_ms
+       })
+       when is_integer(timeout_ms) and timeout_ms > 0 and
+              is_integer(queue_wait_ms) and queue_wait_ms >= 0 and
+              is_integer(max_cold_start_ms) and max_cold_start_ms >= 0 do
+    {:ok,
+     %{
+       timeout_ms: timeout_ms,
+       queue_wait_ms: queue_wait_ms,
+       max_cold_start_ms: max_cold_start_ms
+     }}
+  end
+
+  defp decode_admission(_admission), do: {:error, :retry_source_unavailable}
 
   defp decode_residency_preference("required_loaded"), do: {:ok, :required_loaded}
   defp decode_residency_preference("prefer_loaded"), do: {:ok, :prefer_loaded}
@@ -375,49 +440,57 @@ defmodule Orchard.Requests.OperatorRetry do
       |> CapturePolicy.narrower(tenant.request_body_capture_mode)
       |> CapturePolicy.resolve(canonical.store?)
 
-    serialized = CanonicalRequestSerializer.serialize(canonical)
+    case RequestOrchestrator.persistable_request_attrs(canonical, model,
+           capture_mode: capture_mode
+         ) do
+      {:ok, attrs, persisted_canonical} ->
+        insert_descendant(attrs, original, persisted_canonical)
 
-    attrs = %{
-      id: canonical.internal_id,
-      public_id: canonical.public_id,
-      endpoint: canonical.endpoint,
-      tenant_id: canonical.tenant_id,
-      principal_type: canonical.principal_type,
-      api_key_id: canonical.api_key_id,
-      service_account_id: canonical.service_account_id,
-      model_id: model.id,
-      requested_model: "#{canonical.model_ref.model_id}@#{canonical.model_ref.version}",
-      retry_of_request_id: original.id,
-      state: :received,
-      stream: canonical.stream?,
-      body_hash: :crypto.hash(:sha256, Jason.encode!(serialized)),
-      payload_capture_mode: capture_mode,
-      canonical_request: serialized,
-      request_payload: %{"prompt" => canonical.rendered_prompt},
-      sampling_params: CanonicalRequestSerializer.sampling_params(canonical.sampling),
-      response_format: %{"type" => Atom.to_string(canonical.response_format.type)},
-      input_tokens: canonical.input_token_count,
-      reserved_output_tokens: max_output_tokens(canonical),
-      timeout_at: RequestDeadline.timeout_at(canonical.admission.timeout_ms, utc_now())
-    }
-
-    Requests.create_request(attrs)
+      {:error, _reason} ->
+        {:error, :retry_source_unavailable}
+    end
   end
 
-  defp max_output_tokens(%CanonicalRequest{sampling: %{max_output_tokens: value}})
-       when is_integer(value) and value > 0,
-       do: value
+  defp insert_descendant(attrs, original, canonical) do
+    case Requests.create_request(Map.put(attrs, :retry_of_request_id, original.id)) do
+      {:ok, request} -> {:ok, request, canonical}
+      {:error, %Ecto.Changeset{}} -> {:error, :retry_source_unavailable}
+    end
+  end
 
-  defp max_output_tokens(%CanonicalRequest{}), do: 4_096
+  defp dispatch(%{request: request, canonical: canonical, model: model}, dispatch_opts) do
+    opts = Keyword.put(dispatch_opts, :success_persistence, &success_persistence_attrs/2)
 
-  defp dispatch(%{request: request, canonical: canonical, model: model}) do
-    _result =
-      RequestOrchestrator.execute_persisted(request, canonical, model,
-        success_persistence: &success_persistence_attrs/2
-      )
+    request
+    |> RequestOrchestrator.execute_persisted(canonical, model, opts)
+    |> handle_dispatch_result(request)
+  end
 
+  defp handle_dispatch_result({:error, {:terminal_persist_failed, _reason}}, request) do
+    log_incomplete_dispatch(request, "terminal_persist_failed")
+    {:error, :retry_dispatch_incomplete}
+  end
+
+  defp handle_dispatch_result({:error, reason}, request) do
+    log_incomplete_dispatch(request, outcome_label(reason))
     {:ok, Requests.get_request!(request.id)}
   end
+
+  defp handle_dispatch_result(_result, request), do: {:ok, Requests.get_request!(request.id)}
+
+  defp log_incomplete_dispatch(request, outcome) do
+    Logger.warning(
+      "operator retry dispatch did not complete: public_id=#{request.public_id} " <>
+        "retry_of_request_id=#{request.retry_of_request_id} outcome=#{outcome}"
+    )
+  end
+
+  defp outcome_label(reason) when is_atom(reason), do: Atom.to_string(reason)
+
+  defp outcome_label(reason) when is_tuple(reason) and tuple_size(reason) > 0,
+    do: outcome_label(elem(reason, 0))
+
+  defp outcome_label(_reason), do: "unknown"
 
   defp success_persistence_attrs(
          %CanonicalRequest{endpoint: :chat_completions} = canonical,
@@ -427,8 +500,6 @@ defmodule Orchard.Requests.OperatorRetry do
 
   defp success_persistence_attrs(%CanonicalRequest{endpoint: :responses} = canonical, events),
     do: ResponsesSerializer.success_persistence_attrs(canonical, events)
-
-  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
 
   defp unwrap_reservation({:ok, reservation}), do: {:ok, reservation}
   defp unwrap_reservation({:error, reason}), do: {:error, reason}

--- a/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
+++ b/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
@@ -1,0 +1,435 @@
+defmodule Orchard.Requests.OperatorRetry do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Governance.Tenant
+
+  alias Orchard.Inference.{
+    ChatResponseSerializer,
+    RequestDeadline,
+    RequestOrchestrator,
+    ResponsesSerializer
+  }
+
+  alias Orchard.Inference.CanonicalRequestSerializer
+  alias Orchard.Models.Model
+  alias Orchard.Repo
+  alias Orchard.Requests
+  alias Orchard.Requests.{CapturePolicy, Request}
+
+  @max_retries 3
+  @retryable_states [:failed, :cancelled, :timed_out, :interrupted]
+  @canonical_keys ~w(
+    internal_id
+    public_id
+    endpoint
+    tenant_id
+    principal_type
+    principal_id
+    service_account_id
+    api_key_id
+    model_ref
+    input_items
+    rendered_prompt
+    input_token_count
+    store
+    stream
+    stream_include_usage
+    sampling
+    response_format
+    tooling
+    metadata
+    admission
+    resolved_policy
+  )
+  @sampling_keys ~w(temperature top_p max_output_tokens stop seed)
+  @response_format_keys ~w(type)
+  @tooling_keys ~w(tools requested_tools tool_choice registry_snapshot execution_snapshot)
+  @admission_keys ~w(timeout_ms queue_wait_ms max_cold_start_ms)
+  @resolved_policy_keys ~w(
+    quota_id
+    routing_policy_id
+    allowed_pool_ids
+    max_active_requests
+    residency_preference
+  )
+
+  @type reservation :: %{
+          request: Request.t(),
+          canonical: CanonicalRequest.t(),
+          model: Model.t()
+        }
+
+  @type retry_error ::
+          :operator_retry_limit_reached
+          | :request_not_found
+          | :retry_source_not_eligible
+          | :retry_source_unavailable
+
+  @spec retry(String.t()) :: {:ok, Request.t()} | {:error, retry_error()}
+  def retry(public_id) do
+    with {:ok, reservation} <- reserve(public_id) do
+      dispatch(reservation)
+    end
+  end
+
+  @spec reserve(String.t()) :: {:ok, reservation()} | {:error, retry_error()}
+  def reserve(public_id) when is_binary(public_id) do
+    Repo.transaction(fn -> reserve_locked(public_id) end)
+    |> unwrap_reservation()
+  end
+
+  def reserve(_public_id), do: {:error, :request_not_found}
+
+  defp reserve_locked(public_id) do
+    with {:ok, source} <- lock_source(public_id),
+         :ok <- ensure_retryable(source),
+         {:ok, original} <- lock_original(source),
+         {:ok, tenant} <- lock_tenant(source.tenant_id),
+         {:ok, model} <- fetch_source_model(source),
+         {:ok, canonical} <- rebuild_legacy_canonical(source, model),
+         :ok <- ensure_dispatchable_canonical(canonical),
+         :ok <- ensure_retry_capacity(original.id),
+         {:ok, request} <- create_descendant(source, original, tenant, model, canonical) do
+      %{request: request, canonical: canonical, model: model}
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp lock_source(public_id) do
+    request =
+      Request
+      |> where([request], request.public_id == ^public_id)
+      |> lock("FOR UPDATE")
+      |> Repo.one()
+
+    case request do
+      %Request{} = request -> {:ok, request}
+      nil -> {:error, :request_not_found}
+    end
+  end
+
+  defp ensure_retryable(%Request{state: state}) when state not in @retryable_states,
+    do: {:error, :retry_source_not_eligible}
+
+  defp ensure_retryable(%Request{
+         payload_capture_mode: :full,
+         canonical_request: canonical_request
+       })
+       when is_map(canonical_request),
+       do: :ok
+
+  defp ensure_retryable(%Request{}), do: {:error, :retry_source_unavailable}
+
+  defp lock_original(%Request{retry_of_request_id: nil} = source), do: {:ok, source}
+
+  defp lock_original(%Request{retry_of_request_id: original_id}) do
+    original =
+      Request
+      |> where([request], request.id == ^original_id)
+      |> lock("FOR UPDATE")
+      |> Repo.one()
+
+    case original do
+      %Request{} = original -> {:ok, original}
+      nil -> {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp lock_tenant(tenant_id) do
+    tenant =
+      Tenant
+      |> where([tenant], tenant.id == ^tenant_id)
+      |> lock("FOR UPDATE")
+      |> Repo.one()
+
+    case tenant do
+      %Tenant{} = tenant -> {:ok, tenant}
+      nil -> {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp fetch_source_model(%Request{model_id: model_id}) when is_binary(model_id) do
+    case Repo.get(Model, model_id) do
+      %Model{} = model -> {:ok, model}
+      nil -> {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp fetch_source_model(%Request{}), do: {:error, :retry_source_unavailable}
+
+  defp rebuild_legacy_canonical(source, model) do
+    canonical = source.canonical_request
+
+    with :ok <- ensure_omitted_legacy_contract(canonical),
+         :ok <- ensure_source_identity(canonical, source, model),
+         {:ok, attrs} <- decode_canonical_attrs(canonical, source) do
+      build_canonical(attrs)
+    end
+  end
+
+  defp ensure_omitted_legacy_contract(canonical) when is_map(canonical) do
+    if Map.has_key?(canonical, "reasoning") do
+      {:error, :retry_source_unavailable}
+    else
+      :ok
+    end
+  end
+
+  defp ensure_omitted_legacy_contract(_canonical), do: {:error, :retry_source_unavailable}
+
+  defp ensure_source_identity(canonical, source, model) do
+    model_ref = Map.get(canonical, "model_ref")
+
+    if source_identity_matches?(canonical, model_ref, source, model) do
+      :ok
+    else
+      {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp source_identity_matches?(canonical, model_ref, source, model) when is_map(model_ref) do
+    source_attributes_match?(canonical, source) and
+      model_reference_matches?(model_ref, source, model)
+  end
+
+  defp source_identity_matches?(_canonical, _model_ref, _source, _model), do: false
+
+  defp source_attributes_match?(canonical, source) do
+    canonical["public_id"] == source.public_id and
+      canonical["endpoint"] == Atom.to_string(source.endpoint) and
+      canonical["tenant_id"] == source.tenant_id and
+      canonical["principal_type"] == Atom.to_string(source.principal_type) and
+      canonical["principal_id"] == principal_id_for(source) and
+      canonical["api_key_id"] == source.api_key_id and
+      canonical["service_account_id"] == source.service_account_id
+  end
+
+  defp model_reference_matches?(model_ref, source, model) do
+    model_ref["model_id"] == model.model_id and
+      model_ref["version"] == model.version and
+      source.requested_model == "#{model.model_id}@#{model.version}"
+  end
+
+  defp principal_id_for(%Request{principal_type: :tenant, tenant_id: tenant_id}), do: tenant_id
+
+  defp principal_id_for(%Request{
+         principal_type: :service_account,
+         service_account_id: account_id
+       }),
+       do: account_id
+
+  defp decode_canonical_attrs(canonical, source) do
+    with true <- required_keys?(canonical, @canonical_keys),
+         {:ok, endpoint} <- decode_endpoint(canonical["endpoint"]),
+         {:ok, principal_type} <- decode_principal_type(canonical["principal_type"]),
+         {:ok, response_format} <- decode_response_format(canonical["response_format"]),
+         {:ok, resolved_policy} <- decode_resolved_policy(canonical["resolved_policy"]),
+         {:ok, registry_snapshot} <-
+           decode_tool_snapshot(canonical["tooling"]["registry_snapshot"]),
+         {:ok, execution_snapshot} <-
+           decode_tool_snapshot(canonical["tooling"]["execution_snapshot"]),
+         true <- required_keys?(canonical["model_ref"], ~w(model_id version)),
+         true <- required_keys?(canonical["sampling"], @sampling_keys),
+         true <- required_keys?(canonical["tooling"], @tooling_keys),
+         true <- required_keys?(canonical["admission"], @admission_keys) do
+      internal_id = Ecto.UUID.generate()
+
+      {:ok,
+       %{
+         internal_id: internal_id,
+         public_id: retry_public_id(endpoint, internal_id),
+         endpoint: endpoint,
+         tenant_id: source.tenant_id,
+         principal_type: principal_type,
+         principal_id: canonical["principal_id"],
+         service_account_id: canonical["service_account_id"],
+         api_key_id: canonical["api_key_id"],
+         model_ref: %{
+           model_id: canonical["model_ref"]["model_id"],
+           version: canonical["model_ref"]["version"]
+         },
+         input_items: canonical["input_items"],
+         rendered_prompt: canonical["rendered_prompt"],
+         input_token_count: canonical["input_token_count"],
+         store?: canonical["store"],
+         stream?: canonical["stream"],
+         stream_include_usage: canonical["stream_include_usage"],
+         sampling: %{
+           temperature: canonical["sampling"]["temperature"],
+           top_p: canonical["sampling"]["top_p"],
+           max_output_tokens: canonical["sampling"]["max_output_tokens"],
+           stop: canonical["sampling"]["stop"],
+           seed: canonical["sampling"]["seed"]
+         },
+         response_format: response_format,
+         tooling: %{
+           tools: canonical["tooling"]["tools"],
+           requested_tools: canonical["tooling"]["requested_tools"],
+           tool_choice: canonical["tooling"]["tool_choice"],
+           registry_snapshot: registry_snapshot,
+           execution_snapshot: execution_snapshot
+         },
+         metadata: canonical["metadata"],
+         admission: %{
+           timeout_ms: canonical["admission"]["timeout_ms"],
+           queue_wait_ms: canonical["admission"]["queue_wait_ms"],
+           max_cold_start_ms: canonical["admission"]["max_cold_start_ms"]
+         },
+         resolved_policy: resolved_policy
+       }}
+    else
+      _invalid -> {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp decode_endpoint("chat_completions"), do: {:ok, :chat_completions}
+  defp decode_endpoint("responses"), do: {:ok, :responses}
+  defp decode_endpoint(_endpoint), do: {:error, :retry_source_unavailable}
+
+  defp decode_principal_type("tenant"), do: {:ok, :tenant}
+  defp decode_principal_type("service_account"), do: {:ok, :service_account}
+  defp decode_principal_type(_principal_type), do: {:error, :retry_source_unavailable}
+
+  defp decode_response_format(response_format) do
+    with true <- required_keys?(response_format, @response_format_keys),
+         {:ok, type} <- decode_response_format_type(response_format["type"]) do
+      {:ok, %{type: type}}
+    else
+      _invalid -> {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp decode_response_format_type("text"), do: {:ok, :text}
+  defp decode_response_format_type("json_object"), do: {:ok, :json_object}
+  defp decode_response_format_type(_type), do: {:error, :retry_source_unavailable}
+
+  defp decode_resolved_policy(resolved_policy) do
+    with true <- required_keys?(resolved_policy, @resolved_policy_keys),
+         {:ok, residency_preference} <-
+           decode_residency_preference(resolved_policy["residency_preference"]) do
+      {:ok,
+       %{
+         quota_id: resolved_policy["quota_id"],
+         routing_policy_id: resolved_policy["routing_policy_id"],
+         allowed_pool_ids: resolved_policy["allowed_pool_ids"],
+         max_active_requests: resolved_policy["max_active_requests"],
+         residency_preference: residency_preference
+       }}
+    else
+      _invalid -> {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp decode_residency_preference("required_loaded"), do: {:ok, :required_loaded}
+  defp decode_residency_preference("prefer_loaded"), do: {:ok, :prefer_loaded}
+  defp decode_residency_preference("allow_cold_load"), do: {:ok, :allow_cold_load}
+  defp decode_residency_preference(_preference), do: {:error, :retry_source_unavailable}
+
+  defp decode_tool_snapshot(%{"entries" => entries}) when is_list(entries),
+    do: {:ok, %{entries: entries}}
+
+  defp decode_tool_snapshot(%{entries: entries}) when is_list(entries),
+    do: {:ok, %{entries: entries}}
+
+  defp decode_tool_snapshot(_snapshot), do: {:error, :retry_source_unavailable}
+
+  defp required_keys?(map, keys) when is_map(map),
+    do: Enum.all?(keys, &Map.has_key?(map, &1))
+
+  defp required_keys?(_value, _keys), do: false
+
+  defp retry_public_id(:chat_completions, internal_id), do: "chatcmpl-" <> internal_id
+  defp retry_public_id(:responses, _internal_id), do: "resp_" <> Ecto.UUID.generate()
+
+  defp build_canonical(attrs) do
+    {:ok, CanonicalRequest.new(attrs)}
+  rescue
+    _error in [ArgumentError, KeyError] -> {:error, :retry_source_unavailable}
+  end
+
+  defp ensure_dispatchable_canonical(canonical) do
+    case RequestOrchestrator.validate_resolved_tooling(canonical) do
+      :ok -> :ok
+      {:error, _reason} -> {:error, :retry_source_unavailable}
+    end
+  end
+
+  defp ensure_retry_capacity(original_id) do
+    retry_count =
+      Request
+      |> where([request], request.retry_of_request_id == ^original_id)
+      |> Repo.aggregate(:count)
+
+    if retry_count < @max_retries,
+      do: :ok,
+      else: {:error, :operator_retry_limit_reached}
+  end
+
+  defp create_descendant(source, original, tenant, model, canonical) do
+    capture_mode =
+      source.payload_capture_mode
+      |> CapturePolicy.narrower(tenant.request_body_capture_mode)
+      |> CapturePolicy.resolve(canonical.store?)
+
+    serialized = CanonicalRequestSerializer.serialize(canonical)
+
+    attrs = %{
+      id: canonical.internal_id,
+      public_id: canonical.public_id,
+      endpoint: canonical.endpoint,
+      tenant_id: canonical.tenant_id,
+      principal_type: canonical.principal_type,
+      api_key_id: canonical.api_key_id,
+      service_account_id: canonical.service_account_id,
+      model_id: model.id,
+      requested_model: "#{canonical.model_ref.model_id}@#{canonical.model_ref.version}",
+      retry_of_request_id: original.id,
+      state: :received,
+      stream: canonical.stream?,
+      body_hash: :crypto.hash(:sha256, Jason.encode!(serialized)),
+      payload_capture_mode: capture_mode,
+      canonical_request: serialized,
+      request_payload: %{"prompt" => canonical.rendered_prompt},
+      sampling_params: CanonicalRequestSerializer.sampling_params(canonical.sampling),
+      response_format: %{"type" => Atom.to_string(canonical.response_format.type)},
+      input_tokens: canonical.input_token_count,
+      reserved_output_tokens: max_output_tokens(canonical),
+      timeout_at: RequestDeadline.timeout_at(canonical.admission.timeout_ms, utc_now())
+    }
+
+    Requests.create_request(attrs)
+  end
+
+  defp max_output_tokens(%CanonicalRequest{sampling: %{max_output_tokens: value}})
+       when is_integer(value) and value > 0,
+       do: value
+
+  defp max_output_tokens(%CanonicalRequest{}), do: 4_096
+
+  defp dispatch(%{request: request, canonical: canonical, model: model}) do
+    _result =
+      RequestOrchestrator.execute_persisted(request, canonical, model,
+        success_persistence: &success_persistence_attrs/2
+      )
+
+    {:ok, Requests.get_request!(request.id)}
+  end
+
+  defp success_persistence_attrs(
+         %CanonicalRequest{endpoint: :chat_completions} = canonical,
+         events
+       ),
+       do: ChatResponseSerializer.success_persistence_attrs(canonical, events)
+
+  defp success_persistence_attrs(%CanonicalRequest{endpoint: :responses} = canonical, events),
+    do: ResponsesSerializer.success_persistence_attrs(canonical, events)
+
+  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+  defp unwrap_reservation({:ok, reservation}), do: {:ok, reservation}
+  defp unwrap_reservation({:error, reason}), do: {:error, reason}
+end

--- a/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
+++ b/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
@@ -206,8 +206,6 @@ defmodule Orchard.Requests.OperatorRetry do
       resolved_policy
       | routing_policy_id: routing_opts[:routing_policy_id],
         allowed_pool_ids: Keyword.get(routing_opts, :allowed_pool_ids, []),
-        max_active_requests:
-          Keyword.get(routing_opts, :max_active_requests, resolved_policy.max_active_requests),
         residency_preference:
           Keyword.get(
             routing_opts,
@@ -441,7 +439,8 @@ defmodule Orchard.Requests.OperatorRetry do
       |> CapturePolicy.resolve(canonical.store?)
 
     case RequestOrchestrator.persistable_request_attrs(canonical, model,
-           capture_mode: capture_mode
+           capture_mode: capture_mode,
+           admission_opts: retained_admission_opts(canonical)
          ) do
       {:ok, attrs, persisted_canonical} ->
         insert_descendant(attrs, original, persisted_canonical)
@@ -449,6 +448,14 @@ defmodule Orchard.Requests.OperatorRetry do
       {:error, _reason} ->
         {:error, :retry_source_unavailable}
     end
+  end
+
+  defp retained_admission_opts(%CanonicalRequest{admission: admission}) do
+    [
+      effective_timeout_ms: admission.timeout_ms,
+      queue_wait_ms: admission.queue_wait_ms,
+      max_cold_start_ms: admission.max_cold_start_ms
+    ]
   end
 
   defp insert_descendant(attrs, original, canonical) do
@@ -467,22 +474,27 @@ defmodule Orchard.Requests.OperatorRetry do
   end
 
   defp handle_dispatch_result({:error, {:terminal_persist_failed, _reason}}, request) do
-    log_incomplete_dispatch(request, "terminal_persist_failed")
+    Logger.warning(
+      "operator retry descendant retained without a terminal outcome: " <>
+        dispatch_identifiers(request) <> " outcome=terminal_persist_failed"
+    )
+
     {:error, :retry_dispatch_incomplete}
   end
 
   defp handle_dispatch_result({:error, reason}, request) do
-    log_incomplete_dispatch(request, outcome_label(reason))
+    Logger.info(
+      "operator retry dispatch failed: " <>
+        dispatch_identifiers(request) <> " outcome=#{outcome_label(reason)}"
+    )
+
     {:ok, Requests.get_request!(request.id)}
   end
 
   defp handle_dispatch_result(_result, request), do: {:ok, Requests.get_request!(request.id)}
 
-  defp log_incomplete_dispatch(request, outcome) do
-    Logger.warning(
-      "operator retry dispatch did not complete: public_id=#{request.public_id} " <>
-        "retry_of_request_id=#{request.retry_of_request_id} outcome=#{outcome}"
-    )
+  defp dispatch_identifiers(request) do
+    "public_id=#{request.public_id} retry_of_request_id=#{request.retry_of_request_id}"
   end
 
   defp outcome_label(reason) when is_atom(reason), do: Atom.to_string(reason)

--- a/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
+++ b/apps/orchard_controller/lib/orchard/requests/operator_retry.ex
@@ -1,5 +1,18 @@
 defmodule Orchard.Requests.OperatorRetry do
-  @moduledoc false
+  @moduledoc """
+  Operator-initiated retry of a terminal Request under `SPEC.md` §7.3.4.
+
+  Reservation and dispatch are separate phases. One transaction locks the
+  source Request, its original Request, and the source Tenant, re-resolves
+  current Model authorization, rebuilds the retained legacy canonical request,
+  and inserts a descendant only while the original has fewer than three. The
+  committed descendant is then dispatched through the ordinary request
+  lifecycle.
+
+  A retained negotiated reasoning snapshot cannot be reconstructed in this
+  revision, so it fails closed as `retry_source_unavailable` before any
+  descendant exists rather than being renegotiated or dropped.
+  """
 
   import Ecto.Query
 
@@ -69,6 +82,14 @@ defmodule Orchard.Requests.OperatorRetry do
           | :retry_source_not_eligible
           | :retry_source_unavailable
 
+  @doc """
+  Reserves and dispatches a retry descendant for the source Request.
+
+  A descendant whose dispatch reached a durable terminal outcome is returned as
+  `{:ok, request}` carrying that state, including a failed one. Only a
+  descendant whose terminal outcome could not be recorded returns
+  `{:error, :retry_dispatch_incomplete}`, and that descendant is retained.
+  """
   @spec retry(String.t(), keyword()) :: {:ok, Request.t()} | {:error, retry_error()}
   def retry(public_id, dispatch_opts \\ []) do
     with {:ok, reservation} <- reserve(public_id) do
@@ -76,6 +97,12 @@ defmodule Orchard.Requests.OperatorRetry do
     end
   end
 
+  @doc """
+  Runs only the reservation transaction for the source Request.
+
+  Separated from `retry/2` so reservation outcomes can be exercised without
+  dispatching inference.
+  """
   @spec reserve(String.t()) :: {:ok, reservation()} | {:error, retry_error()}
   def reserve(public_id) when is_binary(public_id) do
     Repo.transaction(fn -> reserve_locked(public_id) end)

--- a/apps/orchard_controller/test/orchard/api/ops/request_retries_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/request_retries_controller_test.exs
@@ -22,10 +22,10 @@ defmodule Orchard.API.Ops.RequestRetriesControllerTest do
   alias Orchard.API.Router
   alias Orchard.Governance
   alias Orchard.Governance.RoleBinding
+  alias Orchard.Models.Access
   alias Orchard.Repo
   alias Orchard.Requests
 
-  import Orchard.TestSupport.ModelRequestFixtures
   import Orchard.TestSupport.OperatorRetryFixtures
 
   setup do
@@ -80,7 +80,7 @@ defmodule Orchard.API.Ops.RequestRetriesControllerTest do
 
     test "creates and dispatches a descendant in the source tenant for a cluster-scoped operator" do
       source_tenant = create_tenant!("operator-retry-source", :full)
-      model = create_model!()
+      model = create_granted_model!(source_tenant)
       source = create_full_legacy_source!(source_tenant, model, state: :failed)
       source_id = source.id
       token = operator_token!("operator-retry-cluster-operator")
@@ -107,7 +107,7 @@ defmodule Orchard.API.Ops.RequestRetriesControllerTest do
 
     test "returns retry_source_unavailable without creating a descendant for a retained negotiated snapshot" do
       source_tenant = create_tenant!("operator-retry-negotiated", :full)
-      model = create_model!()
+      model = create_granted_model!(source_tenant)
       source = create_full_legacy_source!(source_tenant, model, state: :failed)
       token = operator_token!("operator-retry-negotiated-operator")
 
@@ -136,9 +136,33 @@ defmodule Orchard.API.Ops.RequestRetriesControllerTest do
       refute_receive {:operator_retry_scheduled, _, _}
     end
 
+    test "returns retry_source_not_authorized without creating a descendant for a revoked grant" do
+      source_tenant = create_tenant!("operator-retry-revoked", :full)
+      model = create_granted_model!(source_tenant)
+      source = create_full_legacy_source!(source_tenant, model, state: :failed)
+      token = operator_token!("operator-retry-revoked-operator")
+
+      assert {:ok, _revocation} = Access.revoke_model_access(source_tenant, model)
+
+      conn = post_retry(token, source.public_id)
+
+      assert conn.status == 409
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "error" => %{
+                 "code" => "retry_source_not_authorized",
+                 "message" =>
+                   "Retry source Tenant is no longer authorized for an active source Model."
+               }
+             }
+
+      assert descendant_count(source.id) == 0
+      refute_receive {:operator_retry_scheduled, _, _}
+    end
+
     test "returns retry_source_not_eligible without creating a descendant for a nonterminal source" do
       source_tenant = create_tenant!("operator-retry-active", :full)
-      model = create_model!()
+      model = create_granted_model!(source_tenant)
       source = create_full_legacy_source!(source_tenant, model, state: :running)
       token = operator_token!("operator-retry-active-operator")
 

--- a/apps/orchard_controller/test/orchard/api/ops/request_retries_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/ops/request_retries_controller_test.exs
@@ -1,0 +1,254 @@
+defmodule Orchard.API.Ops.RequestRetriesControllerTest.RetryScheduler do
+  @moduledoc false
+
+  alias Orchard.CanonicalRequest
+
+  def schedule(%CanonicalRequest{} = request, opts) do
+    send(
+      Application.fetch_env!(:orchard_controller, :operator_retry_scheduler_owner),
+      {:operator_retry_scheduled, request.public_id, opts}
+    )
+
+    {:error, :no_active_nodes}
+  end
+end
+
+defmodule Orchard.API.Ops.RequestRetriesControllerTest do
+  use Orchard.ConnCase, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Changeset
+  alias Orchard.API.Router
+  alias Orchard.Governance
+  alias Orchard.Governance.RoleBinding
+  alias Orchard.Repo
+  alias Orchard.Requests
+
+  import Orchard.TestSupport.ModelRequestFixtures
+  import Orchard.TestSupport.OperatorRetryFixtures
+
+  setup do
+    inference = Application.fetch_env!(:orchard_controller, :inference)
+
+    Application.put_env(
+      :orchard_controller,
+      :inference,
+      Keyword.put(
+        inference,
+        :scheduler_impl,
+        Orchard.API.Ops.RequestRetriesControllerTest.RetryScheduler
+      )
+    )
+
+    Application.put_env(:orchard_controller, :operator_retry_scheduler_owner, self())
+
+    on_exit(fn ->
+      Application.put_env(:orchard_controller, :inference, inference)
+      Application.delete_env(:orchard_controller, :operator_retry_scheduler_owner)
+    end)
+
+    :ok
+  end
+
+  describe "POST /ops/v1/requests/:id/retry" do
+    @describetag :db
+
+    test "SPEC.md §7.3 rejects missing and malformed bearer tokens with 401" do
+      assert_operator_auth_error(build_conn(:post, retry_path("missing-token")), 401)
+
+      conn =
+        build_conn(:post, retry_path("malformed-token"))
+        |> put_req_header("authorization", "Token nope")
+
+      assert_operator_auth_error(conn, 401)
+    end
+
+    test "SPEC.md §7.3 rejects public tenant and tenant-scoped operator tokens with 403" do
+      %{token: tenant_token} = create_tenant_token!("operator-retry-public")
+
+      tenant_token
+      |> authorized_conn("public-token")
+      |> assert_operator_required()
+
+      %{token: scoped_token} = create_api_client_token!("operator-retry-tenant-operator", :tenant)
+
+      scoped_token
+      |> authorized_conn("tenant-operator")
+      |> assert_operator_required()
+    end
+
+    test "creates and dispatches a descendant in the source tenant for a cluster-scoped operator" do
+      source_tenant = create_tenant!("operator-retry-source", :full)
+      model = create_model!()
+      source = create_full_legacy_source!(source_tenant, model, state: :failed)
+      source_id = source.id
+      token = operator_token!("operator-retry-cluster-operator")
+
+      conn = post_retry(token, source.public_id)
+
+      assert conn.status == 201
+
+      assert %{
+               "id" => descendant_public_id,
+               "object" => "request",
+               "retry_of_request_id" => ^source_id,
+               "state" => state
+             } = Jason.decode!(conn.resp_body)
+
+      assert state in ["received", "failed"]
+      assert_receive {:operator_retry_scheduled, ^descendant_public_id, [exclude_node_ids: []]}
+
+      descendant = Requests.get_request_by_public_id(descendant_public_id)
+      assert descendant.tenant_id == source_tenant.id
+      assert descendant.retry_of_request_id == source.id
+      assert descendant.idempotency_key == nil
+    end
+
+    test "returns retry_source_unavailable without creating a descendant for a retained negotiated snapshot" do
+      source_tenant = create_tenant!("operator-retry-negotiated", :full)
+      model = create_model!()
+      source = create_full_legacy_source!(source_tenant, model, state: :failed)
+      token = operator_token!("operator-retry-negotiated-operator")
+
+      source =
+        Repo.update!(
+          Changeset.change(source,
+            canonical_request:
+              Map.put(source.canonical_request, "reasoning", %{"mode" => "negotiated"})
+          )
+        )
+
+      assert descendant_count(source.id) == 0
+
+      conn = post_retry(token, source.public_id)
+
+      assert conn.status == 422
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "error" => %{
+                 "code" => "retry_source_unavailable",
+                 "message" => "Retry source canonical request is unavailable."
+               }
+             }
+
+      assert descendant_count(source.id) == 0
+      refute_receive {:operator_retry_scheduled, _, _}
+    end
+
+    test "returns retry_source_not_eligible without creating a descendant for a nonterminal source" do
+      source_tenant = create_tenant!("operator-retry-active", :full)
+      model = create_model!()
+      source = create_full_legacy_source!(source_tenant, model, state: :running)
+      token = operator_token!("operator-retry-active-operator")
+
+      conn = post_retry(token, source.public_id)
+
+      assert conn.status == 409
+
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "retry_source_not_eligible"
+      assert descendant_count(source.id) == 0
+      refute_receive {:operator_retry_scheduled, _, _}
+    end
+  end
+
+  defp post_retry(token, request_id) do
+    token
+    |> authorized_conn(request_id)
+    |> Router.call(Router.init([]))
+  end
+
+  defp authorized_conn(token, request_id) do
+    build_conn(:post, retry_path(request_id))
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("authorization", "Bearer #{token}")
+  end
+
+  defp retry_path(request_id), do: "/ops/v1/requests/#{request_id}/retry"
+
+  defp assert_operator_auth_error(conn, status) do
+    conn = Router.call(conn, Router.init([]))
+
+    assert conn.halted
+    assert conn.status == status
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "error" => %{
+               "code" => "invalid_api_key",
+               "message" => "Invalid API key provided."
+             }
+           }
+  end
+
+  defp assert_operator_required(conn) do
+    conn = Router.call(conn, Router.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+
+    assert Jason.decode!(conn.resp_body) == %{
+             "error" => %{
+               "code" => "operator_required",
+               "message" =>
+                 "Operator API requires a cluster-scoped operator or admin API Client token."
+             }
+           }
+  end
+
+  defp create_tenant!(prefix, capture_mode) do
+    suffix = System.unique_integer([:positive])
+
+    {:ok, tenant} =
+      Governance.create_tenant(%{
+        slug: "#{prefix}-#{suffix}",
+        name: "#{prefix} #{suffix}",
+        request_body_capture_mode: capture_mode
+      })
+
+    tenant
+  end
+
+  defp create_tenant_token!(prefix) do
+    tenant = create_tenant!(prefix, :full)
+    {:ok, %{token: token}} = Governance.create_api_key(tenant, %{name: "Primary"})
+    %{tenant: tenant, token: token}
+  end
+
+  defp operator_token!(prefix) do
+    %{token: token} = create_api_client_token!(prefix, :cluster)
+    token
+  end
+
+  defp create_api_client_token!(prefix, scope) do
+    tenant = create_tenant!(prefix, :full)
+
+    {:ok, api_client} =
+      Governance.upsert_api_client(tenant, %{
+        name: "#{prefix}-client",
+        owner_contact: "owner@example.com"
+      })
+
+    tenant_scope_id = if scope == :cluster, do: nil, else: tenant.id
+
+    {:ok, _role_binding} =
+      %RoleBinding{}
+      |> RoleBinding.changeset(%{
+        principal_type: :service_account,
+        principal_id: api_client.id,
+        role: :operator,
+        tenant_scope_id: tenant_scope_id
+      })
+      |> Repo.insert()
+
+    {:ok, %{token: token}} =
+      Governance.create_api_client_api_token(api_client, %{name: "Primary"})
+
+    %{tenant: tenant, token: token}
+  end
+
+  defp descendant_count(original_id) do
+    Orchard.Requests.Request
+    |> where([request], request.retry_of_request_id == ^original_id)
+    |> Repo.aggregate(:count)
+  end
+end

--- a/apps/orchard_controller/test/orchard/inference/admission_policy_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/admission_policy_test.exs
@@ -172,6 +172,39 @@ defmodule Orchard.Inference.AdmissionPolicyTest do
     assert upgraded.admission.max_cold_start_ms == 15_000
   end
 
+  test "an already-effective deadline keeps explicit zero budgets without adding headroom" do
+    request =
+      base_request(
+        admission: %Admission{timeout_ms: 30_000, queue_wait_ms: 1_000, max_cold_start_ms: 1_000},
+        resolved_policy: %ResolvedPolicy{residency_preference: :allow_cold_load}
+      )
+
+    resolved =
+      AdmissionPolicy.resolve(request,
+        effective_timeout_ms: 30_000,
+        queue_wait_ms: 0,
+        max_cold_start_ms: 0
+      )
+
+    assert resolved.admission.timeout_ms == 30_000
+    assert resolved.admission.queue_wait_ms == 0
+    assert resolved.admission.max_cold_start_ms == 0
+    assert resolved.resolved_policy.residency_preference == :allow_cold_load
+  end
+
+  test "an already-effective deadline is still capped at the deployment ceiling" do
+    with_inference_config([max_request_deadline_ms: 360_000], fn ->
+      log =
+        capture_log(fn ->
+          resolved = AdmissionPolicy.resolve(base_request(), effective_timeout_ms: 400_000)
+
+          assert resolved.admission.timeout_ms == 360_000
+        end)
+
+      assert log =~ "capped at 360000 ms"
+    end)
+  end
+
   test "default_attrs mirrors resolve defaults" do
     attrs = AdmissionPolicy.default_attrs()
 

--- a/apps/orchard_controller/test/orchard/requests/operator_retry_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/operator_retry_test.exs
@@ -1,13 +1,21 @@
+defmodule Orchard.Requests.OperatorRetryTest.UnschedulableScheduler do
+  @moduledoc false
+
+  def schedule(_canonical, _opts), do: {:error, :no_active_nodes}
+end
+
 defmodule Orchard.Requests.OperatorRetryTest do
   use Orchard.DataCase, async: false
 
   import Ecto.Query
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias Ecto.Changeset
   alias Orchard.Governance
+  alias Orchard.Governance.Tenant
+  alias Orchard.Models.{Access, Model, TenantModelAccess}
   alias Orchard.Repo
-  alias Orchard.Requests
-  alias Orchard.Requests.OperatorRetry
+  alias Orchard.Requests.{OperatorRetry, Request}
 
   import Orchard.TestSupport.ModelRequestFixtures
   import Orchard.TestSupport.OperatorRetryFixtures
@@ -15,7 +23,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
   describe "reserve/1" do
     test "SPEC.md §7.3.4 creates an eligible terminal legacy descendant from retained full evidence" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
 
       for {state, endpoint} <-
             for(
@@ -50,7 +58,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
 
     test "rejects completed and active sources without creating a descendant" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
 
       for state <- [:completed, :received, :running] do
         source = create_full_legacy_source!(tenant, model, state: state)
@@ -62,7 +70,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
 
     test "returns retry_source_unavailable for terminal sources without retained full canonical evidence" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
 
       missing_capture =
         create_full_legacy_source!(tenant, model,
@@ -83,7 +91,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
 
     test "rejects a retained negotiated reasoning snapshot before creating or dispatching a descendant" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
       source = create_full_legacy_source!(tenant, model, state: :failed)
 
       negotiated = %{
@@ -106,7 +114,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
 
     test "rejects an identity-inconsistent retained source without creating a descendant" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
       source = create_full_legacy_source!(tenant, model, state: :failed)
 
       source =
@@ -123,7 +131,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
 
     test "rejects an unusable retained legacy tooling snapshot without creating a descendant" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
       source = create_full_legacy_source!(tenant, model, state: :failed)
 
       source =
@@ -139,10 +147,9 @@ defmodule Orchard.Requests.OperatorRetryTest do
     end
 
     test "uses the narrower current tenant capture policy without widening a full source snapshot" do
-      model = create_model!()
-
       for {mode, expected} <- [metadata: :metadata, none: :none] do
         tenant = tenant!(mode)
+        model = create_granted_model!(tenant)
         source = create_full_legacy_source!(tenant, model, state: :failed)
 
         assert {:ok, %{request: descendant}} = OperatorRetry.reserve(source.public_id)
@@ -159,7 +166,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
 
     test "caps every original Request at three descendants and retains original lineage" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
       source = create_full_legacy_source!(tenant, model, state: :failed)
 
       descendants =
@@ -175,7 +182,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
 
     test "uses the original Request as the lineage target when retrying a descendant" do
       tenant = tenant!(:full)
-      model = create_model!()
+      model = create_granted_model!(tenant)
       original = create_full_legacy_source!(tenant, model, state: :failed)
 
       assert {:ok, %{request: first_descendant}} = OperatorRetry.reserve(original.public_id)
@@ -193,25 +200,237 @@ defmodule Orchard.Requests.OperatorRetryTest do
       assert descendant_count(original.id) == 2
     end
 
-    test "serializes concurrent reservations under the original Request lock" do
+    test "SPEC.md §7.3.4 fails closed when the current Tenant Model access no longer authorizes the source" do
+      for revoke <- [&Access.revoke_model_access/2, &Access.disable_model_access/2] do
+        tenant = tenant!(:full)
+        model = create_granted_model!(tenant)
+        source = create_full_legacy_source!(tenant, model, state: :failed)
+
+        assert {:ok, %{access: _access}} = revoke.(tenant, model)
+
+        assert {:error, :retry_source_not_authorized} = OperatorRetry.reserve(source.public_id)
+        assert descendant_count(source.id) == 0
+      end
+    end
+
+    test "SPEC.md §7.3.4 fails closed when the source Model is no longer active" do
+      for state <- [:registered, :deprecated, :retired] do
+        tenant = tenant!(:full)
+        model = create_granted_model!(tenant)
+        source = create_full_legacy_source!(tenant, model, state: :failed)
+
+        Repo.update!(Changeset.change(model, state: state))
+
+        assert {:error, :retry_source_not_authorized} = OperatorRetry.reserve(source.public_id)
+        assert descendant_count(source.id) == 0
+      end
+    end
+
+    test "applies the current access grant routing policy without widening retained budgets" do
       tenant = tenant!(:full)
-      model = create_model!()
+
+      {:ok, policy} =
+        Access.create_routing_policy(%{
+          name: "operator-retry-policy-#{System.unique_integer([:positive])}",
+          allowed_pool_ids: [],
+          preferred_pool_ids: [],
+          residency_preference: :required_loaded,
+          max_cold_start_ms: 0,
+          max_queue_wait_ms: 250,
+          priority: 100
+        })
+
+      model = create_granted_model!(tenant, routing_policy_id: policy.id)
       source = create_full_legacy_source!(tenant, model, state: :failed)
+      retained = source.canonical_request
+
+      assert {:ok, %{request: descendant, canonical: canonical}} =
+               OperatorRetry.reserve(source.public_id)
+
+      assert retained["resolved_policy"]["routing_policy_id"] == nil
+      assert retained["resolved_policy"]["residency_preference"] == "allow_cold_load"
+      assert retained["admission"]["queue_wait_ms"] == 1_000
+      assert retained["admission"]["max_cold_start_ms"] == 1_000
+
+      assert canonical.resolved_policy.routing_policy_id == policy.id
+      assert canonical.resolved_policy.residency_preference == :required_loaded
+      assert canonical.admission.queue_wait_ms == 250
+      assert canonical.admission.max_cold_start_ms == 0
+      assert canonical.admission.timeout_ms == retained["admission"]["timeout_ms"]
+
+      assert descendant.canonical_request["resolved_policy"]["routing_policy_id"] == policy.id
+      assert descendant.canonical_request["admission"]["queue_wait_ms"] == 250
+    end
+
+    test "rejects a retained admission snapshot without a positive timeout" do
+      tenant = tenant!(:full)
+      model = create_granted_model!(tenant)
+
+      for admission <- [%{"timeout_ms" => nil}, %{"timeout_ms" => 0}, %{"queue_wait_ms" => nil}] do
+        source = create_full_legacy_source!(tenant, model, state: :failed)
+
+        source =
+          Repo.update!(
+            Changeset.change(source,
+              canonical_request:
+                Map.update!(
+                  source.canonical_request,
+                  "admission",
+                  &Map.merge(&1, admission)
+                )
+            )
+          )
+
+        assert {:error, :retry_source_unavailable} = OperatorRetry.reserve(source.public_id)
+        assert descendant_count(source.id) == 0
+      end
+    end
+
+    test "rejects a retained canonical source whose nested sections are not maps" do
+      tenant = tenant!(:full)
+      model = create_granted_model!(tenant)
+
+      for {key, value} <- [{"tooling", []}, {"tooling", "none"}, {"sampling", 7}] do
+        source = create_full_legacy_source!(tenant, model, state: :failed)
+
+        source =
+          Repo.update!(
+            Changeset.change(source,
+              canonical_request: Map.put(source.canonical_request, key, value)
+            )
+          )
+
+        assert {:error, :retry_source_unavailable} = OperatorRetry.reserve(source.public_id)
+        assert descendant_count(source.id) == 0
+      end
+    end
+
+    test "serializes concurrent reservations for one original lineage across real connections" do
+      %{source: source} = committed_retry_source!()
 
       results =
         1..4
         |> Task.async_stream(
-          fn _ -> OperatorRetry.reserve(source.public_id) end,
+          fn _ ->
+            Sandbox.unboxed_run(Repo, fn -> OperatorRetry.reserve(source.public_id) end)
+          end,
           max_concurrency: 4,
           ordered: false,
-          timeout: 5_000
+          timeout: 15_000
         )
         |> Enum.map(fn {:ok, result} -> result end)
 
       assert Enum.count(results, &match?({:ok, _reservation}, &1)) == 3
       assert Enum.count(results, &(&1 == {:error, :operator_retry_limit_reached})) == 1
-      assert descendant_count(source.id) == 3
+
+      assert Sandbox.unboxed_run(Repo, fn -> descendant_count(source.id) end) == 3
     end
+  end
+
+  describe "retry/2" do
+    test "SPEC.md §7.3.4 retains the descendant and reports an incomplete dispatch outcome" do
+      use_unschedulable_scheduler()
+
+      tenant = tenant!(:full)
+      model = create_granted_model!(tenant)
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+
+      assert {:error, :retry_dispatch_incomplete} =
+               OperatorRetry.retry(source.public_id,
+                 terminal_persister: fn _request, _attrs, _steps ->
+                   {:error, :terminal_row_unavailable}
+                 end
+               )
+
+      assert descendant_count(source.id) == 1
+
+      descendant =
+        Request
+        |> where([request], request.retry_of_request_id == ^source.id)
+        |> Repo.one!()
+
+      refute descendant.state in [:completed, :failed, :cancelled, :timed_out, :interrupted]
+    end
+
+    test "reports a created descendant when dispatch reaches a terminal failure" do
+      use_unschedulable_scheduler()
+
+      tenant = tenant!(:full)
+      model = create_granted_model!(tenant)
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+
+      assert {:ok, descendant} = OperatorRetry.retry(source.public_id)
+      assert descendant.retry_of_request_id == source.id
+      assert descendant.state == :failed
+    end
+  end
+
+  defp use_unschedulable_scheduler do
+    inference = Application.fetch_env!(:orchard_controller, :inference)
+
+    Application.put_env(
+      :orchard_controller,
+      :inference,
+      Keyword.put(
+        inference,
+        :scheduler_impl,
+        Orchard.Requests.OperatorRetryTest.UnschedulableScheduler
+      )
+    )
+
+    on_exit(fn -> Application.put_env(:orchard_controller, :inference, inference) end)
+  end
+
+  defp committed_retry_source! do
+    :ok = Sandbox.checkin(Repo)
+
+    fixture = Sandbox.unboxed_run(Repo, &insert_committed_retry_source!/0)
+
+    on_exit(fn -> Sandbox.unboxed_run(Repo, fn -> delete_committed_fixture!(fixture) end) end)
+
+    fixture
+  end
+
+  defp insert_committed_retry_source! do
+    suffix = System.unique_integer([:positive])
+
+    tenant =
+      Repo.insert!(
+        Tenant.changeset(%Tenant{}, %{
+          slug: "operator-retry-race-#{suffix}",
+          name: "Operator Retry Race #{suffix}",
+          request_body_capture_mode: :full
+        })
+      )
+
+    model = create_model!(%{state: :active})
+
+    Repo.insert!(
+      TenantModelAccess.changeset(%TenantModelAccess{}, %{
+        tenant_id: tenant.id,
+        model_id: model.id,
+        enabled: true
+      })
+    )
+
+    %{
+      tenant: tenant,
+      model: model,
+      source: create_full_legacy_source!(tenant, model, state: :failed)
+    }
+  end
+
+  defp delete_committed_fixture!(%{tenant: tenant, model: model}) do
+    Repo.delete_all(
+      from(request in Request,
+        where: request.tenant_id == ^tenant.id and not is_nil(request.retry_of_request_id)
+      )
+    )
+
+    Repo.delete_all(from(request in Request, where: request.tenant_id == ^tenant.id))
+    Repo.delete_all(from(access in TenantModelAccess, where: access.tenant_id == ^tenant.id))
+    Repo.delete_all(from(candidate in Model, where: candidate.id == ^model.id))
+    Repo.delete_all(from(candidate in Tenant, where: candidate.id == ^tenant.id))
   end
 
   defp tenant!(capture_mode) do
@@ -228,7 +447,7 @@ defmodule Orchard.Requests.OperatorRetryTest do
   end
 
   defp descendant_count(original_id) do
-    Requests.Request
+    Request
     |> where([request], request.retry_of_request_id == ^original_id)
     |> Repo.aggregate(:count)
   end

--- a/apps/orchard_controller/test/orchard/requests/operator_retry_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/operator_retry_test.exs
@@ -262,6 +262,70 @@ defmodule Orchard.Requests.OperatorRetryTest do
       assert descendant.canonical_request["admission"]["queue_wait_ms"] == 250
     end
 
+    test "preserves the retained deadline and explicit zero budgets under a cold-load grant" do
+      tenant = tenant!(:full)
+
+      {:ok, policy} =
+        Access.create_routing_policy(%{
+          name: "operator-retry-cold-load-#{System.unique_integer([:positive])}",
+          allowed_pool_ids: [],
+          preferred_pool_ids: [],
+          residency_preference: :allow_cold_load,
+          max_cold_start_ms: 0,
+          max_queue_wait_ms: 0,
+          priority: 100
+        })
+
+      model = create_granted_model!(tenant, routing_policy_id: policy.id)
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+      retained_timeout_ms = source.canonical_request["admission"]["timeout_ms"]
+
+      assert {:ok, %{request: descendant, canonical: canonical}} =
+               OperatorRetry.reserve(source.public_id)
+
+      assert canonical.resolved_policy.residency_preference == :allow_cold_load
+      assert canonical.admission.queue_wait_ms == 0
+      assert canonical.admission.max_cold_start_ms == 0
+      assert canonical.admission.timeout_ms == retained_timeout_ms
+
+      assert descendant.canonical_request["admission"] == %{
+               "timeout_ms" => retained_timeout_ms,
+               "queue_wait_ms" => 0,
+               "max_cold_start_ms" => 0
+             }
+    end
+
+    test "does not re-derive the retained deadline for a widened cold-load grant" do
+      tenant = tenant!(:full)
+
+      {:ok, policy} =
+        Access.create_routing_policy(%{
+          name: "operator-retry-headroom-#{System.unique_integer([:positive])}",
+          allowed_pool_ids: [],
+          preferred_pool_ids: [],
+          residency_preference: :allow_cold_load,
+          max_cold_start_ms: 500,
+          max_queue_wait_ms: 500,
+          priority: 100
+        })
+
+      model = create_granted_model!(tenant, routing_policy_id: policy.id)
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+      retained_timeout_ms = source.canonical_request["admission"]["timeout_ms"]
+
+      assert {:ok, %{request: descendant, canonical: canonical}} =
+               OperatorRetry.reserve(source.public_id)
+
+      assert canonical.admission.queue_wait_ms == 500
+      assert canonical.admission.max_cold_start_ms == 500
+      assert canonical.admission.timeout_ms == retained_timeout_ms
+
+      assert descendant.canonical_request["admission"]["timeout_ms"] == retained_timeout_ms
+
+      assert DateTime.diff(descendant.timeout_at, descendant.inserted_at, :millisecond) <=
+               retained_timeout_ms
+    end
+
     test "rejects a retained admission snapshot without a positive timeout" do
       tenant = tenant!(:full)
       model = create_granted_model!(tenant)

--- a/apps/orchard_controller/test/orchard/requests/operator_retry_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/operator_retry_test.exs
@@ -1,0 +1,235 @@
+defmodule Orchard.Requests.OperatorRetryTest do
+  use Orchard.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Changeset
+  alias Orchard.Governance
+  alias Orchard.Repo
+  alias Orchard.Requests
+  alias Orchard.Requests.OperatorRetry
+
+  import Orchard.TestSupport.ModelRequestFixtures
+  import Orchard.TestSupport.OperatorRetryFixtures
+
+  describe "reserve/1" do
+    test "SPEC.md §7.3.4 creates an eligible terminal legacy descendant from retained full evidence" do
+      tenant = tenant!(:full)
+      model = create_model!()
+
+      for {state, endpoint} <-
+            for(
+              state <- [:failed, :cancelled, :timed_out, :interrupted],
+              endpoint <- [:chat_completions, :responses],
+              do: {state, endpoint}
+            ) do
+        source =
+          create_full_legacy_source!(tenant, model,
+            state: state,
+            endpoint: endpoint,
+            idempotency_key: "retry-source-#{state}-#{endpoint}"
+          )
+
+        assert {:ok, %{request: descendant, canonical: canonical, model: ^model}} =
+                 OperatorRetry.reserve(source.public_id)
+
+        assert descendant.retry_of_request_id == source.id
+        assert descendant.tenant_id == source.tenant_id
+        assert descendant.payload_capture_mode == :full
+        assert source.idempotency_key != nil
+        assert descendant.idempotency_key == nil
+        assert canonical.public_id == descendant.public_id
+        assert canonical.input_items == source.canonical_request["input_items"]
+        assert canonical.rendered_prompt == source.canonical_request["rendered_prompt"]
+        refute Map.has_key?(descendant.canonical_request, "reasoning")
+
+        assert descendant.body_hash ==
+                 :crypto.hash(:sha256, Jason.encode!(descendant.canonical_request))
+      end
+    end
+
+    test "rejects completed and active sources without creating a descendant" do
+      tenant = tenant!(:full)
+      model = create_model!()
+
+      for state <- [:completed, :received, :running] do
+        source = create_full_legacy_source!(tenant, model, state: state)
+
+        assert {:error, :retry_source_not_eligible} = OperatorRetry.reserve(source.public_id)
+        assert descendant_count(source.id) == 0
+      end
+    end
+
+    test "returns retry_source_unavailable for terminal sources without retained full canonical evidence" do
+      tenant = tenant!(:full)
+      model = create_model!()
+
+      missing_capture =
+        create_full_legacy_source!(tenant, model,
+          state: :failed,
+          payload_capture_mode: :metadata,
+          canonical_request: nil
+        )
+
+      missing_canonical = create_full_legacy_source!(tenant, model, state: :failed)
+
+      Repo.update!(Changeset.change(missing_canonical, canonical_request: nil))
+
+      for source <- [missing_capture, missing_canonical] do
+        assert {:error, :retry_source_unavailable} = OperatorRetry.reserve(source.public_id)
+        assert descendant_count(source.id) == 0
+      end
+    end
+
+    test "rejects a retained negotiated reasoning snapshot before creating or dispatching a descendant" do
+      tenant = tenant!(:full)
+      model = create_model!()
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+
+      negotiated = %{
+        "effective_contract" => %{
+          "mode" => "negotiated",
+          "model_artifact_digest" => String.duplicate("a", 64)
+        }
+      }
+
+      source =
+        Repo.update!(
+          Changeset.change(source,
+            canonical_request: Map.put(source.canonical_request, "reasoning", negotiated)
+          )
+        )
+
+      assert {:error, :retry_source_unavailable} = OperatorRetry.reserve(source.public_id)
+      assert descendant_count(source.id) == 0
+    end
+
+    test "rejects an identity-inconsistent retained source without creating a descendant" do
+      tenant = tenant!(:full)
+      model = create_model!()
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+
+      source =
+        Repo.update!(
+          Changeset.change(source,
+            canonical_request:
+              Map.put(source.canonical_request, "principal_id", Ecto.UUID.generate())
+          )
+        )
+
+      assert {:error, :retry_source_unavailable} = OperatorRetry.reserve(source.public_id)
+      assert descendant_count(source.id) == 0
+    end
+
+    test "rejects an unusable retained legacy tooling snapshot without creating a descendant" do
+      tenant = tenant!(:full)
+      model = create_model!()
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+
+      source =
+        Repo.update!(
+          Changeset.change(source,
+            canonical_request:
+              put_in(source.canonical_request, ["tooling", "execution_snapshot", "entries"], [%{}])
+          )
+        )
+
+      assert {:error, :retry_source_unavailable} = OperatorRetry.reserve(source.public_id)
+      assert descendant_count(source.id) == 0
+    end
+
+    test "uses the narrower current tenant capture policy without widening a full source snapshot" do
+      model = create_model!()
+
+      for {mode, expected} <- [metadata: :metadata, none: :none] do
+        tenant = tenant!(mode)
+        source = create_full_legacy_source!(tenant, model, state: :failed)
+
+        assert {:ok, %{request: descendant}} = OperatorRetry.reserve(source.public_id)
+        assert descendant.payload_capture_mode == expected
+        assert descendant.canonical_request == nil
+        assert descendant.request_payload == nil
+
+        case expected do
+          :metadata -> assert is_map(descendant.request_shape)
+          :none -> assert descendant.request_shape == nil
+        end
+      end
+    end
+
+    test "caps every original Request at three descendants and retains original lineage" do
+      tenant = tenant!(:full)
+      model = create_model!()
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+
+      descendants =
+        for _ <- 1..3 do
+          assert {:ok, %{request: descendant}} = OperatorRetry.reserve(source.public_id)
+          descendant
+        end
+
+      assert Enum.all?(descendants, &(&1.retry_of_request_id == source.id))
+      assert {:error, :operator_retry_limit_reached} = OperatorRetry.reserve(source.public_id)
+      assert descendant_count(source.id) == 3
+    end
+
+    test "uses the original Request as the lineage target when retrying a descendant" do
+      tenant = tenant!(:full)
+      model = create_model!()
+      original = create_full_legacy_source!(tenant, model, state: :failed)
+
+      assert {:ok, %{request: first_descendant}} = OperatorRetry.reserve(original.public_id)
+
+      first_descendant =
+        Repo.update!(
+          Changeset.change(first_descendant, state: :failed, completed_at: DateTime.utc_now())
+        )
+
+      assert {:ok, %{request: second_descendant}} =
+               OperatorRetry.reserve(first_descendant.public_id)
+
+      assert first_descendant.retry_of_request_id == original.id
+      assert second_descendant.retry_of_request_id == original.id
+      assert descendant_count(original.id) == 2
+    end
+
+    test "serializes concurrent reservations under the original Request lock" do
+      tenant = tenant!(:full)
+      model = create_model!()
+      source = create_full_legacy_source!(tenant, model, state: :failed)
+
+      results =
+        1..4
+        |> Task.async_stream(
+          fn _ -> OperatorRetry.reserve(source.public_id) end,
+          max_concurrency: 4,
+          ordered: false,
+          timeout: 5_000
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.count(results, &match?({:ok, _reservation}, &1)) == 3
+      assert Enum.count(results, &(&1 == {:error, :operator_retry_limit_reached})) == 1
+      assert descendant_count(source.id) == 3
+    end
+  end
+
+  defp tenant!(capture_mode) do
+    suffix = System.unique_integer([:positive])
+
+    {:ok, tenant} =
+      Governance.create_tenant(%{
+        slug: "operator-retry-#{suffix}",
+        name: "Operator Retry #{suffix}",
+        request_body_capture_mode: capture_mode
+      })
+
+    tenant
+  end
+
+  defp descendant_count(original_id) do
+    Requests.Request
+    |> where([request], request.retry_of_request_id == ^original_id)
+    |> Repo.aggregate(:count)
+  end
+end

--- a/apps/orchard_controller/test/support/operator_retry_fixtures.ex
+++ b/apps/orchard_controller/test/support/operator_retry_fixtures.ex
@@ -4,6 +4,26 @@ defmodule Orchard.TestSupport.OperatorRetryFixtures do
   alias Orchard.CanonicalRequest
   alias Orchard.Inference.CanonicalRequestSerializer
   alias Orchard.Requests
+  alias Orchard.TestSupport.ModelRequestFixtures
+
+  @doc """
+  Creates an active Model the Tenant is currently authorized to use.
+
+  Operator retry re-resolves current Model state and Tenant Model access, so a
+  retryable source needs both.
+  """
+  @spec create_granted_model!(struct(), keyword()) :: struct()
+  def create_granted_model!(tenant, opts \\ []) do
+    model = ModelRequestFixtures.create_model!(%{state: :active})
+
+    ModelRequestFixtures.grant_model_access!(
+      tenant,
+      model,
+      Keyword.get(opts, :routing_policy_id)
+    )
+
+    model
+  end
 
   @spec create_full_legacy_source!(struct(), struct(), keyword()) :: struct()
   def create_full_legacy_source!(tenant, model, opts \\ []) do

--- a/apps/orchard_controller/test/support/operator_retry_fixtures.ex
+++ b/apps/orchard_controller/test/support/operator_retry_fixtures.ex
@@ -1,0 +1,84 @@
+defmodule Orchard.TestSupport.OperatorRetryFixtures do
+  @moduledoc false
+
+  alias Orchard.CanonicalRequest
+  alias Orchard.Inference.CanonicalRequestSerializer
+  alias Orchard.Requests
+
+  @spec create_full_legacy_source!(struct(), struct(), keyword()) :: struct()
+  def create_full_legacy_source!(tenant, model, opts \\ []) do
+    endpoint = Keyword.get(opts, :endpoint, :chat_completions)
+    internal_id = Ecto.UUID.generate()
+    public_id = public_id(endpoint, internal_id)
+
+    canonical =
+      CanonicalRequest.new(%{
+        internal_id: internal_id,
+        public_id: public_id,
+        endpoint: endpoint,
+        tenant_id: tenant.id,
+        principal_type: :tenant,
+        principal_id: tenant.id,
+        model_ref: %{model_id: model.model_id, version: model.version},
+        input_items: [%{"role" => "user", "content" => "retry this request"}],
+        rendered_prompt: "user retry this request\nassistant",
+        input_token_count: 5,
+        stream?: false,
+        sampling: %{temperature: 0.7, top_p: 0.9, max_output_tokens: 64, stop: [], seed: nil},
+        response_format: %{type: :text},
+        tooling: %{
+          tools: [],
+          requested_tools: [],
+          tool_choice: nil,
+          registry_snapshot: %{entries: []},
+          execution_snapshot: %{entries: []}
+        },
+        metadata: %{},
+        admission: %{timeout_ms: 10_000, queue_wait_ms: 1_000, max_cold_start_ms: 1_000},
+        resolved_policy: %{
+          quota_id: nil,
+          routing_policy_id: nil,
+          allowed_pool_ids: [],
+          max_active_requests: nil,
+          residency_preference: :allow_cold_load
+        }
+      })
+
+    serialized = CanonicalRequestSerializer.serialize(canonical)
+
+    attrs =
+      %{
+        id: internal_id,
+        public_id: public_id,
+        endpoint: endpoint,
+        tenant_id: tenant.id,
+        principal_type: :tenant,
+        model_id: model.id,
+        requested_model: "#{model.model_id}@#{model.version}",
+        state: :failed,
+        stream: false,
+        payload_capture_mode: :full,
+        canonical_request: serialized,
+        request_payload: %{"prompt" => canonical.rendered_prompt},
+        body_hash: :crypto.hash(:sha256, Jason.encode!(serialized)),
+        sampling_params: CanonicalRequestSerializer.sampling_params(canonical.sampling),
+        response_format: %{"type" => "text"},
+        input_tokens: canonical.input_token_count,
+        output_tokens: 0,
+        reserved_output_tokens: 0,
+        timeout_at: DateTime.add(DateTime.utc_now(), 10_000, :millisecond)
+      }
+      |> Map.merge(Map.new(Keyword.drop(opts, [:endpoint])))
+
+    case Requests.create_request(attrs) do
+      {:ok, request} ->
+        request
+
+      {:error, changeset} ->
+        raise ArgumentError, "retry source fixture failed: #{inspect(changeset.errors)}"
+    end
+  end
+
+  defp public_id(:chat_completions, internal_id), do: "chatcmpl-#{internal_id}"
+  defp public_id(:responses, _internal_id), do: "resp_#{Ecto.UUID.generate()}"
+end

--- a/docs/glossary/CONTEXT.md
+++ b/docs/glossary/CONTEXT.md
@@ -450,6 +450,11 @@ The single Controller-initiated second Inference Attempt allowed before Output C
 Its two-attempt bound, fail-closed gates, hard prior-Node exclusion, and original-deadline rule are normative in `SPEC.md` §§5.8-5.9.
 _Avoid_: queue re-entry, Operator Retry, cohort retry, same-Node redispatch
 
+**Operator Retry**:
+A cluster-operator-initiated new Request built from an eligible terminal Request's retained full-capture canonical source, whose `retry_of_request_id` points at the original Request.
+Its operator-only authorization, source-evidence dependency, default three-descendant bound per original Request, and no-widening capture rule are normative in `SPEC.md` §§7.3.4 and 10.10.
+_Avoid_: Automatic Attempt Retry, Inference Attempt, queue re-entry, client resubmission
+
 **Tool Call**:
 A model-proposed function invocation returned to the client in current base v1 behavior.
 _Avoid_: Tool Execution, server-side tool run

--- a/openspec/changes/add-operator-request-retry/design.md
+++ b/openspec/changes/add-operator-request-retry/design.md
@@ -8,6 +8,24 @@ The unmerged #327 negotiated reasoning work is not available on this base. A sto
 
 The retry service runs one database transaction that locks the source Request, locks its original Request (the source itself for first-generation retry), locks the source tenant for its current capture policy, validates the source and its legacy canonical serialization, counts existing descendants, and inserts the new descendant only when the count is below three. Locking the original serializes concurrent retry reservations for one lineage.
 
+Retry re-enters admission at the point where a Request row is created, so the
+reservation transaction re-resolves the authorization inputs that the public
+path resolves in `Orchard.Inference.RequestPreparation`: the source Model must
+still be `active`, and the source Tenant must still hold an enabled Model access
+grant. A revoked grant, a disabled grant, or a non-active Model returns
+`retry_source_not_authorized` before a descendant exists, so a retry cannot
+dispatch inference or account usage for a Tenant that is no longer authorized.
+The descendant's resolved policy comes from that current grant rather than the
+retained snapshot, and a retained queue-wait or cold-start budget is narrowed to
+the current grant's budget instead of being widened by it. The retained
+generation budget is preserved and remains subject to the deployment deadline
+ceiling.
+
+One request-attrs builder on `Orchard.Inference.RequestOrchestrator` serves both
+the public persistence path and retry, so the pre-persistence admission
+fail-safe, the persistable-deadline check, canonical serialization rescue, the
+deadline ceiling, and reserved-output defaults cannot drift between them.
+
 The service accepts only the `failed`, `cancelled`, `timed_out`, and `interrupted` source states. It accepts only `payload_capture_mode: :full` with a complete canonical map whose stored endpoint, tenant, principal, credential, model reference, and public identifier agree with the durable source row. It decodes only the fixed legacy serialization vocabulary and preserves legacy omitted-reasoning behavior. Missing or malformed retained evidence returns `retry_source_unavailable` and rolls back the transaction.
 
 The service rejects every retained `reasoning` key before it creates a descendant. This is the dependency-safe #327 gate: it neither fabricates nor drops negotiated identity and dispatches nothing on that path.
@@ -16,11 +34,20 @@ The descendant receives a fresh canonical and public identifier, its `retry_of_r
 
 After the transaction commits, the retry service hands the already-persisted descendant to the existing request lifecycle and scheduler seam. It does not parse a public request, reserve a new idempotency key, or introduce automatic retry behavior.
 
+A dispatch that reaches a durable terminal outcome is reported as a created
+descendant carrying that state. When the orchestrator cannot write the terminal
+row, the descendant is retained for audit and recovery, a bounded log records
+only the descendant public identifier, its original Request identifier, and an
+outcome label, and the caller receives `retry_dispatch_incomplete` instead of a
+success response.
+
 ## Failure Handling
 
 - Missing source: `request_not_found`.
 - Non-terminal or unsupported source state: `retry_source_not_eligible`.
-- Missing, non-full, malformed, identity-inconsistent, or negotiated retained canonical source: `retry_source_unavailable` with no descendant and no dispatch.
+- Missing, non-full, malformed, identity-inconsistent, or negotiated retained canonical source: `retry_source_unavailable` with no descendant and no dispatch. Malformed includes a non-map nested section, a non-positive retained `timeout_ms`, a canonical serialization that cannot be produced, and a descendant insert the database rejects.
+- Non-active Model or revoked/disabled Tenant Model access: `retry_source_not_authorized` with no descendant and no dispatch.
+- Created descendant whose terminal outcome cannot be persisted: `retry_dispatch_incomplete`, with the descendant retained.
 - Three existing descendants for the original: `operator_retry_limit_reached` with no new row.
 - Existing control-plane write authorization remains before reservation and dispatch.
 

--- a/openspec/changes/add-operator-request-retry/design.md
+++ b/openspec/changes/add-operator-request-retry/design.md
@@ -15,11 +15,27 @@ still be `active`, and the source Tenant must still hold an enabled Model access
 grant. A revoked grant, a disabled grant, or a non-active Model returns
 `retry_source_not_authorized` before a descendant exists, so a retry cannot
 dispatch inference or account usage for a Tenant that is no longer authorized.
-The descendant's resolved policy comes from that current grant rather than the
-retained snapshot, and a retained queue-wait or cold-start budget is narrowed to
-the current grant's budget instead of being widened by it. The retained
-generation budget is preserved and remains subject to the deployment deadline
-ceiling.
+The descendant's routing policy, allowed pools, and residency preference come
+from that current grant rather than the retained snapshot, and a retained
+queue-wait or cold-start budget is narrowed to the current grant's budget
+instead of being widened by it. The resolved policy keeps its retained quota and
+active-request limit, because no grant-side source for either exists in this
+revision.
+
+The retry deliberately preserves the retained deadline instead of re-deriving it
+under the current residency preference. A current grant that newly permits cold
+loading therefore spends queue-wait and cold-start time from that retained
+deadline rather than receiving fresh headroom, which keeps a retry from
+outliving the budget its source was admitted under. The retained deadline still
+passes through the deployment deadline ceiling.
+
+Narrowed budgets and the retained deadline are handed to admission resolution
+explicitly, through `AdmissionPolicy`'s `:effective_timeout_ms`,
+`:queue_wait_ms`, and `:max_cold_start_ms` options. Without that, the
+zero-means-unset fallbacks in admission resolution would replace an explicit
+zero queue-wait or cold-start budget with a default, and supplying the budgets
+without an already-effective deadline would add them to the retained deadline a
+second time.
 
 One request-attrs builder on `Orchard.Inference.RequestOrchestrator` serves both
 the public persistence path and retry, so the pre-persistence admission
@@ -35,11 +51,12 @@ The descendant receives a fresh canonical and public identifier, its `retry_of_r
 After the transaction commits, the retry service hands the already-persisted descendant to the existing request lifecycle and scheduler seam. It does not parse a public request, reserve a new idempotency key, or introduce automatic retry behavior.
 
 A dispatch that reaches a durable terminal outcome is reported as a created
-descendant carrying that state. When the orchestrator cannot write the terminal
-row, the descendant is retained for audit and recovery, a bounded log records
-only the descendant public identifier, its original Request identifier, and an
-outcome label, and the caller receives `retry_dispatch_incomplete` instead of a
-success response.
+descendant carrying that state, and its failure is logged at info because the
+outcome was recorded. When the orchestrator cannot write the terminal row, the
+descendant is retained for audit and recovery, the anomaly is logged at warning,
+and the caller receives `retry_dispatch_incomplete` instead of a success
+response. Both logs record only the descendant public identifier, its original
+Request identifier, and an outcome label.
 
 ## Failure Handling
 

--- a/openspec/changes/add-operator-request-retry/design.md
+++ b/openspec/changes/add-operator-request-retry/design.md
@@ -1,0 +1,29 @@
+## Context
+
+`SPEC.md` §7.3.4 makes retry an operator-only, source-evidence-dependent new Request. The existing request row has `retry_of_request_id`, the canonical serializer preserves legacy omission behavior, and `CapturePolicy` provides the capture lattice. No existing endpoint atomically reserves descendants or re-enters a durable request through normal dispatch.
+
+The unmerged #327 negotiated reasoning work is not available on this base. A stored `reasoning` entry therefore cannot prove a complete effective identity or compatible Runtime Endpoint. This slice must treat it as unavailable rather than infer a mode, remove the entry, or renegotiate.
+
+## Design
+
+The retry service runs one database transaction that locks the source Request, locks its original Request (the source itself for first-generation retry), locks the source tenant for its current capture policy, validates the source and its legacy canonical serialization, counts existing descendants, and inserts the new descendant only when the count is below three. Locking the original serializes concurrent retry reservations for one lineage.
+
+The service accepts only the `failed`, `cancelled`, `timed_out`, and `interrupted` source states. It accepts only `payload_capture_mode: :full` with a complete canonical map whose stored endpoint, tenant, principal, credential, model reference, and public identifier agree with the durable source row. It decodes only the fixed legacy serialization vocabulary and preserves legacy omitted-reasoning behavior. Missing or malformed retained evidence returns `retry_source_unavailable` and rolls back the transaction.
+
+The service rejects every retained `reasoning` key before it creates a descendant. This is the dependency-safe #327 gate: it neither fabricates nor drops negotiated identity and dispatches nothing on that path.
+
+The descendant receives a fresh canonical and public identifier, its `retry_of_request_id` points to the original Request, and it has no idempotency key. Its canonical body hash is calculated from the exact legacy serializer output. Its capture mode is the lattice minimum of the retained source and the currently locked tenant policy, followed by ordinary `store` resolution; existing persistence sanitizes content for `metadata` and `none`.
+
+After the transaction commits, the retry service hands the already-persisted descendant to the existing request lifecycle and scheduler seam. It does not parse a public request, reserve a new idempotency key, or introduce automatic retry behavior.
+
+## Failure Handling
+
+- Missing source: `request_not_found`.
+- Non-terminal or unsupported source state: `retry_source_not_eligible`.
+- Missing, non-full, malformed, identity-inconsistent, or negotiated retained canonical source: `retry_source_unavailable` with no descendant and no dispatch.
+- Three existing descendants for the original: `operator_retry_limit_reached` with no new row.
+- Existing control-plane write authorization remains before reservation and dispatch.
+
+## #327-Gated Follow-Up
+
+Once #327 and its prerequisite canonical reasoning work are merged and accepted, add a separate negotiated branch that reconstructs and verifies the complete stored effective reasoning tuple and proves compatible Runtime Endpoint capability before the existing reservation and dispatch path. Until then, retain the fail-closed `retry_source_unavailable` branch.

--- a/openspec/changes/add-operator-request-retry/proposal.md
+++ b/openspec/changes/add-operator-request-retry/proposal.md
@@ -1,0 +1,31 @@
+# Add the first operator Request retry slice (#411)
+
+## Why
+
+`SPEC.md` §§7.3.4 and 10.10 already require an operator-only retry of an eligible terminal Request when a complete retained canonical source exists. Orchard has durable retry lineage and capture-policy foundations, but no operator retry endpoint or atomic descendant reservation path.
+
+Issue #327 is not merged. Its negotiated reasoning runtime identity cannot be reconstructed or renegotiated in this slice, so a retained negotiated snapshot must fail closed before a descendant is created or dispatched.
+
+## What Changes
+
+- Add the cluster-operator-only `POST /ops/v1/requests/:id/retry` endpoint.
+- Permit only `failed`, `cancelled`, `timed_out`, and `interrupted` full-capture sources with a complete legacy canonical serialization.
+- Atomically reserve at most three descendants per original Request, with each descendant pointing to that original Request.
+- Reconstruct legacy canonical data without parser or normalizer re-entry; create a fresh descendant and dispatch it through the existing lifecycle and scheduler.
+- Resolve retry capture to the narrower retained-source and current-tenant policy, including ordinary `store` resolution.
+- Return `retry_source_unavailable` without a row or dispatch for unavailable, malformed, or retained negotiated sources.
+
+## Out Of Scope
+
+- Automatic retry, request parsing, Runtime Endpoint or protobuf work, quotas, and public inference APIs.
+- Negotiated reasoning retry support before #327 supplies a complete retained identity and compatible endpoint path.
+- Changes to the retry limit, capture lattice, or terminal eligibility defined by `SPEC.md`.
+
+## SPEC.md Impact
+
+This implementation applies the existing requirements in `SPEC.md` §§7.3.4 and 10.10. It introduces no unresolved product-policy decision and does not modify `SPEC.md`.
+
+## Impact
+
+- `Orchard.API.Ops`, `Orchard.Requests`, and the existing request orchestration seam.
+- Focused request, authorization, tenant-isolation, and scheduler-handoff tests.

--- a/openspec/changes/add-operator-request-retry/proposal.md
+++ b/openspec/changes/add-operator-request-retry/proposal.md
@@ -13,7 +13,9 @@ Issue #327 is not merged. Its negotiated reasoning runtime identity cannot be re
 - Atomically reserve at most three descendants per original Request, with each descendant pointing to that original Request.
 - Reconstruct legacy canonical data without parser or normalizer re-entry; create a fresh descendant and dispatch it through the existing lifecycle and scheduler.
 - Resolve retry capture to the narrower retained-source and current-tenant policy, including ordinary `store` resolution.
+- Re-resolve current Model state and Tenant Model access inside the reservation transaction, apply the current grant's routing values without widening retained admission budgets, and fail closed with `retry_source_not_authorized` before any descendant exists.
 - Return `retry_source_unavailable` without a row or dispatch for unavailable, malformed, or retained negotiated sources.
+- Retain a created descendant and return a stable server error when its dispatch outcome cannot be recorded.
 
 ## Out Of Scope
 
@@ -23,7 +25,7 @@ Issue #327 is not merged. Its negotiated reasoning runtime identity cannot be re
 
 ## SPEC.md Impact
 
-This implementation applies the existing requirements in `SPEC.md` §§7.3.4 and 10.10. It introduces no unresolved product-policy decision and does not modify `SPEC.md`.
+This implementation applies the existing requirements in `SPEC.md` §§7.3.4 and 10.10, and keeps the operator retry path consistent with the `SPEC.md` §5.2 admission steps that resolve an active Model and authorize Tenant Model access. It introduces no unresolved product-policy decision and does not modify `SPEC.md`.
 
 ## Impact
 

--- a/openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md
+++ b/openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Operator Retry Requires an Eligible Retained Source
+
+Orchard SHALL expose operator retry only through `POST /ops/v1/requests/:id/retry` to a server-authenticated cluster-scoped operator or admin API Client. Before a descendant is created, Orchard SHALL require a source Request in `failed`, `cancelled`, `timed_out`, or `interrupted`, with `payload_capture_mode` of `full` and a complete retained canonical source. Orchard SHALL reject a retained canonical source that is missing, malformed, identity-inconsistent, or contains negotiated reasoning evidence that this revision cannot reconstruct, with `retry_source_unavailable`; it MUST NOT create or dispatch a descendant on that path. A noneligible state SHALL return `retry_source_not_eligible` with no descendant.
+
+This requirement implements `SPEC.md` §§7.3.4 and 10.10.
+
+#### Scenario: Tenant-scoped token cannot retry another tenant's Request
+
+- **WHEN** a caller presents a tenant-scoped service-account token to the retry endpoint
+- **THEN** Orchard rejects the request as operator authorization failure
+- **AND** it does not reveal or mutate the source Request
+
+#### Scenario: Retained negotiated source is unavailable before #327 support
+
+- **WHEN** a terminal full-capture source contains retained negotiated reasoning evidence
+- **THEN** Orchard returns `retry_source_unavailable`
+- **AND** it creates no descendant and performs no scheduler dispatch
+
+### Requirement: Operator Retry Preserves Atomic Original Lineage
+
+Orchard SHALL atomically cap operator-created descendants at three per original Request. A retry of either an original Request or one of its descendants SHALL set the new descendant's `retry_of_request_id` to the original Request. The descendant SHALL have a fresh Request identity and no idempotency key. Concurrent reservations for one original SHALL not create a fourth descendant.
+
+#### Scenario: Four concurrent retry requests target one original
+
+- **WHEN** four eligible operator retry requests are concurrent for the same original lineage
+- **THEN** exactly three descendants are created
+- **AND** the remaining request returns `operator_retry_limit_reached`
+
+#### Scenario: A descendant is retried
+
+- **WHEN** an eligible descendant is retried
+- **THEN** the new descendant points to the first original Request
+- **AND** it does not form a chain through the immediate source
+
+### Requirement: Operator Retry Cannot Widen Capture
+
+Orchard SHALL resolve the retry capture mode to the narrower of the retained source capture mode and the current source-tenant capture policy, then apply the existing `store` resolution. A retry SHALL preserve legacy canonical serialization and body-hash behavior only while its resolved capture permits full retention; metadata and none modes SHALL retain no canonical request content.
+
+#### Scenario: Tenant policy narrows after a full source was retained
+
+- **WHEN** a full-capture source is retried after its tenant policy becomes metadata or none
+- **THEN** the descendant uses metadata or none respectively
+- **AND** its canonical request content is absent

--- a/openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md
+++ b/openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md
@@ -41,10 +41,13 @@ Model is currently `active` and that the source Tenant currently holds an
 enabled Model access grant. Orchard SHALL fail closed with
 `retry_source_not_authorized` and create no descendant when the Model is not
 `active`, when the grant is revoked, or when the grant is disabled. Orchard
-SHALL resolve the descendant's routing policy, allowed pools, residency
-preference, and active-request limit from that current grant, and SHALL NOT
-widen a retained queue-wait or cold-start budget beyond the current grant's
-budget. This requirement applies `SPEC.md` §5.2 steps 3 and 7 to the operator
+SHALL resolve the descendant's routing policy, allowed pools, and residency
+preference from that current grant, and SHALL NOT widen a retained queue-wait
+or cold-start budget beyond the current grant's budget, including a grant budget
+of zero. Orchard SHALL preserve the retained request deadline rather than
+re-deriving it under the current residency preference, so a current grant that
+permits cold loading spends queue-wait and cold-start time from that retained
+deadline. This requirement applies `SPEC.md` §5.2 steps 3 and 7 to the operator
 retry path.
 
 #### Scenario: Tenant Model access was revoked after the source Request failed
@@ -70,6 +73,14 @@ retry path.
   preference, and the narrower budgets
 - **AND** it does not record a budget wider than either the retained snapshot or
   the current grant
+- **AND** it records the retained request deadline
+
+#### Scenario: The current grant sets a zero queue-wait or cold-start budget
+
+- **WHEN** an eligible source is retried under a grant whose routing policy sets
+  a zero queue-wait or cold-start budget while permitting cold loading
+- **THEN** the descendant records that zero budget
+- **AND** no default budget replaces it
 
 ### Requirement: Operator Retry Reports an Unrecorded Dispatch Outcome
 

--- a/openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md
+++ b/openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md
@@ -34,6 +34,58 @@ Orchard SHALL atomically cap operator-created descendants at three per original 
 - **THEN** the new descendant points to the first original Request
 - **AND** it does not form a chain through the immediate source
 
+### Requirement: Operator Retry Re-Resolves Current Model Authorization
+
+Before a descendant is created, Orchard SHALL require that the source Request's
+Model is currently `active` and that the source Tenant currently holds an
+enabled Model access grant. Orchard SHALL fail closed with
+`retry_source_not_authorized` and create no descendant when the Model is not
+`active`, when the grant is revoked, or when the grant is disabled. Orchard
+SHALL resolve the descendant's routing policy, allowed pools, residency
+preference, and active-request limit from that current grant, and SHALL NOT
+widen a retained queue-wait or cold-start budget beyond the current grant's
+budget. This requirement applies `SPEC.md` §5.2 steps 3 and 7 to the operator
+retry path.
+
+#### Scenario: Tenant Model access was revoked after the source Request failed
+
+- **WHEN** an operator retries a terminal full-capture source whose Tenant Model
+  access has been revoked or disabled
+- **THEN** Orchard returns `retry_source_not_authorized`
+- **AND** it creates no descendant and performs no scheduler dispatch
+
+#### Scenario: The source Model is no longer active
+
+- **WHEN** an operator retries a terminal full-capture source whose Model is
+  `registered`, `deprecated`, or `retired`
+- **THEN** Orchard returns `retry_source_not_authorized`
+- **AND** it creates no descendant and performs no scheduler dispatch
+
+#### Scenario: The current grant carries a narrower routing policy
+
+- **WHEN** an eligible source is retried after its Tenant Model access is bound
+  to a routing policy with a stricter residency preference and smaller
+  queue-wait and cold-start budgets than the retained snapshot
+- **THEN** the descendant records the current routing policy, its residency
+  preference, and the narrower budgets
+- **AND** it does not record a budget wider than either the retained snapshot or
+  the current grant
+
+### Requirement: Operator Retry Reports an Unrecorded Dispatch Outcome
+
+When a descendant has been created but Orchard cannot record its terminal
+outcome, Orchard SHALL retain the descendant row for audit and recovery, log
+only bounded non-sensitive identifiers and an outcome label, and return a stable
+server error rather than a success response. A dispatch that reaches a durable
+terminal outcome SHALL remain a created-descendant success response carrying that
+state.
+
+#### Scenario: The terminal row cannot be written after dispatch
+
+- **WHEN** dispatch of a created descendant cannot persist its terminal outcome
+- **THEN** Orchard returns a stable `retry_dispatch_incomplete` server error
+- **AND** the descendant row is retained for audit and recovery
+
 ### Requirement: Operator Retry Cannot Widen Capture
 
 Orchard SHALL resolve the retry capture mode to the narrower of the retained source capture mode and the current source-tenant capture policy, then apply the existing `store` resolution. A retry SHALL preserve legacy canonical serialization and body-hash behavior only while its resolved capture permits full retention; metadata and none modes SHALL retain no canonical request content.

--- a/openspec/changes/add-operator-request-retry/tasks.md
+++ b/openspec/changes/add-operator-request-retry/tasks.md
@@ -1,0 +1,13 @@
+## 1. Operator Retry Slice
+
+- [x] 1.1 Add a cluster-operator-only retry route and server-side write authorization.
+- [x] 1.2 Atomically validate an eligible full-capture legacy source, reserve a descendant, cap lineage at three, and preserve the original Request pointer.
+- [x] 1.3 Reconstruct only the legacy canonical serialization and reject retained negotiated reasoning evidence fail closed.
+- [x] 1.4 Resolve retry capture to the narrower source and current tenant policy, then dispatch the persisted descendant through the existing lifecycle.
+- [x] 1.5 Add authorization, tenant isolation, source eligibility, race, capture-lattice, lineage, idempotency, scheduler-handoff, and no-row-on-failure coverage.
+- [ ] 1.6 After #327 and prerequisite canonical reasoning work merge and are accepted, implement and test the negotiated-identity proof branch in a separate change.
+
+## 2. Validation
+
+- [x] 2.1 Run strict validation for this change and all OpenSpec changes.
+- [x] 2.2 Run the applicable full Elixir quality and coverage workflow.

--- a/openspec/changes/add-operator-request-retry/tasks.md
+++ b/openspec/changes/add-operator-request-retry/tasks.md
@@ -4,8 +4,10 @@
 - [x] 1.2 Atomically validate an eligible full-capture legacy source, reserve a descendant, cap lineage at three, and preserve the original Request pointer.
 - [x] 1.3 Reconstruct only the legacy canonical serialization and reject retained negotiated reasoning evidence fail closed.
 - [x] 1.4 Resolve retry capture to the narrower source and current tenant policy, then dispatch the persisted descendant through the existing lifecycle.
-- [x] 1.5 Add authorization, tenant isolation, source eligibility, race, capture-lattice, lineage, idempotency, scheduler-handoff, and no-row-on-failure coverage.
-- [ ] 1.6 After #327 and prerequisite canonical reasoning work merge and are accepted, implement and test the negotiated-identity proof branch in a separate change.
+- [x] 1.5 Re-resolve current Model state and Tenant Model access in the reservation transaction, apply current grant routing values without widening retained budgets, and fail closed before descendant creation.
+- [x] 1.6 Retain a created descendant, log bounded identifiers, and return a stable server error when its terminal dispatch outcome cannot be persisted.
+- [x] 1.7 Add authorization, tenant isolation, source eligibility, race, capture-lattice, lineage, idempotency, scheduler-handoff, and no-row-on-failure coverage.
+- [ ] 1.8 After #327 and prerequisite canonical reasoning work merge and are accepted, implement and test the negotiated-identity proof branch in a separate change.
 
 ## 2. Validation
 


### PR DESCRIPTION
## Intent

Implement the dependency-safe first slice of #411: cluster-operator-only POST /ops/v1/requests/:id/retry for terminal full-capture legacy requests, atomic three-descendant original lineage, fail-closed retained negotiated reasoning as retry_source_unavailable until #327, capture non-widening, and no public inference or automatic retry changes.

## What Changed

- Added `Orchard.Requests.OperatorRetry` and the cluster-operator-only `POST /ops/v1/requests/:id/retry` route. Reservation runs in one transaction that locks the source Request, its original, and the Tenant: it accepts only `failed`/`cancelled`/`timed_out`/`interrupted` full-capture sources with a complete legacy canonical snapshot, caps lineage at three descendants per original (each pointing at the original), re-resolves current Model state and Tenant Model access before any row is written, and resolves descendant capture to the narrower of the retained snapshot and the current Tenant policy. Retained negotiated reasoning and malformed canonical evidence fail closed as `retry_source_unavailable` with no descendant; the controller maps each failure mode to a distinct 404/409/422/500/503 error envelope.
- Extracted reusable seams from `RequestOrchestrator` — `execute_persisted/4`, `persistable_request_attrs/3`, and a now-public `validate_resolved_tooling/1` — so the retry path shares the public path's timeout validation, canonical serialization, deadline ceiling, and dispatch lifecycle instead of cloning them; `persist_request/3` was refactored onto the same helper. Also added `CapturePolicy.narrower/2` for the capture lattice comparison.
- Extended `AdmissionPolicy.resolve/2` with an internal `:effective_timeout_ms` option so a caller holding an authoritative retained deadline can pass explicit queue-wait and cold-start budgets without those budgets being added to the deadline again; the option is deliberately excluded from the normalizer allowlist, so public inference callers cannot supply it. Documented the capability in the OpenSpec `add-operator-request-retry` change package and added an "Operator Retry" glossary entry.

## Risk Assessment

✅ Low: Every round-1 and round-2 finding is resolved per your decisions, the shared `AdmissionPolicy` change is provably inert when `:effective_timeout_ms` is absent and unreachable from any public entry point, and the new behavior is covered by targeted tests at both the policy and retry layers with the accepted tradeoffs written into the OpenSpec delta.

## Testing

Ran the two new retry suites plus admission-policy tests (39 passed) and the adjacent orchestrator/capture suites affected by the shared AdmissionPolicy and RequestOrchestrator edits (158 passed), then proved the feature as an operator would experience it: a real controller HTTP endpoint on a throwaway Postgres database, exercised with 16 curl calls plus a four-way parallel burst, and cross-checked against the persisted rows with psql. The transcript shows cluster-operator-only access (401/403/201), terminal full-capture eligibility, three-descendant original-lineage capping with 409 on the fourth (3 rows in the database, even when four retries race), retained negotiated reasoning failing closed as 422 retry_source_unavailable with no row, revoked grants returning 409 retry_source_not_authorized, capture narrowing to metadata with canonical content absent, the current grant's narrower routing and budgets applied while the retained deadline is preserved, and no public /v1 retry route while /v1/models still returns 200. Two things a reviewer should know: the harness has no inference node, so each created descendant dispatches and settles as failed — the 201 bodies and persisted rows are the evidence, not the terminal state; and the retry_dispatch_incomplete 500 path needs persistence fault injection, so it stays covered by its unit test rather than the HTTP transcript. Everything passed and no source files were changed.

<details>
<summary>Evidence: Live operator-retry HTTP transcript (16 scenarios against a real controller)</summary>

<code>### 3. Tenant-scoped operator token — 403 (cluster-scoped operator required)&#10;$ curl -i -X POST -H &#39;authorization: Bearer &lt;token&gt;&#39; .../ops/v1/requests/chatcmpl-f9fde499…/retry&#10;HTTP 403&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;operator_required&#34;, &#34;message&#34;: &#34;Operator API requires a cluster-scoped operator or admin API Client token.&#34;}}&#10;&#10;### 4. Cluster-scoped operator retries the terminal full-capture source — 201 descendant #1&#10;HTTP 201&#10;{&#34;id&#34;: &#34;chatcmpl-0932c37d-…&#34;, &#34;state&#34;: &#34;failed&#34;, &#34;retry_of_request_id&#34;: &#34;b4f21fb2-87d5-4763-b583-ad9adeb6ab38&#34;, &#34;object&#34;: &#34;request&#34;}&#10;&#10;### 5. Operator retries descendant #1 — lineage stays anchored on the ORIGINAL Request&#10;HTTP 201&#10;{&#34;id&#34;: &#34;chatcmpl-37946d89-…&#34;, &#34;retry_of_request_id&#34;: &#34;b4f21fb2-87d5-4763-b583-ad9adeb6ab38&#34;}&#10;&#10;### 7. Fourth retry in the same original lineage — 409 operator_retry_limit_reached&#10;HTTP 409&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;operator_retry_limit_reached&#34;}}&#10;&#10;### 8. Retained negotiated reasoning evidence — 422 retry_source_unavailable (fail closed until #327)&#10;HTTP 422&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;retry_source_unavailable&#34;, &#34;message&#34;: &#34;Retry source canonical request is unavailable.&#34;}}&#10;&#10;### 10. Tenant Model access revoked after the source failed — 409 retry_source_not_authorized&#10;HTTP 409&#10;{&#34;error&#34;: {&#34;code&#34;: &#34;retry_source_not_authorized&#34;}}&#10;&#10;### 13. No public inference retry surface exists (public /v1 namespace)&#10;HTTP 404 {&#34;errors&#34;: {&#34;detail&#34;: &#34;Not Found&#34;}}&#10;&#10;### 15. Four concurrent operator retries of one original lineage (fired in parallel)&#10;status tally: 3 x HTTP 201 + 1 x HTTP 409 operator_retry_limit_reached; descendant rows created in the database: 3&#10;&#10;### 16. Public inference surface untouched: tenant key still lists models on /v1/models&#10;HTTP 200 {&#34;object&#34;:&#34;list&#34;,&#34;model_ids&#34;:[&#34;mlx-community/phi-3-2@main&#34;]}</code>

```text
# Orchard operator retry — live HTTP transcript (POST /ops/v1/requests/:id/retry)
base_url: http://127.0.0.1:4137
source Request (terminal `failed`, payload_capture_mode=full): chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea

### 1. No credentials — operator endpoint rejects the caller
$ curl -i -X POST http://127.0.0.1:4137/ops/v1/requests/chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea/retry
HTTP 401
{
  "error": {
    "code": "invalid_api_key",
    "message": "Invalid API key provided."
  }
}

### 2. Public tenant API key (not an operator) — 403
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea/retry
HTTP 403
{
  "error": {
    "code": "operator_required",
    "message": "Operator API requires a cluster-scoped operator or admin API Client token."
  }
}

### 3. Tenant-scoped operator token — 403 (cluster-scoped operator required)
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea/retry
HTTP 403
{
  "error": {
    "code": "operator_required",
    "message": "Operator API requires a cluster-scoped operator or admin API Client token."
  }
}

### 4. Cluster-scoped operator retries the terminal full-capture source — 201 descendant #1
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea/retry
HTTP 201
{
  "id": "chatcmpl-0932c37d-b923-4a0a-b4b5-7dc487898f39",
  "state": "failed",
  "retry_of_request_id": "b4f21fb2-87d5-4763-b583-ad9adeb6ab38",
  "object": "request"
}
descendant #1 public_id=chatcmpl-0932c37d-b923-4a0a-b4b5-7dc487898f39

### 5. Operator retries descendant #1 — lineage stays anchored on the ORIGINAL Request
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-0932c37d-b923-4a0a-b4b5-7dc487898f39/retry
HTTP 201
{
  "id": "chatcmpl-37946d89-729b-4aac-b806-66fb8092cd0a",
  "state": "failed",
  "retry_of_request_id": "b4f21fb2-87d5-4763-b583-ad9adeb6ab38",
  "object": "request"
}
descendant #2 public_id=chatcmpl-37946d89-729b-4aac-b806-66fb8092cd0a (retry_of_request_id above is still the original, not chatcmpl-0932c37d-b923-4a0a-b4b5-7dc487898f39)

### 6. Operator retries the original again — 201 descendant #3
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea/retry
HTTP 201
{
  "id": "chatcmpl-ad042841-fe34-47bc-b9fe-6160ff78eef9",
  "state": "failed",
  "retry_of_request_id": "b4f21fb2-87d5-4763-b583-ad9adeb6ab38",
  "object": "request"
}
descendant #3 public_id=chatcmpl-ad042841-fe34-47bc-b9fe-6160ff78eef9

### 7. Fourth retry in the same original lineage — 409 operator_retry_limit_reached
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea/retry
HTTP 409
{
  "error": {
    "code": "operator_retry_limit_reached",
    "message": "The original Request has reached the operator retry limit."
  }
}

### 8. Retained negotiated reasoning evidence — 422 retry_source_unavailable (fail closed until #327)
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-05bcd233-2fb3-45da-9652-9a009c270109/retry
HTTP 422
{
  "error": {
    "code": "retry_source_unavailable",
    "message": "Retry source canonical request is unavailable."
  }
}

### 9. Nonterminal (running) source — 409 retry_source_not_eligible
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-c7e32372-c913-4922-b625-e96d458f1936/retry
HTTP 409
{
  "error": {
    "code": "retry_source_not_eligible",
    "message": "Request is not eligible for operator retry."
  }
}

### 10. Tenant Model access revoked after the source failed — 409 retry_source_not_authorized
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-55189e2e-2acb-4269-aa6a-89effe346516/retry
HTTP 409
{
  "error": {
    "code": "retry_source_not_authorized",
    "message": "Retry source Tenant is no longer authorized for an active source Model."
  }
}

### 11. Tenant capture policy narrowed to metadata after a full source was retained — 201, capture not widened
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-221632eb-f9ee-41da-a09e-faad3bc0953b/retry
HTTP 201
{
  "id": "chatcmpl-bd5ce21a-5cd3-49da-9b01-16455f785a36",
  "state": "failed",
  "retry_of_request_id": "b06e86b2-f197-4e4e-8f9e-1f1b3bffa28a",
  "object": "request"
}
descendant public_id=chatcmpl-bd5ce21a-5cd3-49da-9b01-16455f785a36

### 12. Unknown request id — 404 request_not_found
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-00000000-0000-4000-a000-000000000000/retry
HTTP 404
{
  "error": {
    "code": "request_not_found",
    "message": "Request was not found."
  }
}

### 13. No public inference retry surface exists (public /v1 namespace)
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/v1/requests/chatcmpl-f9fde499-cf46-4715-b0ec-468d8c54bdea/retry
HTTP 404
{
  "errors": {
    "detail": "Not Found"
  }
}

descendant ids: chatcmpl-0932c37d-b923-4a0a-b4b5-7dc487898f39 chatcmpl-37946d89-729b-4aac-b806-66fb8092cd0a chatcmpl-ad042841-fe34-47bc-b9fe-6160ff78eef9 | narrowed-capture descendant: chatcmpl-bd5ce21a-5cd3-49da-9b01-16455f785a36

### 14. Current Tenant Model grant now carries a narrower routing policy (required_loaded, queue-wait 250ms, cold-start 0ms) than the retained snapshot (allow_cold_load, 1000ms/1000ms)
$ curl -i -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-e7b5ba71-f363-404b-bd61-a4d059cc1463/retry
HTTP 201
{
  "id": "chatcmpl-9c8b2242-0bb3-4bc4-800a-f83d73bfc261",
  "state": "failed",
  "retry_of_request_id": "5a1e0369-1d50-41e1-b12e-b0ecf7de816a",
  "object": "request"
}

### 15. Four concurrent operator retries of one original lineage (fired in parallel)
$ for i in 1 2 3 4; do curl -X POST -H 'authorization: Bearer <token>' http://127.0.0.1:4137/ops/v1/requests/chatcmpl-d15f26c4-d8e3-4df2-acf3-386767b43dec/retry & done; wait
response 1: HTTP 201 {"id":"chatcmpl-75bab0cb-375d-41a5-a33c-d1c65c0b0767","retry_of_request_id":"aad033e1-8b6b-416a-ad57-d6070856465f","error":null}
response 2: HTTP 201 {"id":"chatcmpl-24228306-783b-4dd5-99aa-6513c5e90eff","retry_of_request_id":"aad033e1-8b6b-416a-ad57-d6070856465f","error":null}
response 3: HTTP 201 {"id":"chatcmpl-e275f575-2306-48f2-93e5-08e4d15e7290","retry_of_request_id":"aad033e1-8b6b-416a-ad57-d6070856465f","error":null}
response 4: HTTP 409 {"id":null,"retry_of_request_id":null,"error":"operator_retry_limit_reached"}
status tally: 3 x HTTP 201 + 1 x HTTP 409 operator_retry_limit_reached; descendant rows created in the database: 3

### 16. Public inference surface untouched: tenant key still lists models on /v1/models
$ curl -i http://127.0.0.1:4137/v1/models -H 'authorization: Bearer <tenant-key>'
HTTP 200
{"object":"list","model_ids":["mlx-community/phi-3-2@main"]}
```
</details>
<details>
<summary>Evidence: Persisted database state behind those responses (lineage, capture, routing, tenant scoping)</summary>

<code>## Fail-closed sources created no descendant row&#10;| source_public_id | state | scenario | descendants |&#10;| chatcmpl-05bcd233-2f | failed | retained negotiated reasoning | 0 |&#10;| chatcmpl-c7e32372-c9 | running | nonterminal source | 0 |&#10;| chatcmpl-55189e2e-2a | failed | revoked tenant model access | 0 |&#10;&#10;## Capture non-widening: tenant policy narrowed to metadata after a full source was retained&#10;| public_id | role | tenant_policy | payload_capture_mode | has_canonical | has_body | has_shape |&#10;| chatcmpl-221632eb-f9 | source | metadata | full | t | t | t |&#10;| chatcmpl-bd5ce21a-5c | descendant | metadata | metadata | f | f | t |&#10;&#10;## Current-grant routing applied without widening retained budgets or re-deriving the deadline&#10;| role | residency | routing_policy_id | queue_wait_ms | max_cold_start_ms | timeout_ms |&#10;| retained source | allow_cold_load | | 1000 | 1000 | 10000 |&#10;| descendant | required_loaded | 16206e22-a778-43c5-b930-970e5cb0fde6 | 250 | 0 | 10000 |&#10;&#10;## Descendant count per original lineage (three-descendant cap)&#10;| chatcmpl-f9fde499-cf | 3 |</code>

```text
Border style is 2.
## Original lineage rows (original + operator-created descendants)
+----------------------+--------+---------------+--------------------+----------------------+-----------------+---------------+
|      public_id       | state  | is_descendant | points_at_original | payload_capture_mode | idempotency_key | has_canonical |
+----------------------+--------+---------------+--------------------+----------------------+-----------------+---------------+
| chatcmpl-f9fde499-cf | failed | f             |                    | full                 |                 | t             |
| chatcmpl-0932c37d-b9 | failed | t             | t                  | full                 |                 | t             |
| chatcmpl-37946d89-72 | failed | t             | t                  | full                 |                 | t             |
| chatcmpl-ad042841-fe | failed | t             | t                  | full                 |                 | t             |
+----------------------+--------+---------------+--------------------+----------------------+-----------------+---------------+
(4 rows)

## Descendant count per original lineage (three-descendant cap)
+----------------------+-------------+
|       original       | descendants |
+----------------------+-------------+
| chatcmpl-f9fde499-cf |           3 |
+----------------------+-------------+
(1 row)

## Fail-closed sources created no descendant row
+----------------------+---------+-------------------------------+-------------+
|   source_public_id   |  state  |           scenario            | descendants |
+----------------------+---------+-------------------------------+-------------+
| chatcmpl-05bcd233-2f | failed  | retained negotiated reasoning |           0 |
| chatcmpl-c7e32372-c9 | running | nonterminal source            |           0 |
| chatcmpl-55189e2e-2a | failed  | revoked tenant model access   |           0 |
+----------------------+---------+-------------------------------+-------------+
(3 rows)

## Capture non-widening: tenant policy narrowed to metadata after a full source was retained
+----------------------+------------+---------------+----------------------+---------------+----------+-----------+
|      public_id       |    role    | tenant_policy | payload_capture_mode | has_canonical | has_body | has_shape |
+----------------------+------------+---------------+----------------------+---------------+----------+-----------+
| chatcmpl-221632eb-f9 | source     | metadata      | full                 | t             | t        | t         |
| chatcmpl-bd5ce21a-5c | descendant | metadata      | metadata             | f             | f        | t         |
+----------------------+------------+---------------+----------------------+---------------+----------+-----------+
(2 rows)

## Current-grant routing applied without widening retained budgets or re-deriving the deadline
+-----------------+-----------------+--------------------------------------+---------------+-------------------+------------+
|      role       |    residency    |          routing_policy_id           | queue_wait_ms | max_cold_start_ms | timeout_ms |
+-----------------+-----------------+--------------------------------------+---------------+-------------------+------------+
| retained source | allow_cold_load |                                      | 1000          | 1000              | 10000      |
| descendant      | required_loaded | 16206e22-a778-43c5-b930-970e5cb0fde6 | 250           | 0                 | 10000      |
+-----------------+-----------------+--------------------------------------+---------------+-------------------+------------+
(2 rows)

## Current grant routing policy for that tenant
+--------------------------------------+----------------------+-------------------+-------------------+
|                 name                 | residency_preference | max_queue_wait_ms | max_cold_start_ms |
+--------------------------------------+----------------------+-------------------+-------------------+
| evidence-narrow-routing-policy-36036 | required_loaded      |               250 |                 0 |
+--------------------------------------+----------------------+-------------------+-------------------+
(1 row)

Border style is 2.
## Descendants stay in the source Tenant (no cross-tenant leakage)
+----------------------+------------------------+------------+
|      public_id       |      tenant_slug       |    role    |
+----------------------+------------------------+------------+
| chatcmpl-f9fde499-cf | evidence-lineage-42501 | source     |
| chatcmpl-0932c37d-b9 | evidence-lineage-42501 | descendant |
| chatcmpl-37946d89-72 | evidence-lineage-42501 | descendant |
| chatcmpl-ad042841-fe | evidence-lineage-42501 | descendant |
+----------------------+------------------------+------------+
(4 rows)
```
</details>
<details>
<summary>Evidence: Reproduction harness: boots the controller HTTP API on a throwaway DB and seeds retry scenarios</summary>

```text
# Evidence harness: boots the real Orchard controller HTTP API against a
# throwaway Postgres database, seeds operator-retry scenarios, then stays alive
# so curl can exercise POST /ops/v1/requests/:id/retry over real HTTP.
require Logger

alias Ecto.Changeset
alias Orchard.Governance
alias Orchard.Governance.RoleBinding
alias Orchard.Models.Access
alias Orchard.Repo
alias Orchard.TestSupport.OperatorRetryFixtures

evidence_dir = System.fetch_env!("EVIDENCE_DIR")
port = String.to_integer(System.get_env("EVIDENCE_HTTP_PORT", "4137"))
db = System.get_env("EVIDENCE_DB", "orchard_retry_evidence")

base = Application.fetch_env!(:orchard_controller, Orchard.Repo)

cfg =
  base
  |> Keyword.delete(:pool)
  |> Keyword.put(:database, db)
  |> Keyword.put(:pool_size, 5)

Application.put_env(:orchard_controller, Orchard.Repo, cfg)

_ = Ecto.Adapters.Postgres.storage_down(cfg)
:ok = Ecto.Adapters.Postgres.storage_up(cfg)

{:ok, _repo} = Repo.start_link()

migrations = Path.join(Application.app_dir(:orchard_controller), "priv/repo/migrations")
Ecto.Migrator.run(Repo, migrations, :up, all: true, log: false, log_migrations_sql: false)

endpoint_config = Application.fetch_env!(:orchard_controller, Orchard.API.Endpoint)

Application.put_env(
  :orchard_controller,
  Orchard.API.Endpoint,
  Keyword.merge(endpoint_config, server: true, http: [ip: {127, 0, 0, 1}, port: port])
)

{:ok, _endpoint} = Orchard.API.Endpoint.start_link()

tenant! = fn prefix, capture_mode ->
  suffix = System.unique_integer([:positive])

  {:ok, tenant} =
    Governance.create_tenant(%{
      slug: "#{prefix}-#{suffix}",
      name: "#{prefix} #{suffix}",
      request_body_capture_mode: capture_mode
    })

  tenant
end

api_client_token! = fn prefix, scope ->
  tenant = tenant!.(prefix, :full)

  {:ok, api_client} =
    Governance.upsert_api_client(tenant, %{
      name: "#{prefix}-client",
      owner_contact: "owner@example.com"
    })

  tenant_scope_id = if scope == :cluster, do: nil, else: tenant.id

  {:ok, _binding} =
    %RoleBinding{}
    |> RoleBinding.changeset(%{
      principal_type: :service_account,
      principal_id: api_client.id,
      role: :operator,
      tenant_scope_id: tenant_scope_id
    })
    |> Repo.insert()

  {:ok, %{token: token}} = Governance.create_api_client_api_token(api_client, %{name: "Primary"})
  token
end

source! = fn prefix, capture_mode, opts ->
  tenant = tenant!.(prefix, capture_mode)
  model = OperatorRetryFixtures.create_granted_model!(tenant)
  source = OperatorRetryFixtures.create_full_legacy_source!(tenant, model, opts)
  %{tenant: tenant, model: model, source: source}
end

operator_token = api_client_token!.("evidence-operator", :cluster)
tenant_scoped_operator_token = api_client_token!.("evidence-tenant-operator", :tenant)

lineage = source!.("evidence-lineage", :full, state: :failed)
negotiated = source!.("evidence-negotiated", :full, state: :failed)

negotiated_source =
  Repo.update!(
    Changeset.change(negotiated.source,
      canonical_request:
        Map.put(negotiated.source.canonical_request, "reasoning", %{"mode" => "negotiated"})
    )
  )

nonterminal = source!.("evidence-nonterminal", :full, state: :running)
revoked = source!.("evidence-revoked", :full, state: :failed)
{:ok, _revocation} = Access.revoke_model_access(revoked.tenant, revoked.model)

narrowed_capture = source!.("evidence-narrowed-capture", :metadata, state: :failed)

{:ok, %{token: tenant_api_key}} =
  Governance.create_api_key(lineage.tenant, %{name: "Tenant Key"})

seed = %{
  base_url: "http://127.0.0.1:#{port}",
  database: db,
  operator_token: operator_token,
  tenant_scoped_operator_token: tenant_scoped_operator_token,
  tenant_api_key: tenant_api_key,
  lineage: %{
    tenant_id: lineage.tenant.id,
    tenant_slug: lineage.tenant.slug,
    source_public_id: lineage.source.public_id,
    source_internal_id: lineage.source.id
  },
  negotiated: %{source_public_id: negotiated_source.public_id},
  nonterminal: %{source_public_id: nonterminal.source.public_id},
  revoked: %{source_public_id: revoked.source.public_id},
  narrowed_capture: %{
    source_public_id: narrowed_capture.source.public_id,
    tenant_capture_mode: to_string(narrowed_capture.tenant.request_body_capture_mode)
  }
}

File.write!(Path.join(evidence_dir, "seed.json"), Jason.encode_to_iodata!(seed))

IO.puts("orchard evidence endpoint listening on http://127.0.0.1:#{port} (db=#{db})")

Process.sleep(:infinity)
```
</details>
<details>
<summary>Evidence: Reproduction harness: curl driver that produced the HTTP transcript</summary>

```text
#!/bin/zsh
# Drives POST /ops/v1/requests/:id/retry over real HTTP and prints an operator transcript.
set -u
EV="${EVIDENCE_DIR}"
SEED="$EV/seed.json"
BASE=$(jq -r .base_url "$SEED")
OPERATOR=$(jq -r .operator_token "$SEED")
TENANT_OPERATOR=$(jq -r .tenant_scoped_operator_token "$SEED")
TENANT_KEY=$(jq -r .tenant_api_key "$SEED")

LINEAGE=$(jq -r .lineage.source_public_id "$SEED")
NEGOTIATED=$(jq -r .negotiated.source_public_id "$SEED")
NONTERMINAL=$(jq -r .nonterminal.source_public_id "$SEED")
REVOKED=$(jq -r .revoked.source_public_id "$SEED")
NARROWED=$(jq -r .narrowed_capture.source_public_id "$SEED")

step() { print -r -- ""; print -r -- "### $1"; }

call() { # call <label> <token-or-"none"> <path>
  local token="$1"; shift
  local req_path="$1"; shift
  if [ "$token" = "none" ]; then
    print -r -- "\$ curl -i -X POST $BASE$req_path"
    curl -sS -o /tmp/_body -w '%{http_code}' -X POST "$BASE$req_path" > /tmp/_code
  else
    print -r -- "\$ curl -i -X POST -H 'authorization: Bearer <token>' $BASE$req_path"
    curl -sS -o /tmp/_body -w '%{http_code}' -X POST \
      -H "authorization: Bearer $token" -H 'accept: application/json' \
      "$BASE$req_path" > /tmp/_code
  fi
  print -r -- "HTTP $(cat /tmp/_code)"
  jq . /tmp/_body 2>/dev/null || cat /tmp/_body
}

retry_path() { print -r -- "/ops/v1/requests/$1/retry"; }

print -r -- "# Orchard operator retry — live HTTP transcript (POST /ops/v1/requests/:id/retry)"
print -r -- "base_url: $BASE"
print -r -- "source Request (terminal \`failed\`, payload_capture_mode=full): $LINEAGE"

step "1. No credentials — operator endpoint rejects the caller"
call none "$(retry_path "$LINEAGE")"

step "2. Public tenant API key (not an operator) — 403"
call "$TENANT_KEY" "$(retry_path "$LINEAGE")"

step "3. Tenant-scoped operator token — 403 (cluster-scoped operator required)"
call "$TENANT_OPERATOR" "$(retry_path "$LINEAGE")"

step "4. Cluster-scoped operator retries the terminal full-capture source — 201 descendant #1"
call "$OPERATOR" "$(retry_path "$LINEAGE")"
D1=$(jq -r .id /tmp/_body)
print -r -- "descendant #1 public_id=$D1"

step "5. Operator retries descendant #1 — lineage stays anchored on the ORIGINAL Request"
call "$OPERATOR" "$(retry_path "$D1")"
D2=$(jq -r .id /tmp/_body)
print -r -- "descendant #2 public_id=$D2 (retry_of_request_id above is still the original, not $D1)"

step "6. Operator retries the original again — 201 descendant #3"
call "$OPERATOR" "$(retry_path "$LINEAGE")"
D3=$(jq -r .id /tmp/_body)
print -r -- "descendant #3 public_id=$D3"

step "7. Fourth retry in the same original lineage — 409 operator_retry_limit_reached"
call "$OPERATOR" "$(retry_path "$LINEAGE")"

step "8. Retained negotiated reasoning evidence — 422 retry_source_unavailable (fail closed until #327)"
call "$OPERATOR" "$(retry_path "$NEGOTIATED")"

step "9. Nonterminal (running) source — 409 retry_source_not_eligible"
call "$OPERATOR" "$(retry_path "$NONTERMINAL")"

step "10. Tenant Model access revoked after the source failed — 409 retry_source_not_authorized"
call "$OPERATOR" "$(retry_path "$REVOKED")"

step "11. Tenant capture policy narrowed to metadata after a full source was retained — 201, capture not widened"
call "$OPERATOR" "$(retry_path "$NARROWED")"
NARROWED_DESCENDANT=$(jq -r .id /tmp/_body)
print -r -- "descendant public_id=$NARROWED_DESCENDANT"

step "12. Unknown request id — 404 request_not_found"
call "$OPERATOR" "$(retry_path "chatcmpl-00000000-0000-4000-a000-000000000000")"

step "13. No public inference retry surface exists (public /v1 namespace)"
call "$TENANT_KEY" "/v1/requests/$LINEAGE/retry"

print -r -- ""
print -r -- "descendant ids: $D1 $D2 $D3 | narrowed-capture descendant: $NARROWED_DESCENDANT"
{
  print -r -- "$D1"
  print -r -- "$D2"
  print -r -- "$D3"
  print -r -- "$NARROWED_DESCENDANT"
} > "$EV/descendants.txt"
rm -f /tmp/_body /tmp/_code
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:155` - `fetch_source_model/1` accepts any `models` row by internal id, so the retry path re-enters admission at SPEC.md §5.2 steps 10-11 (create request record, attempt schedule) while skipping steps 3, 6 and 7. The public path enforces all three in `Orchard.Inference.RequestPreparation.prepare/3`: `resolve_model/1` rejects any model whose `state != :active`, `enforce_context_window/2` checks the model limit, and `authorize_model/1` calls `Orchard.Models.Access.authorize/2`, which fails closed with `:model_not_authorized` when the `tenant_model_access` row is missing or `enabled: false`. None of those run here.

Concrete reachable sequence: tenant T&#39;s chat request for model M fails under `full` capture; an admin then revokes or disables T&#39;s grant for M (`Orchard.Models.Access.revoke_model_access`/`disable_model_access`, audited as `tenant_model_access.revoked`), or M is moved to `:retired`; a cluster operator POSTs `/ops/v1/requests/&lt;source&gt;/retry`; `reserve_locked/1` validates identity agreement only (`model_reference_matches?/3` compares the stored `model_ref` to the same row), creates the descendant, and `dispatch/1` runs real inference and bills usage for a tenant that is no longer authorized for that model.

A second consequence of the same root cause: `resolved_policy` is restored verbatim from the snapshot at operator_retry.ex:310-325, so `tenant_active_limit/1` (request_orchestrator.ex:449) enforces the stale `max_active_requests` instead of the value the current access grant&#39;s routing policy would resolve.

This needs your call rather than a silent fix: either re-resolve the current grant (`Access.authorize/2` plus a `state: :active` check) inside the reservation transaction and fail closed, or record in the OpenSpec design/spec delta that this slice deliberately trusts the operator over SPEC.md §5.2 steps 3/6/7.
- ⚠️ `apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex:23` - `create_descendant/5` ends in `Requests.create_request(attrs)` (operator_retry.ex:404), whose spec is `{:ok, struct()} | {:error, Ecto.Changeset.t()}`. On insert failure the `else` branch in `reserve_locked/1` does `Repo.rollback(changeset)`, and `unwrap_reservation/1` passes it straight out, so `OperatorRetry.reserve/1` and `retry/1` can return `{:error, %Ecto.Changeset{}}` despite their `@spec ... {:error, retry_error()}`.

`send_error/2` in this controller has clauses only for the four retry atoms plus the two control-plane atoms and no catch-all, so a changeset (or any future error atom) raises `FunctionClauseError` and the operator gets a bare 500 with no error envelope instead of a JSON error. `Request.create_changeset/2` declares `unique_constraint(:public_id)`, `unique_constraint(:idempotency_key)`, and `foreign_key_constraint(:model_id | :retry_of_request_id | :service_account_id)`, all of which surface as changeset errors.

Fix: map insert failure to a defined `retry_error()` (e.g. `:retry_source_unavailable`) in `create_descendant/5`, and add a catch-all `send_error/2` clause that returns a stable 500 envelope.
- ⚠️ `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:378` - The module&#39;s documented contract (design.md: &#34;Missing or malformed retained evidence returns `retry_source_unavailable` and rolls back the transaction&#34;) does not hold for two classes of malformed `canonical_request` JSON, both of which raise inside `Repo.transaction/1` and produce an unhandled 500 rather than 422:

1. `decode_canonical_attrs/2` only checks key presence (`required_keys?/2`), and `CanonicalRequest.new/1` permits `admission.timeout_ms: nil` (canonical_request.ex:636). A stored `&#34;admission&#34; =&gt; %{&#34;timeout_ms&#34; =&gt; nil, ...}` therefore passes `build_canonical/1`, and then `CanonicalRequestSerializer.serialize/1` raises `ArgumentError` at canonical_request_serializer.ex:100 (and `RequestDeadline.timeout_at/2` at operator_retry.ex:401 raises for the same input). The public path guards this with `validate_persistable_timeout/1` and rescues serialization via `serialize_canonical_request/1` (request_orchestrator.ex:1569, 3090); neither guard exists here.

2. operator_retry.ex:232 and :234 traverse `canonical[&#34;tooling&#34;][&#34;registry_snapshot&#34;]` before `required_keys?(canonical[&#34;tooling&#34;], @tooling_keys)` proves `tooling` is a map (that check is at line 237). If the stored `tooling` value is a JSON array, `Access.get/3` raises `ArgumentError`; if it is a string or number it raises `FunctionClauseError`. The `with`&#39;s `_invalid -&gt;` else branch catches return values, not exceptions.

Fix: validate `admission.timeout_ms` as a positive integer in `decode_canonical_attrs/2`, reorder the `tooling` map check before its nested reads, and wrap `create_descendant/5`&#39;s serialization the way `serialize_canonical_request/1` already does.
- ⚠️ `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:414` - `dispatch/1` binds `_result = RequestOrchestrator.execute_persisted(...)` and unconditionally returns `{:ok, Requests.get_request!(request.id)}`, so every dispatch failure is swallowed with no log and the endpoint still answers `201 Created`.

The case that matters: `execute_persisted/4` can return `{:error, {:terminal_persist_failed, _}}` (request_orchestrator.ex:283-305), which means the orchestrator could not write the terminal row. The descendant is then left in a non-terminal state (`received`/`dispatching`/`running`) with no request server driving it, and the operator sees `201` with that state and no error signal — the controller test at request_retries_controller_test.exs:99 already has to accept `state in [&#34;received&#34;, &#34;failed&#34;]` because of this.

The returned-row design is defensible (the descendant really was created), so the shape of the response is your call, but the dispatch error should at least be logged, and `terminal_persist_failed` should probably not be reported as success.
- ⚠️ `apps/orchard_controller/test/orchard/requests/operator_retry_test.exs:196` - &#34;serializes concurrent reservations under the original Request lock&#34; cannot exercise the invariant it names. The case is `use Orchard.DataCase, async: false`, and `Orchard.DataCase.setup_sandbox/1` (data_case.ex:50-52) puts the sandbox into `{:shared, self()}` for any non-async test, so all four `Task.async_stream` processes check out the *same* connection. DBConnection serializes their `Repo.transaction/1` calls by itself, which means the 3-created/1-`operator_retry_limit_reached` assertion would pass identically with the `lock(&#34;FOR UPDATE&#34;)` calls at operator_retry.ex:106/133 removed.

Since &#34;atomic three-descendant original lineage&#34; is a stated required behavior of this change (and the spec delta scenario &#34;Four concurrent retry requests target one original&#34;), the cap is currently unverified against real concurrent connections. Run the concurrent arms outside the shared sandbox connection (e.g. `Ecto.Adapters.SQL.Sandbox.unboxed_run/2` with explicit cleanup) so the row lock is actually what produces the result.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:380` - `create_descendant/5`&#39;s 20-key attrs map is a near-exact clone of `RequestOrchestrator.request_attrs/4` (request_orchestrator.ex:1598-1625), differing only in `retry_of_request_id` and how `payload_capture_mode` is derived, and `max_output_tokens/1` (operator_retry.ex:407-411) re-hardcodes the `4_096` default from `effective_max_output_tokens/1` (request_orchestrator.ex:3084-3088).

This duplication is where the divergences above come from, plus one more: the public path runs `AdmissionPolicy.resolve/2` as a pre-persistence fail-safe, whose `cap_timeout_ms/1` clamps the deadline to `Inference.max_request_deadline_ms()` (admission_policy.ex:188-200). The retry path skips it, so if the deployment deadline ceiling was lowered since the source ran, the descendant persists a `timeout_at` above the current ceiling.

The earliest shared boundary is a public request-attrs builder on `RequestOrchestrator` (or a small `Orchard.Requests` helper) that both `persist_request/3` and `create_descendant/5` call, keeping the timeout validation, serialization rescue, and deadline cap in one place.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/capture_policy.ex:141` - `CapturePolicy.narrower/2` is new public API with exactly one call site (operator_retry.ex:374), where `ensure_retryable/1` has already guaranteed `source.payload_capture_mode == :full`. Since `:full` is the lattice maximum, `narrower(:full, tenant_mode)` always returns `tenant_mode`, so the lattice computation is currently a no-op and the effective mode is just the tenant policy resolved by `store?`.

Noting it as a tradeoff rather than a defect: the explicit `narrower/2` call mirrors the SPEC.md §7.3.4 wording (&#34;MUST NOT be wider than either the source Request snapshot or the current Tenant policy&#34;) and keeps the non-widening intent readable if the `:full`-only precondition is ever relaxed. No action needed.

🔧 Fix: harden operator retry authorization, persistence, and dispatch reporting
4 issues (1 warning, 3 infos) still open:
- ⚠️ `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:204` - `current_resolved_policy/2` now adopts the current grant&#39;s `residency_preference`, but the deadline it is paired with is never re-derived under that preference, so the descendant can be permitted to cold-load on a deadline that has no cold-start headroom.

Mechanism: `decode_admission/1` keeps the retained `timeout_ms` verbatim, and `create_descendant/5` reaches the deadline through `RequestOrchestrator.persistable_request_attrs/3`, which calls `AdmissionPolicy.resolve(canonical)` with **no opts**. `policy_timeout?/2` (admission_policy.ex:202) only adds the queue-wait and cold-start budgets when `:max_cold_start_ms` or `:residency_preference` is present in opts, so with empty opts it returns false and `timeout_ms` passes through unchanged. The public path does supply them: `RequestPreparation.authorize_model/1` (request_preparation.ex:173-178) calls `AdmissionPolicy.resolve(canonical, routing_opts)` with the grant&#39;s `residency_preference` and `max_cold_start_ms`.

Concrete sequence: source ran under a grant whose routing policy was `residency_preference: :required_loaded`, so its retained `timeout_ms` is the bare generation budget (e.g. 30_000 ms, no headroom). An admin rebinds the grant to a policy with `residency_preference: :allow_cold_load, max_cold_start_ms: 15_000, max_queue_wait_ms: 3_000`. On retry, `current_resolved_policy/2` writes `:allow_cold_load` and `current_admission/2` writes the 3_000/15_000 budgets, but `timeout_ms` stays 30_000 — so up to 18_000 ms of the absolute deadline can be spent queueing and cold-loading before generation starts, and the descendant is likely to terminalize `timed_out`. A fresh public request under the same grant would have persisted 48_000 ms.

Earliest shared boundary: the fix already created the right seam. Let `persistable_request_attrs/3` accept a `:routing_opts` keyword and forward it to `AdmissionPolicy.resolve/2`, then have `OperatorRetry` pass the `min`-narrowed budgets plus the current residency preference through it, matching `authorize_model/1`. This is ask-user rather than auto-fix because it lets the descendant&#39;s deadline grow relative to the retained snapshot, which is a call you should make explicitly alongside the &#34;without widening retained budgets&#34; invariant you asserted.
- ℹ️ `openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md:46` - The new requirement sentence &#34;SHALL NOT widen a retained queue-wait or cold-start budget beyond the current grant&#39;s budget&#34; is not guaranteed when the current grant&#39;s budget is `0`, which `RoutingPolicy.changeset/2` explicitly permits (`validate_number(..., greater_than_or_equal_to: 0)`, routing_policy.ex:64-65).

`narrower_budget/2` correctly produces `min(retained, 0) == 0`, but `persistable_request_attrs/3` then runs `AdmissionPolicy.resolve(canonical)` whose zero-means-unset fallbacks restore the defaults: `resolve_queue_wait_ms(0, [])` fails the `current &gt; 0` test and returns `@default_queue_wait_ms` (3_000), and `resolve_max_cold_start_ms(0, :allow_cold_load, [])` hits the `current == 0 and residency in [:allow_cold_load, :prefer_loaded]` branch and returns `@default_max_cold_start_ms` (15_000). A grant configured with `max_queue_wait_ms: 0` therefore yields a descendant with a 3_000 ms queue-wait budget.

To be fair to the change: this is a pre-existing quirk of `AdmissionPolicy.resolve/1`-with-empty-opts that `persist_request/3` has always had, so the public path widens identically and the retry path introduces no divergence here. What is new is the written requirement, which now claims a guarantee the code does not provide. The existing coverage does not catch it because &#34;applies the current access grant routing policy without widening retained budgets&#34; pairs `max_cold_start_ms: 0` with `:required_loaded` (which bypasses the upgrade branch) and uses a non-zero `max_queue_wait_ms: 250`. Either soften the requirement to non-zero budgets or route the narrowed budgets through `AdmissionPolicy.resolve/2` opts, which is the same seam as the finding above.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:209` - `current_resolved_policy/2` reads `Keyword.get(routing_opts, :max_active_requests, resolved_policy.max_active_requests)`, but `Access.routing_resolution/1` never emits that key: the no-policy branch returns `AdmissionPolicy.default_routing_opts()` (routing_policy_id, allowed_pool_ids, residency_preference, max_cold_start_ms, queue_wait_ms) and the policy branch returns the same five keys (access.ex:320-332). `routing_policies` has no `max_active_requests` column at all (routing_policy.ex:22-35), so the fallback to the retained snapshot value is taken unconditionally.

This is not a reachable defect today — `%ResolvedPolicy{}` defaults `max_active_requests` to `nil` and nothing in the resolver chain ever sets it, so both the current and retained values are `nil` and `tenant_active_limit/1` (request_orchestrator.ex:449) returns `nil` on every path. The issue is that the accompanying spec delta states Orchard &#34;SHALL resolve the descendant&#39;s routing policy, allowed pools, residency preference, and active-request limit from that current grant&#34;, which cannot hold for the active-request limit until a grant-side source for it exists (SPEC.md:1501 reserves the field but no resolver populates it).

Drop the active-request limit from that requirement sentence, or note it as pending the routing-policy field, so the delta does not assert behavior the code cannot implement.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:474` - `handle_dispatch_result({:error, reason}, request)` calls `log_incomplete_dispatch/2` for every non-`terminal_persist_failed` dispatch error, emitting `Logger.warning(&#34;operator retry dispatch did not complete: ...&#34;)`. But every such error has already been durably terminalized by `fail_and_return_error/4` or `handle_start_failure/3` — the dispatch *did* complete, as a recorded failure, and the function goes on to return `{:ok, refetched}` with that terminal state, which design.md describes as the normal success shape.

So an ordinary, expected outcome (`no_active_nodes` on a cluster with no eligible node) produces an operator-facing warning whose text asserts the opposite of what happened, while the genuinely anomalous case (`terminal_persist_failed`, where the row really is left non-terminal) uses the same wording and level. Split the two: keep the warning for the retained-non-terminal path and log the durably-terminalized path at info with wording like &#34;operator retry dispatch failed&#34;. The bounded identifier set is already correct.

🔧 Fix: preserve retained retry deadline and explicit zero budgets
2 infos still open:
- ℹ️ `apps/orchard_controller/lib/orchard/inference/admission_policy.ex:37` - `:effective_timeout_ms` was added to `@type resolve_opts` (line 29) but deliberately left out of `@resolve_option_keys` (lines 37-46), and nothing records that the omission is intentional.

That omission is load-bearing for the intent&#39;s &#34;no public inference changes&#34; constraint. `ChatRequestNormalizer.normalize/2` builds its policy opts with `policy_opts = Keyword.take(opts, AdmissionPolicy.resolve_option_keys())` (chat_request_normalizer.ex:48) before calling `AdmissionPolicy.resolve/2`, and `ResponsesRequestNormalizer.normalize/2` delegates through it with its own narrower `Keyword.take` allowlist. So today a public `/v1/chat/completions` or `/v1/responses` caller cannot supply `:effective_timeout_ms`, which is what keeps `policy_timeout?/2`&#39;s new short-circuit (line 220) off the public path.

Because `resolve_option_keys/0` is `@doc false` and reads like a mechanical mirror of the type, a future reader is likely to &#34;fix&#34; the mismatch by adding the key — which would silently let a public caller pass an authoritative deadline that bypasses the queue-wait and cold-start derivation in `resolve_timeout_ms/5`. A one-line comment above `@resolve_option_keys` stating that `:effective_timeout_ms` is an internal-caller option excluded from normalizer opts on purpose removes that hazard.
- ℹ️ `apps/orchard_controller/lib/orchard/requests/operator_retry.ex:453` - Recording the concrete shape of the accepted tradeoff, since design.md and the spec delta state it only in the abstract.

For a routing policy configured with `max_queue_wait_ms: 0` or `max_cold_start_ms: 0` while `residency_preference: :allow_cold_load`, the two persistence paths now disagree. The retry path honors the zero: `retained_admission_opts/1` forwards the `narrower_budget/2` result as explicit `:queue_wait_ms`/`:max_cold_start_ms` opts, so `resolve_queue_wait_ms/2` (admission_policy.ex:227) and `resolve_max_cold_start_ms/3` (admission_policy.ex:235) take their `keyword_integer?` branches and return 0. The public path still upgrades it: `persist_request/3` calls `persistable_request_attrs/3` with no `:admission_opts`, so the empty-opts resolve falls into the zero-means-unset fallbacks and persists 3_000 / 15_000.

Observable consequence: a source request admitted under such a grant persists `queue_wait_ms: 3000, max_cold_start_ms: 15000`, and its retry persists `0, 0` — a descendant that can neither queue nor cold-load where its source could. That is exactly the behavior the new spec delta requires (&#34;SHALL NOT widen a retained queue-wait or cold-start budget beyond the current grant&#39;s budget, including a grant budget of zero&#34;), and the residual oddity lives in the pre-existing public-path fallback that you explicitly scoped out of this slice, so no change is needed here. Worth knowing so the divergence is not later misread as a retry defect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/requests/operator_retry_test.exs apps/orchard_controller/test/orchard/api/ops/request_retries_controller_test.exs apps/orchard_controller/test/orchard/inference/admission_policy_test.exs` — 39 passed</code>
- <code>`mise exec -- mix test apps/orchard_controller/test/orchard/inference/request_orchestrator_test.exs apps/orchard_controller/test/orchard/inference/chat_orchestrator_test.exs apps/orchard_controller/test/orchard/requests/capture_policy_test.exs apps/orchard_controller/test/orchard/requests/capture_enforcement_test.exs` — 158 passed (shared admission/orchestrator/capture paths touched by this change)</code>
- <code>Manual end-to-end: booted the real controller HTTP endpoint on `http://127.0.0.1:4137` against a throwaway `orchard_retry_evidence` Postgres database (`EVIDENCE_DIR=… MIX_ENV=test mise exec -- mix run --no-halt retry_evidence_server.exs`), seeded retry scenarios, and drove 16 curl calls against `POST /ops/v1/requests/:id/retry`</code>
- <code>Manual authorization checks over HTTP: no credentials → 401 `invalid_api_key`; public tenant API key → 403 `operator_required`; tenant-scoped operator token → 403 `operator_required`; cluster-scoped operator token → 201</code>
- <code>Manual lineage checks over HTTP: retry of original → 201; retry of a descendant → 201 with `retry_of_request_id` still the original; third retry → 201; fourth → 409 `operator_retry_limit_reached`</code>
- <code>Manual concurrency check: `for i in 1 2 3 4; do curl -X POST …/retry &amp; done; wait` on one fresh original → three 201s + one 409, with exactly 3 descendant rows persisted</code>
- <code>Manual fail-closed checks over HTTP: retained negotiated reasoning → 422 `retry_source_unavailable`; `running` source → 409 `retry_source_not_eligible`; revoked Tenant Model access → 409 `retry_source_not_authorized`; unknown id → 404 `request_not_found` (all with zero descendant rows)</code>
- <code>Manual capture/routing checks: metadata-policy tenant retry → descendant `payload_capture_mode=metadata` with NULL `canonical_request`/`request_payload`; narrower current grant (required_loaded, 250 ms queue-wait, 0 ms cold-start) → descendant records those narrower values and the retained 10000 ms deadline</code>
- <code>Manual no-public-change checks: `POST /v1/requests/:id/retry` → 404; `GET /v1/models` with a tenant key → 200</code>
- <code>Manual persisted-state verification with `psql -d orchard_retry_evidence` (lineage rows, descendant counts, fail-closed zero-row confirmation, capture columns, canonical admission/resolved_policy JSON, tenant scoping)</code>
- <code>Teardown: stopped the evidence controller, confirmed the listener closed, and ran `DROP DATABASE orchard_retry_evidence`; `git status --porcelain` clean</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `openspec/changes/enforce-inference-capture-modes/specs/inference-capture/spec.md:51` - The in-flight `enforce-inference-capture-modes` package still describes operator retry as hypothetical (&#34;A future operator retry SHALL return `retry_source_unavailable`...&#34;, &#34;Any future retry Request MUST snapshot a mode no wider than both...&#34;). Once this slice lands, operator retry exists and the capture no-widening rule is owned by SPEC.md 7.3.4/10.10 plus the new `operator-request-retry` capability, so that wording becomes stale prose that would be carried into `openspec/specs/inference-capture/spec.md` at archive time. Left unedited here: it is another pending change&#39;s normative delta under independent review (its tasks.md 5.2 is still open), and rewriting it from this branch would alter that change&#39;s reviewed intent. Suggested follow-up: drop the &#34;future&#34; framing and reduce those two lines to a pointer at SPEC 7.3.4/10.10 when either package is archived.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a cluster-operator-only endpoint for creating and dispatching bounded retry descendants from retained terminal Request evidence.

- Revalidates current Model state and Tenant Model access before creating a descendant.
- Serializes lineage reservation and limits each original Request to three descendants.
- Reconstructs legacy canonical requests fail-closed and rejects unsupported negotiated reasoning.
- Preserves the retained deadline, narrows current admission and capture policy, and reuses the normal persistence and dispatch lifecycle.
- Adds controller, authorization, malformed-evidence, routing, capture, dispatch-failure, and real-connection concurrency coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

The implementation fail-closes unsupported or malformed retained evidence, rechecks current authorization, atomically enforces the lineage cap, narrows retained policies, and distinguishes durable dispatch failures; the investigated edge cases did not establish a concrete failure.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/orchard_controller/lib/orchard/requests/operator_retry.ex | Implements transactional retry reservation, canonical reconstruction, current authorization checks, capture narrowing, lineage limits, and dispatch-result handling. |
| apps/orchard_controller/lib/orchard/inference/request_orchestrator.ex | Extracts shared persisted-request attribute construction and dispatch entry points while retaining the existing public persistence lifecycle. |
| apps/orchard_controller/lib/orchard/inference/admission_policy.ex | Adds an internal effective-deadline option that preserves explicit budgets without adding deadline headroom twice. |
| apps/orchard_controller/lib/orchard/api/ops/request_retries_controller.ex | Exposes the operator retry operation and maps its defined outcomes to stable JSON error envelopes. |
| apps/orchard_controller/test/orchard/requests/operator_retry_test.exs | Covers eligibility, malformed evidence, authorization, capture and routing policy, lineage, real-connection concurrency, and dispatch persistence failures. |
| openspec/changes/add-operator-request-retry/specs/operator-request-retry/spec.md | Defines the endpoint’s authorization, source eligibility, lineage, current-policy, failure-reporting, and capture guarantees. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Operator
    participant API as Ops Retry API
    participant Retry as OperatorRetry
    participant DB as PostgreSQL
    participant Lifecycle as RequestOrchestrator

    Operator->>API: POST /ops/v1/requests/:id/retry
    API->>API: Verify cluster operator and write authority
    API->>Retry: retry(public_id)
    Retry->>DB: Begin transaction
    Retry->>DB: Lock source, original, and tenant
    Retry->>DB: Check terminal/full source and lineage capacity
    Retry->>DB: Re-resolve active Model and current access
    Retry->>Retry: Rebuild canonical and narrow policy/capture
    Retry->>DB: Insert descendant pointing to original
    DB-->>Retry: Commit descendant
    Retry->>Lifecycle: execute_persisted(descendant, canonical, model)
    Lifecycle-->>Retry: Durable terminal result or incomplete persistence
    Retry-->>API: Created descendant or stable error envelope
    API-->>Operator: 201 / 404 / 409 / 422 / 500 / 503
```
</details>

<sub>Reviews (1): Last reviewed commit: ["no-mistakes(document): document operator..."](https://github.com/kapitan-ai/orchard/commit/63a877d30d7a177ef5ce36e50d4655c13e8fd904) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63007825)</sub>

<!-- /greptile_comment -->