### PR TITLE
test(worker_mlx): harden misleading-name and cancellation-reset regressions

### DIFF
--- a/native/orchard_worker_mlx/README.md
+++ b/native/orchard_worker_mlx/README.md
@@ -45,8 +45,10 @@ Aggregate capacity is the conservative limit the node agent enforces across load
 
 Issue #409 keeps compatibility and lifecycle regression evidence separate from
 model qualification. The native suite covers normalized EOS IDs independently
-of text stop sequences, manifest identity and bundle-relative paths despite
-misleading names, and empty, partial, and hybrid prefix-cache snapshots.
+of text stop sequences, manifest-bound capability evidence and bundle-relative
+paths despite misleading requested, manifest, folder, and config names, and
+empty, partial, and hybrid prefix-cache snapshots. A name never grants EOS,
+parser, tool, or capability authority.
 
 `test_batch_partial_prefill_cancel_preserves_peer_events_until_batch_cleanup`
 holds two synthetic requests in one batch after partial prefill, cancels one,
@@ -54,9 +56,12 @@ and proves the other retains its output, exact usage, and one completion while
 the shared runtime retains both active entries until the batch returns terminal
 responses. It then proves the request and detokenizer registries are empty.
 `test_batch_generator_runtime_cancel_resets_after_bounded_drain_timeout` covers
-the distinct reset policy: an undrained cancellation resets the shared batch
-and gives other active requests a retryable collateral failure. It is not a
-peer-preservation path.
+the distinct reset policy. It admits both synthetic requests before cancelling
+one, then proves an undrained cancellation resets the shared batch, leaving the
+cancelled request exactly one terminal event and the collateral request a
+single retryable failure with no terminal event of its own, and leaves the
+runtime request, active, and detokenizer registries empty before teardown. It
+is not a peer-preservation path.
 
 These tests use fake generation dependencies and do not establish MLX-LM cache
 reachability, real Metal behavior, model compatibility, Apple Silicon hardware

--- a/native/orchard_worker_mlx/tests/test_generation.py
+++ b/native/orchard_worker_mlx/tests/test_generation.py
@@ -2394,22 +2394,36 @@ def test_batch_generator_runtime_cancel_resets_after_bounded_drain_timeout() -> 
 
     thread_a = threading.Thread(target=run_a)
     thread_b = threading.Thread(target=run_b)
-    thread_a.start()
-    thread_b.start()
 
-    cancel_event_a.set()
-    thread_a.join(timeout=2.0)
-    thread_b.join(timeout=3.0)
+    try:
+        thread_a.start()
+        thread_b.start()
+        assert _wait_until(lambda: len(runtime._active_by_uid) == 2)
 
-    runtime.close()
+        cancel_event_a.set()
+        thread_a.join(timeout=2.0)
+        thread_b.join(timeout=3.0)
 
