### PR TITLE
test(worker_mlx): cover MLX compatibility regressions

### DIFF
--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -56,7 +56,8 @@ These controls reduce dynamic-code exposure but do not make model execution a se
 
 Residual: signature negotiation drops a distrust keyword argument rather than replacing it with another control.
 Model loading fails closed when signature inspection itself raises, but tokenizer loading falls through to the upstream default in that case, and a loader that no longer accepts the keyword argument silently loses Orchard's explicit setting on both paths.
-`test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust` pins that fallback, asserting that a caller-supplied `trust_remote_code=True` is never forwarded and that stripped loaders still receive verified-local bundle paths.
+`test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust` pins that fallback, asserting that a caller-supplied `trust_remote_code=True` is never forwarded and that stripped loaders still receive local bundle filesystem paths — the caller-supplied weights directory as given and the bundle directory holding the tokenizer assets — rather than a rewritten repo id or remote reference.
+Bundle-relative path verification is a separate control asserted through `load_session` and its `bundle_path_escape` tests.
 Re-audit remote-code exposure whenever the MLX-LM pin moves.
 
 Residual: MLX-LM's `sharded_load` falls back to `{"trust_remote_code": True}` for the tokenizer whenever `tokenizer_config` is omitted or empty, so its model-side `trust_remote_code=False` does not cover the tokenizer by itself.

--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -49,9 +49,15 @@ The dependency still reports version `0.31.3`, so the full Git revision and comm
 Transformers remains constrained to `>=5.7,<5.13` until its broader compatibility matrix is accepted separately.
 
 Orchard rejects model configurations containing `model_file` before upstream loading.
-The production loader also passes `trust_remote_code=False` for model loading and `tokenizer_config_extra={"trust_remote_code": False}` for tokenizer loading.
+Against the pinned commit the production loader passes `trust_remote_code=False` for model loading and `tokenizer_config_extra={"trust_remote_code": False}` for tokenizer loading.
+Both keyword arguments are negotiated against the resolved upstream signature first, because newer MLX-LM loaders reject unknown keyword arguments.
 Resolved-environment tests verify the same explicit settings on MLX-LM's sharded loading surface.
 These controls reduce dynamic-code exposure but do not make model execution a security sandbox.
+
+Residual: signature negotiation drops a distrust keyword argument rather than replacing it with another control.
+Model loading fails closed when signature inspection itself raises, but tokenizer loading falls through to the upstream default in that case, and a loader that no longer accepts the keyword argument silently loses Orchard's explicit setting on both paths.
+`test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust` pins that fallback, asserting that a caller-supplied `trust_remote_code=True` is never forwarded and that stripped loaders still receive verified-local bundle paths.
+Re-audit remote-code exposure whenever the MLX-LM pin moves.
 
 Residual: MLX-LM's `sharded_load` falls back to `{"trust_remote_code": True}` for the tokenizer whenever `tokenizer_config` is omitted or empty, so its model-side `trust_remote_code=False` does not cover the tokenizer by itself.
 Orchard does not reach that path today; issue #116 sharded loading must pass an explicit `{"trust_remote_code": False}` tokenizer config rather than relying on the upstream default.

--- a/native/orchard_worker_mlx/tests/test_generation.py
+++ b/native/orchard_worker_mlx/tests/test_generation.py
@@ -551,6 +551,59 @@ class _LogprobsBatchGenerator(_FakeBatchGenerator):
     response_includes_logprobs = True
 
 
