### PR TITLE
fix(inference): return content-free internal_error for reasoning conformance failures

### DIFF
--- a/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
+++ b/apps/orchard_controller/lib/orchard/dispatch/request_dispatcher.ex
@@ -534,6 +534,13 @@ defmodule Orchard.Dispatch.RequestDispatcher do
 
   defp failure_source(code)
        when code in [
+              "reasoning_parser_conformance_failed",
+              "reasoning_policy_conformance_failed"
+            ],
+       do: %{category: :terminal_conformance, code: code}
+
+  defp failure_source(code)
+       when code in [
               "runtime_endpoint_missing_terminal",
               "runtime_endpoint_duplicate_terminal",
               "runtime_endpoint_post_terminal_event"

--- a/apps/orchard_controller/lib/orchard/inference/chat_error.ex
+++ b/apps/orchard_controller/lib/orchard/inference/chat_error.ex
@@ -10,6 +10,9 @@ defmodule Orchard.Inference.ChatError do
 
   alias Orchard.Inference.ModelLoadFailure
   alias Orchard.InferenceEvent
+  alias Orchard.Requests.InferenceAttemptFailure
+
+  @reasoning_conformance_codes InferenceAttemptFailure.reasoning_conformance_codes()
 
   @type kind ::
           :missing_required_field
@@ -31,6 +34,7 @@ defmodule Orchard.Inference.ChatError do
           | :request_cancelled
           | :request_interrupted
           | :request_failed
+          | :reasoning_conformance
           | :runtime_endpoint_conformance
           | :orchestration_crash
           | :internal
@@ -355,6 +359,16 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def api_mapping(%__MODULE__{kind: :reasoning_conformance}) do
+    %{
+      status: :internal_server_error,
+      type: "api_error",
+      code: "internal_error",
+      message: "Internal error",
+      param: nil
+    }
+  end
+
   def api_mapping(%__MODULE__{kind: :runtime_endpoint_conformance}) do
     %{
       status: :internal_server_error,
@@ -409,6 +423,15 @@ defmodule Orchard.Inference.ChatError do
       type: "server_error",
       code: "request_cancelled",
       message: "Request was cancelled",
+      param: nil
+    }
+  end
+
+  def sse_mapping(%__MODULE__{kind: :reasoning_conformance}) do
+    %{
+      type: "server_error",
+      code: "internal_error",
+      message: "Internal error",
       param: nil
     }
   end
@@ -546,6 +569,15 @@ defmodule Orchard.Inference.ChatError do
     }
   end
 