-    assert thread_a.is_alive() is False
-    assert thread_b.is_alive() is False
-    assert events_a[-1]["kind"] == "failed"
-    assert events_a[-1]["code"] == "cancelled"
-    assert error_b
-    assert error_b[0].code == "generation_failed"
-    assert "reset" in error_b[0].message
+        assert thread_a.is_alive() is False
+        assert thread_b.is_alive() is False
+        assert [
+            event["kind"] for event in events_a if event["kind"] in {"failed", "completed"}
+        ] == ["failed"]
+        assert events_a[-1]["code"] == "cancelled"
+        assert [
+            event["kind"] for event in events_b if event["kind"] in {"failed", "completed"}
+        ] == []
+        assert len(error_b) == 1
+        assert error_b[0].code == "generation_failed"
+        assert "reset" in error_b[0].message
+        assert runtime._active_by_uid == {}
+        assert runtime._requests_by_id == {}
+        assert runtime._active_detokenizer_ids == set()
+    finally:
+        cancel_event_a.set()
+        runtime.close()
+        thread_a.join(timeout=2.0)
+        thread_b.join(timeout=2.0)
 
 
 def test_batch_generator_runtime_watchdog_resets_when_next_is_blocked() -> None:

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -751,6 +751,7 @@ def test_spec_6_4_loader_uses_artifact_evidence_despite_misleading_names(
     assert session.bundle_path == misleading_bundle
     assert session.eos_token_ids == ()
     assert session.tool_calling == {"supported": False, "parser_type": None}
+    assert session.manifest.capabilities == ("chat",)
 
 
 def test_load_session_model_load_failure(writable_bundle: Path) -> None:

--- a/native/orchard_worker_mlx/tests/test_model_loader.py
+++ b/native/orchard_worker_mlx/tests/test_model_loader.py
@@ -720,11 +720,17 @@ def test_load_session_tokenizer_receives_resolved_path(writable_bundle: Path) ->
     assert captured_paths[0].endswith("tokenizer.json")
 
 
-def test_spec_6_4_loader_uses_verified_local_paths_despite_misleading_bundle_name(
+def test_spec_6_4_loader_uses_artifact_evidence_despite_misleading_names(
     writable_bundle: Path,
 ) -> None:
-    """A bundle name never replaces manifest identity or its local artifact paths."""
-    misleading_bundle = writable_bundle.with_name("remote-tool-model-reasoning-capable")
+    """Model and bundle names never replace manifest-bound capability evidence."""
+    misleading_model_id = "remote-tool-model-reasoning-capable"
+    manifest_path = writable_bundle / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["model_id"] = misleading_model_id
+    manifest_path.write_text(json.dumps(manifest))
+
+    misleading_bundle = writable_bundle.with_name("eos-tool-reasoning-model")
     writable_bundle.rename(misleading_bundle)
 
     base_deps = _make_fake_deps(model_config={"model_type": "misleading-family"})
@@ -733,7 +739,7 @@ def test_spec_6_4_loader_uses_verified_local_paths_despite_misleading_bundle_nam
     deps = replace(base_deps, load_model=load_model, load_tokenizer=load_tokenizer)
 
     session = load_session(
-        model_id="test-org/tiny-llm",
+        model_id=misleading_model_id,
         version="mlx-q4-v1",
         model_path=str(misleading_bundle),
         deps=deps,
@@ -741,7 +747,7 @@ def test_spec_6_4_loader_uses_verified_local_paths_despite_misleading_bundle_nam
 
     load_model.assert_called_once_with(misleading_bundle / "weights", lazy=True, strict=False)
     load_tokenizer.assert_called_once_with(misleading_bundle / "tokenizer.json")
-    assert session.manifest.model_id == "test-org/tiny-llm"
+    assert session.manifest.model_id == misleading_model_id
     assert session.bundle_path == misleading_bundle
     assert session.eos_token_ids == ()
     assert session.tool_calling == {"supported": False, "parser_type": None}


### PR DESCRIPTION
## Intent

Close only the remaining deterministic, model-free regression gaps in #409 after merged PRs #424 and #428. No production/runtime behavior, model downloads, inference, host/service changes, dependency changes, cache policy, or `ArraysCache.extract` reachability assumptions.

## Existing coverage retained

- EOS union and multi-token stop-sequence separation
- verified-local loader paths, offline behavior, and disabled model/tokenizer trust across supported signatures
- empty, partial, composite, and hybrid cache operations, including untouched slots
- pre-cancel and partial-prefill peer isolation
- Controller capacity release and provider-neutral lifecycle conformance

## What changed

- Strengthened the misleading-name regression across requested/manifest model ID, bundle folder, and model-config family. Names remain inert: local artifact paths are unchanged, EOS/parser/tool evidence remains absent, and manifest capabilities remain exactly `("chat",)`.
- Made the bounded cancellation-reset regression deterministic by waiting until both peers are admitted before cancellation. It now proves one cancelled terminal, one collateral reset failure with no native terminal, and empty request/active/detokenizer registries before teardown.
- Refreshed the existing package README statements to match those tested boundaries without making hardware, model-support, or Controller-capacity claims.

## Validation

Local:

- `mise exec -- uv run --directory native/orchard_worker_mlx ruff format` — passed
- `mise exec -- uv run --directory native/orchard_worker_mlx ruff check` — passed
- focused strengthened regressions — `2 passed`
- `mise exec -- uv run --directory native/orchard_worker_mlx pytest` — `758 passed, 9 skipped`
- `mise exec -- uv run --directory native/orchard_worker_mlx pytest --cov` — `758 passed, 9 skipped`, total coverage `85%`
- `make macos-native-test-helpers` — passed
- `mise exec -- mix test apps/orchard_node_agent/test/orchard_node_agent_test.exs:3199` — `1 passed`
- `scripts/test-provider-neutral-conformance.sh` — binding generation/drift checks passed; Python `9 passed`; Elixir `28 + 66 + 52 + 12 passed`

No-mistakes run `01M2B0591RV69BS4TDAA8CB36Q` reached `checks-passed`. Review added the user-approved exact manifest-capability assertion; no unresolved pipeline findings remain.

Exact-head CI at `ad76d9c1f9de5349526e79c89502ffa48dd2aed9` is green for classification, Linux portable core, provider-neutral conformance, macOS host, MLX provider, Orchard.app/DMG, OpenSpec, required-validation aggregate, and Greptile review.

## Evidence and limits

- [Sanitized validation screenshot](https://github.com/kapitan-ai/orchard/blob/53b220f38654fea1513238edb7a26b5253188c7e/orchard-pr432-validation.svg.png?raw=true)
- [Evidence comment](https://github.com/kapitan-ai/orchard/pull/432#issuecomment-5646708627)

The tests are synthetic and model-free. They do not establish real MLX-LM cache reachability, Metal behavior, hardware qualification, model compatibility, or a support claim.

Refs #409.