+def test_batch_pre_cancelled_request_does_not_enter_runtime_or_affect_peer() -> None:
+    """Issue #409: pre-cancelled work leaves a batch peer and runtime state isolated."""
+    session = _make_fake_session()
+    session.tokenizer = _ToyTokenizer()
+    runtime = BatchGeneratorRuntime(
+        session,
+        generation_deps=GenerationDeps(
+            stream_generate=lambda *_args, **_kwargs: iter([]),
+            make_sampler=lambda **_kw: MagicMock(),
+        ),
+        batch_deps=BatchGenerationDeps(batch_generator_cls=_FakeBatchGenerator),
+    )
+    cancelled = threading.Event()
+    cancelled.set()
+
+    try:
+        cancelled_events = list(
+            generate_events(
+                session,
+                _make_fake_request(input_tokens=3, max_output_tokens=2),
+                cancelled,
+                deps=runtime.generation_deps(),
+            )
+        )
+        peer_events = list(
+            generate_events(
+                session,
+                _make_fake_request(input_tokens=3, max_output_tokens=2),
+                threading.Event(),
+                deps=runtime.generation_deps(),
+            )
+        )
+    finally:
+        runtime.close()
+
+    assert cancelled_events == [
+        {
+            "kind": "failed",
+            "code": "cancelled",
+            "message": "request cancelled",
+            "retryable": False,
+        }
+    ]
+    assert [event["delta"] for event in peer_events if event["kind"] == "output_text_delta"] == [
+        "A",
+        "B",
+    ]
+    assert [event["kind"] for event in peer_events].count("completed") == 1
+    assert peer_events[-1]["usage"]["output_tokens"] == 2
+    assert runtime._requests_by_id == {}
+    assert runtime._active_by_uid == {}
+
+
 def test_batch_generator_runtime_opt_in_off_emits_no_token_delta_events() -> None:
     session = _make_fake_session()
     session.tokenizer = _ToyTokenizer()
@@ -5016,6 +5069,26 @@ def test_orchard_eos_with_stop_buffer_flushes() -> None:
     assert all_text == "hello"  # entire text flushed
 
     assert events[-1]["finish_reason"] == "FINISH_REASON_STOP"
+
+
+def test_eos_union_flushes_partial_multi_token_stop_sequence() -> None:
+    """Issue #409: every normalized EOS ID stops independently of text stops."""
+    responses = [
+        FakeGenerationResponse(text="answerEN", token=73),
+        FakeGenerationResponse(text="D-after-eos", token=11),
+    ]
+    session = _make_fake_session(eos_token_ids=(41, 73))
+    request = _make_fake_request(stop_sequences=["END"])
+
+    events = _collect_events(session, request, _make_deps(responses))
+
+    assert [event["delta"] for event in events if event["kind"] == "output_text_delta"] == [
+        "answer",
+        "EN",
+    ]
+    assert events[-1]["kind"] == "completed"
+    assert events[-1]["finish_reason"] == "FINISH_REASON_STOP"
+    assert events[-1]["usage"]["output_tokens"] == 1
 
 
 def test_empty_eos_token_ids_does_not_trigger() -> None:

--- a/native/orchard_worker_mlx/tests/test_generation.py
+++ b/native/orchard_worker_mlx/tests/test_generation.py
@@ -575,6 +575,10 @@ def test_batch_pre_cancelled_request_does_not_enter_runtime_or_affect_peer() -> 
                 deps=runtime.generation_deps(),
             )
         )
+        assert runtime._next_request_id == 0
+        assert runtime._requests_by_id == {}
+        assert runtime._active_by_uid == {}
+
         peer_events = list(
             generate_events(
                 session,
@@ -583,6 +587,9 @@ def test_batch_pre_cancelled_request_does_not_enter_runtime_or_affect_peer() -> 
                 deps=runtime.generation_deps(),
             )
         )
+        assert runtime._next_request_id == 1
+        assert runtime._requests_by_id == {}
+        assert runtime._active_by_uid == {}
     finally:
         runtime.close()
 
@@ -600,8 +607,6 @@ def test_batch_pre_cancelled_request_does_not_enter_runtime_or_affect_peer() -> 
     ]
     assert [event["kind"] for event in peer_events].count("completed") == 1
     assert peer_events[-1]["usage"]["output_tokens"] == 2
-    assert runtime._requests_by_id == {}
-    assert runtime._active_by_uid == {}
 
 
 def test_batch_generator_runtime_opt_in_off_emits_no_token_delta_events() -> None:

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -2278,19 +2278,16 @@ class TestDefaultMlxDepsSamplerWiring:
             )
 
         monkeypatch.setattr(ml, "_import_required_mlx_runtime_modules", _fake_import_required)
-        sys.modules["mlx_lm"] = types.SimpleNamespace()
-        sys.modules.pop("mlx_lm.sample_utils", None)
+        monkeypatch.setitem(sys.modules, "mlx_lm", types.SimpleNamespace())
+        monkeypatch.delitem(sys.modules, "mlx_lm.sample_utils", raising=False)
         bundle = tmp_path / "bundle"
         weights = bundle / "weights"
         weights.mkdir(parents=True)
         (weights / "config.json").write_text(json.dumps({"model_type": "llama"}))
 