+  def terminal_attrs(%__MODULE__{kind: :reasoning_conformance}) do
+    %{
+      state: :failed,
+      http_status: 500,
+      error_code: "internal_error",
+      error_message: "Internal error"
+    }
+  end
+
   def terminal_attrs(%__MODULE__{kind: :runtime_endpoint_conformance} = error) do
     %{
       state: :failed,
@@ -611,6 +643,9 @@ defmodule Orchard.Inference.ChatError do
   defp failed_event_kind(code)
        when code in ["request_client_disconnect", "request_caller_disconnect"],
        do: :request_cancelled
+
+  defp failed_event_kind(code) when code in @reasoning_conformance_codes,
+    do: :reasoning_conformance
 
   defp failed_event_kind(code)
        when code in [

--- a/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
+++ b/apps/orchard_controller/lib/orchard/requests/inference_attempt_failure.ex
@@ -30,6 +30,9 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
   )
   @acceptance_proof_failure_class "pre_acceptance_unavailable"
   @acceptance_proof_failure_code "runtime_incompatible"
+  @reasoning_conformance_codes ~w(
+    reasoning_parser_conformance_failed reasoning_policy_conformance_failed
+  )
   @type evidence :: %{required(String.t()) => String.t()}
 
   @spec stable_error_codes() :: [String.t()]
@@ -40,6 +43,9 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
 
   @spec model_load_codes() :: [String.t()]
   def model_load_codes, do: @model_load_codes
+
+  @spec reasoning_conformance_codes() :: [String.t()]
+  def reasoning_conformance_codes, do: @reasoning_conformance_codes
 
   @spec acceptance_proof_failure?(String.t(), String.t()) :: boolean()
   def acceptance_proof_failure?(
@@ -81,7 +87,7 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
         {"deadline", deadline_code(code)}
 
       category in [:terminal_conformance, "terminal_conformance"] ->
-        {"terminal_conformance", "orchestration_error"}
+        {"terminal_conformance", terminal_conformance_code(code)}
 
       category in [:capacity, "capacity", :capacity_rejection, "capacity_rejection"] ->
         {capacity_failure_class(code), capacity_code(code)}
@@ -156,6 +162,11 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
 
   defp pre_acceptance_code(_code), do: "internal_error"
 
+  defp terminal_conformance_code(code) when code in @reasoning_conformance_codes,
+    do: "internal_error"
+
+  defp terminal_conformance_code(_code), do: "orchestration_error"
+
   defp capacity_failure_class("dispatch_capacity_caller_down"), do: "cancellation"
 
   defp capacity_failure_class("dispatch_capacity_node_identity_mismatch"),
@@ -181,6 +192,10 @@ defmodule Orchard.Requests.InferenceAttemptFailure do
 
   defp controller_code(code) when code in ["orchestration_error", "request_interrupted"], do: code
   defp controller_code(_code), do: "internal_error"
+
+  defp maybe_put_raw_source_code(evidence, code, _stable)
+       when code in @reasoning_conformance_codes,
+       do: evidence
 
   defp maybe_put_raw_source_code(evidence, nil, _stable), do: evidence
   defp maybe_put_raw_source_code(evidence, stable, stable), do: evidence

--- a/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/chat_completions_controller_test.exs
@@ -900,6 +900,45 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
                "Inference failed: model did not emit any required tool calls"
     end
 
+    test "SPEC.md §7.5.3a hides reasoning conformance details in sync Chat errors" do
+      worker_message = "<think>worker marker bytes and model output</think>"
+
+      for code <- [
+            "reasoning_parser_conformance_failed",
+            "reasoning_policy_conformance_failed"
+          ] do
+        canonical = stub_chat_canonical(false)
+
+        stub_chat_orchestrator(
+          prepare: {:ok, canonical, %{}},
+          execute:
+            {:ok, canonical,
+             [
+               InferenceEvent.accepted(1_710_000_123_000),
+               InferenceEvent.failed(code, worker_message, false)
+             ]}
+        )
+
+        conn =
+          post_chat(%{
+            "model" => "stub-tool-model@v1",
+            "messages" => [%{"role" => "user", "content" => "hello"}]
+          })
+
+        assert conn.status == 500
+
+        assert Jason.decode!(conn.resp_body)["error"] == %{
+                 "code" => "internal_error",
+                 "message" => "Internal error",
+                 "param" => nil,
+                 "type" => "api_error"
+               }
+
+        refute conn.resp_body =~ code
+        refute conn.resp_body =~ worker_message
+      end
+    end
+
     test "SPEC 7.5.5 non-stream terminal conformance failure is a generic 500" do
       canonical = stub_chat_canonical(false)
 
@@ -1830,6 +1869,48 @@ defmodule Orchard.API.ChatCompletionsControllerTest do
       request = Requests.get_request_by_public_id(request_id)
       assert request.state == :failed
       assert_tool_serializer_failure!(request)
+    end
+
+    test "SPEC.md §7.5.3a hides reasoning conformance details in streaming Chat errors" do
+      worker_message = "<think>worker marker bytes and model output</think>"
+
+      for code <- [
+            "reasoning_parser_conformance_failed",
+            "reasoning_policy_conformance_failed"
+          ] do
+        stub_chat_orchestrator(
+          prepare: {:ok, stub_chat_canonical(), %{}},
+          events: [
+            InferenceEvent.accepted(1_710_000_123_000),
+            InferenceEvent.failed(code, worker_message, false)
+          ],
+          execute: {:ok, stub_chat_canonical(), []}
+        )
+
+        conn =
+          post_chat(%{
+            "model" => "stub-tool-model@v1",
+            "messages" => [%{"role" => "user", "content" => "hello"}],
+            "stream" => true
+          })
+
+        assert conn.status == 200
+        events = parse_sse_body(conn.resp_body)
+
+        assert [{:error, payload}] =
+                 Enum.filter(events, fn {type, _payload} -> type == :error end)
+
+        assert payload["error"] == %{
+                 "code" => "internal_error",
+                 "message" => "Internal error",
+                 "param" => nil,
+                 "type" => "server_error"
+               }
+
+        refute Enum.any?(events, fn {type, _payload} -> type == :done end)
+        refute conn.resp_body =~ code
+        refute conn.resp_body =~ worker_message
+      end
     end
 
     test "SPEC 7.5.5 streaming terminal conformance failure emits one generic SSE error" do

--- a/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
+++ b/apps/orchard_controller/test/orchard/api/responses_controller_test.exs
@@ -525,6 +525,41 @@ defmodule Orchard.API.ResponsesControllerTest do
              "Inference failed: model emitted tool call outside required function lookup_weather"
   end
 
+  test "SPEC.md §7.5.3a hides reasoning conformance details in sync Responses errors" do
+    worker_message = "<think>worker marker bytes and model output</think>"
+
+    for code <- [
+          "reasoning_parser_conformance_failed",
+          "reasoning_policy_conformance_failed"
+        ] do
+      canonical = stub_responses_canonical(false)
+
+      stub_responses_orchestrator(
+        prepare: {:ok, canonical, %{}},
+        execute:
+          {:ok, canonical,
+           [
+             InferenceEvent.accepted(1_710_000_123_000),
+             InferenceEvent.failed(code, worker_message, false)
+           ]}
+      )
+
+      conn = post_responses(%{"model" => "stub-tool-model@v1", "input" => "hello"})
+
+      assert conn.status == 500
+
+      assert Jason.decode!(conn.resp_body)["error"] == %{
+               "code" => "internal_error",
+               "message" => "Internal error",
+               "param" => nil,
+               "type" => "api_error"
+             }
+
+      refute conn.resp_body =~ code
+      refute conn.resp_body =~ worker_message
+    end
+  end
+
   test "SPEC 7.5.5 sync terminal conformance failure is a generic 500" do
     canonical = stub_responses_canonical(false)
 
@@ -1705,6 +1740,46 @@ defmodule Orchard.API.ResponsesControllerTest do
     request = Requests.get_request_by_public_id(request_id)
     assert request.state == :failed
     assert_tool_serializer_failure!(request)
+  end
+
+  test "SPEC.md §7.5.3a hides reasoning conformance details in streaming Responses errors" do
+    worker_message = "<think>worker marker bytes and model output</think>"
+
+    for code <- [
+          "reasoning_parser_conformance_failed",
+          "reasoning_policy_conformance_failed"
+        ] do
+      stub_responses_orchestrator(
+        prepare: {:ok, stub_responses_canonical(true), %{}},
+        events: [
+          InferenceEvent.accepted(1_710_000_123_000),
+          InferenceEvent.failed(code, worker_message, false)
+        ],
+        execute: {:ok, stub_responses_canonical(true), []}
+      )
+
+      conn =
+        post_responses(%{
+          "model" => "stub-tool-model@v1",
+          "input" => "hello",
+          "stream" => true
+        })
+
+      assert conn.status == 200
+      events = parse_typed_sse_events(conn)
+      assert Enum.map(events, & &1.type) == ["response.created", "response.failed"]
+
+      assert List.last(events).data["response"]["error"] == %{
+               "code" => "internal_error",
+               "message" => "Internal error",
+               "param" => nil,
+               "type" => "server_error"
+             }
+
+      refute String.contains?(collect_chunked_body(conn), "[DONE]")
+      refute String.contains?(collect_chunked_body(conn), code)
+      refute String.contains?(collect_chunked_body(conn), worker_message)
+    end
   end
 
   test "SPEC 7.5.5 streaming terminal conformance failure emits response.failed" do

--- a/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
+++ b/apps/orchard_controller/test/orchard/dispatch/dispatch_test.exs
@@ -194,6 +194,17 @@ defmodule Orchard.Dispatch.DispatchTest.TerminalContractClient do
     ]
   end
 
+  defp events_for("req-dispatch-reasoning-conformance-" <> code)
+       when code in [
+              "reasoning_parser_conformance_failed",
+              "reasoning_policy_conformance_failed"
+            ] do
+    [
+      InferenceEvent.accepted(0),
+      InferenceEvent.failed(code, "<think>untrusted model output</think>", false)
+    ]
+  end
+
   defp events_for("req-dispatch-preaccept-" <> code),
     do: [InferenceEvent.failed(code, "capacity exhausted", false)]
 
@@ -687,6 +698,33 @@ defmodule Orchard.Dispatch.DispatchTest do
                    "failure_code" => "internal_error"
                  },
                  output_committed: false
