### PR TITLE
test: cover partial prefill peer cancellation

### DIFF
--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -41,6 +41,31 @@ The worker `GetStatus` path reports overlapping `Generate` calls and effective w
 The node-agent publishes aggregate capacity through cluster `StatusResponse.active_request_count` and `StatusResponse.max_concurrency`, plus loaded-placement capacity through `StatusResponse.runtime_model_placements`.
 Aggregate capacity is the conservative limit the node agent enforces across loaded workers, while each loaded placement keeps its own reported capacity.
 
+## Model-free regression evidence
+
+Issue #409 keeps compatibility and lifecycle regression evidence separate from
+model qualification. The native suite covers normalized EOS IDs independently
+of text stop sequences, manifest identity and bundle-relative paths despite
+misleading names, and empty, partial, and hybrid prefix-cache snapshots.
+
+`test_batch_partial_prefill_cancel_preserves_peer_events_until_batch_cleanup`
+holds two synthetic requests in one batch after partial prefill, cancels one,
+and proves the other retains its output, exact usage, and one completion while
+the shared runtime retains both active entries until the batch returns terminal
+responses. It then proves the request and detokenizer registries are empty.
+`test_batch_generator_runtime_cancel_resets_after_bounded_drain_timeout` covers
+the distinct reset policy: an undrained cancellation resets the shared batch
+and gives other active requests a retryable collateral failure. It is not a
+peer-preservation path.
+
+These tests use fake generation dependencies and do not establish MLX-LM cache
+reachability, real Metal behavior, model compatibility, Apple Silicon hardware
+qualification, or a support claim. Those cases require an exact artifact,
+pinned runtime, Apple Silicon host, verified-local/offline load, and scoped
+ADR 0028 qualification evidence.
+Runtime-local registry cleanup does not prove Controller dispatch-capacity
+release.
+
 ## MLX-LM security baseline
 
 The `mlx` extra pins MLX-LM commit `ab1806e8f5d6aa035973af194a1b9198ab4754dc`.