-        try:
-            deps = _default_mlx_deps()
-            deps.load_model(weights, lazy=True, strict=False, trust_remote_code=True)
-            deps.load_tokenizer(bundle / "tokenizer.json")
-        finally:
-            sys.modules.pop("mlx_lm", None)
+        deps = _default_mlx_deps()
+        deps.load_model(weights, lazy=True, strict=False, trust_remote_code=True)
+        deps.load_tokenizer(bundle / "tokenizer.json")
 
         assert model_calls == [(weights, {"lazy": True, "strict": False})]
         assert tokenizer_calls == [bundle]

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -2245,6 +2245,56 @@ class TestDefaultMlxDepsSamplerWiring:
             trust_remote_code=False,
         )
 
+    def test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        """Issue #409: loaders without the trust kwargs still receive local paths only."""
+        import orchard_worker_mlx.model_loader as ml
+
+        model_calls: list[tuple[Any, dict[str, Any]]] = []
+        tokenizer_calls: list[Any] = []
+
+        def narrow_load_model(model_path, lazy=False, strict=True):
+            model_calls.append((model_path, {"lazy": lazy, "strict": strict}))
+            return (MagicMock(name="model"), {"model_type": "llama"})
+
+        def narrow_load_tokenizer(tokenizer_dir):
+            tokenizer_calls.append(tokenizer_dir)
+            return MagicMock(name="tokenizer")
+
+        fake_mx = types.SimpleNamespace(
+            eval=lambda t: None,
+            clear_cache=lambda: None,
+        )
+
+        def _fake_import_required():
+            return (
+                fake_mx,
+                MagicMock(name="stream_generate"),
+                narrow_load_model,
+                narrow_load_tokenizer,
+            )
+
+        monkeypatch.setattr(ml, "_import_required_mlx_runtime_modules", _fake_import_required)
+        sys.modules["mlx_lm"] = types.SimpleNamespace()
+        sys.modules.pop("mlx_lm.sample_utils", None)
+        bundle = tmp_path / "bundle"
+        weights = bundle / "weights"
+        weights.mkdir(parents=True)
+        (weights / "config.json").write_text(json.dumps({"model_type": "llama"}))
+
+        try:
+            deps = _default_mlx_deps()
+            deps.load_model(weights, lazy=True, strict=False, trust_remote_code=True)
+            deps.load_tokenizer(bundle / "tokenizer.json")
+        finally:
+            sys.modules.pop("mlx_lm", None)
+
+        assert model_calls == [(weights, {"lazy": True, "strict": False})]
+        assert tokenizer_calls == [bundle]
+
     def test_default_mlx_deps_rejects_model_file_config_before_upstream_load_model(
         self,
         monkeypatch,

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -6,6 +6,7 @@ import json
 import shutil
 import sys
 import types
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -717,6 +718,31 @@ def test_load_session_tokenizer_receives_resolved_path(writable_bundle: Path) ->
     )
     assert len(captured_paths) == 1
     assert captured_paths[0].endswith("tokenizer.json")
+
+
+def test_spec_6_4_loader_uses_verified_local_paths_despite_misleading_bundle_name(
+    writable_bundle: Path,
+) -> None:
+    """A bundle name never replaces manifest identity or its local artifact paths."""
+    misleading_bundle = writable_bundle.with_name("remote-tool-model-reasoning-capable")
+    writable_bundle.rename(misleading_bundle)
+
+    base_deps = _make_fake_deps(model_config={"model_type": "misleading-family"})
+    load_model = MagicMock(wraps=base_deps.load_model)
+    load_tokenizer = MagicMock(wraps=base_deps.load_tokenizer)
+    deps = replace(base_deps, load_model=load_model, load_tokenizer=load_tokenizer)
+
+    session = load_session(
+        model_id="test-org/tiny-llm",
+        version="mlx-q4-v1",
+        model_path=str(misleading_bundle),
+        deps=deps,
+    )
+
+    load_model.assert_called_once_with(misleading_bundle / "weights", lazy=True, strict=False)
+    load_tokenizer.assert_called_once_with(misleading_bundle / "tokenizer.json")
+    assert session.manifest.model_id == "test-org/tiny-llm"
+    assert session.bundle_path == misleading_bundle
 
 
 def test_load_session_model_load_failure(writable_bundle: Path) -> None:

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -743,6 +743,8 @@ def test_spec_6_4_loader_uses_verified_local_paths_despite_misleading_bundle_nam
     load_tokenizer.assert_called_once_with(misleading_bundle / "tokenizer.json")
     assert session.manifest.model_id == "test-org/tiny-llm"
     assert session.bundle_path == misleading_bundle