+               } =
+                 RequestDispatcher.dispatch(
+                   build_schedule(request_id),
+                   execute_request(request_id),
+                   model_load_request(bundle),
+                   client_impl: Orchard.Dispatch.DispatchTest.TerminalContractClient
+                 )
+      end
+    end
+
+    test "SPEC.md §7.5.3a reasoning conformance is uncommitted terminal evidence", %{
+      bundle: bundle
+    } do
+      for code <- [
+            "reasoning_parser_conformance_failed",
+            "reasoning_policy_conformance_failed"
+          ] do
+        request_id = "req-dispatch-reasoning-conformance-#{code}"
+
+        assert %AttemptOutcome{
+                 attempt_outcome: :failed,
+                 accepted: true,
+                 output_committed: false,
+                 failure: %{
+                   "failure_class" => "terminal_conformance",
+                   "failure_code" => "internal_error"
+                 }
                } =
                  RequestDispatcher.dispatch(
                    build_schedule(request_id),

--- a/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
+++ b/apps/orchard_controller/test/orchard/inference/chat_error_test.exs
@@ -4,6 +4,7 @@ defmodule Orchard.Inference.ChatErrorTest do
   alias Orchard.API.InferenceControllerSupport
   alias Orchard.Inference.{ChatError, ModelLoadFailure}
   alias Orchard.InferenceEvent
+  alias Orchard.Requests.CapturePolicy
 
   test "prepare validation mappings preserve OpenAI envelope fields" do
     error = ChatError.from_prepare_reason({:validation, {:missing_required_field, "model"}})
@@ -186,6 +187,54 @@ defmodule Orchard.Inference.ChatErrorTest do
                error_code: code,
                error_message: message
              }