--- a/native/orchard_worker_mlx/tests/test_generation.py
+++ b/native/orchard_worker_mlx/tests/test_generation.py
@@ -1906,6 +1906,7 @@ def test_batch_partial_prefill_cancel_preserves_peer_events_until_batch_cleanup(
         def __init__(self, _model: Any, **_kwargs: Any) -> None:
             self._next_uid = 0
             self._active: list[int] = []
+            self._step = 0
             self.prefill_started = threading.Event()
             self.release_responses = threading.Event()
             self.__class__.instances.append(self)
@@ -1926,17 +1927,25 @@ def test_batch_partial_prefill_cancel_preserves_peer_events_until_batch_cleanup(
             return uids
 
         def next(self) -> tuple[list[Any], list[Any]]:
-            if not self.prefill_started.is_set():
+            active = list(self._active)
+            if self._step == 0:
+                self._step += 1
+                return (
+                    [
+                        _prompt_response(active[0], 10, 100),
+                        _prompt_response(active[1], 20, 100),
+                    ],
+                    [],
+                )
+
+            if self._step == 1:
+                self._step += 1
                 self.prefill_started.set()
                 self.release_responses.wait(timeout=5.0)
 
-            active = list(self._active)
             self._active.clear()
             return (
-                [
-                    _prompt_response(active[0], 10, 100),
-                    _prompt_response(active[1], 20, 100),
-                ],
+                [],
                 [
                     _batch_response(active[0], token=11, finish_reason="stop"),
                     _batch_response(active[1], token=21, finish_reason="stop"),
@@ -1999,6 +2008,15 @@ def test_batch_partial_prefill_cancel_preserves_peer_events_until_batch_cleanup(
 
         generator = _PartialPrefillBatchGenerator.instances[0]
         assert generator.prefill_started.wait(timeout=2.0)
+        assert _wait_until(
+            lambda: (
+                runtime._active_by_uid[0].last_prefill_progress == (10, 100)
+                and runtime._active_by_uid[1].last_prefill_progress == (20, 100)
+            )
+        )
+        with runtime._cv:
+            assert runtime._active_by_uid[0].last_prefill_progress == (10, 100)
+            assert runtime._active_by_uid[1].last_prefill_progress == (20, 100)
         cancelled.set()
         assert _wait_until(
             lambda: len([event for event in cancelled_events if event["kind"] == "failed"]) == 1

--- a/native/orchard_worker_mlx/tests/test_generation.py
+++ b/native/orchard_worker_mlx/tests/test_generation.py
@@ -1895,6 +1895,156 @@ def test_batch_prefill_attribution_detaches_closed_member_before_finalize(
     assert runtime._prefill_attribution_by_insert_set_id == {}
 
 
+def test_batch_partial_prefill_cancel_preserves_peer_events_until_batch_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #409: cancelling one prefill peer does not terminalize the other peer."""
+
+    class _PartialPrefillBatchGenerator:
+        instances: list[_PartialPrefillBatchGenerator] = []
+
+        def __init__(self, _model: Any, **_kwargs: Any) -> None:
+            self._next_uid = 0
+            self._active: list[int] = []
+            self.prefill_started = threading.Event()
+            self.release_responses = threading.Event()
+            self.__class__.instances.append(self)
+
+        def insert(
+            self,
+            prompts: list[list[int]],
+            max_tokens: list[int],
+            caches: list[Any] | None = None,
+            samplers: list[Any] | None = None,
+            logits_processors: list[Any] | None = None,
+            **_kwargs: Any,
+        ) -> list[int]:
+            del max_tokens, caches, samplers, logits_processors
+            uids = list(range(self._next_uid, self._next_uid + len(prompts)))
+            self._next_uid += len(prompts)
+            self._active.extend(uids)
+            return uids
+
+        def next(self) -> tuple[list[Any], list[Any]]:
+            if not self.prefill_started.is_set():
+                self.prefill_started.set()
+                self.release_responses.wait(timeout=5.0)
+
+            active = list(self._active)
+            self._active.clear()
+            return (
+                [
+                    _prompt_response(active[0], 10, 100),
+                    _prompt_response(active[1], 20, 100),
+                ],
+                [
+                    _batch_response(active[0], token=11, finish_reason="stop"),
+                    _batch_response(active[1], token=21, finish_reason="stop"),
+                ],
+            )
+
+        def close(self) -> None:
+            self.release_responses.set()
+
+    delayed_pumps: list[threading.Thread] = []
+    original_start = threading.Thread.start
+
+    def delay_pump_start(thread: threading.Thread) -> None:
+        if thread.name == "mlx-batch-generator":
+            delayed_pumps.append(thread)
+            return
+        original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", delay_pump_start)
+
+    session = _make_fake_session()
+    session.tokenizer = _ToyTokenizer()
+    runtime = BatchGeneratorRuntime(
+        session,
+        generation_deps=GenerationDeps(
+            stream_generate=lambda *_args, **_kwargs: iter([]),
+            make_sampler=lambda **_kw: MagicMock(),
+        ),
+        batch_deps=BatchGenerationDeps(batch_generator_cls=_PartialPrefillBatchGenerator),
+    )
+    cancelled = threading.Event()
+    cancelled_events: list[dict[str, Any]] = []
+    peer_events: list[dict[str, Any]] = []
+
+    def run(events: list[dict[str, Any]], request: Any, cancel_event: threading.Event) -> None:
+        events.extend(
+            generate_events(session, request, cancel_event, deps=runtime.generation_deps())
+        )
+
+    cancelled_thread = threading.Thread(
+        target=run,
+        args=(cancelled_events, _make_fake_request(input_tokens=3, max_output_tokens=2), cancelled),
+    )
+    peer_thread = threading.Thread(
+        target=run,
+        args=(
+            peer_events,
+            _make_fake_request(input_tokens=3, max_output_tokens=2),
+            threading.Event(),
+        ),
+    )
+
+    try:
+        cancelled_thread.start()
+        assert _wait_until(lambda: len(runtime._requests_by_id) == 1)
+        peer_thread.start()
+        assert _wait_until(lambda: len(runtime._requests_by_id) == 2)
+        assert delayed_pumps
+        original_start(delayed_pumps[0])
+
+        generator = _PartialPrefillBatchGenerator.instances[0]
+        assert generator.prefill_started.wait(timeout=2.0)
+        cancelled.set()
+        assert _wait_until(
+            lambda: len([event for event in cancelled_events if event["kind"] == "failed"]) == 1
+        )
+
+        with runtime._cv:
+            assert len(runtime._active_by_uid) == 2
+            assert len(runtime._active_detokenizer_ids) == 1
+
+        generator.release_responses.set()
+        cancelled_thread.join(timeout=2.0)
+        peer_thread.join(timeout=2.0)
+
+        assert cancelled_thread.is_alive() is False
+        assert peer_thread.is_alive() is False
+        assert [
+            event["kind"] for event in cancelled_events if event["kind"] in {"failed", "completed"}
+        ] == ["failed"]
+        assert cancelled_events[-1]["code"] == "cancelled"
+        assert [
+            event["delta"] for event in peer_events if event["kind"] == "output_text_delta"
+        ] == ["X"]
+        assert [
+            event["kind"] for event in peer_events if event["kind"] in {"failed", "completed"}
+        ] == ["completed"]
+        assert peer_events[-1]["usage"] == {
+            "input_tokens": 3,
+            "output_tokens": 1,
+            "total_tokens": 4,
+        }
+        assert _wait_until(
+            lambda: (
+                runtime._active_by_uid == {}
+                and runtime._requests_by_id == {}
+                and runtime._active_detokenizer_ids == set()
+            )
+        )
+        assert runtime._active_by_uid == {}
+        assert runtime._requests_by_id == {}
+        assert runtime._active_detokenizer_ids == set()
+    finally:
+        runtime.close()
+        cancelled_thread.join(timeout=2.0)
+        peer_thread.join(timeout=2.0)
+
+
 def test_batch_generator_runtime_rejects_shared_detokenizer_instances() -> None:
     session = _make_fake_session()
     session.tokenizer = _SharedDetokenizerTokenizer()


### PR DESCRIPTION
## Summary

- Adds deterministic, model-free coverage for cancellation of one co-resident partial-prefill request while its peer retains output, usage, and exactly one terminal event.
- Verifies runtime registry cleanup occurs after the terminal batch responses, before `runtime.close()`.
- Documents the synthetic-evidence boundary. An undrained cancellation reset continues to give peers a retryable collateral failure; this is not a peer-preservation path.

## Scope boundary

This does not qualify Controller dispatch-capacity release, MLX-LM cache reachability, Metal behavior, model compatibility, or Apple Silicon hardware support. It does not change runtime behavior. Those actual-runtime and hardware qualifications remain separate work.

Related: #409 (intentionally not closing this issue).

## Validation

- `mise exec -- uv run --directory native/orchard_worker_mlx ruff format`
- `mise exec -- uv run --directory native/orchard_worker_mlx ruff check`
- `mise exec -- uv run --directory native/orchard_worker_mlx pytest` — 758 passed, 9 skipped
- `mise exec -- uv run --directory native/orchard_worker_mlx pytest --cov` — 758 passed, 9 skipped; 85% total coverage
- focused partial-prefill regression — 1 passed

The nine skips require either a real local bundle via `ORCHARD_MLX_SMOKE_MODEL_PATH` or uninstalled optional MLX dependencies; no model was downloaded or hardware qualification run.