+    assert session.eos_token_ids == ()
+    assert session.tool_calling == {"supported": False, "parser_type": None}
 
 
 def test_load_session_model_load_failure(writable_bundle: Path) -> None:

--- a/native/orchard_worker_mlx/tests/test_prefix_cache.py
+++ b/native/orchard_worker_mlx/tests/test_prefix_cache.py
@@ -128,6 +128,28 @@ class TestPromptCacheLength:
         cache = [BoolEntry()]
         assert prompt_cache_length(cache) == 0
 
+    def test_composite_cache_ignores_untouched_slots(self) -> None:
+        """Partially populated hybrid caches report only populated entry lengths."""
+        cache = [FakeOffsetEntry(10), None, FakeSizeEntry(12)]
+
+        assert prompt_cache_length(cache) == 12
+
+
+@pytest.mark.parametrize("cache_factory", [KVPrefixCache, TriePrefixCache])
+def test_hybrid_cache_lookup_preserves_untouched_slots(cache_factory: Any) -> None:
+    """Issue #409: cache lookup must preserve partial hybrid cache slots."""
+    cache = cache_factory(max_entries=2)
+    original = [FakeOffsetEntry(3), None, FakeSizeEntry(3)]
+    cache.store([11, 12, 13], original)
+
+    hit = cache.lookup([11, 12], trim_fn=fake_trim)
+
+    assert hit is not None
+    assert hit.remaining_ids == [12]
+    assert hit.prompt_cache[1] is None
+    assert prompt_cache_length(hit.prompt_cache) == 1
+    assert prompt_cache_length(original) == 3
+
 
 # ---------------------------------------------------------------------------
 # Tests: KVPrefixCache basic operations


### PR DESCRIPTION
## Intent

Resolve Draft PR #424 review thread 3988461296 by making only the test-isolation correction in the native orchard_worker_mlx narrow-signature mlx_lm test: use pytest monkeypatch so pre-existing sys.modules entries are restored. Make no production changes, model downloads or inference, loader refactor, or unrelated #409 coverage changes. Validate the focused regression and the complete native-worker Ruff, pytest, and coverage workflow; update the same Draft PR and resolve only this fixed thread.

## What Changed

- Added issue #409 regression tests to the MLX worker suite: a pre-cancelled batch request never enters `BatchGeneratorRuntime` state and leaves a co-resident batch peer's stream intact, every normalized EOS id stops generation independently of text stop sequences, hybrid prefix-cache lookups preserve untouched `None` slots (parametrized over `KVPrefixCache` and `TriePrefixCache`) without mutating the stored cache, and a misleading bundle directory name never displaces manifest identity or the resolved local weights/tokenizer paths.
- Added `test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust`, which pins the trust-kwarg signature-negotiation fallback: when the resolved MLX-LM loaders do not accept `trust_remote_code`, the wrapper strips a caller-supplied `trust_remote_code=True` rather than forwarding it, and passes the caller's local bundle paths through unchanged. The test patches `sys.modules` through pytest `monkeypatch` so pre-existing `mlx_lm` and `mlx_lm.sample_utils` entries are restored on teardown instead of being evicted for the rest of the session.
- Documented that fallback and its residual remote-code exposure in `native/orchard_worker_mlx/README.md`, worded to match only what the test asserts, and pointed bundle-relative path verification at the separate `load_session` `bundle_path_escape` tests. No production code changed on this branch.

## Risk Assessment

✅ Low: The only new commit narrows a README security-residual sentence to exactly what the cited test asserts and correctly attributes bundle-path verification to the three existing `load_session` `bundle_path_escape` tests, leaving the branch a tests-and-docs-only change whose sole functional edit remains the pytest-monkeypatch sys.modules isolation fix.

## Testing