+    end
+  end
+
+  test "SPEC.md §7.5.3a reasoning conformance stays Controller-owned under every capture mode" do
+    worker_message = "<think>marker bytes and model output</think>"
+
+    for code <- [
+          "reasoning_parser_conformance_failed",
+          "reasoning_policy_conformance_failed"
+        ] do
+      error =
+        code
+        |> InferenceEvent.failed(worker_message, false)
+        |> ChatError.from_failed_event()
+
+      assert error.kind == :reasoning_conformance
+
+      assert ChatError.api_mapping(error) == %{
+               status: :internal_server_error,
+               type: "api_error",
+               code: "internal_error",
+               message: "Internal error",
+               param: nil
+             }
+
+      assert ChatError.sse_mapping(error) == %{
+               type: "server_error",
+               code: "internal_error",
+               message: "Internal error",
+               param: nil
+             }
+
+      assert ChatError.terminal_attrs(error) == %{
+               state: :failed,
+               http_status: 500,
+               error_code: "internal_error",
+               error_message: "Internal error"
+             }
+
+      for mode <- [:none, :metadata, :full] do
+        attrs =
+          error |> ChatError.terminal_attrs() |> then(&CapturePolicy.terminal_attrs(mode, &1))
+
+        assert attrs.error_code == "internal_error"
+        assert attrs.error_message in [nil, "Internal error"]
+        refute inspect(attrs) =~ code
+        refute inspect(attrs) =~ worker_message
+      end
     end
   end
 

--- a/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
+++ b/apps/orchard_controller/test/orchard/requests/inference_attempt_failure_test.exs
@@ -1,7 +1,8 @@
 defmodule Orchard.Requests.InferenceAttemptFailureTest do
   use ExUnit.Case, async: true
 
-  alias Orchard.Inference.ModelLoadFailure
+  alias Orchard.Inference.{ChatError, ModelLoadFailure}
+  alias Orchard.InferenceEvent
   alias Orchard.Requests.InferenceAttemptFailure
 
   test "normalizes structured source categories without inspecting messages" do
@@ -56,6 +57,60 @@ defmodule Orchard.Requests.InferenceAttemptFailureTest do
     for {source, expected} <- cases do
       assert normalized(source.category, source.code) == expected
     end
+  end
+
+  test "SPEC.md §7.5.3a maps only closed reasoning conformance codes to internal_error" do
+    codes = [
+      "reasoning_parser_conformance_failed",
+      "reasoning_policy_conformance_failed"
+    ]
+
+    assert InferenceAttemptFailure.reasoning_conformance_codes() == codes
+
+    for code <- codes do
+      assert InferenceAttemptFailure.normalize(%{
+               category: :terminal_conformance,
+               code: code,
+               message: "<think>untrusted model output</think>"
+             }) == %{
+               "failure_class" => "terminal_conformance",
+               "failure_code" => "internal_error"
+             }
+    end
+  end
+
+  test "SPEC.md §7.5.3a reasoning-like near-miss keeps the unknown-code fallback" do
+    code = "reasoning_parser_conformance_failure"
+    worker_message = "near-miss worker detail"
+
+    refute code in InferenceAttemptFailure.reasoning_conformance_codes()
+
+    assert InferenceAttemptFailure.normalize(%{
+             category: :runtime,
+             code: code,
+             message: worker_message
+           }) == %{
+             "failure_class" => "runtime_failure",
+             "failure_code" => "internal_error",
+             "raw_source_code" => code
+           }
+
+    error =
+      code
+      |> InferenceEvent.failed(worker_message, false)
+      |> ChatError.from_failed_event()
+
+    assert error.kind == :request_failed
+    assert error.source_code == code
+    assert error.source_message == worker_message
+
+    assert ChatError.api_mapping(error) == %{
+             status: :internal_server_error,
+             type: "server_error",
+             code: "internal_error",
+             message: "Inference failed: #{worker_message}",
+             param: nil
+           }
   end
 
   test "untrusted pre-acceptance codes do not acquire retryable stable codes" do