I exercised the focused #409 narrow-signature regression test and then demonstrated the actual review-thread intent — pre-existing `sys.modules` entries being restored — with a before/after probe that seeds an existing `mlx_lm` import around the test: the pre-fix body evicts both `mlx_lm` and `mlx_lm.sample_utils` (and a later import returns a different module object), while the committed monkeypatch version leaves the identical modules intact, confirmed both with synthetic modules and with the real installed mlx-lm 0.31.3 extra resolved offline from cache. A mutation of the production trust-kwarg strip made the test fail as expected, so the regression still guards real behavior, and the production tree was reverted and confirmed unchanged (the branch contains no production edits, no model downloads, and no inference). I also ran an ordered same-session run of the loader tests plus the real import-smoke guards (128 passed), the complete native-worker pytest suite (764 passed, 2 pre-existing bundle-path skips), and the coverage run (model_loader.py 93%, total 85%); Ruff was deliberately not run because linting belongs to the lint phase. Evidence is CLI transcripts rather than visuals since this change is a Python test-isolation fix with no rendered surface.

<details>
<summary>Evidence: Isolation before/after against the real installed mlx-lm 0.31.3 runtime</summary>

<code>### PRE-FIX test body vs the REAL installed mlx-lm 0.31.3 runtime ###&#10;[probe] BEFORE test: mlx_lm -&gt; installed module at .../site-packages/mlx_lm/__init__.py&#10;[probe] BEFORE test: mlx_lm.sample_utils -&gt; installed module at .../site-packages/mlx_lm/sample_utils.py&#10;[probe] AFTER test: mlx_lm -&gt; EVICTED from sys.modules&#10;[probe] AFTER test: mlx_lm.sample_utils -&gt; EVICTED from sys.modules&#10;[probe] consequence: a later `import mlx_lm` now returns a DIFFERENT object&#10;[probe] RESULT: TEST ISOLATION VIOLATED — the installed mlx-lm runtime other tests import was not restored: [&#39;mlx_lm&#39;, &#39;mlx_lm.sample_utils&#39;]&#10;&#10;### FIXED committed test vs the REAL installed mlx-lm 0.31.3 runtime ###&#10;[probe] BEFORE test: mlx_lm -&gt; installed module at .../site-packages/mlx_lm/__init__.py&#10;[probe] BEFORE test: mlx_lm.sample_utils -&gt; installed module at .../site-packages/mlx_lm/sample_utils.py&#10;[probe] AFTER test: mlx_lm -&gt; still the same installed module object&#10;[probe] AFTER test: mlx_lm.sample_utils -&gt; still the same installed module object&#10;[probe] RESULT: TEST ISOLATION HELD — the real installed mlx-lm runtime is intact for every later test in the same session.</code>

```text
### PRE-FIX test body vs the REAL installed mlx-lm 0.31.3 runtime ###

[probe] importing the real optional MLX runtime before tests_isolation_evidence/test_prefix_replica.py::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
[probe]   BEFORE test: mlx_lm -> installed module at .../site-packages/mlx_lm/__init__.py
[probe]   BEFORE test: mlx_lm.sample_utils -> installed module at .../site-packages/mlx_lm/sample_utils.py
.[probe] teardown finished for tests_isolation_evidence/test_prefix_replica.py::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
[probe]   AFTER  test: mlx_lm -> EVICTED from sys.modules
[probe]   AFTER  test: mlx_lm.sample_utils -> EVICTED from sys.modules
[probe]   consequence: a later `import mlx_lm` now returns a DIFFERENT object

[probe] RESULT: TEST ISOLATION VIOLATED — the installed mlx-lm runtime other tests import was not restored: ['mlx_lm', 'mlx_lm.sample_utils']

=============================== warnings summary ===============================
tests_isolation_evidence/test_prefix_replica.py::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

tests_isolation_evidence/test_prefix_replica.py::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

### FIXED committed test vs the REAL installed mlx-lm 0.31.3 runtime ###
[probe]   BEFORE test: mlx_lm -> installed module at .../site-packages/mlx_lm/__init__.py
[probe]   BEFORE test: mlx_lm.sample_utils -> installed module at .../site-packages/mlx_lm/sample_utils.py
.[probe] teardown finished for tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
[probe]   AFTER  test: mlx_lm -> still the same installed module object
[probe]   AFTER  test: mlx_lm.sample_utils -> still the same installed module object

[probe] RESULT: TEST ISOLATION HELD — the real installed mlx-lm runtime is intact for every later test in the same session.

=============================== warnings summary ===============================
tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust

tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
</details>
<details>
<summary>Evidence: Isolation before/after with synthetic pre-existing sys.modules entries</summary>

<code>### BEFORE the fix (replica of pre-fix test body) ###&#10;[probe] BEFORE test: mlx_lm=&lt;pre-existing module, marker=&#39;real-mlx_lm-imported-by-an-earlier-test&#39;&gt;&#10;[probe] AFTER test: mlx_lm=&lt;ABSENT from sys.modules&gt;&#10;[probe] AFTER test: mlx_lm.sample_utils=&lt;ABSENT from sys.modules&gt;&#10;[probe] RESULT: TEST ISOLATION VIOLATED — pre-existing sys.modules entries were not restored: [&#39;mlx_lm&#39;, &#39;mlx_lm.sample_utils&#39;]&#10;&#10;### AFTER the fix (committed test, monkeypatch.setitem/delitem) ###&#10;[probe] BEFORE test: mlx_lm=&lt;pre-existing module, marker=&#39;real-mlx_lm-imported-by-an-earlier-test&#39;&gt;&#10;[probe] AFTER test: mlx_lm=&lt;pre-existing module, marker=&#39;real-mlx_lm-imported-by-an-earlier-test&#39;&gt;&#10;[probe] AFTER test: mlx_lm.sample_utils=&lt;pre-existing module, marker=&#39;real-mlx_lm.sample_utils-imported-earlier&#39;&gt;&#10;[probe] RESULT: TEST ISOLATION HELD — every pre-existing sys.modules entry was restored to the identical module object after the test.</code>

```text
### BEFORE the fix (replica of pre-fix test body) ###

[probe] simulating an earlier real import before tests_isolation_evidence/test_prefix_replica.py::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
[probe]   BEFORE test: mlx_lm=<pre-existing module, marker='real-mlx_lm-imported-by-an-earlier-test'>
[probe]   BEFORE test: mlx_lm.sample_utils=<pre-existing module, marker='real-mlx_lm.sample_utils-imported-earlier'>
.[probe] teardown finished for tests_isolation_evidence/test_prefix_replica.py::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
[probe]   AFTER  test: mlx_lm=<ABSENT from sys.modules>
[probe]   AFTER  test: mlx_lm.sample_utils=<ABSENT from sys.modules>

[probe] RESULT: TEST ISOLATION VIOLATED — pre-existing sys.modules entries were not restored: ['mlx_lm', 'mlx_lm.sample_utils']


### AFTER the fix (committed test, monkeypatch.setitem/delitem) ###

[probe] simulating an earlier real import before tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
[probe]   BEFORE test: mlx_lm=<pre-existing module, marker='real-mlx_lm-imported-by-an-earlier-test'>
[probe]   BEFORE test: mlx_lm.sample_utils=<pre-existing module, marker='real-mlx_lm.sample_utils-imported-earlier'>
.[probe] teardown finished for tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
[probe]   AFTER  test: mlx_lm=<pre-existing module, marker='real-mlx_lm-imported-by-an-earlier-test'>
[probe]   AFTER  test: mlx_lm.sample_utils=<pre-existing module, marker='real-mlx_lm.sample_utils-imported-earlier'>

[probe] RESULT: TEST ISOLATION HELD — every pre-existing sys.modules entry was restored to the identical module object after the test.
```
</details>
<details>
<summary>Evidence: Mutation check: the regression test still fails when production stops stripping the trust kwarg</summary>

<code>if accepts_trust:&#10;kwargs[&#34;trust_remote_code&#34;] = False&#10;else:&#10;pass # MUTATION: stop stripping the unsupported trust kwarg&#10;&#10;&gt; return mlx_lm_load(Path(model_path), **kwargs)&#10;E TypeError: ...narrow_load_model() got an unexpected keyword argument &#39;trust_remote_code&#39;&#10;src/orchard_worker_mlx/model_loader.py:622: TypeError&#10;FAILED tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust&#10;(production file reverted afterwards; git status --porcelain empty)</code>

```text
### Mutation check: production loader stops stripping the unsupported trust kwarg ###
            params = inspect.signature(mlx_lm_load).parameters
            accepts_trust = "trust_remote_code" in params or any(
                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
            )
        except (TypeError, ValueError):
            # Fail closed: if signature inspection fails, still force disable.
            accepts_trust = True
    
        if accepts_trust:
            kwargs["trust_remote_code"] = False
        else:
            pass  # MUTATION: stop stripping the unsupported trust kwarg
    