--- a/openspec/specs/runtime-endpoints/spec.md
+++ b/openspec/specs/runtime-endpoints/spec.md
@@ -716,6 +716,31 @@ This requirement traces to `SPEC.md` §5.8, §§12.1-12.3, §12.7, and `docs/dec
 - **AND** normalizes restricted-capture durable evidence to the existing stable Controller-owned terminal failure code
 - **AND** no Automatic Attempt Retry begins
 
+### Requirement: Reasoning conformance failure codes are a closed shared vocabulary
+`reasoning_parser_conformance_failed` and `reasoning_policy_conformance_failed` SHALL be the only Runtime Endpoint `Failed` codes that report a post-execution negotiated reasoning parser or generation-policy conformance failure.
+A producer SHALL emit exactly those spellings and the Controller SHALL recognize exactly those spellings; no other spelling, prefix, synonym, or category pairing SHALL receive reasoning conformance treatment.
+Both codes SHALL classify as the `terminal_conformance` failure class with the stable Controller-owned failure code `internal_error`, and SHALL remain non-retryable.
+The Controller MUST NOT expose the source code, source message, parser control markers, or model output through the synchronous HTTP body, the streaming error event, or durable terminal evidence, and SHALL retain no raw source code for either code under `none`, `metadata`, or `full` capture.
+A reasoning-only conformance failure commits no validated content-bearing output and SHALL record `output_committed = false`.
+This vocabulary is a shared failure-code contract only: it adds no protobuf field, no public reasoning control, and no parser behavior, and it SHALL NOT broaden the `orchestration_error` default that every other `terminal_conformance` code keeps.
+This requirement traces to `SPEC.md` §7.2.7 and §7.5.3a.
+
+#### Scenario: Parser conformance failure stays content-free
+- **WHEN** a negotiated attempt fails post-execution with `reasoning_parser_conformance_failed`
+- **THEN** the synchronous and streaming public errors carry only `internal_error` with a generic message
+- **AND** durable terminal evidence records `terminal_conformance` plus `internal_error` with no raw source code under any capture mode
+- **AND** no Automatic Attempt Retry begins
+
+#### Scenario: Generation-policy conformance failure stays content-free
+- **WHEN** a negotiated attempt fails post-execution with `reasoning_policy_conformance_failed`
+- **THEN** Orchard applies the same content-free `terminal_conformance` plus `internal_error` outcome
+- **AND** the reasoning-only failure records `output_committed = false`
+
+#### Scenario: Reasoning-like code outside the closed pair is not reasoning conformance
+- **WHEN** a Runtime Endpoint `Failed` event carries a reasoning-like code that is not one of the two closed spellings
+- **THEN** Orchard does not apply the reasoning conformance classification or mapping
+- **AND** the code follows the existing unknown-code classification instead
+
 ### Requirement: Execution resolution precedes retry
 The Controller SHALL allow a pre-acceptance failure to qualify for retry only after cleanup and capacity release are affirmatively resolved.
 An accepted pre-commit failure MAY qualify only when a valid terminal event or cancellation drain proves execution termination.


### PR DESCRIPTION
## Intent and scope

Clean replacement for closed unmerged PR #422, referencing issue #328.

This Draft is limited to the Controller terminal-conformance/internal-error mapping slice:

- `reasoning_parser_conformance_failed` and `reasoning_policy_conformance_failed` receive stable, content-free `internal_error` handling.
- `reasoning_parser_conformance_failure` remains an unknown code and retains the existing fallback.
- The unused `reasoning_conformance_code?/1` predicate and its stale direct coverage remain removed.
- No protocol/runtime behavior, scheduling or dispatch activation, public controls, usage writers, production registrations, model-family handling, or unrelated cleanup is included.

## Changed behavior

- The two closed reasoning-conformance codes are classified as `terminal_conformance` and normalized to `internal_error`.
- Chat and Responses APIs emit only the stable `internal_error` / `Internal error` envelope for those codes in synchronous and streaming flows.
- Durable failure evidence suppresses the provider code and message under capture modes `none`, `metadata`, and `full`.
- The deterministic near-miss regression proves unknown reasoning-like codes do not receive special handling.

## SPEC impact

No apex `SPEC.md` behavior change. The implementation and runtime-endpoints OpenSpec coverage trace the existing `SPEC.md` terminal-conformance contract.

## Validation

- Focused mapping suite: 34 passed.
- Five new SPEC section 7.5.3a regressions: 5 passed.
- Full affected Controller suite: 169 passed.
- Remaining changed-module blast-radius suite: 237 passed.
- `make check-elixir`: passed; compilation with warnings as errors, Credo strict, Dialyzer, 5,376 tests, and coverage all succeeded.
- `OPENSPEC_TELEMETRY=0 mise exec -- npm run openspec -- validate --all --strict --no-interactive`: 55 passed, 0 failed.
- `scripts/test-provider-neutral-conformance.sh`: passed; Python 9 passed, Elixir groups 28 + 66 + 52 + 12 passed, binding match passed, and deliberate-drift rejection passed.
- `git diff --check`: passed.
- No-mistakes AXI: `checks-passed`; the rebase step was explicitly skipped under the approved exact-base custody.
- All required GitHub CI checks reached terminal success.

## Review status

- Draft PR; no merge performed.
- The sole automated review thread proposed a non-blocking shared-vocabulary refactor. It was kept out of this intentionally narrow replacement, the reviewer agreed no action was needed, and the thread is resolved.
- No unresolved review threads remain.

## Sanitized evidence

![Sanitized terminal-conformance validation evidence for issue 328](https://github.com/user-attachments/assets/599bebae-6e87-4add-b431-7e08be6eb762)