>       return mlx_lm_load(Path(model_path), **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: TestDefaultMlxDepsSamplerWiring.test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust.<locals>.narrow_load_model() got an unexpected keyword argument 'trust_remote_code'

src/orchard_worker_mlx/model_loader.py:622: TypeError
=========================== short test summary info ============================
FAILED tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust
```
</details>
<details>
<summary>Evidence: README-cited guarantees pass together</summary>

<code>tests/test_model_loader.py::test_load_session_rejects_absolute_entrypoint PASSED&#10;tests/test_model_loader.py::test_load_session_rejects_parent_traversal_entrypoint PASSED&#10;tests/test_model_loader.py::test_load_session_rejects_parent_traversal_tokenizer PASSED&#10;tests/test_model_loader.py::test_load_session_tokenizer_receives_resolved_path PASSED&#10;tests/test_model_loader.py::test_spec_6_4_loader_uses_verified_local_paths_despite_misleading_bundle_name PASSED&#10;tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust PASSED&#10;6 passed, 118 deselected</code>

```text
### README-cited guarantees exercised together (native/orchard_worker_mlx) ###
tests/test_model_loader.py::test_load_session_rejects_absolute_entrypoint PASSED [ 16%]
tests/test_model_loader.py::test_load_session_rejects_parent_traversal_entrypoint PASSED [ 33%]
tests/test_model_loader.py::test_load_session_rejects_parent_traversal_tokenizer PASSED [ 50%]
tests/test_model_loader.py::test_load_session_tokenizer_receives_resolved_path PASSED [ 66%]
tests/test_model_loader.py::test_spec_6_4_loader_uses_verified_local_paths_despite_misleading_bundle_name PASSED [ 83%]
tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust PASSED [100%]
====================== 6 passed, 118 deselected in 0.03s =======================
```
</details>
<details>
<summary>Evidence: Ordered same-session run with the real mlx extra (no cross-test contamination)</summary>

<code>### Ordered same-session run against the real mlx-lm 0.31.3 extra: #409 loader tests first, then the audited import-smoke guards ###&#10;128 passed, 2 warnings in 0.69s</code>

```text
### Ordered same-session run against the real mlx-lm 0.31.3 extra: #409 loader tests first, then the audited import-smoke guards ###
........................................................................ [ 56%]
........................................................                 [100%]
tests/test_mlx_import_smoke.py::test_mlx_lm_imports_with_autotokenizer_path
tests/test_mlx_import_smoke.py::test_mlx_lm_imports_with_autotokenizer_path
128 passed, 2 warnings in 0.69s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `native/orchard_worker_mlx/README.md:59` - The MLX-LM security-baseline residual note says the narrow-signature test asserts &#34;stripped loaders still receive verified-local bundle paths&#34;, but the test never exercises Orchard&#39;s path verification. `test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust` (tests/test_model_loader.py:2248) builds `tmp_path/bundle/weights` by hand and calls `deps.load_model(...)` / `deps.load_tokenizer(...)` directly on `_default_mlx_deps()`; it bypasses `load_session()` and therefore `_resolve_bundle_subpath()` (model_loader.py:893), which is where bundle-relative paths are actually verified against escape and absolute-path rejection. What the test genuinely pins is (a) a caller-supplied `trust_remote_code=True` is stripped rather than forwarded, and (b) the wrapper forwards the caller-supplied local path unchanged without rewriting it into a repo id or remote reference. Because this paragraph is the repo&#39;s standing record of a remote-code-execution residual, the current wording implies more assurance than the cited test provides. Suggested narrowing: &#34;and that the caller-supplied local bundle paths are forwarded unchanged&#34;. This is the author&#39;s deliberate security-posture wording, so worth confirming rather than silently rewriting.

🔧 Fix: narrow MLX trust-kwarg residual doc to tested guarantees
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`mise exec -- uv run --directory native/orchard_worker_mlx pytest tests/test_model_loader.py -k &#34;narrow_signature_loaders_stay_local_and_strip_trust&#34; -v` (focused regression, passes)</code>
- <code>Isolation probe (transient pytest plugin seeding pre-existing `mlx_lm`/`mlx_lm.sample_utils` before the target test, reporting state after teardown) run against a verbatim replica of the pre-fix body from `git show e0d5bbf0^` → ISOLATION VIOLATED (both entries evicted)</code>
- <code>Same probe run against the committed test `tests/test_model_loader.py::TestDefaultMlxDepsSamplerWiring::test_default_mlx_deps_narrow_signature_loaders_stay_local_and_strip_trust` → ISOLATION HELD (identical module objects restored)</code>
- <code>Both probe runs repeated against the real installed optional runtime via `mise exec -- uv run --offline --directory native/orchard_worker_mlx --extra mlx pytest ... -p _real_mlx_isolation_probe -s` (mlx-lm 0.31.3 from uv cache; pre-fix run also showed a later `import mlx_lm` returning a different object)</code>
- <code>Ordered same-session cross-contamination check: `mise exec -- uv run --offline --directory native/orchard_worker_mlx --extra mlx pytest tests/test_model_loader.py tests/test_mlx_import_smoke.py -o addopts= -q` → 128 passed (target test co-resident with the audited real-import guards)</code>
- <code>Mutation check that the regression test has teeth: replaced `kwargs.pop(&#34;trust_remote_code&#34;, None)` in `src/orchard_worker_mlx/model_loader.py` with a no-op, reran the focused test → FAILED with `narrow_load_model() got an unexpected keyword argument &#39;trust_remote_code&#39;`, then reverted the production file (verified via `git status --porcelain`)</code>
- <code>README-cited guarantees: `mise exec -- uv run --directory native/orchard_worker_mlx pytest tests/test_model_loader.py -o addopts= -k &#34;narrow_signature or rejects_absolute_entrypoint or rejects_parent_traversal or misleading_bundle_name or tokenizer_receives_resolved_path&#34; -v` → 6 passed (confirms the `bundle_path_escape` load_session controls the narrowed doc text now points at actually exist and pass)</code>
- <code>`mise exec -- uv run --directory native/orchard_worker_mlx pytest` → 764 passed, 2 skipped (skips are pre-existing CLI MLX smoke tests requiring `ORCHARD_MLX_SMOKE_MODEL_PATH`)</code>
- <code>`mise exec -- uv run --directory native/orchard_worker_mlx pytest --cov` → model_loader.py 93%, prefix_cache.py 94%, generation.py 87%, TOTAL 85%</code>
- <code>Cleanup: removed transient probe plugins and replica test, pruned the temporarily installed mlx extra with `mise exec -- uv sync --exact --offline --directory native/orchard_worker_mlx`, removed the generated `.coverage`, and confirmed `git status --porcelain` is empty</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deterministic, model-free regression coverage for MLX worker compatibility and lifecycle behavior.
- Covers EOS-union stopping while flushing buffered partial text-stop content.
- Verifies pre-cancelled requests do not enter shared batch state or affect a peer.
- Exercises misleading bundle names, narrow loader signatures, and local-path handling without enabling remote-code trust.
- Covers partially populated composite prefix caches while preserving untouched slots.
- Documents the security limitations of dependency-signature negotiation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

The previous import-state finding is resolved, and the latest changes safely restore module state while correcting the README’s description of what the loader test verifies. The additive tests exercise the intended MLX generation, loading, cancellation, and cache invariants without changing production behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| native/orchard_worker_mlx/README.md | Clarifies trust-keyword signature negotiation, its residual exposure, and the distinction between local-path forwarding and bundle-path verification. |
| native/orchard_worker_mlx/tests/test_generation.py | Adds focused coverage for secondary EOS handling and pre-cancellation isolation with runtime state checked before shutdown. |
| native/orchard_worker_mlx/tests/test_model_loader.py | Adds misleading-name and narrow-signature loader tests while safely restoring mocked import state through monkeypatch. |
| native/orchard_worker_mlx/tests/test_prefix_cache.py | Adds composite-cache length and hybrid-slot preservation coverage for both prefix-cache implementations. |

</details>

<sub>Reviews (2): Last reviewed commit: ["no-mistakes(review): narrow MLX trust-kw..."](https://github.com/kapitan-ai/orchard/commit/d136204c9f2ada3e9cdad7295a25c8ef6c56741d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63029647)</sub>

<!-- /greptile_comment -->